### PR TITLE
Fix buckets 107-111

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ codex_autorunner = ["static/*", "static/**/*"]
 [tool.typer]
 completions = true
 
+[tool.pytest.ini_options]
+cache_dir = ".codex-autorunner/pytest-cache"
+
 [tool.ruff]
 line-length = 88
 target-version = "py39"

--- a/src/codex_autorunner/core/git_utils.py
+++ b/src/codex_autorunner/core/git_utils.py
@@ -6,6 +6,8 @@ import subprocess
 from pathlib import Path
 from typing import List, Optional
 
+from .utils import subprocess_env
+
 
 class GitError(Exception):
     """Raised when a git operation fails."""
@@ -41,6 +43,7 @@ def run_git(
             capture_output=True,
             text=True,
             timeout=timeout_seconds,
+            env=subprocess_env(),
         )
     except FileNotFoundError as exc:
         raise GitError("git binary not found", returncode=127) from exc
@@ -116,6 +119,7 @@ def git_ls_files(repo_root: Path) -> List[str]:
             ["git", "ls-files", "-z"],
             cwd=str(repo_root),
             capture_output=True,
+            env=subprocess_env(),
         )
     except FileNotFoundError:
         return []

--- a/src/codex_autorunner/core/optional_dependencies.py
+++ b/src/codex_autorunner/core/optional_dependencies.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
 import importlib.util
-from typing import Optional, Sequence, Tuple
+from typing import Optional, Sequence, Tuple, Union
 
 from .config import ConfigError
 
-OptionalDependency = Tuple[str, str]
+OptionalDependency = Tuple[Union[str, Sequence[str]], str]
 
 
 def missing_optional_dependencies(
     deps: Sequence[OptionalDependency],
 ) -> list[str]:
     missing: list[str] = []
-    for module_name, display_name in deps:
-        if importlib.util.find_spec(module_name) is None:
+    for module_names, display_name in deps:
+        candidates = (
+            [module_names] if isinstance(module_names, str) else list(module_names)
+        )
+        if not any(importlib.util.find_spec(name) is not None for name in candidates):
             missing.append(display_name)
     return missing
 

--- a/src/codex_autorunner/core/prompt.py
+++ b/src/codex_autorunner/core/prompt.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from typing import Mapping, Optional
 
@@ -47,9 +48,8 @@ def build_prompt_text(
         "{{SPEC_PATH}}": doc_paths.get("spec", ""),
         "{{SUMMARY_PATH}}": doc_paths.get("summary", ""),
     }
-    for marker, value in replacements.items():
-        template = template.replace(marker, value)
-    return template
+    pattern = re.compile("|".join(re.escape(key) for key in replacements))
+    return pattern.sub(lambda match: replacements[match.group(0)], template)
 
 
 def build_final_summary_prompt(

--- a/src/codex_autorunner/integrations/app_server/supervisor.py
+++ b/src/codex_autorunner/integrations/app_server/supervisor.py
@@ -112,6 +112,7 @@ class WorkspaceAppServerSupervisor:
         async with self._lock:
             existing = self._handles.get(workspace_id)
             if existing is not None:
+                existing.last_used_at = time.monotonic()
                 return existing
             handles_to_close.extend(self._pop_idle_handles_locked())
             evicted = self._evict_lru_handle_locked()

--- a/src/codex_autorunner/web/middleware.py
+++ b/src/codex_autorunner/web/middleware.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import hmac
 import logging
 import time
 import uuid
@@ -257,7 +258,7 @@ class AuthTokenMiddleware:
                 scope
             )
 
-        if token != self.token:
+        if not token or not hmac.compare_digest(token, self.token):
             if scope.get("type") == "websocket":
                 return await self._reject_ws(scope, receive, send)
             return await self._reject_http(scope, receive, send)

--- a/tests/test_app_server_supervisor.py
+++ b/tests/test_app_server_supervisor.py
@@ -1,0 +1,53 @@
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from codex_autorunner.integrations.app_server.supervisor import (
+    WorkspaceAppServerSupervisor,
+)
+from codex_autorunner.workspace import canonical_workspace_root, workspace_id_for_path
+
+
+@pytest.mark.anyio
+async def test_get_client_touches_handle_before_prune(tmp_path: Path) -> None:
+    def env_builder(
+        _workspace_root: Path, _workspace_id: str, _state_dir: Path
+    ) -> dict:
+        return {}
+
+    supervisor = WorkspaceAppServerSupervisor(
+        [sys.executable, "-c", "print('noop')"],
+        state_root=tmp_path,
+        env_builder=env_builder,
+        idle_ttl_seconds=1,
+    )
+    canonical_root = canonical_workspace_root(tmp_path)
+    workspace_id = workspace_id_for_path(canonical_root)
+    handle = await supervisor._ensure_handle(workspace_id, canonical_root)
+    handle.last_used_at = time.monotonic() - 10
+
+    started_event = asyncio.Event()
+    release_event = asyncio.Event()
+
+    async def hold_start(_handle) -> None:
+        started_event.set()
+        await release_event.wait()
+
+    async def no_op_close() -> None:
+        return None
+
+    supervisor._ensure_started = hold_start  # type: ignore[assignment]
+    handle.client.close = no_op_close  # type: ignore[assignment]
+
+    get_task = asyncio.create_task(supervisor.get_client(tmp_path))
+    await started_event.wait()
+
+    closed = await supervisor.prune_idle()
+    release_event.set()
+    await get_task
+
+    assert closed == 0
+    assert workspace_id in supervisor._handles

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -32,3 +32,18 @@ def test_require_optional_dependencies_raises(monkeypatch) -> None:
             extra="voice",
         )
     assert "pip install codex-autorunner[voice]" in str(exc.value)
+
+
+def test_missing_optional_dependencies_accepts_alternatives(monkeypatch) -> None:
+    def fake_find_spec(name: str) -> object | None:
+        return object() if name == "alternate" else None
+
+    monkeypatch.setattr(
+        optional_dependencies.importlib.util,
+        "find_spec",
+        fake_find_spec,
+    )
+    missing = optional_dependencies.missing_optional_dependencies(
+        [(("missing", "alternate"), "Alt Dep")]
+    )
+    assert missing == []

--- a/tests/test_patch_utils.py
+++ b/tests/test_patch_utils.py
@@ -1,4 +1,15 @@
-from codex_autorunner.core.patch_utils import infer_patch_strip, normalize_patch_text
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codex_autorunner.core.patch_utils import (
+    PatchError,
+    apply_patch_file,
+    infer_patch_strip,
+    normalize_patch_text,
+    preview_patch,
+)
 
 
 def test_normalize_patch_text_default_target_adds_strip_prefix():
@@ -32,3 +43,33 @@ def test_normalize_patch_text_apply_patch_format_infers_strip():
 
     assert normalized.startswith("--- a/docs/PROGRESS.md\n+++ b/docs/PROGRESS.md\n")
     assert infer_patch_strip(targets) == 1
+
+
+def test_apply_patch_file_reports_missing_patch_binary(
+    tmp_path: Path, monkeypatch
+) -> None:
+    def fake_run(*_args, **_kwargs):
+        raise FileNotFoundError("patch missing")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    patch_path = tmp_path / "diff.patch"
+    patch_path.write_text("", encoding="utf-8")
+
+    with pytest.raises(PatchError, match="patch command not found"):
+        apply_patch_file(tmp_path, patch_path, ["a/docs/TODO.md"])
+
+
+def test_preview_patch_passes_timeout(tmp_path: Path, monkeypatch) -> None:
+    def fake_run(*_args, **kwargs):
+        assert kwargs.get("timeout") is not None
+        return subprocess.CompletedProcess(args=["patch"], returncode=0, stdout="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = preview_patch(
+        tmp_path,
+        "@@ -1 +1 @@\n-old\n+new",
+        ["a/docs/TODO.md"],
+        base_content={"docs/TODO.md": "current"},
+    )
+
+    assert result["docs/TODO.md"] == "current"

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -37,3 +37,16 @@ def test_build_prompt_text_includes_prev_run_block() -> None:
     assert "PATH=TODO.md" in rendered
     assert "<PREV_RUN_OUTPUT>" in rendered
     assert "finished" in rendered
+
+
+def test_build_prompt_text_single_pass_replacement() -> None:
+    template = "TODO={{TODO}}\nSPEC={{SPEC}}"
+    rendered = build_prompt_text(
+        template=template,
+        docs={"todo": "Check {{SPEC}} details", "spec": "Spec contents"},
+        doc_paths={},
+        prev_run_output=None,
+    )
+
+    assert "Check {{SPEC}} details" in rendered
+    assert "SPEC=Spec contents" in rendered


### PR DESCRIPTION
## Summary
- fix app-server handle touch/prune race, prompt substitution, and edit command parsing
- harden config doc paths and auth token comparison
- cancel/await lifespan background tasks and harden patch/git subprocesses
- accept python_multipart optional dep and set pytest cache dir

## Testing
- make check (black, ruff, mypy, eslint, tsc, pytest)

Closes #107
Closes #108
Closes #109
Closes #110
Closes #111