### PR TITLE
Add Telegram conversation ID logging context

### DIFF
--- a/src/codex_autorunner/core/logging_utils.py
+++ b/src/codex_autorunner/core/logging_utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Mapping, Optional, OrderedDict
 
 from .config import LogConfig
-from .request_context import get_request_id
+from .request_context import get_conversation_id, get_request_id
 
 _MAX_CACHED_LOGGERS = 64
 _LOGGER_CACHE: "OrderedDict[str, logging.Logger]" = collections.OrderedDict()
@@ -102,6 +102,10 @@ def log_event(
         request_id = get_request_id()
         if request_id:
             fields["request_id"] = request_id
+    if "conversation_id" not in fields:
+        conversation_id = get_conversation_id()
+        if conversation_id:
+            fields["conversation_id"] = conversation_id
     if fields:
         payload.update(_sanitize_fields(fields))
     if exc is not None:

--- a/src/codex_autorunner/core/request_context.py
+++ b/src/codex_autorunner/core/request_context.py
@@ -7,6 +7,10 @@ _REQUEST_ID: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "codex_autorunner_request_id",
     default=None,
 )
+_CONVERSATION_ID: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "codex_autorunner_conversation_id",
+    default=None,
+)
 
 
 def set_request_id(request_id: Optional[str]) -> contextvars.Token[Optional[str]]:
@@ -19,3 +23,17 @@ def reset_request_id(token: contextvars.Token[Optional[str]]) -> None:
 
 def get_request_id() -> Optional[str]:
     return _REQUEST_ID.get()
+
+
+def set_conversation_id(
+    conversation_id: Optional[str],
+) -> contextvars.Token[Optional[str]]:
+    return _CONVERSATION_ID.set(conversation_id)
+
+
+def reset_conversation_id(token: contextvars.Token[Optional[str]]) -> None:
+    _CONVERSATION_ID.reset(token)
+
+
+def get_conversation_id() -> Optional[str]:
+    return _CONVERSATION_ID.get()


### PR DESCRIPTION
## Summary\n- add a conversation_id context var to enrich structured log events\n- set conversation ID during Telegram dispatch and queued work execution\n- include conversation context when outbox retries log delivery failures\n\n## Testing\n- black\n- ruff\n- mypy\n- eslint\n- tsc\n- pytest\n\nCloses #153