### PR TITLE
Add agent picker for Telegram /agent

### DIFF
--- a/src/codex_autorunner/integrations/telegram/adapter.py
+++ b/src/codex_autorunner/integrations/telegram/adapter.py
@@ -147,6 +147,11 @@ class BindCallback:
 
 
 @dataclass(frozen=True)
+class AgentCallback:
+    agent: str
+
+
+@dataclass(frozen=True)
 class ModelCallback:
     model_id: str
 
@@ -596,6 +601,12 @@ def encode_bind_callback(repo_id: str) -> str:
     return data
 
 
+def encode_agent_callback(agent: str) -> str:
+    data = f"agent:{agent}"
+    _validate_callback_data(data)
+    return data
+
+
 def encode_model_callback(model_id: str) -> str:
     data = f"model:{model_id}"
     _validate_callback_data(data)
@@ -651,6 +662,7 @@ def parse_callback_data(
         ApprovalCallback,
         ResumeCallback,
         BindCallback,
+        AgentCallback,
         ModelCallback,
         EffortCallback,
         UpdateCallback,
@@ -679,6 +691,11 @@ def parse_callback_data(
         if not repo_id:
             return None
         return BindCallback(repo_id=repo_id)
+    if data.startswith("agent:"):
+        _, _, agent = data.partition(":")
+        if not agent:
+            return None
+        return AgentCallback(agent=agent)
     if data.startswith("model:"):
         _, _, model_id = data.partition(":")
         if not model_id:
@@ -760,6 +777,23 @@ def build_resume_keyboard(
         rows.append([InlineButton(label, callback_data)])
     if include_cancel:
         rows.append([InlineButton("Cancel", encode_cancel_callback("resume"))])
+    return build_inline_keyboard(rows)
+
+
+def build_agent_keyboard(
+    options: Sequence[tuple[str, str]],
+    *,
+    page_button: Optional[tuple[str, str]] = None,
+    include_cancel: bool = False,
+) -> dict[str, Any]:
+    rows = [
+        [InlineButton(label, encode_agent_callback(agent))] for agent, label in options
+    ]
+    if page_button:
+        label, callback_data = page_button
+        rows.append([InlineButton(label, callback_data)])
+    if include_cancel:
+        rows.append([InlineButton("Cancel", encode_cancel_callback("agent"))])
     return build_inline_keyboard(rows)
 
 

--- a/src/codex_autorunner/integrations/telegram/constants.py
+++ b/src/codex_autorunner/integrations/telegram/constants.py
@@ -52,6 +52,7 @@ RESUME_PICKER_PROMPT = (
     "Select a thread to resume (buttons below or reply with number/id)."
 )
 BIND_PICKER_PROMPT = "Select a repo to bind (buttons below or reply with number/id)."
+AGENT_PICKER_PROMPT = "Select an agent (buttons below)."
 MODEL_PICKER_PROMPT = "Select a model (buttons below)."
 EFFORT_PICKER_PROMPT = "Select a reasoning effort for {model}."
 UPDATE_PICKER_PROMPT = "Select update target (buttons below)."

--- a/src/codex_autorunner/integrations/telegram/handlers/callbacks.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/callbacks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Sequence
 
 from ..adapter import (
+    AgentCallback,
     ApprovalCallback,
     BindCallback,
     CancelCallback,
@@ -46,6 +47,9 @@ async def handle_callback(handlers: Any, callback: TelegramCallbackQuery) -> Non
                 await handlers._answer_callback(callback, "Selection expired")
                 return
             await handlers._bind_topic_by_repo_id(key, parsed.repo_id, callback)
+    elif isinstance(parsed, AgentCallback):
+        if key:
+            await handlers._handle_agent_callback(key, callback, parsed)
     elif isinstance(parsed, ModelCallback):
         if key:
             await handlers._handle_model_callback(key, callback, parsed)

--- a/src/codex_autorunner/integrations/telegram/handlers/messages.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/messages.py
@@ -63,6 +63,7 @@ async def _clear_pending_options(
 ) -> None:
     handlers._resume_options.pop(key, None)
     handlers._bind_options.pop(key, None)
+    handlers._agent_options.pop(key, None)
     handlers._model_options.pop(key, None)
     handlers._model_pending.pop(key, None)
     handlers._review_commit_options.pop(key, None)
@@ -191,6 +192,7 @@ async def handle_message_inner(
     if text and text.startswith("!") and not has_media:
         handlers._resume_options.pop(key, None)
         handlers._bind_options.pop(key, None)
+        handlers._agent_options.pop(key, None)
         handlers._model_options.pop(key, None)
         handlers._model_pending.pop(key, None)
         handlers._enqueue_topic_work(
@@ -221,6 +223,8 @@ async def handle_message_inner(
             handlers._resume_options.pop(key, None)
         if command.name != "bind":
             handlers._bind_options.pop(key, None)
+        if command.name != "agent":
+            handlers._agent_options.pop(key, None)
         if command.name != "model":
             handlers._model_options.pop(key, None)
             handlers._model_pending.pop(key, None)
@@ -232,6 +236,7 @@ async def handle_message_inner(
     else:
         handlers._resume_options.pop(key, None)
         handlers._bind_options.pop(key, None)
+        handlers._agent_options.pop(key, None)
         handlers._model_options.pop(key, None)
         handlers._model_pending.pop(key, None)
         handlers._review_commit_options.pop(key, None)

--- a/src/codex_autorunner/integrations/telegram/service.py
+++ b/src/codex_autorunner/integrations/telegram/service.py
@@ -140,6 +140,7 @@ class TelegramBotService(
         )
         self._model_options: dict[str, ModelPickerState] = {}
         self._model_pending: dict[str, ModelOption] = {}
+        self._agent_options: dict[str, SelectionState] = {}
         self._voice_config = voice_config
         self._voice_service = voice_service
         self._housekeeping_config = housekeeping_config
@@ -695,6 +696,8 @@ class TelegramBotService(
                 self._resume_options.pop(key, None)
             elif cache_name == "bind_options":
                 self._bind_options.pop(key, None)
+            elif cache_name == "agent_options":
+                self._agent_options.pop(key, None)
             elif cache_name == "update_options":
                 self._update_options.pop(key, None)
             elif cache_name == "update_confirm_options":
@@ -739,6 +742,9 @@ class TelegramBotService(
             )
             self._evict_expired_cache_entries(
                 "bind_options", SELECTION_STATE_TTL_SECONDS
+            )
+            self._evict_expired_cache_entries(
+                "agent_options", SELECTION_STATE_TTL_SECONDS
             )
             self._evict_expired_cache_entries(
                 "update_options", SELECTION_STATE_TTL_SECONDS


### PR DESCRIPTION
## Summary\n- add agent picker callbacks and keyboard support\n- show agent selection buttons for /agent with state caching\n- handle agent selection/cancel/pagination and cache cleanup\n\n## Testing\n- make lint (via pre-commit hooks)\n- pytest (318 passed, 35 deselected)