### PR TITLE
Default Telegram model when switching agents

### DIFF
--- a/src/codex_autorunner/integrations/telegram/constants.py
+++ b/src/codex_autorunner/integrations/telegram/constants.py
@@ -101,6 +101,10 @@ COMMAND_DISABLED_TEMPLATE = "'/{name}' is disabled while a task is in progress."
 MAX_MENTION_BYTES = 200_000
 VALID_REASONING_EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh"}
 VALID_AGENT_VALUES = {"codex", "opencode"}
+DEFAULT_AGENT_MODELS = {
+    "codex": "gpt-5.2-codex",
+    "opencode": "zai-coding-plan/glm-4.7",
+}
 CONTEXT_BASELINE_TOKENS = 12000
 APPROVAL_POLICY_VALUES = {"untrusted", "on-failure", "on-request", "never"}
 APPROVAL_PRESETS = {

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -52,6 +52,7 @@ from ..constants import (
     COMMAND_DISABLED_TEMPLATE,
     COMPACT_SUMMARY_PROMPT,
     DEFAULT_AGENT,
+    DEFAULT_AGENT_MODELS,
     DEFAULT_MCP_LIST_LIMIT,
     DEFAULT_MODEL_LIST_LIMIT,
     DEFAULT_PAGE_SIZE,
@@ -250,6 +251,7 @@ class TelegramCommandHandlers:
             record.pending_compact_seed_thread_id = None
             if not self._agent_supports_effort(desired):
                 record.effort = None
+            record.model = DEFAULT_AGENT_MODELS.get(desired)
 
         self._router.update_topic(chat_id, thread_id, apply)
         if not self._agent_supports_resume(desired):


### PR DESCRIPTION
## Summary
- set per-agent default models when switching via Telegram /agent
- default codex to gpt-5.2-codex and opencode to zai-coding-plan/glm-4.7

## Testing
- `pytest`

Closes #164