### PR TITLE
Add Telegram resume support for opencode

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -403,7 +403,7 @@ class TelegramCommandHandlers:
         return agent == "codex"
 
     def _agent_supports_resume(self, agent: str) -> bool:
-        return agent == "codex"
+        return agent in ("codex", "opencode")
 
     def _opencode_available(self) -> bool:
         raw_command = getenv("CAR_OPENCODE_COMMAND")
@@ -2901,7 +2901,7 @@ class TelegramCommandHandlers:
             if not self._agent_supports_resume(agent):
                 await self._send_message(
                     message.chat_id,
-                    "Resume is only supported for the codex agent. Use /agent codex to switch.",
+                    "Resume is only supported for the codex and opencode agents. Use /agent codex or /agent opencode to switch.",
                     thread_id=message.thread_id,
                     reply_to=message.message_id,
                 )

--- a/src/codex_autorunner/integrations/telegram/helpers.py
+++ b/src/codex_autorunner/integrations/telegram/helpers.py
@@ -840,7 +840,7 @@ def _format_help_text(command_specs: dict[str, CommandSpec]) -> str:
         lines.append("/review detached ...")
     lines.append("")
     lines.append("Other:")
-    lines.append("Note: /resume is only supported for the codex agent.")
+    lines.append("Note: /resume is supported for the codex and opencode agents.")
     lines.append(
         "!<cmd> - run a bash command in the bound workspace (non-interactive; long-running commands time out)"
     )


### PR DESCRIPTION
## Summary
- allow Telegram /resume for the opencode agent
- update help and guidance text for resume support

Closes #163