### PR TITLE
Restore doc chat history and events UI

### DIFF
--- a/src/codex_autorunner/static/docChatRender.js
+++ b/src/codex_autorunner/static/docChatRender.js
@@ -87,8 +87,7 @@ export function renderChat() {
   }
 
   const activeDoc = getActiveDoc();
-  const draft =
-    getDraft(activeDoc) || (latest?.drafts ? latest.drafts[activeDoc] : null);
+  const draft = getDraft(activeDoc);
   const hasPatch = !!(draft && (draft.patch || "").trim());
   const previewing = hasPatch && isDraftPreview(activeDoc);
   if (chatUI.patchMain) {

--- a/src/codex_autorunner/static/index.html
+++ b/src/codex_autorunner/static/index.html
@@ -376,6 +376,25 @@
               </div>
               <div class="doc-chat-stream" id="doc-chat-stream">
                 <div id="doc-chat-error" class="doc-chat-error hidden"></div>
+                <div id="doc-chat-events" class="doc-chat-events hidden">
+                  <div class="doc-chat-section-header">
+                    <div class="doc-chat-section-title">
+                      Agent updates
+                      <span id="doc-chat-events-count" class="doc-chat-count">0</span>
+                    </div>
+                    <button id="doc-chat-events-toggle" class="ghost sm hidden">
+                      Show more
+                    </button>
+                  </div>
+                  <div id="doc-chat-events-list" class="doc-chat-events-list"></div>
+                </div>
+                <div class="doc-chat-section-header">
+                  <div class="doc-chat-section-title">
+                    History
+                    <span id="doc-chat-history-count" class="doc-chat-count">0</span>
+                  </div>
+                </div>
+                <div id="doc-chat-history" class="doc-chat-history"></div>
               </div>
             </div>
           </div>

--- a/src/codex_autorunner/static/styles.css
+++ b/src/codex_autorunner/static/styles.css
@@ -2384,6 +2384,208 @@ button.icon-btn {
   background: var(--muted);
 }
 
+/* Doc chat stream sections */
+.doc-chat-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  font-size: 10px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.doc-chat-section-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.doc-chat-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 16px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  font-size: 9px;
+  color: var(--muted);
+}
+
+.doc-chat-events,
+.doc-chat-history {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.doc-chat-events.hidden {
+  display: none;
+}
+
+.doc-chat-events-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.doc-chat-event {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel);
+  padding: 6px 8px;
+  display: grid;
+  gap: 2px;
+  font-size: 10px;
+}
+
+.doc-chat-event-title {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.doc-chat-event-summary {
+  color: var(--text);
+  opacity: 0.85;
+}
+
+.doc-chat-event-detail,
+.doc-chat-event-meta {
+  color: var(--muted);
+  font-size: 9px;
+}
+
+.doc-chat-event.thinking {
+  border-color: rgba(108, 245, 216, 0.3);
+  background: rgba(108, 245, 216, 0.08);
+}
+
+.doc-chat-event.command {
+  border-color: rgba(255, 166, 77, 0.35);
+}
+
+.doc-chat-event.file {
+  border-color: rgba(241, 250, 140, 0.35);
+}
+
+.doc-chat-event.error {
+  border-color: rgba(255, 85, 102, 0.35);
+  background: rgba(255, 85, 102, 0.08);
+}
+
+.doc-chat-events-empty,
+.doc-chat-empty {
+  text-align: center;
+  color: var(--muted);
+  padding: 10px 8px;
+  font-size: 10px;
+  opacity: 0.7;
+}
+
+.doc-chat-entry {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel);
+  padding: 6px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+}
+
+.doc-chat-entry-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.doc-chat-entry-header .prompt-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.doc-chat-entry-header .prompt {
+  color: var(--text);
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.copy-prompt-btn {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  min-height: 20px;
+  border-radius: 6px;
+  font-size: 11px;
+  padding: 0;
+}
+
+.copy-prompt-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.doc-chat-entry-header .meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 9px;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.doc-chat-entry-header .status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--muted);
+}
+
+.doc-chat-entry.running .status-dot {
+  background: var(--accent);
+}
+
+.doc-chat-entry.error .status-dot {
+  background: var(--error);
+}
+
+.doc-chat-entry.interrupted .status-dot {
+  background: var(--accent-2);
+}
+
+.doc-chat-entry-response {
+  color: var(--text);
+  white-space: pre-wrap;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.doc-chat-entry-response.streaming {
+  color: var(--accent);
+}
+
+.doc-chat-entry-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  font-size: 9px;
+  color: var(--muted);
+}
+
 /* Empty state */
 .chat-empty {
   text-align: center;


### PR DESCRIPTION
## Summary
- restore doc chat history and agent event panels in the docs UI
- style doc chat history/event entries to match existing panel aesthetics
- avoid showing stale draft panels after applying/discarding drafts

## Testing
- black
- ruff
- mypy
- eslint
- tsc
- pytest

Closes #161