### PR TITLE
Log OpenCode doc chat output in logs

### DIFF
--- a/src/codex_autorunner/core/doc_chat.py
+++ b/src/codex_autorunner/core/doc_chat.py
@@ -409,15 +409,17 @@ class DocChatService:
         with self.engine.log_path.open("a", encoding="utf-8") as f:
             f.write(line)
 
-    def _log_stdout(self, chat_id: str, text: str) -> None:
+    def _log_output(
+        self, chat_id: str, text: Optional[str], label: str = "stdout"
+    ) -> None:
         if text is None:
             return
         lines = text.splitlines()
         if not lines:
-            self._log(chat_id, "stdout: ")
+            self._log(chat_id, f"{label}: ")
             return
         for line in lines:
-            self._log(chat_id, f"stdout: {line}")
+            self._log(chat_id, f"{label}: {line}")
 
     def _doc_pointer(self, targets: Optional[tuple[str, ...]]) -> str:
         config = self._repo_config()
@@ -1286,8 +1288,7 @@ class DocChatService:
         allowed_kinds = ALLOWED_DOC_KINDS
         unexpected: list[str] = []
         config = self._repo_config()
-        if backend == "opencode":
-            self._log_stdout(chat_id, response_text or output)
+        self._log_output(chat_id, response_text or output)
         for kind in ALLOWED_DOC_KINDS:
             path = config.doc_path(kind)
             after = path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary\n- log OpenCode doc chat output lines to the main log so they appear when summary view is disabled\n- keep output formatting consistent with existing doc-chat stdout prefixes\n\n## Testing\n- make lint\n- make test