### PR TITLE
Remove redundant /quit and /exit commands from Telegram bot

### DIFF
--- a/docs/codex/slash-commands.md
+++ b/docs/codex/slash-commands.md
@@ -105,7 +105,6 @@ Recommended commands to support (matching Codex CLI docs):
 * `/skills`
 * `/logout`
 * `/feedback`
-* `/quit`, `/exit` (Telegram-local; see §2.15)
 
 ### 2.1 Task-in-progress restrictions (match CLI behavior)
 
@@ -115,7 +114,7 @@ If `activeTurnId` is set (turn started but not completed), reject these commands
 
 Allowed during an active turn:
 
-* `/diff`, `/mention`, `/skills`, `/status`, `/mcp`, `/feedback`, `/quit`, `/exit`
+* `/diff`, `/mention`, `/skills`, `/status`, `/mcp`, `/feedback`
 
 Return:
 
@@ -727,20 +726,6 @@ Response contains a tracking `threadId` for the report.
 
 ---
 
-## 2.16 `/quit` and `/exit` (Telegram-local)
-
-In Codex CLI, these exit the UI. For Telegram, choose one:
-
-Option A (recommended): respond:
-
-> “This command is not applicable in Telegram. Use /new to start fresh or /resume to switch threads.”
-
-Option B: unbind the current Telegram topic from its `threadId` (CAR-local “detach”), without deleting anything.
-
-Do not attempt to kill the Codex app-server process unless your architecture explicitly supports that.
-
----
-
 ## 3) Approval request handling (required for correctness)
 
 If approvals are enabled, the server may issue **requests to the client** during a turn. CAR must respond, or the turn will stall.
@@ -915,7 +900,6 @@ These are the CLI’s built-in slash command strings (kebab-case; you should sup
 * `/status` — show session config and token usage
 * `/mcp` — list configured MCP tools
 * `/logout` — log out
-* `/quit`, `/exit` — exit Codex (not meaningful in Telegram; see notes)
 * `/feedback` — send logs/feedback
 * `/rollout` — print rollout path (debug/unstable in CLI; but thread metadata contains a path)
 * `/ps` — list background terminals (CLI-only; see notes)
@@ -1748,14 +1732,6 @@ In CLI it inserts `@` to mention a file in the composer. In Telegram, users can 
 
 * no-op, or
 * “Reply with the file path you want to reference.”
-
-### 5.4 `/quit` and `/exit`
-
-These are meaningful in an interactive terminal. In Telegram, you can:
-
-* unbind the chat from the current thread (forget mapping), or
-* archive the thread with `thread/archive`, or
-* just respond: “Not applicable in Telegram.”
 
 ---
 

--- a/src/codex_autorunner/integrations/telegram/handlers/commands.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands.py
@@ -149,18 +149,6 @@ def build_command_specs(handlers: Any) -> dict[str, CommandSpec]:
             ),
             allow_during_turn=True,
         ),
-        "quit": CommandSpec(
-            "quit",
-            "end the session (Telegram-local)",
-            handlers._handle_quit,
-            allow_during_turn=True,
-        ),
-        "exit": CommandSpec(
-            "exit",
-            "end the session (Telegram-local)",
-            handlers._handle_quit,
-            allow_during_turn=True,
-        ),
         "help": CommandSpec(
             "help",
             "show this help message",

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -6859,13 +6859,3 @@ class TelegramCommandHandlers:
             thread_id=message.thread_id,
             reply_to=message.message_id,
         )
-
-    async def _handle_quit(
-        self, message: TelegramMessage, _args: str, _runtime: Any
-    ) -> None:
-        await self._send_message(
-            message.chat_id,
-            "This command is not applicable in Telegram. Use /new to start fresh or /resume to switch threads.",
-            thread_id=message.thread_id,
-            reply_to=message.message_id,
-        )

--- a/src/codex_autorunner/integrations/telegram/helpers.py
+++ b/src/codex_autorunner/integrations/telegram/helpers.py
@@ -822,8 +822,6 @@ def _format_help_text(command_specs: dict[str, CommandSpec]) -> str:
         "feedback",
         "logout",
         "interrupt",
-        "quit",
-        "exit",
         "help",
     ]
     lines = ["Commands:"]


### PR DESCRIPTION
## Summary
Remove the redundant and unusable `/quit` and `/exit` commands from the Telegram bot integration.

## Changes
- **Removed** `quit` and `exit` CommandSpec entries from `commands.py`
- **Removed** `_handle_quit` handler from `commands_runtime.py`
- **Removed** `quit` and `exit` from help text in `helpers.py`
- **Updated** documentation to remove quit/exit references

## Rationale
- Both `/quit` and `/exit` pointed to the same handler (`_handle_quit`)
- The handler explicitly informed users that these commands were not applicable in Telegram
- All other 25 Telegram commands are properly implemented and working
- Removes technical and UX debt

## Testing
- All 117 existing Telegram tests pass
- No tests referenced these removed commands
- Telegram will automatically unregister the commands on next bot startup

Fixes #170