### PR TITLE
Show remaining context percent in telegram progress

### DIFF
--- a/src/codex_autorunner/integrations/telegram/helpers.py
+++ b/src/codex_autorunner/integrations/telegram/helpers.py
@@ -542,8 +542,8 @@ def _extract_context_usage_percent(
         return None
     if context_window <= 0:
         return None
-    percent_used = round(total_tokens / context_window * 100)
-    return min(max(percent_used, 0), 100)
+    percent_remaining = round((context_window - total_tokens) / context_window * 100)
+    return min(max(percent_remaining, 0), 100)
 
 
 def _format_turn_metrics(


### PR DESCRIPTION
## Summary\n- invert ctx percent to show remaining context instead of used\n- align telegram progress display with final turn summary