### PR TITLE
Fix OpenCode client routing + PATH discovery

### DIFF
--- a/src/codex_autorunner/core/utils.py
+++ b/src/codex_autorunner/core/utils.py
@@ -50,10 +50,13 @@ def _default_path_prefixes() -> list[str]:
     launchd and other non-interactive runners often have a minimal PATH that
     excludes Homebrew/MacPorts locations.
     """
+    home = Path.home()
     candidates = [
         "/opt/homebrew/bin",  # Apple Silicon Homebrew
         "/usr/local/bin",  # Intel Homebrew + common user installs
         "/opt/local/bin",  # MacPorts
+        str(home / ".opencode" / "bin"),  # OpenCode default install
+        str(home / ".local" / "bin"),  # Common user-local installs
     ]
     return [p for p in candidates if os.path.isdir(p)]
 

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 import httpx
 
+from ....agents.opencode.client import OpenCodeProtocolError
 from ....agents.opencode.harness import OpenCodeHarness
 from ....agents.opencode.runtime import (
     PERMISSION_ALLOW,
@@ -263,6 +264,13 @@ def _format_opencode_exception(exc: Exception) -> Optional[str]:
         if detail:
             return f"OpenCode backend unavailable ({detail})."
         return "OpenCode backend unavailable."
+    if isinstance(exc, OpenCodeProtocolError):
+        detail = str(exc).strip()
+        if detail:
+            return f"OpenCode protocol error: {detail}"
+        return "OpenCode protocol error."
+    if isinstance(exc, json.JSONDecodeError):
+        return "OpenCode returned invalid JSON."
     if isinstance(exc, httpx.HTTPStatusError):
         detail = None
         try:


### PR DESCRIPTION
## Summary\n- route OpenCode prompt calls to /session/:id/message with a /prompt_async fallback\n- surface protocol errors for invalid JSON and improve Telegram error formatting\n- include ~/.opencode/bin in PATH augmentation for minimal environments\n\n## Testing\n- .venv/bin/python -m black src/codex_autorunner/agents/opencode/client.py\n- ruff\n- mypy\n- eslint (warnings only, pre-existing)\n- pytest