### PR TITLE
Improve OpenCode progress stream and output filtering

### DIFF
--- a/src/codex_autorunner/integrations/telegram/progress_stream.py
+++ b/src/codex_autorunner/integrations/telegram/progress_stream.py
@@ -106,6 +106,24 @@ class TurnProgressTracker:
         action.text = normalized
         action.status = status
 
+    def update_action_by_item_id(
+        self,
+        item_id: Optional[str],
+        text: str,
+        status: str,
+        *,
+        label: Optional[str] = None,
+    ) -> bool:
+        if not item_id:
+            return False
+        for index, action in enumerate(self.actions):
+            if action.item_id == item_id:
+                if label:
+                    action.label = label
+                self.update_action(index, text, status)
+                return True
+        return False
+
     def note_thinking(self, text: str) -> None:
         if self.last_thinking_index is None:
             self.add_action("thinking", text, "update", track_thinking=True)


### PR DESCRIPTION
## Summary\n- accumulate OpenCode reasoning deltas to show a stable thinking preview\n- keep tool/patch/step updates as incremental actions in the progress stream\n- filter user-role parts out of OpenCode final responses\n\n## Testing\n- .venv/bin/python -m black src/codex_autorunner/agents/opencode/runtime.py src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py src/codex_autorunner/integrations/telegram/progress_stream.py\n- ruff\n- mypy\n- eslint (warnings only, pre-existing)\n- pytest