### PR TITLE
Restore OpenCode output without role metadata

### DIFF
--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -286,6 +286,7 @@ async def collect_opencode_output_from_events(
     error: Optional[str] = None
     message_roles: dict[str, str] = {}
     message_roles_seen = False
+    last_role_seen: Optional[str] = None
     pending_text: dict[str, list[str]] = {}
 
     def _message_id_from_info(info: Any) -> Optional[str]:
@@ -307,7 +308,7 @@ async def collect_opencode_output_from_events(
         return None
 
     def _register_message_role(payload: Any) -> tuple[Optional[str], Optional[str]]:
-        nonlocal message_roles_seen
+        nonlocal last_role_seen, message_roles_seen
         if not isinstance(payload, dict):
             return None, None
         info = payload.get("info")
@@ -320,6 +321,7 @@ async def collect_opencode_output_from_events(
         if isinstance(role, str) and msg_id:
             message_roles[msg_id] = role
             message_roles_seen = True
+            last_role_seen = role
         return msg_id, role if isinstance(role, str) else None
 
     def _append_text_for_message(message_id: Optional[str], text: str) -> None:
@@ -327,6 +329,9 @@ async def collect_opencode_output_from_events(
             return
         if message_id is None:
             if not message_roles_seen:
+                text_parts.append(text)
+                return
+            if last_role_seen != "user":
                 text_parts.append(text)
             return
         role = message_roles.get(message_id)


### PR DESCRIPTION
## Summary\n- allow text parts without message IDs when the last known role is not user\n- keep user-echo filtering when role metadata exists\n\n## Testing\n- .venv/bin/python -m black src/codex_autorunner/agents/opencode/runtime.py\n- ruff\n- mypy\n- eslint (warnings only, pre-existing)\n- pytest