### PR TITLE
Flush OpenCode pending text when roles are missing

### DIFF
--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -353,6 +353,14 @@ async def collect_opencode_output_from_events(
         if pending:
             text_parts.extend(pending)
 
+    def _flush_all_pending_text() -> None:
+        if not pending_text:
+            return
+        for pending in list(pending_text.values()):
+            if pending:
+                text_parts.extend(pending)
+        pending_text.clear()
+
     async for event in events:
         if should_stop is not None and should_stop():
             break
@@ -448,6 +456,8 @@ async def collect_opencode_output_from_events(
             if message_result.error and not error:
                 error = message_result.error
         if event.event == "session.idle":
+            if not text_parts and pending_text:
+                _flush_all_pending_text()
             break
 
     return OpenCodeTurnOutput(text="".join(text_parts).strip(), error=error)


### PR DESCRIPTION
## Summary\n- flush pending text parts on session idle when roles never arrive\n- continue to filter user-role parts when roles are known\n\n## Testing\n- .venv/bin/python -m black src/codex_autorunner/agents/opencode/runtime.py\n- ruff\n- mypy\n- eslint (warnings only, pre-existing)\n- pytest