### PR TITLE
Filter OpenCode reasoning from final output

### DIFF
--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -423,8 +423,10 @@ async def collect_opencode_output_from_events(
             else:
                 delta_text = None
             if isinstance(delta_text, str) and delta_text:
-                if part_type in (None, "text") and not part_ignored:
+                if part_type == "text" and not part_ignored:
                     _append_text_for_message(part_message_id, delta_text)
+                elif part_type == "reasoning":
+                    pass
                 elif part_handler and part_dict and part_type:
                     await part_handler(part_type, part_dict, delta_text)
             elif (


### PR DESCRIPTION
## Summary\n- only append OpenCode text deltas to the final response\n- ignore reasoning deltas while still streaming them via progress updates\n\n## Testing\n- .venv/bin/python -m black src/codex_autorunner/agents/opencode/runtime.py\n- ruff\n- mypy\n- eslint (warnings only, pre-existing)\n- pytest