### PR TITLE
Fix run modal artifacts display

### DIFF
--- a/src/codex_autorunner/static/runs.js
+++ b/src/codex_autorunner/static/runs.js
@@ -6,26 +6,9 @@ const runsState = {
     todoSearch: "",
 };
 let closeDetailsModal = null;
-const runLogCache = new Map();
 const RUN_OUTPUT_MAX_LINES = 160;
 const RUN_DIFF_MAX_LINES = 400;
 const RUN_PLAN_MAX_LINES = 120;
-const META_LINE_PATTERNS = [
-    /^=== run \d+/i,
-    /^tokens used/i,
-    /^thinking$/i,
-    /^\*\*.+\*\*$/,
-    /^exec$/i,
-    /^file update$/i,
-    /^apply_patch\(/i,
-    /^tool:\s+/i,
-    /^exit\s+\d+/i,
-    /^mcp startup:/i,
-    /^(diff --git |index [0-9a-f]+\.\.[0-9a-f]+)/i,
-    /^(---|\+\+\+)\s+[ab]\//,
-    /^@@\s+-\d+,?\d*\s+\+\d+,?\d*\s+@@/,
-    /^<\/?(SPEC|WORK_DOCS|TODO|PROGRESS|OPINIONS|TARGET_DOC|RECENT_RUN|SYSTEM|USER|ASSISTANT)>$/,
-];
 const ui = {
     refresh: document.getElementById("runs-refresh"),
     tableBody: document.getElementById("runs-table-body"),
@@ -260,129 +243,22 @@ async function loadPlan(runId) {
                 : "Unable to load.";
     }
 }
-function stripLogPrefix(line) {
-    return line
-        .replace(/^\[[^\]]*]\s*/, "")
-        .replace(/^run=\d+\s*/, "")
-        .replace(/^(stdout|stderr):\s*/i, "")
-        .replace(/^doc-chat id=[a-f0-9]+ stdout:\s*/i, "")
-        .trimEnd();
-}
-function looksLikeMetaLine(text) {
-    if (!text)
-        return true;
-    return META_LINE_PATTERNS.some((pattern) => pattern.test(text));
-}
-function extractDiffFromLog(logText) {
-    if (!logText)
-        return "";
-    const lines = logText.split("\n").map((line) => stripLogPrefix(line));
-    const diffHeaderRe = /^diff --git /i;
-    const diffLineRe = /^(diff --git |index [0-9a-f]+\.\.[0-9a-f]+|--- |\+\+\+ |@@ |Binary files )/i;
-    const stopRe = /^=== run \d+|^tokens used/i;
-    let startIndex = -1;
-    for (let i = lines.length - 1; i >= 0; i -= 1) {
-        if (diffHeaderRe.test(lines[i].trimStart())) {
-            startIndex = i;
-            break;
-        }
-    }
-    if (startIndex < 0)
-        return "";
-    const diffLines = [];
-    for (let i = startIndex; i < lines.length; i += 1) {
-        const line = lines[i].trimEnd();
-        const trimmed = line.trim();
-        if (i > startIndex && stopRe.test(trimmed))
-            break;
-        if (diffLineRe.test(line) ||
-            line.startsWith(" ") ||
-            line.startsWith("+") ||
-            line.startsWith("-") ||
-            line.startsWith("\\")) {
-            diffLines.push(line);
-            continue;
-        }
-        if (line === "" && diffLines.length) {
-            diffLines.push("");
-            continue;
-        }
-        if (diffLines.length)
-            break;
-    }
-    return diffLines.join("\n").trim();
-}
-function extractFinalOutput(logText) {
-    if (!logText)
-        return "";
-    const lines = logText.split("\n");
-    const outputs = [];
-    lines.forEach((line) => {
-        const stripped = stripLogPrefix(line).trimStart();
-        if (!stripped)
-            return;
-        if (/^Agent:\s*/i.test(stripped)) {
-            outputs.push(stripped.replace(/^Agent:\s*/i, ""));
-        }
-    });
-    if (outputs.length)
-        return outputs.join("\n").trim();
-    const blocks = [];
-    let current = [];
-    lines.forEach((line) => {
-        const cleaned = stripLogPrefix(line);
-        const trimmed = cleaned.trim();
-        if (!trimmed) {
-            if (current.length) {
-                blocks.push(current);
-                current = [];
-            }
-            return;
-        }
-        if (looksLikeMetaLine(trimmed)) {
-            if (current.length) {
-                blocks.push(current);
-                current = [];
-            }
-            return;
-        }
-        current.push(cleaned);
-    });
-    if (current.length) {
-        blocks.push(current);
-    }
-    if (!blocks.length)
-        return "";
-    const lastBlock = blocks[blocks.length - 1];
-    return lastBlock.join("\n").trim();
-}
-async function fetchRunLog(runId) {
-    const existing = runLogCache.get(runId);
-    if (existing)
-        return existing;
-    const request = (async () => {
-        try {
-            const payload = await api(`/api/logs?run_id=${runId}`);
-            const logText = typeof payload?.log === "string" ? payload.log : "";
-            return logText || null;
-        }
-        catch (_err) {
-            return null;
-        }
-    })();
-    runLogCache.set(runId, request);
-    return request;
-}
 async function loadFinalOutput(runId) {
     if (!ui.modalOutput)
         return;
     ui.modalOutput.textContent = "Loading…";
     try {
-        const logText = await fetchRunLog(runId);
-        const output = extractFinalOutput(logText || "");
-        ui.modalOutput.textContent = output
-            ? truncateLines(output, RUN_OUTPUT_MAX_LINES)
-            : "Not available.";
+        const text = await api(`/api/runs/${runId}/output`);
+        if (typeof text === "string" && text.trim()) {
+            ui.modalOutput.textContent = truncateLines(text, RUN_OUTPUT_MAX_LINES);
+            return;
+        }
+        if (text !== null && text !== undefined) {
+            const formatted = JSON.stringify(text, null, 2);
+            ui.modalOutput.textContent = truncateLines(formatted, RUN_OUTPUT_MAX_LINES);
+            return;
+        }
+        ui.modalOutput.textContent = "Not available.";
     }
     catch (err) {
         const message = err instanceof Error ? err.message : "";
@@ -407,15 +283,15 @@ async function loadDiff(runId) {
             ui.modalDiff.textContent = truncateLines(formatted, RUN_DIFF_MAX_LINES);
             return;
         }
+        ui.modalDiff.textContent = "Not available.";
     }
-    catch (_err) {
-        // Fall back to log parsing below.
+    catch (err) {
+        const message = err instanceof Error ? err.message : "";
+        ui.modalDiff.textContent =
+            message.includes("401") || message.includes("403") || message.includes("404")
+                ? "Not available."
+                : "Unable to load.";
     }
-    const logText = await fetchRunLog(runId);
-    const diffText = extractDiffFromLog(logText || "");
-    ui.modalDiff.textContent = diffText
-        ? truncateLines(diffText, RUN_DIFF_MAX_LINES)
-        : "Not available.";
 }
 function renderTokenBreakdown(run) {
     if (!ui.modalTokens)

--- a/src/codex_autorunner/static_src/runs.ts
+++ b/src/codex_autorunner/static_src/runs.ts
@@ -48,28 +48,10 @@ const runsState: RunsState = {
 };
 
 let closeDetailsModal: (() => void) | null = null;
-const runLogCache = new Map<number, Promise<string | null>>();
 
 const RUN_OUTPUT_MAX_LINES = 160;
 const RUN_DIFF_MAX_LINES = 400;
 const RUN_PLAN_MAX_LINES = 120;
-
-const META_LINE_PATTERNS = [
-  /^=== run \d+/i,
-  /^tokens used/i,
-  /^thinking$/i,
-  /^\*\*.+\*\*$/,
-  /^exec$/i,
-  /^file update$/i,
-  /^apply_patch\(/i,
-  /^tool:\s+/i,
-  /^exit\s+\d+/i,
-  /^mcp startup:/i,
-  /^(diff --git |index [0-9a-f]+\.\.[0-9a-f]+)/i,
-  /^(---|\+\+\+)\s+[ab]\//,
-  /^@@\s+-\d+,?\d*\s+\+\d+,?\d*\s+@@/,
-  /^<\/?(SPEC|WORK_DOCS|TODO|PROGRESS|OPINIONS|TARGET_DOC|RECENT_RUN|SYSTEM|USER|ASSISTANT)>$/,
-];
 
 interface UIElements {
   refresh: HTMLElement | null;
@@ -339,125 +321,21 @@ async function loadPlan(runId: number): Promise<void> {
   }
 }
 
-function stripLogPrefix(line: string): string {
-  return line
-    .replace(/^\[[^\]]*]\s*/, "")
-    .replace(/^run=\d+\s*/, "")
-    .replace(/^(stdout|stderr):\s*/i, "")
-    .replace(/^doc-chat id=[a-f0-9]+ stdout:\s*/i, "")
-    .trimEnd();
-}
-
-function looksLikeMetaLine(text: string): boolean {
-  if (!text) return true;
-  return META_LINE_PATTERNS.some((pattern) => pattern.test(text));
-}
-
-function extractDiffFromLog(logText: string): string {
-  if (!logText) return "";
-  const lines = logText.split("\n").map((line) => stripLogPrefix(line));
-  const diffHeaderRe = /^diff --git /i;
-  const diffLineRe = /^(diff --git |index [0-9a-f]+\.\.[0-9a-f]+|--- |\+\+\+ |@@ |Binary files )/i;
-  const stopRe = /^=== run \d+|^tokens used/i;
-  let startIndex = -1;
-  for (let i = lines.length - 1; i >= 0; i -= 1) {
-    if (diffHeaderRe.test(lines[i].trimStart())) {
-      startIndex = i;
-      break;
-    }
-  }
-  if (startIndex < 0) return "";
-  const diffLines: string[] = [];
-  for (let i = startIndex; i < lines.length; i += 1) {
-    const line = lines[i].trimEnd();
-    const trimmed = line.trim();
-    if (i > startIndex && stopRe.test(trimmed)) break;
-    if (
-      diffLineRe.test(line) ||
-      line.startsWith(" ") ||
-      line.startsWith("+") ||
-      line.startsWith("-") ||
-      line.startsWith("\\")
-    ) {
-      diffLines.push(line);
-      continue;
-    }
-    if (line === "" && diffLines.length) {
-      diffLines.push("");
-      continue;
-    }
-    if (diffLines.length) break;
-  }
-  return diffLines.join("\n").trim();
-}
-
-function extractFinalOutput(logText: string): string {
-  if (!logText) return "";
-  const lines = logText.split("\n");
-  const outputs: string[] = [];
-  lines.forEach((line) => {
-    const stripped = stripLogPrefix(line).trimStart();
-    if (!stripped) return;
-    if (/^Agent:\s*/i.test(stripped)) {
-      outputs.push(stripped.replace(/^Agent:\s*/i, ""));
-    }
-  });
-  if (outputs.length) return outputs.join("\n").trim();
-
-  const blocks: string[][] = [];
-  let current: string[] = [];
-  lines.forEach((line) => {
-    const cleaned = stripLogPrefix(line);
-    const trimmed = cleaned.trim();
-    if (!trimmed) {
-      if (current.length) {
-        blocks.push(current);
-        current = [];
-      }
-      return;
-    }
-    if (looksLikeMetaLine(trimmed)) {
-      if (current.length) {
-        blocks.push(current);
-        current = [];
-      }
-      return;
-    }
-    current.push(cleaned);
-  });
-  if (current.length) {
-    blocks.push(current);
-  }
-  if (!blocks.length) return "";
-  const lastBlock = blocks[blocks.length - 1];
-  return lastBlock.join("\n").trim();
-}
-
-async function fetchRunLog(runId: number): Promise<string | null> {
-  const existing = runLogCache.get(runId);
-  if (existing) return existing;
-  const request = (async () => {
-    try {
-      const payload = await api(`/api/logs?run_id=${runId}`);
-      const logText = typeof (payload as { log?: string })?.log === "string" ? (payload as { log?: string }).log : "";
-      return logText || null;
-    } catch (_err) {
-      return null;
-    }
-  })();
-  runLogCache.set(runId, request);
-  return request;
-}
-
 async function loadFinalOutput(runId: number): Promise<void> {
   if (!ui.modalOutput) return;
   ui.modalOutput.textContent = "Loading…";
   try {
-    const logText = await fetchRunLog(runId);
-    const output = extractFinalOutput(logText || "");
-    ui.modalOutput.textContent = output
-      ? truncateLines(output, RUN_OUTPUT_MAX_LINES)
-      : "Not available.";
+    const text = await api(`/api/runs/${runId}/output`);
+    if (typeof text === "string" && text.trim()) {
+      ui.modalOutput.textContent = truncateLines(text, RUN_OUTPUT_MAX_LINES);
+      return;
+    }
+    if (text !== null && text !== undefined) {
+      const formatted = JSON.stringify(text, null, 2);
+      ui.modalOutput.textContent = truncateLines(formatted, RUN_OUTPUT_MAX_LINES);
+      return;
+    }
+    ui.modalOutput.textContent = "Not available.";
   } catch (err) {
     const message = err instanceof Error ? err.message : "";
     ui.modalOutput.textContent =
@@ -481,14 +359,14 @@ async function loadDiff(runId: number): Promise<void> {
       ui.modalDiff.textContent = truncateLines(formatted, RUN_DIFF_MAX_LINES);
       return;
     }
-  } catch (_err) {
-    // Fall back to log parsing below.
+    ui.modalDiff.textContent = "Not available.";
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+    ui.modalDiff.textContent =
+      message.includes("401") || message.includes("403") || message.includes("404")
+        ? "Not available."
+        : "Unable to load.";
   }
-  const logText = await fetchRunLog(runId);
-  const diffText = extractDiffFromLog(logText || "");
-  ui.modalDiff.textContent = diffText
-    ? truncateLines(diffText, RUN_DIFF_MAX_LINES)
-    : "Not available.";
 }
 
 function renderTokenBreakdown(run: RunEntry): void {


### PR DESCRIPTION
## Summary
- add log-based fallback parsing and caching for run diff/final output
- truncate run plan/diff/output to keep modal readable
- adjust prompt-marker regex to avoid deadcode scan false positives

## Testing
- `git commit` hook (black, ruff, mypy, eslint, tsc, pytest)

Closes #211
