### PR TITLE
Fix Telegram OpenCode token usage tracking

### DIFF
--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -279,6 +279,23 @@ def _extract_total_tokens(usage: dict[str, Any]) -> Optional[int]:
     return None
 
 
+def _extract_usage_details(usage: dict[str, Any]) -> dict[str, int]:
+    details: dict[str, int] = {}
+    input_tokens = _extract_usage_field(usage, _OPENCODE_USAGE_INPUT_KEYS)
+    if input_tokens is not None:
+        details["inputTokens"] = input_tokens
+    cached_tokens = _extract_usage_field(usage, _OPENCODE_USAGE_CACHED_KEYS)
+    if cached_tokens is not None:
+        details["cachedInputTokens"] = cached_tokens
+    output_tokens = _extract_usage_field(usage, _OPENCODE_USAGE_OUTPUT_KEYS)
+    if output_tokens is not None:
+        details["outputTokens"] = output_tokens
+    reasoning_tokens = _extract_usage_field(usage, _OPENCODE_USAGE_REASONING_KEYS)
+    if reasoning_tokens is not None:
+        details["reasoningTokens"] = reasoning_tokens
+    return details
+
+
 def _extract_context_window(
     payload: Any, usage: Optional[dict[str, Any]]
 ) -> Optional[int]:
@@ -611,6 +628,7 @@ async def collect_opencode_output_from_events(
                 if usage is not None:
                     total_tokens = _extract_total_tokens(usage)
                     context_window = _extract_context_window(payload, usage)
+                    usage_details = _extract_usage_details(usage)
                     if (
                         total_tokens != last_usage_total
                         or context_window != last_context_window
@@ -620,6 +638,8 @@ async def collect_opencode_output_from_events(
                         usage_snapshot: dict[str, Any] = {}
                         if total_tokens is not None:
                             usage_snapshot["totalTokens"] = total_tokens
+                        if usage_details:
+                            usage_snapshot.update(usage_details)
                         if context_window is not None:
                             usage_snapshot["modelContextWindow"] = context_window
                         if usage_snapshot:

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -89,6 +89,8 @@ from ..constants import (
     TELEGRAM_MAX_MESSAGE_LENGTH,
     THREAD_LIST_MAX_PAGES,
     THREAD_LIST_PAGE_LIMIT,
+    TOKEN_USAGE_CACHE_LIMIT,
+    TOKEN_USAGE_TURN_CACHE_LIMIT,
     UPDATE_PICKER_PROMPT,
     UPDATE_TARGET_OPTIONS,
     VALID_AGENT_VALUES,
@@ -300,12 +302,118 @@ def _coerce_int(value: Any) -> Optional[int]:
         return None
 
 
+_OPENCODE_USAGE_TOTAL_KEYS = ("totalTokens", "total_tokens", "total")
+_OPENCODE_USAGE_INPUT_KEYS = (
+    "inputTokens",
+    "input_tokens",
+    "promptTokens",
+    "prompt_tokens",
+)
+_OPENCODE_USAGE_CACHED_KEYS = (
+    "cachedInputTokens",
+    "cached_input_tokens",
+    "cachedTokens",
+    "cached_tokens",
+)
+_OPENCODE_USAGE_OUTPUT_KEYS = (
+    "outputTokens",
+    "output_tokens",
+    "completionTokens",
+    "completion_tokens",
+)
+_OPENCODE_USAGE_REASONING_KEYS = (
+    "reasoningTokens",
+    "reasoning_tokens",
+    "reasoningOutputTokens",
+    "reasoning_output_tokens",
+)
+_OPENCODE_CONTEXT_WINDOW_KEYS = (
+    "modelContextWindow",
+    "contextWindow",
+    "context_window",
+    "contextWindowSize",
+    "context_window_size",
+    "contextLength",
+    "context_length",
+    "maxTokens",
+    "max_tokens",
+)
+
+
+def _extract_opencode_usage_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    for key in (
+        "usage",
+        "tokenUsage",
+        "token_usage",
+        "usage_stats",
+        "usageStats",
+        "stats",
+    ):
+        usage = payload.get(key)
+        if isinstance(usage, dict):
+            return usage
+    return payload
+
+
+def _extract_opencode_usage_value(
+    payload: dict[str, Any], keys: tuple[str, ...]
+) -> Optional[int]:
+    for key in keys:
+        value = _coerce_int(payload.get(key))
+        if value is not None:
+            return value
+    return None
+
+
 def _build_opencode_token_usage(payload: dict[str, Any]) -> Optional[dict[str, Any]]:
-    total_tokens = _coerce_int(payload.get("totalTokens"))
-    context_window = _coerce_int(payload.get("modelContextWindow"))
+    usage_payload = _extract_opencode_usage_payload(payload)
+    total_tokens = _extract_opencode_usage_value(
+        usage_payload, _OPENCODE_USAGE_TOTAL_KEYS
+    )
+    input_tokens = _extract_opencode_usage_value(
+        usage_payload, _OPENCODE_USAGE_INPUT_KEYS
+    )
+    cached_tokens = _extract_opencode_usage_value(
+        usage_payload, _OPENCODE_USAGE_CACHED_KEYS
+    )
+    output_tokens = _extract_opencode_usage_value(
+        usage_payload, _OPENCODE_USAGE_OUTPUT_KEYS
+    )
+    reasoning_tokens = _extract_opencode_usage_value(
+        usage_payload, _OPENCODE_USAGE_REASONING_KEYS
+    )
+    if total_tokens is None:
+        components = [
+            value
+            for value in (
+                input_tokens,
+                cached_tokens,
+                output_tokens,
+                reasoning_tokens,
+            )
+            if isinstance(value, int)
+        ]
+        if components:
+            total_tokens = sum(components)
     if total_tokens is None:
         return None
-    token_usage: dict[str, Any] = {"last": {"totalTokens": total_tokens}}
+    usage_line: dict[str, Any] = {"totalTokens": total_tokens}
+    if input_tokens is not None:
+        usage_line["inputTokens"] = input_tokens
+    if cached_tokens is not None:
+        usage_line["cachedInputTokens"] = cached_tokens
+    if output_tokens is not None:
+        usage_line["outputTokens"] = output_tokens
+    if reasoning_tokens is not None:
+        usage_line["reasoningTokens"] = reasoning_tokens
+    token_usage: dict[str, Any] = {"last": usage_line}
+    context_window = _extract_opencode_usage_value(
+        payload, _OPENCODE_CONTEXT_WINDOW_KEYS
+    )
+    if context_window is None:
+        context_window = _extract_opencode_usage_value(
+            usage_payload, _OPENCODE_CONTEXT_WINDOW_KEYS
+        )
     if context_window is not None and context_window > 0:
         token_usage["modelContextWindow"] = context_window
     return token_usage
@@ -1730,6 +1838,34 @@ class TelegramCommandHandlers:
                                     else None
                                 )
                                 if token_usage:
+                                    if is_primary_session:
+                                        self._token_usage_by_thread[thread_id] = (
+                                            token_usage
+                                        )
+                                        self._token_usage_by_thread.move_to_end(
+                                            thread_id
+                                        )
+                                        while (
+                                            len(self._token_usage_by_thread)
+                                            > TOKEN_USAGE_CACHE_LIMIT
+                                        ):
+                                            self._token_usage_by_thread.popitem(
+                                                last=False
+                                            )
+                                        if turn_id:
+                                            self._token_usage_by_turn[turn_id] = (
+                                                token_usage
+                                            )
+                                            self._token_usage_by_turn.move_to_end(
+                                                turn_id
+                                            )
+                                            while (
+                                                len(self._token_usage_by_turn)
+                                                > TOKEN_USAGE_TURN_CACHE_LIMIT
+                                            ):
+                                                self._token_usage_by_turn.popitem(
+                                                    last=False
+                                                )
                                     await self._note_progress_context_usage(
                                         token_usage,
                                         turn_id=turn_id,

--- a/tests/test_telegram_opencode_usage.py
+++ b/tests/test_telegram_opencode_usage.py
@@ -1,0 +1,31 @@
+from codex_autorunner.integrations.telegram.handlers.commands_runtime import (
+    _build_opencode_token_usage,
+)
+
+
+def test_build_opencode_token_usage_with_total_and_context() -> None:
+    usage = _build_opencode_token_usage(
+        {"totalTokens": 120, "modelContextWindow": 2000}
+    )
+    assert usage == {
+        "last": {"totalTokens": 120},
+        "modelContextWindow": 2000,
+    }
+
+
+def test_build_opencode_token_usage_with_components() -> None:
+    usage = _build_opencode_token_usage(
+        {
+            "usage": {"input_tokens": 50, "output_tokens": 25, "cached_tokens": 5},
+            "contextWindow": 1000,
+        }
+    )
+    assert usage == {
+        "last": {
+            "totalTokens": 80,
+            "inputTokens": 50,
+            "cachedInputTokens": 5,
+            "outputTokens": 25,
+        },
+        "modelContextWindow": 1000,
+    }


### PR DESCRIPTION
## Summary
- include richer OpenCode token usage details when streaming events
- cache OpenCode usage in Telegram so ctx countdown + turn metrics render
- add coverage for OpenCode usage parsing

## Testing
- .venv/bin/python -m pytest tests/test_telegram_opencode_usage.py
- .venv/bin/python -m pytest

Fixes #217
Fixes #221