### PR TITLE
Web: Full-fidelity logs when Summary is unchecked (Codex + OpenCode)

### DIFF
--- a/src/codex_autorunner/agents/opencode/logging.py
+++ b/src/codex_autorunner/agents/opencode/logging.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+
+class OpenCodeEventFormatter:
+    def __init__(self) -> None:
+        self._seen_reasoning_parts: set[str] = set()
+        self._tool_last_status: dict[str, str] = {}
+        self._seen_patch_hashes: set[str] = set()
+        self._logger = logging.getLogger(__name__)
+
+    def reset(self) -> None:
+        self._seen_reasoning_parts.clear()
+        self._tool_last_status.clear()
+        self._seen_patch_hashes.clear()
+
+    def format_part(
+        self, part_type: str, part: dict[str, Any], delta_text: Optional[str]
+    ) -> list[str]:
+        lines: list[str] = []
+        part_id = part.get("id") or part.get("partId")
+
+        if part_type == "reasoning":
+            lines.extend(self._format_reasoning_part(part_id, delta_text))
+
+        elif part_type == "tool":
+            lines.extend(self._format_tool_part(part))
+
+        elif part_type == "patch":
+            lines.extend(self._format_patch_part(part))
+
+        return lines
+
+    def _format_reasoning_part(
+        self, part_id: Optional[str], delta_text: Optional[str]
+    ) -> list[str]:
+        lines: list[str] = []
+        key = part_id or "reasoning"
+
+        if delta_text:
+            if key not in self._seen_reasoning_parts:
+                lines.append("thinking")
+                self._seen_reasoning_parts.add(key)
+
+            for line in delta_text.splitlines() or [""]:
+                if line.strip():
+                    lines.append(f"**{line.strip()}**")
+        return lines
+
+    def _format_tool_part(self, part: dict[str, Any]) -> list[str]:
+        lines: list[str] = []
+        tool_id = part.get("callID") or part.get("id")
+        tool_name = part.get("tool") or part.get("name") or ""
+
+        if not isinstance(tool_name, str) or not tool_name:
+            return lines
+
+        state = part.get("state", {})
+        if not isinstance(state, dict):
+            state = {}
+
+        status = state.get("status")
+        if isinstance(status, str) and status:
+            key = f"{tool_id}:{tool_name}" if tool_id else tool_name
+            last_status = self._tool_last_status.get(key)
+
+            if last_status != status:
+                self._tool_last_status[key] = status
+
+                if status in ("running", "pending"):
+                    lines.append("exec")
+                    lines.append(f"tool: {tool_name}")
+
+                elif status == "completed":
+                    if last_status not in ("running", "pending"):
+                        lines.append("exec")
+                        lines.append(f"tool: {tool_name}")
+                    exit_code = state.get("exitCode")
+                    if exit_code is not None:
+                        lines.append(f"exit {exit_code}")
+
+                elif status in ("error", "failed"):
+                    if last_status not in ("running", "pending"):
+                        lines.append("exec")
+                        lines.append(f"tool: {tool_name}")
+                    error = state.get("error")
+                    if isinstance(error, (str, dict)):
+                        if isinstance(error, dict):
+                            error = error.get("message") or error.get("error")
+                        if isinstance(error, str) and error:
+                            lines.append(f"error: {error}")
+
+        elif tool_id is None:
+            lines.append("exec")
+            lines.append(f"tool: {tool_name}")
+
+        return lines
+
+    def _format_patch_part(self, part: dict[str, Any]) -> list[str]:
+        lines: list[str] = []
+        patch_hash = part.get("hash")
+
+        if isinstance(patch_hash, str) and patch_hash:
+            if patch_hash in self._seen_patch_hashes:
+                return lines
+            self._seen_patch_hashes.add(patch_hash)
+
+        files = part.get("files")
+        if isinstance(files, list):
+            if files:
+                lines.append("file update")
+                for file_entry in files:
+                    if isinstance(file_entry, dict):
+                        path = file_entry.get("path") or file_entry.get("file")
+                        action = file_entry.get("status") or "M"
+                        if isinstance(path, str) and path:
+                            lines.append(f"{action} {path}")
+                    elif isinstance(file_entry, str):
+                        lines.append(f"M {file_entry}")
+
+        elif isinstance(files, str):
+            lines.append("file update")
+            lines.append(f"M {files}")
+
+        return lines
+
+    def format_usage(self, usage: dict[str, Any]) -> list[str]:
+        lines: list[str] = []
+
+        total = usage.get("totalTokens")
+        if isinstance(total, int):
+            input_tokens = usage.get("inputTokens")
+            cached_tokens = usage.get("cachedInputTokens")
+            output_tokens = usage.get("outputTokens")
+            reasoning_tokens = usage.get("reasoningTokens")
+
+            parts: list[str] = []
+            if isinstance(input_tokens, int):
+                parts.append(f"input: {input_tokens}")
+            if isinstance(cached_tokens, int) and cached_tokens > 0:
+                parts.append(f"cached: {cached_tokens}")
+            if isinstance(output_tokens, int):
+                parts.append(f"output: {output_tokens}")
+            if isinstance(reasoning_tokens, int):
+                parts.append(f"reasoning: {reasoning_tokens}")
+
+            if parts:
+                lines.append(f"tokens used - {', '.join(parts)}")
+            else:
+                lines.append(f"tokens used: {total}")
+
+            context_window = usage.get("modelContextWindow")
+            if isinstance(context_window, int) and context_window > 0:
+                lines.append(f"context window: {context_window}")
+
+        return lines
+
+    def format_permission(self, properties: dict[str, Any]) -> list[str]:
+        lines: list[str] = []
+
+        reason = properties.get("reason") or properties.get("message")
+        if isinstance(reason, str) and reason:
+            lines.append(f"permission: {reason}")
+        else:
+            lines.append("permission requested")
+
+        return lines
+
+    def format_error(self, error: Any) -> list[str]:
+        lines: list[str] = []
+
+        message = None
+        if isinstance(error, dict):
+            message = error.get("message") or error.get("error") or error.get("detail")
+        elif isinstance(error, str):
+            message = error
+
+        if isinstance(message, str) and message:
+            lines.append(f"error: {message}")
+        else:
+            lines.append("error: session error")
+
+        return lines


### PR DESCRIPTION
## Summary

Implements full-fidelity logs when "Summary" toggle is unchecked, with consistent styling for both Codex and OpenCode runs.

## Changes

### Backend
- **New file**: `src/codex_autorunner/agents/opencode/logging.py`
  - Added `OpenCodeEventFormatter` class that converts OpenCode part updates to the same textual markers the UI already knows how to classify:
    - `thinking` + bold summary lines (`**...**`)
    - `exec` + tool/command summary (e.g., `tool: bash`)
    - `file update` + `M <file>` lines
    - `error: ...` lines for errors
  
- **Updated**: `src/codex_autorunner/core/engine.py`
  - Added `OpenCodeEventFormatter` instance to Engine
  - Reset formatter on each run (same as AppServerEventFormatter)
  - Wire in `part_handler` for OpenCode output collection that:
    - Calls formatter to produce log lines
    - Emits them via `self.log_line(run_id, f"stdout: {line}")`

### Frontend
- **Updated**: `src/codex_autorunner/static_src/logs.ts`
  - **Always use fancy renderer**: Removed `appendRawLine()` path; both Summary checked/unchecked now use `appendRenderedLine()`
  - **Summary filtering**: Added priority-based filter that hides lines with `priority > 2` when Summary is checked:
    - Keeps: run boundaries, agent output, thinking, errors, tokens
    - Hides: tool calls, file updates, diffs, prompt context
  - **New classifier patterns**:
    - `tool:` for tool lines (e.g., `tool: bash`)
    - `exit <code>` for simple exit lines
    - `error:` for simple error lines
  - **Context rule**: After an `exec-label` line, treat the next non-empty output-ish line as `exec-command` to improve tool call highlighting
  - **Hide prompt blocks in summary mode**: Track prompt marker state even when skipping lines

- **Rebuilt**: `src/codex_autorunner/static/logs.js` via `pnpm build`

## Acceptance Criteria

- [x] Run an OpenCode task that invokes at least one tool (e.g., bash)
- [x] In Logs tab with Summary unchecked:
  - See `thinking` sections (if OpenCode emits reasoning parts)
  - See `exec` blocks for tool calls
  - See `file update` blocks when patches are produced
  - Styling matches the legend (icons/colors)
- [x] Codex runs continue to show tool calls/thinking/file updates when Summary unchecked
- [x] No regression in prompt block collapsing, tail loading, "Load older", timestamp/run toggles, or streaming
- [x] With Summary checked, verbose internals (tool calls, diffs, prompt context) are suppressed while run boundaries, agent output, and errors remain visible

Closes #215