### PR TITLE
Fix OpenCode ctx countdown in Telegram

### DIFF
--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -455,6 +455,22 @@ def _extract_context_window(
             prop_info = properties.get("info")
             if isinstance(prop_info, dict):
                 containers.append(prop_info)
+        response = payload.get("response")
+        if isinstance(response, dict):
+            containers.append(response)
+            response_info = response.get("info")
+            if isinstance(response_info, dict):
+                containers.append(response_info)
+            response_props = response.get("properties")
+            if isinstance(response_props, dict):
+                containers.append(response_props)
+                response_prop_info = response_props.get("info")
+                if isinstance(response_prop_info, dict):
+                    containers.append(response_prop_info)
+        for key in ("model", "modelInfo", "model_info", "modelConfig", "model_config"):
+            model = payload.get(key)
+            if isinstance(model, dict):
+                containers.append(model)
     if isinstance(usage, dict):
         containers.insert(0, usage)
     for container in containers:

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -90,8 +90,6 @@ from ..constants import (
     TELEGRAM_MAX_MESSAGE_LENGTH,
     THREAD_LIST_MAX_PAGES,
     THREAD_LIST_PAGE_LIMIT,
-    TOKEN_USAGE_CACHE_LIMIT,
-    TOKEN_USAGE_TURN_CACHE_LIMIT,
     UPDATE_PICKER_PROMPT,
     UPDATE_TARGET_OPTIONS,
     VALID_AGENT_VALUES,
@@ -1951,33 +1949,11 @@ class TelegramCommandHandlers:
                                 )
                                 if token_usage:
                                     if is_primary_session:
-                                        self._token_usage_by_thread[thread_id] = (
-                                            token_usage
+                                        self._cache_token_usage(
+                                            token_usage,
+                                            turn_id=turn_id,
+                                            thread_id=thread_id,
                                         )
-                                        self._token_usage_by_thread.move_to_end(
-                                            thread_id
-                                        )
-                                        while (
-                                            len(self._token_usage_by_thread)
-                                            > TOKEN_USAGE_CACHE_LIMIT
-                                        ):
-                                            self._token_usage_by_thread.popitem(
-                                                last=False
-                                            )
-                                        if turn_id:
-                                            self._token_usage_by_turn[turn_id] = (
-                                                token_usage
-                                            )
-                                            self._token_usage_by_turn.move_to_end(
-                                                turn_id
-                                            )
-                                            while (
-                                                len(self._token_usage_by_turn)
-                                                > TOKEN_USAGE_TURN_CACHE_LIMIT
-                                            ):
-                                                self._token_usage_by_turn.popitem(
-                                                    last=False
-                                                )
                                     await self._note_progress_context_usage(
                                         token_usage,
                                         turn_id=turn_id,
@@ -6356,6 +6332,12 @@ class TelegramCommandHandlers:
                                 else None
                             )
                             if token_usage:
+                                if is_primary_session:
+                                    self._cache_token_usage(
+                                        token_usage,
+                                        turn_id=turn_id,
+                                        thread_id=review_session_id,
+                                    )
                                 await self._note_progress_context_usage(
                                     token_usage,
                                     turn_id=turn_id,


### PR DESCRIPTION
## Summary
- cache OpenCode token usage in Telegram handlers so final turn stats include tokens
- reuse token usage cache helper across app-server and OpenCode events
- broaden OpenCode context window extraction to pick up response/model metadata

## Testing
- .venv/bin/python -m pytest tests/test_opencode_runtime.py tests/test_telegram_review_opencode.py
- pytest (full suite via commit hooks)