### PR TITLE
Fix Telegram question callback deadlock

### DIFF
--- a/src/codex_autorunner/integrations/telegram/dispatch.py
+++ b/src/codex_autorunner/integrations/telegram/dispatch.py
@@ -9,6 +9,8 @@ from ...core.request_context import reset_conversation_id, set_conversation_id
 from .adapter import (
     ApprovalCallback,
     CancelCallback,
+    QuestionCancelCallback,
+    QuestionOptionCallback,
     TelegramUpdate,
     allowlist_allows,
     parse_callback_data,
@@ -93,9 +95,9 @@ async def _dispatch_callback(
     if callback is None:
         return
     parsed = parse_callback_data(callback.data)
-    should_bypass_queue = isinstance(parsed, ApprovalCallback) or (
-        isinstance(parsed, CancelCallback) and parsed.kind == "interrupt"
-    )
+    should_bypass_queue = isinstance(
+        parsed, (ApprovalCallback, QuestionOptionCallback, QuestionCancelCallback)
+    ) or (isinstance(parsed, CancelCallback) and parsed.kind == "interrupt")
     if context.topic_key:
         if not should_bypass_queue:
             handlers._enqueue_topic_work(


### PR DESCRIPTION
## Summary
- bypass the per-topic queue for question option/cancel callbacks to avoid deadlocks during question waits
- keep approval/cancel interrupt behavior unchanged

## Testing
- 
- 
- 
> codex-autorunner-ui@ build /Users/dazheng/workspace/codex-autorunner-ws/wt-2
> tsc -p tsconfig.json,workdir:/Users/dazheng/workspace/codex-autorunner-ws/wt-2