### PR TITLE
Add multi-select and custom input support for Telegram questions

### DIFF
--- a/src/codex_autorunner/integrations/telegram/dispatch.py
+++ b/src/codex_autorunner/integrations/telegram/dispatch.py
@@ -10,6 +10,8 @@ from .adapter import (
     ApprovalCallback,
     CancelCallback,
     QuestionCancelCallback,
+    QuestionCustomCallback,
+    QuestionDoneCallback,
     QuestionOptionCallback,
     TelegramUpdate,
     allowlist_allows,
@@ -96,7 +98,14 @@ async def _dispatch_callback(
         return
     parsed = parse_callback_data(callback.data)
     should_bypass_queue = isinstance(
-        parsed, (ApprovalCallback, QuestionOptionCallback, QuestionCancelCallback)
+        parsed,
+        (
+            ApprovalCallback,
+            QuestionOptionCallback,
+            QuestionDoneCallback,
+            QuestionCustomCallback,
+            QuestionCancelCallback,
+        ),
     ) or (isinstance(parsed, CancelCallback) and parsed.kind == "interrupt")
     if context.topic_key:
         if not should_bypass_queue:

--- a/src/codex_autorunner/integrations/telegram/handlers/messages.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/messages.py
@@ -18,6 +18,7 @@ from ..adapter import (
     parse_command,
 )
 from ..config import TelegramMediaCandidate
+from .questions import handle_custom_text_input
 
 MEDIA_BATCH_WINDOW_SECONDS = 1.0
 IMAGE_CONTENT_TYPES = {
@@ -89,6 +90,11 @@ async def handle_message(handlers: Any, message: TelegramMessage) -> None:
         if placeholder_id is not None:
             await handlers._delete_message(message.chat_id, placeholder_id)
         return
+
+    if trimmed_text and not has_media:
+        custom_handled = await handle_custom_text_input(handlers, message)
+        if custom_handled:
+            return
 
     should_bypass = False
     if trimmed_text:

--- a/src/codex_autorunner/integrations/telegram/types.py
+++ b/src/codex_autorunner/integrations/telegram/types.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Optional, Union
 
 from ..app_server.client import ApprovalDecision
 from .helpers import ModelOption
@@ -35,7 +35,11 @@ class PendingQuestion:
     question_index: int
     prompt: str
     options: list[str]
-    future: asyncio.Future[Optional[int]]
+    future: asyncio.Future[Union[list[int], str, None]]
+    multiple: bool = False
+    custom: bool = True
+    selected_indices: set[int] = field(default_factory=set)
+    awaiting_custom_input: bool = False
 
 
 @dataclass


### PR DESCRIPTION
## Summary
Implements support for OpenCode question tool's `multiple` and `custom` options in the Telegram integration.

## Changes

### Type System Updates
- **PendingQuestion** (`types.py`): Updated to support multi-select state and custom input
  - Added `multiple: bool` flag
  - Added `custom: bool` flag (defaults to `True` per OpenCode spec)
  - Added `selected_indices: set[int]` to track multi-select state
  - Added `awaiting_custom_input: bool` for custom input state
  - Updated `future` type to `Future[list[int] | str | None]`

### Callback Types (`adapter.py`)
- Added **QuestionDoneCallback**: For submitting multi-select selections
- Added **QuestionCustomCallback**: For triggering custom text input
- Added encoding functions: `encode_question_done_callback()`, `encode_question_custom_callback()`
- Updated `parse_callback_data()` to handle new callback types

### Keyboard Builder (`adapter.py`)
- Updated `build_question_keyboard()` to support:
  - Toggle indicators (`✓`) for selected options in multi-select mode
  - "Type your own answer" button when `custom=True`
  - "Done" button when `multiple=True`
- Dynamic button layout based on question flags

### Question Handler (`questions.py`)
- Updated `_extract_question_options()` to return `(options, multiple, custom)` tuple
- Updated `_handle_question_request()` to:
  - Extract and pass `multiple` and `custom` flags
  - Initialize `selected_indices` and `awaiting_custom_input` state
  - Handle different result types (list for multi-select, str for custom, None for cancel)
- Rewrote `_handle_question_callback()` to handle:
  - **Cancel**: Same as before
  - **Custom**: Triggers follow-up prompt for text input
  - **Done**: Submits multi-select selections
  - **Option**: Single-select (submit) or multi-select (toggle with live keyboard update)
- Added `handle_custom_text_input()` for processing custom text responses

### Message Handler (`messages.py`)
- Added custom input detection in `handle_message()`
- Delegates to `handle_custom_text_input()` when awaiting custom input
- Automatically cleans up user's text message after processing

### Dispatch Updates (`dispatch.py`)
- Updated `_dispatch_callback()` to bypass queue for new callback types

### Tests (`test_telegram_adapter.py`)
- Added tests for new callback encoding/parsing
- Added tests for multi-select keyboard layout
- Added tests for custom option in keyboard
- Added tests for selection indicator display

## UI Behavior

### Single-Select Questions (unchanged)
```
Question:
Which option do you prefer?

[Option A]
[Option B]
[Type your own answer]
[Cancel]
```

### Multi-Select Questions
```
Question:
Which checks should I run?

[✓ Unit tests]
[✓ Lint]
[  Typecheck]
[Type your own answer]
[Done]
[Cancel]
```
- Options toggle on/off with ✓ indicator
- Live keyboard updates showing selections
- "Done" button submits all selected options

### Custom Input Flow
1. User clicks "Type your own answer"
2. Bot sends prompt: "Please type your custom answer:"
3. User types custom text
4. Bot captures text, deletes user's message
5. Original question updates to: "Selected: {custom_text}"

### Combined Multi-Select + Custom
Per OpenCode spec, users can select multiple options AND add custom values:
```
Selected: Unit tests, Lint, Staging tenants
```

## Testing
- All existing tests pass (426 tests)
- Added 4 new tests for callback types and keyboard variations
- Manual testing recommended for:
  - Multi-select toggle behavior
  - Custom input flow
  - Combined multi-select + custom
  - Timeout handling during custom input

## Compatibility
- **Backward compatible**: Single-select questions work exactly as before
- **OpenCode compliant**: Follows `multiple` and `custom` field semantics
- **Telegram limits respected**: Callback data stays within 64-byte limit