### PR TITLE
Fix Telegram media download handling and interrupts

### DIFF
--- a/tests/test_telegram_bot_integration.py
+++ b/tests/test_telegram_bot_integration.py
@@ -246,7 +246,9 @@ async def test_document_message_saves_inbox(tmp_path: Path) -> None:
     service._bot = fake_bot
     bind_message = build_message("/bind", message_id=10)
 
-    async def fake_download(_file_id: str) -> tuple[bytes, str, int]:
+    async def fake_download(
+        _file_id: str, *, max_bytes: Optional[int] = None
+    ) -> tuple[bytes, str, int]:
         return b"data", "files/report.txt", 4
 
     service._download_telegram_file = fake_download

--- a/tests/test_telegram_topic_queue.py
+++ b/tests/test_telegram_topic_queue.py
@@ -1,0 +1,30 @@
+import asyncio
+
+import pytest
+
+from codex_autorunner.integrations.telegram.state import TopicQueue
+
+
+@pytest.mark.anyio
+async def test_topic_queue_cancel_active_allows_next() -> None:
+    queue = TopicQueue()
+    started = asyncio.Event()
+    unblock = asyncio.Event()
+
+    async def work() -> str:
+        started.set()
+        await unblock.wait()
+        return "done"
+
+    task = asyncio.create_task(queue.enqueue(work))
+    await started.wait()
+    assert queue.cancel_active() is True
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=1.0)
+
+    async def follow_up() -> str:
+        return "ok"
+
+    result = await queue.enqueue(follow_up)
+    assert result == "ok"
+    await queue.close()


### PR DESCRIPTION
## Summary
- surface telegram media download failure details and enforce configured size limits
- allow interrupts to cancel active queued work without hanging the queue worker
- add a topic queue cancellation test

## Testing
- `.venv/bin/python -m pytest tests/test_telegram_topic_queue.py tests/test_telegram_media_batch_failure.py`
- `.venv/bin/python -m pytest tests/test_telegram_fast_ack.py -vv`
- full pre-commit test suite (428 passed, 35 deselected)

Closes #248