### PR TITLE
Fix Telegram file download URL

### DIFF
--- a/src/codex_autorunner/integrations/telegram/adapter.py
+++ b/src/codex_autorunner/integrations/telegram/adapter.py
@@ -1086,7 +1086,7 @@ class TelegramBotClient:
     ) -> None:
         self._bot_token = bot_token
         self._base_url = "https://api.telegram.org"
-        self._file_base_url = "https://api.telegram.org"
+        self._file_base_url = f"https://api.telegram.org/file/bot{bot_token}"
         self._logger = logger or logging.getLogger(__name__)
         if client is None:
             self._client = httpx.AsyncClient(timeout=timeout_seconds)
@@ -1301,7 +1301,8 @@ class TelegramBotClient:
     async def download_file(
         self, file_path: str, max_size_bytes: int = 50 * 1024 * 1024
     ) -> bytes:
-        url = f"{self._file_base_url}/bot{self._bot_token}/{file_path}"
+        safe_path = file_path.lstrip("/")
+        url = f"{self._file_base_url}/{safe_path}"
         log_event(
             self._logger, logging.INFO, "telegram.file.download", file_path=file_path
         )


### PR DESCRIPTION
## Summary
- point Telegram file downloads at the correct /file/bot<token> base
- guard against leading slashes in file paths
- add a test to assert the download URL

## Testing
- ============================= test session starts ==============================
platform darwin -- Python 3.9.6, pytest-8.4.2, pluggy-1.6.0
cachedir: .codex-autorunner/pytest-cache
rootdir: /Users/dazheng/car-workspace/codex-autorunner
configfile: pyproject.toml
plugins: anyio-4.12.0
collected 1 item

tests/test_telegram_adapter.py .                                         [100%]

=============================== warnings summary ===============================
.venv/lib/python3.9/site-packages/_pytest/config/__init__.py:1474
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

.venv/lib/python3.9/site-packages/_pytest/config/__init__.py:1474
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 1 passed, 2 warnings in 0.07s =========================
- ============================= test session starts ==============================
platform darwin -- Python 3.9.6, pytest-8.4.2, pluggy-1.6.0
cachedir: .codex-autorunner/pytest-cache
rootdir: /Users/dazheng/car-workspace/codex-autorunner
configfile: pyproject.toml
plugins: anyio-4.12.0
collected 464 items

tests/core/test_path_utils.py ..........................                 [  5%]
tests/test_about_car_terminal_context.py ...                             [  6%]
tests/test_api_contract.py .                                             [  6%]
tests/test_app_server_client.py ................                         [  9%]
tests/test_app_server_events.py ..                                       [ 10%]
tests/test_app_server_prompts.py ...                                     [ 10%]
tests/test_app_server_supervisor.py .                                    [ 11%]
tests/test_app_server_thread_registry.py ..                              [ 11%]
tests/test_auth_middleware.py ..............                             [ 14%]
tests/test_base_path.py ......                                           [ 15%]
tests/test_base_path_static.py ......                                    [ 17%]
tests/test_chatops.py ........                                           [ 18%]
tests/test_cli_init.py .....                                             [ 20%]
tests/test_cli_sessions.py ..                                            [ 20%]
tests/test_cli_snapshot.py .                                             [ 20%]
tests/test_codex_cli_flags.py .                                          [ 20%]
tests/test_codex_runner.py ..                                            [ 21%]
tests/test_config_resolution.py .........                                [ 23%]
tests/test_doc_chat.py ................                                  [ 26%]
tests/test_doc_chat_ui.py .                                              [ 26%]
tests/test_docs_todos.py .                                               [ 27%]
tests/test_docs_validation.py ...                                        [ 27%]
tests/test_engine_app_server.py .....                                    [ 28%]
tests/test_engine_logs.py ..                                             [ 29%]
tests/test_github_context_hook.py .....                                  [ 30%]
tests/test_github_service.py ..........                                  [ 32%]
tests/test_github_sync_pr_agentic.py ....                                [ 33%]
tests/test_housekeeping.py .....                                         [ 34%]
tests/test_hub_create.py ......                                          [ 35%]
tests/test_hub_foundation.py .....                                       [ 36%]
tests/test_hub_supervisor.py ............                                [ 39%]
tests/test_hub_terminal_sessions.py .                                    [ 39%]
tests/test_hub_ui_escape.py .                                            [ 39%]
tests/test_lock_utils.py ..                                              [ 40%]
tests/test_logging_utils.py ....                                         [ 41%]
tests/test_notifications.py ..                                           [ 41%]
tests/test_opencode_integration.py FFFFFFFFFFFFFFFFF                     [ 45%]
tests/test_opencode_review_arguments.py ....                             [ 46%]
tests/test_opencode_runtime.py .......                                   [ 47%]
tests/test_optional_dependencies.py ...                                  [ 48%]
tests/test_origin_middleware.py ....                                     [ 49%]
tests/test_patch_utils.py ....                                           [ 50%]
tests/test_pr_flow.py .............                                      [ 52%]
tests/test_prompt.py ...                                                 [ 53%]
tests/test_request_logging.py ...                                        [ 54%]
tests/test_review_service.py ..                                          [ 54%]
tests/test_runner_controller.py ..                                       [ 54%]
tests/test_snapshot_api.py ...                                           [ 55%]
tests/test_snapshot_core.py ..                                           [ 56%]
tests/test_snapshot_incremental.py ....                                  [ 56%]
tests/test_spec_ingest.py ..                                             [ 57%]
tests/test_sse_streams.py .                                              [ 57%]
tests/test_state_lock.py .                                               [ 57%]
tests/test_state_sessions.py .                                           [ 57%]
tests/test_static.py ....                                                [ 58%]
tests/test_static_asset_cache.py .......                                 [ 60%]
tests/test_system_update_check.py .                                      [ 60%]
tests/test_system_update_worker.py ...........                           [ 62%]
tests/test_telegram_adapter.py ...................................       [ 70%]
tests/test_telegram_bot_config.py ............                           [ 73%]
tests/test_telegram_bot_integration.py ...F..............                [ 76%]
tests/test_telegram_bot_lock.py ..                                       [ 77%]
tests/test_telegram_cache_cleanup.py .                                   [ 77%]
tests/test_telegram_command_registry.py ...                              [ 78%]
tests/test_telegram_fast_ack.py ...                                      [ 78%]
tests/test_telegram_handlers_callbacks.py ......                         [ 80%]
tests/test_telegram_handlers_messages.py ........................        [ 85%]
tests/test_telegram_interrupt_status.py ...                              [ 85%]
tests/test_telegram_media_batch_failure.py ..                            [ 86%]
tests/test_telegram_opencode_usage.py ..                                 [ 86%]
tests/test_telegram_outbox.py .                                          [ 87%]
tests/test_telegram_overflow.py ...                                      [ 87%]
tests/test_telegram_paths_compatible.py ...                              [ 88%]
tests/test_telegram_pr_flow.py ....                                      [ 89%]
tests/test_telegram_review_opencode.py ..                                [ 89%]
tests/test_telegram_state.py .                                           [ 89%]
tests/test_telegram_task_tracking.py .                                   [ 90%]
tests/test_telegram_thread_paths.py ..                                   [ 90%]
tests/test_telegram_topic_queue.py .                                     [ 90%]
tests/test_telegram_transport.py ...                                     [ 91%]
tests/test_telegram_turn_queue.py ....                                   [ 92%]
tests/test_telegram_update_dedupe.py ..                                  [ 92%]
tests/test_telegram_whisper_disclaimer.py ...                            [ 93%]
tests/test_terminal_idle_timeout.py ..                                   [ 93%]
tests/test_terminal_input_dedupe.py ...                                  [ 94%]
tests/test_usage.py ......                                               [ 95%]
tests/test_voice_capture.py ..                                           [ 96%]
tests/test_voice_config.py ...                                           [ 96%]
tests/test_voice_service.py ...                                          [ 97%]
tests/test_voice_transcribe_endpoint.py .                                [ 97%]
tests/test_voice_ui.py .                                                 [ 97%]
tests/test_voice_whisper_mime_types.py ....                              [ 98%]
tests/test_voice_whisper_provider.py ....                                [ 99%]
tests/test_workspace_helpers.py ..                                       [100%]

=================================== FAILURES ===================================
____________________ test_supervisor_starts_opencode_server ____________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
________________________ test_supervisor_reuses_handle _________________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
________________________ test_supervisor_closes_handle _________________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
_____________________ test_supervisor_max_handles_eviction _____________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
____________________________ test_client_providers _____________________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
_____________________ test_client_create_and_list_sessions _____________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
___________________________ test_client_send_message ___________________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
__________________________ test_client_stream_events ___________________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
__________________________ test_harness_model_catalog __________________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
_____________________ test_harness_conversation_lifecycle ______________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
___________________________ test_harness_start_turn ____________________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
__________________________ test_harness_start_review ___________________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
____________________________ test_harness_interrupt ____________________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
_______________________ test_harness_stream_turn_events ________________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
____________________________ test_sse_event_parsing ____________________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
___________________________ test_prune_idle_handles ____________________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
___________________________ test_supervisor_timeout ____________________________
async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
______________ test_outbox_pending_file_sent_after_turn[asyncio] _______________

tmp_path = PosixPath('/private/var/folders/mt/n_7gqc_n6jn3klnf17n3t43h0000gn/T/pytest-of-dazheng/pytest-1035/test_outbox_pending_file_sent_0')

    @pytest.mark.anyio
    async def test_outbox_pending_file_sent_after_turn(tmp_path: Path) -> None:
        repo = tmp_path / "repo"
        repo.mkdir()
        config = make_config(tmp_path, fixture_command("basic"))
        service = TelegramBotService(config, hub_root=tmp_path)
        fake_bot = FakeBot()
        service._bot = fake_bot
        bind_message = build_message("/bind", message_id=10)
        try:
            await service._handle_bind(bind_message, str(repo))
            key = service._router.resolve_key(bind_message.chat_id, bind_message.thread_id)
>           pending_dir = service._files_outbox_pending_dir(str(repo), key)

tests/test_telegram_bot_integration.py:282: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py:3735: in _files_outbox_pending_dir
    return self._files_topic_dir(workspace_path, topic_key) / "outbox" / "pending"
src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py:3727: in _files_topic_dir
    return self._files_root_dir(workspace_path) / self._sanitize_topic_dir_name(
src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py:3718: in _sanitize_topic_dir_name
    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", key).strip("._-")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

pattern = '[^A-Za-z0-9._-]+', repl = '_'
string = <coroutine object TopicRouter.resolve_key at 0x11166fa40>, count = 0
flags = 0

    def sub(pattern, repl, string, count=0, flags=0):
        """Return the string obtained by replacing the leftmost
        non-overlapping occurrences of the pattern in string by the
        replacement repl.  repl can be either a string or a callable;
        if a string, backslash escapes in it are processed.  If it is
        a callable, it's passed the Match object and must return
        a replacement string to be used."""
>       return _compile(pattern, flags).sub(repl, string, count)
E       TypeError: expected string or bytes-like object

/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/re.py:210: TypeError
=============================== warnings summary ===============================
.venv/lib/python3.9/site-packages/_pytest/config/__init__.py:1474
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

.venv/lib/python3.9/site-packages/_pytest/config/__init__.py:1474
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

tests/test_opencode_integration.py:65
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:65: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:76
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:76: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:87
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:87: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:101
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:101: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:125
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:125: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:141
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:141: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:169
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:169: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:194
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:194: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:243
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:243: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:260
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:260: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:284
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:284: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:311
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:311: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:341
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:341: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:369
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:369: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:417
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:417: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:440
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:440: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:464
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:464: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py::test_supervisor_starts_opencode_server
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_supervisor_starts_opencode_server' requested an async fixture 'supervisor', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_supervisor_starts_opencode_server
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_supervisor_starts_opencode_server' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_supervisor_reuses_handle
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_supervisor_reuses_handle' requested an async fixture 'supervisor', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_supervisor_reuses_handle
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_supervisor_reuses_handle' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_supervisor_closes_handle
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_supervisor_closes_handle' requested an async fixture 'supervisor', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_supervisor_closes_handle
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_supervisor_closes_handle' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_supervisor_max_handles_eviction
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_supervisor_max_handles_eviction' requested an async fixture 'supervisor', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_client_providers
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_client_providers' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_client_create_and_list_sessions
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_client_create_and_list_sessions' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_client_send_message
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_client_send_message' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_client_stream_events
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_client_stream_events' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_harness_model_catalog
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_harness_model_catalog' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_harness_conversation_lifecycle
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_harness_conversation_lifecycle' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_harness_start_turn
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_harness_start_turn' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_harness_start_review
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_harness_start_review' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_harness_interrupt
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_harness_interrupt' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_harness_stream_turn_events
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_harness_stream_turn_events' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_prune_idle_handles
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_prune_idle_handles' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_opencode_integration.py::test_supervisor_timeout
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/fixtures.py:1182: PytestRemovedIn9Warning: 'test_supervisor_timeout' requested an async fixture 'workspace', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
  See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
    warnings.warn(

tests/test_telegram_bot_integration.py::test_status_creates_record[asyncio]
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/anyio/_backends/_asyncio.py:2250: RuntimeWarning: coroutine 'TopicRouter.get_topic' was never awaited
    retval = await coro
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_telegram_bot_integration.py::test_outbox_pending_file_sent_after_turn[asyncio]
  <string>:3: RuntimeWarning: coroutine 'TopicRouter.resolve_key' was never awaited
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_telegram_bot_integration.py::test_resume_refresh_updates_cached_preview[asyncio]
  /Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/threading.py:432: RuntimeWarning: coroutine 'TopicRouter.resolve_key' was never awaited
    with self._cond:
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_telegram_update_dedupe.py::test_update_dedupe_skips_frequent_persist[asyncio]
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/httpcore/_synchronization.py:26: RuntimeWarning: coroutine 'TopicRouter.resolve_key' was never awaited
    import sniffio
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_opencode_integration.py::test_supervisor_starts_opencode_server
FAILED tests/test_opencode_integration.py::test_supervisor_reuses_handle - Fa...
FAILED tests/test_opencode_integration.py::test_supervisor_closes_handle - Fa...
FAILED tests/test_opencode_integration.py::test_supervisor_max_handles_eviction
FAILED tests/test_opencode_integration.py::test_client_providers - Failed: as...
FAILED tests/test_opencode_integration.py::test_client_create_and_list_sessions
FAILED tests/test_opencode_integration.py::test_client_send_message - Failed:...
FAILED tests/test_opencode_integration.py::test_client_stream_events - Failed...
FAILED tests/test_opencode_integration.py::test_harness_model_catalog - Faile...
FAILED tests/test_opencode_integration.py::test_harness_conversation_lifecycle
FAILED tests/test_opencode_integration.py::test_harness_start_turn - Failed: ...
FAILED tests/test_opencode_integration.py::test_harness_start_review - Failed...
FAILED tests/test_opencode_integration.py::test_harness_interrupt - Failed: a...
FAILED tests/test_opencode_integration.py::test_harness_stream_turn_events - ...
FAILED tests/test_opencode_integration.py::test_sse_event_parsing - Failed: a...
FAILED tests/test_opencode_integration.py::test_prune_idle_handles - Failed: ...
FAILED tests/test_opencode_integration.py::test_supervisor_timeout - Failed: ...
FAILED tests/test_telegram_bot_integration.py::test_outbox_pending_file_sent_after_turn[asyncio]
================= 18 failed, 446 passed, 42 warnings in 16.08s =================