### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/src/codex_autorunner/routes/sessions.py
+++ b/src/codex_autorunner/routes/sessions.py
@@ -121,15 +121,17 @@ def build_sessions_routes() -> APIRouter:
             repo_root = Path(request.app.state.engine.repo_root)
             normalized_repo_path = repo_path.strip()
             if normalized_repo_path:
-                candidate = Path(normalized_repo_path)
-                if not candidate.is_absolute():
-                    candidate = (repo_root / candidate).resolve()
+                raw_path = Path(normalized_repo_path)
+                if raw_path.is_absolute():
+                    resolved = raw_path.resolve()
+                else:
+                    resolved = (repo_root / raw_path).resolve()
                 try:
-                    candidate.relative_to(repo_root)
+                    resolved.relative_to(repo_root)
                 except ValueError:
                     normalized_repo_path = ""
                 else:
-                    normalized_repo_path = str(candidate)
+                    normalized_repo_path = str(resolved)
             candidates: list[str] = []
             if normalized_repo_path:
                 candidates.extend(


### PR DESCRIPTION
Potential fix for [https://github.com/Git-on-my-level/codex-autorunner/security/code-scanning/2](https://github.com/Git-on-my-level/codex-autorunner/security/code-scanning/2)

In general, to fix uncontrolled-path issues, you should (1) treat all user-supplied path fragments as untrusted, (2) normalize them (for example with `Path.resolve()`), and (3) enforce that the resolved path stays within a known safe root directory using a containment check like `resolved_path.relative_to(root)` in a `try/except` block. Do not use user input directly with path-joining or file APIs without this validation.

For this specific code, the goal is to keep the existing behavior—mapping a user-supplied `repo_path` to a canonical absolute path under `repo_root` if valid, or discarding it otherwise—but to make the normalization/containment logic explicit and avoid using the intermediate `candidate` object in a way that confuses static analysis. The simplest way is:

- Build a `Path` from the stripped string: `raw_path = Path(normalized_repo_path)`.
- If it is absolute, keep it as is; if not, join it to `repo_root`: `joined = repo_root / raw_path`.
- Resolve the joined path to eliminate `..` segments and symlinks: `resolved = joined.resolve()`.
- Attempt `resolved.relative_to(repo_root)`; on `ValueError`, treat the path as invalid (`normalized_repo_path = ""`); otherwise, set `normalized_repo_path = str(resolved)`.

This keeps the semantics (only allow paths that resolve inside `repo_root`) while making the validation clearer and ensuring that any path derived from user input is checked before it is accepted. Only the block around lines 120–133 in `src/codex_autorunner/routes/sessions.py` needs to change; no new imports or helper functions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
