### PR TITLE
Add Telegram turn timeout handling

### DIFF
--- a/docs/ops/telegram-bot-runbook.md
+++ b/docs/ops/telegram-bot-runbook.md
@@ -82,6 +82,9 @@ Operate and troubleshoot the Telegram polling bot that proxies Codex app-server 
 - Turns failing:
   - Check `telegram.turn.failed` and `app_server.*` logs.
   - Verify the Codex app-server is installed and in `telegram_bot.app_server_command` or `CAR_TELEGRAM_APP_SERVER_COMMAND`.
+- Turns hanging:
+  - Look for `telegram.turn.timeout` in the hub log.
+  - Adjust `telegram_bot.app_server.turn_timeout_seconds` if longer turns are expected.
 - App-server disconnect loops:
   - Look for repeated `app_server.disconnected` or `telegram.app_server.start_failed` events.
   - Confirm the `codex app-server` binary is healthy/compatible with this autorunner build.

--- a/docs/ops/telegram-debugging.md
+++ b/docs/ops/telegram-debugging.md
@@ -44,6 +44,9 @@ If you see `app_server.turn.completed` but no `telegram.turn.completed`, the bot
 - **Silent drop**
   - `telegram.turn.completed` exists, but no outbox events.
   - Indicates delivery path skipped or crashed before enqueue.
+- **Turn timed out**
+  - Look for `telegram.turn.timeout` or `telegram.turn.timeout_grace_exhausted`.
+  - Increase `telegram_bot.app_server.turn_timeout_seconds` if the work legitimately runs longer.
 
 ## Useful Commands
 

--- a/docs/telegram/architecture.md
+++ b/docs/telegram/architecture.md
@@ -21,6 +21,7 @@ Config lives under `telegram_bot` in `codex-autorunner.yml` and the generated
 - `telegram_bot.parse_mode`: `HTML`, `Markdown`, `MarkdownV2`, or null.
 - `telegram_bot.debug.prefix_context`: when true, prefix outgoing messages with routing metadata.
 - `telegram_bot.app_server_command(_env)`: how to launch `codex app-server`.
+- `telegram_bot.app_server`: app-server tuning (`max_handles`, `idle_ttl_seconds`, `turn_timeout_seconds`).
 - `telegram_bot.media`: image/voice handling limits and prompts.
 - `telegram_bot.shell`: `!<cmd>` settings (enable flag, timeouts, output limits).
 - `telegram_bot.defaults`: approval/sandbox defaults for the app-server client.

--- a/src/codex_autorunner/core/config.py
+++ b/src/codex_autorunner/core/config.py
@@ -229,6 +229,7 @@ DEFAULT_REPO_CONFIG: Dict[str, Any] = {
         "app_server": {
             "max_handles": 20,
             "idle_ttl_seconds": 3600,
+            "turn_timeout_seconds": 28800,
         },
         "polling": {
             "timeout_seconds": 30,
@@ -452,6 +453,7 @@ DEFAULT_HUB_CONFIG: Dict[str, Any] = {
         "app_server": {
             "max_handles": 20,
             "idle_ttl_seconds": 3600,
+            "turn_timeout_seconds": 28800,
         },
         "polling": {
             "timeout_seconds": 30,
@@ -2167,6 +2169,18 @@ def _validate_telegram_bot_config(cfg: Dict[str, Any]) -> None:
         telegram_cfg.get("app_server_command"), (list, str)
     ):
         raise ConfigError("telegram_bot.app_server_command must be a list or string")
+    app_server_cfg = telegram_cfg.get("app_server")
+    if app_server_cfg is not None and not isinstance(app_server_cfg, dict):
+        raise ConfigError("telegram_bot.app_server must be a mapping if provided")
+    if isinstance(app_server_cfg, dict):
+        if (
+            "turn_timeout_seconds" in app_server_cfg
+            and app_server_cfg.get("turn_timeout_seconds") is not None
+            and not isinstance(app_server_cfg.get("turn_timeout_seconds"), (int, float))
+        ):
+            raise ConfigError(
+                "telegram_bot.app_server.turn_timeout_seconds must be a number or null"
+            )
     polling_cfg = telegram_cfg.get("polling")
     if polling_cfg is not None and not isinstance(polling_cfg, dict):
         raise ConfigError("telegram_bot.polling must be a mapping if provided")

--- a/src/codex_autorunner/integrations/telegram/config.py
+++ b/src/codex_autorunner/integrations/telegram/config.py
@@ -22,6 +22,7 @@ DEFAULT_APP_SERVER_MAX_HANDLES = 20
 DEFAULT_APP_SERVER_IDLE_TTL_SECONDS = 3600
 DEFAULT_APP_SERVER_START_TIMEOUT_SECONDS = 30
 DEFAULT_APP_SERVER_START_MAX_ATTEMPTS: Optional[int] = None
+DEFAULT_APP_SERVER_TURN_TIMEOUT_SECONDS = 28800
 DEFAULT_APPROVAL_TIMEOUT_SECONDS = 300.0
 DEFAULT_MEDIA_MAX_IMAGE_BYTES = 10 * 1024 * 1024
 DEFAULT_MEDIA_MAX_VOICE_BYTES = 10 * 1024 * 1024
@@ -161,6 +162,7 @@ class TelegramBotConfig:
     app_server_idle_ttl_seconds: Optional[int]
     app_server_start_timeout_seconds: float
     app_server_start_max_attempts: Optional[int]
+    app_server_turn_timeout_seconds: Optional[float]
     poll_timeout_seconds: int
     poll_allowed_updates: list[str]
     message_overflow: str
@@ -426,6 +428,15 @@ class TelegramBotConfig:
                 app_server_start_max_attempts = None
         else:
             app_server_start_max_attempts = None
+        app_server_turn_timeout_raw = app_server_raw.get(
+            "turn_timeout_seconds", DEFAULT_APP_SERVER_TURN_TIMEOUT_SECONDS
+        )
+        if app_server_turn_timeout_raw is None:
+            app_server_turn_timeout_seconds = None
+        else:
+            app_server_turn_timeout_seconds = float(app_server_turn_timeout_raw)
+            if app_server_turn_timeout_seconds <= 0:
+                app_server_turn_timeout_seconds = None
 
         polling_raw_value = cfg.get("polling")
         polling_raw: dict[str, Any] = (
@@ -465,6 +476,7 @@ class TelegramBotConfig:
             app_server_idle_ttl_seconds=app_server_idle_ttl_seconds,
             app_server_start_timeout_seconds=app_server_start_timeout_seconds,
             app_server_start_max_attempts=app_server_start_max_attempts,
+            app_server_turn_timeout_seconds=app_server_turn_timeout_seconds,
             poll_timeout_seconds=poll_timeout_seconds,
             poll_allowed_updates=poll_allowed_updates,
             message_overflow=message_overflow,

--- a/src/codex_autorunner/integrations/telegram/service.py
+++ b/src/codex_autorunner/integrations/telegram/service.py
@@ -544,6 +544,7 @@ class TelegramBotService(
                 media_enabled=self._config.media.enabled,
                 media_images=self._config.media.images,
                 media_voice=self._config.media.voice,
+                app_server_turn_timeout_seconds=self._config.app_server_turn_timeout_seconds,
                 poller_offset=self._poller.offset,
             )
             try:

--- a/tests/test_telegram_turn_queue.py
+++ b/tests/test_telegram_turn_queue.py
@@ -31,7 +31,7 @@ class _TurnHandle:
         self.turn_id = turn_id
         self._wait_event = wait_event
 
-    async def wait(self) -> _TurnResult:
+    async def wait(self, *_args: object, **_kwargs: object) -> _TurnResult:
         await self._wait_event.wait()
         return _TurnResult()
 
@@ -110,7 +110,8 @@ class _HandlerStub(TelegramCommandHandlers):
             concurrency=SimpleNamespace(
                 max_parallel_turns=max_parallel_turns,
                 per_topic_queue=False,
-            )
+            ),
+            app_server_turn_timeout_seconds=None,
         )
         self._router = _RouterStub(records)
         self._turn_semaphore = asyncio.Semaphore(max_parallel_turns)


### PR DESCRIPTION
## Summary\n- add a per-turn timeout for Telegram Codex turns/reviews and interrupt on expiry\n- add config support for telegram_bot.app_server.turn_timeout_seconds with default\n- document timeout troubleshooting and config\n\n## Testing\n- black\n- ruff\n- mypy\n- eslint (warnings only)\n- pnpm run build\n- pytest