### PR TITLE
Fix terminal input handler after reconnect

### DIFF
--- a/src/codex_autorunner/static/terminalManager.js
+++ b/src/codex_autorunner/static/terminalManager.js
@@ -1886,6 +1886,14 @@ export class TerminalManager {
             return false;
         }
         if (this.term) {
+            if (!this.inputDisposable) {
+                this.inputDisposable = this.term.onData((data) => {
+                    if (!this.socket || this.socket.readyState !== WebSocket.OPEN)
+                        return;
+                    this._markSessionActive();
+                    this.socket.send(textEncoder.encode(data));
+                });
+            }
             return true;
         }
         const container = document.getElementById("terminal-container");

--- a/src/codex_autorunner/static_src/terminalManager.ts
+++ b/src/codex_autorunner/static_src/terminalManager.ts
@@ -1967,6 +1967,13 @@ export class TerminalManager {
       return false;
     }
     if (this.term) {
+      if (!this.inputDisposable) {
+        this.inputDisposable = this.term.onData((data) => {
+          if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+          this._markSessionActive();
+          this.socket.send(textEncoder.encode(data));
+        });
+      }
       return true;
     }
     const container = document.getElementById("terminal-container") as HTMLElement | null;


### PR DESCRIPTION
## Summary\n- reattach the xterm onData handler when reconnecting to an existing terminal\n- keep terminal input forwarding available across disconnects\n\n## Testing\n- pre-commit checks (black, ruff, mypy, eslint warnings)\n- pnpm run build\n- pytest\n\nCloses #257