### PR TITLE
Fix Telegram polling and retry stability

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -2587,7 +2587,7 @@ class TelegramCommandHandlers:
                     transcript_message_id,
                     transcript_text,
                 )
-                turn_key: Optional[TurnKey] = None
+            turn_key: Optional[TurnKey] = None
             try:
                 queue_wait_ms = int((time.monotonic() - queue_started_at) * 1000)
                 log_event(

--- a/src/codex_autorunner/integrations/telegram/transport.py
+++ b/src/codex_autorunner/integrations/telegram/transport.py
@@ -283,7 +283,7 @@ class TelegramMessageTransport:
                             message_thread_id=thread_id,
                             reply_to_message_id=reply_to if idx == 0 else None,
                             reply_markup=reply_markup if idx == 0 else None,
-                            parse_mode="HTML",
+                            parse_mode=used_mode,
                         )
                     return
                 if overflow_mode == "trim":


### PR DESCRIPTION
## Summary
- fix poll offset logging when no updates
- avoid turn runner crashes on unassigned turn keys
- make update dedupe persistence best-effort and fix split message parse_mode
- classify Telegram API errors and honor retry_after rate limits

## Testing
- pytest tests/test_telegram_adapter.py tests/test_telegram_transport.py tests/test_telegram_update_dedupe.py
- pytest

Closes #261