### PR TITLE
Fix OpenCode Telegram thinking display

### DIFF
--- a/tests/test_telegram_progress_stream.py
+++ b/tests/test_telegram_progress_stream.py
@@ -23,5 +23,5 @@ def test_render_progress_text_subagent_thinking_block() -> None:
     tracker.note_thinking("Parent thinking")
     rendered = render_progress_text(tracker, max_length=2000, now=0.0)
     assert "🧠 Parent thinking" in rendered
-    assert "--- @subagent thinking ---" in rendered
+    assert "🤖 @subagent thinking" in rendered
     assert "Subagent planning" in rendered


### PR DESCRIPTION
## Summary
- format subagent thinking as a distinct block in Telegram progress rendering
- keep progress truncation aligned to action blocks so recent thinking stays visible
- add OpenCode runtime usage emission tests for info.tokens payloads

## Testing
- .venv/bin/python -m pytest tests/test_telegram_progress_stream.py tests/test_opencode_runtime.py
- pytest
- pnpm run build

Closes #272
