### PR TITLE
Fix telegram custom answer queueing

### DIFF
--- a/src/codex_autorunner/integrations/telegram/dispatch.py
+++ b/src/codex_autorunner/integrations/telegram/dispatch.py
@@ -125,12 +125,12 @@ async def _dispatch_message(
     if message is None:
         return
     if context.topic_key:
-        await handlers._maybe_send_queued_placeholder(
-            message, topic_key=context.topic_key
-        )
         if handlers._should_bypass_topic_queue(message):
             await handlers._handle_message(message)
             return
+        await handlers._maybe_send_queued_placeholder(
+            message, topic_key=context.topic_key
+        )
         handlers._enqueue_topic_work(
             context.topic_key,
             lambda: handlers._handle_message(message),

--- a/src/codex_autorunner/integrations/telegram/handlers/messages.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/messages.py
@@ -139,6 +139,13 @@ async def handle_message(handlers: Any, message: TelegramMessage) -> None:
 
 
 def should_bypass_topic_queue(handlers: Any, message: TelegramMessage) -> bool:
+    for pending in handlers._pending_questions.values():
+        if (
+            pending.awaiting_custom_input
+            and pending.chat_id == message.chat_id
+            and (pending.thread_id is None or pending.thread_id == message.thread_id)
+        ):
+            return True
     _raw_text, text_candidate, entities = _message_text_candidate(message)
     if not text_candidate:
         return False

--- a/tests/test_telegram_handlers_messages.py
+++ b/tests/test_telegram_handlers_messages.py
@@ -134,6 +134,7 @@ def test_should_bypass_topic_queue_for_interrupt() -> None:
     handlers = types.SimpleNamespace(
         _bot_username="CodexBot",
         _command_specs={},
+        _pending_questions={},
     )
     message = _message(text="^C")
     assert should_bypass_topic_queue(handlers, message) is True
@@ -149,6 +150,7 @@ def test_should_bypass_topic_queue_for_allow_during_turn() -> None:
     handlers = types.SimpleNamespace(
         _bot_username="CodexBot",
         _command_specs={"status": spec},
+        _pending_questions={},
     )
     message = _message(
         text="/status",
@@ -167,12 +169,28 @@ def test_should_not_bypass_topic_queue_without_allow_during_turn() -> None:
     handlers = types.SimpleNamespace(
         _bot_username="CodexBot",
         _command_specs={"new": spec},
+        _pending_questions={},
     )
     message = _message(
         text="/new",
         entities=(TelegramMessageEntity("bot_command", 0, len("/new")),),
     )
     assert should_bypass_topic_queue(handlers, message) is False
+
+
+def test_should_bypass_topic_queue_for_custom_answer() -> None:
+    pending = types.SimpleNamespace(
+        awaiting_custom_input=True,
+        chat_id=3,
+        thread_id=4,
+    )
+    handlers = types.SimpleNamespace(
+        _bot_username="CodexBot",
+        _command_specs={},
+        _pending_questions={"req-1": pending},
+    )
+    message = _message(text="Purple")
+    assert should_bypass_topic_queue(handlers, message) is True
 
 
 def test_has_batchable_media_with_photos() -> None:


### PR DESCRIPTION
## Summary
- bypass topic queue for custom question responses
- avoid queued placeholder for custom answers while a turn is busy
- add coverage for custom answer queue bypass

## Testing
- .venv/bin/python -m pytest tests/test_telegram_handlers_messages.py tests/test_telegram_fast_ack.py
- full pre-commit suite (black/ruff/mypy/eslint/tsc/pytest) via git commit hooks