### PR TITLE
Fix OpenCode permissions, streaming, and model catalogs

### DIFF
--- a/src/codex_autorunner/agents/opencode/supervisor.py
+++ b/src/codex_autorunner/agents/opencode/supervisor.py
@@ -52,7 +52,9 @@ class OpenCodeSupervisor:
         self._request_timeout = request_timeout
         self._max_handles = max_handles
         self._idle_ttl_seconds = idle_ttl_seconds
-        self._auth = (username, password) if username and password else None
+        if password and not username:
+            username = "opencode"
+        self._auth = (username, password) if password else None
         self._base_env = base_env
         self._handles: dict[str, OpenCodeHandle] = {}
         self._lock = asyncio.Lock()

--- a/src/codex_autorunner/core/doc_chat.py
+++ b/src/codex_autorunner/core/doc_chat.py
@@ -23,10 +23,12 @@ from typing import (
 
 from ..agents.opencode.runtime import (
     PERMISSION_ALLOW,
+    OpenCodeTurnOutput,
     build_turn_id,
     collect_opencode_output,
     extract_session_id,
     opencode_missing_env,
+    parse_message_response,
     split_model_id,
 )
 from ..agents.opencode.supervisor import OpenCodeSupervisor
@@ -1102,6 +1104,7 @@ class DocChatService:
                 on_turn_start=on_turn_start,
             )
             permission_policy = PERMISSION_ALLOW
+            ready_event = asyncio.Event()
             output_task = asyncio.create_task(
                 collect_opencode_output(
                     client,
@@ -1110,10 +1113,13 @@ class DocChatService:
                     permission_policy=permission_policy,
                     question_policy="auto_first_option",
                     should_stop=active.interrupt_event.is_set,
+                    ready_event=ready_event,
                 )
             )
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(ready_event.wait(), timeout=2.0)
             prompt_task = asyncio.create_task(
-                client.prompt(
+                client.prompt_async(
                     thread_id,
                     message=prompt,
                     model=model_payload,
@@ -1123,8 +1129,9 @@ class DocChatService:
             timeout_task = asyncio.create_task(asyncio.sleep(DOC_CHAT_TIMEOUT_SECONDS))
             interrupt_task = asyncio.create_task(active.interrupt_event.wait())
             try:
+                prompt_response = None
                 try:
-                    await prompt_task
+                    prompt_response = await prompt_task
                 except Exception as exc:
                     active.interrupt_event.set()
                     output_task.cancel()
@@ -1162,6 +1169,14 @@ class DocChatService:
                             "turn_id": turn_id,
                         }
                 output_result = await output_task
+                if output_result.text or output_result.error:
+                    pass
+                elif prompt_response is not None:
+                    fallback = parse_message_response(prompt_response)
+                    if fallback.text:
+                        output_result = OpenCodeTurnOutput(
+                            text=fallback.text, error=fallback.error
+                        )
             finally:
                 self._clear_active_turn(turn_id)
                 timeout_task.cancel()

--- a/src/codex_autorunner/core/utils.py
+++ b/src/codex_autorunner/core/utils.py
@@ -231,6 +231,8 @@ def build_opencode_supervisor(
         base_env = os.environ
     username = base_env.get("OPENCODE_SERVER_USERNAME")
     password = base_env.get("OPENCODE_SERVER_PASSWORD")
+    if password and not username:
+        username = "opencode"
 
     from ..agents.opencode.supervisor import OpenCodeSupervisor
 
@@ -240,8 +242,8 @@ def build_opencode_supervisor(
         request_timeout=request_timeout,
         max_handles=max_handles,
         idle_ttl_seconds=idle_ttl_seconds,
-        username=username if username and password else None,
-        password=password if username and password else None,
+        username=username if password else None,
+        password=password if password else None,
         base_env=base_env,
     )
 

--- a/tests/test_opencode_model_catalog.py
+++ b/tests/test_opencode_model_catalog.py
@@ -1,0 +1,23 @@
+from codex_autorunner.routes.agents import _build_opencode_model_catalog
+
+
+def test_build_opencode_model_catalog_from_list_models() -> None:
+    payload = {
+        "default": {"openai": "gpt-4o-mini"},
+        "providers": [
+            {
+                "id": "openai",
+                "models": [
+                    {"id": "gpt-4o", "name": "GPT-4o", "limit": {"context": 128000}},
+                    {"id": "gpt-4o-mini"},
+                ],
+            }
+        ],
+    }
+
+    catalog = _build_opencode_model_catalog(payload)
+
+    model_ids = {model.id for model in catalog.models}
+    assert catalog.default_model == "openai/gpt-4o-mini"
+    assert "openai/gpt-4o" in model_ids
+    assert "openai/gpt-4o-mini" in model_ids

--- a/tests/test_telegram_opencode_context_cache.py
+++ b/tests/test_telegram_opencode_context_cache.py
@@ -27,6 +27,20 @@ class _FakeOpenCodeClient:
         }
 
 
+class _FakeOpenCodeListClient:
+    async def providers(self, directory: Optional[str] = None) -> dict[str, object]:
+        return {
+            "providers": [
+                {
+                    "id": "provider",
+                    "models": [
+                        {"id": "model-a", "limit": {"context": 4096}},
+                    ],
+                }
+            ]
+        }
+
+
 @pytest.mark.anyio
 async def test_opencode_context_cache_scoped_by_workspace() -> None:
     handler = TelegramCommandHandlers()
@@ -44,3 +58,17 @@ async def test_opencode_context_cache_scoped_by_workspace() -> None:
 
     assert context_a == 1000
     assert context_b == 2000
+
+
+@pytest.mark.anyio
+async def test_opencode_context_window_from_list_models() -> None:
+    handler = TelegramCommandHandlers()
+    client = _FakeOpenCodeListClient()
+    model_payload = {"providerID": "provider", "modelID": "model-a"}
+    workspace = Path("/tmp/workspace_list")
+
+    context = await handler._resolve_opencode_model_context_window(
+        client, workspace, model_payload
+    )
+
+    assert context == 4096


### PR DESCRIPTION
## Summary
- map OpenCode permission policy decisions to reply enums, log invalid replies, and accept Telegram decision variants
- switch to prompt_async + SSE readiness + fallback prompt response when streaming misses deltas
- parse provider model lists + limit.context, default auth username on password-only, and stop on session.status idle
- add tests for OpenCode model catalogs from list responses and Telegram context windows

## Testing
- .venv/bin/python -m pytest tests/test_opencode_model_catalog.py tests/test_telegram_opencode_context_cache.py
- pre-commit hook ran full pytest suite, build, lint, and mypy (ESLint warnings are pre-existing)
