### PR TITLE
Fix hub UI showing all repos as 'uninit'

### DIFF
--- a/src/codex_autorunner/static/hub.js
+++ b/src/codex_autorunner/static/hub.js
@@ -67,7 +67,7 @@ function loadSessionCache(key, maxAgeMs) {
     }
 }
 function formatRunSummary(repo) {
-    if (!repo.initialzed)
+    if (!repo.initialized)
         return "Not initialized";
     if (!repo.exists_on_disk)
         return "Missing on disk";
@@ -79,7 +79,7 @@ function formatRunSummary(repo) {
     return `#${repo.last_run_id}${exit}`;
 }
 function formatLastActivity(repo) {
-    if (!repo.initialzed)
+    if (!repo.initialized)
         return "";
     const time = repo.last_run_finished_at || repo.last_run_started_at;
     if (!time)
@@ -685,11 +685,11 @@ function buildActions(repo) {
     else if (!missing && repo.init_error) {
         actions.push({
             key: "init",
-            label: repo.initialzed ? "Re-init" : "Init",
+            label: repo.initialized ? "Re-init" : "Init",
             kind: "primary",
         });
     }
-    else if (!missing && !repo.initialzed) {
+    else if (!missing && !repo.initialized) {
         actions.push({ key: "init", label: "Init", kind: "primary" });
     }
     if (!missing && kind === "base") {
@@ -869,7 +869,7 @@ function renderRepos(repos) {
         const lockBadge = repo.lock_status && repo.lock_status !== "unlocked"
             ? `<span class="pill pill-small pill-warn">${escapeHtml(repo.lock_status.replace("_", " "))}</span>`
             : "";
-        const initBadge = !repo.initialzed
+        const initBadge = !repo.initialized
             ? '<span class="pill pill-small pill-warn">uninit</span>'
             : "";
         let noteText = "";

--- a/src/codex_autorunner/static_src/hub.ts
+++ b/src/codex_autorunner/static_src/hub.ts
@@ -14,7 +14,6 @@ import { HUB_BASE } from "./env.js";
 interface HubRepo {
   id: string;
   display_name: string;
-  initialzed?: boolean;
   initialized?: boolean;
   exists_on_disk: boolean;
   status: string;
@@ -181,7 +180,7 @@ function loadSessionCache<T>(key: string, maxAgeMs: number): T | null {
 }
 
 function formatRunSummary(repo: HubRepo): string {
-  if (!repo.initialzed) return "Not initialized";
+  if (!repo.initialized) return "Not initialized";
   if (!repo.exists_on_disk) return "Missing on disk";
   if (!repo.last_run_id) return "No runs yet";
   const exit =
@@ -192,7 +191,7 @@ function formatRunSummary(repo: HubRepo): string {
 }
 
 function formatLastActivity(repo: HubRepo): string {
-  if (!repo.initialzed) return "";
+  if (!repo.initialized) return "";
   const time = repo.last_run_finished_at || repo.last_run_started_at;
   if (!time) return "";
   return formatTimeCompact(time);
@@ -893,10 +892,10 @@ function buildActions(repo: HubRepo): RepoAction[] {
   } else if (!missing && repo.init_error) {
     actions.push({
       key: "init",
-      label: repo.initialzed ? "Re-init" : "Init",
+      label: repo.initialized ? "Re-init" : "Init",
       kind: "primary",
     });
-  } else if (!missing && !repo.initialzed) {
+  } else if (!missing && !repo.initialized) {
     actions.push({ key: "init", label: "Init", kind: "primary" });
   }
   if (!missing && kind === "base") {
@@ -1092,7 +1091,7 @@ function renderRepos(repos: HubRepo[]): void {
             repo.lock_status.replace("_", " ")
           )}</span>`
         : "";
-    const initBadge = !repo.initialzed
+    const initBadge = !repo.initialized
       ? '<span class="pill pill-small pill-warn">uninit</span>'
       : "";
 


### PR DESCRIPTION
## Problem
All repos appeared as "uninit" on the hub page, even when they were already initialized. Clicking "Init" would work on the backend, but the UI would not reflect the change.

## Root Cause
The `HubRepo` TypeScript interface had a typo: a duplicate property `initialzed` (missing "i") alongside the correct `initialized` property. The frontend code was checking for the typoed property name, which was always `undefined` (falsy), while the backend correctly returned `initialized: true`.

## Solution
- Removed duplicate `initialzed` property from HubRepo interface
- Changed all 5 references from `repo.initialzed` to `repo.initialized`
- Rebuilt JavaScript bundle

## Files Changed
- `src/codex_autorunner/static_src/hub.ts` (TypeScript source)
- `src/codex_autorunner/static/hub.js` (Compiled JavaScript)