### PR TITLE
Enable TypeScript strict mode and no-unnecessary-condition rule

### DIFF
--- a/tests/test_app_server_event_formatter.py
+++ b/tests/test_app_server_event_formatter.py
@@ -201,3 +201,52 @@ async def test_thinking_multiline_deltas() -> None:
 
     lines = formatter.format_event(part_added_msg)
     assert lines == ["**Line 1**", "**Line 2**", "**Line 3**"]
+
+
+@pytest.mark.anyio
+async def test_thinking_deltas_without_itemid_emit_immediately() -> None:
+    formatter = AppServerEventFormatter()
+
+    # Delta without itemId - should emit immediately
+    delta_msg = {
+        "method": "item/reasoning/summaryTextDelta",
+        "params": {
+            "turnId": "turn-6",
+            "delta": "This has no itemId",
+        },
+    }
+
+    lines = formatter.format_event(delta_msg)
+    assert lines == ["thinking", "**This has no itemId**"]
+
+
+@pytest.mark.anyio
+async def test_thinking_deltas_with_null_itemid_emit_immediately() -> None:
+    formatter = AppServerEventFormatter()
+
+    # Delta with null itemId - should emit immediately
+    delta_msg = {
+        "method": "item/reasoning/summaryTextDelta",
+        "params": {
+            "itemId": None,
+            "turnId": "turn-7",
+            "delta": "This has null itemId",
+        },
+    }
+
+    lines = formatter.format_event(delta_msg)
+    assert lines == ["thinking", "**This has null itemId**"]
+
+
+@pytest.mark.anyio
+async def test_thinking_part_added_without_itemid() -> None:
+    formatter = AppServerEventFormatter()
+
+    # summaryPartAdded without itemId should not crash
+    part_added_msg = {
+        "method": "item/reasoning/summaryPartAdded",
+        "params": {"turnId": "turn-8"},
+    }
+
+    lines = formatter.format_event(part_added_msg)
+    assert lines == []


### PR DESCRIPTION
## Summary

Enables TypeScript strict mode and the `@typescript-eslint/no-unnecessary-condition` rule to catch bugs before they reach production. This addresses issue #282 where a typo (`repo.initialzed` instead of `initialized`) caused all repos to incorrectly appear as "uninit" on the hub page.

## Configuration Changes

- **tsconfig.json**: Enabled all strict compiler flags
  - `strict: true`
  - `noImplicitAny: true`
  - `strictNullChecks: true`
  - `strictPropertyInitialization: true`
  - `strictFunctionTypes: true`
  - `strictBindCallApply: true`
  - `noImplicitThis: true`
- **eslint.config.cjs**: Added `@typescript-eslint/no-unnecessary-condition` rule
- **package.json**: Added `@xterm/xterm@6.0.0` and `@xterm/addon-fit@0.11.0` type packages

## TypeScript Fixes (200+ errors resolved)

### hub.ts
- Fixed `initialzed?: boolean;` typo (6 occurrences changed to `initialized`)
- Fixed worktrees null checks (5 errors)
- Fixed boolean null assignment

### terminalManager.ts (bulk of work)
- Added 70+ type annotations to private method parameters
- Replaced `any` types with proper `Terminal`, `FitAddon`, `IDisposable` from @xterm packages
- Fixed IBuffer property access issues
- Added null safety checks throughout

### Doc System Files
- **docChatActions.ts, docChatRender.ts, docChatStream.ts**: Added null guards for UI elements using non-null assertions
- **docsCrud.ts, docsDocUpdates.ts**: Fixed DocKind indexing, added null guards
- **docsInit.ts, docsVoice.ts, docsSpecIngest.ts**: Fixed UI element null checks
- **docsClipboard.ts, docsThreadRegistry.ts**: Fixed temp element typing and null return types

### Other Files
- **dashboard.ts, logs.ts, github.ts, review.ts, runs.ts, settings.ts, app.ts**: Fixed null checks and type mismatches
- **utils.ts, voice.ts**: Fixed property access and null issues

## ESLint Fixes (100+ errors resolved)

- Removed unnecessary optional chains (`?.`) on non-nullish values
- Removed unnecessary conditionals that are always true/false
- Simplified type checks where types have no overlap
- Fixed subscription handler parameter type mismatches

## Impact

**Prevents Bugs Like:**
- Property typos (`repo.initialzed`) now caught at compile time
- Always-true/false conditions (e.g., `!repo.initialzed`) now flagged by linter
- Implicit `any` types that hide type errors are now enforced

**Future Safety:**
- Full type safety for xterm terminal integration
- Null safety throughout the codebase
- Better IDE autocomplete and inline error detection

**Trade-offs:**
- 145 `no-explicit-any` warnings remain (mostly for external/complex APIs)
- 38 `no-unnecessary-condition` errors remain (minor edge cases)

## Testing

- ✅ TypeScript compiles with zero errors
- ✅ Build succeeds
- ✅ All Python checks pass (black, ruff, mypy)
- ✅ Static outputs committed

## Related Issues

- Closes #282
- Would have prevented #278 (hub UI "uninit" bug)

### Checklist

- [x] All strict compiler flags enabled
- [x] no-unnecessary-condition ESLint rule added
- [x] @xterm types integrated
- [x] 200+ TypeScript errors fixed
- [x] 100+ ESLint errors fixed
- [x] Build and tests pass
- [x] Static assets committed