### PR TITLE
Remove dashboard model auto display

### DIFF
--- a/src/codex_autorunner/static/dashboard.js
+++ b/src/codex_autorunner/static/dashboard.js
@@ -52,10 +52,6 @@ function renderState(state) {
     if (runnerPidEl) {
         runnerPidEl.textContent = `Runner pid: ${state.runner_pid ?? "–"}`;
     }
-    const modelEl = document.getElementById("runner-model");
-    if (modelEl) {
-        modelEl.textContent = state.codex_model || "auto";
-    }
     const summaryBtn = document.getElementById("open-summary");
     if (summaryBtn) {
         const done = Number(state.outstanding_count ?? NaN) === 0;

--- a/src/codex_autorunner/static/index.html
+++ b/src/codex_autorunner/static/index.html
@@ -131,10 +131,6 @@
                   <p id="done-count" class="metric">–</p>
                 </div>
               </div>
-              <div class="runner-config">
-                <span class="runner-config-label">Model</span>
-                <span id="runner-model" class="runner-config-value">auto</span>
-              </div>
               <div class="doc-agent-controls dashboard-agent-controls">
                 <select id="dashboard-agent-select" title="Agent"></select>
                 <select id="dashboard-model-select" title="Model"></select>

--- a/src/codex_autorunner/static_src/dashboard.ts
+++ b/src/codex_autorunner/static_src/dashboard.ts
@@ -42,7 +42,6 @@ interface State {
   outstanding_count?: number | null;
   done_count?: number | null;
   runner_pid?: number | null;
-  codex_model?: string | null;
 }
 
 function renderState(state: State | null): void {
@@ -80,11 +79,6 @@ function renderState(state: State | null): void {
   if (runnerPidEl) {
     runnerPidEl.textContent = `Runner pid: ${state.runner_pid ?? "–"}`;
   }
-  const modelEl = document.getElementById("runner-model");
-  if (modelEl) {
-    modelEl.textContent = state.codex_model || "auto";
-  }
-
   const summaryBtn = document.getElementById("open-summary");
   if (summaryBtn) {
     const done = Number(state.outstanding_count ?? NaN) === 0;


### PR DESCRIPTION
## Summary
- remove the dashboard model auto summary row now replaced by the agent/model picker
- stop updating the removed model label in dashboard state rendering

## Testing
- ./scripts/check.sh
Formatting check (black)...
Linting Python (ruff)...
All checks passed!
Linting injected context hints...
Injected context hint check passed.
Linting command resolution...
Checking work docs...
Validating hub interface contracts...
✓ Hub interface contracts match schema
Type check (mypy)...
Success: no issues found in 41 source files
Linting JS/TS (eslint)...

/Users/dazheng/car-workspace/codex-autorunner/src/codex_autorunner/static_src/dashboard.ts
  304:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  392:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  460:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  461:21  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  462:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  475:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/dazheng/car-workspace/codex-autorunner/src/codex_autorunner/static_src/docChatRender.ts
   93:35  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  107:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/dazheng/car-workspace/codex-autorunner/src/codex_autorunner/static_src/docChatStream.ts
  316:72  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  333:55  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  343:71  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  386:30  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/dazheng/car-workspace/codex-autorunner/src/codex_autorunner/static_src/docsCrud.ts
  118:84  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/dazheng/car-workspace/codex-autorunner/src/codex_autorunner/static_src/docsParse.ts
  22:12  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/dazheng/car-workspace/codex-autorunner/src/codex_autorunner/static_src/hub.ts
  452:29  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  541:27  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  604:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  605:21  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  606:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  619:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/dazheng/car-workspace/codex-autorunner/src/codex_autorunner/static_src/mobileCompact.ts
   18:15  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   25:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   50:25  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   99:41  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  109:45  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  120:42  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/Users/dazheng/car-workspace/codex-autorunner/src/codex_autorunner/static_src/terminalManager.ts
   160:45  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   204:9   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   205:13  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   207:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   530:53  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   687:41  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   748:65  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   765:52  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1964:21  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1964:50  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1982:32  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1996:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2315:31  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2315:57  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  2843:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3006:47  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3046:47  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3047:43  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3053:26  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3054:47  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3126:31  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3127:79  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3212:42  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3258:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  3258:65  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

✖ 51 problems (0 errors, 51 warnings)

Build static assets (pnpm run build)...

> codex-autorunner-ui@ build /Users/dazheng/car-workspace/codex-autorunner
> tsc -p tsconfig.json

Checking static build outputs are committed...
Running tests (pytest)...
============================= test session starts ==============================
platform darwin -- Python 3.9.6, pytest-8.4.2, pluggy-1.6.0
cachedir: .codex-autorunner/pytest-cache
rootdir: /Users/dazheng/car-workspace/codex-autorunner
configfile: pyproject.toml
plugins: anyio-4.12.0
collected 493 items / 35 deselected / 458 selected

tests/core/test_path_utils.py ..........................                 [  5%]
tests/test_about_car_terminal_context.py ...                             [  6%]
tests/test_api_contract.py .                                             [  6%]
tests/test_app_server_client.py ................                         [ 10%]
tests/test_app_server_event_formatter.py ........                        [ 11%]
tests/test_app_server_events.py ..                                       [ 12%]
tests/test_app_server_prompts.py ...                                     [ 12%]
tests/test_app_server_supervisor.py .                                    [ 13%]
tests/test_app_server_thread_registry.py ..                              [ 13%]
tests/test_auth_middleware.py ..............                             [ 16%]
tests/test_base_path.py ......                                           [ 17%]
tests/test_base_path_static.py ......                                    [ 19%]
tests/test_chatops.py ........                                           [ 20%]
tests/test_cli_init.py .....                                             [ 22%]
tests/test_cli_sessions.py ..                                            [ 22%]
tests/test_cli_snapshot.py .                                             [ 22%]
tests/test_cli_status.py ..                                              [ 23%]
tests/test_codex_cli_flags.py .                                          [ 23%]
tests/test_codex_runner.py ..                                            [ 23%]
tests/test_config_resolution.py .........                                [ 25%]
tests/test_doc_chat.py ................                                  [ 29%]
tests/test_doc_chat_ui.py .                                              [ 29%]
tests/test_docs_todos.py .                                               [ 29%]
tests/test_docs_validation.py ...                                        [ 30%]
tests/test_engine_app_server.py .....                                    [ 31%]
tests/test_engine_logs.py ..                                             [ 31%]
tests/test_github_context_hook.py .....                                  [ 32%]
tests/test_github_service.py ..........                                  [ 35%]
tests/test_github_sync_pr_agentic.py ....                                [ 36%]
tests/test_housekeeping.py .....                                         [ 37%]
tests/test_hub_create.py ......                                          [ 38%]
tests/test_hub_foundation.py .....                                       [ 39%]
tests/test_hub_supervisor.py ............                                [ 42%]
tests/test_hub_terminal_sessions.py .                                    [ 42%]
tests/test_hub_ui_escape.py .                                            [ 42%]
tests/test_lock_utils.py ..                                              [ 43%]
tests/test_logging_utils.py ....                                         [ 43%]
tests/test_notifications.py ..                                           [ 44%]
tests/test_opencode_model_catalog.py .                                   [ 44%]
tests/test_opencode_review_arguments.py ....                             [ 45%]
tests/test_opencode_runtime.py ................                          [ 48%]
tests/test_optional_dependencies.py ...                                  [ 49%]
tests/test_origin_middleware.py ....                                     [ 50%]
tests/test_patch_utils.py ....                                           [ 51%]
tests/test_pr_flow.py .............                                      [ 54%]
tests/test_prompt.py ...                                                 [ 54%]
tests/test_request_logging.py ...                                        [ 55%]
tests/test_review_service.py ..                                          [ 55%]
tests/test_runner_controller.py ..                                       [ 56%]
tests/test_snapshot_api.py ...                                           [ 56%]
tests/test_snapshot_core.py ..                                           [ 57%]
tests/test_snapshot_incremental.py ....                                  [ 58%]
tests/test_spec_ingest.py ..                                             [ 58%]
tests/test_sse_streams.py .                                              [ 58%]
tests/test_state_lock.py .                                               [ 59%]
tests/test_state_sessions.py .                                           [ 59%]
tests/test_static.py ....                                                [ 60%]
tests/test_static_asset_cache.py .......                                 [ 61%]
tests/test_system_update_check.py .                                      [ 62%]
tests/test_system_update_worker.py ...........                           [ 64%]
tests/test_telegram_adapter.py ...................................       [ 72%]
tests/test_telegram_bot_config.py ............                           [ 74%]
tests/test_telegram_bot_lock.py ..                                       [ 75%]
tests/test_telegram_cache_cleanup.py .                                   [ 75%]
tests/test_telegram_command_registry.py ...                              [ 75%]
tests/test_telegram_fast_ack.py ...                                      [ 76%]
tests/test_telegram_handlers_callbacks.py ........                       [ 78%]
tests/test_telegram_handlers_messages.py .........................       [ 83%]
tests/test_telegram_interrupt_status.py ...                              [ 84%]
tests/test_telegram_media_batch_failure.py ..                            [ 84%]
tests/test_telegram_opencode_context_cache.py ..                         [ 85%]
tests/test_telegram_opencode_usage.py ...                                [ 86%]
tests/test_telegram_outbox.py .                                          [ 86%]
tests/test_telegram_overflow.py ...                                      [ 86%]
tests/test_telegram_paths_compatible.py ...                              [ 87%]
tests/test_telegram_pr_flow.py ....                                      [ 88%]
tests/test_telegram_progress_stream.py .                                 [ 88%]
tests/test_telegram_review_opencode.py ..                                [ 89%]
tests/test_telegram_state.py .                                           [ 89%]
tests/test_telegram_status_rate_limits.py ..                             [ 89%]
tests/test_telegram_task_tracking.py .                                   [ 89%]
tests/test_telegram_thread_paths.py ..                                   [ 90%]
tests/test_telegram_topic_queue.py .                                     [ 90%]
tests/test_telegram_transport.py ...                                     [ 91%]
tests/test_telegram_turn_queue.py ....                                   [ 92%]
tests/test_telegram_update_dedupe.py ..                                  [ 92%]
tests/test_telegram_whisper_disclaimer.py ...                            [ 93%]
tests/test_terminal_idle_timeout.py ..                                   [ 93%]
tests/test_terminal_input_dedupe.py ...                                  [ 94%]
tests/test_usage.py ......                                               [ 95%]
tests/test_voice_capture.py ..                                           [ 96%]
tests/test_voice_config.py ...                                           [ 96%]
tests/test_voice_service.py ...                                          [ 97%]
tests/test_voice_transcribe_endpoint.py .                                [ 97%]
tests/test_voice_ui.py .                                                 [ 97%]
tests/test_voice_whisper_mime_types.py ....                              [ 98%]
tests/test_voice_whisper_provider.py ....                                [ 99%]
tests/test_workspace_helpers.py ..                                       [100%]

=============================== warnings summary ===============================
.venv/lib/python3.9/site-packages/_pytest/config/__init__.py:1474
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

.venv/lib/python3.9/site-packages/_pytest/config/__init__.py:1474
  /Users/dazheng/car-workspace/codex-autorunner/.venv/lib/python3.9/site-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

tests/test_opencode_integration.py:65
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:65: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:76
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:76: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:87
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:87: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:101
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:101: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:125
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:125: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:141
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:141: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:169
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:169: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:194
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:194: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:243
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:243: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:260
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:260: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:284
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:284: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:311
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:311: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:341
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:341: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:369
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:369: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:417
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:417: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:440
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:440: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

tests/test_opencode_integration.py:464
  /Users/dazheng/car-workspace/codex-autorunner/tests/test_opencode_integration.py:464: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============== 458 passed, 35 deselected, 19 warnings in 15.87s ===============
Dead-code check (heuristic)...
New likely-dead code (not in baseline): none
Checks passed.