### PR TITLE
refactor: Make SharedHelpers a base class for all command mixins

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands/approvals.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/approvals.py
@@ -13,9 +13,10 @@ from ...helpers import (
     _normalize_approval_preset,
     _set_policy_overrides,
 )
+from .shared import SharedHelpers
 
 
-class ApprovalsCommands:
+class ApprovalsCommands(SharedHelpers):
     async def _read_rate_limits(
         self, workspace_path: Optional[str], *, agent: str
     ) -> Optional[dict[str, Any]]:

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -6,7 +6,6 @@ import logging
 import math
 import re
 import secrets
-import shlex
 import time
 from contextlib import suppress
 from dataclasses import dataclass
@@ -79,6 +78,8 @@ from ...helpers import (
 
 if TYPE_CHECKING:
     from ...state import TelegramTopicRecord
+
+from .shared import SharedHelpers
 
 PROMPT_CONTEXT_RE = re.compile(r"\bprompt\b", re.IGNORECASE)
 PROMPT_CONTEXT_HINT = (
@@ -453,7 +454,7 @@ def _format_download_failure_response(kind: str, detail: Optional[str]) -> str:
     return base
 
 
-class ExecutionCommands:
+class ExecutionCommands(SharedHelpers):
     """Execution-related command handlers for Telegram integration."""
 
     def _maybe_append_whisper_disclaimer(
@@ -600,14 +601,6 @@ class ExecutionCommands:
             )
         )
         return f"{prompt_text}{separator}{injection}", True
-
-    def _parse_command_args(self, args: str) -> list[str]:
-        if not args:
-            return []
-        try:
-            return [part for part in shlex.split(args) if part]
-        except ValueError:
-            return [part for part in args.split() if part]
 
     def _effective_policies(
         self, record: "TelegramTopicRecord"

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/github.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/github.py
@@ -71,6 +71,8 @@ from ..utils import _build_opencode_token_usage
 if TYPE_CHECKING:
     from ...state import TelegramTopicRecord
 
+from .shared import SharedHelpers
+
 
 def _opencode_review_arguments(target: dict[str, Any]) -> str:
     target_type = target.get("type")
@@ -94,7 +96,7 @@ def _opencode_review_arguments(target: dict[str, Any]) -> str:
     return json.dumps(target, sort_keys=True)
 
 
-class GitHubCommands:
+class GitHubCommands(SharedHelpers):
     """GitHub/PR command handlers for Telegram integration.
 
     This class is designed to be used as a mixin in command handler classes.
@@ -1495,8 +1497,7 @@ class GitHubCommands:
         )
         await self._send_message(
             message.chat_id,
-            f"Detected GitHub issue: {slug}#{number}\n"
-            f"Start PR flow to create a PR?",
+            f"Detected GitHub issue: {slug}#{number}\nStart PR flow to create a PR?",
             thread_id=message.thread_id,
             reply_to=message.message_id,
             reply_markup=keyboard,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/voice.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/voice.py
@@ -11,8 +11,10 @@ from ...state import PendingVoiceRecord
 if TYPE_CHECKING:
     pass
 
+from .shared import SharedHelpers
 
-class VoiceCommands:
+
+class VoiceCommands(SharedHelpers):
     async def _send_voice_progress_message(
         self, record: PendingVoiceRecord, text: str
     ) -> Optional[int]:

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -56,6 +56,7 @@ from ...helpers import (
 )
 from ...state import APPROVAL_MODE_YOLO, normalize_agent
 from ...types import SelectionState
+from .shared import SharedHelpers
 
 if TYPE_CHECKING:
     from ...state import TelegramTopicRecord
@@ -80,8 +81,7 @@ def _extract_opencode_session_path(payload: Any) -> Optional[str]:
     return None
 
 
-class WorkspaceCommands:
-
+class WorkspaceCommands(SharedHelpers):
     async def _apply_agent_change(
         self,
         chat_id: int,


### PR DESCRIPTION
## Summary
All command mixin classes now inherit from `SharedHelpers`:
- `WorkspaceCommands(SharedHelpers)`
- `GitHubCommands(SharedHelpers)`
- `FilesCommands(SharedHelpers)` - already inherited
- `VoiceCommands(SharedHelpers)`
- `ExecutionCommands(SharedHelpers)`
- `ApprovalsCommands(SharedHelpers)`

Also removes duplicate `_parse_command_args` from `ExecutionCommands` since it's already defined in `SharedHelpers`.

## Benefits
- Consistent access to shared utility methods across all command modules
- Clearer inheritance hierarchy
- Easier maintenance when adding new shared utilities
- Reduced code duplication

Resolves #304