### PR TITLE
Fix #316: Reduce console errors from state streaming and doc chat polling

### DIFF
--- a/src/codex_autorunner/static/docChatActions.js
+++ b/src/codex_autorunner/static/docChatActions.js
@@ -271,6 +271,11 @@ export async function reloadPatch(kind = getActiveDoc(), silent = false) {
             if (!silent)
                 flash("No pending draft");
         }
+        else if (message.includes("Autorunner") &&
+            (message.includes("running") || message.includes("lock") || message.includes("blocked"))) {
+            if (!silent)
+                flash(message || "Repo busy; try again later", "info");
+        }
         else if (!silent) {
             flash(message || "Failed to load pending draft", "error");
         }

--- a/src/codex_autorunner/static/state.js
+++ b/src/codex_autorunner/static/state.js
@@ -25,7 +25,9 @@ export function startStatePolling() {
             return;
         loadState({ notify: false }).catch(() => { });
         cancelStream = streamEvents("/api/state/stream", {
-            onMessage: (data) => {
+            onMessage: (data, event) => {
+                if (event && event !== "message")
+                    return;
                 try {
                     const state = JSON.parse(data);
                     publish("state:update", state);

--- a/src/codex_autorunner/static_src/docChatActions.ts
+++ b/src/codex_autorunner/static_src/docChatActions.ts
@@ -289,6 +289,11 @@ export async function reloadPatch(kind: DocType | null = getActiveDoc() as DocTy
         syncDocEditor(kind, { force: true });
       }
       if (!silent) flash("No pending draft");
+    } else if (
+      message.includes("Autorunner") &&
+      (message.includes("running") || message.includes("lock") || message.includes("blocked"))
+    ) {
+      if (!silent) flash(message || "Repo busy; try again later", "info");
     } else if (!silent) {
       flash(message || "Failed to load pending draft", "error");
     }

--- a/src/codex_autorunner/static_src/state.ts
+++ b/src/codex_autorunner/static_src/state.ts
@@ -31,7 +31,8 @@ export function startStatePolling(): () => void {
     loadState({ notify: false }).catch(() => {});
 
     cancelStream = streamEvents("/api/state/stream", {
-      onMessage: (data: string) => {
+      onMessage: (data: string, event: string) => {
+        if (event && event !== "message") return;
         try {
           const state = JSON.parse(data);
           publish("state:update", state);


### PR DESCRIPTION
## Summary
Fixes two sources of noisy console errors in the web UI:

1. **SSE timeout events**: Server sends `event: timeout` events with plain text data, but frontend was trying to parse as JSON, causing "Bad state payload" errors. Now filters non-"message" events.

2. **409 conflicts during polling**: When autorunner is running, the `/api/docs/*/chat/pending` endpoint returns 409 errors repeatedly. These are now handled as info-level messages instead of errors, since they represent expected temporary states (repo busy/locked).

## Changes
- `state.ts`: Add event parameter to `onMessage` callback and skip non-"message" events
- `docChatActions.ts`: Detect autorunner busy errors and show info flash instead of error

Resolves #316