### PR TITLE
Fix OpenCode event stream parsing

### DIFF
--- a/tests/test_opencode_client.py
+++ b/tests/test_opencode_client.py
@@ -1,0 +1,37 @@
+import json
+
+from codex_autorunner.agents.opencode.client import _normalize_sse_event
+from codex_autorunner.agents.opencode.events import SSEEvent
+
+
+def test_normalize_sse_event_unwraps_payload() -> None:
+    event = SSEEvent(
+        event="message",
+        data=(
+            '{"directory":"/repo","payload":{"type":"message.part.updated","properties":'
+            '{"sessionID":"s1"}}}'
+        ),
+    )
+    normalized = _normalize_sse_event(event)
+    assert normalized.event == "message.part.updated"
+    assert json.loads(normalized.data) == {
+        "type": "message.part.updated",
+        "properties": {"sessionID": "s1"},
+    }
+
+
+def test_normalize_sse_event_uses_payload_type() -> None:
+    event = SSEEvent(
+        event="message",
+        data='{"type":"session.idle","sessionID":"s1"}',
+    )
+    normalized = _normalize_sse_event(event)
+    assert normalized.event == "session.idle"
+    assert json.loads(normalized.data) == {"type": "session.idle", "sessionID": "s1"}
+
+
+def test_normalize_sse_event_keeps_non_json() -> None:
+    event = SSEEvent(event="message", data="ping")
+    normalized = _normalize_sse_event(event)
+    assert normalized.event == "message"
+    assert normalized.data == "ping"


### PR DESCRIPTION
## Summary
- normalize OpenCode SSE events to unwrap `/global/event` payloads and emit correct event types
- prefer per-directory `/event` streams when available to avoid wrapper-only payloads
- add coverage for SSE normalization behavior

## Testing
- `tests/test_opencode_client.py`
