### PR TITLE
Fix OpenCode autorunner stall (#325)

### DIFF
--- a/src/codex_autorunner/agents/opencode/client.py
+++ b/src/codex_autorunner/agents/opencode/client.py
@@ -246,6 +246,14 @@ class OpenCodeClient:
     async def get_session(self, session_id: str) -> Any:
         return await self._request("GET", f"/session/{session_id}", expect_json=True)
 
+    async def session_status(self, *, directory: Optional[str] = None) -> Any:
+        return await self._request(
+            "GET",
+            "/session/status",
+            params=self._dir_params(directory),
+            expect_json=True,
+        )
+
     async def send_message(
         self,
         session_id: str,

--- a/src/codex_autorunner/agents/opencode/harness.py
+++ b/src/codex_autorunner/agents/opencode/harness.py
@@ -236,7 +236,11 @@ class OpenCodeHarness(AgentHarness):
             session_id = extract_session_id(parsed)
             status_type = None
             if event.event == "session.status" and isinstance(parsed, dict):
-                status = parsed.get("status") or {}
+                properties = parsed.get("properties")
+                if isinstance(properties, dict):
+                    status = properties.get("status") or {}
+                else:
+                    status = parsed.get("status") or {}
                 if isinstance(status, dict):
                     status_type = status.get("type") or status.get("status")
             if (


### PR DESCRIPTION
Fixes #325

## Summary

This PR fixes the autorunner hanging between agents when using OpenCode. The issue was that CAR couldn't detect when OpenCode sessions became idle.

## Changes

### Root Cause A: Parse `session.status` correctly
- Updated `_extract_status_type()` to correctly parse `properties.status.type` from OpenCode's `session.status` event payloads
- Also updated `harness.py` to check status under `properties` when parsing `session.status` events

### Root Cause B: Poll correct endpoint for status
- Added `session_status()` method to `OpenCodeClient` to call OpenCode's `GET /session/status` endpoint
- Updated `_fetch_session()` to use the new `session_status()` method
- Fixed return shape to be consistent: always returns `{"status": {...}}` instead of sometimes `{}`

### Root Cause C: `/global/event` handling
- The existing `_normalize_sse_event()` already correctly unwraps `{payload: {...}}` format from `/global/event`
- No changes needed for this case

## Testing

- All unit tests pass (19 tests in `test_opencode_runtime.py` and `test_opencode_client.py`)
- Full test suite passes (561 tests)