### PR TITLE
feat: Add run index reconciliation for authoritative runner status

### DIFF
--- a/tests/test_runner_controller.py
+++ b/tests/test_runner_controller.py
@@ -44,3 +44,223 @@ def test_start_and_resume_spawn_commands(repo: Path) -> None:
     assert calls[0][3] == "once"
     assert calls[1][3] == "resume"
     assert calls[1][-1] == "--once"
+
+
+def test_reconcile_run_index_stale_entries(repo: Path, monkeypatch) -> None:
+    engine = Engine(repo)
+    state = load_state(engine.state_path)
+    state.status = "idle"
+    state.runner_pid = None
+    state.last_run_id = 2
+    state.last_exit_code = 1
+    save_state(engine.state_path, state)
+
+    engine._run_index_store.merge_entry(1, {"started_at": "2025-01-01T00:00:00Z"})
+    engine._run_index_store.merge_entry(2, {"started_at": "2025-01-01T01:00:00Z"})
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.locks.process_alive",
+        lambda _pid: False,
+    )
+
+    engine.reconcile_run_index()
+
+    index = engine._load_run_index()
+    entry_1 = index.get("1", {})
+    entry_2 = index.get("2", {})
+
+    assert entry_1.get("finished_at") is not None
+    assert entry_1.get("exit_code") == 1
+    assert entry_1.get("reconciled_at") is not None
+    assert entry_1.get("reconciled_reason") == "runner_inactive"
+
+    assert entry_2.get("finished_at") is not None
+    assert entry_2.get("exit_code") == 1
+    assert entry_2.get("reconciled_at") is not None
+    assert entry_2.get("reconciled_reason") == "runner_inactive"
+
+
+def test_reconcile_run_index_active_run_not_modified(repo: Path, monkeypatch) -> None:
+    from codex_autorunner.core import engine
+
+    engine_instance = Engine(repo)
+    state = load_state(engine_instance.state_path)
+    state.status = "running"
+    state.runner_pid = 12345
+    state.last_run_id = 3
+    state.last_exit_code = None
+    save_state(engine_instance.state_path, state)
+
+    engine_instance._run_index_store.merge_entry(
+        1, {"started_at": "2025-01-01T00:00:00Z"}
+    )
+    engine_instance._run_index_store.merge_entry(
+        2, {"started_at": "2025-01-01T01:00:00Z"}
+    )
+    engine_instance._run_index_store.merge_entry(
+        3, {"started_at": "2025-01-01T02:00:00Z"}
+    )
+
+    monkeypatch.setattr(engine, "process_alive", lambda _pid: True)
+
+    engine_instance.reconcile_run_index()
+
+    index = engine_instance._load_run_index()
+    entry_1 = index.get("1", {})
+    entry_2 = index.get("2", {})
+    entry_3 = index.get("3", {})
+
+    assert entry_1.get("finished_at") is not None
+    assert entry_1.get("exit_code") == 1
+
+    assert entry_2.get("finished_at") is not None
+    assert entry_2.get("exit_code") == 1
+
+    assert entry_3.get("finished_at") is None
+    assert entry_3.get("exit_code") is None
+    assert entry_3.get("reconciled_at") is None
+
+
+def test_reconcile_run_index_already_reconciled_not_modified(
+    repo: Path, monkeypatch
+) -> None:
+    engine = Engine(repo)
+    state = load_state(engine.state_path)
+    state.status = "idle"
+    state.runner_pid = None
+    state.last_run_id = 1
+    save_state(engine.state_path, state)
+
+    engine._run_index_store.merge_entry(
+        1,
+        {
+            "started_at": "2025-01-01T00:00:00Z",
+            "finished_at": "2025-01-01T00:05:00Z",
+            "exit_code": 0,
+            "reconciled_at": "2025-01-01T00:10:00Z",
+        },
+    )
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.locks.process_alive",
+        lambda _pid: False,
+    )
+
+    original_finished_at = engine._load_run_index().get("1", {}).get("finished_at")
+    engine.reconcile_run_index()
+
+    index = engine._load_run_index()
+    entry = index.get("1", {})
+
+    assert entry.get("finished_at") == original_finished_at
+    assert entry.get("exit_code") == 0
+
+
+def test_reconcile_run_index_completed_entries_not_modified(
+    repo: Path, monkeypatch
+) -> None:
+    engine = Engine(repo)
+    state = load_state(engine.state_path)
+    state.status = "idle"
+    state.runner_pid = None
+    state.last_run_id = 2
+    save_state(engine.state_path, state)
+
+    engine._run_index_store.merge_entry(
+        1,
+        {
+            "started_at": "2025-01-01T00:00:00Z",
+            "finished_at": "2025-01-01T00:05:00Z",
+            "exit_code": 0,
+        },
+    )
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.locks.process_alive",
+        lambda _pid: False,
+    )
+
+    original_finished_at = engine._load_run_index().get("1", {}).get("finished_at")
+    engine.reconcile_run_index()
+
+    index = engine._load_run_index()
+    entry = index.get("1", {})
+
+    assert entry.get("finished_at") == original_finished_at
+    assert entry.get("exit_code") == 0
+    assert entry.get("reconciled_at") is None
+
+
+def test_reconcile_run_index_uses_last_exit_code(repo: Path, monkeypatch) -> None:
+    engine = Engine(repo)
+    state = load_state(engine.state_path)
+    state.status = "idle"
+    state.runner_pid = None
+    state.last_run_id = 2
+    state.last_exit_code = 42
+    save_state(engine.state_path, state)
+
+    engine._run_index_store.merge_entry(1, {"started_at": "2025-01-01T00:00:00Z"})
+    engine._run_index_store.merge_entry(2, {"started_at": "2025-01-01T01:00:00Z"})
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.locks.process_alive",
+        lambda _pid: False,
+    )
+
+    engine.reconcile_run_index()
+
+    index = engine._load_run_index()
+    entry_1 = index.get("1", {})
+    entry_2 = index.get("2", {})
+
+    assert entry_1.get("finished_at") is not None
+    assert entry_1.get("exit_code") == 1
+
+    assert entry_2.get("finished_at") is not None
+    assert entry_2.get("exit_code") == 42
+
+
+def test_reconcile_run_index_runner_active_different_run(
+    repo: Path, monkeypatch
+) -> None:
+    from codex_autorunner.core import engine as engine_module
+
+    engine_instance = Engine(repo)
+    state = load_state(engine_instance.state_path)
+    state.status = "running"
+    state.runner_pid = 12345
+    state.last_run_id = 3
+    state.last_exit_code = None
+    save_state(engine_instance.state_path, state)
+
+    engine_instance._run_index_store.merge_entry(
+        1, {"started_at": "2025-01-01T00:00:00Z"}
+    )
+    engine_instance._run_index_store.merge_entry(
+        2, {"started_at": "2025-01-01T01:00:00Z"}
+    )
+    engine_instance._run_index_store.merge_entry(
+        3, {"started_at": "2025-01-01T02:00:00Z"}
+    )
+
+    monkeypatch.setattr(engine_module, "process_alive", lambda _pid: True)
+
+    engine_instance.reconcile_run_index()
+
+    index = engine_instance._load_run_index()
+    entry_1 = index.get("1", {})
+    entry_2 = index.get("2", {})
+    entry_3 = index.get("3", {})
+
+    assert entry_1.get("finished_at") is not None
+    assert entry_1.get("exit_code") == 1
+    assert entry_1.get("reconciled_reason") == "runner_active"
+
+    assert entry_2.get("finished_at") is not None
+    assert entry_2.get("exit_code") == 1
+    assert entry_2.get("reconciled_reason") == "runner_active"
+
+    assert entry_3.get("finished_at") is None
+    assert entry_3.get("exit_code") is None
+    assert entry_3.get("reconciled_at") is None


### PR DESCRIPTION
Fixes https://github.com/Git-on-my-level/codex-autorunner/issues/335
## Summary

Adds reconciliation logic so stale "RUNNING" runs self-heal based on runner truth, using `RunnerState` and lock PID as the authoritative signal for active run status.

### Problem
The Runs UI derives status from `run_index` (`finished_at`/`exit_code`), which is not authoritative if the runner dies before emitting the `end` marker. This causes runs to appear stuck in "RUNNING" state indefinitely.

### Solution
- Implement `reconcile_run_index()` method that uses `RunnerState.runner_pid` or lock PID to determine if a runner is active
- Mark stale entries without `finished_at`/`exit_code` as completed with appropriate exit codes
- Reconciliation runs automatically at:
  - After `/api/run/kill`
  - Before serving `/api/runs`
  - On runner startup or resume
- Active runs are protected from modification

### Changes
- **src/codex_autorunner/core/engine.py**: Add `reconcile_run_index()` method (lines 839-921)
- **Integration points**:
  - `routes/repos.py:126` - after kill endpoint
  - `routes/runs.py:70` - before runs endpoint
  - `runner_controller.py:57,89` - on startup/resume
- **tests/test_runner_controller.py**: Add 6 comprehensive test cases covering:
  - Stale run entries reconciliation
  - Active run protection
  - Idempotency
  - Completed entries handling
  - Exit code inference from `RunnerState.last_exit_code`
  - Runner active state scenarios

### Testing
All tests pass (8/8 in test_runner_controller.py).