### PR TITLE
Fix OpenCode ctx% backfill

### DIFF
--- a/src/codex_autorunner/agents/opencode/run_prompt.py
+++ b/src/codex_autorunner/agents/opencode/run_prompt.py
@@ -112,6 +112,7 @@ async def run_opencode_prompt(
             client,
             session_id=session_id,
             workspace_path=config.workspace_root,
+            model_payload=model_payload,
             permission_policy=permission_policy,
             should_stop=should_stop,
             ready_event=ready_event,

--- a/src/codex_autorunner/core/doc_chat.py
+++ b/src/codex_autorunner/core/doc_chat.py
@@ -1109,6 +1109,7 @@ class DocChatService:
                     client,
                     session_id=thread_id,
                     workspace_path=str(self.engine.repo_root),
+                    model_payload=model_payload,
                     permission_policy=permission_policy,
                     question_policy="auto_first_option",
                     should_stop=active.interrupt_event.is_set,

--- a/src/codex_autorunner/core/engine.py
+++ b/src/codex_autorunner/core/engine.py
@@ -1624,6 +1624,7 @@ class Engine:
                 client,
                 session_id=thread_id,
                 workspace_path=str(self.repo_root),
+                model_payload=model_payload,
                 permission_policy=permission_policy,
                 question_policy="auto_first_option",
                 should_stop=active.interrupt_event.is_set,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -1692,6 +1692,7 @@ class ExecutionCommands(SharedHelpers):
                             opencode_client,
                             session_id=thread_id,
                             workspace_path=str(workspace_root),
+                            model_payload=model_payload,
                             progress_session_ids=watched_session_ids,
                             permission_policy=permission_policy,
                             permission_handler=(

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/github.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/github.py
@@ -1212,6 +1212,7 @@ class GitHubCommands(SharedHelpers):
                         setup.client,
                         session_id=setup.review_session_id,
                         workspace_path=str(setup.workspace_root),
+                        model_payload=model_payload,
                         progress_session_ids=watched_session_ids,
                         permission_policy=setup.permission_policy,
                         permission_handler=(

--- a/src/codex_autorunner/spec_ingest.py
+++ b/src/codex_autorunner/spec_ingest.py
@@ -618,6 +618,7 @@ class SpecIngestService:
                 client,
                 session_id=thread_id,
                 workspace_path=str(self.engine.repo_root),
+                model_payload=model_payload,
                 permission_policy=permission_policy,
                 question_policy="auto_first_option",
                 should_stop=active.interrupt_event.is_set,


### PR DESCRIPTION
## Summary
- ensure opencode usage snapshots always include provider/model ids and modelContextWindow even when SSE payloads omit them
- feed selected model into usage collection across orchestrator/engine/doc chat/spec ingest/telegram
- add regression coverage for provider-based context window backfill

## Testing
- make check

Closes #337.