### PR TITLE
Fix stalls in app-server and OpenCode

### DIFF
--- a/src/codex_autorunner/agents/opencode/client.py
+++ b/src/codex_autorunner/agents/opencode/client.py
@@ -48,7 +48,18 @@ def _normalize_sse_event(event: SSEEvent) -> SSEEvent:
         payload_obj = None
 
     if isinstance(payload_obj, dict) and isinstance(payload_obj.get("payload"), dict):
-        payload_obj = payload_obj["payload"]
+        outer = payload_obj
+        inner = dict(outer.get("payload") or {})
+        if "type" not in inner and isinstance(outer.get("type"), str):
+            inner["type"] = outer["type"]
+        for key in ("sessionID", "sessionId", "session_id"):
+            if key in outer and key not in inner:
+                inner[key] = outer[key]
+        if "session" in outer and "session" not in inner:
+            inner["session"] = outer["session"]
+        if "properties" in outer and "properties" not in inner:
+            inner["properties"] = outer["properties"]
+        payload_obj = inner
 
     if isinstance(payload_obj, dict):
         payload_type = payload_obj.get("type")

--- a/src/codex_autorunner/agents/opencode/logging.py
+++ b/src/codex_autorunner/agents/opencode/logging.py
@@ -120,6 +120,27 @@ class OpenCodeEventFormatter:
             lines.append("exec")
             lines.append(f"tool: {tool_name}")
 
+        input_preview: Optional[str] = None
+        for key in ("input", "command", "cmd", "script"):
+            value = part.get(key)
+            if isinstance(value, str) and value.strip():
+                input_preview = value.strip()
+                break
+        if input_preview is None:
+            args = part.get("args") or part.get("arguments") or part.get("params")
+            if isinstance(args, dict):
+                for key in ("command", "cmd", "script", "input"):
+                    value = args.get(key)
+                    if isinstance(value, str) and value.strip():
+                        input_preview = value.strip()
+                        break
+            elif isinstance(args, str) and args.strip():
+                input_preview = args.strip()
+        if input_preview:
+            if len(input_preview) > 240:
+                input_preview = input_preview[:240] + "…"
+            lines.append(f"input: {input_preview}")
+
         return lines
 
     def _format_patch_part(self, part: dict[str, Any]) -> list[str]:

--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -138,7 +138,7 @@ def extract_session_id(
                 return value
     session = payload.get("session")
     if isinstance(session, dict):
-        return extract_session_id(session, allow_fallback_id=allow_fallback_id)
+        return extract_session_id(session, allow_fallback_id=True)
     return None
 
 
@@ -947,7 +947,7 @@ async def collect_opencode_output_from_events(
             await aclose()
 
     stream_iter = _new_stream().__aiter__()
-    last_event_at = time.monotonic()
+    last_relevant_event_at = time.monotonic()
     last_primary_completion_at: Optional[float] = None
     reconnect_attempts = 0
     can_reconnect = (
@@ -982,6 +982,7 @@ async def collect_opencode_output_from_events(
                             session_id=session_id,
                             exc=exc,
                         )
+                idle_seconds = now - last_relevant_event_at
                 if _status_is_idle(status_type):
                     log_event(
                         logger,
@@ -989,7 +990,7 @@ async def collect_opencode_output_from_events(
                         "opencode.stream.stalled.session_idle",
                         session_id=session_id,
                         status_type=status_type,
-                        idle_seconds=now - last_event_at,
+                        idle_seconds=idle_seconds,
                     )
                     if not text_parts and pending_text:
                         _flush_all_pending_text()
@@ -1001,7 +1002,7 @@ async def collect_opencode_output_from_events(
                         "opencode.stream.stalled.after_completion",
                         session_id=session_id,
                         status_type=status_type,
-                        idle_seconds=now - last_event_at,
+                        idle_seconds=idle_seconds,
                     )
                 if not can_reconnect:
                     break
@@ -1016,7 +1017,7 @@ async def collect_opencode_output_from_events(
                     logging.WARNING,
                     "opencode.stream.stalled.reconnecting",
                     session_id=session_id,
-                    idle_seconds=now - last_event_at,
+                    idle_seconds=idle_seconds,
                     backoff_seconds=backoff,
                     status_type=status_type,
                     attempts=reconnect_attempts,
@@ -1024,21 +1025,86 @@ async def collect_opencode_output_from_events(
                 await _close_stream(stream_iter)
                 await asyncio.sleep(backoff)
                 stream_iter = _new_stream().__aiter__()
+                last_relevant_event_at = now
                 continue
-            last_event_at = time.monotonic()
+            now = time.monotonic()
             raw = event.data or ""
             try:
                 payload = json.loads(raw) if raw else {}
             except json.JSONDecodeError:
                 payload = {}
             event_session_id = extract_session_id(payload)
-            if not event_session_id:
+            is_relevant = False
+            if event_session_id:
+                if progress_session_ids is None:
+                    is_relevant = event_session_id == session_id
+                else:
+                    is_relevant = event_session_id in progress_session_ids
+            if not is_relevant:
+                if (
+                    stall_timeout_seconds is not None
+                    and now - last_relevant_event_at > stall_timeout_seconds
+                ):
+                    idle_seconds = now - last_relevant_event_at
+                    last_relevant_event_at = now
+                    status_type = None
+                    if session_fetcher is not None:
+                        try:
+                            payload = await session_fetcher()
+                            status_type = _extract_status_type(payload)
+                        except Exception as exc:
+                            log_event(
+                                logger,
+                                logging.WARNING,
+                                "opencode.session.poll_failed",
+                                session_id=session_id,
+                                exc=exc,
+                            )
+                    if _status_is_idle(status_type):
+                        log_event(
+                            logger,
+                            logging.INFO,
+                            "opencode.stream.stalled.session_idle",
+                            session_id=session_id,
+                            status_type=status_type,
+                            idle_seconds=idle_seconds,
+                        )
+                        if not text_parts and pending_text:
+                            _flush_all_pending_text()
+                        break
+                    if last_primary_completion_at is not None:
+                        log_event(
+                            logger,
+                            logging.INFO,
+                            "opencode.stream.stalled.after_completion",
+                            session_id=session_id,
+                            status_type=status_type,
+                            idle_seconds=idle_seconds,
+                        )
+                    if not can_reconnect:
+                        break
+                    backoff_index = min(
+                        reconnect_attempts,
+                        len(_OPENCODE_STREAM_RECONNECT_BACKOFF_SECONDS) - 1,
+                    )
+                    backoff = _OPENCODE_STREAM_RECONNECT_BACKOFF_SECONDS[backoff_index]
+                    reconnect_attempts += 1
+                    log_event(
+                        logger,
+                        logging.WARNING,
+                        "opencode.stream.stalled.reconnecting",
+                        session_id=session_id,
+                        idle_seconds=idle_seconds,
+                        backoff_seconds=backoff,
+                        status_type=status_type,
+                        attempts=reconnect_attempts,
+                    )
+                    await _close_stream(stream_iter)
+                    await asyncio.sleep(backoff)
+                    stream_iter = _new_stream().__aiter__()
                 continue
-            if progress_session_ids is None:
-                if event_session_id != session_id:
-                    continue
-            elif event_session_id not in progress_session_ids:
-                continue
+            last_relevant_event_at = now
+            reconnect_attempts = 0
             is_primary_session = event_session_id == session_id
             if event.event == "question.asked":
                 request_id, props = _extract_question_request(payload)
@@ -1428,6 +1494,7 @@ async def collect_opencode_output(
     should_stop: Optional[Callable[[], bool]] = None,
     ready_event: Optional[Any] = None,
     part_handler: Optional[PartHandler] = None,
+    stall_timeout_seconds: Optional[float] = _OPENCODE_STREAM_STALL_TIMEOUT_SECONDS,
 ) -> OpenCodeTurnOutput:
     async def _respond(request_id: str, reply: str) -> None:
         await client.respond_permission(request_id=request_id, reply=reply)
@@ -1471,6 +1538,7 @@ async def collect_opencode_output(
         event_stream_factory=_stream_factory,
         session_fetcher=_fetch_session,
         provider_fetcher=_fetch_providers,
+        stall_timeout_seconds=stall_timeout_seconds,
     )
 
 

--- a/src/codex_autorunner/agents/opencode/supervisor.py
+++ b/src/codex_autorunner/agents/opencode/supervisor.py
@@ -53,12 +53,14 @@ class OpenCodeSupervisor:
         base_env: Optional[Mapping[str, str]] = None,
         base_url: Optional[str] = None,
         subagent_models: Optional[Mapping[str, str]] = None,
+        session_stall_timeout_seconds: Optional[float] = None,
     ) -> None:
         self._command = [str(arg) for arg in command]
         self._logger = logger or logging.getLogger(__name__)
         self._request_timeout = request_timeout
         self._max_handles = max_handles
         self._idle_ttl_seconds = idle_ttl_seconds
+        self._session_stall_timeout_seconds = session_stall_timeout_seconds
         if password and not username:
             username = "opencode"
         self._auth: Optional[tuple[str, str]] = (
@@ -69,6 +71,10 @@ class OpenCodeSupervisor:
         self._subagent_models = subagent_models or {}
         self._handles: dict[str, OpenCodeHandle] = {}
         self._lock: Optional[asyncio.Lock] = None
+
+    @property
+    def session_stall_timeout_seconds(self) -> Optional[float]:
+        return self._session_stall_timeout_seconds
 
     async def get_client(self, workspace_root: Path) -> OpenCodeClient:
         canonical_root = canonical_workspace_root(workspace_root)

--- a/src/codex_autorunner/cli.py
+++ b/src/codex_autorunner/cli.py
@@ -815,6 +815,9 @@ def ingest_spec_cmd(
                 max_handles=config.app_server.max_handles,
                 idle_ttl_seconds=config.app_server.idle_ttl_seconds,
                 request_timeout=config.app_server.request_timeout,
+                turn_stall_timeout_seconds=config.app_server.turn_stall_timeout_seconds,
+                turn_stall_poll_interval_seconds=config.app_server.turn_stall_poll_interval_seconds,
+                turn_stall_recovery_min_interval_seconds=config.app_server.turn_stall_recovery_min_interval_seconds,
             )
             service = SpecIngestService(engine, app_server_supervisor=supervisor)
             try:
@@ -912,6 +915,9 @@ def snapshot(
                 max_handles=config.app_server.max_handles,
                 idle_ttl_seconds=config.app_server.idle_ttl_seconds,
                 request_timeout=config.app_server.request_timeout,
+                turn_stall_timeout_seconds=config.app_server.turn_stall_timeout_seconds,
+                turn_stall_poll_interval_seconds=config.app_server.turn_stall_poll_interval_seconds,
+                turn_stall_recovery_min_interval_seconds=config.app_server.turn_stall_recovery_min_interval_seconds,
             )
             from .core.snapshot import SnapshotService
 

--- a/src/codex_autorunner/core/doc_chat.py
+++ b/src/codex_autorunner/core/doc_chat.py
@@ -1113,6 +1113,7 @@ class DocChatService:
                     question_policy="auto_first_option",
                     should_stop=active.interrupt_event.is_set,
                     ready_event=ready_event,
+                    stall_timeout_seconds=self.engine.config.opencode.session_stall_timeout_seconds,
                 )
             )
             with contextlib.suppress(asyncio.TimeoutError):

--- a/src/codex_autorunner/core/engine.py
+++ b/src/codex_autorunner/core/engine.py
@@ -1366,6 +1366,9 @@ class Engine:
             max_handles=config.max_handles,
             idle_ttl_seconds=config.idle_ttl_seconds,
             request_timeout=config.request_timeout,
+            turn_stall_timeout_seconds=config.turn_stall_timeout_seconds,
+            turn_stall_poll_interval_seconds=config.turn_stall_poll_interval_seconds,
+            turn_stall_recovery_min_interval_seconds=config.turn_stall_recovery_min_interval_seconds,
         )
 
     def _ensure_app_server_supervisor(
@@ -1407,6 +1410,7 @@ class Engine:
             request_timeout=config.request_timeout,
             max_handles=config.max_handles,
             idle_ttl_seconds=config.idle_ttl_seconds,
+            session_stall_timeout_seconds=self.config.opencode.session_stall_timeout_seconds,
             base_env=None,
             subagent_models=subagent_models,
         )
@@ -1629,6 +1633,7 @@ class Engine:
                 should_stop=active.interrupt_event.is_set,
                 part_handler=_opencode_part_handler,
                 ready_event=ready_event,
+                stall_timeout_seconds=self.config.opencode.session_stall_timeout_seconds,
             )
         )
         with contextlib.suppress(asyncio.TimeoutError):

--- a/src/codex_autorunner/core/utils.py
+++ b/src/codex_autorunner/core/utils.py
@@ -190,6 +190,7 @@ def build_opencode_supervisor(
     request_timeout: Optional[float] = None,
     max_handles: Optional[int] = None,
     idle_ttl_seconds: Optional[float] = None,
+    session_stall_timeout_seconds: Optional[float] = None,
     base_env: Optional[MutableMapping[str, str]] = None,
     subagent_models: Optional[Mapping[str, str]] = None,
 ) -> Optional["OpenCodeSupervisor"]:
@@ -244,6 +245,7 @@ def build_opencode_supervisor(
         request_timeout=request_timeout,
         max_handles=max_handles,
         idle_ttl_seconds=idle_ttl_seconds,
+        session_stall_timeout_seconds=session_stall_timeout_seconds,
         username=username if password else None,
         password=password if password else None,
         base_env=base_env,

--- a/src/codex_autorunner/integrations/app_server/supervisor.py
+++ b/src/codex_autorunner/integrations/app_server/supervisor.py
@@ -36,6 +36,9 @@ class WorkspaceAppServerSupervisor:
         logger: Optional[logging.Logger] = None,
         auto_restart: bool = True,
         request_timeout: Optional[float] = None,
+        turn_stall_timeout_seconds: Optional[float] = None,
+        turn_stall_poll_interval_seconds: Optional[float] = None,
+        turn_stall_recovery_min_interval_seconds: Optional[float] = None,
         default_approval_decision: str = "cancel",
         max_handles: Optional[int] = None,
         idle_ttl_seconds: Optional[float] = None,
@@ -48,6 +51,11 @@ class WorkspaceAppServerSupervisor:
         self._logger = logger or logging.getLogger(__name__)
         self._auto_restart = auto_restart
         self._request_timeout = request_timeout
+        self._turn_stall_timeout_seconds = turn_stall_timeout_seconds
+        self._turn_stall_poll_interval_seconds = turn_stall_poll_interval_seconds
+        self._turn_stall_recovery_min_interval_seconds = (
+            turn_stall_recovery_min_interval_seconds
+        )
         self._default_approval_decision = default_approval_decision
         self._max_handles = max_handles
         self._idle_ttl_seconds = idle_ttl_seconds
@@ -129,6 +137,9 @@ class WorkspaceAppServerSupervisor:
                 default_approval_decision=self._default_approval_decision,
                 auto_restart=self._auto_restart,
                 request_timeout=self._request_timeout,
+                turn_stall_timeout_seconds=self._turn_stall_timeout_seconds,
+                turn_stall_poll_interval_seconds=self._turn_stall_poll_interval_seconds,
+                turn_stall_recovery_min_interval_seconds=self._turn_stall_recovery_min_interval_seconds,
                 notification_handler=self._notification_handler,
                 logger=self._logger,
             )

--- a/src/codex_autorunner/spec_ingest.py
+++ b/src/codex_autorunner/spec_ingest.py
@@ -622,6 +622,7 @@ class SpecIngestService:
                 question_policy="auto_first_option",
                 should_stop=active.interrupt_event.is_set,
                 ready_event=ready_event,
+                stall_timeout_seconds=self.engine.config.opencode.session_stall_timeout_seconds,
             )
         )
         with contextlib.suppress(asyncio.TimeoutError):

--- a/src/codex_autorunner/web/app.py
+++ b/src/codex_autorunner/web/app.py
@@ -249,6 +249,9 @@ def _build_app_server_supervisor(
         max_handles=config.max_handles,
         idle_ttl_seconds=config.idle_ttl_seconds,
         request_timeout=config.request_timeout,
+        turn_stall_timeout_seconds=config.turn_stall_timeout_seconds,
+        turn_stall_poll_interval_seconds=config.turn_stall_poll_interval_seconds,
+        turn_stall_recovery_min_interval_seconds=config.turn_stall_recovery_min_interval_seconds,
         notification_handler=notification_handler,
         approval_handler=approval_handler,
     )
@@ -273,6 +276,7 @@ def _build_opencode_supervisor(
     logger: logging.Logger,
     env: Mapping[str, str],
     subagent_models: Optional[Mapping[str, str]] = None,
+    session_stall_timeout_seconds: Optional[float] = None,
 ) -> tuple[Optional[OpenCodeSupervisor], Optional[float]]:
     supervisor = build_opencode_supervisor(
         opencode_command=opencode_command,
@@ -282,6 +286,7 @@ def _build_opencode_supervisor(
         request_timeout=config.request_timeout,
         max_handles=config.max_handles,
         idle_ttl_seconds=config.idle_ttl_seconds,
+        session_stall_timeout_seconds=session_stall_timeout_seconds,
         base_env=env,
         subagent_models=subagent_models,
     )
@@ -441,6 +446,7 @@ def _build_app_context(
         logger=logger,
         env=env,
         subagent_models=subagent_models,
+        session_stall_timeout_seconds=config.opencode.session_stall_timeout_seconds,
     )
     doc_chat = DocChatService(
         engine,

--- a/tests/test_opencode_client.py
+++ b/tests/test_opencode_client.py
@@ -35,3 +35,15 @@ def test_normalize_sse_event_keeps_non_json() -> None:
     normalized = _normalize_sse_event(event)
     assert normalized.event == "message"
     assert normalized.data == "ping"
+
+
+def test_normalize_sse_event_preserves_wrapper_metadata() -> None:
+    event = SSEEvent(
+        event="message",
+        data='{"type":"session.status","sessionID":"s42","payload":{"state":"running"}}',
+    )
+    normalized = _normalize_sse_event(event)
+    payload = json.loads(normalized.data)
+    assert payload["sessionID"] == "s42"
+    assert payload.get("state") == "running"
+    assert normalized.event == "session.status"

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -3,6 +3,7 @@ import pytest
 from codex_autorunner.agents.opencode.events import SSEEvent
 from codex_autorunner.agents.opencode.runtime import (
     collect_opencode_output_from_events,
+    extract_session_id,
     parse_message_response,
 )
 
@@ -10,6 +11,11 @@ from codex_autorunner.agents.opencode.runtime import (
 async def _iter_events(events):
     for event in events:
         yield event
+
+
+def test_extract_session_id_prefers_nested_session_id() -> None:
+    payload = {"session": {"id": "session-xyz"}}
+    assert extract_session_id(payload) == "session-xyz"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Summary:
- Add per-turn stall heartbeat/recovery for app-server (thread/resume fallback, resilient agent text extraction, delta buffering, capped raw-event logs) and plumb new stall timeout configs through supervisors/CLI/web
- Harden OpenCode SSE handling (preserve wrapper metadata, accept nested session ids, per-session stall detection/poll+reconnect, tool input previews) with configurable session stall timeout
- Extend coverage for stall recovery and SSE normalization plus new config defaults

Testing:
- .venv/bin/python -m pytest tests/test_app_server_client.py tests/test_opencode_client.py tests/test_opencode_runtime.py
- pnpm run build
- .venv/bin/python -m pytest

Closes #355, #356.
