### PR TITLE
Extend OpenCode Telegram turn timeout

### DIFF
--- a/codex-autorunner.yml
+++ b/codex-autorunner.yml
@@ -208,6 +208,10 @@ telegram_bot:
   app_server:
     # Close idle app-server handles after this many seconds; null/<=0 disables pruning.
     idle_ttl_seconds: 28800
+  # Per-agent turn timeout (seconds); null/<=0 disables for that agent.
+  agent_timeouts:
+    codex: 28800
+    opencode: 28800
   polling:
     timeout_seconds: 30
     # HTTP request timeout for getUpdates (should exceed timeout_seconds).

--- a/src/codex_autorunner/core/config.py
+++ b/src/codex_autorunner/core/config.py
@@ -270,6 +270,10 @@ DEFAULT_REPO_CONFIG: Dict[str, Any] = {
             "idle_ttl_seconds": 3600,
             "turn_timeout_seconds": 28800,
         },
+        "agent_timeouts": {
+            "codex": 28800,
+            "opencode": 28800,
+        },
         "polling": {
             "timeout_seconds": 30,
             "allowed_updates": ["message", "edited_message", "callback_query"],
@@ -2368,6 +2372,17 @@ def _validate_telegram_bot_config(cfg: Dict[str, Any]) -> None:
             raise ConfigError(
                 "telegram_bot.app_server.turn_timeout_seconds must be a number or null"
             )
+    agent_timeouts_cfg = telegram_cfg.get("agent_timeouts")
+    if agent_timeouts_cfg is not None and not isinstance(agent_timeouts_cfg, dict):
+        raise ConfigError("telegram_bot.agent_timeouts must be a mapping if provided")
+    if isinstance(agent_timeouts_cfg, dict):
+        for _key, value in agent_timeouts_cfg.items():
+            if value is None:
+                continue
+            if not isinstance(value, (int, float)):
+                raise ConfigError(
+                    "telegram_bot.agent_timeouts values must be numbers or null"
+                )
     polling_cfg = telegram_cfg.get("polling")
     if polling_cfg is not None and not isinstance(polling_cfg, dict):
         raise ConfigError("telegram_bot.polling must be a mapping if provided")

--- a/src/codex_autorunner/integrations/telegram/constants.py
+++ b/src/codex_autorunner/integrations/telegram/constants.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 DEFAULT_PAGE_SIZE = 10
 TELEGRAM_MAX_MESSAGE_LENGTH = 4096
 TELEGRAM_CALLBACK_DATA_LIMIT = 64
@@ -22,22 +20,10 @@ TOKEN_USAGE_TURN_CACHE_LIMIT = 512
 DEFAULT_INTERRUPT_TIMEOUT_SECONDS = 30.0
 
 
-def _env_float(name: str, default: float) -> float:
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    raw = raw.strip()
-    if not raw:
-        return default
-    try:
-        return float(raw)
-    except ValueError:
-        return default
-
-
-# Hard stop for a single OpenCode “turn” in Telegram/GitHub flows.
-# Set CAR_OPENCODE_TURN_TIMEOUT_SECONDS=0 to disable.
-OPENCODE_TURN_TIMEOUT_SECONDS = _env_float("CAR_OPENCODE_TURN_TIMEOUT_SECONDS", 28800.0)
+DEFAULT_AGENT_TURN_TIMEOUT_SECONDS = {
+    "codex": 28800.0,
+    "opencode": 28800.0,
+}
 DEFAULT_WORKSPACE_STATE_ROOT = "~/.codex-autorunner/workspaces"
 DEFAULT_AGENT = "codex"
 APP_SERVER_START_BACKOFF_INITIAL_SECONDS = 1.0

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -46,7 +46,6 @@ from ...constants import (
     DEFAULT_INTERRUPT_TIMEOUT_SECONDS,
     MAX_MENTION_BYTES,
     MAX_TOPIC_THREAD_HISTORY,
-    OPENCODE_TURN_TIMEOUT_SECONDS,
     PLACEHOLDER_TEXT,
     QUEUED_PLACEHOLDER_TEXT,
     RESUME_PREVIEW_ASSISTANT_LIMIT,
@@ -1720,10 +1719,13 @@ class ExecutionCommands(SharedHelpers):
                         codex_thread_id=thread_id,
                         sse_ready_ms=sse_ready_ms,
                     )
+                    timeout_seconds = self._config.agent_turn_timeout_seconds.get(
+                        "opencode"
+                    )
                     timeout_task: Optional[asyncio.Task] = None
-                    if OPENCODE_TURN_TIMEOUT_SECONDS > 0:
+                    if timeout_seconds is not None and timeout_seconds > 0:
                         timeout_task = asyncio.create_task(
-                            asyncio.sleep(OPENCODE_TURN_TIMEOUT_SECONDS)
+                            asyncio.sleep(timeout_seconds)
                         )
                     prompt_sent_at = time.monotonic()
                     prompt_task = asyncio.create_task(
@@ -2230,7 +2232,9 @@ class ExecutionCommands(SharedHelpers):
                 result = await self._wait_for_turn_result(
                     client,
                     turn_handle,
-                    timeout_seconds=self._config.app_server_turn_timeout_seconds,
+                    timeout_seconds=self._config.agent_turn_timeout_seconds.get(
+                        "codex"
+                    ),
                     topic_key=key,
                     chat_id=message.chat_id,
                     thread_id=message.thread_id,

--- a/src/codex_autorunner/integrations/telegram/service.py
+++ b/src/codex_autorunner/integrations/telegram/service.py
@@ -569,6 +569,9 @@ class TelegramBotService(
                 media_images=self._config.media.images,
                 media_voice=self._config.media.voice,
                 app_server_turn_timeout_seconds=self._config.app_server_turn_timeout_seconds,
+                agent_turn_timeout_seconds=dict(
+                    self._config.agent_turn_timeout_seconds
+                ),
                 poller_offset=self._poller.offset,
             )
             try:

--- a/tests/test_telegram_review_opencode.py
+++ b/tests/test_telegram_review_opencode.py
@@ -100,6 +100,7 @@ class _ReviewHandlerStub(TelegramCommandHandlers):
             progress_stream=SimpleNamespace(
                 enabled=False, max_actions=0, max_output_chars=0
             ),
+            agent_turn_timeout_seconds={"codex": 28800.0, "opencode": 28800.0},
         )
         self._router = _RouterStub(record)
         self._opencode_supervisor = supervisor

--- a/tests/test_telegram_turn_queue.py
+++ b/tests/test_telegram_turn_queue.py
@@ -112,6 +112,7 @@ class _HandlerStub(TelegramCommandHandlers):
                 per_topic_queue=False,
             ),
             app_server_turn_timeout_seconds=None,
+            agent_turn_timeout_seconds={"codex": None, "opencode": None},
         )
         self._router = _RouterStub(records)
         self._turn_semaphore = asyncio.Semaphore(max_parallel_turns)


### PR DESCRIPTION
## Summary
- set OpenCode turn timeout default to 8 hours (28800s) with env override
- allow disabling the timeout via CAR_OPENCODE_TURN_TIMEOUT_SECONDS=0
- guard timeout handling in Telegram OpenCode execution/review flows when disabled

## Testing
- pre-commit hooks (black, ruff, mypy, eslint warnings only)
- pnpm run build
- pytest