### PR TITLE
Add Takopi-inspired plugin API and Telegram trigger mode

### DIFF
--- a/codex-autorunner.yml
+++ b/codex-autorunner.yml
@@ -175,6 +175,8 @@ telegram_bot:
   allowed_chat_ids: []
   allowed_user_ids: []
   require_topics: false
+  # When set to 'mentions', only start runs when explicitly invoked (e.g. @botname mention or reply).
+  trigger_mode: all
   defaults:
     approval_mode: yolo
     approval_policy: on-request

--- a/docs/adding-an-agent.md
+++ b/docs/adding-an-agent.md
@@ -195,12 +195,19 @@ Reference existing implementations:
 
 ## Step 3: Register the Agent
 
-Add your agent to `src/codex_autorunner/agents/registry.py`:
+There are two supported registration paths:
+
+### Option A: In-tree (modify CAR)
+
+If you are adding an agent directly to the CAR codebase, register it in:
+
+- `src/codex_autorunner/agents/registry.py` (add to `_BUILTIN_AGENTS`)
+
+Example (in-tree):
 
 ```python
 # Add import
 from .myagent.harness import MyAgentHarness
-from .myagent.supervisor import MyAgentSupervisor
 
 def _make_myagent_harness(ctx: Any) -> AgentHarness:
     supervisor = ctx.myagent_supervisor
@@ -209,27 +216,60 @@ def _make_myagent_harness(ctx: Any) -> AgentHarness:
     return MyAgentHarness(supervisor)
 
 def _check_myagent_health(ctx: Any) -> bool:
-    supervisor = ctx.myagent_supervisor
-    return supervisor is not None
+    return ctx.myagent_supervisor is not None
 
-# Add to _REGISTERED_AGENTS
-_REGISTERED_AGENTS: dict[str, AgentDescriptor] = {
-    # ... existing agents ...
-    "myagent": AgentDescriptor(
-        id="myagent",
-        name="My Agent",
-        capabilities=frozenset([
-            "threads",
-            "turns",
-            "model_listing",
-            "event_streaming",
-            # Add other capabilities as needed
-        ]),
-        make_harness=_make_myagent_harness,
-        healthcheck=_check_myagent_health,
-    ),
-}
+# Add to _BUILTIN_AGENTS
+_BUILTIN_AGENTS["myagent"] = AgentDescriptor(
+    id="myagent",
+    name="My Agent",
+    capabilities=frozenset([
+        "threads",
+        "turns",
+        "model_listing",
+        "event_streaming",
+        # Add other capabilities as needed
+    ]),
+    make_harness=_make_myagent_harness,
+    healthcheck=_check_myagent_health,
+)
 ```
+
+### Option B: Out-of-tree plugin (recommended)
+
+This mirrors Takopi’s entrypoint-based plugin approach: publish a Python package
+that exposes an `AgentDescriptor` via a standard entry point group.
+
+1) In your plugin package, define an exported descriptor:
+
+```python
+# my_package/my_agent_plugin.py
+from __future__ import annotations
+
+from codex_autorunner.api import AgentDescriptor, AgentHarness, CAR_PLUGIN_API_VERSION
+
+def _make(ctx: object) -> AgentHarness:
+    # construct your harness from ctx (supervisors, settings, etc)
+    raise NotImplementedError
+
+AGENT_BACKEND = AgentDescriptor(
+    id="myagent",
+    name="My Agent",
+    capabilities=frozenset(["threads", "turns"]),
+    make_harness=_make,
+    plugin_api_version=CAR_PLUGIN_API_VERSION,
+)
+```
+
+2) Declare an entry point in your plugin’s `pyproject.toml`:
+
+```toml
+[project.entry-points."codex_autorunner.agent_backends"]
+myagent = "my_package.my_agent_plugin:AGENT_BACKEND"
+```
+
+At runtime, CAR will discover and load the plugin backend automatically.
+Conflicting ids are rejected (plugin ids may not override built-ins).
+
 
 ## Step 4: Add Configuration
 

--- a/docs/ops/telegram-bot-runbook.md
+++ b/docs/ops/telegram-bot-runbook.md
@@ -16,6 +16,7 @@ Operate and troubleshoot the Telegram polling bot that proxies Codex app-server 
 - Ensure `telegram_bot.allowed_user_ids` includes your Telegram user id.
 - `telegram_bot.shell.enabled` is off by default; set it to `true` to enable `!<cmd>` support.
 - Enabling shell allows remote command execution gated only by the Telegram allowlist.
+- In group chats where the bot is an admin, consider `telegram_bot.trigger_mode: mentions` to avoid reacting to every message.
 - Example:
   ```yaml
   telegram_bot:

--- a/docs/reference/plugin-api.md
+++ b/docs/reference/plugin-api.md
@@ -1,0 +1,56 @@
+# CAR Plugin API
+
+This document describes the stable public API surface for external plugins.
+
+## Scope
+
+CAR supports plugin loading via Python packaging **entry points**.
+
+Currently supported plugin type:
+
+- **Agent backends**: add a new agent implementation (harness + supervisor).
+
+## Versioning
+
+Plugins MUST declare compatibility with the current plugin API version:
+
+- `codex_autorunner.api.CAR_PLUGIN_API_VERSION`
+
+CAR will skip plugins whose declared `plugin_api_version` does not match.
+
+## Agent backend entry point
+
+Entry point group:
+
+- `codex_autorunner.api.CAR_AGENT_ENTRYPOINT_GROUP`
+- (currently: `codex_autorunner.agent_backends`)
+
+A plugin package should expose an `AgentDescriptor` object:
+
+```python
+from codex_autorunner.api import AgentDescriptor, AgentHarness, CAR_PLUGIN_API_VERSION
+
+def _make(ctx: object) -> AgentHarness:
+    raise NotImplementedError
+
+AGENT_BACKEND = AgentDescriptor(
+    id="myagent",
+    name="My Agent",
+    capabilities=frozenset(["threads", "turns"]),
+    make_harness=_make,
+    plugin_api_version=CAR_PLUGIN_API_VERSION,
+)
+```
+
+and declare it in `pyproject.toml`:
+
+```toml
+[project.entry-points."codex_autorunner.agent_backends"]
+myagent = "my_package.my_agent_plugin:AGENT_BACKEND"
+```
+
+Notes:
+
+- Plugin ids are normalized to lowercase.
+- Plugins cannot override built-in agent ids.
+- Plugins SHOULD avoid import-time side effects; do heavy initialization inside `make_harness`.

--- a/docs/telegram/architecture.md
+++ b/docs/telegram/architecture.md
@@ -18,6 +18,7 @@ Config lives under `telegram_bot` in `codex-autorunner.yml` and the generated
 - `telegram_bot.allowed_chat_ids`: allowlist of chat ids.
 - `telegram_bot.allowed_user_ids`: allowlist of Telegram user ids.
 - `telegram_bot.require_topics`: if true, only accept messages in forum topics.
+- `telegram_bot.trigger_mode`: `all` (default) or `mentions` (only start runs when explicitly invoked).
 - `telegram_bot.parse_mode`: `HTML`, `Markdown`, `MarkdownV2`, or null.
 - `telegram_bot.debug.prefix_context`: when true, prefix outgoing messages with routing metadata.
 - `telegram_bot.app_server_command(_env)`: how to launch `codex app-server`.

--- a/src/codex_autorunner/agents/registry.py
+++ b/src/codex_autorunner/agents/registry.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import importlib.metadata
 import logging
 from dataclasses import dataclass
-from typing import Any, Callable, Literal, Optional
+from typing import Any, Callable, Iterable, Literal, Optional
 
+from ..plugin_api import CAR_AGENT_ENTRYPOINT_GROUP, CAR_PLUGIN_API_VERSION
 from .base import AgentHarness
 from .codex.harness import CodexHarness
 from .opencode.harness import OpenCodeHarness
@@ -22,11 +24,20 @@ AgentCapability = Literal[
 
 @dataclass(frozen=True)
 class AgentDescriptor:
+    """A registered agent backend.
+
+    Built-in backends live in `_BUILTIN_AGENTS`. Additional backends MAY be loaded
+    via Python entry points (see `CAR_AGENT_ENTRYPOINT_GROUP`).
+
+    Plugins SHOULD set `plugin_api_version` to `CAR_PLUGIN_API_VERSION`.
+    """
+
     id: str
     name: str
     capabilities: frozenset[AgentCapability]
     make_harness: Callable[[Any], AgentHarness]
     healthcheck: Optional[Callable[[Any], bool]] = None
+    plugin_api_version: int = CAR_PLUGIN_API_VERSION
 
 
 def _make_codex_harness(ctx: Any) -> AgentHarness:
@@ -54,7 +65,7 @@ def _check_opencode_health(ctx: Any) -> bool:
     return supervisor is not None
 
 
-_REGISTERED_AGENTS: dict[str, AgentDescriptor] = {
+_BUILTIN_AGENTS: dict[str, AgentDescriptor] = {
     "codex": AgentDescriptor(
         id="codex",
         name="Codex",
@@ -88,32 +99,146 @@ _REGISTERED_AGENTS: dict[str, AgentDescriptor] = {
     ),
 }
 
+# Lazy-loaded cache of built-in + plugin agents.
+_AGENT_CACHE: Optional[dict[str, AgentDescriptor]] = None
+
+
+def _select_entry_points(group: str) -> Iterable[importlib.metadata.EntryPoint]:
+    """Compatibility wrapper for `importlib.metadata.entry_points()` across py versions."""
+
+    eps = importlib.metadata.entry_points()
+    if hasattr(eps, "select"):
+        return eps.select(group=group)
+    # Python 3.9: may return a dict
+    if isinstance(eps, dict):
+        return eps.get(group, [])
+    return []
+
+
+def _load_agent_plugins() -> dict[str, AgentDescriptor]:
+    loaded: dict[str, AgentDescriptor] = {}
+    for ep in _select_entry_points(CAR_AGENT_ENTRYPOINT_GROUP):
+        try:
+            obj = ep.load()
+        except Exception as exc:  # noqa: BLE001
+            _logger.warning(
+                "Failed to load agent plugin entry point %s:%s: %s",
+                ep.group,
+                ep.name,
+                exc,
+            )
+            continue
+
+        descriptor: Optional[AgentDescriptor] = None
+        if isinstance(obj, AgentDescriptor):
+            descriptor = obj
+        elif callable(obj):
+            try:
+                maybe = obj()
+            except Exception as exc:  # noqa: BLE001
+                _logger.warning(
+                    "Agent plugin entry point %s:%s factory failed: %s",
+                    ep.group,
+                    ep.name,
+                    exc,
+                )
+                continue
+            if isinstance(maybe, AgentDescriptor):
+                descriptor = maybe
+
+        if descriptor is None:
+            _logger.warning(
+                "Ignoring agent plugin entry point %s:%s: expected AgentDescriptor or factory",
+                ep.group,
+                ep.name,
+            )
+            continue
+
+        agent_id = (descriptor.id or "").strip().lower()
+        if not agent_id:
+            _logger.warning(
+                "Ignoring agent plugin entry point %s:%s: missing id",
+                ep.group,
+                ep.name,
+            )
+            continue
+
+        if descriptor.plugin_api_version != CAR_PLUGIN_API_VERSION:
+            _logger.warning(
+                "Ignoring agent plugin %s (api_version=%s): expected %s",
+                agent_id,
+                descriptor.plugin_api_version,
+                CAR_PLUGIN_API_VERSION,
+            )
+            continue
+
+        if agent_id in _BUILTIN_AGENTS:
+            _logger.warning(
+                "Ignoring agent plugin %s: conflicts with built-in agent id",
+                agent_id,
+            )
+            continue
+        if agent_id in loaded:
+            _logger.warning(
+                "Ignoring duplicate agent plugin id %s from entry point %s:%s",
+                agent_id,
+                ep.group,
+                ep.name,
+            )
+            continue
+
+        loaded[agent_id] = descriptor
+        _logger.info("Loaded agent plugin: %s (%s)", agent_id, descriptor.name)
+
+    return loaded
+
+
+def _all_agents() -> dict[str, AgentDescriptor]:
+    global _AGENT_CACHE
+    if _AGENT_CACHE is None:
+        agents = _BUILTIN_AGENTS.copy()
+        agents.update(_load_agent_plugins())
+        _AGENT_CACHE = agents
+    return _AGENT_CACHE
+
+
+def reload_agents() -> dict[str, AgentDescriptor]:
+    """Clear the plugin cache and reload agent backends.
+
+    This is primarily useful for tests and local development.
+    """
+
+    global _AGENT_CACHE
+    _AGENT_CACHE = None
+    return get_registered_agents()
+
 
 def get_registered_agents() -> dict[str, AgentDescriptor]:
-    return _REGISTERED_AGENTS.copy()
+    return _all_agents().copy()
 
 
 def get_available_agents(app_ctx: Any) -> dict[str, AgentDescriptor]:
-    available = {}
-    for agent_id, descriptor in _REGISTERED_AGENTS.items():
+    available: dict[str, AgentDescriptor] = {}
+    for agent_id, descriptor in _all_agents().items():
         if descriptor.healthcheck is None or descriptor.healthcheck(app_ctx):
             available[agent_id] = descriptor
     return available
 
 
 def get_agent_descriptor(agent_id: str) -> Optional[AgentDescriptor]:
-    return _REGISTERED_AGENTS.get(agent_id)
+    normalized = (agent_id or "").strip().lower()
+    return _all_agents().get(normalized)
 
 
 def validate_agent_id(agent_id: str) -> str:
     normalized = (agent_id or "").strip().lower()
-    if normalized not in _REGISTERED_AGENTS:
+    if normalized not in _all_agents():
         raise ValueError(f"Unknown agent: {agent_id!r}")
     return normalized
 
 
 def has_capability(agent_id: str, capability: AgentCapability) -> bool:
-    descriptor = _REGISTERED_AGENTS.get(agent_id)
+    descriptor = get_agent_descriptor(agent_id)
     if descriptor is None:
         return False
     return capability in descriptor.capabilities
@@ -122,9 +247,12 @@ def has_capability(agent_id: str, capability: AgentCapability) -> bool:
 __all__ = [
     "AgentCapability",
     "AgentDescriptor",
+    "CAR_PLUGIN_API_VERSION",
+    "CAR_AGENT_ENTRYPOINT_GROUP",
     "get_registered_agents",
     "get_available_agents",
     "get_agent_descriptor",
     "validate_agent_id",
     "has_capability",
+    "reload_agents",
 ]

--- a/src/codex_autorunner/api.py
+++ b/src/codex_autorunner/api.py
@@ -1,0 +1,25 @@
+"""Stable public API for Codex Autorunner plugins.
+
+Everything else in the codebase should be treated as internal unless documented.
+"""
+
+from __future__ import annotations
+
+from .agents.base import AgentHarness
+from .agents.registry import AgentCapability, AgentDescriptor, reload_agents
+from .agents.types import AgentId, ConversationRef, ModelCatalog, ModelSpec, TurnRef
+from .plugin_api import CAR_AGENT_ENTRYPOINT_GROUP, CAR_PLUGIN_API_VERSION
+
+__all__ = [
+    "AgentCapability",
+    "AgentDescriptor",
+    "AgentHarness",
+    "AgentId",
+    "ConversationRef",
+    "ModelCatalog",
+    "ModelSpec",
+    "TurnRef",
+    "CAR_AGENT_ENTRYPOINT_GROUP",
+    "CAR_PLUGIN_API_VERSION",
+    "reload_agents",
+]

--- a/src/codex_autorunner/integrations/telegram/config.py
+++ b/src/codex_autorunner/integrations/telegram/config.py
@@ -18,6 +18,8 @@ DEFAULT_SAFE_APPROVAL_POLICY = "on-request"
 DEFAULT_YOLO_APPROVAL_POLICY = "never"
 DEFAULT_YOLO_SANDBOX_POLICY = "dangerFullAccess"
 DEFAULT_PARSE_MODE = "HTML"
+DEFAULT_TRIGGER_MODE = "all"
+TRIGGER_MODE_OPTIONS = {"all", "mentions"}
 DEFAULT_STATE_FILE = ".codex-autorunner/telegram_state.sqlite3"
 DEFAULT_APP_SERVER_COMMAND = ["codex", "app-server"]
 DEFAULT_APP_SERVER_MAX_HANDLES = 20
@@ -151,6 +153,7 @@ class TelegramBotConfig:
     allowed_chat_ids: set[int]
     allowed_user_ids: set[int]
     require_topics: bool
+    trigger_mode: str
     defaults: TelegramBotDefaults
     concurrency: TelegramBotConcurrency
     media: TelegramBotMediaConfig
@@ -205,6 +208,10 @@ class TelegramBotConfig:
         allowed_user_ids = set(_parse_int_list(cfg.get("allowed_user_ids")))
 
         require_topics = bool(cfg.get("require_topics", False))
+
+        trigger_mode = (
+            str(cfg.get("trigger_mode", DEFAULT_TRIGGER_MODE)).strip().lower()
+        )
 
         defaults_raw_value = cfg.get("defaults")
         defaults_raw: dict[str, Any] = (
@@ -501,6 +508,7 @@ class TelegramBotConfig:
             allowed_chat_ids=allowed_chat_ids,
             allowed_user_ids=allowed_user_ids,
             require_topics=require_topics,
+            trigger_mode=trigger_mode,
             defaults=defaults,
             concurrency=concurrency,
             media=media,
@@ -546,6 +554,8 @@ class TelegramBotConfig:
             issues.append(
                 "poll_request_timeout_seconds must be greater than poll_timeout_seconds"
             )
+        if self.trigger_mode not in TRIGGER_MODE_OPTIONS:
+            issues.append(f"trigger_mode must be one of {sorted(TRIGGER_MODE_OPTIONS)}")
         if issues:
             raise TelegramBotConfigError("; ".join(issues))
 

--- a/src/codex_autorunner/integrations/telegram/handlers/messages.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/messages.py
@@ -19,6 +19,7 @@ from ..adapter import (
 )
 from ..config import TelegramMediaCandidate
 from ..constants import TELEGRAM_MAX_MESSAGE_LENGTH
+from ..trigger_mode import should_trigger_run
 from .questions import handle_custom_text_input
 
 COALESCE_LONG_MESSAGE_WINDOW_SECONDS = 6.0
@@ -356,6 +357,23 @@ async def handle_message_inner(
             )
             await _clear_placeholder()
             return
+
+    if handlers._config.trigger_mode == "mentions" and not should_trigger_run(
+        message,
+        text=text,
+        bot_username=handlers._bot_username,
+    ):
+        log_event(
+            handlers._logger,
+            logging.INFO,
+            "telegram.trigger.ignored",
+            chat_id=message.chat_id,
+            thread_id=message.thread_id,
+            message_id=message.message_id,
+            reason="mentions_only",
+        )
+        await _clear_placeholder()
+        return
 
     if has_media:
 

--- a/src/codex_autorunner/integrations/telegram/trigger_mode.py
+++ b/src/codex_autorunner/integrations/telegram/trigger_mode.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from .adapter import TelegramMessage
+
+TriggerMode = Literal["all", "mentions"]
+
+
+def should_trigger_run(
+    message: TelegramMessage,
+    *,
+    text: str,
+    bot_username: Optional[str],
+) -> bool:
+    """Return True if this message should start a run in mentions-only mode.
+
+    This mirrors Takopi's "mentions" trigger mode semantics (subset):
+
+    - Always trigger in private chats.
+    - Trigger when the bot is explicitly mentioned: "@<bot_username>" anywhere in the text.
+    - Trigger when replying to a bot message (but ignore the common forum-topic
+      "implicit root reply" case where clients set reply_to_message_id == thread_id).
+    - Otherwise, do not trigger (commands and other explicit affordances are handled elsewhere).
+    """
+
+    if message.chat_type == "private":
+        return True
+
+    lowered = (text or "").lower()
+    if bot_username:
+        needle = f"@{bot_username}".lower()
+        if needle in lowered:
+            return True
+
+    implicit_topic_reply = (
+        message.thread_id is not None
+        and message.reply_to_message_id is not None
+        and message.reply_to_message_id == message.thread_id
+    )
+
+    if message.reply_to_is_bot and not implicit_topic_reply:
+        return True
+
+    if (
+        bot_username
+        and message.reply_to_username
+        and message.reply_to_username.lower() == bot_username.lower()
+        and not implicit_topic_reply
+    ):
+        return True
+
+    return False

--- a/src/codex_autorunner/plugin_api.py
+++ b/src/codex_autorunner/plugin_api.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Codex Autorunner plugin API metadata.
+
+This module is intentionally small and stable. External plugins SHOULD depend
+only on the public API in `codex_autorunner.api` + this version constant.
+
+Notes:
+- Backwards-incompatible changes to the plugin API MUST bump
+  `CAR_PLUGIN_API_VERSION`.
+"""
+
+CAR_PLUGIN_API_VERSION = 1
+
+# Entry point groups (Python packaging entry points).
+#
+# Plugins can publish new agent backends by defining an entry point:
+#
+#   [project.entry-points."codex_autorunner.agent_backends"]
+#   myagent = "my_package.my_module:AGENT_BACKEND"
+#
+CAR_AGENT_ENTRYPOINT_GROUP = "codex_autorunner.agent_backends"

--- a/tests/test_agents_plugins.py
+++ b/tests/test_agents_plugins.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib.metadata
+
+from codex_autorunner.agents.registry import (
+    CAR_AGENT_ENTRYPOINT_GROUP,
+    CAR_PLUGIN_API_VERSION,
+    AgentDescriptor,
+    get_registered_agents,
+    reload_agents,
+)
+
+
+class _FakeEntryPoint:
+    def __init__(self, name: str, obj):
+        self.name = name
+        self.group = CAR_AGENT_ENTRYPOINT_GROUP
+        self._obj = obj
+
+    def load(self):
+        return self._obj
+
+
+class _FakeEntryPoints(list):
+    def select(self, *, group: str, **kwargs):
+        if group == CAR_AGENT_ENTRYPOINT_GROUP:
+            return self
+        return _FakeEntryPoints()
+
+
+def test_load_agent_plugin(monkeypatch):
+    plugin = AgentDescriptor(
+        id="myagent",
+        name="My Agent",
+        capabilities=frozenset(["threads"]),
+        make_harness=lambda ctx: None,  # type: ignore[return-value]
+        plugin_api_version=CAR_PLUGIN_API_VERSION,
+    )
+
+    def fake_entry_points():
+        return _FakeEntryPoints([_FakeEntryPoint("myagent", plugin)])
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+    reload_agents()
+
+    agents = get_registered_agents()
+    assert "myagent" in agents
+    assert agents["myagent"].name == "My Agent"
+
+
+def test_skip_agent_plugin_version_mismatch(monkeypatch):
+    plugin = AgentDescriptor(
+        id="badagent",
+        name="Bad Agent",
+        capabilities=frozenset(["threads"]),
+        make_harness=lambda ctx: None,  # type: ignore[return-value]
+        plugin_api_version=CAR_PLUGIN_API_VERSION + 1,
+    )
+
+    def fake_entry_points():
+        return _FakeEntryPoints([_FakeEntryPoint("badagent", plugin)])
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+    reload_agents()
+
+    agents = get_registered_agents()
+    assert "badagent" not in agents

--- a/tests/test_telegram_bot_config.py
+++ b/tests/test_telegram_bot_config.py
@@ -245,3 +245,20 @@ def test_telegram_bot_config_metrics_mode_override(tmp_path: Path) -> None:
     }
     cfg = TelegramBotConfig.from_raw(raw, root=tmp_path, env=env)
     assert cfg.metrics_mode == "append_to_response"
+
+
+def test_telegram_bot_config_validate_trigger_mode(tmp_path: Path) -> None:
+    raw = {
+        "enabled": True,
+        "bot_token_env": "TEST_BOT_TOKEN",
+        "chat_id_env": "TEST_CHAT_ID",
+        "allowed_user_ids": [123],
+        "trigger_mode": "nope",
+    }
+    env = {
+        "TEST_BOT_TOKEN": "token",
+        "TEST_CHAT_ID": "123",
+    }
+    cfg = TelegramBotConfig.from_raw(raw, root=tmp_path, env=env)
+    with pytest.raises(TelegramBotConfigError):
+        cfg.validate()

--- a/tests/test_telegram_trigger_mode.py
+++ b/tests/test_telegram_trigger_mode.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from codex_autorunner.integrations.telegram.adapter import TelegramMessage
+from codex_autorunner.integrations.telegram.trigger_mode import should_trigger_run
+
+
+def _base_message(**kwargs) -> TelegramMessage:
+    base = dict(
+        update_id=1,
+        message_id=10,
+        chat_id=-100,
+        thread_id=None,
+        from_user_id=123,
+        text="hi",
+        date=0,
+        is_topic_message=False,
+        chat_type="supergroup",
+    )
+    base.update(kwargs)
+    return TelegramMessage(**base)
+
+
+def test_mentions_mode_triggers_in_private_chat() -> None:
+    msg = _base_message(chat_type="private", text="hello")
+    assert should_trigger_run(msg, text="hello", bot_username="MyBot") is True
+
+
+def test_mentions_mode_triggers_on_username_mention() -> None:
+    msg = _base_message(text="hey @MyBot please run")
+    assert should_trigger_run(msg, text=msg.text or "", bot_username="MyBot") is True
+
+
+def test_mentions_mode_triggers_on_reply_to_bot() -> None:
+    msg = _base_message(reply_to_is_bot=True, reply_to_message_id=999)
+    assert should_trigger_run(msg, text=msg.text or "", bot_username="MyBot") is True
+
+
+def test_mentions_mode_ignores_implicit_topic_root_reply() -> None:
+    msg = _base_message(thread_id=77, reply_to_is_bot=True, reply_to_message_id=77)
+    assert should_trigger_run(msg, text=msg.text or "", bot_username="MyBot") is False
+
+
+def test_mentions_mode_does_not_trigger_without_invocation() -> None:
+    msg = _base_message(text="regular message")
+    assert should_trigger_run(msg, text=msg.text or "", bot_username="MyBot") is False


### PR DESCRIPTION
## Summary
- add versioned plugin API surface with entrypoint-loaded agent backends
- introduce Telegram trigger_mode (all|mentions) with gating helper and tests
- document plugin API and Telegram run-trigger policy updates

## Testing
- .venv/bin/python -m pytest -q tests/test_telegram_adapter.py tests/test_telegram_trigger_mode.py tests/test_telegram_bot_config.py tests/test_agents_plugins.py
