### PR TITLE
Update docs to reflect app-server backend and OpenCode support

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,6 +1,6 @@
 Codex Autorunner - Design
 
-Single-repo autorunner that drives the Codex CLI using markdown docs in .codex-autorunner/ as the control surface. Ships a CLI and local web UI/API; hub mode supervises multiple repos/worktrees.
+Single-repo autorunner that drives the Codex app-server (with OpenCode support) using markdown docs in .codex-autorunner/ as the control surface. Ships a CLI and local web UI/API; hub mode supervises multiple repos/worktrees. The Codex CLI is primarily used for the interactive terminal surface (PTY).
 
 ## Goals / Non-goals
 - Goals: autonomous loop, doc-driven control surface, small local footprint, repo-local state, UI + API for control.
@@ -25,13 +25,13 @@ Repo root:
 Hub additions:
   .codex-autorunner/manifest.yml, hub_state.json, codex-autorunner-hub.log
 
-Config sections (repo): docs, codex, prompt, runner, git, github, server, terminal, voice, log, server_log.
+Config sections (repo): docs, codex, prompt, runner, git, github, server, terminal, voice, log, server_log, app_server, opencode.
 Precedence: built-ins < codex-autorunner.yml < override < .codex-autorunner/config.yml < env.
 
 ## Core loop
 - Parse TODO checkboxes and preserve ordering.
 - Build prompt from docs plus bounded prior run output.
-- Run Codex CLI with streaming logs.
+- Run Codex app-server with streaming logs via OpenCode runtime.
 - Update state and stop on empty TODOs, non-zero exit, stop_after_runs, wallclock limit, or external stop flag.
 
 ## API surface (repo)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # codex-autorunner
 [![PyPI](https://img.shields.io/pypi/v/codex-autorunner.svg)](https://pypi.org/project/codex-autorunner/)
 
-An opinionated autorunner that uses the Codex CLI to work on large tasks via a simple loop. On each loop we feed the Codex instance the last one's final output along with core documents.
+An opinionated autorunner that uses the Codex app-server as the primary execution backend with OpenCode support to work on large tasks via a simple loop. On each loop we feed the Codex instance the last one's final output along with core documents.
 1. TODO - Tracks long-horizon tasks
 2. PROGRESS - High level overview of what's been done already that may be relevant for future agents
 3. OPINIONS - Guidelines for how we should approach implementation
@@ -28,7 +28,7 @@ Mobile-first experience, code on the go with Whisper support (BYOK)
 
 ## What it does
 - Initializes a repo with Codex-friendly docs and config.
-- Runs Codex in a loop against the repo, streaming logs.
+- Runs Codex app-server in a loop against the repo, streaming logs via OpenCode runtime.
 - Tracks state, logs, and config under `.codex-autorunner/`.
 - Exposes a power-user HTTP API and web UI for docs, logs, runner control, and a Codex TUI terminal.
 - Optionally runs a Telegram bot for interactive, user-in-the-loop Codex sessions.

--- a/src/codex_autorunner/core/codex_runner.py
+++ b/src/codex_autorunner/core/codex_runner.py
@@ -1,3 +1,9 @@
+# DEPRECATED: This module implements a Codex CLI subprocess runner.
+# The primary execution path now uses the Codex app-server via OpenCode runtime.
+# This file is kept for potential future CLI-as-backend support but is currently
+# not referenced by the main engine. See src/codex_autorunner/core/engine.py for
+# the current execution path (_run_codex_app_server_async).
+
 import asyncio
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
## Summary

This PR updates the documentation to accurately reflect the current implementation using app-server as the primary execution backend with OpenCode support.

## Changes

### README.md
- Updated language to describe app-server as the primary execution backend
- Clarified that Codex CLI is primarily for the interactive terminal surface (PTY)

### DESIGN.md
- Updated configuration section list to include `app_server` and `opencode`
- Clarified the backend architecture and execution paths

### Core code
- Added deprecation comment to core/codex_runner.py noting it's legacy

Closes #395