### PR TITLE
Fix TypeScript lint hot-spots in UI code

### DIFF
--- a/src/codex_autorunner/static_src/dashboard.ts
+++ b/src/codex_autorunner/static_src/dashboard.ts
@@ -278,7 +278,7 @@ function renderUsageChart(data: UsageChartData | null): void {
   const series = data?.series || [];
   const isLoading = data?.status === "loading";
   if (!buckets.length || !series.length) {
-    (container as any).__usageChartBound = false;
+    (container as UsageChartElement).__usageChartBound = false;
     container.innerHTML = isLoading
       ? '<div class="usage-chart-empty">Loading…</div>'
       : '<div class="usage-chart-empty">No data</div>';
@@ -366,7 +366,7 @@ function renderUsageChart(data: UsageChartData | null): void {
   }
 
   svg += "</svg>";
-  (container as any).__usageChartBound = false;
+  (container as UsageChartElement).__usageChartBound = false;
   container.innerHTML = svg;
   attachUsageChartInteraction(container, {
     buckets,
@@ -421,6 +421,11 @@ function setChartLoading(container: HTMLElement | null, loading: boolean): void 
   container.classList.toggle("loading", loading);
 }
 
+interface UsageChartElement extends HTMLElement {
+  __usageChartBound?: boolean;
+  __usageChartState?: ChartInteractionState;
+}
+
 interface ChartInteractionState {
   buckets: string[];
   series: SeriesEntry[];
@@ -434,9 +439,9 @@ interface ChartInteractionState {
 }
 
 function attachUsageChartInteraction(container: HTMLElement, state: ChartInteractionState): void {
-  (container as any).__usageChartState = state;
-  if ((container as any).__usageChartBound) return;
-  (container as any).__usageChartBound = true;
+  (container as UsageChartElement).__usageChartState = state;
+  if ((container as UsageChartElement).__usageChartBound) return;
+  (container as UsageChartElement).__usageChartBound = true;
 
   const focus = document.createElement("div");
   focus.className = "usage-chart-focus";
@@ -449,7 +454,7 @@ function attachUsageChartInteraction(container: HTMLElement, state: ChartInterac
   container.appendChild(tooltip);
 
   const updateTooltip = (event: PointerEvent) => {
-    const chartState = (container as any).__usageChartState as ChartInteractionState;
+    const chartState = (container as UsageChartElement).__usageChartState;
     if (!chartState) return;
     const rect = container.getBoundingClientRect();
     const x = event.clientX - rect.left;

--- a/src/codex_autorunner/static_src/docChatRender.ts
+++ b/src/codex_autorunner/static_src/docChatRender.ts
@@ -27,7 +27,7 @@ export function updatePatchPreviewFromDraft(draft: DraftPayload | undefined): vo
 
 export function renderChat(): void {
   const state = getChatState();
-  const latest = state.history[0];
+  const latest = state.history[0] as ChatHistoryEntry | undefined;
   const isRunning = state.status === "running";
   const hasError = !!state.error;
 
@@ -90,7 +90,7 @@ export function renderChat(): void {
   }
 
   const activeDoc = getActiveDoc();
-  const latestDrafts = (latest as any)?.drafts as Record<string, DraftPayload> | undefined;
+  const latestDrafts = latest?.drafts as Record<string, DraftPayload> | undefined;
   const draft =
     (getDraft(activeDoc) as DraftPayload | null) || (latestDrafts?.[activeDoc] || null);
   const hasPatch = !!(draft && (draft.patch || "").trim());
@@ -104,7 +104,7 @@ export function renderChat(): void {
     if (hasPatch) {
       chatUI.patchSummary.textContent =
         draft?.agentMessage ||
-        (latest as any)?.response ||
+        latest?.response ||
         state.error ||
         "Draft ready";
     } else {

--- a/src/codex_autorunner/static_src/docChatStream.ts
+++ b/src/codex_autorunner/static_src/docChatStream.ts
@@ -12,6 +12,7 @@ import {
   parseMaybeJson,
   recoverDraftMap,
   recoverPatchFromRaw,
+  type DraftPayload,
 } from "./docsParse.js";
 import { applyDraftUpdates } from "./docsDrafts.js";
 import { renderChat, updatePatchPreviewFromDraft } from "./docChatRender.js";
@@ -313,14 +314,14 @@ export async function handleStreamEvent(event: string, rawData: string, state: C
         entry.updated = updated;
         entry.drafts = recoveredDrafts;
         applyDraftUpdates(recoveredDrafts);
-        updatePatchPreviewFromDraft(recoveredDrafts[getActiveDoc()] as any);
+        updatePatchPreviewFromDraft(recoveredDrafts[getActiveDoc()] as DraftPayload);
         entry.status = "done";
         renderChat();
         return;
       }
       const recoveredPatch = recoverPatchFromRaw(rawData);
       if (recoveredPatch) {
-        const recoveredDraft: Record<string, unknown> = {
+        const recoveredDraft: DraftPayload = {
           patch: recoveredPatch,
           content: "",
           agentMessage: "",
@@ -330,7 +331,7 @@ export async function handleStreamEvent(event: string, rawData: string, state: C
         entry.updated = [getActiveDoc()];
         entry.drafts = { [getActiveDoc()]: recoveredDraft };
         applyDraftUpdates(entry.drafts);
-        updatePatchPreviewFromDraft(recoveredDraft as any);
+        updatePatchPreviewFromDraft(recoveredDraft);
         entry.status = "done";
         renderChat();
         return;
@@ -340,7 +341,7 @@ export async function handleStreamEvent(event: string, rawData: string, state: C
       entry.updated = updated;
       entry.drafts = payload.drafts || {};
       applyDraftUpdates(payload.drafts);
-      updatePatchPreviewFromDraft(payload.drafts?.[getActiveDoc()] as any);
+      updatePatchPreviewFromDraft(payload.drafts?.[getActiveDoc()] as DraftPayload);
       entry.status = "done";
     }
     renderChat();
@@ -383,7 +384,7 @@ export function applyChatResult(payload: unknown, state: ChatState, entry: ChatE
   const parsed = parseChatPayload(payload);
   if (parsed.interrupted) {
     entry.status = "interrupted";
-    entry.error = (parsed as any).detail || "Doc chat interrupted";
+    entry.error = (parsed as Record<string, unknown>).detail as string || "Doc chat interrupted";
     state.status = "interrupted";
     state.error = "";
     return;

--- a/src/codex_autorunner/static_src/messages.ts
+++ b/src/codex_autorunner/static_src/messages.ts
@@ -36,6 +36,17 @@ interface ThreadsResponse {
   threads?: ThreadSummary[];
 }
 
+interface FileAttachment {
+  name: string;
+  url: string;
+  size?: number | null;
+}
+
+interface ReplyMessage {
+  title?: string | null;
+  body?: string | null;
+}
+
 interface ThreadDetail {
   run?: {
     id: string;
@@ -292,7 +303,7 @@ function renderFiles(files: Array<{ name: string; url: string; size?: number | n
   return `<ul class="messages-files">${items}</ul>`;
 }
 
-function renderHandoff(entry: { seq: number; message?: AgentMessage | null; files?: any[]; created_at?: string | null }): string {
+function renderHandoff(entry: { seq: number; message?: AgentMessage | null; files?: FileAttachment[]; created_at?: string | null }): string {
   const msg = entry.message;
   const title = msg?.title || "Agent message";
   const mode = msg?.mode ? ` <span class="pill pill-small">${escapeHtml(msg.mode)}</span>` : "";
@@ -307,7 +318,7 @@ function renderHandoff(entry: { seq: number; message?: AgentMessage | null; file
   `;
 }
 
-function renderReply(entry: { seq: number; reply?: any; files?: any[]; created_at?: string | null }): string {
+function renderReply(entry: { seq: number; reply?: ReplyMessage | null; files?: FileAttachment[]; created_at?: string | null }): string {
   const rep = entry.reply;
   const title = rep?.title || "Reply";
   const body = rep?.body ? `<div class="messages-body messages-markdown">${renderMarkdown(rep.body)}</div>` : "";


### PR DESCRIPTION
## Summary

This PR cleans up TypeScript lint warnings in the most-read UI codepaths, replacing `any` types with proper types.

## Changes

### Type fixes
- static_src/dashboard.ts: Replaced `any` with proper types
- static_src/messages.ts: Replaced `any` with proper types  
- static_src/docChatRender.ts: Replaced `any` with proper types
- static_src/docChatStream.ts: Replaced `any` with proper types

### Approach
- Used lightweight types or `unknown` + narrowing where appropriate
- Avoided large refactors
- No functional changes
- pnpm build and eslint pass

### Impact
- Significantly reduces eslint no-explicit-any warning count
- Improves type safety without changing behavior

Closes #386