### PR TITLE
Fix Telegram /experimental feature flags

### DIFF
--- a/src/codex_autorunner/integrations/telegram/helpers.py
+++ b/src/codex_autorunner/integrations/telegram/helpers.py
@@ -49,6 +49,21 @@ class CodexFeatureRow:
     enabled: bool
 
 
+def derive_codex_features_command(app_server_command: Sequence[str]) -> list[str]:
+    """
+    Build a Codex CLI invocation for `features list` that mirrors the configured app-server command.
+
+    We strip a trailing \"app-server\" subcommand (plus keep any preceding flags/binary),
+    so custom binaries or wrapper scripts stay aligned with the running app server.
+    """
+    base = list(app_server_command or [])
+    if base and base[-1] == "app-server":
+        base = base[:-1]
+    if not base:
+        base = ["codex"]
+    return [*base, "features", "list"]
+
+
 def parse_codex_features_list(stdout: str) -> list[CodexFeatureRow]:
     rows: list[CodexFeatureRow] = []
     if not isinstance(stdout, str):

--- a/tests/test_telegram_codex_feature_flags.py
+++ b/tests/test_telegram_codex_feature_flags.py
@@ -1,5 +1,6 @@
 from codex_autorunner.integrations.telegram.helpers import (
     CodexFeatureRow,
+    derive_codex_features_command,
     format_codex_features,
     parse_codex_features_list,
 )
@@ -49,3 +50,18 @@ def test_format_codex_features_all() -> None:
     assert "- alpha: True" in text
     assert "- bravo: False" in text
     assert "/experimental all" not in text  # already listing all
+
+
+def test_derive_codex_features_command_strips_app_server_suffix() -> None:
+    command = derive_codex_features_command(["/opt/codex/bin/codex", "app-server"])
+    assert command == ["/opt/codex/bin/codex", "features", "list"]
+
+
+def test_derive_codex_features_command_keeps_flags() -> None:
+    command = derive_codex_features_command(["codex", "--foo", "app-server"])
+    assert command == ["codex", "--foo", "features", "list"]
+
+
+def test_derive_codex_features_command_fallback() -> None:
+    command = derive_codex_features_command([])
+    assert command == ["codex", "features", "list"]


### PR DESCRIPTION
## Summary
- use app_server_command-derived codex invocation for /experimental feature discovery to match running app server
- add helper + tests for deriving command and parsing/formatting codex features output
- validate enable/disable flow still uses runtime-discovered features with override messaging

## Testing
- .venv/bin/pytest tests/test_telegram_codex_feature_flags.py
- .venv/bin/pytest  # run by pre-commit hooks (passes; eslint emits existing any warnings)