### PR TITLE
Increase ticket flow max turns to 50

### DIFF
--- a/scripts/add-static-banner.js
+++ b/scripts/add-static-banner.js
@@ -7,9 +7,8 @@
 
 import fs from 'fs';
 import path from 'path';
-import glob from 'glob';
+import { glob } from 'glob';
 import { fileURLToPath } from 'url';
-import { promisify } from 'util';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -20,8 +19,7 @@ async function main() {
   const staticDir = path.join(__dirname, '..', 'src', 'codex_autorunner', 'static');
   const pattern = path.join(staticDir, '**', '*.js').replace(/\\/g, '/');
 
-  const globAsync = promisify(glob);
-  const files = await globAsync(pattern, {
+  const files = await glob(pattern, {
     ignore: ['**/vendor/**', '**/node_modules/**']
   });
   

--- a/src/codex_autorunner/flows/ticket_flow/definition.py
+++ b/src/codex_autorunner/flows/ticket_flow/definition.py
@@ -6,7 +6,12 @@ from typing import Any, Dict, Optional
 from ...core.flows.definition import EmitEventFn, FlowDefinition, StepOutcome
 from ...core.flows.models import FlowEventType, FlowRunRecord
 from ...core.utils import find_repo_root
-from ...tickets import AgentPool, TicketRunConfig, TicketRunner
+from ...tickets import (
+    DEFAULT_MAX_TOTAL_TURNS,
+    AgentPool,
+    TicketRunConfig,
+    TicketRunner,
+)
 
 
 def build_ticket_flow_definition(*, agent_pool: AgentPool) -> FlowDefinition:
@@ -33,7 +38,9 @@ def build_ticket_flow_definition(*, agent_pool: AgentPool) -> FlowDefinition:
         workspace_root = Path(input_data.get("workspace_root") or repo_root)
         ticket_dir = Path(input_data.get("ticket_dir") or ".codex-autorunner/tickets")
         runs_dir = Path(input_data.get("runs_dir") or ".codex-autorunner/runs")
-        max_total_turns = int(input_data.get("max_total_turns") or 25)
+        max_total_turns = int(
+            input_data.get("max_total_turns") or DEFAULT_MAX_TOTAL_TURNS
+        )
         max_lint_retries = int(input_data.get("max_lint_retries") or 3)
         max_commit_retries = int(input_data.get("max_commit_retries") or 2)
         auto_commit = bool(

--- a/src/codex_autorunner/tickets/__init__.py
+++ b/src/codex_autorunner/tickets/__init__.py
@@ -5,10 +5,17 @@ markdown tickets with YAML frontmatter.
 """
 
 from .agent_pool import AgentPool, AgentTurnRequest, AgentTurnResult
-from .models import TicketDoc, TicketFrontmatter, TicketResult, TicketRunConfig
+from .models import (
+    DEFAULT_MAX_TOTAL_TURNS,
+    TicketDoc,
+    TicketFrontmatter,
+    TicketResult,
+    TicketRunConfig,
+)
 from .runner import TicketRunner
 
 __all__ = [
+    "DEFAULT_MAX_TOTAL_TURNS",
     "AgentPool",
     "AgentTurnRequest",
     "AgentTurnResult",

--- a/src/codex_autorunner/tickets/models.py
+++ b/src/codex_autorunner/tickets/models.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
+DEFAULT_MAX_TOTAL_TURNS = 50
+
 
 @dataclass(frozen=True)
 class TicketFrontmatter:
@@ -70,7 +72,7 @@ class DispatchRecord:
 class TicketRunConfig:
     ticket_dir: Path
     runs_dir: Path
-    max_total_turns: int = 25
+    max_total_turns: int = DEFAULT_MAX_TOTAL_TURNS
     max_lint_retries: int = 3
     max_commit_retries: int = 2
     auto_commit: bool = True

--- a/tests/tickets/test_ticket_runner.py
+++ b/tests/tickets/test_ticket_runner.py
@@ -6,7 +6,10 @@ from typing import Callable
 import pytest
 
 from codex_autorunner.tickets.agent_pool import AgentTurnRequest, AgentTurnResult
-from codex_autorunner.tickets.models import TicketRunConfig
+from codex_autorunner.tickets.models import (
+    DEFAULT_MAX_TOTAL_TURNS,
+    TicketRunConfig,
+)
 from codex_autorunner.tickets.runner import TicketRunner
 
 
@@ -40,6 +43,15 @@ def _corrupt_ticket_frontmatter(path: Path) -> None:
     # Make 'done' invalid.
     raw = raw.replace("done: false", "done: notabool")
     path.write_text(raw, encoding="utf-8")
+
+
+def test_ticket_run_config_default_max_turns() -> None:
+    cfg = TicketRunConfig(
+        ticket_dir=Path(".codex-autorunner/tickets"),
+        runs_dir=Path(".codex-autorunner/runs"),
+        auto_commit=False,
+    )
+    assert cfg.max_total_turns == DEFAULT_MAX_TOTAL_TURNS
 
 
 class FakeAgentPool:


### PR DESCRIPTION
## Summary
- raise ticket flow default max_total_turns to 50 via shared constant and flow default
- add regression test covering the default TicketRunConfig turn limit
- fix add-static-banner glob import so the build hook runs on glob@11/node20

## Testing
- pnpm run build
- .venv/bin/python -m pytest tests/tickets/test_ticket_runner.py
- git commit hook (full suite)
