### PR TITLE
Guard ticket bootstrap when tickets already exist

### DIFF
--- a/src/codex_autorunner/routes/flows.py
+++ b/src/codex_autorunner/routes/flows.py
@@ -647,6 +647,8 @@ def build_flow_routes() -> APIRouter:
         ticket_dir = repo_root / ".codex-autorunner" / "tickets"
         ticket_dir.mkdir(parents=True, exist_ok=True)
         ticket_path = ticket_dir / "TICKET-001.md"
+        existing_tickets = list_ticket_paths(ticket_dir)
+        tickets_exist = bool(existing_tickets)
         flow_request = request or FlowStartRequest()
         meta = flow_request.metadata if isinstance(flow_request.metadata, dict) else {}
         force_new = bool(meta.get("force_new"))
@@ -670,7 +672,7 @@ def build_flow_routes() -> APIRouter:
                 return resp
 
         seeded = False
-        if not ticket_path.exists():
+        if not tickets_exist and not ticket_path.exists():
             template = """---
 agent: codex
 done: false


### PR DESCRIPTION
## Summary
- align bootstrap seeding with readiness guard so existing tickets skip issue bootstrap
- keep ticket flow reuse logic intact and avoid creating TICKET-001 when any ticket is present
- add regression test covering existing-ticket bootstrap path

## Testing
- pytest tests/routes/test_flow_bootstrap_guard.py -q
- pytest
