### PR TITLE
Fix car doctor when docs config omits todo/progress/opinions

### DIFF
--- a/src/codex_autorunner/core/engine.py
+++ b/src/codex_autorunner/core/engine.py
@@ -2920,7 +2920,8 @@ def doctor(start_path: Path) -> DoctorReport:
 
     if repo_config is not None:
         missing = []
-        for key in ("todo", "progress", "opinions"):
+        configured_docs = repo_config.docs or {}
+        for key in configured_docs:
             path = repo_config.doc_path(key)
             if not path.exists():
                 missing.append(path)
@@ -2929,16 +2930,16 @@ def doctor(start_path: Path) -> DoctorReport:
             _append_check(
                 checks,
                 "docs.required",
-                "error",
-                f"Missing doc files: {names}",
-                "Run `car init` or create the missing files.",
+                "warning",
+                f"Configured doc files are missing: {names}",
+                "Create the missing files (workspace docs are optional but recommended).",
             )
         else:
             _append_check(
                 checks,
                 "docs.required",
                 "ok",
-                "Required doc files are present.",
+                "Configured doc files are present.",
             )
 
         if ensure_executable(repo_config.codex_binary):


### PR DESCRIPTION
## Summary
- avoid KeyError in `car doctor` when repo docs omit legacy todo/progress/opinions keys
- check configured docs dynamically and downgrade missing files to a warning so doctor can complete

## Testing
- .venv/bin/car doctor --repo .
- .venv/bin/car doctor --repo /Users/dazheng/car-workspace
- .venv/bin/python -m pytest
