### PR TITLE
Inline hub repo usage and roll up worktree tokens

### DIFF
--- a/src/codex_autorunner/static/index.html
+++ b/src/codex_autorunner/static/index.html
@@ -51,14 +51,6 @@
       </div>
       <div class="hub-inbox-list" id="hub-inbox-list">Loading…</div>
     </section>
-    <section class="hub-usage-compact">
-      <div class="hub-usage-header">
-        <span class="label">Usage</span>
-        <span class="hub-usage-path" id="hub-usage-meta">–</span>
-        <button class="ghost sm icon-btn" id="hub-usage-refresh" title="Refresh usage">↻</button>
-      </div>
-      <div class="hub-usage-grid" id="hub-usage-list">Loading…</div>
-    </section>
     <section class="hub-usage-chart">
       <div class="hub-usage-chart-header">
         <span class="label">Usage Trend</span>

--- a/src/codex_autorunner/static/styles.css
+++ b/src/codex_autorunner/static/styles.css
@@ -1097,6 +1097,30 @@ main {
   overflow: hidden;
 }
 
+.hub-repo-usage-line {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+  font-size: 10px;
+}
+
+.hub-usage-pill {
+  background: rgba(108, 245, 216, 0.08);
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+.hub-usage-pill-meta {
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.hub-usage-unmatched-note {
+  margin-top: 4px;
+  padding-left: 2px;
+}
+
 a.hub-pr-pill {
   text-decoration: none;
   border-color: rgba(108, 245, 216, 0.35);
@@ -6394,6 +6418,8 @@ button.loading::after {
 
   .hub-repo-row {
     gap: 6px;
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .hub-repo-left {
@@ -6413,8 +6439,16 @@ button.loading::after {
     font-size: 10px;
   }
 
+  .hub-repo-usage-line {
+    font-size: 10px;
+    width: 100%;
+  }
+
   .hub-repo-right {
     gap: 3px;
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
   }
 
   .hub-repo-right button {


### PR DESCRIPTION
## Summary\n- move usage tokens inline into each repo card (with placeholder and unmatched note) to remove the chip row while keeping the chart\n- add mobile-friendly stacked repo layout and wrap actions; ensure usage fetch does not block repo render\n- roll up cleaned worktree token logs heuristically to parent repos and add tests\n\n## Testing\n- make check