### PR TITLE
Ensure pause dispatches DM Telegram fallback

### DIFF
--- a/src/codex_autorunner/integrations/telegram/config.py
+++ b/src/codex_autorunner/integrations/telegram/config.py
@@ -538,11 +538,17 @@ class TelegramBotConfig:
 
         default_notification_chat_raw = cfg.get("default_notification_chat_id")
         default_notification_chat_id: Optional[int] = None
-        try:
-            if default_notification_chat_raw is not None:
+        env_chat_candidates = _parse_int_list(env.get(chat_id_env))
+        if default_notification_chat_raw is not None:
+            try:
                 default_notification_chat_id = int(default_notification_chat_raw)
-        except (TypeError, ValueError):
-            default_notification_chat_id = None
+            except (TypeError, ValueError):
+                default_notification_chat_id = None
+        if default_notification_chat_id is None:
+            if env_chat_candidates:
+                default_notification_chat_id = env_chat_candidates[0]
+            elif allowed_chat_ids:
+                default_notification_chat_id = min(allowed_chat_ids)
 
         agent_binaries = dict(agent_binaries or {})
         command_reg_raw_value = cfg.get("command_registration")


### PR DESCRIPTION
## Summary\n- default pause dispatch notifications now fall back to the configured chat id when no topic is bound, so paused runs DM the user\n- keep explicit default_notification_chat_id respected while falling back to env/allowlist when unset or invalid\n- expand config tests to cover new defaults and allowlist fallback\n\n## Testing\n- .venv/bin/python -m pytest tests/test_telegram_bot_config.py tests/test_telegram_ticket_flow_bridge.py\n- git commit hooks (full suite)