### PR TITLE
Coalesce OpenCode streaming deltas

### DIFF
--- a/src/codex_autorunner/core/text_delta_coalescer.py
+++ b/src/codex_autorunner/core/text_delta_coalescer.py
@@ -41,3 +41,57 @@ class TextDeltaCoalescer:
 
     def clear(self) -> None:
         self._buffer = ""
+
+
+class StreamingTextCoalescer:
+    """
+    Coalesce small streaming text deltas into larger, readable chunks.
+
+    - Flushes whole lines as soon as a newline is observed.
+    - Flushes buffered text when it grows past `min_flush_chars` and ends at a
+      natural boundary (whitespace or sentence punctuation).
+    - Enforces an upper bound on the buffer size to avoid unbounded growth.
+    """
+
+    def __init__(self, min_flush_chars: int = 32, max_buffer_chars: int = 2048):
+        self._buffer: str = ""
+        self._min_flush_chars = max(1, int(min_flush_chars))
+        self._max_buffer_chars = max(self._min_flush_chars, int(max_buffer_chars))
+
+    def add(self, delta: Optional[str]) -> list[str]:
+        chunks: list[str] = []
+        if not isinstance(delta, str) or not delta:
+            return chunks
+
+        self._buffer += delta
+        self._flush_complete_lines(chunks)
+        self._flush_if_boundary(chunks)
+        self._flush_if_oversized(chunks)
+        return chunks
+
+    def flush(self) -> list[str]:
+        if not self._buffer:
+            return []
+        chunk = self._buffer
+        self._buffer = ""
+        return [chunk]
+
+    def _flush_complete_lines(self, chunks: list[str]) -> None:
+        while "\n" in self._buffer:
+            line, remainder = self._buffer.split("\n", 1)
+            # Preserve the newline boundary so the caller keeps the same text.
+            chunks.append(f"{line}\n")
+            self._buffer = remainder
+
+    def _flush_if_boundary(self, chunks: list[str]) -> None:
+        if len(self._buffer) < self._min_flush_chars:
+            return
+        last_char = self._buffer[-1]
+        if last_char.isspace() or last_char in ".!?;:":
+            chunks.append(self._buffer)
+            self._buffer = ""
+
+    def _flush_if_oversized(self, chunks: list[str]) -> None:
+        while len(self._buffer) > self._max_buffer_chars:
+            chunks.append(self._buffer[: self._max_buffer_chars])
+            self._buffer = self._buffer[self._max_buffer_chars :]

--- a/tests/test_opencode_backend_streaming.py
+++ b/tests/test_opencode_backend_streaming.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from codex_autorunner.agents.opencode.events import SSEEvent
+from codex_autorunner.core.ports.run_event import Completed, OutputDelta
+from codex_autorunner.integrations.agents.opencode_backend import OpenCodeBackend
+
+
+class _FakeOpenCodeClient:
+    def __init__(self, events: list[SSEEvent]):
+        self._events = events
+
+    async def stream_events(self, *, directory=None, ready_event=None, paths=None):
+        if ready_event is not None:
+            ready_event.set()
+        for event in self._events:
+            yield event
+
+    async def session_status(self, directory=None):
+        return {"status": {"type": "idle"}}
+
+    async def providers(self, directory=None):
+        return {}
+
+    async def respond_permission(self, request_id: str, reply: str):
+        return None
+
+    async def reply_question(self, request_id: str, answers):
+        return None
+
+    async def reject_question(self, request_id: str):
+        return None
+
+    async def prompt_async(self, *args, **kwargs):
+        return {}
+
+    async def send_command(self, *args, **kwargs):
+        return None
+
+
+@pytest.mark.anyio
+async def test_opencode_streaming_coalesces_text_deltas(tmp_path: Path) -> None:
+    session_id = "s-test"
+    deltas = ["Hello ", "world", " from ", "test", "."]
+    events = [
+        SSEEvent(
+            event="message.part.updated",
+            data='{"sessionID":"s-test","properties":{"delta":{"text":"Hello "},'
+            '"part":{"type":"text","text":"Hello "}}}',
+        ),
+        SSEEvent(
+            event="message.part.updated",
+            data='{"sessionID":"s-test","properties":{"delta":{"text":"world"},'
+            '"part":{"type":"text","text":"Hello world"}}}',
+        ),
+        SSEEvent(
+            event="message.part.updated",
+            data='{"sessionID":"s-test","properties":{"delta":{"text":" from "},'
+            '"part":{"type":"text","text":"Hello world from "}}}',
+        ),
+        SSEEvent(
+            event="message.part.updated",
+            data='{"sessionID":"s-test","properties":{"delta":{"text":"test"},'
+            '"part":{"type":"text","text":"Hello world from test"}}}',
+        ),
+        SSEEvent(
+            event="message.part.updated",
+            data='{"sessionID":"s-test","properties":{"delta":{"text":"."},'
+            '"part":{"type":"text","text":"Hello world from test."}}}',
+        ),
+        SSEEvent(event="session.idle", data='{"sessionID":"s-test"}'),
+    ]
+
+    backend = OpenCodeBackend(workspace_root=tmp_path, supervisor=None)
+    backend._client = _FakeOpenCodeClient(events)
+
+    assistant_chunks: list[str] = []
+    final_message: Optional[str] = None
+
+    async for event in backend.run_turn_events(session_id, "Ping"):
+        if isinstance(event, OutputDelta) and event.delta_type == "assistant_stream":
+            assistant_chunks.append(event.content)
+        if isinstance(event, Completed):
+            final_message = event.final_message
+
+    assert final_message == "".join(deltas)
+    assert "".join(assistant_chunks) == "".join(deltas)
+    # Regression: avoid emitting one OutputDelta per tiny delta
+    assert len(assistant_chunks) <= len(deltas) // 2


### PR DESCRIPTION
## Summary
- add a shared StreamingTextCoalescer to batch streaming text deltas on natural boundaries
- use the coalescer in the OpenCode backend so assistant_stream events stop arriving one word at a time
- add a regression test covering OpenCode streaming to guard the behaviour

## Testing
- .venv/bin/pytest tests/test_opencode_backend_streaming.py
- .venv/bin/pytest tests/test_opencode_runtime.py
- git commit (repo hooks: black, ruff, mypy, eslint, pnpm build, full pytest)