### PR TITLE
Add mobile workspace actions for mobile

### DIFF
--- a/src/codex_autorunner/static/index.html
+++ b/src/codex_autorunner/static/index.html
@@ -358,6 +358,16 @@
               </button>
               <div class="workspace-mobile-actions">
                 <span class="muted small" id="workspace-status-mobile"></span>
+                <div class="workspace-mobile-menu">
+                  <button class="ghost sm icon-btn" id="workspace-mobile-menu-toggle" title="Workspace actions">⋯</button>
+                  <div class="workspace-mobile-dropdown hidden" id="workspace-mobile-dropdown">
+                    <button class="workspace-mobile-item" id="workspace-mobile-upload">Upload files</button>
+                    <button class="workspace-mobile-item" id="workspace-mobile-new-folder">New folder</button>
+                    <button class="workspace-mobile-item" id="workspace-mobile-new-file">New file</button>
+                    <button class="workspace-mobile-item" id="workspace-mobile-download">Download ZIP</button>
+                    <button class="workspace-mobile-item hidden" id="workspace-mobile-generate">Generate tickets</button>
+                  </div>
+                </div>
                 <button class="ghost sm" id="workspace-reload-mobile" title="Reload">↻</button>
                 <button class="primary sm" id="workspace-save-mobile">Save</button>
               </div>

--- a/src/codex_autorunner/static/styles.css
+++ b/src/codex_autorunner/static/styles.css
@@ -3536,6 +3536,39 @@ button.icon-btn {
   display: none;
 }
 
+.workspace-mobile-menu {
+  position: relative;
+}
+
+.workspace-mobile-dropdown {
+  position: absolute;
+  right: 0;
+  top: 110%;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  padding: 6px;
+  min-width: 170px;
+  z-index: 30;
+}
+
+.workspace-mobile-item {
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  background: transparent;
+  color: var(--text);
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+}
+
+.workspace-mobile-item:hover,
+.workspace-mobile-item:active {
+  background: rgba(108, 245, 216, 0.1);
+}
+
 /* Mobile file selector button - clean, square aesthetic */
 .workspace-file-btn {
   display: inline-flex;
@@ -7036,6 +7069,14 @@ button.loading::after {
     gap: 8px;
     padding: 2px 0;
     margin: 0;
+  }
+
+  .workspace-mobile-menu {
+    margin-left: auto;
+  }
+
+  .workspace-mobile-dropdown {
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
   }
 
   /* Tighten spacing around toolbar */


### PR DESCRIPTION
## Summary
- add mobile workspace action menu so uploads/new file/folder/download/generate are available on phones
- wire menu buttons to existing workspace actions and sync generate visibility
- keep download label contextual to folder and close menu on outside tap

## Testing
- pnpm build
- pytest