### PR TITLE
Fix mobile overflow menus taps

### DIFF
--- a/src/codex_autorunner/static/tickets.js
+++ b/src/codex_autorunner/static/tickets.js
@@ -1890,21 +1890,26 @@ export function initTicketFlow() {
     const { overflowToggle, overflowDropdown, overflowNew, overflowRestart, overflowArchive } = els();
     if (overflowToggle && overflowDropdown) {
         const toggleMenu = (e) => {
+            e.preventDefault();
             e.stopPropagation();
             const isHidden = overflowDropdown.classList.contains("hidden");
             overflowDropdown.classList.toggle("hidden", !isHidden);
         };
-        overflowToggle.addEventListener("click", toggleMenu);
-        overflowToggle.addEventListener("touchend", (e) => {
-            e.preventDefault(); // Prevent ghost click
-            toggleMenu(e);
+        const closeMenu = () => overflowDropdown.classList.add("hidden");
+        overflowToggle.addEventListener("pointerdown", toggleMenu);
+        overflowToggle.addEventListener("click", (e) => {
+            e.preventDefault(); // swallow synthetic click after pointerdown
+        });
+        overflowToggle.addEventListener("keydown", (e) => {
+            if (e.key === "Enter" || e.key === " ")
+                toggleMenu(e);
         });
         // Close on outside click
-        document.addEventListener("click", (e) => {
+        document.addEventListener("pointerdown", (e) => {
             if (!overflowDropdown.classList.contains("hidden") &&
                 !overflowToggle.contains(e.target) &&
                 !overflowDropdown.contains(e.target)) {
-                overflowDropdown.classList.add("hidden");
+                closeMenu();
             }
         });
     }

--- a/src/codex_autorunner/static/workspace.js
+++ b/src/codex_autorunner/static/workspace.js
@@ -715,11 +715,21 @@ export async function initWorkspace() {
         }
     });
     // Mobile action sheet
-    mobileMenuToggle?.addEventListener("click", (evt) => {
+    const handleMobileToggle = (evt) => {
+        evt.preventDefault();
         evt.stopPropagation();
         toggleMobileMenu();
+    };
+    mobileMenuToggle?.addEventListener("pointerdown", handleMobileToggle);
+    mobileMenuToggle?.addEventListener("click", (evt) => {
+        evt.preventDefault(); // swallow synthetic click after pointerdown
     });
-    document.addEventListener("click", (evt) => {
+    mobileMenuToggle?.addEventListener("keydown", (evt) => {
+        if (evt.key === "Enter" || evt.key === " ") {
+            handleMobileToggle(evt);
+        }
+    });
+    document.addEventListener("pointerdown", (evt) => {
         if (!mobileDropdown || mobileDropdown.classList.contains("hidden"))
             return;
         if (evt.target instanceof Node && mobileDropdown.contains(evt.target))

--- a/src/codex_autorunner/static_src/tickets.ts
+++ b/src/codex_autorunner/static_src/tickets.ts
@@ -2128,22 +2128,27 @@ export function initTicketFlow(): void {
 
   if (overflowToggle && overflowDropdown) {
     const toggleMenu = (e: Event) => {
+      e.preventDefault();
       e.stopPropagation();
       const isHidden = overflowDropdown.classList.contains("hidden");
       overflowDropdown.classList.toggle("hidden", !isHidden);
     };
-    overflowToggle.addEventListener("click", toggleMenu);
-    overflowToggle.addEventListener("touchend", (e) => {
-      e.preventDefault(); // Prevent ghost click
-      toggleMenu(e);
+    const closeMenu = () => overflowDropdown.classList.add("hidden");
+
+    overflowToggle.addEventListener("pointerdown", toggleMenu);
+    overflowToggle.addEventListener("click", (e) => {
+      e.preventDefault(); // swallow synthetic click after pointerdown
+    });
+    overflowToggle.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") toggleMenu(e);
     });
 
     // Close on outside click
-    document.addEventListener("click", (e) => {
+    document.addEventListener("pointerdown", (e) => {
       if (!overflowDropdown.classList.contains("hidden") && 
           !overflowToggle.contains(e.target as Node) && 
           !overflowDropdown.contains(e.target as Node)) {
-        overflowDropdown.classList.add("hidden");
+        closeMenu();
       }
     });
   }

--- a/src/codex_autorunner/static_src/workspace.ts
+++ b/src/codex_autorunner/static_src/workspace.ts
@@ -810,12 +810,23 @@ export async function initWorkspace(): Promise<void> {
   });
 
   // Mobile action sheet
-  mobileMenuToggle?.addEventListener("click", (evt) => {
+  const handleMobileToggle = (evt: Event) => {
+    evt.preventDefault();
     evt.stopPropagation();
     toggleMobileMenu();
+  };
+
+  mobileMenuToggle?.addEventListener("pointerdown", handleMobileToggle);
+  mobileMenuToggle?.addEventListener("click", (evt) => {
+    evt.preventDefault(); // swallow synthetic click after pointerdown
+  });
+  mobileMenuToggle?.addEventListener("keydown", (evt) => {
+    if (evt.key === "Enter" || evt.key === " ") {
+      handleMobileToggle(evt);
+    }
   });
 
-  document.addEventListener("click", (evt) => {
+  document.addEventListener("pointerdown", (evt) => {
     if (!mobileDropdown || mobileDropdown.classList.contains("hidden")) return;
     if (evt.target instanceof Node && mobileDropdown.contains(evt.target)) return;
     closeMobileMenu();


### PR DESCRIPTION
## Summary
- ensure workspace mobile overflow menu responds to touch/pointer and keyboard
- make ticket overflow menu handle pointerdown/touch and close reliably on mobile
- keep desktop behavior unchanged while preventing ghost clicks

## Testing
- pnpm build
- .venv/bin/pytest