### PR TITLE
Return raw ticket body when frontmatter invalid

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/flows.py
+++ b/src/codex_autorunner/surfaces/web/routes/flows.py
@@ -680,6 +680,39 @@ You are the first ticket in a new ticket_flow run.
             "tickets": tickets,
         }
 
+    @router.get("/ticket_flow/tickets/{index}", response_model=TicketResponse)
+    async def get_ticket(index: int):
+        """Fetch a single ticket by index; return raw body even if frontmatter is invalid."""
+        repo_root = find_repo_root()
+        ticket_dir = repo_root / ".codex-autorunner" / "tickets"
+        ticket_path = _find_ticket_path_by_index(ticket_dir, index)
+
+        if not ticket_path:
+            raise HTTPException(status_code=404, detail=f"Ticket {index:03d} not found")
+
+        doc, errors = read_ticket(ticket_path)
+        if doc and not errors:
+            return TicketResponse(
+                path=safe_relpath(ticket_path, repo_root),
+                index=doc.index,
+                frontmatter=asdict(doc.frontmatter),
+                body=doc.body,
+            )
+
+        # Mirror list endpoint: surface raw body for repair when frontmatter is broken.
+        try:
+            raw_body = ticket_path.read_text(encoding="utf-8")
+            parsed_frontmatter, parsed_body = parse_markdown_frontmatter(raw_body)
+        except Exception:
+            parsed_frontmatter, parsed_body = {}, None
+
+        return TicketResponse(
+            path=safe_relpath(ticket_path, repo_root),
+            index=parse_ticket_index(ticket_path.name),
+            frontmatter=parsed_frontmatter or {},
+            body=parsed_body,
+        )
+
     @router.post("/ticket_flow/tickets", response_model=TicketResponse)
     async def create_ticket(request: TicketCreateRequest):
         """Create a new ticket with auto-generated index."""

--- a/tests/routes/test_ticket_first_contracts.py
+++ b/tests/routes/test_ticket_first_contracts.py
@@ -97,3 +97,68 @@ def test_ticket_list_returns_body_even_when_frontmatter_invalid(tmp_path, monkey
         assert "Describe the task details here" in (ticket["body"] or "")
         # Errors surface frontmatter problems.
         assert ticket["errors"]
+
+
+def test_get_ticket_by_index(tmp_path, monkeypatch):
+    """GET /api/flows/ticket_flow/tickets/{index} returns a single ticket."""
+
+    ticket_dir = tmp_path / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True)
+    ticket_path = ticket_dir / "TICKET-002.md"
+    ticket_path.write_text(
+        "---\nagent: codex\ndone: false\ntitle: Demo\n---\n\nBody here\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(flow_routes, "find_repo_root", lambda: Path(tmp_path))
+
+    app = FastAPI()
+    app.include_router(flow_routes.build_flow_routes())
+
+    with TestClient(app) as client:
+        resp = client.get("/api/flows/ticket_flow/tickets/2")
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["index"] == 2
+        assert payload["frontmatter"]["agent"] == "codex"
+        assert "Body here" in payload["body"]
+
+
+def test_get_ticket_by_index_returns_body_on_invalid_frontmatter(tmp_path, monkeypatch):
+    """Single-ticket endpoint should mirror list behavior when frontmatter is broken."""
+
+    ticket_dir = tmp_path / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True)
+    ticket_path = ticket_dir / "TICKET-003.md"
+    ticket_path.write_text(
+        "---\nagent: codex\n# missing done\n---\n\nStill show body\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(flow_routes, "find_repo_root", lambda: Path(tmp_path))
+
+    app = FastAPI()
+    app.include_router(flow_routes.build_flow_routes())
+
+    with TestClient(app) as client:
+        resp = client.get("/api/flows/ticket_flow/tickets/3")
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["index"] == 3
+        # Invalid frontmatter should not block access; parsed fields may be partial.
+        assert payload["frontmatter"].get("agent") == "codex"
+        assert "Still show body" in (payload["body"] or "")
+
+
+def test_get_ticket_by_index_404(tmp_path, monkeypatch):
+    """GET /api/flows/ticket_flow/tickets/{index} returns 404 when missing."""
+
+    (tmp_path / ".codex-autorunner" / "tickets").mkdir(parents=True)
+    monkeypatch.setattr(flow_routes, "find_repo_root", lambda: Path(tmp_path))
+
+    app = FastAPI()
+    app.include_router(flow_routes.build_flow_routes())
+
+    with TestClient(app) as client:
+        resp = client.get("/api/flows/ticket_flow/tickets/99")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add GET /api/flows/ticket_flow/tickets/{index} handling that returns raw body when frontmatter lint fails
- mirror list endpoint behavior so broken tickets remain viewable/editable instead of 400s
- add regression tests for single-ticket fetch success, invalid frontmatter, and 404

## Testing
- pnpm build
- .venv/bin/pytest
