### PR TITLE
Fix PMA media routing in Telegram topics

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands/files.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/files.py
@@ -543,6 +543,15 @@ class FilesCommands(SharedHelpers):
             first_msg.chat_id, first_msg.thread_id
         )
         record = await self._router.get_topic(topic_key)
+        record, pma_error = message_handlers._record_with_media_workspace(self, record)
+        if pma_error:
+            await self._send_message(
+                first_msg.chat_id,
+                pma_error,
+                thread_id=first_msg.thread_id,
+                reply_to=first_msg.message_id,
+            )
+            return None
         if record is None or not record.workspace_path:
             await self._send_message(
                 first_msg.chat_id,

--- a/tests/test_telegram_pma_routing.py
+++ b/tests/test_telegram_pma_routing.py
@@ -6,10 +6,17 @@ from typing import Optional
 
 import pytest
 
-from codex_autorunner.integrations.telegram.adapter import TelegramMessage
+from codex_autorunner.integrations.telegram.adapter import (
+    TelegramDocument,
+    TelegramMessage,
+    TelegramVoice,
+)
 from codex_autorunner.integrations.telegram.handlers.commands.execution import (
     ExecutionCommands,
     _TurnRunResult,
+)
+from codex_autorunner.integrations.telegram.handlers.messages import (
+    handle_media_message,
 )
 from codex_autorunner.integrations.telegram.state import TelegramTopicRecord
 
@@ -123,3 +130,193 @@ async def test_pma_prompt_routing_uses_hub_root(tmp_path: Path) -> None:
     assert "<hub_snapshot>" in prompt_text
     assert "<user_message>" in prompt_text
     assert "hello" in prompt_text
+
+
+@pytest.mark.anyio
+async def test_pma_media_uses_hub_root(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir(parents=True, exist_ok=True)
+    record = TelegramTopicRecord(pma_enabled=True, workspace_path=None)
+    sent: list[str] = []
+    captured: dict[str, object] = {}
+
+    class _MediaRouterStub:
+        async def get_topic(self, _key: str) -> TelegramTopicRecord:
+            return record
+
+    class _MediaHandlerStub:
+        def __init__(self) -> None:
+            self._hub_root = hub_root
+            self._router = _MediaRouterStub()
+            self._logger = logging.getLogger("test")
+            self._config = SimpleNamespace(
+                media=SimpleNamespace(
+                    enabled=True,
+                    images=True,
+                    voice=True,
+                    files=True,
+                    max_image_bytes=10_000_000,
+                    max_voice_bytes=10_000_000,
+                    max_file_bytes=10_000_000,
+                ),
+                ticket_flow_auto_resume=False,
+            )
+            self._ticket_flow_pause_targets = {}
+            self._ticket_flow_bridge = SimpleNamespace(
+                auto_resume_run=lambda *_, **__: None
+            )
+            self._bot_username = None
+
+        async def _resolve_topic_key(
+            self, chat_id: int, thread_id: Optional[int]
+        ) -> str:
+            return f"{chat_id}:{thread_id}"
+
+        async def _send_message(
+            self,
+            _chat_id: int,
+            text: str,
+            *,
+            thread_id: Optional[int],
+            reply_to: Optional[int],
+        ) -> None:
+            sent.append(text)
+
+        def _get_paused_ticket_flow(
+            self, _workspace_root: Path, *, preferred_run_id: Optional[str]
+        ) -> Optional[tuple[str, object]]:
+            return None
+
+        async def _handle_file_message(
+            self,
+            message: TelegramMessage,
+            runtime: object,
+            record_arg: TelegramTopicRecord,
+            candidate: object,
+            caption_text: str,
+            *,
+            placeholder_id: Optional[int] = None,
+        ) -> None:
+            captured["workspace_path"] = record_arg.workspace_path
+            captured["caption"] = caption_text
+            captured["kind"] = "file"
+
+    handler = _MediaHandlerStub()
+    message = TelegramMessage(
+        update_id=1,
+        message_id=2,
+        chat_id=111,
+        thread_id=222,
+        from_user_id=333,
+        text=None,
+        date=None,
+        is_topic_message=True,
+        document=TelegramDocument(
+            file_id="file-1",
+            file_unique_id=None,
+            file_name="notes.txt",
+            mime_type="text/plain",
+            file_size=10,
+        ),
+        caption="please review",
+    )
+    await handle_media_message(
+        handler, message, runtime=object(), caption_text="please review"
+    )
+
+    assert not sent  # no "Topic not bound" error
+    assert captured["workspace_path"] == str(hub_root)
+    assert captured["caption"] == "please review"
+    assert captured["kind"] == "file"
+
+
+@pytest.mark.anyio
+async def test_pma_voice_uses_hub_root(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir(parents=True, exist_ok=True)
+    record = TelegramTopicRecord(pma_enabled=True, workspace_path=None)
+    sent: list[str] = []
+    captured: dict[str, object] = {}
+
+    class _VoiceRouterStub:
+        async def get_topic(self, _key: str) -> TelegramTopicRecord:
+            return record
+
+    class _VoiceHandlerStub:
+        def __init__(self) -> None:
+            self._hub_root = hub_root
+            self._router = _VoiceRouterStub()
+            self._logger = logging.getLogger("test")
+            self._config = SimpleNamespace(
+                media=SimpleNamespace(
+                    enabled=True,
+                    images=True,
+                    voice=True,
+                    files=True,
+                    max_image_bytes=10_000_000,
+                    max_voice_bytes=10_000_000,
+                    max_file_bytes=10_000_000,
+                ),
+                ticket_flow_auto_resume=False,
+            )
+            self._ticket_flow_pause_targets = {}
+            self._ticket_flow_bridge = SimpleNamespace(
+                auto_resume_run=lambda *_, **__: None
+            )
+            self._bot_username = None
+
+        async def _resolve_topic_key(
+            self, chat_id: int, thread_id: Optional[int]
+        ) -> str:
+            return f"{chat_id}:{thread_id}"
+
+        async def _send_message(
+            self,
+            _chat_id: int,
+            text: str,
+            *,
+            thread_id: Optional[int],
+            reply_to: Optional[int],
+        ) -> None:
+            sent.append(text)
+
+        def _get_paused_ticket_flow(
+            self, _workspace_root: Path, *, preferred_run_id: Optional[str]
+        ) -> Optional[tuple[str, object]]:
+            return None
+
+        async def _handle_voice_message(
+            self,
+            message: TelegramMessage,
+            runtime: object,
+            record_arg: TelegramTopicRecord,
+            candidate: object,
+            caption_text: str,
+            *,
+            placeholder_id: Optional[int] = None,
+        ) -> None:
+            captured["workspace_path"] = record_arg.workspace_path
+            captured["caption"] = caption_text
+            captured["kind"] = "voice"
+
+    handler = _VoiceHandlerStub()
+    message = TelegramMessage(
+        update_id=1,
+        message_id=2,
+        chat_id=111,
+        thread_id=222,
+        from_user_id=333,
+        text=None,
+        date=None,
+        is_topic_message=True,
+        voice=TelegramVoice("voice-1", None, 3, "audio/ogg", 100),
+        caption="voice note",
+    )
+    await handle_media_message(
+        handler, message, runtime=object(), caption_text="voice note"
+    )
+
+    assert not sent  # no "Topic not bound" error
+    assert captured["workspace_path"] == str(hub_root)
+    assert captured["caption"] == "voice note"
+    assert captured["kind"] == "voice"


### PR DESCRIPTION
## Summary
- route Telegram PMA media (files/voice) through hub root so bindings work inside topics
- add regression tests for PMA media + voice hub-root fallback
- install eval_type_backport dev dependency to keep hooks green on py39

## Testing
- .venv/bin/python -m pytest tests/test_telegram_pma_routing.py -k pma
- scripts/check.sh