### PR TITLE
Allow /files in PMA topics and improve hub flow/status UX

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -2052,22 +2052,29 @@ class WorkspaceCommands(SharedHelpers):
             runtime = self._router.runtime_for(key)
         approval_policy, sandbox_policy = self._effective_policies(record)
         agent = self._effective_agent(record)
+        is_pma = bool(getattr(record, "pma_enabled", False))
+        workspace_label = record.workspace_path or ("hub" if is_pma else "unbound")
         effort_label = (
             record.effort or "default" if self._agent_supports_effort(agent) else "n/a"
         )
-        lines = [
-            f"Workspace: {record.workspace_path or 'unbound'}",
-            f"Workspace ID: {record.workspace_id or 'unknown'}",
-            f"Active thread: {record.active_thread_id or 'none'}",
-            f"Active turn: {runtime.current_turn_id or 'none'}",
-            f"Agent: {agent}",
-            f"Resume: {'supported' if self._agent_supports_resume(agent) else 'unsupported'}",
-            f"Model: {record.model or 'default'}",
-            f"Effort: {effort_label}",
-            f"Approval mode: {record.approval_mode}",
-            f"Approval policy: {approval_policy or 'default'}",
-            f"Sandbox policy: {_format_sandbox_policy(sandbox_policy)}",
-        ]
+        lines = []
+        if is_pma:
+            lines.append("Mode: PMA (hub)")
+        lines.extend(
+            [
+                f"Workspace: {workspace_label}",
+                f"Workspace ID: {record.workspace_id or 'unknown'}",
+                f"Active thread: {record.active_thread_id or 'none'}",
+                f"Active turn: {runtime.current_turn_id or 'none'}",
+                f"Agent: {agent}",
+                f"Resume: {'supported' if self._agent_supports_resume(agent) else 'unsupported'}",
+                f"Model: {record.model or 'default'}",
+                f"Effort: {effort_label}",
+                f"Approval mode: {record.approval_mode}",
+                f"Approval policy: {approval_policy or 'default'}",
+                f"Sandbox policy: {_format_sandbox_policy(sandbox_policy)}",
+            ]
+        )
         pending = await self._store.pending_approvals_for_key(key)
         if pending:
             lines.append(f"Pending approvals: {len(pending)}")
@@ -2086,45 +2093,48 @@ class WorkspaceCommands(SharedHelpers):
             lines.extend(_format_token_usage(token_usage))
         rate_limits = await self._read_rate_limits(record.workspace_path, agent=agent)
         lines.extend(_format_rate_limits(rate_limits))
-        if not record.workspace_path:
+
+        manifest_path = getattr(self, "_manifest_path", None)
+        hub_root = getattr(self, "_hub_root", None)
+        if is_pma and manifest_path and hub_root:
+            try:
+                manifest = load_manifest(manifest_path, hub_root)
+                enabled_repos = [repo for repo in manifest.repos if repo.enabled]
+                lines.append(
+                    f"Hub repos: {len(enabled_repos)}/{len(manifest.repos)} enabled"
+                )
+                active_count = 0
+                paused_count = 0
+                for repo in manifest.repos:
+                    if not repo.enabled:
+                        continue
+                    repo_root = (hub_root / repo.path).resolve()
+                    db_path = repo_root / ".codex-autorunner" / "flows.db"
+                    if not db_path.exists():
+                        continue
+
+                    store = FlowStore(db_path)
+                    try:
+                        store.initialize()
+                        runs = store.list_flow_runs(flow_type="ticket_flow")
+                        if runs:
+                            latest = runs[0]
+                            if latest.status.is_active():
+                                active_count += 1
+                            elif latest.status == FlowRunStatus.PAUSED:
+                                paused_count += 1
+                    except Exception:
+                        pass
+                    finally:
+                        store.close()
+                lines.append(f"Hub flows: {active_count} active, {paused_count} paused")
+            except Exception:
+                pass
+
+        if not record.workspace_path and not is_pma:
             lines.append("Use /bind <repo_id> or /bind <path>.")
 
-        if record.pma_enabled:
-            if self._manifest_path and self._hub_root:
-                try:
-                    manifest = load_manifest(self._manifest_path, self._hub_root)
-                    active_count = 0
-                    paused_count = 0
-                    for repo in manifest.repos:
-                        if not repo.enabled:
-                            continue
-                        repo_root = (self._hub_root / repo.path).resolve()
-                        db_path = repo_root / ".codex-autorunner" / "flows.db"
-                        if not db_path.exists():
-                            continue
-
-                        store = FlowStore(db_path)
-                        try:
-                            store.initialize()
-                            runs = store.list_flow_runs(flow_type="ticket_flow")
-                            if runs:
-                                latest = runs[0]
-                                if latest.status.is_active():
-                                    active_count += 1
-                                elif latest.status == FlowRunStatus.PAUSED:
-                                    paused_count += 1
-                        except Exception:
-                            pass
-                        finally:
-                            store.close()
-
-                    if active_count or paused_count:
-                        lines.append(
-                            f"Hub Flows: {active_count} active, {paused_count} paused"
-                        )
-                except Exception:
-                    pass
-        elif record.workspace_path:
+        if record.workspace_path and not is_pma:
             repo_root = Path(record.workspace_path)
             db_path = repo_root / ".codex-autorunner" / "flows.db"
             if db_path.exists():

--- a/tests/test_telegram_files_pma.py
+++ b/tests/test_telegram_files_pma.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from codex_autorunner.integrations.telegram.adapter import TelegramMessage
+from codex_autorunner.integrations.telegram.handlers.commands.files import (
+    FilesCommands,
+)
+from codex_autorunner.integrations.telegram.state import TelegramTopicRecord
+
+
+class _RouterStub:
+    def __init__(self, record: TelegramTopicRecord) -> None:
+        self._record = record
+
+    async def ensure_topic(
+        self, _chat_id: int, _thread_id: int | None
+    ) -> TelegramTopicRecord:
+        return self._record
+
+    async def get_topic(self, _key: str) -> TelegramTopicRecord:
+        return self._record
+
+
+class _FilesHandlerStub(FilesCommands):
+    def __init__(self, hub_root: Path, record: TelegramTopicRecord) -> None:
+        media_cfg = SimpleNamespace(
+            enabled=True,
+            files=True,
+            max_image_bytes=1024 * 1024,
+            max_file_bytes=1024 * 1024,
+            batch_uploads=False,
+        )
+        self._config = SimpleNamespace(media=media_cfg)
+        self._hub_root = hub_root
+        self._router = _RouterStub(record)
+        self._sent: list[str] = []
+
+    def _with_conversation_id(
+        self, text: str, *, chat_id: int, thread_id: int | None
+    ) -> str:
+        _ = (chat_id, thread_id)
+        return text
+
+    async def _resolve_topic_key(self, chat_id: int, thread_id: int | None) -> str:
+        return f"{chat_id}:{thread_id}"
+
+    async def _send_message(
+        self,
+        _chat_id: int,
+        text: str,
+        *,
+        thread_id: int | None = None,
+        reply_to: int | None = None,
+        reply_markup: dict[str, object] | None = None,
+    ) -> None:
+        _ = (thread_id, reply_to, reply_markup)
+        self._sent.append(text)
+
+
+def _message(text: str = "/files") -> TelegramMessage:
+    return TelegramMessage(
+        update_id=1,
+        message_id=1,
+        chat_id=10,
+        thread_id=20,
+        from_user_id=2,
+        text=text,
+        date=None,
+        is_topic_message=True,
+    )
+
+
+@pytest.mark.anyio
+async def test_files_lists_for_pma_topic(tmp_path: Path) -> None:
+    record = TelegramTopicRecord(pma_enabled=True)
+    handler = _FilesHandlerStub(tmp_path, record)
+
+    await handler._handle_files(_message(), "", _runtime=None)
+
+    assert handler._sent, "should respond in PMA mode"
+    text = handler._sent[-1]
+    assert "Inbox:" in text
+    assert "Outbox pending:" in text
+    assert "Use /bind" not in text
+
+
+@pytest.mark.anyio
+async def test_files_requires_binding_when_no_pma(tmp_path: Path) -> None:
+    record = TelegramTopicRecord(pma_enabled=False)
+    handler = _FilesHandlerStub(tmp_path, record)
+
+    await handler._handle_files(_message(), "", _runtime=None)
+
+    assert handler._sent
+    assert "Use /bind" in handler._sent[-1]


### PR DESCRIPTION
## Summary\n- allow /files to operate in PMA/unbound topics by using the hub root filebox paths\n- show PMA/hub context in /status and use hub overview for /flow_status from PMA/unbound\n- add regression tests covering PMA /files and flow/status behaviour\n\n## Testing\n- .venv/bin/python -m pytest tests/test_telegram_files_pma.py tests/test_telegram_status_rate_limits.py tests/test_telegram_flow_status.py tests/test_telegram_flow_aliases.py\n- (full suite auto-ran in CI pre-commit hook)