### PR TITLE
Fix /flow_status parse_mode regression in PMA topics

### DIFF
--- a/src/codex_autorunner/integrations/telegram/runtime.py
+++ b/src/codex_autorunner/integrations/telegram/runtime.py
@@ -265,8 +265,11 @@ class TelegramRuntimeHelpers:
             text = f"{prefix}{text}"
         return self._prepare_message(text)
 
-    def _render_message(self, text: str) -> tuple[str, Optional[str]]:
-        parse_mode = self._config.parse_mode
+    def _render_message(
+        self, text: str, *, parse_mode: Optional[str] = None
+    ) -> tuple[str, Optional[str]]:
+        # Allow callers to override parse_mode (needed for ad-hoc Markdown/HTML sends)
+        parse_mode = self._config.parse_mode if parse_mode is None else parse_mode
         if not parse_mode:
             return text, None
         if parse_mode == "HTML":
@@ -275,8 +278,10 @@ class TelegramRuntimeHelpers:
             return _format_telegram_markdown(text, parse_mode), parse_mode
         return text, parse_mode
 
-    def _prepare_message(self, text: str) -> tuple[str, Optional[str]]:
-        rendered, parse_mode = self._render_message(text)
+    def _prepare_message(
+        self, text: str, *, parse_mode: Optional[str] = None
+    ) -> tuple[str, Optional[str]]:
+        rendered, parse_mode = self._render_message(text, parse_mode=parse_mode)
         # Avoid parse_mode when chunking to keep markup intact.
         if parse_mode and len(rendered) <= TELEGRAM_MAX_MESSAGE_LENGTH:
             return rendered, parse_mode


### PR DESCRIPTION
## Summary
- fix /flow_status hub overview in PMA/unbound topics by allowing parse_mode override in Telegram send helpers
- allow runtime message render/prepare to honor caller-specified parse_mode
- add regression test covering hub overview send with Markdown parse_mode

## Testing
- .venv/bin/python -m pytest tests/test_telegram_flow_status.py
