### PR TITLE
Fix hub /flow overview for unregistered worktrees

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
@@ -71,8 +71,8 @@ def _ticket_dir(repo_root: Path) -> Path:
     return repo_root.resolve() / ".codex-autorunner" / "tickets"
 
 
-def _load_flow_store(repo_root: Path) -> FlowStore:
-    config = load_repo_config(repo_root)
+def _load_flow_store(repo_root: Path, hub_root: Optional[Path] = None) -> FlowStore:
+    config = load_repo_config(repo_root, hub_root)
     return FlowStore(_flow_paths(repo_root)[0], durable=config.durable_writes)
 
 


### PR DESCRIPTION
## Summary
- include unregistered worktrees with flows in Telegram hub /flow overview
- add scan-based detection for worktrees under the hub worktrees root
- hint to run `car hub scan` when unregistered worktrees are found

## Testing
- scripts/check.sh (via pre-commit hook)