### PR TITLE
Fix markdown rendering for relative chat links

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "typecheck": "tsc -p tsconfig.json",
     "build": "tsc -p tsconfig.json",
     "postbuild": "node scripts/add-static-banner.js",
-    "test:dom": "node scripts/check_dom_structure.mjs"
+    "test:dom": "node scripts/check_dom_structure.mjs",
+    "test:markdown": "node --test tests/js/markdown_render.test.js"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/src/codex_autorunner/static_src/messages.ts
+++ b/src/codex_autorunner/static_src/messages.ts
@@ -467,6 +467,26 @@ function formatBytes(size?: number | null): string {
   return `${size} B`;
 }
 
+function isSafeHref(url: string): boolean {
+  const trimmed = (url || "").trim();
+  if (!trimmed) return false;
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith("javascript:")) return false;
+  if (lower.startsWith("data:")) return false;
+  if (lower.startsWith("vbscript:")) return false;
+  if (lower.startsWith("file:")) return false;
+
+  return (
+    lower.startsWith("http://") ||
+    lower.startsWith("https://") ||
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("./") ||
+    trimmed.startsWith("../") ||
+    trimmed.startsWith("#") ||
+    lower.startsWith("mailto:")
+  );
+}
+
 export function renderMarkdown(body?: string | null): string {
   if (!body) return "";
   let text = escapeHtml(body);
@@ -493,7 +513,11 @@ export function renderMarkdown(body?: string | null): string {
 
   // Extract markdown links [text](url) to avoid double-linking
   const links: string[] = [];
-  text = text.replace(/\[([^\]]+)\]\((https?:[^)]+)\)/g, (_m, label, url) => {
+  text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, label, rawUrl) => {
+    const url = (rawUrl || "").trim();
+    if (!isSafeHref(url)) {
+      return match;
+    }
     const placeholder = `@@LINK_${links.length}@@`;
     // Note: label and url are already escaped because text is escaped.
     links.push(`<a href="${url}" target="_blank" rel="noopener">${label}</a>`);

--- a/tests/js/markdown_render.test.js
+++ b/tests/js/markdown_render.test.js
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>");
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.navigator = dom.window.navigator;
+globalThis.HTMLElement = dom.window.HTMLElement;
+
+const { renderMarkdown } = await import("../../src/codex_autorunner/static/messages.js");
+
+test("renders relative markdown links", () => {
+  const html = renderMarkdown("See [file](/car/hub/filebox/foo.zip)");
+  assert.match(html, /<a href="\/car\/hub\/filebox\/foo.zip"[^>]*>file<\/a>/);
+});
+
+test("leaves unsafe markdown links as text", () => {
+  const html = renderMarkdown("Do not [run](javascript:alert(1))");
+  assert.match(html, /\[run\]\(javascript:alert\(1\)\)/);
+  assert.doesNotMatch(html, /href="javascript:alert\(1\)"/);
+});


### PR DESCRIPTION
## Summary
- allow markdown links to render when pointing at safe relative or mailto URLs (e.g., filebox paths) while keeping unsafe schemes blocked
- add regression coverage for the markdown renderer and expose it via a small node test script
- wire the new test into package scripts for easy execution

## Testing
- pnpm build
- pnpm test:markdown
- pre-commit hook (auto)
