### PR TITLE
Gate PMA routes and UI when disabled

### DIFF
--- a/src/codex_autorunner/static/app.js
+++ b/src/codex_autorunner/static/app.js
@@ -68,12 +68,10 @@ async function probePMAEnabled() {
             method: "GET",
             headers,
         });
-        if (res.status === 404)
-            return false;
-        return true;
+        return res.ok;
     }
     catch {
-        return true;
+        return false;
     }
 }
 async function initHubShell() {
@@ -104,6 +102,7 @@ async function initHubShell() {
             btn.disabled = true;
             btn.setAttribute("aria-disabled", "true");
             btn.title = "Enable PMA in config to use Project Manager";
+            btn.classList.add("hidden");
             btn.classList.remove("active");
             btn.setAttribute("aria-selected", "false");
         });

--- a/src/codex_autorunner/static/pma.js
+++ b/src/codex_autorunner/static/pma.js
@@ -834,8 +834,8 @@ function resetThread() {
 }
 async function resetThreadOnServer() {
     const elements = getElements();
-    const agent = elements.agentSelect?.value || getSelectedAgent();
-    const resetAgent = (agent || "").trim() || "all";
+    const rawAgent = (elements.agentSelect?.value || getSelectedAgent() || "").trim().toLowerCase();
+    const resetAgent = rawAgent === "codex" || rawAgent === "opencode" ? rawAgent : "all";
     await api("/hub/pma/thread/reset", {
         method: "POST",
         body: { agent: resetAgent },

--- a/src/codex_autorunner/static_src/app.ts
+++ b/src/codex_autorunner/static_src/app.ts
@@ -79,10 +79,9 @@ async function probePMAEnabled(): Promise<boolean> {
       method: "GET",
       headers,
     });
-    if (res.status === 404) return false;
-    return true;
+    return res.ok;
   } catch {
-    return true;
+    return false;
   }
 }
 
@@ -121,6 +120,7 @@ async function initHubShell(): Promise<void> {
       btn.disabled = true;
       btn.setAttribute("aria-disabled", "true");
       btn.title = "Enable PMA in config to use Project Manager";
+      btn.classList.add("hidden");
       btn.classList.remove("active");
       btn.setAttribute("aria-selected", "false");
     });

--- a/src/codex_autorunner/static_src/pma.ts
+++ b/src/codex_autorunner/static_src/pma.ts
@@ -939,8 +939,8 @@ function resetThread(): void {
 
 async function resetThreadOnServer(): Promise<void> {
   const elements = getElements();
-  const agent = elements.agentSelect?.value || getSelectedAgent();
-  const resetAgent = (agent || "").trim() || "all";
+  const rawAgent = (elements.agentSelect?.value || getSelectedAgent() || "").trim().toLowerCase();
+  const resetAgent = rawAgent === "codex" || rawAgent === "opencode" ? rawAgent : "all";
   await api("/hub/pma/thread/reset", {
     method: "POST",
     body: { agent: resetAgent },

--- a/src/codex_autorunner/surfaces/web/routes/pma.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma.py
@@ -302,6 +302,9 @@ def build_pma_routes() -> APIRouter:
 
     @router.get("/agents")
     def list_pma_agents(request: Request) -> dict[str, Any]:
+        pma_config = _get_pma_config(request)
+        if not pma_config.get("enabled", True):
+            raise HTTPException(status_code=404, detail="PMA is disabled")
         if (
             getattr(request.app.state, "app_server_supervisor", None) is None
             and getattr(request.app.state, "opencode_supervisor", None) is None
@@ -323,6 +326,9 @@ def build_pma_routes() -> APIRouter:
 
     @router.get("/agents/{agent}/models")
     async def list_pma_agent_models(agent: str, request: Request):
+        pma_config = _get_pma_config(request)
+        if not pma_config.get("enabled", True):
+            raise HTTPException(status_code=404, detail="PMA is disabled")
         agent_id = (agent or "").strip().lower()
         hub_root = request.app.state.config.root
         if agent_id == "codex":

--- a/tests/test_pma_routes.py
+++ b/tests/test_pma_routes.py
@@ -29,6 +29,13 @@ def _enable_pma(
     _write_config(hub_root / CONFIG_FILENAME, cfg)
 
 
+def _disable_pma(hub_root: Path) -> None:
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg.setdefault("pma", {})
+    cfg["pma"]["enabled"] = False
+    _write_config(hub_root / CONFIG_FILENAME, cfg)
+
+
 def test_pma_agents_endpoint(hub_env) -> None:
     _enable_pma(hub_env.hub_root)
     app = create_hub_app(hub_env.hub_root)
@@ -53,6 +60,14 @@ def test_pma_routes_enabled_by_default(hub_env) -> None:
     client = TestClient(app)
     assert client.get("/hub/pma/agents").status_code == 200
     assert client.post("/hub/pma/chat", json={}).status_code == 400
+
+
+def test_pma_routes_disabled_by_config(hub_env) -> None:
+    _disable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+    client = TestClient(app)
+    assert client.get("/hub/pma/agents").status_code == 404
+    assert client.post("/hub/pma/chat", json={"message": "hi"}).status_code == 404
 
 
 def test_pma_chat_applies_model_reasoning_defaults(hub_env) -> None:


### PR DESCRIPTION
## Summary
- hide/disable the PMA UI when config disables PMA and when /hub/pma/agents returns non-OK
- return 404 for PMA agents/model routes when disabled and tighten thread reset agent selection
- add tests for disabled PMA configuration

## Testing
- Not run (missing .venv/bin/python; attempted `.venv/bin/python -m pytest tests/test_pma_routes.py`)

## Risks / Follow-ups
- PMA enable probe now fails closed on non-OK responses; transient errors may hide PMA until reload