### PR TITLE
Fix PMA stale thinking stream on new turn

### DIFF
--- a/src/codex_autorunner/static/pma.js
+++ b/src/codex_autorunner/static/pma.js
@@ -437,6 +437,8 @@ async function sendMessage() {
         cancelRequest();
         return;
     }
+    // Ensure prior turn event streams are cleared so we don't render stale actions.
+    stopTurnEventsStream();
     elements.input.value = "";
     elements.input.style.height = "auto";
     const agent = elements.agentSelect?.value || getSelectedAgent();
@@ -448,6 +450,8 @@ async function sendMessage() {
     pmaChat.state.controller = currentController;
     pmaChat.state.status = "running";
     pmaChat.state.error = "";
+    pmaChat.state.statusText = "";
+    pmaChat.state.contextUsagePercent = null;
     pmaChat.state.streamText = "";
     pmaChat.state.startTime = Date.now();
     pmaChat.clearEvents();

--- a/src/codex_autorunner/static_src/pma.ts
+++ b/src/codex_autorunner/static_src/pma.ts
@@ -505,6 +505,9 @@ async function sendMessage(): Promise<void> {
     return;
   }
 
+  // Ensure prior turn event streams are cleared so we don't render stale actions.
+  stopTurnEventsStream();
+
   elements.input.value = "";
   elements.input.style.height = "auto";
 
@@ -518,6 +521,8 @@ async function sendMessage(): Promise<void> {
   pmaChat.state.controller = currentController;
   pmaChat.state.status = "running";
   pmaChat.state.error = "";
+  pmaChat.state.statusText = "";
+  pmaChat.state.contextUsagePercent = null;
   pmaChat.state.streamText = "";
   pmaChat.state.startTime = Date.now();
   pmaChat.clearEvents();


### PR DESCRIPTION
## Summary
- stop prior PMA turn event streams before starting a new message to prevent stale thinking/tool events
- reset inline status/context state for each new PMA request

## Testing
- pnpm run build
- pytest -m "not integration"