### PR TITLE
Show remaining context in chat UIs (#483)

### DIFF
--- a/src/codex_autorunner/static/docChatCore.js
+++ b/src/codex_autorunner/static/docChatCore.js
@@ -306,7 +306,7 @@ export function createDocChat(config) {
                 if (msg.meta.duration)
                     parts.push(`${msg.meta.duration.toFixed(1)}s`);
                 if (state.contextUsagePercent !== null && msg.isFinal) {
-                    parts.push(`ctx ${state.contextUsagePercent}%`);
+                    parts.push(`ctx left ${state.contextUsagePercent}%`);
                 }
                 if (parts.length)
                     metaText += ` · ${parts.join(" · ")}`;
@@ -375,7 +375,7 @@ export function createDocChat(config) {
                     if (state.contextUsagePercent !== null) {
                         const context = document.createElement("span");
                         context.className = "chat-thinking-steps";
-                        context.textContent = ` · ctx ${state.contextUsagePercent}%`;
+                        context.textContent = ` · ctx left ${state.contextUsagePercent}%`;
                         header.appendChild(context);
                     }
                     // Only show the toggle if we have more than a couple steps.

--- a/src/codex_autorunner/static/fileChat.js
+++ b/src/codex_autorunner/static/fileChat.js
@@ -1,6 +1,6 @@
 // GENERATED FILE - do not edit directly. Source: static_src/
 import { resolvePath, getAuthToken, api } from "./utils.js";
-import { readEventStream, parseMaybeJson } from "./streamUtils.js";
+import { extractContextRemainingPercent, readEventStream, parseMaybeJson } from "./streamUtils.js";
 export async function sendFileChat(target, message, controller, handlers = {}, options = {}) {
     const endpoint = resolvePath(options.basePath || "/api/file-chat");
     const headers = {
@@ -67,6 +67,16 @@ function handleStreamEvent(event, rawData, handlers) {
                 ? parsed
                 : parsed.token || parsed.text || rawData || "";
             handlers.onToken?.(token);
+            break;
+        }
+        case "token_usage": {
+            if (typeof parsed === "object" && parsed !== null) {
+                const usage = parsed;
+                const percent = extractContextRemainingPercent(usage);
+                if (percent !== null) {
+                    handlers.onTokenUsage?.(percent, usage);
+                }
+            }
             break;
         }
         case "update": {

--- a/src/codex_autorunner/static/streamUtils.js
+++ b/src/codex_autorunner/static/streamUtils.js
@@ -8,6 +8,22 @@ export function parseMaybeJson(data) {
         return data;
     }
 }
+export function extractContextRemainingPercent(usage) {
+    if (!usage || typeof usage !== "object")
+        return null;
+    const payload = usage;
+    const totalRaw = payload.totalTokens ?? payload.total ?? payload.total_tokens;
+    const contextRaw = payload.modelContextWindow ?? payload.contextWindow ?? payload.model_context_window;
+    const totalTokens = typeof totalRaw === "number" ? totalRaw : Number(totalRaw);
+    const contextWindow = typeof contextRaw === "number" && Number.isFinite(contextRaw)
+        ? contextRaw
+        : Number(contextRaw);
+    if (!Number.isFinite(totalTokens) || !Number.isFinite(contextWindow) || contextWindow <= 0) {
+        return null;
+    }
+    const percentRemaining = Math.round(((contextWindow - totalTokens) / contextWindow) * 100);
+    return Math.max(0, Math.min(100, percentRemaining));
+}
 export async function readEventStream(res, handler) {
     if (!res.body)
         throw new Error("Streaming not supported in this browser");

--- a/src/codex_autorunner/static/workspace.js
+++ b/src/codex_autorunner/static/workspace.js
@@ -663,6 +663,7 @@ async function sendChat() {
     chatState.error = "";
     chatState.statusText = "queued";
     chatState.streamText = "";
+    chatState.contextUsagePercent = null;
     workspaceChat.clearEvents();
     workspaceChat.addUserMessage(message);
     renderChat();
@@ -695,6 +696,10 @@ async function sendChat() {
             onEvent: (event) => {
                 workspaceChat.applyAppEvent(event);
                 workspaceChat.renderEvents();
+            },
+            onTokenUsage: (percent) => {
+                chatState.contextUsagePercent = percent;
+                renderChat();
             },
             onUpdate: (update) => {
                 applyChatUpdate(update);
@@ -755,6 +760,7 @@ async function cancelChat() {
     }
     chatState.status = "interrupted";
     chatState.streamText = "";
+    chatState.contextUsagePercent = null;
     renderChat();
     clearPendingTurnState();
 }
@@ -769,6 +775,7 @@ async function resetThread() {
         const chatState = workspaceChat.state;
         chatState.messages = [];
         chatState.streamText = "";
+        chatState.contextUsagePercent = null;
         workspaceChat.clearEvents();
         clearPendingTurnState();
         renderChat();

--- a/src/codex_autorunner/static_src/docChatCore.ts
+++ b/src/codex_autorunner/static_src/docChatCore.ts
@@ -440,7 +440,7 @@ export function createDocChat(config: ChatConfig): DocChatInstance {
         if (msg.meta.steps) parts.push(`${msg.meta.steps} steps`);
         if (msg.meta.duration) parts.push(`${msg.meta.duration.toFixed(1)}s`);
         if (state.contextUsagePercent !== null && msg.isFinal) {
-          parts.push(`ctx ${state.contextUsagePercent}%`);
+          parts.push(`ctx left ${state.contextUsagePercent}%`);
         }
         if (parts.length) metaText += ` · ${parts.join(" · ")}`;
       }
@@ -518,7 +518,7 @@ export function createDocChat(config: ChatConfig): DocChatInstance {
           if (state.contextUsagePercent !== null) {
             const context = document.createElement("span");
             context.className = "chat-thinking-steps";
-            context.textContent = ` · ctx ${state.contextUsagePercent}%`;
+            context.textContent = ` · ctx left ${state.contextUsagePercent}%`;
             header.appendChild(context);
           }
 

--- a/src/codex_autorunner/static_src/streamUtils.ts
+++ b/src/codex_autorunner/static_src/streamUtils.ts
@@ -8,6 +8,27 @@ export function parseMaybeJson(data: string): unknown {
   }
 }
 
+export function extractContextRemainingPercent(usage: unknown): number | null {
+  if (!usage || typeof usage !== "object") return null;
+  const payload = usage as Record<string, unknown>;
+  const totalRaw = payload.totalTokens ?? payload.total ?? payload.total_tokens;
+  const contextRaw =
+    payload.modelContextWindow ?? payload.contextWindow ?? payload.model_context_window;
+
+  const totalTokens = typeof totalRaw === "number" ? totalRaw : Number(totalRaw);
+  const contextWindow =
+    typeof contextRaw === "number" && Number.isFinite(contextRaw)
+      ? contextRaw
+      : Number(contextRaw);
+
+  if (!Number.isFinite(totalTokens) || !Number.isFinite(contextWindow) || contextWindow <= 0) {
+    return null;
+  }
+
+  const percentRemaining = Math.round(((contextWindow - totalTokens) / contextWindow) * 100);
+  return Math.max(0, Math.min(100, percentRemaining));
+}
+
 export async function readEventStream(
   res: Response,
   handler: (event: string, data: string) => void

--- a/src/codex_autorunner/static_src/workspace.ts
+++ b/src/codex_autorunner/static_src/workspace.ts
@@ -734,6 +734,7 @@ async function sendChat(): Promise<void> {
   chatState.error = "";
   chatState.statusText = "queued";
   chatState.streamText = "";
+  chatState.contextUsagePercent = null;
   workspaceChat.clearEvents();
   workspaceChat.addUserMessage(message);
   renderChat();
@@ -772,6 +773,10 @@ async function sendChat(): Promise<void> {
         onEvent: (event) => {
           workspaceChat.applyAppEvent(event);
           workspaceChat.renderEvents();
+        },
+        onTokenUsage: (percent) => {
+          chatState.contextUsagePercent = percent;
+          renderChat();
         },
         onUpdate: (update) => {
           applyChatUpdate(update);
@@ -832,6 +837,7 @@ async function cancelChat(): Promise<void> {
   }
   chatState.status = "interrupted";
   chatState.streamText = "";
+  chatState.contextUsagePercent = null;
   renderChat();
   clearPendingTurnState();
 }
@@ -846,6 +852,7 @@ async function resetThread(): Promise<void> {
     const chatState = workspaceChat.state as ChatState;
     chatState.messages = [];
     chatState.streamText = "";
+    chatState.contextUsagePercent = null;
     workspaceChat.clearEvents();
     clearPendingTurnState();
     renderChat();


### PR DESCRIPTION
Closes #483.

## Summary
- parse token_usage stream events into a shared helper and reset chat context meters between turns
- propagate remaining context percent through PMA, ticket, and workspace chats so inline thinking bubbles show "ctx left" beside steps
- surface token usage from file chat streams so doc/workspace chat also displays context remaining

## Testing
- pnpm run build
- pytest
