### PR TITLE
Add hub PMA ABOUT_CAR doc

### DIFF
--- a/src/codex_autorunner/bootstrap.py
+++ b/src/codex_autorunner/bootstrap.py
@@ -125,6 +125,14 @@ def seed_repo_files(
     ensure_ticket_manager(repo_root, force=force)
 
 
+def ensure_pma_docs(hub_root: Path, force: bool = False) -> None:
+    ca_dir = hub_root / ".codex-autorunner"
+    pma_dir = ca_dir / "pma"
+    pma_dir.mkdir(parents=True, exist_ok=True)
+    _seed_doc(pma_dir / "prompt.md", force, pma_prompt_content())
+    _seed_doc(pma_dir / "ABOUT_CAR.md", force, pma_about_content())
+
+
 def seed_hub_files(hub_root: Path, force: bool = False) -> None:
     """
     Initialize a hub workspace with defaults and a manifest.
@@ -138,10 +146,7 @@ def seed_hub_files(hub_root: Path, force: bool = False) -> None:
 
     write_hub_config(hub_root, force=force)
 
-    pma_dir = ca_dir / "pma"
-    pma_dir.mkdir(parents=True, exist_ok=True)
-    _seed_doc(pma_dir / "prompt.md", force, _pma_prompt_content())
-    _seed_doc(pma_dir / "notes.md", force, _pma_notes_content())
+    ensure_pma_docs(hub_root, force=force)
 
     manifest_path = hub_root / DEFAULT_HUB_CONFIG["hub"]["manifest"]
     load_manifest(manifest_path, hub_root)
@@ -154,7 +159,7 @@ def seed_hub_files(hub_root: Path, force: bool = False) -> None:
         )
 
 
-def _pma_prompt_content() -> str:
+def pma_prompt_content() -> str:
     return """# Project Management Agent (PMA)
 
 You are the hub-level Project Management Agent (PMA), the user's primary interface for coordinating work across repos.
@@ -168,11 +173,11 @@ Coordinate tickets and flows across multiple repos. Delegate code changes to rep
 - Use CAR-native artifacts (tickets, ticket_flow, dispatch, PMA inbox/outbox).
 - Ask questions when requirements are ambiguous; keep updates concise.
 - Treat this prompt as code: keep it short and stable.
-- See `.codex-autorunner/pma/notes.md` for operational how-to.
+- See `.codex-autorunner/pma/ABOUT_CAR.md` for operational how-to.
 """
 
 
-def _pma_notes_content() -> str:
+def pma_notes_content() -> str:
     return """# PMA Operations Guide
 
 ## Tickets (create/modify)
@@ -205,3 +210,7 @@ def _pma_notes_content() -> str:
 - User uploads arrive in `.codex-autorunner/pma/inbox/`.
 - Send user-facing files by writing to `.codex-autorunner/pma/outbox/`.
 """
+
+
+def pma_about_content() -> str:
+    return pma_notes_content()

--- a/src/codex_autorunner/core/pma_context.py
+++ b/src/codex_autorunner/core/pma_context.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from typing import Any, Optional
 
+from ..bootstrap import ensure_pma_docs
 from ..tickets.files import list_ticket_paths, safe_relpath, ticket_is_done
 from ..tickets.outbox import parse_dispatch, resolve_outbox_paths
 from .config import load_repo_config
@@ -45,6 +46,10 @@ def _trim_extra(extra: Any, limit: int) -> Any:
 def load_pma_prompt(hub_root: Path) -> str:
     path = hub_root / ".codex-autorunner" / "pma" / "prompt.md"
     try:
+        ensure_pma_docs(hub_root)
+    except Exception:
+        pass
+    try:
         return path.read_text(encoding="utf-8")
     except Exception:
         return ""
@@ -54,7 +59,7 @@ def format_pma_prompt(base_prompt: str, snapshot: dict[str, Any], message: str) 
     snapshot_text = json.dumps(snapshot, sort_keys=True)
     return (
         f"{base_prompt}\n\n"
-        "Ops guide: `.codex-autorunner/pma/notes.md` (tickets, ticket_flow, dispatch).\n"
+        "Ops guide: `.codex-autorunner/pma/ABOUT_CAR.md`.\n"
         "To send a file to the user, write it to `.codex-autorunner/pma/outbox/`.\n"
         "User uploaded files are in `.codex-autorunner/pma/inbox/`.\n\n"
         "<hub_snapshot>\n"

--- a/tests/test_pma_bootstrap.py
+++ b/tests/test_pma_bootstrap.py
@@ -17,11 +17,11 @@ def test_pma_files_created_on_hub_init(tmp_path: Path) -> None:
     assert "Project Management Agent" in prompt_content
     assert "You are the hub-level" in prompt_content
 
-    notes_path = pma_dir / "notes.md"
-    assert notes_path.exists()
-    notes_content = notes_path.read_text(encoding="utf-8")
-    assert "PMA Operations Guide" in notes_content
-    assert "Ticket flow" in notes_content
+    about_path = pma_dir / "ABOUT_CAR.md"
+    assert about_path.exists()
+    about_content = about_path.read_text(encoding="utf-8")
+    assert "PMA Operations Guide" in about_content
+    assert "Ticket flow" in about_content
 
 
 def test_pma_config_defaults(tmp_path: Path) -> None:
@@ -45,12 +45,12 @@ def test_pma_files_not_overridden_without_force(tmp_path: Path) -> None:
 
     pma_dir = tmp_path / ".codex-autorunner" / "pma"
     prompt_path = pma_dir / "prompt.md"
-    notes_path = pma_dir / "notes.md"
+    about_path = pma_dir / "ABOUT_CAR.md"
 
     prompt_path.write_text("custom prompt", encoding="utf-8")
-    notes_path.write_text("custom notes", encoding="utf-8")
+    about_path.write_text("custom about", encoding="utf-8")
 
     seed_hub_files(tmp_path, force=False)
 
     assert prompt_path.read_text(encoding="utf-8") == "custom prompt"
-    assert notes_path.read_text(encoding="utf-8") == "custom notes"
+    assert about_path.read_text(encoding="utf-8") == "custom about"


### PR DESCRIPTION
## Summary
- drop legacy PMA notes.md and standardize on .codex-autorunner/pma/ABOUT_CAR.md
- keep PMA prompt + seed logic aligned with ABOUT_CAR
- update PMA bootstrap tests for ABOUT_CAR only

## Testing
- .venv/bin/python -m pytest tests/test_pma_bootstrap.py
- repo hooks: black/ruff/mypy/eslint/pnpm build/full pytest (pre-commit)
