### PR TITLE
Register CLI flow workers in metadata

### DIFF
--- a/src/codex_autorunner/core/flows/worker_process.py
+++ b/src/codex_autorunner/core/flows/worker_process.py
@@ -211,6 +211,31 @@ def check_worker_health(
     )
 
 
+def register_worker_metadata(
+    repo_root: Path,
+    run_id: str,
+    *,
+    artifacts_root: Optional[Path] = None,
+    pid: Optional[int] = None,
+    cmd: Optional[list[str]] = None,
+    entrypoint: str = "codex_autorunner",
+) -> Path:
+    normalized_run_id = _normalized_run_id(run_id)
+    artifacts_dir = _worker_artifacts_dir(repo_root, normalized_run_id, artifacts_root)
+
+    resolved_pid = pid or os.getpid()
+    resolved_cmd = cmd or _read_process_cmdline(resolved_pid)
+    if not resolved_cmd:
+        resolved_cmd = _build_worker_cmd(entrypoint, normalized_run_id)
+
+    _write_worker_metadata(
+        _worker_metadata_path(artifacts_dir),
+        resolved_pid,
+        resolved_cmd,
+    )
+    return artifacts_dir
+
+
 def spawn_flow_worker(
     repo_root: Path,
     run_id: str,

--- a/src/codex_autorunner/surfaces/cli/cli.py
+++ b/src/codex_autorunner/surfaces/cli/cli.py
@@ -31,7 +31,11 @@ from ...core.config import (
 from ...core.flows import FlowController, FlowStore
 from ...core.flows.models import FlowRunRecord, FlowRunStatus
 from ...core.flows.ux_helpers import build_flow_status_snapshot, ensure_worker
-from ...core.flows.worker_process import check_worker_health, clear_worker_metadata
+from ...core.flows.worker_process import (
+    check_worker_health,
+    clear_worker_metadata,
+    register_worker_metadata,
+)
 from ...core.git_utils import GitError, run_git
 from ...core.hub import HubSupervisor
 from ...core.locks import file_lock
@@ -1865,6 +1869,15 @@ def flow_worker(
                 raise typer.Exit(code=0)
 
         store.close()
+
+        try:
+            register_worker_metadata(
+                engine.repo_root,
+                normalized_run_id,
+                artifacts_root=artifacts_root,
+            )
+        except Exception as exc:
+            typer.echo(f"Failed to register worker metadata: {exc}", err=True)
 
         agent_pool: AgentPool | None = None
 


### PR DESCRIPTION
## Summary
- write flow worker metadata when running `car flow worker` in the foreground so the web UI can see the live worker
- use the current process cmdline when available to avoid worker-command mismatches

## Testing
- black
- ruff
- mypy
- eslint
- pnpm run build
- pytest
