### PR TITLE
Quote ticket frontmatter scalars and add regression test

### DIFF
--- a/src/codex_autorunner/static/ticketEditor.js
+++ b/src/codex_autorunner/static/ticketEditor.js
@@ -306,20 +306,24 @@ function extractFrontmatter(ticket) {
 /**
  * Build full markdown content from frontmatter form + body textarea
  */
+function yamlQuote(value) {
+    // Use JSON.stringify for simple, safe double-quoted scalars (handles colons, quotes, newlines).
+    return JSON.stringify(value ?? "");
+}
 function buildTicketContent() {
     const { content } = els();
     const fm = getFrontmatterFromForm();
     const body = content?.value || "";
-    // Reconstruct frontmatter YAML
+    // Reconstruct frontmatter YAML with quoted scalars to tolerate special characters.
     const lines = ["---"];
-    lines.push(`agent: ${fm.agent}`);
+    lines.push(`agent: ${yamlQuote(fm.agent)}`);
     lines.push(`done: ${fm.done}`);
     if (fm.title)
-        lines.push(`title: ${fm.title}`);
+        lines.push(`title: ${yamlQuote(fm.title)}`);
     if (fm.model)
-        lines.push(`model: ${fm.model}`);
+        lines.push(`model: ${yamlQuote(fm.model)}`);
     if (fm.reasoning)
-        lines.push(`reasoning: ${fm.reasoning}`);
+        lines.push(`reasoning: ${yamlQuote(fm.reasoning)}`);
     lines.push("---");
     lines.push("");
     lines.push(body);

--- a/src/codex_autorunner/static_src/ticketEditor.ts
+++ b/src/codex_autorunner/static_src/ticketEditor.ts
@@ -394,19 +394,24 @@ function extractFrontmatter(ticket: TicketData): FrontmatterState {
 /**
  * Build full markdown content from frontmatter form + body textarea
  */
+function yamlQuote(value: string): string {
+  // Use JSON.stringify for simple, safe double-quoted scalars (handles colons, quotes, newlines).
+  return JSON.stringify(value ?? "");
+}
+
 function buildTicketContent(): string {
   const { content } = els();
   const fm = getFrontmatterFromForm();
   const body = content?.value || "";
 
-  // Reconstruct frontmatter YAML
+  // Reconstruct frontmatter YAML with quoted scalars to tolerate special characters.
   const lines: string[] = ["---"];
 
-  lines.push(`agent: ${fm.agent}`);
+  lines.push(`agent: ${yamlQuote(fm.agent)}`);
   lines.push(`done: ${fm.done}`);
-  if (fm.title) lines.push(`title: ${fm.title}`);
-  if (fm.model) lines.push(`model: ${fm.model}`);
-  if (fm.reasoning) lines.push(`reasoning: ${fm.reasoning}`);
+  if (fm.title) lines.push(`title: ${yamlQuote(fm.title)}`);
+  if (fm.model) lines.push(`model: ${yamlQuote(fm.model)}`);
+  if (fm.reasoning) lines.push(`reasoning: ${yamlQuote(fm.reasoning)}`);
 
   lines.push("---");
   lines.push("");

--- a/src/codex_autorunner/surfaces/web/routes/flows.py
+++ b/src/codex_autorunner/surfaces/web/routes/flows.py
@@ -802,13 +802,18 @@ You are the first ticket in a new ticket_flow run.
         while next_index in existing_indices:
             next_index += 1
 
-        # Build frontmatter
-        title_line = f"title: {request.title}\n" if request.title else ""
-        goal_line = f"goal: {request.goal}\n" if request.goal else ""
+        # Build frontmatter (quote scalars to avoid YAML parse issues with colons, etc.)
+        def _quote(val: Optional[str]) -> str:
+            return (
+                json.dumps(val) if val is not None else ""
+            )  # JSON string is valid YAML scalar
+
+        title_line = f"title: {_quote(request.title)}\n" if request.title else ""
+        goal_line = f"goal: {_quote(request.goal)}\n" if request.goal else ""
 
         content = (
             "---\n"
-            f"agent: {request.agent}\n"
+            f"agent: {_quote(request.agent)}\n"
             "done: false\n"
             f"{title_line}"
             f"{goal_line}"


### PR DESCRIPTION
## Summary
- quote ticket frontmatter fields (agent/title/model/reasoning) in UI and backend ticket creation to avoid YAML mapping errors when values contain colons or parentheses
- add regression test ensuring colon-heavy titles/models save via API
- rebuild static assets

## Testing
- pnpm run build
- ./.venv/bin/pytest tests/routes/test_ticket_first_contracts.py -q
- git commit hook full suite (795 passed, 3 skipped, 59 deselected)