### PR TITLE
Replace native confirms with confirm modal

### DIFF
--- a/src/codex_autorunner/static/fileboxUi.js
+++ b/src/codex_autorunner/static/fileboxUi.js
@@ -1,5 +1,5 @@
 // GENERATED FILE - do not edit directly. Source: static_src/
-import { api, escapeHtml, flash, resolvePath } from "./utils.js";
+import { api, confirmModal, escapeHtml, flash, resolvePath } from "./utils.js";
 function formatBytes(size) {
     if (!size && size !== 0)
         return "";
@@ -89,7 +89,7 @@ export function createFileBoxWidget(opts) {
                 const file = target.dataset.file || "";
                 if (!boxName || !file)
                     return;
-                const confirmed = window.confirm(`Delete ${file}?`);
+                const confirmed = await confirmModal(`Delete ${file}?`);
                 if (!confirmed)
                     return;
                 try {

--- a/src/codex_autorunner/static/pma.js
+++ b/src/codex_autorunner/static/pma.js
@@ -2,7 +2,7 @@
 /**
  * PMA (Project Management Agent) - Hub-level chat interface
  */
-import { api, resolvePath, getAuthToken, escapeHtml, flash } from "./utils.js";
+import { api, confirmModal, resolvePath, getAuthToken, escapeHtml, flash } from "./utils.js";
 import { createDocChat, } from "./docChatCore.js";
 import { initChatPasteUpload } from "./chatUploads.js";
 import { clearAgentSelectionStorage, getSelectedAgent, getSelectedModel, getSelectedReasoning, initAgentControls, refreshAgentControls, } from "./agentControls.js";
@@ -282,8 +282,9 @@ async function snapshotActiveContext() {
         flash("Failed to snapshot active context", "error");
     }
 }
-function resetActiveContext() {
-    if (!confirm("Reset active context to default?"))
+async function resetActiveContext() {
+    const confirmed = await confirmModal("Reset active context to default?");
+    if (!confirmed)
         return;
     const editor = document.getElementById("pma-docs-editor");
     if (!editor)

--- a/src/codex_autorunner/static/ticketChatActions.js
+++ b/src/codex_autorunner/static/ticketChatActions.js
@@ -2,7 +2,7 @@
 /**
  * Ticket Chat Actions - handles sending messages, applying/discarding patches
  */
-import { api, flash, splitMarkdownFrontmatter } from "./utils.js";
+import { api, confirmModal, flash, splitMarkdownFrontmatter } from "./utils.js";
 import { performTicketChatRequest } from "./ticketChatStream.js";
 import { renderTicketMessages, renderTicketEvents } from "./ticketChatEvents.js";
 import { publish } from "./bus.js";
@@ -88,7 +88,7 @@ export function resetTicketChatState() {
 export async function startNewTicketChatThread() {
     if (ticketChatState.ticketIndex == null)
         return;
-    const confirmed = window.confirm("Start a new conversation thread for this ticket?");
+    const confirmed = await confirmModal("Start a new conversation thread for this ticket?");
     if (!confirmed)
         return;
     try {

--- a/src/codex_autorunner/static/ticketEditor.js
+++ b/src/codex_autorunner/static/ticketEditor.js
@@ -2,7 +2,7 @@
 /**
  * Ticket Editor Modal - handles creating, editing, and deleting tickets
  */
-import { api, flash, updateUrlParams, splitMarkdownFrontmatter } from "./utils.js";
+import { api, confirmModal, flash, updateUrlParams, splitMarkdownFrontmatter } from "./utils.js";
 import { publish } from "./bus.js";
 import { clearTicketChatHistory } from "./ticketChatStorage.js";
 import { setTicketIndex, sendTicketChat, cancelTicketChat, applyTicketPatch, discardTicketPatch, loadTicketPending, renderTicketChat, resetTicketChatState, ticketChatState, resumeTicketPendingTurn, } from "./ticketChatActions.js";
@@ -673,7 +673,7 @@ export async function deleteTicket() {
         flash("Cannot delete: no ticket selected", "error");
         return;
     }
-    const confirmed = window.confirm(`Delete TICKET-${String(state.ticketIndex).padStart(3, "0")}.md? This cannot be undone.`);
+    const confirmed = await confirmModal(`Delete TICKET-${String(state.ticketIndex).padStart(3, "0")}.md? This cannot be undone.`);
     if (!confirmed)
         return;
     setButtonsLoading(true);

--- a/src/codex_autorunner/static/tickets.js
+++ b/src/codex_autorunner/static/tickets.js
@@ -1,5 +1,5 @@
 // GENERATED FILE - do not edit directly. Source: static_src/
-import { api, flash, getUrlParams, resolvePath, statusPill, getAuthToken, openModal, inputModal, setButtonLoading, } from "./utils.js";
+import { api, confirmModal, flash, getUrlParams, resolvePath, statusPill, getAuthToken, openModal, inputModal, setButtonLoading, } from "./utils.js";
 // Note: activateTab removed - header now used for collapse, not inbox navigation
 import { registerAutoRefresh } from "./autoRefresh.js";
 import { CONSTANTS } from "./constants.js";
@@ -1757,7 +1757,8 @@ async function restartTicketFlow() {
         flash("Create a ticket first before restarting the flow.", "error");
         return;
     }
-    if (!confirm("Restart ticket flow? This will stop the current run and start a new one.")) {
+    const confirmed = await confirmModal("Restart ticket flow? This will stop the current run and start a new one.");
+    if (!confirmed) {
         return;
     }
     setButtonsDisabled(true);
@@ -1797,7 +1798,8 @@ async function archiveTicketFlow() {
         flash("No ticket flow run to archive", "info");
         return;
     }
-    if (!confirm("Archive all tickets from this flow? They will be moved to the run's artifact directory.")) {
+    const confirmed = await confirmModal("Archive all tickets from this flow? They will be moved to the run's artifact directory.");
+    if (!confirmed) {
         return;
     }
     setButtonsDisabled(true);

--- a/src/codex_autorunner/static/workspace.js
+++ b/src/codex_autorunner/static/workspace.js
@@ -1,5 +1,5 @@
 // GENERATED FILE - do not edit directly. Source: static_src/
-import { api, flash, setButtonLoading } from "./utils.js";
+import { api, confirmModal, flash, setButtonLoading } from "./utils.js";
 import { initAgentControls, getSelectedAgent, getSelectedModel, getSelectedReasoning } from "./agentControls.js";
 import { fetchWorkspace, ingestSpecToTickets, listTickets, fetchWorkspaceTree, uploadWorkspaceFiles, downloadWorkspaceZip, createWorkspaceFolder, writeWorkspace, } from "./workspaceApi.js";
 import { applyDraft, discardDraft, fetchPendingDraft, sendFileChat, interruptFileChat, newClientTurnId, streamTurnEvents, } from "./fileChat.js";
@@ -367,7 +367,7 @@ const workspaceTreeRefresh = createSmartRefresh({
                 },
                 onPathChange: () => updateDownloadButton(),
                 onRefresh: () => loadFiles(state.target?.path, "manual"),
-                onConfirm: (message) => window.workspaceConfirm?.(message) ?? Promise.resolve(confirm(message)),
+                onConfirm: (message) => window.workspaceConfirm?.(message) ?? confirmModal(message),
             });
         }
         const defaultPath = payload.defaultPath ?? state.target?.path ?? undefined;
@@ -484,7 +484,7 @@ async function applyWorkspaceDraft() {
     try {
         const isStale = Boolean(state.draft?.is_stale);
         if (isStale) {
-            const confirmForce = window.confirm("This draft is stale because the file changed after it was created. Force apply anyway?");
+            const confirmForce = await confirmModal("This draft is stale because the file changed after it was created. Force apply anyway?");
             if (!confirmForce)
                 return;
         }

--- a/src/codex_autorunner/static/workspaceFileBrowser.js
+++ b/src/codex_autorunner/static/workspaceFileBrowser.js
@@ -1,6 +1,6 @@
 // GENERATED FILE - do not edit directly. Source: static_src/
 import { deleteWorkspaceFile, deleteWorkspaceFolder, downloadWorkspaceFile, downloadWorkspaceZip } from "./workspaceApi.js";
-import { flash } from "./utils.js";
+import { confirmModal, flash } from "./utils.js";
 export class WorkspaceFileBrowser {
     constructor(options) {
         this.tree = [];
@@ -274,7 +274,9 @@ export class WorkspaceFileBrowser {
                     delBtn.title = "Delete file";
                     delBtn.addEventListener("click", async (evt) => {
                         evt.stopPropagation();
-                        const ok = this.onConfirm ? await this.onConfirm(`Delete ${node.name}?`) : confirm(`Delete ${node.name}?`);
+                        const ok = this.onConfirm
+                            ? await this.onConfirm(`Delete ${node.name}?`)
+                            : await confirmModal(`Delete ${node.name}?`);
                         if (!ok)
                             return;
                         try {
@@ -301,7 +303,7 @@ export class WorkspaceFileBrowser {
                         evt.stopPropagation();
                         const ok = this.onConfirm
                             ? await this.onConfirm(`Delete folder ${node.name}? (must be empty)`)
-                            : confirm(`Delete folder ${node.name}? (must be empty)`);
+                            : await confirmModal(`Delete folder ${node.name}? (must be empty)`);
                         if (!ok)
                             return;
                         try {
@@ -418,7 +420,7 @@ export class WorkspaceFileBrowser {
                     e.stopPropagation();
                     const ok = this.onConfirm
                         ? await this.onConfirm(`Delete ${node.name}${node.type === "folder" ? " (must be empty)" : ""}?`)
-                        : confirm(`Delete ${node.name}${node.type === "folder" ? " (must be empty)" : ""}?`);
+                        : await confirmModal(`Delete ${node.name}${node.type === "folder" ? " (must be empty)" : ""}?`);
                     if (!ok)
                         return;
                     try {

--- a/src/codex_autorunner/static_src/fileboxUi.ts
+++ b/src/codex_autorunner/static_src/fileboxUi.ts
@@ -1,4 +1,4 @@
-import { api, escapeHtml, flash, resolvePath } from "./utils.js";
+import { api, confirmModal, escapeHtml, flash, resolvePath } from "./utils.js";
 
 export type FileBoxEntry = {
   name: string;
@@ -135,7 +135,7 @@ export function createFileBoxWidget(opts: FileBoxWidgetOpts) {
         const boxName = (target.dataset.box || "") as "inbox" | "outbox";
         const file = target.dataset.file || "";
         if (!boxName || !file) return;
-        const confirmed = window.confirm(`Delete ${file}?`);
+        const confirmed = await confirmModal(`Delete ${file}?`);
         if (!confirmed) return;
         try {
           await deleteFile(opts, boxName, file);

--- a/src/codex_autorunner/static_src/pma.ts
+++ b/src/codex_autorunner/static_src/pma.ts
@@ -1,7 +1,7 @@
 /**
  * PMA (Project Management Agent) - Hub-level chat interface
  */
-import { api, resolvePath, getAuthToken, escapeHtml, flash } from "./utils.js";
+import { api, confirmModal, resolvePath, getAuthToken, escapeHtml, flash } from "./utils.js";
 import {
   createDocChat,
   type ChatConfig,
@@ -342,8 +342,9 @@ async function snapshotActiveContext(): Promise<void> {
   }
 }
 
-function resetActiveContext(): void {
-  if (!confirm("Reset active context to default?")) return;
+async function resetActiveContext(): Promise<void> {
+  const confirmed = await confirmModal("Reset active context to default?");
+  if (!confirmed) return;
   const editor = document.getElementById("pma-docs-editor") as HTMLTextAreaElement | null;
   if (!editor) return;
   void loadPMADocDefaultContent("active_context.md").then((resetContent) => {

--- a/src/codex_autorunner/static_src/ticketChatActions.ts
+++ b/src/codex_autorunner/static_src/ticketChatActions.ts
@@ -1,7 +1,7 @@
 /**
  * Ticket Chat Actions - handles sending messages, applying/discarding patches
  */
-import { api, flash, splitMarkdownFrontmatter } from "./utils.js";
+import { api, confirmModal, flash, splitMarkdownFrontmatter } from "./utils.js";
 import { performTicketChatRequest } from "./ticketChatStream.js";
 import { renderTicketMessages, renderTicketEvents } from "./ticketChatEvents.js";
 import { publish } from "./bus.js";
@@ -110,7 +110,7 @@ export function resetTicketChatState(): void {
 export async function startNewTicketChatThread(): Promise<void> {
   if (ticketChatState.ticketIndex == null) return;
 
-  const confirmed = window.confirm("Start a new conversation thread for this ticket?");
+  const confirmed = await confirmModal("Start a new conversation thread for this ticket?");
   if (!confirmed) return;
 
   try {

--- a/src/codex_autorunner/static_src/ticketEditor.ts
+++ b/src/codex_autorunner/static_src/ticketEditor.ts
@@ -1,7 +1,7 @@
 /**
  * Ticket Editor Modal - handles creating, editing, and deleting tickets
  */
-import { api, flash, updateUrlParams, splitMarkdownFrontmatter } from "./utils.js";
+import { api, confirmModal, flash, updateUrlParams, splitMarkdownFrontmatter } from "./utils.js";
 import { publish } from "./bus.js";
 import { clearTicketChatHistory } from "./ticketChatStorage.js";
 import {
@@ -812,7 +812,7 @@ export async function deleteTicket(): Promise<void> {
     return;
   }
 
-  const confirmed = window.confirm(
+  const confirmed = await confirmModal(
     `Delete TICKET-${String(state.ticketIndex).padStart(3, "0")}.md? This cannot be undone.`
   );
   if (!confirmed) return;

--- a/src/codex_autorunner/static_src/tickets.ts
+++ b/src/codex_autorunner/static_src/tickets.ts
@@ -1,5 +1,6 @@
 import {
   api,
+  confirmModal,
   flash,
   getUrlParams,
   resolvePath,
@@ -2032,7 +2033,10 @@ async function restartTicketFlow(): Promise<void> {
     flash("Create a ticket first before restarting the flow.", "error");
     return;
   }
-  if (!confirm("Restart ticket flow? This will stop the current run and start a new one.")) {
+  const confirmed = await confirmModal(
+    "Restart ticket flow? This will stop the current run and start a new one."
+  );
+  if (!confirmed) {
     return;
   }
   setButtonsDisabled(true);
@@ -2070,7 +2074,10 @@ async function archiveTicketFlow(): Promise<void> {
     flash("No ticket flow run to archive", "info");
     return;
   }
-  if (!confirm("Archive all tickets from this flow? They will be moved to the run's artifact directory.")) {
+  const confirmed = await confirmModal(
+    "Archive all tickets from this flow? They will be moved to the run's artifact directory."
+  );
+  if (!confirmed) {
     return;
   }
   setButtonsDisabled(true);

--- a/src/codex_autorunner/static_src/workspace.ts
+++ b/src/codex_autorunner/static_src/workspace.ts
@@ -1,4 +1,4 @@
-import { api, flash, setButtonLoading } from "./utils.js";
+import { api, confirmModal, flash, setButtonLoading } from "./utils.js";
 import { initAgentControls, getSelectedAgent, getSelectedModel, getSelectedReasoning } from "./agentControls.js";
 import {
   fetchWorkspace,
@@ -429,7 +429,7 @@ const workspaceTreeRefresh = createSmartRefresh<WorkspaceTreePayload>({
         onConfirm: (message) =>
           (window as unknown as { workspaceConfirm?: (msg: string) => Promise<boolean> }).workspaceConfirm?.(
             message
-          ) ?? Promise.resolve(confirm(message)),
+          ) ?? confirmModal(message),
       });
     }
 
@@ -550,7 +550,7 @@ async function applyWorkspaceDraft(): Promise<void> {
   try {
     const isStale = Boolean(state.draft?.is_stale);
     if (isStale) {
-      const confirmForce = window.confirm(
+      const confirmForce = await confirmModal(
         "This draft is stale because the file changed after it was created. Force apply anyway?"
       );
       if (!confirmForce) return;

--- a/src/codex_autorunner/static_src/workspaceFileBrowser.ts
+++ b/src/codex_autorunner/static_src/workspaceFileBrowser.ts
@@ -1,5 +1,5 @@
 import { WorkspaceNode, deleteWorkspaceFile, deleteWorkspaceFolder, downloadWorkspaceFile, downloadWorkspaceZip } from "./workspaceApi.js";
-import { flash } from "./utils.js";
+import { confirmModal, flash } from "./utils.js";
 
 type ChangeHandler = (file: WorkspaceNode) => void;
 
@@ -308,7 +308,9 @@ export class WorkspaceFileBrowser {
           delBtn.title = "Delete file";
           delBtn.addEventListener("click", async (evt) => {
             evt.stopPropagation();
-            const ok = this.onConfirm ? await this.onConfirm(`Delete ${node.name}?`) : confirm(`Delete ${node.name}?`);
+            const ok = this.onConfirm
+              ? await this.onConfirm(`Delete ${node.name}?`)
+              : await confirmModal(`Delete ${node.name}?`);
             if (!ok) return;
             try {
               await deleteWorkspaceFile(node.path);
@@ -334,7 +336,7 @@ export class WorkspaceFileBrowser {
             evt.stopPropagation();
             const ok = this.onConfirm
               ? await this.onConfirm(`Delete folder ${node.name}? (must be empty)`)
-              : confirm(`Delete folder ${node.name}? (must be empty)`);
+              : await confirmModal(`Delete folder ${node.name}? (must be empty)`);
             if (!ok) return;
             try {
               await deleteWorkspaceFolder(node.path);
@@ -449,15 +451,15 @@ export class WorkspaceFileBrowser {
         delBtn.className = "ghost sm danger";
         delBtn.textContent = "✕";
         delBtn.title = `Delete ${node.type}`;
-        delBtn.addEventListener("click", async (e) => {
-          e.stopPropagation();
-          const ok = this.onConfirm
-            ? await this.onConfirm(`Delete ${node.name}${node.type === "folder" ? " (must be empty)" : ""}?`)
-            : confirm(`Delete ${node.name}${node.type === "folder" ? " (must be empty)" : ""}?`);
-          if (!ok) return;
-          try {
-            if (node.type === "folder") {
-              await deleteWorkspaceFolder(node.path);
+          delBtn.addEventListener("click", async (e) => {
+            e.stopPropagation();
+            const ok = this.onConfirm
+              ? await this.onConfirm(`Delete ${node.name}${node.type === "folder" ? " (must be empty)" : ""}?`)
+              : await confirmModal(`Delete ${node.name}${node.type === "folder" ? " (must be empty)" : ""}?`);
+            if (!ok) return;
+            try {
+              if (node.type === "folder") {
+                await deleteWorkspaceFolder(node.path);
             } else {
               await deleteWorkspaceFile(node.path);
               if (this.selectedPath === node.path) this.selectedPath = null;


### PR DESCRIPTION
## Summary
- replace all in-app native confirm prompts with the shared confirm modal
- update workspace file browser + stale draft handling to rely on modal confirmation
- rebuild static assets

## Testing
- pnpm run build
- pytest