### PR TITLE
Fix notification bell badge and click

### DIFF
--- a/src/codex_autorunner/static/notifications.js
+++ b/src/codex_autorunner/static/notifications.js
@@ -205,11 +205,17 @@ function attachRoot(root) {
     root.trigger.addEventListener("pointerdown", (event) => {
         event.preventDefault();
         event.stopPropagation();
-        toggleDropdown(root);
     });
     root.trigger.addEventListener("click", (event) => {
         event.preventDefault();
         event.stopPropagation();
+        if (notificationItems.length === 1) {
+            const [item] = notificationItems;
+            closeDropdown();
+            openNotificationsModal(item, root.trigger);
+            return;
+        }
+        toggleDropdown(root);
     });
     root.dropdown.addEventListener("click", (event) => {
         const target = event.target?.closest(".notifications-item");

--- a/src/codex_autorunner/static/styles.css
+++ b/src/codex_autorunner/static/styles.css
@@ -936,6 +936,7 @@ main {
 
 .notifications-bell-btn {
   position: relative;
+  overflow: visible;
 }
 
 .notifications-bell-badge {
@@ -953,6 +954,7 @@ main {
   text-align: center;
   border: 1px solid var(--bg);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+  pointer-events: none;
 }
 
 .notifications-dropdown {

--- a/src/codex_autorunner/static_src/notifications.ts
+++ b/src/codex_autorunner/static_src/notifications.ts
@@ -255,12 +255,18 @@ function attachRoot(root: NotificationRoot): void {
   root.trigger.addEventListener("pointerdown", (event) => {
     event.preventDefault();
     event.stopPropagation();
-    toggleDropdown(root);
   });
 
   root.trigger.addEventListener("click", (event) => {
     event.preventDefault();
     event.stopPropagation();
+    if (notificationItems.length === 1) {
+      const [item] = notificationItems;
+      closeDropdown();
+      openNotificationsModal(item, root.trigger);
+      return;
+    }
+    toggleDropdown(root);
   });
 
   root.dropdown.addEventListener("click", (event) => {


### PR DESCRIPTION
## Summary
- stop clipping on the notifications badge by allowing overflow and ignoring pointer events on the badge
- make the bell click open the single-notification modal (otherwise keep the dropdown)
- keep dropdown behavior for multiple/empty notifications

## Testing
- pnpm run build
- pytest
