### PR TITLE
Fix notifications dropdown positioning

### DIFF
--- a/src/codex_autorunner/static/notifications.js
+++ b/src/codex_autorunner/static/notifications.js
@@ -8,6 +8,8 @@ let closeModalFn = null;
 let documentListenerInstalled = false;
 let modalElements = null;
 let isRefreshing = false;
+const DROPDOWN_MARGIN = 8;
+const DROPDOWN_OFFSET = 6;
 const NOTIFICATIONS_REFRESH_ID = "notifications";
 const NOTIFICATIONS_REFRESH_MS = 15000;
 function getModalElements() {
@@ -93,9 +95,39 @@ function closeDropdown() {
     if (!activeRoot)
         return;
     activeRoot.dropdown.classList.add("hidden");
+    activeRoot.dropdown.style.position = "";
+    activeRoot.dropdown.style.left = "";
+    activeRoot.dropdown.style.right = "";
+    activeRoot.dropdown.style.top = "";
+    activeRoot.dropdown.style.visibility = "";
     activeRoot.trigger.setAttribute("aria-expanded", "false");
     activeRoot = null;
     removeDocumentListener();
+}
+function positionDropdown(root) {
+    const { trigger, dropdown } = root;
+    const triggerRect = trigger.getBoundingClientRect();
+    dropdown.style.position = "fixed";
+    dropdown.style.left = "0";
+    dropdown.style.right = "auto";
+    dropdown.style.top = "0";
+    dropdown.style.visibility = "hidden";
+    const dropdownRect = dropdown.getBoundingClientRect();
+    const width = dropdownRect.width || 240;
+    const height = dropdownRect.height || 0;
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    let left = triggerRect.right - width;
+    left = Math.min(Math.max(left, DROPDOWN_MARGIN), viewportWidth - width - DROPDOWN_MARGIN);
+    const preferredTop = triggerRect.bottom + DROPDOWN_OFFSET;
+    const fallbackTop = triggerRect.top - DROPDOWN_OFFSET - height;
+    let top = preferredTop;
+    if (preferredTop + height > viewportHeight - DROPDOWN_MARGIN) {
+        top = Math.max(DROPDOWN_MARGIN, fallbackTop);
+    }
+    dropdown.style.left = `${Math.max(DROPDOWN_MARGIN, left)}px`;
+    dropdown.style.top = `${Math.max(DROPDOWN_MARGIN, top)}px`;
+    dropdown.style.visibility = "";
 }
 function openDropdown(root) {
     if (activeRoot && activeRoot !== root) {
@@ -105,6 +137,7 @@ function openDropdown(root) {
     activeRoot = root;
     renderDropdown(root);
     root.dropdown.classList.remove("hidden");
+    positionDropdown(root);
     root.trigger.setAttribute("aria-expanded", "true");
     installDocumentListener();
 }

--- a/src/codex_autorunner/static_src/notifications.ts
+++ b/src/codex_autorunner/static_src/notifications.ts
@@ -52,6 +52,8 @@ let closeModalFn: (() => void) | null = null;
 let documentListenerInstalled = false;
 let modalElements: ModalElements | null = null;
 let isRefreshing = false;
+const DROPDOWN_MARGIN = 8;
+const DROPDOWN_OFFSET = 6;
 
 const NOTIFICATIONS_REFRESH_ID = "notifications";
 const NOTIFICATIONS_REFRESH_MS = 15000;
@@ -141,9 +143,44 @@ function renderDropdownError(root: NotificationRoot): void {
 function closeDropdown(): void {
   if (!activeRoot) return;
   activeRoot.dropdown.classList.add("hidden");
+  activeRoot.dropdown.style.position = "";
+  activeRoot.dropdown.style.left = "";
+  activeRoot.dropdown.style.right = "";
+  activeRoot.dropdown.style.top = "";
+  activeRoot.dropdown.style.visibility = "";
   activeRoot.trigger.setAttribute("aria-expanded", "false");
   activeRoot = null;
   removeDocumentListener();
+}
+
+function positionDropdown(root: NotificationRoot): void {
+  const { trigger, dropdown } = root;
+  const triggerRect = trigger.getBoundingClientRect();
+  dropdown.style.position = "fixed";
+  dropdown.style.left = "0";
+  dropdown.style.right = "auto";
+  dropdown.style.top = "0";
+  dropdown.style.visibility = "hidden";
+
+  const dropdownRect = dropdown.getBoundingClientRect();
+  const width = dropdownRect.width || 240;
+  const height = dropdownRect.height || 0;
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  let left = triggerRect.right - width;
+  left = Math.min(Math.max(left, DROPDOWN_MARGIN), viewportWidth - width - DROPDOWN_MARGIN);
+
+  const preferredTop = triggerRect.bottom + DROPDOWN_OFFSET;
+  const fallbackTop = triggerRect.top - DROPDOWN_OFFSET - height;
+  let top = preferredTop;
+  if (preferredTop + height > viewportHeight - DROPDOWN_MARGIN) {
+    top = Math.max(DROPDOWN_MARGIN, fallbackTop);
+  }
+
+  dropdown.style.left = `${Math.max(DROPDOWN_MARGIN, left)}px`;
+  dropdown.style.top = `${Math.max(DROPDOWN_MARGIN, top)}px`;
+  dropdown.style.visibility = "";
 }
 
 function openDropdown(root: NotificationRoot): void {
@@ -154,6 +191,7 @@ function openDropdown(root: NotificationRoot): void {
   activeRoot = root;
   renderDropdown(root);
   root.dropdown.classList.remove("hidden");
+  positionDropdown(root);
   root.trigger.setAttribute("aria-expanded", "true");
   installDocumentListener();
 }


### PR DESCRIPTION
## Summary
- position the notifications dropdown as a fixed, viewport-anchored popover
- compute a safe top/left so it stays in view instead of being clipped by the hub header
- reset inline positioning styles when closing the dropdown

## Testing
- `pnpm run build`
- `pytest`
