### PR TITLE
Fix notification handoff navigation

### DIFF
--- a/src/codex_autorunner/static/index.html
+++ b/src/codex_autorunner/static/index.html
@@ -1154,7 +1154,7 @@
     </div>
   </div>
   <!-- Notifications Modal -->
-  <div class="modal-overlay hidden" id="notifications-modal">
+  <div class="modal-overlay" hidden="" id="notifications-modal">
     <div aria-labelledby="notifications-modal-title" aria-modal="true" class="modal-dialog notifications-modal-dialog"
       role="dialog" tabindex="-1">
       <div class="notifications-modal-header">

--- a/src/codex_autorunner/static/notifications.js
+++ b/src/codex_autorunner/static/notifications.js
@@ -248,12 +248,19 @@ function attachRoot(root) {
         const target = event.target?.closest(".notifications-item");
         if (!target)
             return;
+        event.preventDefault();
+        event.stopPropagation();
         const index = Number(target.dataset.index || "-1");
         const item = notificationItems[index];
         if (!item)
             return;
         closeDropdown();
-        openNotificationsModal(item, root.trigger);
+        const mouseEvent = event;
+        if (mouseEvent.shiftKey) {
+            openNotificationsModal(item, root.trigger);
+            return;
+        }
+        window.location.href = resolvePath(item.openUrl);
     });
 }
 function attachModalHandlers() {

--- a/src/codex_autorunner/static_src/notifications.ts
+++ b/src/codex_autorunner/static_src/notifications.ts
@@ -306,11 +306,18 @@ function attachRoot(root: NotificationRoot): void {
       ".notifications-item"
     );
     if (!target) return;
+    event.preventDefault();
+    event.stopPropagation();
     const index = Number(target.dataset.index || "-1");
     const item = notificationItems[index];
     if (!item) return;
     closeDropdown();
-    openNotificationsModal(item, root.trigger);
+    const mouseEvent = event as MouseEvent;
+    if (mouseEvent.shiftKey) {
+      openNotificationsModal(item, root.trigger);
+      return;
+    }
+    window.location.href = resolvePath(item.openUrl);
   });
 }
 


### PR DESCRIPTION
## Summary
- navigate directly to notification handoff on click (modal still available via Shift-click)
- fix notifications modal overlay to use the hidden attribute so it opens/closes without trapping clicks

## Testing
- pre-commit hooks (ruff, mypy, eslint, pnpm build)
- pytest
