### PR TITLE
Recover stale Telegram active threads during verification

### DIFF
--- a/tests/fixtures/app_server_fixture.py
+++ b/tests/fixtures/app_server_fixture.py
@@ -187,6 +187,14 @@ class FixtureServer:
         if method == "thread/start":
             thread_id = f"thread-{self._next_thread}"
             self._next_thread += 1
+            if self._scenario == "thread_start_error":
+                self.send(
+                    {
+                        "id": req_id,
+                        "error": {"code": -32603, "message": "thread start failed"},
+                    }
+                )
+                return
             if self._scenario == "thread_id_key":
                 result = {"threadId": thread_id, "cwd": params.get("cwd")}
             elif self._scenario == "thread_id_snake":

--- a/tests/test_telegram_bot_integration.py
+++ b/tests/test_telegram_bot_integration.py
@@ -475,6 +475,53 @@ async def test_stale_active_thread_is_recovered_during_verification(
 
 
 @pytest.mark.anyio
+async def test_new_surfaces_thread_start_errors(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config = make_config(tmp_path, fixture_command("thread_start_error"))
+    service = TelegramBotService(config, hub_root=tmp_path)
+    fake_bot = FakeBot()
+    service._bot = fake_bot
+    bind_message = build_message("/bind", message_id=10)
+    new_message = build_message("/new", message_id=11)
+    try:
+        await service._handle_bind(bind_message, str(repo))
+        await service._handle_new(new_message)
+    finally:
+        await service._app_server_supervisor.close_all()
+    assert any(
+        "Failed to start a new thread; check logs for details." in msg["text"]
+        for msg in fake_bot.messages
+    )
+
+
+@pytest.mark.anyio
+async def test_resume_missing_thread_clears_stale_topic_state(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config = make_config(tmp_path, fixture_command("thread_resume_missing_thread"))
+    service = TelegramBotService(config, hub_root=tmp_path)
+    fake_bot = FakeBot()
+    service._bot = fake_bot
+    bind_message = build_message("/bind", message_id=10)
+    new_message = build_message("/new", message_id=11)
+    try:
+        await service._handle_bind(bind_message, str(repo))
+        await service._handle_new(new_message)
+        key = await service._router.resolve_key(
+            bind_message.chat_id, bind_message.thread_id
+        )
+        await service._resume_thread_by_id(key, "thread-1")
+        record = await service._router.get_topic(key)
+    finally:
+        await service._app_server_supervisor.close_all()
+    assert record is not None
+    assert record.active_thread_id is None
+    assert "thread-1" not in record.thread_ids
+    assert any("Thread no longer exists." in msg["text"] for msg in fake_bot.messages)
+
+
+@pytest.mark.anyio
 async def test_resume_lists_threads_from_data_shape(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary
- treat `thread/resume` "thread not found" responses during active-thread verification as stale metadata
- clear stale `active_thread_id` and continue so normal message flow auto-starts a fresh thread
- handle `/resume` missing-thread failures by clearing stale local topic state and returning a guided recovery message
- handle `/new` and `/reset` `thread/start` errors explicitly so failures are surfaced to users instead of appearing as no-op
- add fixture scenarios and integration tests for these failure paths

## Why
Two related failure loops were possible in Telegram bound chats:
- stale active-thread pointers forced repeated `/resume` or `/new` prompts
- app-server `thread/start` errors in `/new` were not surfaced cleanly, so `/new` could look like it did nothing

## Testing
- `python3 -m pytest -q tests/test_telegram_bot_integration.py -k "stale_active_thread_is_recovered_during_verification or new_surfaces_thread_start_errors or resume_missing_thread_clears_stale_topic_state"`
- pre-commit pipeline during commit (includes full pytest suite)
