### PR TITLE
Make worktree cleanup dialog more informative

### DIFF
--- a/src/codex_autorunner/static/hub.js
+++ b/src/codex_autorunner/static/hub.js
@@ -1094,7 +1094,7 @@ async function handleRepoAction(repoId, action) {
             const displayName = repoId.includes("--")
                 ? repoId.split("--").pop()
                 : repoId;
-            const ok = await confirmModal(`Remove worktree "${displayName}"? This will delete the worktree directory and its branch.`, { confirmText: "Remove", danger: true });
+            const ok = await confirmModal(`Clean up worktree "${displayName}"?\n\nCAR will archive its runtime files for later viewing in the Archive tab, then remove the worktree directory and branch.`, { confirmText: "Archive & remove" });
             if (!ok)
                 return;
             await startHubJob("/hub/jobs/worktrees/cleanup", {

--- a/src/codex_autorunner/static_src/hub.ts
+++ b/src/codex_autorunner/static_src/hub.ts
@@ -1352,8 +1352,8 @@ async function handleRepoAction(repoId: string, action: string): Promise<void> {
         ? repoId.split("--").pop()
         : repoId;
       const ok = await confirmModal(
-        `Remove worktree "${displayName}"? This will delete the worktree directory and its branch.`,
-        { confirmText: "Remove", danger: true }
+        `Clean up worktree "${displayName}"?\n\nCAR will archive its runtime files for later viewing in the Archive tab, then remove the worktree directory and branch.`,
+        { confirmText: "Archive & remove" }
       );
       if (!ok) return;
       await startHubJob("/hub/jobs/worktrees/cleanup", {


### PR DESCRIPTION
## Summary
- make the worktree cleanup confirmation copy informational rather than alarm-style
- explain that CAR archives runtime artifacts before removal and where to find them
- rename the confirm CTA to `Archive & remove`

## Changes
- update cleanup modal copy in `src/codex_autorunner/static_src/hub.ts`
- regenerate `src/codex_autorunner/static/hub.js`

## Validation
- pre-commit checks passed during commit
- `pnpm run build`
- `pytest` (980 passed, 3 skipped, 64 deselected)
