### PR TITLE
Fix contextspace migration regressions (init, uploads/pinned selection, thread reset)

### DIFF
--- a/scripts/check_dom_structure.mjs
+++ b/scripts/check_dom_structure.mjs
@@ -10,6 +10,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const INDEX_PATH = resolve("src/codex_autorunner/static/index.html");
+const CONTEXTSPACE_JS_PATH = resolve("src/codex_autorunner/static/contextspace.js");
 
 function fail(message) {
   console.error(message);
@@ -78,6 +79,14 @@ function main() {
       `Expected 1 active panel, found ${activePanels.length}: [${activePanels
         .map((p) => p.id || "(no id)")
         .join(", ")}]`
+    );
+  }
+
+  // 4) Contextspace bootstrap guard should target #contextspace panel.
+  const contextspaceJs = readFileSync(CONTEXTSPACE_JS_PATH, "utf8");
+  if (contextspaceJs.includes('document.getElementById("workspace")')) {
+    fail(
+      'Contextspace bootstrap guard is checking "#workspace"; expected "#contextspace".'
     );
   }
 

--- a/src/codex_autorunner/static/contextspace.js
+++ b/src/codex_autorunner/static/contextspace.js
@@ -162,7 +162,7 @@ async function writeContextspaceContent(path, content) {
         }
         catch (err) {
             const msg = err.message || "";
-            if (!msg.toLowerCase().includes("invalid workspace doc kind")) {
+            if (!msg.toLowerCase().includes("invalid contextspace doc kind")) {
                 throw err;
             }
             // Fallback to generic file write in case detection misfires
@@ -177,6 +177,9 @@ function target() {
     if (!state.target)
         return "contextspace:active_context";
     return `contextspace:${state.target.path}`;
+}
+function contextspaceThreadKey(path) {
+    return `file_chat.contextspace_${(path || "").replace(/\//g, "_")}`;
 }
 function setStatus(text) {
     const { status, statusMobile } = els();
@@ -294,7 +297,7 @@ function openCreateModal(mode) {
     createPath.innerHTML = "";
     const rootOption = document.createElement("option");
     rootOption.value = "";
-    rootOption.textContent = "Workspace (root)";
+    rootOption.textContent = "Contextspace (root)";
     createPath.appendChild(rootOption);
     const folders = listFolderPaths(state.files);
     folders.forEach((path) => {
@@ -430,7 +433,7 @@ async function refreshWorkspaceFile(path, reason = "manual") {
         await workspaceContentRefresh.refresh(async () => ({ path, content: await readWorkspaceContent(path) }), { reason });
     }
     catch (err) {
-        const message = err.message || "Failed to load workspace file";
+        const message = err.message || "Failed to load contextspace file";
         flash(message, "error");
         setStatus(message);
     }
@@ -672,7 +675,7 @@ async function sendChat() {
     chatSend?.setAttribute("disabled", "true");
     chatCancel?.classList.remove("hidden");
     clearTurnEventsStream();
-    const clientTurnId = newClientTurnId("workspace");
+    const clientTurnId = newClientTurnId("contextspace");
     savePendingTurn(CONTEXTSPACE_PENDING_KEY, {
         clientTurnId,
         message,
@@ -770,7 +773,7 @@ async function resetThread() {
     try {
         await api("/api/app-server/threads/reset", {
             method: "POST",
-            body: { key: `file_chat.workspace.${state.target.path}` },
+            body: { key: contextspaceThreadKey(state.target.path) },
         });
         const chatState = workspaceChat.state;
         chatState.messages = [];
@@ -779,7 +782,7 @@ async function resetThread() {
         workspaceChat.clearEvents();
         clearPendingTurnState();
         renderChat();
-        flash("New workspace chat thread", "success");
+        flash("New contextspace chat thread", "success");
     }
     catch (err) {
         flash(err.message || "Failed to reset thread", "error");
@@ -804,7 +807,7 @@ async function loadFiles(defaultPath, reason = "manual") {
 }
 export async function initContextspace() {
     const { generateBtn, uploadBtn, uploadInput, mobileMenuToggle, mobileDropdown, mobileUpload, mobileNewFolder, mobileNewFile, mobileDownload, mobileGenerate, newFolderBtn, saveBtn, saveBtnMobile, reloadBtn, reloadBtnMobile, patchApply, patchDiscard, patchReload, chatSend, chatCancel, chatNewThread, } = els();
-    if (!document.getElementById("workspace"))
+    if (!document.getElementById("contextspace"))
         return;
     initAgentControls({
         agentSelect: els().agentSelect,

--- a/src/codex_autorunner/static/contextspaceFileBrowser.js
+++ b/src/codex_autorunner/static/contextspaceFileBrowser.js
@@ -348,7 +348,7 @@ export class ContextspaceFileBrowser {
         crumbs.className = "file-picker-crumbs";
         const root = document.createElement("button");
         root.type = "button";
-        root.textContent = "Workspace";
+        root.textContent = "Contextspace";
         root.addEventListener("click", () => {
             this.currentPath = "";
             this.render();

--- a/src/codex_autorunner/static/styles.css
+++ b/src/codex_autorunner/static/styles.css
@@ -7812,7 +7812,7 @@ button.loading::after {
   }
 
   /* Tighten spacing around toolbar */
-  #workspace-content {
+  #contextspace-content {
     margin-bottom: 0;
   }
 
@@ -7828,17 +7828,17 @@ button.loading::after {
     display: none;
   }
 
-  #workspace.panel.active {
+  #contextspace.panel.active {
     display: flex;
     flex-direction: column;
   }
 
-  #workspace .contextspace-main {
+  #contextspace .contextspace-main {
     flex: 1;
     min-height: 0;
   }
 
-  #workspace-content {
+  #contextspace-content {
     min-height: 150px;
     font-size: 14px;
   }

--- a/src/codex_autorunner/static_src/contextspace.ts
+++ b/src/codex_autorunner/static_src/contextspace.ts
@@ -217,7 +217,7 @@ async function writeContextspaceContent(path: string, content: string): Promise<
       return (res[kind] as string) || "";
     } catch (err) {
       const msg = (err as Error).message || "";
-      if (!msg.toLowerCase().includes("invalid workspace doc kind")) {
+      if (!msg.toLowerCase().includes("invalid contextspace doc kind")) {
         throw err;
       }
       // Fallback to generic file write in case detection misfires
@@ -232,6 +232,10 @@ async function writeContextspaceContent(path: string, content: string): Promise<
 function target(): string {
   if (!state.target) return "contextspace:active_context";
   return `contextspace:${state.target.path}`;
+}
+
+function contextspaceThreadKey(path: string): string {
+  return `file_chat.contextspace_${(path || "").replace(/\//g, "_")}`;
 }
 
 function setStatus(text: string): void {
@@ -354,7 +358,7 @@ function openCreateModal(mode: CreateMode): void {
   createPath.innerHTML = "";
   const rootOption = document.createElement("option");
   rootOption.value = "";
-  rootOption.textContent = "Workspace (root)";
+  rootOption.textContent = "Contextspace (root)";
   createPath.appendChild(rootOption);
   const folders = listFolderPaths(state.files);
   folders.forEach((path) => {
@@ -494,7 +498,7 @@ async function refreshWorkspaceFile(path: string, reason: SmartRefreshReason = "
       { reason }
     );
   } catch (err) {
-    const message = (err as Error).message || "Failed to load workspace file";
+    const message = (err as Error).message || "Failed to load contextspace file";
     flash(message, "error");
     setStatus(message);
   } finally {
@@ -743,7 +747,7 @@ async function sendChat(): Promise<void> {
   chatCancel?.classList.remove("hidden");
   clearTurnEventsStream();
 
-  const clientTurnId = newClientTurnId("workspace");
+  const clientTurnId = newClientTurnId("contextspace");
   savePendingTurn(CONTEXTSPACE_PENDING_KEY, {
     clientTurnId,
     message,
@@ -847,7 +851,7 @@ async function resetThread(): Promise<void> {
   try {
     await api("/api/app-server/threads/reset", {
       method: "POST",
-      body: { key: `file_chat.workspace.${state.target.path}` },
+      body: { key: contextspaceThreadKey(state.target.path) },
     });
     const chatState = workspaceChat.state as ChatState;
     chatState.messages = [];
@@ -856,7 +860,7 @@ async function resetThread(): Promise<void> {
     workspaceChat.clearEvents();
     clearPendingTurnState();
     renderChat();
-    flash("New workspace chat thread", "success");
+    flash("New contextspace chat thread", "success");
   } catch (err) {
     flash((err as Error).message || "Failed to reset thread", "error");
   }
@@ -907,7 +911,7 @@ export async function initContextspace(): Promise<void> {
     chatNewThread,
   } = els();
 
-  if (!document.getElementById("workspace")) return;
+  if (!document.getElementById("contextspace")) return;
 
   initAgentControls({
     agentSelect: els().agentSelect,

--- a/src/codex_autorunner/static_src/contextspaceFileBrowser.ts
+++ b/src/codex_autorunner/static_src/contextspaceFileBrowser.ts
@@ -378,7 +378,7 @@ export class ContextspaceFileBrowser {
     crumbs.className = "file-picker-crumbs";
     const root = document.createElement("button");
     root.type = "button";
-    root.textContent = "Workspace";
+    root.textContent = "Contextspace";
     root.addEventListener("click", () => {
       this.currentPath = "";
       this.render();


### PR DESCRIPTION
## Summary
This PR fixes regressions introduced by the workspace -> contextspace migration that broke core Contextspace interactions without console errors.

## Root causes found
1. `initContextspace()` exited early because it checked for `#workspace` instead of `#contextspace`.
   - Impact: contextspace tab wiring never initialized (file selection, pinned docs interaction, upload handlers, agent/model/reasoning selectors, chat actions).
2. Contextspace "New thread" reset used the old key shape `file_chat.workspace.<path>` instead of the active contextspace state key namespace.
   - Impact: reset endpoint succeeded/failed against the wrong thread key, so contextspace new-thread behavior was inconsistent/broken.
3. Remaining migration leftovers in contextspace UX and responsive CSS.
   - Impact: stale labels and missing mobile textarea/layout selectors (`#workspace-content` / `#workspace` selectors no longer matched contextspace DOM).
4. Error fallback text still matched `invalid workspace doc kind`.
   - Impact: incorrect fallback condition for contextspace write path handling.

## Changes
- Fixed contextspace bootstrap guard to use `#contextspace`.
- Added `contextspaceThreadKey()` and switched thread reset to `file_chat.contextspace_<rel_path_with_underscores>`.
- Updated contextspace strings/messages and create modal root label to `Contextspace`.
- Updated contextspace mobile CSS selectors to `#contextspace` / `#contextspace-content`.
- Added DOM regression guard in `scripts/check_dom_structure.mjs` to fail if contextspace bootstrap checks `#workspace`.
- Regenerated static JS from `static_src` via build.

## Validation
- `pnpm build`
- `pnpm test:dom`
- `python3 -m pytest -q tests/test_workspace_functional.py tests/test_file_chat_drafts.py tests/routes/test_contextspace_routes.py`
  - Result: `12 passed, 1 skipped`

## Notes
The changes are intentionally scoped to contextspace migration regressions and do not alter unrelated thread-key behavior for ticket chat.
