### PR TITLE
Telegram: backtick copyable repo/run IDs in flow output

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/selections.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/selections.py
@@ -530,9 +530,9 @@ class TelegramSelectionHandlers:
         lines = [FLOW_RUNS_PICKER_PROMPT]
         for run_id, label in page_items:
             if label:
-                lines.append(f"- {run_id} — {label}")
+                lines.append(f"- `{run_id}` — {label}")
             else:
-                lines.append(f"- {run_id}")
+                lines.append(f"- `{run_id}`")
         base = "\n".join(lines)
         return _format_selection_prompt(base, state.page, total_pages)
 

--- a/tests/test_telegram_flow_bootstrap.py
+++ b/tests/test_telegram_flow_bootstrap.py
@@ -43,8 +43,9 @@ class _FlowBootstrapHandler(FlowCommands):
         thread_id: int | None = None,
         reply_to: int | None = None,
         reply_markup: dict[str, object] | None = None,
+        parse_mode: str | None = None,
     ) -> None:
-        _ = (thread_id, reply_to, reply_markup)
+        _ = (thread_id, reply_to, reply_markup, parse_mode)
         self.sent.append(text)
 
     async def _prompt_flow_text_input(

--- a/tests/test_telegram_flow_lifecycle.py
+++ b/tests/test_telegram_flow_lifecycle.py
@@ -51,8 +51,9 @@ class _FlowLifecycleHandler(FlowCommands):
         thread_id: int | None = None,
         reply_to: int | None = None,
         reply_markup: dict[str, object] | None = None,
+        parse_mode: str | None = None,
     ) -> None:
-        _ = (thread_id, reply_to, reply_markup)
+        _ = (thread_id, reply_to, reply_markup, parse_mode)
         self.sent.append(text)
 
     def _stop_flow_worker(self, _repo_root: Path, run_id: str) -> None:
@@ -113,7 +114,7 @@ async def test_flow_resume_defaults_latest_paused(
 
     assert controller.resume_calls == [run_new]
     assert spawned == [run_new]
-    assert any(f"Resumed run {run_new}" in text for text in handler.sent)
+    assert any(f"Resumed run `{run_new}`" in text for text in handler.sent)
 
 
 @pytest.mark.anyio
@@ -136,7 +137,7 @@ async def test_flow_stop_defaults_latest_active(
     await handler._handle_flow_stop(_message(), tmp_path, argv=[])
 
     assert controller.stop_calls == [run_running]
-    assert any(f"Stopped run {run_running}" in text for text in handler.sent)
+    assert any(f"Stopped run `{run_running}`" in text for text in handler.sent)
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_flow_status.py
+++ b/tests/test_telegram_flow_status.py
@@ -143,8 +143,9 @@ class _FlowStatusHandler(FlowCommands):
         thread_id: int | None = None,
         reply_to: int | None = None,
         reply_markup: dict[str, object] | None = None,
+        parse_mode: str | None = None,
     ) -> None:
-        _ = (thread_id, reply_to)
+        _ = (thread_id, reply_to, parse_mode)
         self.sent.append(text)
         self.markups.append(reply_markup)
 
@@ -224,8 +225,9 @@ class _PMAFlowStatusHandler(FlowCommands):
         thread_id: int | None = None,
         reply_to: int | None = None,
         reply_markup: dict[str, object] | None = None,
+        parse_mode: str | None = None,
     ) -> None:
-        _ = (thread_id, reply_to, reply_markup)
+        _ = (thread_id, reply_to, reply_markup, parse_mode)
         self.sent.append(text)
 
 
@@ -335,5 +337,6 @@ async def test_flow_hub_overview_allows_parse_mode_override(
     await handler._send_flow_hub_overview(message)
 
     assert handler.sent
-    # parse_mode override should be propagated without raising TypeError
-    assert handler.sent[0][1] is None
+    assert "`r1`" in handler.sent[0][0]
+    assert "`/flow <repo-id> status`" in handler.sent[0][0]
+    assert handler.sent[0][1] == "Markdown"


### PR DESCRIPTION
## Summary
- Wrap hub overview repo IDs in backticks so they are one-tap copyable in Telegram.
- Wrap `/flow` run IDs and command hints in backticks (status, runs, bootstrap, resume/stop/recover/archive).
- Format flow run picker entries with backticked run IDs for easier copy/paste.

## Why
- `/flow <repo-id> ...` accepts repo IDs directly, and Telegram code spans are easier to copy without selecting surrounding prose.
- Run IDs are also frequently reused as command arguments and benefit from the same treatment.

## Validation
- `.venv/bin/python -m pytest tests/test_telegram_flow_status.py tests/test_telegram_flow_bootstrap.py tests/test_telegram_flow_lifecycle.py`
- Pre-commit checks executed during commit, including full test suite (`980 passed, 3 skipped, 64 deselected`).
