### PR TITLE
Fix PMA repo-scoped /flow callback refresh and related actions

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
@@ -316,12 +316,14 @@ class FlowCommands(SharedHelpers):
         argv = self._parse_command_args(args)
 
         target_repo_root = None
+        target_repo_id: Optional[str] = None
         effective_args = args
 
         if argv:
             resolved = self._resolve_workspace(argv[0])
             if resolved:
                 target_repo_root = Path(resolved[0])
+                target_repo_id = resolved[1]
                 argv = argv[1:]
                 # Reconstruct args for remainder logic (imperfect but sufficient for text commands)
                 effective_args = " ".join(argv)
@@ -370,10 +372,14 @@ class FlowCommands(SharedHelpers):
 
         try:
             if action == "status":
-                await self._handle_flow_status_action(message, repo_root, rest_argv)
+                await self._handle_flow_status_action(
+                    message, repo_root, rest_argv, repo_id=target_repo_id
+                )
                 return
             if action == "runs":
-                await self._handle_flow_runs(message, repo_root, rest_argv)
+                await self._handle_flow_runs(
+                    message, repo_root, rest_argv, repo_id=target_repo_id
+                )
                 return
             if action == "bootstrap":
                 await self._handle_flow_bootstrap(message, repo_root, rest_argv)
@@ -447,6 +453,8 @@ class FlowCommands(SharedHelpers):
         callback: TelegramCallbackQuery,
         repo_root: Path,
         run_id_raw: Optional[str],
+        *,
+        repo_id: Optional[str] = None,
     ) -> None:
         store = _load_flow_store(repo_root)
         try:
@@ -457,7 +465,9 @@ class FlowCommands(SharedHelpers):
                     callback, error, reply_markup={"inline_keyboard": []}
                 )
                 return
-            text, keyboard = self._build_flow_status_card(repo_root, record, store)
+            text, keyboard = self._build_flow_status_card(
+                repo_root, record, store, repo_id=repo_id
+            )
         finally:
             store.close()
         await self._edit_callback_message(callback, text, reply_markup=keyboard)
@@ -469,22 +479,30 @@ class FlowCommands(SharedHelpers):
             return
         key = await self._resolve_topic_key(callback.chat_id, callback.thread_id)
         record = await self._store.get_topic(key)
-        if not record or not record.workspace_path:
+        repo_root: Optional[Path] = None
+        if parsed.repo_id:
+            resolved = self._resolve_workspace(parsed.repo_id)
+            if resolved:
+                repo_root = canonicalize_path(Path(resolved[0]))
+        if repo_root is None and record and record.workspace_path:
+            repo_root = canonicalize_path(Path(record.workspace_path))
+        if repo_root is None:
             await self._answer_callback(callback, "No workspace bound")
             await self._edit_callback_message(
                 callback,
-                "No workspace bound. Use /bind to bind this topic to a repo first.",
+                "No workspace bound. Use /flow <repo-id> status, or /bind to bind this topic to a repo first.",
                 reply_markup={"inline_keyboard": []},
             )
             return
 
-        repo_root = canonicalize_path(Path(record.workspace_path))
         action = (parsed.action or "").strip().lower()
         run_id_raw = parsed.run_id
 
         if action in {"refresh", "status"}:
             await self._answer_callback(callback, "Refreshing...")
-            await self._render_flow_status_callback(callback, repo_root, run_id_raw)
+            await self._render_flow_status_callback(
+                callback, repo_root, run_id_raw, repo_id=parsed.repo_id
+            )
             return
 
         error = None
@@ -633,7 +651,9 @@ class FlowCommands(SharedHelpers):
             await self._answer_callback(callback, error)
         elif notice:
             await self._answer_callback(callback, notice)
-        await self._render_flow_status_callback(callback, repo_root, run_id_raw)
+        await self._render_flow_status_callback(
+            callback, repo_root, run_id_raw, repo_id=parsed.repo_id
+        )
 
     def _resolve_run_id_input(
         self, store: FlowStore, raw_run_id: Optional[str]
@@ -763,7 +783,11 @@ class FlowCommands(SharedHelpers):
         return lines
 
     def _build_flow_status_keyboard(
-        self, record: Optional[object], *, health: Optional[FlowWorkerHealth]
+        self,
+        record: Optional[object],
+        *,
+        health: Optional[FlowWorkerHealth],
+        repo_id: Optional[str] = None,
     ) -> Optional[dict[str, object]]:
         if record is None or health is None:
             return None
@@ -775,52 +799,90 @@ class FlowCommands(SharedHelpers):
         if status == FlowRunStatus.PAUSED:
             rows.append(
                 [
-                    InlineButton("Resume", encode_flow_callback("resume", run_id)),
-                    InlineButton("Restart", encode_flow_callback("restart", run_id)),
+                    InlineButton(
+                        "Resume",
+                        encode_flow_callback("resume", run_id, repo_id=repo_id),
+                    ),
+                    InlineButton(
+                        "Restart",
+                        encode_flow_callback("restart", run_id, repo_id=repo_id),
+                    ),
                 ]
             )
             rows.append(
-                [InlineButton("Archive", encode_flow_callback("archive", run_id))]
+                [
+                    InlineButton(
+                        "Archive",
+                        encode_flow_callback("archive", run_id, repo_id=repo_id),
+                    )
+                ]
             )
         elif status.is_terminal():
             rows.append(
                 [
-                    InlineButton("Restart", encode_flow_callback("restart", run_id)),
-                    InlineButton("Archive", encode_flow_callback("archive", run_id)),
+                    InlineButton(
+                        "Restart",
+                        encode_flow_callback("restart", run_id, repo_id=repo_id),
+                    ),
+                    InlineButton(
+                        "Archive",
+                        encode_flow_callback("archive", run_id, repo_id=repo_id),
+                    ),
                 ]
             )
             rows.append(
-                [InlineButton("Refresh", encode_flow_callback("refresh", run_id))]
+                [
+                    InlineButton(
+                        "Refresh",
+                        encode_flow_callback("refresh", run_id, repo_id=repo_id),
+                    )
+                ]
             )
         else:
             if health.status in {"dead", "mismatch", "invalid", "absent"}:
                 rows.append(
                     [
                         InlineButton(
-                            "Recover", encode_flow_callback("recover", run_id)
+                            "Recover",
+                            encode_flow_callback("recover", run_id, repo_id=repo_id),
                         ),
                         InlineButton(
-                            "Refresh", encode_flow_callback("refresh", run_id)
+                            "Refresh",
+                            encode_flow_callback("refresh", run_id, repo_id=repo_id),
                         ),
                     ]
                 )
             elif status == FlowRunStatus.RUNNING:
                 rows.append(
                     [
-                        InlineButton("Stop", encode_flow_callback("stop", run_id)),
                         InlineButton(
-                            "Refresh", encode_flow_callback("refresh", run_id)
+                            "Stop",
+                            encode_flow_callback("stop", run_id, repo_id=repo_id),
+                        ),
+                        InlineButton(
+                            "Refresh",
+                            encode_flow_callback("refresh", run_id, repo_id=repo_id),
                         ),
                     ]
                 )
             else:
                 rows.append(
-                    [InlineButton("Refresh", encode_flow_callback("refresh", run_id))]
+                    [
+                        InlineButton(
+                            "Refresh",
+                            encode_flow_callback("refresh", run_id, repo_id=repo_id),
+                        )
+                    ]
                 )
         return build_inline_keyboard(rows) if rows else None
 
     def _build_flow_status_card(
-        self, repo_root: Path, record: Optional[object], store: Optional[FlowStore]
+        self,
+        repo_root: Path,
+        record: Optional[object],
+        store: Optional[FlowStore],
+        *,
+        repo_id: Optional[str] = None,
     ) -> tuple[str, Optional[dict[str, object]]]:
         if record is None:
             return (
@@ -832,7 +894,9 @@ class FlowCommands(SharedHelpers):
         lines = self._format_flow_status_lines(
             repo_root, record, store, health=health, snapshot=snapshot
         )
-        keyboard = self._build_flow_status_keyboard(record, health=health)
+        keyboard = self._build_flow_status_keyboard(
+            record, health=health, repo_id=repo_id
+        )
         return "\n".join(lines), keyboard
 
     async def _send_flow_help_block(self, message: TelegramMessage) -> None:
@@ -1030,7 +1094,12 @@ class FlowCommands(SharedHelpers):
         )
 
     async def _handle_flow_status_action(
-        self, message: TelegramMessage, repo_root: Path, argv: list[str]
+        self,
+        message: TelegramMessage,
+        repo_root: Path,
+        argv: list[str],
+        *,
+        repo_id: Optional[str] = None,
     ) -> None:
         store = _load_flow_store(repo_root)
         try:
@@ -1045,7 +1114,9 @@ class FlowCommands(SharedHelpers):
                     reply_to=message.message_id,
                 )
                 return
-            text, keyboard = self._build_flow_status_card(repo_root, record, store)
+            text, keyboard = self._build_flow_status_card(
+                repo_root, record, store, repo_id=repo_id
+            )
         finally:
             store.close()
         await self._send_message(
@@ -1057,7 +1128,12 @@ class FlowCommands(SharedHelpers):
         )
 
     async def _handle_flow_runs(
-        self, message: TelegramMessage, repo_root: Path, argv: list[str]
+        self,
+        message: TelegramMessage,
+        repo_root: Path,
+        argv: list[str],
+        *,
+        repo_id: Optional[str] = None,
     ) -> None:
         limit = 5
         limit_raw = self._first_non_flag(argv)
@@ -1100,7 +1176,9 @@ class FlowCommands(SharedHelpers):
             button_label = f"{short_id} {status_label}"
             button_labels[run.id] = _truncate_text(button_label, 32)
 
-        state = SelectionState(items=items, button_labels=button_labels)
+        state = SelectionState(
+            items=items, button_labels=button_labels, repo_id=repo_id
+        )
         key = await self._resolve_topic_key(message.chat_id, message.thread_id)
         self._flow_run_options[key] = state
         self._touch_cache_timestamp("flow_run_options", key)

--- a/src/codex_autorunner/integrations/telegram/handlers/selections.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/selections.py
@@ -409,7 +409,8 @@ class TelegramSelectionHandlers:
             return
         self._flow_run_options.pop(key, None)
         await self._handle_flow_callback(
-            callback, FlowCallback(action="status", run_id=parsed.run_id)
+            callback,
+            FlowCallback(action="status", run_id=parsed.run_id, repo_id=state.repo_id),
         )
 
     def _selection_prompt(self, base: str, state: SelectionState) -> str:

--- a/src/codex_autorunner/integrations/telegram/types.py
+++ b/src/codex_autorunner/integrations/telegram/types.py
@@ -65,6 +65,7 @@ class SelectionState:
     items: list[tuple[str, str]]
     page: int = 0
     button_labels: Optional[dict[str, str]] = None
+    repo_id: Optional[str] = None
 
 
 @dataclass

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -9,6 +9,7 @@ from codex_autorunner.integrations.telegram.adapter import (
     BindCallback,
     CancelCallback,
     CompactCallback,
+    FlowCallback,
     FlowRunCallback,
     PageCallback,
     QuestionCancelCallback,
@@ -37,6 +38,7 @@ from codex_autorunner.integrations.telegram.adapter import (
     encode_bind_callback,
     encode_cancel_callback,
     encode_compact_callback,
+    encode_flow_callback,
     encode_flow_run_callback,
     encode_page_callback,
     encode_question_cancel_callback,
@@ -600,6 +602,16 @@ def test_callback_encoding_and_parsing() -> None:
     flow_run = encode_flow_run_callback("run-123")
     parsed_flow_run = parse_callback_data(flow_run)
     assert parsed_flow_run == FlowRunCallback(run_id="run-123")
+    flow = encode_flow_callback("refresh", "run-123", repo_id="repo-1")
+    parsed_flow = parse_callback_data(flow)
+    assert parsed_flow == FlowCallback(
+        action="refresh", run_id="run-123", repo_id="repo-1"
+    )
+
+
+def test_flow_callback_repo_id_requires_run_id() -> None:
+    with pytest.raises(ValueError, match="requires run_id"):
+        encode_flow_callback("refresh", repo_id="repo-1")
 
 
 def test_build_keyboards() -> None:

--- a/tests/test_telegram_flow_status.py
+++ b/tests/test_telegram_flow_status.py
@@ -193,6 +193,51 @@ async def test_flow_status_action_sends_keyboard(
     assert handler.markups[0] is not None
 
 
+@pytest.mark.anyio
+async def test_flow_status_action_callback_keeps_repo_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = FlowStore(tmp_path / ".codex-autorunner" / "flows.db")
+    store.initialize()
+    run_id = str(uuid.uuid4())
+    store.create_flow_run(run_id, "ticket_flow", {})
+    store.update_flow_run_status(run_id, FlowRunStatus.RUNNING)
+    store.close()
+
+    snapshot = {
+        "worker_health": _health(tmp_path),
+        "effective_current_ticket": None,
+        "last_event_seq": None,
+        "last_event_at": None,
+    }
+    monkeypatch.setattr(
+        flows_module,
+        "build_flow_status_snapshot",
+        lambda _root, _record, _store: snapshot,
+    )
+
+    handler = _FlowStatusHandler()
+    message = TelegramMessage(
+        update_id=1,
+        message_id=2,
+        chat_id=3,
+        thread_id=4,
+        from_user_id=5,
+        text="/flow repo status",
+        date=None,
+        is_topic_message=True,
+    )
+
+    await handler._handle_flow_status_action(
+        message, tmp_path, argv=[], repo_id="car-wt-3"
+    )
+
+    keyboard = handler.markups[0]
+    assert keyboard is not None
+    callback = keyboard["inline_keyboard"][0][1]["callback_data"]
+    assert callback.endswith(":car-wt-3")
+
+
 class _TopicStoreStub:
     def __init__(self, record: object | None) -> None:
         self._record = record


### PR DESCRIPTION
## Summary
- fix `/flow` callback handling to work in unbound PMA topics when the status card was generated from a repo-specific command (for example `/flow <repo-id> status`)
- carry `repo_id` through flow callback payloads so `Refresh` and other action buttons continue to resolve the target repo without requiring `/bind`
- propagate repo context through `/flow runs` selection callbacks to avoid the same unbound-topic failure path
- preserve backward compatibility for legacy callback payloads without `repo_id`

## Tests
- `python3 -m pytest -q tests/test_telegram_adapter.py tests/test_telegram_flow_callback_actions.py tests/test_telegram_flow_status.py tests/test_telegram_handlers_callbacks.py`
- `python3 -m ruff check src/codex_autorunner/integrations/telegram/adapter.py src/codex_autorunner/integrations/telegram/handlers/commands/flows.py src/codex_autorunner/integrations/telegram/handlers/selections.py src/codex_autorunner/integrations/telegram/types.py tests/test_telegram_adapter.py tests/test_telegram_flow_callback_actions.py tests/test_telegram_flow_status.py`
- `python3 -m black --check src/codex_autorunner/integrations/telegram/adapter.py src/codex_autorunner/integrations/telegram/handlers/commands/flows.py src/codex_autorunner/integrations/telegram/handlers/selections.py src/codex_autorunner/integrations/telegram/types.py tests/test_telegram_adapter.py tests/test_telegram_flow_callback_actions.py tests/test_telegram_flow_status.py`
