### PR TITLE
Fix contextspace editor textarea styling regression

### DIFF
--- a/src/codex_autorunner/static/styles.css
+++ b/src/codex_autorunner/static/styles.css
@@ -4194,8 +4194,9 @@ button.icon-btn {
   min-height: 0;
 }
 
-/* Workspace content textarea - dark mode styling */
-#workspace-content {
+/* Workspace/contextspace content textarea - dark mode styling */
+#workspace-content,
+#contextspace-content {
   flex: 1;
   min-height: 300px;
   padding: 10px;
@@ -4209,12 +4210,14 @@ button.icon-btn {
   resize: none;
 }
 
-#workspace-content:focus {
+#workspace-content:focus,
+#contextspace-content:focus {
   outline: none;
   border-color: var(--accent);
 }
 
-#workspace-content::placeholder {
+#workspace-content::placeholder,
+#contextspace-content::placeholder {
   color: var(--muted);
   opacity: 0.6;
 }


### PR DESCRIPTION
## Summary
- restore the contextspace editor textarea styling/sizing that regressed during workspace->contextspace migration
- apply the existing editor style rules to both `#workspace-content` and `#contextspace-content` selectors
- keep compatibility for any remaining workspace surface usage while fixing current contextspace UI

## Root Cause
- `index.html` was migrated from `id="workspace-content"` to `id="contextspace-content"`
- `styles.css` still targeted only `#workspace-content` for the main editor styles, so contextspace fell back to default textarea styling

## Validation
- pre-commit hooks passed:
  - black
  - ruff
  - import boundary checks
  - mypy
  - eslint
  - `pnpm run build`
  - pytest (`984 passed, 3 skipped, 64 deselected`)
