### PR TITLE
Give PMA ticket-flow state-machine guidance and prompt-context visibility

### DIFF
--- a/src/codex_autorunner/bootstrap.py
+++ b/src/codex_autorunner/bootstrap.py
@@ -246,6 +246,19 @@ You are an **abstraction layer, not an executor**. Coordinate tickets and flows 
 - Treat this prompt as code: keep it short and stable.
 - See `.codex-autorunner/pma/ABOUT_CAR.md` for operational how-to.
 
+## Ticket planning constraints
+
+- Ticket flow executes `TICKET-###*.md` in ascending numeric order.
+- It repeatedly selects the first ticket with `done != true`, runs that ticket, then advances.
+- Do not create lower-numbered tickets that depend on higher-numbered tickets.
+- If prerequisites are discovered late, split/reorder tickets so prerequisite work appears earlier.
+
+## Ticket agent context (what each turn already gets)
+
+- Current ticket file (`.codex-autorunner/tickets/TICKET-###*.md`).
+- Pinned contextspace docs when present: `active_context.md`, `decisions.md`, `spec.md`.
+- Prior human reply context and previous agent output when available.
+
 ## Worktrees (hub-managed)
 
 - Prefer hub-owned worktrees:
@@ -283,6 +296,19 @@ def pma_notes_content() -> str:
   `car flow ticket_flow status --repo <path> [--run-id <uuid>]`
   `car flow ticket_flow stop --repo <path> [--run-id <uuid>]`
 - See `<repo>/.codex-autorunner/TICKET_FLOW_QUICKSTART.md` for CLI entrypoints + gotchas.
+
+## Ticket flow mechanics (planning constraints)
+
+- Ticket flow is an ordered queue, not a DAG scheduler.
+- It chooses the first not-done ticket by number and runs one agent turn for that ticket.
+- To avoid stuck runs, ensure prerequisites appear in earlier ticket numbers.
+- If a ticket needs context from previous work, persist that context in `.codex-autorunner/contextspace/`.
+
+## Ticket turn prompt context (what agents can read)
+
+- The current ticket file (full markdown, including YAML frontmatter).
+- Pinned contextspace docs when present: `active_context.md`, `decisions.md`, `spec.md`.
+- Reply history from dispatch pauses and previous agent output when present.
 
 ## Worktrees 101 (Hub-managed)
 

--- a/src/codex_autorunner/core/pma_context.py
+++ b/src/codex_autorunner/core/pma_context.py
@@ -41,6 +41,17 @@ Web UI map (user perspective):
 - Hub root: `/` (repos list + global notifications).
 - Repo view: `/repos/<repo_id>/` tabs: Tickets | Inbox | Contextspace | Terminal | Analytics | Archive.
   - Tickets: edit queue; Inbox: paused run dispatches; Contextspace: active_context/spec/decisions.
+
+Ticket planning constraints (state machine):
+- Ticket flow processes `.codex-autorunner/tickets/TICKET-###*.md` in ascending numeric order.
+- On each turn it picks the first ticket where `done != true`; when that ticket is completed, it advances to the next.
+- Avoid creating dependency edges from lower-numbered tickets to higher-numbered tickets. That can deadlock the flow.
+- If a later ticket would unblock an earlier one, reorder/split tickets so prerequisites appear earlier.
+
+What each ticket agent turn can already see:
+- The current ticket file (full markdown + frontmatter).
+- Pinned contextspace docs when present: `active_context.md`, `decisions.md`, `spec.md` (truncated).
+- Reply context from prior user dispatches and prior agent output (if present).
 </pma_fastpath>
 """
 

--- a/tests/test_pma_bootstrap.py
+++ b/tests/test_pma_bootstrap.py
@@ -16,12 +16,19 @@ def test_pma_files_created_on_hub_init(tmp_path: Path) -> None:
     prompt_content = prompt_path.read_text(encoding="utf-8")
     assert "Project Management Agent" in prompt_content
     assert "You are the hub-level" in prompt_content
+    assert "Ticket planning constraints" in prompt_content
+    assert "ascending numeric order" in prompt_content
+    assert "active_context.md" in prompt_content
+    assert "decisions.md" in prompt_content
+    assert "spec.md" in prompt_content
 
     about_path = pma_dir / "ABOUT_CAR.md"
     assert about_path.exists()
     about_content = about_path.read_text(encoding="utf-8")
     assert "PMA Operations Guide" in about_content
     assert "Ticket flow" in about_content
+    assert "Ticket flow mechanics (planning constraints)" in about_content
+    assert "Ticket turn prompt context" in about_content
 
 
 def test_pma_config_defaults(tmp_path: Path) -> None:

--- a/tests/test_pma_context.py
+++ b/tests/test_pma_context.py
@@ -264,6 +264,10 @@ def test_format_pma_prompt_includes_hub_snapshot_and_message(tmp_path: Path) -> 
 
     assert "<hub_snapshot>" in result
     assert "Inbox (paused runs needing attention):" in result
+    assert "Ticket planning constraints (state machine):" in result
+    assert "active_context.md" in result
+    assert "decisions.md" in result
+    assert "spec.md" in result
     assert "repo_id=repo-1" in result
     assert "run_id=run-9" in result
     assert "mode=pause" in result


### PR DESCRIPTION
## Summary\n- add explicit ticket-flow state-machine constraints to PMA runtime fastpath so existing hubs get guidance immediately\n- update seeded PMA prompt/ABOUT docs with concise ticket ordering constraints and ticket-turn context visibility\n- add regression assertions for the new guidance in PMA bootstrap/context tests\n\n## Testing\n- python3 -m pytest -q tests/test_pma_bootstrap.py tests/test_pma_context.py\n\nCloses #575