### PR TITLE
Fix Telegram GitHub context injection for shared issue links

### DIFF
--- a/src/codex_autorunner/integrations/github/service.py
+++ b/src/codex_autorunner/integrations/github/service.py
@@ -219,15 +219,14 @@ def _parse_repo_info(payload: dict) -> RepoInfo:
     )
 
 
-_GITHUB_HOST_RE = r"(?:www\.)?github\.com"
 ISSUE_URL_RE = re.compile(
-    rf"^https?://{_GITHUB_HOST_RE}/(?P<owner>[^/]+)/(?P<repo>[^/]+)/issues/(?P<num>\d+)(?:[/?#?].*)?$"
+    r"^https?://(?:www\.)?github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/issues/(?P<num>\d+)(?:[/?#?].*)?$"
 )
 PR_URL_RE = re.compile(
-    rf"^https?://{_GITHUB_HOST_RE}/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<num>\d+)(?:[/?#?].*)?$"
+    r"^https?://(?:www\.)?github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<num>\d+)(?:[/?#?].*)?$"
 )
 GITHUB_LINK_RE = re.compile(
-    rf"https?://{_GITHUB_HOST_RE}/[^/\s]+/[^/\s]+/(?:issues|pull)/\d+(?:[/?#?][^\s]*)?"
+    r"https?://(?:www\.)?github\.com/[^/\s]+/[^/\s]+/(?:issues|pull)/\d+(?:[/?#?][^\s]*)?"
 )
 
 

--- a/tests/test_github_url_parsing.py
+++ b/tests/test_github_url_parsing.py
@@ -1,4 +1,7 @@
-from codex_autorunner.integrations.github.service import find_github_links, parse_github_url
+from codex_autorunner.integrations.github.service import (
+    find_github_links,
+    parse_github_url,
+)
 
 
 def test_parse_github_issue_url_with_query_string() -> None:
@@ -16,9 +19,7 @@ def test_parse_github_pr_url_with_www_host_and_query_string() -> None:
 
 
 def test_find_github_links_matches_issue_urls_with_query_strings() -> None:
-    text = (
-        "Context: https://github.com/Git-on-my-level/codex-autorunner/issues/577?notification_referrer_id=NT_kwDO"
-    )
+    text = "Context: https://github.com/Git-on-my-level/codex-autorunner/issues/577?notification_referrer_id=NT_kwDO"
     links = find_github_links(text)
     assert links == [
         "https://github.com/Git-on-my-level/codex-autorunner/issues/577?notification_referrer_id=NT_kwDO"


### PR DESCRIPTION
## Summary
- fix GitHub URL parsing so Telegram context injection accepts issue/PR links with query-string suffixes
- accept both github.com and www.github.com hosts in URL parsing/link detection
- add regression tests for query-string issue links and www host URLs

## Validation
- .venv/bin/pytest -q tests/test_github_url_parsing.py
- .venv/bin/pytest -q tests/test_telegram_turn_queue.py tests/test_telegram_pma_routing.py

Closes #577
