### PR TITLE
Fix OpenCode ticket runs stalling in unbounded reconnect loops

### DIFF
--- a/src/codex_autorunner/tickets/agent_pool.py
+++ b/src/codex_autorunner/tickets/agent_pool.py
@@ -395,6 +395,7 @@ class AgentPool:
             workspace_path=directory,
             model_payload=model_payload,
             part_handler=_part_handler if req.emit_event is not None else None,
+            stall_timeout_seconds=self._config.opencode.session_stall_timeout_seconds,
         )
 
         if req.emit_event is not None and output.text:

--- a/tests/test_opencode_agent_pool.py
+++ b/tests/test_opencode_agent_pool.py
@@ -104,6 +104,7 @@ async def test_opencode_turn_respects_model_override(monkeypatch, tmp_path: Path
             "session_id": session_id,
             "workspace_path": workspace_path,
             "model_payload": model_payload,
+            "stall_timeout_seconds": kwargs.get("stall_timeout_seconds"),
         }
         return OpenCodeTurnOutput(text="ok")
 
@@ -112,7 +113,7 @@ async def test_opencode_turn_respects_model_override(monkeypatch, tmp_path: Path
     )
 
     cfg = SimpleNamespace(
-        app_server=None, opencode=SimpleNamespace(session_stall_timeout_seconds=None)
+        app_server=None, opencode=SimpleNamespace(session_stall_timeout_seconds=42.0)
     )
     pool = AgentPool(cfg)  # type: ignore[arg-type]
     pool._opencode_supervisor = supervisor
@@ -130,6 +131,7 @@ async def test_opencode_turn_respects_model_override(monkeypatch, tmp_path: Path
     assert client.prompt_calls[0]["model"] == expected_model
     assert client.prompt_calls[0]["variant"] == "fast"
     assert calls["collect"]["model_payload"] == expected_model
+    assert calls["collect"]["stall_timeout_seconds"] == 42.0
     assert result.text == "ok"
 
 


### PR DESCRIPTION
## Summary
- propagate `opencode.session_stall_timeout_seconds` from ticket flow into `collect_opencode_output(...)`
- bound OpenCode stream stall reconnect loops with deterministic attempt/time limits
- emit reconnect progress/timeout status events via `part_handler` and return an explicit `opencode_stream_stalled_timeout` error when bounds are exceeded
- add tests for timeout propagation and bounded reconnect failure behavior

## Validation
- `.venv/bin/python -m pytest tests/test_opencode_runtime.py tests/test_opencode_agent_pool.py -q`
- pre-commit checks in `git commit` hook (black, ruff, mypy, pnpm build, pytest)

Closes #579
