### PR TITLE
Fix Telegram /interrupt failures from stale topic resolution

### DIFF
--- a/src/codex_autorunner/integrations/telegram/service.py
+++ b/src/codex_autorunner/integrations/telegram/service.py
@@ -1179,11 +1179,7 @@ class TelegramBotService(
         key = await self._resolve_topic_key(chat_id, thread_id)
         record = await self._router.get_topic(key)
         turn_ctx = self._resolve_turn_context(turn_id, thread_id=codex_thread_id)
-        if (
-            turn_ctx is not None
-            and turn_ctx.topic_key
-            and turn_ctx.topic_key != key
-        ):
+        if turn_ctx is not None and turn_ctx.topic_key and turn_ctx.topic_key != key:
             scoped_record = await self._router.get_topic(turn_ctx.topic_key)
             if scoped_record is not None:
                 key = turn_ctx.topic_key

--- a/tests/test_telegram_interrupt_dispatch.py
+++ b/tests/test_telegram_interrupt_dispatch.py
@@ -78,7 +78,9 @@ class _DispatchServiceStub:
         self.workspace_requests.append(workspace_path)
         return self._codex_client
 
-    async def _edit_message_text(self, chat_id: int, message_id: int, text: str) -> bool:
+    async def _edit_message_text(
+        self, chat_id: int, message_id: int, text: str
+    ) -> bool:
         self.edits.append((chat_id, message_id, text))
         return True
 
@@ -87,7 +89,9 @@ class _DispatchServiceStub:
 async def test_interrupt_uses_turn_context_topic_for_codex_workspace() -> None:
     codex_client = _CodexClientStub()
     records = {
-        "current": SimpleNamespace(agent="codex", workspace_path=None, active_thread_id=None),
+        "current": SimpleNamespace(
+            agent="codex", workspace_path=None, active_thread_id=None
+        ),
         "scoped": SimpleNamespace(
             agent="codex",
             workspace_path="/tmp/scoped-workspace",
@@ -126,7 +130,9 @@ async def test_interrupt_uses_turn_context_topic_for_opencode_session() -> None:
     opencode_client = _OpenCodeClientStub()
     opencode_supervisor = _OpenCodeSupervisorStub(opencode_client)
     records = {
-        "current": SimpleNamespace(agent="codex", workspace_path=None, active_thread_id=None),
+        "current": SimpleNamespace(
+            agent="codex", workspace_path=None, active_thread_id=None
+        ),
         "scoped": SimpleNamespace(
             agent="opencode",
             workspace_path="/tmp/opencode-workspace",
@@ -159,4 +165,3 @@ async def test_interrupt_uses_turn_context_topic_for_opencode_session() -> None:
     assert opencode_supervisor.roots == [Path("/tmp/opencode-workspace")]
     assert opencode_client.abort_calls == ["session-from-turn"]
     assert service.edits == []
-


### PR DESCRIPTION
## Summary
- root cause: interrupt dispatch resolved the current topic key/record, which can drift from the active turn's original topic context
- when that drift happens, /interrupt may target the wrong workspace/agent path and return "Interrupt failed (app-server error)"
- fix: in _dispatch_interrupt_request, prefer the active turn context (turn_id + codex_thread_id) to recover the turn's original topic record before routing interrupt
- for OpenCode, also fall back to codex_thread_id when active_thread_id is temporarily absent

## Validation
- `.venv/bin/pytest -q tests/test_telegram_interrupt_dispatch.py`
- `.venv/bin/pytest -q tests/test_app_server_client.py::test_turn_interrupt`

## Notes
- this hardens Codex and OpenCode interrupt routing against topic key/binding drift during active turns
