### PR TITLE
fix: car doctor checking wrong config file path

### DIFF
--- a/src/codex_autorunner/core/runtime.py
+++ b/src/codex_autorunner/core/runtime.py
@@ -147,7 +147,7 @@ def doctor(
         )
 
     # Check config file
-    config_path = repo_root / "codex-autorunner.yml"
+    config_path = repo_root / ".codex-autorunner" / "config.yml"
     if not config_path.exists():
         checks.append(
             DoctorCheck(


### PR DESCRIPTION
Fixes #593

The `car doctor` command was checking for `codex-autorunner.yml` at the repo root, but the actual runtime config is located at `.codex-autorunner/config.yml`. The root `codex-autorunner.yml` is only for optional base defaults.

This change updates the doctor check to verify the correct config file path.