### PR TITLE
Fix hub-local car shim producing no output

### DIFF
--- a/src/codex_autorunner/cli.py
+++ b/src/codex_autorunner/cli.py
@@ -6,3 +6,10 @@ Re-export the Typer app from the CLI surface.
 from .surfaces.cli.cli import _resolve_repo_api_path, app, main  # noqa: F401
 
 __all__ = ["app", "main", "_resolve_repo_api_path"]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    # The hub-local shim executes `python -m codex_autorunner.cli ...`.
+    # This module is primarily a re-export layer, but it must be runnable so
+    # basic commands like `--help`/`--version` produce output.
+    main()

--- a/src/codex_autorunner/surfaces/cli/cli.py
+++ b/src/codex_autorunner/surfaces/cli/cli.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib.metadata
 import ipaddress
 import json
 import logging
@@ -132,6 +133,36 @@ worktree_app = typer.Typer(add_completion=False)
 hub_tickets_app = typer.Typer(add_completion=False)
 flow_app = typer.Typer(add_completion=False)
 ticket_flow_app = typer.Typer(add_completion=False)
+
+
+def _car_version() -> str:
+    try:
+        return importlib.metadata.version("codex-autorunner")
+    except Exception:
+        return "unknown"
+
+
+def _version_callback(value: bool) -> None:
+    if not value:
+        return
+    typer.echo(f"codex-autorunner {_car_version()}")
+    raise typer.Exit(code=0)
+
+
+@app.callback()
+def _root(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the version and exit.",
+    ),
+) -> None:
+    # Intentionally empty; subcommands implement behavior.
+    #
+    # `--version` is handled eagerly via `_version_callback`.
+    return
 
 
 def main() -> None:

--- a/tests/test_cli_module_entrypoint.py
+++ b/tests/test_cli_module_entrypoint.py
@@ -1,0 +1,36 @@
+import runpy
+import sys
+
+
+def _run_module(argv: list[str]) -> int:
+    original_argv = sys.argv[:]
+    original_cli_module = sys.modules.pop("codex_autorunner.cli", None)
+    try:
+        sys.argv = argv[:]
+        try:
+            runpy.run_module("codex_autorunner.cli", run_name="__main__")
+        except SystemExit as exc:
+            code = exc.code if isinstance(exc.code, int) else 0
+        else:
+            code = 0
+        return code
+    finally:
+        sys.argv = original_argv
+        if original_cli_module is not None:
+            sys.modules["codex_autorunner.cli"] = original_cli_module
+
+
+def test_python_m_codex_autorunner_cli_help_prints_output(capsys):
+    code = _run_module(["python -m codex_autorunner.cli", "--help"])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out.strip() != ""
+    assert "Usage:" in captured.out
+
+
+def test_python_m_codex_autorunner_cli_version_prints_output(capsys):
+    code = _run_module(["python -m codex_autorunner.cli", "--version"])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out.strip() != ""
+    assert captured.out.startswith("codex-autorunner ")


### PR DESCRIPTION
Fixes #598.

## Problem
The hub-local shim runs `python -m codex_autorunner.cli ...`, but `codex_autorunner/cli.py` was a re-export module that didn't execute the Typer app when invoked as a module.

Result: `car --help` / `car --version` / other commands could exit 0 with zero output.

## Changes
- Make `python -m codex_autorunner.cli` runnable by calling `main()` from `src/codex_autorunner/cli.py` when executed as `__main__`.
- Add a real `--version` flag to the CLI surface.
- Add tests to prevent regressions.
