### PR TITLE
Fix Telegram ctx percent for OpenCode usage

### DIFF
--- a/tests/test_telegram_context_usage_percent.py
+++ b/tests/test_telegram_context_usage_percent.py
@@ -1,0 +1,31 @@
+from codex_autorunner.integrations.telegram.helpers import (
+    _extract_context_usage_percent,
+    _format_tui_token_usage,
+)
+
+
+def test_extract_context_usage_percent_prefers_total_usage_bucket() -> None:
+    token_usage = {
+        "last": {"totalTokens": 40},
+        "total": {"totalTokens": 12000},
+        "modelContextWindow": 20000,
+    }
+    assert _extract_context_usage_percent(token_usage) == 60
+
+
+def test_extract_context_usage_percent_uses_context_consumed_percent() -> None:
+    token_usage = {
+        "last": {"totalTokens": 500},
+        "modelContextWindow": 2000,
+    }
+    assert _extract_context_usage_percent(token_usage) == 25
+
+
+def test_format_tui_token_usage_uses_total_for_ctx_percent() -> None:
+    token_usage = {
+        "last": {"totalTokens": 80, "inputTokens": 60, "outputTokens": 20},
+        "total": {"totalTokens": 1500, "inputTokens": 1000, "outputTokens": 500},
+        "modelContextWindow": 2000,
+    }
+    line = _format_tui_token_usage(token_usage)
+    assert line == "Token usage: total 1500 input 1000 output 500 ctx 75%"


### PR DESCRIPTION
## Summary
- fix Telegram context-percent calculation to use consumed context instead of remaining context
- prefer `tokenUsage.total` over `tokenUsage.last` when both are present
- keep metrics and progress-stream `ctx` formatting consistent by routing both through the same helper
- add regression tests for total-vs-last selection and percent semantics

## Root Cause
Telegram computed `ctx` as:
- remaining context (`(contextWindow - totalTokens) / contextWindow`), and
- from `tokenUsage.last` first.

For OpenCode, `last` is often a small per-call usage snapshot. Combined with rounding, that value frequently rounded to `100`, so Telegram kept showing `ctx 100%`.

## Validation
- `./.venv/bin/pytest tests/test_telegram_context_usage_percent.py tests/test_telegram_opencode_usage.py`
- pre-commit pipeline on commit (black, ruff, mypy, eslint/static build, full pytest): passed
