### PR TITLE
Remove dispatch inbox section from Hub page

### DIFF
--- a/src/codex_autorunner/static/index.html
+++ b/src/codex_autorunner/static/index.html
@@ -57,15 +57,6 @@
         <p class="muted small">missing</p>
       </div>
     </section>
-    <section class="hub-inbox">
-      <div class="hub-panel-header">
-        <span class="label">Run Dispatches</span>
-        <div class="hub-panel-actions">
-          <button class="ghost sm" id="hub-inbox-refresh">Refresh</button>
-        </div>
-      </div>
-      <div class="hub-inbox-list" id="hub-inbox-list">Loading…</div>
-    </section>
     <section class="hub-usage-chart">
       <div class="hub-usage-chart-header">
         <span class="label">Usage Trend</span>


### PR DESCRIPTION
## Summary
- remove the `Run Dispatches` inbox panel from the Hub page to prevent it from crowding out the repositories list
- delete hub-page-only inbox rendering/fetch logic from `static_src/hub.ts`
- keep notification flow intact via the bell icon and modal

## Validation
- `pnpm run build`
- full pre-commit suite (black, ruff, mypy, eslint, static build, pytest)
