### PR TITLE
Fix Telegram spark model visibility and /models alias

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -94,7 +94,9 @@ async def _model_list_with_agent_compat(
     *,
     params: dict[str, Any],
 ) -> Any:
-    request_params = dict(params)
+    # Avoid sending explicit nulls (for example cursor=None), which can trigger
+    # different pagination behavior on some app-server builds.
+    request_params = {key: value for key, value in params.items() if value is not None}
     requested_agent = request_params.get("agent")
     if not isinstance(requested_agent, str) or not requested_agent:
         requested_agent = None

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -128,6 +128,10 @@ Place files in outbox pending to send after this turn finishes.
 Check delivery with /files outbox.
 Max file size: {max_bytes} bytes."""
 
+_COMMAND_ALIASES = {
+    "models": "model",
+}
+
 
 @dataclass
 class _RuntimeStub:
@@ -389,13 +393,15 @@ class TelegramCommandHandlers(
     async def _handle_command(
         self, command: TelegramCommand, message: TelegramMessage, runtime: Any
     ) -> None:
-        name = command.name
+        original_name = command.name
+        name = _COMMAND_ALIASES.get(original_name, original_name)
         args = command.args
         log_event(
             self._logger,
             logging.INFO,
             "telegram.command",
             name=name,
+            original_name=original_name,
             args_len=len(args),
             chat_id=message.chat_id,
             thread_id=message.thread_id,

--- a/tests/test_telegram_command_aliases.py
+++ b/tests/test_telegram_command_aliases.py
@@ -1,0 +1,77 @@
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from codex_autorunner.integrations.telegram.adapter import (
+    TelegramCommand,
+    TelegramMessage,
+)
+from codex_autorunner.integrations.telegram.handlers.commands import CommandSpec
+from codex_autorunner.integrations.telegram.handlers.commands_runtime import (
+    TelegramCommandHandlers,
+)
+
+
+class _AliasHarness(TelegramCommandHandlers):
+    def __init__(self) -> None:
+        self._logger = logging.getLogger(__name__)
+        self._resume_options: dict[str, Any] = {}
+        self._bind_options: dict[str, Any] = {}
+        self._agent_options: dict[str, Any] = {}
+        self._model_options: dict[str, Any] = {}
+        self._model_pending: dict[str, Any] = {}
+        self.sent_messages: list[str] = []
+        self.model_calls: list[str] = []
+
+        async def _handle_model_alias(
+            _message: TelegramMessage, args: str, _runtime: Any
+        ) -> None:
+            self.model_calls.append(args)
+
+        self._command_specs = {
+            "model": CommandSpec(
+                name="model",
+                description="list or set the model",
+                handler=_handle_model_alias,
+            )
+        }
+
+    async def _resolve_topic_key(self, _chat_id: int, _thread_id: Any) -> str:
+        return "1:root"
+
+    async def _send_message(
+        self,
+        _chat_id: int,
+        text: str,
+        *,
+        thread_id: Any = None,
+        reply_to: Any = None,
+    ) -> None:
+        self.sent_messages.append(text)
+
+
+def _message() -> TelegramMessage:
+    return TelegramMessage(
+        update_id=1,
+        message_id=2,
+        chat_id=3,
+        thread_id=4,
+        from_user_id=5,
+        text="/models",
+        date=0,
+        is_topic_message=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_models_alias_routes_to_model_handler() -> None:
+    harness = _AliasHarness()
+    runtime = SimpleNamespace(current_turn_id=None)
+    command = TelegramCommand(name="models", args="list", raw="/models list")
+
+    await harness._handle_command(command, _message(), runtime)
+
+    assert harness.model_calls == ["list"]
+    assert harness.sent_messages == []

--- a/tests/test_telegram_workspace_model_list_compat.py
+++ b/tests/test_telegram_workspace_model_list_compat.py
@@ -42,7 +42,7 @@ async def test_model_list_with_agent_compat_uses_agent_filter() -> None:
     )
 
     assert result == {"data": [{"id": "gpt-5.3-codex-spark"}]}
-    assert client.calls == [{"agent": "codex", "limit": 25, "cursor": None}]
+    assert client.calls == [{"agent": "codex", "limit": 25}]
 
 
 @pytest.mark.asyncio
@@ -63,8 +63,8 @@ async def test_model_list_with_agent_compat_falls_back_for_invalid_params(
 
     assert result == {"data": [{"id": "gpt-5.3-codex-spark"}]}
     assert client.calls == [
-        {"agent": "codex", "limit": 25, "cursor": None},
-        {"limit": 25, "cursor": None},
+        {"agent": "codex", "limit": 25},
+        {"limit": 25},
     ]
 
 
@@ -82,7 +82,7 @@ async def test_model_list_with_agent_compat_raises_non_compat_errors() -> None:
             params={"agent": "codex", "limit": 25, "cursor": None},
         )
 
-    assert client.calls == [{"agent": "codex", "limit": 25, "cursor": None}]
+    assert client.calls == [{"agent": "codex", "limit": 25}]
 
 
 @pytest.mark.asyncio
@@ -96,3 +96,16 @@ async def test_model_list_with_agent_compat_without_agent_keeps_params() -> None
 
     assert result == {"data": [{"id": "gpt-5.3-codex-spark"}]}
     assert client.calls == [{"limit": 10, "cursor": "next-cursor"}]
+
+
+@pytest.mark.asyncio
+async def test_model_list_with_agent_compat_drops_none_params() -> None:
+    client = _StubClient(response={"data": [{"id": "gpt-5.3-codex-spark"}]})
+
+    result = await _model_list_with_agent_compat(
+        client,
+        params={"agent": "codex", "limit": 25, "cursor": None, "foo": None},
+    )
+
+    assert result == {"data": [{"id": "gpt-5.3-codex-spark"}]}
+    assert client.calls == [{"agent": "codex", "limit": 25}]


### PR DESCRIPTION
## Summary
- fix Telegram `model/list` compatibility calls to strip `None` params (notably `cursor=None`) before sending requests
- keep agent-filter compatibility fallback behavior while preserving non-null pagination params
- add `/models` as a Telegram command alias for `/model`
- add regression tests for both fixes

## Root Cause
Telegram was passing `cursor=None` to `model/list`, while web calls did not. On some app-server builds, explicit null cursor changes pagination behavior and can return a truncated model set, which prevented `gpt-5.3-codex-spark` from appearing in Telegram model picker results. Separately, `/models` was not recognized as a command alias.

## Validation
- `.venv/bin/python -m pytest -q tests/test_telegram_workspace_model_list_compat.py tests/test_telegram_command_aliases.py`
- `.venv/bin/python -m ruff check src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py tests/test_telegram_workspace_model_list_compat.py tests/test_telegram_command_aliases.py`
- full pre-commit suite during commit (black, ruff, mypy, eslint/static build, pytest)
