### PR TITLE
Handle stale current_ticket when ticket file is renamed

### DIFF
--- a/src/codex_autorunner/tickets/runner.py
+++ b/src/codex_autorunner/tickets/runner.py
@@ -310,6 +310,8 @@ class TicketRunner:
             state.pop("last_agent_output", None)
             state.pop("lint", None)
             state.pop("commit", None)
+            commit_pending = False
+            commit_retries = 0
 
         # If current ticket is done, clear it unless we're in the middle of a
         # bounded "commit required" follow-up loop.

--- a/tests/tickets/test_ticket_runner.py
+++ b/tests/tickets/test_ticket_runner.py
@@ -159,6 +159,7 @@ async def test_ticket_runner_recovers_when_current_ticket_path_is_stale(
 
     assert result.status == "continue"
     assert len(pool.requests) == 1
+    assert "<CAR_COMMIT_REQUIRED>" not in pool.requests[0].prompt
     assert (
         result.state.get("current_ticket")
         == ".codex-autorunner/tickets/TICKET-009-ALREADY-DONE.md"


### PR DESCRIPTION
## Summary\n- detect when persisted `state["current_ticket"]` points to a ticket path that no longer exists\n- clear stale per-ticket state and reselect the next open ticket from current on-disk ticket paths\n- add a regression test that reproduces the rename scenario and verifies runner recovery\n\n## Validation\n- .venv/bin/python -m pytest tests/tickets/test_ticket_runner.py -k stale -q\n- .venv/bin/python -m pytest tests/tickets/test_ticket_runner.py -q\n- .venv/bin/python -m pytest tests/tickets/test_runner_stale_pause.py -q\n- pre-commit/commit hooks ran full project checks and tests\n\nCloses #618