### PR TITLE
Default new hub worktrees to origin/main

### DIFF
--- a/docs/AGENT_SETUP_GUIDE.md
+++ b/docs/AGENT_SETUP_GUIDE.md
@@ -190,7 +190,7 @@ Once basic setup is complete, suggest these next steps:
 | `car hub scan` | Scan for repositories |
 | `car hub clone <url>` | Clone a repo into the hub |
 | `car hub create <name>` | Create a new repo in the hub |
-| `car hub worktree create <base_repo_id> <branch>` | Create a hub-owned worktree (defaults to `origin/main`) |
+| `car hub worktree create <base_repo_id> <branch>` | Create a hub-owned worktree (defaults to `origin/<default-branch>`) |
 | `car doctor` | Validate hub/repo setup |
 
 ### Repo Commands (run from within a repo, or use `--repo`)

--- a/docs/ops/worktrees-101.md
+++ b/docs/ops/worktrees-101.md
@@ -23,7 +23,7 @@ Examples:
 - `car hub worktree create myrepo feature/pma-worktree-ux --start-point origin/main`
 
 Notes:
-- If `--start-point` is omitted, CAR creates the worktree from `origin/main`.
+- If `--start-point` is omitted, CAR creates the worktree from `origin/<default-branch>`.
 - The worktree directory is created under: `<hub_root>/<hub.worktrees_root>/<worktree_repo_id>/`
 - Worktrees are treated as full repos and get their own `.codex-autorunner/` state/docs.
 

--- a/src/codex_autorunner/bootstrap.py
+++ b/src/codex_autorunner/bootstrap.py
@@ -303,7 +303,7 @@ You are an **abstraction layer, not an executor**. Coordinate tickets and flows 
 - Prefer hub-owned worktrees:
   - Hub UI: “New Worktree”
   - CLI: `car hub worktree create <base_repo_id> <branch> [--start-point <ref>]`
-  - Default start point is `origin/main` unless `--start-point` is provided.
+  - Default start point is `origin/<default-branch>` unless `--start-point` is provided.
 - If a worktree was created manually (e.g. `git worktree add`), it MUST be registered:
   - `car hub scan --path <hub_root>`
 - Never copy `.codex-autorunner/` between worktrees. Each worktree has its own CAR state/docs.
@@ -356,7 +356,7 @@ Canonical worktree creation:
 - Hub UI: “New Worktree”
 - CLI (from hub root):
   `car hub worktree create <base_repo_id> <branch> [--start-point <ref>]`
-  (defaults to `origin/main` when `--start-point` is omitted)
+  (defaults to `origin/<default-branch>` when `--start-point` is omitted)
 
 Registering a manually-created worktree:
 - If you used `git worktree add`, run:

--- a/src/codex_autorunner/surfaces/cli/cli.py
+++ b/src/codex_autorunner/surfaces/cli/cli.py
@@ -1858,7 +1858,7 @@ def hub_worktree_create(
     start_point: Optional[str] = typer.Option(
         None,
         "--start-point",
-        help="Optional git ref to branch from (default: origin/main)",
+        help="Optional git ref to branch from (default: origin/<default-branch>)",
     ),
 ):
     """Create a new hub-managed worktree."""
@@ -3073,7 +3073,7 @@ def hub_tickets_setup_pack(
     start_point: Optional[str] = typer.Option(
         None,
         "--start-point",
-        help="Optional git ref for worktree branch (legacy, default: origin/main)",
+        help="Optional git ref for worktree branch (legacy, default: origin/<default-branch>)",
     ),
     force: bool = typer.Option(
         False, "--force", help="Allow existing worktree path (legacy)"


### PR DESCRIPTION
## Summary
- default `HubSupervisor.create_worktree` to branch from `origin/main` when `start_point` is not provided
- refresh `origin` before resolving remote refs so defaulting to `origin/main` uses current remote state
- keep explicit `start_point` override behavior, including existing-branch SHA alignment checks
- update worktree CLI help/docs to make the `origin/main` default explicit
- update hub supervisor tests for the new default and use explicit `start_point` where tests intentionally operate on repos without remotes

## Why
New worktrees should start from a fresh `origin/main` baseline by default, unless an explicit branch/commit override is provided, to reduce stale worktree creation.

## Validation
- `./.venv/bin/python -m pytest tests/test_hub_supervisor.py tests/test_cli_hub_worktree.py`
- pre-commit pipeline during commit:
  - black / ruff / mypy / eslint / static build
  - full pytest suite (`1119 passed, 3 skipped, 64 deselected`)
  - dead-code heuristic check
