### PR TITLE
fix: pass workspace_root in input_data when starting ticket_flow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-autorunner"
-version = "1.3.3"
+version = "1.3.4"
 description = "Codex autorunner CLI per DESIGN-V1"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/codex_autorunner/surfaces/cli/cli.py
+++ b/src/codex_autorunner/surfaces/cli/cli.py
@@ -4415,7 +4415,10 @@ def ticket_flow_start(
     controller, agent_pool = _ticket_flow_controller(engine)
     try:
         run_id = str(uuid.uuid4())
-        record = asyncio.run(controller.start_flow(input_data={}, run_id=run_id))
+        input_data = {"workspace_root": str(engine.repo_root)}
+        record = asyncio.run(
+            controller.start_flow(input_data=input_data, run_id=run_id)
+        )
         _start_ticket_flow_worker(engine.repo_root, record.id, is_terminal=False)
     finally:
         controller.shutdown()


### PR DESCRIPTION
## Summary
- Fixes issue #637 where the flow worker dies with `RepoNotFoundError` when running ticket_flow in worktrees
- The flow step was calling `find_repo_root()` without a starting path because `input_data` was empty
- This caused the worker to fail when the worker's cwd was not the repo root

## Changes
- Pass `workspace_root` in `input_data` when starting the ticket_flow in `cli.py:ticket_flow_start`
- This ensures the flow step has the correct repo path to use for `find_repo_root(start=workspace_root)`