### PR TITLE
Support /flow <repo-id> <worktree-id> status targeting

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
@@ -332,12 +332,17 @@ class FlowCommands(SharedHelpers):
         effective_args = args
 
         if argv:
-            resolved = self._resolve_workspace(argv[0])
-            consumed = 1
-            if not resolved and len(argv) >= 2:
+            resolved = None
+            consumed = 0
+            if len(argv) >= 2:
                 combined_repo_id = f"{argv[0]}--{argv[1]}"
                 resolved = self._resolve_workspace(combined_repo_id)
-                consumed = 2
+                if resolved:
+                    consumed = 2
+            if not resolved:
+                resolved = self._resolve_workspace(argv[0])
+                if resolved:
+                    consumed = 1
             if resolved:
                 target_repo_root = Path(resolved[0])
                 target_repo_id = resolved[1]

--- a/tests/test_telegram_flow_status.py
+++ b/tests/test_telegram_flow_status.py
@@ -279,6 +279,7 @@ class _PMAFlowStatusHandler(FlowCommands):
 class _FlowWorktreeTargetHandler(FlowCommands):
     def __init__(self, repo_root: Path) -> None:
         self._store = _TopicStoreStub(None)
+        self._base_root = (repo_root / "base").resolve()
         self._repo_root = repo_root.resolve()
         self.status_calls: list[tuple[Path, list[str], str | None]] = []
         self.sent: list[str] = []
@@ -287,6 +288,8 @@ class _FlowWorktreeTargetHandler(FlowCommands):
         return "topic"
 
     def _resolve_workspace(self, arg: str) -> tuple[str, str] | None:
+        if arg == "base":
+            return str(self._base_root), "base"
         if arg == "base--wt-1":
             return str(self._repo_root), "base--wt-1"
         return None
@@ -357,7 +360,9 @@ async def test_flow_default_unbound_topic_uses_hub_overview() -> None:
 
 
 @pytest.mark.anyio
-async def test_flow_repo_and_worktree_default_to_status(tmp_path: Path) -> None:
+async def test_flow_repo_and_worktree_default_to_status_when_both_resolve(
+    tmp_path: Path,
+) -> None:
     handler = _FlowWorktreeTargetHandler(tmp_path)
     message = TelegramMessage(
         update_id=1,


### PR DESCRIPTION
## Summary
- add `/flow <repo-id> <worktree-id>` workspace resolution by combining the first two command args as `<repo-id>--<worktree-id>` when the first arg alone does not resolve
- keep existing behavior for direct/full repo IDs while allowing the new shorthand shown in Hub Flow Overview
- update Telegram guidance/tip text to reference `/flow <repo-id> <worktree-id>`
- add regression coverage to verify repo+worktree defaults to flow status routing

## Testing
- `./.venv/bin/pytest tests/test_telegram_flow_status.py tests/test_telegram_flow_callback_actions.py tests/test_telegram_flow_commands.py`
- pre-commit hooks on commit (black, ruff, mypy, eslint/build, full pytest suite)
