### PR TITLE
Fix Telegram image inbox visibility for opencode

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands/files.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/files.py
@@ -96,6 +96,7 @@ class MediaBatchResult:
     """Outcome of media batch processing."""
 
     saved_image_paths: list[Path]
+    saved_image_inbox_info: list[tuple[str, str, int]]
     saved_file_info: list[tuple[str, str, int]]
     stats: MediaBatchStats
 
@@ -331,9 +332,55 @@ class FilesCommands(SharedHelpers):
                 reply_to=message.message_id,
             )
             return
-        prompt_text = caption_text.strip()
-        if not prompt_text:
-            prompt_text = self._config.media.image_prompt
+        key = await self._resolve_topic_key(message.chat_id, message.thread_id)
+        image_inbox_path: Optional[Path] = None
+        pma_enabled = bool(getattr(record, "pma_enabled", False))
+        try:
+            image_inbox_path = self._save_inbox_file(
+                record.workspace_path,
+                key,
+                data,
+                candidate=candidate,
+                file_path=file_path,
+                pma_enabled=pma_enabled,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            log_event(
+                self._logger,
+                logging.WARNING,
+                "telegram.media.image.inbox_save_failed",
+                chat_id=message.chat_id,
+                thread_id=message.thread_id,
+                message_id=message.message_id,
+                exc=exc,
+            )
+        prompt_parts = [caption_text.strip() or self._config.media.image_prompt]
+        if image_inbox_path is not None:
+            original_name = (
+                candidate.file_name
+                or (Path(file_path).name if file_path else None)
+                or image_inbox_path.name
+            )
+            prompt_parts.append(
+                "\n".join(
+                    [
+                        "Image details:",
+                        f"- Name: {original_name}",
+                        f"- Size: {file_size or len(data)} bytes",
+                        f"- Saved to: {image_inbox_path}",
+                    ]
+                )
+            )
+        prompt_parts.append(
+            self._build_files_hint(
+                workspace_path=record.workspace_path,
+                topic_key=key,
+                pma_enabled=pma_enabled,
+            )
+        )
+        prompt_text = "\n\n".join(prompt_parts)
         input_items = [
             {"type": "text", "text": prompt_text},
             {"type": "localImage", "path": str(image_path)},
@@ -346,6 +393,7 @@ class FilesCommands(SharedHelpers):
             thread_id=message.thread_id,
             message_id=message.message_id,
             path=str(image_path),
+            inbox_path=str(image_inbox_path) if image_inbox_path else None,
             prompt_len=len(prompt_text),
         )
         await self._handle_normal_message(
@@ -649,6 +697,7 @@ class FilesCommands(SharedHelpers):
         """Process all messages in the media batch and collect results."""
         stats = MediaBatchStats()
         saved_image_paths: list[Path] = []
+        saved_image_inbox_info: list[tuple[str, str, int]] = []
         saved_file_info: list[tuple[str, str, int]] = []
         for msg in context.sorted_messages:
             image_candidate = message_handlers.select_image_candidate(msg)
@@ -665,6 +714,7 @@ class FilesCommands(SharedHelpers):
                     context,
                     stats,
                     saved_image_paths,
+                    saved_image_inbox_info,
                 )
             if file_candidate and not skip_remaining:
                 await self._process_file_candidate(
@@ -676,6 +726,7 @@ class FilesCommands(SharedHelpers):
                 )
         return MediaBatchResult(
             saved_image_paths=saved_image_paths,
+            saved_image_inbox_info=saved_image_inbox_info,
             saved_file_info=saved_file_info,
             stats=stats,
         )
@@ -687,6 +738,7 @@ class FilesCommands(SharedHelpers):
         context: MediaBatchContext,
         stats: MediaBatchStats,
         saved_image_paths: list[Path],
+        saved_image_inbox_info: list[tuple[str, str, int]],
     ) -> bool:
         """Process a single image candidate; returns True to skip further work."""
         if not self._config.media.images:
@@ -752,6 +804,26 @@ class FilesCommands(SharedHelpers):
                 pma_enabled=bool(getattr(context.record, "pma_enabled", False)),
             )
             saved_image_paths.append(image_path)
+            image_inbox_path = self._save_inbox_file(
+                context.record.workspace_path,
+                context.topic_key,
+                data,
+                candidate=candidate,
+                file_path=file_path,
+                pma_enabled=bool(getattr(context.record, "pma_enabled", False)),
+            )
+            original_name = (
+                candidate.file_name
+                or (Path(file_path).name if file_path else None)
+                or image_inbox_path.name
+            )
+            saved_image_inbox_info.append(
+                (
+                    original_name,
+                    str(image_inbox_path),
+                    file_size or len(data),
+                )
+            )
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -887,6 +959,11 @@ class FilesCommands(SharedHelpers):
             prompt_parts.append(self._config.media.image_prompt)
         else:
             prompt_parts.append("Media received.")
+        if result.saved_image_inbox_info:
+            image_summary = ["\nImages:"]
+            for name, path, size in result.saved_image_inbox_info:
+                image_summary.append(f"- {name} ({size} bytes) -> {path}")
+            prompt_parts.append("\n".join(image_summary))
         if result.saved_file_info:
             file_summary = ["\nFiles:"]
             for name, path, size in result.saved_file_info:

--- a/tests/test_telegram_bot_integration.py
+++ b/tests/test_telegram_bot_integration.py
@@ -8,6 +8,7 @@ import pytest
 from codex_autorunner.integrations.telegram.adapter import (
     TelegramDocument,
     TelegramMessage,
+    TelegramPhotoSize,
 )
 from codex_autorunner.integrations.telegram.config import TelegramBotConfig
 from codex_autorunner.integrations.telegram.service import TelegramBotService
@@ -83,6 +84,30 @@ def build_document_message(
         date=0,
         is_topic_message=thread_id is not None,
         document=document,
+    )
+
+
+def build_photo_message(
+    photos: tuple[TelegramPhotoSize, ...],
+    *,
+    chat_id: int = 123,
+    thread_id: Optional[int] = None,
+    user_id: int = 456,
+    message_id: int = 1,
+    update_id: int = 1,
+    caption: Optional[str] = None,
+) -> TelegramMessage:
+    return TelegramMessage(
+        update_id=update_id,
+        message_id=message_id,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        from_user_id=user_id,
+        text=None,
+        caption=caption,
+        date=0,
+        is_topic_message=thread_id is not None,
+        photos=photos,
     )
 
 
@@ -267,6 +292,37 @@ async def test_document_message_saves_inbox(tmp_path: Path) -> None:
     inbox_root = repo / ".codex-autorunner" / "uploads" / "telegram-files"
     inbox_files = [path for path in inbox_root.rglob("*") if path.is_file()]
     assert inbox_files
+
+
+@pytest.mark.anyio
+async def test_photo_batch_message_saves_inbox(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config = make_config(tmp_path, fixture_command("basic"))
+    service = TelegramBotService(config, hub_root=tmp_path)
+    fake_bot = FakeBot()
+    service._bot = fake_bot
+    bind_message = build_message("/bind", message_id=10)
+
+    async def fake_download(
+        _file_id: str, *, max_bytes: Optional[int] = None
+    ) -> tuple[bytes, str, int]:
+        return b"img", "photos/sample.jpg", 3
+
+    service._download_telegram_file = fake_download
+    message = build_photo_message(
+        (TelegramPhotoSize("p1", None, 800, 600, 3),),
+        message_id=11,
+    )
+    try:
+        await service._handle_bind(bind_message, str(repo))
+        await service._handle_media_batch([message])
+    finally:
+        await service._app_server_supervisor.close_all()
+    inbox_root = repo / ".codex-autorunner" / "uploads" / "telegram-files"
+    inbox_files = [path for path in inbox_root.rglob("*") if path.is_file()]
+    assert inbox_files
+    assert any(path.suffix.lower() == ".jpg" for path in inbox_files)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- mirror Telegram images into the topic inbox (`.codex-autorunner/uploads/telegram-files/.../inbox`) in both single-image and media-batch flows
- include saved image inbox paths in the prompt context so non-multimodal agents can locate images via inbox hints
- keep existing `localImage` input behavior for Codex-compatible multimodal handling
- add an integration regression test for batched photo uploads to ensure inbox files are created

## Root Cause
Telegram photo handling saved images to `telegram-images` and passed them as `localImage` inputs, but did not persist them in the topic inbox. For opencode turns, `input_items` are not used, so the agent relied on inbox hints and reported no new image files.

## Testing
- `.venv/bin/python -m pytest tests/test_telegram_bot_integration.py -k "document_message_saves_inbox or photo_batch_message_saves_inbox"`
- `.venv/bin/python -m pytest tests/test_telegram_media_batch_failure.py tests/test_telegram_pma_routing.py -q`
- pre-commit hook suite (black, ruff, mypy, eslint/build, full pytest) during commit
