### PR TITLE
Fix false ticket-flow worker mismatch detection on macOS

### DIFF
--- a/tests/flows/test_worker_process.py
+++ b/tests/flows/test_worker_process.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import subprocess
 import sys
+from pathlib import Path
 
 from codex_autorunner.core.flows import worker_process
 
@@ -41,3 +43,60 @@ def test_check_worker_health_prefers_metadata_cmdline(monkeypatch, tmp_path):
 
     assert health.status == "alive"
     assert health.cmdline == stored_cmd
+
+
+def test_cmdline_matches_when_executable_resolves_differently(tmp_path: Path) -> None:
+    real_exec = tmp_path / "python-real"
+    real_exec.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_exec.chmod(0o755)
+    alias_exec = tmp_path / "python-alias"
+    alias_exec.symlink_to(real_exec)
+
+    expected = [
+        str(alias_exec),
+        "-m",
+        "codex_autorunner",
+        "flow",
+        "worker",
+        "--repo",
+        str(tmp_path),
+        "--run-id",
+        "3022db08-82b8-40dd-8cfa-d04eb0fcded2",
+    ]
+    actual = [str(real_exec), *expected[1:]]
+
+    assert worker_process._cmdline_matches(expected, actual)
+
+
+def test_read_process_cmdline_uses_wide_ps(monkeypatch) -> None:
+    seen: list[list[str]] = []
+
+    def fake_check_output(cmd: list[str], stderr=None):  # type: ignore[no-untyped-def]
+        seen.append(list(cmd))
+        return b"python -m codex_autorunner flow worker --repo /tmp --run-id test"
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    cmdline = worker_process._read_process_cmdline(123)
+
+    assert cmdline is not None
+    assert seen
+    assert seen[0] == ["ps", "-ww", "-p", "123", "-o", "command="]
+
+
+def test_read_process_cmdline_falls_back_without_wide_flag(monkeypatch) -> None:
+    seen: list[list[str]] = []
+
+    def fake_check_output(cmd: list[str], stderr=None):  # type: ignore[no-untyped-def]
+        seen.append(list(cmd))
+        if cmd[:2] == ["ps", "-ww"]:
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+        return b"python -m codex_autorunner flow worker --repo /tmp --run-id test"
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    cmdline = worker_process._read_process_cmdline(456)
+
+    assert cmdline is not None
+    assert seen[0] == ["ps", "-ww", "-p", "456", "-o", "command="]
+    assert seen[1] == ["ps", "-p", "456", "-o", "command="]


### PR DESCRIPTION
## Summary
- fix false ticket-flow worker `mismatch` detection that can kill runs seconds after start/resume
- use wide `ps` output first (`-ww`) when reading worker cmdline
- tolerate executable-path aliasing/symlink resolution when comparing stored vs live worker command lines
- add regression tests for:
  - symlinked executable vs resolved executable command matching
  - wide `ps` usage
  - fallback behavior when wide `ps` fails

## Root cause
On macOS/BSD we resolve worker cmdline via `ps` (no `/proc/<pid>/cmdline`).
The previous comparison required exact command tokens, including `argv[0]`.
For venv-installed Python, stored metadata often used a symlink path (for example `.venv/bin/python`) while `ps` reported the resolved interpreter path, causing false `status=mismatch` and downstream `Worker died` failures.

## Validation
- pre-commit checks passed
- focused tests:
  - `tests/flows/test_worker_process.py`
  - `tests/flows/test_flow_reconcile.py`
  - `tests/flows/test_transition_table.py`
  - `tests/flows/test_worker_crash.py`
- full repository test suite executed by pre-commit:
  - `1249 passed, 3 skipped, 76 deselected`
