### PR TITLE
Code analysis: Constitution violations and tech debt fixes

### DIFF
--- a/src/codex_autorunner/surfaces/cli/cli.py
+++ b/src/codex_autorunner/surfaces/cli/cli.py
@@ -1540,23 +1540,6 @@ def kill(
 
 
 @app.command()
-def resume(
-    repo: Optional[Path] = typer.Option(None, "--repo", help="Repo path"),
-    hub: Optional[Path] = typer.Option(None, "--hub", help="Hub root path"),
-):
-    """Resume a paused/running ticket flow (now uses ticket_flow).
-
-    This command now uses ticket_flow for execution. For full control over
-    flows, use 'car flow' commands instead.
-    """
-    # Note: Resume is now handled by 'car flow ticket_flow/start' which
-    # will reuse an active/paused run automatically.
-    typer.echo("The 'resume' command has been deprecated in favor of ticket_flow.")
-    typer.echo("Use 'car flow ticket_flow/start' to resume existing flows.")
-    raise typer.Exit(code=0)
-
-
-@app.command()
 def log(
     repo: Optional[Path] = typer.Option(None, "--repo", help="Repo path"),
     hub: Optional[Path] = typer.Option(None, "--hub", help="Hub root path"),


### PR DESCRIPTION
## Summary

This PR addresses findings from a code analysis crawl of the codebase for constitution violations, tech debt, and code smells.

### Changes Made

1. **Constitution Violation Fix**: Moved `AGENTS.md` from `.codex-autorunner/tickets/` to `.codex-autorunner/tickets_guide.md`
   - The tickets folder should only contain `TICKET-###.md` files per the CAR Constitution
   - Note: This change is in the gitignored `.codex-autorunner/` directory

2. **Removed Deprecated CLI Command**: Removed the deprecated `resume` command from `cli.py`
   - The command was a stub that just printed a deprecation message
   - Functionality replaced by `ticket_flow` commands

### Analysis Findings (Not Addressed)

The code analysis also identified several issues that were not addressed in this PR:

- **Tech Debt**: 326+ exception handlers, scattered hardcoded timeouts (30+ files), large monolithic files (cli.py 4776 lines, commands_runtime.py 2955 lines)
- **Code Smells**: Missing logging in error paths, magic numbers, complex nested conditionals, dead code/pass statements
- **Constitution**: Missing `.codex-autorunner/config.yml` (expected - auto-generated at runtime)

These issues would require larger refactoring efforts and are noted for future work.