### PR TITLE
Fix /flow PMA repo/worktree alias resolution

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
@@ -60,6 +60,21 @@ from .shared import SharedHelpers
 
 _logger = logging.getLogger(__name__)
 _FLOW_REPO_CONTEXT_CACHE_MAX = 512
+_FLOW_ACTION_TOKENS = {
+    "help",
+    "status",
+    "runs",
+    "bootstrap",
+    "issue",
+    "plan",
+    "resume",
+    "stop",
+    "recover",
+    "restart",
+    "archive",
+    "reply",
+    "start",
+}
 
 
 def _flow_paths(repo_root: Path) -> tuple[Path, Path]:
@@ -360,6 +375,10 @@ class FlowCommands(SharedHelpers):
         if resolved:
             repo_root = canonicalize_path(Path(resolved[0]))
             return repo_root, resolved[1], consumed
+
+        # Preserve flow actions unless the token resolved as an exact repo/path above.
+        if (argv[0] or "").strip().lower() in _FLOW_ACTION_TOKENS:
+            return None, None, 0
 
         repos = self._flow_manifest_repos()
         if not repos:


### PR DESCRIPTION
## Summary
- fix `/flow` target parsing in PMA/unbound topics so it resolves repo/worktree selectors by manifest aliases (repo id, display name, branch, and `base--worktree` suffix)
- support the PMA case where both args are worktree/branch labels under the same base repo, and resolve the second arg as the target worktree
- keep existing exact-id behavior first, then alias fallback to avoid changing normal command flows

## Root cause
`/flow` only tried two selectors before treating arg1 as an action:
1. `<arg1>--<arg2>` as a full manifest repo id
2. `<arg1>` as a full manifest repo id/path

For PMA usage like:
`/flow architecture-boundary-refactors process-opencode-leak-remediation`

neither lookup matched (actual ids were `codex-autorunner--...`), so parsing fell through and returned "No workspace bound" instead of resolving the worktree target.

## Validation
- `.venv/bin/python -m pytest tests/test_telegram_flow_status.py`
- `.venv/bin/python -m pytest tests/test_telegram_flow_aliases.py`
- full pre-commit suite passed during commit (including full pytest run)
