### PR TITLE
fix(worker): use proper signal names in crash info

### DIFF
--- a/src/codex_autorunner/core/flows/worker_process.py
+++ b/src/codex_autorunner/core/flows/worker_process.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import subprocess
 import sys
 import uuid
@@ -74,7 +75,10 @@ def _signal_from_returncode(returncode: Optional[int]) -> Optional[str]:
         return None
     if returncode >= 0:
         return None
-    return f"SIG{-returncode}"
+    try:
+        return signal.Signals(-returncode).name
+    except (ValueError, AttributeError):
+        return f"SIG{-returncode}"
 
 
 def _tail_file(

--- a/tests/flows/test_worker_crash.py
+++ b/tests/flows/test_worker_crash.py
@@ -34,10 +34,34 @@ def test_write_worker_crash_info_roundtrip(tmp_path: Path) -> None:
     assert payload is not None
     assert payload["worker_pid"] == 4321
     assert payload["exit_code"] == -9
-    assert payload["signal"] == "SIG9"
+    assert payload["signal"] == "SIGKILL"
     assert payload["last_event"] == "item/reasoning/summaryTextDelta"
     assert payload["exception"] == "RepoNotFoundError: cwd mismatch"
     assert payload["stack_trace"] == "Traceback ..."
+
+
+def test_write_worker_crash_info_derives_signal_name_from_exit_code(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path
+    run_id = "323e4567-e89b-12d3-a456-426614174000"
+
+    crash_path = write_worker_crash_info(
+        repo_root,
+        run_id,
+        worker_pid=5678,
+        exit_code=-15,
+        last_event="account/rateLimits/updated",
+    )
+    assert crash_path is not None
+    assert crash_path.exists()
+
+    payload = read_worker_crash_info(repo_root, run_id)
+    assert payload is not None
+    assert payload["worker_pid"] == 5678
+    assert payload["exit_code"] == -15
+    assert payload["signal"] == "SIGTERM"
+    assert payload["last_event"] == "account/rateLimits/updated"
 
 
 def test_reconcile_paused_dead_worker_creates_crash_dispatch(


### PR DESCRIPTION
## Summary
- Fix `_signal_from_returncode` to use `signal.Signals(-returncode).name` instead of naive `"SIG{n}"` formatting
- Ensures crash.json shows "SIGTERM" instead of "SIG15", "SIGKILL" instead of "SIG9", etc.

## Why this approach
This is the minimal fix that addresses the root cause without regressions:

| Approach | PR #668 | This PR |
|----------|---------|---------|
| Termination mechanism | Changes to `sys.exit()` (breaks exit semantics) | Keeps `os.kill()` (preserves semantics) |
| Signal naming | Still shows "SIG15" | Shows "SIGTERM" ✓ |
| Crash enrichment | N/A | Preserved (reconciler enriches with last_event/exception) |

PR #668's `sys.exit(-signum)` approach:
1. Changes shell exit semantics (exit code becomes `n & 255`)
2. Still produces "SIG15" since `_signal_from_returncode` wasn't fixed
3. Had a valid point about PR #667's original approach (writing crash.json in signal handler) blocking reconciler enrichment

This fix goes to the source: fix `_signal_from_returncode` to produce proper signal names. The reconciler still enriches crash info with last_event, exception, etc.

Closes #666