### PR TITLE
Unify Telegram and Web hub flow status logic

### DIFF
--- a/schemas/hub.json
+++ b/schemas/hub.json
@@ -49,6 +49,18 @@
           "total_count": {"type": "integer"},
           "current_step": {"type": ["null", "integer"]}
         }
+      },
+      "ticket_flow_display": {
+        "type": ["null", "object"],
+        "properties": {
+          "status": {"type": "string"},
+          "status_label": {"type": "string"},
+          "status_icon": {"type": "string"},
+          "is_active": {"type": "boolean"},
+          "done_count": {"type": "integer"},
+          "total_count": {"type": "integer"},
+          "run_id": {"type": ["null", "string"]}
+        }
       }
     },
     "required": [

--- a/scripts/validate_interfaces.py
+++ b/scripts/validate_interfaces.py
@@ -15,7 +15,7 @@ SCHEMA_BINDINGS = {
     "RepoSnapshot": {
         "typescript": "HubRepo",
         "python": "RepoSnapshot",
-        "python_extra": {"mounted", "mount_error", "ticket_flow"},
+        "python_extra": {"mounted", "mount_error", "ticket_flow", "ticket_flow_display"},
     },
     "HubState": {"typescript": "HubData", "python": "HubState"},
 }

--- a/src/codex_autorunner/core/ticket_flow_summary.py
+++ b/src/codex_autorunner/core/ticket_flow_summary.py
@@ -13,6 +13,19 @@ from .flows.failure_diagnostics import format_failure_summary, get_failure_paylo
 from .flows.models import FlowRunRecord
 
 _PR_URL_RE = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+", re.IGNORECASE)
+_FLOW_STATUS_ICONS = {
+    "running": "🟢",
+    "pending": "🟡",
+    "stopping": "🟡",
+    "paused": "🔴",
+    "completed": "🔵",
+    "done": "🔵",
+    "failed": "⚫",
+    "stopped": "⚫",
+    "superseded": "⚫",
+    "idle": "⚪",
+}
+_ACTIVE_FLOW_STATUSES = {"running", "pending", "paused", "stopping"}
 
 
 def _extract_pr_url_from_ticket(path: Path) -> Optional[str]:
@@ -36,23 +49,50 @@ def get_latest_ticket_flow_run(store: FlowStore) -> Optional[FlowRunRecord]:
     return runs[0] if runs else None
 
 
+def _load_latest_ticket_flow_run(repo_path: Path) -> Optional[FlowRunRecord]:
+    db_path = repo_path / ".codex-autorunner" / "flows.db"
+    if not db_path.exists():
+        return None
+    config = load_repo_config(repo_path)
+    with FlowStore(db_path, durable=config.durable_writes) as store:
+        return get_latest_ticket_flow_run(store)
+
+
+def build_ticket_flow_display(
+    *,
+    status: Optional[str],
+    done_count: int,
+    total_count: int,
+    run_id: Optional[str],
+) -> dict[str, Any]:
+    done = max(int(done_count or 0), 0)
+    total = max(int(total_count or 0), 0)
+    normalized = str(status or "").strip().lower()
+
+    if normalized:
+        effective_status = normalized
+        status_label = normalized
+    else:
+        completed_without_run = total > 0 and done >= total
+        effective_status = "done" if completed_without_run else "idle"
+        status_label = "Done" if completed_without_run else "Idle"
+
+    return {
+        "status": effective_status,
+        "status_label": status_label,
+        "status_icon": _FLOW_STATUS_ICONS.get(effective_status, "⚪"),
+        "is_active": effective_status in _ACTIVE_FLOW_STATUSES,
+        "done_count": done,
+        "total_count": total,
+        "run_id": run_id,
+    }
+
+
 def build_ticket_flow_summary(
     repo_path: Path,
     *,
     include_failure: bool,
 ) -> Optional[dict[str, Any]]:
-    db_path = repo_path / ".codex-autorunner" / "flows.db"
-    if not db_path.exists():
-        return None
-    try:
-        config = load_repo_config(repo_path)
-        with FlowStore(db_path, durable=config.durable_writes) as store:
-            latest = get_latest_ticket_flow_run(store)
-            if not latest:
-                return None
-    except Exception:
-        return None
-
     ticket_dir = repo_path / ".codex-autorunner" / "tickets"
     ticket_paths = list_ticket_paths(ticket_dir)
     if not ticket_paths:
@@ -92,22 +132,37 @@ def build_ticket_flow_summary(
 
     pr_url = open_pr_ticket_url
 
-    state = latest.state if isinstance(latest.state, dict) else {}
+    try:
+        latest = _load_latest_ticket_flow_run(repo_path)
+    except Exception:
+        return None
+
+    display = build_ticket_flow_display(
+        status=latest.status.value if latest else None,
+        done_count=done_count,
+        total_count=total_count,
+        run_id=latest.id if latest else None,
+    )
+
+    state = latest.state if latest and isinstance(latest.state, dict) else {}
     engine = state.get("ticket_engine") if isinstance(state, dict) else {}
     engine = engine if isinstance(engine, dict) else {}
     current_step = engine.get("total_turns")
 
     summary: dict[str, Any] = {
-        "status": latest.status.value,
-        "done_count": done_count,
-        "total_count": total_count,
+        "status": display["status"],
+        "status_label": display["status_label"],
+        "status_icon": display["status_icon"],
+        "run_id": display["run_id"],
+        "done_count": display["done_count"],
+        "total_count": display["total_count"],
         "current_step": current_step,
         "pr_url": pr_url,
         "pr_opened": bool(pr_url),
         "final_review_status": final_review_status,
     }
     if include_failure:
-        failure_payload = get_failure_payload(latest)
+        failure_payload = get_failure_payload(latest) if latest else None
         summary["failure"] = failure_payload
         summary["failure_summary"] = (
             format_failure_summary(failure_payload) if failure_payload else None

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
@@ -31,7 +31,7 @@ from .....core.flows.worker_process import (
 from .....core.logging_utils import log_event
 from .....core.runtime import RuntimeContext
 from .....core.state import now_iso
-from .....core.ticket_flow_summary import get_latest_ticket_flow_run
+from .....core.ticket_flow_summary import build_ticket_flow_display
 from .....core.utils import atomic_write, canonicalize_path
 from .....flows.ticket_flow import build_ticket_flow_definition
 from .....integrations.agents import build_backend_orchestrator
@@ -1247,46 +1247,24 @@ class FlowCommands(SharedHelpers):
             store = _load_flow_store(repo_root)
             try:
                 store.initialize()
+                runs = store.list_flow_runs(flow_type="ticket_flow")
+                latest = runs[0] if runs else None
                 progress = ticket_progress(repo_root)
-                done = progress.get("done", 0)
-                total = progress.get("total", 0)
-                progress_label = f"{done}/{total}"
-                latest = get_latest_ticket_flow_run(store)
-                if latest:
-                    status_icon = "⚪"
-                    if latest.status == FlowRunStatus.RUNNING:
-                        status_icon = "🟢"
-                    elif latest.status in (
-                        FlowRunStatus.PENDING,
-                        FlowRunStatus.STOPPING,
-                    ):
-                        status_icon = "🟡"
-                    elif latest.status == FlowRunStatus.PAUSED:
-                        status_icon = "🔴"
-                    elif latest.status == FlowRunStatus.COMPLETED:
-                        status_icon = "🔵"
-                    elif latest.status in (
-                        FlowRunStatus.STOPPED,
-                        FlowRunStatus.FAILED,
-                    ):
-                        status_icon = "⚫"
-                    status_line = _format_status_line(
-                        label,
-                        status_icon=status_icon,
-                        status_value=latest.status.value,
-                        progress_label=progress_label,
-                        run_id=latest.id,
-                        indent=indent,
-                    )
-                else:
-                    status_line = _format_status_line(
-                        label,
-                        status_icon="🔵" if total > 0 and done >= total else "⚪",
-                        status_value="Done" if total > 0 and done >= total else "Idle",
-                        progress_label=progress_label,
-                        run_id=None,
-                        indent=indent,
-                    )
+                display = build_ticket_flow_display(
+                    status=latest.status.value if latest else None,
+                    done_count=progress.get("done", 0),
+                    total_count=progress.get("total", 0),
+                    run_id=latest.id if latest else None,
+                )
+                progress_label = f"{display['done_count']}/{display['total_count']}"
+                status_line = _format_status_line(
+                    label,
+                    status_icon=str(display["status_icon"]),
+                    status_value=str(display["status_label"]),
+                    progress_label=progress_label,
+                    run_id=display.get("run_id"),
+                    indent=indent,
+                )
             except Exception:
                 status_line = f"{indent}❓ {_code(label)}: Error reading state"
             finally:

--- a/src/codex_autorunner/static/hub.js
+++ b/src/codex_autorunner/static/hub.js
@@ -894,29 +894,32 @@ function renderRepos(repos) {
           ${escapeHtml(usageInfo.label)}
         </span>
       </div>`;
+        const flowDisplay = repo.ticket_flow_display;
         // Ticket flow progress line
         let ticketFlowLine = "";
         const tf = repo.ticket_flow;
-        if (tf && tf.total_count > 0) {
-            const percent = Math.round((tf.done_count / tf.total_count) * 100);
-            const isActive = tf.status === "running" || tf.status === "paused";
-            const statusSuffix = tf.status === "paused"
+        if (flowDisplay && flowDisplay.total_count > 0) {
+            const percent = Math.round((flowDisplay.done_count / flowDisplay.total_count) * 100);
+            const isActive = Boolean(flowDisplay.is_active);
+            const currentStep = tf?.current_step;
+            const statusSuffix = flowDisplay.status === "paused"
                 ? " · paused"
-                : tf.current_step
-                    ? ` · step ${tf.current_step}`
+                : currentStep
+                    ? ` · step ${currentStep}`
                     : "";
             ticketFlowLine = `
         <div class="hub-repo-flow-line${isActive ? " active" : ""}">
           <div class="hub-flow-bar">
             <div class="hub-flow-fill" style="width:${percent}%"></div>
           </div>
-          <span class="hub-flow-text">${tf.done_count}/${tf.total_count}${statusSuffix}</span>
+          <span class="hub-flow-text">${escapeHtml(flowDisplay.status_label)} ${flowDisplay.done_count}/${flowDisplay.total_count}${statusSuffix}</span>
         </div>`;
         }
+        const statusText = flowDisplay?.status_label || repo.status;
         card.innerHTML = `
       <div class="hub-repo-row">
         <div class="hub-repo-left">
-            <span class="pill pill-small hub-status-pill">${escapeHtml(repo.status)}</span>
+            <span class="pill pill-small hub-status-pill">${escapeHtml(statusText)}</span>
             ${mountBadge}
             ${lockBadge}
             ${initBadge}
@@ -938,7 +941,7 @@ function renderRepos(repos) {
     `;
         const statusEl = card.querySelector(".hub-status-pill");
         if (statusEl) {
-            statusPill(statusEl, repo.status);
+            statusPill(statusEl, flowDisplay?.status || repo.status);
         }
         repoListEl.appendChild(card);
     };


### PR DESCRIPTION
## Summary
This PR unifies the flow-status logic used by Telegram `/flow` hub overview and the Web Hub repo status display so they derive from the same canonical rules.

## Drift Found
Before this change, Telegram and Web diverged in several places:

1. **Status source mismatch**
- Telegram `/flow` hub overview used latest `ticket_flow` run status + ticket progress.
- Web hub row badge used repo runner status (`repo.status`), which can be `error` even when flow is `completed`.

2. **No-run fallback mismatch**
- Telegram explicitly showed `Done` when tickets were all complete without an active run, otherwise `Idle`.
- Web summary path could return `None` with no run, so no equivalent `Done/Idle` flow fallback existed.

3. **Duplicated status/icon mapping**
- Telegram hardcoded icon/status mapping in command handler.
- Web had separate rendering assumptions and did not share that mapping.

## What Changed
1. Added a shared core helper:
- `build_ticket_flow_display(...)` in `src/codex_autorunner/core/ticket_flow_summary.py`
- Canonicalizes:
  - effective flow status (`running/pending/paused/stopping/completed/failed/stopped/superseded`)
  - no-run fallbacks (`Done` / `Idle`)
  - status icon
  - active flag
  - progress + run id

2. Updated `build_ticket_flow_summary(...)` to include flow-display fields and support no-run fallback status when tickets exist.

3. Telegram `/flow` hub overview now uses `build_ticket_flow_display(...)` for status/icon/label instead of inline custom mapping.

4. Web hub API now emits `ticket_flow_display` in `/hub/repos` payload, derived from the same shared helper.

5. Web hub UI (`static_src/hub.ts`) now displays flow-derived status badge + flow line text using `ticket_flow_display` (same logic source as Telegram).

6. Updated hub interface contract schema/checks for the new `ticket_flow_display` field.

## Validation
- Full repository check pipeline executed by pre-commit hook, including:
  - black, ruff, mypy, eslint, TS build, generated-static verification
  - full pytest suite
- Result: `1288 passed, 3 skipped, 76 deselected`

## Files
- `src/codex_autorunner/core/ticket_flow_summary.py`
- `src/codex_autorunner/integrations/telegram/handlers/commands/flows.py`
- `src/codex_autorunner/surfaces/web/routes/hub_repos.py`
- `src/codex_autorunner/static_src/hub.ts`
- `src/codex_autorunner/static/hub.js`
- `schemas/hub.json`
- `scripts/validate_interfaces.py`
- `tests/core/test_ticket_flow_summary.py`
