### PR TITLE
Fix terminal reconnect loop on short-lived websocket flaps

### DIFF
--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -24,6 +24,7 @@ def test_static_mobile_terminal_compose_view_assets():
         )
         assert "mobile-terminal-view" in styles
         assert "_setMobileViewActive" in terminal_manager
+        assert "Math.round(delay / 1000)" in terminal_manager
     finally:
         if stack is not None:
             stack.close()


### PR DESCRIPTION
## Summary
- fix terminal websocket auto-reconnect loops caused by short-lived connection flaps
- keep reconnect-attempt state across unstable opens and only reset after a stable connection window (15s) or user-initiated reconnect
- fix reconnect status text to display real seconds (`delay / 1000` instead of `delay / 100`)
- add a static asset regression assertion for the reconnect status expression

## Root Cause
The reconnect loop was caused by `reconnectAttempts` being reset on every `socket.onopen`, even when the websocket immediately closed again. In flap scenarios, this prevented the retry counter from ever reaching the max-retry cutoff, so the client could reconnect forever.

## Validation
- `pnpm run build`
- `.venv/bin/pytest tests/test_static.py`
- pre-commit suite via `git commit` hooks (full repo checks)
