### PR TITLE
Update global car CLI during safe refresh

### DIFF
--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -354,7 +354,7 @@ if [[ ! -d "${PIPX_VENV}" ]]; then
   fi
 fi
 
-for cmd in git launchctl curl; do
+for cmd in git launchctl curl pipx; do
   if ! command -v "${cmd}" >/dev/null 2>&1; then
     fail "Missing required command: ${cmd}."
   fi
@@ -1049,9 +1049,6 @@ echo "Switching ${CURRENT_VENV_LINK} -> ${next_venv}"
 ln -sfn "${next_venv}" "${CURRENT_VENV_LINK}"
 swap_completed=true
 
-echo "Updating global car CLI..."
-pipx install --force "${PACKAGE_SRC}"
-
 if [[ "${should_reload_hub}" == "true" ]]; then
   echo "Restarting launchd service ${LABEL}..."
   _ensure_plist_uses_current_venv
@@ -1078,6 +1075,8 @@ if [[ "${health_ok}" == "true" ]]; then
   if [[ -n "${telegram_health_reason}" ]]; then
     status_msg+=" ${telegram_health_reason}"
   fi
+  echo "Updating global car CLI..."
+  pipx install --force "${PACKAGE_SRC}"
   write_status "ok" "${status_msg}"
 else
   _rollback "Health check failed; rolling back to ${current_target}..."


### PR DESCRIPTION
## Summary
- After swapping to the new venv during safe refresh, also reinstall the package via pipx to keep the global `codex-autorunner` CLI in sync with the running services
- This ensures the CLI command in PATH matches what the launchd services are using, regardless of whether web, telegram, or both are updated