### PR TITLE
Fix image processing failure due to missing IMAGE_EXTS import

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands/files.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/files.py
@@ -15,6 +15,7 @@ from .....core.filebox import outbox_dir as filebox_outbox_dir
 from .....core.injected_context import wrap_injected_context
 from .....core.logging_utils import log_event
 from .....core.state import now_iso
+from ....chat.media import IMAGE_CONTENT_TYPES, IMAGE_EXTS
 from ...adapter import TelegramMessage
 from ...config import TelegramMediaCandidate
 from ...helpers import _path_within, format_public_error
@@ -1087,11 +1088,11 @@ class FilesCommands(SharedHelpers):
         for candidate in (file_path, file_name):
             if candidate:
                 suffix = Path(candidate).suffix.lower()
-                if suffix in message_handlers.IMAGE_EXTS:
+                if suffix in IMAGE_EXTS:
                     return suffix
         if mime_type:
             base = mime_type.lower().split(";", 1)[0].strip()
-            mapped = message_handlers.IMAGE_CONTENT_TYPES.get(base)
+            mapped = IMAGE_CONTENT_TYPES.get(base)
             if mapped:
                 return mapped
         return ".img"


### PR DESCRIPTION
## Summary
- Fixes image processing failures that caused "1 image(s) failed to save" errors
- Root cause: `_choose_image_extension` in `files.py` was trying to access `message_handlers.IMAGE_EXTS` and `message_handlers.IMAGE_CONTENT_TYPES`, but these constants are defined in `chat.media` module, not in `telegram.handlers.messages`
- This caused an `AttributeError` when processing any image, making all image saves fail

## Fix
- Import `IMAGE_EXTS` and `IMAGE_CONTENT_TYPES` directly from `chat.media` module
- Use the directly imported constants in `_choose_image_extension` method

## Testing
- All image-related tests pass
- Specifically fixes `test_photo_batch_inbox_save_failure_still_processes_image` which was failing before