### PR TITLE
fix(discord): route component interactions for /car bind picker

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -74,6 +74,7 @@ from .interactions import (
     extract_interaction_id,
     extract_interaction_token,
     extract_user_id,
+    is_component_interaction,
 )
 from .outbox import DiscordOutboxManager
 from .rendering import (
@@ -1027,6 +1028,10 @@ class DiscordBotService:
                 await self._dispatcher.dispatch(event, self._handle_chat_event)
 
     async def _handle_interaction(self, interaction_payload: dict[str, Any]) -> None:
+        if is_component_interaction(interaction_payload):
+            await self._handle_component_interaction(interaction_payload)
+            return
+
         interaction_id = extract_interaction_id(interaction_payload)
         interaction_token = extract_interaction_token(interaction_payload)
         channel_id = extract_channel_id(interaction_payload)


### PR DESCRIPTION
## Summary
- Fix Discord interaction routing so component interactions (`type=3`) are handled on the gateway path.
- This restores `/car bind` picker selection behavior (no more Discord "interaction failed" timeout after selecting a repo).
- Add a regression test that drives a real `bind_select` component payload through `INTERACTION_CREATE` and verifies binding + response.

## Root cause
- `INTERACTION_CREATE` events were routed to `_handle_interaction`.
- `_handle_interaction` only attempted slash-command ingress parsing (`extract_command_path_and_options` + `canonicalize_command_ingress`).
- Component payloads do not carry slash command fields (`data.name`), so ingress parsing produced no route and returned without any interaction response.
- `_handle_component_interaction` existed (including `bind_select` handling) but was never invoked from this live gateway path.

## Changes
- `src/codex_autorunner/integrations/discord/service.py`
  - Import and use `is_component_interaction`.
  - Add an early dispatch in `_handle_interaction`:
    - if payload is a component interaction, route to `_handle_component_interaction` and return.
- `tests/integrations/discord/test_service_routing.py`
  - Add helper payload for `bind_select` component interactions.
  - Add `test_service_routes_bind_picker_component_interaction`.

## Validation
- `.venv/bin/python -m pytest tests/integrations/discord/test_service_routing.py -q`
- `.venv/bin/python -m pytest tests/integrations/discord/test_message_turns.py -q`
- `.venv/bin/python -m ruff check src/codex_autorunner/integrations/discord/service.py tests/integrations/discord/test_service_routing.py`
- Pre-commit/full repo checks passed during commit (`1838 passed, 3 skipped`).

## Note on PMA behavior
- PMA chat turns in PMA mode are still covered by existing message-turn tests and were not changed here.
- `/car flow*` commands in PMA mode remain intentionally blocked by `_require_bound_workspace` with guidance to run `/pma off` first.
