### PR TITLE
test(discord): shift interaction regressions to dev-time guardrails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ PIPX_ROOT ?= $(HOME)/.local/pipx
 PIPX_VENV ?= $(PIPX_ROOT)/venvs/codex-autorunner
 PIPX_PYTHON ?= $(PIPX_VENV)/bin/python
 
-.PHONY: install dev hooks build test check preflight-hub-startup format serve serve-dev launchd-hub deadcode-baseline venv venv-dev setup npm-install car-artifacts lint-html dom-check frontend-check _inject-static-banners protocol-schemas-check protocol-schemas-refresh
+.PHONY: install dev hooks build test test-discord-contract check preflight-hub-startup format serve serve-dev launchd-hub deadcode-baseline venv venv-dev setup npm-install car-artifacts lint-html dom-check frontend-check _inject-static-banners protocol-schemas-check protocol-schemas-refresh
 
 _inject-static-banners:
 	pnpm run postbuild
@@ -72,6 +72,14 @@ hooks:
 
 test:
 	$(PYTHON) -m pytest -m "not integration"
+
+test-discord-contract:
+	$(PYTHON) -m pytest -q \
+		tests/integrations/discord/test_service_routing.py \
+		tests/integrations/discord/test_interactions_parse.py \
+		tests/integrations/chat/test_parity_checker.py \
+		tests/test_doctor_checks.py::test_chat_doctor_checks_use_parity_contract_group \
+		tests/test_doctor_checks.py::test_chat_doctor_checks_failures_are_actionable
 
 test-integration:
 	$(PYTHON) -m pytest -m integration

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -41,6 +41,7 @@ elif command -v python3 >/dev/null 2>&1; then
   PYTHON_BIN="python3"
 fi
 need_cmd "$PYTHON_BIN"
+need_cmd make
 need_cmd node
 need_cmd pnpm
 
@@ -57,6 +58,9 @@ paths=(src)
 if [ -d tests ]; then
   paths+=(tests)
 fi
+
+echo "Running fast Discord contract guardrails..."
+make test-discord-contract PYTHON="$PYTHON_BIN"
 
 echo "Formatting check (black)..."
 "$PYTHON_BIN" -m black --check "${paths[@]}"

--- a/tests/integrations/chat/test_parity_checker.py
+++ b/tests/integrations/chat/test_parity_checker.py
@@ -43,6 +43,43 @@ def test_parity_checker_fails_when_known_prefix_can_leak_to_generic_fallback(
     )
 
 
+def test_parity_checker_fails_when_component_fallback_is_missing(
+    tmp_path: Path,
+) -> None:
+    repo_root = _write_fixture_repo(
+        tmp_path,
+        include_component_unknown_fallback=False,
+    )
+
+    results_by_id = {
+        result.id: result for result in run_parity_checks(repo_root=repo_root)
+    }
+
+    guard_check = results_by_id["discord.interaction_component_guard_paths"]
+    assert not guard_check.passed
+    assert "component_unknown_fallback" in guard_check.metadata["failed_predicates"]
+
+
+def test_parity_checker_fails_when_parse_error_response_is_missing(
+    tmp_path: Path,
+) -> None:
+    repo_root = _write_fixture_repo(
+        tmp_path,
+        include_interaction_parse_failure_response=False,
+    )
+
+    results_by_id = {
+        result.id: result for result in run_parity_checks(repo_root=repo_root)
+    }
+
+    guard_check = results_by_id["discord.interaction_component_guard_paths"]
+    assert not guard_check.passed
+    assert (
+        "interaction_parse_failure_response"
+        in guard_check.metadata["failed_predicates"]
+    )
+
+
 def test_parity_checker_fails_when_shared_helper_usage_is_missing(
     tmp_path: Path,
 ) -> None:
@@ -166,6 +203,11 @@ def _write_fixture_repo(
     include_telegram_trigger_bridge: bool = True,
     include_pma_status_route_in_normalized: bool = True,
     include_pma_status_route_in_direct: bool = True,
+    include_component_unknown_fallback: bool = True,
+    include_interaction_parse_failure_response: bool = True,
+    include_component_missing_custom_id_response: bool = True,
+    include_component_bind_value_response: bool = True,
+    include_component_flow_runs_value_response: bool = True,
     use_canonicalize_temporary_names: bool = False,
     use_early_ingress_none_guard_in_normalized: bool = False,
     use_truthy_ingress_guard_in_normalized: bool = False,
@@ -178,6 +220,11 @@ def _write_fixture_repo(
         include_discord_turn_policy=include_discord_turn_policy,
         include_pma_status_route_in_normalized=include_pma_status_route_in_normalized,
         include_pma_status_route_in_direct=include_pma_status_route_in_direct,
+        include_component_unknown_fallback=include_component_unknown_fallback,
+        include_interaction_parse_failure_response=include_interaction_parse_failure_response,
+        include_component_missing_custom_id_response=include_component_missing_custom_id_response,
+        include_component_bind_value_response=include_component_bind_value_response,
+        include_component_flow_runs_value_response=include_component_flow_runs_value_response,
         use_canonicalize_temporary_names=use_canonicalize_temporary_names,
         use_early_ingress_none_guard_in_normalized=use_early_ingress_none_guard_in_normalized,
         use_truthy_ingress_guard_in_normalized=use_truthy_ingress_guard_in_normalized,
@@ -214,6 +261,11 @@ def _build_discord_service_fixture(
     include_discord_turn_policy: bool,
     include_pma_status_route_in_normalized: bool,
     include_pma_status_route_in_direct: bool,
+    include_component_unknown_fallback: bool,
+    include_interaction_parse_failure_response: bool,
+    include_component_missing_custom_id_response: bool,
+    include_component_bind_value_response: bool,
+    include_component_flow_runs_value_response: bool,
     use_canonicalize_temporary_names: bool,
     use_early_ingress_none_guard_in_normalized: bool,
     use_truthy_ingress_guard_in_normalized: bool,
@@ -294,7 +346,7 @@ def _build_discord_service_fixture(
 """
 
     interaction_pma_guard = (
-        '    if ingress.command_path[:1] == ("pma",):\n        return\n'
+        '        if ingress.command_path[:1] == ("pma",):\n            return\n'
         if include_interaction_pma_prefix_guard
         else ""
     )
@@ -335,6 +387,61 @@ def _handle_message_event(text: str) -> None:
         if include_pma_status_route_in_direct
         else ""
     )
+    component_unknown_fallback = (
+        """
+        _respond_ephemeral(
+            "interaction-id",
+            "interaction-token",
+            f"Unknown component: {custom_id}",
+        )
+"""
+        if include_component_unknown_fallback
+        else ""
+    )
+    interaction_parse_failure_response = (
+        """
+        _respond_ephemeral(
+            "interaction-id",
+            "interaction-token",
+            "I could not parse this interaction. Please retry the command.",
+        )
+"""
+        if include_interaction_parse_failure_response
+        else ""
+    )
+    component_missing_custom_id_response = (
+        """
+        _respond_ephemeral(
+            "interaction-id",
+            "interaction-token",
+            "I could not identify this interaction action. Please retry.",
+        )
+"""
+        if include_component_missing_custom_id_response
+        else ""
+    )
+    component_bind_value_response = (
+        """
+                _respond_ephemeral(
+                    "interaction-id",
+                    "interaction-token",
+                    "Please select a repository and try again.",
+                )
+"""
+        if include_component_bind_value_response
+        else ""
+    )
+    component_flow_runs_value_response = (
+        """
+                _respond_ephemeral(
+                    "interaction-id",
+                    "interaction-token",
+                    "Please select a run and try again.",
+                )
+"""
+        if include_component_flow_runs_value_response
+        else ""
+    )
 
     return (
         "from ...integrations.chat.turn_policy import PlainTextTurnContext, should_trigger_plain_text_turn\n"
@@ -353,12 +460,79 @@ def _handle_interaction(command_path: tuple[str, ...], options: dict[str, object
 """
         + interaction_ingress
         + """
-    if ingress.command_path[:1] == ("car",):
+    if ingress is None:
+"""
+        + interaction_parse_failure_response
+        + """
         return
+
+    try:
+        if ingress.command_path[:1] == ("car",):
+            return
 """
         + interaction_pma_guard
         + """
-    _ = "Command not implemented yet for Discord."
+        _respond_ephemeral(
+            "interaction-id",
+            "interaction-token",
+            "Command not implemented yet for Discord.",
+        )
+    except Exception as exc:
+        log_event(
+            logger,
+            40,
+            "discord.interaction.unhandled_error",
+            exc=exc,
+        )
+        _respond_ephemeral(
+            "interaction-id",
+            "interaction-token",
+            "An unexpected error occurred. Please try again later.",
+        )
+
+
+def _handle_component_interaction(custom_id: str | None) -> None:
+    if not custom_id:
+        self._logger.debug("missing custom_id")
+"""
+        + component_missing_custom_id_response
+        + """
+        return
+
+    try:
+        if custom_id == "bind_select":
+            values = []
+            if not values:
+"""
+        + component_bind_value_response
+        + """
+                return
+            return
+        if custom_id == "flow_runs_select":
+            values = []
+            if not values:
+"""
+        + component_flow_runs_value_response
+        + """
+                return
+            return
+        if custom_id.startswith("flow:"):
+            return
+"""
+        + component_unknown_fallback
+        + """
+    except Exception as exc:
+        log_event(
+            logger,
+            40,
+            "discord.component.unhandled_error",
+            exc=exc,
+        )
+        _respond_ephemeral(
+            "interaction-id",
+            "interaction-token",
+            "An unexpected error occurred. Please try again later.",
+        )
 
 
 def _handle_car_command(command_path: tuple[str, ...]) -> None:

--- a/tests/integrations/discord/test_interactions_parse.py
+++ b/tests/integrations/discord/test_interactions_parse.py
@@ -69,6 +69,12 @@ def test_extract_component_custom_id() -> None:
     assert extract_component_custom_id(payload) == "flow:run-123:resume"
 
 
+def test_extract_component_custom_id_returns_none_for_missing_or_blank() -> None:
+    assert extract_component_custom_id({"data": {}}) is None
+    assert extract_component_custom_id({"data": {"custom_id": "   "}}) is None
+    assert extract_component_custom_id({"data": "not-a-dict"}) is None
+
+
 def test_extract_component_values() -> None:
     payload = {"data": {"values": ["repo-1", "repo-2"]}}
     assert extract_component_values(payload) == ["repo-1", "repo-2"]
@@ -77,3 +83,14 @@ def test_extract_component_values() -> None:
 def test_extract_component_values_returns_empty_for_no_values() -> None:
     payload = {"data": {}}
     assert extract_component_values(payload) == []
+
+
+def test_extract_component_values_filters_non_scalar_values() -> None:
+    payload = {"data": {"values": ["repo-1", 2, 3.5, None, {"k": "v"}, ["nested"]]}}
+    assert extract_component_values(payload) == ["repo-1", "2", "3.5"]
+
+
+def test_extract_command_path_and_options_returns_empty_for_malformed_payload() -> None:
+    assert extract_command_path_and_options({}) == ((), {})
+    assert extract_command_path_and_options({"data": "not-a-dict"}) == ((), {})
+    assert extract_command_path_and_options({"data": {"name": ""}}) == ((), {})

--- a/tests/test_doctor_checks.py
+++ b/tests/test_doctor_checks.py
@@ -168,6 +168,18 @@ def test_chat_doctor_checks_use_parity_contract_group(monkeypatch):
             "shared helper usage for command ingress",
             "canonicalize_command_ingress",
         ),
+        (
+            ParityCheckResult(
+                id="discord.interaction_component_guard_paths",
+                passed=False,
+                message="guard coverage incomplete",
+                metadata={
+                    "failed_predicates": ["component_unknown_fallback"],
+                },
+            ),
+            "guard coverage incomplete",
+            "align command routing/guard helpers",
+        ),
     ],
 )
 def test_chat_doctor_checks_failures_are_actionable(


### PR DESCRIPTION
## Summary
- adds a fast Discord contract test target (`make test-discord-contract`) and runs it early in local check flow (`scripts/check.sh`) to fail fast on Discord routing regressions
- adds development-time parity checks for Discord interaction/component guard paths in `parity_checker`, focused on preventing silent interaction handling regressions
- hardens Discord interaction handling to return explicit ephemeral errors for:
  - unparseable interaction ingress
  - component interactions missing `custom_id`
  - empty select values for `bind_select` and `flow_runs_select`
- extends Discord + parity test coverage for malformed interaction payloads and component guard/error paths

## Why
We were finding Discord failures at runtime (slash actions or component interactions silently doing nothing). This shifts detection left by enforcing guard-path contracts in tests and static parity checks, while also making critical silent runtime paths explicit.

## Validation
- `make test-discord-contract`
- `.venv/bin/python -m pytest -q tests/integrations/discord`
- `.venv/bin/python -m pytest -q tests/integrations/chat/test_parity_checker.py tests/test_doctor_checks.py`
- `./scripts/check.sh`

## Notes
- Per request, implementation used regular subagents and a final subagent review pass before PR creation.
