### PR TITLE
fix(discord): add /car update parity and harden timeout/fatal paths

### DIFF
--- a/src/codex_autorunner/integrations/chat/command_contract.py
+++ b/src/codex_autorunner/integrations/chat/command_contract.py
@@ -42,6 +42,12 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         status="stable",
     ),
     CommandContractEntry(
+        id="car.update",
+        path=("car", "update"),
+        requires_bound_workspace=False,
+        status="stable",
+    ),
+    CommandContractEntry(
         id="pma.on",
         path=("pma", "on"),
         requires_bound_workspace=False,

--- a/src/codex_autorunner/integrations/discord/commands.py
+++ b/src/codex_autorunner/integrations/discord/commands.py
@@ -78,6 +78,19 @@ def build_application_commands() -> list[dict[str, Any]]:
                 },
                 {
                     "type": SUB_COMMAND,
+                    "name": "update",
+                    "description": "Update CAR service (both, web, telegram, or status)",
+                    "options": [
+                        {
+                            "type": STRING,
+                            "name": "target",
+                            "description": "Target: both, web, telegram, or status (default: both)",
+                            "required": False,
+                        }
+                    ],
+                },
+                {
+                    "type": SUB_COMMAND,
                     "name": "help",
                     "description": "Show available commands",
                 },

--- a/src/codex_autorunner/surfaces/cli/commands/discord.py
+++ b/src/codex_autorunner/surfaces/cli/commands/discord.py
@@ -85,8 +85,19 @@ def register_discord_commands(
             if not discord_cfg.enabled:
                 raise_exit("discord_bot is disabled; set discord_bot.enabled: true")
             logger = setup_rotating_logger("codex-autorunner-discord", config.log)
+            update_repo_url = config.update_repo_url
+            update_repo_ref = config.update_repo_ref
+            update_backend = config.update_backend
+            update_linux_service_names = config.update_linux_service_names
             service = create_discord_bot_service(
-                discord_cfg, logger=logger, manifest_path=config.manifest_path
+                discord_cfg,
+                logger=logger,
+                manifest_path=config.manifest_path,
+                update_repo_url=update_repo_url,
+                update_repo_ref=update_repo_ref,
+                update_skip_checks=config.update_skip_checks,
+                update_backend=update_backend,
+                update_linux_service_names=update_linux_service_names,
             )
             asyncio.run(service.run_forever())
         except DiscordBotConfigError as exc:

--- a/tests/integrations/chat/test_command_contract.py
+++ b/tests/integrations/chat/test_command_contract.py
@@ -26,6 +26,7 @@ def test_command_contract_contains_expected_commands() -> None:
         "car.model": (("car", "model"), True, "stable"),
         "car.status": (("car", "status"), False, "stable"),
         "car.new": (("car", "new"), True, "stable"),
+        "car.update": (("car", "update"), False, "stable"),
         "pma.on": (("pma", "on"), False, "stable"),
         "pma.off": (("pma", "off"), False, "stable"),
         "pma.status": (("pma", "status"), False, "stable"),

--- a/tests/integrations/discord/test_commands_payload.py
+++ b/tests/integrations/discord/test_commands_payload.py
@@ -27,6 +27,7 @@ def test_build_application_commands_structure_is_stable() -> None:
         "debug",
         "agent",
         "model",
+        "update",
         "help",
         "ids",
         "diff",
@@ -63,6 +64,9 @@ def test_required_options_are_marked_required() -> None:
     bind = _find_option(car_options, "bind")
     bind_workspace = _find_option(bind["options"], "workspace")
     assert bind_workspace["required"] is False
+    update = _find_option(car_options, "update")
+    update_target = _find_option(update["options"], "target")
+    assert update_target["required"] is False
 
     flow = _find_option(car_options, "flow")
     flow_reply = _find_option(flow["options"], "reply")


### PR DESCRIPTION
## Summary
This PR focuses on Discord runtime reliability and parity with Telegram while keeping the implementation small and test-guarded.

### Root cause confidence
Two concrete failure patterns were addressed:

1. **`/car new` interaction timeout risk**
   - `Discord` requires an interaction ack quickly.
   - The previous `/car new` path could do work before first response, which can produce `The application did not respond` under latency.
   - Fix: `/car new` now immediately sends a deferred ephemeral ack and completes via followup.

2. **Fatal gateway reconnect storm risk**
   - Fatal Discord gateway failures (token/intents/auth close codes) previously kept reconnecting.
   - This can lead to repeated reconnect pressure and token resets.
   - Fix: on fatal gateway failures, reconnect loop is halted and logs give explicit remediation (`fix token/intents/config and restart`).

## What changed
- Added **Discord `/car update` parity** (start update + status reporting):
  - Command payload includes `car update` with optional `target`.
  - Service routes and handles `("car", "update")`.
  - Supports `target: status` as status query.
  - Uses shared update worker plumbing (`_spawn_update_process`, `_read_update_status`) and hub update config.
- Wired Discord service startup with hub update settings:
  - `update_repo_url`, `update_repo_ref`, `update_skip_checks`, `update_backend`, `update_linux_service_names`.
- Hardened `/car new` interaction flow with deferred ack + followup response.
- Hardened gateway fatal behavior to avoid reconnect loops after fatal conditions.
- Extended contract/parity guardrails:
  - Added `car.update` to chat command contract.
  - Updated parity checker fixture and assertions.
  - Added test coverage for missing `car.update` route detection.

## Tests
All repository hooks passed on commit, including full test suite run in hooks:
- `1882 passed, 3 skipped`

Targeted relevant suites also passed during development:
- `tests/integrations/discord/*`
- `tests/integrations/chat/test_parity_checker.py`
- `tests/integrations/chat/test_command_contract.py`

## Notes
- I attempted to run subagents for parallel triage, but subagent spawning was unavailable in this runtime session (`spawn_agent` returned `aborted`). Work proceeded manually with focused tests and full hook validation.
