### PR TITLE
docs(discord): make invite permissions + no-response diagnosis explicit

### DIFF
--- a/docs/AGENT_SETUP_DISCORD_GUIDE.md
+++ b/docs/AGENT_SETUP_DISCORD_GUIDE.md
@@ -50,6 +50,9 @@ In Discord Developer Portal:
 4. Invite the bot to the server with OAuth scopes:
    - `bot`
    - `applications.commands`
+5. In `OAuth2 -> URL Generator`, set Bot Permissions (permissions integer):
+   - `2322563695115328`
+   - Re-invite the bot after changing permissions/scope settings.
 
 Set env vars:
 
@@ -131,7 +134,11 @@ Required or likely-needed permissions:
 
 1. Bot present in target server.
 2. `applications.commands` scope granted (for slash commands).
-3. Bot can send messages in the target channel.
+3. Bot can view and reply in target channels:
+   - `View Channels`
+   - `Send Messages`
+   - `Read Message History`
+   - `Send Messages in Threads` (if using threads)
 4. Operator can run slash commands in that channel.
 
 You usually do not need broad admin permissions for baseline CAR Discord usage.
@@ -219,6 +226,28 @@ If PMA is disabled globally in hub config, `/pma` commands will return an action
 2. Confirm workspace path exists on the CAR host.
 3. Run `car doctor` and check Discord check results for missing deps/env/state file issues.
 
+### Slash commands work, but normal messages get no response
+
+This usually means Discord command registration is fine, but the bot user cannot actually access guild/channel message events.
+
+1. Re-invite the bot with both scopes:
+   - `bot`
+   - `applications.commands`
+2. Use permissions integer:
+   - `2322563695115328`
+3. Confirm channel overrides do not deny:
+   - `View Channels`
+   - `Send Messages`
+   - `Read Message History`
+4. Restart Discord bot process after re-invite/permission changes.
+5. Re-test with:
+   - `/car status` (slash path)
+   - plain text message (non-slash turn path)
+
+High-signal diagnostics for this failure mode:
+- REST responses like `Missing Access (50001)` for channel lookups.
+- REST responses like `Unknown Guild (10004)` for expected guild IDs.
+
 ---
 
 ## Logs and Events to Check First
@@ -233,6 +262,8 @@ High-signal Discord events/logs:
 - `discord.pause_watch.scan_failed`
 - `discord.outbox.send_failed`
 - `Discord gateway error; reconnecting`
+- `Discord API request failed ... Missing Access`
+- `Discord API request failed ... Unknown Guild`
 
 Quick grep:
 

--- a/src/codex_autorunner/integrations/discord/doctor.py
+++ b/src/codex_autorunner/integrations/discord/doctor.py
@@ -18,6 +18,8 @@ from .config import (
 )
 from .constants import DISCORD_INTENT_MESSAGE_CONTENT
 
+RECOMMENDED_BOT_PERMISSIONS_INTEGER = "2322563695115328"
+
 
 def discord_doctor_checks(config: HubConfig) -> list[DoctorCheck]:
     """Run Discord-specific doctor checks for hub configuration."""
@@ -111,6 +113,22 @@ def discord_doctor_checks(config: HubConfig) -> list[DoctorCheck]:
                 severity="info",
             )
         )
+        checks.append(
+            DoctorCheck(
+                name="Discord invite URL",
+                passed=True,
+                message=(
+                    "Use this OAuth URL to (re)invite the bot with expected scopes "
+                    "and permissions. This often fixes the case where slash commands "
+                    "work but plain text turns do not.\n"
+                    f"https://discord.com/oauth2/authorize?client_id={app_id}"
+                    f"&permissions={RECOMMENDED_BOT_PERMISSIONS_INTEGER}"
+                    "&scope=bot%20applications.commands"
+                ),
+                check_id="discord.invite_url",
+                severity="info",
+            )
+        )
     else:
         checks.append(
             DoctorCheck(
@@ -119,6 +137,19 @@ def discord_doctor_checks(config: HubConfig) -> list[DoctorCheck]:
                 message=f"Discord application ID not found in environment: {app_id_env}",
                 check_id="discord.app_id",
                 fix=f"Set {app_id_env} environment variable.",
+            )
+        )
+        checks.append(
+            DoctorCheck(
+                name="Discord invite URL",
+                passed=True,
+                message=(
+                    "Set Discord application ID first, then generate a re-invite URL "
+                    "with scopes `bot applications.commands` and permissions integer "
+                    f"{RECOMMENDED_BOT_PERMISSIONS_INTEGER}."
+                ),
+                check_id="discord.invite_url",
+                severity="info",
             )
         )
 

--- a/src/codex_autorunner/surfaces/discord/README.md
+++ b/src/codex_autorunner/surfaces/discord/README.md
@@ -9,6 +9,7 @@ Discord bot surface and adapters.
 3. Invite the bot to your server with OAuth2 scopes:
    - `bot`
    - `applications.commands`
+   - Recommended permissions integer: `2322563695115328`
 4. Configure `discord_bot.enabled: true` and allowlists in `codex-autorunner.yml`.
 5. Configure command registration:
    - development: `command_registration.scope: guild` with at least one `guild_id`
@@ -21,6 +22,15 @@ Discord bot surface and adapters.
    - `car discord register-commands`
 
 Recommended during development: use guild-scoped command registration so command updates propagate quickly.
+
+## Common Failure Mode: Slash Works, Messages Do Not
+
+If `/car ...` works but normal channel messages do not get replies, the bot usually lacks effective guild/channel access.
+
+1. Re-invite bot with scopes `bot` + `applications.commands`.
+2. Use permissions integer `2322563695115328`.
+3. Ensure channel permissions allow `View Channels`, `Send Messages`, and `Read Message History`.
+4. Restart the Discord bot process and retest.
 
 ## Example config
 

--- a/tests/integrations/discord/test_doctor_checks.py
+++ b/tests/integrations/discord/test_doctor_checks.py
@@ -47,6 +47,8 @@ def test_discord_doctor_checks_missing_env_vars_are_failures(
     assert "TEST_DISCORD_TOKEN" in by_id["discord.bot_token"].message
     assert by_id["discord.app_id"].passed is False
     assert "TEST_DISCORD_APP_ID" in by_id["discord.app_id"].message
+    assert by_id["discord.invite_url"].passed is True
+    assert "2322563695115328" in by_id["discord.invite_url"].message
 
 
 def test_discord_doctor_checks_empty_allowlists_is_actionable_failure(
@@ -75,6 +77,12 @@ def test_discord_doctor_checks_empty_allowlists_is_actionable_failure(
     assert allowlist_check.passed is False
     assert allowlist_check.fix is not None
     assert "Configure at least one" in allowlist_check.fix
+
+    invite_check = next(
+        check for check in checks if check.check_id == "discord.invite_url"
+    )
+    assert invite_check.passed is True
+    assert "client_id=123456" in invite_check.message
 
 
 def test_discord_doctor_checks_legacy_message_content_intent_is_actionable_warning(


### PR DESCRIPTION
## Summary
- document the Discord OAuth invite permissions integer (`2322563695115328`) in onboarding/setup docs
- add an explicit troubleshooting path for the high-friction failure mode where slash commands work but plain-text chat turns do not
- surface a Discord re-invite URL directly in `car doctor` output (with required scopes + permissions integer)

## Why
We hit repeated incidents where Discord command sync appeared healthy but message turns were silent because bot access/permissions were not fully correct. This PR makes diagnosis and remediation obvious during setup.

## Changes
- `docs/AGENT_SETUP_DISCORD_GUIDE.md`
  - adds permissions-integer guidance in setup flow
  - adds channel permission checklist details
  - adds dedicated troubleshooting section for "slash works, messages don't"
  - adds concrete API error signatures (`Missing Access`, `Unknown Guild`)
- `src/codex_autorunner/surfaces/discord/README.md`
  - mirrors permissions integer and failure-mode guidance
- `src/codex_autorunner/integrations/discord/doctor.py`
  - adds `discord.invite_url` doctor check with actionable re-invite URL
- `tests/integrations/discord/test_doctor_checks.py`
  - asserts new `discord.invite_url` check behavior

## Validation
- `python3 -m pytest tests/integrations/discord/test_doctor_checks.py`
- full pre-commit pipeline passed during commit:
  - discord contract guardrails
  - black / ruff / mypy / eslint / static build
  - full pytest suite
