### PR TITLE
Discord: stream mid-turn progress state in-channel

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -29,6 +29,7 @@ from ...core.logging_utils import log_event
 from ...core.pma_context import build_hub_snapshot, format_pma_prompt, load_pma_prompt
 from ...core.pma_sink import PmaActiveSinkStore
 from ...core.ports.run_event import (
+    RUN_EVENT_DELTA_TYPE_USER_MESSAGE,
     ApprovalRequested,
     Completed,
     Failed,
@@ -739,6 +740,8 @@ class DiscordBotService:
                     if isinstance(run_event.session_id, str) and run_event.session_id:
                         session_from_events = run_event.session_id
                 elif isinstance(run_event, OutputDelta):
+                    if run_event.delta_type == RUN_EVENT_DELTA_TYPE_USER_MESSAGE:
+                        continue
                     if isinstance(run_event.content, str) and run_event.content.strip():
                         tracker.note_output(run_event.content)
                         await _edit_progress()


### PR DESCRIPTION
## Summary
- add Discord in-channel mid-turn visibility for plain-text turns using a single progress placeholder message
- stream progress via throttled message edits during turn execution (output deltas, tool calls, approvals, run notices)
- finalize progress message on completion/failure without changing existing final response chunk delivery
- keep progress updates best-effort: failures are logged and do not block turn completion

## Implementation details
- updated `DiscordBotService._run_agent_turn_for_message` to:
  - create a progress tracker and send initial `working` placeholder
  - map run events to tracker updates and edit the same placeholder message
  - throttle edit cadence to avoid Discord API spam
  - apply failure backoff on edit failures and disable edits after repeated failures
  - handle unexpected generator exceptions by marking progress as failed before propagating
- reused Telegram progress primitives (`TurnProgressTracker`, `render_progress_text`) and Discord truncation helper

## Tests
- extended `tests/integrations/discord/test_message_turns.py` with streaming-focused scenarios:
  - placeholder is posted before progress edits
  - final response still delivered after streaming
  - progress send/edit failures are best-effort and do not block completion
  - streaming generator exceptions mark progress failed and still surface turn failure message

## Validation run
- `make test-discord-contract`
- `.venv/bin/python -m pytest tests/integrations/discord/test_message_turns.py -q`
- `.venv/bin/python -m pytest tests/integrations/discord/test_service_routing.py tests/integrations/discord/test_outbox_retry.py -q`
- `.venv/bin/python -m ruff check src/codex_autorunner/integrations/discord/service.py tests/integrations/discord/test_message_turns.py`
- pre-commit hooks via `git commit`:
  - fast Discord guardrails
  - black
  - ruff
  - mypy
  - static build
  - full pytest suite (`1891 passed, 3 skipped`)
