### PR TITLE
fix(discord): Render markdown in Discord messages

### DIFF
--- a/tests/integrations/discord/test_rendering.py
+++ b/tests/integrations/discord/test_rendering.py
@@ -100,10 +100,11 @@ class TestFormatDiscordMessage:
         result = format_discord_message(text)
         assert "`code`" in result
 
-    def test_escapes_special_chars_outside_code(self) -> None:
-        text = "This is *bold* and _italic_"
+    def test_preserves_bold_and_italic(self) -> None:
+        text = "This is *italic* and **bold**"
         result = format_discord_message(text)
-        assert "\\_" in result
+        assert "*italic*" in result
+        assert "**bold**" in result
 
     def test_handles_empty_text(self) -> None:
         assert format_discord_message("") == ""


### PR DESCRIPTION
## Summary
- Root cause: Messages sent via Discord service were not going through the `format_discord_message` function, which properly handles Discord's markdown formatting
- This caused markdown like `**bold**` and `` `code` `` to appear as literal text instead of being rendered by Discord
- Fix: Apply `format_discord_message` to all messages that contain markdown characters (backticks for inline code, asterisks for bold/italic)
- Also fixed a test that incorrectly asserted markdown should be escaped

## Changes
- `src/codex_autorunner/integrations/discord/service.py`: Applied `format_discord_message` to all messages with markdown in:
  - Channel binding error messages
  - Help command output
  - Repository list
  - Agent/model status messages
  - Update status messages
- `tests/integrations/discord/test_rendering.py`: Fixed test to reflect correct Discord markdown behavior