### PR TITLE
fix(discord): increase REST client timeout from 10s to 30s

### DIFF
--- a/src/codex_autorunner/integrations/discord/rest.py
+++ b/src/codex_autorunner/integrations/discord/rest.py
@@ -23,7 +23,7 @@ class DiscordRestClient:
         self,
         *,
         bot_token: str,
-        timeout_seconds: float = 10.0,
+        timeout_seconds: float = 30.0,
         base_url: str = DISCORD_API_BASE_URL,
         max_retries: int = 3,
         retry_base_delay: float = 1.0,


### PR DESCRIPTION
## Summary
- Increase `DiscordRestClient` default timeout from 10s to 30s to match Telegram's `TelegramBotClient` default
- Fixes issue where progress message edits timeout when Discord API is slow, causing streaming to appear frozen after 3 failures

## Root Cause
The `DiscordRestClient` had a 10-second timeout for all HTTP requests. When editing the progress message during a turn took longer than 10s (due to slow Discord API), the edit would fail. After 3 consecutive failures (`service.py:702-705`), progress edits were disabled entirely, making it appear as if streaming stopped.

## Why Telegram Works
Telegram's `TelegramBotClient` (`adapter.py:974`) already uses `timeout_seconds: float = 30.0` as the default, which is why this issue wasn't observed on Telegram.

## Testing
- All 158 Discord integration tests pass
- Pre-commit checks pass (verified manually)