### PR TITLE
Add RuntimeServices caching to Discord for ticket flow

### DIFF
--- a/tests/integrations/discord/test_rendering.py
+++ b/tests/integrations/discord/test_rendering.py
@@ -100,10 +100,11 @@ class TestFormatDiscordMessage:
         result = format_discord_message(text)
         assert "`code`" in result
 
-    def test_escapes_special_chars_outside_code(self) -> None:
-        text = "This is *bold* and _italic_"
+    def test_preserves_bold_and_italic(self) -> None:
+        text = "This is *italic* and **bold**"
         result = format_discord_message(text)
-        assert "\\_" in result
+        assert "*italic*" in result
+        assert "**bold**" in result
 
     def test_handles_empty_text(self) -> None:
         assert format_discord_message("") == ""


### PR DESCRIPTION
## Summary

- Discord was calling `build_ticket_flow_controller()` directly each time, creating a new `BackendOrchestrator` and losing session/thread state between turns
- This caused agents to stop running after a while (the root cause of the Discord issue where Telegram works fine)
- Now uses `RuntimeServices` (like Telegram does) to cache the ticket flow controller per workspace, preserving session state across turns

## Changes

- Added `RuntimeServices` to Discord service with `flow_runtime_builder`
- Updated all `build_ticket_flow_controller()` calls to use `self._runtime_services.get_ticket_flow_controller()`
- Added proper cleanup of `RuntimeServices` in the `_shutdown` method