### PR TITLE
Fix app-server disconnect handling for in-flight turns

### DIFF
--- a/src/codex_autorunner/integrations/app_server/client.py
+++ b/src/codex_autorunner/integrations/app_server/client.py
@@ -1559,7 +1559,11 @@ class CodexAppServerClient:
             stderr_tail=list(self._stderr_tail),
         )
         disconnect_error = CodexAppServerDisconnected("App-server disconnected")
-        preserve_turns = self._auto_restart and not self._closed
+        preserve_turns = (
+            self._auto_restart
+            and not self._closed
+            and self._turn_stall_timeout_seconds is not None
+        )
         self._fail_pending(
             disconnect_error,
             include_turns=not preserve_turns,


### PR DESCRIPTION
## Summary
- Fixes a disconnect-handling gap in `CodexAppServerClient` that could break ticket-flow turns right after initial reasoning output.
- `CodexAppServerClient._handle_disconnect()` now:
  - always fails pending request futures on disconnect;
  - preserves active turn futures only for recoverable auto-restart disconnects;
  - still fails active turns when the client is closed (prevents stuck/hanging `handle.wait()`).
- Refactors `_fail_pending(...)` to support selective failure of requests vs turn futures.

## Why
Investigation of flow `2795a77b-dc04-4168-afe7-9a77f13dc94c` showed:
- stream/events stop after the first reasoning summary,
- worker remains active with no terminal flow event,
- worker stderr contains `app_server.disconnected` with `active_turns: 1`.

This pointed to disconnect semantics around in-flight turn futures: we need to preserve turns for recoverable reconnects, but force-fail them when the client is already closed.

## Tests
Added regression tests in `tests/test_app_server_client.py`:
- `test_disconnect_with_autorestart_preserves_active_turns`
- `test_disconnect_when_closed_fails_active_turns`

Local verification:
- `./.venv/bin/pytest tests/test_app_server_client.py -q`
- `./.venv/bin/pytest tests/test_backend_run_event_contract.py -q`
- Full pre-commit/CI gate run during commit (including full pytest) passed.
