### PR TITLE
Remove part-number prefixes from Telegram/Discord split messages

### DIFF
--- a/src/codex_autorunner/integrations/discord/adapter.py
+++ b/src/codex_autorunner/integrations/discord/adapter.py
@@ -63,7 +63,7 @@ class DiscordTextRenderer(TextRenderer):
     ) -> tuple[RenderedText, ...]:
         limit = max_length or DISCORD_MAX_MESSAGE_LENGTH
         chunks = chunk_discord_message(
-            rendered.text, max_len=limit, with_numbering=True
+            rendered.text, max_len=limit, with_numbering=False
         )
         return tuple(RenderedText(text=chunk, parse_mode=None) for chunk in chunks)
 

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -631,7 +631,7 @@ class DiscordBotService:
         chunks = chunk_discord_message(
             response_text or "(No response text returned.)",
             max_len=self._config.max_message_length,
-            with_numbering=True,
+            with_numbering=False,
         )
         if not chunks:
             chunks = ["(No response text returned.)"]
@@ -1703,7 +1703,7 @@ class DiscordBotService:
             chunks = chunk_discord_message(
                 snapshot.dispatch_markdown,
                 max_len=self._config.max_message_length,
-                with_numbering=True,
+                with_numbering=False,
             )
             if not chunks:
                 chunks = ["(pause notification had no content)"]

--- a/src/codex_autorunner/integrations/pma_delivery.py
+++ b/src/codex_autorunner/integrations/pma_delivery.py
@@ -121,7 +121,7 @@ async def deliver_pma_output_to_active_sink(
     chat_id, thread_id = target
 
     chunks = chunk_text(
-        assistant_text, max_len=TELEGRAM_MAX_MESSAGE_LENGTH, with_numbering=True
+        assistant_text, max_len=TELEGRAM_MAX_MESSAGE_LENGTH, with_numbering=False
     )
     if not chunks:
         return False
@@ -175,7 +175,7 @@ async def _deliver_to_discord(
         discord_state_path = hub_root / ".codex-autorunner" / "discord_state.sqlite3"
 
     chunks = chunk_text(
-        assistant_text, max_len=DISCORD_MAX_MESSAGE_LENGTH, with_numbering=True
+        assistant_text, max_len=DISCORD_MAX_MESSAGE_LENGTH, with_numbering=False
     )
     if not chunks:
         return False

--- a/src/codex_autorunner/integrations/telegram/adapter.py
+++ b/src/codex_autorunner/integrations/telegram/adapter.py
@@ -1260,7 +1260,7 @@ class TelegramBotClient:
         disable_web_page_preview: bool = True,
         max_len: int = TELEGRAM_MAX_MESSAGE_LENGTH,
     ) -> list[dict[str, Any]]:
-        chunks = chunk_message(text, max_len=max_len, with_numbering=True)
+        chunks = chunk_message(text, max_len=max_len, with_numbering=False)
         if not chunks:
             return []
         responses: list[dict[str, Any]] = []

--- a/src/codex_autorunner/integrations/telegram/ticket_flow_bridge.py
+++ b/src/codex_autorunner/integrations/telegram/ticket_flow_bridge.py
@@ -401,7 +401,7 @@ class TelegramTicketFlowBridge:
             chunks = chunk_message(
                 full_text,
                 max_len=TELEGRAM_MAX_MESSAGE_LENGTH,
-                with_numbering=True,
+                with_numbering=False,
             )
         else:
             chunks = [full_text]

--- a/src/codex_autorunner/integrations/telegram/transport.py
+++ b/src/codex_autorunner/integrations/telegram/transport.py
@@ -308,6 +308,7 @@ class TelegramMessageTransport:
                         text,
                         max_len=TELEGRAM_MAX_MESSAGE_LENGTH,
                         render=split_renderer,
+                        include_indicator=False,
                     )
                     for idx, chunk in enumerate(chunks):
                         await self._bot.send_message(

--- a/tests/integrations/discord/test_adapter.py
+++ b/tests/integrations/discord/test_adapter.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import asyncio
 
 from codex_autorunner.integrations.chat.models import ChatMessageEvent
-from codex_autorunner.integrations.discord.adapter import DiscordChatAdapter
+from codex_autorunner.integrations.chat.renderer import RenderedText
+from codex_autorunner.integrations.discord.adapter import (
+    DiscordChatAdapter,
+    DiscordTextRenderer,
+)
 
 
 class _UnusedRestClient:
@@ -126,3 +130,13 @@ def test_adapter_parses_attachment_source_url_metadata() -> None:
     assert proxy_attachment.source_url == (
         "https://media.discordapp.net/attachments/alt.png"
     )
+
+
+def test_discord_text_renderer_split_text_has_no_part_prefix() -> None:
+    renderer = DiscordTextRenderer()
+    rendered = RenderedText(text=("alpha " * 500), parse_mode=None)
+
+    chunks = renderer.split_text(rendered, max_length=120)
+
+    assert len(chunks) > 1
+    assert all(not chunk.text.startswith("Part ") for chunk in chunks)

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -520,6 +520,10 @@ async def test_send_message_chunks_long_text() -> None:
     second_payload = calls[1]["payload"]
     assert "reply_markup" in first_payload
     assert "reply_markup" not in second_payload
+    assert isinstance(first_payload.get("text"), str)
+    assert isinstance(second_payload.get("text"), str)
+    assert not first_payload["text"].startswith("Part ")
+    assert not second_payload["text"].startswith("Part ")
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_ticket_flow_bridge.py
+++ b/tests/test_telegram_ticket_flow_bridge.py
@@ -85,6 +85,7 @@ async def test_pause_dispatch_sends_text_and_attachments(tmp_path: Path) -> None
 
     # Chunked text should produce more than one message
     assert len(calls) >= 2
+    assert all(not text.startswith("Part ") for _, text, _ in calls)
     assert docs == ["note.txt"]
     assert record.last_ticket_dispatch_seq == "run1:0001"
 


### PR DESCRIPTION
## Summary
- remove `Part x/y` chunk prefixes from Telegram message splitting (`send_message_chunks`)
- remove chunk indicators from Telegram markdown overflow splitting so split messages stay contiguous
- remove `Part x/y` chunk prefixes from Discord split message paths (adapter renderer + service pause/turn delivery)
- align PMA Telegram/Discord sink delivery to split without part metadata

## Tests
- `.venv/bin/python -m pytest tests/test_telegram_adapter.py -k "send_message_chunks_long_text"`
- `.venv/bin/python -m pytest tests/test_telegram_ticket_flow_bridge.py`
- `.venv/bin/python -m pytest tests/integrations/discord/test_pause_bridge.py`
- `.venv/bin/python -m pytest tests/integrations/test_pma_delivery_routing.py`
- `.venv/bin/python -m pytest tests/integrations/discord/test_adapter.py`
- pre-commit hook suite on commit (includes full pytest)
