### PR TITLE
discord: show queued notice for backlogged message turns

### DIFF
--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import subprocess
 from pathlib import Path
@@ -1704,6 +1705,87 @@ async def test_message_create_attachment_only_resumes_paused_flow_run(
             for msg in rest.channel_messages
         )
     finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_message_create_sends_queued_notice_when_dispatch_queue_is_busy(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            ("MESSAGE_CREATE", _message_create("first message", message_id="m-1")),
+            ("MESSAGE_CREATE", _message_create("second message", message_id="m-2")),
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    turn_count = 0
+
+    async def _fake_run_turn(
+        self,
+        *,
+        workspace_root: Path,
+        prompt_text: str,
+        agent: str,
+        model_override: Optional[str],
+        reasoning_effort: Optional[str],
+        session_key: str,
+        orchestrator_channel_key: str,
+    ) -> str:
+        nonlocal turn_count
+        turn_count += 1
+        if turn_count == 1:
+            first_started.set()
+            await release_first.wait()
+            return "first reply"
+        return "second reply"
+
+    service._run_agent_turn_for_message = _fake_run_turn.__get__(
+        service, DiscordBotService
+    )
+
+    async def _release_later() -> None:
+        await first_started.wait()
+        await asyncio.sleep(0.05)
+        release_first.set()
+
+    release_task = asyncio.create_task(_release_later())
+    try:
+        await asyncio.wait_for(service.run_forever(), timeout=5)
+        contents = [msg["payload"].get("content", "") for msg in rest.channel_messages]
+        assert any(
+            "Queued (waiting for available worker...)" in content
+            for content in contents
+        )
+        assert any("first reply" in content for content in contents)
+        assert any("second reply" in content for content in contents)
+    finally:
+        if not release_task.done():
+            release_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await release_task
         await store.close()
 
 

--- a/tests/integrations/test_chat_dispatcher_queueing.py
+++ b/tests/integrations/test_chat_dispatcher_queueing.py
@@ -123,6 +123,8 @@ async def test_dispatcher_dedupe_hook_short_circuits_processing() -> None:
 
     assert duplicate_result.status == "duplicate"
     assert accepted_result.status == "queued"
+    assert accepted_result.queued_pending == 1
+    assert accepted_result.queued_while_busy is False
     assert seen == ["ok"]
 
 
@@ -178,6 +180,8 @@ async def test_dispatcher_supports_custom_bypass_rules() -> None:
 
     assert queued.status == "queued"
     assert queued.bypassed is False
+    assert queued.queued_while_busy is True
+    assert queued.queued_pending == 1
     assert bypassed.status == "dispatched"
     assert bypassed.bypassed is True
     assert observed[:4] == ["normal-1-start", "bypass", "normal-1-end", "queued"]


### PR DESCRIPTION
## Summary
Align Discord message-turn queue UX with Telegram by sending an explicit queued notice when a user message is admitted while a conversation is already busy.

## Problem
Telegram tells users when their message is queued (`Queued (waiting for available worker...)`).
Discord queued turns internally but provided no user-visible signal, making it look like the bot ignored the message.

## What Changed
- Extended `DispatchResult` with queue context:
  - `queued_pending`
  - `queued_while_busy`
- Updated `ChatDispatcher._enqueue` to return queue depth and whether the conversation already had in-flight/queued work.
- Added Discord queued-notice handling in `DiscordBotService`:
  - centralized dispatch path via `_dispatch_chat_event`
  - `_maybe_send_queued_notice` sends `Queued (waiting for available worker...)` only when:
    - dispatch status is `queued`
    - `queued_while_busy` is true
    - event is a turn-candidate message (same basic turn-gate checks)
- Wired both Discord ingress paths (`_on_dispatch` and adapter poll loop) through the same dispatch/notice flow.

## Tests
- Added dispatcher assertions for new queue metadata:
  - `tests/integrations/test_chat_dispatcher_queueing.py`
- Added Discord integration coverage for busy-queue notice behavior:
  - `tests/integrations/discord/test_message_turns.py`

## Verification
- `python -m pytest tests/integrations/test_chat_dispatcher_queueing.py tests/integrations/discord/test_message_turns.py -q`
  - `35 passed`
- Commit-time checks on the source commit also passed (includes full repo pytest, lint, mypy, static build).
