### PR TITLE
Fix /newt base repo resolution when worktree metadata is missing

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -80,7 +80,9 @@ if TYPE_CHECKING:
 _model_list_with_agent_compat = _workspace_model_list_with_agent_compat
 
 
-def _resolve_base_repo_id(repo_entry: object) -> Optional[str]:
+def _resolve_base_repo_id(
+    repo_entry: object, *, manifest_repos: Optional[Sequence[object]] = None
+) -> Optional[str]:
     worktree_of = getattr(repo_entry, "worktree_of", None)
     if isinstance(worktree_of, str) and worktree_of.strip():
         return worktree_of.strip()
@@ -90,11 +92,28 @@ def _resolve_base_repo_id(repo_entry: object) -> Optional[str]:
         return None
     repo_id = repo_id.strip()
 
-    if getattr(repo_entry, "kind", None) == "worktree" and "--" in repo_id:
-        base_repo_id, _ = repo_id.split("--", 1)
-        if base_repo_id:
-            return base_repo_id
-        return None
+    if getattr(repo_entry, "kind", None) == "worktree":
+        if manifest_repos:
+            candidates: list[str] = []
+            for candidate in manifest_repos:
+                candidate_id = getattr(candidate, "id", None)
+                if not isinstance(candidate_id, str):
+                    continue
+                candidate_id = candidate_id.strip()
+                if not candidate_id:
+                    continue
+                if getattr(candidate, "kind", None) == "worktree":
+                    continue
+                if repo_id == candidate_id or repo_id.startswith(f"{candidate_id}--"):
+                    candidates.append(candidate_id)
+            if candidates:
+                return max(candidates, key=len)
+
+        if "--" in repo_id:
+            inferred_base, _ = repo_id.rsplit("--", 1)
+            if inferred_base:
+                return inferred_base
+            return None
 
     return repo_id
 
@@ -1366,7 +1385,7 @@ class WorkspaceCommands(SharedHelpers):
             )
             return
 
-        base_repo_id = _resolve_base_repo_id(repo_entry)
+        base_repo_id = _resolve_base_repo_id(repo_entry, manifest_repos=manifest.repos)
 
         if not base_repo_id:
             await self._send_message(

--- a/tests/integrations/discord/test_newt_base_repo_id.py
+++ b/tests/integrations/discord/test_newt_base_repo_id.py
@@ -22,3 +22,21 @@ def test_resolve_base_repo_id_infers_from_worktree_repo_id() -> None:
 
     assert discord_service_module._resolve_base_repo_id(repo_entry) == "base-repo"
 
+
+def test_resolve_base_repo_id_prefers_longest_manifest_prefix_match() -> None:
+    repo_entry = SimpleNamespace(
+        kind="worktree",
+        id="ml--infra--thread--chat-123",
+        worktree_of=None,
+    )
+    manifest_repos = [
+        SimpleNamespace(kind="base", id="ml"),
+        SimpleNamespace(kind="base", id="ml--infra"),
+    ]
+
+    assert (
+        discord_service_module._resolve_base_repo_id(
+            repo_entry, manifest_repos=manifest_repos
+        )
+        == "ml--infra"
+    )

--- a/tests/test_telegram_pma_routing.py
+++ b/tests/test_telegram_pma_routing.py
@@ -811,9 +811,10 @@ async def test_newt_branch_name_includes_chat_identity(
     )
     handler = _NewtHandler(record, hub_root=hub_root)
     manifest_stub = SimpleNamespace(
+        repos=[SimpleNamespace(kind="base", id="base-repo")],
         get_by_path=lambda _hub_root, _workspace_root: SimpleNamespace(
             kind="repo", id="base-repo", worktree_of=None
-        )
+        ),
     )
     monkeypatch.setattr(
         workspace_commands_module, "load_manifest", lambda *_: manifest_stub
@@ -850,11 +851,12 @@ async def test_newt_infers_base_repo_from_worktree_id_when_missing_metadata(
     )
     handler = _NewtHandler(record, hub_root=hub_root)
     manifest_stub = SimpleNamespace(
+        repos=[SimpleNamespace(kind="base", id="base-repo")],
         get_by_path=lambda _hub_root, _workspace_root: SimpleNamespace(
             kind="worktree",
             id="base-repo--thread-chat-7777-thread-333",
             worktree_of=None,
-        )
+        ),
     )
     monkeypatch.setattr(
         workspace_commands_module, "load_manifest", lambda *_: manifest_stub
@@ -883,6 +885,51 @@ async def test_newt_infers_base_repo_from_worktree_id_when_missing_metadata(
 
 
 @pytest.mark.anyio
+async def test_newt_prefers_longest_manifest_base_match_for_worktree_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hub_root = tmp_path / "hub"
+    workspace = hub_root / "worktrees" / "ml--infra--thread--chat-7777-thread-333"
+    workspace.mkdir(parents=True)
+    record = TelegramTopicRecord(
+        workspace_path=str(workspace),
+        thread_ids=["old-thread"],
+        active_thread_id="old-thread",
+    )
+    handler = _NewtHandler(record, hub_root=hub_root)
+    manifest_stub = SimpleNamespace(
+        repos=[
+            SimpleNamespace(kind="base", id="ml"),
+            SimpleNamespace(kind="base", id="ml--infra"),
+        ],
+        get_by_path=lambda _hub_root, _workspace_root: SimpleNamespace(
+            kind="worktree",
+            id="ml--infra--thread--chat-7777-thread-333",
+            worktree_of=None,
+        ),
+    )
+    monkeypatch.setattr(
+        workspace_commands_module, "load_manifest", lambda *_: manifest_stub
+    )
+    message = TelegramMessage(
+        update_id=100,
+        message_id=200,
+        chat_id=-7777,
+        thread_id=333,
+        from_user_id=42,
+        text="/newt",
+        date=None,
+        is_topic_message=True,
+    )
+
+    await handler._handle_newt(message)
+
+    calls = handler._hub_supervisor.create_calls
+    assert len(calls) == 1
+    assert calls[0]["base_repo_id"] == "ml--infra"
+
+
+@pytest.mark.anyio
 async def test_newt_thread_fallback_and_workspace_state_reset(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -901,9 +948,10 @@ async def test_newt_thread_fallback_and_workspace_state_reset(
     )
     handler = _NewtHandler(record, hub_root=hub_root)
     manifest_stub = SimpleNamespace(
+        repos=[SimpleNamespace(kind="base", id="base-repo")],
         get_by_path=lambda _hub_root, _workspace_root: SimpleNamespace(
             kind="repo", id="base-repo", worktree_of=None
-        )
+        ),
     )
     monkeypatch.setattr(
         workspace_commands_module, "load_manifest", lambda *_: manifest_stub


### PR DESCRIPTION
## Summary
- fix `/newt` base repository resolution when the bound workspace is a worktree entry missing `worktree_of`
- add a fallback that infers base repo id from worktree repo ids formatted as `<base_repo_id>--<branch>`
- apply the same resolution logic to both Telegram `/newt` and Discord `/car newt`

## Why this fixes the issue
Previously, `/newt` only used `repo_entry.worktree_of` for worktree repos. If that metadata was absent, it always replied:
`Could not determine base repository for worktree creation.`

Now it falls back to the worktree repo id prefix, so worktree-scoped topics can still create a new sibling worktree.

## Tests
- added `test_newt_infers_base_repo_from_worktree_id_when_missing_metadata`
- added `tests/integrations/discord/test_newt_base_repo_id.py`
- ran targeted tests:
  - `.venv/bin/pytest tests/test_telegram_pma_routing.py -k newt tests/integrations/discord/test_newt_base_repo_id.py`
- dogfooding/validation via repo hooks on commit (full suite):
  - `1965 passed, 3 skipped`
