### PR TITLE
Add conversation IDs to Discord turn failure errors

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -837,13 +837,19 @@ class DiscordBotService:
                 logging.WARNING,
                 "discord.turn.failed",
                 channel_id=channel_id,
+                conversation_id=context.conversation_id,
                 workspace_root=str(workspace_root),
                 agent=agent,
                 exc=exc,
             )
             await self._send_channel_message_safe(
                 channel_id,
-                {"content": f"Turn failed: {exc}"},
+                {
+                    "content": (
+                        f"Turn failed: {exc} "
+                        f"(conversation {context.conversation_id})"
+                    )
+                },
             )
             return
 

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -1561,7 +1561,8 @@ async def test_message_create_streaming_turn_exception_marks_progress_failed(
             for msg in rest.edited_channel_messages
         )
         assert any(
-            "Turn failed: boom" in msg["payload"].get("content", "")
+            "Turn failed: boom (conversation discord:channel-1:guild-1)"
+            in msg["payload"].get("content", "")
             for msg in rest.channel_messages
         )
     finally:


### PR DESCRIPTION
## Summary
- include `conversation_id` in `discord.turn.failed` structured logs
- append `(conversation <id>)` to Discord turn failure messages sent to channel
- update Discord turn-failure test to assert the new traceability suffix

## Testing
- `.venv/bin/pytest tests/integrations/discord/test_message_turns.py`
- pre-commit hooks run during commit (including full pytest suite)
