### PR TITLE
Audit: harden Discord token cache bounds and guard-path parity tests

### DIFF
--- a/tests/integrations/chat/test_parity_checker.py
+++ b/tests/integrations/chat/test_parity_checker.py
@@ -135,6 +135,46 @@ def test_parity_checker_fails_when_parse_error_response_is_missing(
     )
 
 
+def test_parity_checker_fails_when_bind_component_value_guard_missing(
+    tmp_path: Path,
+) -> None:
+    repo_root = _write_fixture_repo(
+        tmp_path,
+        include_component_bind_value_response=False,
+    )
+
+    results_by_id = {
+        result.id: result for result in run_parity_checks(repo_root=repo_root)
+    }
+
+    guard_check = results_by_id["discord.interaction_component_guard_paths"]
+    assert not guard_check.passed
+    assert (
+        "component_bind_selection_requires_value"
+        in guard_check.metadata["failed_predicates"]
+    )
+
+
+def test_parity_checker_fails_when_flow_runs_component_value_guard_missing(
+    tmp_path: Path,
+) -> None:
+    repo_root = _write_fixture_repo(
+        tmp_path,
+        include_component_flow_runs_value_response=False,
+    )
+
+    results_by_id = {
+        result.id: result for result in run_parity_checks(repo_root=repo_root)
+    }
+
+    guard_check = results_by_id["discord.interaction_component_guard_paths"]
+    assert not guard_check.passed
+    assert (
+        "component_flow_runs_selection_requires_value"
+        in guard_check.metadata["failed_predicates"]
+    )
+
+
 def test_parity_checker_fails_when_shared_helper_usage_is_missing(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
Audit-driven follow-up for recent Discord parity work:

- bound Discord adapter interaction token caches to prevent unbounded growth under sustained traffic
- add deterministic cache insertion/eviction helper and apply it to both interaction tokens and follow-up message token tracking
- expand parity checker tests to enforce component guard predicates for:
  - `bind_select` requiring a selected repo value
  - `flow_runs_select` requiring a selected run value
- add Discord adapter tests validating both cache bounds paths

## Why
Subagent audit findings identified:
- a memory growth/code-smell risk in unbounded token maps in `DiscordChatAdapter`
- missing parity checker test coverage for two guard paths that are required for Discord/Telegram parity drift detection

## Validation
- `tests/integrations/discord/test_adapter.py`
- `tests/integrations/chat/test_parity_checker.py`
- `tests/integrations/discord/test_service_routing.py`
- full pre-commit suite (lint/type/build/full pytest) during commit
