### PR TITLE
Fix Discord compact flow: remove part labels and add continue state

### DIFF
--- a/src/codex_autorunner/integrations/discord/components.py
+++ b/src/codex_autorunner/integrations/discord/components.py
@@ -199,3 +199,18 @@ def build_cancel_turn_button(
             )
         ]
     )
+
+
+def build_continue_turn_button(
+    *,
+    custom_id: str = "continue_turn",
+) -> dict[str, Any]:
+    return build_action_row(
+        [
+            build_button(
+                "Continue",
+                custom_id,
+                style=DISCORD_BUTTON_STYLE_SUCCESS,
+            )
+        ]
+    )

--- a/tests/integrations/discord/test_components.py
+++ b/tests/integrations/discord/test_components.py
@@ -7,6 +7,7 @@ from codex_autorunner.integrations.discord.components import (
     build_action_row,
     build_bind_picker,
     build_button,
+    build_continue_turn_button,
     build_flow_runs_picker,
     build_flow_status_buttons,
     build_select_menu,
@@ -124,3 +125,13 @@ class TestBuildFlowRunsPicker:
         menu = picker["components"][0]
         assert len(menu["options"]) == 1
         assert menu["options"][0]["value"] == "none"
+
+
+class TestTurnButtons:
+    def test_build_continue_turn_button(self) -> None:
+        row = build_continue_turn_button()
+        assert row["type"] == 1
+        button = row["components"][0]
+        assert button["label"] == "Continue"
+        assert button["custom_id"] == "continue_turn"
+        assert button["style"] == DISCORD_BUTTON_STYLE_SUCCESS


### PR DESCRIPTION
## Summary
- remove `Part x/y` numbering from `/car session compact` final summary output in Discord
- ensure compact completion no longer leaves a stale `Cancel` button on the progress message
- add an explicit `Continue` button/state after compact completes so users can clearly continue or start new with `/car new`
- handle `continue_turn` interaction in both raw and normalized component paths
- add fallback behavior: if preview edit fails, send first compact chunk with `Continue` button

## Why
Compact currently looked unfinished in Discord:
- summary chunks could still show `Part 1/3`
- the red `Cancel` button could remain after completion
- there was no clear post-compact “continue” affordance

## Testing
- pre-commit/hooks passed during commit (including full pytest run): `2067 passed, 3 skipped`
- targeted regression checks:
  - `.venv/bin/python -m pytest tests/integrations/discord/test_components.py tests/integrations/discord/test_message_turns.py -k "continue_turn_button or car_session_compact_reuses_preview_without_part_numbering or message_create_streaming_turn_completion_sends_final_and_deletes_preview"`
  - result: `3 passed`

## Files
- `src/codex_autorunner/integrations/discord/components.py`
- `src/codex_autorunner/integrations/discord/service.py`
- `tests/integrations/discord/test_components.py`
- `tests/integrations/discord/test_message_turns.py`
