### PR TITLE
Harden PMA ticket-flow state contract and reliability

### DIFF
--- a/docs/STATE_ROOTS.md
+++ b/docs/STATE_ROOTS.md
@@ -32,6 +32,7 @@ All durable artifacts must live under one of these roots:
 **Notable repo-local artifacts**:
 - `flows/<run_id>/chat/inbound.jsonl` - Mirrored inbound chat events for a flow run
 - `flows/<run_id>/chat/outbound.jsonl` - Mirrored outbound chat events for a flow run
+- `tickets/ingest_state.json` - Canonical ticket-ingest receipt (`ingested`, `ingested_at`, `source`)
 
 **Resolution**: `resolve_repo_state_root(repo_root)` in `core/state_roots.py`
 

--- a/src/codex_autorunner/core/lifecycle_events.py
+++ b/src/codex_autorunner/core/lifecycle_events.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 LIFECYCLE_EVENTS_FILENAME = "lifecycle_events.json"
 LIFECYCLE_EVENTS_LOCK_SUFFIX = ".lock"
+TRANSITION_TOKEN_KEY = "transition_token"
 
 
 class LifecycleEventType(str, Enum):
@@ -45,6 +46,12 @@ class LifecycleEvent:
             object.__setattr__(self, "event_id", str(uuid.uuid4()))
 
 
+@dataclass
+class LifecycleEventAppendResult:
+    event: LifecycleEvent
+    deduped: bool = False
+
+
 def default_lifecycle_events_path(hub_root: Path) -> Path:
     return hub_root / ".codex-autorunner" / LIFECYCLE_EVENTS_FILENAME
 
@@ -60,68 +67,152 @@ class LifecycleEventStore:
     def _lock_path(self) -> Path:
         return self._path.with_suffix(LIFECYCLE_EVENTS_LOCK_SUFFIX)
 
+    @staticmethod
+    def _is_terminal_flow_event(event_type: LifecycleEventType) -> bool:
+        return event_type in {
+            LifecycleEventType.FLOW_COMPLETED,
+            LifecycleEventType.FLOW_FAILED,
+            LifecycleEventType.FLOW_STOPPED,
+        }
+
+    @staticmethod
+    def _extract_transition_token(data: dict[str, Any]) -> Optional[str]:
+        raw = data.get(TRANSITION_TOKEN_KEY)
+        if isinstance(raw, str):
+            token = raw.strip()
+            if token:
+                return token
+        return None
+
+    def _semantic_identity(self, event: LifecycleEvent) -> tuple[str, ...]:
+        key: tuple[str, ...] = (
+            event.event_type.value,
+            event.repo_id,
+            event.run_id,
+        )
+        token = self._extract_transition_token(event.data)
+        if token:
+            key = (*key, token)
+        return key
+
+    @staticmethod
+    def _parse_duplicate_count(value: Any) -> int:
+        if isinstance(value, bool):
+            return int(value)
+        if isinstance(value, int):
+            return value if value >= 0 else 0
+        if isinstance(value, str):
+            try:
+                parsed = int(value.strip())
+                return parsed if parsed >= 0 else 0
+            except Exception:
+                return 0
+        return 0
+
+    @staticmethod
+    def _resolve_first_seen_at(
+        existing: LifecycleEvent,
+        event_data: dict[str, Any],
+        *,
+        fallback: str,
+    ) -> str:
+        first_seen = event_data.get("first_seen_at")
+        if isinstance(first_seen, str) and first_seen.strip():
+            return first_seen.strip()
+        if isinstance(existing.timestamp, str) and existing.timestamp.strip():
+            return existing.timestamp.strip()
+        return fallback
+
+    def _annotate_duplicate(
+        self,
+        existing: LifecycleEvent,
+        *,
+        duplicate_seen_at: str,
+    ) -> None:
+        data = dict(existing.data or {})
+        duplicate_count = self._parse_duplicate_count(data.get("duplicate_count"))
+        first_seen_at = self._resolve_first_seen_at(
+            existing, data, fallback=duplicate_seen_at
+        )
+        data["duplicate_count"] = duplicate_count + 1
+        data["first_seen_at"] = first_seen_at
+        data["last_seen_at"] = duplicate_seen_at
+        existing.data = data
+
+    def _find_duplicate_terminal_event(
+        self, events: list[LifecycleEvent], candidate: LifecycleEvent
+    ) -> Optional[LifecycleEvent]:
+        if not self._is_terminal_flow_event(candidate.event_type):
+            return None
+        candidate_key = self._semantic_identity(candidate)
+        for existing in events:
+            if not self._is_terminal_flow_event(existing.event_type):
+                continue
+            if self._semantic_identity(existing) == candidate_key:
+                return existing
+        return None
+
+    def _load_unlocked(self) -> list[LifecycleEvent]:
+        if not self._path.exists():
+            return []
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.warning("Failed to read lifecycle events at %s: %s", self._path, exc)
+            return []
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "Failed to parse lifecycle events at %s: %s", self._path, exc
+            )
+            return []
+        if not isinstance(data, list):
+            logger.warning("Lifecycle events data is not a list: %s", self._path)
+            return []
+        events: list[LifecycleEvent] = []
+        for entry in data:
+            try:
+                if not isinstance(entry, dict):
+                    continue
+                event_type_str = entry.get("event_type")
+                if not isinstance(event_type_str, str):
+                    continue
+                try:
+                    event_type = LifecycleEventType(event_type_str)
+                except ValueError:
+                    continue
+                event_id_raw = entry.get("event_id")
+                event_id = str(event_id_raw) if isinstance(event_id_raw, str) else ""
+                if not event_id:
+                    import uuid
+
+                    event_id = str(uuid.uuid4())
+                origin_raw = entry.get("origin")
+                origin = (
+                    str(origin_raw).strip()
+                    if isinstance(origin_raw, str) and origin_raw.strip()
+                    else "system"
+                )
+                event = LifecycleEvent(
+                    event_type=event_type,
+                    repo_id=str(entry.get("repo_id", "")),
+                    run_id=str(entry.get("run_id", "")),
+                    data=dict(entry.get("data", {})),
+                    origin=origin,
+                    timestamp=str(entry.get("timestamp", "")),
+                    processed=bool(entry.get("processed", False)),
+                    event_id=event_id,
+                )
+                events.append(event)
+            except Exception as exc:
+                logger.debug("Failed to parse lifecycle event entry: %s", exc)
+                continue
+        return events
+
     def load(self, *, ensure_exists: bool = True) -> list[LifecycleEvent]:
         with file_lock(self._lock_path()):
-            if not self._path.exists():
-                return []
-            try:
-                raw = self._path.read_text(encoding="utf-8")
-            except OSError as exc:
-                logger.warning(
-                    "Failed to read lifecycle events at %s: %s", self._path, exc
-                )
-                return []
-            try:
-                data = json.loads(raw)
-            except json.JSONDecodeError as exc:
-                logger.warning(
-                    "Failed to parse lifecycle events at %s: %s", self._path, exc
-                )
-                return []
-            if not isinstance(data, list):
-                logger.warning("Lifecycle events data is not a list: %s", self._path)
-                return []
-            events: list[LifecycleEvent] = []
-            for entry in data:
-                try:
-                    if not isinstance(entry, dict):
-                        continue
-                    event_type_str = entry.get("event_type")
-                    if not isinstance(event_type_str, str):
-                        continue
-                    try:
-                        event_type = LifecycleEventType(event_type_str)
-                    except ValueError:
-                        continue
-                    event_id_raw = entry.get("event_id")
-                    event_id = (
-                        str(event_id_raw) if isinstance(event_id_raw, str) else ""
-                    )
-                    if not event_id:
-                        import uuid
-
-                        event_id = str(uuid.uuid4())
-                    origin_raw = entry.get("origin")
-                    origin = (
-                        str(origin_raw).strip()
-                        if isinstance(origin_raw, str) and origin_raw.strip()
-                        else "system"
-                    )
-                    event = LifecycleEvent(
-                        event_type=event_type,
-                        repo_id=str(entry.get("repo_id", "")),
-                        run_id=str(entry.get("run_id", "")),
-                        data=dict(entry.get("data", {})),
-                        origin=origin,
-                        timestamp=str(entry.get("timestamp", "")),
-                        processed=bool(entry.get("processed", False)),
-                        event_id=event_id,
-                    )
-                    events.append(event)
-                except Exception as exc:
-                    logger.debug("Failed to parse lifecycle event entry: %s", exc)
-                    continue
-            return events
+            return self._load_unlocked()
 
     def save(self, events: list[LifecycleEvent]) -> None:
         with file_lock(self._lock_path()):
@@ -144,10 +235,23 @@ class LifecycleEventStore:
         ]
         atomic_write(self._path, json.dumps(data, indent=2) + "\n")
 
+    def append_with_result(self, event: LifecycleEvent) -> LifecycleEventAppendResult:
+        with file_lock(self._lock_path()):
+            events = self._load_unlocked()
+            duplicate = self._find_duplicate_terminal_event(events, event)
+            if duplicate is not None:
+                seen_at = event.timestamp
+                if not isinstance(seen_at, str) or not seen_at.strip():
+                    seen_at = datetime.now(timezone.utc).isoformat()
+                self._annotate_duplicate(duplicate, duplicate_seen_at=seen_at)
+                self._save_unlocked(events)
+                return LifecycleEventAppendResult(event=duplicate, deduped=True)
+            events.append(event)
+            self._save_unlocked(events)
+            return LifecycleEventAppendResult(event=event, deduped=False)
+
     def append(self, event: LifecycleEvent) -> None:
-        events = self.load(ensure_exists=False)
-        events.append(event)
-        self.save(events)
+        self.append_with_result(event)
 
     def mark_processed(self, event_id: str) -> Optional[LifecycleEvent]:
         if not event_id:
@@ -183,13 +287,15 @@ class LifecycleEventEmitter:
         self._listeners: list[Callable[[LifecycleEvent], None]] = []
 
     def emit(self, event: LifecycleEvent) -> str:
-        self._store.append(event)
+        append_result = self._store.append_with_result(event)
+        if append_result.deduped:
+            return append_result.event.event_id
         for listener in self._listeners:
             try:
-                listener(event)
+                listener(append_result.event)
             except Exception as exc:
                 logger.exception("Error in lifecycle event listener: %s", exc)
-        return event.event_id
+        return append_result.event.event_id
 
     def emit_flow_paused(
         self,

--- a/src/codex_autorunner/core/pma_context.py
+++ b/src/codex_autorunner/core/pma_context.py
@@ -27,6 +27,7 @@ from .flows.worker_process import check_worker_health, read_worker_crash_info
 from .hub import HubSupervisor
 from .pma_thread_store import PmaThreadStore, default_pma_threads_db_path
 from .state_roots import resolve_hub_templates_root
+from .ticket_flow_projection import build_canonical_state_v1
 from .ticket_flow_summary import build_ticket_flow_summary
 from .utils import atomic_write
 
@@ -1103,21 +1104,21 @@ def build_ticket_flow_run_state(
     }
 
 
-def get_latest_ticket_flow_run_state(
+def get_latest_ticket_flow_run_state_with_record(
     repo_root: Path, repo_id: str
-) -> Optional[dict[str, Any]]:
+) -> tuple[Optional[dict[str, Any]], Optional[FlowRunRecord]]:
     db_path = repo_root / ".codex-autorunner" / "flows.db"
     if not db_path.exists():
-        return None
+        return None, None
     try:
         config = load_repo_config(repo_root)
         with FlowStore(db_path, durable=config.durable_writes) as store:
             records = store.list_flow_runs(flow_type="ticket_flow")
             if not records:
-                return None
+                return None, None
             record = _select_newest_run(records)
             if record is None:
-                return None
+                return None, None
             latest = _latest_dispatch(
                 repo_root,
                 str(record.id),
@@ -1162,7 +1163,7 @@ def get_latest_ticket_flow_run_state(
                     )
                 else:
                     reason = "Run is paused without an actionable dispatch"
-            return build_ticket_flow_run_state(
+            run_state = build_ticket_flow_run_state(
                 repo_root=repo_root,
                 repo_id=repo_id,
                 record=record,
@@ -1170,11 +1171,12 @@ def get_latest_ticket_flow_run_state(
                 has_pending_dispatch=has_dispatch,
                 dispatch_state_reason=reason,
             )
+            return run_state, record
     except Exception as exc:
         _logger.warning(
             "Failed to get latest ticket flow run state for repo %s: %s", repo_id, exc
         )
-        return None
+        return None, None
 
 
 def _gather_inbox(
@@ -1300,6 +1302,14 @@ def _gather_inbox(
                         "status": record.status.value,
                         "open_url": f"/repos/{snap.id}/?tab=inbox&run_id={record_id}",
                         "run_state": run_state,
+                        "canonical_state_v1": build_canonical_state_v1(
+                            repo_root=repo_root,
+                            repo_id=snap.id,
+                            run_state=run_state,
+                            record=record,
+                            store=store,
+                            preferred_run_id=newest_run_id,
+                        ),
                         "active_run_id": active_run_id,
                     }
                     if has_dispatch:
@@ -1412,10 +1422,23 @@ async def build_hub_snapshot(
             "last_exit_code": snap.last_exit_code,
             "ticket_flow": None,
             "run_state": None,
+            "canonical_state_v1": None,
         }
         if snap.initialized and snap.exists_on_disk:
             summary["ticket_flow"] = _get_ticket_flow_summary(snap.path)
-            summary["run_state"] = get_latest_ticket_flow_run_state(snap.path, snap.id)
+            run_state, run_record = get_latest_ticket_flow_run_state_with_record(
+                snap.path, snap.id
+            )
+            summary["run_state"] = run_state
+            summary["canonical_state_v1"] = build_canonical_state_v1(
+                repo_root=snap.path,
+                repo_id=snap.id,
+                run_state=summary["run_state"],
+                record=run_record,
+                preferred_run_id=(
+                    str(snap.last_run_id) if snap.last_run_id is not None else None
+                ),
+            )
         repos.append(summary)
 
     inbox = await asyncio.to_thread(

--- a/src/codex_autorunner/core/ticket_flow_projection.py
+++ b/src/codex_autorunner/core/ticket_flow_projection.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from ..tickets.files import list_ticket_paths
+from ..tickets.frontmatter import parse_markdown_frontmatter
+from ..tickets.ingest_state import read_ingest_receipt
+from .config import load_repo_config
+from .flows.models import FlowRunRecord
+from .flows.store import FlowStore
+
+_START_NEW_FLOW_TOKEN = " flow ticket_flow start "
+_COMPLETED_FLOW_STATUSES = {"completed", "done"}
+_ATTENTION_STATES = {"blocked", "dead", "paused"}
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_optional_int(value: Any) -> Optional[int]:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.isdigit():
+            return int(stripped)
+    return None
+
+
+def _select_newest_run(
+    records: list[FlowRunRecord],
+    *,
+    preferred_run_id: Optional[str] = None,
+    represented_run_id: Optional[str] = None,
+) -> Optional[FlowRunRecord]:
+    if not records:
+        return None
+    if represented_run_id:
+        represented = next(
+            (r for r in records if str(r.id) == represented_run_id), None
+        )
+        if represented is not None:
+            return represented
+    if preferred_run_id:
+        preferred = next((r for r in records if str(r.id) == preferred_run_id), None)
+        if preferred is not None:
+            return preferred
+    return max(
+        records,
+        key=lambda r: (
+            str(r.created_at or ""),
+            str(r.started_at or ""),
+            str(r.finished_at or ""),
+            str(r.id),
+        ),
+    )
+
+
+def _is_start_new_flow_action(action: str) -> bool:
+    normalized = f" {action.strip().lower()} "
+    return _START_NEW_FLOW_TOKEN in normalized and " --run-id " not in normalized
+
+
+def _collect_ticket_frontmatter_state(repo_root: Path) -> dict[str, Any]:
+    ticket_dir = repo_root / ".codex-autorunner" / "tickets"
+    try:
+        ticket_paths = list_ticket_paths(ticket_dir)
+    except Exception:
+        ticket_paths = []
+
+    total_count = len(ticket_paths)
+    done_count = 0
+    effective_next_ticket: Optional[str] = None
+
+    for path in ticket_paths:
+        done_flag = False
+        try:
+            raw = path.read_text(encoding="utf-8")
+            frontmatter, _ = parse_markdown_frontmatter(raw)
+            if isinstance(frontmatter, dict) and isinstance(
+                frontmatter.get("done"), bool
+            ):
+                done_flag = frontmatter["done"]
+        except Exception:
+            done_flag = False
+
+        if done_flag:
+            done_count += 1
+        elif effective_next_ticket is None:
+            effective_next_ticket = path.name
+
+    return {
+        "frontmatter_total_count": total_count,
+        "frontmatter_done_count": done_count,
+        "effective_next_ticket": effective_next_ticket,
+    }
+
+
+def _resolve_ingest_state(
+    repo_root: Path,
+    *,
+    frontmatter_total_count: int,
+) -> tuple[bool, Optional[str], str]:
+    receipt = read_ingest_receipt(repo_root)
+    if receipt is not None:
+        source = _normalize_optional_str(receipt.get("source")) or "ticket_files"
+        return True, _normalize_optional_str(receipt.get("ingested_at")), source
+    return frontmatter_total_count > 0, None, "ticket_files"
+
+
+def _resolve_last_event_meta(
+    *,
+    repo_root: Path,
+    record: Optional[FlowRunRecord],
+    store: Optional[FlowStore],
+    preferred_run_id: Optional[str],
+    represented_run_id: Optional[str],
+) -> tuple[Optional[FlowRunRecord], Optional[int], Optional[str]]:
+    if record is not None:
+        if store is None:
+            return record, None, None
+        seq, event_at = store.get_last_event_meta(str(record.id))
+        return (
+            record,
+            _normalize_optional_int(seq),
+            _normalize_optional_str(event_at),
+        )
+
+    if store is not None:
+        records = store.list_flow_runs(flow_type="ticket_flow")
+        latest = _select_newest_run(
+            records,
+            preferred_run_id=preferred_run_id,
+            represented_run_id=represented_run_id,
+        )
+        if latest is None:
+            return None, None, None
+        seq, event_at = store.get_last_event_meta(str(latest.id))
+        return (
+            latest,
+            _normalize_optional_int(seq),
+            _normalize_optional_str(event_at),
+        )
+
+    db_path = repo_root / ".codex-autorunner" / "flows.db"
+    if not db_path.exists():
+        return None, None, None
+
+    try:
+        config = load_repo_config(repo_root)
+        with FlowStore(db_path, durable=config.durable_writes) as local_store:
+            records = local_store.list_flow_runs(flow_type="ticket_flow")
+            latest = _select_newest_run(
+                records,
+                preferred_run_id=preferred_run_id,
+                represented_run_id=represented_run_id,
+            )
+            if latest is None:
+                return None, None, None
+            seq, event_at = local_store.get_last_event_meta(str(latest.id))
+            return (
+                latest,
+                _normalize_optional_int(seq),
+                _normalize_optional_str(event_at),
+            )
+    except Exception:
+        return None, None, None
+
+
+def build_canonical_state_v1(
+    *,
+    repo_root: Path,
+    repo_id: str,
+    run_state: Optional[dict[str, Any]],
+    record: Optional[FlowRunRecord] = None,
+    store: Optional[FlowStore] = None,
+    preferred_run_id: Optional[str] = None,
+) -> dict[str, Any]:
+    observed_at = _iso_now()
+    ticket_state = _collect_ticket_frontmatter_state(repo_root)
+    frontmatter_total_count = int(ticket_state["frontmatter_total_count"])
+    frontmatter_done_count = int(ticket_state["frontmatter_done_count"])
+    effective_next_ticket = _normalize_optional_str(
+        ticket_state["effective_next_ticket"]
+    )
+
+    run_state_payload = run_state if isinstance(run_state, dict) else {}
+    run_state_run_id = _normalize_optional_str(run_state_payload.get("run_id"))
+    record_run_id = (
+        _normalize_optional_str(getattr(record, "id", None))
+        if record is not None
+        else None
+    )
+    represented_run_id = record_run_id or run_state_run_id
+
+    latest_record, last_event_seq, last_event_at = _resolve_last_event_meta(
+        repo_root=repo_root,
+        record=record,
+        store=store,
+        preferred_run_id=preferred_run_id,
+        represented_run_id=represented_run_id,
+    )
+
+    latest_run_id = (
+        _normalize_optional_str(getattr(latest_record, "id", None))
+        if latest_record is not None
+        else represented_run_id
+    )
+    latest_status_raw = (
+        getattr(getattr(latest_record, "status", None), "value", None)
+        if latest_record is not None
+        else run_state_payload.get("flow_status")
+    )
+    latest_run_status = _normalize_optional_str(latest_status_raw)
+
+    state = _normalize_optional_str(run_state_payload.get("state"))
+    if state is None:
+        state = latest_run_status
+
+    blocking_reason = _normalize_optional_str(run_state_payload.get("blocking_reason"))
+    flow_current_ticket = _normalize_optional_str(
+        run_state_payload.get("current_ticket")
+    )
+
+    attention_required_raw = run_state_payload.get("attention_required")
+    if isinstance(attention_required_raw, bool):
+        attention_required = attention_required_raw
+    else:
+        attention_required = bool(state in _ATTENTION_STATES)
+
+    recommended_actions: list[str] = []
+    raw_actions = run_state_payload.get("recommended_actions")
+    if isinstance(raw_actions, list):
+        for candidate in raw_actions:
+            action = _normalize_optional_str(candidate)
+            if action:
+                recommended_actions.append(action)
+
+    recommended_action = _normalize_optional_str(
+        run_state_payload.get("recommended_action")
+    )
+    if recommended_action and recommended_action not in recommended_actions:
+        recommended_actions.insert(0, recommended_action)
+    elif not recommended_action and recommended_actions:
+        recommended_action = recommended_actions[0]
+
+    ingested, ingested_at, ingest_source = _resolve_ingest_state(
+        repo_root,
+        frontmatter_total_count=frontmatter_total_count,
+    )
+    completed_by_flow = bool(
+        state == "completed"
+        or (
+            latest_run_status is not None
+            and latest_run_status in _COMPLETED_FLOW_STATUSES
+        )
+    )
+
+    recommendation_stale_reason = None
+    if (
+        recommended_action
+        and _is_start_new_flow_action(recommended_action)
+        and effective_next_ticket
+    ):
+        recommendation_stale_reason = (
+            "recommended_action_stale:start_new_flow_while_next_ticket_exists"
+        )
+
+    contradictions: list[str] = []
+    if run_state_run_id and record_run_id and run_state_run_id != record_run_id:
+        contradictions.append("run_state_run_id_mismatch_record")
+    if represented_run_id and latest_run_id and represented_run_id != latest_run_id:
+        contradictions.append("represented_run_mismatch_latest")
+    if latest_run_id and not ingested:
+        contradictions.append("run_exists_without_ticket_ingest")
+    if completed_by_flow and effective_next_ticket:
+        contradictions.append("completed_flow_with_remaining_tickets")
+    if attention_required and not recommended_actions:
+        contradictions.append("attention_required_without_recommendation")
+
+    recommendation_confidence = "high"
+    if recommendation_stale_reason:
+        recommendation_confidence = "low"
+    elif contradictions:
+        recommendation_confidence = "medium"
+
+    return {
+        "schema_version": 1,
+        "observed_at": observed_at,
+        "repo_id": repo_id,
+        "repo_root": str(repo_root),
+        "ingested": ingested,
+        "ingested_at": ingested_at,
+        "ingest_source": ingest_source,
+        "represented_run_id": represented_run_id,
+        "frontmatter_total_count": frontmatter_total_count,
+        "frontmatter_done_count": frontmatter_done_count,
+        "effective_next_ticket": effective_next_ticket,
+        "latest_run_id": latest_run_id,
+        "latest_run_status": latest_run_status,
+        "completed_by_flow": completed_by_flow,
+        "flow_current_ticket": flow_current_ticket,
+        "last_event_seq": last_event_seq,
+        "last_event_at": last_event_at,
+        "state": state,
+        "blocking_reason": blocking_reason,
+        "attention_required": attention_required,
+        "recommended_action": recommended_action,
+        "recommended_actions": recommended_actions,
+        "recommendation_generated_at": observed_at,
+        "recommendation_confidence": recommendation_confidence,
+        "recommendation_stale_reason": recommendation_stale_reason,
+        "contradictions": contradictions,
+    }

--- a/src/codex_autorunner/core/ticket_linter_cli.py
+++ b/src/codex_autorunner/core/ticket_linter_cli.py
@@ -37,6 +37,7 @@ _SCRIPT = dedent(
 
 
     _TICKET_NAME_RE = re.compile(r"^TICKET-(\\d{3,})(?:[^/]*)\\.md$", re.IGNORECASE)
+    _IGNORED_NON_TICKET_FILENAMES = {"AGENTS.md", "ingest_state.json"}
 
 
     def _ticket_paths(tickets_dir: Path) -> Tuple[List[Path], List[str]]:
@@ -48,7 +49,7 @@ _SCRIPT = dedent(
         for path in sorted(tickets_dir.iterdir()):
             if not path.is_file():
                 continue
-            if path.name == "AGENTS.md":
+            if path.name in _IGNORED_NON_TICKET_FILENAMES:
                 continue
             match = _TICKET_NAME_RE.match(path.name)
             if not match:

--- a/src/codex_autorunner/core/ticket_manager_cli.py
+++ b/src/codex_autorunner/core/ticket_manager_cli.py
@@ -50,6 +50,7 @@ except ImportError:  # pragma: no cover
     yaml = None
 
 _TICKET_NAME_RE = re.compile(r"^TICKET-(\\d{3,})([^/]*)\\.md$", re.IGNORECASE)
+_IGNORED_NON_TICKET_FILENAMES = {"AGENTS.md", "ingest_state.json"}
 
 
 @dataclass
@@ -71,7 +72,7 @@ def _ticket_paths(ticket_dir: Path) -> Tuple[List[Path], List[str]]:
     for path in sorted(ticket_dir.iterdir()):
         if not path.is_file():
             continue
-        if path.name == "AGENTS.md":
+        if path.name in _IGNORED_NON_TICKET_FILENAMES:
             continue
         m = _TICKET_NAME_RE.match(path.name)
         if not m:

--- a/src/codex_autorunner/surfaces/cli/commands/utils.py
+++ b/src/codex_autorunner/surfaces/cli/commands/utils.py
@@ -30,6 +30,7 @@ from ....core.utils import (
 )
 from ....manifest import load_manifest
 from ....tickets.files import list_ticket_paths, read_ticket, safe_relpath
+from ....tickets.ingest_state import INGEST_STATE_FILENAME
 from ....tickets.lint import lint_ticket_directory, parse_ticket_index
 
 if TYPE_CHECKING:
@@ -454,7 +455,7 @@ def ticket_lint_details(ticket_dir: Path) -> dict[str, list[str]]:
     for path in sorted(ticket_dir.iterdir()):
         if not path.is_file():
             continue
-        if path.name == "AGENTS.md":
+        if path.name in {"AGENTS.md", INGEST_STATE_FILENAME}:
             continue
         if parse_ticket_index(path.name) is None:
             rel_path = safe_relpath(path, ticket_root)

--- a/src/codex_autorunner/tickets/ingest_state.py
+++ b/src/codex_autorunner/tickets/ingest_state.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from ..core.state_roots import resolve_repo_state_root
+from ..core.utils import atomic_write
+
+INGEST_STATE_SCHEMA_VERSION = 1
+INGEST_STATE_FILENAME = "ingest_state.json"
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _is_valid_iso_timestamp(value: str) -> bool:
+    text = value.strip()
+    if not text:
+        return False
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        datetime.fromisoformat(normalized)
+    except ValueError:
+        return False
+    return True
+
+
+def ingest_state_path(repo_root: Path) -> Path:
+    return resolve_repo_state_root(repo_root) / "tickets" / INGEST_STATE_FILENAME
+
+
+def normalize_ingest_receipt(payload: Any) -> Optional[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("schema_version") != INGEST_STATE_SCHEMA_VERSION:
+        return None
+    if payload.get("ingested") is not True:
+        return None
+
+    ingested_at = payload.get("ingested_at")
+    if not isinstance(ingested_at, str) or not _is_valid_iso_timestamp(ingested_at):
+        return None
+
+    source = payload.get("source")
+    if not isinstance(source, str) or not source.strip():
+        return None
+
+    details = payload.get("details")
+    if details is not None and not isinstance(details, dict):
+        return None
+
+    normalized: dict[str, Any] = {
+        "schema_version": INGEST_STATE_SCHEMA_VERSION,
+        "ingested": True,
+        "ingested_at": ingested_at.strip(),
+        "source": source.strip(),
+    }
+    if isinstance(details, dict):
+        normalized["details"] = details
+    return normalized
+
+
+def read_ingest_receipt(repo_root: Path) -> Optional[dict[str, Any]]:
+    path = ingest_state_path(repo_root)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return None
+    return normalize_ingest_receipt(payload)
+
+
+def write_ingest_receipt(
+    repo_root: Path,
+    *,
+    source: str,
+    details: Optional[dict[str, Any]] = None,
+    ingested_at: Optional[str] = None,
+) -> dict[str, Any]:
+    source_text = str(source).strip()
+    if not source_text:
+        raise ValueError("Ingest receipt source must be non-empty.")
+
+    if ingested_at is None:
+        timestamp = _iso_now()
+    else:
+        timestamp = str(ingested_at).strip()
+        if not _is_valid_iso_timestamp(timestamp):
+            raise ValueError("Ingest receipt ingested_at must be an ISO timestamp.")
+
+    if details is not None and not isinstance(details, dict):
+        raise ValueError("Ingest receipt details must be an object.")
+
+    payload: dict[str, Any] = {
+        "schema_version": INGEST_STATE_SCHEMA_VERSION,
+        "ingested": True,
+        "ingested_at": timestamp,
+        "source": source_text,
+    }
+    if details is not None:
+        payload["details"] = details
+
+    atomic_write(ingest_state_path(repo_root), json.dumps(payload, indent=2) + "\n")
+    return payload

--- a/tests/core/test_ticket_flow_projection.py
+++ b/tests/core/test_ticket_flow_projection.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_autorunner.core.flows.models import FlowRunStatus
+from codex_autorunner.core.flows.store import FlowStore
+from codex_autorunner.core.ticket_flow_projection import build_canonical_state_v1
+
+
+def _seed_run(repo_root: Path, run_id: str, status: FlowRunStatus) -> None:
+    db_path = repo_root / ".codex-autorunner" / "flows.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with FlowStore(db_path) as store:
+        store.initialize()
+        store.create_flow_run(
+            run_id,
+            "ticket_flow",
+            input_data={"workspace_root": str(repo_root)},
+            state={},
+            metadata={},
+        )
+        store.update_flow_run_status(run_id, status)
+
+
+def test_build_canonical_state_v1_uses_represented_run_when_preferred_is_stale(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True, exist_ok=True)
+
+    stale_run_id = "c1111111-1111-1111-1111-111111111111"
+    represented_run_id = "c2222222-2222-2222-2222-222222222222"
+    _seed_run(repo_root, stale_run_id, FlowRunStatus.COMPLETED)
+    _seed_run(repo_root, represented_run_id, FlowRunStatus.PAUSED)
+
+    run_state = {
+        "run_id": represented_run_id,
+        "state": "paused",
+        "flow_status": "paused",
+        "recommended_action": "car flow ticket_flow resume --run-id c222",
+    }
+    canonical = build_canonical_state_v1(
+        repo_root=repo_root,
+        repo_id="repo-1",
+        run_state=run_state,
+        preferred_run_id=stale_run_id,
+    )
+
+    assert canonical.get("represented_run_id") == represented_run_id
+    assert canonical.get("latest_run_id") == represented_run_id
+    assert canonical.get("latest_run_status") == "paused"
+    contradictions = canonical.get("contradictions") or []
+    assert "represented_run_mismatch_latest" not in contradictions
+
+
+def test_build_canonical_state_v1_prefers_ingest_receipt(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    ticket_dir = repo_root / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True, exist_ok=True)
+    (ticket_dir / "ingest_state.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "ingested": True,
+                "ingested_at": "2026-02-28T12:00:00+00:00",
+                "source": "import_pack",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    canonical = build_canonical_state_v1(
+        repo_root=repo_root,
+        repo_id="repo-1",
+        run_state={},
+    )
+    assert canonical.get("ingested") is True
+    assert canonical.get("ingested_at") == "2026-02-28T12:00:00+00:00"
+    assert canonical.get("ingest_source") == "import_pack"
+
+
+def test_build_canonical_state_v1_falls_back_when_ingest_receipt_invalid(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    ticket_dir = repo_root / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True, exist_ok=True)
+    (ticket_dir / "ingest_state.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 999,
+                "ingested": True,
+                "ingested_at": "2026-02-28T12:00:00+00:00",
+                "source": "import_pack",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (ticket_dir / "TICKET-001.md").write_text(
+        "---\nagent: codex\ndone: false\n---\n\nBody\n",
+        encoding="utf-8",
+    )
+
+    canonical = build_canonical_state_v1(
+        repo_root=repo_root,
+        repo_id="repo-1",
+        run_state={},
+    )
+    assert canonical.get("ingested") is True
+    assert canonical.get("ingested_at") is None
+    assert canonical.get("ingest_source") == "ticket_files"

--- a/tests/test_cli_hub_setup_pack.py
+++ b/tests/test_cli_hub_setup_pack.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import zipfile
 from pathlib import Path
 from types import SimpleNamespace
@@ -93,6 +94,14 @@ def test_hub_tickets_setup_pack_new_mode_assigns_and_preserves_depends_on(
     assert fm1.get("agent") == "opencode"
     assert fm2.get("agent") == "codex"
     assert fm1.get("depends_on") == ["TICKET-002"]
+
+    receipt_path = ticket_dir / "ingest_state.json"
+    assert receipt_path.exists()
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["schema_version"] == 1
+    assert receipt["ingested"] is True
+    assert receipt["source"] == "setup_pack_new"
+    assert receipt["ingested_at"]
 
 
 def test_hub_tickets_setup_pack_new_mode_start_invokes_ticket_flow_start(

--- a/tests/test_ticket_linter_cli.py
+++ b/tests/test_ticket_linter_cli.py
@@ -116,3 +116,17 @@ def test_linter_detects_duplicate_indices(repo: Path) -> None:
     result_clean = _run_linter(repo)
     assert result_clean.returncode == 0
     assert "OK" in result_clean.stdout
+
+
+def test_linter_ignores_ingest_receipt_file(repo: Path) -> None:
+    tickets_dir = repo / ".codex-autorunner" / "tickets"
+    tickets_dir.mkdir(parents=True, exist_ok=True)
+
+    (tickets_dir / "TICKET-001.md").write_text(
+        "---\nagent: codex\ndone: false\n---\nBody\n", encoding="utf-8"
+    )
+    (tickets_dir / "ingest_state.json").write_text("{}", encoding="utf-8")
+
+    result = _run_linter(repo)
+    assert result.returncode == 0
+    assert "Invalid ticket filename" not in result.stderr

--- a/tests/test_ticket_manager_cli.py
+++ b/tests/test_ticket_manager_cli.py
@@ -111,3 +111,14 @@ def test_insert_rejects_title_with_count_gt_one(repo: Path) -> None:
     res = _run(repo, "insert", "--before", "1", "--count", "2", "--title", "Nope")
     assert res.returncode != 0
     assert "--title is only supported with --count 1" in res.stderr
+
+
+def test_tool_lint_ignores_ingest_receipt_file(repo: Path) -> None:
+    tickets = repo / ".codex-autorunner" / "tickets"
+    tickets.mkdir(parents=True, exist_ok=True)
+    _run(repo, "create", "--title", "Only", "--agent", "codex")
+    (tickets / "ingest_state.json").write_text("{}", encoding="utf-8")
+
+    res = _run(repo, "lint")
+    assert res.returncode == 0
+    assert "Invalid ticket filename" not in res.stderr

--- a/tests/test_workspace_functional.py
+++ b/tests/test_workspace_functional.py
@@ -1,4 +1,5 @@
 import io
+import json
 import zipfile
 from pathlib import Path
 
@@ -256,6 +257,13 @@ def test_spec_ingest_ticket_generation(hub_env, client, repo: Path):
     ticket_files = list(tickets_dir.glob("TICKET-*.md"))
     assert len(ticket_files) == 1
     assert (tickets_dir / "TICKET-001.md").exists()
+    receipt_path = tickets_dir / "ingest_state.json"
+    assert receipt_path.exists()
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["schema_version"] == 1
+    assert receipt["ingested"] is True
+    assert receipt["source"] == "spec_ingest"
+    assert receipt["ingested_at"]
 
 
 def test_ticket_runner_workspace_doc_injection(hub_env, repo: Path):

--- a/tests/tickets/test_import_pack.py
+++ b/tests/tickets/test_import_pack.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import logging
 import zipfile
 from pathlib import Path
 
@@ -43,6 +45,14 @@ def test_import_ticket_pack_strips_depends_on(tmp_path: Path) -> None:
     assert "depends_on" not in raw.split("---", 2)[1]
     assert "CAR ticket-pack note: depends_on=" in raw
 
+    receipt_path = ticket_dir / "ingest_state.json"
+    assert receipt_path.exists()
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["schema_version"] == 1
+    assert receipt["ingested"] is True
+    assert receipt["source"] == "import_pack"
+    assert receipt["ingested_at"]
+
 
 def test_import_ticket_pack_warns_on_depends_on_ordering_conflict(
     tmp_path: Path,
@@ -71,6 +81,7 @@ def test_import_ticket_pack_warns_on_depends_on_ordering_conflict(
     assert report.depends_on_summary["has_depends_on"] is True
     assert report.depends_on_summary["ordering_conflicts"]
     assert report.depends_on_summary["reconciled"] is False
+    assert not (ticket_dir / "ingest_state.json").exists()
 
 
 def test_import_ticket_pack_auto_reconciles_depends_on_order(tmp_path: Path) -> None:
@@ -100,3 +111,37 @@ def test_import_ticket_pack_auto_reconciles_depends_on_order(tmp_path: Path) -> 
     t2 = (ticket_dir / "TICKET-002.md").read_text(encoding="utf-8")
     assert "B" in t1
     assert "A" in t2
+
+
+def test_import_ticket_pack_receipt_write_failure_is_non_fatal(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
+    repo_root = tmp_path
+    ticket_dir = repo_root / ".codex-autorunner" / "tickets"
+    zip_path = tmp_path / "pack.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("TICKET-001.md", "---\nagent: codex\ndone: false\n---\n\nA\n")
+
+    def _fail_receipt(*_args, **_kwargs) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(
+        "codex_autorunner.tickets.import_pack.write_ingest_receipt", _fail_receipt
+    )
+
+    with caplog.at_level(logging.WARNING):
+        report = import_ticket_pack(
+            repo_id="repo",
+            repo_root=repo_root,
+            ticket_dir=ticket_dir,
+            zip_path=zip_path,
+            lint=False,
+            dry_run=False,
+            strip_depends_on=True,
+        )
+
+    assert report.ok()
+    assert report.created == 1
+    assert (ticket_dir / "TICKET-001.md").exists()
+    assert not (ticket_dir / "ingest_state.json").exists()
+    assert "Failed to write ingest receipt" in caplog.text

--- a/tests/tickets/test_ingest_state.py
+++ b/tests/tickets/test_ingest_state.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_autorunner.tickets.ingest_state import (
+    ingest_state_path,
+    read_ingest_receipt,
+    write_ingest_receipt,
+)
+
+
+def test_write_and_read_ingest_receipt(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True, exist_ok=True)
+
+    write_ingest_receipt(
+        repo_root,
+        source="import_pack",
+        details={"created": 2},
+        ingested_at="2026-02-28T00:00:00+00:00",
+    )
+    receipt = read_ingest_receipt(repo_root)
+
+    assert receipt is not None
+    assert receipt["schema_version"] == 1
+    assert receipt["ingested"] is True
+    assert receipt["source"] == "import_pack"
+    assert receipt["ingested_at"] == "2026-02-28T00:00:00+00:00"
+    assert receipt["details"] == {"created": 2}
+
+
+def test_read_ingest_receipt_returns_none_for_invalid_payload(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    path = ingest_state_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "ingested": True,
+                "ingested_at": "not-an-iso",
+                "source": "import_pack",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert read_ingest_receipt(repo_root) is None

--- a/tests/tickets/test_pack_import.py
+++ b/tests/tickets/test_pack_import.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+import zipfile
+from pathlib import Path
+
+from codex_autorunner.tickets.pack_import import setup_ticket_pack
+
+
+def test_setup_ticket_pack_receipt_write_failure_is_non_fatal(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True, exist_ok=True)
+    zip_path = tmp_path / "pack.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("TICKET-001.md", "---\nagent: codex\ndone: false\n---\n\nA\n")
+
+    def _fail_receipt(*_args, **_kwargs) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(
+        "codex_autorunner.tickets.pack_import.write_ingest_receipt", _fail_receipt
+    )
+
+    with caplog.at_level(logging.WARNING):
+        report = setup_ticket_pack(target_path=repo_root, zip_path=zip_path)
+
+    assert report.extracted_files == ["TICKET-001.md"]
+    assert (repo_root / ".codex-autorunner" / "tickets" / "TICKET-001.md").exists()
+    assert not (
+        repo_root / ".codex-autorunner" / "tickets" / "ingest_state.json"
+    ).exists()
+    assert "Failed to write ingest receipt" in caplog.text

--- a/tests/tickets/test_spec_ingest.py
+++ b/tests/tickets/test_spec_ingest.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from codex_autorunner.tickets.spec_ingest import ingest_workspace_spec_to_tickets
+
+
+def test_spec_ingest_receipt_write_failure_is_non_fatal(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
+    repo_root = tmp_path
+    spec_path = repo_root / ".codex-autorunner" / "contextspace" / "spec.md"
+    spec_path.parent.mkdir(parents=True, exist_ok=True)
+    spec_path.write_text("# Spec\n", encoding="utf-8")
+
+    def _fail_receipt(*_args, **_kwargs) -> None:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(
+        "codex_autorunner.tickets.spec_ingest.write_ingest_receipt", _fail_receipt
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = ingest_workspace_spec_to_tickets(repo_root)
+
+    assert result.created == 1
+    assert result.first_ticket_path == ".codex-autorunner/tickets/TICKET-001.md"
+    assert (repo_root / ".codex-autorunner" / "tickets" / "TICKET-001.md").exists()
+    assert not (
+        repo_root / ".codex-autorunner" / "tickets" / "ingest_state.json"
+    ).exists()
+    assert "Failed to write ingest receipt" in caplog.text


### PR DESCRIPTION
## Summary
This is a single cohesive refactor for PMA/state-consistency issue #797 that hardens ticket-flow truth surfaces and stale-state handling across CLI, hub APIs, lifecycle events, and UI.

## What changed
1. Canonical ticket-flow projection contract (`canonical_state_v1`)
- Added a shared projection module to derive one canonical state payload from tickets + flow runs.
- Added explicit semantics for ingest/completion/next-ticket and freshness/confidence/staleness.
- Added contradiction markers and represented-run selection to avoid mixed-run drift.

2. Hub + PMA integration
- Wired canonical projection into:
  - PMA context hub snapshot/inbox
  - `/hub/messages`
  - `/hub/repos`
- Reduced run-state ambiguity by using a coherent represented run id and contradiction flags.

3. `car flow ticket_flow status` reliability
- Fixed status command path that could return empty output despite known state.
- Ensured command emits both text and JSON payloads reliably after preflight.

4. Lifecycle idempotency and dedupe
- Added semantic dedupe for terminal flow lifecycle events.
- Added duplicate metadata (`duplicate_count`, first/last seen) and made deduped emits return existing id without replaying listener callbacks.
- Added transition metadata in runtime emits to improve dedupe keying.

5. Ingest receipt as explicit state
- Added `tickets/ingest_state.json` writer/reader (`ingest_state.py`).
- Writers integrated for `spec_ingest`, `import_pack`, and setup-pack new mode.
- Canonical projection now prefers receipt over implicit file-inference where available.

6. Backward compatibility + robustness fixes
- Excluded `ingest_state.json` from ticket lint/preflight/portable ticket scanner expectations.
- Made receipt writes best-effort (non-fatal) after ticket writes, with warning logging.

7. UI stale recommendation clarity
- Notification bell now prefers canonical recommendation/state and degrades stale/low-confidence recommendations to `Suggestion:` instead of hard `Next:`.

## Why this addresses #797
- Reduces state drift by projecting one canonical truth layer across surfaces.
- Separates `ingested` from `done/executed` semantics explicitly.
- Marks stale/conflicting recommendations with freshness/confidence signals.
- Removes empty status output class for ticket flow status command.
- Reduces duplicate lifecycle noise and clarifies idempotency.

## Validation
- Full pre-commit suite passed, including mypy/eslint/build and full pytest gate (`2280 passed, 3 skipped`).
- Additional targeted regression suites for these changes passed (`102 passed` in focused run).

Refs #797
