### PR TITLE
Improve channel directory UX and PMA target friendly labels

### DIFF
--- a/src/codex_autorunner/static/hub.js
+++ b/src/codex_autorunner/static/hub.js
@@ -43,7 +43,6 @@ const hubUsageChartSegment = document.getElementById("hub-usage-chart-segment");
 const hubVersionEl = document.getElementById("hub-version");
 const pmaVersionEl = document.getElementById("pma-version");
 const hubChannelQueryInput = document.getElementById("hub-channel-query");
-const hubChannelLimitInput = document.getElementById("hub-channel-limit");
 const hubChannelSearchBtn = document.getElementById("hub-channel-search");
 const hubChannelRefreshBtn = document.getElementById("hub-channel-refresh");
 const hubChannelListEl = document.getElementById("hub-channel-list");
@@ -221,19 +220,6 @@ function parseDockerMountList(value) {
         mounts.push({ source, target });
     }
     return { mounts, error: null };
-}
-function resolveHubChannelLimit() {
-    const raw = (hubChannelLimitInput?.value || "").trim();
-    if (!raw)
-        return 100;
-    const parsed = Number(raw);
-    if (!Number.isInteger(parsed) || parsed <= 0) {
-        throw new Error("Channel directory limit must be a positive integer.");
-    }
-    if (parsed > 1000) {
-        throw new Error("Channel directory limit must be <= 1000.");
-    }
-    return parsed;
 }
 function setButtonLoading(scanning) {
     const buttons = [
@@ -1690,7 +1676,7 @@ function renderHubChannelEntries(entries) {
             <div class="hub-channel-key">${escapeHtml(row.key)}</div>
             <div class="hub-channel-meta muted small">${escapeHtml(label)} · seen ${escapeHtml(seen)}</div>
           </div>
-          <button class="ghost sm" data-action="copy_channel_key" data-key="${escapeHtml(row.key)}">Copy</button>
+          <button class="ghost sm" data-action="copy_channel_key" data-key="${escapeHtml(row.key)}" title="Copy PMA delivery target ref">Copy Ref</button>
         </div>
       `;
     })
@@ -1700,18 +1686,17 @@ function renderHubChannelEntries(entries) {
 async function loadHubChannelDirectory({ silent = false } = {}) {
     const query = (hubChannelQueryInput?.value || "").trim();
     try {
-        const limit = resolveHubChannelLimit();
         const params = new URLSearchParams();
-        params.set("limit", String(limit));
         if (query)
             params.set("query", query);
         if (hubChannelRefreshBtn)
             hubChannelRefreshBtn.disabled = true;
         if (hubChannelSearchBtn)
             hubChannelSearchBtn.disabled = true;
-        if (hubChannelLimitInput)
-            hubChannelLimitInput.disabled = true;
-        const payload = (await api(`/hub/chat/channels?${params.toString()}`, {
+        const path = params.toString()
+            ? `/hub/chat/channels?${params.toString()}`
+            : "/hub/chat/channels";
+        const payload = (await api(path, {
             method: "GET",
         }));
         renderHubChannelEntries(Array.isArray(payload.entries) ? payload.entries : []);
@@ -1726,8 +1711,6 @@ async function loadHubChannelDirectory({ silent = false } = {}) {
             hubChannelRefreshBtn.disabled = false;
         if (hubChannelSearchBtn)
             hubChannelSearchBtn.disabled = false;
-        if (hubChannelLimitInput)
-            hubChannelLimitInput.disabled = false;
     }
 }
 async function copyTextToClipboard(value) {
@@ -1939,14 +1922,6 @@ function attachHubHandlers() {
             }
         });
     }
-    if (hubChannelLimitInput) {
-        hubChannelLimitInput.addEventListener("keydown", (event) => {
-            if (event.key === "Enter") {
-                event.preventDefault();
-                loadHubChannelDirectory().catch(() => { });
-            }
-        });
-    }
     if (hubChannelListEl) {
         hubChannelListEl.addEventListener("click", (event) => {
             const target = event.target;
@@ -1957,8 +1932,8 @@ function attachHubHandlers() {
             if (!key)
                 return;
             copyTextToClipboard(key)
-                .then(() => flash(`Copied key: ${key}`, "success"))
-                .catch((err) => flash(err.message || "Failed to copy key", "error"));
+                .then(() => flash(`Copied channel ref: ${key}. Paste it into PMA > Delivery targets.`, "success"))
+                .catch((err) => flash(err.message || "Failed to copy channel ref", "error"));
         });
     }
     if (newRepoBtn) {

--- a/src/codex_autorunner/static/index.html
+++ b/src/codex_autorunner/static/index.html
@@ -120,15 +120,13 @@
           <div class="form-group">
             <input id="hub-channel-query" type="text" placeholder="Search key/display/meta…" spellcheck="false" />
           </div>
-          <div class="form-group">
-            <input id="hub-channel-limit" type="number" min="1" max="1000" step="1" value="100" placeholder="Limit" />
-          </div>
         </div>
         <div class="hub-panel-actions">
           <button class="ghost sm" id="hub-channel-search" type="button">Search</button>
           <button class="ghost sm" id="hub-channel-refresh" type="button">Refresh</button>
         </div>
       </div>
+      <div class="muted small">Copy Ref copies a PMA delivery target ref (for example, <code>telegram:-100123:5</code>).</div>
       <div class="hub-channel-list muted small" id="hub-channel-list">Loading channel directory…</div>
     </section>
   </div>

--- a/src/codex_autorunner/static/pma.js
+++ b/src/codex_autorunner/static/pma.js
@@ -736,14 +736,28 @@ function renderPMATargets(rows) {
         if (row.active) {
             item.classList.add("is-active");
         }
+        const friendlyLabel = typeof row.friendly_label === "string" && row.friendly_label.trim()
+            ? row.friendly_label.trim()
+            : "";
+        if (friendlyLabel) {
+            const label = document.createElement("span");
+            label.className = "pma-target-label";
+            label.textContent = friendlyLabel;
+            label.title = friendlyLabel;
+            item.appendChild(label);
+        }
         const key = document.createElement("code");
         key.className = "pma-target-key";
         key.textContent = row.key;
         item.appendChild(key);
-        if (row.label) {
+        const fallbackLabel = typeof row.label === "string" && row.label.trim() ? row.label.trim() : "";
+        if (fallbackLabel &&
+            fallbackLabel !== row.key &&
+            fallbackLabel !== friendlyLabel) {
             const label = document.createElement("span");
             label.className = "pma-target-label muted";
-            label.textContent = row.label;
+            label.textContent = fallbackLabel;
+            label.title = fallbackLabel;
             item.appendChild(label);
         }
         if (row.active) {

--- a/src/codex_autorunner/static_src/pma.ts
+++ b/src/codex_autorunner/static_src/pma.ts
@@ -69,6 +69,7 @@ type PMADocUpdate = {
 type PMATargetRow = {
   key: string;
   label?: string;
+  friendly_label?: string;
   active?: boolean;
   target?: Record<string, unknown>;
 };
@@ -850,15 +851,34 @@ function renderPMATargets(rows: PMATargetRow[]): void {
       item.classList.add("is-active");
     }
 
+    const friendlyLabel =
+      typeof row.friendly_label === "string" && row.friendly_label.trim()
+        ? row.friendly_label.trim()
+        : "";
+    if (friendlyLabel) {
+      const label = document.createElement("span");
+      label.className = "pma-target-label";
+      label.textContent = friendlyLabel;
+      label.title = friendlyLabel;
+      item.appendChild(label);
+    }
+
     const key = document.createElement("code");
     key.className = "pma-target-key";
     key.textContent = row.key;
     item.appendChild(key);
 
-    if (row.label) {
+    const fallbackLabel =
+      typeof row.label === "string" && row.label.trim() ? row.label.trim() : "";
+    if (
+      fallbackLabel &&
+      fallbackLabel !== row.key &&
+      fallbackLabel !== friendlyLabel
+    ) {
       const label = document.createElement("span");
       label.className = "pma-target-label muted";
-      label.textContent = row.label;
+      label.textContent = fallbackLabel;
+      label.title = fallbackLabel;
       item.appendChild(label);
     }
 

--- a/tests/surfaces/web/test_hub_destination_and_channels.py
+++ b/tests/surfaces/web/test_hub_destination_and_channels.py
@@ -309,10 +309,10 @@ def test_hub_ui_exposes_destination_and_channel_directory_controls() -> None:
         repo_root / "src" / "codex_autorunner" / "static" / "index.html"
     ).read_text(encoding="utf-8")
     assert 'id="hub-channel-query"' in index_html
-    assert 'id="hub-channel-limit"' in index_html
     assert 'id="hub-channel-search"' in index_html
     assert 'id="hub-channel-refresh"' in index_html
     assert 'id="hub-channel-list"' in index_html
+    assert "Copy Ref copies a PMA delivery target ref" in index_html
 
     hub_source = (
         repo_root / "src" / "codex_autorunner" / "static_src" / "hub.ts"
@@ -323,5 +323,5 @@ def test_hub_ui_exposes_destination_and_channel_directory_controls() -> None:
     assert "container_name" in hub_source
     assert "env_passthrough" in hub_source
     assert "mounts" in hub_source
-    assert "hub-channel-limit" in hub_source
     assert "copy_channel_key" in hub_source
+    assert "Copied channel ref" in hub_source


### PR DESCRIPTION
## Summary
- simplify the Hub Channel Directory controls by removing the manual `limit` input (search + refresh only)
- clarify Channel Directory copy behavior:
  - button text changed from `Copy` to `Copy Ref`
  - inline helper text explains it copies a PMA delivery target ref
  - success toast now tells users to paste into `PMA > Delivery targets`
- add friendly channel names to PMA delivery targets:
  - `/hub/pma/targets*` responses now include `friendly_label` when a matching Channel Directory entry exists
  - PMA target list renders that friendly label prominently while keeping canonical target keys visible
- add/adjust tests for the updated UI/route behavior

## Why
Users reported confusion about:
- what value is copied from Channel Directory and where to use it
- ID-only PMA target rows that are hard to recognize quickly

This improves day-to-day target management ergonomics without changing delivery routing behavior.

## Testing
- `.venv/bin/pytest tests/test_pma_routes.py tests/surfaces/web/test_hub_destination_and_channels.py`
- full pre-commit hook suite passed during commit (including mypy, eslint/ts build, and full pytest run)

## Related
- Relates to #806
