### PR TITLE
Inline chat channel activity under chat-bound worktrees

### DIFF
--- a/src/codex_autorunner/static/styles.css
+++ b/src/codex_autorunner/static/styles.css
@@ -1310,59 +1310,57 @@ main {
   overflow: auto;
 }
 
-.hub-channel-row {
+.hub-chat-binding-block {
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid var(--border-subtle);
   display: flex;
-  align-items: flex-start;
-  justify-content: flex-start;
-  gap: 8px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 6px 8px;
-  background: var(--bg);
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hub-chat-binding-row {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
   min-height: 0;
 }
 
-.hub-channel-row-merged {
-  border-color: var(--border-subtle);
-}
-
-.hub-channel-main {
-  min-width: 0;
-  flex: 1;
+.hub-chat-binding-main {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 2px;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
 }
 
-.hub-channel-primary {
-  font-size: 11px;
+.hub-chat-binding-label {
+  font-size: 10px;
+  font-weight: 600;
   color: var(--text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  width: 100%;
+  flex: 0 1 auto;
+  min-width: 0;
 }
 
-.hub-channel-secondary {
+.hub-chat-binding-key {
+  color: var(--muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
     "Courier New", monospace;
   font-size: 10px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  width: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
-.hub-channel-meta {
+.hub-chat-binding-meta {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   width: 100%;
-}
-
-.hub-merged-section-title {
-  margin-top: 8px;
 }
 
 /* Hub worktrees (worktree repos grouped under a base repo) */
@@ -7396,8 +7394,13 @@ button.loading::after {
     gap: 4px;
   }
 
-  .hub-channel-row {
-    padding: 6px 8px;
+  .hub-chat-binding-main {
+    gap: 4px;
+    flex-wrap: wrap;
+  }
+
+  .hub-chat-binding-meta {
+    white-space: normal;
   }
 
   .hub-repo-card {

--- a/src/codex_autorunner/static_src/hub.ts
+++ b/src/codex_autorunner/static_src/hub.ts
@@ -1216,12 +1216,15 @@ function channelDisplayLabel(channel: HubChannelEntry): string {
   return channel.key;
 }
 
-function channelMetaSummary(channel: HubChannelEntry): string {
+function channelMetaSummary(
+  channel: HubChannelEntry,
+  { includeRepo = true }: { includeRepo?: boolean } = {}
+): string {
   const parts: string[] = [];
   const status = String(channel.status_label || channel.channel_status || "unknown")
     .trim()
     .toLowerCase();
-  parts.push(`status ${status || "unknown"}`);
+  parts.push(status || "unknown");
   if (channel.seen_at) {
     parts.push(`seen ${formatTimeCompact(channel.seen_at)}`);
   }
@@ -1239,12 +1242,40 @@ function channelMetaSummary(channel: HubChannelEntry): string {
     }
     parts.push(diffPart);
   }
-  if (typeof channel.repo_id === "string" && channel.repo_id.trim()) {
-    parts.push(`repo ${channel.repo_id.trim()}`);
-  } else {
-    parts.push("repo unbound");
+  if (includeRepo) {
+    if (typeof channel.repo_id === "string" && channel.repo_id.trim()) {
+      parts.push(`repo ${channel.repo_id.trim()}`);
+    } else {
+      parts.push("repo unbound");
+    }
   }
   return parts.join(" · ");
+}
+
+function channelSeenAtMs(channel: HubChannelEntry): number {
+  if (!channel.seen_at) return 0;
+  const parsed = Date.parse(channel.seen_at);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function channelsByRepoId(entries: HubChannelEntry[]): Map<string, HubChannelEntry[]> {
+  const byRepo = new Map<string, HubChannelEntry[]>();
+  entries.forEach((entry) => {
+    const repoId = String(entry.repo_id || "").trim();
+    if (!repoId) return;
+    if (!byRepo.has(repoId)) {
+      byRepo.set(repoId, []);
+    }
+    byRepo.get(repoId)!.push(entry);
+  });
+  byRepo.forEach((repoEntries) => {
+    repoEntries.sort((a, b) => {
+      const seenDiff = channelSeenAtMs(b) - channelSeenAtMs(a);
+      if (seenDiff !== 0) return seenDiff;
+      return channelDisplayLabel(a).localeCompare(channelDisplayLabel(b));
+    });
+  });
+  return byRepo;
 }
 
 function buildRepoGroups(repos: HubRepo[]): {
@@ -1311,13 +1342,10 @@ function renderRepos(repos: HubRepo[]): void {
   if (!repoListEl) return;
   repoListEl.innerHTML = "";
   const searchQuery = normalizedHubSearch();
-  const filteredChannels = hubChannelEntries.filter((entry) =>
-    channelMatchesSearch(entry, searchQuery)
-  );
+  const repoChannels = channelsByRepoId(hubChannelEntries);
 
-  if (!repos.length && !filteredChannels.length) {
-    repoListEl.innerHTML =
-      '<div class="hub-empty muted">No repos or channels found.</div>';
+  if (!repos.length) {
+    repoListEl.innerHTML = '<div class="hub-empty muted">No repos found.</div>';
     return;
   }
 
@@ -1364,21 +1392,49 @@ function renderRepos(repos: HubRepo[]): void {
       : chatBoundWorktrees.filter((repo) =>
           repoMatchesFlowFilter(repo, hubViewPrefs.flowFilter)
         );
-  const queryFilteredChatBound = filteredChatBound.filter((repo) =>
-    repoMatchesSearch(repo, searchQuery)
-  );
+  const queryFilteredChatBound = filteredChatBound
+    .map((repo) => {
+      const channels = repoChannels.get(repo.id) || [];
+      if (!searchQuery) {
+        return { repo, channels };
+      }
+      const repoMatch = repoMatchesSearch(repo, searchQuery);
+      const channelMatches = channels.filter((channel) =>
+        channelMatchesSearch(channel, searchQuery)
+      );
+      if (!repoMatch && !channelMatches.length) {
+        return null;
+      }
+      return {
+        repo,
+        channels: repoMatch ? channels : channelMatches,
+      };
+    })
+    .filter((item): item is { repo: HubRepo; channels: HubChannelEntry[] } =>
+      Boolean(item)
+    );
   queryFilteredOrphans.sort((a, b) => compareReposForSort(a, b, hubViewPrefs.sortOrder));
   queryFilteredChatBound.sort((a, b) =>
-    compareReposForSort(a, b, hubViewPrefs.sortOrder)
+    compareReposForSort(a.repo, b.repo, hubViewPrefs.sortOrder)
   );
 
-  if (!orderedGroups.length && !queryFilteredOrphans.length && !queryFilteredChatBound.length && !filteredChannels.length) {
+  if (
+    !orderedGroups.length &&
+    !queryFilteredOrphans.length &&
+    !queryFilteredChatBound.length
+  ) {
     repoListEl.innerHTML =
       '<div class="hub-empty muted">No rows match current filters.</div>';
     return;
   }
 
-  const renderRepoCard = (repo: HubRepo, { isWorktreeRow = false } = {}): void => {
+  const renderRepoCard = (
+    repo: HubRepo,
+    {
+      isWorktreeRow = false,
+      inlineChannels = [],
+    }: { isWorktreeRow?: boolean; inlineChannels?: HubChannelEntry[] } = {}
+  ): void => {
     const card = document.createElement("div");
     card.className = isWorktreeRow
       ? "hub-repo-card hub-worktree-card"
@@ -1470,6 +1526,30 @@ function renderRepos(repos: HubRepo[]): void {
     const infoSubline = infoLine
       ? `<div class="hub-repo-subline">${infoLine}</div>`
       : "";
+    const inlineChannelRows = inlineChannels
+      .map((channel) => {
+        const label = channelDisplayLabel(channel);
+        const key = String(channel.key || "").trim();
+        const keyMarkup =
+          key && key !== label
+            ? `<span class="hub-chat-binding-key">${escapeHtml(key)}</span>`
+            : "";
+        return `
+          <div class="hub-chat-binding-row">
+            <div class="hub-chat-binding-main">
+              <span class="hub-chat-binding-label">${escapeHtml(label)}</span>
+              ${keyMarkup}
+            </div>
+            <div class="hub-chat-binding-meta muted small">${escapeHtml(
+              channelMetaSummary(channel, { includeRepo: false })
+            )}</div>
+          </div>
+        `;
+      })
+      .join("");
+    const inlineChannelBlock = inlineChannelRows
+      ? `<div class="hub-chat-binding-block">${inlineChannelRows}</div>`
+      : "";
 
     const setupBadge =
       (repo.worktree_setup_commands || []).length > 0 && repo.kind === "base"
@@ -1530,6 +1610,7 @@ function renderRepos(repos: HubRepo[]): void {
           </div>
           ${infoSubline}
           ${ticketFlowLine}
+          ${inlineChannelBlock}
         </div>
         <div class="hub-repo-right">
           ${actions || ""}
@@ -1597,41 +1678,16 @@ function renderRepos(repos: HubRepo[]): void {
     header.className = "hub-worktree-orphans muted small";
     header.textContent = "Chat bound worktrees";
     repoListEl.appendChild(header);
-    queryFilteredChatBound.forEach((wt) => {
-      renderRepoCard(wt, { isWorktreeRow: true });
+    queryFilteredChatBound.forEach(({ repo, channels }) => {
+      renderRepoCard(repo, {
+        isWorktreeRow: true,
+        inlineChannels: channels,
+      });
       renderedRepoRows += 1;
     });
   }
 
-  if (filteredChannels.length) {
-    const header = document.createElement("div");
-    header.className = "hub-worktree-orphans muted small hub-merged-section-title";
-    header.textContent = "Channels";
-    repoListEl.appendChild(header);
-    filteredChannels.forEach((entry) => {
-      const row = document.createElement("div");
-      row.className = "hub-channel-row hub-channel-row-merged";
-      const label = channelDisplayLabel(entry);
-      const secondary =
-        entry.key && entry.key !== label
-          ? `<div class="hub-channel-secondary muted small">${escapeHtml(
-              entry.key
-            )}</div>`
-          : "";
-      row.innerHTML = `
-        <div class="hub-channel-main">
-          <div class="hub-channel-primary">${escapeHtml(label)}</div>
-          <div class="hub-channel-meta muted small">${escapeHtml(
-            channelMetaSummary(entry)
-          )}</div>
-          ${secondary}
-        </div>
-      `;
-      repoListEl.appendChild(row);
-    });
-  }
-
-  if (!renderedRepoRows && !filteredChannels.length) {
+  if (!renderedRepoRows) {
     repoListEl.innerHTML =
       '<div class="hub-empty muted">No rows match current filters.</div>';
     return;

--- a/tests/surfaces/web/test_hub_destination_and_channels.py
+++ b/tests/surfaces/web/test_hub_destination_and_channels.py
@@ -734,5 +734,7 @@ def test_hub_ui_exposes_destination_and_channel_directory_controls() -> None:
     assert "env_passthrough" in hub_source
     assert "mounts" in hub_source
     assert "hubRepoSearchInput" in hub_source
+    assert "hub-chat-binding-row" in hub_source
+    assert 'header.textContent = "Channels"' not in hub_source
     assert "copy_channel_key" not in hub_source
     assert "Copied channel ref" not in hub_source


### PR DESCRIPTION
## Summary
- remove standalone "Channels" block rendering from the Hub repository list
- inline channel binding/activity rows directly under each **chat-bound worktree** card
- keep chat-bound repo card layout consistent, with channel details as a compact sub-row block
- keep global search behavior, but make chat-bound rows match by either repo fields or bound channel fields

## UX intent
This implements the requested model:
- chat-bound worktree remains the primary row
- channel context appears in-line beneath that row
- at-a-glance visibility of:
  - where it is bound (channel display + key)
  - activity status (`working/final/clean`)
  - last seen time
  - token usage
  - diff stats (`+/-`, files)

## Implementation details
- frontend grouping maps channel directory entries by `repo_id`
- chat-bound worktree rendering injects `hub-chat-binding-row` sub-rows
- channel metadata summary reused with inline-specific formatting
- removed old "Channels" section append path from `renderRepos`
- responsive CSS added for inline chat-binding rows on mobile

## Validation
- `pnpm run build`
- `.venv/bin/python -m pytest tests/surfaces/web/test_hub_destination_and_channels.py -q`
- full pre-commit gate passed (mypy/eslint/build/full pytest)

## Changed files
- `src/codex_autorunner/static_src/hub.ts`
- `src/codex_autorunner/static/styles.css`
- `src/codex_autorunner/static/hub.js`
- `tests/surfaces/web/test_hub_destination_and_channels.py`
