### PR TITLE
Fix hub top-bar search row and tighten repo badge spacing

### DIFF
--- a/src/codex_autorunner/static/index.html
+++ b/src/codex_autorunner/static/index.html
@@ -83,9 +83,8 @@
               </select>
             </label>
             <label class="hub-repo-control hub-repo-search-control">
-              Search
               <input id="hub-repo-search" class="hub-repo-search-input" type="text"
-                placeholder="Search repos + channels…" spellcheck="false" />
+                placeholder="Search…" spellcheck="false" aria-label="Search repos and channels" />
             </label>
           </div>
         </div>

--- a/src/codex_autorunner/static/styles.css
+++ b/src/codex_autorunner/static/styles.css
@@ -1255,7 +1255,8 @@ main {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  min-width: 0;
 }
 
 .hub-repo-control {
@@ -1283,7 +1284,8 @@ main {
 }
 
 .hub-repo-search-control {
-  flex: 1 1 240px;
+  flex: 0 1 220px;
+  min-width: 140px;
 }
 
 .hub-repo-search-input {
@@ -1437,7 +1439,7 @@ main {
 .hub-repo-mainline {
   display: flex;
   align-items: center;
-  gap: var(--sp-3);
+  gap: var(--sp-2);
   min-width: 0;
   overflow: hidden;
 }
@@ -1457,7 +1459,8 @@ main {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  flex: 1;
+  min-width: 0;
+  flex: 0 1 auto;
 }
 
 .hub-repo-clickable:hover .hub-repo-title {
@@ -7372,18 +7375,24 @@ button.loading::after {
     width: 100%;
     justify-content: flex-start;
     gap: 6px;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 2px;
   }
 
   .hub-repo-control {
-    flex: 1 1 160px;
+    flex: 0 0 auto;
   }
 
   .hub-repo-select {
-    width: 100%;
+    width: auto;
+    min-width: 86px;
+    max-width: 130px;
   }
 
   .hub-repo-search-control {
-    flex: 1 1 100%;
+    flex: 1 1 120px;
+    min-width: 100px;
   }
 
   .hub-repo-search-input {


### PR DESCRIPTION
## Summary
Address two Hub UI regressions after the inline chat-bound worktree changes:

1. Search should not introduce a new row in the repositories top bar.
2. Repo badges (including token usage) should sit snugly next to the repo title, including chat-bound rows.

## What changed
- Removed the explicit `Search` label text from the control and kept a compact input (`Search…`) with aria-label.
- Tightened top-bar control layout so controls stay on one line on desktop.
- Updated mobile control behavior to remain a single compact row (with horizontal overflow instead of forced wrapping to a new line).
- Tightened mainline spacing between title, badges, and usage badge.
- Stopped repo title from expanding and pushing badges away (`flex` behavior adjusted).

## Files
- `src/codex_autorunner/static/index.html`
- `src/codex_autorunner/static/styles.css`

## Validation
- `.venv/bin/python -m pytest tests/surfaces/web/test_hub_destination_and_channels.py -q`
- Full commit gate passed (mypy/eslint/build/full pytest)
