### PR TITLE
Fix PMA login-shell PATH so global car resolves

### DIFF
--- a/scripts/launchd-hub.sh
+++ b/scripts/launchd-hub.sh
@@ -57,18 +57,31 @@ ensure_login_shell_path() {
     return 0
   fi
   for profile in "${HOME}/.zprofile" "${HOME}/.bash_profile" "${HOME}/.profile"; do
-    mkdir -p "$(dirname "${profile}")"
-    touch "${profile}"
-    if grep -Fq "${marker_start}" "${profile}"; then
+    if ! mkdir -p "$(dirname "${profile}")"; then
+      echo "Warning: could not create directory for ${profile}; skipping." >&2
       continue
     fi
-    {
+    if [[ ! -e "${profile}" ]] && ! touch "${profile}"; then
+      echo "Warning: could not create ${profile}; skipping." >&2
+      continue
+    fi
+    if [[ ! -w "${profile}" ]]; then
+      echo "Warning: ${profile} is not writable; skipping." >&2
+      continue
+    fi
+    if grep -Fq "${marker_start}" "${profile}" 2>/dev/null; then
+      continue
+    fi
+    if ! {
       echo ""
       echo "${marker_start}"
       echo "# Ensure pipx-installed CAR is available in login/non-interactive shells."
       printf 'export PATH="%s:$PATH"\n' "${path_entry}"
       echo "${marker_end}"
-    } >> "${profile}"
+    } >> "${profile}"; then
+      echo "Warning: failed to update ${profile}; skipping." >&2
+      continue
+    fi
     echo "Updated ${profile} to include ${path_entry} in PATH."
   done
 }

--- a/scripts/safe-refresh-local-linux-hub.sh
+++ b/scripts/safe-refresh-local-linux-hub.sh
@@ -78,18 +78,31 @@ ensure_login_shell_path() {
     return 0
   fi
   for profile in "${HOME}/.zprofile" "${HOME}/.bash_profile" "${HOME}/.profile"; do
-    mkdir -p "$(dirname "${profile}")"
-    touch "${profile}"
-    if grep -Fq "${marker_start}" "${profile}"; then
+    if ! mkdir -p "$(dirname "${profile}")"; then
+      echo "Warning: could not create directory for ${profile}; skipping." >&2
       continue
     fi
-    {
+    if [[ ! -e "${profile}" ]] && ! touch "${profile}"; then
+      echo "Warning: could not create ${profile}; skipping." >&2
+      continue
+    fi
+    if [[ ! -w "${profile}" ]]; then
+      echo "Warning: ${profile} is not writable; skipping." >&2
+      continue
+    fi
+    if grep -Fq "${marker_start}" "${profile}" 2>/dev/null; then
+      continue
+    fi
+    if ! {
       echo ""
       echo "${marker_start}"
       echo "# Ensure user-local CAR binaries are available in login/non-interactive shells."
       printf 'export PATH="%s:$PATH"\n' "${path_entry}"
       echo "${marker_end}"
-    } >> "${profile}"
+    } >> "${profile}"; then
+      echo "Warning: failed to update ${profile}; skipping." >&2
+      continue
+    fi
     echo "Updated ${profile} to include ${path_entry} in PATH."
   done
 }

--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -123,18 +123,31 @@ ensure_login_shell_path() {
     return 0
   fi
   for profile in "${HOME}/.zprofile" "${HOME}/.bash_profile" "${HOME}/.profile"; do
-    mkdir -p "$(dirname "${profile}")"
-    touch "${profile}"
-    if grep -Fq "${marker_start}" "${profile}"; then
+    if ! mkdir -p "$(dirname "${profile}")"; then
+      echo "Warning: could not create directory for ${profile}; skipping." >&2
       continue
     fi
-    {
+    if [[ ! -e "${profile}" ]] && ! touch "${profile}"; then
+      echo "Warning: could not create ${profile}; skipping." >&2
+      continue
+    fi
+    if [[ ! -w "${profile}" ]]; then
+      echo "Warning: ${profile} is not writable; skipping." >&2
+      continue
+    fi
+    if grep -Fq "${marker_start}" "${profile}" 2>/dev/null; then
+      continue
+    fi
+    if ! {
       echo ""
       echo "${marker_start}"
       echo "# Ensure pipx-installed CAR is available in login/non-interactive shells."
       printf 'export PATH="%s:$PATH"\n' "${path_entry}"
       echo "${marker_end}"
-    } >> "${profile}"
+    } >> "${profile}"; then
+      echo "Warning: failed to update ${profile}; skipping." >&2
+      continue
+    fi
     echo "Updated ${profile} to include ${path_entry} in PATH."
   done
 }


### PR DESCRIPTION
## Summary
Fixes `car` resolution failures in PMA/managed-agent login shells by making install/update flows persist a user-local PATH bootstrap.

Root cause:
- PMA command execution uses login shells (for example `zsh -lc`).
- Login shells rebuild `PATH` from profile startup files.
- On affected systems, `~/.local/bin` is absent from login-shell `PATH`.
- Global CAR is installed at `~/.local/bin/car` (pipx), so `car` becomes `command not found` despite being installed.

## What changed
- Added an idempotent `ensure_login_shell_path` helper in these scripts:
  - `scripts/install-local-mac-hub.sh`
  - `scripts/safe-refresh-local-mac-hub.sh`
  - `scripts/safe-refresh-local-linux-hub.sh`
  - `scripts/launchd-hub.sh`
- The helper appends a marked PATH block to login profile files:
  - `~/.zprofile`
  - `~/.bash_profile`
  - `~/.profile`
- The block prepends `${LOCAL_BIN}` (default `~/.local/bin`) to `PATH` for login/non-interactive shells.
- Hooked this into install/update flow so the profile bootstrap is automatically applied where CAR is installed/refreshed.

## Why this is the general fix
- Covers both macOS launchd and Linux systemd-user scripted workflows.
- Covers the dominant login-shell paths for managed agents (`zsh`/`bash`).
- Makes agent shell command resolution independent of ad-hoc user shell dotfile setup.

## Validation
- Reproduced failure locally:
  - `zsh -lc 'command -v car || echo not-found'` -> `not-found`
  - while `~/.local/bin/car` existed.
- Verified shell behavior with temporary HOME:
  - adding `export PATH="$HOME/.local/bin:$PATH"` to `.zprofile` made `zsh -lc` include local bin.
- Script syntax checks: `bash -n` for all modified scripts.
- Full repo pre-commit suite passed in commit hook (tests/lint/type/build).

Closes #818
