### PR TITLE
Clean up CAR-managed Docker containers during worktree cleanup

### DIFF
--- a/src/codex_autorunner/core/destinations.py
+++ b/src/codex_autorunner/core/destinations.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, Mapping, Optional, Protocol, Sequence
 import yaml
 
 from ..manifest import ManifestRepo, normalize_manifest_destination
+from ..workspace import workspace_id_for_path
 from .utils import subprocess_env
 
 
@@ -164,6 +165,10 @@ def probe_docker_readiness(
 
 def default_local_destination() -> Dict[str, Any]:
     return LocalDestination().to_dict()
+
+
+def default_car_docker_container_name(repo_root: Path) -> str:
+    return f"car-ws-{workspace_id_for_path(repo_root)}"
 
 
 def parse_destination_config(
@@ -448,6 +453,7 @@ __all__ = [
     "DockerReadiness",
     "DockerDestination",
     "LocalDestination",
+    "default_car_docker_container_name",
     "default_local_destination",
     "parse_destination_config",
     "probe_docker_readiness",

--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -27,6 +27,8 @@ from .archive import archive_worktree_snapshot, build_snapshot_id
 from .chat_bindings import repo_has_active_chat_binding
 from .config import HubConfig, RepoConfig, derive_repo_config, load_hub_config
 from .destinations import (
+    DockerDestination,
+    default_car_docker_container_name,
     default_local_destination,
     resolve_effective_repo_destination,
 )
@@ -1006,6 +1008,200 @@ class HubSupervisor:
                 f"Worktree {worktree_repo_id} has uncommitted changes; commit or stash before archiving"
             )
 
+    def _run_docker_command(
+        self, args: List[str], *, timeout_seconds: Optional[float] = None
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["docker", *[str(part) for part in args]],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=subprocess_env(),
+            timeout=timeout_seconds,
+        )
+
+    def _cleanup_worktree_docker_container(
+        self,
+        *,
+        worktree_repo_id: str,
+        worktree_path: Path,
+        destination: DockerDestination,
+    ) -> Dict[str, object]:
+        explicit_name = bool(destination.container_name)
+        container_name = (
+            destination.container_name
+            or default_car_docker_container_name(worktree_path.resolve())
+        )
+        if explicit_name:
+            message = (
+                "Skipping docker container cleanup for explicit container_name "
+                "(treated as shared)"
+            )
+            logger.info(
+                "Hub cleanup worktree docker skipped id=%s container=%s reason=%s",
+                worktree_repo_id,
+                container_name,
+                message,
+            )
+            return {
+                "status": "skipped_explicit",
+                "container_name": container_name,
+                "managed": False,
+                "message": message,
+            }
+
+        try:
+            inspect_proc = self._run_docker_command(
+                ["inspect", "--format", "{{.State.Running}}", container_name],
+                timeout_seconds=15,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            message = f"docker inspect failed: {exc}"
+            logger.warning(
+                "Hub cleanup worktree docker inspect failed id=%s container=%s: %s",
+                worktree_repo_id,
+                container_name,
+                exc,
+            )
+            return {
+                "status": "error",
+                "container_name": container_name,
+                "managed": True,
+                "message": message,
+            }
+        if inspect_proc.returncode != 0:
+            inspect_detail = (inspect_proc.stderr or inspect_proc.stdout or "").strip()
+            inspect_detail_lower = inspect_detail.lower()
+            if (
+                "no such object" in inspect_detail_lower
+                or "no such container" in inspect_detail_lower
+            ):
+                logger.info(
+                    "Hub cleanup worktree docker container missing id=%s container=%s",
+                    worktree_repo_id,
+                    container_name,
+                )
+                return {
+                    "status": "not_found",
+                    "container_name": container_name,
+                    "managed": True,
+                    "message": "container not found",
+                }
+            message = f"docker inspect failed: {inspect_detail or 'unknown error'}"
+            logger.warning(
+                "Hub cleanup worktree docker inspect failed id=%s container=%s: %s",
+                worktree_repo_id,
+                container_name,
+                inspect_detail,
+            )
+            return {
+                "status": "error",
+                "container_name": container_name,
+                "managed": True,
+                "message": message,
+            }
+
+        running = (inspect_proc.stdout or "").strip().lower() == "true"
+        if running:
+            try:
+                stop_proc = self._run_docker_command(
+                    ["stop", "-t", "10", container_name],
+                    timeout_seconds=15,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+                message = f"docker stop failed: {exc}"
+                logger.warning(
+                    "Hub cleanup worktree docker stop failed id=%s container=%s: %s",
+                    worktree_repo_id,
+                    container_name,
+                    exc,
+                )
+                return {
+                    "status": "error",
+                    "container_name": container_name,
+                    "managed": True,
+                    "message": message,
+                }
+            if stop_proc.returncode != 0:
+                stop_detail = (stop_proc.stderr or stop_proc.stdout or "").strip()
+                message = f"docker stop failed: {stop_detail or 'unknown error'}"
+                logger.warning(
+                    "Hub cleanup worktree docker stop failed id=%s container=%s: %s",
+                    worktree_repo_id,
+                    container_name,
+                    stop_detail,
+                )
+                return {
+                    "status": "error",
+                    "container_name": container_name,
+                    "managed": True,
+                    "message": message,
+                }
+
+        try:
+            rm_proc = self._run_docker_command(
+                ["rm", container_name],
+                timeout_seconds=30,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            message = f"docker rm failed: {exc}"
+            logger.warning(
+                "Hub cleanup worktree docker remove failed id=%s container=%s: %s",
+                worktree_repo_id,
+                container_name,
+                exc,
+            )
+            return {
+                "status": "error",
+                "container_name": container_name,
+                "managed": True,
+                "message": message,
+            }
+
+        if rm_proc.returncode != 0:
+            rm_detail = (rm_proc.stderr or rm_proc.stdout or "").strip()
+            rm_detail_lower = rm_detail.lower()
+            if (
+                "no such object" in rm_detail_lower
+                or "no such container" in rm_detail_lower
+            ):
+                logger.info(
+                    "Hub cleanup worktree docker container already removed id=%s container=%s",
+                    worktree_repo_id,
+                    container_name,
+                )
+                return {
+                    "status": "not_found",
+                    "container_name": container_name,
+                    "managed": True,
+                    "message": "container not found",
+                }
+            message = f"docker rm failed: {rm_detail or 'unknown error'}"
+            logger.warning(
+                "Hub cleanup worktree docker remove failed id=%s container=%s: %s",
+                worktree_repo_id,
+                container_name,
+                rm_detail,
+            )
+            return {
+                "status": "error",
+                "container_name": container_name,
+                "managed": True,
+                "message": message,
+            }
+
+        logger.info(
+            "Hub cleanup worktree docker removed id=%s container=%s",
+            worktree_repo_id,
+            container_name,
+        )
+        return {
+            "status": "removed",
+            "container_name": container_name,
+            "managed": True,
+            "message": "container stopped and removed",
+        }
+
     def cleanup_worktree(
         self,
         *,
@@ -1016,7 +1212,7 @@ class HubSupervisor:
         force_archive: bool = False,
         archive_note: Optional[str] = None,
         force: bool = False,
-    ) -> None:
+    ) -> Dict[str, object]:
         if self.hub_config.pma.cleanup_require_archive and not archive:
             raise ValueError(
                 "Worktree cleanup requires archiving per PMA policy "
@@ -1075,6 +1271,19 @@ class HubSupervisor:
                 force=force_archive,
             )
 
+        repos_by_id = {repo.id: repo for repo in manifest.repos}
+        effective_destination = resolve_effective_repo_destination(entry, repos_by_id)
+        docker_cleanup: Dict[str, object] = {
+            "status": "not_applicable",
+            "message": "effective destination is not docker",
+        }
+        if isinstance(effective_destination.destination, DockerDestination):
+            docker_cleanup = self._cleanup_worktree_docker_container(
+                worktree_repo_id=worktree_repo_id,
+                worktree_path=worktree_path,
+                destination=effective_destination.destination,
+            )
+
         # Remove worktree from base repo.
         try:
             proc = run_git(
@@ -1126,6 +1335,7 @@ class HubSupervisor:
 
         manifest.repos = [r for r in manifest.repos if r.id != worktree_repo_id]
         save_manifest(self.hub_config.manifest_path, manifest, self.hub_config.root)
+        return {"status": "ok", "docker_cleanup": docker_cleanup}
 
     def _has_active_chat_binding(self, repo_id: str) -> bool:
         return repo_has_active_chat_binding(

--- a/src/codex_autorunner/integrations/agents/destination_wrapping.py
+++ b/src/codex_autorunner/integrations/agents/destination_wrapping.py
@@ -9,10 +9,10 @@ from ...core.destinations import (
     Destination,
     DockerDestination,
     LocalDestination,
+    default_car_docker_container_name,
     parse_destination_config,
 )
 from ...core.utils import is_within
-from ...workspace import workspace_id_for_path
 from ..docker.profile_contracts import (
     expand_profile_paths,
     resolve_docker_profile_contract,
@@ -36,10 +36,6 @@ def resolve_destination_from_config(raw_destination: object) -> Destination:
     return parsed.destination
 
 
-def _default_container_name(repo_root: Path) -> str:
-    return f"car-ws-{workspace_id_for_path(repo_root)}"
-
-
 def wrap_command_for_destination(
     *,
     command: Sequence[str],
@@ -57,7 +53,9 @@ def wrap_command_for_destination(
 
     runtime = docker_runtime or DockerRuntime()
     repo_abs = repo_root.resolve()
-    container_name = destination.container_name or _default_container_name(repo_abs)
+    container_name = destination.container_name or default_car_docker_container_name(
+        repo_abs
+    )
 
     spec = build_docker_container_spec(
         name=container_name,

--- a/src/codex_autorunner/integrations/docker/runtime.py
+++ b/src/codex_autorunner/integrations/docker/runtime.py
@@ -591,6 +591,33 @@ class DockerRuntime:
             )
         return True
 
+    def remove_container(
+        self,
+        container_name: str,
+        *,
+        force: bool = False,
+    ) -> bool:
+        inspect_proc = self._run(
+            ["inspect", "--format", "{{.Id}}", container_name],
+            check=False,
+            timeout_seconds=15,
+        )
+        if inspect_proc.returncode != 0:
+            details = (inspect_proc.stderr or inspect_proc.stdout or "").lower()
+            if "no such object" in details or "no such container" in details:
+                return False
+            raise DockerRuntimeError(
+                f"Unable to inspect container {container_name}: "
+                f"{(inspect_proc.stderr or inspect_proc.stdout or '').strip()}"
+            )
+
+        cmd = ["rm"]
+        if force:
+            cmd.append("-f")
+        cmd.append(container_name)
+        self._run(cmd, timeout_seconds=30)
+        return True
+
     def reap_container_if_expired(
         self,
         container_name: str,

--- a/src/codex_autorunner/surfaces/cli/commands/worktree.py
+++ b/src/codex_autorunner/surfaces/cli/commands/worktree.py
@@ -20,6 +20,24 @@ def _worktree_snapshot_payload(snapshot) -> dict:
     }
 
 
+def _emit_cleanup_status(result: object) -> None:
+    typer.echo("ok")
+    if not isinstance(result, dict):
+        return
+    docker_cleanup = result.get("docker_cleanup")
+    if not isinstance(docker_cleanup, dict):
+        return
+    status = str(docker_cleanup.get("status", "unknown")).strip() or "unknown"
+    parts = [f"docker_cleanup={status}"]
+    container_name = docker_cleanup.get("container_name")
+    if isinstance(container_name, str) and container_name.strip():
+        parts.append(f"container={container_name.strip()}")
+    message = docker_cleanup.get("message")
+    if isinstance(message, str) and message.strip():
+        parts.append(f"detail={message.strip()}")
+    typer.echo(" ".join(parts))
+
+
 def register_worktree_commands(
     worktree_app: typer.Typer,
     *,
@@ -144,7 +162,7 @@ def register_worktree_commands(
         config = require_hub_config(hub)
         supervisor = build_supervisor(config)
         try:
-            supervisor.cleanup_worktree(
+            result = supervisor.cleanup_worktree(
                 worktree_repo_id=worktree_repo_id,
                 delete_branch=delete_branch,
                 delete_remote=delete_remote,
@@ -155,7 +173,7 @@ def register_worktree_commands(
             )
         except Exception as exc:
             raise_exit(str(exc), cause=exc)
-        typer.echo("ok")
+        _emit_cleanup_status(result)
 
     @worktree_app.command("archive")
     def hub_worktree_archive(
@@ -184,7 +202,7 @@ def register_worktree_commands(
         config = require_hub_config(hub)
         supervisor = build_supervisor(config)
         try:
-            supervisor.cleanup_worktree(
+            result = supervisor.cleanup_worktree(
                 worktree_repo_id=worktree_repo_id,
                 delete_branch=delete_branch,
                 delete_remote=delete_remote,
@@ -195,7 +213,7 @@ def register_worktree_commands(
             )
         except Exception as exc:
             raise_exit(str(exc), cause=exc)
-        typer.echo("ok")
+        _emit_cleanup_status(result)
 
     @worktree_app.command("setup")
     def hub_worktree_setup(

--- a/src/codex_autorunner/surfaces/web/routes/hub_repos.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repos.py
@@ -1613,7 +1613,7 @@ def build_hub_repo_routes(
             ),
         )
         try:
-            await asyncio.to_thread(
+            result = await asyncio.to_thread(
                 context.supervisor.cleanup_worktree,
                 worktree_repo_id=str(worktree_repo_id),
                 delete_branch=delete_branch,
@@ -1625,12 +1625,14 @@ def build_hub_repo_routes(
             )
         except Exception as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if isinstance(result, dict):
+            return result
         return {"status": "ok"}
 
     @router.post("/hub/jobs/worktrees/cleanup", response_model=HubJobResponse)
     async def cleanup_worktree_job(payload: HubCleanupWorktreeRequest):
         def _run_cleanup_worktree():
-            context.supervisor.cleanup_worktree(
+            result = context.supervisor.cleanup_worktree(
                 worktree_repo_id=str(payload.worktree_repo_id),
                 delete_branch=payload.delete_branch,
                 delete_remote=payload.delete_remote,
@@ -1639,6 +1641,8 @@ def build_hub_repo_routes(
                 force_archive=payload.force_archive,
                 archive_note=payload.archive_note,
             )
+            if isinstance(result, dict):
+                return result
             return {"status": "ok"}
 
         job = await context.job_manager.submit(

--- a/tests/integrations/docker/test_runtime.py
+++ b/tests/integrations/docker/test_runtime.py
@@ -374,6 +374,36 @@ def test_stop_container_returns_false_for_missing_container() -> None:
     assert runtime.stop_container("missing") is False
 
 
+def test_remove_container_returns_false_for_missing_container() -> None:
+    def _run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        _ = kwargs
+        if cmd[1] == "inspect":
+            return _proc(cmd, returncode=1, stderr="No such object")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    runtime = DockerRuntime(run_fn=_run)
+    assert runtime.remove_container("missing", force=False) is False
+
+
+def test_remove_container_uses_non_forced_rm_by_default() -> None:
+    calls: list[list[str]] = []
+
+    def _run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        _ = kwargs
+        calls.append(list(cmd))
+        if cmd[1] == "inspect":
+            return _proc(cmd, stdout="container-id\n")
+        if cmd[1] == "rm":
+            return _proc(cmd, stdout="demo\n")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    runtime = DockerRuntime(run_fn=_run)
+    removed = runtime.remove_container("demo")
+    assert removed is True
+    assert calls[0][:3] == ["docker", "inspect", "--format"]
+    assert calls[1] == ["docker", "rm", "demo"]
+
+
 def test_reap_container_if_expired_stops_container() -> None:
     calls: list[list[str]] = []
     started_at = "2020-01-01T00:00:00Z"

--- a/tests/test_cli_hub_worktree.py
+++ b/tests/test_cli_hub_worktree.py
@@ -259,6 +259,63 @@ def test_cli_hub_worktree_cleanup_forwards_force_flag(tmp_path, monkeypatch) -> 
     assert calls["force"] is True
 
 
+def test_cli_hub_worktree_cleanup_prints_docker_cleanup_status(
+    tmp_path, monkeypatch
+) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    seed_hub_files(hub_root, force=True)
+
+    def _fake_cleanup(
+        self,
+        *,
+        worktree_repo_id,
+        delete_branch=False,
+        delete_remote=False,
+        archive=True,
+        force_archive=False,
+        archive_note=None,
+        force=False,
+    ):
+        _ = (
+            self,
+            worktree_repo_id,
+            delete_branch,
+            delete_remote,
+            archive,
+            force_archive,
+            archive_note,
+            force,
+        )
+        return {
+            "status": "ok",
+            "docker_cleanup": {
+                "status": "removed",
+                "container_name": "car-ws-abcd1234",
+                "message": "container stopped and removed",
+            },
+        }
+
+    monkeypatch.setattr(HubSupervisor, "cleanup_worktree", _fake_cleanup)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "hub",
+            "worktree",
+            "cleanup",
+            "wt-1",
+            "--path",
+            str(hub_root),
+            "--no-archive",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "docker_cleanup=removed" in result.output
+    assert "container=car-ws-abcd1234" in result.output
+
+
 def test_cli_hub_worktree_archive_uses_cleanup_with_archive(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -2,6 +2,7 @@ import concurrent.futures
 import json
 import shutil
 import sqlite3
+import subprocess
 import time
 from pathlib import Path
 from typing import Optional
@@ -17,6 +18,7 @@ from codex_autorunner.core.config import (
     DEFAULT_HUB_CONFIG,
     load_hub_config,
 )
+from codex_autorunner.core.destinations import default_car_docker_container_name
 from codex_autorunner.core.git_utils import run_git
 from codex_autorunner.core.hub import HubSupervisor, RepoStatus
 from codex_autorunner.core.pma_thread_store import PmaThreadStore
@@ -930,6 +932,271 @@ def test_cleanup_worktree_without_archive_allows_dirty_worktree(tmp_path: Path):
 
     supervisor.cleanup_worktree(worktree_repo_id=worktree.id, archive=False)
     assert not worktree.path.exists()
+
+
+def test_cleanup_worktree_removes_car_managed_docker_container(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg["pma"]["cleanup_require_archive"] = False
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    manifest_path = hub_root / ".codex-autorunner" / "manifest.yml"
+    manifest = load_manifest(manifest_path, hub_root)
+    base_entry = manifest.get("base")
+    assert base_entry is not None
+    base_entry.destination = {"kind": "docker", "image": "busybox:latest"}
+    save_manifest(manifest_path, manifest, hub_root)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/docker-cleanup-managed",
+        start_point="HEAD",
+    )
+
+    calls: list[list[str]] = []
+
+    def _fake_run_docker(self, args, *, timeout_seconds=None):
+        _ = self, timeout_seconds
+        args_list = [str(part) for part in args]
+        calls.append(args_list)
+        if args_list[0] == "inspect":
+            return subprocess.CompletedProcess(
+                args=args_list,
+                returncode=0,
+                stdout="true\n",
+                stderr="",
+            )
+        if args_list[0] == "stop":
+            return subprocess.CompletedProcess(
+                args=args_list,
+                returncode=0,
+                stdout="stopped\n",
+                stderr="",
+            )
+        if args_list[0] == "rm":
+            return subprocess.CompletedProcess(
+                args=args_list,
+                returncode=0,
+                stdout="removed\n",
+                stderr="",
+            )
+        raise AssertionError(f"unexpected docker call: {args_list}")
+
+    monkeypatch.setattr(HubSupervisor, "_run_docker_command", _fake_run_docker)
+
+    result = supervisor.cleanup_worktree(worktree_repo_id=worktree.id, archive=False)
+    assert result["status"] == "ok"
+    docker_cleanup = result["docker_cleanup"]
+    assert isinstance(docker_cleanup, dict)
+    assert docker_cleanup["status"] == "removed"
+    expected_name = default_car_docker_container_name(worktree.path.resolve())
+    assert docker_cleanup["container_name"] == expected_name
+    assert calls == [
+        ["inspect", "--format", "{{.State.Running}}", expected_name],
+        ["stop", "-t", "10", expected_name],
+        ["rm", expected_name],
+    ]
+    assert not worktree.path.exists()
+
+
+def test_cleanup_worktree_skips_explicit_docker_container_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg["pma"]["cleanup_require_archive"] = False
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    manifest_path = hub_root / ".codex-autorunner" / "manifest.yml"
+    manifest = load_manifest(manifest_path, hub_root)
+    base_entry = manifest.get("base")
+    assert base_entry is not None
+    base_entry.destination = {
+        "kind": "docker",
+        "image": "busybox:latest",
+        "container_name": "shared-container",
+    }
+    save_manifest(manifest_path, manifest, hub_root)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/docker-cleanup-explicit",
+        start_point="HEAD",
+    )
+
+    def _unexpected_run_docker(self, args, *, timeout_seconds=None):
+        _ = self, args, timeout_seconds
+        raise AssertionError("explicit container_name should not be auto-cleaned")
+
+    monkeypatch.setattr(HubSupervisor, "_run_docker_command", _unexpected_run_docker)
+
+    result = supervisor.cleanup_worktree(worktree_repo_id=worktree.id, archive=False)
+    assert result["status"] == "ok"
+    docker_cleanup = result["docker_cleanup"]
+    assert isinstance(docker_cleanup, dict)
+    assert docker_cleanup["status"] == "skipped_explicit"
+    assert docker_cleanup["container_name"] == "shared-container"
+    assert "explicit container_name" in str(docker_cleanup["message"])
+    assert not worktree.path.exists()
+
+
+def test_cleanup_worktree_continues_when_docker_cleanup_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg["pma"]["cleanup_require_archive"] = False
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    manifest_path = hub_root / ".codex-autorunner" / "manifest.yml"
+    manifest = load_manifest(manifest_path, hub_root)
+    base_entry = manifest.get("base")
+    assert base_entry is not None
+    base_entry.destination = {"kind": "docker", "image": "busybox:latest"}
+    save_manifest(manifest_path, manifest, hub_root)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/docker-cleanup-error",
+        start_point="HEAD",
+    )
+
+    def _fake_run_docker(self, args, *, timeout_seconds=None):
+        _ = self, timeout_seconds
+        args_list = [str(part) for part in args]
+        if args_list[0] == "inspect":
+            return subprocess.CompletedProcess(
+                args=args_list,
+                returncode=0,
+                stdout="true\n",
+                stderr="",
+            )
+        if args_list[0] == "stop":
+            return subprocess.CompletedProcess(
+                args=args_list,
+                returncode=0,
+                stdout="stopped\n",
+                stderr="",
+            )
+        if args_list[0] == "rm":
+            return subprocess.CompletedProcess(
+                args=args_list,
+                returncode=1,
+                stdout="",
+                stderr="docker daemon unavailable",
+            )
+        raise AssertionError(f"unexpected docker call: {args_list}")
+
+    monkeypatch.setattr(HubSupervisor, "_run_docker_command", _fake_run_docker)
+
+    result = supervisor.cleanup_worktree(worktree_repo_id=worktree.id, archive=False)
+    assert result["status"] == "ok"
+    docker_cleanup = result["docker_cleanup"]
+    assert isinstance(docker_cleanup, dict)
+    assert docker_cleanup["status"] == "error"
+    assert "docker rm failed" in str(docker_cleanup["message"])
+    assert not worktree.path.exists()
+
+
+def test_hub_api_cleanup_worktree_returns_docker_cleanup_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg["pma"]["cleanup_require_archive"] = False
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    manifest_path = hub_root / ".codex-autorunner" / "manifest.yml"
+    manifest = load_manifest(manifest_path, hub_root)
+    base_entry = manifest.get("base")
+    assert base_entry is not None
+    base_entry.destination = {"kind": "docker", "image": "busybox:latest"}
+    save_manifest(manifest_path, manifest, hub_root)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/docker-cleanup-api",
+        start_point="HEAD",
+    )
+
+    calls: list[list[str]] = []
+
+    def _fake_run_docker(self, args, *, timeout_seconds=None):
+        _ = self, timeout_seconds
+        args_list = [str(part) for part in args]
+        calls.append(args_list)
+        if args_list[0] == "inspect":
+            return subprocess.CompletedProcess(
+                args=args_list,
+                returncode=0,
+                stdout="true\n",
+                stderr="",
+            )
+        if args_list[0] == "stop":
+            return subprocess.CompletedProcess(
+                args=args_list,
+                returncode=0,
+                stdout="stopped\n",
+                stderr="",
+            )
+        if args_list[0] == "rm":
+            return subprocess.CompletedProcess(
+                args=args_list,
+                returncode=0,
+                stdout="removed\n",
+                stderr="",
+            )
+        raise AssertionError(f"unexpected docker call: {args_list}")
+
+    monkeypatch.setattr(HubSupervisor, "_run_docker_command", _fake_run_docker)
+
+    app = create_hub_app(hub_root)
+    client = TestClient(app)
+    resp = client.post(
+        "/hub/worktrees/cleanup",
+        json={"worktree_repo_id": worktree.id, "archive": False},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["status"] == "ok"
+    assert payload["docker_cleanup"]["status"] == "removed"
+    expected_name = default_car_docker_container_name(worktree.path.resolve())
+    assert payload["docker_cleanup"]["container_name"] == expected_name
+    assert calls == [
+        ["inspect", "--format", "{{.State.Running}}", expected_name],
+        ["stop", "-t", "10", expected_name],
+        ["rm", expected_name],
+    ]
 
 
 def test_cleanup_worktree_rejects_chat_bound_without_force(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add CAR-managed Docker container cleanup to `HubSupervisor.cleanup_worktree`
- remove auto-managed containers (`car-ws-<workspace-id>`) on cleanup by stopping then removing
- skip auto-delete for explicit `destination.container_name` values and report skip reason
- include `docker_cleanup` status in cleanup responses for both CLI and web routes
- share default Docker container naming via `core.destinations.default_car_docker_container_name`
- add `DockerRuntime.remove_container(..., force=False)` runtime API and tests

## Behavior
- Worktree cleanup now resolves the effective destination.
- For Docker destinations using the default CAR-managed name, cleanup attempts:
  - `docker inspect`
  - `docker stop` (if running)
  - `docker rm` (non-forced)
- For Docker destinations with explicit `container_name`, cleanup does not delete the container and returns a `skipped_explicit` status.
- Docker cleanup failures are warning-only and reported via `docker_cleanup.status=error`; git worktree cleanup still proceeds.

## Tests
- `./.venv/bin/python -m pytest tests/integrations/docker/test_runtime.py tests/test_hub_supervisor.py tests/test_cli_hub_worktree.py`
- Pre-commit/full checks executed during commit (format/lint/mypy/full pytest) and passed.

Closes #823
