### PR TITLE
fix: include .zshenv in PATH bootstrap for CAR local-bin

### DIFF
--- a/scripts/install-local-mac-hub.sh
+++ b/scripts/install-local-mac-hub.sh
@@ -52,10 +52,10 @@ ensure_login_shell_path() {
   marker_start="# >>> codex-autorunner local-bin >>>"
   marker_end="# <<< codex-autorunner local-bin <<<"
   if [[ -z "${HOME:-}" || ! -d "${HOME}" ]]; then
-    echo "Skipping login-shell PATH bootstrap; HOME is unavailable." >&2
+    echo "Skipping shell PATH bootstrap; HOME is unavailable." >&2
     return 0
   fi
-  for profile in "${HOME}/.zprofile" "${HOME}/.bash_profile" "${HOME}/.profile"; do
+  for profile in "${HOME}/.zshenv" "${HOME}/.zprofile" "${HOME}/.bash_profile" "${HOME}/.profile"; do
     if ! mkdir -p "$(dirname "${profile}")"; then
       echo "Warning: could not create directory for ${profile}; skipping." >&2
       continue
@@ -74,7 +74,7 @@ ensure_login_shell_path() {
     if ! {
       echo ""
       echo "${marker_start}"
-      echo "# Ensure pipx-installed CAR is available in login/non-interactive shells."
+      echo "# Ensure pipx-installed CAR is available in login shells and zsh -c commands."
       printf 'export PATH="%s:$PATH"\n' "${path_entry}"
       echo "${marker_end}"
     } >> "${profile}"; then

--- a/scripts/safe-refresh-local-linux-hub.sh
+++ b/scripts/safe-refresh-local-linux-hub.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 #   HEALTH_TIMEOUT_SECONDS       web health timeout (default: 30)
 #   HEALTH_INTERVAL_SECONDS      web health poll interval (default: 0.5)
 #   HELPER_PYTHON                python binary used for install/status writes
-#   LOCAL_BIN                    User-local bin path to ensure in login shells (default: ~/.local/bin)
+#   LOCAL_BIN                    User-local bin path to ensure in login shells and zsh -c commands (default: ~/.local/bin)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PACKAGE_SRC="${PACKAGE_SRC:-$SCRIPT_DIR/..}"
@@ -74,10 +74,10 @@ ensure_login_shell_path() {
   marker_start="# >>> codex-autorunner local-bin >>>"
   marker_end="# <<< codex-autorunner local-bin <<<"
   if [[ -z "${HOME:-}" || ! -d "${HOME}" ]]; then
-    echo "Skipping login-shell PATH bootstrap; HOME is unavailable." >&2
+    echo "Skipping shell PATH bootstrap; HOME is unavailable." >&2
     return 0
   fi
-  for profile in "${HOME}/.zprofile" "${HOME}/.bash_profile" "${HOME}/.profile"; do
+  for profile in "${HOME}/.zshenv" "${HOME}/.zprofile" "${HOME}/.bash_profile" "${HOME}/.profile"; do
     if ! mkdir -p "$(dirname "${profile}")"; then
       echo "Warning: could not create directory for ${profile}; skipping." >&2
       continue
@@ -96,7 +96,7 @@ ensure_login_shell_path() {
     if ! {
       echo ""
       echo "${marker_start}"
-      echo "# Ensure user-local CAR binaries are available in login/non-interactive shells."
+      echo "# Ensure user-local CAR binaries are available in login shells and zsh -c commands."
       printf 'export PATH="%s:$PATH"\n' "${path_entry}"
       echo "${marker_end}"
     } >> "${profile}"; then

--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -119,10 +119,10 @@ ensure_login_shell_path() {
   marker_start="# >>> codex-autorunner local-bin >>>"
   marker_end="# <<< codex-autorunner local-bin <<<"
   if [[ -z "${HOME:-}" || ! -d "${HOME}" ]]; then
-    echo "Skipping login-shell PATH bootstrap; HOME is unavailable." >&2
+    echo "Skipping shell PATH bootstrap; HOME is unavailable." >&2
     return 0
   fi
-  for profile in "${HOME}/.zprofile" "${HOME}/.bash_profile" "${HOME}/.profile"; do
+  for profile in "${HOME}/.zshenv" "${HOME}/.zprofile" "${HOME}/.bash_profile" "${HOME}/.profile"; do
     if ! mkdir -p "$(dirname "${profile}")"; then
       echo "Warning: could not create directory for ${profile}; skipping." >&2
       continue
@@ -141,7 +141,7 @@ ensure_login_shell_path() {
     if ! {
       echo ""
       echo "${marker_start}"
-      echo "# Ensure pipx-installed CAR is available in login/non-interactive shells."
+      echo "# Ensure pipx-installed CAR is available in login shells and zsh -c commands."
       printf 'export PATH="%s:$PATH"\n' "${path_entry}"
       echo "${marker_end}"
     } >> "${profile}"; then


### PR DESCRIPTION
## Summary
This PR updates CAR install/refresh scripts to also bootstrap `LOCAL_BIN` into `~/.zshenv` (in addition to existing profile files).

Why:
- PMA shell commands are executed via Codex `commandExecution` as `zsh -c` in this environment.
- `zsh -c` relies on `~/.zshenv` for PATH setup.
- If `~/.local/bin` is only in login-shell profiles (`.zprofile`, `.bash_profile`, `.profile`), PMA may not find `car`.

What changed:
- Include `~/.zshenv` in `ensure_login_shell_path` update targets.
- Adjust related log/comment text from login-only wording to include `zsh -c` commands.

Files:
- `scripts/install-local-mac-hub.sh`
- `scripts/safe-refresh-local-mac-hub.sh`
- `scripts/safe-refresh-local-linux-hub.sh`

## Validation
- Shell syntax checks:
  - `bash -n scripts/install-local-mac-hub.sh`
  - `bash -n scripts/safe-refresh-local-mac-hub.sh`
  - `bash -n scripts/safe-refresh-local-linux-hub.sh`
- Full pre-commit suite passed during commit (including pytest/mypy/lint/build).

## Operational context
In this incident, PMA reported:
- `car is not on PATH in this shell`
- PATH lacked `~/.local/bin`

After adding `~/.local/bin` in `~/.zshenv`, app-server `commandExecution` resolved `car` successfully.
This script change ensures that behavior is persisted by installer/refresh flows going forward.
