### PR TITLE
Fix Discord GitHub URL context injection consistency

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -957,7 +957,7 @@ class DiscordBotService:
         prompt_text, github_injected = await self._maybe_inject_github_context(
             prompt_text,
             workspace_root,
-            link_source_text=text if pma_enabled else None,
+            link_source_text=text,
             allow_cross_repo=pma_enabled,
         )
 

--- a/src/codex_autorunner/integrations/github/context_injection.py
+++ b/src/codex_autorunner/integrations/github/context_injection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from pathlib import Path
 from typing import Optional
 
@@ -18,12 +19,18 @@ _ISSUE_ONLY_LINK_WRAPPERS = (
     "[{link}]",
     "`{link}`",
 )
+_ISSUE_ONLY_LEADING_MENTION_RE = re.compile(
+    r"^(?:(?:<@!?\d+>|<@&\d+>|<#\d+>)\s*[:,]?\s*)+"
+)
 
 
 def issue_only_link(prompt_text: str, links: list[str]) -> Optional[str]:
     if not prompt_text or not links or len(links) != 1:
         return None
     stripped = prompt_text.strip()
+    if not stripped:
+        return None
+    stripped = _ISSUE_ONLY_LEADING_MENTION_RE.sub("", stripped).strip()
     if not stripped:
         return None
     link = links[0]

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -574,6 +574,90 @@ async def test_message_create_non_pma_injects_prompt_context_hints(
 
 
 @pytest.mark.anyio
+async def test_message_create_non_pma_uses_raw_message_for_github_link_source(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    user_text = (
+        "please write a prompt for triage https://github.com/example/repo/issues/123"
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway([("MESSAGE_CREATE", _message_create(user_text))])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    captured_link_source: list[Optional[str]] = []
+    captured_prompt: list[str] = []
+
+    async def _fake_maybe_inject_github_context(
+        self,
+        prompt_text: str,
+        workspace_root: Path,
+        *,
+        link_source_text: Optional[str] = None,
+        allow_cross_repo: bool = False,
+    ) -> tuple[str, bool]:
+        _ = (workspace_root, allow_cross_repo)
+        captured_prompt.append(prompt_text)
+        captured_link_source.append(link_source_text)
+        return prompt_text, False
+
+    async def _fake_run_turn(
+        self,
+        *,
+        workspace_root: Path,
+        prompt_text: str,
+        agent: str,
+        model_override: Optional[str],
+        reasoning_effort: Optional[str],
+        session_key: str,
+        orchestrator_channel_key: str,
+    ) -> str:
+        _ = (
+            workspace_root,
+            prompt_text,
+            agent,
+            model_override,
+            reasoning_effort,
+            session_key,
+            orchestrator_channel_key,
+        )
+        return "Done from fake turn"
+
+    service._maybe_inject_github_context = _fake_maybe_inject_github_context.__get__(
+        service, DiscordBotService
+    )
+    service._run_agent_turn_for_message = _fake_run_turn.__get__(
+        service, DiscordBotService
+    )
+
+    try:
+        await service.run_forever()
+        assert captured_link_source == [user_text]
+        assert captured_prompt
+        assert CAR_AWARENESS_BLOCK in captured_prompt[0]
+        assert PROMPT_WRITING_HINT in captured_prompt[0]
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_message_create_attachment_only_downloads_to_inbox_and_runs_turn(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_github_context_injection.py
+++ b/tests/test_github_context_injection.py
@@ -32,6 +32,17 @@ class _GitHubServiceStub:
         }
 
 
+def test_issue_only_link_accepts_discord_mention_prefix() -> None:
+    link = "https://github.com/example/repo/issues/123"
+    assert context_module.issue_only_link(f"<@123456789> {link}", [link]) == link
+    assert context_module.issue_only_link(f"<@!123456789>\n<{link}>", [link]) == link
+
+
+def test_issue_only_link_rejects_plain_at_prefix() -> None:
+    link = "https://github.com/example/repo/issues/123"
+    assert context_module.issue_only_link(f"@help {link}", [link]) is None
+
+
 @pytest.mark.anyio
 async def test_pma_injection_uses_user_message_links_only(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -79,6 +90,34 @@ async def test_pma_injection_falls_back_to_workspace_when_repo_not_found(
 
     assert injected is True
     assert "Context: injected" in injected_prompt
+    assert "Issue-only GitHub message detected" in injected_prompt
+    assert "Closes #123" in injected_prompt
+
+
+@pytest.mark.anyio
+async def test_pma_injection_issue_only_with_discord_mention_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        context_module,
+        "find_repo_root",
+        lambda _path: (_ for _ in ()).throw(RepoNotFoundError("no repo")),
+    )
+    monkeypatch.setattr(context_module, "load_repo_config", lambda _path: None)
+    monkeypatch.setattr(context_module, "GitHubService", _GitHubServiceStub)
+
+    prompt_text = "PMA prompt"
+    source_text = "<@123456789> https://github.com/example/repo/issues/123"
+    injected_prompt, injected = await context_module.maybe_inject_github_context(
+        prompt_text=prompt_text,
+        link_source_text=source_text,
+        workspace_root=tmp_path,
+        logger=logging.getLogger("test.github_context.mention_prefix"),
+        event_prefix="test.github_context",
+        allow_cross_repo=True,
+    )
+
+    assert injected is True
     assert "Issue-only GitHub message detected" in injected_prompt
     assert "Closes #123" in injected_prompt
 


### PR DESCRIPTION
## Summary
- make Discord plain-message GitHub context injection always parse links from raw user message text (non-PMA and PMA)
- support issue-only detection when a GitHub issue URL is prefixed by Discord mention tokens like `<@...>`
- avoid false positives by not treating plain `@text` prefixes as Discord mentions
- add regression tests for mention-prefixed issue-only detection and Discord non-PMA link-source forwarding

## Root cause
Discord messages often include bot mention tokens before URLs (for example `<@bot_id> https://github.com/...`).
The issue-only detector previously required the message body to be only the link wrapper, so the workflow hint to implement the issue and open a PR could be skipped.

## Validation
- pre-commit/full checks during commit hook completed successfully
- pytest result from hook: `2388 passed, 3 skipped`
- targeted regression run: `4 passed, 41 deselected`
