### PR TITLE
Default new setups to local Whisper

### DIFF
--- a/codex-autorunner.yml
+++ b/codex-autorunner.yml
@@ -111,7 +111,7 @@ repo_defaults:
   voice:
     # Voice input via Whisper.
     enabled: true
-    provider: openai_whisper
+    provider: local_whisper
     latency_mode: balanced
     chunk_ms: 600
     sample_rate: 16000

--- a/docs/AGENT_SETUP_DISCORD_GUIDE.md
+++ b/docs/AGENT_SETUP_DISCORD_GUIDE.md
@@ -106,7 +106,7 @@ OpenAI Whisper (API):
 
 1. Set an API key env var (default key name):
    - `OPENAI_API_KEY=...`
-2. Keep or set provider:
+2. Set provider:
    - `voice.provider: openai_whisper`
 
 Local Whisper (on-device):
@@ -129,7 +129,7 @@ Example config:
 ```yaml
 voice:
   enabled: true
-  provider: openai_whisper # or local_whisper
+  provider: local_whisper # or openai_whisper
   providers:
     openai_whisper:
       api_key_env: OPENAI_API_KEY

--- a/docs/voice/architecture.md
+++ b/docs/voice/architecture.md
@@ -11,7 +11,7 @@ This document outlines the shared speech input architecture for Codex Autorunner
 
 ## Config Surface (YAML + env overrides)
 - `voice.enabled` (bool, default `false`; env `CODEX_AUTORUNNER_VOICE_ENABLED`).
-- `voice.provider` (string, default `openai_whisper`; env `CODEX_AUTORUNNER_VOICE_PROVIDER`).
+- `voice.provider` (string, default `local_whisper`; env `CODEX_AUTORUNNER_VOICE_PROVIDER`).
 - `voice.latency_mode` (enum `realtime|balanced|quality`; env `CODEX_AUTORUNNER_VOICE_LATENCY`).
 - `voice.push_to_talk`: `{ max_ms: 15000, silence_auto_stop_ms: 1200, min_hold_ms: 150 }`.
 - `voice.chunk_ms` (default `600`) and `voice.sample_rate` (default `16000`) guide capture chunking.

--- a/src/codex_autorunner/core/config.py
+++ b/src/codex_autorunner/core/config.py
@@ -574,7 +574,7 @@ DEFAULT_REPO_CONFIG: Dict[str, Any] = {
     "terminal": _default_terminal_section(),
     "voice": {
         "enabled": True,
-        "provider": "openai_whisper",
+        "provider": "local_whisper",
         "latency_mode": "balanced",
         "chunk_ms": 600,
         "sample_rate": 16_000,

--- a/src/codex_autorunner/voice/config.py
+++ b/src/codex_autorunner/voice/config.py
@@ -64,7 +64,7 @@ class VoiceConfig:
         env = env or os.environ
         merged: MutableMapping[str, Any] = {
             "enabled": False,
-            "provider": "openai_whisper",
+            "provider": "local_whisper",
             "latency_mode": "balanced",
             "chunk_ms": 600,
             "sample_rate": 16_000,
@@ -106,7 +106,7 @@ class VoiceConfig:
             # Auto-enable if the provider's API key is available
             provider_name_raw = env.get(
                 "CODEX_AUTORUNNER_VOICE_PROVIDER",
-                merged.get("provider", "openai_whisper"),
+                merged.get("provider", "local_whisper"),
             )
             provider_name = (
                 "local_whisper"
@@ -134,7 +134,7 @@ class VoiceConfig:
         if explicit_warn is not None:
             merged["warn_on_remote_api"] = _env_bool(explicit_warn, True)
         else:
-            provider_name_raw = merged.get("provider", "openai_whisper")
+            provider_name_raw = merged.get("provider", "local_whisper")
             provider_name = (
                 "local_whisper"
                 if str(provider_name_raw).strip().lower() == "local"

--- a/tests/fixtures/default_hub_config.v2.json
+++ b/tests/fixtures/default_hub_config.v2.json
@@ -359,7 +359,7 @@
       "chunk_ms": 600,
       "enabled": true,
       "latency_mode": "balanced",
-      "provider": "openai_whisper",
+      "provider": "local_whisper",
       "providers": {
         "local_whisper": {
           "beam_size": 1,

--- a/tests/fixtures/default_repo_config.v2.json
+++ b/tests/fixtures/default_repo_config.v2.json
@@ -417,7 +417,7 @@
     "chunk_ms": 600,
     "enabled": true,
     "latency_mode": "balanced",
-    "provider": "openai_whisper",
+    "provider": "local_whisper",
     "providers": {
       "local_whisper": {
         "beam_size": 1,

--- a/tests/test_voice_transcribe_endpoint.py
+++ b/tests/test_voice_transcribe_endpoint.py
@@ -10,7 +10,9 @@ def _client(hub_env) -> TestClient:
     return TestClient(app)
 
 
-def test_voice_transcribe_reads_uploaded_file_bytes(hub_env, repo: Path) -> None:
+def test_voice_transcribe_reads_uploaded_file_bytes(
+    hub_env, repo: Path, monkeypatch
+) -> None:
     """
     The web UI uploads audio as multipart/form-data (FormData).
     The server must read the uploaded file bytes, not the raw multipart body.
@@ -19,6 +21,9 @@ def test_voice_transcribe_reads_uploaded_file_bytes(hub_env, repo: Path) -> None
     (multipart boundaries) and we'd get a provider error instead of empty_audio.
     """
 
+    # Keep this endpoint contract test independent from local-whisper optional deps.
+    monkeypatch.setenv("CODEX_AUTORUNNER_VOICE_PROVIDER", "openai_whisper")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     client = _client(hub_env)
     res = client.post(
         f"/repos/{hub_env.repo_id}/api/voice/transcribe",


### PR DESCRIPTION
## Summary
- default new repo/hub voice configuration to `local_whisper` instead of `openai_whisper`
- align `VoiceConfig.from_raw` fallback defaults to `local_whisper`
- update config snapshot fixtures and docs to match the new default
- make the voice multipart endpoint contract test provider-agnostic so it remains stable when local-whisper extras are absent

## Changes
- `src/codex_autorunner/core/config.py`
- `src/codex_autorunner/voice/config.py`
- `codex-autorunner.yml`
- `tests/fixtures/default_repo_config.v2.json`
- `tests/fixtures/default_hub_config.v2.json`
- `tests/test_voice_transcribe_endpoint.py`
- `docs/voice/architecture.md`
- `docs/AGENT_SETUP_DISCORD_GUIDE.md`

## Validation
- pre-commit hook suite during commit:
  - formatting/lint/type checks
  - JS build + asset manifest check
  - pytest full suite
- result: `2395 passed, 3 skipped`
