### PR TITLE
Fix Discord compact Continue button placement for multi-part output

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -7891,7 +7891,8 @@ class DiscordBotService:
             chunks = ["**Conversation Summary:**\n\n(No summary generated.)"]
 
         next_chunk_index = 0
-        continue_button_applied = False
+        last_chunk_index = len(chunks) - 1
+        preview_chunk_applied = False
         preview_message_id = (
             turn_result.preview_message_id
             if isinstance(turn_result.preview_message_id, str)
@@ -7901,15 +7902,18 @@ class DiscordBotService:
 
         if preview_message_id:
             try:
+                preview_payload: dict[str, Any] = {"content": chunks[0]}
+                if last_chunk_index == 0:
+                    preview_payload["components"] = [build_continue_turn_button()]
+                else:
+                    # This message is not terminal for long compactions.
+                    preview_payload["components"] = []
                 await self._rest.edit_channel_message(
                     channel_id=channel_id,
                     message_id=preview_message_id,
-                    payload={
-                        "content": chunks[0],
-                        "components": [build_continue_turn_button()],
-                    },
+                    payload=preview_payload,
                 )
-                continue_button_applied = True
+                preview_chunk_applied = True
                 next_chunk_index = 1
             except Exception as exc:
                 log_event(
@@ -7921,18 +7925,23 @@ class DiscordBotService:
                     exc=exc,
                 )
 
-        if not continue_button_applied:
+        if not preview_chunk_applied:
+            first_payload: dict[str, Any] = {"content": chunks[0]}
+            if last_chunk_index == 0:
+                first_payload["components"] = [build_continue_turn_button()]
             await self._send_channel_message_safe(
                 channel_id,
-                {
-                    "content": chunks[0],
-                    "components": [build_continue_turn_button()],
-                },
+                first_payload,
             )
             next_chunk_index = 1
 
-        for chunk in chunks[next_chunk_index:]:
-            await self._send_channel_message_safe(channel_id, {"content": chunk})
+        for chunk_index, chunk in enumerate(
+            chunks[next_chunk_index:], next_chunk_index
+        ):
+            payload: dict[str, Any] = {"content": chunk}
+            if chunk_index == last_chunk_index:
+                payload["components"] = [build_continue_turn_button()]
+            await self._send_channel_message_safe(channel_id, payload)
 
     async def _handle_car_rollout(
         self,

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -2976,9 +2976,14 @@ async def test_car_session_compact_reuses_preview_without_part_numbering(
         assert rest.edited_channel_messages
         compact_preview_edit = rest.edited_channel_messages[-1]
         assert compact_preview_edit["message_id"] == "preview-1"
-        components = compact_preview_edit["payload"].get("components") or []
-        assert components
-        button = components[0]["components"][0]
+        assert compact_preview_edit["payload"].get("components") == []
+        assert rest.channel_messages
+
+        for msg in rest.channel_messages[:-1]:
+            assert not (msg["payload"].get("components") or [])
+        tail_components = rest.channel_messages[-1]["payload"].get("components") or []
+        assert tail_components
+        button = tail_components[0]["components"][0]
         assert button["label"] == "Continue"
         assert button["custom_id"] == "continue_turn"
 
@@ -2987,6 +2992,103 @@ async def test_car_session_compact_reuses_preview_without_part_numbering(
             msg["payload"].get("content", "") for msg in rest.channel_messages
         )
         assert len(rendered_chunks) > 1
+        assert any("Conversation Summary" in chunk for chunk in rendered_chunks)
+        assert all(
+            not re.match(r"^Part \d+/\d+$", (chunk.splitlines() or [""])[0].strip())
+            for chunk in rendered_chunks
+        )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_car_session_compact_places_continue_button_on_last_chunk_without_preview(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, max_message_length=120),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    class _CompactOrchestrator:
+        def get_thread_id(self, session_key: str) -> Optional[str]:
+            _ = session_key
+            return "thread-1"
+
+    async def _fake_orchestrator_for_workspace(*args: Any, **kwargs: Any):
+        _ = args, kwargs
+        return _CompactOrchestrator()
+
+    summary = "\n".join(
+        [
+            f"- compact summary detail line {idx} with enough content to wrap"
+            for idx in range(1, 30)
+        ]
+    )
+
+    async def _fake_run_turn(
+        *,
+        workspace_root: Path,
+        prompt_text: str,
+        agent: str,
+        model_override: Optional[str],
+        reasoning_effort: Optional[str],
+        session_key: str,
+        orchestrator_channel_key: str,
+    ) -> DiscordMessageTurnResult:
+        _ = (
+            workspace_root,
+            prompt_text,
+            agent,
+            model_override,
+            reasoning_effort,
+            session_key,
+            orchestrator_channel_key,
+        )
+        return DiscordMessageTurnResult(
+            final_message=summary,
+            preview_message_id=None,
+        )
+
+    service._orchestrator_for_workspace = _fake_orchestrator_for_workspace  # type: ignore[assignment]
+    service._run_agent_turn_for_message = _fake_run_turn  # type: ignore[assignment]
+
+    try:
+        await service._handle_car_compact(
+            "interaction-1",
+            "token-1",
+            channel_id="channel-1",
+        )
+        assert not rest.edited_channel_messages
+        assert len(rest.channel_messages) > 1
+
+        for msg in rest.channel_messages[:-1]:
+            assert not (msg["payload"].get("components") or [])
+        tail_components = rest.channel_messages[-1]["payload"].get("components") or []
+        assert tail_components
+        button = tail_components[0]["components"][0]
+        assert button["label"] == "Continue"
+        assert button["custom_id"] == "continue_turn"
+
+        rendered_chunks = [
+            msg["payload"].get("content", "") for msg in rest.channel_messages
+        ]
         assert any("Conversation Summary" in chunk for chunk in rendered_chunks)
         assert all(
             not re.match(r"^Part \d+/\d+$", (chunk.splitlines() or [""])[0].strip())


### PR DESCRIPTION
## Summary
- fix `/car session compact` message rendering so the `Continue` button is attached to the final Discord chunk instead of the first
- handle both preview-reuse and non-preview flows with the same terminal-chunk button placement
- clear components on non-terminal preview edits to avoid showing `Continue` on the first message when compaction spans multiple messages
- add integration coverage for both compact flows to prevent regressions

## Testing
- `.venv/bin/pytest tests/integrations/discord/test_message_turns.py -k "car_session_compact_reuses_preview_without_part_numbering or car_session_compact_places_continue_button_on_last_chunk_without_preview"`
