### PR TITLE
Fix PMA FileBox stale list race during delete

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/pma.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma.py
@@ -3129,10 +3129,13 @@ def build_pma_routes() -> APIRouter:
         }
 
     @router.get("/files")
-    def list_pma_files(request: Request) -> dict[str, list[dict[str, Any]]]:
+    async def list_pma_files(request: Request) -> dict[str, list[dict[str, Any]]]:
         hub_root = request.app.state.config.root
         result: dict[str, list[dict[str, Any]]] = {"inbox": [], "outbox": []}
-        listing = filebox.list_filebox(hub_root, include_legacy=True)
+        async with await _get_pma_lock():
+            listing = await asyncio.to_thread(
+                filebox.list_filebox, hub_root, include_legacy=True
+            )
         for box in ("inbox", "outbox"):
             entries = listing.get(box, [])
             result[box] = [
@@ -3200,7 +3203,10 @@ def build_pma_routes() -> APIRouter:
                     detail=f"File too large (max {max_upload_bytes} bytes)",
                 )
             try:
-                target_path = filebox.save_file(hub_root, box, filename, content)
+                async with await _get_pma_lock():
+                    target_path = await asyncio.to_thread(
+                        filebox.save_file, hub_root, box, filename, content
+                    )
                 saved.append(target_path.name)
                 _get_safety_checker(request).record_action(
                     action_type=PmaActionType.FILE_UPLOADED,
@@ -3244,24 +3250,23 @@ def build_pma_routes() -> APIRouter:
         return FileResponse(entry.path, filename=entry.name)
 
     @router.delete("/files/{box}/{filename}")
-    def delete_pma_file(box: str, filename: str, request: Request):
+    async def delete_pma_file(box: str, filename: str, request: Request):
         if box not in ("inbox", "outbox"):
             raise HTTPException(status_code=400, detail="Invalid box")
         hub_root = request.app.state.config.root
+        entry: Optional[filebox.FileBoxEntry] = None
         try:
-            entry = filebox.resolve_file(hub_root, box, filename)
+            async with await _get_pma_lock():
+                entry = await asyncio.to_thread(
+                    filebox.resolve_file, hub_root, box, filename
+                )
+                if entry is None:
+                    logger.warning("File not found in PMA delete: %s", filename)
+                    raise HTTPException(status_code=404, detail="File not found")
+                await asyncio.to_thread(entry.path.unlink)
         except ValueError as exc:
             logger.warning("Invalid filename in PMA delete: %s (%s)", filename, exc)
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        if entry is None:
-            logger.warning("File not found in PMA delete: %s", filename)
-            raise HTTPException(status_code=404, detail="File not found")
-        try:
-            entry.path.unlink()
-            _get_safety_checker(request).record_action(
-                action_type=PmaActionType.FILE_DELETED,
-                details={"box": box, "filename": entry.name, "size": entry.size},
-            )
         except HTTPException:
             raise
         except FileNotFoundError:
@@ -3272,21 +3277,29 @@ def build_pma_routes() -> APIRouter:
             raise HTTPException(
                 status_code=500, detail="Failed to delete file"
             ) from exc
+        if entry is not None:
+            _get_safety_checker(request).record_action(
+                action_type=PmaActionType.FILE_DELETED,
+                details={"box": box, "filename": entry.name, "size": entry.size},
+            )
         return {"status": "ok"}
 
     @router.delete("/files/{box}")
-    def delete_pma_box(box: str, request: Request):
+    async def delete_pma_box(box: str, request: Request):
         if box not in ("inbox", "outbox"):
             raise HTTPException(status_code=400, detail="Invalid box")
         hub_root = request.app.state.config.root
         deleted_files: list[str] = []
-        entries = filebox.list_filebox(hub_root, include_legacy=True).get(box, [])
-        for entry in entries:
-            try:
-                entry.path.unlink()
-                deleted_files.append(entry.name)
-            except FileNotFoundError:
-                continue
+        async with await _get_pma_lock():
+            entries = await asyncio.to_thread(
+                filebox.list_filebox, hub_root, include_legacy=True
+            )
+            for entry in entries.get(box, []):
+                try:
+                    await asyncio.to_thread(entry.path.unlink)
+                    deleted_files.append(entry.name)
+                except FileNotFoundError:
+                    continue
         _get_safety_checker(request).record_action(
             action_type=PmaActionType.FILE_BULK_DELETED,
             details={

--- a/tests/test_pma_routes.py
+++ b/tests/test_pma_routes.py
@@ -1,5 +1,7 @@
 import asyncio
+import concurrent.futures
 import json
+import threading
 from pathlib import Path
 from typing import Any, Optional
 
@@ -1123,6 +1125,43 @@ def test_pma_files_bulk_delete_preserves_hidden_legacy_duplicate(hub_env) -> Non
     payload = client.get("/hub/pma/files").json()
     assert payload["outbox"][0]["name"] == "shared.txt"
     assert payload["outbox"][0]["source"] == "pma"
+
+
+def test_pma_files_list_waits_for_bulk_delete_to_finish(hub_env, monkeypatch) -> None:
+    seed_hub_files(hub_env.hub_root, force=True)
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+    client = TestClient(app)
+
+    filebox.ensure_structure(hub_env.hub_root)
+    race_file = filebox.inbox_dir(hub_env.hub_root) / "race.txt"
+    race_file.write_bytes(b"race")
+
+    unlink_started = threading.Event()
+    release_unlink = threading.Event()
+    original_unlink = Path.unlink
+
+    def _gated_unlink(path: Path, *args: Any, **kwargs: Any) -> None:
+        if path == race_file and not unlink_started.is_set():
+            unlink_started.set()
+            if not release_unlink.wait(timeout=3):
+                raise AssertionError("Timed out waiting to release bulk delete unlink")
+        original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", _gated_unlink)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        delete_future = executor.submit(lambda: client.delete("/hub/pma/files/inbox"))
+        assert unlink_started.wait(timeout=3), "Bulk delete did not reach unlink gate"
+        list_future = executor.submit(lambda: client.get("/hub/pma/files"))
+        release_unlink.set()
+
+        delete_resp = delete_future.result(timeout=3)
+        list_resp = list_future.result(timeout=3)
+
+    assert delete_resp.status_code == 200
+    assert list_resp.status_code == 200
+    assert list_resp.json()["inbox"] == []
 
 
 def test_pma_files_rejects_invalid_filenames(hub_env) -> None:


### PR DESCRIPTION
## Summary
- serialize PMA file listing and file mutations (`list`, `upload`, `delete file`, `delete box`) behind the shared PMA route lock
- run FileBox filesystem operations via `asyncio.to_thread` while holding the lock so list snapshots cannot interleave with concurrent bulk delete
- keep existing PMA file API behavior unchanged while eliminating stale read windows after delete completes

## Testing
- `.venv/bin/pytest tests/test_pma_routes.py -k "pma_files"`
- pre-commit suite during `git commit`:
  - lint/type checks
  - `pytest` full suite (`2410 passed, 3 skipped`)

Closes #864
