### PR TITLE
discord: add bind pagination and workspace autocomplete

### DIFF
--- a/src/codex_autorunner/integrations/discord/adapter.py
+++ b/src/codex_autorunner/integrations/discord/adapter.py
@@ -28,6 +28,7 @@ from ..chat.renderer import RenderedText, TextRenderer
 from .constants import DISCORD_MAX_MESSAGE_LENGTH
 from .errors import DiscordAPIError
 from .interactions import (
+    extract_autocomplete_command_context,
     extract_channel_id,
     extract_command_path_and_options,
     extract_component_custom_id,
@@ -35,6 +36,7 @@ from .interactions import (
     extract_interaction_id,
     extract_interaction_token,
     extract_user_id,
+    is_autocomplete_interaction,
     is_component_interaction,
 )
 from .rendering import (
@@ -347,6 +349,18 @@ class DiscordChatAdapter(ChatAdapter):
                 if isinstance(values, list):
                     payload_data["values"] = values
             payload_data["type"] = "component"
+        elif is_autocomplete_interaction(payload):
+            command_path, options, focused_name, focused_value = (
+                extract_autocomplete_command_context(payload)
+            )
+            command_str = ":".join(command_path) if command_path else ""
+            payload_data["command"] = command_str
+            payload_data["options"] = options
+            payload_data["autocomplete"] = {
+                "name": focused_name,
+                "value": focused_value,
+            }
+            payload_data["type"] = "autocomplete"
         else:
             command_path, options = extract_command_path_and_options(payload)
             command_str = ":".join(command_path) if command_path else ""

--- a/src/codex_autorunner/integrations/discord/commands.py
+++ b/src/codex_autorunner/integrations/discord/commands.py
@@ -25,7 +25,8 @@ def build_application_commands() -> list[dict[str, Any]]:
                         {
                             "type": STRING,
                             "name": "workspace",
-                            "description": "Workspace path (optional - shows picker if omitted)",
+                            "description": "Workspace path or repo id (optional - shows picker if omitted)",
+                            "autocomplete": True,
                             "required": False,
                         }
                     ],

--- a/src/codex_autorunner/integrations/discord/interactions.py
+++ b/src/codex_autorunner/integrations/discord/interactions.py
@@ -17,11 +17,61 @@ def extract_command_path_and_options(
     if not isinstance(data, dict):
         return (), {}
 
-    root_name = data.get("name")
-    if not isinstance(root_name, str) or not root_name:
+    path, current_options = _extract_command_path_and_leaf_options(data)
+    if not path:
         return (), {}
 
-    path: list[str] = [root_name]
+    parsed_options: dict[str, Any] = {}
+    for item in current_options:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        parsed_options[name] = item.get("value")
+
+    return tuple(path), parsed_options
+
+
+def extract_autocomplete_command_context(
+    interaction_payload: dict[str, Any],
+) -> tuple[tuple[str, ...], dict[str, Any], Optional[str], str]:
+    data = interaction_payload.get("data")
+    if not isinstance(data, dict):
+        return (), {}, None, ""
+
+    path, current_options = _extract_command_path_and_leaf_options(data)
+    if not path:
+        return (), {}, None, ""
+
+    parsed_options: dict[str, Any] = {}
+    focused_name: Optional[str] = None
+    focused_value = ""
+
+    for item in current_options:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        value = item.get("value")
+        parsed_options[name] = value
+
+        if bool(item.get("focused")):
+            focused_name = name
+            focused_value = str(value) if value is not None else ""
+
+    return tuple(path), parsed_options, focused_name, focused_value
+
+
+def _extract_command_path_and_leaf_options(
+    data: dict[str, Any],
+) -> tuple[list[str], list[dict[str, Any]]]:
+    root_name = data.get("name")
+    if not isinstance(root_name, str) or not root_name:
+        return [], []
+
+    path = [root_name]
     options = data.get("options")
     current_options = options if isinstance(options, list) else []
 
@@ -37,17 +87,8 @@ def extract_command_path_and_options(
             path.append(name)
         nested = first.get("options")
         current_options = nested if isinstance(nested, list) else []
-
-    parsed_options: dict[str, Any] = {}
-    for item in current_options:
-        if not isinstance(item, dict):
-            continue
-        name = item.get("name")
-        if not isinstance(name, str) or not name:
-            continue
-        parsed_options[name] = item.get("value")
-
-    return tuple(path), parsed_options
+    normalized_options = [item for item in current_options if isinstance(item, dict)]
+    return path, normalized_options
 
 
 def extract_interaction_id(interaction_payload: dict[str, Any]) -> Optional[str]:
@@ -83,6 +124,11 @@ def extract_user_id(interaction_payload: dict[str, Any]) -> Optional[str]:
 def is_component_interaction(interaction_payload: dict[str, Any]) -> bool:
     interaction_type = interaction_payload.get("type")
     return interaction_type == 3
+
+
+def is_autocomplete_interaction(interaction_payload: dict[str, Any]) -> bool:
+    interaction_type = interaction_payload.get("type")
+    return interaction_type == 4
 
 
 def extract_component_custom_id(interaction_payload: dict[str, Any]) -> Optional[str]:

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -138,8 +138,10 @@ from .command_registry import sync_commands
 from .commands import build_application_commands
 from .components import (
     DISCORD_SELECT_OPTION_MAX_OPTIONS,
+    build_action_row,
     build_agent_picker,
     build_bind_picker,
+    build_button,
     build_cancel_turn_button,
     build_continue_turn_button,
     build_flow_runs_picker,
@@ -154,6 +156,7 @@ from .config import DiscordBotConfig
 from .errors import DiscordAPIError, DiscordTransientError
 from .gateway import DiscordGatewayClient
 from .interactions import (
+    extract_autocomplete_command_context,
     extract_channel_id,
     extract_command_path_and_options,
     extract_component_custom_id,
@@ -162,6 +165,7 @@ from .interactions import (
     extract_interaction_id,
     extract_interaction_token,
     extract_user_id,
+    is_autocomplete_interaction,
     is_component_interaction,
 )
 from .outbox import DiscordOutboxManager
@@ -202,6 +206,8 @@ FLOW_ACTION_SELECT_PREFIX = "flow_action_select"
 UPDATE_TARGET_SELECT_ID = "update_target_select"
 REVIEW_COMMIT_SELECT_ID = "review_commit_select"
 MODEL_EFFORT_SELECT_ID = "model_effort_select"
+BIND_PAGE_CUSTOM_ID_PREFIX = "bind_page"
+REPO_AUTOCOMPLETE_TOKEN_PREFIX = "repo@"
 FLOW_ACTIONS_WITH_RUN_PICKER = {
     "status",
     "restart",
@@ -663,6 +669,38 @@ class DiscordBotService:
                 values=payload_data.get("values"),
                 guild_id=payload_data.get("guild_id"),
                 user_id=event.from_user_id,
+            )
+            return
+
+        if payload_data.get("type") == "autocomplete":
+            command_raw = payload_data.get("command")
+            command_path = (
+                tuple(part for part in str(command_raw).split(":") if part)
+                if isinstance(command_raw, str)
+                else ()
+            )
+            autocomplete_payload = payload_data.get("autocomplete")
+            focused_name: Optional[str] = None
+            focused_value = ""
+            if isinstance(autocomplete_payload, dict):
+                focused_name_raw = autocomplete_payload.get("name")
+                focused_value_raw = autocomplete_payload.get("value")
+                if isinstance(focused_name_raw, str) and focused_name_raw.strip():
+                    focused_name = focused_name_raw.strip()
+                if isinstance(focused_value_raw, str):
+                    focused_value = focused_value_raw
+            options = (
+                payload_data.get("options")
+                if isinstance(payload_data.get("options"), dict)
+                else {}
+            )
+            await self._handle_command_autocomplete(
+                interaction_id,
+                interaction_token,
+                command_path=command_path,
+                options=options,
+                focused_name=focused_name,
+                focused_value=focused_value,
             )
             return
 
@@ -3017,6 +3055,9 @@ class DiscordBotService:
         if is_component_interaction(interaction_payload):
             await self._handle_component_interaction(interaction_payload)
             return
+        if is_autocomplete_interaction(interaction_payload):
+            await self._handle_autocomplete_interaction(interaction_payload)
+            return
 
         interaction_id = extract_interaction_id(interaction_payload)
         interaction_token = extract_interaction_token(interaction_payload)
@@ -3105,6 +3146,43 @@ class DiscordBotService:
                 "An unexpected error occurred. Please try again later.",
             )
 
+    async def _handle_autocomplete_interaction(
+        self, interaction_payload: dict[str, Any]
+    ) -> None:
+        interaction_id = extract_interaction_id(interaction_payload)
+        interaction_token = extract_interaction_token(interaction_payload)
+        channel_id = extract_channel_id(interaction_payload)
+
+        if not interaction_id or not interaction_token or not channel_id:
+            self._logger.warning(
+                "handle_autocomplete_interaction: missing required fields (interaction_id=%s, token=%s, channel=%s)",
+                bool(interaction_id),
+                bool(interaction_token),
+                bool(channel_id),
+            )
+            return
+
+        if not allowlist_allows(interaction_payload, self._allowlist):
+            await self._respond_autocomplete(
+                interaction_id, interaction_token, choices=[]
+            )
+            return
+
+        (
+            command_path,
+            options,
+            focused_name,
+            focused_value,
+        ) = extract_autocomplete_command_context(interaction_payload)
+        await self._handle_command_autocomplete(
+            interaction_id,
+            interaction_token,
+            command_path=command_path,
+            options=options,
+            focused_name=focused_name,
+            focused_value=focused_value,
+        )
+
     async def _handle_bind(
         self,
         interaction_id: str,
@@ -3134,11 +3212,11 @@ class DiscordBotService:
             )
             return
 
-        components = [build_bind_picker(repos)]
+        prompt, components = self._build_bind_page_prompt_and_components(repos, page=0)
         await self._respond_with_components(
             interaction_id,
             interaction_token,
-            "Select a workspace to bind:",
+            prompt,
             components,
         )
 
@@ -3147,13 +3225,172 @@ class DiscordBotService:
             return []
         try:
             manifest = load_manifest(self._manifest_path, self._config.root)
-            return [
-                (repo.id, str(self._config.root / repo.path))
-                for repo in manifest.repos
-                if repo.id
-            ]
+            ordered: list[tuple[int, int, str, str]] = []
+            for index, repo in enumerate(manifest.repos):
+                if not repo.id:
+                    continue
+                worktree_priority = 0 if repo.kind == "worktree" else 1
+                ordered.append(
+                    (
+                        worktree_priority,
+                        -index,
+                        repo.id,
+                        str(self._config.root / repo.path),
+                    )
+                )
+            ordered.sort(key=lambda item: (item[0], item[1], item[2]))
+            return [(repo_id, path) for _, _, repo_id, path in ordered]
         except Exception:
             return []
+
+    def _build_bind_page_prompt_and_components(
+        self,
+        repos: list[tuple[str, str]],
+        *,
+        page: int,
+    ) -> tuple[str, list[dict[str, Any]]]:
+        page_size = DISCORD_SELECT_OPTION_MAX_OPTIONS
+        total = len(repos)
+        total_pages = max(1, (total + page_size - 1) // page_size)
+        bounded_page = max(0, min(page, total_pages - 1))
+        start = bounded_page * page_size
+        end = start + page_size
+        page_repos = repos[start:end]
+
+        prompt = "Select a workspace to bind:"
+        if total > page_size:
+            prompt = (
+                "Select a workspace to bind "
+                f"(page {bounded_page + 1}/{total_pages}, {total} total; "
+                "recent worktrees first). Use `/car bind workspace:<repo_id>` "
+                "or `/car bind workspace:<path>` for any repo not listed."
+            )
+
+        components: list[dict[str, Any]] = [build_bind_picker(page_repos)]
+        if total_pages > 1:
+            components.append(
+                build_action_row(
+                    [
+                        build_button(
+                            "Prev",
+                            f"{BIND_PAGE_CUSTOM_ID_PREFIX}:{bounded_page - 1}",
+                            disabled=bounded_page <= 0,
+                        ),
+                        build_button(
+                            f"Page {bounded_page + 1}/{total_pages}",
+                            f"{BIND_PAGE_CUSTOM_ID_PREFIX}:noop",
+                            disabled=True,
+                        ),
+                        build_button(
+                            "Next",
+                            f"{BIND_PAGE_CUSTOM_ID_PREFIX}:{bounded_page + 1}",
+                            disabled=bounded_page >= total_pages - 1,
+                        ),
+                    ]
+                )
+            )
+
+        return prompt, components
+
+    def _repo_autocomplete_value(self, repo_id: str) -> str:
+        normalized_id = repo_id.strip()
+        if len(normalized_id) <= 100:
+            return normalized_id
+        digest = hashlib.sha256(normalized_id.encode("utf-8")).hexdigest()[:24]
+        return f"{REPO_AUTOCOMPLETE_TOKEN_PREFIX}{digest}"
+
+    def _resolve_repo_from_token(
+        self, token: str, repos: list[tuple[str, str]]
+    ) -> Optional[tuple[str, str]]:
+        normalized = token.strip()
+        if not normalized:
+            return None
+
+        for repo_id, repo_path in repos:
+            if repo_id == normalized:
+                return repo_id, repo_path
+
+        if normalized.startswith(REPO_AUTOCOMPLETE_TOKEN_PREFIX):
+            digest = normalized[len(REPO_AUTOCOMPLETE_TOKEN_PREFIX) :]
+            if digest:
+                matches = [
+                    (repo_id, repo_path)
+                    for repo_id, repo_path in repos
+                    if hashlib.sha256(repo_id.encode("utf-8"))
+                    .hexdigest()
+                    .startswith(digest)
+                ]
+                if len(matches) == 1:
+                    return matches[0]
+
+        return None
+
+    def _build_bind_autocomplete_choices(self, query: str) -> list[dict[str, str]]:
+        repos = self._list_manifest_repos()
+        normalized_query = query.strip().lower()
+        scored: list[tuple[int, int, str, str]] = []
+
+        for index, (repo_id, path) in enumerate(repos):
+            rid = repo_id.lower()
+            pth = path.lower()
+            if (
+                normalized_query
+                and normalized_query not in rid
+                and normalized_query not in pth
+            ):
+                continue
+
+            score = 0
+            if normalized_query:
+                if rid.startswith(normalized_query):
+                    score += 40
+                elif normalized_query in rid:
+                    score += 20
+                if pth.startswith(normalized_query):
+                    score += 10
+                elif normalized_query in pth:
+                    score += 5
+
+            scored.append((score, -index, repo_id, path))
+
+        scored.sort(key=lambda item: (-item[0], -item[1], item[2]))
+        seen: set[str] = set()
+        choices: list[dict[str, str]] = []
+        for _score, _neg_index, repo_id, path in scored:
+            value = self._repo_autocomplete_value(repo_id)
+            if not value or value in seen:
+                continue
+            seen.add(value)
+            option_name = f"{repo_id} - {path}"
+            choices.append(
+                {
+                    "name": option_name[:100],
+                    "value": self._repo_autocomplete_value(value),
+                }
+            )
+            if len(choices) >= DISCORD_SELECT_OPTION_MAX_OPTIONS:
+                break
+        return choices
+
+    async def _handle_command_autocomplete(
+        self,
+        interaction_id: str,
+        interaction_token: str,
+        *,
+        command_path: tuple[str, ...],
+        options: dict[str, Any],
+        focused_name: Optional[str],
+        focused_value: str,
+    ) -> None:
+        _ = options
+        choices: list[dict[str, str]] = []
+        if command_path == ("car", "bind") and focused_name == "workspace":
+            choices = self._build_bind_autocomplete_choices(focused_value)
+        await self._respond_autocomplete(
+            interaction_id,
+            interaction_token,
+            choices=choices,
+        )
 
     async def _bind_with_path(
         self,
@@ -3164,10 +3401,22 @@ class DiscordBotService:
         guild_id: Optional[str],
         raw_path: str,
     ) -> None:
-        candidate = Path(raw_path)
-        if not candidate.is_absolute():
-            candidate = self._config.root / candidate
-        workspace = canonicalize_path(candidate)
+        token = raw_path.strip()
+        repos = self._list_manifest_repos()
+        resolved_repo = self._resolve_repo_from_token(token, repos)
+        repo_match = resolved_repo[1] if resolved_repo else None
+        if repo_match:
+            workspace = canonicalize_path(Path(repo_match))
+            selected_repo_id: Optional[str] = (
+                resolved_repo[0] if resolved_repo else None
+            )
+        else:
+            candidate = Path(token)
+            if not candidate.is_absolute():
+                candidate = self._config.root / candidate
+            workspace = canonicalize_path(candidate)
+            selected_repo_id = None
+
         if not workspace.exists() or not workspace.is_dir():
             await self._respond_ephemeral(
                 interaction_id,
@@ -3180,7 +3429,7 @@ class DiscordBotService:
             channel_id=channel_id,
             guild_id=guild_id,
             workspace_path=str(workspace),
-            repo_id=None,
+            repo_id=selected_repo_id,
         )
         await self._respond_ephemeral(
             interaction_id,
@@ -6358,6 +6607,43 @@ class DiscordBotService:
                     interaction_id,
                 )
 
+    async def _respond_autocomplete(
+        self,
+        interaction_id: str,
+        interaction_token: str,
+        *,
+        choices: list[dict[str, str]],
+    ) -> None:
+        sanitized_choices: list[dict[str, str]] = []
+        for choice in choices[:DISCORD_SELECT_OPTION_MAX_OPTIONS]:
+            name = choice.get("name", "")
+            value = choice.get("value", "")
+            if not isinstance(name, str) or not isinstance(value, str):
+                continue
+            normalized_name = name.strip()
+            normalized_value = value.strip()
+            if not normalized_name or not normalized_value:
+                continue
+            sanitized_choices.append(
+                {
+                    "name": normalized_name[:100],
+                    "value": normalized_value[:100],
+                }
+            )
+
+        try:
+            await self._rest.create_interaction_response(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                payload={"type": 8, "data": {"choices": sanitized_choices}},
+            )
+        except DiscordAPIError as exc:
+            self._logger.error(
+                "Failed to send autocomplete response: %s (interaction_id=%s)",
+                exc,
+                interaction_id,
+            )
+
     async def _update_component_message(
         self,
         *,
@@ -6458,6 +6744,15 @@ class DiscordBotService:
             return
 
         try:
+            if custom_id.startswith(f"{BIND_PAGE_CUSTOM_ID_PREFIX}:"):
+                page_token = custom_id.split(":", 1)[1].strip()
+                await self._handle_bind_page_component(
+                    interaction_id,
+                    interaction_token,
+                    page_token=page_token,
+                )
+                return
+
             if custom_id == "bind_select":
                 values = extract_component_values(interaction_payload)
                 if not values:
@@ -6781,6 +7076,15 @@ class DiscordBotService:
         user_id: Optional[str] = None,
     ) -> None:
         try:
+            if custom_id.startswith(f"{BIND_PAGE_CUSTOM_ID_PREFIX}:"):
+                page_token = custom_id.split(":", 1)[1].strip()
+                await self._handle_bind_page_component(
+                    interaction_id,
+                    interaction_token,
+                    page_token=page_token,
+                )
+                return
+
             if custom_id == "bind_select":
                 if not values:
                     await self._respond_ephemeral(
@@ -7130,6 +7434,50 @@ class DiscordBotService:
             interaction_id,
             interaction_token,
             f"Bound this channel to: {selected_repo_id} ({workspace})",
+        )
+
+    async def _handle_bind_page_component(
+        self,
+        interaction_id: str,
+        interaction_token: str,
+        *,
+        page_token: str,
+    ) -> None:
+        if page_token == "noop":
+            await self._respond_ephemeral(
+                interaction_id,
+                interaction_token,
+                "Already on this page.",
+            )
+            return
+        try:
+            requested_page = int(page_token)
+        except (TypeError, ValueError):
+            await self._respond_ephemeral(
+                interaction_id,
+                interaction_token,
+                "Invalid bind page selection.",
+            )
+            return
+
+        repos = self._list_manifest_repos()
+        if not repos:
+            await self._respond_ephemeral(
+                interaction_id,
+                interaction_token,
+                "No repos found in manifest.",
+            )
+            return
+
+        prompt, components = self._build_bind_page_prompt_and_components(
+            repos,
+            page=requested_page,
+        )
+        await self._update_component_message(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            text=prompt,
+            components=components,
         )
 
     async def _handle_flow_button(

--- a/tests/integrations/discord/test_commands_payload.py
+++ b/tests/integrations/discord/test_commands_payload.py
@@ -87,6 +87,7 @@ def test_required_options_are_marked_required() -> None:
     bind = _find_option(car_options, "bind")
     bind_workspace = _find_option(bind["options"], "workspace")
     assert bind_workspace["required"] is False
+    assert bind_workspace["autocomplete"] is True
     update = _find_option(car_options, "update")
     update_target = _find_option(update["options"], "target")
     assert update_target["required"] is False

--- a/tests/integrations/discord/test_interactions_parse.py
+++ b/tests/integrations/discord/test_interactions_parse.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from codex_autorunner.integrations.discord.interactions import (
+    extract_autocomplete_command_context,
     extract_channel_id,
     extract_command_path_and_options,
     extract_component_custom_id,
@@ -9,6 +10,7 @@ from codex_autorunner.integrations.discord.interactions import (
     extract_interaction_id,
     extract_interaction_token,
     extract_user_id,
+    is_autocomplete_interaction,
     is_component_interaction,
 )
 
@@ -64,6 +66,16 @@ def test_is_component_interaction_returns_false_for_type_2() -> None:
     assert is_component_interaction(payload) is False
 
 
+def test_is_autocomplete_interaction_returns_true_for_type_4() -> None:
+    payload = {"type": 4, "data": {"name": "car"}}
+    assert is_autocomplete_interaction(payload) is True
+
+
+def test_is_autocomplete_interaction_returns_false_for_type_2() -> None:
+    payload = {"type": 2, "data": {"name": "car"}}
+    assert is_autocomplete_interaction(payload) is False
+
+
 def test_extract_component_custom_id() -> None:
     payload = {"data": {"custom_id": "flow:run-123:resume"}}
     assert extract_component_custom_id(payload) == "flow:run-123:resume"
@@ -112,3 +124,33 @@ def test_extract_command_path_and_options_for_car_new() -> None:
     path, options = extract_command_path_and_options(payload)
     assert path == ("car", "new")
     assert options == {}
+
+
+def test_extract_autocomplete_command_context_for_bind_workspace() -> None:
+    payload = {
+        "type": 4,
+        "data": {
+            "name": "car",
+            "options": [
+                {
+                    "type": 1,
+                    "name": "bind",
+                    "options": [
+                        {
+                            "type": 3,
+                            "name": "workspace",
+                            "value": "codex-autor",
+                            "focused": True,
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+    path, options, focused_name, focused_value = extract_autocomplete_command_context(
+        payload
+    )
+    assert path == ("car", "bind")
+    assert options == {"workspace": "codex-autor"}
+    assert focused_name == "workspace"
+    assert focused_value == "codex-autor"

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -27,6 +27,12 @@ from codex_autorunner.integrations.discord.config import (
 from codex_autorunner.integrations.discord.errors import DiscordAPIError
 from codex_autorunner.integrations.discord.service import DiscordBotService
 from codex_autorunner.integrations.discord.state import DiscordStateStore
+from codex_autorunner.manifest import (
+    MANIFEST_VERSION,
+    Manifest,
+    ManifestRepo,
+    save_manifest,
+)
 
 
 class _FakeRest:
@@ -217,6 +223,40 @@ def _bind_select_interaction(
     }
 
 
+def _autocomplete_interaction(
+    *,
+    name: str,
+    focused_name: str,
+    focused_value: str,
+    user_id: str = "user-1",
+) -> dict[str, Any]:
+    return {
+        "id": "inter-autocomplete-1",
+        "token": "token-autocomplete-1",
+        "channel_id": "channel-1",
+        "guild_id": "guild-1",
+        "type": 4,
+        "member": {"user": {"id": user_id}},
+        "data": {
+            "name": "car",
+            "options": [
+                {
+                    "type": 1,
+                    "name": name,
+                    "options": [
+                        {
+                            "type": 3,
+                            "name": focused_name,
+                            "value": focused_value,
+                            "focused": True,
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+
+
 def _component_interaction(
     *, custom_id: str | None, values: list[Any] | None = None, user_id: str = "user-1"
 ) -> dict[str, Any]:
@@ -397,6 +437,338 @@ async def test_service_bind_then_status_updates_and_reads_store(tmp_path: Path) 
         assert status_payload["data"]["flags"] == 64
         assert "bound this channel" in bind_payload["data"]["content"].lower()
         assert "channel is bound" in status_payload["data"]["content"].lower()
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_service_bind_picker_prioritizes_recent_worktrees_when_truncated(
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / ".codex-autorunner" / "manifest.yml"
+    repos = [
+        ManifestRepo(
+            id=f"base-{index:02d}",
+            path=Path(f"repos/base-{index:02d}"),
+            kind="base",
+        )
+        for index in range(26)
+    ]
+    repos.append(
+        ManifestRepo(
+            id="base-00--new-worktree",
+            path=Path("worktrees/base-00--new-worktree"),
+            kind="worktree",
+            worktree_of="base-00",
+            branch="new-worktree",
+        )
+    )
+    save_manifest(
+        manifest_path,
+        Manifest(version=MANIFEST_VERSION, repos=repos),
+        tmp_path,
+    )
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    gateway = _FakeGateway([_interaction(name="bind", options=[])])
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+        manifest_path=manifest_path,
+    )
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 1
+        payload = rest.interaction_responses[0]["payload"]
+        content = payload["data"]["content"]
+        assert "page 1/2" in content
+        menu = payload["data"]["components"][0]["components"][0]
+        values = [option["value"] for option in menu["options"]]
+        assert len(values) == 25
+        assert "base-00--new-worktree" in values
+        assert "base-00" not in values
+        nav = payload["data"]["components"][1]["components"]
+        assert [button["label"] for button in nav] == ["Prev", "Page 1/2", "Next"]
+        assert nav[0]["disabled"] is True
+        assert nav[1]["disabled"] is True
+        assert nav[2]["disabled"] is False
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_service_bind_accepts_repo_id_as_workspace_option(tmp_path: Path) -> None:
+    workspace = tmp_path / "worktrees" / "repo-1"
+    workspace.mkdir(parents=True)
+    manifest_path = tmp_path / ".codex-autorunner" / "manifest.yml"
+    save_manifest(
+        manifest_path,
+        Manifest(
+            version=MANIFEST_VERSION,
+            repos=[
+                ManifestRepo(
+                    id="repo-1",
+                    path=Path("worktrees/repo-1"),
+                    kind="worktree",
+                    worktree_of="base-1",
+                    branch="feature/repo-1",
+                )
+            ],
+        ),
+        tmp_path,
+    )
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _interaction(
+                name="bind",
+                options=[{"type": 3, "name": "workspace", "value": "repo-1"}],
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+        manifest_path=manifest_path,
+    )
+
+    try:
+        await service.run_forever()
+        binding = await store.get_binding(channel_id="channel-1")
+        assert binding is not None
+        assert binding["repo_id"] == "repo-1"
+        assert binding["workspace_path"] == str(workspace.resolve())
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_service_routes_bind_page_component_interaction(tmp_path: Path) -> None:
+    repos = [(f"repo-{index:02d}", f"/tmp/repo-{index:02d}") for index in range(30)]
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    gateway = _FakeGateway([_component_interaction(custom_id="bind_page:1")])
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    service._list_manifest_repos = lambda: repos
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 1
+        payload = rest.interaction_responses[0]["payload"]
+        assert payload["type"] == 7
+        menu = payload["data"]["components"][0]["components"][0]
+        values = [option["value"] for option in menu["options"]]
+        assert values == [f"repo-{index:02d}" for index in range(25, 30)]
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_service_bind_workspace_autocomplete_returns_matching_repo_ids(
+    tmp_path: Path,
+) -> None:
+    repos = [
+        ("codex-autorunner--discord-1", "/tmp/worktrees/codex-autorunner--discord-1"),
+        ("codex-autorunner--discord-2", "/tmp/worktrees/codex-autorunner--discord-2"),
+        ("ios-app-template", "/tmp/repos/ios-app-template"),
+    ]
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _autocomplete_interaction(
+                name="bind",
+                focused_name="workspace",
+                focused_value="discord",
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    service._list_manifest_repos = lambda: repos
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 1
+        payload = rest.interaction_responses[0]["payload"]
+        assert payload["type"] == 8
+        choices = payload["data"]["choices"]
+        assert [choice["value"] for choice in choices] == [
+            "codex-autorunner--discord-1",
+            "codex-autorunner--discord-2",
+        ]
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_service_bind_workspace_autocomplete_long_repo_id_uses_token(
+    tmp_path: Path,
+) -> None:
+    long_repo_id = "repo-" + ("x" * 140)
+    repos = [(long_repo_id, "/tmp/worktrees/repo-long")]
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _autocomplete_interaction(
+                name="bind",
+                focused_name="workspace",
+                focused_value="repo-",
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    service._list_manifest_repos = lambda: repos
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 1
+        payload = rest.interaction_responses[0]["payload"]
+        assert payload["type"] == 8
+        choices = payload["data"]["choices"]
+        assert len(choices) == 1
+        assert choices[0]["value"].startswith("repo@")
+        assert len(choices[0]["value"]) <= 100
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_service_bind_accepts_autocomplete_repo_token(tmp_path: Path) -> None:
+    long_repo_id = "repo-" + ("y" * 140)
+    workspace = tmp_path / "worktrees" / "repo-token"
+    workspace.mkdir(parents=True)
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    gateway = _FakeGateway([_interaction(name="bind", options=[])])
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    service._list_manifest_repos = lambda: [(long_repo_id, str(workspace))]
+    token = service._repo_autocomplete_value(long_repo_id)
+    assert token.startswith("repo@")
+
+    bind_gateway = _FakeGateway(
+        [
+            _interaction(
+                name="bind",
+                options=[{"type": 3, "name": "workspace", "value": token}],
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=bind_gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    service._list_manifest_repos = lambda: [(long_repo_id, str(workspace))]
+
+    try:
+        await service.run_forever()
+        binding = await store.get_binding(channel_id="channel-1")
+        assert binding is not None
+        assert binding["repo_id"] == long_repo_id
+        assert binding["workspace_path"] == str(workspace.resolve())
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_service_bind_accepts_disabled_repo_id(tmp_path: Path) -> None:
+    workspace = tmp_path / "worktrees" / "repo-disabled"
+    workspace.mkdir(parents=True)
+    manifest_path = tmp_path / ".codex-autorunner" / "manifest.yml"
+    save_manifest(
+        manifest_path,
+        Manifest(
+            version=MANIFEST_VERSION,
+            repos=[
+                ManifestRepo(
+                    id="repo-disabled",
+                    path=Path("worktrees/repo-disabled"),
+                    kind="worktree",
+                    worktree_of="base-1",
+                    branch="feature/repo-disabled",
+                    enabled=False,
+                )
+            ],
+        ),
+        tmp_path,
+    )
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _interaction(
+                name="bind",
+                options=[{"type": 3, "name": "workspace", "value": "repo-disabled"}],
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+        manifest_path=manifest_path,
+    )
+
+    try:
+        await service.run_forever()
+        binding = await store.get_binding(channel_id="channel-1")
+        assert binding is not None
+        assert binding["repo_id"] == "repo-disabled"
     finally:
         await store.close()
 


### PR DESCRIPTION
## Summary
- add Discord `/car bind` pagination so workspace picker can navigate beyond the 25-option platform limit
- add slash autocomplete support for `/car bind workspace` with ranked repo-id/path matching
- allow autocomplete-safe tokens for long repo IDs and resolve them back to full repo IDs on bind
- keep manual binding support for `/car bind workspace:<repo_id>` and `/car bind workspace:<path>`
- preserve previous behavior for disabled repos in repo-id binding flows

## Implementation Notes
- command schema now sets `autocomplete: true` on `car.bind.workspace`
- interaction parser/adapter now supports Discord autocomplete interactions (`type=4`)
- bind picker now includes `Prev`/`Next` navigation buttons (`bind_page:*`)
- autocomplete responses are sent as interaction callback `type=8`
- long repo IDs use short deterministic autocomplete tokens (`repo@<sha-prefix>`) to stay within Discord value limits

## Testing
- `.venv/bin/pytest -q tests/integrations/discord/test_service_routing.py -k "bind or autocomplete" tests/integrations/discord/test_interactions_parse.py tests/integrations/discord/test_commands_payload.py`
- `.venv/bin/pytest -q tests/integrations/discord/test_components.py tests/integrations/discord/test_adapter.py`
- `.venv/bin/ruff check src/codex_autorunner/integrations/discord/service.py src/codex_autorunner/integrations/discord/interactions.py src/codex_autorunner/integrations/discord/adapter.py src/codex_autorunner/integrations/discord/commands.py tests/integrations/discord/test_service_routing.py tests/integrations/discord/test_interactions_parse.py tests/integrations/discord/test_commands_payload.py`
- pre-commit gate run during `git commit` (format/lint/mypy/build/full pytest) passed
