### PR TITLE
Discord: suppress filebox hint for voice-only attachments

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -333,6 +333,7 @@ class _SavedDiscordAttachment:
     path: Path
     mime_type: Optional[str]
     size_bytes: int
+    is_audio: bool
     transcript_text: Optional[str] = None
     transcript_warning: Optional[str] = None
 
@@ -1277,6 +1278,9 @@ class DiscordBotService:
                 if not Path(transcription_name).suffix:
                     transcription_name = path.name
                 mime_type = getattr(attachment, "mime_type", None)
+                is_audio = self._is_audio_attachment(
+                    attachment, mime_type if isinstance(mime_type, str) else None
+                )
                 transcript_text, transcript_warning = (
                     await self._transcribe_voice_attachment(
                         workspace_root=workspace_root,
@@ -1293,6 +1297,7 @@ class DiscordBotService:
                         path=path,
                         mime_type=mime_type if isinstance(mime_type, str) else None,
                         size_bytes=len(data),
+                        is_audio=is_audio,
                         transcript_text=transcript_text,
                         transcript_warning=transcript_warning,
                     )
@@ -1334,18 +1339,19 @@ class DiscordBotService:
                     wrap_injected_context(DISCORD_WHISPER_TRANSCRIPT_DISCLAIMER)
                 )
 
-        details.append("")
-        details.append(
-            wrap_injected_context(
-                "\n".join(
-                    [
-                        f"Inbox: {inbox}",
-                        f"Outbox (pending): {outbox_pending_dir(workspace_root)}",
-                        "Use inbox files as local inputs and place reply files in outbox (pending).",
-                    ]
+        if any(not item.is_audio for item in saved):
+            details.append("")
+            details.append(
+                wrap_injected_context(
+                    "\n".join(
+                        [
+                            f"Inbox: {inbox}",
+                            f"Outbox (pending): {outbox_pending_dir(workspace_root)}",
+                            "Use inbox files as local inputs and place reply files in outbox (pending).",
+                        ]
+                    )
                 )
             )
-        )
         attachment_context = "\n".join(details)
 
         if prompt_text.strip():

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -920,6 +920,7 @@ async def test_message_create_audio_attachment_injects_transcript_context(
         prompt = captured_prompts[0]
         assert "Inbound Discord attachments:" in prompt
         assert "Transcript: Do we have whisper support?" in prompt
+        assert "Outbox (pending):" not in prompt
         assert fake_voice.calls
         assert fake_voice.calls[0]["audio_bytes"] == b"voice-bytes"
         assert fake_voice.calls[0]["client"] == "discord"
@@ -1012,6 +1013,7 @@ async def test_message_create_audio_attachment_does_not_transcribe_when_voice_di
         await service.run_forever()
         assert captured_prompts
         assert "Transcript:" not in captured_prompts[0]
+        assert "Outbox (pending):" not in captured_prompts[0]
         assert fake_voice.calls == []
     finally:
         await store.close()
@@ -1101,6 +1103,7 @@ async def test_message_create_audio_attachment_without_content_type_still_transc
         assert captured_prompts
         prompt = captured_prompts[0]
         assert "Transcript: transcribed despite missing mime" in prompt
+        assert "Outbox (pending):" not in prompt
         assert fake_voice.calls
         assert fake_voice.calls[0]["audio_bytes"] == b"voice-bytes"
         assert fake_voice.calls[0]["filename"] == "voice-note.ogg"
@@ -1195,10 +1198,113 @@ async def test_message_create_audio_attachment_with_generic_content_type_transcr
         assert captured_prompts
         prompt = captured_prompts[0]
         assert "Transcript: transcribed generic mime" in prompt
+        assert "Outbox (pending):" not in prompt
         assert fake_voice.calls
         assert fake_voice.calls[0]["audio_bytes"] == b"voice-bytes"
         assert fake_voice.calls[0]["content_type"] == "audio/ogg"
         assert str(fake_voice.calls[0]["filename"]).endswith(".ogg")
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_message_create_mixed_audio_and_file_attachment_keeps_outbox_hint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    audio_url = "https://cdn.discordapp.com/attachments/audio-mixed"
+    file_url = "https://cdn.discordapp.com/attachments/file-mixed"
+    rest = _FakeRest()
+    rest.attachment_data_by_url[audio_url] = b"voice-bytes"
+    rest.attachment_data_by_url[file_url] = b"report-bytes"
+    gateway = _FakeGateway(
+        [
+            (
+                "MESSAGE_CREATE",
+                _message_create(
+                    content="",
+                    attachments=[
+                        {
+                            "id": "att-audio-mixed",
+                            "filename": "voice-note.ogg",
+                            "content_type": "audio/ogg",
+                            "size": 11,
+                            "url": audio_url,
+                        },
+                        {
+                            "id": "att-file-mixed",
+                            "filename": "report.txt",
+                            "content_type": "text/plain",
+                            "size": 12,
+                            "url": file_url,
+                        },
+                    ],
+                ),
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    fake_voice = _FakeVoiceService("mixed transcript")
+    monkeypatch.setattr(
+        service,
+        "_voice_service_for_workspace",
+        lambda _workspace: (fake_voice, SimpleNamespace(provider="local_whisper")),
+    )
+
+    captured_prompts: list[str] = []
+
+    async def _fake_run_turn(
+        self,
+        *,
+        workspace_root: Path,
+        prompt_text: str,
+        agent: str,
+        model_override: Optional[str],
+        reasoning_effort: Optional[str],
+        session_key: str,
+        orchestrator_channel_key: str,
+    ) -> str:
+        _ = (
+            workspace_root,
+            agent,
+            model_override,
+            reasoning_effort,
+            session_key,
+            orchestrator_channel_key,
+        )
+        captured_prompts.append(prompt_text)
+        return "Done"
+
+    service._run_agent_turn_for_message = _fake_run_turn.__get__(
+        service, DiscordBotService
+    )
+
+    try:
+        await service.run_forever()
+        assert captured_prompts
+        prompt = captured_prompts[0]
+        assert "Transcript: mixed transcript" in prompt
+        assert "Outbox (pending):" in prompt
+        assert "voice-note.ogg" in prompt
+        assert "report.txt" in prompt
+        assert fake_voice.calls
     finally:
         await store.close()
 


### PR DESCRIPTION
## Summary
- suppress Discord filebox inbox/outbox hint injection for voice-only attachment turns
- keep attachment/transcript context for voice turns unchanged
- retain existing hint behavior when at least one non-audio attachment is present
- add a mixed-audio+file test to lock the boundary behavior

## Why
Voice inputs should not trigger file-handling guidance. Inbox/outbox hints are intended for file workflows only.

## Validation
- `.venv/bin/python -m pytest tests/integrations/discord/test_message_turns.py -k "attachment_only_downloads_to_inbox or audio_attachment_injects_transcript_context or audio_attachment_does_not_transcribe_when_voice_disabled or audio_attachment_without_content_type_still_transcribes or audio_attachment_with_generic_content_type_transcribes or mixed_audio_and_file_attachment_keeps_outbox_hint"`
- pre-commit/full checks on commit:
  - formatting/lint/type checks
  - full pytest suite (`2438 passed, 3 skipped`)

## Review
- sub-agent review completed (approve); added requested mixed-attachment coverage before opening this PR.
