### PR TITLE
Fix Discord /new reset to clear runtime backend session state

### DIFF
--- a/src/codex_autorunner/core/ports/agent_backend.py
+++ b/src/codex_autorunner/core/ports/agent_backend.py
@@ -115,6 +115,10 @@ class AgentBackend:
         """Optional backend configuration hook; default is no-op."""
         _ = options
 
+    def reset_session_state(self) -> None:
+        """Optional hook to clear in-memory session/thread state."""
+        return None
+
     async def start_session(self, target: dict, context: dict) -> str:
         raise NotImplementedError
 

--- a/src/codex_autorunner/integrations/agents/backend_orchestrator.py
+++ b/src/codex_autorunner/integrations/agents/backend_orchestrator.py
@@ -22,6 +22,9 @@ from ...core.ports.backend_orchestrator import (
 from ...core.ports.run_event import RunEvent
 from ...core.state import RunnerState
 from ...integrations.app_server.threads import (
+    FILE_CHAT_OPENCODE_KEY,
+    FILE_CHAT_OPENCODE_PREFIX,
+    PMA_OPENCODE_KEY,
     AppServerThreadRegistry,
     default_app_server_threads_path,
 )
@@ -254,6 +257,8 @@ class BackendOrchestrator:
 
     def reset_thread_id(self, session_key: str) -> bool:
         """Reset the persisted thread ID for a given session key."""
+        target_agent = self._agent_for_session_key(session_key)
+        self._clear_runtime_session_state(agent_id=target_agent)
         with self._app_server_threads_lock:
             return self._app_server_threads.reset_thread(session_key)
 
@@ -261,6 +266,39 @@ class BackendOrchestrator:
         if isinstance(self._backend_factory, AgentBackendFactory):
             return self._backend_factory
         return None
+
+    @staticmethod
+    def _agent_for_session_key(session_key: str) -> Optional[str]:
+        normalized = session_key.strip().lower() if isinstance(session_key, str) else ""
+        if not normalized:
+            return None
+        if (
+            normalized == PMA_OPENCODE_KEY
+            or normalized == FILE_CHAT_OPENCODE_KEY
+            or normalized.startswith(FILE_CHAT_OPENCODE_PREFIX)
+            or normalized.endswith(".opencode")
+        ):
+            return "opencode"
+        return "codex"
+
+    def _clear_runtime_session_state(self, *, agent_id: Optional[str]) -> None:
+        if self._context is not None and (
+            agent_id is None or self._context.agent_id == agent_id
+        ):
+            self._context.session_id = None
+            self._context.turn_id = None
+            self._context.thread_info = None
+
+        factory = self._agent_backend_factory()
+        if factory is not None:
+            factory.reset_session_state(agent_id=agent_id)
+            return
+
+        if self._active_backend is None:
+            return
+        reset = getattr(self._active_backend, "reset_session_state", None)
+        if callable(reset):
+            reset()
 
     def ensure_opencode_supervisor(self) -> Optional[Any]:
         """

--- a/src/codex_autorunner/integrations/agents/codex_backend.py
+++ b/src/codex_autorunner/integrations/agents/codex_backend.py
@@ -174,6 +174,15 @@ class CodexAppServerBackend(AgentBackend):
         self._event_queue: asyncio.Queue[RunEvent] = asyncio.Queue()
         self._latest_completed_agent_message: str = ""
 
+    def reset_session_state(self) -> None:
+        """Clear cached session/thread ids so the next turn starts fresh."""
+        self._session_id = None
+        self._thread_id = None
+        self._turn_id = None
+        self._thread_info = None
+        self._reasoning_summary_buffers.clear()
+        self._latest_completed_agent_message = ""
+
     async def _ensure_client(self) -> CodexAppServerClient:
         if self._client is None:
             self._client = await self._supervisor.get_client(self._workspace_root)

--- a/src/codex_autorunner/integrations/agents/opencode_backend.py
+++ b/src/codex_autorunner/integrations/agents/opencode_backend.py
@@ -83,6 +83,11 @@ class OpenCodeBackend(AgentBackend):
         self._last_token_total: Optional[dict[str, Any]] = None
         self._event_formatter = OpenCodeEventFormatter()
 
+    def reset_session_state(self) -> None:
+        """Clear cached session ids so the next turn creates/resumes explicitly."""
+        self._session_id = None
+        self._last_turn_id = None
+
     def configure(self, **options: Any) -> None:
         self._model = options.get("model")
         reasoning = options.get("reasoning")

--- a/src/codex_autorunner/integrations/agents/wiring.py
+++ b/src/codex_autorunner/integrations/agents/wiring.py
@@ -189,6 +189,19 @@ class AgentBackendFactory:
         self._opencode_supervisor = supervisor
         return supervisor
 
+    def reset_session_state(self, *, agent_id: Optional[str] = None) -> None:
+        """Clear cached in-memory session state for one or all backends."""
+        if isinstance(agent_id, str) and agent_id:
+            backends = [self._backend_cache.get(agent_id)]
+        else:
+            backends = list(self._backend_cache.values())
+        for backend in backends:
+            if backend is None:
+                continue
+            reset = getattr(backend, "reset_session_state", None)
+            if callable(reset):
+                reset()
+
     async def close_all(self) -> None:
         backends = list(self._backend_cache.values())
         self._backend_cache = {}

--- a/tests/test_backend_orchestrator_configuration.py
+++ b/tests/test_backend_orchestrator_configuration.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Optional
 
 import pytest
 
@@ -12,6 +12,7 @@ from codex_autorunner.core.ports.agent_backend import AgentBackend
 from codex_autorunner.core.ports.run_event import Completed, RunEvent, now_iso
 from codex_autorunner.core.state import RunnerState
 from codex_autorunner.integrations.agents.backend_orchestrator import (
+    BackendContext,
     BackendOrchestrator,
 )
 
@@ -124,3 +125,110 @@ async def test_backend_orchestrator_uses_generic_backend_configure(
 def test_backend_orchestrator_run_turn_has_no_backend_isinstance_checks() -> None:
     source = inspect.getsource(BackendOrchestrator.run_turn)
     assert "isinstance(backend" not in source
+
+
+@pytest.mark.asyncio
+async def test_reset_thread_id_clears_runtime_state_for_codex_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def _fake_factory(*_args: Any, **_kwargs: Any):
+        def _build_backend(
+            agent_id: str, state: RunnerState, notification_handler: Any
+        ) -> AgentBackend:
+            _ = agent_id, state, notification_handler
+            raise AssertionError("backend should not be created in this test")
+
+        return _build_backend
+
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.agents.wiring.build_agent_backend_factory",
+        _fake_factory,
+    )
+
+    config = SimpleNamespace(
+        autorunner_reuse_session=False,
+        app_server=SimpleNamespace(turn_timeout_seconds=321.0),
+        ticket_flow=TicketFlowConfig(
+            approval_mode="yolo",
+            default_approval_decision="accept",
+            include_previous_ticket_context=False,
+        ),
+    )
+    orchestrator = BackendOrchestrator(repo_root=tmp_path, config=config)
+    orchestrator._context = BackendContext(
+        agent_id="codex",
+        session_id="thread-old",
+        turn_id="turn-old",
+        thread_info={"id": "thread-old"},
+    )
+
+    reset_calls: list[Optional[str]] = []
+
+    class _Factory:
+        def reset_session_state(self, *, agent_id: Optional[str] = None) -> None:
+            reset_calls.append(agent_id)
+
+    monkeypatch.setattr(orchestrator, "_agent_backend_factory", lambda: _Factory())
+
+    cleared = orchestrator.reset_thread_id("file_chat.discord.channel.123456789abc")
+    assert cleared is False
+    assert reset_calls == ["codex"]
+    assert orchestrator._context is not None
+    assert orchestrator._context.session_id is None
+    assert orchestrator._context.turn_id is None
+    assert orchestrator._context.thread_info is None
+
+
+@pytest.mark.asyncio
+async def test_reset_thread_id_targets_opencode_runtime_for_opencode_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def _fake_factory(*_args: Any, **_kwargs: Any):
+        def _build_backend(
+            agent_id: str, state: RunnerState, notification_handler: Any
+        ) -> AgentBackend:
+            _ = agent_id, state, notification_handler
+            raise AssertionError("backend should not be created in this test")
+
+        return _build_backend
+
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.agents.wiring.build_agent_backend_factory",
+        _fake_factory,
+    )
+
+    config = SimpleNamespace(
+        autorunner_reuse_session=False,
+        app_server=SimpleNamespace(turn_timeout_seconds=321.0),
+        ticket_flow=TicketFlowConfig(
+            approval_mode="yolo",
+            default_approval_decision="accept",
+            include_previous_ticket_context=False,
+        ),
+    )
+    orchestrator = BackendOrchestrator(repo_root=tmp_path, config=config)
+    orchestrator._context = BackendContext(
+        agent_id="codex",
+        session_id="thread-old",
+        turn_id="turn-old",
+        thread_info={"id": "thread-old"},
+    )
+
+    reset_calls: list[Optional[str]] = []
+
+    class _Factory:
+        def reset_session_state(self, *, agent_id: Optional[str] = None) -> None:
+            reset_calls.append(agent_id)
+
+    monkeypatch.setattr(orchestrator, "_agent_backend_factory", lambda: _Factory())
+
+    cleared = orchestrator.reset_thread_id(
+        "file_chat.opencode.discord.channel.123456789abc"
+    )
+    assert cleared is False
+    assert reset_calls == ["opencode"]
+    assert orchestrator._context is not None
+    # codex context should remain intact when resetting opencode state.
+    assert orchestrator._context.session_id == "thread-old"
+    assert orchestrator._context.turn_id == "turn-old"
+    assert orchestrator._context.thread_info == {"id": "thread-old"}


### PR DESCRIPTION
## Summary
Fix `/car new`, `/car newt`, and `/car session reset` semantics in Discord by clearing in-memory backend session state when thread state is reset.

Previously we only removed the persisted thread mapping (`app_server_threads.json`), but the cached backend instance still held the old session/thread id, so the next turn could continue on the old model thread/context.

## Root Cause
- Discord reset flows call `BackendOrchestrator.reset_thread_id(session_key)`.
- That method only reset persisted mapping and did not clear runtime backend state.
- Cached backends (`CodexAppServerBackend`, `OpenCodeBackend`) retained prior `_thread_id`/`_session_id` and reused them.

## Changes
- Added `AgentBackend.reset_session_state()` hook (default no-op).
- Implemented `reset_session_state()` for:
  - `CodexAppServerBackend`
  - `OpenCodeBackend`
- Added `AgentBackendFactory.reset_session_state(agent_id=...)` to clear targeted cached backend runtime state.
- Updated `BackendOrchestrator.reset_thread_id()` to:
  - infer target agent from `session_key`
  - clear runtime orchestrator/backend state before clearing persisted mapping.
- Added regression tests in `tests/test_backend_orchestrator_configuration.py` covering:
  - codex-key reset clears codex runtime state
  - opencode-key reset targets opencode runtime state only.

## Platform Impact Check
- **Discord**: affected (this fix).
- **Telegram**: not affected by this path; `/new` and `/newt` explicitly create a fresh thread/session (`thread_start`/`create_session`) and store it.
- **Web file chat / ticket chat**: not affected by this path; new-thread flow resets registry and execution path explicitly `thread_start`s when no active key.

## Validation
- Full repo pre-commit hooks passed.
- Full pytest suite passed in commit hook:
  - `2444 passed, 3 skipped`
- Additional targeted runs:
  - `tests/test_backend_orchestrator_configuration.py`
  - `tests/integrations/discord/test_service_routing.py -k "car_newt or car_new_resets_repo_session_key"`
