### PR TITLE
fix: make /newt branch naming collision-resistant across chat platforms

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -4078,7 +4078,10 @@ class DiscordBotService:
         safe_channel_id = re.sub(r"[^a-zA-Z0-9]+", "-", channel_id).strip("-")
         if not safe_channel_id:
             safe_channel_id = "channel"
-        branch_name = f"thread-{safe_channel_id}"
+        branch_suffix = hashlib.sha256(str(workspace_root).encode("utf-8")).hexdigest()[
+            :10
+        ]
+        branch_name = f"thread-{safe_channel_id}-{branch_suffix}"
 
         try:
             default_branch = await asyncio.to_thread(

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import hashlib
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -1309,7 +1310,10 @@ class WorkspaceCommands(SharedHelpers):
         safe_thread_id = re.sub(r"[^a-zA-Z0-9]+", "-", thread_identity).strip("-")
         if not safe_thread_id:
             safe_thread_id = "unscoped"
-        branch_name = f"thread-chat-{safe_chat_id}-{safe_thread_id}"
+        branch_suffix = hashlib.sha256(str(workspace_root).encode("utf-8")).hexdigest()[
+            :10
+        ]
+        branch_name = f"thread-chat-{safe_chat_id}-{safe_thread_id}-{branch_suffix}"
 
         try:
             default_branch = await asyncio.to_thread(

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 from pathlib import Path
@@ -2525,10 +2526,14 @@ async def test_car_newt_resets_current_workspace_branch_and_session(
 
     try:
         await service.run_forever()
+        expected_branch = (
+            "thread-channel-1-"
+            f"{hashlib.sha256(str(workspace.resolve()).encode('utf-8')).hexdigest()[:10]}"
+        )
         assert branch_calls == [
             {
                 "repo_root": workspace.resolve(),
-                "branch_name": "thread-channel-1",
+                "branch_name": expected_branch,
             }
         ]
         assert fake_orchestrator.reset_keys

--- a/tests/test_telegram_pma_routing.py
+++ b/tests/test_telegram_pma_routing.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import logging
 from pathlib import Path
 from types import SimpleNamespace
@@ -821,7 +822,11 @@ async def test_newt_branch_name_includes_chat_identity(
 
     assert len(branch_calls) == 1
     assert branch_calls[0]["repo_root"] == workspace.resolve()
-    assert branch_calls[0]["branch_name"] == "thread-chat-7777-thread-333"
+    expected_branch = (
+        "thread-chat-7777-thread-333-"
+        f"{hashlib.sha256(str(workspace.resolve()).encode('utf-8')).hexdigest()[:10]}"
+    )
+    assert branch_calls[0]["branch_name"] == expected_branch
 
 
 @pytest.mark.anyio
@@ -903,7 +908,11 @@ async def test_newt_infers_base_repo_from_worktree_id_when_missing_metadata(
 
     assert len(branch_calls) == 1
     assert branch_calls[0]["repo_root"] == workspace.resolve()
-    assert branch_calls[0]["branch_name"] == "thread-chat-7777-thread-333"
+    expected_branch = (
+        "thread-chat-7777-thread-333-"
+        f"{hashlib.sha256(str(workspace.resolve()).encode('utf-8')).hexdigest()[:10]}"
+    )
+    assert branch_calls[0]["branch_name"] == expected_branch
     assert all("Failed to reset branch" not in text for text in handler._sent)
 
 
@@ -936,7 +945,11 @@ async def test_newt_infers_base_repo_from_legacy_wt_worktree_id(
 
     assert len(branch_calls) == 1
     assert branch_calls[0]["repo_root"] == workspace.resolve()
-    assert branch_calls[0]["branch_name"] == "thread-chat-7777-thread-333"
+    expected_branch = (
+        "thread-chat-7777-thread-333-"
+        f"{hashlib.sha256(str(workspace.resolve()).encode('utf-8')).hexdigest()[:10]}"
+    )
+    assert branch_calls[0]["branch_name"] == expected_branch
 
 
 @pytest.mark.anyio
@@ -968,7 +981,11 @@ async def test_newt_prefers_longest_manifest_base_match_for_worktree_id(
 
     assert len(branch_calls) == 1
     assert branch_calls[0]["repo_root"] == workspace.resolve()
-    assert branch_calls[0]["branch_name"] == "thread-chat-7777-thread-333"
+    expected_branch = (
+        "thread-chat-7777-thread-333-"
+        f"{hashlib.sha256(str(workspace.resolve()).encode('utf-8')).hexdigest()[:10]}"
+    )
+    assert branch_calls[0]["branch_name"] == expected_branch
 
 
 @pytest.mark.anyio
@@ -1005,7 +1022,11 @@ async def test_newt_thread_fallback_and_workspace_state_reset(
 
     assert len(branch_calls) == 1
     assert branch_calls[0]["repo_root"] == workspace.resolve()
-    assert branch_calls[0]["branch_name"] == "thread-chat-123456-msg-808-upd-909"
+    expected_branch = (
+        "thread-chat-123456-msg-808-upd-909-"
+        f"{hashlib.sha256(str(workspace.resolve()).encode('utf-8')).hexdigest()[:10]}"
+    )
+    assert branch_calls[0]["branch_name"] == expected_branch
 
     # First topic update is /newt state reset before new thread is attached.
     reset_snapshot = handler._router.update_snapshots[0]


### PR DESCRIPTION
## Summary
- make `/newt` branch naming collision-resistant in Discord by appending a workspace-derived hash suffix
- make `/newt` branch naming collision-resistant in Telegram with the same suffix pattern
- update `/newt` tests on both platforms to assert the new branch naming format

## Why
`/newt` previously used deterministic branch names based only on channel/chat identities (for example `thread-<channel_id>`), which can collide when the same branch name is already checked out by another worktree. Git then rejects `checkout -B` with `already used by worktree`.

Adding workspace entropy keeps names readable while avoiding cross-worktree collisions for both Discord and Telegram flows.

## Validation
- `pytest tests/integrations/discord/test_service_routing.py::test_car_newt_resets_current_workspace_branch_and_session tests/test_telegram_pma_routing.py -k "newt"`
- `./scripts/check.sh`
