### PR TITLE
Install mlx whisper deps during mac setup and safe refresh

### DIFF
--- a/scripts/install-local-mac-hub.sh
+++ b/scripts/install-local-mac-hub.sh
@@ -183,16 +183,31 @@ if not provider and config_path.exists():
     except Exception:
         data = {}
     if isinstance(data, dict):
+        legacy_fallback = False
+        repo_provider = ""
         repo_defaults = data.get("repo_defaults")
-        voice = None
         if isinstance(repo_defaults, dict):
-            voice = repo_defaults.get("voice")
-        if not isinstance(voice, dict):
+            repo_voice = repo_defaults.get("voice")
+            if isinstance(repo_voice, dict):
+                raw_provider = repo_voice.get("provider")
+                if isinstance(raw_provider, str):
+                    repo_provider = raw_provider.strip()
+
+        if not repo_provider:
             voice = data.get("voice")
-        if isinstance(voice, dict):
-            raw_provider = voice.get("provider")
-            if isinstance(raw_provider, str):
-                provider = raw_provider.strip()
+            if isinstance(voice, dict):
+                raw_provider = voice.get("provider")
+                if isinstance(raw_provider, str):
+                    repo_provider = raw_provider.strip()
+                    legacy_fallback = bool(repo_provider)
+
+        provider = repo_provider
+        if legacy_fallback:
+            print(
+                "Hint: Found legacy top-level voice.provider. "
+                "Please migrate to repo_defaults.voice.provider in hub config.",
+                file=sys.stderr,
+            )
 
 provider = provider.strip().lower()
 if provider == "local":
@@ -354,11 +369,11 @@ PY
   )"
   case "${VOICE_PROVIDER}" in
     local_whisper)
-      echo "Voice provider is local_whisper; installing faster-whisper optional deps..."
+      echo "Voice provider is local_whisper; installing local Whisper optional deps..."
       "${CURRENT_VENV_LINK}/bin/python" -m pip -q install --force-reinstall "${PACKAGE_SRC}[voice-local]"
       ;;
     mlx_whisper)
-      echo "Voice provider is mlx_whisper; installing mlx-whisper optional deps..."
+      echo "Voice provider is mlx_whisper; installing MLX Whisper optional deps..."
       "${CURRENT_VENV_LINK}/bin/python" -m pip -q install --force-reinstall "${PACKAGE_SRC}[voice-mlx]"
       ;;
   esac

--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -320,6 +320,9 @@ _voice_provider_for_hub_root() {
   fi
   if [[ -z "${provider}" ]]; then
     provider="$(_config_python "${root}" "voice.provider" || true)"
+    if [[ -n "${provider}" ]]; then
+      echo "Hint: Found legacy top-level voice.provider; migrate to repo_defaults.voice.provider in hub config." >&2
+    fi
   fi
   _normalize_voice_provider "${provider}"
 }


### PR DESCRIPTION
## Summary
- install `voice-mlx` optional dependency when configured voice provider resolves to `mlx_whisper` in `scripts/install-local-mac-hub.sh`
- keep setup provider resolution aligned with hub config semantics by checking `repo_defaults.voice.provider` before legacy top-level `voice.provider`
- update `scripts/safe-refresh-local-mac-hub.sh` to:
  - normalize `mlx`/`mlx_whisper`
  - resolve provider from `.env` then `repo_defaults.voice.provider` then `voice.provider`
  - stage/install `codex-autorunner[voice-mlx]` when provider is `mlx_whisper`
- add package extra `voice-mlx` in `pyproject.toml`

## Why
This makes MLX install behavior parity with existing local whisper install behavior during setup and safe refresh/restart flows, so switching to `mlx_whisper` installs the matching dependency set automatically.

## Validation
- `bash -n scripts/install-local-mac-hub.sh scripts/safe-refresh-local-mac-hub.sh`
- `.venv/bin/python -m pytest -q tests/test_doctor_checks.py tests/integrations/discord/test_doctor_checks.py tests/test_voice_service.py tests/test_voice_config.py`
- full pre-commit hook suite passed during commit (`2444 passed, 3 skipped`)
