### PR TITLE
Fix mlx whisper defaults (model alias + beam-size behavior)

### DIFF
--- a/codex-autorunner.yml
+++ b/codex-autorunner.yml
@@ -147,7 +147,7 @@ repo_defaults:
         remote_api: false
         model: small
         language: null
-        beam_size: 1
+        beam_size: null
         temperature: 0.0
         condition_on_previous_text: false
         word_timestamps: false

--- a/docs/voice/architecture.md
+++ b/docs/voice/architecture.md
@@ -19,7 +19,7 @@ This document outlines the shared speech input architecture for Codex Autorunner
 - Provider-specific block:
   - `voice.providers.openai_whisper`: `{ remote_api: true, api_key_env: "OPENAI_API_KEY", model: "whisper-1", base_url: null, temperature: 0, language: null, redact_request: true }`.
   - `voice.providers.local_whisper`: `{ remote_api: false, model: "small", device: "auto", compute_type: "default", cpu_threads: 0, num_workers: 1, local_files_only: false, beam_size: 1, vad_filter: true, language: null }`.
-  - `voice.providers.mlx_whisper`: `{ remote_api: false, model: "small", language: null, beam_size: 1, temperature: 0.0, condition_on_previous_text: false, word_timestamps: false, initial_prompt: null }`.
+  - `voice.providers.mlx_whisper`: `{ remote_api: false, model: "small", language: null, beam_size: null, temperature: 0.0, condition_on_previous_text: false, word_timestamps: false, initial_prompt: null }`.
 - Defaults live in config; env vars override for runtime toggles/keys without editing files.
 
 ## Shared Modules and Interfaces

--- a/src/codex_autorunner/core/config.py
+++ b/src/codex_autorunner/core/config.py
@@ -612,7 +612,7 @@ DEFAULT_REPO_CONFIG: Dict[str, Any] = {
                 "remote_api": False,
                 "model": "small",
                 "language": None,
-                "beam_size": 1,
+                "beam_size": None,
                 "temperature": 0.0,
                 "condition_on_previous_text": False,
                 "word_timestamps": False,

--- a/src/codex_autorunner/voice/config.py
+++ b/src/codex_autorunner/voice/config.py
@@ -34,7 +34,7 @@ DEFAULT_PROVIDER_CONFIG: Dict[str, Dict[str, Any]] = {
         "remote_api": False,
         "model": "small",
         "language": None,
-        "beam_size": 1,
+        "beam_size": None,
         "temperature": 0.0,
         "condition_on_previous_text": False,
         "word_timestamps": False,

--- a/src/codex_autorunner/voice/providers/mlx_whisper.py
+++ b/src/codex_autorunner/voice/providers/mlx_whisper.py
@@ -17,14 +17,14 @@ from ..provider import (
 )
 
 _MODEL_ALIAS_TO_REPO = {
-    "tiny": "mlx-community/whisper-tiny",
-    "tiny.en": "mlx-community/whisper-tiny.en",
-    "base": "mlx-community/whisper-base",
-    "base.en": "mlx-community/whisper-base.en",
-    "small": "mlx-community/whisper-small",
-    "small.en": "mlx-community/whisper-small.en",
-    "medium": "mlx-community/whisper-medium",
-    "medium.en": "mlx-community/whisper-medium.en",
+    "tiny": "mlx-community/whisper-tiny-mlx",
+    "tiny.en": "mlx-community/whisper-tiny.en-mlx",
+    "base": "mlx-community/whisper-base-mlx",
+    "base.en": "mlx-community/whisper-base.en-mlx",
+    "small": "mlx-community/whisper-small-mlx",
+    "small.en": "mlx-community/whisper-small.en-mlx",
+    "medium": "mlx-community/whisper-medium-mlx",
+    "medium.en": "mlx-community/whisper-medium.en-mlx",
     "large-v3": "mlx-community/whisper-large-v3-turbo",
     "turbo": "mlx-community/whisper-turbo",
 }
@@ -34,7 +34,7 @@ _MODEL_ALIAS_TO_REPO = {
 class MlxWhisperSettings:
     model: str = "small"
     language: Optional[str] = None
-    beam_size: int = 1
+    beam_size: Optional[int] = None
     temperature: float = 0.0
     condition_on_previous_text: bool = False
     word_timestamps: bool = False
@@ -43,6 +43,7 @@ class MlxWhisperSettings:
 
     @classmethod
     def from_mapping(cls, raw: Mapping[str, Any]) -> "MlxWhisperSettings":
+        raw_beam_size = raw.get("beam_size")
         return cls(
             model=str(raw.get("model", "small")),
             language=(
@@ -50,7 +51,7 @@ class MlxWhisperSettings:
                 if raw.get("language") is not None
                 else None
             ),
-            beam_size=max(1, int(raw.get("beam_size", 1))),
+            beam_size=_coerce_beam_size(raw_beam_size),
             temperature=float(raw.get("temperature", 0.0)),
             condition_on_previous_text=bool(
                 raw.get("condition_on_previous_text", False)
@@ -118,7 +119,7 @@ class MlxWhisperProvider(SpeechProvider):
                 condition_on_previous_text=bool(
                     payload.get("condition_on_previous_text", False)
                 ),
-                beam_size=int(payload.get("beam_size", 1)),
+                **_beam_size_kwargs(payload.get("beam_size")),
             )
         finally:
             try:
@@ -196,13 +197,14 @@ class _MlxWhisperStream(TranscriptionStream):
     def _build_payload(self) -> Dict[str, Any]:
         payload: Dict[str, Any] = {
             "path_or_hf_repo": _resolve_mlx_model_path(self._settings.model),
-            "beam_size": self._settings.beam_size,
             "temperature": self._settings.temperature,
             "condition_on_previous_text": self._settings.condition_on_previous_text,
             "word_timestamps": self._settings.word_timestamps,
             "initial_prompt": self._settings.initial_prompt,
             "language": self._settings.language or self._session.language,
         }
+        if self._settings.beam_size is not None:
+            payload["beam_size"] = self._settings.beam_size
         if not self._settings.redact_request:
             payload.update(
                 {
@@ -236,6 +238,27 @@ def _resolve_mlx_model_path(model: str) -> str:
     if normalized in _MODEL_ALIAS_TO_REPO:
         return _MODEL_ALIAS_TO_REPO[normalized]
     return candidate
+
+
+def _coerce_beam_size(raw: Any) -> Optional[int]:
+    if raw is None:
+        return None
+    try:
+        parsed = int(raw)
+    except (TypeError, ValueError):
+        return None
+    # mlx-whisper currently runs greedy decoding by default; beam search kwargs
+    # can fail in environments where beam decoding isn't implemented.
+    if parsed <= 1:
+        return None
+    return parsed
+
+
+def _beam_size_kwargs(beam_size: Any) -> Dict[str, int]:
+    normalized = _coerce_beam_size(beam_size)
+    if normalized is None:
+        return {}
+    return {"beam_size": normalized}
 
 
 def build_mlx_whisper_provider(

--- a/tests/fixtures/default_hub_config.v2.json
+++ b/tests/fixtures/default_hub_config.v2.json
@@ -376,7 +376,7 @@
           "vad_filter": true
         },
         "mlx_whisper": {
-          "beam_size": 1,
+          "beam_size": null,
           "condition_on_previous_text": false,
           "initial_prompt": null,
           "language": null,

--- a/tests/fixtures/default_repo_config.v2.json
+++ b/tests/fixtures/default_repo_config.v2.json
@@ -434,7 +434,7 @@
         "vad_filter": true
       },
       "mlx_whisper": {
-        "beam_size": 1,
+        "beam_size": null,
         "condition_on_previous_text": false,
         "initial_prompt": null,
         "language": null,

--- a/tests/test_voice_whisper_provider.py
+++ b/tests/test_voice_whisper_provider.py
@@ -9,6 +9,7 @@ from codex_autorunner.voice import (
     VoiceConfig,
     resolve_speech_provider,
 )
+from codex_autorunner.voice.providers import mlx_whisper as mlx_whisper_provider
 
 
 def test_openai_whisper_respects_env_and_redaction():
@@ -167,7 +168,8 @@ def test_resolve_speech_provider_builds_local():
             "provider": "local_whisper",
             "providers": {"local_whisper": {"model": "small"}},
             "warn_on_remote_api": False,
-        }
+        },
+        env={"TEST_ENV": "1"},
     )
     provider = resolve_speech_provider(voice_config=config, logger=None)
     assert isinstance(provider, LocalWhisperProvider)
@@ -199,3 +201,25 @@ def test_resolve_speech_provider_accepts_mlx_alias():
     )
     provider = resolve_speech_provider(voice_config=config, logger=None)
     assert isinstance(provider, MlxWhisperProvider)
+
+
+def test_mlx_whisper_model_aliases_resolve_to_public_repos():
+    assert (
+        mlx_whisper_provider._resolve_mlx_model_path("small")
+        == "mlx-community/whisper-small-mlx"
+    )
+    assert (
+        mlx_whisper_provider._resolve_mlx_model_path("small.en")
+        == "mlx-community/whisper-small.en-mlx"
+    )
+
+
+def test_mlx_whisper_beam_size_coercion_defaults_to_greedy():
+    assert mlx_whisper_provider._coerce_beam_size(None) is None
+    assert mlx_whisper_provider._coerce_beam_size(0) is None
+    assert mlx_whisper_provider._coerce_beam_size(1) is None
+    assert mlx_whisper_provider._coerce_beam_size(2) == 2
+
+    assert mlx_whisper_provider._beam_size_kwargs(None) == {}
+    assert mlx_whisper_provider._beam_size_kwargs(1) == {}
+    assert mlx_whisper_provider._beam_size_kwargs(2) == {"beam_size": 2}


### PR DESCRIPTION
## Summary
- fix MLX model alias mapping to currently valid/public HF repos:
  - `small` -> `mlx-community/whisper-small-mlx` (and same `-mlx` pattern for tiny/base/medium + `.en` variants)
- make MLX beam search opt-in instead of default-on:
  - default `beam_size` for `mlx_whisper` is now `null`
  - coerce `beam_size <= 1` to greedy decoding (omit `beam_size` kwarg)
  - only pass `beam_size` to `mlx_whisper.transcribe` when `beam_size > 1`
- update default configs/docs/snapshots for MLX `beam_size: null`
- add tests covering MLX alias resolution and beam-size coercion helpers

## Why
Current defaults can fail at runtime with:
- invalid model repo alias (`mlx-community/whisper-small`), and
- `Beam search decoder is not yet implemented` when `beam_size=1` is passed.

This makes MLX transcription work out-of-the-box with greedy decoding defaults.

## Validation
- `.venv/bin/python -m ruff check src/codex_autorunner/voice/providers/mlx_whisper.py src/codex_autorunner/voice/config.py src/codex_autorunner/core/config.py tests/test_voice_whisper_provider.py tests/test_voice_config.py tests/test_voice_service.py`
- `.venv/bin/python -m pytest -q tests/test_voice_whisper_provider.py tests/test_voice_config.py tests/test_voice_service.py tests/test_config_default_snapshots.py`
- full commit hook suite passed (`2453 passed, 3 skipped`)
