### PR TITLE
Add ffmpeg preflight checks for local voice providers

### DIFF
--- a/docs/AGENT_SETUP_DISCORD_GUIDE.md
+++ b/docs/AGENT_SETUP_DISCORD_GUIDE.md
@@ -113,6 +113,7 @@ Local Whisper (on-device, faster-whisper):
 
 1. Install local voice dependencies:
    - `pip install "codex-autorunner[voice-local]"`
+   - Ensure `ffmpeg` is installed and on PATH (for macOS: `brew install ffmpeg`)
    - macOS launchd path (`scripts/install-local-mac-hub.sh` / `scripts/safe-refresh-local-mac-hub.sh`) now installs this automatically when voice provider resolves to `local_whisper` or `mlx_whisper`.
 2. Set provider:
    - `voice.provider: local_whisper`
@@ -122,6 +123,7 @@ MLX Whisper (on-device, Apple Silicon):
 
 1. Install MLX voice dependencies:
    - `pip install "codex-autorunner[voice-mlx]"`
+   - Ensure `ffmpeg` is installed and on PATH (for macOS: `brew install ffmpeg`)
    - macOS launchd setup auto-selects this for new Apple Silicon installs.
 2. Set provider:
    - `voice.provider: mlx_whisper`

--- a/docs/ops/env-and-defaults.md
+++ b/docs/ops/env-and-defaults.md
@@ -98,6 +98,7 @@ Local provider:
 - Install local deps with `pip install "codex-autorunner[voice-local]"`.
 - `voice.provider: mlx_whisper` uses on-device transcription via `mlx-whisper` (Apple Silicon).
 - Install MLX deps with `pip install "codex-autorunner[voice-mlx]"`.
+- Local voice providers also require `ffmpeg` available on PATH.
 
 ## OpenCode server credentials
 

--- a/src/codex_autorunner/core/runtime.py
+++ b/src/codex_autorunner/core/runtime.py
@@ -13,7 +13,10 @@ from typing import Any, Optional, Union
 
 from ..manifest import load_manifest, load_manifest_with_issues
 from ..voice.config import VoiceConfig
-from ..voice.provider_catalog import local_voice_provider_spec
+from ..voice.provider_catalog import (
+    local_voice_provider_spec,
+    missing_local_voice_runtime_commands,
+)
 from .config import HubConfig, RepoConfig, load_repo_config
 from .destinations import (
     probe_docker_readiness,
@@ -298,19 +301,55 @@ def _append_local_voice_dependency_check(
     provider, deps, extra = provider_spec
 
     missing_local_voice = missing_optional_dependencies(deps)
+    missing_runtime_commands = missing_local_voice_runtime_commands(provider)
     if missing_local_voice:
         missing_desc = ", ".join(missing_local_voice)
+        runtime_hint = ""
+        if missing_runtime_commands:
+            missing_runtime_desc = ", ".join(missing_runtime_commands)
+            runtime_hint = (
+                " Required runtime command(s) are also missing from PATH: "
+                f"{missing_runtime_desc}."
+            )
         checks.append(
             DoctorCheck(
                 name="Voice dependencies",
                 passed=False,
                 message=(
                     f"Voice is enabled with {provider} but {missing_desc} is "
-                    "not installed."
+                    f"not installed.{runtime_hint}"
                 ),
                 severity="error",
                 check_id=check_id or "voice.dependencies",
-                fix=f"Install with `pip install codex-autorunner[{extra}]`.",
+                fix=(
+                    f"Install with `pip install codex-autorunner[{extra}]`."
+                    + (
+                        " Install ffmpeg and ensure it is on PATH (for macOS: "
+                        "`brew install ffmpeg`)."
+                        if "ffmpeg" in missing_runtime_commands
+                        else ""
+                    )
+                ),
+            )
+        )
+        return
+
+    if missing_runtime_commands:
+        missing_runtime_desc = ", ".join(missing_runtime_commands)
+        checks.append(
+            DoctorCheck(
+                name="Voice dependencies",
+                passed=False,
+                message=(
+                    f"Voice is enabled with {provider} but required runtime "
+                    f"command(s) are missing from PATH: {missing_runtime_desc}."
+                ),
+                severity="error",
+                check_id=check_id or "voice.dependencies",
+                fix=(
+                    "Install ffmpeg and ensure it is on PATH (for macOS: "
+                    "`brew install ffmpeg`)."
+                ),
             )
         )
         return

--- a/src/codex_autorunner/integrations/discord/doctor.py
+++ b/src/codex_autorunner/integrations/discord/doctor.py
@@ -10,7 +10,10 @@ from ...core.config import HubConfig
 from ...core.optional_dependencies import missing_optional_dependencies
 from ...core.runtime import DoctorCheck
 from ...voice.config import VoiceConfig
-from ...voice.provider_catalog import local_voice_provider_spec
+from ...voice.provider_catalog import (
+    local_voice_provider_spec,
+    missing_local_voice_runtime_commands,
+)
 from .config import (
     DEFAULT_APP_ID_ENV,
     DEFAULT_BOT_TOKEN_ENV,
@@ -85,8 +88,16 @@ def discord_doctor_checks(config: HubConfig) -> list[DoctorCheck]:
     ):
         provider_name, deps, extra = local_provider_spec
         missing_local_voice = missing_optional_dependencies(deps)
+        missing_runtime_commands = missing_local_voice_runtime_commands(provider_name)
         if missing_local_voice:
             missing_desc = ", ".join(missing_local_voice)
+            runtime_hint = ""
+            if missing_runtime_commands:
+                missing_runtime_desc = ", ".join(missing_runtime_commands)
+                runtime_hint = (
+                    " Required runtime command(s) are also missing from PATH: "
+                    f"{missing_runtime_desc}."
+                )
             checks.append(
                 DoctorCheck(
                     name="Discord voice dependencies",
@@ -94,10 +105,38 @@ def discord_doctor_checks(config: HubConfig) -> list[DoctorCheck]:
                     message=(
                         "Discord voice transcription is configured with "
                         f"{provider_name} but {missing_desc} is not installed."
+                        f"{runtime_hint}"
                     ),
                     check_id="discord.voice.dependencies",
                     severity="error",
-                    fix=f"Install with `pip install codex-autorunner[{extra}]`.",
+                    fix=(
+                        f"Install with `pip install codex-autorunner[{extra}]`."
+                        + (
+                            " Install ffmpeg and ensure it is on PATH (for macOS: "
+                            "`brew install ffmpeg`)."
+                            if "ffmpeg" in missing_runtime_commands
+                            else ""
+                        )
+                    ),
+                )
+            )
+        elif missing_runtime_commands:
+            missing_runtime_desc = ", ".join(missing_runtime_commands)
+            checks.append(
+                DoctorCheck(
+                    name="Discord voice dependencies",
+                    passed=False,
+                    message=(
+                        "Discord voice transcription is configured with "
+                        f"{provider_name} but required runtime command(s) are "
+                        f"missing from PATH: {missing_runtime_desc}."
+                    ),
+                    check_id="discord.voice.dependencies",
+                    severity="error",
+                    fix=(
+                        "Install ffmpeg and ensure it is on PATH (for macOS: "
+                        "`brew install ffmpeg`)."
+                    ),
                 )
             )
         else:

--- a/src/codex_autorunner/integrations/telegram/doctor.py
+++ b/src/codex_autorunner/integrations/telegram/doctor.py
@@ -10,7 +10,10 @@ from ...core.config import HubConfig, RepoConfig
 from ...core.optional_dependencies import missing_optional_dependencies
 from ...core.runtime import DoctorCheck
 from ...voice.config import VoiceConfig
-from ...voice.provider_catalog import local_voice_provider_spec
+from ...voice.provider_catalog import (
+    local_voice_provider_spec,
+    missing_local_voice_runtime_commands,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,8 +83,18 @@ def telegram_doctor_checks(
         ):
             provider_name, deps, extra = local_provider_spec
             missing_local_voice = missing_optional_dependencies(deps)
+            missing_runtime_commands = missing_local_voice_runtime_commands(
+                provider_name
+            )
             if missing_local_voice:
                 missing_desc = ", ".join(missing_local_voice)
+                runtime_hint = ""
+                if missing_runtime_commands:
+                    missing_runtime_desc = ", ".join(missing_runtime_commands)
+                    runtime_hint = (
+                        " Required runtime command(s) are also missing from PATH: "
+                        f"{missing_runtime_desc}."
+                    )
                 checks.append(
                     DoctorCheck(
                         name="Telegram voice dependencies",
@@ -89,10 +102,38 @@ def telegram_doctor_checks(
                         message=(
                             "Telegram voice transcription is configured with "
                             f"{provider_name} but {missing_desc} is not installed."
+                            f"{runtime_hint}"
                         ),
                         check_id="telegram.voice.dependencies",
                         severity="error",
-                        fix=f"Install with `pip install codex-autorunner[{extra}]`.",
+                        fix=(
+                            f"Install with `pip install codex-autorunner[{extra}]`."
+                            + (
+                                " Install ffmpeg and ensure it is on PATH (for macOS: "
+                                "`brew install ffmpeg`)."
+                                if "ffmpeg" in missing_runtime_commands
+                                else ""
+                            )
+                        ),
+                    )
+                )
+            elif missing_runtime_commands:
+                missing_runtime_desc = ", ".join(missing_runtime_commands)
+                checks.append(
+                    DoctorCheck(
+                        name="Telegram voice dependencies",
+                        passed=False,
+                        message=(
+                            "Telegram voice transcription is configured with "
+                            f"{provider_name} but required runtime command(s) are "
+                            f"missing from PATH: {missing_runtime_desc}."
+                        ),
+                        check_id="telegram.voice.dependencies",
+                        severity="error",
+                        fix=(
+                            "Install ffmpeg and ensure it is on PATH (for macOS: "
+                            "`brew install ffmpeg`)."
+                        ),
                     )
                 )
             else:

--- a/src/codex_autorunner/voice/capture.py
+++ b/src/codex_autorunner/voice/capture.py
@@ -311,6 +311,7 @@ class PushToTalkCapture(VoiceCaptureSession):
             "audio_too_large",
             "rate_limited",
             "local_provider_unavailable",
+            "local_runtime_dependency_missing",
         ):
             self.fail(reason)
             return False

--- a/src/codex_autorunner/voice/provider_catalog.py
+++ b/src/codex_autorunner/voice/provider_catalog.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Optional, Sequence, Tuple, Union
 
+from ..core.utils import resolve_executable
+
 OptionalDependency = Tuple[Union[str, Sequence[str]], str]
 
 _LOCAL_PROVIDER_DEPS: dict[str, tuple[tuple[OptionalDependency, ...], str]] = {
@@ -13,6 +15,11 @@ _LOCAL_PROVIDER_DEPS: dict[str, tuple[tuple[OptionalDependency, ...], str]] = {
         (("mlx_whisper", "mlx-whisper"),),
         "voice-mlx",
     ),
+}
+
+_LOCAL_PROVIDER_RUNTIME_COMMANDS: dict[str, tuple[str, ...]] = {
+    "local_whisper": ("ffmpeg",),
+    "mlx_whisper": ("ffmpeg",),
 }
 
 _ALIASES = {
@@ -39,3 +46,9 @@ def local_voice_provider_spec(
         return None
     deps, extra = spec
     return normalized, deps, extra
+
+
+def missing_local_voice_runtime_commands(provider: Any) -> list[str]:
+    normalized = normalize_voice_provider(provider)
+    commands = _LOCAL_PROVIDER_RUNTIME_COMMANDS.get(normalized, ())
+    return [command for command in commands if resolve_executable(command) is None]

--- a/src/codex_autorunner/voice/providers/local_whisper.py
+++ b/src/codex_autorunner/voice/providers/local_whisper.py
@@ -125,12 +125,20 @@ class LocalWhisperProvider(SpeechProvider):
     ) -> Dict[str, Any]:
         model = self._get_model()
         audio_buffer = io.BytesIO(audio_bytes)
-        segments, info = model.transcribe(
-            audio_buffer,
-            language=cast(Optional[str], payload.get("language")),
-            beam_size=int(payload.get("beam_size", 1)),
-            vad_filter=bool(payload.get("vad_filter", True)),
-        )
+        try:
+            segments, info = model.transcribe(
+                audio_buffer,
+                language=cast(Optional[str], payload.get("language")),
+                beam_size=int(payload.get("beam_size", 1)),
+                vad_filter=bool(payload.get("vad_filter", True)),
+            )
+        except FileNotFoundError as exc:
+            if _is_missing_ffmpeg_error(exc):
+                raise RuntimeError(
+                    "Local Whisper provider requires ffmpeg on PATH. "
+                    "Install ffmpeg (for macOS: brew install ffmpeg)."
+                ) from exc
+            raise
         text_parts = []
         for segment in segments:
             text = str(getattr(segment, "text", "") or "").strip()
@@ -186,6 +194,13 @@ class _LocalWhisperStream(TranscriptionStream):
                         text="", is_final=True, error="local_provider_unavailable"
                     )
                 ]
+            if "requires ffmpeg on PATH" in message:
+                self._logger.error("Local Whisper unavailable: %s", message)
+                return [
+                    TranscriptionEvent(
+                        text="", is_final=True, error="local_runtime_dependency_missing"
+                    )
+                ]
             self._logger.error("Local Whisper transcription failed: %s", exc)
             return [TranscriptionEvent(text="", is_final=True, error="provider_error")]
         except Exception as exc:
@@ -225,3 +240,10 @@ def build_local_whisper_provider(
 ) -> LocalWhisperProvider:
     settings = LocalWhisperSettings.from_mapping(config)
     return LocalWhisperProvider(settings=settings, logger=logger)
+
+
+def _is_missing_ffmpeg_error(exc: FileNotFoundError) -> bool:
+    filename = getattr(exc, "filename", None)
+    if isinstance(filename, str) and filename.strip().lower() == "ffmpeg":
+        return True
+    return "ffmpeg" in str(exc).lower()

--- a/src/codex_autorunner/voice/providers/mlx_whisper.py
+++ b/src/codex_autorunner/voice/providers/mlx_whisper.py
@@ -109,18 +109,26 @@ class MlxWhisperProvider(SpeechProvider):
             with os.fdopen(fd, "wb") as temp_file:
                 temp_file.write(audio_bytes)
 
-            result = transcribe(
-                temp_path,
-                path_or_hf_repo=str(payload.get("path_or_hf_repo", "small")),
-                language=payload.get("language"),
-                temperature=float(payload.get("temperature", 0.0)),
-                initial_prompt=payload.get("initial_prompt"),
-                word_timestamps=bool(payload.get("word_timestamps", False)),
-                condition_on_previous_text=bool(
-                    payload.get("condition_on_previous_text", False)
-                ),
-                **_beam_size_kwargs(payload.get("beam_size")),
-            )
+            try:
+                result = transcribe(
+                    temp_path,
+                    path_or_hf_repo=str(payload.get("path_or_hf_repo", "small")),
+                    language=payload.get("language"),
+                    temperature=float(payload.get("temperature", 0.0)),
+                    initial_prompt=payload.get("initial_prompt"),
+                    word_timestamps=bool(payload.get("word_timestamps", False)),
+                    condition_on_previous_text=bool(
+                        payload.get("condition_on_previous_text", False)
+                    ),
+                    **_beam_size_kwargs(payload.get("beam_size")),
+                )
+            except FileNotFoundError as exc:
+                if _is_missing_ffmpeg_error(exc):
+                    raise RuntimeError(
+                        "MLX Whisper provider requires ffmpeg on PATH. "
+                        "Install ffmpeg (for macOS: brew install ffmpeg)."
+                    ) from exc
+                raise
         finally:
             try:
                 os.unlink(temp_path)
@@ -178,6 +186,13 @@ class _MlxWhisperStream(TranscriptionStream):
                 return [
                     TranscriptionEvent(
                         text="", is_final=True, error="local_provider_unavailable"
+                    )
+                ]
+            if "requires ffmpeg on PATH" in message:
+                self._logger.error("MLX Whisper unavailable: %s", message)
+                return [
+                    TranscriptionEvent(
+                        text="", is_final=True, error="local_runtime_dependency_missing"
                     )
                 ]
             self._logger.error("MLX Whisper transcription failed: %s", exc)
@@ -267,3 +282,10 @@ def build_mlx_whisper_provider(
 ) -> MlxWhisperProvider:
     settings = MlxWhisperSettings.from_mapping(config)
     return MlxWhisperProvider(settings=settings, logger=logger)
+
+
+def _is_missing_ffmpeg_error(exc: FileNotFoundError) -> bool:
+    filename = getattr(exc, "filename", None)
+    if isinstance(filename, str) and filename.strip().lower() == "ffmpeg":
+        return True
+    return "ffmpeg" in str(exc).lower()

--- a/src/codex_autorunner/voice/service.py
+++ b/src/codex_autorunner/voice/service.py
@@ -166,6 +166,19 @@ class VoiceService:
                     "OpenAI rate limited the request; wait a moment and try again.",
                     user_message="Voice transcription rate limited. Retrying...",
                 )
+            if buffer.error_reason == "local_runtime_dependency_missing":
+                provider = normalize_voice_provider(
+                    self.config.provider or "local_whisper"
+                )
+                raise VoicePermanentError(
+                    "local_runtime_dependency_missing",
+                    "Local voice runtime dependencies are unavailable. Ensure ffmpeg "
+                    "is installed and available on PATH.",
+                    user_message=(
+                        f"Voice transcription failed: local provider '{provider}' "
+                        "needs ffmpeg on PATH."
+                    ),
+                )
             if buffer.error_reason == "local_provider_unavailable":
                 provider = normalize_voice_provider(
                     self.config.provider or "local_whisper"

--- a/tests/integrations/discord/test_doctor_checks.py
+++ b/tests/integrations/discord/test_doctor_checks.py
@@ -244,6 +244,47 @@ def test_discord_doctor_checks_mlx_voice_missing_dependency_is_failure(
     assert "voice-mlx" in voice_check.fix
 
 
+def test_discord_doctor_checks_voice_missing_ffmpeg_is_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TEST_DISCORD_TOKEN", "token")
+    monkeypatch.setenv("TEST_DISCORD_APP_ID", "123456")
+    monkeypatch.setenv("CODEX_AUTORUNNER_VOICE_PROVIDER", "mlx_whisper")
+
+    original_missing = discord_doctor.missing_optional_dependencies
+
+    def _missing(deps):
+        if deps == (("mlx_whisper", "mlx-whisper"),):
+            return []
+        return original_missing(deps)
+
+    monkeypatch.setattr(discord_doctor, "missing_optional_dependencies", _missing)
+    monkeypatch.setattr(
+        discord_doctor,
+        "missing_local_voice_runtime_commands",
+        lambda provider: ["ffmpeg"],
+    )
+
+    hub_config = _load_hub_with_discord(
+        tmp_path,
+        {
+            "enabled": True,
+            "bot_token_env": "TEST_DISCORD_TOKEN",
+            "app_id_env": "TEST_DISCORD_APP_ID",
+            "allowed_guild_ids": ["123"],
+        },
+    )
+
+    checks = discord_doctor_checks(hub_config)
+    by_id = {check.check_id: check for check in checks}
+    voice_check = by_id["discord.voice.dependencies"]
+    assert voice_check.passed is False
+    assert voice_check.severity == "error"
+    assert "ffmpeg" in voice_check.message
+    assert voice_check.fix is not None
+    assert "ffmpeg" in voice_check.fix
+
+
 def test_discord_doctor_checks_voice_disabled_skips_local_dependency_check(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_doctor_checks.py
+++ b/tests/test_doctor_checks.py
@@ -113,6 +113,44 @@ def test_telegram_doctor_checks_mlx_voice_dependency_missing(monkeypatch):
     assert "voice-mlx" in voice_check.fix
 
 
+def test_telegram_doctor_checks_voice_missing_ffmpeg(monkeypatch):
+    """Test Telegram doctor check catches missing ffmpeg runtime command."""
+
+    def _missing_optional(deps):
+        if deps == (("httpx", "httpx"),):
+            return []
+        if deps == (("mlx_whisper", "mlx-whisper"),):
+            return []
+        return []
+
+    monkeypatch.setattr(
+        telegram_doctor, "missing_optional_dependencies", _missing_optional
+    )
+    monkeypatch.setattr(
+        telegram_doctor,
+        "missing_local_voice_runtime_commands",
+        lambda provider: ["ffmpeg"],
+    )
+    cfg = {"telegram_bot": {"enabled": True}}
+    with patch.dict(
+        os.environ,
+        {
+            "CODEX_AUTORUNNER_VOICE_ENABLED": "1",
+            "CODEX_AUTORUNNER_VOICE_PROVIDER": "mlx_whisper",
+        },
+        clear=True,
+    ):
+        checks = telegram_doctor_checks(cfg)
+
+    by_id = {check.check_id: check for check in checks}
+    voice_check = by_id["telegram.voice.dependencies"]
+    assert voice_check.passed is False
+    assert voice_check.severity == "error"
+    assert "ffmpeg" in voice_check.message
+    assert voice_check.fix is not None
+    assert "ffmpeg" in voice_check.fix
+
+
 def test_telegram_doctor_checks_openai_voice_skips_local_dependency_check(monkeypatch):
     """Test Telegram doctor check skips local deps when provider is OpenAI."""
 
@@ -226,6 +264,52 @@ def test_doctor_reports_missing_mlx_voice_dependency(
     assert voice_check.severity == "error"
     assert voice_check.fix is not None
     assert "voice-mlx" in voice_check.fix
+
+
+def test_doctor_reports_missing_mlx_voice_runtime_dependency(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test core doctor reports missing ffmpeg for local MLX voice."""
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    seed_hub_files(hub_root, force=True)
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.git_utils.run_git",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0),
+    )
+
+    def _missing_optional(deps):
+        if deps == (("mlx_whisper", "mlx-whisper"),):
+            return []
+        return []
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.runtime.missing_optional_dependencies",
+        _missing_optional,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.runtime.missing_local_voice_runtime_commands",
+        lambda provider: ["ffmpeg"],
+    )
+
+    with patch.dict(
+        os.environ,
+        {
+            "CODEX_AUTORUNNER_VOICE_ENABLED": "1",
+            "CODEX_AUTORUNNER_VOICE_PROVIDER": "mlx_whisper",
+        },
+        clear=True,
+    ):
+        report = doctor(hub_root)
+
+    by_id = {check.check_id: check for check in report.checks if check.check_id}
+    voice_check = by_id["voice.dependencies"]
+    assert voice_check.passed is False
+    assert voice_check.severity == "error"
+    assert "ffmpeg" in voice_check.message
+    assert voice_check.fix is not None
+    assert "ffmpeg" in voice_check.fix
 
 
 def test_pma_doctor_checks_invalid_agent():

--- a/tests/test_voice_service.py
+++ b/tests/test_voice_service.py
@@ -107,6 +107,19 @@ def test_voice_service_reports_missing_mlx_provider_with_voice_mlx_hint():
     assert "voice-mlx" in str(exc.value)
 
 
+def test_voice_service_reports_missing_local_runtime_dependency():
+    cfg = VoiceConfig.from_raw(
+        {"enabled": True, "provider": "mlx_whisper", "warn_on_remote_api": False},
+        env={"TEST_ENV": "1"},
+    )
+    provider = DummyProvider(DummyStream(error="local_runtime_dependency_missing"))
+    service = VoiceService(cfg, provider_resolver=lambda _: provider)
+
+    with pytest.raises(VoiceServiceError) as exc:
+        service.transcribe(b"audio")
+    assert "ffmpeg" in str(exc.value).lower()
+
+
 def test_voice_service_passes_env_to_provider_resolver():
     cfg = VoiceConfig.from_raw({"enabled": True, "warn_on_remote_api": False})
     provider = DummyProvider(DummyStream("ok"))


### PR DESCRIPTION
## Summary
- add ffmpeg runtime preflight to local voice dependency checks in core `doctor`, Discord doctor, and Telegram doctor
- add explicit local runtime dependency handling for both `local_whisper` and `mlx_whisper` providers when `ffmpeg` is missing
- map runtime-missing failures to a dedicated voice error reason (`local_runtime_dependency_missing`) with actionable user-facing messaging
- document ffmpeg as a required local runtime dependency in setup/env docs

## Why
Recent Discord voice failures showed `provider_error` when `ffmpeg` was missing from PATH. Python extras were installed, but the runtime dependency was not validated early enough.

## Changes
- `src/codex_autorunner/voice/provider_catalog.py`
  - added local provider runtime command requirements and missing-command detection
- `src/codex_autorunner/core/runtime.py`
  - extended local voice doctor check to fail when required runtime commands are missing
- `src/codex_autorunner/integrations/discord/doctor.py`
- `src/codex_autorunner/integrations/telegram/doctor.py`
  - extended voice dependency checks with runtime command validation
- `src/codex_autorunner/voice/providers/local_whisper.py`
- `src/codex_autorunner/voice/providers/mlx_whisper.py`
  - detect missing ffmpeg and return a specific transcription error
- `src/codex_autorunner/voice/capture.py`
- `src/codex_autorunner/voice/service.py`
  - treat runtime-missing errors as non-retryable permanent errors with actionable hints
- docs updates:
  - `docs/AGENT_SETUP_DISCORD_GUIDE.md`
  - `docs/ops/env-and-defaults.md`

## Tests
- `tests/integrations/discord/test_doctor_checks.py`
  - added ffmpeg-missing doctor coverage
- `tests/test_doctor_checks.py`
  - added ffmpeg-missing coverage for Telegram and core doctor
- `tests/test_voice_service.py`
  - added runtime-missing voice service error coverage

Ran:
- `.venv/bin/pytest tests/integrations/discord/test_doctor_checks.py tests/test_doctor_checks.py tests/test_voice_service.py`
- full pre-commit hooks (including full pytest suite): `2457 passed, 3 skipped`
