### PR TITLE
Fix Discord model picker for OpenCode agent

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Optional
 
+from ...agents.opencode.harness import OpenCodeHarness
 from ...core.config import load_repo_config, resolve_env_for_root
 from ...core.context_awareness import (
     maybe_inject_car_awareness,
@@ -77,6 +78,9 @@ from ...core.utils import (
 )
 from ...flows.ticket_flow.runtime_helpers import build_ticket_flow_controller
 from ...integrations.agents.backend_orchestrator import BackendOrchestrator
+from ...integrations.agents.opencode_supervisor_factory import (
+    build_opencode_supervisor_from_repo_config,
+)
 from ...integrations.app_server.client import (
     CodexAppServerClient,
     CodexAppServerResponseError,
@@ -273,6 +277,13 @@ def _coerce_model_picker_items(result: Any) -> list[tuple[str, str]]:
     return options
 
 
+def _is_valid_opencode_model_name(model_name: str) -> bool:
+    if "/" not in model_name:
+        return False
+    provider_id, model_id = model_name.split("/", 1)
+    return bool(provider_id.strip() and model_id.strip())
+
+
 def _path_within(root: Path, target: Path) -> bool:
     try:
         root = canonicalize_path(root)
@@ -452,6 +463,8 @@ class DiscordBotService:
         self._backend_lock = asyncio.Lock()
         self._app_server_supervisors: dict[str, WorkspaceAppServerSupervisor] = {}
         self._app_server_lock = asyncio.Lock()
+        self._opencode_supervisors: dict[str, Any] = {}
+        self._opencode_lock = asyncio.Lock()
         self._app_server_state_root = resolve_global_state_root() / "workspaces"
         self._channel_directory_store = ChannelDirectoryStore(self._config.root)
         self._guild_name_cache: dict[str, str] = {}
@@ -1637,6 +1650,64 @@ class DiscordBotService:
                 await asyncio.sleep(sleep_time)
                 delay = min(delay * 2, APP_SERVER_START_BACKOFF_MAX_SECONDS)
 
+    async def _opencode_supervisor_for_workspace(
+        self, workspace_root: Path
+    ) -> Optional[Any]:
+        key = str(workspace_root)
+        async with self._opencode_lock:
+            existing = self._opencode_supervisors.get(key)
+            if existing is not None:
+                return existing
+            repo_config = load_repo_config(
+                workspace_root,
+                hub_path=self._hub_config_path,
+            )
+            supervisor = build_opencode_supervisor_from_repo_config(
+                repo_config,
+                workspace_root=workspace_root,
+                logger=self._logger,
+                base_env=None,
+            )
+            if supervisor is None:
+                return None
+            self._opencode_supervisors[key] = supervisor
+            return supervisor
+
+    async def _list_opencode_models_for_picker(
+        self,
+        *,
+        workspace_path: Optional[str],
+    ) -> Optional[list[tuple[str, str]]]:
+        if not isinstance(workspace_path, str) or not workspace_path.strip():
+            return None
+        try:
+            workspace_root = canonicalize_path(Path(workspace_path))
+        except Exception:
+            return None
+        if not workspace_root.exists() or not workspace_root.is_dir():
+            return None
+        supervisor = await self._opencode_supervisor_for_workspace(workspace_root)
+        if supervisor is None:
+            raise RuntimeError("OpenCode backend unavailable for this workspace")
+        harness = OpenCodeHarness(supervisor)
+        catalog = await harness.model_catalog(workspace_root)
+        options: list[tuple[str, str]] = []
+        seen: set[str] = set()
+        for model in catalog.models:
+            model_id = model.id.strip() if isinstance(model.id, str) else ""
+            if not model_id or model_id in seen:
+                continue
+            seen.add(model_id)
+            label = model_id
+            if (
+                isinstance(model.display_name, str)
+                and model.display_name
+                and not _display_name_is_model_alias(model_id, model.display_name)
+            ):
+                label = f"{model_id} ({model.display_name})"
+            options.append((model_id, label))
+        return options
+
     async def _list_threads_paginated(
         self,
         client: CodexAppServerClient,
@@ -2731,6 +2802,12 @@ class DiscordBotService:
             supervisors = list(self._app_server_supervisors.values())
             self._app_server_supervisors.clear()
         for supervisor in supervisors:
+            with contextlib.suppress(Exception):
+                await supervisor.close_all()
+        async with self._opencode_lock:
+            opencode_supervisors = list(self._opencode_supervisors.values())
+            self._opencode_supervisors.clear()
+        for supervisor in opencode_supervisors:
             with contextlib.suppress(Exception):
                 await supervisor.close_all()
 
@@ -4641,59 +4718,92 @@ class DiscordBotService:
                     text,
                 )
 
-            try:
-                client = await self._client_for_workspace(binding.get("workspace_path"))
-            except AppServerUnavailableError as exc:
-                log_event(
-                    self._logger,
-                    logging.WARNING,
-                    "discord.model.list.failed",
-                    channel_id=channel_id,
-                    agent=current_agent,
-                    exc=exc,
-                )
-                await _send_model_picker_or_fallback(
-                    _fallback_model_text(
-                        "Model picker unavailable right now (app server unavailable)."
-                    ),
-                )
-                return
-            if client is None:
-                await _send_model_picker_or_fallback(
-                    _fallback_model_text(
-                        "Workspace unavailable for model picker. Re-bind this channel with `/car bind` and try again."
-                    ),
-                )
-                return
-            try:
-                result = await _model_list_with_agent_compat(
-                    client,
-                    params={
-                        "cursor": None,
-                        "limit": DISCORD_SELECT_OPTION_MAX_OPTIONS,
-                        "agent": current_agent,
-                    },
-                )
-                model_items = _coerce_model_picker_items(result)
-            except Exception as exc:
-                log_event(
-                    self._logger,
-                    logging.WARNING,
-                    "discord.model.list.failed",
-                    channel_id=channel_id,
-                    agent=current_agent,
-                    exc=exc,
-                )
-                await _send_model_picker_or_fallback(
-                    _fallback_model_text("Failed to list models for picker."),
-                )
-                return
+            if current_agent == "opencode":
+                try:
+                    model_items = await self._list_opencode_models_for_picker(
+                        workspace_path=binding.get("workspace_path")
+                    )
+                except Exception as exc:
+                    log_event(
+                        self._logger,
+                        logging.WARNING,
+                        "discord.model.list.failed",
+                        channel_id=channel_id,
+                        agent=current_agent,
+                        exc=exc,
+                    )
+                    await _send_model_picker_or_fallback(
+                        _fallback_model_text("Failed to list models for picker."),
+                    )
+                    return
+                if model_items is None:
+                    await _send_model_picker_or_fallback(
+                        _fallback_model_text(
+                            "Workspace unavailable for model picker. Re-bind this channel with `/car bind` and try again."
+                        ),
+                    )
+                    return
+                if not model_items and not current_model:
+                    await _send_model_picker_or_fallback(
+                        _fallback_model_text("No models found from OpenCode."),
+                    )
+                    return
+            else:
+                try:
+                    client = await self._client_for_workspace(
+                        binding.get("workspace_path")
+                    )
+                except AppServerUnavailableError as exc:
+                    log_event(
+                        self._logger,
+                        logging.WARNING,
+                        "discord.model.list.failed",
+                        channel_id=channel_id,
+                        agent=current_agent,
+                        exc=exc,
+                    )
+                    await _send_model_picker_or_fallback(
+                        _fallback_model_text(
+                            "Model picker unavailable right now (app server unavailable)."
+                        ),
+                    )
+                    return
+                if client is None:
+                    await _send_model_picker_or_fallback(
+                        _fallback_model_text(
+                            "Workspace unavailable for model picker. Re-bind this channel with `/car bind` and try again."
+                        ),
+                    )
+                    return
+                try:
+                    result = await _model_list_with_agent_compat(
+                        client,
+                        params={
+                            "cursor": None,
+                            "limit": DISCORD_SELECT_OPTION_MAX_OPTIONS,
+                            "agent": current_agent,
+                        },
+                    )
+                    model_items = _coerce_model_picker_items(result)
+                except Exception as exc:
+                    log_event(
+                        self._logger,
+                        logging.WARNING,
+                        "discord.model.list.failed",
+                        channel_id=channel_id,
+                        agent=current_agent,
+                        exc=exc,
+                    )
+                    await _send_model_picker_or_fallback(
+                        _fallback_model_text("Failed to list models for picker."),
+                    )
+                    return
 
-            if not model_items and not current_model:
-                await _send_model_picker_or_fallback(
-                    _fallback_model_text("No models found from the app server."),
-                )
-                return
+                if not model_items and not current_model:
+                    await _send_model_picker_or_fallback(
+                        _fallback_model_text("No models found from the app server."),
+                    )
+                    return
 
             lines = [
                 f"Current agent: {current_agent}",
@@ -4727,6 +4837,16 @@ class DiscordBotService:
             )
             await self._respond_ephemeral(
                 interaction_id, interaction_token, "Model override cleared."
+            )
+            return
+
+        if current_agent == "opencode" and not _is_valid_opencode_model_name(
+            model_name
+        ):
+            await self._respond_ephemeral(
+                interaction_id,
+                interaction_token,
+                "OpenCode model must be in `provider/model` format.",
             )
             return
 

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -1327,6 +1327,78 @@ async def test_car_model_without_name_returns_picker_when_bound(tmp_path: Path) 
 
 
 @pytest.mark.anyio
+async def test_car_model_without_name_uses_opencode_catalog_for_opencode_agent(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+    await store.update_agent_state(channel_id="channel-1", agent="opencode")
+    rest = _FakeRest()
+    gateway = _FakeGateway([_interaction(name="model", options=[])])
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    class _FakeOpenCodeClient:
+        async def providers(self, *, directory: str | None = None) -> Any:
+            _ = directory
+            return {
+                "providers": [
+                    {
+                        "id": "openai",
+                        "models": {
+                            "gpt-4o": {"name": "GPT-4o"},
+                        },
+                    }
+                ]
+            }
+
+    class _FakeOpenCodeSupervisor:
+        async def get_client(self, _workspace_root: Path) -> Any:
+            return _FakeOpenCodeClient()
+
+    async def _fake_opencode_supervisor_for_workspace(_workspace_root: Path) -> Any:
+        return _FakeOpenCodeSupervisor()
+
+    async def _unexpected_client_for_workspace(_workspace_path: str) -> Any:
+        raise AssertionError("Codex app-server client should not be used for opencode")
+
+    service._opencode_supervisor_for_workspace = (  # type: ignore[assignment]
+        _fake_opencode_supervisor_for_workspace
+    )
+    service._client_for_workspace = _unexpected_client_for_workspace  # type: ignore[assignment]
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        assert len(rest.followup_messages) == 1
+        data = rest.followup_messages[0]["payload"]
+        assert "current agent: opencode" in data["content"].lower()
+        components = data.get("components") or []
+        assert components
+        menu = components[0]["components"][0]
+        assert menu["custom_id"] == "model_select"
+        values = [opt["value"] for opt in menu["options"]]
+        assert "openai/gpt-4o" in values
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_car_model_without_name_defers_before_model_lookup(
     tmp_path: Path,
 ) -> None:
@@ -1431,7 +1503,7 @@ async def test_component_interaction_model_select_updates_model(tmp_path: Path) 
     await store.update_agent_state(channel_id="channel-1", agent="opencode")
     rest = _FakeRest()
     gateway = _FakeGateway(
-        [_component_interaction(custom_id="model_select", values=["gpt-5.3-codex"])]
+        [_component_interaction(custom_id="model_select", values=["openai/gpt-4o"])]
     )
     service = DiscordBotService(
         _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
@@ -1446,10 +1518,53 @@ async def test_component_interaction_model_select_updates_model(tmp_path: Path) 
         await service.run_forever()
         binding = await store.get_binding(channel_id="channel-1")
         assert binding is not None
-        assert binding.get("model_override") == "gpt-5.3-codex"
+        assert binding.get("model_override") == "openai/gpt-4o"
         assert len(rest.interaction_responses) == 1
         content = rest.interaction_responses[0]["payload"]["data"]["content"].lower()
-        assert "model set to gpt-5.3-codex" in content
+        assert "model set to openai/gpt-4o" in content
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_car_model_rejects_invalid_opencode_model_name(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+    await store.update_agent_state(channel_id="channel-1", agent="opencode")
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _interaction(
+                name="model",
+                options=[{"name": "name", "value": "gpt-5.3-codex"}],
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await service.run_forever()
+        binding = await store.get_binding(channel_id="channel-1")
+        assert binding is not None
+        assert binding.get("model_override") is None
+        assert len(rest.interaction_responses) == 1
+        content = rest.interaction_responses[0]["payload"]["data"]["content"].lower()
+        assert "provider/model" in content
     finally:
         await store.close()
 
@@ -1705,16 +1820,16 @@ async def test_normalized_component_model_select_updates_model(tmp_path: Path) -
     try:
         event = _normalized_component_event(
             component_id="model_select",
-            values=["gpt-5.3-codex"],
+            values=["openai/gpt-4o"],
         )
         context = build_dispatch_context(event)
         await service._handle_normalized_interaction(event, context)
         binding = await store.get_binding(channel_id="channel-1")
         assert binding is not None
-        assert binding.get("model_override") == "gpt-5.3-codex"
+        assert binding.get("model_override") == "openai/gpt-4o"
         assert len(rest.interaction_responses) == 1
         content = rest.interaction_responses[0]["payload"]["data"]["content"].lower()
-        assert "model set to gpt-5.3-codex" in content
+        assert "model set to openai/gpt-4o" in content
     finally:
         await store.close()
 


### PR DESCRIPTION
## Summary
- fix Discord `/car model` picker to use OpenCode model catalog when channel agent is `opencode`
- keep existing Codex app-server model listing path for `codex`
- validate OpenCode model overrides to require `provider/model` format
- close cached OpenCode supervisors during Discord service shutdown

## Root Cause
Discord always sourced picker options from the Codex app-server `model/list` path, even with `agent=opencode`. Those IDs can differ from OpenCode's required model ID format. OpenCode only applies model overrides in `provider/model` format, so invalid values were effectively ignored.

## Tests
- added `test_car_model_without_name_uses_opencode_catalog_for_opencode_agent`
- added `test_car_model_rejects_invalid_opencode_model_name`
- updated OpenCode model-selection expectations in existing Discord component tests to use `provider/model` IDs
- full pre-commit suite ran successfully (format/lint/typecheck/js/tests/pytest)
