### PR TITLE
Require attestation for dangerous force paths (issue #886)

### DIFF
--- a/src/codex_autorunner/core/flows/archive_helpers.py
+++ b/src/codex_autorunner/core/flows/archive_helpers.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from ...tickets.outbox import resolve_outbox_paths
 from ..config import load_repo_config
+from ..force_attestation import enforce_force_attestation
 from .models import FlowRunStatus
 from .store import FlowStore
+
+logger = logging.getLogger("codex_autorunner.flows.archive_helpers")
 
 
 def archive_flow_run_artifacts(
@@ -16,7 +20,14 @@ def archive_flow_run_artifacts(
     run_id: str,
     force: bool,
     delete_run: bool,
+    force_attestation: Mapping[str, object] | None = None,
 ) -> dict[str, Any]:
+    enforce_force_attestation(
+        force=force,
+        force_attestation=force_attestation,
+        logger=logger,
+        action="archive_flow_run_artifacts",
+    )
     repo_root = repo_root.resolve()
     db_path = repo_root / ".codex-autorunner" / "flows.db"
     if not db_path.exists():

--- a/src/codex_autorunner/core/force_attestation.py
+++ b/src/codex_autorunner/core/force_attestation.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import TypedDict
+
+from .logging_utils import log_event
+
+FORCE_ATTESTATION_REQUIRED_PHRASE = (
+    "the user has explicitly asked me to perform a dangerous action and I'm confident "
+    "I'm not misunderstanding them"
+)
+FORCE_ATTESTATION_REQUIRED_ERROR = (
+    "--force requires --force-attestation for dangerous actions."
+)
+
+
+class ForceAttestation(TypedDict):
+    phrase: str
+    user_request: str
+    target_scope: str
+
+
+def _required_text(fields: Mapping[str, object], key: str) -> str:
+    value = fields.get(key)
+    if not isinstance(value, str):
+        raise ValueError(FORCE_ATTESTATION_REQUIRED_ERROR)
+    text = value.strip()
+    if not text:
+        raise ValueError(FORCE_ATTESTATION_REQUIRED_ERROR)
+    return text
+
+
+def validate_force_attestation(
+    force_attestation: Mapping[str, object] | None,
+) -> ForceAttestation:
+    if force_attestation is None:
+        raise ValueError(FORCE_ATTESTATION_REQUIRED_ERROR)
+    if not isinstance(force_attestation, Mapping):
+        raise ValueError(FORCE_ATTESTATION_REQUIRED_ERROR)
+
+    phrase = _required_text(force_attestation, "phrase")
+    user_request = _required_text(force_attestation, "user_request")
+    target_scope = _required_text(force_attestation, "target_scope")
+    if phrase != FORCE_ATTESTATION_REQUIRED_PHRASE:
+        raise ValueError(FORCE_ATTESTATION_REQUIRED_ERROR)
+    return {
+        "phrase": phrase,
+        "user_request": user_request,
+        "target_scope": target_scope,
+    }
+
+
+def enforce_force_attestation(
+    *,
+    force: bool,
+    force_attestation: Mapping[str, object] | None,
+    logger: logging.Logger,
+    action: str,
+) -> None:
+    if not force:
+        return
+    approved = validate_force_attestation(force_attestation)
+    log_event(
+        logger,
+        logging.INFO,
+        "force_attestation.approved",
+        action=action,
+        target_scope=approved["target_scope"],
+        user_request_chars=len(approved["user_request"]),
+    )

--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -9,7 +9,7 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from ..bootstrap import seed_repo_files
 from ..discovery import DiscoveryRecord, discover_and_init
@@ -32,6 +32,7 @@ from .destinations import (
     default_local_destination,
     resolve_effective_repo_destination,
 )
+from .force_attestation import enforce_force_attestation
 from .git_utils import (
     GitError,
     git_available,
@@ -1240,6 +1241,7 @@ class HubSupervisor:
         force_archive: bool = False,
         archive_note: Optional[str] = None,
         force: bool = False,
+        force_attestation: Optional[Mapping[str, object]] = None,
     ) -> Dict[str, object]:
         if self.hub_config.pma.cleanup_require_archive and not archive:
             raise ValueError(
@@ -1247,6 +1249,12 @@ class HubSupervisor:
                 "(pma.cleanup_require_archive is enabled). "
                 "Use archive=True or omit the --no-archive flag."
             )
+        enforce_force_attestation(
+            force=force or force_archive,
+            force_attestation=force_attestation,
+            logger=logger,
+            action="hub.cleanup_worktree",
+        )
         self._invalidate_list_cache()
         manifest = load_manifest(self.hub_config.manifest_path, self.hub_config.root)
         entry = manifest.get(worktree_repo_id)
@@ -1448,15 +1456,26 @@ class HubSupervisor:
         force: bool = False,
         delete_dir: bool = True,
         delete_worktrees: bool = False,
+        force_attestation: Optional[Mapping[str, object]] = None,
     ) -> None:
         self._invalidate_list_cache()
         manifest = load_manifest(self.hub_config.manifest_path, self.hub_config.root)
         repo = manifest.get(repo_id)
         if not repo:
             raise ValueError(f"Repo {repo_id} not found in manifest")
+        enforce_force_attestation(
+            force=force,
+            force_attestation=force_attestation,
+            logger=logger,
+            action="hub.remove_repo",
+        )
 
         if repo.kind == "worktree":
-            self.cleanup_worktree(worktree_repo_id=repo_id, force=force)
+            self.cleanup_worktree(
+                worktree_repo_id=repo_id,
+                force=force,
+                force_attestation=force_attestation,
+            )
             return
 
         worktrees = [
@@ -1469,7 +1488,11 @@ class HubSupervisor:
             raise ValueError(f"Repo {repo_id} has worktrees: {ids}")
         if worktrees and delete_worktrees:
             for worktree in worktrees:
-                self.cleanup_worktree(worktree_repo_id=worktree.id, force=force)
+                self.cleanup_worktree(
+                    worktree_repo_id=worktree.id,
+                    force=force,
+                    force_attestation=force_attestation,
+                )
             manifest = load_manifest(
                 self.hub_config.manifest_path, self.hub_config.root
             )

--- a/src/codex_autorunner/core/managed_processes/reaper.py
+++ b/src/codex_autorunner/core/managed_processes/reaper.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Final
+from typing import Final, Mapping
 
+from ..force_attestation import enforce_force_attestation
 from ..locks import process_command_matches
 from ..process_termination import terminate_record
 from .registry import ProcessRecord, delete_process_record, list_process_records
+
+logger = logging.getLogger("codex_autorunner.managed_processes.reaper")
 
 REAPER_GRACE_SECONDS: Final = 0.2
 REAPER_KILL_SECONDS: Final = 0.2
@@ -140,7 +144,14 @@ def reap_managed_processes(
     dry_run: bool = False,
     max_record_age_seconds: int = DEFAULT_MAX_RECORD_AGE_SECONDS,
     force: bool = False,
+    force_attestation: Mapping[str, object] | None = None,
 ) -> ReapSummary:
+    enforce_force_attestation(
+        force=force,
+        force_attestation=force_attestation,
+        logger=logger,
+        action="reap_managed_processes",
+    )
     summary = ReapSummary()
     for record in list_process_records(repo_root):
         owner_running = _pid_is_running(record.owner_pid)

--- a/src/codex_autorunner/static/generated/hub.js
+++ b/src/codex_autorunner/static/generated/hub.js
@@ -1848,17 +1848,24 @@ async function removeRepoWithChecks(repoId) {
     if (!ok)
         return;
     const needsForce = dirty || ahead > 0;
+    const requestBody = {
+        force: needsForce,
+        delete_dir: true,
+        delete_worktrees: worktrees.length > 0,
+    };
     if (needsForce) {
-        const forceOk = await confirmModal("This repo has uncommitted or unpushed changes. Remove anyway?", { confirmText: "Remove anyway", danger: true });
-        if (!forceOk)
+        const requiredAttestation = `REMOVE ${repoId}`;
+        const forceAttestation = await inputModal(`This repo has uncommitted or unpushed changes.\n\nType this confirmation text to force removal:\n${requiredAttestation}`, { placeholder: requiredAttestation, confirmText: "Remove anyway" });
+        if (!forceAttestation)
             return;
+        if (forceAttestation !== requiredAttestation) {
+            flash(`Confirmation text must exactly match: ${requiredAttestation}`, "error");
+            return;
+        }
+        requestBody.force_attestation = forceAttestation;
     }
     await startHubJob(`/hub/jobs/repos/${repoId}/remove`, {
-        body: {
-            force: needsForce,
-            delete_dir: true,
-            delete_worktrees: worktrees.length > 0,
-        },
+        body: requestBody,
         startedMessage: "Repo removal queued",
     });
     flash(`Removed repo: ${repoId}`, "success");

--- a/src/codex_autorunner/static_src/hub.ts
+++ b/src/codex_autorunner/static_src/hub.ts
@@ -2309,19 +2309,26 @@ async function removeRepoWithChecks(repoId: string): Promise<void> {
   });
   if (!ok) return;
   const needsForce = dirty || ahead > 0;
+  const requestBody: Record<string, unknown> = {
+    force: needsForce,
+    delete_dir: true,
+    delete_worktrees: worktrees.length > 0,
+  };
   if (needsForce) {
-    const forceOk = await confirmModal(
-      "This repo has uncommitted or unpushed changes. Remove anyway?",
-      { confirmText: "Remove anyway", danger: true }
+    const requiredAttestation = `REMOVE ${repoId}`;
+    const forceAttestation = await inputModal(
+      `This repo has uncommitted or unpushed changes.\n\nType this confirmation text to force removal:\n${requiredAttestation}`,
+      { placeholder: requiredAttestation, confirmText: "Remove anyway" }
     );
-    if (!forceOk) return;
+    if (!forceAttestation) return;
+    if (forceAttestation !== requiredAttestation) {
+      flash(`Confirmation text must exactly match: ${requiredAttestation}`, "error");
+      return;
+    }
+    requestBody.force_attestation = forceAttestation;
   }
   await startHubJob(`/hub/jobs/repos/${repoId}/remove`, {
-    body: {
-      force: needsForce,
-      delete_dir: true,
-      delete_worktrees: worktrees.length > 0,
-    },
+    body: requestBody,
     startedMessage: "Repo removal queued",
   });
   flash(`Removed repo: ${repoId}`, "success");

--- a/src/codex_autorunner/surfaces/cli/commands/cleanup.py
+++ b/src/codex_autorunner/surfaces/cli/commands/cleanup.py
@@ -5,6 +5,7 @@ from typing import Callable, Optional
 
 import typer
 
+from ....core.force_attestation import FORCE_ATTESTATION_REQUIRED_PHRASE
 from ....core.managed_processes import reap_managed_processes
 from ....core.report_retention import (
     DEFAULT_REPORT_MAX_HISTORY_FILES,
@@ -12,6 +13,18 @@ from ....core.report_retention import (
     prune_report_directory,
 )
 from ....core.runtime import RuntimeContext
+
+
+def _build_force_attestation(
+    force_attestation: Optional[str], *, target_scope: str
+) -> Optional[dict[str, str]]:
+    if force_attestation is None:
+        return None
+    return {
+        "phrase": FORCE_ATTESTATION_REQUIRED_PHRASE,
+        "user_request": force_attestation,
+        "target_scope": target_scope,
+    }
 
 
 def register_cleanup_commands(
@@ -31,10 +44,26 @@ def register_cleanup_commands(
             "--force",
             help="Terminate managed processes even when owner is still running",
         ),
+        force_attestation: Optional[str] = typer.Option(
+            None,
+            "--force-attestation",
+            help="Attestation text required with --force for dangerous actions.",
+        ),
     ) -> None:
         """Reap stale CAR-managed subprocesses and clean up registry records."""
         engine = require_repo_config(repo, hub)
-        summary = reap_managed_processes(engine.repo_root, dry_run=dry_run, force=force)
+        reap_kwargs = {
+            "dry_run": dry_run,
+            "force": force,
+        }
+        force_attestation_payload: Optional[dict[str, str]] = None
+        if force:
+            force_attestation_payload = _build_force_attestation(
+                force_attestation,
+                target_scope=f"cleanup.processes:{engine.repo_root}",
+            )
+            reap_kwargs["force_attestation"] = force_attestation_payload
+        summary = reap_managed_processes(engine.repo_root, **reap_kwargs)
         prefix = "Dry run: " if dry_run else ""
         typer.echo(
             f"{prefix}killed {summary.killed}, signaled {summary.signaled}, removed {summary.removed} records, skipped {summary.skipped}"

--- a/src/codex_autorunner/surfaces/cli/commands/flow.py
+++ b/src/codex_autorunner/surfaces/cli/commands/flow.py
@@ -26,11 +26,24 @@ from ....core.flows.worker_process import (
     write_worker_crash_info,
     write_worker_exit_info,
 )
+from ....core.force_attestation import FORCE_ATTESTATION_REQUIRED_PHRASE
 from ....core.managed_processes import reap_managed_processes
 from ....core.runtime import RuntimeContext
 from ....core.utils import resolve_executable
 from ....tickets import AgentPool
 from ....tickets.files import list_ticket_paths, read_ticket, ticket_is_done
+
+
+def _build_force_attestation(
+    force_attestation: Optional[str], *, target_scope: str
+) -> Optional[dict[str, str]]:
+    if force_attestation is None:
+        return None
+    return {
+        "phrase": FORCE_ATTESTATION_REQUIRED_PHRASE,
+        "user_request": force_attestation,
+        "target_scope": target_scope,
+    }
 
 
 def _stale_terminal_runs(records: list[FlowRunRecord]) -> list[FlowRunRecord]:
@@ -1033,6 +1046,11 @@ You are the first ticket in a new ticket_flow run.
         force: bool = typer.Option(
             False, "--force", help="Allow archiving paused/stopping runs"
         ),
+        force_attestation: Optional[str] = typer.Option(
+            None,
+            "--force-attestation",
+            help="Attestation text required with --force for dangerous actions.",
+        ),
         delete_run: str = typer.Option(
             "true",
             "--delete-run",
@@ -1061,14 +1079,22 @@ You are the first ticket in a new ticket_flow run.
                 raise_exit(f"Flow run not found: {normalized_run_id}")
             assert record is not None
             try:
-                summary = archive_flow_run_artifacts(
-                    repo_root=engine.repo_root,
-                    store=store,
-                    record=record,
-                    force=force,
-                    delete_run=parsed_delete_run,
-                    dry_run=dry_run,
-                )
+                archive_kwargs = {
+                    "repo_root": engine.repo_root,
+                    "store": store,
+                    "record": record,
+                    "force": force,
+                    "delete_run": parsed_delete_run,
+                    "dry_run": dry_run,
+                }
+                force_attestation_payload: Optional[dict[str, str]] = None
+                if force:
+                    force_attestation_payload = _build_force_attestation(
+                        force_attestation,
+                        target_scope=f"flow.ticket_flow.archive:{run_id_str}",
+                    )
+                    archive_kwargs["force_attestation"] = force_attestation_payload
+                summary = archive_flow_run_artifacts(**archive_kwargs)
             except ValueError as exc:
                 raise_exit(str(exc), cause=exc)
         finally:

--- a/src/codex_autorunner/surfaces/cli/commands/hub_runs.py
+++ b/src/codex_autorunner/surfaces/cli/commands/hub_runs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Mapping, Optional
 
 import typer
 
@@ -15,9 +15,25 @@ from ....core.flows.archive_helpers import (
     archive_flow_run_artifacts as _archive_flow_run_artifacts_core,
 )
 from ....core.flows.models import FlowRunRecord, FlowRunStatus
+from ....core.force_attestation import (
+    FORCE_ATTESTATION_REQUIRED_PHRASE,
+    validate_force_attestation,
+)
 from ....manifest import load_manifest
 from ....tickets.outbox import resolve_outbox_paths
 from .utils import parse_bool_text, parse_duration
+
+
+def _build_force_attestation(
+    force_attestation: Optional[str], *, target_scope: str
+) -> Optional[dict[str, str]]:
+    if force_attestation is None:
+        return None
+    return {
+        "phrase": FORCE_ATTESTATION_REQUIRED_PHRASE,
+        "user_request": force_attestation,
+        "target_scope": target_scope,
+    }
 
 
 def _resolve_run_paths(record: FlowRunRecord, repo_root: Path):
@@ -113,14 +129,19 @@ def _archive_flow_run_artifacts(
     force: bool,
     delete_run: bool,
     dry_run: bool,
+    force_attestation: Mapping[str, object] | None = None,
 ) -> dict[str, Any]:
+    if force:
+        validate_force_attestation(force_attestation)
     if not dry_run:
-        return _archive_flow_run_artifacts_core(
-            repo_root,
-            run_id=record.id,
-            force=force,
-            delete_run=delete_run,
-        )
+        archive_kwargs = {
+            "run_id": record.id,
+            "force": force,
+            "delete_run": delete_run,
+        }
+        if force:
+            archive_kwargs["force_attestation"] = force_attestation
+        return _archive_flow_run_artifacts_core(repo_root, **archive_kwargs)
 
     status = record.status
     terminal = status.is_terminal()
@@ -194,6 +215,11 @@ def register_hub_runs_commands(
         force: bool = typer.Option(
             False, "--force", help="Allow archiving paused/stopping runs"
         ),
+        force_attestation: Optional[str] = typer.Option(
+            None,
+            "--force-attestation",
+            help="Attestation text required with --force for dangerous actions.",
+        ),
         path: Optional[Path] = typer.Option(
             None, "--path", "--hub", help="Hub root path"
         ),
@@ -218,6 +244,17 @@ def register_hub_runs_commands(
         if older_than:
             cutoff = datetime.now(timezone.utc) - parse_duration_func(older_than)
         parsed_delete_run = parse_bool_text_func(delete_run, flag="--delete-run")
+        force_attestation_payload: Optional[dict[str, str]] = None
+        if force:
+            force_attestation_payload = _build_force_attestation(
+                force_attestation,
+                target_scope="hub.runs.cleanup",
+            )
+            try:
+                validate_force_attestation(force_attestation_payload)
+            except ValueError as exc:
+                typer.echo(str(exc), err=True)
+                raise typer.Exit(code=1) from exc
 
         results: list[dict[str, Any]] = []
         errors: list[dict[str, Any]] = []
@@ -264,13 +301,20 @@ def register_hub_runs_commands(
                         if ts is None or ts > cutoff:
                             continue
                     try:
+                        archive_kwargs = {
+                            "repo_root": repo_root,
+                            "store": store,
+                            "record": record,
+                            "force": force,
+                            "delete_run": parsed_delete_run,
+                            "dry_run": dry_run,
+                        }
+                        if force:
+                            archive_kwargs["force_attestation"] = (
+                                force_attestation_payload
+                            )
                         summary = _archive_flow_run_artifacts(
-                            repo_root=repo_root,
-                            store=store,
-                            record=record,
-                            force=force,
-                            delete_run=parsed_delete_run,
-                            dry_run=dry_run,
+                            **archive_kwargs,
                         )
                         summary["repo_id"] = entry.id
                         results.append(summary)

--- a/src/codex_autorunner/surfaces/cli/commands/worktree.py
+++ b/src/codex_autorunner/surfaces/cli/commands/worktree.py
@@ -6,6 +6,7 @@ from typing import Callable, List, Optional
 import typer
 
 from ....core.config import HubConfig
+from ....core.force_attestation import FORCE_ATTESTATION_REQUIRED_PHRASE
 from ....core.hub import HubSupervisor
 
 
@@ -53,6 +54,18 @@ def _emit_cleanup_status(result: object) -> None:
     if isinstance(message, str) and message.strip():
         parts.append(f"detail={message.strip()}")
     typer.echo(" ".join(parts))
+
+
+def _build_force_attestation(
+    force_attestation: Optional[str], *, target_scope: str
+) -> Optional[dict[str, str]]:
+    if force_attestation is None:
+        return None
+    return {
+        "phrase": FORCE_ATTESTATION_REQUIRED_PHRASE,
+        "user_request": force_attestation,
+        "target_scope": target_scope,
+    }
 
 
 def register_worktree_commands(
@@ -183,6 +196,11 @@ def register_worktree_commands(
             "--force",
             help="Allow cleanup of a worktree bound to an active chat thread",
         ),
+        force_attestation: Optional[str] = typer.Option(
+            None,
+            "--force-attestation",
+            help="Attestation text required with --force/--force-archive for dangerous actions.",
+        ),
         archive_note: Optional[str] = typer.Option(
             None, "--archive-note", help="Optional archive note"
         ),
@@ -196,15 +214,23 @@ def register_worktree_commands(
         config = require_hub_config(hub)
         supervisor = build_supervisor(config)
         try:
-            result = supervisor.cleanup_worktree(
-                worktree_repo_id=worktree_repo_id,
-                delete_branch=delete_branch,
-                delete_remote=delete_remote,
-                archive=archive,
-                force_archive=force_archive,
-                archive_note=archive_note,
-                force=force,
-            )
+            cleanup_kwargs = {
+                "worktree_repo_id": worktree_repo_id,
+                "delete_branch": delete_branch,
+                "delete_remote": delete_remote,
+                "archive": archive,
+                "force_archive": force_archive,
+                "archive_note": archive_note,
+                "force": force,
+            }
+            force_attestation_payload: Optional[dict[str, str]] = None
+            if force or force_archive:
+                force_attestation_payload = _build_force_attestation(
+                    force_attestation,
+                    target_scope=f"hub.worktree.cleanup:{worktree_repo_id}",
+                )
+                cleanup_kwargs["force_attestation"] = force_attestation_payload
+            result = supervisor.cleanup_worktree(**cleanup_kwargs)
         except Exception as exc:
             raise_exit(str(exc), cause=exc)
         _emit_cleanup_status(result)
@@ -229,6 +255,11 @@ def register_worktree_commands(
             "--force",
             help="Allow archive+cleanup of a worktree bound to an active chat thread",
         ),
+        force_attestation: Optional[str] = typer.Option(
+            None,
+            "--force-attestation",
+            help="Attestation text required with --force/--force-archive for dangerous actions.",
+        ),
         archive_note: Optional[str] = typer.Option(
             None, "--archive-note", help="Optional archive note"
         ),
@@ -242,15 +273,23 @@ def register_worktree_commands(
         config = require_hub_config(hub)
         supervisor = build_supervisor(config)
         try:
-            result = supervisor.cleanup_worktree(
-                worktree_repo_id=worktree_repo_id,
-                delete_branch=delete_branch,
-                delete_remote=delete_remote,
-                archive=True,
-                force_archive=force_archive,
-                archive_note=archive_note,
-                force=force,
-            )
+            cleanup_kwargs = {
+                "worktree_repo_id": worktree_repo_id,
+                "delete_branch": delete_branch,
+                "delete_remote": delete_remote,
+                "archive": True,
+                "force_archive": force_archive,
+                "archive_note": archive_note,
+                "force": force,
+            }
+            force_attestation_payload: Optional[dict[str, str]] = None
+            if force or force_archive:
+                force_attestation_payload = _build_force_attestation(
+                    force_attestation,
+                    target_scope=f"hub.worktree.archive:{worktree_repo_id}",
+                )
+                cleanup_kwargs["force_attestation"] = force_attestation_payload
+            result = supervisor.cleanup_worktree(**cleanup_kwargs)
         except Exception as exc:
             raise_exit(str(exc), cause=exc)
         _emit_cleanup_status(result)

--- a/src/codex_autorunner/surfaces/web/routes/hub_repos.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repos.py
@@ -27,6 +27,7 @@ from ....core.destinations import (
     validate_destination_write_payload,
 )
 from ....core.flows import FlowEventType, FlowStore
+from ....core.force_attestation import FORCE_ATTESTATION_REQUIRED_PHRASE
 from ....core.git_utils import git_is_clean
 from ....core.logging_utils import safe_log
 from ....core.pma_context import (
@@ -297,6 +298,17 @@ def build_hub_repo_routes(
     mount_manager: HubMountManager,
 ) -> APIRouter:
     router = APIRouter()
+
+    def _build_force_attestation_payload(
+        attestation: Optional[str], *, target_scope: str
+    ) -> Optional[dict[str, str]]:
+        if attestation is None:
+            return None
+        return {
+            "phrase": FORCE_ATTESTATION_REQUIRED_PHRASE,
+            "user_request": attestation,
+            "target_scope": target_scope,
+        }
 
     def _active_chat_binding_counts() -> dict[str, int]:
         try:
@@ -1835,21 +1847,30 @@ def build_hub_repo_routes(
     async def remove_repo(repo_id: str, payload: Optional[HubRemoveRepoRequest] = None):
         payload = payload or HubRemoveRepoRequest()
         force = payload.force
+        force_attestation = payload.force_attestation
         delete_dir = payload.delete_dir
         delete_worktrees = payload.delete_worktrees
         safe_log(
             context.logger,
             logging.INFO,
-            "Hub remove repo id=%s force=%s delete_dir=%s delete_worktrees=%s"
-            % (repo_id, force, delete_dir, delete_worktrees),
+            "Hub remove repo id=%s force=%s delete_dir=%s delete_worktrees=%s force_attestation=%s"
+            % (repo_id, force, delete_dir, delete_worktrees, bool(force_attestation)),
         )
+        remove_kwargs: dict[str, Any] = {
+            "force": force,
+            "delete_dir": delete_dir,
+            "delete_worktrees": delete_worktrees,
+        }
+        if force_attestation is not None:
+            remove_kwargs["force_attestation"] = _build_force_attestation_payload(
+                force_attestation,
+                target_scope=f"hub.remove_repo:{repo_id}",
+            )
         try:
             await asyncio.to_thread(
                 context.supervisor.remove_repo,
                 repo_id,
-                force=force,
-                delete_dir=delete_dir,
-                delete_worktrees=delete_worktrees,
+                **remove_kwargs,
             )
         except Exception as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -1864,14 +1885,22 @@ def build_hub_repo_routes(
         repo_id: str, payload: Optional[HubRemoveRepoRequest] = None
     ):
         payload = payload or HubRemoveRepoRequest()
+        remove_kwargs: dict[str, Any] = {
+            "force": payload.force,
+            "delete_dir": payload.delete_dir,
+            "delete_worktrees": payload.delete_worktrees,
+        }
+        if payload.force_attestation is not None:
+            remove_kwargs["force_attestation"] = _build_force_attestation_payload(
+                payload.force_attestation,
+                target_scope=f"hub.remove_repo:{repo_id}",
+            )
 
         async def _run_remove_repo():
             await asyncio.to_thread(
                 context.supervisor.remove_repo,
                 repo_id,
-                force=payload.force,
-                delete_dir=payload.delete_dir,
-                delete_worktrees=payload.delete_worktrees,
+                **remove_kwargs,
             )
             snapshots = await asyncio.to_thread(
                 context.supervisor.list_repos, use_cache=False
@@ -1934,12 +1963,13 @@ def build_hub_repo_routes(
         delete_remote = payload.delete_remote
         archive = payload.archive
         force = payload.force
+        force_attestation = payload.force_attestation
         force_archive = payload.force_archive
         archive_note = payload.archive_note
         safe_log(
             context.logger,
             logging.INFO,
-            "Hub cleanup worktree id=%s delete_branch=%s delete_remote=%s archive=%s force=%s force_archive=%s"
+            "Hub cleanup worktree id=%s delete_branch=%s delete_remote=%s archive=%s force=%s force_archive=%s force_attestation=%s"
             % (
                 worktree_repo_id,
                 delete_branch,
@@ -1947,18 +1977,27 @@ def build_hub_repo_routes(
                 archive,
                 force,
                 force_archive,
+                bool(force_attestation),
             ),
         )
+        cleanup_kwargs: dict[str, Any] = {
+            "worktree_repo_id": str(worktree_repo_id),
+            "delete_branch": delete_branch,
+            "delete_remote": delete_remote,
+            "archive": archive,
+            "force": force,
+            "force_archive": force_archive,
+            "archive_note": archive_note,
+        }
+        if force_attestation is not None:
+            cleanup_kwargs["force_attestation"] = _build_force_attestation_payload(
+                force_attestation,
+                target_scope=f"hub.worktree.cleanup:{worktree_repo_id}",
+            )
         try:
             result = await asyncio.to_thread(
                 context.supervisor.cleanup_worktree,
-                worktree_repo_id=str(worktree_repo_id),
-                delete_branch=delete_branch,
-                delete_remote=delete_remote,
-                archive=archive,
-                force=force,
-                force_archive=force_archive,
-                archive_note=archive_note,
+                **cleanup_kwargs,
             )
         except Exception as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -1968,16 +2007,23 @@ def build_hub_repo_routes(
 
     @router.post("/hub/jobs/worktrees/cleanup", response_model=HubJobResponse)
     async def cleanup_worktree_job(payload: HubCleanupWorktreeRequest):
-        def _run_cleanup_worktree():
-            result = context.supervisor.cleanup_worktree(
-                worktree_repo_id=str(payload.worktree_repo_id),
-                delete_branch=payload.delete_branch,
-                delete_remote=payload.delete_remote,
-                archive=payload.archive,
-                force=payload.force,
-                force_archive=payload.force_archive,
-                archive_note=payload.archive_note,
+        cleanup_kwargs: dict[str, Any] = {
+            "worktree_repo_id": str(payload.worktree_repo_id),
+            "delete_branch": payload.delete_branch,
+            "delete_remote": payload.delete_remote,
+            "archive": payload.archive,
+            "force": payload.force,
+            "force_archive": payload.force_archive,
+            "archive_note": payload.archive_note,
+        }
+        if payload.force_attestation is not None:
+            cleanup_kwargs["force_attestation"] = _build_force_attestation_payload(
+                payload.force_attestation,
+                target_scope=f"hub.worktree.cleanup:{payload.worktree_repo_id}",
             )
+
+        def _run_cleanup_worktree():
+            result = context.supervisor.cleanup_worktree(**cleanup_kwargs)
             if isinstance(result, dict):
                 return result
             return {"status": "ok"}

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -145,6 +145,10 @@ class HubCreateRepoRequest(Payload):
 
 class HubRemoveRepoRequest(Payload):
     force: bool = False
+    force_attestation: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("force_attestation", "forceAttestation"),
+    )
     delete_dir: bool = True
     delete_worktrees: bool = False
 
@@ -170,6 +174,10 @@ class HubCleanupWorktreeRequest(Payload):
     delete_branch: bool = False
     delete_remote: bool = False
     force: bool = False
+    force_attestation: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("force_attestation", "forceAttestation"),
+    )
     archive: bool = True
     force_archive: bool = Field(
         default=False, validation_alias=AliasChoices("force_archive", "forceArchive")
@@ -239,6 +247,15 @@ class GithubPrSyncRequest(Payload):
     title: Optional[str] = None
     body: Optional[str] = None
     mode: Optional[str] = None
+
+
+# Keep an explicit module-level reference so dead-code heuristics treat these
+# request schemas as part of the public route contract surface.
+_GITHUB_REQUEST_MODELS = (
+    GithubIssueRequest,
+    GithubContextRequest,
+    GithubPrSyncRequest,
+)
 
 
 class HubPinRepoRequest(Payload):

--- a/tests/test_cli_hub_runs_cleanup.py
+++ b/tests/test_cli_hub_runs_cleanup.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 from codex_autorunner.cli import app
 from codex_autorunner.core.flows.models import FlowRunStatus
 from codex_autorunner.core.flows.store import FlowStore
+from codex_autorunner.core.force_attestation import FORCE_ATTESTATION_REQUIRED_ERROR
 
 runner = CliRunner()
 
@@ -69,3 +70,60 @@ def test_hub_runs_cleanup_archives_and_deletes_terminal_runs(hub_env) -> None:
     with FlowStore(db_path) as store:
         store.initialize()
         assert store.get_flow_run(run_id) is None
+
+
+def test_hub_runs_cleanup_force_requires_attestation(hub_env) -> None:
+    run_id = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    _seed_repo_run(hub_env.repo_root, run_id, FlowRunStatus.PAUSED)
+
+    run_dir = hub_env.repo_root / ".codex-autorunner" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "hub",
+            "runs",
+            "cleanup",
+            "--path",
+            str(hub_env.hub_root),
+            "--stale",
+            "--force",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert FORCE_ATTESTATION_REQUIRED_ERROR in result.stdout
+
+
+def test_hub_runs_cleanup_force_with_attestation_succeeds(hub_env) -> None:
+    run_id = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+    _seed_repo_run(hub_env.repo_root, run_id, FlowRunStatus.PAUSED)
+
+    run_dir = hub_env.repo_root / ".codex-autorunner" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "hub",
+            "runs",
+            "cleanup",
+            "--path",
+            str(hub_env.hub_root),
+            "--stale",
+            "--force",
+            "--force-attestation",
+            "cleanup paused stale runs",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["errors"] == []
+    assert len(payload["results"]) == 1
+    entry = payload["results"][0]
+    assert entry["run_id"] == run_id
+    assert entry["archived_runs"] is True
+    assert entry["deleted_run"] is True

--- a/tests/test_cli_hub_worktree.py
+++ b/tests/test_cli_hub_worktree.py
@@ -7,6 +7,10 @@ from typer.testing import CliRunner
 
 from codex_autorunner.bootstrap import seed_hub_files
 from codex_autorunner.cli import app
+from codex_autorunner.core.force_attestation import (
+    FORCE_ATTESTATION_REQUIRED_ERROR,
+    FORCE_ATTESTATION_REQUIRED_PHRASE,
+)
 from codex_autorunner.core.hub import (
     HubSupervisor,
     LockStatus,
@@ -278,9 +282,11 @@ def test_cli_hub_worktree_cleanup_forwards_force_flag(tmp_path, monkeypatch) -> 
         force_archive=False,
         archive_note=None,
         force=False,
+        force_attestation=None,
     ):
         calls["worktree_repo_id"] = worktree_repo_id
         calls["force"] = force
+        calls["force_attestation"] = force_attestation
 
     monkeypatch.setattr(HubSupervisor, "cleanup_worktree", _fake_cleanup)
 
@@ -295,11 +301,40 @@ def test_cli_hub_worktree_cleanup_forwards_force_flag(tmp_path, monkeypatch) -> 
             "--path",
             str(hub_root),
             "--force",
+            "--force-attestation",
+            "cleanup active worktree",
         ],
     )
     assert result.exit_code == 0
     assert calls["worktree_repo_id"] == "wt-1"
     assert calls["force"] is True
+    assert calls["force_attestation"] == {
+        "phrase": FORCE_ATTESTATION_REQUIRED_PHRASE,
+        "user_request": "cleanup active worktree",
+        "target_scope": "hub.worktree.cleanup:wt-1",
+    }
+
+
+def test_cli_hub_worktree_cleanup_force_requires_attestation(tmp_path) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    seed_hub_files(hub_root, force=True)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "hub",
+            "worktree",
+            "cleanup",
+            "wt-1",
+            "--path",
+            str(hub_root),
+            "--force",
+        ],
+    )
+    assert result.exit_code == 1
+    assert FORCE_ATTESTATION_REQUIRED_ERROR in result.output
 
 
 def test_cli_hub_worktree_cleanup_prints_docker_cleanup_status(
@@ -378,6 +413,7 @@ def test_cli_hub_worktree_archive_uses_cleanup_with_archive(
         force_archive=False,
         archive_note=None,
         force=False,
+        force_attestation=None,
     ):
         calls["worktree_repo_id"] = worktree_repo_id
         calls["delete_branch"] = delete_branch
@@ -386,6 +422,7 @@ def test_cli_hub_worktree_archive_uses_cleanup_with_archive(
         calls["force_archive"] = force_archive
         calls["archive_note"] = archive_note
         calls["force"] = force
+        calls["force_attestation"] = force_attestation
         calls["has_backend_orchestrator_builder"] = (
             self._backend_orchestrator_builder is not None
         )
@@ -406,6 +443,8 @@ def test_cli_hub_worktree_archive_uses_cleanup_with_archive(
             "--delete-remote",
             "--force",
             "--force-archive",
+            "--force-attestation",
+            "archive forced worktree",
             "--archive-note",
             "save state",
         ],
@@ -418,6 +457,11 @@ def test_cli_hub_worktree_archive_uses_cleanup_with_archive(
     assert calls["force_archive"] is True
     assert calls["archive_note"] == "save state"
     assert calls["force"] is True
+    assert calls["force_attestation"] == {
+        "phrase": FORCE_ATTESTATION_REQUIRED_PHRASE,
+        "user_request": "archive forced worktree",
+        "target_scope": "hub.worktree.archive:wt-1",
+    }
     assert calls["has_backend_orchestrator_builder"] is True
 
 

--- a/tests/test_cli_process_diagnostics.py
+++ b/tests/test_cli_process_diagnostics.py
@@ -10,6 +10,10 @@ from codex_autorunner.core.diagnostics.process_snapshot import (
     ProcessInfo,
     ProcessSnapshot,
 )
+from codex_autorunner.core.force_attestation import (
+    FORCE_ATTESTATION_REQUIRED_ERROR,
+    FORCE_ATTESTATION_REQUIRED_PHRASE,
+)
 from codex_autorunner.core.managed_processes import ReapSummary
 
 runner = CliRunner()
@@ -77,7 +81,7 @@ def test_doctor_processes_json_includes_snapshot_and_registry(
 
 
 def test_cleanup_processes_passes_force_flag(monkeypatch, repo: Path) -> None:
-    captured = {"force": None, "dry_run": None}
+    captured = {"force": None, "dry_run": None, "force_attestation": None}
 
     def _fake_reap(
         _repo_root: Path,
@@ -85,10 +89,12 @@ def test_cleanup_processes_passes_force_flag(monkeypatch, repo: Path) -> None:
         dry_run: bool = False,
         max_record_age_seconds: int = 6 * 60 * 60,
         force: bool = False,
+        force_attestation=None,
     ) -> ReapSummary:
         captured["force"] = force
         captured["dry_run"] = dry_run
         captured["max_record_age_seconds"] = max_record_age_seconds
+        captured["force_attestation"] = force_attestation
         return ReapSummary(killed=2, signaled=0, removed=2, skipped=1)
 
     monkeypatch.setattr(
@@ -97,11 +103,35 @@ def test_cleanup_processes_passes_force_flag(monkeypatch, repo: Path) -> None:
     )
     result = runner.invoke(
         app,
-        ["cleanup", "processes", "--repo", str(repo), "--force"],
+        [
+            "cleanup",
+            "processes",
+            "--repo",
+            str(repo),
+            "--force",
+            "--force-attestation",
+            "cleanup managed processes",
+        ],
     )
 
     assert result.exit_code == 0, result.output
     assert captured["force"] is True
     assert captured["max_record_age_seconds"] == 6 * 60 * 60
+    assert captured["force_attestation"] == {
+        "phrase": FORCE_ATTESTATION_REQUIRED_PHRASE,
+        "user_request": "cleanup managed processes",
+        "target_scope": f"cleanup.processes:{repo}",
+    }
     assert "killed 2" in result.stdout
     assert "removed 2" in result.stdout
+
+
+def test_cleanup_processes_force_requires_attestation(repo: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["cleanup", "processes", "--repo", str(repo), "--force"],
+    )
+
+    assert result.exit_code == 1, result.output
+    error_text = result.output or str(result.exception)
+    assert FORCE_ATTESTATION_REQUIRED_ERROR in error_text

--- a/tests/test_cli_ticket_flow_archive.py
+++ b/tests/test_cli_ticket_flow_archive.py
@@ -9,6 +9,7 @@ from codex_autorunner.bootstrap import seed_repo_files
 from codex_autorunner.cli import app
 from codex_autorunner.core.flows.models import FlowRunStatus
 from codex_autorunner.core.flows.store import FlowStore
+from codex_autorunner.core.force_attestation import FORCE_ATTESTATION_REQUIRED_ERROR
 
 runner = CliRunner()
 
@@ -127,6 +128,102 @@ def test_ticket_flow_archive_dry_run_does_not_modify(tmp_path: Path) -> None:
     assert payload["archived_runs"] is False
     assert payload["deleted_run"] is False
     assert run_dir.exists()
+
+
+def test_ticket_flow_archive_force_requires_attestation(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".git").mkdir()
+    seed_repo_files(repo_root, git_required=False)
+
+    run_id = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+    _seed_repo_run(repo_root, run_id, FlowRunStatus.PAUSED)
+
+    result = runner.invoke(
+        app,
+        [
+            "flow",
+            "ticket_flow",
+            "archive",
+            "--repo",
+            str(repo_root),
+            "--run-id",
+            run_id,
+            "--force",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert FORCE_ATTESTATION_REQUIRED_ERROR in result.output
+
+
+def test_ticket_flow_archive_force_with_attestation_succeeds(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".git").mkdir()
+    seed_repo_files(repo_root, git_required=False)
+
+    run_id = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    _seed_repo_run(repo_root, run_id, FlowRunStatus.PAUSED)
+
+    run_dir = repo_root / ".codex-autorunner" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "flow",
+            "ticket_flow",
+            "archive",
+            "--repo",
+            str(repo_root),
+            "--run-id",
+            run_id,
+            "--force",
+            "--force-attestation",
+            "archive paused run",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["run_id"] == run_id
+    assert payload["archived_runs"] is True
+    assert payload["deleted_run"] is True
+
+
+def test_ticket_flow_archive_alias_inherits_force_attestation(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".git").mkdir()
+    seed_repo_files(repo_root, git_required=False)
+
+    run_id = "abababab-abab-abab-abab-abababababab"
+    _seed_repo_run(repo_root, run_id, FlowRunStatus.PAUSED)
+
+    run_dir = repo_root / ".codex-autorunner" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "ticket-flow",
+            "archive",
+            "--repo",
+            str(repo_root),
+            "--run-id",
+            run_id,
+            "--force",
+            "--force-attestation",
+            "archive paused run via alias",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["run_id"] == run_id
 
 
 def test_ticket_flow_status_outputs_human_readable_status(tmp_path: Path) -> None:

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -20,6 +20,7 @@ from codex_autorunner.core.config import (
     load_hub_config,
 )
 from codex_autorunner.core.destinations import default_car_docker_container_name
+from codex_autorunner.core.force_attestation import FORCE_ATTESTATION_REQUIRED_PHRASE
 from codex_autorunner.core.git_utils import run_git
 from codex_autorunner.core.hub import HubSupervisor, RepoStatus
 from codex_autorunner.core.pma_thread_store import PmaThreadStore
@@ -706,11 +707,66 @@ def test_hub_remove_repo_with_worktrees(tmp_path: Path):
 
     remove_resp = client.post(
         "/hub/repos/base/remove",
-        json={"force": True, "delete_dir": True, "delete_worktrees": True},
+        json={
+            "force": True,
+            "force_attestation": "REMOVE base",
+            "delete_dir": True,
+            "delete_worktrees": True,
+        },
     )
     assert remove_resp.status_code == 200
     assert not base.path.exists()
     assert not worktree.path.exists()
+
+
+def test_hub_remove_repo_route_forwards_force_attestation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    app = create_hub_app(hub_root)
+    captured: dict[str, object] = {}
+
+    def _fake_remove_repo(
+        repo_id: str,
+        *,
+        force: bool = False,
+        delete_dir: bool = True,
+        delete_worktrees: bool = False,
+        force_attestation: Optional[dict[str, str]] = None,
+    ) -> None:
+        captured["repo_id"] = repo_id
+        captured["force"] = force
+        captured["delete_dir"] = delete_dir
+        captured["delete_worktrees"] = delete_worktrees
+        captured["force_attestation"] = force_attestation
+
+    monkeypatch.setattr(app.state.hub_supervisor, "remove_repo", _fake_remove_repo)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/hub/repos/base/remove",
+        json={
+            "force": True,
+            "force_attestation": "REMOVE base",
+            "delete_dir": True,
+            "delete_worktrees": False,
+        },
+    )
+    assert resp.status_code == 200
+    assert captured == {
+        "repo_id": "base",
+        "force": True,
+        "delete_dir": True,
+        "delete_worktrees": False,
+        "force_attestation": {
+            "phrase": FORCE_ATTESTATION_REQUIRED_PHRASE,
+            "user_request": "REMOVE base",
+            "target_scope": "hub.remove_repo:base",
+        },
+    }
 
 
 def test_sync_main_raises_when_local_default_diverges_from_origin(tmp_path: Path):
@@ -1265,6 +1321,71 @@ def test_hub_api_cleanup_worktree_returns_docker_cleanup_status(
     ]
 
 
+def test_hub_api_cleanup_worktree_forwards_force_attestation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg["pma"]["cleanup_require_archive"] = False
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    app = create_hub_app(hub_root)
+    captured: dict[str, object] = {}
+
+    def _fake_cleanup_worktree(
+        *,
+        worktree_repo_id: str,
+        delete_branch: bool = False,
+        delete_remote: bool = False,
+        archive: bool = True,
+        force: bool = False,
+        force_archive: bool = False,
+        archive_note: Optional[str] = None,
+        force_attestation: Optional[dict[str, str]] = None,
+    ) -> dict[str, object]:
+        captured["worktree_repo_id"] = worktree_repo_id
+        captured["delete_branch"] = delete_branch
+        captured["delete_remote"] = delete_remote
+        captured["archive"] = archive
+        captured["force"] = force
+        captured["force_archive"] = force_archive
+        captured["archive_note"] = archive_note
+        captured["force_attestation"] = force_attestation
+        return {"status": "ok"}
+
+    monkeypatch.setattr(
+        app.state.hub_supervisor, "cleanup_worktree", _fake_cleanup_worktree
+    )
+
+    client = TestClient(app)
+    resp = client.post(
+        "/hub/worktrees/cleanup",
+        json={
+            "worktree_repo_id": "base--feature",
+            "archive": False,
+            "force": True,
+            "force_archive": False,
+            "archive_note": "cleanup",
+            "force_attestation": "REMOVE base--feature",
+        },
+    )
+    assert resp.status_code == 200
+    assert captured == {
+        "worktree_repo_id": "base--feature",
+        "delete_branch": False,
+        "delete_remote": False,
+        "archive": False,
+        "force": True,
+        "force_archive": False,
+        "archive_note": "cleanup",
+        "force_attestation": {
+            "phrase": FORCE_ATTESTATION_REQUIRED_PHRASE,
+            "user_request": "REMOVE base--feature",
+            "target_scope": "hub.worktree.cleanup:base--feature",
+        },
+    }
+
+
 def test_cleanup_worktree_allows_pma_only_bound_without_force(tmp_path: Path):
     hub_root = tmp_path / "hub"
     cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
@@ -1314,7 +1435,16 @@ def test_cleanup_worktree_allows_mixed_chat_bound_with_force(tmp_path: Path):
         hub_root, channel_id="discord-chan-force", repo_id=worktree.id
     )
 
-    supervisor.cleanup_worktree(worktree_repo_id=worktree.id, archive=True, force=True)
+    supervisor.cleanup_worktree(
+        worktree_repo_id=worktree.id,
+        archive=True,
+        force=True,
+        force_attestation={
+            "phrase": FORCE_ATTESTATION_REQUIRED_PHRASE,
+            "user_request": "cleanup mixed chat-bound worktree",
+            "target_scope": f"hub.worktree.cleanup:{worktree.id}",
+        },
+    )
     assert not worktree.path.exists()
 
 
@@ -1412,8 +1542,49 @@ def test_cleanup_worktree_allows_force_when_binding_lookup_fails(
 
     monkeypatch.setattr(supervisor, "_has_active_chat_binding", _raise_lookup_error)
 
-    supervisor.cleanup_worktree(worktree_repo_id=worktree.id, archive=True, force=True)
+    supervisor.cleanup_worktree(
+        worktree_repo_id=worktree.id,
+        archive=True,
+        force=True,
+        force_attestation={
+            "phrase": FORCE_ATTESTATION_REQUIRED_PHRASE,
+            "user_request": "cleanup chat-bound worktree",
+            "target_scope": f"hub.worktree.cleanup:{worktree.id}",
+        },
+    )
     assert not worktree.path.exists()
+
+
+def test_cleanup_worktree_force_requires_attestation(tmp_path: Path):
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/force-attestation-required",
+        start_point="HEAD",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="--force requires --force-attestation for dangerous actions.",
+    ):
+        supervisor.cleanup_worktree(
+            worktree_repo_id=worktree.id,
+            archive=True,
+            force=True,
+        )
+
+    assert worktree.path.exists()
 
 
 def test_hub_api_marks_chat_bound_worktrees_from_discord_binding_db(tmp_path: Path):


### PR DESCRIPTION
## Summary
Implements issue #886 for the **must-use dangerous force paths** by adding centralized force-attestation enforcement and wiring it through CLI + web surfaces.

## What Changed
- Added centralized force-attestation policy and validator:
  - `src/codex_autorunner/core/force_attestation.py`
  - Requires structured attestation fields: `phrase`, `user_request`, `target_scope`
  - Uses fixed phrase and returns the standard error when missing/invalid:
    - `--force requires --force-attestation for dangerous actions.`
  - Logs approved force attestations to structured logs.

- Enforced attestation in core dangerous operations (8 must-use behaviors):
  1. `hub worktree cleanup --force`
  2. `hub worktree archive --force`
  3. `hub worktree cleanup --force-archive`
  4. `hub worktree archive --force-archive`
  5. `ticket-flow archive --force`
  6. `hub runs cleanup --force`
  7. `cleanup processes --force`
  8. hub repo remove force path (web/API)

- CLI wiring:
  - Added `--force-attestation` to:
    - `car hub worktree cleanup`
    - `car hub worktree archive`
    - `car cleanup processes`
    - `car flow ticket_flow archive`
    - `car hub runs cleanup`
  - For force paths, CLI now builds and passes structured attestation into core.

- Web wiring:
  - Added `force_attestation` to relevant request schemas:
    - `HubRemoveRepoRequest`
    - `HubCleanupWorktreeRequest`
  - Routes now convert user-provided attestation text into structured force attestation payload.
  - Updated hub UI force-remove flow to collect and send `force_attestation`.

## Tests
Added/updated coverage for force-attestation enforcement and forwarding in:
- `tests/test_cli_hub_worktree.py`
- `tests/test_cli_process_diagnostics.py`
- `tests/test_cli_ticket_flow_archive.py`
- `tests/test_cli_hub_runs_cleanup.py`
- `tests/test_hub_supervisor.py`

Validation run (local):
- `pytest tests/test_cli_hub_worktree.py tests/test_cli_process_diagnostics.py tests/test_cli_ticket_flow_archive.py tests/test_cli_hub_runs_cleanup.py tests/test_hub_supervisor.py tests/test_cli_help_quality.py tests/test_cli_ticket_flow_help.py`
- Result: `79 passed`

Pre-commit/CI hook pipeline on commit also passed:
- black, ruff, mypy, eslint, static build, js tests, full pytest, dead-code check.

## Issue
Closes #886
