### PR TITLE
Discord: harden final output delivery and late-failure handling

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -2051,6 +2051,7 @@ class DiscordBotService:
         known_session = orchestrator.get_thread_id(session_key)
         final_message = ""
         assistant_stream_fallback = ""
+        completed_seen = False
         token_usage: Optional[dict[str, Any]] = None
         error_message = None
         session_from_events = known_session
@@ -2087,11 +2088,15 @@ class DiscordBotService:
                 elif isinstance(run_event, OutputDelta):
                     if run_event.delta_type == RUN_EVENT_DELTA_TYPE_USER_MESSAGE:
                         continue
+                    if (
+                        run_event.delta_type == "assistant_stream"
+                        and isinstance(run_event.content, str)
+                        and run_event.content
+                    ):
+                        assistant_stream_fallback = _merge_assistant_stream(
+                            assistant_stream_fallback, run_event.content
+                        )
                     if isinstance(run_event.content, str) and run_event.content.strip():
-                        if run_event.delta_type == "assistant_stream":
-                            assistant_stream_fallback = _merge_assistant_stream(
-                                assistant_stream_fallback, run_event.content
-                            )
                         tracker.note_output(run_event.content)
                         await _edit_progress()
                 elif isinstance(run_event, ToolCall):
@@ -2124,12 +2129,13 @@ class DiscordBotService:
                         )
                 elif isinstance(run_event, Completed):
                     final_message = run_event.final_message or final_message
+                    completed_seen = True
                     tracker.clear_transient_action()
                     tracker.set_label("done")
                     await _edit_progress(force=True, remove_components=True)
                 elif isinstance(run_event, Failed):
                     failed_message = run_event.error_message or "Turn failed"
-                    if final_message.strip() or assistant_stream_fallback.strip():
+                    if completed_seen:
                         log_event(
                             self._logger,
                             logging.WARNING,

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -2218,6 +2218,68 @@ async def test_message_create_streaming_turn_ignores_late_failed_with_stream_fal
 
 
 @pytest.mark.anyio
+async def test_message_create_streaming_turn_failure_before_completion_still_fails(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway([("MESSAGE_CREATE", _message_create("ship it"))])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    orchestrator = _StreamingFakeOrchestrator(
+        [
+            Started(timestamp="2026-01-01T00:00:00Z", session_id="thread-1"),
+            OutputDelta(
+                timestamp="2026-01-01T00:00:01Z",
+                content="partial output before failure",
+                delta_type="assistant_stream",
+            ),
+            Failed(
+                timestamp="2026-01-01T00:00:02Z",
+                error_message="hard failure before completion",
+            ),
+        ]
+    )
+
+    async def _fake_orchestrator_for_workspace(*args: Any, **kwargs: Any):
+        _ = args, kwargs
+        return orchestrator
+
+    service._orchestrator_for_workspace = _fake_orchestrator_for_workspace  # type: ignore[assignment]
+
+    try:
+        await service.run_forever()
+        assert any(
+            "Turn failed:" in msg["payload"].get("content", "")
+            and "hard failure before completion" in msg["payload"].get("content", "")
+            for msg in rest.channel_messages
+        )
+        assert not any(
+            "partial output before failure" in msg["payload"].get("content", "")
+            and "Turn failed:" not in msg["payload"].get("content", "")
+            for msg in rest.channel_messages
+        )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_message_create_streaming_turn_multi_chunk_deletes_preview_and_sends_chunks(
     tmp_path: Path,
 ) -> None:
@@ -2522,6 +2584,75 @@ async def test_message_create_streaming_turn_fallback_preserves_multichunk_white
             OutputDelta(
                 timestamp="2026-01-01T00:00:03Z",
                 content="\nnext line",
+                delta_type="assistant_stream",
+            ),
+            Completed(timestamp="2026-01-01T00:00:04Z", final_message=""),
+        ]
+    )
+
+    async def _fake_orchestrator_for_workspace(*args: Any, **kwargs: Any):
+        _ = args, kwargs
+        return orchestrator
+
+    service._orchestrator_for_workspace = _fake_orchestrator_for_workspace  # type: ignore[assignment]
+
+    try:
+        await service.run_forever()
+        final_candidates = [*rest.edited_channel_messages, *rest.channel_messages]
+        final_content = ""
+        for message in final_candidates:
+            content = str(message.get("payload", {}).get("content", ""))
+            if expected_text in content:
+                final_content = content
+                break
+        assert final_content
+        assert expected_text in final_content
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_message_create_streaming_turn_fallback_preserves_whitespace_only_chunks(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway([("MESSAGE_CREATE", _message_create("ship it"))])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    expected_text = "line 1\n\nline 2"
+    orchestrator = _StreamingFakeOrchestrator(
+        [
+            Started(timestamp="2026-01-01T00:00:00Z", session_id="thread-1"),
+            OutputDelta(
+                timestamp="2026-01-01T00:00:01Z",
+                content="line 1",
+                delta_type="assistant_stream",
+            ),
+            OutputDelta(
+                timestamp="2026-01-01T00:00:02Z",
+                content="\n\n",
+                delta_type="assistant_stream",
+            ),
+            OutputDelta(
+                timestamp="2026-01-01T00:00:03Z",
+                content="line 2",
                 delta_type="assistant_stream",
             ),
             Completed(timestamp="2026-01-01T00:00:04Z", final_message=""),


### PR DESCRIPTION
## Summary
This PR hardens Discord final-turn delivery when agent final output is intermittently missing or arrives with late failure events.

## What changed
- Added assistant-stream fallback for empty `Completed.final_message` in Discord turn handling.
- Prevented metrics-only final posts by prepending explicit fallback text when output is empty.
- Added warning telemetry when stream fallback is used.
- Preserved successful final output when a `Failed` run event arrives after completion (`discord.turn.failed_late_ignored`).
- Fixed review single-chunk preview path so outbox file flush failures no longer trigger preview delete / fallback resend.
- Added Discord integration regression tests for:
  - empty-final + assistant-stream fallback
  - empty-final + metrics fallback text
  - multichunk whitespace/repetition handling
  - cumulative delta handling
  - late-failed-after-completed handling (final text and stream fallback variants)
  - review preview edit behavior when outbox flush fails

## Validation
- Full pre-commit hooks passed on both commits, including:
  - `black`
  - `ruff`
  - `mypy`
  - frontend build/tests
  - full pytest suite
- Additional targeted checks run during development:
  - `pytest tests/integrations/discord/test_message_turns.py -k "uses_assistant_stream_when_final_empty or empty_final_includes_text_fallback_with_metrics or fallback_preserves_multichunk_whitespace or fallback_handles_cumulative_deltas or ignores_late_failed_after_completed_output or ignores_late_failed_with_stream_fallback or review_single_chunk_preview_edit_does_not_fallback_when_flush_fails or appends_final_metrics"`
