### PR TITLE
Strip injected context from /resume thread previews

### DIFF
--- a/src/codex_autorunner/core/injected_context.py
+++ b/src/codex_autorunner/core/injected_context.py
@@ -1,9 +1,27 @@
 from __future__ import annotations
 
+import re
+
 INJECTED_CONTEXT_START = "<injected context>"
 INJECTED_CONTEXT_END = "</injected context>"
+
+_INJECTED_CONTEXT_BLOCK_RE = re.compile(
+    rf"(?is){re.escape(INJECTED_CONTEXT_START)}\s*.*?\s*{re.escape(INJECTED_CONTEXT_END)}"
+)
 
 
 def wrap_injected_context(text: str) -> str:
     """Wrap prompt hints in injected context blocks."""
     return f"{INJECTED_CONTEXT_START}\n{text}\n{INJECTED_CONTEXT_END}"
+
+
+def strip_injected_context_blocks(text: str | None) -> str | None:
+    """Remove injected context blocks from mixed user-visible text."""
+    if not isinstance(text, str) or not text:
+        return text
+    lowered = text.lower()
+    if INJECTED_CONTEXT_START not in lowered and INJECTED_CONTEXT_END not in lowered:
+        return text
+    stripped = _INJECTED_CONTEXT_BLOCK_RE.sub("", text)
+    stripped = re.sub(r"\n{3,}", "\n\n", stripped)
+    return stripped.strip()

--- a/src/codex_autorunner/integrations/telegram/helpers.py
+++ b/src/codex_autorunner/integrations/telegram/helpers.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Optional, Sequence
 
 from ...core.coercion import coerce_int
+from ...core.injected_context import strip_injected_context_blocks
 from ...core.redaction import redact_text
 from ...core.state_roots import resolve_global_state_root
 from ...core.utils import (
@@ -1379,6 +1380,7 @@ def _sanitize_user_preview(text: Optional[str]) -> Optional[str]:
     if not isinstance(text, str):
         return text
     stripped = _strip_dispatch_begin(text)
+    stripped = strip_injected_context_blocks(stripped)
     if _is_ignored_first_user_preview(stripped):
         return None
     return stripped
@@ -1679,9 +1681,9 @@ def _extract_rollout_first_user_preview(path: Path) -> Optional[str]:
             continue
         for role, text in _iter_role_texts(payload):
             if role == "user" and text:
-                stripped = _strip_dispatch_begin(text)
-                if stripped and not _is_ignored_first_user_preview(stripped):
-                    return stripped
+                sanitized = _sanitize_user_preview(text)
+                if sanitized:
+                    return sanitized
     return None
 
 
@@ -1739,9 +1741,9 @@ def _extract_turns_first_user_preview(turns: Any) -> Optional[str]:
             for item in iterable:
                 for role, text in _iter_role_texts(item):
                     if role == "user" and text:
-                        stripped = _strip_dispatch_begin(text)
-                        if stripped and not _is_ignored_first_user_preview(stripped):
-                            return stripped
+                        sanitized = _sanitize_user_preview(text)
+                        if sanitized:
+                            return sanitized
     return None
 
 
@@ -1876,10 +1878,9 @@ def _extract_first_user_preview(entry: Any) -> Optional[str]:
         "initial_message",
         "initialMessage",
     )
-    user_preview = _coerce_preview_field(entry, user_preview_keys)
-    user_preview = _strip_dispatch_begin(user_preview)
-    if _is_ignored_first_user_preview(user_preview):
-        user_preview = None
+    user_preview = _sanitize_user_preview(
+        _coerce_preview_field(entry, user_preview_keys)
+    )
     turns = entry.get("turns")
     if not user_preview and turns:
         user_preview = _extract_turns_first_user_preview(turns)
@@ -1935,7 +1936,9 @@ def _format_resume_summary(
 
 
 def _format_summary_preview(summary: ThreadSummary) -> str:
-    user_preview = _preview_from_text(summary.user_preview, RESUME_PREVIEW_USER_LIMIT)
+    user_preview = _preview_from_text(
+        _sanitize_user_preview(summary.user_preview), RESUME_PREVIEW_USER_LIMIT
+    )
     assistant_preview = _preview_from_text(
         summary.assistant_preview, RESUME_PREVIEW_ASSISTANT_LIMIT
     )

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -362,6 +362,25 @@ def test_session_thread_picker_label_falls_back_to_thread_id() -> None:
     assert label == thread_id
 
 
+def test_session_thread_picker_label_strips_injected_context_from_preview() -> None:
+    thread_id = "019cc77b-ec10-7981-8e8b-ec5db4619efb"
+    label = discord_service_module._format_session_thread_picker_label(
+        thread_id,
+        {
+            "id": thread_id,
+            "last_user_message": (
+                "<injected context>\n"
+                "You are operating inside a Codex Autorunner (CAR) managed repo.\n"
+                "</injected context>\n\n"
+                "Resume this thread"
+            ),
+        },
+        is_current=False,
+    )
+    assert "<injected context>" not in label
+    assert "Resume this thread" in label
+
+
 @pytest.mark.anyio
 async def test_model_list_with_agent_compat_retries_without_agent() -> None:
     class _FakeClient:

--- a/tests/test_telegram_resume_preview_sanitization.py
+++ b/tests/test_telegram_resume_preview_sanitization.py
@@ -1,0 +1,36 @@
+from codex_autorunner.integrations.telegram.helpers import (
+    _extract_first_user_preview,
+    _extract_thread_preview_parts,
+)
+
+
+def test_extract_thread_preview_parts_strips_injected_context_from_user_preview() -> (
+    None
+):
+    user_preview, assistant_preview = _extract_thread_preview_parts(
+        {
+            "last_user_message": (
+                "<injected context>\n"
+                "You are operating inside a Codex Autorunner (CAR) managed repo.\n"
+                "</injected context>\n\n"
+                "Resume this thread with useful labels."
+            ),
+            "last_assistant_message": "Sure, I can do that.",
+        }
+    )
+    assert user_preview == "Resume this thread with useful labels."
+    assert assistant_preview == "Sure, I can do that."
+
+
+def test_extract_first_user_preview_strips_injected_context_blocks() -> None:
+    preview = _extract_first_user_preview(
+        {
+            "first_user_message": (
+                "<injected context>\n"
+                "workspace details here\n"
+                "</injected context>\n\n"
+                "Fix resume picker text."
+            )
+        }
+    )
+    assert preview == "Fix resume picker text."


### PR DESCRIPTION
## Summary
- strip `<injected context>...</injected context>` blocks from user-facing resume previews via a shared core helper
- route Telegram resume preview sanitization (first/last user previews, rollout/turn extraction, and cached summary rendering) through that helper
- keep Discord aligned by relying on the shared Telegram preview helpers used by the Discord session resume picker

## Why
`/resume` labels were often dominated by injected context text, which made different resumable sessions look identical and hid the actual user prompt.

## Testing
- `.venv/bin/pytest tests/test_telegram_resume_preview_sanitization.py tests/integrations/discord/test_service_routing.py -k "session_thread_picker_label or injected_context"`
- pre-commit hooks on commit (black, ruff, mypy, frontend build/tests, full pytest) passed
