### PR TITLE
Fix Discord/Telegram intermediate output accumulation + formatting

### DIFF
--- a/src/codex_autorunner/core/ports/run_event.py
+++ b/src/codex_autorunner/core/ports/run_event.py
@@ -12,11 +12,13 @@ from ..time_utils import now_iso
 # - Backend deltas should use the canonical delta_type set below.
 RUN_EVENT_DELTA_TYPE_USER_MESSAGE = "user_message"
 RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM = "assistant_stream"
+RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE = "assistant_message"
 RUN_EVENT_DELTA_TYPE_LOG_LINE = "log_line"
 RUN_EVENT_DELTA_TYPES = frozenset(
     {
         RUN_EVENT_DELTA_TYPE_USER_MESSAGE,
         RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
+        RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
         RUN_EVENT_DELTA_TYPE_LOG_LINE,
     }
 )
@@ -97,6 +99,7 @@ def is_terminal_run_event(event: RunEvent) -> bool:
 __all__ = [
     "RUN_EVENT_DELTA_TYPE_USER_MESSAGE",
     "RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM",
+    "RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE",
     "RUN_EVENT_DELTA_TYPE_LOG_LINE",
     "RUN_EVENT_DELTA_TYPES",
     "RunEvent",

--- a/src/codex_autorunner/integrations/agents/agent_pool_impl.py
+++ b/src/codex_autorunner/integrations/agents/agent_pool_impl.py
@@ -96,12 +96,19 @@ class DefaultAgentPool:
             return
 
         if isinstance(event, OutputDelta):
-            if event.delta_type == "assistant_stream" and event.content:
+            if (
+                event.delta_type in {"assistant_stream", "assistant_message"}
+                and event.content
+            ):
                 emit_event(
                     FlowEventType.AGENT_STREAM_DELTA,
                     {"delta": event.content, "turn_id": turn_id},
                 )
-            if event.delta_type in {"assistant_stream", "log_line"} and event.content:
+            if (
+                event.delta_type
+                in {"assistant_stream", "assistant_message", "log_line"}
+                and event.content
+            ):
                 emit_event(
                     FlowEventType.APP_SERVER_EVENT,
                     {
@@ -173,7 +180,10 @@ class DefaultAgentPool:
                     if event.turn_id:
                         turn_id = event.turn_id
                 elif isinstance(event, OutputDelta):
-                    if event.delta_type == "assistant_stream" and event.content:
+                    if (
+                        event.delta_type in {"assistant_stream", "assistant_message"}
+                        and event.content
+                    ):
                         assistant_parts.append(event.content)
                     elif event.delta_type == "log_line" and event.content:
                         log_lines.append(event.content)

--- a/src/codex_autorunner/integrations/agents/codex_backend.py
+++ b/src/codex_autorunner/integrations/agents/codex_backend.py
@@ -8,6 +8,8 @@ from ...core.circuit_breaker import CircuitBreaker
 from ...core.logging_utils import log_event
 from ...core.ports.agent_backend import AgentBackend, AgentEvent, now_iso
 from ...core.ports.run_event import (
+    RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
+    RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
     ApprovalRequested,
     Completed,
     Failed,
@@ -566,7 +568,9 @@ class CodexAppServerBackend(AgentBackend):
             if not content:
                 return None
             return OutputDelta(
-                timestamp=now_iso(), content=content, delta_type="assistant_stream"
+                timestamp=now_iso(),
+                content=content,
+                delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
             )
 
         if method == "turn/streamDelta" or "outputdelta" in method_lower:
@@ -600,7 +604,7 @@ class CodexAppServerBackend(AgentBackend):
                     return OutputDelta(
                         timestamp=now_iso(),
                         content=text,
-                        delta_type="assistant_stream",
+                        delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
                     )
                 return None
             tool_name, tool_input = _normalize_tool_name(params)
@@ -637,7 +641,7 @@ class CodexAppServerBackend(AgentBackend):
             if not content:
                 return AgentEvent.stream_delta(content="", delta_type="unknown_event")
             return AgentEvent.stream_delta(
-                content=content, delta_type="assistant_stream"
+                content=content, delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM
             )
 
         if method == "turn/streamDelta" or "outputdelta" in method_lower:
@@ -667,7 +671,8 @@ class CodexAppServerBackend(AgentBackend):
                 text = _extract_agent_message_text(item)
                 if text.strip():
                     return AgentEvent.stream_delta(
-                        content=text, delta_type="assistant_stream"
+                        content=text,
+                        delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
                     )
                 return AgentEvent.stream_delta(content="", delta_type="unknown_event")
             tool_name, tool_input = _normalize_tool_name(params)

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -50,6 +50,8 @@ from ...core.injected_context import wrap_injected_context
 from ...core.logging_utils import log_event
 from ...core.pma_context import build_hub_snapshot, format_pma_prompt, load_pma_prompt
 from ...core.ports.run_event import (
+    RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
+    RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
     RUN_EVENT_DELTA_TYPE_USER_MESSAGE,
     ApprovalRequested,
     Completed,
@@ -2158,7 +2160,11 @@ class DiscordBotService:
                     if run_event.delta_type == RUN_EVENT_DELTA_TYPE_USER_MESSAGE:
                         continue
                     if (
-                        run_event.delta_type == "assistant_stream"
+                        run_event.delta_type
+                        in {
+                            RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
+                            RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
+                        }
                         and isinstance(run_event.content, str)
                         and run_event.content
                     ):
@@ -2166,7 +2172,25 @@ class DiscordBotService:
                             assistant_stream_fallback, run_event.content
                         )
                     if isinstance(run_event.content, str) and run_event.content.strip():
-                        tracker.note_output(run_event.content)
+                        if (
+                            run_event.delta_type
+                            == RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE
+                        ):
+                            latest_output = tracker.latest_output_text().strip()
+                            incoming_output = run_event.content.strip()
+                            if latest_output and (
+                                incoming_output == latest_output
+                                or incoming_output.startswith(latest_output)
+                            ):
+                                tracker.note_output(run_event.content)
+                            else:
+                                tracker.note_output(
+                                    run_event.content,
+                                    new_segment=True,
+                                )
+                            tracker.end_output_segment()
+                        else:
+                            tracker.note_output(run_event.content)
                         await _edit_progress()
                 elif isinstance(run_event, ToolCall):
                     tool_name = (
@@ -2198,6 +2222,8 @@ class DiscordBotService:
                         )
                 elif isinstance(run_event, Completed):
                     final_message = run_event.final_message or final_message
+                    if final_message.strip():
+                        tracker.drop_terminal_output_if_duplicate(final_message)
                     completed_seen = True
                     tracker.clear_transient_action()
                     tracker.set_label("done")

--- a/src/codex_autorunner/integrations/telegram/notifications.py
+++ b/src/codex_autorunner/integrations/telegram/notifications.py
@@ -361,8 +361,18 @@ class TelegramNotificationHandlers:
             tool = item.get("name") or item.get("tool") or item.get("id") or "Tool call"
             tracker.note_tool(str(tool))
         elif item_type == "agentMessage":
-            text = item.get("text") or "Agent message"
-            tracker.add_action("agent", str(text), "done")
+            text = item.get("text")
+            if isinstance(text, str) and text.strip():
+                latest_output = tracker.latest_output_text().strip()
+                incoming_output = text.strip()
+                if latest_output and (
+                    incoming_output == latest_output
+                    or incoming_output.startswith(latest_output)
+                ):
+                    tracker.note_output(text)
+                else:
+                    tracker.note_output(text, new_segment=True)
+                tracker.end_output_segment()
         else:
             text = item.get("text") or item.get("message") or "Item completed"
             tracker.add_action("item", str(text), "done")
@@ -435,6 +445,9 @@ class TelegramNotificationHandlers:
             tracker.set_label("failed")
         else:
             tracker.set_label("done")
+        final_text = _extract_turn_completed_final_text(params)
+        if final_text:
+            tracker.drop_terminal_output_if_duplicate(final_text)
         tracker.clear_transient_action()
         tracker.finalized = True
         await self._emit_progress_edit(turn_key, force=True, render_mode="final")
@@ -581,4 +594,25 @@ def _extract_error_message(params: dict[str, Any]) -> str:
         return err
     if isinstance(params.get("message"), str):
         return params["message"]
+    return ""
+
+
+def _extract_turn_completed_final_text(params: dict[str, Any]) -> str:
+    direct_keys = (
+        "finalMessage",
+        "final_message",
+        "message",
+        "output",
+        "text",
+    )
+    for key in direct_keys:
+        value = params.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    result = params.get("result")
+    if isinstance(result, dict):
+        for key in direct_keys:
+            value = result.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
     return ""

--- a/src/codex_autorunner/integrations/telegram/progress_stream.py
+++ b/src/codex_autorunner/integrations/telegram/progress_stream.py
@@ -44,15 +44,25 @@ def _merge_output_text(current: str, incoming: str) -> str:
         return incoming
     if current.endswith(incoming):
         return current
-    if incoming in current:
-        return current
-    if current[-1:].isspace() or incoming[:1].isspace():
-        separator = ""
-    elif incoming[:1] in ".,!?;:)]}":
-        separator = ""
-    else:
-        separator = " "
-    return f"{current}{separator}{incoming}"
+    max_overlap = min(len(current), len(incoming))
+    for overlap in range(max_overlap, 0, -1):
+        if current[-overlap:] == incoming[:overlap]:
+            return f"{current}{incoming[overlap:]}"
+    return f"{current}{incoming}"
+
+
+def _output_matches_final_message(output_text: str, final_text: str) -> bool:
+    output_norm = _normalize_output_text(output_text).strip()
+    final_norm = _normalize_output_text(final_text).strip()
+    if not output_norm or not final_norm:
+        return False
+    if output_norm == final_norm:
+        return True
+    if output_norm.startswith("..."):
+        tail = output_norm[3:]
+        if tail and final_norm.endswith(tail):
+            return True
+    return False
 
 
 @dataclass
@@ -185,22 +195,60 @@ class TurnProgressTracker:
     def clear_transient_action(self) -> None:
         self.transient_action = None
 
+    def end_output_segment(self) -> None:
+        self.last_output_index = None
+
+    def latest_output_text(self) -> str:
+        for action in reversed(self.actions):
+            if action.label == "output" and action.text.strip():
+                return action.text
+        return ""
+
+    def drop_terminal_output_if_duplicate(self, final_text: str) -> bool:
+        if not isinstance(final_text, str) or not final_text.strip():
+            return False
+        for index in range(len(self.actions) - 1, -1, -1):
+            action = self.actions[index]
+            if action.label != "output" or not action.text.strip():
+                continue
+            if not _output_matches_final_message(action.text, final_text):
+                continue
+            self.actions.pop(index)
+            if self.last_output_index is not None:
+                if index == self.last_output_index:
+                    self.last_output_index = None
+                elif index < self.last_output_index:
+                    self.last_output_index -= 1
+            self.output_buffer = ""
+            for prior_index in range(len(self.actions) - 1, -1, -1):
+                prior = self.actions[prior_index]
+                if prior.label == "output" and prior.text.strip():
+                    self.last_output_index = prior_index
+                    self.output_buffer = prior.text
+                    break
+            return True
+        return False
+
     def note_thinking(self, text: str) -> None:
         normalized = _normalize_text(text)
         if not normalized:
             return
         self.add_action("thinking", normalized, "update")
 
-    def note_output(self, text: str) -> None:
+    def note_output(
+        self,
+        text: str,
+        *,
+        new_segment: bool = False,
+    ) -> None:
         output_piece = _normalize_output_text(text)
         if not output_piece.strip():
             return
         self.clear_transient_action()
-        self.output_buffer = _truncate_tail(
-            _merge_output_text(self.output_buffer, output_piece),
-            self.max_output_chars,
-        )
+        if new_segment:
+            self.last_output_index = None
         if self.last_output_index is None:
+            self.output_buffer = _truncate_tail(output_piece, self.max_output_chars)
             self.add_action(
                 "output",
                 self.output_buffer,
@@ -209,6 +257,11 @@ class TurnProgressTracker:
                 normalize_text=False,
             )
             return
+        current_output = self.actions[self.last_output_index].text
+        self.output_buffer = _truncate_tail(
+            _merge_output_text(current_output, output_piece),
+            self.max_output_chars,
+        )
         self.update_action_raw(self.last_output_index, self.output_buffer, "update")
 
     def note_command(self, text: str) -> None:
@@ -249,10 +302,28 @@ def render_progress_text(
     if tracker.context_usage_percent is not None:
         parts.append(f"ctx {tracker.context_usage_percent}%")
     header = " · ".join(parts)
+
+    def _render_output_blocks(blocks: list[str], limit: int) -> str:
+        if not blocks:
+            return ""
+        candidate_blocks = list(blocks)
+        rendered = "\n\n".join(candidate_blocks)
+        while len(rendered) > limit and len(candidate_blocks) > 1:
+            candidate_blocks.pop(0)
+            rendered = "\n\n".join(candidate_blocks)
+        if len(rendered) <= limit:
+            return rendered
+        return _truncate_tail(rendered, limit)
+
     is_final_mode = render_mode == "final"
     if is_final_mode:
-        if tracker.output_buffer.strip():
-            return _truncate_tail(tracker.output_buffer, max_length)
+        output_blocks = [
+            action.text
+            for action in tracker.actions
+            if action.label == "output" and action.text.strip()
+        ]
+        if output_blocks:
+            return _render_output_blocks(output_blocks, max_length)
         actions = [
             action
             for action in tracker.actions
@@ -266,6 +337,30 @@ def render_progress_text(
         actions = (
             tracker.actions[-tracker.max_actions :] if tracker.max_actions > 0 else []
         )
+        if not any(action.label == "output" for action in actions):
+            latest_output_action = next(
+                (
+                    action
+                    for action in reversed(tracker.actions)
+                    if action.label == "output" and action.text.strip()
+                ),
+                None,
+            )
+            if latest_output_action is not None:
+                if tracker.max_actions <= 0:
+                    actions = [latest_output_action]
+                elif tracker.max_actions == 1:
+                    actions = [latest_output_action]
+                else:
+                    non_output_tail = [
+                        action
+                        for action in actions
+                        if action is not latest_output_action
+                    ]
+                    actions = [
+                        latest_output_action,
+                        *non_output_tail[-(tracker.max_actions - 1) :],
+                    ]
     if not is_final_mode and tracker.transient_action is not None:
         actions = [*actions, tracker.transient_action]
         if tracker.max_actions > 0 and len(actions) > tracker.max_actions:
@@ -331,9 +426,10 @@ def render_progress_text(
         header = lines[0]
         remaining = max_length - len(header) - 1
         if remaining > 0:
-            if tracker.output_buffer.strip():
-                output_lines = tracker.output_buffer.splitlines()
-                focus_line = output_lines[-1] if output_lines else tracker.output_buffer
+            latest_output_text = tracker.latest_output_text()
+            if latest_output_text.strip():
+                output_lines = latest_output_text.splitlines()
+                focus_line = output_lines[-1] if output_lines else latest_output_text
                 return f"{header}\n{_truncate_tail(focus_line, remaining)}"
             focus_line = _select_fallback_line(lines)
             return f"{header}\n{_truncate_line_for_fallback(focus_line, remaining)}"

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -24,6 +24,7 @@ from codex_autorunner.core.filebox import (
     outbox_sent_dir,
 )
 from codex_autorunner.core.ports.run_event import (
+    RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
     Completed,
     Failed,
     OutputDelta,
@@ -2005,6 +2006,135 @@ async def test_message_create_streaming_turn_persists_full_output_in_progress(
         assert any(
             full_output in msg["payload"].get("content", "")
             for msg in rest.edited_channel_messages
+        )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_message_create_streaming_turn_accumulates_segmented_intermediate_outputs(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway([("MESSAGE_CREATE", _message_create("ship it"))])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    orchestrator = _StreamingFakeOrchestrator(
+        [
+            Started(timestamp="2026-01-01T00:00:00Z", session_id="thread-1"),
+            OutputDelta(
+                timestamp="2026-01-01T00:00:01Z",
+                content="intermediate output one",
+                delta_type="assistant_stream",
+            ),
+            OutputDelta(
+                timestamp="2026-01-01T00:00:02Z",
+                content="intermediate output two",
+                delta_type="assistant_message",
+            ),
+            Completed(timestamp="2026-01-01T00:00:03Z", final_message="done"),
+        ]
+    )
+
+    async def _fake_orchestrator_for_workspace(*args: Any, **kwargs: Any):
+        _ = args, kwargs
+        return orchestrator
+
+    service._orchestrator_for_workspace = _fake_orchestrator_for_workspace  # type: ignore[assignment]
+
+    try:
+        await service.run_forever()
+        assert rest.edited_channel_messages
+        rendered_progress = [
+            str(msg["payload"].get("content", ""))
+            for msg in rest.edited_channel_messages
+        ]
+        final_progress = rendered_progress[-1]
+        assert "intermediate output one" in final_progress
+        assert "intermediate output two" in final_progress
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_message_create_streaming_turn_final_progress_omits_duplicate_terminal_output(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway([("MESSAGE_CREATE", _message_create("ship it"))])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    final_text = "terminal final answer"
+    orchestrator = _StreamingFakeOrchestrator(
+        [
+            Started(timestamp="2026-01-01T00:00:00Z", session_id="thread-1"),
+            OutputDelta(
+                timestamp="2026-01-01T00:00:01Z",
+                content="intermediate output one",
+                delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
+            ),
+            OutputDelta(
+                timestamp="2026-01-01T00:00:02Z",
+                content=final_text,
+                delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
+            ),
+            Completed(timestamp="2026-01-01T00:00:03Z", final_message=final_text),
+        ]
+    )
+
+    async def _fake_orchestrator_for_workspace(*args: Any, **kwargs: Any):
+        _ = args, kwargs
+        return orchestrator
+
+    service._orchestrator_for_workspace = _fake_orchestrator_for_workspace  # type: ignore[assignment]
+
+    try:
+        await service.run_forever()
+        assert rest.edited_channel_messages
+        rendered_progress = [
+            str(msg["payload"].get("content", ""))
+            for msg in rest.edited_channel_messages
+        ]
+        final_progress = rendered_progress[-1]
+        assert "intermediate output one" in final_progress
+        assert final_text not in final_progress
+        assert any(
+            final_text in str(msg["payload"].get("content", ""))
+            for msg in rest.channel_messages
         )
     finally:
         await store.close()

--- a/tests/test_backend_run_event_contract.py
+++ b/tests/test_backend_run_event_contract.py
@@ -173,7 +173,8 @@ async def test_codex_backend_run_turn_events_keeps_completion_event_when_wait_an
     assistant_deltas = [
         event.content
         for event in events
-        if isinstance(event, OutputDelta) and event.delta_type == "assistant_stream"
+        if isinstance(event, OutputDelta)
+        and event.delta_type in {"assistant_stream", "assistant_message"}
     ]
     assert streamed_completion_text in assistant_deltas
     assert isinstance(events[-1], Completed)
@@ -392,6 +393,7 @@ def test_codex_notification_parser_supports_outputdelta_reasoning_and_item_compl
 
     assert isinstance(events[6], OutputDelta)
     assert events[6].content == "done"
+    assert events[6].delta_type == "assistant_message"
 
     assert isinstance(events[7], TokenUsage)
     assert events[7].usage["input_tokens"] == 10

--- a/tests/test_telegram_flow_status.py
+++ b/tests/test_telegram_flow_status.py
@@ -32,6 +32,7 @@ from codex_autorunner.integrations.telegram.handlers.commands.flows import FlowC
 from codex_autorunner.integrations.telegram.notifications import (
     TelegramNotificationHandlers,
 )
+from codex_autorunner.integrations.telegram.progress_stream import TurnProgressTracker
 
 
 def _health(tmp_path: Path, status: str = "alive") -> FlowWorkerHealth:
@@ -269,6 +270,54 @@ class _AsyncNoopLock:
         return False
 
 
+class _TurnCompletionProgressHarness(TelegramNotificationHandlers):
+    def __init__(self) -> None:
+        self._config = SimpleNamespace(
+            progress_stream=SimpleNamespace(
+                enabled=True,
+                min_edit_interval_seconds=0.5,
+                max_actions=8,
+                max_output_chars=400,
+            )
+        )
+        self._turn_key = ("turn-1", "thread-1")
+        self._turn_progress_trackers: dict[tuple[str, str], Any] = {
+            self._turn_key: TurnProgressTracker(
+                started_at=0.0,
+                agent="codex",
+                model="mock-model",
+                label="working",
+                max_actions=8,
+                max_output_chars=400,
+            )
+        }
+        self._turn_contexts: dict[tuple[str, str], Any] = {self._turn_key: object()}
+        self.edits: list[tuple[tuple[str, str], bool, str]] = []
+        self.cleared: list[tuple[str, str]] = []
+
+    def _resolve_turn_key(
+        self, turn_id: Optional[str], *, thread_id: Optional[str] = None
+    ) -> Optional[tuple[str, str]]:
+        if turn_id == self._turn_key[0] and thread_id == self._turn_key[1]:
+            return self._turn_key
+        return None
+
+    async def _emit_progress_edit(
+        self,
+        turn_key: tuple[str, str],
+        *,
+        ctx: Optional[Any] = None,
+        now: Optional[float] = None,
+        force: bool = False,
+        render_mode: str = "live",
+    ) -> None:
+        _ = (ctx, now)
+        self.edits.append((turn_key, force, render_mode))
+
+    def _clear_turn_progress(self, turn_key: tuple[str, str]) -> None:
+        self.cleared.append(turn_key)
+
+
 @pytest.mark.anyio
 async def test_progress_edit_cadence_emits_when_interval_elapsed(
     monkeypatch: pytest.MonkeyPatch,
@@ -349,6 +398,34 @@ async def test_ensure_turn_progress_lock_returns_same_instance_for_concurrent_ca
     first = locks[0]
     assert all(lock is first for lock in locks)
     assert harness._turn_progress_locks[key] is first
+
+
+@pytest.mark.anyio
+async def test_turn_completed_prunes_duplicate_terminal_output_from_progress() -> None:
+    harness = _TurnCompletionProgressHarness()
+    key = harness._turn_key
+    tracker: TurnProgressTracker = harness._turn_progress_trackers[key]
+    tracker.note_output("intermediate output one")
+    tracker.end_output_segment()
+    tracker.note_output("terminal final answer")
+
+    await harness._note_progress_turn_completed(
+        {
+            "turnId": "turn-1",
+            "threadId": "thread-1",
+            "status": "completed",
+            "finalMessage": "terminal final answer",
+        }
+    )
+
+    output_blocks = [
+        action.text for action in tracker.actions if action.label == "output"
+    ]
+    assert output_blocks == ["intermediate output one"]
+    assert tracker.label == "done"
+    assert tracker.finalized is True
+    assert harness.edits == [(key, True, "final")]
+    assert harness.cleared == [key]
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_progress_stream.py
+++ b/tests/test_telegram_progress_stream.py
@@ -45,6 +45,43 @@ def test_note_output_accumulates_across_updates() -> None:
     assert len([a for a in tracker.actions if a.label == "output"]) == 1
 
 
+def test_note_output_does_not_insert_artificial_spaces_between_chunks() -> None:
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="codex",
+        model="mock-model",
+        label="working",
+        max_actions=10,
+        max_output_chars=200,
+    )
+    tracker.note_output("orches")
+    tracker.note_output("tration")
+    tracker.note_output(" isn't")
+    tracker.note_output(" broken")
+
+    rendered = render_progress_text(tracker, max_length=2000, now=1.0)
+
+    assert "orchestration isn't broken" in rendered
+    assert "orches tration" not in rendered
+
+
+def test_note_output_does_not_drop_internal_substring_chunks() -> None:
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="codex",
+        model="mock-model",
+        label="working",
+        max_actions=10,
+        max_output_chars=200,
+    )
+    tracker.note_output("abcdef")
+    tracker.note_output("cd")
+
+    rendered = render_progress_text(tracker, max_length=2000, now=1.0)
+
+    assert "abcdefcd" in rendered
+
+
 def test_note_thinking_is_transient_and_cleared_by_output() -> None:
     tracker = TurnProgressTracker(
         started_at=0.0,
@@ -103,6 +140,27 @@ def test_output_after_transient_events_remains_visible() -> None:
 
     rendered = render_progress_text(tracker, max_length=2000, now=3.0)
     assert "second output" in rendered
+
+
+def test_live_mode_keeps_latest_output_visible_when_window_is_full_of_non_output() -> (
+    None
+):
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="codex",
+        model="mock-model",
+        label="working",
+        max_actions=3,
+        max_output_chars=200,
+    )
+    tracker.note_output("important output")
+    tracker.add_action("notice", "notice one", "update")
+    tracker.add_action("notice", "notice two", "update")
+    tracker.add_action("notice", "notice three", "update")
+
+    rendered = render_progress_text(tracker, max_length=2000, now=3.0)
+
+    assert "important output" in rendered
 
 
 def test_render_progress_text_keeps_output_block_when_message_budget_is_tight() -> None:
@@ -226,6 +284,122 @@ def test_final_mode_uses_consolidated_output_after_interleaved_actions() -> None
     assert rendered.count("first output") == 1
     assert rendered.count("second output") == 1
     assert "run_tests" not in rendered
+
+
+def test_final_mode_accumulates_segmented_outputs() -> None:
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="codex",
+        model="mock-model",
+        label="working",
+        max_actions=10,
+        max_output_chars=500,
+    )
+    tracker.note_output("intermediate output one")
+    tracker.note_output("intermediate output two", new_segment=True)
+
+    rendered = render_progress_text(
+        tracker, max_length=2000, now=1.0, render_mode="final"
+    )
+
+    assert "intermediate output one" in rendered
+    assert "intermediate output two" in rendered
+    assert "\n\n" in rendered
+
+
+def test_end_output_segment_forces_next_output_into_new_block() -> None:
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="codex",
+        model="mock-model",
+        label="working",
+        max_actions=10,
+        max_output_chars=500,
+    )
+    tracker.note_output("output one")
+    tracker.end_output_segment()
+    tracker.note_output("output two")
+
+    rendered = render_progress_text(
+        tracker, max_length=2000, now=1.0, render_mode="final"
+    )
+
+    assert "output one" in rendered
+    assert "output two" in rendered
+    assert "\n\n" in rendered
+
+
+def test_drop_terminal_output_if_duplicate_removes_matching_final_block() -> None:
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="codex",
+        model="mock-model",
+        label="working",
+        max_actions=10,
+        max_output_chars=500,
+    )
+    tracker.note_output("intermediate output")
+    tracker.end_output_segment()
+    tracker.note_output("final answer")
+
+    dropped = tracker.drop_terminal_output_if_duplicate("final answer")
+    rendered = render_progress_text(
+        tracker, max_length=2000, now=1.0, render_mode="final"
+    )
+
+    assert dropped is True
+    assert "intermediate output" in rendered
+    assert "final answer" not in rendered
+
+
+def test_drop_terminal_output_if_duplicate_matches_truncated_tail() -> None:
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="codex",
+        model="mock-model",
+        label="working",
+        max_actions=10,
+        max_output_chars=20,
+    )
+    final_text = "this is a very long final answer that gets truncated"
+    tracker.note_output("intermediate output")
+    tracker.end_output_segment()
+    tracker.note_output(final_text)
+
+    dropped = tracker.drop_terminal_output_if_duplicate(final_text)
+    rendered = render_progress_text(
+        tracker, max_length=2000, now=1.0, render_mode="final"
+    )
+
+    assert dropped is True
+    assert "intermediate output" in rendered
+    assert "final answer" not in rendered
+
+
+def test_drop_terminal_output_if_duplicate_scans_past_newer_nonmatching_outputs() -> (
+    None
+):
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="codex",
+        model="mock-model",
+        label="working",
+        max_actions=10,
+        max_output_chars=500,
+    )
+    tracker.note_output("intermediate output")
+    tracker.end_output_segment()
+    tracker.note_output("terminal final answer")
+    tracker.end_output_segment()
+    tracker.note_output("post-final notice")
+
+    dropped = tracker.drop_terminal_output_if_duplicate("terminal final answer")
+    output_blocks = [
+        action.text for action in tracker.actions if action.label == "output"
+    ]
+
+    assert dropped is True
+    assert output_blocks == ["intermediate output", "post-final notice"]
 
 
 def test_final_mode_output_truncates_from_tail() -> None:


### PR DESCRIPTION
## Summary
This PR fixes intermediate-output UX regressions in chat surfaces so progress messages persist useful intermediate outputs (with proper whitespace/formatting) while final turn output is still sent as a separate message.

It applies to both Discord and Telegram, with shared behavior implemented in `TurnProgressTracker`.

## Root Causes Addressed
- Progress output merge logic inserted artificial spaces and could collapse/double text when chunk boundaries were unfavorable.
- Final progress rendering relied on a single `output_buffer`, so only the latest output was retained.
- `item/completed` `agentMessage` events were not consistently handled as first-class output segments.
- Final output could duplicate in the persisted progress block and then appear again in the separate final message.

## What Changed
- Added canonical run-event delta type: `assistant_message` and threaded it through backend + pool handling.
- Updated Discord + Telegram notification paths to treat completed `agentMessage` payloads as output segments.
- Enhanced shared progress tracker behavior:
  - overlap-aware output merge without artificial space insertion
  - explicit output segment boundaries (`end_output_segment`)
  - final-mode rendering from accumulated output blocks (not a single buffer)
  - live-mode visibility preference for latest output block
  - terminal de-dupe helper to drop duplicate final output from persisted progress
- Added extraction/handling in Telegram completion path to apply terminal de-dupe when final text is present.

## Tests
- Added/updated unit/integration tests for:
  - no artificial whitespace insertion between chunks
  - no internal-substring chunk loss
  - segmented output accumulation in final render mode
  - preserving latest output visibility in live mode under action-window pressure
  - Discord segmented intermediate output accumulation
  - Discord terminal de-dupe (final separate message, duplicate removed from progress)
  - Telegram completion terminal de-dupe path
  - backend run-event contract updates for `assistant_message`

### Validation run locally
- `pytest -q tests/test_telegram_progress_stream.py tests/test_telegram_flow_status.py tests/integrations/discord/test_message_turns.py tests/test_backend_run_event_contract.py tests/test_opencode_agent_pool.py`
- `pytest -q tests/test_telegram_progress_stream.py tests/test_backend_run_event_contract.py tests/test_telegram_turn_queue.py tests/test_telegram_review_opencode.py tests/test_telegram_pma_routing.py tests/test_telegram_bot_integration.py tests/test_telegram_outbox.py tests/test_telegram_chat_adapter_ops.py tests/test_telegram_transport.py tests/test_telegram_flow_status.py tests/integrations/discord/test_message_turns.py tests/test_opencode_agent_pool.py`
- Pre-commit gate (full repo checks) also passed during commit, including full pytest.

## Notes
- Final subagent review was run and reported no merge blockers.
