### PR TITLE
Preserve tool/reasoning lines in live overflow progress

### DIFF
--- a/src/codex_autorunner/integrations/telegram/progress_stream.py
+++ b/src/codex_autorunner/integrations/telegram/progress_stream.py
@@ -89,6 +89,8 @@ class TurnProgressTracker:
     finalized: bool = False
     output_buffer: str = ""
     transient_action: Optional[ProgressAction] = None
+    last_thinking_trace: Optional[ProgressAction] = None
+    last_tool_trace: Optional[ProgressAction] = None
 
     def set_label(self, label: str) -> None:
         if label:
@@ -117,13 +119,18 @@ class TurnProgressTracker:
         if not normalized.strip():
             return
         if label in {"thinking", "tool", "command"}:
-            self.transient_action = ProgressAction(
+            trace_action = ProgressAction(
                 label=label,
                 text=normalized,
                 status=status,
                 item_id=item_id,
                 subagent_label=subagent_label,
             )
+            self.transient_action = trace_action
+            if label == "thinking":
+                self.last_thinking_trace = trace_action
+            else:
+                self.last_tool_trace = trace_action
             # Force the next output delta to create a fresh trailing output slot.
             self.last_output_index = None
             self.step += 1
@@ -408,6 +415,26 @@ def render_progress_text(
     def _truncate_line_for_fallback(line: str, limit: int) -> str:
         return _truncate_text(line, limit)
 
+    def _format_trace_line(action: Optional[ProgressAction]) -> str:
+        if action is None or not action.text.strip():
+            return ""
+        if action.label == "thinking":
+            if action.subagent_label:
+                return f"🤖 {action.subagent_label} thinking: {action.text}"
+            return f"🧠 {action.text}"
+        icon = STATUS_ICONS.get(action.status, STATUS_ICONS["running"])
+        return f"{icon} {action.label}: {action.text}"
+
+    def _reserved_live_trace_lines() -> list[str]:
+        lines: list[str] = []
+        thinking_line = _format_trace_line(tracker.last_thinking_trace)
+        if thinking_line:
+            lines.append(thinking_line)
+        tool_line = _format_trace_line(tracker.last_tool_trace)
+        if tool_line:
+            lines.append(tool_line)
+        return lines
+
     def _select_fallback_line(lines_with_header: list[str]) -> str:
         for line in reversed(lines_with_header[1:]):
             stripped = line.strip()
@@ -427,6 +454,26 @@ def render_progress_text(
         remaining = max_length - len(header) - 1
         if remaining > 0:
             latest_output_text = tracker.latest_output_text()
+            if not is_final_mode and latest_output_text.strip():
+                trace_lines = _reserved_live_trace_lines()
+                if trace_lines:
+                    for trace_limit in (240, 180, 140, 100, 80, 60, 45, 30, 20, 12):
+                        trimmed_traces = [
+                            _truncate_line_for_fallback(line, trace_limit)
+                            for line in trace_lines
+                        ]
+                        traces_chunk = "\n".join(trimmed_traces)
+                        output_budget = remaining - len(traces_chunk) - 1
+                        if output_budget <= 0:
+                            continue
+                        output_lines = latest_output_text.splitlines()
+                        focus_line = (
+                            output_lines[-1] if output_lines else latest_output_text
+                        )
+                        output_tail = _truncate_tail(focus_line, output_budget)
+                        candidate = f"{header}\n{output_tail}\n{traces_chunk}"
+                        if len(candidate) <= max_length:
+                            return candidate
             if latest_output_text.strip():
                 output_lines = latest_output_text.splitlines()
                 focus_line = output_lines[-1] if output_lines else latest_output_text

--- a/tests/test_telegram_progress_stream.py
+++ b/tests/test_telegram_progress_stream.py
@@ -202,6 +202,48 @@ def test_render_progress_text_prefers_subagent_thinking_content_in_fallback() ->
     assert not rendered.endswith("\n---")
 
 
+def test_live_fallback_reserves_trace_lines_and_keeps_output_tail() -> None:
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="codex",
+        model="mock-model",
+        label="working",
+        max_actions=10,
+        max_output_chars=10_000,
+    )
+    tracker.note_tool("run_tests --all")
+    tracker.note_thinking("investigating truncation behavior")
+    tracker.note_output("prefix " + ("x" * 800) + " tail")
+
+    rendered = render_progress_text(tracker, max_length=200, now=1.0)
+
+    assert "tail" in rendered
+    assert "🧠 investigating truncation behavior" in rendered
+    assert "tool: run_tests --all" in rendered
+    assert len(rendered) <= 200
+
+
+def test_live_fallback_can_use_persisted_traces_after_transient_clears() -> None:
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="codex",
+        model="mock-model",
+        label="working",
+        max_actions=10,
+        max_output_chars=10_000,
+    )
+    tracker.note_tool("run_tests")
+    tracker.note_thinking("checking parser edge cases")
+    # This clears transient_action; fallback should still use persisted traces.
+    tracker.note_output("start " + ("y" * 900) + " done")
+
+    rendered = render_progress_text(tracker, max_length=180, now=1.0)
+
+    assert "done" in rendered
+    assert "checking parser edge cases" in rendered
+    assert "tool: run_tests" in rendered
+
+
 def test_render_progress_text_final_mode_keeps_only_output_when_available() -> None:
     tracker = TurnProgressTracker(
         started_at=0.0,


### PR DESCRIPTION
## Summary
Follow-up fix for chat progress UX regression where long intermediate outputs crowd out tool/reasoning visibility.

This change updates the shared progress renderer used by both Discord and Telegram so that in **live overflow mode** it:
- keeps output focused on the **tail** (latest content), and
- reserves the bottom lines for the latest reasoning/tool traces.

## Root cause
When progress text exceeded the per-platform limit, fallback logic prioritized output-only display and dropped earlier blocks first. On long outputs this removed tool/reasoning traces from the rendered message entirely.

## What changed
- `TurnProgressTracker` now keeps lightweight persistent snapshots of the latest:
  - reasoning trace (`last_thinking_trace`)
  - tool/command trace (`last_tool_trace`)
- Live overflow fallback in `render_progress_text` now attempts a combined layout:
  - header
  - output tail (truncated from tail)
  - reserved trace lines (thinking/tool), truncated as needed to fit
- If combined layout cannot fit, renderer falls back to previous output-focused behavior.

Because this is shared renderer logic, it applies to both Discord and Telegram while still respecting each platform’s message-length cap.

## Tests
Added coverage in `tests/test_telegram_progress_stream.py`:
- reserves trace lines while keeping output tail under tight budget
- uses persisted trace snapshots even after transient trace action has been cleared by later output

## Validation
- `pytest -q tests/test_telegram_progress_stream.py tests/integrations/discord/test_message_turns.py tests/test_telegram_flow_status.py`
- `pytest -q tests/test_backend_run_event_contract.py tests/test_opencode_agent_pool.py`
- Full pre-commit gate passed (format/lint/type/build/full pytest)
