### PR TITLE
Fix Discord/Telegram hub flow overview sibling worktree rendering

### DIFF
--- a/src/codex_autorunner/core/flows/hub_overview.py
+++ b/src/codex_autorunner/core/flows/hub_overview.py
@@ -14,7 +14,7 @@ class HubFlowOverviewEntry:
     repo_id: str
     repo_root: Path
     label: str
-    indent: str
+    is_worktree: bool
     group: str
     unregistered: bool = False
 
@@ -134,7 +134,7 @@ def build_hub_flow_overview_entries(
                 repo_id=repo_id,
                 repo_root=repo_root,
                 label=label,
-                indent="  - " if is_worktree else "",
+                is_worktree=is_worktree,
                 group=_group_id_for_repo(repo),
                 unregistered=False,
             )
@@ -160,7 +160,7 @@ def build_hub_flow_overview_entries(
                 repo_id=repo_id,
                 repo_root=repo_root.resolve(),
                 label=label,
-                indent="  - ",
+                is_worktree=True,
                 group=_group_id_for_repo_id(repo_id),
                 unregistered=True,
             )

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -5695,6 +5695,7 @@ class DiscordBotService:
         has_unregistered = any(entry.unregistered for entry in overview_entries)
         for entry in overview_entries:
             line_label = display_label_by_repo_id.get(entry.repo_id, entry.label)
+            line_prefix = "  -> " if entry.is_worktree else ""
             if entry.group not in groups:
                 groups[entry.group] = []
                 group_order.append(entry.group)
@@ -5704,7 +5705,7 @@ class DiscordBotService:
                 groups[entry.group].append(
                     (
                         line_label,
-                        f"{entry.indent}❓ {line_label}: Error reading state",
+                        f"{line_prefix}❓ {line_label}: Error reading state",
                     )
                 )
                 continue
@@ -5721,11 +5722,11 @@ class DiscordBotService:
                 run_id = display.get("run_id")
                 run_suffix = f" run {run_id}" if run_id else ""
                 line = (
-                    f"{entry.indent}{display['status_icon']} {line_label}: "
+                    f"{line_prefix}{display['status_icon']} {line_label}: "
                     f"{display['status_label']} {display['done_count']}/{display['total_count']}{run_suffix}"
                 )
             except Exception:
-                line = f"{entry.indent}❓ {line_label}: Error reading state"
+                line = f"{line_prefix}❓ {line_label}: Error reading state"
             finally:
                 store.close()
             groups[entry.group].append((line_label, line))

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
@@ -1103,12 +1103,12 @@ class FlowCommands(SharedHelpers):
             status_value: str,
             progress_label: str,
             run_id: Optional[str],
-            indent: str = "",
+            prefix: str = "",
         ) -> str:
             run_suffix = f" run {_code(run_id)}" if run_id else ""
             repo_label = _code(label)
             return (
-                f"{indent}{status_icon} {repo_label}: {status_value} "
+                f"{prefix}{status_icon} {repo_label}: {status_value} "
                 f"{progress_label}{run_suffix}"
             )
 
@@ -1132,7 +1132,7 @@ class FlowCommands(SharedHelpers):
         for entry in overview_entries:
             repo_root = entry.repo_root
             label = entry.label
-            indent = entry.indent
+            line_prefix = "  -> " if entry.is_worktree else ""
             group = entry.group
             if group not in groups:
                 groups[group] = []
@@ -1157,10 +1157,10 @@ class FlowCommands(SharedHelpers):
                     status_value=str(display["status_label"]),
                     progress_label=progress_label,
                     run_id=display.get("run_id"),
-                    indent=indent,
+                    prefix=line_prefix,
                 )
             except Exception:
-                status_line = f"{indent}❓ {_code(label)}: Error reading state"
+                status_line = f"{line_prefix}❓ {_code(label)}: Error reading state"
             finally:
                 store.close()
 

--- a/tests/core/flows/test_hub_overview.py
+++ b/tests/core/flows/test_hub_overview.py
@@ -152,4 +152,4 @@ def test_base_repo_id_with_double_dash_is_not_treated_as_worktree(
     )
 
     assert [entry.repo_id for entry in entries] == ["base--name"]
-    assert entries[0].indent == ""
+    assert entries[0].is_worktree is False

--- a/tests/integrations/discord/test_flow_handlers.py
+++ b/tests/integrations/discord/test_flow_handlers.py
@@ -1044,6 +1044,8 @@ async def test_flow_status_in_pma_mode_shows_only_active_chat_bound_worktrees(
         content = rest.interaction_responses[0]["payload"]["data"]["content"]
         assert "wt-visible" in content
         assert "wt-hidden" not in content
+        assert "\n  -> " in content
+        assert "\n  - " not in content
     finally:
         await store.close()
 

--- a/tests/test_telegram_flow_status.py
+++ b/tests/test_telegram_flow_status.py
@@ -1352,6 +1352,8 @@ async def test_flow_hub_overview_shows_only_active_chat_bound_worktrees(
     content = handler.sent[0][0]
     assert "`wt-visible`" in content
     assert "`wt-hidden`" not in content
+    assert "\n  -> " in content
+    assert "\n  - " not in content
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- remove markdown list-marker semantics from hub flow overview entry modeling by replacing `indent` with `is_worktree`
- render worktree rows with a plain-text prefix (`  -> `) in both Discord and Telegram flow overview paths so siblings do not appear nested under the first sibling
- keep existing group/order/status behavior and add regression assertions that the old `\n  - ` list prefix is not emitted

## Testing
- `.venv/bin/python -m pytest -q tests/core/flows/test_hub_overview.py tests/integrations/discord/test_flow_handlers.py::test_flow_status_in_pma_mode_shows_only_active_chat_bound_worktrees tests/test_telegram_flow_status.py::test_flow_hub_overview_shows_only_active_chat_bound_worktrees`
- `.venv/bin/python -m pytest -q tests/test_telegram_flow_status.py -k "flow_hub_overview"`
- pre-commit hooks during commit (`2619 passed, 3 skipped`)
