### PR TITLE
Add keyword-contract enforcement for path containment APIs

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -86,6 +86,9 @@ echo "Checking for legacy TODO/SUMMARY pipeline code..."
 echo "Checking destination contract drift..."
 "$PYTHON_BIN" scripts/check_destination_contract_drift.py
 
+echo "Checking keyword contracts..."
+"$PYTHON_BIN" scripts/check_keyword_contracts.py --report-only
+
 echo "Type check (mypy)..."
 "$PYTHON_BIN" -m mypy src/codex_autorunner/core src/codex_autorunner/integrations/app_server src/codex_autorunner/integrations/telegram
 

--- a/scripts/check_keyword_contracts.py
+++ b/scripts/check_keyword_contracts.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Check for positional calls to keyword-contracted APIs.
+
+This script detects positional argument calls to functions/methods that
+require keyword arguments to prevent swapped-argument bugs where multiple
+same-typed parameters are involved.
+
+Usage:
+    python scripts/check_keyword_contracts.py [--allowlist PATH]
+
+Exit codes:
+    0 - No new violations (existing violations are in allowlist)
+    1 - New violations detected (not in allowlist)
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+PACKAGE_ROOT = SRC_ROOT / "codex_autorunner"
+
+KEYWORD_CONTRACTED_APIS: dict[str, dict[str, str]] = {
+    "is_within": {
+        "module": "codex_autorunner.core.utils",
+        "description": "Path containment check (root, target)",
+    },
+    "_is_within": {
+        "module": "codex_autorunner.core.archive",
+        "description": "Path containment check (root, target)",
+    },
+    "_path_within": {
+        "module": "codex_autorunner.integrations.discord.service",
+        "description": "Path containment check (root, target)",
+    },
+}
+
+
+@dataclass(frozen=True)
+class Violation:
+    file_path: str
+    line: int
+    col: int
+    function_name: str
+    description: str
+
+    def key(self) -> str:
+        return f"{self.file_path}:{self.line}:{self.function_name}"
+
+
+@dataclass
+class Allowlist:
+    entries: dict[str, str]
+
+    @classmethod
+    def load(cls, path: Path) -> "Allowlist":
+        if not path.exists():
+            return cls(entries={})
+        payload = json.loads(path.read_text())
+        entries: dict[str, str] = {}
+        for item in payload.get("violations", []):
+            key = item.get("key")
+            reason = item.get("reason", "")
+            if key:
+                entries[key] = reason
+        return cls(entries=entries)
+
+
+def collect_python_files(root: Path) -> Sequence[Path]:
+    return sorted(p for p in root.rglob("*.py") if p.is_file())
+
+
+def is_positional_call(node: ast.Call) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    if isinstance(node.func, ast.Name):
+        return len(node.args) > 0
+    if isinstance(node.func, ast.Attribute):
+        return len(node.args) > 0
+    return False
+
+
+def get_called_name(node: ast.Call) -> str | None:
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr
+    return None
+
+
+def check_file(path: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    try:
+        source = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return violations
+
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return violations
+
+    rel_path = str(path.relative_to(REPO_ROOT))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+
+        name = get_called_name(node)
+        if name is None:
+            continue
+
+        if name not in KEYWORD_CONTRACTED_APIS:
+            continue
+
+        if len(node.args) > 0:
+            api_info = KEYWORD_CONTRACTED_APIS[name]
+            violations.append(
+                Violation(
+                    file_path=rel_path,
+                    line=node.lineno,
+                    col=node.col_offset,
+                    function_name=name,
+                    description=api_info["description"],
+                )
+            )
+
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check for positional calls to keyword-contracted APIs."
+    )
+    parser.add_argument(
+        "--allowlist",
+        default=str(REPO_ROOT / "scripts" / "keyword_contracts_allowlist.json"),
+        help="Path to allowlist JSON file.",
+    )
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="Report all violations without using allowlist (for CI).",
+    )
+    args = parser.parse_args()
+
+    allowlist = Allowlist.load(Path(args.allowlist))
+
+    violations: list[Violation] = []
+    for path in collect_python_files(PACKAGE_ROOT):
+        violations.extend(check_file(path))
+
+    violations.sort(key=lambda v: (v.file_path, v.line))
+
+    if args.report_only:
+        if violations:
+            print("Keyword contract violations detected:")
+            for v in violations:
+                print(
+                    f"  {v.file_path}:{v.line}:{v.col}: "
+                    f"positional call to '{v.function_name}' ({v.description})"
+                )
+            print(
+                "\nThese APIs require keyword arguments to prevent swapped-argument bugs."
+            )
+            print("Update calls to use: function_name(root=..., target=...)")
+            return 1
+        else:
+            print("No keyword contract violations found.")
+            return 0
+
+    unallowlisted = [v for v in violations if v.key() not in allowlist.entries]
+    stale = [
+        key for key in allowlist.entries if key not in {v.key() for v in violations}
+    ]
+
+    if unallowlisted:
+        print("New keyword contract violations detected:")
+        for v in unallowlisted:
+            print(
+                f"  {v.file_path}:{v.line}:{v.col}: "
+                f"positional call to '{v.function_name}' ({v.description})"
+            )
+        print(
+            "\nThese APIs require keyword arguments to prevent swapped-argument bugs."
+        )
+        print("Add to allowlist (with reason) or fix the calls.")
+    if stale:
+        print("\nAllowlist entries no longer needed:")
+        for key in sorted(stale):
+            reason = allowlist.entries.get(key, "")
+            reason_suffix = f" — {reason}" if reason else ""
+            print(f"  {key}{reason_suffix}")
+
+    return 1 if unallowlisted else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/keyword_contracts_allowlist.json
+++ b/scripts/keyword_contracts_allowlist.json
@@ -1,0 +1,3 @@
+{
+  "violations": []
+}

--- a/src/codex_autorunner/core/archive.py
+++ b/src/codex_autorunner/core/archive.py
@@ -44,7 +44,7 @@ def _sanitize_branch(branch: Optional[str]) -> str:
     return cleaned or "unknown"
 
 
-def _is_within(root: Path, target: Path) -> bool:
+def _is_within(*, root: Path, target: Path) -> bool:
     try:
         return target.resolve().is_relative_to(root.resolve())
     except FileNotFoundError:
@@ -105,7 +105,7 @@ def _copy_entry(
         except FileNotFoundError:
             skipped_symlinks.append(str(src))
             return False
-        if not _is_within(worktree_root, resolved):
+        if not _is_within(root=worktree_root, target=resolved):
             skipped_symlinks.append(str(src))
             return False
         if resolved.is_dir():

--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -777,7 +777,7 @@ class HubSupervisor:
         if manifest.get(repo_id) and not force:
             raise ValueError(f"Worktree repo already exists: {repo_id}")
         worktree_path = (worktrees_root / repo_id).resolve()
-        if not is_within(worktrees_root, worktree_path):
+        if not is_within(root=worktrees_root, target=worktree_path):
             raise ValueError(
                 "Worktree path escapes worktrees_root: "
                 f"{worktree_path} (root={worktrees_root})"

--- a/src/codex_autorunner/core/review_context.py
+++ b/src/codex_autorunner/core/review_context.py
@@ -104,7 +104,7 @@ def _artifact_entries(
         path = Path(raw).expanduser()
         if not path.is_absolute():
             path = (repo_root / path).resolve()
-        if not is_within(repo_root, path) or not path.exists():
+        if not is_within(root=repo_root, target=path) or not path.exists():
             continue
         label = label_by_kind.get(artifact.kind, f"Artifact ({artifact.kind})")
         content = _truncate_text(_safe_read(path), limit)

--- a/src/codex_autorunner/core/utils.py
+++ b/src/codex_autorunner/core/utils.py
@@ -143,7 +143,7 @@ def canonicalize_path(path: Path) -> Path:
     return path.expanduser().resolve()
 
 
-def is_within(root: Path, target: Path) -> bool:
+def is_within(*, root: Path, target: Path) -> bool:
     try:
         target.relative_to(root)
         return True

--- a/src/codex_autorunner/integrations/agents/destination_wrapping.py
+++ b/src/codex_autorunner/integrations/agents/destination_wrapping.py
@@ -89,7 +89,7 @@ def wrap_command_for_destination(
 
     # Docker destination runs inside repo mount, so keep supervisor state under repo state root.
     state_root = repo_abs / ".codex-autorunner" / "app_server_workspaces"
-    if not is_within(repo_abs, state_root):
+    if not is_within(root=repo_abs, target=state_root):
         state_root = repo_abs / ".codex-autorunner" / "app_server_workspaces"
     return WrappedCommand(command=wrapped, state_root_override=state_root)
 

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -325,13 +325,13 @@ def _is_valid_opencode_model_name(model_name: str) -> bool:
     return bool(provider_id.strip() and model_id.strip())
 
 
-def _path_within(root: Path, target: Path) -> bool:
+def _path_within(*, root: Path, target: Path) -> bool:
     try:
         root = canonicalize_path(root)
         target = canonicalize_path(target)
     except Exception:
         return False
-    return is_within(root, target)
+    return is_within(root=root, target=target)
 
 
 async def _model_list_with_agent_compat(
@@ -1207,8 +1207,7 @@ class DiscordBotService:
                 channel_id,
                 {
                     "content": (
-                        f"Turn failed: {exc} "
-                        f"(conversation {context.conversation_id})"
+                        f"Turn failed: {exc} (conversation {context.conversation_id})"
                     )
                 },
             )
@@ -1452,15 +1451,16 @@ class DiscordBotService:
                     mime_type if isinstance(mime_type, str) else None,
                     str(original_name),
                 )
-                transcript_text, transcript_warning = (
-                    await self._transcribe_voice_attachment(
-                        workspace_root=workspace_root,
-                        channel_id=channel_id,
-                        attachment=attachment,
-                        data=data,
-                        file_name=transcription_name,
-                        mime_type=mime_type if isinstance(mime_type, str) else None,
-                    )
+                (
+                    transcript_text,
+                    transcript_warning,
+                ) = await self._transcribe_voice_attachment(
+                    workspace_root=workspace_root,
+                    channel_id=channel_id,
+                    attachment=attachment,
+                    data=data,
+                    file_name=transcription_name,
+                    mime_type=mime_type if isinstance(mime_type, str) else None,
                 )
                 saved.append(
                     _SavedDiscordAttachment(
@@ -1650,7 +1650,9 @@ class DiscordBotService:
         if not isinstance(current_ticket, str) or not current_ticket.strip():
             return False
         ticket_path = (workspace_root / current_ticket).resolve()
-        if not ticket_path.is_file() or not is_within(workspace_root, ticket_path):
+        if not ticket_path.is_file() or not is_within(
+            root=workspace_root, target=ticket_path
+        ):
             return False
         ticket_doc, errors = read_ticket(ticket_path)
         if errors or ticket_doc is None:
@@ -8056,7 +8058,7 @@ class DiscordBotService:
 
         sent_dir = outbox_sent_dir(workspace_root)
         for source_dir, path in files:
-            if not _path_within(source_dir, path):
+            if not _path_within(root=source_dir, target=path):
                 log_event(
                     self._logger,
                     logging.WARNING,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -646,7 +646,7 @@ class ExecutionCommands(SharedHelpers):
                 reply_to=message.message_id,
             )
             return
-        if not _path_within(workspace, path):
+        if not _path_within(root=workspace, target=path):
             await self._send_message(
                 message.chat_id,
                 "File must be within the bound workspace.",

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/files.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/files.py
@@ -1424,7 +1424,7 @@ class FilesCommands(SharedHelpers):
         sent_dir = self._files_outbox_sent_dir(record.workspace_path, key)
         max_bytes = self._config.media.max_file_bytes
         for path in files:
-            if not _path_within(pending_dir, path):
+            if not _path_within(root=pending_dir, target=path):
                 continue
             try:
                 size = path.stat().st_size
@@ -1688,7 +1688,10 @@ class FilesCommands(SharedHelpers):
                 return
             name = Path(argv[1]).name
             candidate = pending_dir / name
-            if not _path_within(pending_dir, candidate) or not candidate.is_file():
+            if (
+                not _path_within(root=pending_dir, target=candidate)
+                or not candidate.is_file()
+            ):
                 await self._send_message(
                     message.chat_id,
                     f"Outbox file not found: {name}",

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -1507,7 +1507,7 @@ class TelegramCommandHandlers(
                 reply_to=message.message_id,
             )
             return
-        if not _path_within(workspace, path):
+        if not _path_within(root=workspace, target=path):
             await self._send_message(
                 message.chat_id,
                 "File must be within the bound workspace.",

--- a/src/codex_autorunner/integrations/telegram/helpers.py
+++ b/src/codex_autorunner/integrations/telegram/helpers.py
@@ -1253,13 +1253,13 @@ def _local_workspace_threads(
     return thread_ids, previews, topic_keys_by_thread
 
 
-def _path_within(root: Path, target: Path) -> bool:
+def _path_within(*, root: Path, target: Path) -> bool:
     try:
         root = canonicalize_path(root)
         target = canonicalize_path(target)
     except Exception:
         return False
-    return is_within(root, target)
+    return is_within(root=root, target=target)
 
 
 def _repo_root(path: Path) -> Optional[Path]:
@@ -1270,9 +1270,9 @@ def _repo_root(path: Path) -> Optional[Path]:
 
 
 def _paths_compatible(workspace_root: Path, resumed_root: Path) -> bool:
-    if _path_within(workspace_root, resumed_root):
+    if _path_within(root=workspace_root, target=resumed_root):
         return True
-    if _path_within(resumed_root, workspace_root):
+    if _path_within(root=resumed_root, target=workspace_root):
         workspace_repo = _repo_root(workspace_root)
         resumed_repo = _repo_root(resumed_root)
         if workspace_repo is None or resumed_repo is None:
@@ -1286,7 +1286,7 @@ def _paths_compatible(workspace_root: Path, resumed_root: Path) -> bool:
         return False
     if workspace_repo != resumed_repo:
         return False
-    return _path_within(workspace_repo, resumed_root)
+    return _path_within(root=workspace_repo, target=resumed_root)
 
 
 def _should_trace_message(text: str) -> bool:

--- a/src/codex_autorunner/surfaces/cli/commands/doctor.py
+++ b/src/codex_autorunner/surfaces/cli/commands/doctor.py
@@ -210,7 +210,9 @@ def _doctor_versions_payload(start_path: Path) -> dict[str, Any]:
     source_matches_checkout = None
     if package_path and repo_root:
         try:
-            source_matches_checkout = is_within(Path(package_path), repo_root)
+            source_matches_checkout = is_within(
+                root=repo_root, target=Path(package_path)
+            )
         except Exception:
             source_matches_checkout = None
 

--- a/src/codex_autorunner/surfaces/cli/commands/utils.py
+++ b/src/codex_autorunner/surfaces/cli/commands/utils.py
@@ -505,8 +505,8 @@ def guard_unregistered_hub_repo(repo_root: Path, hub: Optional[Path]) -> None:
         raise_exit(str(exc), cause=exc)
 
     repo_root = repo_root.resolve()
-    under_repos = is_within(hub_config.repos_root, repo_root)
-    under_worktrees = is_within(hub_config.worktrees_root, repo_root)
+    under_repos = is_within(root=hub_config.repos_root, target=repo_root)
+    under_worktrees = is_within(root=hub_config.worktrees_root, target=repo_root)
     if not (under_repos or under_worktrees):
         return
 

--- a/src/codex_autorunner/surfaces/web/routes/app_server.py
+++ b/src/codex_autorunner/surfaces/web/routes/app_server.py
@@ -125,7 +125,7 @@ def build_app_server_routes() -> APIRouter:
             raise HTTPException(status_code=404, detail="No backup available")
         path = Path(backup_path)
         engine = request.app.state.engine
-        if not is_within(engine.repo_root, path):
+        if not is_within(root=engine.repo_root, target=path):
             raise HTTPException(status_code=400, detail="Invalid backup path")
         if not path.exists():
             raise HTTPException(status_code=404, detail="Backup not found")

--- a/tests/unit/test_keyword_contracts.py
+++ b/tests/unit/test_keyword_contracts.py
@@ -1,0 +1,91 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from codex_autorunner.core.utils import is_within
+
+
+class TestIsWithinSemantics:
+    def test_target_within_root_returns_true(self, tmp_path: Path):
+        root = tmp_path / "root"
+        root.mkdir()
+        target = root / "subdir" / "file.txt"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.touch()
+        assert is_within(root=root, target=target) is True
+
+    def test_target_not_within_root_returns_false(self, tmp_path: Path):
+        root = tmp_path / "root"
+        other = tmp_path / "other"
+        root.mkdir()
+        other.mkdir()
+        target = other / "file.txt"
+        target.touch()
+        assert is_within(root=root, target=target) is False
+
+    def test_root_equals_target_returns_true(self, tmp_path: Path):
+        root = tmp_path / "root"
+        root.mkdir()
+        assert is_within(root=root, target=root) is True
+
+    def test_target_is_parent_of_root_returns_false(self, tmp_path: Path):
+        parent = tmp_path
+        child = parent / "child"
+        child.mkdir()
+        assert is_within(root=child, target=parent) is False
+
+    def test_reversed_arguments_would_be_wrong(self, tmp_path: Path):
+        root = tmp_path / "root"
+        root.mkdir()
+        target = root / "subdir"
+        target.mkdir()
+        assert is_within(root=root, target=target) is True
+        assert is_within(root=target, target=root) is False
+
+
+class TestIsWithinKeywordOnly:
+    def test_positional_call_raises_type_error(self, tmp_path: Path):
+        root = tmp_path / "root"
+        root.mkdir()
+        target = root / "file.txt"
+        target.touch()
+        with pytest.raises(TypeError, match="positional argument"):
+            is_within(root, target)
+
+    def test_missing_root_raises_type_error(self, tmp_path: Path):
+        target = tmp_path / "file.txt"
+        target.touch()
+        with pytest.raises(TypeError):
+            is_within(target=target)
+
+    def test_missing_target_raises_type_error(self, tmp_path: Path):
+        root = tmp_path
+        with pytest.raises(TypeError):
+            is_within(root=root)
+
+
+class TestKeywordContractChecker:
+    def test_checker_script_exists(self):
+        script_path = (
+            Path(__file__).parent.parent.parent
+            / "scripts"
+            / "check_keyword_contracts.py"
+        )
+        assert script_path.exists()
+
+    def test_checker_finds_no_violations(self):
+        script_path = (
+            Path(__file__).parent.parent.parent
+            / "scripts"
+            / "check_keyword_contracts.py"
+        )
+        result = subprocess.run(
+            [sys.executable, str(script_path), "--report-only"],
+            capture_output=True,
+            text=True,
+        )
+        assert (
+            result.returncode == 0
+        ), f"Checker found violations:\n{result.stdout}\n{result.stderr}"


### PR DESCRIPTION
## Summary
- Introduces a systematic guardrail against swapped-argument bugs by converting high-risk path containment APIs to keyword-only signatures
- Adds an AST checker script to detect positional calls to keyword-contracted APIs in CI
- Fixes a reversed-argument bug in `doctor.py` discovered during audit

## Changes
1. **AST Checker** (`scripts/check_keyword_contracts.py`): New script that detects positional calls to keyword-contracted APIs and reports violations
2. **Keyword-only conversions**:
   - `is_within(*, root, target)` in `core/utils.py`
   - `_is_within(*, root, target)` in `core/archive.py`
   - `_path_within(*, root, target)` in both Discord and Telegram integrations
3. **Bug fix**: In `doctor.py:213`, the call `is_within(Path(package_path), repo_root)` was checking if `repo_root` is within `package_path` (wrong), instead of checking if `package_path` is within `repo_root` (correct). Fixed to use `is_within(root=repo_root, target=Path(package_path))`.
4. **Tests**: Added `tests/unit/test_keyword_contracts.py` with tests for:
   - Semantics of `is_within` (correct argument order behavior)
   - Keyword-only enforcement (positional calls raise TypeError)
   - Checker script integration
5. **CI integration**: Added the checker to `scripts/check.sh`

## Motivation
Per issue #899, PR #898 fixed a production-facing bug where argument order was accidentally swapped in a path containment check. Both parameters are `Path`, so static typing (`mypy`) did not catch the bug. This PR prevents recurrence by requiring keyword arguments for these high-risk APIs.

Closes #899