### PR TITLE
Normalize PMA managed thread status model

### DIFF
--- a/docs/ops/pma-managed-thread-status.md
+++ b/docs/ops/pma-managed-thread-status.md
@@ -1,0 +1,42 @@
+# PMA Managed-Thread Status Model
+
+CAR uses one normalized operator-facing status for PMA managed threads.
+
+## Status Enum
+
+| Status | Meaning | Terminal |
+| --- | --- | --- |
+| `idle` | Healthy and waiting for work | no |
+| `running` | A managed turn is currently executing | no |
+| `paused` | Execution was intentionally compacted/paused | no |
+| `completed` | The latest managed turn finished successfully | yes |
+| `failed` | The latest managed turn finished unsuccessfully | yes |
+| `archived` | The thread is read-only and archived | yes |
+
+## Transition Table
+
+| Current | Signal | Next |
+| --- | --- | --- |
+| any | `thread_created` | `idle` |
+| `paused`, `archived` | `thread_resumed` | `idle` |
+| `idle`, `completed`, `failed`, `paused` | `turn_started` | `running` |
+| `idle`, `completed`, `failed`, `paused` | `thread_compacted` | `paused` |
+| `running` | `managed_turn_completed` | `completed` |
+| `running` | `managed_turn_failed` | `failed` |
+| `running` | `managed_turn_interrupted` | `failed` |
+| any | `thread_archived` | `archived` |
+
+## Persisted Context
+
+Each managed thread persists:
+
+- `normalized_status`
+- `status_reason_code`
+- `status_updated_at`
+- `status_terminal`
+- `status_turn_id`
+
+API, CLI, and hub UI surfaces read these persisted fields instead of re-inferring
+status from mixed lifecycle signals. Operator-facing payloads keep compatibility
+aliases such as `status_reason` and `status_changed_at`, while lifecycle write
+admission remains separate in `lifecycle_status`.

--- a/src/codex_autorunner/core/managed_thread_status.py
+++ b/src/codex_autorunner/core/managed_thread_status.py
@@ -1,0 +1,339 @@
+"""Canonical managed-thread status model.
+
+Normalized statuses:
+- ``idle``: healthy and waiting for work
+- ``running``: a managed turn is in flight
+- ``paused``: execution is intentionally compacted/paused without finishing
+- ``completed``: the latest managed turn finished successfully
+- ``failed``: the latest managed turn finished unsuccessfully
+- ``archived``: the thread is terminal and read-only
+
+Lifecycle write-admission status remains separate:
+- ``active``
+- ``archived``
+
+Transition table:
+
+| Current | Signal | Next | Terminal |
+| --- | --- | --- | --- |
+| any | ``thread_created`` | ``idle`` | no |
+| ``paused``/``archived`` | ``thread_resumed`` | ``idle`` | no |
+| ``idle``/``completed``/``failed``/``paused`` | ``turn_started`` | ``running`` | no |
+| ``idle``/``completed``/``failed``/``paused`` | ``thread_compacted`` | ``paused`` | no |
+| ``running`` | ``managed_turn_completed`` | ``completed`` | yes |
+| ``running`` | ``managed_turn_failed`` | ``failed`` | yes |
+| ``running`` | ``managed_turn_interrupted`` | ``failed`` | yes |
+| any | ``thread_archived`` | ``archived`` | yes |
+
+Rules:
+- duplicate signals are idempotent
+- older signals are ignored when their timestamp predates the stored transition
+- same-timestamp duplicates are ignored when status/reason/turn are unchanged
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Mapping, Optional
+
+
+class ManagedThreadStatus(str, Enum):
+    ACTIVE = "active"
+    ARCHIVED = "archived"
+    IDLE = "idle"
+    RUNNING = "running"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ManagedThreadStatusReason(str, Enum):
+    THREAD_CREATED = "thread_created"
+    THREAD_RESUMED = "thread_resumed"
+    THREAD_ARCHIVED = "thread_archived"
+    THREAD_COMPACTED = "thread_compacted"
+    TURN_STARTED = "turn_started"
+    MANAGED_TURN_COMPLETED = "managed_turn_completed"
+    MANAGED_TURN_FAILED = "managed_turn_failed"
+    MANAGED_TURN_INTERRUPTED = "managed_turn_interrupted"
+
+
+TERMINAL_STATUSES = frozenset(
+    {
+        ManagedThreadStatus.COMPLETED.value,
+        ManagedThreadStatus.FAILED.value,
+        ManagedThreadStatus.ARCHIVED.value,
+    }
+)
+
+TRANSITION_TABLE: tuple[dict[str, Any], ...] = (
+    {
+        "signal": ManagedThreadStatusReason.THREAD_CREATED.value,
+        "from": "*",
+        "to": ManagedThreadStatus.IDLE.value,
+    },
+    {
+        "signal": ManagedThreadStatusReason.THREAD_RESUMED.value,
+        "from": (
+            ManagedThreadStatus.PAUSED.value,
+            ManagedThreadStatus.ARCHIVED.value,
+        ),
+        "to": ManagedThreadStatus.IDLE.value,
+    },
+    {
+        "signal": ManagedThreadStatusReason.TURN_STARTED.value,
+        "from": (
+            ManagedThreadStatus.IDLE.value,
+            ManagedThreadStatus.COMPLETED.value,
+            ManagedThreadStatus.FAILED.value,
+            ManagedThreadStatus.PAUSED.value,
+        ),
+        "to": ManagedThreadStatus.RUNNING.value,
+    },
+    {
+        "signal": ManagedThreadStatusReason.THREAD_COMPACTED.value,
+        "from": (
+            ManagedThreadStatus.IDLE.value,
+            ManagedThreadStatus.COMPLETED.value,
+            ManagedThreadStatus.FAILED.value,
+            ManagedThreadStatus.PAUSED.value,
+        ),
+        "to": ManagedThreadStatus.PAUSED.value,
+    },
+    {
+        "signal": ManagedThreadStatusReason.MANAGED_TURN_COMPLETED.value,
+        "from": (ManagedThreadStatus.RUNNING.value,),
+        "to": ManagedThreadStatus.COMPLETED.value,
+    },
+    {
+        "signal": ManagedThreadStatusReason.MANAGED_TURN_FAILED.value,
+        "from": (ManagedThreadStatus.RUNNING.value,),
+        "to": ManagedThreadStatus.FAILED.value,
+    },
+    {
+        "signal": ManagedThreadStatusReason.MANAGED_TURN_INTERRUPTED.value,
+        "from": (ManagedThreadStatus.RUNNING.value,),
+        "to": ManagedThreadStatus.FAILED.value,
+    },
+    {
+        "signal": ManagedThreadStatusReason.THREAD_ARCHIVED.value,
+        "from": "*",
+        "to": ManagedThreadStatus.ARCHIVED.value,
+    },
+)
+
+_TRANSITIONS = {
+    str(entry["signal"]).strip().lower(): entry for entry in TRANSITION_TABLE
+}
+
+
+def _normalize_text(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _parse_iso(value: Any) -> Optional[datetime]:
+    text = _normalize_text(value)
+    if text is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _normalize_reason(value: str | ManagedThreadStatusReason) -> str:
+    if isinstance(value, ManagedThreadStatusReason):
+        return value.value
+    return str(value).strip().lower()
+
+
+def normalize_status_timestamp(value: Optional[str]) -> str:
+    parsed = _parse_iso(value)
+    if parsed is None:
+        parsed = datetime.now(timezone.utc)
+    return parsed.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass(frozen=True)
+class ManagedThreadStatusSnapshot:
+    status: str = ManagedThreadStatus.IDLE.value
+    reason_code: str = ManagedThreadStatusReason.THREAD_CREATED.value
+    changed_at: str = ""
+    terminal: bool = False
+    turn_id: Optional[str] = None
+
+    @classmethod
+    def from_mapping(
+        cls, data: Mapping[str, Any] | None
+    ) -> "ManagedThreadStatusSnapshot":
+        if not isinstance(data, Mapping):
+            return cls()
+        status = _normalize_text(data.get("normalized_status")) or _normalize_text(
+            data.get("status")
+        )
+        if status is None:
+            status = ManagedThreadStatus.IDLE.value
+        reason_code = _normalize_text(
+            data.get("status_reason_code") or data.get("status_reason")
+        ) or (
+            ManagedThreadStatusReason.THREAD_ARCHIVED.value
+            if status == ManagedThreadStatus.ARCHIVED.value
+            else ManagedThreadStatusReason.THREAD_CREATED.value
+        )
+        changed_at = normalize_status_timestamp(
+            _normalize_text(
+                data.get("status_updated_at") or data.get("status_changed_at")
+            )
+        )
+        terminal_raw = data.get("status_terminal")
+        terminal = (
+            terminal_raw
+            if isinstance(terminal_raw, bool)
+            else (
+                bool(terminal_raw)
+                if terminal_raw is not None
+                else status in TERMINAL_STATUSES
+            )
+        )
+        return cls(
+            status=status,
+            reason_code=reason_code,
+            changed_at=changed_at,
+            terminal=terminal,
+            turn_id=_normalize_text(data.get("status_turn_id")),
+        )
+
+    def to_record(self) -> dict[str, Any]:
+        return {
+            "normalized_status": self.status,
+            "status_reason_code": self.reason_code,
+            "status_updated_at": self.changed_at,
+            "status_terminal": self.terminal,
+            "status_turn_id": self.turn_id,
+        }
+
+
+def build_managed_thread_status_snapshot(
+    *,
+    reason: str | ManagedThreadStatusReason,
+    changed_at: Optional[str],
+    turn_id: Optional[str] = None,
+) -> ManagedThreadStatusSnapshot:
+    reason_code = _normalize_reason(reason)
+    transition = _TRANSITIONS.get(reason_code)
+    target = (
+        transition["to"] if transition is not None else ManagedThreadStatus.IDLE.value
+    )
+    return ManagedThreadStatusSnapshot(
+        status=target,
+        reason_code=reason_code,
+        changed_at=normalize_status_timestamp(changed_at),
+        terminal=target in TERMINAL_STATUSES,
+        turn_id=_normalize_text(turn_id),
+    )
+
+
+def _transition_allowed(current_status: str, reason_code: str) -> bool:
+    transition = _TRANSITIONS.get(reason_code)
+    if transition is None:
+        return False
+    allowed = transition["from"]
+    if allowed == "*":
+        return True
+    return current_status in allowed
+
+
+def transition_managed_thread_status(
+    current: ManagedThreadStatusSnapshot,
+    *,
+    reason: str | ManagedThreadStatusReason,
+    changed_at: Optional[str],
+    turn_id: Optional[str] = None,
+) -> ManagedThreadStatusSnapshot:
+    reason_code = _normalize_reason(reason)
+    if not _transition_allowed(current.status, reason_code):
+        return current
+
+    incoming_at = _parse_iso(changed_at)
+    current_at = _parse_iso(current.changed_at)
+    if current_at is not None and incoming_at is not None and incoming_at < current_at:
+        return current
+
+    candidate = build_managed_thread_status_snapshot(
+        reason=reason_code,
+        changed_at=changed_at,
+        turn_id=turn_id,
+    )
+    if (
+        candidate.status == current.status
+        and candidate.reason_code == current.reason_code
+        and candidate.turn_id == current.turn_id
+    ):
+        return current
+    return candidate
+
+
+def backfill_managed_thread_status(
+    *,
+    lifecycle_status: str | None,
+    latest_turn_status: str | None,
+    changed_at: Optional[str],
+    compacted: bool = False,
+) -> ManagedThreadStatusSnapshot:
+    normalized_lifecycle = str(lifecycle_status or "").strip().lower()
+    normalized_turn = str(latest_turn_status or "").strip().lower()
+    if normalized_lifecycle == ManagedThreadStatus.ARCHIVED.value:
+        return build_managed_thread_status_snapshot(
+            reason=ManagedThreadStatusReason.THREAD_ARCHIVED,
+            changed_at=changed_at,
+        )
+    if normalized_turn == "running":
+        return build_managed_thread_status_snapshot(
+            reason=ManagedThreadStatusReason.TURN_STARTED,
+            changed_at=changed_at,
+        )
+    if normalized_turn == "ok":
+        return build_managed_thread_status_snapshot(
+            reason=ManagedThreadStatusReason.MANAGED_TURN_COMPLETED,
+            changed_at=changed_at,
+        )
+    if normalized_turn == "interrupted":
+        return build_managed_thread_status_snapshot(
+            reason=ManagedThreadStatusReason.MANAGED_TURN_INTERRUPTED,
+            changed_at=changed_at,
+        )
+    if normalized_turn == "error":
+        return build_managed_thread_status_snapshot(
+            reason=ManagedThreadStatusReason.MANAGED_TURN_FAILED,
+            changed_at=changed_at,
+        )
+    if compacted:
+        return build_managed_thread_status_snapshot(
+            reason=ManagedThreadStatusReason.THREAD_COMPACTED,
+            changed_at=changed_at,
+        )
+    return build_managed_thread_status_snapshot(
+        reason=ManagedThreadStatusReason.THREAD_CREATED,
+        changed_at=changed_at,
+    )
+
+
+__all__ = [
+    "ManagedThreadStatus",
+    "ManagedThreadStatusReason",
+    "ManagedThreadStatusSnapshot",
+    "TERMINAL_STATUSES",
+    "TRANSITION_TABLE",
+    "backfill_managed_thread_status",
+    "build_managed_thread_status_snapshot",
+    "normalize_status_timestamp",
+    "transition_managed_thread_status",
+]

--- a/src/codex_autorunner/core/pma_context.py
+++ b/src/codex_autorunner/core/pma_context.py
@@ -483,7 +483,14 @@ def _snapshot_pma_threads(
                 "repo_id": thread.get("repo_id"),
                 "workspace_root": workspace_root,
                 "name": thread.get("name"),
-                "status": thread.get("status"),
+                "status": thread.get("normalized_status") or thread.get("status"),
+                "lifecycle_status": thread.get("lifecycle_status")
+                or thread.get("status"),
+                "status_reason": thread.get("status_reason")
+                or thread.get("status_reason_code"),
+                "status_terminal": bool(thread.get("status_terminal")),
+                "status_changed_at": thread.get("status_changed_at")
+                or thread.get("status_updated_at"),
                 "last_turn_id": thread.get("last_turn_id"),
                 "last_message_preview": _truncate(
                     str(thread.get("last_message_preview") or ""),
@@ -879,6 +886,14 @@ def _render_hub_snapshot(
             repo_id = _truncate(str(thread.get("repo_id") or "-"), max_field_chars)
             agent = _truncate(str(thread.get("agent") or ""), max_field_chars)
             status = _truncate(str(thread.get("status") or ""), max_field_chars)
+            lifecycle_status = _truncate(
+                str(thread.get("lifecycle_status") or "-"),
+                max_field_chars,
+            )
+            status_reason = _truncate(
+                str(thread.get("status_reason") or "-"),
+                max_field_chars,
+            )
             name = _truncate(str(thread.get("name") or "-"), max_field_chars)
             preview = _truncate(
                 str(thread.get("last_message_preview") or "-"),
@@ -886,7 +901,8 @@ def _render_hub_snapshot(
             )
             lines.append(
                 f"- {managed_thread_id} repo_id={repo_id} agent={agent} "
-                f"status={status} name={name} last={preview}"
+                f"status={status} lifecycle={lifecycle_status} "
+                f"reason={status_reason} name={name} last={preview}"
             )
             freshness_summary = _render_freshness_summary(
                 thread.get("freshness"), max_field_chars=max_field_chars

--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -6,6 +6,13 @@ from pathlib import Path
 from typing import Any, Iterator, Optional
 
 from .locks import file_lock
+from .managed_thread_status import (
+    ManagedThreadStatusReason,
+    ManagedThreadStatusSnapshot,
+    backfill_managed_thread_status,
+    build_managed_thread_status_snapshot,
+    transition_managed_thread_status,
+)
 from .sqlite_utils import open_sqlite
 from .time_utils import now_iso
 
@@ -46,6 +53,61 @@ def pma_threads_db_lock(db_path: Path) -> Iterator[None]:
         yield
 
 
+def _row_to_dict(row: Any) -> dict[str, Any]:
+    return {key: row[key] for key in row.keys()}
+
+
+def _table_columns(conn: Any, table_name: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+    columns: set[str] = set()
+    for row in rows:
+        name = row["name"] if "name" in row.keys() else None
+        if isinstance(name, str) and name:
+            columns.add(name)
+    return columns
+
+
+def _coerce_text(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _latest_turn_for_thread(
+    conn: Any, managed_thread_id: str
+) -> Optional[dict[str, Any]]:
+    row = conn.execute(
+        """
+        SELECT *
+          FROM pma_managed_turns
+         WHERE managed_thread_id = ?
+         ORDER BY started_at DESC, rowid DESC
+         LIMIT 1
+        """,
+        (managed_thread_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return _row_to_dict(row)
+
+
+def _normalize_thread_record(row: Any) -> dict[str, Any]:
+    record = _row_to_dict(row)
+    lifecycle_status = _coerce_text(record.get("status")) or "active"
+    snapshot = ManagedThreadStatusSnapshot.from_mapping(record)
+    record["status"] = lifecycle_status
+    record["lifecycle_status"] = lifecycle_status
+    record["normalized_status"] = snapshot.status
+    record["status_reason_code"] = snapshot.reason_code
+    record["status_reason"] = snapshot.reason_code
+    record["status_updated_at"] = snapshot.changed_at
+    record["status_changed_at"] = snapshot.changed_at
+    record["status_terminal"] = bool(snapshot.terminal)
+    record["status_turn_id"] = snapshot.turn_id
+    return record
+
+
 def _ensure_schema(conn: Any) -> None:
     with conn:
         conn.execute(
@@ -58,6 +120,11 @@ def _ensure_schema(conn: Any) -> None:
                 name TEXT,
                 backend_thread_id TEXT,
                 status TEXT NOT NULL,
+                normalized_status TEXT,
+                status_reason_code TEXT,
+                status_updated_at TEXT,
+                status_terminal INTEGER,
+                status_turn_id TEXT,
                 last_turn_id TEXT,
                 last_message_preview TEXT,
                 compact_seed TEXT,
@@ -102,10 +169,44 @@ def _ensure_schema(conn: Any) -> None:
             )
             """
         )
+
+    thread_columns = _table_columns(conn, "pma_managed_threads")
+    for statement in (
+        (
+            "normalized_status",
+            "ALTER TABLE pma_managed_threads ADD COLUMN normalized_status TEXT",
+        ),
+        (
+            "status_reason_code",
+            "ALTER TABLE pma_managed_threads ADD COLUMN status_reason_code TEXT",
+        ),
+        (
+            "status_updated_at",
+            "ALTER TABLE pma_managed_threads ADD COLUMN status_updated_at TEXT",
+        ),
+        (
+            "status_terminal",
+            "ALTER TABLE pma_managed_threads ADD COLUMN status_terminal INTEGER",
+        ),
+        (
+            "status_turn_id",
+            "ALTER TABLE pma_managed_threads ADD COLUMN status_turn_id TEXT",
+        ),
+    ):
+        if statement[0] not in thread_columns:
+            with conn:
+                conn.execute(statement[1])
+    with conn:
         conn.execute(
             """
             CREATE INDEX IF NOT EXISTS idx_pma_managed_threads_status
             ON pma_managed_threads(status)
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_pma_managed_threads_normalized_status
+            ON pma_managed_threads(normalized_status)
             """
         )
         conn.execute(
@@ -127,9 +228,62 @@ def _ensure_schema(conn: Any) -> None:
             """
         )
 
+    _backfill_missing_thread_status(conn)
 
-def _row_to_dict(row: Any) -> dict[str, Any]:
-    return {key: row[key] for key in row.keys()}
+
+def _backfill_missing_thread_status(conn: Any) -> None:
+    rows = conn.execute(
+        """
+        SELECT *
+          FROM pma_managed_threads
+         WHERE normalized_status IS NULL
+            OR TRIM(COALESCE(normalized_status, '')) = ''
+            OR status_reason_code IS NULL
+            OR TRIM(COALESCE(status_reason_code, '')) = ''
+            OR status_updated_at IS NULL
+            OR TRIM(COALESCE(status_updated_at, '')) = ''
+            OR status_terminal IS NULL
+        """
+    ).fetchall()
+    if not rows:
+        return
+
+    with conn:
+        for row in rows:
+            record = _row_to_dict(row)
+            managed_thread_id = str(record["managed_thread_id"])
+            latest_turn = _latest_turn_for_thread(conn, managed_thread_id)
+            snapshot = backfill_managed_thread_status(
+                lifecycle_status=_coerce_text(record.get("status")),
+                latest_turn_status=_coerce_text((latest_turn or {}).get("status")),
+                changed_at=(
+                    _coerce_text(record.get("status_updated_at"))
+                    or _coerce_text((latest_turn or {}).get("finished_at"))
+                    or _coerce_text((latest_turn or {}).get("started_at"))
+                    or _coerce_text(record.get("updated_at"))
+                    or _coerce_text(record.get("created_at"))
+                ),
+                compacted=_coerce_text(record.get("compact_seed")) is not None,
+            )
+            conn.execute(
+                """
+                UPDATE pma_managed_threads
+                   SET normalized_status = ?,
+                       status_reason_code = ?,
+                       status_updated_at = ?,
+                       status_terminal = ?,
+                       status_turn_id = COALESCE(status_turn_id, ?)
+                 WHERE managed_thread_id = ?
+                """,
+                (
+                    snapshot.status,
+                    snapshot.reason_code,
+                    snapshot.changed_at,
+                    1 if snapshot.terminal else 0,
+                    snapshot.turn_id,
+                    managed_thread_id,
+                ),
+            )
 
 
 class PmaThreadStore:
@@ -154,6 +308,67 @@ class PmaThreadStore:
                 _ensure_schema(conn)
                 yield conn
 
+    def _fetch_thread(
+        self, conn: Any, managed_thread_id: str
+    ) -> Optional[dict[str, Any]]:
+        row = conn.execute(
+            """
+            SELECT *
+              FROM pma_managed_threads
+             WHERE managed_thread_id = ?
+            """,
+            (managed_thread_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return _normalize_thread_record(row)
+
+    def _transition_thread_status(
+        self,
+        conn: Any,
+        managed_thread_id: str,
+        *,
+        reason: str | ManagedThreadStatusReason,
+        changed_at: Optional[str] = None,
+        turn_id: Optional[str] = None,
+    ) -> Optional[dict[str, Any]]:
+        thread = self._fetch_thread(conn, managed_thread_id)
+        if thread is None:
+            return None
+        current = ManagedThreadStatusSnapshot.from_mapping(thread)
+        resolved_changed_at = changed_at or now_iso()
+        snapshot = transition_managed_thread_status(
+            current,
+            reason=reason,
+            changed_at=resolved_changed_at,
+            turn_id=turn_id,
+        )
+        if snapshot == current:
+            return thread
+        with conn:
+            conn.execute(
+                """
+                UPDATE pma_managed_threads
+                   SET normalized_status = ?,
+                       status_reason_code = ?,
+                       status_updated_at = ?,
+                       status_terminal = ?,
+                       status_turn_id = ?,
+                       updated_at = ?
+                 WHERE managed_thread_id = ?
+                """,
+                (
+                    snapshot.status,
+                    snapshot.reason_code,
+                    snapshot.changed_at,
+                    1 if snapshot.terminal else 0,
+                    snapshot.turn_id,
+                    resolved_changed_at,
+                    managed_thread_id,
+                ),
+            )
+        return self._fetch_thread(conn, managed_thread_id)
+
     def create_thread(
         self,
         agent: str,
@@ -169,6 +384,10 @@ class PmaThreadStore:
         if not workspace.is_absolute():
             raise ValueError("workspace_root must be absolute")
 
+        snapshot = build_managed_thread_status_snapshot(
+            reason=ManagedThreadStatusReason.THREAD_CREATED,
+            changed_at=now,
+        )
         with self._write_conn() as conn:
             with conn:
                 conn.execute(
@@ -181,12 +400,17 @@ class PmaThreadStore:
                         name,
                         backend_thread_id,
                         status,
+                        normalized_status,
+                        status_reason_code,
+                        status_updated_at,
+                        status_terminal,
+                        status_turn_id,
                         last_turn_id,
                         last_message_preview,
                         compact_seed,
                         created_at,
                         updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         managed_thread_id,
@@ -196,6 +420,11 @@ class PmaThreadStore:
                         name,
                         backend_thread_id,
                         "active",
+                        snapshot.status,
+                        snapshot.reason_code,
+                        snapshot.changed_at,
+                        1 if snapshot.terminal else 0,
+                        snapshot.turn_id,
                         None,
                         None,
                         None,
@@ -203,38 +432,22 @@ class PmaThreadStore:
                         now,
                     ),
                 )
-            row = conn.execute(
-                """
-                SELECT *
-                  FROM pma_managed_threads
-                 WHERE managed_thread_id = ?
-                """,
-                (managed_thread_id,),
-            ).fetchone()
-
-        if row is None:
+            created = self._fetch_thread(conn, managed_thread_id)
+        if created is None:
             raise RuntimeError("Failed to create managed PMA thread")
-        return _row_to_dict(row)
+        return created
 
     def get_thread(self, managed_thread_id: str) -> Optional[dict[str, Any]]:
         with open_sqlite(self._path, durable=self._durable) as conn:
-            row = conn.execute(
-                """
-                SELECT *
-                  FROM pma_managed_threads
-                 WHERE managed_thread_id = ?
-                """,
-                (managed_thread_id,),
-            ).fetchone()
-        if row is None:
-            return None
-        return _row_to_dict(row)
+            _ensure_schema(conn)
+            return self._fetch_thread(conn, managed_thread_id)
 
     def list_threads(
         self,
         *,
         agent: Optional[str] = None,
         status: Optional[str] = None,
+        normalized_status: Optional[str] = None,
         repo_id: Optional[str] = None,
         limit: int = 200,
     ) -> list[dict[str, Any]]:
@@ -253,6 +466,9 @@ class PmaThreadStore:
         if status is not None:
             query += " AND status = ?"
             params.append(status)
+        if normalized_status is not None:
+            query += " AND normalized_status = ?"
+            params.append(normalized_status)
         if repo_id is not None:
             query += " AND repo_id = ?"
             params.append(repo_id)
@@ -261,8 +477,9 @@ class PmaThreadStore:
         params.append(limit)
 
         with open_sqlite(self._path, durable=self._durable) as conn:
+            _ensure_schema(conn)
             rows = conn.execute(query, params).fetchall()
-        return [_row_to_dict(row) for row in rows]
+        return [_normalize_thread_record(row) for row in rows]
 
     def count_threads_by_repo(
         self, *, agent: Optional[str] = None, status: Optional[str] = None
@@ -283,6 +500,7 @@ class PmaThreadStore:
         query += " GROUP BY TRIM(repo_id)"
 
         with open_sqlite(self._path, durable=self._durable) as conn:
+            _ensure_schema(conn)
             rows = conn.execute(query, params).fetchall()
         counts: dict[str, int] = {}
         for row in rows:
@@ -339,12 +557,13 @@ class PmaThreadStore:
         *,
         reset_backend_id: bool = False,
     ) -> None:
+        changed_at = now_iso()
         query = """
             UPDATE pma_managed_threads
                SET compact_seed = ?,
                    updated_at = ?
         """
-        params: list[Any] = [compact_seed, now_iso()]
+        params: list[Any] = [compact_seed, changed_at]
         if reset_backend_id:
             query += ", backend_thread_id = NULL"
         query += " WHERE managed_thread_id = ?"
@@ -353,8 +572,16 @@ class PmaThreadStore:
         with self._write_conn() as conn:
             with conn:
                 conn.execute(query, params)
+            if _coerce_text(compact_seed) is not None:
+                self._transition_thread_status(
+                    conn,
+                    managed_thread_id,
+                    reason=ManagedThreadStatusReason.THREAD_COMPACTED,
+                    changed_at=changed_at,
+                )
 
     def archive_thread(self, managed_thread_id: str) -> None:
+        changed_at = now_iso()
         with self._write_conn() as conn:
             with conn:
                 conn.execute(
@@ -364,10 +591,17 @@ class PmaThreadStore:
                            updated_at = ?
                      WHERE managed_thread_id = ?
                     """,
-                    (now_iso(), managed_thread_id),
+                    (changed_at, managed_thread_id),
                 )
+            self._transition_thread_status(
+                conn,
+                managed_thread_id,
+                reason=ManagedThreadStatusReason.THREAD_ARCHIVED,
+                changed_at=changed_at,
+            )
 
     def activate_thread(self, managed_thread_id: str) -> None:
+        changed_at = now_iso()
         with self._write_conn() as conn:
             with conn:
                 conn.execute(
@@ -377,8 +611,14 @@ class PmaThreadStore:
                            updated_at = ?
                      WHERE managed_thread_id = ?
                     """,
-                    (now_iso(), managed_thread_id),
+                    (changed_at, managed_thread_id),
                 )
+            self._transition_thread_status(
+                conn,
+                managed_thread_id,
+                reason=ManagedThreadStatusReason.THREAD_RESUMED,
+                changed_at=changed_at,
+            )
 
     def create_turn(
         self,
@@ -459,6 +699,13 @@ class PmaThreadStore:
                             managed_thread_id, thread_status
                         )
                     raise ManagedThreadAlreadyHasRunningTurnError(managed_thread_id)
+            self._transition_thread_status(
+                conn,
+                managed_thread_id,
+                reason=ManagedThreadStatusReason.TURN_STARTED,
+                changed_at=started_at,
+                turn_id=managed_turn_id,
+            )
             row = conn.execute(
                 """
                 SELECT *
@@ -481,10 +728,27 @@ class PmaThreadStore:
         error: Optional[str] = None,
         backend_turn_id: Optional[str] = None,
         transcript_turn_id: Optional[str] = None,
-    ) -> None:
+    ) -> bool:
+        finished_at = now_iso()
+        reason = (
+            ManagedThreadStatusReason.MANAGED_TURN_COMPLETED
+            if status == "ok"
+            else ManagedThreadStatusReason.MANAGED_TURN_FAILED
+        )
         with self._write_conn() as conn:
+            row = conn.execute(
+                """
+                SELECT managed_thread_id
+                  FROM pma_managed_turns
+                 WHERE managed_turn_id = ?
+                """,
+                (managed_turn_id,),
+            ).fetchone()
+            if row is None:
+                return False
+            managed_thread_id = str(row["managed_thread_id"])
             with conn:
-                conn.execute(
+                cursor = conn.execute(
                     """
                     UPDATE pma_managed_turns
                        SET status = ?,
@@ -502,10 +766,20 @@ class PmaThreadStore:
                         error,
                         backend_turn_id,
                         transcript_turn_id,
-                        now_iso(),
+                        finished_at,
                         managed_turn_id,
                     ),
                 )
+            if cursor.rowcount == 0:
+                return False
+            self._transition_thread_status(
+                conn,
+                managed_thread_id,
+                reason=reason,
+                changed_at=finished_at,
+                turn_id=managed_turn_id,
+            )
+        return True
 
     def set_turn_backend_turn_id(
         self, managed_turn_id: str, backend_turn_id: Optional[str]
@@ -521,18 +795,41 @@ class PmaThreadStore:
                     (backend_turn_id, managed_turn_id),
                 )
 
-    def mark_turn_interrupted(self, managed_turn_id: str) -> None:
+    def mark_turn_interrupted(self, managed_turn_id: str) -> bool:
+        finished_at = now_iso()
         with self._write_conn() as conn:
+            row = conn.execute(
+                """
+                SELECT managed_thread_id
+                  FROM pma_managed_turns
+                 WHERE managed_turn_id = ?
+                """,
+                (managed_turn_id,),
+            ).fetchone()
+            if row is None:
+                return False
+            managed_thread_id = str(row["managed_thread_id"])
             with conn:
-                conn.execute(
+                cursor = conn.execute(
                     """
                     UPDATE pma_managed_turns
                        SET status = 'interrupted',
                            finished_at = ?
                      WHERE managed_turn_id = ?
+                       AND status = 'running'
                     """,
-                    (now_iso(), managed_turn_id),
+                    (finished_at, managed_turn_id),
                 )
+            if cursor.rowcount == 0:
+                return False
+            self._transition_thread_status(
+                conn,
+                managed_thread_id,
+                reason=ManagedThreadStatusReason.MANAGED_TURN_INTERRUPTED,
+                changed_at=finished_at,
+                turn_id=managed_turn_id,
+            )
+        return True
 
     def list_turns(
         self, managed_thread_id: str, *, limit: int = 50
@@ -541,6 +838,7 @@ class PmaThreadStore:
             return []
 
         with open_sqlite(self._path, durable=self._durable) as conn:
+            _ensure_schema(conn)
             rows = conn.execute(
                 """
                 SELECT *
@@ -555,6 +853,7 @@ class PmaThreadStore:
 
     def has_running_turn(self, managed_thread_id: str) -> bool:
         with open_sqlite(self._path, durable=self._durable) as conn:
+            _ensure_schema(conn)
             row = conn.execute(
                 """
                 SELECT 1
@@ -569,6 +868,7 @@ class PmaThreadStore:
 
     def get_running_turn(self, managed_thread_id: str) -> Optional[dict[str, Any]]:
         with open_sqlite(self._path, durable=self._durable) as conn:
+            _ensure_schema(conn)
             row = conn.execute(
                 """
                 SELECT *
@@ -588,6 +888,7 @@ class PmaThreadStore:
         self, managed_thread_id: str, managed_turn_id: str
     ) -> Optional[dict[str, Any]]:
         with open_sqlite(self._path, durable=self._durable) as conn:
+            _ensure_schema(conn)
             row = conn.execute(
                 """
                 SELECT *
@@ -629,6 +930,7 @@ class PmaThreadStore:
 
 __all__ = [
     "ManagedThreadAlreadyHasRunningTurnError",
+    "ManagedThreadNotActiveError",
     "PMA_THREADS_DB_FILENAME",
     "PmaThreadStore",
     "default_pma_threads_db_path",

--- a/src/codex_autorunner/static/generated/hub.js
+++ b/src/codex_autorunner/static/generated/hub.js
@@ -1094,6 +1094,10 @@ function channelPmaDetails(channel) {
     if (managedId) {
         parts.push(`thread ${managedId.slice(0, 12)}`);
     }
+    const reason = String(channel.provenance?.status_reason_code || channel.meta?.status_reason_code || "").trim();
+    if (reason) {
+        parts.push(reason);
+    }
     return parts.join(" · ");
 }
 function channelDisplayLabel(channel) {

--- a/src/codex_autorunner/static_src/hub.ts
+++ b/src/codex_autorunner/static_src/hub.ts
@@ -104,6 +104,7 @@ interface HubChannelEntry {
     managed_thread_id?: string | null;
     agent?: string | null;
     status?: string | null;
+    status_reason_code?: string | null;
   } | null;
   repo_id?: string | null;
   workspace_path?: string | null;
@@ -1414,6 +1415,12 @@ function channelPmaDetails(channel: HubChannelEntry): string {
   ).trim();
   if (managedId) {
     parts.push(`thread ${managedId.slice(0, 12)}`);
+  }
+  const reason = String(
+    channel.provenance?.status_reason_code || channel.meta?.status_reason_code || ""
+  ).trim();
+  if (reason) {
+    parts.push(reason);
   }
   return parts.join(" · ");
 }

--- a/src/codex_autorunner/surfaces/cli/pma_cli.py
+++ b/src/codex_autorunner/surfaces/cli/pma_cli.py
@@ -274,7 +274,9 @@ def _render_thread_status_snapshot(data: dict[str, Any]) -> None:
     managed_thread_id = str(data.get("managed_thread_id") or "")
     agent = str(thread.get("agent") or "-")
     repo_id = str(thread.get("repo_id") or "-")
-    thread_state = str(thread.get("status") or "-")
+    thread_state = str(data.get("status") or thread.get("status") or "-")
+    lifecycle_state = str(thread.get("lifecycle_status") or "-")
+    status_reason = str(data.get("status_reason") or thread.get("status_reason") or "-")
     managed_turn_id = str(turn.get("managed_turn_id") or "-")
     turn_state = str(turn.get("status") or "-")
     activity = str(turn.get("activity") or "-")
@@ -288,10 +290,12 @@ def _render_thread_status_snapshot(data: dict[str, Any]) -> None:
                 f"agent={agent}",
                 f"repo={repo_id}",
                 f"thread={thread_state}",
+                f"lifecycle={lifecycle_state}",
                 f"alive={alive}",
             ]
         )
     )
+    typer.echo(f"reason={status_reason}")
     typer.echo(
         f"turn={managed_turn_id} status={turn_state} activity={activity} elapsed={elapsed} idle={idle}"
     )
@@ -865,6 +869,7 @@ def pma_thread_list(
                     str(thread.get("managed_thread_id") or ""),
                     f"agent={thread.get('agent') or ''}",
                     f"status={thread.get('status') or ''}",
+                    f"reason={thread.get('status_reason') or '-'}",
                     f"repo={thread.get('repo_id') or '-'}",
                 ]
             ).strip()

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/channels.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/channels.py
@@ -475,6 +475,8 @@ class HubChannelService:
                 "name",
                 "backend_thread_id",
                 "status",
+                "normalized_status",
+                "status_reason_code",
                 "updated_at",
             ]
             select_exprs = [col for col in select_cols if col in columns]
@@ -534,6 +536,28 @@ class HubChannelService:
                 updated_at = row["updated_at"] if "updated_at" in columns else None
                 if not isinstance(updated_at, str) or not updated_at.strip():
                     updated_at = None
+                normalized_status = (
+                    row["normalized_status"] if "normalized_status" in columns else None
+                )
+                if (
+                    not isinstance(normalized_status, str)
+                    or not normalized_status.strip()
+                ):
+                    normalized_status = None
+                else:
+                    normalized_status = normalized_status.strip()
+                status_reason_code = (
+                    row["status_reason_code"]
+                    if "status_reason_code" in columns
+                    else None
+                )
+                if (
+                    not isinstance(status_reason_code, str)
+                    or not status_reason_code.strip()
+                ):
+                    status_reason_code = None
+                else:
+                    status_reason_code = status_reason_code.strip()
                 has_running_turn = bool(
                     row["has_running_turn"] if has_turns_table else False
                 )
@@ -546,6 +570,8 @@ class HubChannelService:
                         "backend_thread_id": backend_thread_id,
                         "name": name,
                         "updated_at": updated_at,
+                        "normalized_status": normalized_status,
+                        "status_reason_code": status_reason_code,
                         "has_running_turn": has_running_turn,
                     }
                 )
@@ -1116,7 +1142,12 @@ class HubChannelService:
             backend_thread_id = thread.get("backend_thread_id")
             agent = self._normalize_agent(thread.get("agent"))
             has_running_turn = bool(thread.get("has_running_turn"))
-            status_label = "working" if has_running_turn else "final"
+            normalized_status = (
+                str(thread.get("normalized_status") or "").strip().lower()
+            )
+            if not normalized_status:
+                normalized_status = "running" if has_running_turn else "idle"
+            status_reason_code = str(thread.get("status_reason_code") or "").strip()
             display_name = thread.get("name")
             short_id = managed_thread_id[:8]
             if not isinstance(display_name, str) or not display_name.strip():
@@ -1130,24 +1161,26 @@ class HubChannelService:
                 "meta": {
                     "agent": agent,
                     "managed_thread_id": managed_thread_id,
-                    "status": "active",
+                    "status": normalized_status,
+                    "status_reason_code": status_reason_code,
                 },
                 "entry": {
                     "platform": "pma_thread",
                     "thread_id": managed_thread_id,
                     "agent": agent,
-                    "status": "active",
+                    "status": normalized_status,
                 },
                 "source": "pma_thread",
                 "provenance": {
                     "source": "pma_thread",
                     "managed_thread_id": managed_thread_id,
                     "agent": agent,
-                    "status": "active",
+                    "status": normalized_status,
+                    "status_reason_code": status_reason_code,
                 },
                 "active_thread_id": managed_thread_id,
-                "channel_status": status_label,
-                "status_label": status_label,
+                "channel_status": normalized_status,
+                "status_label": normalized_status,
             }
             if isinstance(repo_id, str) and repo_id:
                 row["repo_id"] = repo_id

--- a/src/codex_autorunner/surfaces/web/routes/hub_repos.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repos.py
@@ -604,6 +604,9 @@ def build_hub_repo_routes(
                 "name",
                 "backend_thread_id",
                 "status",
+                "normalized_status",
+                "status_reason_code",
+                "status_updated_at",
                 "updated_at",
             ]
             select_exprs = [col for col in select_cols if col in columns]
@@ -664,6 +667,34 @@ def build_hub_repo_routes(
                 has_running_turn = bool(
                     row["has_running_turn"] if has_turns_table else False
                 )
+                normalized_status = (
+                    row["normalized_status"] if "normalized_status" in columns else None
+                )
+                if (
+                    not isinstance(normalized_status, str)
+                    or not normalized_status.strip()
+                ):
+                    normalized_status = "running" if has_running_turn else "idle"
+                else:
+                    normalized_status = normalized_status.strip()
+                status_reason_code = (
+                    row["status_reason_code"]
+                    if "status_reason_code" in columns
+                    else None
+                )
+                if (
+                    not isinstance(status_reason_code, str)
+                    or not status_reason_code.strip()
+                ):
+                    status_reason_code = None
+                status_updated_at = (
+                    row["status_updated_at"] if "status_updated_at" in columns else None
+                )
+                if (
+                    not isinstance(status_updated_at, str)
+                    or not status_updated_at.strip()
+                ):
+                    status_updated_at = updated_at
                 threads.append(
                     {
                         "managed_thread_id": managed_thread_id.strip(),
@@ -674,6 +705,9 @@ def build_hub_repo_routes(
                         "name": name,
                         "updated_at": updated_at,
                         "has_running_turn": has_running_turn,
+                        "normalized_status": normalized_status,
+                        "status_reason_code": status_reason_code,
+                        "status_updated_at": status_updated_at,
                     }
                 )
             return threads

--- a/src/codex_autorunner/surfaces/web/routes/pma.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma.py
@@ -629,6 +629,28 @@ def build_pma_routes() -> APIRouter:
             )
         return notify_on
 
+    def _serialize_managed_thread(thread: dict[str, Any]) -> dict[str, Any]:
+        payload = dict(thread)
+        lifecycle_status = _normalize_optional_text(
+            thread.get("lifecycle_status") or thread.get("status")
+        )
+        normalized_status = _normalize_optional_text(thread.get("normalized_status"))
+        payload["lifecycle_status"] = lifecycle_status
+        payload["normalized_status"] = normalized_status or lifecycle_status or ""
+        payload["status"] = payload["normalized_status"]
+        payload["status_reason"] = _normalize_optional_text(
+            thread.get("status_reason") or thread.get("status_reason_code")
+        )
+        payload["status_changed_at"] = _normalize_optional_text(
+            thread.get("status_changed_at") or thread.get("status_updated_at")
+        )
+        payload["status_terminal"] = bool(thread.get("status_terminal"))
+        payload["status_turn_id"] = _normalize_optional_text(
+            thread.get("status_turn_id")
+        )
+        payload["accepts_messages"] = lifecycle_status == "active"
+        return payload
+
     def _build_terminal_notify_subscription_payload(
         *,
         managed_thread_id: str,
@@ -2019,7 +2041,7 @@ def build_pma_routes() -> APIRouter:
                     else None
                 ),
             )
-        response: dict[str, Any] = {"thread": thread}
+        response: dict[str, Any] = {"thread": _serialize_managed_thread(thread)}
         if notification is not None:
             response["notification"] = notification
         return response
@@ -2029,19 +2051,29 @@ def build_pma_routes() -> APIRouter:
         request: Request,
         agent: Optional[str] = None,
         status: Optional[str] = None,
+        lifecycle_status: Optional[str] = None,
         repo_id: Optional[str] = None,
         limit: int = 200,
     ) -> dict[str, Any]:
         if limit <= 0:
             raise HTTPException(status_code=400, detail="limit must be greater than 0")
+        normalized_status = _normalize_optional_text(status)
+        normalized_lifecycle_status = _normalize_optional_text(lifecycle_status)
+        if (
+            normalized_status in {"active", "archived"}
+            and normalized_lifecycle_status is None
+        ):
+            normalized_lifecycle_status = normalized_status
+            normalized_status = None
         store = PmaThreadStore(request.app.state.config.root)
         threads = store.list_threads(
             agent=_normalize_optional_text(agent),
-            status=_normalize_optional_text(status),
+            status=normalized_lifecycle_status,
+            normalized_status=normalized_status,
             repo_id=_normalize_optional_text(repo_id),
             limit=limit,
         )
-        return {"threads": threads}
+        return {"threads": [_serialize_managed_thread(thread) for thread in threads]}
 
     @router.get("/threads/{managed_thread_id}")
     def get_managed_thread(managed_thread_id: str, request: Request) -> dict[str, Any]:
@@ -2049,7 +2081,7 @@ def build_pma_routes() -> APIRouter:
         thread = store.get_thread(managed_thread_id)
         if thread is None:
             raise HTTPException(status_code=404, detail="Managed thread not found")
-        return {"thread": thread}
+        return {"thread": _serialize_managed_thread(thread)}
 
     @router.post("/threads/{managed_thread_id}/compact")
     def compact_managed_thread(
@@ -2099,7 +2131,7 @@ def build_pma_routes() -> APIRouter:
         updated = store.get_thread(managed_thread_id)
         if updated is None:
             raise HTTPException(status_code=404, detail="Managed thread not found")
-        return {"thread": updated}
+        return {"thread": _serialize_managed_thread(updated)}
 
     @router.post("/threads/{managed_thread_id}/resume")
     def resume_managed_thread(
@@ -2137,7 +2169,7 @@ def build_pma_routes() -> APIRouter:
         updated = store.get_thread(managed_thread_id)
         if updated is None:
             raise HTTPException(status_code=404, detail="Managed thread not found")
-        return {"thread": updated}
+        return {"thread": _serialize_managed_thread(updated)}
 
     @router.post("/threads/{managed_thread_id}/archive")
     def archive_managed_thread(
@@ -2161,7 +2193,7 @@ def build_pma_routes() -> APIRouter:
         updated = store.get_thread(managed_thread_id)
         if updated is None:
             raise HTTPException(status_code=404, detail="Managed thread not found")
-        return {"thread": updated}
+        return {"thread": _serialize_managed_thread(updated)}
 
     async def _build_managed_thread_tail_snapshot(
         *,
@@ -2339,8 +2371,19 @@ def build_pma_routes() -> APIRouter:
 
         return {
             "managed_thread_id": managed_thread_id,
-            "thread": thread,
+            "thread": _serialize_managed_thread(thread),
             "is_alive": is_alive,
+            "status": _normalize_optional_text(thread.get("normalized_status"))
+            or _normalize_optional_text(thread.get("status"))
+            or "",
+            "status_reason": _normalize_optional_text(
+                thread.get("status_reason") or thread.get("status_reason_code")
+            )
+            or "",
+            "status_changed_at": _normalize_optional_text(
+                thread.get("status_changed_at") or thread.get("status_updated_at")
+            ),
+            "status_terminal": bool(thread.get("status_terminal")),
             "turn": {
                 "managed_turn_id": snapshot.get("managed_turn_id"),
                 "status": snapshot.get("turn_status"),
@@ -3008,30 +3051,31 @@ def build_pma_routes() -> APIRouter:
         else:
             backend_error = f"Unknown managed thread agent: {agent}"
 
-        store.mark_turn_interrupted(managed_turn_id)
-        await _notify_managed_thread_terminal_transition(
-            request,
-            thread=thread,
-            managed_thread_id=managed_thread_id,
-            managed_turn_id=managed_turn_id,
-            to_state="failed",
-            reason=backend_error or "managed_turn_interrupted",
-        )
-        store.append_action(
-            "managed_thread_interrupt",
-            managed_thread_id=managed_thread_id,
-            payload_json=json.dumps(
-                {
-                    "agent": agent,
-                    "managed_turn_id": managed_turn_id,
-                    "backend_thread_id": backend_thread_id,
-                    "backend_turn_id": backend_turn_id,
-                    "backend_interrupt_attempted": backend_interrupt_attempted,
-                    "backend_error": backend_error,
-                },
-                ensure_ascii=True,
-            ),
-        )
+        interrupted = store.mark_turn_interrupted(managed_turn_id)
+        if interrupted:
+            await _notify_managed_thread_terminal_transition(
+                request,
+                thread=thread,
+                managed_thread_id=managed_thread_id,
+                managed_turn_id=managed_turn_id,
+                to_state="failed",
+                reason=backend_error or "managed_turn_interrupted",
+            )
+            store.append_action(
+                "managed_thread_interrupt",
+                managed_thread_id=managed_thread_id,
+                payload_json=json.dumps(
+                    {
+                        "agent": agent,
+                        "managed_turn_id": managed_turn_id,
+                        "backend_thread_id": backend_thread_id,
+                        "backend_turn_id": backend_turn_id,
+                        "backend_interrupt_attempted": backend_interrupt_attempted,
+                        "backend_error": backend_error,
+                    },
+                    ensure_ascii=True,
+                ),
+            )
         updated_turn = store.get_turn(managed_thread_id, managed_turn_id)
         return {
             "status": "ok",

--- a/tests/core/test_managed_thread_status.py
+++ b/tests/core/test_managed_thread_status.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from codex_autorunner.core.managed_thread_status import (
+    ManagedThreadStatusReason,
+    backfill_managed_thread_status,
+    build_managed_thread_status_snapshot,
+    transition_managed_thread_status,
+)
+
+
+def test_transient_failure_recovery_is_deterministic() -> None:
+    state = build_managed_thread_status_snapshot(
+        reason=ManagedThreadStatusReason.THREAD_CREATED,
+        changed_at="2026-03-08T00:00:00Z",
+    )
+    state = transition_managed_thread_status(
+        state,
+        reason=ManagedThreadStatusReason.TURN_STARTED,
+        changed_at="2026-03-08T00:00:10Z",
+        turn_id="turn-1",
+    )
+    state = transition_managed_thread_status(
+        state,
+        reason=ManagedThreadStatusReason.MANAGED_TURN_FAILED,
+        changed_at="2026-03-08T00:00:20Z",
+        turn_id="turn-1",
+    )
+    state = transition_managed_thread_status(
+        state,
+        reason=ManagedThreadStatusReason.TURN_STARTED,
+        changed_at="2026-03-08T00:00:30Z",
+        turn_id="turn-2",
+    )
+    state = transition_managed_thread_status(
+        state,
+        reason=ManagedThreadStatusReason.MANAGED_TURN_COMPLETED,
+        changed_at="2026-03-08T00:00:40Z",
+        turn_id="turn-2",
+    )
+
+    assert state.status == "completed"
+    assert state.reason_code == "managed_turn_completed"
+    assert state.turn_id == "turn-2"
+    assert state.terminal is True
+
+
+def test_paused_then_resumed_returns_to_idle() -> None:
+    state = build_managed_thread_status_snapshot(
+        reason=ManagedThreadStatusReason.THREAD_CREATED,
+        changed_at="2026-03-08T00:00:00Z",
+    )
+    state = transition_managed_thread_status(
+        state,
+        reason=ManagedThreadStatusReason.THREAD_COMPACTED,
+        changed_at="2026-03-08T00:00:10Z",
+    )
+    state = transition_managed_thread_status(
+        state,
+        reason=ManagedThreadStatusReason.THREAD_RESUMED,
+        changed_at="2026-03-08T00:00:20Z",
+    )
+
+    assert state.status == "idle"
+    assert state.reason_code == "thread_resumed"
+    assert state.terminal is False
+
+
+def test_duplicate_completion_event_is_idempotent() -> None:
+    state = build_managed_thread_status_snapshot(
+        reason=ManagedThreadStatusReason.THREAD_CREATED,
+        changed_at="2026-03-08T00:00:00Z",
+    )
+    state = transition_managed_thread_status(
+        state,
+        reason=ManagedThreadStatusReason.TURN_STARTED,
+        changed_at="2026-03-08T00:00:10Z",
+        turn_id="turn-1",
+    )
+    completed = transition_managed_thread_status(
+        state,
+        reason=ManagedThreadStatusReason.MANAGED_TURN_COMPLETED,
+        changed_at="2026-03-08T00:00:20Z",
+        turn_id="turn-1",
+    )
+    duplicate = transition_managed_thread_status(
+        completed,
+        reason=ManagedThreadStatusReason.MANAGED_TURN_COMPLETED,
+        changed_at="2026-03-08T00:00:20Z",
+        turn_id="turn-1",
+    )
+
+    assert duplicate == completed
+
+
+def test_out_of_order_event_delivery_ignores_stale_transition() -> None:
+    state = build_managed_thread_status_snapshot(
+        reason=ManagedThreadStatusReason.THREAD_CREATED,
+        changed_at="2026-03-08T00:00:00Z",
+    )
+    state = transition_managed_thread_status(
+        state,
+        reason=ManagedThreadStatusReason.TURN_STARTED,
+        changed_at="2026-03-08T00:00:10Z",
+        turn_id="turn-1",
+    )
+    state = transition_managed_thread_status(
+        state,
+        reason=ManagedThreadStatusReason.MANAGED_TURN_COMPLETED,
+        changed_at="2026-03-08T00:00:20Z",
+        turn_id="turn-1",
+    )
+    stale = transition_managed_thread_status(
+        state,
+        reason=ManagedThreadStatusReason.TURN_STARTED,
+        changed_at="2026-03-08T00:00:15Z",
+        turn_id="turn-1",
+    )
+
+    assert stale == state
+
+
+def test_backfill_prefers_terminal_latest_turn_over_compacted_state() -> None:
+    completed = backfill_managed_thread_status(
+        lifecycle_status="active",
+        latest_turn_status="ok",
+        changed_at="2026-03-08T00:00:20Z",
+        compacted=True,
+    )
+    failed = backfill_managed_thread_status(
+        lifecycle_status="active",
+        latest_turn_status="error",
+        changed_at="2026-03-08T00:00:20Z",
+        compacted=True,
+    )
+
+    assert completed.status == "completed"
+    assert completed.reason_code == "managed_turn_completed"
+    assert failed.status == "failed"
+    assert failed.reason_code == "managed_turn_failed"

--- a/tests/surfaces/web/test_hub_destination_and_channels.py
+++ b/tests/surfaces/web/test_hub_destination_and_channels.py
@@ -1003,7 +1003,9 @@ def test_hub_channel_directory_route_includes_pma_managed_threads(
     assert pma_row["provenance"]["source"] == "pma_thread"
     assert pma_row["provenance"]["agent"] == "codex"
     assert pma_row["provenance"]["managed_thread_id"] == managed_thread_id
-    assert pma_row["channel_status"] in {"working", "final"}
+    assert pma_row["channel_status"] == "idle"
+    assert pma_row["status_label"] == "idle"
+    assert pma_row["provenance"]["status_reason_code"] == "thread_created"
 
     filtered = client.get("/hub/chat/channels", params={"query": "pma", "limit": 1})
     assert filtered.status_code == 200

--- a/tests/test_pma_context.py
+++ b/tests/test_pma_context.py
@@ -787,7 +787,9 @@ def test_build_hub_snapshot_includes_pma_threads_section(hub_env) -> None:
     assert first["managed_thread_id"] == managed_thread_id
     assert first["agent"] == "codex"
     assert first["repo_id"] == hub_env.repo_id
-    assert first["status"] == "active"
+    assert first["status"] == "idle"
+    assert first["lifecycle_status"] == "active"
+    assert first["status_reason"] == "thread_created"
     assert "last_message_preview" in first
     thread_freshness = first.get("freshness") or {}
     assert thread_freshness.get("generated_at")
@@ -799,7 +801,9 @@ def test_build_hub_snapshot_includes_pma_threads_section(hub_env) -> None:
     assert managed_thread_id in rendered
     assert f"repo_id={hub_env.repo_id}" in rendered
     assert "agent=codex" in rendered
-    assert "status=active" in rendered
+    assert "status=idle" in rendered
+    assert "lifecycle=active" in rendered
+    assert "reason=thread_created" in rendered
     assert "freshness: status=" in rendered
 
 

--- a/tests/test_pma_managed_threads_interrupt.py
+++ b/tests/test_pma_managed_threads_interrupt.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
@@ -200,3 +201,85 @@ def test_interrupt_managed_thread_notifies_automation_failure(hub_env) -> None:
     assert transition["from_state"] == "running"
     assert transition["to_state"] == "failed"
     assert transition["reason"] == "managed_turn_interrupted"
+
+
+def test_interrupt_managed_thread_skips_failed_side_effects_when_turn_already_finished(
+    hub_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeAutomationStore:
+        def __init__(self) -> None:
+            self.transitions: list[dict[str, object]] = []
+
+        def notify_transition(self, payload: dict[str, object]) -> None:
+            self.transitions.append(dict(payload))
+
+    class FakeClient:
+        async def turn_interrupt(
+            self, turn_id: str, *, thread_id: str | None = None
+        ) -> None:
+            _ = turn_id, thread_id
+
+    class FakeSupervisor:
+        async def get_client(self, hub_root: Path):
+            _ = hub_root
+            return FakeClient()
+
+    fake_store = FakeAutomationStore()
+    app.state.hub_supervisor.get_pma_automation_store = lambda: fake_store
+    app.state.app_server_supervisor = FakeSupervisor()
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={"agent": "codex", "repo_id": hub_env.repo_id},
+        )
+        assert create_resp.status_code == 200
+        managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+    store = PmaThreadStore(hub_env.hub_root)
+    turn = store.create_turn(managed_thread_id, prompt="running turn")
+    managed_turn_id = turn["managed_turn_id"]
+    store.set_thread_backend_id(managed_thread_id, "backend-thread-1")
+    store.set_turn_backend_turn_id(managed_turn_id, "backend-turn-1")
+
+    original_mark_turn_finished = PmaThreadStore.mark_turn_finished
+
+    def finish_then_report_not_interrupted(
+        self: PmaThreadStore, managed_turn_id_arg: str
+    ) -> bool:
+        assert managed_turn_id_arg == managed_turn_id
+        assert (
+            original_mark_turn_finished(
+                self,
+                managed_turn_id_arg,
+                status="ok",
+                assistant_text="completed before interrupt persisted",
+            )
+            is True
+        )
+        return False
+
+    monkeypatch.setattr(
+        PmaThreadStore,
+        "mark_turn_interrupted",
+        finish_then_report_not_interrupted,
+    )
+
+    with TestClient(app) as client:
+        interrupt_resp = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/interrupt",
+        )
+
+    assert interrupt_resp.status_code == 200
+    payload = interrupt_resp.json()
+    assert payload["status"] == "ok"
+    assert payload["managed_turn_id"] == managed_turn_id
+    assert len(fake_store.transitions) == 0
+
+    updated_turn = store.get_turn(managed_thread_id, managed_turn_id)
+    assert updated_turn is not None
+    assert updated_turn["status"] == "ok"
+    assert updated_turn["assistant_text"] == "completed before interrupt persisted"

--- a/tests/test_pma_managed_threads_lifecycle.py
+++ b/tests/test_pma_managed_threads_lifecycle.py
@@ -132,6 +132,8 @@ def test_managed_thread_compact_archive_resume_lifecycle(hub_env) -> None:
         archived_thread = store.get_thread(managed_thread_id)
         assert archived_thread is not None
         assert archived_thread["status"] == "archived"
+        assert archived_thread["normalized_status"] == "archived"
+        assert archived_thread["status_reason"] == "thread_archived"
 
         blocked = client.post(
             f"/hub/pma/threads/{managed_thread_id}/messages",
@@ -149,6 +151,8 @@ def test_managed_thread_compact_archive_resume_lifecycle(hub_env) -> None:
         resumed_thread = store.get_thread(managed_thread_id)
         assert resumed_thread is not None
         assert resumed_thread["status"] == "active"
+        assert resumed_thread["normalized_status"] == "idle"
+        assert resumed_thread["status_reason"] == "thread_resumed"
         assert resumed_thread["backend_thread_id"] == resume_backend_id
 
         resumed_msg = client.post(

--- a/tests/test_pma_managed_threads_routes.py
+++ b/tests/test_pma_managed_threads_routes.py
@@ -38,7 +38,10 @@ def test_create_managed_thread_with_repo_id(hub_env) -> None:
     assert thread["workspace_root"] == str(hub_env.repo_root.resolve())
     assert thread["name"] == "Primary thread"
     assert thread["backend_thread_id"] == "thread-backend-1"
-    assert thread["status"] == "active"
+    assert thread["status"] == "idle"
+    assert thread["lifecycle_status"] == "active"
+    assert thread["status_reason"] == "thread_created"
+    assert thread["status_terminal"] is False
     assert thread["managed_thread_id"]
 
 
@@ -140,6 +143,28 @@ def test_list_managed_threads_returns_created_thread(hub_env) -> None:
     threads = list_resp.json()["threads"]
     assert isinstance(threads, list)
     assert any(thread["managed_thread_id"] == created_id for thread in threads)
+
+
+def test_list_managed_threads_supports_normalized_status_filter(hub_env) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={"agent": "codex", "repo_id": hub_env.repo_id},
+        )
+        assert create_resp.status_code == 200
+
+        ready_resp = client.get("/hub/pma/threads", params={"status": "idle"})
+        active_resp = client.get(
+            "/hub/pma/threads",
+            params={"lifecycle_status": "active"},
+        )
+
+    assert ready_resp.status_code == 200
+    assert len(ready_resp.json()["threads"]) == 1
+    assert active_resp.status_code == 200
+    assert len(active_resp.json()["threads"]) == 1
 
 
 def test_get_managed_thread_returns_created_thread(hub_env) -> None:
@@ -283,7 +308,8 @@ def test_resume_managed_thread_allows_send_without_new_backend_thread(hub_env) -
         )
         assert resume_resp.status_code == 200
         resumed_thread = resume_resp.json()["thread"]
-        assert resumed_thread["status"] == "active"
+        assert resumed_thread["status"] == "idle"
+        assert resumed_thread["lifecycle_status"] == "active"
         assert resumed_thread["backend_thread_id"] == resumed_backend_id
 
         send_resp = client.post(
@@ -297,7 +323,8 @@ def test_resume_managed_thread_allows_send_without_new_backend_thread(hub_env) -
 
         get_resp = client.get(f"/hub/pma/threads/{managed_thread_id}")
         assert get_resp.status_code == 200
-        assert get_resp.json()["thread"]["status"] == "active"
+        assert get_resp.json()["thread"]["status"] == "completed"
+        assert get_resp.json()["thread"]["lifecycle_status"] == "active"
 
     assert fake_supervisor.client.resume_calls == [resumed_backend_id]
     assert fake_supervisor.client.thread_start_calls == 0

--- a/tests/test_pma_managed_threads_tail.py
+++ b/tests/test_pma_managed_threads_tail.py
@@ -150,6 +150,10 @@ def test_managed_thread_status_aggregates_thread_turn_and_progress(hub_env) -> N
         assert payload["managed_thread_id"] == managed_thread_id
         assert isinstance(payload.get("thread"), dict)
         assert isinstance(payload.get("turn"), dict)
+        assert payload["status"] == "completed"
+        assert payload["status_reason"] == "managed_turn_completed"
+        assert payload["status_terminal"] is True
+        assert payload["thread"]["lifecycle_status"] == "active"
         assert payload["turn"]["status"] == "ok"
         assert payload["is_alive"] is False
         assert isinstance(payload.get("recent_progress"), list)

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -32,6 +32,10 @@ def test_create_list_get_thread(tmp_path: Path) -> None:
     assert store.path == default_pma_threads_db_path(hub_root)
     assert store.path.exists()
     assert created["status"] == "active"
+    assert created["lifecycle_status"] == "active"
+    assert created["normalized_status"] == "idle"
+    assert created["status_reason"] == "thread_created"
+    assert created["status_terminal"] is False
     assert created["repo_id"] == "repo-123"
     assert created["name"] == "Primary"
     assert created["backend_thread_id"] == "backend-1"
@@ -43,6 +47,14 @@ def test_create_list_get_thread(tmp_path: Path) -> None:
     listed = store.list_threads(agent="codex", status="active", repo_id="repo-123")
     assert len(listed) == 1
     assert listed[0]["managed_thread_id"] == created["managed_thread_id"]
+
+    normalized_listed = store.list_threads(
+        agent="codex",
+        normalized_status="idle",
+        repo_id="repo-123",
+    )
+    assert len(normalized_listed) == 1
+    assert normalized_listed[0]["managed_thread_id"] == created["managed_thread_id"]
 
 
 def test_create_finish_turn_and_query(tmp_path: Path) -> None:
@@ -79,6 +91,12 @@ def test_create_finish_turn_and_query(tmp_path: Path) -> None:
     assert len(listed) == 1
     assert listed[0]["managed_turn_id"] == turn["managed_turn_id"]
 
+    thread_after = store.get_thread(thread["managed_thread_id"])
+    assert thread_after is not None
+    assert thread_after["normalized_status"] == "completed"
+    assert thread_after["status_reason"] == "managed_turn_completed"
+    assert thread_after["status_terminal"] is True
+
 
 def test_create_turn_rejects_when_running_turn_exists(tmp_path: Path) -> None:
     store = PmaThreadStore(tmp_path / "hub")
@@ -102,19 +120,22 @@ def test_mark_turn_finished_does_not_override_interrupted_status(
     thread = store.create_thread("codex", tmp_path / "workspace")
     turn = store.create_turn(thread["managed_thread_id"], prompt="hello")
 
-    store.mark_turn_interrupted(turn["managed_turn_id"])
+    assert store.mark_turn_interrupted(turn["managed_turn_id"]) is True
     interrupted = store.get_turn(thread["managed_thread_id"], turn["managed_turn_id"])
     assert interrupted is not None
     interrupted_finished_at = interrupted["finished_at"]
     assert interrupted["status"] == "interrupted"
     assert interrupted_finished_at
 
-    store.mark_turn_finished(
-        turn["managed_turn_id"],
-        status="ok",
-        assistant_text="should-not-overwrite",
-        backend_turn_id="backend-turn-overwrite",
-        transcript_turn_id="transcript-overwrite",
+    assert (
+        store.mark_turn_finished(
+            turn["managed_turn_id"],
+            status="ok",
+            assistant_text="should-not-overwrite",
+            backend_turn_id="backend-turn-overwrite",
+            transcript_turn_id="transcript-overwrite",
+        )
+        is False
     )
 
     final = store.get_turn(thread["managed_thread_id"], turn["managed_turn_id"])
@@ -124,6 +145,12 @@ def test_mark_turn_finished_does_not_override_interrupted_status(
     assert final["backend_turn_id"] is None
     assert final["transcript_turn_id"] is None
     assert final["finished_at"] == interrupted_finished_at
+
+    thread_after = store.get_thread(thread["managed_thread_id"])
+    assert thread_after is not None
+    assert thread_after["normalized_status"] == "failed"
+    assert thread_after["status_reason"] == "managed_turn_interrupted"
+    assert thread_after["status_terminal"] is True
 
 
 def test_concurrent_create_turn_admission_is_atomic(tmp_path: Path) -> None:
@@ -170,6 +197,10 @@ def test_archive_thread_changes_status(tmp_path: Path) -> None:
     archived = store.get_thread(thread["managed_thread_id"])
     assert archived is not None
     assert archived["status"] == "archived"
+    assert archived["lifecycle_status"] == "archived"
+    assert archived["normalized_status"] == "archived"
+    assert archived["status_reason"] == "thread_archived"
+    assert archived["status_terminal"] is True
 
 
 def test_create_turn_rejects_archived_thread(tmp_path: Path) -> None:
@@ -201,6 +232,71 @@ def test_set_compact_seed_and_reset_backend_id(tmp_path: Path) -> None:
     assert updated is not None
     assert updated["compact_seed"] == "compact-seed"
     assert updated["backend_thread_id"] is None
+
+
+def test_transient_failure_recovery_promotes_status_back_to_completed(
+    tmp_path: Path,
+) -> None:
+    store = PmaThreadStore(tmp_path / "hub")
+    thread = store.create_thread("codex", tmp_path / "workspace")
+
+    first_turn = store.create_turn(thread["managed_thread_id"], prompt="first")
+    assert (
+        store.mark_turn_finished(first_turn["managed_turn_id"], status="error") is True
+    )
+
+    failed_thread = store.get_thread(thread["managed_thread_id"])
+    assert failed_thread is not None
+    assert failed_thread["normalized_status"] == "failed"
+    assert failed_thread["status_reason"] == "managed_turn_failed"
+
+    second_turn = store.create_turn(thread["managed_thread_id"], prompt="retry")
+    running_thread = store.get_thread(thread["managed_thread_id"])
+    assert running_thread is not None
+    assert running_thread["normalized_status"] == "running"
+    assert running_thread["status_reason"] == "turn_started"
+    assert running_thread["status_terminal"] is False
+
+    assert store.mark_turn_finished(second_turn["managed_turn_id"], status="ok") is True
+    recovered_thread = store.get_thread(thread["managed_thread_id"])
+    assert recovered_thread is not None
+    assert recovered_thread["normalized_status"] == "completed"
+    assert recovered_thread["status_reason"] == "managed_turn_completed"
+    assert recovered_thread["status_terminal"] is True
+
+
+def test_archive_then_activate_restores_ready_status(tmp_path: Path) -> None:
+    store = PmaThreadStore(tmp_path / "hub")
+    thread = store.create_thread("codex", tmp_path / "workspace")
+
+    store.archive_thread(thread["managed_thread_id"])
+    store.activate_thread(thread["managed_thread_id"])
+
+    resumed = store.get_thread(thread["managed_thread_id"])
+    assert resumed is not None
+    assert resumed["status"] == "active"
+    assert resumed["lifecycle_status"] == "active"
+    assert resumed["normalized_status"] == "idle"
+    assert resumed["status_reason"] == "thread_resumed"
+    assert resumed["status_terminal"] is False
+
+
+def test_duplicate_completion_event_is_idempotent(tmp_path: Path) -> None:
+    store = PmaThreadStore(tmp_path / "hub")
+    thread = store.create_thread("codex", tmp_path / "workspace")
+    turn = store.create_turn(thread["managed_thread_id"], prompt="hello")
+
+    assert store.mark_turn_finished(turn["managed_turn_id"], status="ok") is True
+    first_thread = store.get_thread(thread["managed_thread_id"])
+    assert first_thread is not None
+    first_changed_at = first_thread["status_changed_at"]
+
+    assert store.mark_turn_finished(turn["managed_turn_id"], status="ok") is False
+    second_thread = store.get_thread(thread["managed_thread_id"])
+    assert second_thread is not None
+    assert second_thread["normalized_status"] == "completed"
+    assert second_thread["status_reason"] == "managed_turn_completed"
+    assert second_thread["status_changed_at"] == first_changed_at
 
 
 def test_schema_creation_is_idempotent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a canonical managed-thread status state machine and persist normalized status context in the PMA thread store
- surface normalized status consistently across PMA API, CLI, hub route consumers, and docs while preserving lifecycle status separately
- add regression coverage for duplicate/out-of-order transitions, paused/resumed flows, and status serialization paths

## Testing
- `.venv/bin/python -m pytest tests/core/test_managed_thread_status.py tests/test_pma_thread_store.py tests/test_pma_managed_threads_routes.py tests/test_pma_managed_threads_lifecycle.py tests/test_pma_managed_threads_tail.py tests/test_pma_context.py tests/test_pma_managed_threads_messages.py tests/test_pma_managed_threads_interrupt.py tests/test_pma_cli.py tests/core/test_chat_bindings.py tests/surfaces/web/test_hub_destination_and_channels.py -q`
- repo pre-commit hook suite: `black`, `ruff`, injected-context lint, command-resolution/import-boundary checks, `mypy`, `eslint`, `pnpm run build`, `pnpm test:markdown`, full `pytest`, dead-code check, optional extended checks

Closes #893
