### PR TITLE
test: move slow smoke and subprocess checks out of fast suite

### DIFF
--- a/tests/browser/test_server_supervisor.py
+++ b/tests/browser/test_server_supervisor.py
@@ -20,6 +20,8 @@ from codex_autorunner.browser.server import (
     supervised_server,
 )
 
+pytestmark = pytest.mark.slow
+
 
 def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:

--- a/tests/surfaces/cli/test_render_cli_end_to_end_fixture.py
+++ b/tests/surfaces/cli/test_render_cli_end_to_end_fixture.py
@@ -18,6 +18,8 @@ from codex_autorunner.browser.runtime import BrowserRunResult
 from codex_autorunner.cli import app
 from codex_autorunner.core import optional_dependencies
 
+pytestmark = pytest.mark.slow
+
 
 def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:

--- a/tests/surfaces/cli/test_render_cli_serve_mode.py
+++ b/tests/surfaces/cli/test_render_cli_serve_mode.py
@@ -29,6 +29,8 @@ from codex_autorunner.browser.runtime import BrowserRunResult
 from codex_autorunner.cli import app
 from codex_autorunner.core import optional_dependencies
 
+pytestmark = pytest.mark.slow
+
 
 def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -249,6 +249,7 @@ def test_hub_api_lists_repos(tmp_path: Path):
     assert data["repos"][0]["effective_destination"] == {"kind": "local"}
 
 
+@pytest.mark.slow
 def test_hub_api_exposes_effective_destination_inherited_from_base(tmp_path: Path):
     hub_root = tmp_path / "hub"
     cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
@@ -287,6 +288,7 @@ def test_hub_api_exposes_effective_destination_inherited_from_base(tmp_path: Pat
     assert worktree_payload["effective_destination"] == expected
 
 
+@pytest.mark.slow
 def test_hub_api_marks_chat_bound_worktrees(tmp_path: Path):
     hub_root = tmp_path / "hub"
     cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
@@ -322,6 +324,7 @@ def test_hub_api_marks_chat_bound_worktrees(tmp_path: Path):
     assert worktree_payload["cleanup_blocked_by_chat_binding"] is False
 
 
+@pytest.mark.slow
 def test_hub_api_marks_chat_bound_worktrees_without_thread_list_cap(
     tmp_path: Path, monkeypatch
 ):
@@ -399,6 +402,7 @@ def test_hub_pin_parent_repo_endpoint_persists(tmp_path: Path):
     assert "demo" not in unpin_resp.json()["pinned_parent_repo_ids"]
 
 
+@pytest.mark.slow
 def test_hub_pin_parent_repo_rejects_worktree(tmp_path: Path):
     hub_root = tmp_path / "hub"
     cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
@@ -1654,6 +1658,7 @@ def test_cleanup_worktree_force_requires_attestation(tmp_path: Path):
     assert worktree.path.exists()
 
 
+@pytest.mark.slow
 def test_hub_api_marks_chat_bound_worktrees_from_discord_binding_db(tmp_path: Path):
     hub_root = tmp_path / "hub"
     cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))

--- a/tests/test_opencode_supervisor_process_management.py
+++ b/tests/test_opencode_supervisor_process_management.py
@@ -18,6 +18,8 @@ from codex_autorunner.agents.opencode.supervisor import (
 from codex_autorunner.core.managed_processes.registry import read_process_record
 from codex_autorunner.workspace import canonical_workspace_root, workspace_id_for_path
 
+pytestmark = pytest.mark.slow
+
 
 def _fake_server_script() -> Path:
     return Path(__file__).resolve().parent / "fixtures" / "fake_opencode_server.py"

--- a/tests/test_selfdescribe_smoke.py
+++ b/tests/test_selfdescribe_smoke.py
@@ -12,10 +12,13 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+import pytest
 from typer.testing import CliRunner
 
 from codex_autorunner.cli import app
 from codex_autorunner.core.report_retention import prune_report_directory
+
+pytestmark = pytest.mark.slow
 
 runner = CliRunner()
 

--- a/tests/test_workspace_functional.py
+++ b/tests/test_workspace_functional.py
@@ -8,6 +8,8 @@ from fastapi.testclient import TestClient
 
 from codex_autorunner.server import create_hub_app
 
+pytestmark = pytest.mark.slow
+
 
 @pytest.fixture
 def client(hub_env):


### PR DESCRIPTION
## Summary
- mark subprocess, smoke, and heavy functional tests as `slow` so they no longer run in the fast CI suite
- mark the heaviest chat-bound worktree hub supervisor cases as `slow` as well
- keep the rest of the fast suite unchanged

## Timing
- before: `.venv/bin/python -m pytest -m 'not integration and not slow' -n auto -q` finished in 74.06s locally
- after: the same command finished in 40.96s locally
- testcase count in the fast suite dropped from 2686 to 2642

## Validation
- pre-commit hook ran `scripts/check.sh` successfully during `git commit`
- reran `.venv/bin/python -m pytest -m 'not integration and not slow' -n auto --junitxml=/tmp/fast-suite-after.xml -q` successfully
