### PR TITLE
Standardize Discord list search fallback

### DIFF
--- a/src/codex_autorunner/integrations/chat/picker_filter.py
+++ b/src/codex_autorunner/integrations/chat/picker_filter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 
 
 def _normalize(value: str) -> str:
@@ -26,6 +27,43 @@ def find_exact_picker_item(
         if normalized_query in candidate_values:
             return value, label
     return None
+
+
+@dataclass(frozen=True)
+class PickerQueryResolution:
+    selected_value: str | None
+    filtered_items: list[tuple[str, str]]
+
+
+def resolve_picker_query(
+    items: Sequence[tuple[str, str]],
+    query: str,
+    *,
+    limit: int,
+    exact_aliases: Mapping[str, Sequence[str]] | None = None,
+    aliases: Mapping[str, Sequence[str]] | None = None,
+) -> PickerQueryResolution:
+    normalized_query = _normalize(query)
+    if not normalized_query:
+        return PickerQueryResolution(selected_value=None, filtered_items=[])
+
+    exact_match = find_exact_picker_item(
+        items,
+        normalized_query,
+        aliases=exact_aliases,
+    )
+    if exact_match is not None:
+        return PickerQueryResolution(selected_value=exact_match[0], filtered_items=[])
+
+    return PickerQueryResolution(
+        selected_value=None,
+        filtered_items=filter_picker_items(
+            items,
+            normalized_query,
+            limit=limit,
+            aliases=aliases,
+        ),
+    )
 
 
 def filter_picker_items(

--- a/src/codex_autorunner/integrations/discord/car_autocomplete.py
+++ b/src/codex_autorunner/integrations/discord/car_autocomplete.py
@@ -105,57 +105,16 @@ def picker_items_to_autocomplete_choices(
 
 def build_bind_autocomplete_choices(service: Any, query: str) -> list[dict[str, str]]:
     candidates = service._list_bind_workspace_candidates()
-    normalized_query = query.strip().lower()
-    scored: list[tuple[int, int, Optional[str], str]] = []
-
-    for index, (repo_id, path) in enumerate(candidates):
-        rid = repo_id.lower() if isinstance(repo_id, str) else ""
-        basename = Path(path).name.lower()
-        pth = path.lower()
-        if (
-            normalized_query
-            and normalized_query not in rid
-            and normalized_query not in basename
-            and normalized_query not in pth
-        ):
-            continue
-
-        score = 0
-        if normalized_query:
-            if rid.startswith(normalized_query):
-                score += 40
-            elif normalized_query in rid:
-                score += 20
-            if basename.startswith(normalized_query):
-                score += 25
-            elif normalized_query in basename:
-                score += 15
-            if pth.startswith(normalized_query):
-                score += 10
-            elif normalized_query in pth:
-                score += 5
-
-        scored.append((score, -index, repo_id, path))
-
-    scored.sort(key=lambda item: (-item[0], -item[1], item[2] or "", item[3]))
-    seen: set[str] = set()
-    choices: list[dict[str, str]] = []
-    for _score, _neg_index, repo_id, path in scored:
-        value = (
-            repo_autocomplete_value(repo_id)
-            if isinstance(repo_id, str) and repo_id
-            else workspace_autocomplete_value(path)
-        )
-        if not value or value in seen:
-            continue
-        seen.add(value)
-        option_name = (
-            f"{repo_id} - {path}" if repo_id else f"{Path(path).name} - {path}"
-        )
-        choices.append({"name": option_name[:100], "value": value})
-        if len(choices) >= DISCORD_SELECT_OPTION_MAX_OPTIONS:
-            break
-    return choices
+    search_items, _exact_aliases, filter_aliases = service._build_bind_search_items(
+        candidates
+    )
+    filtered = filter_picker_items(
+        search_items,
+        query,
+        limit=DISCORD_SELECT_OPTION_MAX_OPTIONS,
+        aliases=filter_aliases,
+    )
+    return picker_items_to_autocomplete_choices(filtered)
 
 
 async def build_model_autocomplete_choices(

--- a/src/codex_autorunner/integrations/discord/components.py
+++ b/src/codex_autorunner/integrations/discord/components.py
@@ -80,21 +80,27 @@ def build_select_option(
 
 
 def build_bind_picker(
-    repos: list[tuple[str, str]],
+    workspaces: list[tuple[str, str] | tuple[str, str, Optional[str]]],
     *,
     custom_id: str = "bind_select",
     placeholder: str = "Select a workspace...",
 ) -> dict[str, Any]:
-    options = [
-        build_select_option(
-            label=repo_id[:100],
-            value=repo_id,
-            description=path[:100] if path else None,
+    options = []
+    for entry in workspaces[:DISCORD_SELECT_OPTION_MAX_OPTIONS]:
+        if len(entry) == 2:
+            value, label = entry
+            description = None
+        else:
+            value, label, description = entry
+        options.append(
+            build_select_option(
+                label=label[:100],
+                value=value,
+                description=description[:100] if description else None,
+            )
         )
-        for repo_id, path in repos[:DISCORD_SELECT_OPTION_MAX_OPTIONS]
-    ]
     if not options:
-        options = [build_select_option("No repos available", "none", default=True)]
+        options = [build_select_option("No workspaces available", "none", default=True)]
     return build_action_row(
         [build_select_menu(custom_id, options, placeholder=placeholder)]
     )

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -105,7 +105,7 @@ from ...integrations.chat.models import (
 )
 from ...integrations.chat.picker_filter import (
     filter_picker_items,
-    find_exact_picker_item,
+    resolve_picker_query,
 )
 from ...integrations.chat.run_mirror import ChatRunMirror
 from ...integrations.chat.turn_policy import (
@@ -145,7 +145,9 @@ from .car_autocomplete import (
     handle_command_autocomplete as handle_car_command_autocomplete,
 )
 from .car_autocomplete import (
+    repo_autocomplete_value,
     resolve_workspace_from_token,
+    workspace_autocomplete_value,
 )
 from .car_command_dispatch import handle_car_command as dispatch_car_command
 from .command_registry import sync_commands
@@ -234,8 +236,6 @@ UPDATE_TARGET_SELECT_ID = "update_target_select"
 REVIEW_COMMIT_SELECT_ID = "review_commit_select"
 MODEL_EFFORT_SELECT_ID = "model_effort_select"
 BIND_PAGE_CUSTOM_ID_PREFIX = "bind_page"
-REPO_AUTOCOMPLETE_TOKEN_PREFIX = "repo@"
-WORKSPACE_AUTOCOMPLETE_TOKEN_PREFIX = "workspace@"
 TICKET_PICKER_TOKEN_PREFIX = "ticket@"
 TICKETS_FILTER_SELECT_ID = "tickets_filter_select"
 TICKETS_SELECT_ID = "tickets_select"
@@ -1789,42 +1789,44 @@ class DiscordBotService:
         items = [(record.id, record.status.value) for record in matching_runs]
         search_items = [(record.id, record.id) for record in matching_runs]
         aliases = {record.id: (record.status.value,) for record in matching_runs}
-        exact_match = find_exact_picker_item(search_items, run_id_value)
-        if exact_match is not None:
-            return exact_match[0]
+        custom_id = f"{FLOW_ACTION_SELECT_PREFIX}:{action}"
 
-        filtered_search_items = filter_picker_items(
-            search_items,
-            run_id_value,
+        async def _prompt_run_matches(
+            query_text: str,
+            filtered_search_items: list[tuple[str, str]],
+        ) -> None:
+            status_by_run_id = {run_id: status for run_id, status in items}
+            filtered_items = [
+                (run_id, status_by_run_id.get(run_id, ""))
+                for run_id, _label in filtered_search_items
+            ]
+            prompt = (
+                f"Matched {len(filtered_items)} runs for `{query_text}`. "
+                f"Select a run to {_flow_action_label(action)}:"
+            )
+            await self._respond_with_components(
+                interaction_id,
+                interaction_token,
+                prompt,
+                [
+                    build_flow_runs_picker(
+                        filtered_items,
+                        custom_id=custom_id,
+                        placeholder=f"Select run to {_flow_action_label(action)}...",
+                    )
+                ],
+            )
+
+        resolved_run_id = await self._resolve_picker_query_or_prompt(
+            query=run_id_value,
+            items=search_items,
             limit=DISCORD_SELECT_OPTION_MAX_OPTIONS,
             aliases=aliases,
+            prompt_filtered_items=_prompt_run_matches,
         )
-        if not filtered_search_items:
-            return run_id_value
-
-        status_by_run_id = {run_id: status for run_id, status in items}
-        filtered_items = [
-            (run_id, status_by_run_id.get(run_id, ""))
-            for run_id, _label in filtered_search_items
-        ]
-        custom_id = f"{FLOW_ACTION_SELECT_PREFIX}:{action}"
-        prompt = (
-            f"Matched {len(filtered_items)} runs for `{run_id_value}`. "
-            f"Select a run to {_flow_action_label(action)}:"
-        )
-        await self._respond_with_components(
-            interaction_id,
-            interaction_token,
-            prompt,
-            [
-                build_flow_runs_picker(
-                    filtered_items,
-                    custom_id=custom_id,
-                    placeholder=f"Select run to {_flow_action_label(action)}...",
-                )
-            ],
-        )
-        return None
+        if resolved_run_id is None:
+            return None
+        return resolved_run_id
 
     async def _run_agent_turn_for_message(
         self,
@@ -2779,6 +2781,85 @@ class DiscordBotService:
 
         return candidates
 
+    @staticmethod
+    def _bind_candidate_value(repo_id: Optional[str], workspace_path: str) -> str:
+        if isinstance(repo_id, str) and repo_id:
+            return repo_autocomplete_value(repo_id)
+        return workspace_autocomplete_value(workspace_path)
+
+    @staticmethod
+    def _bind_candidate_label(repo_id: Optional[str], workspace_path: str) -> str:
+        if isinstance(repo_id, str) and repo_id:
+            return repo_id
+        return Path(workspace_path).name or workspace_path
+
+    def _build_bind_picker_items(
+        self,
+        candidates: list[tuple[Optional[str], str]],
+    ) -> list[tuple[str, str, Optional[str]]]:
+        items: list[tuple[str, str, Optional[str]]] = []
+        for repo_id, workspace_path in candidates:
+            value = self._bind_candidate_value(repo_id, workspace_path)
+            label = self._bind_candidate_label(repo_id, workspace_path)
+            items.append((value, label, workspace_path))
+        return items
+
+    def _build_bind_search_items(
+        self,
+        candidates: list[tuple[Optional[str], str]],
+    ) -> tuple[
+        list[tuple[str, str]],
+        dict[str, tuple[str, ...]],
+        dict[str, tuple[str, ...]],
+    ]:
+        search_items: list[tuple[str, str]] = []
+        exact_aliases: dict[str, tuple[str, ...]] = {}
+        filter_aliases: dict[str, tuple[str, ...]] = {}
+        for repo_id, workspace_path in candidates:
+            value = self._bind_candidate_value(repo_id, workspace_path)
+            label = repo_id if isinstance(repo_id, str) and repo_id else workspace_path
+            search_items.append((value, label))
+            exact_aliases[value] = (workspace_path,)
+            alias_values = [workspace_path]
+            if isinstance(repo_id, str) and repo_id:
+                alias_values.append(repo_id)
+            basename = Path(workspace_path).name
+            if basename:
+                alias_values.append(basename)
+            filter_aliases[value] = tuple(alias_values)
+        return search_items, exact_aliases, filter_aliases
+
+    async def _resolve_picker_query_or_prompt(
+        self,
+        *,
+        query: str,
+        items: list[tuple[str, str]],
+        limit: int,
+        prompt_filtered_items: Callable[
+            [str, list[tuple[str, str]]],
+            Awaitable[None],
+        ],
+        exact_aliases: Optional[dict[str, tuple[str, ...]]] = None,
+        aliases: Optional[dict[str, tuple[str, ...]]] = None,
+    ) -> Optional[str]:
+        normalized_query = query.strip()
+        if not normalized_query:
+            return None
+
+        resolution = resolve_picker_query(
+            items,
+            normalized_query,
+            limit=limit,
+            exact_aliases=exact_aliases,
+            aliases=aliases,
+        )
+        if resolution.selected_value is not None:
+            return resolution.selected_value
+        if resolution.filtered_items:
+            await prompt_filtered_items(normalized_query, resolution.filtered_items)
+            return None
+        return normalized_query
+
     def _build_bind_page_prompt_and_components(
         self,
         repos: list[tuple[str, str]],
@@ -2802,7 +2883,13 @@ class DiscordBotService:
                 "or `/car bind workspace:<path>` for any repo not listed."
             )
 
-        components: list[dict[str, Any]] = [build_bind_picker(page_repos)]
+        components: list[dict[str, Any]] = [
+            build_bind_picker(
+                self._build_bind_picker_items(
+                    [(repo_id, path) for repo_id, path in page_repos]
+                )
+            )
+        ]
         if total_pages > 1:
             components.append(
                 build_action_row(
@@ -3151,15 +3238,66 @@ class DiscordBotService:
         token = raw_path.strip()
         candidates = self._list_bind_workspace_candidates()
         resolved_workspace = self._resolve_workspace_from_token(token, candidates)
-        if resolved_workspace:
-            selected_repo_id, workspace_path = resolved_workspace
-            workspace = canonicalize_path(Path(workspace_path))
-        else:
-            candidate = Path(token)
-            if not candidate.is_absolute():
-                candidate = self._config.root / candidate
-            workspace = canonicalize_path(candidate)
-            selected_repo_id = None
+        if resolved_workspace is None:
+            search_items, exact_aliases, filter_aliases = self._build_bind_search_items(
+                candidates
+            )
+
+            async def _prompt_bind_matches(
+                query_text: str,
+                filtered_items: list[tuple[str, str]],
+            ) -> None:
+                filtered_values = {value for value, _label in filtered_items}
+                filtered_candidates = [
+                    candidate
+                    for candidate in candidates
+                    if self._bind_candidate_value(candidate[0], candidate[1])
+                    in filtered_values
+                ]
+                await self._respond_with_components(
+                    interaction_id,
+                    interaction_token,
+                    (
+                        f"Matched {len(filtered_candidates)} workspaces for `{query_text}`. "
+                        "Select a workspace to bind:"
+                    ),
+                    [
+                        build_bind_picker(
+                            self._build_bind_picker_items(filtered_candidates)
+                        )
+                    ],
+                )
+
+            resolved_value = await self._resolve_picker_query_or_prompt(
+                query=token,
+                items=search_items,
+                limit=DISCORD_SELECT_OPTION_MAX_OPTIONS,
+                exact_aliases=exact_aliases,
+                aliases=filter_aliases,
+                prompt_filtered_items=_prompt_bind_matches,
+            )
+            if resolved_value is None:
+                return
+            resolved_workspace = self._resolve_workspace_from_token(
+                resolved_value,
+                candidates,
+            )
+
+        if resolved_workspace is not None:
+            await self._bind_to_workspace_candidate(
+                interaction_id,
+                interaction_token,
+                channel_id=channel_id,
+                guild_id=guild_id,
+                selected_repo_id=resolved_workspace[0],
+                workspace_path=resolved_workspace[1],
+            )
+            return
+
+        candidate = Path(token)
+        if not candidate.is_absolute():
+            candidate = self._config.root / candidate
+        workspace = canonicalize_path(candidate)
 
         if not workspace.exists() or not workspace.is_dir():
             await self._respond_ephemeral(
@@ -3169,16 +3307,13 @@ class DiscordBotService:
             )
             return
 
-        await self._store.upsert_binding(
-            channel_id=channel_id,
-            guild_id=guild_id,
-            workspace_path=str(workspace),
-            repo_id=selected_repo_id,
-        )
-        await self._respond_ephemeral(
+        await self._bind_to_workspace_candidate(
             interaction_id,
             interaction_token,
-            f"Bound this channel to workspace: {workspace}",
+            channel_id=channel_id,
+            guild_id=guild_id,
+            selected_repo_id=None,
+            workspace_path=str(workspace),
         )
 
     async def _handle_status(
@@ -4356,39 +4491,43 @@ class DiscordBotService:
                 current_thread_id=current_thread_id,
             )
             if thread_items:
-                exact_match = find_exact_picker_item(thread_items, thread_id)
-                if exact_match is not None:
-                    thread_id = exact_match[0]
-                else:
-                    filtered_items = filter_picker_items(
-                        thread_items,
-                        thread_id,
-                        limit=DISCORD_SELECT_OPTION_MAX_OPTIONS,
+
+                async def _prompt_thread_matches(
+                    query_text: str,
+                    filtered_items: list[tuple[str, str]],
+                ) -> None:
+                    header = (
+                        f"Current thread: `{current_thread_id}`\n\n"
+                        if current_thread_id
+                        else ""
                     )
-                    if filtered_items:
-                        header = (
-                            f"Current thread: `{current_thread_id}`\n\n"
-                            if current_thread_id
-                            else ""
-                        )
-                        await self._send_or_respond_ephemeral(
-                            interaction_id=interaction_id,
-                            interaction_token=interaction_token,
-                            deferred=deferred,
-                            text=format_discord_message(
-                                header
-                                + (
-                                    f"Matched {len(filtered_items)} threads for "
-                                    f"`{thread_id}`. Select a thread to resume:"
-                                )
-                            ),
-                        )
-                        await self._send_followup_ephemeral(
-                            interaction_token=interaction_token,
-                            content="Choose one thread from the filtered picker below.",
-                            components=[build_session_threads_picker(filtered_items)],
-                        )
-                        return
+                    await self._send_or_respond_ephemeral(
+                        interaction_id=interaction_id,
+                        interaction_token=interaction_token,
+                        deferred=deferred,
+                        text=format_discord_message(
+                            header
+                            + (
+                                f"Matched {len(filtered_items)} threads for "
+                                f"`{query_text}`. Select a thread to resume:"
+                            )
+                        ),
+                    )
+                    await self._send_followup_ephemeral(
+                        interaction_token=interaction_token,
+                        content="Choose one thread from the filtered picker below.",
+                        components=[build_session_threads_picker(filtered_items)],
+                    )
+
+                resolved_thread_id = await self._resolve_picker_query_or_prompt(
+                    query=thread_id,
+                    items=thread_items,
+                    limit=DISCORD_SELECT_OPTION_MAX_OPTIONS,
+                    prompt_filtered_items=_prompt_thread_matches,
+                )
+                if resolved_thread_id is None:
+                    return
+                thread_id = resolved_thread_id
             orchestrator.set_thread_id(session_key, thread_id)
             mode_label = "PMA" if pma_enabled else "repo"
             text = format_discord_message(
@@ -4906,38 +5045,42 @@ class DiscordBotService:
             available_model_items = None
 
         if available_model_items:
-            exact_match = find_exact_picker_item(available_model_items, model_name)
-            if exact_match is not None:
-                model_name = exact_match[0]
-            else:
-                filtered_items = filter_picker_items(
-                    available_model_items,
-                    model_name,
-                    limit=max(1, DISCORD_SELECT_OPTION_MAX_OPTIONS - 1),
+
+            async def _prompt_model_matches(
+                query_text: str,
+                filtered_items: list[tuple[str, str]],
+            ) -> None:
+                lines = [
+                    f"Current agent: {current_agent}",
+                    f"Current model: {current_model or '(default)'}",
+                    "",
+                    f"Matched {len(filtered_items)} models for `{query_text}`:",
+                    "Select a model override:",
+                    "(default model) clears the override.",
+                ]
+                if isinstance(current_effort, str) and current_effort.strip():
+                    lines.insert(2, f"Reasoning effort: {current_effort}")
+                await self._respond_with_components(
+                    interaction_id,
+                    interaction_token,
+                    format_discord_message("\n".join(lines)),
+                    [
+                        build_model_picker(
+                            filtered_items,
+                            current_model=current_model,
+                        )
+                    ],
                 )
-                if filtered_items:
-                    lines = [
-                        f"Current agent: {current_agent}",
-                        f"Current model: {current_model or '(default)'}",
-                        "",
-                        f"Matched {len(filtered_items)} models for `{model_name}`:",
-                        "Select a model override:",
-                        "(default model) clears the override.",
-                    ]
-                    if isinstance(current_effort, str) and current_effort.strip():
-                        lines.insert(2, f"Reasoning effort: {current_effort}")
-                    await self._respond_with_components(
-                        interaction_id,
-                        interaction_token,
-                        format_discord_message("\n".join(lines)),
-                        [
-                            build_model_picker(
-                                filtered_items,
-                                current_model=current_model,
-                            )
-                        ],
-                    )
-                    return
+
+            resolved_model_name = await self._resolve_picker_query_or_prompt(
+                query=model_name,
+                items=available_model_items,
+                limit=max(1, DISCORD_SELECT_OPTION_MAX_OPTIONS - 1),
+                prompt_filtered_items=_prompt_model_matches,
+            )
+            if resolved_model_name is None:
+                return
+            model_name = resolved_model_name
 
         if current_agent == "opencode" and not _is_valid_opencode_model_name(
             model_name
@@ -7224,7 +7367,7 @@ class DiscordBotService:
                     interaction_token,
                     channel_id=channel_id,
                     guild_id=extract_guild_id(interaction_payload),
-                    selected_repo_id=values[0],
+                    selected_workspace_value=values[0],
                 )
                 return
 
@@ -7573,7 +7716,7 @@ class DiscordBotService:
                     interaction_token,
                     channel_id=channel_id,
                     guild_id=guild_id,
-                    selected_repo_id=values[0],
+                    selected_workspace_value=values[0],
                 )
                 return
 
@@ -7862,34 +8005,16 @@ class DiscordBotService:
                 "An unexpected error occurred. Please try again later.",
             )
 
-    async def _handle_bind_selection(
+    async def _bind_to_workspace_candidate(
         self,
         interaction_id: str,
         interaction_token: str,
         *,
         channel_id: str,
         guild_id: Optional[str],
-        selected_repo_id: str,
+        selected_repo_id: Optional[str],
+        workspace_path: str,
     ) -> None:
-        if selected_repo_id == "none":
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                "No workspace selected.",
-            )
-            return
-
-        repos = self._list_manifest_repos()
-        matching = [(rid, path) for rid, path in repos if rid == selected_repo_id]
-        if not matching:
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                f"Repo not found: {selected_repo_id}",
-            )
-            return
-
-        _, workspace_path = matching[0]
         workspace = canonicalize_path(Path(workspace_path))
         if not workspace.exists() or not workspace.is_dir():
             await self._respond_ephemeral(
@@ -7905,10 +8030,54 @@ class DiscordBotService:
             workspace_path=str(workspace),
             repo_id=selected_repo_id,
         )
+
+        if selected_repo_id:
+            message = f"Bound this channel to: {selected_repo_id} ({workspace})"
+        else:
+            message = f"Bound this channel to workspace: {workspace}"
         await self._respond_ephemeral(
             interaction_id,
             interaction_token,
-            f"Bound this channel to: {selected_repo_id} ({workspace})",
+            message,
+        )
+
+    async def _handle_bind_selection(
+        self,
+        interaction_id: str,
+        interaction_token: str,
+        *,
+        channel_id: str,
+        guild_id: Optional[str],
+        selected_workspace_value: str,
+    ) -> None:
+        if selected_workspace_value == "none":
+            await self._respond_ephemeral(
+                interaction_id,
+                interaction_token,
+                "No workspace selected.",
+            )
+            return
+
+        candidates = self._list_bind_workspace_candidates()
+        resolved_workspace = self._resolve_workspace_from_token(
+            selected_workspace_value,
+            candidates,
+        )
+        if resolved_workspace is None:
+            await self._respond_ephemeral(
+                interaction_id,
+                interaction_token,
+                f"Workspace not found: {selected_workspace_value}",
+            )
+            return
+
+        await self._bind_to_workspace_candidate(
+            interaction_id,
+            interaction_token,
+            channel_id=channel_id,
+            guild_id=guild_id,
+            selected_repo_id=resolved_workspace[0],
+            workspace_path=resolved_workspace[1],
         )
 
     async def _handle_bind_page_component(
@@ -8149,8 +8318,56 @@ class DiscordBotService:
             elif target_lower == "commit" or target_lower.startswith("commit "):
                 sha = target_text[6:].strip()
                 if sha:
-                    target_type = "commit"
-                    target_value = sha
+                    commits = await self._list_recent_commits_for_picker(workspace_root)
+                    commit_subjects = {
+                        commit_sha: subject for commit_sha, subject in commits
+                    }
+                    search_items = [
+                        (commit_sha, commit_sha) for commit_sha, _ in commits
+                    ]
+                    aliases = {
+                        commit_sha: (subject,) if subject else ()
+                        for commit_sha, subject in commits
+                    }
+
+                    async def _prompt_commit_matches(
+                        query_text: str,
+                        filtered_search_items: list[tuple[str, str]],
+                    ) -> None:
+                        filtered_commits = [
+                            (commit_sha, commit_subjects.get(commit_sha, ""))
+                            for commit_sha, _label in filtered_search_items
+                        ]
+                        await self._respond_with_components(
+                            interaction_id,
+                            interaction_token,
+                            (
+                                f"Matched {len(filtered_commits)} commits for `{query_text}`. "
+                                "Select a commit to review:"
+                            ),
+                            [
+                                build_review_commit_picker(
+                                    filtered_commits,
+                                    custom_id=REVIEW_COMMIT_SELECT_ID,
+                                )
+                            ],
+                        )
+
+                    resolved_commit = await self._resolve_picker_query_or_prompt(
+                        query=sha,
+                        items=search_items,
+                        limit=DISCORD_SELECT_OPTION_MAX_OPTIONS,
+                        aliases=aliases,
+                        prompt_filtered_items=_prompt_commit_matches,
+                    )
+                    if resolved_commit is not None:
+                        target_type = "commit"
+                        target_value = resolved_commit
+                    elif commits:
+                        return
+                    else:
+                        target_type = "commit"
+                        target_value = sha
                 else:
                     prompt_commit_picker = True
             elif target_lower in ("uncommitted", ""):

--- a/tests/integrations/chat/test_picker_filter.py
+++ b/tests/integrations/chat/test_picker_filter.py
@@ -1,6 +1,7 @@
 from codex_autorunner.integrations.chat.picker_filter import (
     filter_picker_items,
     find_exact_picker_item,
+    resolve_picker_query,
 )
 
 
@@ -39,3 +40,29 @@ def test_filter_picker_items_supports_multi_token_query() -> None:
         ("run-20260101-a", "alpha"),
         ("run-20260102-b", "beta"),
     ]
+
+
+def test_resolve_picker_query_uses_aliases_for_filter_without_forcing_exact_match() -> (
+    None
+):
+    items = [("run-a", "run-a"), ("run-b", "run-b")]
+    aliases = {"run-a": ("paused",), "run-b": ("paused",)}
+
+    resolution = resolve_picker_query(items, "paused", limit=5, aliases=aliases)
+
+    assert resolution.selected_value is None
+    assert resolution.filtered_items == [("run-a", "run-a"), ("run-b", "run-b")]
+
+
+def test_resolve_picker_query_supports_exact_aliases_separately() -> None:
+    items = [("repo@token", "repo-a")]
+    resolution = resolve_picker_query(
+        items,
+        "/tmp/repo-a",
+        limit=5,
+        exact_aliases={"repo@token": ("/tmp/repo-a",)},
+        aliases={"repo@token": ("/tmp/repo-a", "repo-a", "repo")},
+    )
+
+    assert resolution.selected_value == "repo@token"
+    assert resolution.filtered_items == []

--- a/tests/integrations/discord/test_components.py
+++ b/tests/integrations/discord/test_components.py
@@ -83,6 +83,20 @@ class TestBuildBindPicker:
         assert menu["custom_id"] == "bind_select"
         assert len(menu["options"]) == 2
 
+    def test_builds_picker_with_explicit_bind_entries(self) -> None:
+        picker = build_bind_picker(
+            [
+                ("repo-token", "repo-a", "/path/one"),
+                ("/path/two", "path-two", "/path/two"),
+            ]
+        )
+        menu = picker["components"][0]
+        assert menu["options"][0]["value"] == "repo-token"
+        assert menu["options"][0]["label"] == "repo-a"
+        assert menu["options"][0]["description"] == "/path/one"
+        assert menu["options"][1]["value"] == "/path/two"
+        assert menu["options"][1]["label"] == "path-two"
+
     def test_builds_picker_with_empty_repos(self) -> None:
         picker = build_bind_picker([])
         menu = picker["components"][0]

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -24,6 +24,7 @@ from codex_autorunner.integrations.chat.models import (
 from codex_autorunner.integrations.discord import service as discord_service_module
 from codex_autorunner.integrations.discord.car_autocomplete import (
     repo_autocomplete_value,
+    workspace_autocomplete_value,
 )
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
@@ -247,7 +248,7 @@ def _pma_interaction(*, name: str, user_id: str = "user-1") -> dict[str, Any]:
 
 
 def _bind_select_interaction(
-    *, selected_repo_id: str = "repo-1", user_id: str = "user-1"
+    *, selected_value: str = "repo-1", user_id: str = "user-1"
 ) -> dict[str, Any]:
     return {
         "id": "inter-component-1",
@@ -259,7 +260,7 @@ def _bind_select_interaction(
         "data": {
             "component_type": 3,
             "custom_id": "bind_select",
-            "values": [selected_repo_id],
+            "values": [selected_value],
         },
     }
 
@@ -853,6 +854,103 @@ async def test_service_bind_accepts_repo_alias_when_manifest_repos_share_workspa
 
 
 @pytest.mark.anyio
+async def test_service_bind_partial_workspace_value_returns_filtered_picker(
+    tmp_path: Path,
+) -> None:
+    stablecoin_workspace = tmp_path / "worktrees" / "stablecoin-engine"
+    stablecoin_workspace.mkdir(parents=True)
+    repos = [
+        ("stablecoin-engine", str(stablecoin_workspace)),
+        ("ios-app-template", str(tmp_path / "repos" / "ios-app-template")),
+    ]
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _interaction(
+                name="bind",
+                options=[{"type": 3, "name": "workspace", "value": "engine"}],
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    service._list_manifest_repos = lambda: repos
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 1
+        payload = rest.interaction_responses[0]["payload"]
+        assert payload["type"] == 4
+        content = payload["data"]["content"].lower()
+        assert "matched 1 workspaces" in content
+        menu = payload["data"]["components"][0]["components"][0]
+        option = menu["options"][0]
+        assert option["label"] == "stablecoin-engine"
+        assert option["value"] == "stablecoin-engine"
+        assert option["description"] == str(stablecoin_workspace.resolve())[:100]
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_service_bind_partial_workspace_value_returns_path_candidate_picker(
+    tmp_path: Path,
+) -> None:
+    engine_workspace = tmp_path / "engine-room"
+    engine_workspace.mkdir()
+    misc_workspace = tmp_path / "misc"
+    misc_workspace.mkdir()
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _interaction(
+                name="bind",
+                options=[{"type": 3, "name": "workspace", "value": "engine"}],
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    service._list_bind_workspace_candidates = lambda: [  # type: ignore[assignment]
+        (None, str(engine_workspace.resolve())),
+        (None, str(misc_workspace.resolve())),
+    ]
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 1
+        payload = rest.interaction_responses[0]["payload"]
+        assert payload["type"] == 4
+        content = payload["data"]["content"].lower()
+        assert "matched 1 workspaces" in content
+        menu = payload["data"]["components"][0]["components"][0]
+        option = menu["options"][0]
+        assert option["label"] == "engine-room"
+        assert option["value"] == workspace_autocomplete_value(
+            str(engine_workspace.resolve())
+        )
+        assert option["description"] == str(engine_workspace.resolve())[:100]
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_service_bind_workspace_autocomplete_long_repo_id_uses_token(
     tmp_path: Path,
 ) -> None:
@@ -889,6 +987,85 @@ async def test_service_bind_workspace_autocomplete_long_repo_id_uses_token(
         assert len(choices) == 1
         assert choices[0]["value"].startswith("repo@")
         assert len(choices[0]["value"]) <= 100
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_service_routes_bind_picker_component_interaction_for_path_candidate(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "engine-room"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [_bind_select_interaction(selected_value=str(workspace.resolve()))]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    service._list_bind_workspace_candidates = lambda: [  # type: ignore[assignment]
+        (None, str(workspace.resolve()))
+    ]
+
+    try:
+        await service.run_forever()
+        binding = await store.get_binding(channel_id="channel-1")
+        assert binding is not None
+        assert binding["repo_id"] is None
+        assert binding["workspace_path"] == str(workspace.resolve())
+
+        assert len(rest.interaction_responses) == 1
+        content = rest.interaction_responses[0]["payload"]["data"]["content"].lower()
+        assert "bound this channel to workspace" in content
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_service_routes_bind_picker_component_interaction_for_tokenized_path_candidate(
+    tmp_path: Path,
+) -> None:
+    long_dir = "workspace-" + ("x" * 120)
+    workspace = tmp_path / long_dir
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _bind_select_interaction(
+                selected_value=workspace_autocomplete_value(str(workspace.resolve()))
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    service._list_bind_workspace_candidates = lambda: [  # type: ignore[assignment]
+        (None, str(workspace.resolve()))
+    ]
+
+    try:
+        await service.run_forever()
+        binding = await store.get_binding(channel_id="channel-1")
+        assert binding is not None
+        assert binding["repo_id"] is None
+        assert binding["workspace_path"] == str(workspace.resolve())
     finally:
         await store.close()
 
@@ -1299,7 +1476,7 @@ async def test_service_routes_bind_picker_component_interaction(tmp_path: Path) 
     store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
     await store.initialize()
     rest = _FakeRest()
-    gateway = _FakeGateway([_bind_select_interaction(selected_repo_id="repo-1")])
+    gateway = _FakeGateway([_bind_select_interaction(selected_value="repo-1")])
     service = DiscordBotService(
         _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
         logger=logging.getLogger("test"),
@@ -2887,6 +3064,63 @@ async def test_car_review_commit_without_sha_returns_picker(tmp_path: Path) -> N
         assert components
         menu = components[0]["components"][0]
         assert menu["custom_id"] == "review_commit_select"
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_car_review_partial_commit_value_returns_filtered_picker(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _interaction(
+                name="review",
+                options=[{"type": 3, "name": "target", "value": "commit fix"}],
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    async def _fake_list_recent_commits(
+        *_args: Any, **_kwargs: Any
+    ) -> list[tuple[str, str]]:
+        return [
+            ("abcdef1234567890", "Fix picker"),
+            ("0123456789abcdef", "Fix search fallback"),
+            ("fedcba9876543210", "Refactor tests"),
+        ]
+
+    service._list_recent_commits_for_picker = _fake_list_recent_commits  # type: ignore[assignment]
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 1
+        payload = rest.interaction_responses[0]["payload"]
+        assert payload["type"] == 4
+        content = payload["data"]["content"].lower()
+        assert "matched 2 commits" in content
+        menu = payload["data"]["components"][0]["components"][0]
+        values = [option["value"] for option in menu["options"]]
+        assert values == ["abcdef1234567890", "0123456789abcdef"]
     finally:
         await store.close()
 


### PR DESCRIPTION
## Summary
- standardize Discord list-command search fallback behind shared picker resolution logic
- add bind search fallback so partial workspace input opens a filtered picker instead of falling through to literal path errors
- extend the same shared flow to review commit selection and keep model/session/flow run selection on the same resolver

## Details
- added `resolve_picker_query()` and `PickerQueryResolution` in `integrations/chat/picker_filter.py`
- updated Discord bind autocomplete and bind picker handling to share the same search/index logic, including tokenized workspace path values
- widened the bind picker payload so path candidates and tokenized values can round-trip through component callbacks
- migrated model, session resume, flow run, and review commit partial-input handling onto the shared resolver
- added regression coverage for bind search fallback, tokenized bind component selection, review commit search fallback, picker helper behavior, and bind picker rendering

## Testing
- `.venv/bin/pytest tests/integrations/discord/test_service_routing.py tests/integrations/discord/test_flow_handlers.py tests/integrations/discord/test_components.py tests/integrations/discord/test_commands_payload.py tests/integrations/chat/test_picker_filter.py -q`
- full commit hook suite passed, including `pytest` (`2657 passed, 3 skipped`)
