### PR TITLE
Replace raw hub chat IDs with channel labels

### DIFF
--- a/src/codex_autorunner/static/generated/hub.js
+++ b/src/codex_autorunner/static/generated/hub.js
@@ -1080,6 +1080,9 @@ function channelSourceBadgeClass(channel) {
         return "pma";
     return "unknown";
 }
+function channelSourceBadgeMarkup(channel) {
+    return `<span class="pill pill-small hub-chat-binding-source hub-chat-binding-source-${escapeHtml(channelSourceBadgeClass(channel))}">${escapeHtml(channelSourceBadgeLabel(channel))}</span>`;
+}
 function channelPmaDetails(channel) {
     if (channelSource(channel) !== "pma_thread")
         return "";
@@ -1142,6 +1145,21 @@ function channelMetaSummary(channel, { includeRepo = true } = {}) {
         }
     }
     return parts.join(" · ");
+}
+function channelSummarySubline(channel, { lastActivity = "", additionalCount = 0, } = {}) {
+    const label = channelDisplayLabel(channel);
+    const additionalMarkup = additionalCount > 0
+        ? `<span class="hub-chat-binding-more muted small">+${additionalCount} more</span>`
+        : "";
+    const activityMarkup = lastActivity
+        ? `<span class="muted small">·</span><span class="hub-repo-info-line">${escapeHtml(lastActivity)}</span>`
+        : "";
+    return `<div class="hub-repo-subline hub-chat-binding-summary">
+    ${channelSourceBadgeMarkup(channel)}
+    <span class="hub-chat-binding-label">${escapeHtml(label)}</span>
+    ${additionalMarkup}
+    ${activityMarkup}
+  </div>`;
 }
 function channelSeenAtMs(channel) {
     if (!channel.seen_at)
@@ -1253,7 +1271,23 @@ function renderRepos(repos) {
     const filteredOrphans = hubViewPrefs.flowFilter === "all"
         ? [...orphanWorktrees]
         : orphanWorktrees.filter((repo) => repoMatchesFlowFilter(repo, hubViewPrefs.flowFilter));
-    const queryFilteredOrphans = filteredOrphans.filter((repo) => repoMatchesSearch(repo, searchQuery));
+    const queryFilteredOrphans = filteredOrphans
+        .map((repo) => {
+        const channels = repoChannels.get(repo.id) || [];
+        if (!searchQuery) {
+            return { repo, channels };
+        }
+        const repoMatch = repoMatchesSearch(repo, searchQuery);
+        const channelMatches = channels.filter((channel) => channelMatchesSearch(channel, searchQuery));
+        if (!repoMatch && !channelMatches.length) {
+            return null;
+        }
+        return {
+            repo,
+            channels: repoMatch ? channels : channelMatches,
+        };
+    })
+        .filter((item) => Boolean(item));
     filteredOrphans.sort((a, b) => compareReposForSort(a, b, hubViewPrefs.sortOrder));
     const filteredChatBound = hubViewPrefs.flowFilter === "all"
         ? [...chatBoundWorktrees]
@@ -1275,7 +1309,7 @@ function renderRepos(repos) {
         };
     })
         .filter((item) => Boolean(item));
-    queryFilteredOrphans.sort((a, b) => compareReposForSort(a, b, hubViewPrefs.sortOrder));
+    queryFilteredOrphans.sort((a, b) => compareReposForSort(a.repo, b.repo, hubViewPrefs.sortOrder));
     queryFilteredChatBound.sort((a, b) => compareReposForSort(a.repo, b.repo, hubViewPrefs.sortOrder));
     if (!orderedGroups.length &&
         !queryFilteredOrphans.length &&
@@ -1338,47 +1372,48 @@ function renderRepos(repos) {
             : "";
         const runSummary = formatRunSummary(repo);
         const lastActivity = formatLastActivity(repo);
+        const primaryChannel = inlineChannels[0] || null;
         const infoItems = [];
-        if (runSummary &&
-            runSummary !== "No runs yet" &&
-            runSummary !== "Not initialized") {
-            infoItems.push(runSummary);
-        }
-        if (lastActivity) {
-            infoItems.push(lastActivity);
+        if (!primaryChannel) {
+            if (runSummary &&
+                runSummary !== "No runs yet" &&
+                runSummary !== "Not initialized") {
+                infoItems.push(runSummary);
+            }
+            if (lastActivity) {
+                infoItems.push(lastActivity);
+            }
         }
         if (freshness?.is_stale === true) {
             const staleSummary = freshnessSummary(freshness);
             infoItems.push(staleSummary ? `Snapshot stale · ${staleSummary}` : "Snapshot stale");
         }
-        const infoLine = infoItems.length > 0
-            ? `<span class="hub-repo-info-line">${escapeHtml(infoItems.join(" · "))}</span>`
-            : "";
-        const infoSubline = infoLine
-            ? `<div class="hub-repo-subline">${infoLine}</div>`
-            : "";
-        const inlineChannelRows = inlineChannels
+        const infoSubline = primaryChannel
+            ? channelSummarySubline(primaryChannel, {
+                lastActivity,
+                additionalCount: Math.max(0, inlineChannels.length - 1),
+            })
+            : infoItems.length > 0
+                ? `<div class="hub-repo-subline"><span class="hub-repo-info-line">${escapeHtml(infoItems.join(" · "))}</span></div>`
+                : "";
+        const overflowChannelRows = inlineChannels
+            .slice(1)
             .map((channel) => {
             const label = channelDisplayLabel(channel);
-            const sourceBadge = `<span class="pill pill-small hub-chat-binding-source hub-chat-binding-source-${escapeHtml(channelSourceBadgeClass(channel))}">${escapeHtml(channelSourceBadgeLabel(channel))}</span>`;
-            const key = String(channel.key || "").trim();
-            const keyMarkup = key && key !== label
-                ? `<span class="hub-chat-binding-key">${escapeHtml(key)}</span>`
-                : "";
+            const sourceBadge = channelSourceBadgeMarkup(channel);
             return `
           <div class="hub-chat-binding-row">
             <div class="hub-chat-binding-main">
               ${sourceBadge}
               <span class="hub-chat-binding-label">${escapeHtml(label)}</span>
-              ${keyMarkup}
             </div>
             <div class="hub-chat-binding-meta muted small">${escapeHtml(channelMetaSummary(channel, { includeRepo: false }))}</div>
           </div>
         `;
         })
             .join("");
-        const inlineChannelBlock = inlineChannelRows
-            ? `<div class="hub-chat-binding-block">${inlineChannelRows}</div>`
+        const inlineChannelBlock = overflowChannelRows
+            ? `<div class="hub-chat-binding-block">${overflowChannelRows}</div>`
             : "";
         const setupBadge = (repo.worktree_setup_commands || []).length > 0 && repo.kind === "base"
             ? '<span class="pill pill-small pill-success">setup</span>'
@@ -1444,27 +1479,50 @@ function renderRepos(repos) {
     };
     let renderedRepoRows = 0;
     orderedGroups.forEach((group) => {
-        const baseMatchesQuery = repoMatchesSearch(group.base, searchQuery);
+        const baseChannels = repoChannels.get(group.base.id) || [];
+        const baseRepoMatchesQuery = repoMatchesSearch(group.base, searchQuery);
+        const matchedBaseChannels = searchQuery
+            ? baseChannels.filter((channel) => channelMatchesSearch(channel, searchQuery))
+            : baseChannels;
+        const baseMatchesQuery = !searchQuery || baseRepoMatchesQuery || matchedBaseChannels.length > 0;
         const worktrees = [...group.filteredWorktrees]
-            .filter((repo) => repoMatchesSearch(repo, searchQuery))
-            .sort((a, b) => compareReposForSort(a, b, hubViewPrefs.sortOrder));
+            .map((repo) => {
+            const channels = repoChannels.get(repo.id) || [];
+            if (!searchQuery) {
+                return { repo, channels };
+            }
+            const repoMatch = repoMatchesSearch(repo, searchQuery);
+            const channelMatches = channels.filter((channel) => channelMatchesSearch(channel, searchQuery));
+            if (!repoMatch && !channelMatches.length) {
+                return null;
+            }
+            return {
+                repo,
+                channels: repoMatch ? channels : channelMatches,
+            };
+        })
+            .filter((item) => Boolean(item))
+            .sort((a, b) => compareReposForSort(a.repo, b.repo, hubViewPrefs.sortOrder));
         const hasRepoMatch = !searchQuery || baseMatchesQuery || worktrees.length > 0;
         if (!hasRepoMatch)
             return;
         const repo = group.base;
-        renderRepoCard(repo, { isWorktreeRow: false });
+        renderRepoCard(repo, {
+            isWorktreeRow: false,
+            inlineChannels: baseRepoMatchesQuery ? baseChannels : matchedBaseChannels,
+        });
         renderedRepoRows += 1;
         if (worktrees.length) {
             const list = document.createElement("div");
             list.className = "hub-worktree-list";
-            worktrees.forEach((wt) => {
+            worktrees.forEach(({ repo: wt, channels }) => {
                 const row = document.createElement("div");
                 row.className = "hub-worktree-row";
                 const tmp = document.createElement("div");
                 tmp.className = "hub-worktree-row-inner";
                 list.appendChild(tmp);
                 const beforeCount = repoListEl.children.length;
-                renderRepoCard(wt, { isWorktreeRow: true });
+                renderRepoCard(wt, { isWorktreeRow: true, inlineChannels: channels });
                 const newNode = repoListEl.children[beforeCount];
                 if (newNode) {
                     repoListEl.removeChild(newNode);
@@ -1480,8 +1538,8 @@ function renderRepos(repos) {
         header.className = "hub-worktree-orphans muted small";
         header.textContent = "Orphan worktrees";
         repoListEl.appendChild(header);
-        queryFilteredOrphans.forEach((wt) => {
-            renderRepoCard(wt, { isWorktreeRow: true });
+        queryFilteredOrphans.forEach(({ repo, channels }) => {
+            renderRepoCard(repo, { isWorktreeRow: true, inlineChannels: channels });
             renderedRepoRows += 1;
         });
     }
@@ -2209,4 +2267,7 @@ export function initHub() {
 }
 export const __hubTest = {
     renderRepos,
+    setHubChannelEntries(entries) {
+        hubChannelEntries = Array.isArray(entries) ? [...entries] : [];
+    },
 };

--- a/src/codex_autorunner/static/styles.css
+++ b/src/codex_autorunner/static/styles.css
@@ -1335,6 +1335,11 @@ main {
   min-width: 0;
 }
 
+.hub-chat-binding-summary {
+  flex-wrap: wrap;
+  row-gap: 2px;
+}
+
 .hub-chat-binding-source {
   text-transform: uppercase;
   letter-spacing: 0.03em;
@@ -1382,6 +1387,10 @@ main {
   text-overflow: ellipsis;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+.hub-chat-binding-more {
+  white-space: nowrap;
 }
 
 .hub-chat-binding-meta {

--- a/src/codex_autorunner/static_src/hub.ts
+++ b/src/codex_autorunner/static_src/hub.ts
@@ -1401,6 +1401,12 @@ function channelSourceBadgeClass(channel: HubChannelEntry): string {
   return "unknown";
 }
 
+function channelSourceBadgeMarkup(channel: HubChannelEntry): string {
+  return `<span class="pill pill-small hub-chat-binding-source hub-chat-binding-source-${escapeHtml(
+    channelSourceBadgeClass(channel)
+  )}">${escapeHtml(channelSourceBadgeLabel(channel))}</span>`;
+}
+
 function channelPmaDetails(channel: HubChannelEntry): string {
   if (channelSource(channel) !== "pma_thread") return "";
   const parts: string[] = [];
@@ -1470,6 +1476,31 @@ function channelMetaSummary(
     }
   }
   return parts.join(" · ");
+}
+
+function channelSummarySubline(
+  channel: HubChannelEntry,
+  {
+    lastActivity = "",
+    additionalCount = 0,
+  }: { lastActivity?: string; additionalCount?: number } = {}
+): string {
+  const label = channelDisplayLabel(channel);
+  const additionalMarkup =
+    additionalCount > 0
+      ? `<span class="hub-chat-binding-more muted small">+${additionalCount} more</span>`
+      : "";
+  const activityMarkup = lastActivity
+    ? `<span class="muted small">·</span><span class="hub-repo-info-line">${escapeHtml(
+        lastActivity
+      )}</span>`
+    : "";
+  return `<div class="hub-repo-subline hub-chat-binding-summary">
+    ${channelSourceBadgeMarkup(channel)}
+    <span class="hub-chat-binding-label">${escapeHtml(label)}</span>
+    ${additionalMarkup}
+    ${activityMarkup}
+  </div>`;
 }
 
 function channelSeenAtMs(channel: HubChannelEntry): number {
@@ -1602,9 +1633,27 @@ function renderRepos(repos: HubRepo[]): void {
       : orphanWorktrees.filter((repo) =>
           repoMatchesFlowFilter(repo, hubViewPrefs.flowFilter)
         );
-  const queryFilteredOrphans = filteredOrphans.filter((repo) =>
-    repoMatchesSearch(repo, searchQuery)
-  );
+  const queryFilteredOrphans = filteredOrphans
+    .map((repo) => {
+      const channels = repoChannels.get(repo.id) || [];
+      if (!searchQuery) {
+        return { repo, channels };
+      }
+      const repoMatch = repoMatchesSearch(repo, searchQuery);
+      const channelMatches = channels.filter((channel) =>
+        channelMatchesSearch(channel, searchQuery)
+      );
+      if (!repoMatch && !channelMatches.length) {
+        return null;
+      }
+      return {
+        repo,
+        channels: repoMatch ? channels : channelMatches,
+      };
+    })
+    .filter((item): item is { repo: HubRepo; channels: HubChannelEntry[] } =>
+      Boolean(item)
+    );
   filteredOrphans.sort((a, b) => compareReposForSort(a, b, hubViewPrefs.sortOrder));
   const filteredChatBound =
     hubViewPrefs.flowFilter === "all"
@@ -1633,7 +1682,9 @@ function renderRepos(repos: HubRepo[]): void {
     .filter((item): item is { repo: HubRepo; channels: HubChannelEntry[] } =>
       Boolean(item)
     );
-  queryFilteredOrphans.sort((a, b) => compareReposForSort(a, b, hubViewPrefs.sortOrder));
+  queryFilteredOrphans.sort((a, b) =>
+    compareReposForSort(a.repo, b.repo, hubViewPrefs.sortOrder)
+  );
   queryFilteredChatBound.sort((a, b) =>
     compareReposForSort(a.repo, b.repo, hubViewPrefs.sortOrder)
   );
@@ -1733,47 +1784,44 @@ function renderRepos(repos: HubRepo[]): void {
 
     const runSummary = formatRunSummary(repo);
     const lastActivity = formatLastActivity(repo);
+    const primaryChannel = inlineChannels[0] || null;
     const infoItems: string[] = [];
-    if (
-      runSummary &&
-      runSummary !== "No runs yet" &&
-      runSummary !== "Not initialized"
-    ) {
-      infoItems.push(runSummary);
-    }
-    if (lastActivity) {
-      infoItems.push(lastActivity);
+    if (!primaryChannel) {
+      if (
+        runSummary &&
+        runSummary !== "No runs yet" &&
+        runSummary !== "Not initialized"
+      ) {
+        infoItems.push(runSummary);
+      }
+      if (lastActivity) {
+        infoItems.push(lastActivity);
+      }
     }
     if (freshness?.is_stale === true) {
       const staleSummary = freshnessSummary(freshness);
       infoItems.push(staleSummary ? `Snapshot stale · ${staleSummary}` : "Snapshot stale");
     }
-    const infoLine =
-      infoItems.length > 0
-        ? `<span class="hub-repo-info-line">${escapeHtml(
-            infoItems.join(" · ")
-           )}</span>`
-        : "";
-    const infoSubline = infoLine
-      ? `<div class="hub-repo-subline">${infoLine}</div>`
+    const infoSubline = primaryChannel
+      ? channelSummarySubline(primaryChannel, {
+          lastActivity,
+          additionalCount: Math.max(0, inlineChannels.length - 1),
+        })
+      : infoItems.length > 0
+      ? `<div class="hub-repo-subline"><span class="hub-repo-info-line">${escapeHtml(
+          infoItems.join(" · ")
+        )}</span></div>`
       : "";
-    const inlineChannelRows = inlineChannels
+    const overflowChannelRows = inlineChannels
+      .slice(1)
       .map((channel) => {
         const label = channelDisplayLabel(channel);
-        const sourceBadge = `<span class="pill pill-small hub-chat-binding-source hub-chat-binding-source-${escapeHtml(
-          channelSourceBadgeClass(channel)
-        )}">${escapeHtml(channelSourceBadgeLabel(channel))}</span>`;
-        const key = String(channel.key || "").trim();
-        const keyMarkup =
-          key && key !== label
-            ? `<span class="hub-chat-binding-key">${escapeHtml(key)}</span>`
-            : "";
+        const sourceBadge = channelSourceBadgeMarkup(channel);
         return `
           <div class="hub-chat-binding-row">
             <div class="hub-chat-binding-main">
               ${sourceBadge}
               <span class="hub-chat-binding-label">${escapeHtml(label)}</span>
-              ${keyMarkup}
             </div>
             <div class="hub-chat-binding-meta muted small">${escapeHtml(
               channelMetaSummary(channel, { includeRepo: false })
@@ -1782,8 +1830,8 @@ function renderRepos(repos: HubRepo[]): void {
         `;
       })
       .join("");
-    const inlineChannelBlock = inlineChannelRows
-      ? `<div class="hub-chat-binding-block">${inlineChannelRows}</div>`
+    const inlineChannelBlock = overflowChannelRows
+      ? `<div class="hub-chat-binding-block">${overflowChannelRows}</div>`
       : "";
 
     const setupBadge =
@@ -1867,27 +1915,55 @@ function renderRepos(repos: HubRepo[]): void {
   let renderedRepoRows = 0;
 
   orderedGroups.forEach((group) => {
-    const baseMatchesQuery = repoMatchesSearch(group.base, searchQuery);
+    const baseChannels = repoChannels.get(group.base.id) || [];
+    const baseRepoMatchesQuery = repoMatchesSearch(group.base, searchQuery);
+    const matchedBaseChannels = searchQuery
+      ? baseChannels.filter((channel) => channelMatchesSearch(channel, searchQuery))
+      : baseChannels;
+    const baseMatchesQuery =
+      !searchQuery || baseRepoMatchesQuery || matchedBaseChannels.length > 0;
     const worktrees = [...group.filteredWorktrees]
-      .filter((repo) => repoMatchesSearch(repo, searchQuery))
-      .sort((a, b) => compareReposForSort(a, b, hubViewPrefs.sortOrder));
+      .map((repo) => {
+        const channels = repoChannels.get(repo.id) || [];
+        if (!searchQuery) {
+          return { repo, channels };
+        }
+        const repoMatch = repoMatchesSearch(repo, searchQuery);
+        const channelMatches = channels.filter((channel) =>
+          channelMatchesSearch(channel, searchQuery)
+        );
+        if (!repoMatch && !channelMatches.length) {
+          return null;
+        }
+        return {
+          repo,
+          channels: repoMatch ? channels : channelMatches,
+        };
+      })
+      .filter((item): item is { repo: HubRepo; channels: HubChannelEntry[] } =>
+        Boolean(item)
+      )
+      .sort((a, b) => compareReposForSort(a.repo, b.repo, hubViewPrefs.sortOrder));
     const hasRepoMatch = !searchQuery || baseMatchesQuery || worktrees.length > 0;
     if (!hasRepoMatch) return;
 
     const repo = group.base;
-    renderRepoCard(repo, { isWorktreeRow: false });
+    renderRepoCard(repo, {
+      isWorktreeRow: false,
+      inlineChannels: baseRepoMatchesQuery ? baseChannels : matchedBaseChannels,
+    });
     renderedRepoRows += 1;
     if (worktrees.length) {
       const list = document.createElement("div");
       list.className = "hub-worktree-list";
-      worktrees.forEach((wt) => {
+      worktrees.forEach(({ repo: wt, channels }) => {
         const row = document.createElement("div");
         row.className = "hub-worktree-row";
         const tmp = document.createElement("div");
         tmp.className = "hub-worktree-row-inner";
         list.appendChild(tmp);
         const beforeCount = repoListEl.children.length;
-        renderRepoCard(wt, { isWorktreeRow: true });
+        renderRepoCard(wt, { isWorktreeRow: true, inlineChannels: channels });
         const newNode = repoListEl.children[beforeCount];
         if (newNode) {
           repoListEl.removeChild(newNode);
@@ -1904,8 +1980,8 @@ function renderRepos(repos: HubRepo[]): void {
     header.className = "hub-worktree-orphans muted small";
     header.textContent = "Orphan worktrees";
     repoListEl.appendChild(header);
-    queryFilteredOrphans.forEach((wt) => {
-      renderRepoCard(wt, { isWorktreeRow: true });
+    queryFilteredOrphans.forEach(({ repo, channels }) => {
+      renderRepoCard(repo, { isWorktreeRow: true, inlineChannels: channels });
       renderedRepoRows += 1;
     });
   }
@@ -2700,4 +2776,7 @@ export function initHub(): void {
 
 export const __hubTest = {
   renderRepos,
+  setHubChannelEntries(entries: HubChannelEntry[]): void {
+    hubChannelEntries = Array.isArray(entries) ? [...entries] : [];
+  },
 };

--- a/tests/js/hub_repo_cards.test.js
+++ b/tests/js/hub_repo_cards.test.js
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM(
+  `<!doctype html><html><body>
+    <div id="hub-repo-list"></div>
+    <div id="hub-last-scan"></div>
+    <div id="pma-last-scan"></div>
+    <div id="hub-count-total"></div>
+    <div id="hub-count-running"></div>
+    <div id="hub-count-missing"></div>
+    <div id="hub-usage-meta"></div>
+    <button id="hub-usage-refresh"></button>
+    <div id="hub-version"></div>
+    <div id="pma-version"></div>
+    <input id="hub-repo-search" value="" />
+    <select id="hub-flow-filter"></select>
+    <select id="hub-sort-order"></select>
+  </body></html>`,
+  { url: "http://localhost/hub/" }
+);
+
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Node = dom.window.Node;
+globalThis.Event = dom.window.Event;
+globalThis.CustomEvent = dom.window.CustomEvent;
+globalThis.localStorage = dom.window.localStorage;
+globalThis.sessionStorage = dom.window.sessionStorage;
+try {
+  globalThis.navigator = dom.window.navigator;
+} catch {
+  // Node 24+ exposes a read-only navigator.
+}
+
+const { __hubTest } = await import(
+  "../../src/codex_autorunner/static/generated/hub.js"
+);
+
+test("repo cards show chat binding labels instead of raw chat ids", () => {
+  const lastActiveAt = new Date(Date.now() - 13 * 60 * 1000 - 5000).toISOString();
+  __hubTest.setHubChannelEntries([
+    {
+      key: "discord:ce806ba9-4e19-459a-9e01-2d3d3c6eafd4",
+      repo_id: "stablecoin-engine",
+      source: "discord",
+      display: "Personal Workspace / #car-1",
+      seen_at: lastActiveAt,
+    },
+  ]);
+
+  __hubTest.renderRepos([
+    {
+      id: "stablecoin-engine",
+      path: "/tmp/stablecoin-engine",
+      display_name: "stablecoin-engine",
+      enabled: true,
+      auto_run: false,
+      worktree_setup_commands: [],
+      kind: "base",
+      worktree_of: null,
+      branch: "main",
+      exists_on_disk: true,
+      is_clean: true,
+      initialized: true,
+      init_error: null,
+      status: "running",
+      lock_status: "unlocked",
+      last_run_id: "ce806ba9-4e19-459a-9e01-2d3d3c6eafd4",
+      last_exit_code: null,
+      last_run_started_at: lastActiveAt,
+      last_run_finished_at: lastActiveAt,
+      runner_pid: null,
+      effective_destination: { kind: "local" },
+      mounted: false,
+      mount_error: null,
+      cleanup_blocked_by_chat_binding: false,
+      ticket_flow: null,
+      ticket_flow_display: null,
+    },
+  ]);
+
+  const text = document.getElementById("hub-repo-list")?.textContent || "";
+  assert.match(text, /Discord/);
+  assert.match(text, /Personal Workspace \/ #car-1/);
+  assert.match(text, /13m ago/);
+  assert.doesNotMatch(text, /ce806ba9-4e19-459a-9e01-2d3d3c6eafd4/);
+});


### PR DESCRIPTION
## Summary
- replace raw chat/thread id subtitles on hub repo cards with the existing platform badge plus human channel label
- use the same chat binding summary on root repos so chat-bound repos show server/channel context instead of opaque ids
- add a JS regression test covering the repo-card rendering change

## Testing
- pnpm run build
- pnpm run test:dom
- pnpm run test:markdown
- pytest
