### PR TITLE
Unify CAR archive state handling

### DIFF
--- a/schemas/hub.json
+++ b/schemas/hub.json
@@ -47,6 +47,7 @@
       "telegram_chat_bound_thread_count": {"type": "integer"},
       "non_pma_chat_bound_thread_count": {"type": "integer"},
       "cleanup_blocked_by_chat_binding": {"type": "boolean"},
+      "has_car_state": {"type": "boolean"},
       "mounted": {"type": "boolean"},
       "mount_error": {"type": ["null", "string"]},
       "ticket_flow": {

--- a/src/codex_autorunner/core/archive.py
+++ b/src/codex_autorunner/core/archive.py
@@ -8,11 +8,34 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, Literal, Optional
 
+from ..manifest import load_manifest
+from ..workspace import workspace_id_for_path
 from .git_utils import git_branch, git_head_sha
-from .state import now_iso
+from .state import load_state, now_iso
 from .utils import atomic_write
 
 ArchiveStatus = Literal["complete", "partial", "failed"]
+ArchiveMode = Literal["copy", "move"]
+
+DEFAULT_CONTEXTSPACE_DOCS = frozenset({"active_context.md", "decisions.md", "spec.md"})
+DEFAULT_TICKETS_FILES = frozenset({"AGENTS.md"})
+SQLITE_SIDE_SUFFIXES = ("-wal", "-shm")
+CAR_STATE_PATHS = (
+    "tickets",
+    "contextspace",
+    "runs",
+    "flows",
+    "flows.db",
+    "state.sqlite3",
+    "app_server_threads.json",
+    "app_server_workspaces",
+    "github_context",
+    "filebox",
+    "codex-autorunner.log",
+    "codex-server.log",
+    "lock",
+    "workspace",
+)
 
 
 @dataclass(frozen=True)
@@ -27,6 +50,50 @@ class ArchiveResult:
     latest_flow_run_id: Optional[str]
     missing_paths: tuple[str, ...]
     skipped_symlinks: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ArchivedCarStateResult:
+    snapshot_id: str
+    snapshot_path: Path
+    meta_path: Path
+    status: ArchiveStatus
+    file_count: int
+    total_bytes: int
+    flow_run_count: int
+    latest_flow_run_id: Optional[str]
+    archived_paths: tuple[str, ...]
+    reset_paths: tuple[str, ...]
+    missing_paths: tuple[str, ...]
+    skipped_symlinks: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ArchiveEntrySpec:
+    label: str
+    source: Path
+    dest: Path
+    mode: ArchiveMode = "copy"
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class ArchiveExecutionSummary:
+    file_count: int
+    total_bytes: int
+    copied_paths: tuple[str, ...]
+    moved_paths: tuple[str, ...]
+    missing_paths: tuple[str, ...]
+    skipped_symlinks: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class WorkspaceArchiveTarget:
+    base_repo_root: Path
+    base_repo_id: str
+    workspace_repo_id: str
+    worktree_of: str
+    source_path: Path | str
 
 
 def _snapshot_timestamp() -> str:
@@ -141,6 +208,501 @@ def _copy_entry(
     return False
 
 
+def _remove_source_entry(src: Path) -> None:
+    if src.is_symlink() or src.is_file():
+        src.unlink()
+        return
+    if src.is_dir():
+        shutil.rmtree(src)
+
+
+def _directory_has_any_entries(path: Path) -> bool:
+    if not path.exists() or not path.is_dir():
+        return False
+    try:
+        next(path.iterdir())
+    except StopIteration:
+        return False
+    return True
+
+
+def _tree_has_payload(path: Path) -> bool:
+    if not path.exists() or not path.is_dir():
+        return False
+    for child in path.rglob("*"):
+        if child.is_file() or child.is_symlink():
+            return True
+    return False
+
+
+def _contextspace_is_dirty(path: Path) -> bool:
+    if not path.exists() or not path.is_dir():
+        return False
+    for child in sorted(path.rglob("*")):
+        if child.is_dir():
+            continue
+        rel_path = child.relative_to(path)
+        try:
+            text = child.read_text(encoding="utf-8").strip()
+        except (OSError, UnicodeDecodeError):
+            return True
+        if (
+            len(rel_path.parts) == 1
+            and rel_path.name in DEFAULT_CONTEXTSPACE_DOCS
+            and text == ""
+        ):
+            continue
+        return True
+    return False
+
+
+def _tickets_are_dirty(path: Path) -> bool:
+    if not path.exists() or not path.is_dir():
+        return False
+    for child in sorted(path.rglob("*")):
+        if child.is_dir():
+            continue
+        rel_path = child.relative_to(path)
+        if len(rel_path.parts) == 1 and rel_path.name in DEFAULT_TICKETS_FILES:
+            continue
+        return True
+    return False
+
+
+def _runner_state_is_dirty(path: Path) -> bool:
+    if not path.exists():
+        return False
+    try:
+        state = load_state(path)
+    except Exception:
+        return True
+    if state.status != "idle":
+        return True
+    if state.last_run_id is not None or state.last_exit_code is not None:
+        return True
+    if state.last_run_started_at is not None or state.last_run_finished_at is not None:
+        return True
+    if state.runner_pid is not None:
+        return True
+    if state.sessions or state.repo_to_session:
+        return True
+    override_values = (
+        state.autorunner_agent_override,
+        state.autorunner_model_override,
+        state.autorunner_effort_override,
+        state.autorunner_approval_policy,
+        state.autorunner_sandbox_mode,
+        state.autorunner_workspace_write_network,
+        state.runner_stop_after_runs,
+    )
+    return any(value is not None for value in override_values)
+
+
+def _json_state_file_is_dirty(path: Path) -> bool:
+    if not path.exists() or not path.is_file():
+        return False
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return True
+    if not raw:
+        return False
+    return raw not in {"{}", "[]", "null"}
+
+
+def _log_file_is_dirty(path: Path) -> bool:
+    return path.exists() and path.is_file() and path.stat().st_size > 0
+
+
+def _car_state_path_is_dirty(car_root: Path, rel_path: str) -> bool:
+    path = car_root / rel_path
+    if rel_path == "tickets":
+        return _tickets_are_dirty(path)
+    if rel_path == "contextspace":
+        return _contextspace_is_dirty(path)
+    if rel_path in {"runs", "flows"}:
+        return _directory_has_any_entries(path)
+    if rel_path in {"github_context", "filebox", "app_server_workspaces", "workspace"}:
+        return _tree_has_payload(path)
+    if rel_path == "state.sqlite3":
+        return _runner_state_is_dirty(path)
+    if rel_path == "app_server_threads.json":
+        return _json_state_file_is_dirty(path)
+    if rel_path in {"codex-autorunner.log", "codex-server.log"}:
+        return _log_file_is_dirty(path)
+    if rel_path == "lock":
+        return path.exists()
+    if rel_path == "flows.db":
+        return path.exists()
+    return path.exists()
+
+
+def dirty_car_state_paths(worktree_root: Path) -> tuple[str, ...]:
+    car_root = worktree_root / ".codex-autorunner"
+    if not car_root.exists():
+        return ()
+    return tuple(
+        rel_path
+        for rel_path in CAR_STATE_PATHS
+        if _car_state_path_is_dirty(car_root, rel_path)
+    )
+
+
+def has_car_state(worktree_root: Path) -> bool:
+    return bool(dirty_car_state_paths(worktree_root))
+
+
+def _car_state_archive_entries(
+    source_root: Path,
+    snapshot_root: Path,
+    dirty_paths: Iterable[str],
+) -> list[ArchiveEntrySpec]:
+    entries: list[ArchiveEntrySpec] = []
+    selected = set(dirty_paths)
+    if "tickets" in selected:
+        entries.append(
+            ArchiveEntrySpec(
+                label="tickets",
+                source=source_root / "tickets",
+                dest=snapshot_root / "tickets",
+            )
+        )
+    if "contextspace" in selected:
+        entries.append(
+            ArchiveEntrySpec(
+                label="contextspace",
+                source=_contextspace_source(source_root),
+                dest=snapshot_root / "contextspace",
+            )
+        )
+    if "runs" in selected:
+        entries.append(
+            ArchiveEntrySpec(
+                label="runs",
+                source=source_root / "runs",
+                dest=snapshot_root / "runs",
+            )
+        )
+    if "flows" in selected:
+        entries.append(
+            ArchiveEntrySpec(
+                label="flows",
+                source=source_root / "flows",
+                dest=snapshot_root / "flows",
+            )
+        )
+    if "flows.db" in selected:
+        entries.append(
+            ArchiveEntrySpec(
+                label="flows.db",
+                source=source_root / "flows.db",
+                dest=snapshot_root / "flows.db",
+            )
+        )
+    if "state.sqlite3" in selected:
+        entries.append(
+            ArchiveEntrySpec(
+                label="state.sqlite3",
+                source=source_root / "state.sqlite3",
+                dest=snapshot_root / "state" / "state.sqlite3",
+            )
+        )
+    if "app_server_threads.json" in selected:
+        entries.append(
+            ArchiveEntrySpec(
+                label="app_server_threads.json",
+                source=source_root / "app_server_threads.json",
+                dest=snapshot_root / "state" / "app_server_threads.json",
+            )
+        )
+    if "app_server_workspaces" in selected:
+        entries.append(
+            ArchiveEntrySpec(
+                label="app_server_workspaces",
+                source=source_root / "app_server_workspaces",
+                dest=snapshot_root / "app_server_workspaces",
+            )
+        )
+    if "github_context" in selected:
+        entries.append(
+            ArchiveEntrySpec(
+                label="github_context",
+                source=source_root / "github_context",
+                dest=snapshot_root / "github_context",
+            )
+        )
+    if "filebox" in selected:
+        entries.append(
+            ArchiveEntrySpec(
+                label="filebox",
+                source=source_root / "filebox",
+                dest=snapshot_root / "filebox",
+            )
+        )
+    if "codex-autorunner.log" in selected:
+        entries.append(
+            ArchiveEntrySpec(
+                label="codex-autorunner.log",
+                source=source_root / "codex-autorunner.log",
+                dest=snapshot_root / "logs" / "codex-autorunner.log",
+            )
+        )
+    if "codex-server.log" in selected:
+        entries.append(
+            ArchiveEntrySpec(
+                label="codex-server.log",
+                source=source_root / "codex-server.log",
+                dest=snapshot_root / "logs" / "codex-server.log",
+            )
+        )
+    if "lock" in selected:
+        entries.append(
+            ArchiveEntrySpec(
+                label="lock",
+                source=source_root / "lock",
+                dest=snapshot_root / "state" / "lock",
+            )
+        )
+    if "workspace" in selected:
+        entries.append(
+            ArchiveEntrySpec(
+                label="workspace",
+                source=source_root / "workspace",
+                dest=snapshot_root / "workspace",
+            )
+        )
+    return entries
+
+
+def _remove_with_sidecars(path: Path) -> None:
+    if path.exists() or path.is_symlink():
+        _remove_source_entry(path)
+    if path.name.endswith(".sqlite3") or path.name.endswith(".db"):
+        for suffix in SQLITE_SIDE_SUFFIXES:
+            sidecar = path.with_name(f"{path.name}{suffix}")
+            if sidecar.exists():
+                sidecar.unlink()
+
+
+def _reset_car_state(worktree_root: Path) -> tuple[str, ...]:
+    from ..bootstrap import seed_repo_files
+
+    car_root = worktree_root / ".codex-autorunner"
+    reset_paths: list[str] = []
+    for rel_path in CAR_STATE_PATHS:
+        target = car_root / rel_path
+        if not target.exists() and not target.is_symlink():
+            continue
+        _remove_with_sidecars(target)
+        reset_paths.append(rel_path)
+    seed_repo_files(worktree_root, force=False, git_required=False)
+    return tuple(reset_paths)
+
+
+def resolve_workspace_archive_target(
+    workspace_root: Path,
+    *,
+    hub_root: Optional[Path] = None,
+    manifest_path: Optional[Path] = None,
+) -> WorkspaceArchiveTarget:
+    workspace_root = workspace_root.resolve()
+    resolved_hub_root = hub_root.resolve() if hub_root is not None else None
+    if (
+        manifest_path is not None
+        and resolved_hub_root is not None
+        and manifest_path.exists()
+    ):
+        try:
+            manifest = load_manifest(manifest_path, resolved_hub_root)
+        except Exception:
+            manifest = None
+        if manifest is not None:
+            entry = manifest.get_by_path(resolved_hub_root, workspace_root)
+            if entry is not None:
+                base_repo_root = workspace_root
+                base_repo_id = entry.id
+                worktree_of = entry.worktree_of or entry.id
+                if entry.kind == "worktree" and entry.worktree_of:
+                    base = manifest.get(entry.worktree_of)
+                    if base is not None:
+                        base_repo_root = (resolved_hub_root / base.path).resolve()
+                        base_repo_id = base.id
+                return WorkspaceArchiveTarget(
+                    base_repo_root=base_repo_root,
+                    base_repo_id=base_repo_id,
+                    workspace_repo_id=entry.id,
+                    worktree_of=worktree_of,
+                    source_path=entry.path,
+                )
+    repo_id = workspace_root.name.strip() or workspace_id_for_path(workspace_root)
+    return WorkspaceArchiveTarget(
+        base_repo_root=workspace_root,
+        base_repo_id=repo_id,
+        workspace_repo_id=repo_id,
+        worktree_of=repo_id,
+        source_path=workspace_root,
+    )
+
+
+def _move_entry(
+    src: Path,
+    dest: Path,
+    worktree_root: Path,
+    stats: dict[str, int],
+    *,
+    visited: set[Path],
+    skipped_symlinks: list[str],
+) -> bool:
+    copied = _copy_entry(
+        src,
+        dest,
+        worktree_root,
+        stats,
+        visited=visited,
+        skipped_symlinks=skipped_symlinks,
+    )
+    if copied:
+        _remove_source_entry(src)
+    return copied
+
+
+def _contextspace_source(source_root: Path) -> Path:
+    contextspace = source_root / "contextspace"
+    if contextspace.exists() or contextspace.is_symlink():
+        return contextspace
+    legacy_workspace = source_root / "workspace"
+    if legacy_workspace.exists() or legacy_workspace.is_symlink():
+        return legacy_workspace
+    return contextspace
+
+
+def build_common_car_archive_entries(
+    source_root: Path,
+    dest_root: Path,
+    *,
+    include_contextspace: bool = True,
+    include_flow_store: bool = True,
+    include_repo_state: bool = True,
+    include_logs: bool = True,
+    include_github_context: bool = True,
+) -> list[ArchiveEntrySpec]:
+    entries: list[ArchiveEntrySpec] = []
+    if include_contextspace:
+        entries.append(
+            ArchiveEntrySpec(
+                label="contextspace",
+                source=_contextspace_source(source_root),
+                dest=dest_root / "contextspace",
+            )
+        )
+    if include_flow_store:
+        entries.append(
+            ArchiveEntrySpec(
+                label="flows.db",
+                source=source_root / "flows.db",
+                dest=dest_root / "flows.db",
+            )
+        )
+    if include_repo_state:
+        entries.extend(
+            [
+                ArchiveEntrySpec(
+                    label="config.yml",
+                    source=source_root / "config.yml",
+                    dest=dest_root / "config" / "config.yml",
+                ),
+                ArchiveEntrySpec(
+                    label="state.sqlite3",
+                    source=source_root / "state.sqlite3",
+                    dest=dest_root / "state" / "state.sqlite3",
+                ),
+                ArchiveEntrySpec(
+                    label="app_server_threads.json",
+                    source=source_root / "app_server_threads.json",
+                    dest=dest_root / "state" / "app_server_threads.json",
+                    required=False,
+                ),
+            ]
+        )
+    if include_logs:
+        entries.extend(
+            [
+                ArchiveEntrySpec(
+                    label="codex-autorunner.log",
+                    source=source_root / "codex-autorunner.log",
+                    dest=dest_root / "logs" / "codex-autorunner.log",
+                ),
+                ArchiveEntrySpec(
+                    label="codex-server.log",
+                    source=source_root / "codex-server.log",
+                    dest=dest_root / "logs" / "codex-server.log",
+                ),
+            ]
+        )
+    if include_github_context:
+        entries.append(
+            ArchiveEntrySpec(
+                label="github_context",
+                source=source_root / "github_context",
+                dest=dest_root / "github_context",
+                required=False,
+            )
+        )
+    return entries
+
+
+def execute_archive_entries(
+    entries: Iterable[ArchiveEntrySpec],
+    *,
+    worktree_root: Path,
+) -> ArchiveExecutionSummary:
+    stats = {"file_count": 0, "total_bytes": 0}
+    copied_paths: list[str] = []
+    moved_paths: list[str] = []
+    missing_paths: list[str] = []
+    skipped_symlinks: list[str] = []
+    visited: set[Path] = set()
+
+    for entry in entries:
+        src = entry.source
+        if not src.exists() and not src.is_symlink():
+            if not entry.required:
+                continue
+            missing_paths.append(entry.label)
+            continue
+        if entry.mode == "move":
+            copied = _move_entry(
+                src,
+                entry.dest,
+                worktree_root,
+                stats,
+                visited=visited,
+                skipped_symlinks=skipped_symlinks,
+            )
+            if copied:
+                moved_paths.append(entry.label)
+            continue
+        copied = _copy_entry(
+            src,
+            entry.dest,
+            worktree_root,
+            stats,
+            visited=visited,
+            skipped_symlinks=skipped_symlinks,
+        )
+        if copied:
+            copied_paths.append(entry.label)
+
+    return ArchiveExecutionSummary(
+        file_count=stats["file_count"],
+        total_bytes=stats["total_bytes"],
+        copied_paths=tuple(copied_paths),
+        moved_paths=tuple(moved_paths),
+        missing_paths=tuple(missing_paths),
+        skipped_symlinks=tuple(skipped_symlinks),
+    )
+
+
 def _flow_summary(flows_dir: Path) -> tuple[int, Optional[str]]:
     if not flows_dir.exists() or not flows_dir.is_dir():
         return 0, None
@@ -235,55 +797,38 @@ def archive_worktree_snapshot(
     snapshot_root.mkdir(parents=True, exist_ok=False)
 
     source_root = worktree_repo_root / ".codex-autorunner"
-    curated: list[tuple[Path, Path]] = [
-        (source_root / "workspace", snapshot_root / "workspace"),
-        (source_root / "tickets", snapshot_root / "tickets"),
-        (source_root / "runs", snapshot_root / "runs"),
-        (source_root / "flows", snapshot_root / "flows"),
-        (source_root / "flows.db", snapshot_root / "flows.db"),
-        (source_root / "config.yml", snapshot_root / "config" / "config.yml"),
-        (source_root / "state.sqlite3", snapshot_root / "state" / "state.sqlite3"),
-        (
-            source_root / "codex-autorunner.log",
-            snapshot_root / "logs" / "codex-autorunner.log",
-        ),
-        (
-            source_root / "codex-server.log",
-            snapshot_root / "logs" / "codex-server.log",
-        ),
-    ]
-
-    stats = {"file_count": 0, "total_bytes": 0}
-    copied_paths: list[str] = []
-    missing_paths: list[str] = []
-    skipped_symlinks: list[str] = []
-    visited: set[Path] = set()
     created_at = now_iso()
     meta_path = snapshot_root / "META.json"
     summary: dict[str, object] = {}
+    entries = build_common_car_archive_entries(source_root, snapshot_root)
+    entries.extend(
+        [
+            ArchiveEntrySpec(
+                label="tickets",
+                source=source_root / "tickets",
+                dest=snapshot_root / "tickets",
+            ),
+            ArchiveEntrySpec(
+                label="runs",
+                source=source_root / "runs",
+                dest=snapshot_root / "runs",
+            ),
+            ArchiveEntrySpec(
+                label="flows",
+                source=source_root / "flows",
+                dest=snapshot_root / "flows",
+            ),
+        ]
+    )
 
     try:
-        for src, dest in curated:
-            rel = src.relative_to(source_root)
-            if not src.exists() and not src.is_symlink():
-                missing_paths.append(str(rel))
-                continue
-            copied = _copy_entry(
-                src,
-                dest,
-                worktree_repo_root,
-                stats,
-                visited=visited,
-                skipped_symlinks=skipped_symlinks,
-            )
-            if copied:
-                copied_paths.append(str(rel))
+        execution = execute_archive_entries(entries, worktree_root=worktree_repo_root)
 
         flow_run_count, latest_flow_run_id = _flow_summary(snapshot_root / "flows")
-        status: ArchiveStatus = "complete" if not missing_paths else "partial"
+        status: ArchiveStatus = "complete" if not execution.missing_paths else "partial"
         summary = {
-            "file_count": stats["file_count"],
-            "total_bytes": stats["total_bytes"],
+            "file_count": execution.file_count,
+            "total_bytes": execution.total_bytes,
             "flow_run_count": flow_run_count,
             "latest_flow_run_id": latest_flow_run_id,
         }
@@ -299,17 +844,17 @@ def archive_worktree_snapshot(
             source_path=(
                 Path(source_path) if source_path is not None else worktree_repo_root
             ),
-            copied_paths=copied_paths,
-            missing_paths=missing_paths,
-            skipped_symlinks=skipped_symlinks,
+            copied_paths=execution.copied_paths,
+            missing_paths=execution.missing_paths,
+            skipped_symlinks=execution.skipped_symlinks,
             summary=summary,
             note=note,
         )
         atomic_write(meta_path, json.dumps(meta, indent=2) + "\n")
     except Exception as exc:
         summary = {
-            "file_count": stats["file_count"],
-            "total_bytes": stats["total_bytes"],
+            "file_count": 0,
+            "total_bytes": 0,
             "flow_run_count": 0,
             "latest_flow_run_id": None,
         }
@@ -325,9 +870,9 @@ def archive_worktree_snapshot(
             source_path=(
                 Path(source_path) if source_path is not None else worktree_repo_root
             ),
-            copied_paths=copied_paths,
-            missing_paths=missing_paths,
-            skipped_symlinks=skipped_symlinks,
+            copied_paths=(),
+            missing_paths=(),
+            skipped_symlinks=(),
             summary=summary,
             note=note,
             error=str(exc),
@@ -340,10 +885,126 @@ def archive_worktree_snapshot(
         snapshot_path=snapshot_root,
         meta_path=meta_path,
         status=status,
-        file_count=stats["file_count"],
-        total_bytes=stats["total_bytes"],
+        file_count=execution.file_count,
+        total_bytes=execution.total_bytes,
         flow_run_count=flow_run_count,
         latest_flow_run_id=latest_flow_run_id,
-        missing_paths=tuple(missing_paths),
-        skipped_symlinks=tuple(skipped_symlinks),
+        missing_paths=execution.missing_paths,
+        skipped_symlinks=execution.skipped_symlinks,
+    )
+
+
+def archive_workspace_car_state(
+    *,
+    base_repo_root: Path,
+    base_repo_id: str,
+    worktree_repo_root: Path,
+    worktree_repo_id: str,
+    branch: Optional[str],
+    worktree_of: str,
+    note: Optional[str] = None,
+    snapshot_id: Optional[str] = None,
+    head_sha: Optional[str] = None,
+    source_path: Optional[Path | str] = None,
+) -> ArchivedCarStateResult:
+    base_repo_root = base_repo_root.resolve()
+    worktree_repo_root = worktree_repo_root.resolve()
+    dirty_paths = dirty_car_state_paths(worktree_repo_root)
+    if not dirty_paths:
+        raise ValueError("No CAR state to archive. Workspace is already clean.")
+
+    branch_name = branch or git_branch(worktree_repo_root) or "unknown"
+    resolved_head_sha = head_sha or git_head_sha(worktree_repo_root) or "unknown"
+    snapshot_id = snapshot_id or build_snapshot_id(branch_name, resolved_head_sha)
+    snapshot_root = (
+        base_repo_root
+        / ".codex-autorunner"
+        / "archive"
+        / "worktrees"
+        / worktree_repo_id
+        / snapshot_id
+    )
+    snapshot_root.mkdir(parents=True, exist_ok=False)
+
+    source_root = worktree_repo_root / ".codex-autorunner"
+    created_at = now_iso()
+    meta_path = snapshot_root / "META.json"
+    entries = _car_state_archive_entries(source_root, snapshot_root, dirty_paths)
+
+    try:
+        execution = execute_archive_entries(entries, worktree_root=worktree_repo_root)
+        reset_paths = _reset_car_state(worktree_repo_root)
+        flow_run_count, latest_flow_run_id = _flow_summary(snapshot_root / "flows")
+        status: ArchiveStatus = "complete" if not execution.missing_paths else "partial"
+        execution_summary: dict[str, object] = {
+            "file_count": execution.file_count,
+            "total_bytes": execution.total_bytes,
+            "flow_run_count": flow_run_count,
+            "latest_flow_run_id": latest_flow_run_id,
+            "archived_paths": list(execution.copied_paths),
+            "reset_paths": list(reset_paths),
+        }
+        meta = _build_meta(
+            snapshot_id=snapshot_id,
+            created_at=created_at,
+            status=status,
+            base_repo_id=base_repo_id,
+            worktree_repo_id=worktree_repo_id,
+            worktree_of=worktree_of,
+            branch=branch_name,
+            head_sha=resolved_head_sha,
+            source_path=(
+                Path(source_path) if source_path is not None else worktree_repo_root
+            ),
+            copied_paths=execution.copied_paths,
+            missing_paths=execution.missing_paths,
+            skipped_symlinks=execution.skipped_symlinks,
+            summary=execution_summary,
+            note=note,
+        )
+        atomic_write(meta_path, json.dumps(meta, indent=2) + "\n")
+    except Exception as exc:
+        failed_summary: dict[str, object] = {
+            "file_count": 0,
+            "total_bytes": 0,
+            "flow_run_count": 0,
+            "latest_flow_run_id": None,
+            "archived_paths": [],
+            "reset_paths": [],
+        }
+        meta = _build_meta(
+            snapshot_id=snapshot_id,
+            created_at=created_at,
+            status="failed",
+            base_repo_id=base_repo_id,
+            worktree_repo_id=worktree_repo_id,
+            worktree_of=worktree_of,
+            branch=branch_name,
+            head_sha=resolved_head_sha,
+            source_path=(
+                Path(source_path) if source_path is not None else worktree_repo_root
+            ),
+            copied_paths=(),
+            missing_paths=(),
+            skipped_symlinks=(),
+            summary=failed_summary,
+            note=note,
+            error=str(exc),
+        )
+        atomic_write(meta_path, json.dumps(meta, indent=2) + "\n")
+        raise
+
+    return ArchivedCarStateResult(
+        snapshot_id=snapshot_id,
+        snapshot_path=snapshot_root,
+        meta_path=meta_path,
+        status=status,
+        file_count=execution.file_count,
+        total_bytes=execution.total_bytes,
+        flow_run_count=flow_run_count,
+        latest_flow_run_id=latest_flow_run_id,
+        archived_paths=execution.copied_paths,
+        reset_paths=reset_paths,
+        missing_paths=execution.missing_paths,
+        skipped_symlinks=execution.skipped_symlinks,
     )

--- a/src/codex_autorunner/core/flows/archive_helpers.py
+++ b/src/codex_autorunner/core/flows/archive_helpers.py
@@ -1,17 +1,63 @@
 from __future__ import annotations
 
-import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
 
+from ...tickets.files import list_ticket_paths
 from ...tickets.outbox import resolve_outbox_paths
+from ..archive import (
+    ArchiveEntrySpec,
+    build_common_car_archive_entries,
+    execute_archive_entries,
+)
 from ..config import load_repo_config
-from ..force_attestation import enforce_force_attestation
 from .models import FlowRunStatus
 from .store import FlowStore
 
-logger = logging.getLogger("codex_autorunner.flows.archive_helpers")
+
+def _next_archive_dir(base_dir: Path) -> Path:
+    if not base_dir.exists():
+        return base_dir
+    suffix = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return base_dir.parent / f"{base_dir.name}_{suffix}"
+
+
+def _build_flow_archive_entries(
+    repo_root: Path,
+    *,
+    run_id: str,
+    run_dir: Path,
+) -> tuple[list[ArchiveEntrySpec], dict[str, Any]]:
+    archive_root = repo_root / ".codex-autorunner" / "flows" / run_id
+    target_runs_dir = _next_archive_dir(archive_root / "archived_runs")
+    ticket_paths = list(list_ticket_paths(repo_root / ".codex-autorunner" / "tickets"))
+    entries = build_common_car_archive_entries(
+        repo_root / ".codex-autorunner", archive_root
+    )
+    entries.extend(
+        ArchiveEntrySpec(
+            label=f"archived_tickets/{ticket_path.name}",
+            source=ticket_path,
+            dest=archive_root / "archived_tickets" / ticket_path.name,
+            mode="move",
+        )
+        for ticket_path in ticket_paths
+    )
+    entries.append(
+        ArchiveEntrySpec(
+            label=target_runs_dir.relative_to(archive_root).as_posix(),
+            source=run_dir,
+            dest=target_runs_dir,
+            mode="move",
+        )
+    )
+    summary: dict[str, Any] = {
+        "archive_root": str(archive_root),
+        "archived_runs_dir": str(target_runs_dir),
+        "ticket_count": len(ticket_paths),
+    }
+    return entries, summary
 
 
 def archive_flow_run_artifacts(
@@ -22,12 +68,6 @@ def archive_flow_run_artifacts(
     delete_run: bool,
     force_attestation: Mapping[str, object] | None = None,
 ) -> dict[str, Any]:
-    enforce_force_attestation(
-        force=force,
-        force_attestation=force_attestation,
-        logger=logger,
-        action="archive_flow_run_artifacts",
-    )
     repo_root = repo_root.resolve()
     db_path = repo_root / ".codex-autorunner" / "flows.db"
     if not db_path.exists():
@@ -60,13 +100,9 @@ def archive_flow_run_artifacts(
             run_id=record.id,
         )
         run_dir = run_paths.run_dir
-
-        artifacts_root = repo_root / ".codex-autorunner" / "flows"
-        archive_root = artifacts_root / record.id
-        target_runs_dir = archive_root / "archived_runs"
-        if target_runs_dir.exists():
-            suffix = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-            target_runs_dir = archive_root / f"archived_runs_{suffix}"
+        entries, archive_plan = _build_flow_archive_entries(
+            repo_root, run_id=record.id, run_dir=run_dir
+        )
 
         summary: dict[str, Any] = {
             "repo_root": str(repo_root),
@@ -74,18 +110,29 @@ def archive_flow_run_artifacts(
             "status": record.status.value,
             "run_dir": str(run_dir),
             "run_dir_exists": run_dir.exists() and run_dir.is_dir(),
-            "archive_dir": str(target_runs_dir),
+            "archive_dir": archive_plan["archive_root"],
+            "archived_runs_dir": archive_plan["archived_runs_dir"],
             "delete_run": delete_run,
             "deleted_run": False,
+            "archived_tickets": 0,
             "archived_runs": False,
+            "archived_contextspace": False,
+            "archived_paths": [],
         }
-
-        if run_dir.exists() and run_dir.is_dir():
-            import shutil
-
-            target_runs_dir.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(run_dir), str(target_runs_dir))
-            summary["archived_runs"] = True
+        execution = execute_archive_entries(entries, worktree_root=repo_root)
+        moved_paths = set(execution.moved_paths)
+        copied_paths = set(execution.copied_paths)
+        summary["archived_tickets"] = sum(
+            1 for path in moved_paths if path.startswith("archived_tickets/")
+        )
+        summary["archived_runs"] = "archived_runs" in moved_paths or any(
+            path.startswith("archived_runs_") for path in moved_paths
+        )
+        summary["archived_contextspace"] = "contextspace" in copied_paths
+        summary["archived_paths"] = sorted(
+            list(execution.copied_paths) + list(execution.moved_paths)
+        )
+        summary["missing_paths"] = list(execution.missing_paths)
 
         if delete_run:
             summary["deleted_run"] = bool(store.delete_flow_run(record.id))
@@ -93,4 +140,4 @@ def archive_flow_run_artifacts(
         return summary
 
 
-__all__ = ["archive_flow_run_artifacts"]
+__all__ = ["archive_flow_run_artifacts", "_build_flow_archive_entries"]

--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -23,7 +23,11 @@ from ..manifest import (
     save_manifest,
 )
 from ..tickets.outbox import set_lifecycle_emitter
-from .archive import archive_worktree_snapshot, build_snapshot_id
+from .archive import (
+    archive_workspace_car_state,
+    archive_worktree_snapshot,
+    build_snapshot_id,
+)
 from .chat_bindings import repo_has_active_non_pma_chat_binding
 from .config import HubConfig, RepoConfig, derive_repo_config, load_hub_config
 from .destinations import (
@@ -142,6 +146,7 @@ class RepoSnapshot:
     telegram_chat_bound_thread_count: int = 0
     non_pma_chat_bound_thread_count: int = 0
     cleanup_blocked_by_chat_binding: bool = False
+    has_car_state: bool = False
 
     def to_dict(self, hub_root: Path) -> Dict[str, object]:
         try:
@@ -177,6 +182,7 @@ class RepoSnapshot:
             "telegram_chat_bound_thread_count": self.telegram_chat_bound_thread_count,
             "non_pma_chat_bound_thread_count": self.non_pma_chat_bound_thread_count,
             "cleanup_blocked_by_chat_binding": self.cleanup_blocked_by_chat_binding,
+            "has_car_state": self.has_car_state,
         }
 
 
@@ -1418,6 +1424,55 @@ class HubSupervisor:
             "total_bytes": result.total_bytes,
             "flow_run_count": result.flow_run_count,
             "latest_flow_run_id": result.latest_flow_run_id,
+        }
+
+    def archive_worktree_state(
+        self,
+        *,
+        worktree_repo_id: str,
+        archive_note: Optional[str] = None,
+    ) -> Dict[str, object]:
+        manifest = load_manifest(self.hub_config.manifest_path, self.hub_config.root)
+        entry = manifest.get(worktree_repo_id)
+        if not entry or entry.kind != "worktree":
+            raise ValueError(f"Worktree repo not found: {worktree_repo_id}")
+        if not entry.worktree_of:
+            raise ValueError("Worktree repo is missing worktree_of metadata")
+        base = manifest.get(entry.worktree_of)
+        if not base or base.kind != "base":
+            raise ValueError(f"Base repo not found: {entry.worktree_of}")
+
+        base_path = (self.hub_config.root / base.path).resolve()
+        worktree_path = (self.hub_config.root / entry.path).resolve()
+        if not worktree_path.exists():
+            raise ValueError(f"Worktree path does not exist: {worktree_path}")
+
+        runner = self._ensure_runner(worktree_repo_id, allow_uninitialized=True)
+        if runner:
+            runner.stop()
+
+        branch_name = entry.branch or git_branch(worktree_path) or "unknown"
+        result = archive_workspace_car_state(
+            base_repo_root=base_path,
+            base_repo_id=base.id,
+            worktree_repo_root=worktree_path,
+            worktree_repo_id=worktree_repo_id,
+            branch=branch_name,
+            worktree_of=entry.worktree_of,
+            note=archive_note,
+            source_path=entry.path,
+        )
+        return {
+            "snapshot_id": result.snapshot_id,
+            "snapshot_path": str(result.snapshot_path),
+            "meta_path": str(result.meta_path),
+            "status": result.status,
+            "file_count": result.file_count,
+            "total_bytes": result.total_bytes,
+            "flow_run_count": result.flow_run_count,
+            "latest_flow_run_id": result.latest_flow_run_id,
+            "archived_paths": list(result.archived_paths),
+            "reset_paths": list(result.reset_paths),
         }
 
     def check_repo_removal(self, repo_id: str) -> Dict[str, object]:

--- a/src/codex_autorunner/integrations/chat/command_contract.py
+++ b/src/codex_autorunner/integrations/chat/command_contract.py
@@ -152,6 +152,14 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         telegram_commands=("repos",),
         discord_paths=(("car", "repos"),),
     ),
+    CommandContractEntry(
+        id="car.archive",
+        path=("car", "archive"),
+        requires_bound_workspace=True,
+        status="stable",
+        telegram_commands=("archive",),
+        discord_paths=(("car", "archive"),),
+    ),
     # Commands with cross-surface shape differences (partial parity).
     CommandContractEntry(
         id="car.files.inbox",

--- a/src/codex_autorunner/integrations/discord/car_command_dispatch.py
+++ b/src/codex_autorunner/integrations/discord/car_command_dispatch.py
@@ -237,6 +237,13 @@ async def handle_car_command(
             channel_id=channel_id,
         )
         return
+    if command_path == ("car", "archive"):
+        await service._handle_car_archive(
+            interaction_id,
+            interaction_token,
+            channel_id=channel_id,
+        )
+        return
 
     if command_path[:2] == ("car", "session"):
         if command_path == ("car", "session", "resume"):

--- a/src/codex_autorunner/integrations/discord/commands.py
+++ b/src/codex_autorunner/integrations/discord/commands.py
@@ -271,6 +271,11 @@ def build_application_commands() -> list[dict[str, Any]]:
                     ],
                 },
                 {
+                    "type": SUB_COMMAND,
+                    "name": "archive",
+                    "description": "Archive workspace state for a fresh start",
+                },
+                {
                     "type": SUB_COMMAND_GROUP,
                     "name": "session",
                     "description": "Session management commands",

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -3753,6 +3753,7 @@ class DiscordBotService:
             "/car experimental [action] [feature] - Toggle experimental features",
             "/car rollout - Show current thread rollout path",
             "/car feedback <reason> - Send feedback and logs",
+            "/car archive - Archive workspace state for a fresh start",
             "",
             "**Session Commands:**",
             "/car session resume [thread_id] - Resume a previous chat thread",
@@ -6817,7 +6818,12 @@ class DiscordBotService:
             await self._respond_ephemeral(interaction_id, interaction_token, str(exc))
             return
 
-        outbound_text = f"Archived run {summary['run_id']} (runs_archived={summary['archived_runs']})."
+        outbound_text = (
+            f"Archived run {summary['run_id']} "
+            f"(tickets={summary['archived_tickets']}, "
+            f"runs_archived={summary['archived_runs']}, "
+            f"contextspace={summary['archived_contextspace']})."
+        )
         await self._respond_ephemeral(
             interaction_id,
             interaction_token,
@@ -6832,7 +6838,11 @@ class DiscordBotService:
             text=outbound_text,
             chat_id=channel_id,
             thread_id=guild_id,
-            meta={"archived_runs": summary.get("archived_runs")},
+            meta={
+                "archived_runs": summary.get("archived_runs"),
+                "archived_tickets": summary.get("archived_tickets"),
+                "archived_contextspace": summary.get("archived_contextspace"),
+            },
         )
 
     async def _handle_flow_reply(
@@ -8527,7 +8537,12 @@ class DiscordBotService:
             await self._respond_ephemeral(
                 interaction_id,
                 interaction_token,
-                f"Archived run {summary['run_id']} (runs_archived={summary['archived_runs']}).",
+                (
+                    f"Archived run {summary['run_id']} "
+                    f"(tickets={summary['archived_tickets']}, "
+                    f"runs_archived={summary['archived_runs']}, "
+                    f"contextspace={summary['archived_contextspace']})."
+                ),
             )
         elif action == "restart":
             await self._handle_flow_restart(
@@ -9446,6 +9461,87 @@ class DiscordBotService:
             interaction_id,
             interaction_token,
             message_text,
+        )
+
+    async def _handle_car_archive(
+        self,
+        interaction_id: str,
+        interaction_token: str,
+        *,
+        channel_id: str,
+    ) -> None:
+        from ...core.archive import (
+            archive_workspace_car_state,
+            resolve_workspace_archive_target,
+        )
+
+        workspace_root = await self._require_bound_workspace(
+            interaction_id,
+            interaction_token,
+            channel_id=channel_id,
+        )
+        if workspace_root is None:
+            return
+
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
+
+        try:
+            target = resolve_workspace_archive_target(
+                workspace_root,
+                hub_root=self._config.root,
+                manifest_path=self._manifest_path,
+            )
+            result = await asyncio.to_thread(
+                archive_workspace_car_state,
+                base_repo_root=target.base_repo_root,
+                base_repo_id=target.base_repo_id,
+                worktree_repo_root=workspace_root,
+                worktree_repo_id=target.workspace_repo_id,
+                branch=None,
+                worktree_of=target.worktree_of,
+                note="Discord /car archive",
+                source_path=target.source_path,
+            )
+        except ValueError as exc:
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=str(exc),
+            )
+            return
+        except Exception as exc:
+            log_event(
+                self._logger,
+                logging.WARNING,
+                "discord.archive_state.failed",
+                workspace_root=str(workspace_root),
+                exc=exc,
+            )
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=format_discord_message("Archive failed; check logs for details."),
+            )
+            return
+
+        await self._send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=format_discord_message(
+                "\n".join(
+                    [
+                        f"Archived workspace state to snapshot `{result.snapshot_id}`.",
+                        f"Archived paths: {', '.join(result.archived_paths) or 'none'}",
+                        "The binding remains active for fresh work.",
+                    ]
+                )
+            ),
         )
 
     async def _handle_car_interrupt(

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import shutil
 import subprocess
 import uuid
 from pathlib import Path
 from typing import Callable, Optional
 
 from .....core.config import load_repo_config
-from .....core.flows import FlowController, FlowStore
+from .....core.flows import FlowController, FlowStore, archive_flow_run_artifacts
 from .....core.flows.hub_overview import build_hub_flow_overview_entries
 from .....core.flows.models import FlowRunStatus
 from .....core.flows.reconciler import reconcile_flow_run
@@ -38,7 +37,6 @@ from .....flows.ticket_flow.runtime_helpers import (
 )
 from .....manifest import load_manifest
 from .....tickets.files import list_ticket_paths
-from .....tickets.outbox import resolve_outbox_paths
 from ....chat.run_mirror import ChatRunMirror
 from ....github.service import GitHubError, GitHubService
 from ...adapter import (
@@ -749,32 +747,23 @@ class FlowCommands(SharedHelpers):
                 store.close()
 
             if error is None:
-                _, artifacts_root = _flow_paths(repo_root)
-                archive_dir = artifacts_root / record.id / "archived_tickets"
-                archive_dir.mkdir(parents=True, exist_ok=True)
-                ticket_dir = _ticket_dir(repo_root)
-                for ticket_path in list_ticket_paths(ticket_dir):
-                    dest = archive_dir / ticket_path.name
-                    shutil.move(str(ticket_path), str(dest))
-
-                runs_dir = Path(
-                    record.input_data.get("runs_dir") or ".codex-autorunner/runs"
-                )
-                outbox_paths = resolve_outbox_paths(
-                    workspace_root=repo_root, runs_dir=runs_dir, run_id=record.id
-                )
-                run_dir = outbox_paths.run_dir
-                if run_dir.exists() and run_dir.is_dir():
-                    archived_runs_dir = artifacts_root / record.id / "archived_runs"
-                    shutil.move(str(run_dir), str(archived_runs_dir))
-
-                store = _load_flow_store(repo_root)
                 try:
-                    store.initialize()
-                    store.delete_flow_run(record.id)
-                finally:
-                    store.close()
-                notice = "Archived."
+                    force_archive = record.status in (
+                        FlowRunStatus.STOPPING,
+                        FlowRunStatus.PAUSED,
+                    )
+                    summary = archive_flow_run_artifacts(
+                        repo_root,
+                        run_id=record.id,
+                        force=force_archive,
+                        delete_run=True,
+                    )
+                    notice = (
+                        f"Archived {summary['archived_tickets']} tickets and "
+                        f"{'moved' if summary['archived_runs'] else 'skipped'} run artifacts."
+                    )
+                except ValueError as exc:
+                    error = str(exc)
         else:
             await self._answer_callback(callback, "Unknown action")
             return
@@ -1888,35 +1877,20 @@ You are the first ticket in a new ticket_flow run.
         finally:
             store.close()
 
-        _, artifacts_root = _flow_paths(repo_root)
-        archive_dir = artifacts_root / record.id / "archived_tickets"
-        archive_dir.mkdir(parents=True, exist_ok=True)
-        ticket_dir = _ticket_dir(repo_root)
-        archived_count = 0
-        for ticket_path in list_ticket_paths(ticket_dir):
-            dest = archive_dir / ticket_path.name
-            shutil.move(str(ticket_path), str(dest))
-            archived_count += 1
-
-        runs_dir = Path(record.input_data.get("runs_dir") or ".codex-autorunner/runs")
-        outbox_paths = resolve_outbox_paths(
-            workspace_root=repo_root, runs_dir=runs_dir, run_id=record.id
+        force_archive = record.status in (
+            FlowRunStatus.STOPPING,
+            FlowRunStatus.PAUSED,
         )
-        run_dir = outbox_paths.run_dir
-        if run_dir.exists() and run_dir.is_dir():
-            archived_runs_dir = artifacts_root / record.id / "archived_runs"
-            shutil.move(str(run_dir), str(archived_runs_dir))
-
-        store = _load_flow_store(repo_root)
-        try:
-            store.initialize()
-            store.delete_flow_run(record.id)
-        finally:
-            store.close()
+        summary = archive_flow_run_artifacts(
+            repo_root,
+            run_id=record.id,
+            force=force_archive,
+            delete_run=True,
+        )
 
         await self._send_message(
             message.chat_id,
-            f"Archived run {_code(record.id)} ({archived_count} tickets).",
+            f"Archived run {_code(record.id)} ({summary['archived_tickets']} tickets).",
             thread_id=message.thread_id,
             reply_to=message.message_id,
             parse_mode="Markdown",

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -1522,6 +1522,111 @@ class WorkspaceCommands(SharedHelpers):
             reply_to=message.message_id,
         )
 
+    async def _handle_archive(self, message: TelegramMessage) -> None:
+        from .....core.archive import (
+            archive_workspace_car_state,
+            resolve_workspace_archive_target,
+        )
+
+        key = await self._resolve_topic_key(message.chat_id, message.thread_id)
+        record = await self._router.get_topic(key)
+        if bool(record and record.pma_enabled):
+            await self._send_message(
+                message.chat_id,
+                "/archive is not available in PMA mode. Use /new instead.",
+                thread_id=message.thread_id,
+                reply_to=message.message_id,
+            )
+            return
+        if record is None or not record.workspace_path:
+            await self._send_message(
+                message.chat_id,
+                "Topic not bound. Use /bind <repo_id> or /bind <path>.",
+                thread_id=message.thread_id,
+                reply_to=message.message_id,
+            )
+            return
+
+        workspace_root = self._canonical_workspace_root(record.workspace_path)
+        if workspace_root is None:
+            await self._send_message(
+                message.chat_id,
+                "Workspace unavailable.",
+                thread_id=message.thread_id,
+                reply_to=message.message_id,
+            )
+            return
+
+        manifest_path = (
+            self._hub_root / ".codex-autorunner" / "manifest.yml"
+            if self._hub_root is not None
+            else None
+        )
+        try:
+            target = resolve_workspace_archive_target(
+                workspace_root,
+                hub_root=self._hub_root,
+                manifest_path=manifest_path,
+            )
+            result = await asyncio.to_thread(
+                archive_workspace_car_state,
+                base_repo_root=target.base_repo_root,
+                base_repo_id=target.base_repo_id,
+                worktree_repo_root=workspace_root,
+                worktree_repo_id=target.workspace_repo_id,
+                branch=None,
+                worktree_of=target.worktree_of,
+                note="Telegram /archive",
+                source_path=target.source_path,
+            )
+        except ValueError as exc:
+            await self._send_message(
+                message.chat_id,
+                str(exc),
+                thread_id=message.thread_id,
+                reply_to=message.message_id,
+            )
+            return
+        except Exception as exc:
+            log_event(
+                self._logger,
+                logging.WARNING,
+                "telegram.archive_state.failed",
+                chat_id=message.chat_id,
+                thread_id=message.thread_id,
+                workspace_path=record.workspace_path,
+                exc=exc,
+            )
+            await self._send_message(
+                message.chat_id,
+                "Archive failed; check logs for details.",
+                thread_id=message.thread_id,
+                reply_to=message.message_id,
+            )
+            return
+
+        def apply(topic_record: "TelegramTopicRecord") -> None:
+            topic_record.active_thread_id = None
+            topic_record.thread_ids = []
+            topic_record.thread_summaries = {}
+            topic_record.rollout_path = None
+            topic_record.pending_compact_seed = None
+            topic_record.pending_compact_seed_thread_id = None
+
+        await self._router.update_topic(message.chat_id, message.thread_id, apply)
+        await self._send_message(
+            message.chat_id,
+            "\n".join(
+                [
+                    f"Archived workspace state to snapshot `{result.snapshot_id}`.",
+                    f"Archived paths: {', '.join(result.archived_paths) or 'none'}",
+                    "The binding remains active for fresh work.",
+                ]
+            ),
+            thread_id=message.thread_id,
+            reply_to=message.message_id,
+        )
+
     async def _handle_opencode_resume(
         self,
         message: TelegramMessage,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_spec.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_spec.py
@@ -37,6 +37,11 @@ def build_command_specs(handlers: Any) -> dict[str, CommandSpec]:
             "reset current workspace branch from origin default branch and start a new session",
             lambda message, _args, _runtime: handlers._handle_newt(message),
         ),
+        "archive": CommandSpec(
+            "archive",
+            "archive workspace state for a fresh start",
+            lambda message, _args, _runtime: handlers._handle_archive(message),
+        ),
         "reset": CommandSpec(
             "reset",
             "reset PMA thread state (clear volatile state)",

--- a/src/codex_autorunner/static/generated/archive.js
+++ b/src/codex_autorunner/static/generated/archive.js
@@ -31,9 +31,9 @@ let treeRequestToken = 0;
 let fileRequestToken = 0;
 let artifactRequestToken = 0;
 const SNAPSHOT_QUICK_LINKS = [
-    { label: "Active Context", path: "workspace/active_context.md", kind: "file" },
-    { label: "Decisions", path: "workspace/decisions.md", kind: "file" },
-    { label: "Spec", path: "workspace/spec.md", kind: "file" },
+    { label: "Active Context", path: "contextspace/active_context.md", kind: "file" },
+    { label: "Decisions", path: "contextspace/decisions.md", kind: "file" },
+    { label: "Spec", path: "contextspace/spec.md", kind: "file" },
     { label: "Tickets", path: "tickets", kind: "folder" },
     { label: "Runs", path: "runs", kind: "folder" },
     { label: "Flows", path: "flows", kind: "folder" },
@@ -564,7 +564,7 @@ function renderFileList() {
                 evt.stopPropagation();
                 if (!fileState)
                     return;
-                downloadArchiveFile(fileState.snapshotId, fileState.worktreeRepoId, node.path);
+                downloadFileForState(fileState, node.path);
             });
             actions.appendChild(dlBtn);
         }

--- a/src/codex_autorunner/static/generated/hub.js
+++ b/src/codex_autorunner/static/generated/hub.js
@@ -729,6 +729,14 @@ function buildActions(repo) {
     }
     if (!missing && kind === "worktree") {
         const cleanupBlockedByChatBinding = isCleanupBlockedByChatBinding(repo);
+        if (repo.has_car_state) {
+            actions.push({
+                key: "archive_state",
+                label: "Archive state",
+                kind: "ghost",
+                title: "Archive CAR runtime state and reset the worktree for fresh work",
+            });
+        }
         actions.push({
             key: "cleanup_worktree",
             label: "Cleanup",
@@ -2057,6 +2065,22 @@ async function handleRepoAction(repoId, action) {
                 startedMessage: "Worktree cleanup queued",
             });
             flash(`Removed worktree: ${repoId}`, "success");
+            await refreshHub();
+            return;
+        }
+        if (action === "archive_state") {
+            const repo = hubData.repos.find((item) => item.id === repoId);
+            if (!repo || !repo.has_car_state)
+                return;
+            const displayName = repo.display_name || repoId;
+            const ok = await confirmModal(`Archive worktree state "${displayName}"?\n\nCAR will archive tickets, dispatches, contextspace, and other dirty runtime state for later viewing in the Archive tab. The worktree and chat bindings will remain active for fresh work.`, { confirmText: "Archive state" });
+            if (!ok)
+                return;
+            await api("/hub/worktrees/archive-state", {
+                method: "POST",
+                body: { worktree_repo_id: repoId, archive_note: null },
+            });
+            flash(`Archived state for worktree: ${repoId}`, "success");
             await refreshHub();
             return;
         }

--- a/src/codex_autorunner/static_src/archive.ts
+++ b/src/codex_autorunner/static_src/archive.ts
@@ -80,9 +80,9 @@ let fileRequestToken = 0;
 let artifactRequestToken = 0;
 
 const SNAPSHOT_QUICK_LINKS: Array<{ label: string; path: string; kind: "file" | "folder" }> = [
-  { label: "Active Context", path: "workspace/active_context.md", kind: "file" },
-  { label: "Decisions", path: "workspace/decisions.md", kind: "file" },
-  { label: "Spec", path: "workspace/spec.md", kind: "file" },
+  { label: "Active Context", path: "contextspace/active_context.md", kind: "file" },
+  { label: "Decisions", path: "contextspace/decisions.md", kind: "file" },
+  { label: "Spec", path: "contextspace/spec.md", kind: "file" },
   { label: "Tickets", path: "tickets", kind: "folder" },
   { label: "Runs", path: "runs", kind: "folder" },
   { label: "Flows", path: "flows", kind: "folder" },
@@ -650,7 +650,7 @@ function renderFileList(): void {
       dlBtn.addEventListener("click", (evt) => {
         evt.stopPropagation();
         if (!fileState) return;
-        downloadArchiveFile(fileState.snapshotId, fileState.worktreeRepoId, node.path);
+        downloadFileForState(fileState, node.path);
       });
       actions.appendChild(dlBtn);
     }

--- a/src/codex_autorunner/static_src/hub.ts
+++ b/src/codex_autorunner/static_src/hub.ts
@@ -73,6 +73,7 @@ interface HubRepo {
   telegram_chat_bound_thread_count?: number | null;
   non_pma_chat_bound_thread_count?: number | null;
   cleanup_blocked_by_chat_binding?: boolean;
+  has_car_state?: boolean;
   ticket_flow?: HubTicketFlow | null;
   ticket_flow_display?: HubTicketFlowDisplay | null;
 }
@@ -1012,6 +1013,14 @@ function buildActions(repo: HubRepo): RepoAction[] {
   }
   if (!missing && kind === "worktree") {
     const cleanupBlockedByChatBinding = isCleanupBlockedByChatBinding(repo);
+    if (repo.has_car_state) {
+      actions.push({
+        key: "archive_state",
+        label: "Archive state",
+        kind: "ghost",
+        title: "Archive CAR runtime state and reset the worktree for fresh work",
+      });
+    }
     actions.push({
       key: "cleanup_worktree",
       label: "Cleanup",
@@ -2562,6 +2571,23 @@ async function handleRepoAction(repoId: string, action: string): Promise<void> {
         startedMessage: "Worktree cleanup queued",
       });
       flash(`Removed worktree: ${repoId}`, "success");
+      await refreshHub();
+      return;
+    }
+    if (action === "archive_state") {
+      const repo = hubData.repos.find((item) => item.id === repoId);
+      if (!repo || !repo.has_car_state) return;
+      const displayName = repo.display_name || repoId;
+      const ok = await confirmModal(
+        `Archive worktree state "${displayName}"?\n\nCAR will archive tickets, dispatches, contextspace, and other dirty runtime state for later viewing in the Archive tab. The worktree and chat bindings will remain active for fresh work.`,
+        { confirmText: "Archive state" }
+      );
+      if (!ok) return;
+      await api("/hub/worktrees/archive-state", {
+        method: "POST",
+        body: { worktree_repo_id: repoId, archive_note: null },
+      });
+      flash(`Archived state for worktree: ${repoId}`, "success");
       await refreshHub();
       return;
     }

--- a/src/codex_autorunner/surfaces/cli/commands/flow.py
+++ b/src/codex_autorunner/surfaces/cli/commands/flow.py
@@ -26,7 +26,10 @@ from ....core.flows.worker_process import (
     write_worker_crash_info,
     write_worker_exit_info,
 )
-from ....core.force_attestation import FORCE_ATTESTATION_REQUIRED_PHRASE
+from ....core.force_attestation import (
+    FORCE_ATTESTATION_REQUIRED_PHRASE,
+    validate_force_attestation,
+)
 from ....core.managed_processes import reap_managed_processes
 from ....core.runtime import RuntimeContext
 from ....core.utils import resolve_executable
@@ -1093,6 +1096,7 @@ You are the first ticket in a new ticket_flow run.
                         force_attestation,
                         target_scope=f"flow.ticket_flow.archive:{run_id_str}",
                     )
+                    validate_force_attestation(force_attestation_payload)
                     archive_kwargs["force_attestation"] = force_attestation_payload
                 summary = archive_flow_run_artifacts(**archive_kwargs)
             except ValueError as exc:
@@ -1105,7 +1109,9 @@ You are the first ticket in a new ticket_flow run.
             return
         typer.echo(
             f"Archived run {summary.get('run_id')} status={summary.get('status')} "
+            f"archived_tickets={summary.get('archived_tickets')} "
             f"archived_runs={summary.get('archived_runs')} "
+            f"archived_contextspace={summary.get('archived_contextspace')} "
             f"deleted_run={summary.get('deleted_run')} dry_run={dry_run}"
         )
 

--- a/src/codex_autorunner/surfaces/cli/commands/hub_runs.py
+++ b/src/codex_autorunner/surfaces/cli/commands/hub_runs.py
@@ -12,6 +12,9 @@ import typer
 from ....core.config import HubConfig, load_repo_config
 from ....core.flows import FlowStore
 from ....core.flows.archive_helpers import (
+    _build_flow_archive_entries,
+)
+from ....core.flows.archive_helpers import (
     archive_flow_run_artifacts as _archive_flow_run_artifacts_core,
 )
 from ....core.flows.models import FlowRunRecord, FlowRunStatus
@@ -152,15 +155,16 @@ def _archive_flow_run_artifacts(
             "Can only archive completed/stopped/failed runs (use --force for paused/stopping)."
         )
 
-    artifacts_root = repo_root / ".codex-autorunner" / "flows"
     run_paths = _resolve_run_paths(record, repo_root)
     run_dir = run_paths.run_dir
-    archive_root = artifacts_root / record.id
-    archived_runs_dir = archive_root / "archived_runs"
-    target_runs_dir = archived_runs_dir
-    if target_runs_dir.exists():
-        suffix = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-        target_runs_dir = archive_root / f"archived_runs_{suffix}"
+    entries, archive_plan = _build_flow_archive_entries(
+        repo_root, run_id=record.id, run_dir=run_dir
+    )
+    moved_ticket_count = sum(
+        1
+        for entry in entries
+        if entry.mode == "move" and entry.label.startswith("archived_tickets/")
+    )
 
     summary = {
         "repo_root": str(repo_root),
@@ -168,10 +172,14 @@ def _archive_flow_run_artifacts(
         "status": record.status.value,
         "run_dir": str(run_dir),
         "run_dir_exists": run_dir.exists() and run_dir.is_dir(),
-        "archive_dir": str(target_runs_dir),
+        "archive_dir": archive_plan["archive_root"],
+        "archived_runs_dir": archive_plan["archived_runs_dir"],
         "delete_run": delete_run,
         "deleted_run": False,
+        "archived_tickets": moved_ticket_count,
         "archived_runs": False,
+        "archived_contextspace": False,
+        "archived_paths": [entry.label for entry in entries],
     }
 
     if dry_run:
@@ -179,6 +187,7 @@ def _archive_flow_run_artifacts(
 
     import shutil
 
+    target_runs_dir = Path(str(archive_plan["archived_runs_dir"]))
     if run_dir.exists() and run_dir.is_dir():
         target_runs_dir.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(run_dir), str(target_runs_dir))

--- a/src/codex_autorunner/surfaces/web/routes/archive.py
+++ b/src/codex_autorunner/surfaces/web/routes/archive.py
@@ -35,6 +35,18 @@ def _local_flows_root(repo_root: Path) -> Path:
     return repo_root / ".codex-autorunner" / "flows"
 
 
+_LOCAL_ARCHIVE_MARKERS = {
+    "archived_tickets",
+    "archived_runs",
+    "contextspace",
+    "config",
+    "state",
+    "logs",
+    "flows.db",
+    "github_context",
+}
+
+
 def _normalize_component(value: str, label: str) -> str:
     cleaned = (value or "").strip()
     if not cleaned:
@@ -75,16 +87,8 @@ def _normalize_archive_rel_path(base: Path, rel_path: str) -> tuple[Path, str]:
     return candidate, rel_posix
 
 
-_LOCAL_ARCHIVE_DIRS = {"archived_tickets", "archived_runs"}
-
-
 def _normalize_local_archive_rel_path(base: Path, rel_path: str) -> tuple[Path, str]:
-    target, rel_posix = _normalize_archive_rel_path(base, rel_path)
-    if rel_posix:
-        head = rel_posix.split("/", 1)[0]
-        if head not in _LOCAL_ARCHIVE_DIRS:
-            raise ValueError("invalid archive path")
-    return target, rel_posix
+    return _normalize_archive_rel_path(base, rel_path)
 
 
 def _resolve_snapshot_root(
@@ -240,11 +244,18 @@ def _iter_local_run_archives(repo_root: Path) -> list[LocalRunArchiveSummary]:
         runs_dir = run_dir / "archived_runs"
         has_tickets = tickets_dir.exists() and tickets_dir.is_dir()
         has_runs = runs_dir.exists() and runs_dir.is_dir()
-        if not has_tickets and not has_runs:
+        other_children = [
+            child
+            for child in run_dir.iterdir()
+            if child.name
+            in (_LOCAL_ARCHIVE_MARKERS - {"archived_tickets", "archived_runs"})
+        ]
+        if not has_tickets and not has_runs and not other_children:
             continue
         mtime_candidates = [
             _safe_mtime(tickets_dir) if has_tickets else None,
             _safe_mtime(runs_dir) if has_runs else None,
+            *[_safe_mtime(child) for child in other_children],
         ]
         mtime = max([ts for ts in mtime_candidates if ts is not None], default=0.0)
         summary = LocalRunArchiveSummary(
@@ -313,16 +324,29 @@ def _list_local_tree(run_root: Path, rel_path: str) -> ArchiveTreeResponse:
     target, rel_posix = _normalize_local_archive_rel_path(run_root, rel_path)
     if not rel_posix:
         nodes: list[ArchiveTreeNode] = []
-        for name in sorted(_LOCAL_ARCHIVE_DIRS):
-            candidate = run_root / name
-            if not candidate.exists() or not candidate.is_dir():
+        for candidate in sorted(run_root.iterdir(), key=lambda p: p.name):
+            if candidate.name == "META.json":
                 continue
+            try:
+                resolved = candidate.resolve(strict=False)
+                resolved.relative_to(run_root.resolve(strict=False))
+            except Exception:
+                continue
+            if candidate.is_dir():
+                node_type: Literal["file", "folder"] = "folder"
+                size_bytes: Optional[int] = None
+            else:
+                node_type = "file"
+                try:
+                    size_bytes = candidate.stat().st_size
+                except OSError:
+                    size_bytes = None
             nodes.append(
                 ArchiveTreeNode(
-                    path=name,
-                    name=name,
-                    type="folder",
-                    size_bytes=None,
+                    path=candidate.name,
+                    name=candidate.name,
+                    type=node_type,
+                    size_bytes=size_bytes,
                     mtime=_safe_mtime(candidate),
                 )
             )

--- a/src/codex_autorunner/surfaces/web/routes/flows.py
+++ b/src/codex_autorunner/surfaces/web/routes/flows.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import re
-import shutil
 import sqlite3
 import subprocess
 import uuid
@@ -24,6 +23,7 @@ from ....core.flows import (
     FlowRunRecord,
     FlowRunStatus,
     FlowStore,
+    archive_flow_run_artifacts,
 )
 from ....core.flows.reconciler import reconcile_flow_run
 from ....core.flows.start_policy import (
@@ -1441,36 +1441,23 @@ You are the first ticket in a new ticket_flow run.
                     detail="Can only archive completed/stopped/failed flows (use force=true for stuck flows)",
                 )
 
-        # Move tickets to run artifacts directory
-        _, artifacts_root = _flow_paths(repo_root)
-        archive_dir = artifacts_root / run_id / "archived_tickets"
-        archive_dir.mkdir(parents=True, exist_ok=True)
-
-        ticket_dir = repo_root / ".codex-autorunner" / "tickets"
-        archived_count = 0
-        for ticket_path in list_ticket_paths(ticket_dir):
-            dest = archive_dir / ticket_path.name
-            shutil.move(str(ticket_path), str(dest))
-            archived_count += 1
-
-        # Archive runs directory (dispatch_history, reply_history, etc.) to dismiss notifications
-        outbox_paths = _resolve_outbox_for_record(record, repo_root)
-        run_dir = outbox_paths.run_dir
-        if run_dir.exists() and run_dir.is_dir():
-            archived_runs_dir = artifacts_root / run_id / "archived_runs"
-            shutil.move(str(run_dir), str(archived_runs_dir))
-
-        # Delete run record if requested
-        if delete_run:
-            store = _require_flow_store(repo_root)
-            if store:
-                store.delete_flow_run(run_id)
-                store.close()
+        try:
+            summary = archive_flow_run_artifacts(
+                repo_root,
+                run_id=run_id,
+                force=force,
+                delete_run=delete_run,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
         return {
             "status": "archived",
             "run_id": run_id,
-            "tickets_archived": archived_count,
+            "tickets_archived": summary["archived_tickets"],
+            "archived_runs": summary["archived_runs"],
+            "archived_contextspace": summary["archived_contextspace"],
+            "missing_paths": summary.get("missing_paths", []),
         }
 
     @router.get("/{run_id}/status", response_model=FlowStatusResponse)

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/services.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/services.py
@@ -18,6 +18,7 @@ class HubRepoEnricher:
         chat_binding_counts: Optional[dict[str, int]] = None,
         chat_binding_counts_by_source: Optional[dict[str, dict[str, int]]] = None,
     ) -> dict:
+        from .....core.archive import has_car_state
         from .....core.freshness import resolve_stale_threshold_seconds
         from .....core.pma_context import (
             get_latest_ticket_flow_run_state_with_record,
@@ -50,6 +51,11 @@ class HubRepoEnricher:
         repo_dict["telegram_chat_bound_thread_count"] = telegram_binding_count
         repo_dict["non_pma_chat_bound_thread_count"] = non_pma_binding_count
         repo_dict["cleanup_blocked_by_chat_binding"] = non_pma_binding_count > 0
+        repo_dict["has_car_state"] = (
+            has_car_state(self._context.config.root / snapshot.path)
+            if snapshot.exists_on_disk
+            else False
+        )
         if snapshot.initialized and snapshot.exists_on_disk:
             ticket_flow = build_ticket_flow_summary(snapshot.path, include_failure=True)
             repo_dict["ticket_flow"] = ticket_flow

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/worktrees.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/worktrees.py
@@ -183,3 +183,25 @@ class HubWorktreeService:
         except Exception as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         return result
+
+    async def archive_worktree_state(
+        self,
+        worktree_repo_id: str,
+        archive_note: Optional[str],
+    ) -> dict:
+        from .....core.logging_utils import safe_log
+
+        safe_log(
+            self._context.logger,
+            logging.INFO,
+            "Hub archive worktree state id=%s" % (worktree_repo_id,),
+        )
+        try:
+            result = await asyncio.to_thread(
+                self._context.supervisor.archive_worktree_state,
+                worktree_repo_id=str(worktree_repo_id),
+                archive_note=archive_note,
+            )
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return result

--- a/src/codex_autorunner/surfaces/web/routes/hub_repos.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repos.py
@@ -41,6 +41,7 @@ from ..app_state import HubAppContext
 from ..schemas import (
     HubArchiveWorktreeRequest,
     HubArchiveWorktreeResponse,
+    HubArchiveWorktreeStateResponse,
     HubCleanupWorktreeRequest,
     HubCreateWorktreeRequest,
     HubDestinationSetRequest,
@@ -1098,6 +1099,16 @@ def build_hub_repo_routes(
     @router.post("/hub/worktrees/archive", response_model=HubArchiveWorktreeResponse)
     async def archive_worktree(payload: HubArchiveWorktreeRequest):
         return await worktree.archive_worktree(
+            worktree_repo_id=payload.worktree_repo_id,
+            archive_note=payload.archive_note,
+        )
+
+    @router.post(
+        "/hub/worktrees/archive-state",
+        response_model=HubArchiveWorktreeStateResponse,
+    )
+    async def archive_worktree_state(payload: HubArchiveWorktreeRequest):
+        return await worktree.archive_worktree_state(
             worktree_repo_id=payload.worktree_repo_id,
             archive_note=payload.archive_note,
         )

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -207,6 +207,19 @@ class HubArchiveWorktreeResponse(ResponseModel):
     latest_flow_run_id: Optional[str]
 
 
+class HubArchiveWorktreeStateResponse(ResponseModel):
+    snapshot_id: str
+    snapshot_path: str
+    meta_path: str
+    status: str
+    file_count: int
+    total_bytes: int
+    flow_run_count: int
+    latest_flow_run_id: Optional[str]
+    archived_paths: list[str]
+    reset_paths: list[str]
+
+
 class AppServerThreadResetRequest(Payload):
     key: str = Field(
         validation_alias=AliasChoices("key", "feature", "feature_key", "featureKey")

--- a/tests/integrations/discord/test_commands_payload.py
+++ b/tests/integrations/discord/test_commands_payload.py
@@ -43,6 +43,7 @@ def test_build_application_commands_structure_is_stable() -> None:
         "experimental",
         "rollout",
         "feedback",
+        "archive",
         "session",
         "files",
         "flow",

--- a/tests/js/hub_repo_cards.test.js
+++ b/tests/js/hub_repo_cards.test.js
@@ -88,3 +88,42 @@ test("repo cards show chat binding labels instead of raw chat ids", () => {
   assert.match(text, /13m ago/);
   assert.doesNotMatch(text, /ce806ba9-4e19-459a-9e01-2d3d3c6eafd4/);
 });
+
+test("worktree cards show archive state action when CAR state is present", () => {
+  __hubTest.setHubChannelEntries([]);
+  __hubTest.renderRepos([
+    {
+      id: "base--feature",
+      path: "/tmp/base--feature",
+      display_name: "base--feature",
+      enabled: true,
+      auto_run: false,
+      worktree_setup_commands: [],
+      kind: "worktree",
+      worktree_of: "base",
+      branch: "feature",
+      exists_on_disk: true,
+      is_clean: true,
+      initialized: true,
+      init_error: null,
+      status: "idle",
+      lock_status: "unlocked",
+      last_run_id: null,
+      last_exit_code: null,
+      last_run_started_at: null,
+      last_run_finished_at: null,
+      runner_pid: null,
+      effective_destination: { kind: "local" },
+      mounted: false,
+      mount_error: null,
+      cleanup_blocked_by_chat_binding: false,
+      has_car_state: true,
+      ticket_flow: null,
+      ticket_flow_display: null,
+    },
+  ]);
+
+  const text = document.getElementById("hub-repo-list")?.textContent || "";
+  assert.match(text, /Archive state/);
+  assert.match(text, /Cleanup/);
+});

--- a/tests/routes/test_archive_routes.py
+++ b/tests/routes/test_archive_routes.py
@@ -25,9 +25,9 @@ def _write_snapshot(
         / snapshot_id
     )
     snapshot_root.mkdir(parents=True, exist_ok=True)
-    workspace_dir = snapshot_root / "workspace"
-    workspace_dir.mkdir(parents=True, exist_ok=True)
-    (workspace_dir / "active_context.md").write_text(
+    contextspace_dir = snapshot_root / "contextspace"
+    contextspace_dir.mkdir(parents=True, exist_ok=True)
+    (contextspace_dir / "active_context.md").write_text(
         "Archived context", encoding="utf-8"
     )
     if with_meta:
@@ -108,7 +108,7 @@ def test_archive_traversal_is_rejected(tmp_path: Path) -> None:
     _write_snapshot(repo_root, "wt1", "snap1", with_meta=False)
 
     res = client.get(
-        "/api/archive/tree", params={"snapshot_id": "../snap1", "path": "workspace"}
+        "/api/archive/tree", params={"snapshot_id": "../snap1", "path": "contextspace"}
     )
     assert res.status_code == 400
 
@@ -132,23 +132,50 @@ def test_archive_tree_and_file_reads(tmp_path: Path) -> None:
     _write_snapshot(repo_root, "wt1", "snap1", with_meta=False)
 
     tree = client.get(
-        "/api/archive/tree", params={"snapshot_id": "snap1", "path": "workspace"}
+        "/api/archive/tree", params={"snapshot_id": "snap1", "path": "contextspace"}
     )
     assert tree.status_code == 200
     nodes = {node["path"]: node for node in tree.json()["nodes"]}
-    assert "workspace/active_context.md" in nodes
-    assert nodes["workspace/active_context.md"]["type"] == "file"
+    assert "contextspace/active_context.md" in nodes
+    assert nodes["contextspace/active_context.md"]["type"] == "file"
 
     read = client.get(
         "/api/archive/file",
-        params={"snapshot_id": "snap1", "path": "workspace/active_context.md"},
+        params={"snapshot_id": "snap1", "path": "contextspace/active_context.md"},
     )
     assert read.status_code == 200
     assert read.text.strip() == "Archived context"
 
     download = client.get(
         "/api/archive/download",
-        params={"snapshot_id": "snap1", "path": "workspace/active_context.md"},
+        params={"snapshot_id": "snap1", "path": "contextspace/active_context.md"},
     )
     assert download.status_code == 200
     assert download.content == b"Archived context"
+
+
+def test_local_archive_tree_reads_any_archived_run_content(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    client = _client_for_repo(repo_root)
+
+    run_root = repo_root / ".codex-autorunner" / "flows" / "run-123"
+    (run_root / "contextspace").mkdir(parents=True, exist_ok=True)
+    (run_root / "contextspace" / "active_context.md").write_text(
+        "Local archived context", encoding="utf-8"
+    )
+    (run_root / "chat").mkdir(parents=True, exist_ok=True)
+    (run_root / "chat" / "outbound.jsonl").write_text("{}", encoding="utf-8")
+
+    tree = client.get("/api/archive/local/tree", params={"run_id": "run-123"})
+    assert tree.status_code == 200
+    nodes = {node["path"]: node for node in tree.json()["nodes"]}
+    assert "contextspace" in nodes
+    assert "chat" in nodes
+
+    read = client.get(
+        "/api/archive/local/file",
+        params={"run_id": "run-123", "path": "contextspace/active_context.md"},
+    )
+    assert read.status_code == 200
+    assert read.text.strip() == "Local archived context"

--- a/tests/test_archive_worktree.py
+++ b/tests/test_archive_worktree.py
@@ -1,7 +1,12 @@
 import os
 from pathlib import Path
 
-from codex_autorunner.core.archive import archive_worktree_snapshot
+from codex_autorunner.bootstrap import seed_repo_files
+from codex_autorunner.core.archive import (
+    archive_workspace_car_state,
+    archive_worktree_snapshot,
+    has_car_state,
+)
 
 
 def _write(path: Path, content: str) -> None:
@@ -16,16 +21,16 @@ def _setup_worktree(tmp_path: Path) -> tuple[Path, Path]:
     worktree_repo.mkdir()
 
     car_root = worktree_repo / ".codex-autorunner"
-    (car_root / "workspace").mkdir(parents=True)
+    (car_root / "contextspace").mkdir(parents=True)
     (car_root / "tickets").mkdir(parents=True)
     (car_root / "runs" / "run-1" / "dispatch").mkdir(parents=True)
     (car_root / "flows").mkdir(parents=True)
 
-    _write(car_root / "workspace" / "notes.txt", "hello")
+    _write(car_root / "contextspace" / "active_context.md", "hello")
     _write(car_root / "tickets" / "TICKET-001.md", "ticket")
     _write(car_root / "runs" / "run-1" / "dispatch" / "DISPATCH.md", "dispatch")
     _write(car_root / "flows.db", "flows-db")
-    _write(car_root / "config.yml", "config")
+    _write(car_root / "config.yml", "version: 2\n")
     _write(car_root / "state.sqlite3", "state")
     _write(car_root / "codex-autorunner.log", "log-a")
     _write(car_root / "codex-server.log", "log-b")
@@ -55,7 +60,7 @@ def test_archive_snapshot_copies_curated_paths(tmp_path: Path) -> None:
     )
 
     assert result.snapshot_path.exists()
-    assert (result.snapshot_path / "workspace" / "notes.txt").read_text(
+    assert (result.snapshot_path / "contextspace" / "active_context.md").read_text(
         encoding="utf-8"
     ) == "hello"
     assert (result.snapshot_path / "tickets" / "TICKET-001.md").exists()
@@ -81,7 +86,7 @@ def test_archive_snapshot_skips_symlink_escape(tmp_path: Path) -> None:
     outside.mkdir()
     secret = outside / "secret.txt"
     secret.write_text("secret", encoding="utf-8")
-    escape = car_root / "workspace" / "escape.txt"
+    escape = car_root / "contextspace" / "escape.txt"
     escape.symlink_to(secret)
 
     result = archive_worktree_snapshot(
@@ -93,7 +98,7 @@ def test_archive_snapshot_skips_symlink_escape(tmp_path: Path) -> None:
         worktree_of="base",
     )
 
-    assert not (result.snapshot_path / "workspace" / "escape.txt").exists()
+    assert not (result.snapshot_path / "contextspace" / "escape.txt").exists()
 
 
 def test_archive_summary_counts_files_and_flows(tmp_path: Path) -> None:
@@ -119,3 +124,58 @@ def test_archive_summary_counts_files_and_flows(tmp_path: Path) -> None:
         if path.is_file() and path.name != "META.json":
             total_bytes += path.stat().st_size
     assert result.total_bytes == total_bytes
+
+
+def test_has_car_state_ignores_seeded_defaults(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    seed_repo_files(repo_root, git_required=False)
+
+    assert has_car_state(repo_root) is False
+
+    _write(
+        repo_root / ".codex-autorunner" / "tickets" / "TICKET-001-demo.md",
+        "demo ticket",
+    )
+    assert has_car_state(repo_root) is True
+
+
+def test_archive_workspace_car_state_resets_runtime_state(tmp_path: Path) -> None:
+    base_repo, worktree_repo = _setup_worktree(tmp_path)
+    _write(
+        worktree_repo / ".codex-autorunner" / "filebox" / "outbox" / "reply.txt",
+        "artifact",
+    )
+
+    result = archive_workspace_car_state(
+        base_repo_root=base_repo,
+        base_repo_id="base",
+        worktree_repo_root=worktree_repo,
+        worktree_repo_id="worktree",
+        branch="feature/archive-viewer",
+        worktree_of="base",
+    )
+
+    assert "tickets" in result.archived_paths
+    assert "contextspace" in result.archived_paths
+    assert "runs" in result.archived_paths
+    assert "flows" in result.archived_paths
+    assert "filebox" in result.archived_paths
+    assert (result.snapshot_path / "tickets" / "TICKET-001.md").exists()
+    assert (
+        result.snapshot_path / "runs" / "run-1" / "dispatch" / "DISPATCH.md"
+    ).exists()
+    assert (result.snapshot_path / "contextspace" / "active_context.md").read_text(
+        encoding="utf-8"
+    ) == "hello"
+
+    tickets_dir = worktree_repo / ".codex-autorunner" / "tickets"
+    assert (tickets_dir / "AGENTS.md").exists()
+    assert not (tickets_dir / "TICKET-001.md").exists()
+    assert (
+        worktree_repo / ".codex-autorunner" / "contextspace" / "active_context.md"
+    ).read_text(encoding="utf-8") == ""
+    assert not (worktree_repo / ".codex-autorunner" / "runs").exists()
+    assert not (worktree_repo / ".codex-autorunner" / "flows").exists()
+    assert not (worktree_repo / ".codex-autorunner" / "filebox").exists()
+    assert has_car_state(worktree_repo) is False

--- a/tests/test_cli_ticket_flow_archive.py
+++ b/tests/test_cli_ticket_flow_archive.py
@@ -48,6 +48,12 @@ def _seed_ticket(repo_root: Path) -> None:
     )
 
 
+def _seed_contextspace(repo_root: Path) -> None:
+    context_dir = repo_root / ".codex-autorunner" / "contextspace"
+    context_dir.mkdir(parents=True, exist_ok=True)
+    (context_dir / "active_context.md").write_text("Active context\n", encoding="utf-8")
+
+
 def test_ticket_flow_archive_moves_run_artifacts_and_deletes_run(
     tmp_path: Path,
 ) -> None:
@@ -58,6 +64,8 @@ def test_ticket_flow_archive_moves_run_artifacts_and_deletes_run(
 
     run_id = "99999999-9999-9999-9999-999999999999"
     _seed_repo_run(repo_root, run_id, FlowRunStatus.STOPPED)
+    _seed_ticket(repo_root)
+    _seed_contextspace(repo_root)
 
     run_dir = (
         repo_root / ".codex-autorunner" / "runs" / run_id / "dispatch_history" / "0001"
@@ -85,10 +93,29 @@ def test_ticket_flow_archive_moves_run_artifacts_and_deletes_run(
     payload = json.loads(result.stdout)
     assert payload["run_id"] == run_id
     assert payload["archived_runs"] is True
+    assert payload["archived_tickets"] == 1
+    assert payload["archived_contextspace"] is True
     assert payload["deleted_run"] is True
 
     archived_root = repo_root / ".codex-autorunner" / "flows" / run_id / "archived_runs"
     assert archived_root.exists()
+    assert (
+        repo_root
+        / ".codex-autorunner"
+        / "flows"
+        / run_id
+        / "archived_tickets"
+        / "TICKET-001.md"
+    ).exists()
+    assert (
+        repo_root
+        / ".codex-autorunner"
+        / "flows"
+        / run_id
+        / "contextspace"
+        / "active_context.md"
+    ).read_text(encoding="utf-8") == "Active context\n"
+    assert not (repo_root / ".codex-autorunner" / "tickets" / "TICKET-001.md").exists()
 
     db_path = repo_root / ".codex-autorunner" / "flows.db"
     with FlowStore(db_path) as store:
@@ -104,6 +131,7 @@ def test_ticket_flow_archive_dry_run_does_not_modify(tmp_path: Path) -> None:
 
     run_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
     _seed_repo_run(repo_root, run_id, FlowRunStatus.FAILED)
+    _seed_ticket(repo_root)
 
     run_dir = repo_root / ".codex-autorunner" / "runs" / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -128,6 +156,7 @@ def test_ticket_flow_archive_dry_run_does_not_modify(tmp_path: Path) -> None:
     assert payload["archived_runs"] is False
     assert payload["deleted_run"] is False
     assert run_dir.exists()
+    assert (repo_root / ".codex-autorunner" / "tickets" / "TICKET-001.md").exists()
 
 
 def test_ticket_flow_archive_force_requires_attestation(tmp_path: Path) -> None:

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -374,6 +374,73 @@ def test_hub_api_marks_chat_bound_worktrees_without_thread_list_cap(
     assert worktree_payload["cleanup_blocked_by_chat_binding"] is False
 
 
+@pytest.mark.slow
+def test_hub_archive_state_endpoint_archives_and_resets_runtime_state(tmp_path: Path):
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg_path = hub_root / CONFIG_FILENAME
+    write_test_config(cfg_path, cfg)
+
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/archive-state",
+        start_point="HEAD",
+    )
+    worktree_car = worktree.path / ".codex-autorunner"
+    (worktree_car / "tickets" / "TICKET-123-demo.md").write_text(
+        "demo ticket", encoding="utf-8"
+    )
+    (worktree_car / "contextspace" / "active_context.md").write_text(
+        "active context", encoding="utf-8"
+    )
+    dispatch_dir = worktree_car / "runs" / "run-1" / "dispatch"
+    dispatch_dir.mkdir(parents=True, exist_ok=True)
+    (dispatch_dir / "DISPATCH.md").write_text("dispatch", encoding="utf-8")
+
+    app = create_hub_app(hub_root)
+    client = TestClient(app)
+
+    repos_resp = client.get("/hub/repos")
+    assert repos_resp.status_code == 200
+    worktree_payload = next(
+        item for item in repos_resp.json()["repos"] if item["id"] == worktree.id
+    )
+    assert worktree_payload["has_car_state"] is True
+
+    archive_resp = client.post(
+        "/hub/worktrees/archive-state",
+        json={"worktree_repo_id": worktree.id},
+    )
+    assert archive_resp.status_code == 200
+    payload = archive_resp.json()
+    assert "tickets" in payload["archived_paths"]
+    assert "runs" in payload["archived_paths"]
+
+    snapshot_root = Path(payload["snapshot_path"])
+    assert (snapshot_root / "tickets" / "TICKET-123-demo.md").exists()
+    assert (snapshot_root / "runs" / "run-1" / "dispatch" / "DISPATCH.md").exists()
+    assert (worktree_car / "contextspace" / "active_context.md").read_text(
+        encoding="utf-8"
+    ) == ""
+    assert not (worktree_car / "tickets" / "TICKET-123-demo.md").exists()
+    assert not (worktree_car / "runs").exists()
+
+    repos_after_resp = client.get("/hub/repos")
+    assert repos_after_resp.status_code == 200
+    worktree_after = next(
+        item for item in repos_after_resp.json()["repos"] if item["id"] == worktree.id
+    )
+    assert worktree_after["has_car_state"] is False
+
+
 def test_hub_pin_parent_repo_endpoint_persists(tmp_path: Path):
     hub_root = tmp_path / "hub"
     cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))


### PR DESCRIPTION
## Summary
- unify CAR archive/reset behavior behind shared core archive helpers
- add workspace state archive actions for Discord, Telegram, and hub worktrees using the same path
- pull in the unique user-facing improvements from #931 while fixing the PMA/defer/reset gaps in that PR

## Testing
- .venv/bin/pytest tests/test_archive_worktree.py tests/test_hub_supervisor.py tests/integrations/chat/test_command_contract.py tests/integrations/discord/test_commands_payload.py -q
- node --test tests/js/hub_repo_cards.test.js
- pnpm run build
- pre-commit/commit checks: mypy, eslint, interface validation, JS tests, full pytest (2691 passed, 3 skipped)
