### PR TITLE
Route pause notifications to one bound chat surface

### DIFF
--- a/src/codex_autorunner/core/chat_bindings.py
+++ b/src/codex_autorunner/core/chat_bindings.py
@@ -59,6 +59,13 @@ def _resolve_state_path(
     return state_path
 
 
+def _chat_surface_enabled(raw_config: Mapping[str, Any], section: str) -> bool:
+    section_cfg = raw_config.get(section)
+    if not isinstance(section_cfg, Mapping):
+        return False
+    return section_cfg.get("enabled") is True
+
+
 def _resolve_manifest_path(hub_root: Path, raw_config: Mapping[str, Any]) -> Path:
     hub_cfg = raw_config.get("hub")
     if not isinstance(hub_cfg, Mapping):
@@ -314,16 +321,18 @@ def _read_discord_repo_counts(
     return dict(counts)
 
 
-def _latest_discord_binding_timestamp_for_workspace(
-    *, db_path: Path, workspace_path: Path
-) -> float:
+def _latest_discord_binding_timestamps_by_workspace(db_path: Path) -> dict[str, float]:
     if not db_path.exists():
-        return float("-inf")
-    target_workspace = _normalize_workspace_path(workspace_path)
-    if target_workspace is None:
-        return float("-inf")
+        return {}
     try:
         with open_sqlite(db_path) as conn:
+            columns = _table_columns(conn, "channel_bindings")
+            if (
+                not columns
+                or "workspace_path" not in columns
+                or "updated_at" not in columns
+            ):
+                return {}
             rows = conn.execute(
                 """
                 SELECT workspace_path, updated_at
@@ -332,55 +341,64 @@ def _latest_discord_binding_timestamp_for_workspace(
             ).fetchall()
     except sqlite3.OperationalError as exc:
         if "no such table" in str(exc).lower():
-            return float("-inf")
+            return {}
         raise RuntimeError(
             f"Failed reading Discord chat bindings from {db_path}: {exc}"
         ) from exc
 
-    latest = float("-inf")
+    latest_by_workspace: dict[str, float] = {}
     for row in rows:
-        if _normalize_workspace_path(row["workspace_path"]) != target_workspace:
+        workspace_path = _normalize_workspace_path(row["workspace_path"])
+        if workspace_path is None:
             continue
-        latest = max(latest, _parse_iso_timestamp(row["updated_at"]))
-    return latest
+        timestamp = _parse_iso_timestamp(row["updated_at"])
+        previous = latest_by_workspace.get(workspace_path, float("-inf"))
+        if timestamp > previous:
+            latest_by_workspace[workspace_path] = timestamp
+    return latest_by_workspace
 
 
-def _latest_current_telegram_binding_timestamp_for_workspace(
-    *, db_path: Path, workspace_path: Path
-) -> float:
+def _latest_current_telegram_binding_timestamps_by_workspace(
+    db_path: Path,
+) -> dict[str, float]:
     if not db_path.exists():
-        return float("-inf")
-    target_workspace = _normalize_workspace_path(workspace_path)
-    if target_workspace is None:
-        return float("-inf")
+        return {}
     try:
         with open_sqlite(db_path) as conn:
+            columns = _table_columns(conn, "telegram_topics")
+            if not columns or "workspace_path" not in columns:
+                return {}
+            select_columns = ["chat_id", "thread_id", "scope", "workspace_path"]
+            if "last_active_at" in columns:
+                select_columns.append("last_active_at")
+            if "updated_at" in columns:
+                select_columns.append("updated_at")
             rows = conn.execute(
-                """
-                SELECT chat_id, thread_id, scope, workspace_path, last_active_at, updated_at
-                  FROM telegram_topics
-                """
+                f"SELECT {', '.join(select_columns)} FROM telegram_topics"
             ).fetchall()
             scope_map = _read_telegram_current_scope_map(conn)
     except sqlite3.OperationalError as exc:
         if "no such table" in str(exc).lower():
-            return float("-inf")
+            return {}
         raise RuntimeError(
             f"Failed reading Telegram chat bindings from {db_path}: {exc}"
         ) from exc
 
-    latest = float("-inf")
+    latest_by_workspace: dict[str, float] = {}
     for row in rows:
         if not _is_current_telegram_topic_row(row=row, scope_map=scope_map):
             continue
-        if _normalize_workspace_path(row["workspace_path"]) != target_workspace:
+        workspace_path = _normalize_workspace_path(row["workspace_path"])
+        if workspace_path is None:
             continue
-        latest = max(
-            latest,
+        timestamp = max(
             _parse_iso_timestamp(row["last_active_at"]),
             _parse_iso_timestamp(row["updated_at"]),
         )
-    return latest
+        previous = latest_by_workspace.get(workspace_path, float("-inf"))
+        if timestamp > previous:
+            latest_by_workspace[workspace_path] = timestamp
+    return latest_by_workspace
 
 
 def _active_pma_thread_counts(
@@ -542,31 +560,54 @@ def preferred_non_pma_chat_notification_source_for_workspace(
 ) -> str | None:
     """Return the preferred bound chat surface for workspace notifications."""
 
-    discord_timestamp = _latest_discord_binding_timestamp_for_workspace(
-        db_path=_resolve_discord_state_path(hub_root, raw_config),
-        workspace_path=workspace_root,
-    )
-    telegram_timestamp = _latest_current_telegram_binding_timestamp_for_workspace(
-        db_path=_resolve_telegram_state_path(hub_root, raw_config),
-        workspace_path=workspace_root,
-    )
-
-    candidates = [
-        ("discord", discord_timestamp),
-        ("telegram", telegram_timestamp),
-    ]
-    available = [item for item in candidates if item[1] != float("-inf")]
-    if not available:
+    workspace_key = _normalize_workspace_path(workspace_root)
+    if workspace_key is None:
         return None
-    # Prefer the freshest persisted binding signal; ties fall back to Telegram.
-    available.sort(key=lambda item: (item[1], 1 if item[0] == "telegram" else 0))
-    return available[-1][0]
+    return preferred_non_pma_chat_notification_sources_by_workspace(
+        hub_root=hub_root,
+        raw_config=raw_config,
+    ).get(workspace_key)
+
+
+def preferred_non_pma_chat_notification_sources_by_workspace(
+    *, hub_root: Path, raw_config: Mapping[str, Any]
+) -> dict[str, str]:
+    """Return preferred non-PMA notification surfaces keyed by workspace path."""
+
+    discord_timestamps: dict[str, float] = {}
+    if _chat_surface_enabled(raw_config, "discord_bot"):
+        discord_timestamps = _latest_discord_binding_timestamps_by_workspace(
+            _resolve_discord_state_path(hub_root, raw_config)
+        )
+    telegram_timestamps: dict[str, float] = {}
+    if _chat_surface_enabled(raw_config, "telegram_bot"):
+        telegram_timestamps = _latest_current_telegram_binding_timestamps_by_workspace(
+            _resolve_telegram_state_path(hub_root, raw_config)
+        )
+
+    preferred_by_workspace: dict[str, str] = {}
+    workspace_paths = set(discord_timestamps) | set(telegram_timestamps)
+    for workspace_path in workspace_paths:
+        discord_timestamp = discord_timestamps.get(workspace_path, float("-inf"))
+        telegram_timestamp = telegram_timestamps.get(workspace_path, float("-inf"))
+        candidates = [
+            ("discord", discord_timestamp),
+            ("telegram", telegram_timestamp),
+        ]
+        available = [item for item in candidates if item[1] != float("-inf")]
+        if not available:
+            continue
+        # Prefer the freshest persisted binding signal; ties fall back to Telegram.
+        available.sort(key=lambda item: (item[1], 1 if item[0] == "telegram" else 0))
+        preferred_by_workspace[workspace_path] = available[-1][0]
+    return preferred_by_workspace
 
 
 __all__ = [
     "active_chat_binding_counts",
     "active_chat_binding_counts_by_source",
     "preferred_non_pma_chat_notification_source_for_workspace",
+    "preferred_non_pma_chat_notification_sources_by_workspace",
     "repo_has_active_chat_binding",
     "repo_has_active_non_pma_chat_binding",
 ]

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -19,6 +19,7 @@ from ...agents.opencode.supervisor import OpenCodeSupervisor
 from ...bootstrap import seed_repo_files
 from ...core.chat_bindings import (
     preferred_non_pma_chat_notification_source_for_workspace,
+    preferred_non_pma_chat_notification_sources_by_workspace,
 )
 from ...core.config import (
     ConfigError,
@@ -2564,15 +2565,18 @@ class DiscordBotService:
 
     async def _scan_and_enqueue_pause_notifications(self) -> None:
         bindings = await self._store.list_bindings()
+        preferred_sources = self._preferred_bound_sources_by_workspace()
         for binding in bindings:
             channel_id = binding.get("channel_id")
             workspace_raw = binding.get("workspace_path")
             if not isinstance(channel_id, str) or not isinstance(workspace_raw, str):
                 continue
             workspace_root = canonicalize_path(Path(workspace_raw))
-            preferred_source = self._preferred_bound_source_for_workspace(
-                workspace_root
-            )
+            preferred_source = preferred_sources.get(str(workspace_root))
+            if preferred_source is None:
+                preferred_source = self._preferred_bound_source_for_workspace(
+                    workspace_root
+                )
             if preferred_source == "telegram":
                 continue
             run_mirror = self._flow_run_mirror(workspace_root)
@@ -2678,6 +2682,28 @@ class DiscordBotService:
                 workspace_root=str(workspace_root),
             )
             return None
+
+    def _preferred_bound_sources_by_workspace(self) -> dict[str, str]:
+        raw_config = self._hub_raw_config_cache
+        if raw_config is None:
+            try:
+                raw_config = load_hub_config(self._config.root).raw
+            except Exception:
+                raw_config = {}
+            self._hub_raw_config_cache = raw_config
+        try:
+            return preferred_non_pma_chat_notification_sources_by_workspace(
+                hub_root=self._config.root,
+                raw_config=raw_config,
+            )
+        except Exception as exc:
+            log_event(
+                self._logger,
+                logging.WARNING,
+                "discord.pause_watch.route_lookup_failed",
+                exc=exc,
+            )
+            return {}
 
     async def _watch_ticket_flow_terminals(self) -> None:
         while True:

--- a/src/codex_autorunner/integrations/telegram/ticket_flow_bridge.py
+++ b/src/codex_autorunner/integrations/telegram/ticket_flow_bridge.py
@@ -8,6 +8,7 @@ from typing import Any, Awaitable, Callable, Optional
 
 from ...core.chat_bindings import (
     preferred_non_pma_chat_notification_source_for_workspace,
+    preferred_non_pma_chat_notification_sources_by_workspace,
 )
 from ...core.config import ConfigError, load_hub_config, load_repo_config
 from ...core.flows import FlowStore
@@ -116,18 +117,28 @@ class TelegramTicketFlowBridge:
             return
         topics = await self._store.list_topics()
         workspace_topics = self._get_all_workspaces(topics or {})
+        preferred_sources = self._preferred_bound_sources_by_workspace()
 
         tasks = []
         for workspace_root, entries in workspace_topics.items():
             if entries:
                 tasks.append(
                     asyncio.create_task(
-                        self._notify_ticket_flow_pause(workspace_root, entries)
+                        self._notify_ticket_flow_pause(
+                            workspace_root,
+                            entries,
+                            preferred_source=preferred_sources.get(str(workspace_root)),
+                        )
                     )
                 )
             else:
                 tasks.append(
-                    asyncio.create_task(self._notify_via_default_chat(workspace_root))
+                    asyncio.create_task(
+                        self._notify_via_default_chat(
+                            workspace_root,
+                            preferred_source=preferred_sources.get(str(workspace_root)),
+                        )
+                    )
                 )
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
@@ -136,8 +147,13 @@ class TelegramTicketFlowBridge:
         self,
         workspace_root: Path,
         entries: list[tuple[str, object]],
+        *,
+        preferred_source: Optional[str] = None,
     ) -> None:
-        preferred_source = self._preferred_bound_source_for_workspace(workspace_root)
+        if preferred_source is None:
+            preferred_source = self._preferred_bound_source_for_workspace(
+                workspace_root
+            )
         if preferred_source == "discord":
             return
         try:
@@ -314,10 +330,18 @@ class TelegramTicketFlowBridge:
                 workspace_root=str(workspace_root),
             )
 
-    async def _notify_via_default_chat(self, workspace_root: Path) -> None:
+    async def _notify_via_default_chat(
+        self,
+        workspace_root: Path,
+        *,
+        preferred_source: Optional[str] = None,
+    ) -> None:
         if not self._pause_config.enabled or self._default_notification_chat_id is None:
             return
-        preferred_source = self._preferred_bound_source_for_workspace(workspace_root)
+        if preferred_source is None:
+            preferred_source = self._preferred_bound_source_for_workspace(
+                workspace_root
+            )
         if preferred_source in {"telegram", "discord"}:
             return
         try:
@@ -388,6 +412,30 @@ class TelegramTicketFlowBridge:
                 workspace_root=str(workspace_root),
             )
             return None
+
+    def _preferred_bound_sources_by_workspace(self) -> dict[str, str]:
+        if self._hub_root is None:
+            return {}
+        raw_config = self._hub_raw_config
+        if raw_config is None:
+            try:
+                raw_config = load_hub_config(self._hub_root).raw
+            except Exception:
+                raw_config = {}
+            self._hub_raw_config = raw_config
+        try:
+            return preferred_non_pma_chat_notification_sources_by_workspace(
+                hub_root=self._hub_root,
+                raw_config=raw_config,
+            )
+        except Exception as exc:
+            log_event(
+                self._logger,
+                logging.WARNING,
+                "telegram.ticket_flow.route_lookup_failed",
+                exc=exc,
+            )
+            return {}
 
     async def _send_full_dispatch(
         self,

--- a/tests/core/test_chat_bindings.py
+++ b/tests/core/test_chat_bindings.py
@@ -441,6 +441,8 @@ def test_preferred_non_pma_chat_notification_source_uses_freshest_binding(
 ) -> None:
     hub_root = tmp_path / "hub"
     cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg["discord_bot"]["enabled"] = True
+    cfg["telegram_bot"]["enabled"] = True
     write_test_config(hub_root / CONFIG_FILENAME, cfg)
 
     workspace = (hub_root / "worktrees" / "repo-a").resolve()
@@ -478,6 +480,44 @@ def test_preferred_non_pma_chat_notification_source_uses_freshest_binding(
         workspace_path=str(workspace),
         updated_at="2026-03-12T03:00:00Z",
         last_active_at="2026-03-12T03:30:00Z",
+    )
+
+    assert (
+        preferred_non_pma_chat_notification_source_for_workspace(
+            hub_root=hub_root,
+            raw_config=cfg,
+            workspace_root=workspace,
+        )
+        == "telegram"
+    )
+
+
+def test_preferred_notification_source_ignores_disabled_surfaces(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg["telegram_bot"]["enabled"] = True
+    cfg["discord_bot"]["enabled"] = False
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    workspace = (hub_root / "worktrees" / "repo-b").resolve()
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    _write_discord_binding(
+        hub_root / ".codex-autorunner" / "discord_state.sqlite3",
+        channel_id="discord-stale",
+        repo_id="repo-b",
+        workspace_path=str(workspace),
+        updated_at="2026-03-12T05:00:00Z",
+    )
+    _write_telegram_binding(
+        hub_root / ".codex-autorunner" / "telegram_state.sqlite3",
+        topic_key="300:400",
+        repo_id="repo-b",
+        workspace_path=str(workspace),
+        updated_at="2026-03-12T01:00:00Z",
+        last_active_at="2026-03-12T01:30:00Z",
     )
 
     assert (

--- a/tests/integrations/discord/test_pause_bridge.py
+++ b/tests/integrations/discord/test_pause_bridge.py
@@ -310,6 +310,7 @@ async def test_pause_bridge_skips_when_telegram_binding_is_preferred(
         state_store=store,
         outbox_manager=_FakeOutboxManager(),
     )
+    service._hub_raw_config_cache = {"telegram_bot": {"enabled": True}}
 
     try:
         await service._scan_and_enqueue_pause_notifications()

--- a/tests/test_telegram_ticket_flow_bridge.py
+++ b/tests/test_telegram_ticket_flow_bridge.py
@@ -284,7 +284,7 @@ async def test_default_chat_skips_when_discord_binding_is_preferred(
         hub_root=hub_root,
         manifest_path=None,
         config_root=workspace,
-        hub_raw_config={},
+        hub_raw_config={"discord_bot": {"enabled": True}},
     )
 
     bridge._load_ticket_flow_pause = lambda path: ("run2", "0002", "body", None)  # type: ignore


### PR DESCRIPTION
## Summary
- add a shared workspace-level helper that chooses one preferred non-PMA chat surface for pause notifications
- suppress Telegram default-chat pause notifications when the workspace is already bound in Telegram or Discord
- suppress Discord pause-watch notifications when Telegram is the fresher bound surface, with regression coverage for both bridges

## Routing rule
- compare the freshest persisted Telegram and Discord binding signals for the workspace
- send the pause notification to only the preferred bound surface
- only use the Telegram default notification chat when no non-PMA bound surface exists

## Testing
- `.venv/bin/python -m pytest tests/core/test_chat_bindings.py tests/test_telegram_ticket_flow_bridge.py tests/integrations/discord/test_pause_bridge.py`
- full pre-commit hook suite from `git commit` (`mypy`, `pnpm run build`, frontend tests, full `pytest`)
