### PR TITLE
Drop stale Discord terminal notifications after archive

### DIFF
--- a/src/codex_autorunner/integrations/discord/outbox.py
+++ b/src/codex_autorunner/integrations/discord/outbox.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Awaitable, Callable, Optional
 
 import httpx
 
+from ...core.config import ConfigError, load_repo_config
+from ...core.flows import FlowStore
 from .state import DiscordStateStore, OutboxRecord
 
 OUTBOX_RETRY_INTERVAL_SECONDS = 5.0
@@ -43,6 +46,23 @@ def _extract_retry_after_seconds(exc: Exception) -> Optional[float]:
                     pass
         current = current.__cause__ or current.__context__
     return None
+
+
+def _terminal_run_id(record_id: str) -> Optional[str]:
+    parts = record_id.split(":", 2)
+    if len(parts) != 3 or parts[0] != "terminal":
+        return None
+    run_id = parts[2].strip()
+    return run_id or None
+
+
+def _has_archived_run_artifacts(workspace_root: Path, run_id: str) -> bool:
+    archive_root = workspace_root / ".codex-autorunner" / "flows" / run_id
+    if not archive_root.exists():
+        return False
+    if (archive_root / "archived_tickets").exists():
+        return True
+    return any(archive_root.glob("archived_runs*"))
 
 
 class DiscordOutboxManager:
@@ -141,6 +161,13 @@ class DiscordOutboxManager:
         if current.attempts >= self._max_attempts:
             await self._drop_exhausted(current)
             return False
+        if await self._should_drop_terminal_notification(current):
+            await self._store.mark_outbox_delivered(current.record_id)
+            self._logger.info(
+                "discord.outbox.dropped_stale_terminal record_id=%s",
+                current.record_id,
+            )
+            return False
         if not await self._mark_inflight(current.record_id):
             return False
         try:
@@ -199,6 +226,37 @@ class DiscordOutboxManager:
             record.last_error,
         )
         await self._store.mark_outbox_delivered(record.record_id)
+
+    async def _should_drop_terminal_notification(self, record: OutboxRecord) -> bool:
+        if record.operation != "send":
+            return False
+        run_id = _terminal_run_id(record.record_id)
+        if run_id is None:
+            return False
+        try:
+            binding = await self._store.get_binding(channel_id=record.channel_id)
+        except Exception:
+            return False
+        workspace_raw = (
+            binding.get("workspace_path") if isinstance(binding, dict) else None
+        )
+        if not isinstance(workspace_raw, str) or not workspace_raw.strip():
+            return False
+        workspace_root = Path(workspace_raw)
+        if _has_archived_run_artifacts(workspace_root, run_id):
+            return True
+        db_path = workspace_root / ".codex-autorunner" / "flows.db"
+        if not db_path.exists():
+            return True
+        try:
+            durable_writes = load_repo_config(workspace_root).durable_writes
+        except ConfigError:
+            durable_writes = False
+        try:
+            with FlowStore(db_path, durable=durable_writes) as store:
+                return store.get_flow_run(run_id) is None
+        except Exception:
+            return False
 
     async def _mark_inflight(self, key: str) -> bool:
         if self._lock is None:

--- a/tests/integrations/discord/test_outbox_retry.py
+++ b/tests/integrations/discord/test_outbox_retry.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 import pytest
 
+from codex_autorunner.bootstrap import seed_repo_files
+from codex_autorunner.core.flows import FlowStore
+from codex_autorunner.core.flows.models import FlowRunStatus
 from codex_autorunner.core.state import now_iso
 from codex_autorunner.integrations.discord.outbox import DiscordOutboxManager
 from codex_autorunner.integrations.discord.state import DiscordStateStore, OutboxRecord
@@ -28,6 +31,20 @@ class _Clock:
     async def sleep(self, seconds: float) -> None:
         self.sleeps.append(seconds)
         self.current = self.current + timedelta(seconds=seconds)
+
+
+def _workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    (workspace / ".git").mkdir()
+    seed_repo_files(workspace, git_required=False)
+    return workspace
+
+
+def _create_terminal_run(workspace: Path, run_id: str) -> None:
+    with FlowStore(workspace / ".codex-autorunner" / "flows.db") as store:
+        store.create_flow_run(run_id, "ticket_flow", input_data={}, state={})
+        store.update_flow_run_status(run_id, FlowRunStatus.COMPLETED)
 
 
 @pytest.mark.anyio
@@ -233,5 +250,108 @@ async def test_flush_drops_previously_exhausted_record(tmp_path: Path) -> None:
         await manager._flush(records)
         assert calls["count"] == 0
         assert await store.get_outbox("drop-2") is None
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_flush_drops_terminal_notice_for_deleted_run(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    run_id = "run-deleted"
+    _create_terminal_run(workspace, run_id)
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    clock = _Clock()
+    calls = {"count": 0}
+
+    async def send_message(_channel_id: str, _payload: dict) -> dict:
+        calls["count"] += 1
+        return {"id": "msg-1"}
+
+    manager = DiscordOutboxManager(
+        store,
+        send_message=send_message,
+        logger=logging.getLogger("test"),
+        now_fn=clock.now,
+        sleep_fn=clock.sleep,
+    )
+
+    try:
+        await store.initialize()
+        await store.upsert_binding(
+            channel_id="chan-1",
+            guild_id=None,
+            workspace_path=str(workspace),
+            repo_id=None,
+        )
+        manager.start()
+        await store.enqueue_outbox(
+            OutboxRecord(
+                record_id=f"terminal:chan-1:{run_id}",
+                channel_id="chan-1",
+                message_id=None,
+                operation="send",
+                payload_json={"content": "done"},
+                created_at=now_iso(),
+            )
+        )
+        with FlowStore(workspace / ".codex-autorunner" / "flows.db") as flow_store:
+            assert flow_store.delete_flow_run(run_id) is True
+
+        await manager._flush(await store.list_outbox())
+        assert calls["count"] == 0
+        assert await store.get_outbox(f"terminal:chan-1:{run_id}") is None
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_flush_drops_terminal_notice_for_archived_run(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    run_id = "run-archived"
+    _create_terminal_run(workspace, run_id)
+    (workspace / ".codex-autorunner" / "flows" / run_id / "archived_runs").mkdir(
+        parents=True, exist_ok=True
+    )
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    clock = _Clock()
+    calls = {"count": 0}
+
+    async def send_message(_channel_id: str, _payload: dict) -> dict:
+        calls["count"] += 1
+        return {"id": "msg-1"}
+
+    manager = DiscordOutboxManager(
+        store,
+        send_message=send_message,
+        logger=logging.getLogger("test"),
+        now_fn=clock.now,
+        sleep_fn=clock.sleep,
+    )
+
+    try:
+        await store.initialize()
+        await store.upsert_binding(
+            channel_id="chan-1",
+            guild_id=None,
+            workspace_path=str(workspace),
+            repo_id=None,
+        )
+        manager.start()
+        await store.enqueue_outbox(
+            OutboxRecord(
+                record_id=f"terminal:chan-1:{run_id}",
+                channel_id="chan-1",
+                message_id=None,
+                operation="send",
+                payload_json={"content": "done"},
+                created_at=now_iso(),
+            )
+        )
+
+        await manager._flush(await store.list_outbox())
+        assert calls["count"] == 0
+        assert await store.get_outbox(f"terminal:chan-1:{run_id}") is None
     finally:
         await store.close()


### PR DESCRIPTION
## Summary
- drop queued Discord terminal notifications when the bound flow run has already been archived or deleted
- treat archive artifacts under `.codex-autorunner/flows/<run_id>/archived_runs*` as a stale-terminal signal during outbox delivery
- add regression tests covering deleted and archived runs

## Testing
- .venv/bin/python -m pytest tests/integrations/discord/test_outbox_retry.py
- pre-commit hook suite during git commit (includes full pytest, mypy, ruff, eslint, pnpm build)
