### PR TITLE
Reset contextspace when archiving ticket flows

### DIFF
--- a/src/codex_autorunner/core/flows/archive_helpers.py
+++ b/src/codex_autorunner/core/flows/archive_helpers.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
 
+from ...bootstrap import seed_repo_files
 from ...tickets.files import list_ticket_paths
 from ...tickets.outbox import resolve_outbox_paths
 from ..archive import (
@@ -31,17 +32,38 @@ def _next_archive_dir(base_dir: Path) -> Path:
     return base_dir.parent / f"{base_dir.name}_{suffix}"
 
 
+def _contextspace_source(car_root: Path) -> Path:
+    contextspace = car_root / "contextspace"
+    if contextspace.exists() or contextspace.is_symlink():
+        return contextspace
+    legacy_workspace = car_root / "workspace"
+    if legacy_workspace.exists() or legacy_workspace.is_symlink():
+        return legacy_workspace
+    return contextspace
+
+
 def _build_flow_archive_entries(
     repo_root: Path,
     *,
     run_id: str,
     run_dir: Path,
 ) -> tuple[list[ArchiveEntrySpec], dict[str, Any]]:
+    car_root = repo_root / ".codex-autorunner"
     archive_root = repo_root / ".codex-autorunner" / "flows" / run_id
     target_runs_dir = _next_archive_dir(archive_root / "archived_runs")
     ticket_paths = list(list_ticket_paths(repo_root / ".codex-autorunner" / "tickets"))
     entries = build_common_car_archive_entries(
-        repo_root / ".codex-autorunner", archive_root
+        car_root,
+        archive_root,
+        include_contextspace=False,
+    )
+    entries.append(
+        ArchiveEntrySpec(
+            label="contextspace",
+            source=_contextspace_source(car_root),
+            dest=archive_root / "contextspace",
+            mode="move",
+        )
     )
     entries.extend(
         ArchiveEntrySpec(
@@ -135,11 +157,15 @@ def archive_flow_run_artifacts(
         summary["archived_runs"] = "archived_runs" in moved_paths or any(
             path.startswith("archived_runs_") for path in moved_paths
         )
-        summary["archived_contextspace"] = "contextspace" in copied_paths
+        summary["archived_contextspace"] = "contextspace" in (
+            copied_paths | moved_paths
+        )
         summary["archived_paths"] = sorted(
             list(execution.copied_paths) + list(execution.moved_paths)
         )
         summary["missing_paths"] = list(execution.missing_paths)
+
+        seed_repo_files(repo_root, force=False, git_required=False)
 
         if delete_run:
             summary["deleted_run"] = bool(store.delete_flow_run(record.id))

--- a/src/codex_autorunner/static/generated/tickets.js
+++ b/src/codex_autorunner/static/generated/tickets.js
@@ -2045,7 +2045,7 @@ async function archiveTicketFlow() {
         flash("No ticket flow run to archive", "info");
         return;
     }
-    const confirmed = await confirmModal("Archive all tickets from this flow? They will be moved to the run's artifact directory.");
+    const confirmed = await confirmModal("Archive this flow? Tickets, contextspace, and run artifacts will move into the run archive and the live workspace state will be reset.");
     if (!confirmed) {
         return;
     }

--- a/src/codex_autorunner/static_src/tickets.ts
+++ b/src/codex_autorunner/static_src/tickets.ts
@@ -2355,7 +2355,7 @@ async function archiveTicketFlow(): Promise<void> {
     return;
   }
   const confirmed = await confirmModal(
-    "Archive all tickets from this flow? They will be moved to the run's artifact directory."
+    "Archive this flow? Tickets, contextspace, and run artifacts will move into the run archive and the live workspace state will be reset."
   );
   if (!confirmed) {
     return;

--- a/src/codex_autorunner/surfaces/cli/commands/hub_runs.py
+++ b/src/codex_autorunner/surfaces/cli/commands/hub_runs.py
@@ -178,7 +178,9 @@ def _archive_flow_run_artifacts(
         "deleted_run": False,
         "archived_tickets": moved_ticket_count,
         "archived_runs": False,
-        "archived_contextspace": False,
+        "archived_contextspace": any(
+            entry.label == "contextspace" for entry in entries
+        ),
         "archived_paths": [entry.label for entry in entries],
     }
 

--- a/src/codex_autorunner/surfaces/web/routes/flows.py
+++ b/src/codex_autorunner/surfaces/web/routes/flows.py
@@ -1454,7 +1454,7 @@ You are the first ticket in a new ticket_flow run.
         delete_run: bool = True,
         force: bool = False,
     ):
-        """Archive a completed flow by moving tickets to the run's artifact directory.
+        """Archive a completed flow and reset live ticket/contextspace state.
 
         Args:
             run_id: The flow run to archive.

--- a/tests/integrations/discord/test_flow_archive.py
+++ b/tests/integrations/discord/test_flow_archive.py
@@ -238,3 +238,57 @@ async def test_flow_archive_button_deletes_run_record_by_default(
         }
     ]
     assert "Archived run" in rest.interaction_responses[0]["payload"]["data"]["content"]
+
+
+@pytest.mark.anyio
+async def test_flow_archive_command_cleans_live_contextspace(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path)
+    run_id = str(uuid.uuid4())
+    _create_run(workspace, run_id, FlowRunStatus.COMPLETED)
+
+    tickets_dir = workspace / ".codex-autorunner" / "tickets"
+    tickets_dir.mkdir(parents=True, exist_ok=True)
+    (tickets_dir / "TICKET-001.md").write_text("ticket", encoding="utf-8")
+
+    context_dir = workspace / ".codex-autorunner" / "contextspace"
+    context_dir.mkdir(parents=True, exist_ok=True)
+    (context_dir / "active_context.md").write_text("Active context\n", encoding="utf-8")
+    (context_dir / "decisions.md").write_text("Decision log\n", encoding="utf-8")
+
+    run_dir = workspace / ".codex-autorunner" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "DISPATCH.md").write_text("dispatch", encoding="utf-8")
+
+    rest = _FakeRest()
+    service = _service(tmp_path, rest)
+
+    try:
+        await service._handle_flow_archive(
+            "interaction-3",
+            "token-3",
+            workspace_root=workspace,
+            options={"run_id": run_id},
+            channel_id="channel-1",
+            guild_id="guild-1",
+        )
+    finally:
+        await service._store.close()
+
+    assert (
+        workspace
+        / ".codex-autorunner"
+        / "flows"
+        / run_id
+        / "contextspace"
+        / "active_context.md"
+    ).read_text(encoding="utf-8") == "Active context\n"
+    assert (
+        workspace / ".codex-autorunner" / "contextspace" / "active_context.md"
+    ).read_text(encoding="utf-8") == ""
+    assert (
+        workspace / ".codex-autorunner" / "contextspace" / "decisions.md"
+    ).read_text(encoding="utf-8") == ""
+    assert not (workspace / ".codex-autorunner" / "tickets" / "TICKET-001.md").exists()
+    assert not (workspace / ".codex-autorunner" / "runs" / run_id).exists()

--- a/tests/routes/test_flow_archive_route.py
+++ b/tests/routes/test_flow_archive_route.py
@@ -27,6 +27,25 @@ def _create_run(repo_root: Path, run_id: str, status: FlowRunStatus) -> None:
         store.update_flow_run_status(run_id, status)
 
 
+def _seed_ticket_state(repo_root: Path, run_id: str) -> None:
+    tickets_dir = repo_root / ".codex-autorunner" / "tickets"
+    tickets_dir.mkdir(parents=True, exist_ok=True)
+    (tickets_dir / "TICKET-001.md").write_text("ticket", encoding="utf-8")
+
+    context_dir = repo_root / ".codex-autorunner" / "contextspace"
+    context_dir.mkdir(parents=True, exist_ok=True)
+    (context_dir / "active_context.md").write_text("Active context\n", encoding="utf-8")
+    (context_dir / "decisions.md").write_text("Decision log\n", encoding="utf-8")
+
+    run_dir = (
+        repo_root / ".codex-autorunner" / "runs" / run_id / "dispatch_history" / "0001"
+    )
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "DISPATCH.md").write_text(
+        "---\nmode: pause\n---\n\nhello\n", encoding="utf-8"
+    )
+
+
 def test_archive_route_deletes_run_record_by_default(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -66,3 +85,39 @@ def test_archive_route_deletes_run_record_by_default(
             "delete_run": True,
         }
     ]
+
+
+def test_archive_route_cleans_live_contextspace_after_archiving(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    client = _client_for_repo(repo_root)
+    run_id = str(uuid.uuid4())
+    _create_run(repo_root, run_id, FlowRunStatus.COMPLETED)
+    _seed_ticket_state(repo_root, run_id)
+
+    response = client.post(f"/api/flows/{run_id}/archive")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["archived_contextspace"] is True
+    assert payload["tickets_archived"] == 1
+
+    archived_context = (
+        repo_root
+        / ".codex-autorunner"
+        / "flows"
+        / run_id
+        / "contextspace"
+        / "active_context.md"
+    )
+    assert archived_context.read_text(encoding="utf-8") == "Active context\n"
+    assert (
+        repo_root / ".codex-autorunner" / "contextspace" / "active_context.md"
+    ).read_text(encoding="utf-8") == ""
+    assert (
+        repo_root / ".codex-autorunner" / "contextspace" / "decisions.md"
+    ).read_text(encoding="utf-8") == ""
+    assert not (repo_root / ".codex-autorunner" / "tickets" / "TICKET-001.md").exists()
+    assert not (repo_root / ".codex-autorunner" / "runs" / run_id).exists()

--- a/tests/test_cli_ticket_flow_archive.py
+++ b/tests/test_cli_ticket_flow_archive.py
@@ -52,6 +52,8 @@ def _seed_contextspace(repo_root: Path) -> None:
     context_dir = repo_root / ".codex-autorunner" / "contextspace"
     context_dir.mkdir(parents=True, exist_ok=True)
     (context_dir / "active_context.md").write_text("Active context\n", encoding="utf-8")
+    (context_dir / "decisions.md").write_text("Decision log\n", encoding="utf-8")
+    (context_dir / "notes.md").write_text("Scratch note\n", encoding="utf-8")
 
 
 def _setup_repo(tmp_path: Path) -> Path:
@@ -125,7 +127,28 @@ def test_ticket_flow_archive_moves_run_artifacts_and_deletes_run(
         / "contextspace"
         / "active_context.md"
     ).read_text(encoding="utf-8") == "Active context\n"
+    assert (
+        repo_root
+        / ".codex-autorunner"
+        / "flows"
+        / run_id
+        / "contextspace"
+        / "decisions.md"
+    ).read_text(encoding="utf-8") == "Decision log\n"
+    assert (
+        repo_root / ".codex-autorunner" / "flows" / run_id / "contextspace" / "notes.md"
+    ).read_text(encoding="utf-8") == "Scratch note\n"
     assert not (repo_root / ".codex-autorunner" / "tickets" / "TICKET-001.md").exists()
+    assert (
+        repo_root / ".codex-autorunner" / "contextspace" / "active_context.md"
+    ).read_text(encoding="utf-8") == ""
+    assert (
+        repo_root / ".codex-autorunner" / "contextspace" / "decisions.md"
+    ).read_text(encoding="utf-8") == ""
+    assert (repo_root / ".codex-autorunner" / "contextspace" / "spec.md").read_text(
+        encoding="utf-8"
+    ) == ""
+    assert not (repo_root / ".codex-autorunner" / "contextspace" / "notes.md").exists()
 
     db_path = repo_root / ".codex-autorunner" / "flows.db"
     with FlowStore(db_path) as store:

--- a/tests/test_telegram_flow_lifecycle.py
+++ b/tests/test_telegram_flow_lifecycle.py
@@ -275,6 +275,11 @@ async def test_flow_archive_defaults_latest_paused(
     tickets_dir.mkdir(parents=True, exist_ok=True)
     (tickets_dir / "TICKET-001.md").write_text("ticket", encoding="utf-8")
 
+    context_dir = tmp_path / ".codex-autorunner" / "contextspace"
+    context_dir.mkdir(parents=True, exist_ok=True)
+    (context_dir / "active_context.md").write_text("Active context\n", encoding="utf-8")
+    (context_dir / "decisions.md").write_text("Decision log\n", encoding="utf-8")
+
     run_dir = tmp_path / ".codex-autorunner" / "runs" / run_paused
     run_dir.mkdir(parents=True, exist_ok=True)
     (run_dir / "DISPATCH.md").write_text("dispatch", encoding="utf-8")
@@ -290,6 +295,20 @@ async def test_flow_archive_defaults_latest_paused(
         tmp_path / ".codex-autorunner" / "flows" / run_paused / "archived_runs"
     )
     assert archived_runs.exists()
+    assert (
+        tmp_path
+        / ".codex-autorunner"
+        / "flows"
+        / run_paused
+        / "contextspace"
+        / "active_context.md"
+    ).read_text(encoding="utf-8") == "Active context\n"
+    assert (
+        tmp_path / ".codex-autorunner" / "contextspace" / "active_context.md"
+    ).read_text(encoding="utf-8") == ""
+    assert (tmp_path / ".codex-autorunner" / "contextspace" / "decisions.md").read_text(
+        encoding="utf-8"
+    ) == ""
     assert handler.stopped_workers == [run_paused]
 
     store = FlowStore(tmp_path / ".codex-autorunner" / "flows.db")


### PR DESCRIPTION
## Summary
- archive flow contextspace by move instead of copy so archiving a flow clears live context docs after snapshotting them into the run archive
- reseed repo defaults after flow archive so web, Discord, and Telegram all leave behind a clean `.codex-autorunner/contextspace/` while preserving archived tickets and run dispatch history
- update regression coverage for CLI, web route, Telegram, and Discord flow archive paths, and refresh the web UI confirmation copy

## Testing
- python3 -m pytest tests/test_cli_ticket_flow_archive.py tests/routes/test_flow_archive_route.py tests/test_telegram_flow_lifecycle.py tests/integrations/discord/test_flow_archive.py
- pre-commit hooks via `git commit` (black, ruff, mypy, eslint, frontend build/tests, full pytest: 2829 passed, 1 skipped)
