### PR TITLE
Default Discord flow status to latest run

### DIFF
--- a/src/codex_autorunner/integrations/discord/components.py
+++ b/src/codex_autorunner/integrations/discord/components.py
@@ -279,15 +279,41 @@ def build_flow_runs_picker(
     *,
     custom_id: str = "flow_runs_select",
     placeholder: str = "Select a run...",
+    current_run_id: Optional[str] = None,
 ) -> dict[str, Any]:
-    options = [
-        build_select_option(
-            label=f"{run_id[:50]} [{status}]"[:100],
-            value=run_id,
-            description=f"Status: {status}",
+    options: list[dict[str, Any]] = []
+    rendered_run_ids: set[str] = set()
+    option_limit = DISCORD_SELECT_OPTION_MAX_OPTIONS
+
+    for run_id, status in runs[:option_limit]:
+        rendered_run_ids.add(run_id)
+        options.append(
+            build_select_option(
+                label=f"{run_id[:50]} [{status}]"[:100],
+                value=run_id,
+                description=f"Status: {status}",
+                default=current_run_id == run_id,
+            )
         )
-        for run_id, status in runs[:DISCORD_SELECT_OPTION_MAX_OPTIONS]
-    ]
+
+    if current_run_id and current_run_id not in rendered_run_ids:
+        current_entry = next(
+            (entry for entry in runs if entry[0] == current_run_id),
+            None,
+        )
+        if current_entry is not None:
+            run_id, status = current_entry
+            if len(options) >= option_limit:
+                options.pop()
+            options.append(
+                build_select_option(
+                    label=f"{run_id[:50]} [{status}]"[:100],
+                    value=run_id,
+                    description=f"Status: {status}",
+                    default=True,
+                )
+            )
+
     if not options:
         options = [build_select_option("No runs available", "none", default=True)]
     return build_action_row(

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -2097,6 +2097,8 @@ class DiscordBotService:
         run_id_opt: Any,
     ) -> Optional[str]:
         if not (isinstance(run_id_opt, str) and run_id_opt.strip()):
+            if action == "status":
+                return ""
             await self._prompt_flow_action_picker(
                 interaction_id,
                 interaction_token,
@@ -6137,6 +6139,27 @@ class DiscordBotService:
             return None
         return select_authoritative_run_record(records)
 
+    @staticmethod
+    def _build_flow_status_components(
+        record: FlowRunRecord,
+        runs: list[FlowRunRecord],
+    ) -> list[dict[str, Any]]:
+        components = build_flow_status_buttons(
+            record.id,
+            record.status.value,
+            include_refresh=True,
+        )
+        run_tuples = [(run.id, run.status.value) for run in runs]
+        if len(run_tuples) > 1:
+            components.append(
+                build_flow_runs_picker(
+                    run_tuples,
+                    placeholder="Select another run...",
+                    current_run_id=record.id,
+                )
+            )
+        return components
+
     async def _handle_flow_status(
         self,
         interaction_id: str,
@@ -6173,11 +6196,13 @@ class DiscordBotService:
             ) from None
         try:
             record: Optional[FlowRunRecord]
+            runs: list[FlowRunRecord] = []
             if isinstance(run_id_opt, str) and run_id_opt.strip():
                 try:
                     record = self._resolve_flow_run_by_id(
                         store, run_id=run_id_opt.strip()
                     )
+                    runs = store.list_flow_runs(flow_type="ticket_flow")
                 except (sqlite3.Error, OSError) as exc:
                     log_event(
                         self._logger,
@@ -6317,11 +6342,7 @@ class DiscordBotService:
             meta={"response_type": "ephemeral"},
         )
 
-        status_buttons = build_flow_status_buttons(
-            record.id,
-            record.status.value,
-            include_refresh=True,
-        )
+        status_buttons = self._build_flow_status_components(record, runs)
         if status_buttons:
             if update_message:
                 await self._update_component_message(

--- a/tests/integrations/discord/test_components.py
+++ b/tests/integrations/discord/test_components.py
@@ -189,6 +189,13 @@ class TestBuildFlowRunsPicker:
         assert menu["custom_id"] == "flow_runs_select"
         assert len(menu["options"]) == 2
 
+    def test_marks_current_run_as_selected(self) -> None:
+        runs = [("run-1", "running"), ("run-2", "paused")]
+        picker = build_flow_runs_picker(runs, current_run_id="run-2")
+        options = picker["components"][0]["options"]
+        assert options[0]["default"] is False
+        assert options[1]["default"] is True
+
     def test_builds_picker_with_empty_runs(self) -> None:
         picker = build_flow_runs_picker([])
         menu = picker["components"][0]

--- a/tests/integrations/discord/test_flow_handlers.py
+++ b/tests/integrations/discord/test_flow_handlers.py
@@ -286,6 +286,62 @@ async def test_flow_status_and_runs_render_expected_output(tmp_path: Path) -> No
 
 
 @pytest.mark.anyio
+async def test_flow_status_without_run_id_uses_latest_run_and_includes_picker(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path)
+    completed_run_id = str(uuid.uuid4())
+    paused_run_id = str(uuid.uuid4())
+    _create_run(workspace, completed_run_id, status=FlowRunStatus.COMPLETED)
+    _create_run(workspace, paused_run_id, status=FlowRunStatus.PAUSED)
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway([_flow_interaction(name="status", options=[])])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 1
+        payload = rest.interaction_responses[0]["payload"]["data"]
+        content = payload["content"]
+        components = payload["components"]
+
+        assert f"Run: {paused_run_id}" in content
+        assert "Status: paused" in content
+        picker_rows = [
+            row
+            for row in components
+            if row["components"][0].get("custom_id") == "flow_runs_select"
+        ]
+        assert len(picker_rows) == 1
+        picker_options = picker_rows[0]["components"][0]["options"]
+        assert [option["value"] for option in picker_options] == [
+            paused_run_id,
+            completed_run_id,
+        ]
+        assert picker_options[0]["default"] is True
+        assert picker_options[1]["default"] is False
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_flow_status_shows_elapsed_for_completed_run(tmp_path: Path) -> None:
     workspace = _workspace(tmp_path)
     completed_run_id = str(uuid.uuid4())


### PR DESCRIPTION
## Summary

- default Discord `/car flow status` to the latest authoritative run when no `run_id` is provided
- include a run picker on the status card so users can jump to a different run without leaving status
- keep `/car flow runs` as the explicit history/list surface

## Testing

- .venv/bin/python -m pytest tests/integrations/discord/test_components.py tests/integrations/discord/test_flow_handlers.py -q
- pre-commit hooks via `git commit` (full repo checks, including full pytest)
