### PR TITLE
fix: fully clear live state when archiving ticket flows

### DIFF
--- a/src/codex_autorunner/core/flows/archive_helpers.py
+++ b/src/codex_autorunner/core/flows/archive_helpers.py
@@ -17,6 +17,14 @@ from .models import FlowRunStatus
 from .store import FlowStore
 
 
+def flow_run_artifacts_root(repo_root: Path, run_id: str) -> Path:
+    return repo_root / ".codex-autorunner" / "flows" / run_id
+
+
+def flow_run_archive_root(repo_root: Path, run_id: str) -> Path:
+    return repo_root / ".codex-autorunner" / "archive" / "runs" / run_id
+
+
 def _get_durable_writes(repo_root: Path) -> bool:
     """Get durable_writes from repo config, defaulting to False if uninitialized."""
     try:
@@ -49,7 +57,8 @@ def _build_flow_archive_entries(
     run_dir: Path,
 ) -> tuple[list[ArchiveEntrySpec], dict[str, Any]]:
     car_root = repo_root / ".codex-autorunner"
-    archive_root = repo_root / ".codex-autorunner" / "flows" / run_id
+    archive_root = flow_run_archive_root(repo_root, run_id)
+    flow_state_root = flow_run_artifacts_root(repo_root, run_id)
     target_runs_dir = _next_archive_dir(archive_root / "archived_runs")
     ticket_paths = list(list_ticket_paths(repo_root / ".codex-autorunner" / "tickets"))
     entries = build_common_car_archive_entries(
@@ -82,9 +91,19 @@ def _build_flow_archive_entries(
             mode="move",
         )
     )
+    entries.append(
+        ArchiveEntrySpec(
+            label="flow_state",
+            source=flow_state_root,
+            dest=archive_root / "flow_state",
+            mode="move",
+            required=False,
+        )
+    )
     summary: dict[str, Any] = {
         "archive_root": str(archive_root),
         "archived_runs_dir": str(target_runs_dir),
+        "archived_flow_state_dir": str(archive_root / "flow_state"),
         "ticket_count": len(ticket_paths),
     }
     return entries, summary
@@ -141,11 +160,13 @@ def archive_flow_run_artifacts(
             "run_dir_exists": run_dir.exists() and run_dir.is_dir(),
             "archive_dir": archive_plan["archive_root"],
             "archived_runs_dir": archive_plan["archived_runs_dir"],
+            "archived_flow_state_dir": archive_plan["archived_flow_state_dir"],
             "delete_run": delete_run,
             "deleted_run": False,
             "archived_tickets": 0,
             "archived_runs": False,
             "archived_contextspace": False,
+            "archived_flow_state": False,
             "archived_paths": [],
         }
         execution = execute_archive_entries(entries, worktree_root=repo_root)
@@ -160,6 +181,7 @@ def archive_flow_run_artifacts(
         summary["archived_contextspace"] = "contextspace" in (
             copied_paths | moved_paths
         )
+        summary["archived_flow_state"] = "flow_state" in moved_paths
         summary["archived_paths"] = sorted(
             list(execution.copied_paths) + list(execution.moved_paths)
         )
@@ -173,4 +195,9 @@ def archive_flow_run_artifacts(
         return summary
 
 
-__all__ = ["archive_flow_run_artifacts", "_build_flow_archive_entries"]
+__all__ = [
+    "archive_flow_run_artifacts",
+    "flow_run_archive_root",
+    "flow_run_artifacts_root",
+    "_build_flow_archive_entries",
+]

--- a/src/codex_autorunner/integrations/discord/outbox.py
+++ b/src/codex_autorunner/integrations/discord/outbox.py
@@ -10,6 +10,7 @@ import httpx
 
 from ...core.config import ConfigError, load_repo_config
 from ...core.flows import FlowStore
+from ...core.flows.archive_helpers import flow_run_archive_root
 from .state import DiscordStateStore, OutboxRecord
 
 OUTBOX_RETRY_INTERVAL_SECONDS = 5.0
@@ -57,12 +58,17 @@ def _terminal_run_id(record_id: str) -> Optional[str]:
 
 
 def _has_archived_run_artifacts(workspace_root: Path, run_id: str) -> bool:
-    archive_root = workspace_root / ".codex-autorunner" / "flows" / run_id
-    if not archive_root.exists():
-        return False
-    if (archive_root / "archived_tickets").exists():
+    archive_root = flow_run_archive_root(workspace_root, run_id)
+    if archive_root.exists() and (archive_root / "archived_tickets").exists():
         return True
-    return any(archive_root.glob("archived_runs*"))
+    if archive_root.exists() and any(archive_root.glob("archived_runs*")):
+        return True
+    legacy_root = workspace_root / ".codex-autorunner" / "flows" / run_id
+    if not legacy_root.exists():
+        return False
+    if (legacy_root / "archived_tickets").exists():
+        return True
+    return any(legacy_root.glob("archived_runs*"))
 
 
 class DiscordOutboxManager:

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -7292,7 +7292,7 @@ class DiscordBotService:
                 workspace_root,
                 run_id=target.id,
                 force=False,
-                delete_run=False,
+                delete_run=True,
             )
         except ValueError as exc:
             await self._respond_ephemeral(interaction_id, interaction_token, str(exc))
@@ -7304,22 +7304,6 @@ class DiscordBotService:
             f"runs_archived={summary['archived_runs']}, "
             f"contextspace={summary['archived_contextspace']})."
         )
-        run_mirror.mirror_outbound(
-            run_id=target.id,
-            platform="discord",
-            event_type="flow_archive_notice",
-            kind="notice",
-            actor="car",
-            text=outbound_text,
-            chat_id=channel_id,
-            thread_id=guild_id,
-            meta={
-                "archived_runs": summary.get("archived_runs"),
-                "archived_tickets": summary.get("archived_tickets"),
-                "archived_contextspace": summary.get("archived_contextspace"),
-            },
-        )
-        self._delete_flow_run_record(workspace_root, target.id)
         await self._respond_ephemeral(
             interaction_id,
             interaction_token,

--- a/src/codex_autorunner/surfaces/web/routes/archive.py
+++ b/src/codex_autorunner/surfaces/web/routes/archive.py
@@ -12,6 +12,7 @@ from typing import Any, Literal, Optional
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, PlainTextResponse
 
+from ....core.flows.archive_helpers import flow_run_archive_root
 from ..schemas import (
     ArchiveSnapshotDetailResponse,
     ArchiveSnapshotsResponse,
@@ -31,7 +32,11 @@ def _archive_worktrees_root(repo_root: Path) -> Path:
     return repo_root / ".codex-autorunner" / "archive" / "worktrees"
 
 
-def _local_flows_root(repo_root: Path) -> Path:
+def _local_run_archives_root(repo_root: Path) -> Path:
+    return repo_root / ".codex-autorunner" / "archive" / "runs"
+
+
+def _legacy_local_flows_root(repo_root: Path) -> Path:
     return repo_root / ".codex-autorunner" / "flows"
 
 
@@ -133,11 +138,13 @@ def _resolve_snapshot_root(
 
 def _resolve_local_run_root(repo_root: Path, run_id: str) -> Path:
     run_id = _normalize_component(run_id, "run_id")
-    flows_root = _local_flows_root(repo_root)
-    run_root = flows_root / run_id
-    if not run_root.exists() or not run_root.is_dir():
-        raise FileNotFoundError("run archive not found")
-    return run_root
+    primary = flow_run_archive_root(repo_root, run_id)
+    if primary.exists() and primary.is_dir():
+        return primary
+    legacy = _legacy_local_flows_root(repo_root) / run_id
+    if legacy.exists() and legacy.is_dir():
+        return legacy
+    raise FileNotFoundError("run archive not found")
 
 
 def _safe_mtime(path: Path) -> Optional[float]:
@@ -233,38 +240,49 @@ def _format_mtime(ts: Optional[float]) -> Optional[str]:
 
 
 def _iter_local_run_archives(repo_root: Path) -> list[LocalRunArchiveSummary]:
-    flows_root = _local_flows_root(repo_root)
-    if not flows_root.exists() or not flows_root.is_dir():
-        return []
+    roots = [
+        (_local_run_archives_root(repo_root), True),
+        (_legacy_local_flows_root(repo_root), False),
+    ]
     entries: list[tuple[float, LocalRunArchiveSummary]] = []
-    for run_dir in sorted(flows_root.iterdir(), key=lambda p: p.name):
-        if not run_dir.is_dir():
+    seen_run_ids: set[str] = set()
+    for root, treat_any_child_as_archive in roots:
+        if not root.exists() or not root.is_dir():
             continue
-        tickets_dir = run_dir / "archived_tickets"
-        runs_dir = run_dir / "archived_runs"
-        has_tickets = tickets_dir.exists() and tickets_dir.is_dir()
-        has_runs = runs_dir.exists() and runs_dir.is_dir()
-        other_children = [
-            child
-            for child in run_dir.iterdir()
-            if child.name
-            in (_LOCAL_ARCHIVE_MARKERS - {"archived_tickets", "archived_runs"})
-        ]
-        if not has_tickets and not has_runs and not other_children:
-            continue
-        mtime_candidates = [
-            _safe_mtime(tickets_dir) if has_tickets else None,
-            _safe_mtime(runs_dir) if has_runs else None,
-            *[_safe_mtime(child) for child in other_children],
-        ]
-        mtime = max([ts for ts in mtime_candidates if ts is not None], default=0.0)
-        summary = LocalRunArchiveSummary(
-            run_id=run_dir.name,
-            archived_at=_format_mtime(mtime) if mtime else None,
-            has_tickets=has_tickets,
-            has_runs=has_runs,
-        )
-        entries.append((mtime, summary))
+        for run_dir in sorted(root.iterdir(), key=lambda p: p.name):
+            if not run_dir.is_dir() or run_dir.name in seen_run_ids:
+                continue
+            tickets_dir = run_dir / "archived_tickets"
+            runs_dir = run_dir / "archived_runs"
+            has_tickets = tickets_dir.exists() and tickets_dir.is_dir()
+            has_runs = runs_dir.exists() and runs_dir.is_dir()
+            if treat_any_child_as_archive:
+                other_children = [
+                    child for child in run_dir.iterdir() if child.name != "META.json"
+                ]
+            else:
+                other_children = [
+                    child
+                    for child in run_dir.iterdir()
+                    if child.name
+                    in (_LOCAL_ARCHIVE_MARKERS - {"archived_tickets", "archived_runs"})
+                ]
+            if not has_tickets and not has_runs and not other_children:
+                continue
+            mtime_candidates = [
+                _safe_mtime(tickets_dir) if has_tickets else None,
+                _safe_mtime(runs_dir) if has_runs else None,
+                *[_safe_mtime(child) for child in other_children],
+            ]
+            mtime = max([ts for ts in mtime_candidates if ts is not None], default=0.0)
+            summary = LocalRunArchiveSummary(
+                run_id=run_dir.name,
+                archived_at=_format_mtime(mtime) if mtime else None,
+                has_tickets=has_tickets,
+                has_runs=has_runs,
+            )
+            entries.append((mtime, summary))
+            seen_run_ids.add(run_dir.name)
     entries.sort(key=lambda item: (item[0], item[1].run_id), reverse=True)
     return [entry[1] for entry in entries]
 

--- a/tests/integrations/discord/test_flow_archive.py
+++ b/tests/integrations/discord/test_flow_archive.py
@@ -135,10 +135,13 @@ async def test_flow_archive_command_deletes_run_record_by_default(
     rest = _FakeRest()
     service = _service(tmp_path, rest)
     captured: list[dict[str, Any]] = []
-    mirrored_run_exists: list[bool] = []
 
     def _archive_flow_run_artifacts(repo_root: Path, **kwargs: Any) -> dict[str, Any]:
         captured.append({"repo_root": str(repo_root), **kwargs})
+        if kwargs.get("delete_run"):
+            with FlowStore(workspace / ".codex-autorunner" / "flows.db") as store:
+                store.initialize()
+                store.delete_flow_run(run_id)
         return {
             "run_id": kwargs["run_id"],
             "archived_tickets": 0,
@@ -151,18 +154,6 @@ async def test_flow_archive_command_deletes_run_record_by_default(
         "archive_flow_run_artifacts",
         _archive_flow_run_artifacts,
     )
-
-    class _Mirror:
-        def mirror_inbound(self, **kwargs: Any) -> None:
-            _ = kwargs
-
-        def mirror_outbound(self, **kwargs: Any) -> None:
-            _ = kwargs
-            with FlowStore(workspace / ".codex-autorunner" / "flows.db") as store:
-                store.initialize()
-                mirrored_run_exists.append(store.get_flow_run(run_id) is not None)
-
-    monkeypatch.setattr(service, "_flow_run_mirror", lambda _workspace_root: _Mirror())
 
     try:
         await service._handle_flow_archive(
@@ -181,10 +172,9 @@ async def test_flow_archive_command_deletes_run_record_by_default(
             "repo_root": str(workspace),
             "run_id": run_id,
             "force": False,
-            "delete_run": False,
+            "delete_run": True,
         }
     ]
-    assert mirrored_run_exists == [True]
     with FlowStore(workspace / ".codex-autorunner" / "flows.db") as store:
         store.initialize()
         assert store.get_flow_run(run_id) is None
@@ -260,6 +250,9 @@ async def test_flow_archive_command_cleans_live_contextspace(
     run_dir = workspace / ".codex-autorunner" / "runs" / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
     (run_dir / "DISPATCH.md").write_text("dispatch", encoding="utf-8")
+    live_flow_dir = workspace / ".codex-autorunner" / "flows" / run_id / "chat"
+    live_flow_dir.mkdir(parents=True, exist_ok=True)
+    (live_flow_dir / "outbound.jsonl").write_text("{}", encoding="utf-8")
 
     rest = _FakeRest()
     service = _service(tmp_path, rest)
@@ -279,11 +272,22 @@ async def test_flow_archive_command_cleans_live_contextspace(
     assert (
         workspace
         / ".codex-autorunner"
-        / "flows"
+        / "archive"
+        / "runs"
         / run_id
         / "contextspace"
         / "active_context.md"
     ).read_text(encoding="utf-8") == "Active context\n"
+    assert (
+        workspace
+        / ".codex-autorunner"
+        / "archive"
+        / "runs"
+        / run_id
+        / "flow_state"
+        / "chat"
+        / "outbound.jsonl"
+    ).read_text(encoding="utf-8") == "{}"
     assert (
         workspace / ".codex-autorunner" / "contextspace" / "active_context.md"
     ).read_text(encoding="utf-8") == ""
@@ -291,4 +295,5 @@ async def test_flow_archive_command_cleans_live_contextspace(
         workspace / ".codex-autorunner" / "contextspace" / "decisions.md"
     ).read_text(encoding="utf-8") == ""
     assert not (workspace / ".codex-autorunner" / "tickets" / "TICKET-001.md").exists()
+    assert not (workspace / ".codex-autorunner" / "flows" / run_id).exists()
     assert not (workspace / ".codex-autorunner" / "runs" / run_id).exists()

--- a/tests/integrations/discord/test_outbox_retry.py
+++ b/tests/integrations/discord/test_outbox_retry.py
@@ -310,9 +310,9 @@ async def test_flush_drops_terminal_notice_for_archived_run(tmp_path: Path) -> N
     workspace = _workspace(tmp_path)
     run_id = "run-archived"
     _create_terminal_run(workspace, run_id)
-    (workspace / ".codex-autorunner" / "flows" / run_id / "archived_runs").mkdir(
-        parents=True, exist_ok=True
-    )
+    (
+        workspace / ".codex-autorunner" / "archive" / "runs" / run_id / "archived_runs"
+    ).mkdir(parents=True, exist_ok=True)
 
     store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
     clock = _Clock()

--- a/tests/routes/test_archive_routes.py
+++ b/tests/routes/test_archive_routes.py
@@ -160,19 +160,21 @@ def test_local_archive_tree_reads_any_archived_run_content(tmp_path: Path) -> No
     repo_root.mkdir()
     client = _client_for_repo(repo_root)
 
-    run_root = repo_root / ".codex-autorunner" / "flows" / "run-123"
+    run_root = repo_root / ".codex-autorunner" / "archive" / "runs" / "run-123"
     (run_root / "contextspace").mkdir(parents=True, exist_ok=True)
     (run_root / "contextspace" / "active_context.md").write_text(
         "Local archived context", encoding="utf-8"
     )
-    (run_root / "chat").mkdir(parents=True, exist_ok=True)
-    (run_root / "chat" / "outbound.jsonl").write_text("{}", encoding="utf-8")
+    (run_root / "flow_state" / "chat").mkdir(parents=True, exist_ok=True)
+    (run_root / "flow_state" / "chat" / "outbound.jsonl").write_text(
+        "{}", encoding="utf-8"
+    )
 
     tree = client.get("/api/archive/local/tree", params={"run_id": "run-123"})
     assert tree.status_code == 200
     nodes = {node["path"]: node for node in tree.json()["nodes"]}
     assert "contextspace" in nodes
-    assert "chat" in nodes
+    assert "flow_state" in nodes
 
     read = client.get(
         "/api/archive/local/file",

--- a/tests/routes/test_flow_archive_route.py
+++ b/tests/routes/test_flow_archive_route.py
@@ -44,6 +44,9 @@ def _seed_ticket_state(repo_root: Path, run_id: str) -> None:
     (run_dir / "DISPATCH.md").write_text(
         "---\nmode: pause\n---\n\nhello\n", encoding="utf-8"
     )
+    live_flow_dir = repo_root / ".codex-autorunner" / "flows" / run_id / "chat"
+    live_flow_dir.mkdir(parents=True, exist_ok=True)
+    (live_flow_dir / "outbound.jsonl").write_text("{}", encoding="utf-8")
 
 
 def test_archive_route_deletes_run_record_by_default(
@@ -107,12 +110,23 @@ def test_archive_route_cleans_live_contextspace_after_archiving(
     archived_context = (
         repo_root
         / ".codex-autorunner"
-        / "flows"
+        / "archive"
+        / "runs"
         / run_id
         / "contextspace"
         / "active_context.md"
     )
     assert archived_context.read_text(encoding="utf-8") == "Active context\n"
+    assert (
+        repo_root
+        / ".codex-autorunner"
+        / "archive"
+        / "runs"
+        / run_id
+        / "flow_state"
+        / "chat"
+        / "outbound.jsonl"
+    ).read_text(encoding="utf-8") == "{}"
     assert (
         repo_root / ".codex-autorunner" / "contextspace" / "active_context.md"
     ).read_text(encoding="utf-8") == ""
@@ -120,4 +134,5 @@ def test_archive_route_cleans_live_contextspace_after_archiving(
         repo_root / ".codex-autorunner" / "contextspace" / "decisions.md"
     ).read_text(encoding="utf-8") == ""
     assert not (repo_root / ".codex-autorunner" / "tickets" / "TICKET-001.md").exists()
+    assert not (repo_root / ".codex-autorunner" / "flows" / run_id).exists()
     assert not (repo_root / ".codex-autorunner" / "runs" / run_id).exists()

--- a/tests/test_cli_hub_runs_cleanup.py
+++ b/tests/test_cli_hub_runs_cleanup.py
@@ -62,7 +62,12 @@ def test_hub_runs_cleanup_archives_and_deletes_terminal_runs(hub_env) -> None:
     assert entry["deleted_run"] is True
 
     archived_root = (
-        hub_env.repo_root / ".codex-autorunner" / "flows" / run_id / "archived_runs"
+        hub_env.repo_root
+        / ".codex-autorunner"
+        / "archive"
+        / "runs"
+        / run_id
+        / "archived_runs"
     )
     assert archived_root.exists()
 

--- a/tests/test_cli_ticket_flow_archive.py
+++ b/tests/test_cli_ticket_flow_archive.py
@@ -86,6 +86,9 @@ def test_ticket_flow_archive_moves_run_artifacts_and_deletes_run(
     (run_dir / "DISPATCH.md").write_text(
         "---\nmode: pause\n---\n\nhello\n", encoding="utf-8"
     )
+    live_flow_dir = repo_root / ".codex-autorunner" / "flows" / run_id / "chat"
+    live_flow_dir.mkdir(parents=True, exist_ok=True)
+    (live_flow_dir / "outbound.jsonl").write_text("{}", encoding="utf-8")
 
     result = runner.invoke(
         app,
@@ -109,12 +112,15 @@ def test_ticket_flow_archive_moves_run_artifacts_and_deletes_run(
     assert payload["archived_contextspace"] is True
     assert payload["deleted_run"] is True
 
-    archived_root = repo_root / ".codex-autorunner" / "flows" / run_id / "archived_runs"
+    archived_root = (
+        repo_root / ".codex-autorunner" / "archive" / "runs" / run_id / "archived_runs"
+    )
     assert archived_root.exists()
     assert (
         repo_root
         / ".codex-autorunner"
-        / "flows"
+        / "archive"
+        / "runs"
         / run_id
         / "archived_tickets"
         / "TICKET-001.md"
@@ -122,7 +128,8 @@ def test_ticket_flow_archive_moves_run_artifacts_and_deletes_run(
     assert (
         repo_root
         / ".codex-autorunner"
-        / "flows"
+        / "archive"
+        / "runs"
         / run_id
         / "contextspace"
         / "active_context.md"
@@ -130,14 +137,32 @@ def test_ticket_flow_archive_moves_run_artifacts_and_deletes_run(
     assert (
         repo_root
         / ".codex-autorunner"
-        / "flows"
+        / "archive"
+        / "runs"
         / run_id
         / "contextspace"
         / "decisions.md"
     ).read_text(encoding="utf-8") == "Decision log\n"
     assert (
-        repo_root / ".codex-autorunner" / "flows" / run_id / "contextspace" / "notes.md"
+        repo_root
+        / ".codex-autorunner"
+        / "archive"
+        / "runs"
+        / run_id
+        / "contextspace"
+        / "notes.md"
     ).read_text(encoding="utf-8") == "Scratch note\n"
+    assert (
+        repo_root
+        / ".codex-autorunner"
+        / "archive"
+        / "runs"
+        / run_id
+        / "flow_state"
+        / "chat"
+        / "outbound.jsonl"
+    ).read_text(encoding="utf-8") == "{}"
+    assert not (repo_root / ".codex-autorunner" / "flows" / run_id).exists()
     assert not (repo_root / ".codex-autorunner" / "tickets" / "TICKET-001.md").exists()
     assert (
         repo_root / ".codex-autorunner" / "contextspace" / "active_context.md"

--- a/tests/test_telegram_flow_lifecycle.py
+++ b/tests/test_telegram_flow_lifecycle.py
@@ -283,32 +283,57 @@ async def test_flow_archive_defaults_latest_paused(
     run_dir = tmp_path / ".codex-autorunner" / "runs" / run_paused
     run_dir.mkdir(parents=True, exist_ok=True)
     (run_dir / "DISPATCH.md").write_text("dispatch", encoding="utf-8")
+    live_flow_dir = tmp_path / ".codex-autorunner" / "flows" / run_paused / "chat"
+    live_flow_dir.mkdir(parents=True, exist_ok=True)
+    (live_flow_dir / "outbound.jsonl").write_text("{}", encoding="utf-8")
 
     handler = _FlowLifecycleHandler()
     await handler._handle_flow_archive(_message(), tmp_path, argv=[])
 
     archive_dir = (
-        tmp_path / ".codex-autorunner" / "flows" / run_paused / "archived_tickets"
+        tmp_path
+        / ".codex-autorunner"
+        / "archive"
+        / "runs"
+        / run_paused
+        / "archived_tickets"
     )
     assert (archive_dir / "TICKET-001.md").exists()
     archived_runs = (
-        tmp_path / ".codex-autorunner" / "flows" / run_paused / "archived_runs"
+        tmp_path
+        / ".codex-autorunner"
+        / "archive"
+        / "runs"
+        / run_paused
+        / "archived_runs"
     )
     assert archived_runs.exists()
     assert (
         tmp_path
         / ".codex-autorunner"
-        / "flows"
+        / "archive"
+        / "runs"
         / run_paused
         / "contextspace"
         / "active_context.md"
     ).read_text(encoding="utf-8") == "Active context\n"
+    assert (
+        tmp_path
+        / ".codex-autorunner"
+        / "archive"
+        / "runs"
+        / run_paused
+        / "flow_state"
+        / "chat"
+        / "outbound.jsonl"
+    ).read_text(encoding="utf-8") == "{}"
     assert (
         tmp_path / ".codex-autorunner" / "contextspace" / "active_context.md"
     ).read_text(encoding="utf-8") == ""
     assert (tmp_path / ".codex-autorunner" / "contextspace" / "decisions.md").read_text(
         encoding="utf-8"
     ) == ""
+    assert not (tmp_path / ".codex-autorunner" / "flows" / run_paused).exists()
     assert handler.stopped_workers == [run_paused]
 
     store = FlowStore(tmp_path / ".codex-autorunner" / "flows.db")


### PR DESCRIPTION
## Summary
- move archived ticket-flow payloads into `.codex-autorunner/archive/runs/<run_id>` instead of reusing the live `.codex-autorunner/flows/<run_id>` namespace
- have the shared archive helper move live per-run flow artifacts into the archive under `flow_state/` so chat mirrors and other run-specific files no longer survive in live state after archive
- align Discord archive command behavior with the shared delete-in-helper flow and update archive/outbox/browser tests for the new layout

## Testing
- `.venv/bin/pytest tests/integrations/discord/test_flow_archive.py tests/test_cli_ticket_flow_archive.py tests/routes/test_flow_archive_route.py tests/test_telegram_flow_lifecycle.py tests/routes/test_archive_routes.py tests/integrations/discord/test_outbox_retry.py tests/test_cli_hub_runs_cleanup.py`
- full pre-commit stack via `git commit` including `mypy`, `pnpm run build`, frontend tests, and full `pytest` (`3012 passed, 1 skipped`)
