### PR TITLE
Fix OpenCode reply parsing for message.part.updated

### DIFF
--- a/src/codex_autorunner/agents/opencode/harness.py
+++ b/src/codex_autorunner/agents/opencode/harness.py
@@ -98,6 +98,54 @@ def _extract_error_text(params: dict[str, Any]) -> Optional[str]:
     )
 
 
+def _extract_message_info(params: dict[str, Any]) -> dict[str, Any]:
+    info = params.get("info")
+    if isinstance(info, dict):
+        return info
+    properties = params.get("properties")
+    if isinstance(properties, dict):
+        nested = properties.get("info")
+        if isinstance(nested, dict):
+            return nested
+    return {}
+
+
+def _extract_message_id(params: dict[str, Any]) -> Optional[str]:
+    info = _extract_message_info(params)
+    for key in ("id", "messageID", "messageId", "message_id"):
+        value = info.get(key)
+        if isinstance(value, str) and value:
+            return value
+    for key in ("messageID", "messageId", "message_id"):
+        value = params.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _extract_message_role(params: dict[str, Any]) -> Optional[str]:
+    info = _extract_message_info(params)
+    role = info.get("role")
+    if isinstance(role, str) and role:
+        return role
+    role = params.get("role")
+    if isinstance(role, str) and role:
+        return role
+    return None
+
+
+def _extract_part_message_id(params: dict[str, Any]) -> Optional[str]:
+    properties = params.get("properties")
+    part = properties.get("part") if isinstance(properties, dict) else None
+    if not isinstance(part, dict):
+        return None
+    for key in ("messageID", "messageId", "message_id"):
+        value = part.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
 def _unwrap_harness_payload(payload: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     if isinstance(payload.get("message"), dict):
         message = payload["message"]
@@ -116,6 +164,10 @@ def _collect_terminal_text(payloads: list[dict[str, Any]]) -> tuple[str, list[st
     output_text = ""
     completed_message: Optional[str] = None
     errors: list[str] = []
+    message_roles: dict[str, str] = {}
+    pending_by_message: dict[str, str] = {}
+    pending_no_id = ""
+    message_roles_seen = False
 
     def _merge_stream(current: str, incoming: str) -> str:
         if not incoming:
@@ -132,6 +184,57 @@ def _collect_terminal_text(payloads: list[dict[str, Any]]) -> tuple[str, list[st
                 return f"{current}{incoming[overlap:]}"
         return f"{current}{incoming}"
 
+    def _append_part_text(message_id: Optional[str], text: str) -> None:
+        nonlocal output_text
+        nonlocal pending_no_id
+        if not text:
+            return
+        if message_id is None:
+            if not message_roles_seen:
+                output_text = _merge_stream(output_text, text)
+            else:
+                pending_no_id = _merge_stream(pending_no_id, text)
+            return
+        role = message_roles.get(message_id)
+        if role == "user":
+            return
+        if role == "assistant":
+            output_text = _merge_stream(output_text, text)
+            return
+        pending_by_message[message_id] = _merge_stream(
+            pending_by_message.get(message_id, ""),
+            text,
+        )
+
+    def _register_role(message_id: Optional[str], role: Optional[str]) -> None:
+        nonlocal output_text
+        nonlocal pending_no_id
+        nonlocal message_roles_seen
+        if not message_id or not role:
+            return
+        message_roles[message_id] = role
+        message_roles_seen = True
+        pending = pending_by_message.pop(message_id, "")
+        if role == "assistant":
+            if pending:
+                output_text = _merge_stream(output_text, pending)
+            if pending_no_id:
+                output_text = _merge_stream(output_text, pending_no_id)
+                pending_no_id = ""
+            return
+        if role == "user":
+            pending_no_id = ""
+
+    def _flush_fallback_pending() -> None:
+        nonlocal output_text
+        if pending_by_message:
+            for message_id, pending in list(pending_by_message.items()):
+                if message_roles.get(message_id) == "assistant":
+                    output_text = _merge_stream(output_text, pending)
+            pending_by_message.clear()
+        if pending_no_id and not message_roles_seen:
+            output_text = _merge_stream(output_text, pending_no_id)
+
     for payload in payloads:
         method, params = _unwrap_harness_payload(payload)
         method_lower = method.lower()
@@ -142,14 +245,21 @@ def _collect_terminal_text(payloads: list[dict[str, Any]]) -> tuple[str, list[st
             "message.completed",
             "message.part.updated",
         }:
+            if method in {"message.updated", "message.completed"}:
+                _register_role(
+                    _extract_message_id(params),
+                    _extract_message_role(params),
+                )
             text = _extract_delta_text(params) or _extract_completed_text(params)
             if text:
                 if method == "message.delta":
                     output_text = _merge_stream(output_text, text)
                 elif method == "message.part.updated":
-                    output_text = _merge_stream(output_text, text)
+                    _append_part_text(_extract_part_message_id(params), text)
                 else:
-                    completed_message = text
+                    role = _extract_message_role(params)
+                    if role != "user":
+                        completed_message = text
             continue
 
         if method == "item/agentMessage/delta" or method == "turn/streamDelta":
@@ -177,6 +287,8 @@ def _collect_terminal_text(payloads: list[dict[str, Any]]) -> tuple[str, list[st
             if error:
                 errors.append(error)
 
+    if not completed_message:
+        _flush_fallback_pending()
     assistant_text = (completed_message or output_text).strip()
     return assistant_text, errors
 

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -49,6 +49,10 @@ class RuntimeThreadRunEventState:
     assistant_stream_text: str = ""
     assistant_message_text: str = ""
     token_usage: Optional[dict[str, Any]] = None
+    message_roles: dict[str, str] = field(default_factory=dict)
+    pending_stream_by_message: dict[str, str] = field(default_factory=dict)
+    pending_stream_no_id: str = ""
+    message_roles_seen: bool = False
 
     def note_stream_text(self, text: str) -> None:
         if isinstance(text, str) and text:
@@ -65,6 +69,83 @@ class RuntimeThreadRunEventState:
         if self.assistant_message_text.strip():
             return self.assistant_message_text
         return self.assistant_stream_text
+
+    def note_message_role(
+        self,
+        message_id: Optional[str],
+        role: Optional[str],
+    ) -> list[RunEvent]:
+        if not message_id or not role:
+            return []
+        self.message_roles[message_id] = role
+        self.message_roles_seen = True
+        if role == "user":
+            self.pending_stream_by_message.pop(message_id, None)
+            self.pending_stream_no_id = ""
+            return []
+        pending = self.pending_stream_by_message.pop(message_id, "")
+        events: list[RunEvent] = []
+        if pending:
+            self.note_stream_text(pending)
+            events.append(
+                OutputDelta(
+                    timestamp=now_iso(),
+                    content=pending,
+                    delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
+                )
+            )
+        if self.pending_stream_no_id:
+            pending_no_id = self.pending_stream_no_id
+            self.pending_stream_no_id = ""
+            self.note_stream_text(pending_no_id)
+            events.append(
+                OutputDelta(
+                    timestamp=now_iso(),
+                    content=pending_no_id,
+                    delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
+                )
+            )
+        return events
+
+    def note_message_part_text(
+        self,
+        message_id: Optional[str],
+        text: str,
+    ) -> list[RunEvent]:
+        if not isinstance(text, str) or not text:
+            return []
+        if message_id is None:
+            if not self.message_roles_seen:
+                self.note_stream_text(text)
+                return [
+                    OutputDelta(
+                        timestamp=now_iso(),
+                        content=text,
+                        delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
+                    )
+                ]
+            self.pending_stream_no_id = _merge_assistant_stream(
+                self.pending_stream_no_id,
+                text,
+            )
+            return []
+        role = self.message_roles.get(message_id)
+        if role == "user":
+            return []
+        if role == "assistant":
+            self.note_stream_text(text)
+            return [
+                OutputDelta(
+                    timestamp=now_iso(),
+                    content=text,
+                    delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
+                )
+            ]
+        self.pending_stream_by_message[message_id] = _merge_assistant_stream(
+            self.pending_stream_by_message.get(message_id, ""),
+            text,
+        )
+        return []
 
 
 async def normalize_runtime_thread_raw_event(
@@ -185,7 +266,10 @@ def _normalize_message_event(
         return _assistant_stream_events(params, state)
 
     if method == "message.part.updated":
-        return _assistant_stream_events(params, state)
+        content = _extract_output_delta(params)
+        if not content:
+            return []
+        return state.note_message_part_text(_extract_part_message_id(params), content)
 
     if method in _APPROVAL_METHODS:
         request_id = _request_id_for_event(method, params)
@@ -246,11 +330,17 @@ def _normalize_message_event(
         ]
 
     if method in {"message.updated", "message.completed"}:
+        role_events = state.note_message_role(
+            _extract_message_id(params),
+            _extract_message_role(params),
+        )
         content = _extract_message_text(params)
         if not content:
-            return []
+            return role_events
+        if _extract_message_role(params) == "user":
+            return role_events
         state.note_message_text(content)
-        return [
+        return role_events + [
             OutputDelta(
                 timestamp=now_iso(),
                 content=content,
@@ -496,6 +586,49 @@ def _extract_message_text(params: dict[str, Any]) -> str:
         if isinstance(value, str) and value.strip():
             return value
     return ""
+
+
+def _extract_message_info(params: dict[str, Any]) -> dict[str, Any]:
+    info = params.get("info")
+    if isinstance(info, dict):
+        return info
+    properties = _coerce_dict(params.get("properties"))
+    nested = properties.get("info")
+    return nested if isinstance(nested, dict) else {}
+
+
+def _extract_message_id(params: dict[str, Any]) -> Optional[str]:
+    info = _extract_message_info(params)
+    for key in ("id", "messageID", "messageId", "message_id"):
+        value = info.get(key)
+        if isinstance(value, str) and value:
+            return value
+    for key in ("messageID", "messageId", "message_id"):
+        value = params.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _extract_message_role(params: dict[str, Any]) -> Optional[str]:
+    info = _extract_message_info(params)
+    role = info.get("role")
+    if isinstance(role, str) and role:
+        return role
+    role = params.get("role")
+    if isinstance(role, str) and role:
+        return role
+    return None
+
+
+def _extract_part_message_id(params: dict[str, Any]) -> Optional[str]:
+    properties = _coerce_dict(params.get("properties"))
+    part = _coerce_dict(properties.get("part"))
+    for key in ("messageID", "messageId", "message_id"):
+        value = part.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
 
 
 __all__ = [

--- a/tests/agents/opencode/test_opencode_harness.py
+++ b/tests/agents/opencode/test_opencode_harness.py
@@ -152,3 +152,43 @@ async def test_opencode_harness_wait_for_turn_merges_cumulative_message_part_upd
     assert result.status == "ok"
     assert result.assistant_text == "Hello world"
     assert result.errors == []
+
+
+@pytest.mark.asyncio
+async def test_opencode_harness_wait_for_turn_ignores_user_message_part_updates() -> (
+    None
+):
+    harness = OpenCodeHarness(
+        _StubSupervisor(
+            _StubClient(
+                [
+                    SSEEvent(
+                        event="message.part.updated",
+                        data='{"sessionID":"session-1","properties":{"part":{"type":"text","messageID":"user-1","text":"user prompt"}}}',
+                    ),
+                    SSEEvent(
+                        event="message.updated",
+                        data='{"sessionID":"session-1","properties":{"info":{"id":"user-1","role":"user"}}}',
+                    ),
+                    SSEEvent(
+                        event="message.part.updated",
+                        data='{"sessionID":"session-1","properties":{"part":{"type":"text","messageID":"assistant-1","text":"assistant reply"}}}',
+                    ),
+                    SSEEvent(
+                        event="message.updated",
+                        data='{"sessionID":"session-1","properties":{"info":{"id":"assistant-1","role":"assistant"}}}',
+                    ),
+                    SSEEvent(
+                        event="session.status",
+                        data='{"sessionID":"session-1","properties":{"status":{"type":"idle"}}}',
+                    ),
+                ]
+            )
+        )
+    )
+
+    result = await harness.wait_for_turn(Path("."), "session-1", "turn-1")
+
+    assert result.status == "ok"
+    assert result.assistant_text == "assistant reply"
+    assert result.errors == []

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -194,3 +194,99 @@ async def test_normalize_runtime_thread_raw_event_handles_opencode_message_part_
     assert isinstance(output[0], OutputDelta)
     assert output[0].content == "OK"
     assert state.best_assistant_text() == "OK"
+
+
+async def test_normalize_runtime_thread_raw_event_ignores_user_message_part_updates() -> (
+    None
+):
+    state = RuntimeThreadRunEventState()
+
+    pending = await normalize_runtime_thread_raw_event(
+        format_sse(
+            "app-server",
+            {
+                "message": {
+                    "method": "message.part.updated",
+                    "params": {
+                        "properties": {
+                            "part": {
+                                "type": "text",
+                                "messageID": "user-1",
+                                "text": "user prompt",
+                            },
+                        }
+                    },
+                }
+            },
+        ),
+        state,
+    )
+    resolved = await normalize_runtime_thread_raw_event(
+        format_sse(
+            "app-server",
+            {
+                "message": {
+                    "method": "message.updated",
+                    "params": {
+                        "properties": {
+                            "info": {"id": "user-1", "role": "user"},
+                        }
+                    },
+                }
+            },
+        ),
+        state,
+    )
+
+    assert pending == []
+    assert resolved == []
+    assert state.best_assistant_text() == ""
+
+
+async def test_normalize_runtime_thread_raw_event_flushes_assistant_message_parts_after_role_update() -> (
+    None
+):
+    state = RuntimeThreadRunEventState()
+
+    pending = await normalize_runtime_thread_raw_event(
+        format_sse(
+            "app-server",
+            {
+                "message": {
+                    "method": "message.part.updated",
+                    "params": {
+                        "properties": {
+                            "part": {
+                                "type": "text",
+                                "messageID": "assistant-1",
+                                "text": "assistant reply",
+                            },
+                        }
+                    },
+                }
+            },
+        ),
+        state,
+    )
+    resolved = await normalize_runtime_thread_raw_event(
+        format_sse(
+            "app-server",
+            {
+                "message": {
+                    "method": "message.updated",
+                    "params": {
+                        "properties": {
+                            "info": {"id": "assistant-1", "role": "assistant"},
+                        }
+                    },
+                }
+            },
+        ),
+        state,
+    )
+
+    assert pending == []
+    assert len(resolved) == 1
+    assert isinstance(resolved[0], OutputDelta)
+    assert resolved[0].content == "assistant reply"
+    assert state.best_assistant_text() == "assistant reply"


### PR DESCRIPTION
## Summary
- fix OpenCode durable-thread parsing to treat `message.part.updated` text parts as assistant output
- update runtime-thread normalization so Discord orchestration can surface the same event shape
- add focused coverage for direct `message.part.updated` replies and cumulative snapshot updates

## Root Cause
Recent OpenCode sessions emitted assistant text through `message.part.updated` events with text under `properties.part.text` / `properties.delta.text`. Our harness and runtime-thread event normalization only treated `message.delta` and `message.updated/completed` as assistant output, so successful turns could finish with an empty assistant message and Discord would fall back to `(No response text returned.)`.

## Verification
- live harness repro before fix returned `assistant_text == ''`
- live harness repro after fix returned `assistant_text == 'OK'`
- `./.venv/bin/pytest tests/agents/opencode/test_opencode_harness.py tests/core/orchestration/test_runtime_thread_events.py tests/test_opencode_backend_streaming.py tests/core/orchestration/test_runtime_threads.py -q`
- pre-commit/full checks from `git commit` passed, including full pytest (`2827 passed, 1 skipped`)
