### PR TITLE
Unify managed-thread progress handling

### DIFF
--- a/src/codex_autorunner/integrations/chat/managed_thread_progress.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_progress.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ...core.ports.run_event import (
+    RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
+    RUN_EVENT_DELTA_TYPE_LOG_LINE,
+    RUN_EVENT_DELTA_TYPE_USER_MESSAGE,
+    ApprovalRequested,
+    Completed,
+    Failed,
+    OutputDelta,
+    RunNotice,
+    ToolCall,
+)
+from .progress_primitives import TurnProgressTracker
+
+
+@dataclass
+class ProgressRuntimeState:
+    final_message: str = ""
+    error_message: str | None = None
+
+
+@dataclass(frozen=True)
+class ProgressTrackerEventOutcome:
+    changed: bool
+    force: bool = False
+    render_mode: str = "live"
+    remove_components: bool = False
+    terminal: bool = False
+
+
+def progress_item_id_for_log_line(content: str) -> str | None:
+    normalized = " ".join(content.split()).strip().lower()
+    if normalized.startswith("tokens used"):
+        return "opencode:token-usage"
+    if normalized.startswith("context window:"):
+        return "opencode:context-window"
+    return None
+
+
+def apply_run_event_to_progress_tracker(
+    tracker: TurnProgressTracker,
+    run_event: Any,
+    *,
+    runtime_state: ProgressRuntimeState,
+) -> ProgressTrackerEventOutcome:
+    if isinstance(run_event, OutputDelta):
+        if run_event.delta_type == RUN_EVENT_DELTA_TYPE_USER_MESSAGE:
+            return ProgressTrackerEventOutcome(changed=False)
+        delta = run_event.content
+        if not isinstance(delta, str) or not delta.strip():
+            return ProgressTrackerEventOutcome(changed=False)
+        if run_event.delta_type == RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE:
+            latest_output = tracker.latest_output_text().strip()
+            incoming_output = delta.strip()
+            if latest_output and (
+                incoming_output == latest_output
+                or incoming_output.startswith(latest_output)
+            ):
+                tracker.note_output(delta)
+            else:
+                tracker.note_output(delta, new_segment=True)
+            tracker.end_output_segment()
+        elif run_event.delta_type == RUN_EVENT_DELTA_TYPE_LOG_LINE:
+            item_id = progress_item_id_for_log_line(delta)
+            if item_id:
+                if not tracker.update_action_by_item_id(
+                    item_id,
+                    delta,
+                    "update",
+                    label="output",
+                ):
+                    tracker.add_action(
+                        "output",
+                        delta,
+                        "update",
+                        item_id=item_id,
+                        normalize_text=False,
+                    )
+            else:
+                tracker.note_output(delta, new_segment=True)
+                tracker.end_output_segment()
+        else:
+            tracker.note_output(delta)
+        return ProgressTrackerEventOutcome(changed=True)
+
+    if isinstance(run_event, ToolCall):
+        tool_name = run_event.tool_name.strip() if run_event.tool_name else ""
+        tracker.note_tool(tool_name or "Tool call")
+        return ProgressTrackerEventOutcome(changed=True)
+
+    if isinstance(run_event, ApprovalRequested):
+        summary = run_event.description.strip() if run_event.description else ""
+        tracker.note_approval(summary or "Approval requested")
+        return ProgressTrackerEventOutcome(changed=True)
+
+    if isinstance(run_event, RunNotice):
+        notice = run_event.message.strip() if run_event.message else ""
+        if not notice:
+            notice = run_event.kind.strip() if run_event.kind else "notice"
+        if run_event.kind in {"thinking", "reasoning"}:
+            tracker.note_thinking(notice)
+            return ProgressTrackerEventOutcome(changed=True)
+        if run_event.kind == "interrupted":
+            if tracker.label == "done" and runtime_state.final_message:
+                return ProgressTrackerEventOutcome(changed=False)
+            runtime_state.error_message = notice or "Turn interrupted"
+            tracker.note_error(runtime_state.error_message)
+            tracker.clear_transient_action()
+            tracker.set_label("cancelled")
+            return ProgressTrackerEventOutcome(
+                changed=True,
+                force=True,
+                remove_components=True,
+                terminal=True,
+            )
+        if run_event.kind == "failed":
+            if tracker.label == "done" and runtime_state.final_message:
+                return ProgressTrackerEventOutcome(changed=False)
+            runtime_state.error_message = notice or "Turn failed"
+            tracker.note_error(runtime_state.error_message)
+            tracker.clear_transient_action()
+            tracker.set_label("failed")
+            return ProgressTrackerEventOutcome(
+                changed=True,
+                force=True,
+                remove_components=True,
+                terminal=True,
+            )
+        tracker.add_action("notice", notice, "update")
+        return ProgressTrackerEventOutcome(changed=True)
+
+    if isinstance(run_event, Completed):
+        runtime_state.final_message = (
+            run_event.final_message or runtime_state.final_message
+        )
+        if runtime_state.final_message.strip():
+            tracker.drop_terminal_output_if_duplicate(runtime_state.final_message)
+        tracker.clear_transient_action()
+        tracker.set_label("done")
+        return ProgressTrackerEventOutcome(
+            changed=True,
+            force=True,
+            render_mode="final",
+            remove_components=True,
+            terminal=True,
+        )
+
+    if isinstance(run_event, Failed):
+        if tracker.label == "done" and runtime_state.final_message:
+            return ProgressTrackerEventOutcome(changed=False)
+        runtime_state.error_message = run_event.error_message or "Turn failed"
+        tracker.note_error(runtime_state.error_message)
+        tracker.clear_transient_action()
+        if "interrupt" in runtime_state.error_message.lower():
+            tracker.set_label("cancelled")
+        else:
+            tracker.set_label("failed")
+        return ProgressTrackerEventOutcome(
+            changed=True,
+            force=True,
+            remove_components=True,
+            terminal=True,
+        )
+
+    return ProgressTrackerEventOutcome(changed=False)

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -48,8 +48,6 @@ from ...core.pma_transcripts import PmaTranscriptStore
 from ...core.ports.run_event import (
     RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
     RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
-    RUN_EVENT_DELTA_TYPE_LOG_LINE,
-    RUN_EVENT_DELTA_TYPE_USER_MESSAGE,
     ApprovalRequested,
     Completed,
     Failed,
@@ -64,6 +62,10 @@ from ...integrations.chat.collaboration_policy import CollaborationEvaluationRes
 from ...integrations.chat.compaction import match_pending_compact_seed
 from ...integrations.chat.dispatcher import DispatchContext
 from ...integrations.chat.models import ChatMessageEvent
+from ..chat.managed_thread_progress import (
+    ProgressRuntimeState,
+    apply_run_event_to_progress_tracker,
+)
 from ..chat.progress_primitives import TurnProgressTracker, render_progress_text
 from ..chat.turn_metrics import (
     _extract_context_usage_percent,
@@ -92,108 +94,13 @@ class DiscordMessageTurnResult:
     elapsed_seconds: Optional[float] = None
 
 
-@dataclass
-class _DiscordProgressRuntimeState:
-    final_message: str = ""
-    error_message: Optional[str] = None
-
-
-def _progress_item_id_for_log_line(content: str) -> Optional[str]:
-    normalized = " ".join(content.split()).strip().lower()
-    if normalized.startswith("tokens used"):
-        return "opencode:token-usage"
-    if normalized.startswith("context window:"):
-        return "opencode:context-window"
-    return None
-
-
 async def _apply_discord_progress_run_event(
     tracker: TurnProgressTracker,
     run_event: Any,
     *,
-    runtime_state: _DiscordProgressRuntimeState,
+    runtime_state: ProgressRuntimeState,
     edit_progress: Any,
 ) -> None:
-    if isinstance(run_event, OutputDelta):
-        if run_event.delta_type == RUN_EVENT_DELTA_TYPE_USER_MESSAGE:
-            return
-        if isinstance(run_event.content, str) and run_event.content.strip():
-            if run_event.delta_type == RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE:
-                latest_output = tracker.latest_output_text().strip()
-                incoming_output = run_event.content.strip()
-                if latest_output and (
-                    incoming_output == latest_output
-                    or incoming_output.startswith(latest_output)
-                ):
-                    tracker.note_output(run_event.content)
-                else:
-                    tracker.note_output(run_event.content, new_segment=True)
-                tracker.end_output_segment()
-            elif run_event.delta_type == RUN_EVENT_DELTA_TYPE_LOG_LINE:
-                item_id = _progress_item_id_for_log_line(run_event.content)
-                if item_id:
-                    if not tracker.update_action_by_item_id(
-                        item_id,
-                        run_event.content,
-                        "update",
-                        label="output",
-                    ):
-                        tracker.add_action(
-                            "output",
-                            run_event.content,
-                            "update",
-                            item_id=item_id,
-                            normalize_text=False,
-                        )
-                else:
-                    tracker.note_output(run_event.content, new_segment=True)
-                    tracker.end_output_segment()
-            else:
-                tracker.note_output(run_event.content)
-            await edit_progress()
-        return
-
-    if isinstance(run_event, ToolCall):
-        tool_name = run_event.tool_name.strip() if run_event.tool_name else ""
-        tracker.note_tool(tool_name or "Tool call")
-        await edit_progress()
-        return
-
-    if isinstance(run_event, ApprovalRequested):
-        summary = run_event.description.strip() if run_event.description else ""
-        tracker.note_approval(summary or "Approval requested")
-        await edit_progress()
-        return
-
-    if isinstance(run_event, RunNotice):
-        notice = run_event.message.strip() if run_event.message else ""
-        if not notice:
-            notice = run_event.kind.strip() if run_event.kind else "notice"
-        if run_event.kind in {"thinking", "reasoning"}:
-            tracker.note_thinking(notice)
-        elif run_event.kind == "interrupted":
-            if tracker.label == "done" and runtime_state.final_message:
-                return
-            runtime_state.error_message = notice or "Turn interrupted"
-            tracker.note_error(runtime_state.error_message)
-            tracker.clear_transient_action()
-            tracker.set_label("cancelled")
-            await edit_progress(force=True, remove_components=True)
-            return
-        elif run_event.kind == "failed":
-            if tracker.label == "done" and runtime_state.final_message:
-                return
-            runtime_state.error_message = notice or "Turn failed"
-            tracker.note_error(runtime_state.error_message)
-            tracker.clear_transient_action()
-            tracker.set_label("failed")
-            await edit_progress(force=True, remove_components=True)
-            return
-        else:
-            tracker.add_action("notice", notice, "update")
-        await edit_progress()
-        return
-
     if isinstance(run_event, TokenUsage):
         usage_payload = run_event.usage
         if isinstance(usage_payload, dict):
@@ -201,33 +108,18 @@ async def _apply_discord_progress_run_event(
                 usage_payload
             )
         return
-
-    if isinstance(run_event, Completed):
-        runtime_state.final_message = (
-            run_event.final_message or runtime_state.final_message
-        )
-        if runtime_state.final_message.strip():
-            tracker.drop_terminal_output_if_duplicate(runtime_state.final_message)
-        tracker.clear_transient_action()
-        tracker.set_label("done")
-        await edit_progress(
-            force=True,
-            remove_components=True,
-            render_mode="final",
-        )
+    outcome = apply_run_event_to_progress_tracker(
+        tracker,
+        run_event,
+        runtime_state=runtime_state,
+    )
+    if not outcome.changed:
         return
-
-    if isinstance(run_event, Failed):
-        if tracker.label == "done" and runtime_state.final_message:
-            return
-        runtime_state.error_message = run_event.error_message or "Turn failed"
-        tracker.note_error(runtime_state.error_message)
-        tracker.clear_transient_action()
-        if "interrupt" in runtime_state.error_message.lower():
-            tracker.set_label("cancelled")
-        else:
-            tracker.set_label("failed")
-        await edit_progress(force=True, remove_components=True)
+    await edit_progress(
+        force=outcome.force,
+        remove_components=outcome.remove_components,
+        render_mode=outcome.render_mode,
+    )
 
 
 async def resolve_bound_workspace_root(
@@ -1529,7 +1421,7 @@ async def _run_discord_orchestrated_turn_for_message(
     progress_rendered: Optional[str] = None
     progress_last_updated = 0.0
     progress_heartbeat_task: Optional[asyncio.Task[None]] = None
-    runtime_state = _DiscordProgressRuntimeState()
+    runtime_state = ProgressRuntimeState()
     active_progress_labels = {"working", "queued", "running", "review"}
 
     async def _edit_progress(

--- a/src/codex_autorunner/integrations/telegram/notifications.py
+++ b/src/codex_autorunner/integrations/telegram/notifications.py
@@ -7,19 +7,16 @@ from typing import Any, Optional
 
 from ...core.logging_utils import log_event
 from ...core.ports.run_event import (
-    RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
     RUN_EVENT_DELTA_TYPE_LOG_LINE,
-    RUN_EVENT_DELTA_TYPE_USER_MESSAGE,
-    ApprovalRequested,
-    Completed,
-    Failed,
-    OutputDelta,
-    RunNotice,
     TokenUsage,
-    ToolCall,
 )
 from ...core.state import now_iso
 from ...core.text_delta_coalescer import TextDeltaCoalescer
+from ..chat.managed_thread_progress import (
+    ProgressRuntimeState,
+    apply_run_event_to_progress_tracker,
+    progress_item_id_for_log_line,
+)
 from .constants import (
     PROGRESS_HEARTBEAT_INTERVAL_SECONDS,
     STREAM_PREVIEW_PREFIX,
@@ -435,9 +432,9 @@ class TelegramNotificationHandlers:
         is_log_line = delta_type == RUN_EVENT_DELTA_TYPE_LOG_LINE
         if not is_log_line and not has_explicit_delta_type and method == "outputDelta":
             # Older emitters may omit deltaType; preserve in-place token usage updates.
-            is_log_line = _progress_item_id_for_log_line(delta) is not None
+            is_log_line = progress_item_id_for_log_line(delta) is not None
         if is_log_line:
-            item_id = _progress_item_id_for_log_line(delta)
+            item_id = progress_item_id_for_log_line(delta)
             if item_id:
                 if not tracker.update_action_by_item_id(
                     item_id,
@@ -505,87 +502,6 @@ class TelegramNotificationHandlers:
         if tracker is None:
             return
 
-        if isinstance(run_event, OutputDelta):
-            if run_event.delta_type == RUN_EVENT_DELTA_TYPE_USER_MESSAGE:
-                return
-            delta = run_event.content
-            if not isinstance(delta, str) or not delta.strip():
-                return
-            if run_event.delta_type == RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE:
-                latest_output = tracker.latest_output_text().strip()
-                incoming_output = delta.strip()
-                if latest_output and (
-                    incoming_output == latest_output
-                    or incoming_output.startswith(latest_output)
-                ):
-                    tracker.note_output(delta)
-                else:
-                    tracker.note_output(delta, new_segment=True)
-                tracker.end_output_segment()
-            elif run_event.delta_type == RUN_EVENT_DELTA_TYPE_LOG_LINE:
-                item_id = _progress_item_id_for_log_line(delta)
-                if item_id:
-                    if not tracker.update_action_by_item_id(
-                        item_id,
-                        delta,
-                        "update",
-                        label="output",
-                    ):
-                        tracker.add_action(
-                            "output",
-                            delta,
-                            "update",
-                            item_id=item_id,
-                            normalize_text=False,
-                        )
-                else:
-                    tracker.note_output(delta, new_segment=True)
-                    tracker.end_output_segment()
-            else:
-                tracker.note_output(delta)
-            await self._schedule_progress_edit(turn_key)
-            return
-
-        if isinstance(run_event, ToolCall):
-            tool_name = run_event.tool_name.strip() if run_event.tool_name else ""
-            tracker.note_tool(tool_name or "Tool call")
-            await self._schedule_progress_edit(turn_key)
-            return
-
-        if isinstance(run_event, ApprovalRequested):
-            summary = run_event.description.strip() if run_event.description else ""
-            tracker.note_approval(summary or "Approval requested")
-            await self._schedule_progress_edit(turn_key)
-            return
-
-        if isinstance(run_event, RunNotice):
-            notice = run_event.message.strip() if run_event.message else ""
-            if not notice:
-                notice = run_event.kind.strip() if run_event.kind else "notice"
-            if run_event.kind in {"thinking", "reasoning"}:
-                tracker.note_thinking(notice)
-                await self._schedule_progress_edit(turn_key)
-                return
-            if run_event.kind == "interrupted":
-                tracker.note_error(notice or "Interrupted")
-                tracker.clear_transient_action()
-                tracker.set_label("cancelled")
-                tracker.finalized = True
-                await self._emit_progress_edit(turn_key, force=True)
-                self._clear_turn_progress(turn_key)
-                return
-            if run_event.kind == "failed":
-                tracker.note_error(notice or "Turn failed")
-                tracker.clear_transient_action()
-                tracker.set_label("failed")
-                tracker.finalized = True
-                await self._emit_progress_edit(turn_key, force=True)
-                self._clear_turn_progress(turn_key)
-                return
-            tracker.add_action("notice", notice, "update")
-            await self._schedule_progress_edit(turn_key)
-            return
-
         if isinstance(run_event, TokenUsage):
             usage_payload = run_event.usage
             if isinstance(usage_payload, dict):
@@ -595,28 +511,23 @@ class TelegramNotificationHandlers:
                 await self._schedule_progress_edit(turn_key)
             return
 
-        if isinstance(run_event, Completed):
-            final_text = run_event.final_message or ""
-            if final_text:
-                tracker.drop_terminal_output_if_duplicate(final_text)
-            tracker.clear_transient_action()
-            tracker.set_label("done")
+        outcome = apply_run_event_to_progress_tracker(
+            tracker,
+            run_event,
+            runtime_state=ProgressRuntimeState(),
+        )
+        if not outcome.changed:
+            return
+        if outcome.terminal:
             tracker.finalized = True
-            await self._emit_progress_edit(turn_key, force=True, render_mode="final")
+            await self._emit_progress_edit(
+                turn_key,
+                force=outcome.force,
+                render_mode=outcome.render_mode,
+            )
             self._clear_turn_progress(turn_key)
             return
-
-        if isinstance(run_event, Failed):
-            message = run_event.error_message or "Turn failed"
-            tracker.note_error(message)
-            tracker.clear_transient_action()
-            if "interrupt" in message.lower():
-                tracker.set_label("cancelled")
-            else:
-                tracker.set_label("failed")
-            tracker.finalized = True
-            await self._emit_progress_edit(turn_key, force=True)
-            self._clear_turn_progress(turn_key)
+        await self._schedule_progress_edit(turn_key)
 
     async def _ensure_turn_progress_lock(
         self, turn_key: tuple[str, str]
@@ -781,12 +692,3 @@ def _extract_turn_completed_final_text(params: dict[str, Any]) -> str:
             if isinstance(value, str) and value.strip():
                 return value
     return ""
-
-
-def _progress_item_id_for_log_line(content: str) -> Optional[str]:
-    normalized = " ".join(content.split()).strip().lower()
-    if normalized.startswith("tokens used"):
-        return "opencode:token-usage"
-    if normalized.startswith("context window:"):
-        return "opencode:context-window"
-    return None

--- a/tests/test_managed_thread_progress.py
+++ b/tests/test_managed_thread_progress.py
@@ -1,0 +1,107 @@
+from codex_autorunner.core.ports.run_event import (
+    RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
+    RUN_EVENT_DELTA_TYPE_LOG_LINE,
+    Completed,
+    OutputDelta,
+    RunNotice,
+    ToolCall,
+)
+from codex_autorunner.integrations.chat.managed_thread_progress import (
+    ProgressRuntimeState,
+    apply_run_event_to_progress_tracker,
+)
+from codex_autorunner.integrations.chat.progress_primitives import TurnProgressTracker
+
+
+def _tracker() -> TurnProgressTracker:
+    return TurnProgressTracker(
+        started_at=0.0,
+        agent="codex",
+        model="default",
+        label="working",
+        max_actions=12,
+        max_output_chars=400,
+    )
+
+
+def test_apply_run_event_to_progress_tracker_records_tool_calls() -> None:
+    tracker = _tracker()
+
+    outcome = apply_run_event_to_progress_tracker(
+        tracker,
+        ToolCall(timestamp="2026-03-15T00:00:00Z", tool_name="exec", tool_input={}),
+        runtime_state=ProgressRuntimeState(),
+    )
+
+    assert outcome.changed is True
+    assert outcome.terminal is False
+    assert tracker.transient_action is not None
+    assert tracker.transient_action.label == "tool"
+    assert tracker.transient_action.text == "exec"
+
+
+def test_apply_run_event_to_progress_tracker_updates_log_line_output() -> None:
+    tracker = _tracker()
+
+    outcome = apply_run_event_to_progress_tracker(
+        tracker,
+        OutputDelta(
+            timestamp="2026-03-15T00:00:00Z",
+            content="Tokens used: 10",
+            delta_type=RUN_EVENT_DELTA_TYPE_LOG_LINE,
+        ),
+        runtime_state=ProgressRuntimeState(),
+    )
+
+    assert outcome.changed is True
+    assert tracker.actions[-1].label == "output"
+    assert tracker.actions[-1].text == "Tokens used: 10"
+    assert tracker.actions[-1].item_id == "opencode:token-usage"
+
+
+def test_apply_run_event_to_progress_tracker_finalizes_completed_turn() -> None:
+    tracker = _tracker()
+    runtime_state = ProgressRuntimeState()
+    apply_run_event_to_progress_tracker(
+        tracker,
+        OutputDelta(
+            timestamp="2026-03-15T00:00:00Z",
+            content="intermediate text",
+            delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
+        ),
+        runtime_state=runtime_state,
+    )
+
+    outcome = apply_run_event_to_progress_tracker(
+        tracker,
+        Completed(
+            timestamp="2026-03-15T00:00:01Z",
+            final_message="final answer",
+        ),
+        runtime_state=runtime_state,
+    )
+
+    assert outcome.changed is True
+    assert outcome.terminal is True
+    assert outcome.render_mode == "final"
+    assert tracker.label == "done"
+    assert runtime_state.final_message == "final answer"
+
+
+def test_apply_run_event_to_progress_tracker_marks_interrupts_terminal() -> None:
+    tracker = _tracker()
+
+    outcome = apply_run_event_to_progress_tracker(
+        tracker,
+        RunNotice(
+            timestamp="2026-03-15T00:00:00Z",
+            kind="interrupted",
+            message="Turn interrupted",
+        ),
+        runtime_state=ProgressRuntimeState(),
+    )
+
+    assert outcome.changed is True
+    assert outcome.force is True
+    assert outcome.terminal is True
+    assert tracker.label == "cancelled"


### PR DESCRIPTION
## Summary
- add a shared managed-thread progress adapter so Discord and Telegram PMA/runtime-thread turns interpret run events through one code path
- switch the Discord and Telegram managed-thread progress handlers over to the shared adapter instead of maintaining duplicate per-surface logic
- add focused tests for the shared adapter to lock in managed-thread progress behavior

## Testing
- .venv/bin/ruff check src/codex_autorunner/integrations/chat/managed_thread_progress.py src/codex_autorunner/integrations/discord/message_turns.py src/codex_autorunner/integrations/telegram/notifications.py tests/test_managed_thread_progress.py
- .venv/bin/pytest tests/test_managed_thread_progress.py tests/test_telegram_progress_stream.py tests/core/orchestration/test_runtime_thread_events.py tests/test_telegram_pma_routing.py -q
- pre-commit/full repo gate via git commit (2834 passed, 1 skipped)
