### PR TITLE
Fix hub panel toggles and agent modal UX

### DIFF
--- a/src/codex_autorunner/static/generated/hub.js
+++ b/src/codex_autorunner/static/generated/hub.js
@@ -58,8 +58,11 @@ const hubFlowFilterEl = document.getElementById("hub-flow-filter");
 const hubSortOrderEl = document.getElementById("hub-sort-order");
 const hubRepoPanelEl = document.getElementById("hub-repo-panel");
 const hubAgentPanelEl = document.getElementById("hub-agent-panel");
-const hubRepoPanelToggleEl = document.getElementById("hub-repo-panel-toggle");
-const hubAgentPanelToggleEl = document.getElementById("hub-agent-panel-toggle");
+const hubShellEl = document.getElementById("hub-shell");
+const hubRepoPanelSummaryEl = document.getElementById("hub-repo-panel-summary");
+const hubAgentPanelSummaryEl = document.getElementById("hub-agent-panel-summary");
+const hubRepoPanelStateEl = document.getElementById("hub-repo-panel-state");
+const hubAgentPanelStateEl = document.getElementById("hub-agent-panel-state");
 const UPDATE_STATUS_SEEN_KEY = "car_update_status_seen";
 const HUB_PANEL_PREFS_KEY = `car:hub-open-panel:${HUB_BASE || "/"}`;
 const HUB_JOB_POLL_INTERVAL_MS = 1200;
@@ -113,7 +116,7 @@ function saveHubOpenPanel(value) {
 function loadHubOpenPanel() {
     try {
         const raw = localStorage.getItem(HUB_PANEL_PREFS_KEY);
-        if (raw === "repos" || raw === "agents" || raw === "none") {
+        if (raw === "repos" || raw === "agents") {
             return raw;
         }
     }
@@ -2096,28 +2099,36 @@ function applyHubPanelState(openPanel) {
     hubOpenPanel = openPanel;
     const reposOpen = openPanel === "repos";
     const agentsOpen = openPanel === "agents";
+    hubShellEl?.setAttribute("data-hub-open-panel", openPanel);
+    hubRepoPanelEl?.classList.toggle("hub-panel-expanded", reposOpen);
     hubRepoPanelEl?.classList.toggle("hub-panel-collapsed", !reposOpen);
+    hubAgentPanelEl?.classList.toggle("hub-panel-expanded", agentsOpen);
     hubAgentPanelEl?.classList.toggle("hub-panel-collapsed", !agentsOpen);
-    if (hubRepoPanelToggleEl) {
-        hubRepoPanelToggleEl.textContent = reposOpen ? "Collapse" : "Expand";
-        hubRepoPanelToggleEl.setAttribute("aria-expanded", reposOpen ? "true" : "false");
+    if (hubRepoPanelSummaryEl) {
+        hubRepoPanelSummaryEl.setAttribute("aria-expanded", reposOpen ? "true" : "false");
     }
-    if (hubAgentPanelToggleEl) {
-        hubAgentPanelToggleEl.textContent = agentsOpen ? "Collapse" : "Expand";
-        hubAgentPanelToggleEl.setAttribute("aria-expanded", agentsOpen ? "true" : "false");
+    if (hubRepoPanelStateEl) {
+        hubRepoPanelStateEl.textContent = reposOpen ? "Expanded" : "Show panel";
+    }
+    if (hubAgentPanelSummaryEl) {
+        hubAgentPanelSummaryEl.setAttribute("aria-expanded", agentsOpen ? "true" : "false");
+    }
+    if (hubAgentPanelStateEl) {
+        hubAgentPanelStateEl.textContent = agentsOpen ? "Expanded" : "Show panel";
     }
 }
 function toggleHubPanel(panel) {
-    const next = hubOpenPanel === panel ? "none" : panel;
-    saveHubOpenPanel(next);
-    applyHubPanelState(next);
+    if (hubOpenPanel === panel)
+        return;
+    saveHubOpenPanel(panel);
+    applyHubPanelState(panel);
 }
 function initHubPanelControls() {
     applyHubPanelState(hubOpenPanel);
-    hubRepoPanelToggleEl?.addEventListener("click", () => {
+    hubRepoPanelSummaryEl?.addEventListener("click", () => {
         toggleHubPanel("repos");
     });
-    hubAgentPanelToggleEl?.addEventListener("click", () => {
+    hubAgentPanelSummaryEl?.addEventListener("click", () => {
         toggleHubPanel("agents");
     });
 }
@@ -2602,10 +2613,16 @@ function attachHubHandlers() {
         });
     }
     if (newRepoBtn) {
-        newRepoBtn.addEventListener("click", showCreateRepoModal);
+        newRepoBtn.addEventListener("click", () => {
+            toggleHubPanel("repos");
+            showCreateRepoModal();
+        });
     }
     if (newAgentBtn) {
-        newAgentBtn.addEventListener("click", showCreateAgentWorkspaceModal);
+        newAgentBtn.addEventListener("click", () => {
+            toggleHubPanel("agents");
+            showCreateAgentWorkspaceModal();
+        });
     }
     if (createCancelBtn) {
         createCancelBtn.addEventListener("click", hideCreateRepoModal);
@@ -2819,6 +2836,10 @@ export const __hubTest = {
     renderAgentWorkspaces,
     applyHubPanelState,
     toggleHubPanel,
+    initInteractionHarness() {
+        attachHubHandlers();
+        initHubPanelControls();
+    },
     setHubChannelEntries(entries) {
         hubChannelEntries = Array.isArray(entries) ? [...entries] : [];
     },

--- a/src/codex_autorunner/static/index.html
+++ b/src/codex_autorunner/static/index.html
@@ -69,8 +69,15 @@
     <section class="hub-repo-panel" id="hub-repo-panel" data-hub-panel="repos">
       <div class="hub-panel-header">
         <div class="hub-panel-header-main">
+          <button class="hub-panel-summary" id="hub-repo-panel-summary" type="button"
+            aria-controls="hub-repo-list" aria-expanded="true">
+            <span class="hub-panel-summary-copy">
+              <span class="label">Repositories</span>
+              <span class="hub-panel-summary-note muted small">Browse repos, worktrees, and flow status</span>
+            </span>
+            <span class="hub-panel-summary-state" id="hub-repo-panel-state">Expanded</span>
+          </button>
           <div class="hub-panel-title">
-            <span class="label">Repositories</span>
             <div class="hub-repo-controls">
               <label class="hub-repo-control">
                 Flow
@@ -100,8 +107,6 @@
             </div>
           </div>
         </div>
-        <button class="ghost sm hub-panel-toggle" id="hub-repo-panel-toggle" type="button"
-          aria-controls="hub-repo-list" aria-expanded="true">Collapse</button>
       </div>
       <div class="hub-repo-list" id="hub-repo-list">
         <div class="muted small">Loading…</div>
@@ -110,13 +115,15 @@
     <section class="hub-repo-panel hub-agent-panel" id="hub-agent-panel" data-hub-panel="agents">
       <div class="hub-panel-header">
         <div class="hub-panel-header-main">
-          <div class="hub-panel-title">
-            <span class="label">Agents</span>
-            <p class="muted small">Managed agent workspaces</p>
-          </div>
+          <button class="hub-panel-summary" id="hub-agent-panel-summary" type="button"
+            aria-controls="hub-agent-workspace-list" aria-expanded="false">
+            <span class="hub-panel-summary-copy">
+              <span class="label">Agents</span>
+              <span class="hub-panel-summary-note muted small">Managed agent workspaces and runtimes</span>
+            </span>
+            <span class="hub-panel-summary-state" id="hub-agent-panel-state">Show panel</span>
+          </button>
         </div>
-        <button class="ghost sm hub-panel-toggle" id="hub-agent-panel-toggle" type="button"
-          aria-controls="hub-agent-workspace-list" aria-expanded="false">Expand</button>
       </div>
       <div class="hub-repo-list hub-agent-list" id="hub-agent-workspace-list">
         <div class="muted small">Loading…</div>

--- a/src/codex_autorunner/static/styles.css
+++ b/src/codex_autorunner/static/styles.css
@@ -307,6 +307,16 @@ body {
   min-height: 0;
 }
 
+.hub-shell[data-hub-open-panel="repos"]>#hub-repo-panel,
+.hub-shell[data-hub-open-panel="agents"]>#hub-agent-panel {
+  flex: 1 1 auto;
+}
+
+.hub-shell[data-hub-open-panel="repos"]>#hub-agent-panel,
+.hub-shell[data-hub-open-panel="agents"]>#hub-repo-panel {
+  flex: 0 0 auto;
+}
+
 .hub-shell>.hub-repo-panel.hub-panel-collapsed {
   flex: 0 0 auto;
   min-height: auto;
@@ -1232,12 +1242,21 @@ main {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: var(--sp-3);
+  transition: border-color 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+
+.hub-panel-expanded {
+  border-color: rgba(108, 245, 216, 0.38);
+  box-shadow: 0 0 0 1px rgba(108, 245, 216, 0.08);
+}
+
+.hub-panel-collapsed {
+  background: rgba(255, 255, 255, 0.015);
 }
 
 .hub-panel-header {
   display: flex;
   align-items: flex-start;
-  justify-content: space-between;
   gap: 8px;
   margin-bottom: 6px;
   padding-bottom: 6px;
@@ -1247,6 +1266,9 @@ main {
 .hub-panel-header-main {
   flex: 1;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .hub-panel-header p {
@@ -1261,10 +1283,58 @@ main {
   flex-wrap: wrap;
 }
 
-.hub-panel-toggle {
-  align-self: center;
+.hub-panel-summary {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border: 1px solid rgba(108, 245, 216, 0.14);
+  border-radius: calc(var(--radius) - 4px);
+  background: rgba(108, 245, 216, 0.03);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.hub-panel-summary:hover {
+  border-color: rgba(108, 245, 216, 0.28);
+  background: rgba(108, 245, 216, 0.06);
+}
+
+.hub-panel-summary-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hub-panel-summary-note {
+  display: block;
+}
+
+.hub-panel-summary-state {
   flex-shrink: 0;
-  min-width: 72px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.hub-panel-summary-state::after {
+  content: "▾";
+  font-size: 12px;
+  line-height: 1;
+  transition: transform 120ms ease;
+}
+
+.hub-panel-summary[aria-expanded="false"] .hub-panel-summary-state::after {
+  transform: rotate(-90deg);
 }
 
 .hub-panel-collapsed .hub-panel-header {
@@ -7435,8 +7505,15 @@ button.loading::after {
 
   .hub-panel-title {
     width: 100%;
-    justify-content: space-between;
     gap: 8px;
+  }
+
+  .hub-panel-summary {
+    padding: 7px 8px;
+  }
+
+  .hub-panel-summary-note {
+    font-size: 9px;
   }
 
   .hub-repo-controls {

--- a/src/codex_autorunner/static_src/hub.ts
+++ b/src/codex_autorunner/static_src/hub.ts
@@ -226,7 +226,7 @@ interface HubViewPrefs {
   sortOrder: HubSortOrder;
 }
 
-type HubOpenPanel = "repos" | "agents" | "none";
+type HubOpenPanel = "repos" | "agents";
 
 interface HubRepoGroup {
   base: HubRepo;
@@ -303,12 +303,15 @@ const hubSortOrderEl = document.getElementById(
 ) as HTMLSelectElement | null;
 const hubRepoPanelEl = document.getElementById("hub-repo-panel");
 const hubAgentPanelEl = document.getElementById("hub-agent-panel");
-const hubRepoPanelToggleEl = document.getElementById(
-  "hub-repo-panel-toggle"
+const hubShellEl = document.getElementById("hub-shell");
+const hubRepoPanelSummaryEl = document.getElementById(
+  "hub-repo-panel-summary"
 ) as HTMLButtonElement | null;
-const hubAgentPanelToggleEl = document.getElementById(
-  "hub-agent-panel-toggle"
+const hubAgentPanelSummaryEl = document.getElementById(
+  "hub-agent-panel-summary"
 ) as HTMLButtonElement | null;
+const hubRepoPanelStateEl = document.getElementById("hub-repo-panel-state");
+const hubAgentPanelStateEl = document.getElementById("hub-agent-panel-state");
 const UPDATE_STATUS_SEEN_KEY = "car_update_status_seen";
 const HUB_PANEL_PREFS_KEY = `car:hub-open-panel:${HUB_BASE || "/"}`;
 const HUB_JOB_POLL_INTERVAL_MS = 1200;
@@ -361,7 +364,7 @@ function saveHubOpenPanel(value: HubOpenPanel): void {
 function loadHubOpenPanel(): HubOpenPanel {
   try {
     const raw = localStorage.getItem(HUB_PANEL_PREFS_KEY);
-    if (raw === "repos" || raw === "agents" || raw === "none") {
+    if (raw === "repos" || raw === "agents") {
       return raw;
     }
   } catch (_err) {
@@ -2657,30 +2660,37 @@ function applyHubPanelState(openPanel: HubOpenPanel): void {
   hubOpenPanel = openPanel;
   const reposOpen = openPanel === "repos";
   const agentsOpen = openPanel === "agents";
+  hubShellEl?.setAttribute("data-hub-open-panel", openPanel);
+  hubRepoPanelEl?.classList.toggle("hub-panel-expanded", reposOpen);
   hubRepoPanelEl?.classList.toggle("hub-panel-collapsed", !reposOpen);
+  hubAgentPanelEl?.classList.toggle("hub-panel-expanded", agentsOpen);
   hubAgentPanelEl?.classList.toggle("hub-panel-collapsed", !agentsOpen);
-  if (hubRepoPanelToggleEl) {
-    hubRepoPanelToggleEl.textContent = reposOpen ? "Collapse" : "Expand";
-    hubRepoPanelToggleEl.setAttribute("aria-expanded", reposOpen ? "true" : "false");
+  if (hubRepoPanelSummaryEl) {
+    hubRepoPanelSummaryEl.setAttribute("aria-expanded", reposOpen ? "true" : "false");
   }
-  if (hubAgentPanelToggleEl) {
-    hubAgentPanelToggleEl.textContent = agentsOpen ? "Collapse" : "Expand";
-    hubAgentPanelToggleEl.setAttribute("aria-expanded", agentsOpen ? "true" : "false");
+  if (hubRepoPanelStateEl) {
+    hubRepoPanelStateEl.textContent = reposOpen ? "Expanded" : "Show panel";
+  }
+  if (hubAgentPanelSummaryEl) {
+    hubAgentPanelSummaryEl.setAttribute("aria-expanded", agentsOpen ? "true" : "false");
+  }
+  if (hubAgentPanelStateEl) {
+    hubAgentPanelStateEl.textContent = agentsOpen ? "Expanded" : "Show panel";
   }
 }
 
-function toggleHubPanel(panel: Exclude<HubOpenPanel, "none">): void {
-  const next: HubOpenPanel = hubOpenPanel === panel ? "none" : panel;
-  saveHubOpenPanel(next);
-  applyHubPanelState(next);
+function toggleHubPanel(panel: HubOpenPanel): void {
+  if (hubOpenPanel === panel) return;
+  saveHubOpenPanel(panel);
+  applyHubPanelState(panel);
 }
 
 function initHubPanelControls(): void {
   applyHubPanelState(hubOpenPanel);
-  hubRepoPanelToggleEl?.addEventListener("click", () => {
+  hubRepoPanelSummaryEl?.addEventListener("click", () => {
     toggleHubPanel("repos");
   });
-  hubAgentPanelToggleEl?.addEventListener("click", () => {
+  hubAgentPanelSummaryEl?.addEventListener("click", () => {
     toggleHubPanel("agents");
   });
 }
@@ -3257,10 +3267,16 @@ function attachHubHandlers(): void {
   }
 
   if (newRepoBtn) {
-    newRepoBtn.addEventListener("click", showCreateRepoModal);
+    newRepoBtn.addEventListener("click", () => {
+      toggleHubPanel("repos");
+      showCreateRepoModal();
+    });
   }
   if (newAgentBtn) {
-    newAgentBtn.addEventListener("click", showCreateAgentWorkspaceModal);
+    newAgentBtn.addEventListener("click", () => {
+      toggleHubPanel("agents");
+      showCreateAgentWorkspaceModal();
+    });
   }
   if (createCancelBtn) {
     createCancelBtn.addEventListener("click", hideCreateRepoModal);
@@ -3479,6 +3495,10 @@ export const __hubTest = {
   renderAgentWorkspaces,
   applyHubPanelState,
   toggleHubPanel,
+  initInteractionHarness(): void {
+    attachHubHandlers();
+    initHubPanelControls();
+  },
   setHubChannelEntries(entries: HubChannelEntry[]): void {
     hubChannelEntries = Array.isArray(entries) ? [...entries] : [];
   },

--- a/tests/js/hub_repo_cards.test.js
+++ b/tests/js/hub_repo_cards.test.js
@@ -4,14 +4,27 @@ import { JSDOM } from "jsdom";
 
 const dom = new JSDOM(
   `<!doctype html><html><body>
-    <section id="hub-repo-panel" class="hub-repo-panel">
-      <button id="hub-repo-panel-toggle" aria-controls="hub-repo-list" aria-expanded="true"></button>
-      <div id="hub-repo-list"></div>
-    </section>
-    <section id="hub-agent-panel" class="hub-repo-panel hub-agent-panel">
-      <button id="hub-agent-panel-toggle" aria-controls="hub-agent-workspace-list" aria-expanded="false"></button>
-      <div id="hub-agent-workspace-list"></div>
-    </section>
+    <div id="hub-shell">
+      <section id="hub-repo-panel" class="hub-repo-panel">
+        <div class="hub-panel-header">
+          <div class="hub-panel-header-main">
+            <button id="hub-repo-panel-summary" aria-controls="hub-repo-list" aria-expanded="true"></button>
+            <span id="hub-repo-panel-state"></span>
+            <div class="hub-repo-controls"></div>
+          </div>
+        </div>
+        <div id="hub-repo-list"></div>
+      </section>
+      <section id="hub-agent-panel" class="hub-repo-panel hub-agent-panel">
+        <div class="hub-panel-header">
+          <div class="hub-panel-header-main">
+            <button id="hub-agent-panel-summary" aria-controls="hub-agent-workspace-list" aria-expanded="false"></button>
+            <span id="hub-agent-panel-state"></span>
+          </div>
+        </div>
+        <div id="hub-agent-workspace-list"></div>
+      </section>
+    </div>
     <div id="hub-last-scan"></div>
     <div id="pma-last-scan"></div>
     <div id="hub-count-total"></div>
@@ -24,6 +37,16 @@ const dom = new JSDOM(
     <input id="hub-repo-search" value="" />
     <select id="hub-flow-filter"></select>
     <select id="hub-sort-order"></select>
+    <button id="hub-new-agent" type="button"></button>
+    <div id="create-agent-workspace-modal" class="modal-overlay" hidden>
+      <div class="modal-dialog" role="dialog">
+        <input id="create-agent-workspace-id" />
+        <input id="create-agent-workspace-runtime" />
+        <input id="create-agent-workspace-name" />
+        <button id="create-agent-workspace-cancel" type="button"></button>
+        <button id="create-agent-workspace-submit" type="button"></button>
+      </div>
+    </div>
   </body></html>`,
   { url: "http://localhost/hub/" }
 );
@@ -227,17 +250,13 @@ test("hub panel state collapses repositories and agents independently with one e
 
   const repoPanel = document.getElementById("hub-repo-panel");
   const agentPanel = document.getElementById("hub-agent-panel");
-  const repoToggle = document.getElementById("hub-repo-panel-toggle");
-  const agentToggle = document.getElementById("hub-agent-panel-toggle");
+  const repoToggle = document.getElementById("hub-repo-panel-summary");
+  const agentToggle = document.getElementById("hub-agent-panel-summary");
 
   assert.equal(repoPanel?.classList.contains("hub-panel-collapsed"), true);
   assert.equal(agentPanel?.classList.contains("hub-panel-collapsed"), false);
   assert.equal(repoToggle?.getAttribute("aria-expanded"), "false");
   assert.equal(agentToggle?.getAttribute("aria-expanded"), "true");
-
-  __hubTest.applyHubPanelState("none");
-  assert.equal(repoPanel?.classList.contains("hub-panel-collapsed"), true);
-  assert.equal(agentPanel?.classList.contains("hub-panel-collapsed"), true);
 });
 
 test("hub panel toggles keep working when localStorage is unavailable", () => {
@@ -254,13 +273,13 @@ test("hub panel toggles keep working when localStorage is unavailable", () => {
     const repoPanel = document.getElementById("hub-repo-panel");
     const agentPanel = document.getElementById("hub-agent-panel");
 
-    __hubTest.applyHubPanelState("none");
+    __hubTest.applyHubPanelState("repos");
     __hubTest.toggleHubPanel("agents");
     assert.equal(agentPanel?.classList.contains("hub-panel-collapsed"), false);
     assert.equal(repoPanel?.classList.contains("hub-panel-collapsed"), true);
 
     __hubTest.toggleHubPanel("agents");
-    assert.equal(agentPanel?.classList.contains("hub-panel-collapsed"), true);
+    assert.equal(agentPanel?.classList.contains("hub-panel-collapsed"), false);
 
     __hubTest.toggleHubPanel("repos");
     assert.equal(repoPanel?.classList.contains("hub-panel-collapsed"), false);
@@ -296,4 +315,24 @@ test("agent workspace cards render runtime, managed path, and lifecycle actions"
   assert.match(text, /Remove/);
   assert.match(text, /Delete/);
   assert.match(text, /zc-main/);
+});
+
+test("hub interaction harness expands agents and opens the agent modal", () => {
+  const agentPanel = document.getElementById("hub-agent-panel");
+  const repoPanel = document.getElementById("hub-repo-panel");
+  const agentSummary = document.getElementById("hub-agent-panel-summary");
+  const newAgentBtn = document.getElementById("hub-new-agent");
+  const agentModal = document.getElementById("create-agent-workspace-modal");
+
+  agentModal.hidden = true;
+  __hubTest.applyHubPanelState("repos");
+  __hubTest.initInteractionHarness();
+
+  agentSummary.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+  assert.equal(agentPanel?.classList.contains("hub-panel-collapsed"), false);
+  assert.equal(repoPanel?.classList.contains("hub-panel-collapsed"), true);
+
+  newAgentBtn.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+  assert.equal(agentPanel?.classList.contains("hub-panel-collapsed"), false);
+  assert.equal(agentModal?.hidden, false);
 });


### PR DESCRIPTION
## Summary
- replace the tiny repo/agent collapse buttons with full-width panel summary controls that clearly signal the active panel state
- enforce a single expanded hub panel at a time so the active repo or agent space owns the available height
- make `+ Agent` open the agents panel before launching the create-workspace modal and add a regression test for the click flow

## Testing
- pnpm run build
- pnpm run test:markdown
- pytest
