### PR TITLE
Recover managed thread bindings after lost backend thread

### DIFF
--- a/src/codex_autorunner/core/orchestration/__init__.py
+++ b/src/codex_autorunner/core/orchestration/__init__.py
@@ -50,6 +50,7 @@ from .models import (
     OrchestrationTableRole,
     TargetCapability,
     TargetKind,
+    ThreadStopOutcome,
     ThreadTarget,
 )
 from .runtime_threads import (
@@ -132,6 +133,7 @@ __all__ = [
     "TargetCapability",
     "TargetKind",
     "ThreadExecutionStore",
+    "ThreadStopOutcome",
     "ThreadControlRequest",
     "ThreadTarget",
     "TranscriptMirrorRow",

--- a/src/codex_autorunner/core/orchestration/interfaces.py
+++ b/src/codex_autorunner/core/orchestration/interfaces.py
@@ -11,6 +11,7 @@ from .models import (
     FlowTarget,
     MessageRequest,
     MessageRequestKind,
+    ThreadStopOutcome,
     ThreadTarget,
 )
 
@@ -281,6 +282,8 @@ class OrchestrationThreadService(Protocol):
     ) -> ExecutionRecord: ...
 
     async def interrupt_thread(self, thread_target_id: str) -> ExecutionRecord: ...
+
+    async def stop_thread(self, thread_target_id: str) -> ThreadStopOutcome: ...
 
     def get_execution(
         self, thread_target_id: str, execution_id: str

--- a/src/codex_autorunner/core/orchestration/models.py
+++ b/src/codex_autorunner/core/orchestration/models.py
@@ -207,6 +207,20 @@ class ExecutionRecord:
 
 
 @dataclass(frozen=True)
+class ThreadStopOutcome:
+    """Result of stopping a managed thread's active/queued execution state."""
+
+    thread_target_id: str
+    cancelled_queued: int = 0
+    execution: Optional[ExecutionRecord] = None
+    interrupted_active: bool = False
+    recovered_lost_backend: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
 class OrchestrationTableDefinition:
     """Schema metadata for one orchestration SQLite table."""
 

--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -27,11 +27,18 @@ from .models import (
     FlowTarget,
     MessageRequest,
     MessageRequestKind,
+    ThreadStopOutcome,
     ThreadTarget,
 )
 from .threads import SurfaceThreadMessageRequest, ThreadControlRequest
 
 MessagePreviewLimit = 120
+LOST_BACKEND_THREAD_ERROR = "Backend thread lost after restart"
+MISSING_BACKEND_THREAD_ERROR = "Backend thread missing from orchestration state"
+_MISSING_THREAD_MARKERS = (
+    "thread not found",
+    "no rollout found for thread id",
+)
 
 
 def _truncate_text(value: str, limit: int = MessagePreviewLimit) -> str:
@@ -51,6 +58,10 @@ def _normalize_request_kind(value: Any) -> MessageRequestKind:
     if normalized == "review":
         return "review"
     return "message"
+
+
+def _is_missing_thread_error(exc: Exception) -> bool:
+    return any(marker in str(exc).lower() for marker in _MISSING_THREAD_MARKERS)
 
 
 def _execution_record_from_store_row(record: Mapping[str, Any]) -> ExecutionRecord:
@@ -716,7 +727,7 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
         )
         running = self.get_running_execution(thread.thread_target_id)
         if running is not None and request.busy_policy == "interrupt":
-            await self.interrupt_thread(thread.thread_target_id)
+            await self.stop_thread(thread.thread_target_id)
             thread = self.get_thread_target(thread.thread_target_id) or thread
 
         execution = self.thread_store.create_execution(
@@ -812,6 +823,67 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
         )
         return self.thread_store.record_execution_interrupted(
             thread_target_id, execution.execution_id
+        )
+
+    async def stop_thread(self, thread_target_id: str) -> ThreadStopOutcome:
+        thread = self.get_thread_target(thread_target_id)
+        if thread is None:
+            raise KeyError(f"Unknown thread target '{thread_target_id}'")
+
+        cancelled_queued = self.cancel_queued_executions(thread_target_id)
+        execution = self.get_running_execution(thread_target_id)
+        if execution is None:
+            return ThreadStopOutcome(
+                thread_target_id=thread_target_id,
+                cancelled_queued=cancelled_queued,
+            )
+
+        backend_thread_id = thread.backend_thread_id
+        if not backend_thread_id:
+            recovered = self.thread_store.record_execution_result(
+                thread_target_id,
+                execution.execution_id,
+                status="error",
+                assistant_text="",
+                error=MISSING_BACKEND_THREAD_ERROR,
+                backend_turn_id=execution.backend_id,
+                transcript_turn_id=None,
+            )
+            self.thread_store.set_thread_backend_id(thread_target_id, None)
+            return ThreadStopOutcome(
+                thread_target_id=thread_target_id,
+                cancelled_queued=cancelled_queued,
+                execution=recovered,
+                recovered_lost_backend=True,
+            )
+
+        try:
+            interrupted = await self.interrupt_thread(thread_target_id)
+        except Exception as exc:
+            if not _is_missing_thread_error(exc):
+                raise
+            recovered = self.thread_store.record_execution_result(
+                thread_target_id,
+                execution.execution_id,
+                status="error",
+                assistant_text="",
+                error=LOST_BACKEND_THREAD_ERROR,
+                backend_turn_id=execution.backend_id,
+                transcript_turn_id=None,
+            )
+            self.thread_store.set_thread_backend_id(thread_target_id, None)
+            return ThreadStopOutcome(
+                thread_target_id=thread_target_id,
+                cancelled_queued=cancelled_queued,
+                execution=recovered,
+                recovered_lost_backend=True,
+            )
+
+        return ThreadStopOutcome(
+            thread_target_id=thread_target_id,
+            cancelled_queued=cancelled_queued,
+            execution=interrupted,
+            interrupted_active=True,
         )
 
     def get_execution(

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -1732,17 +1732,16 @@ class DiscordBotService:
         )
         had_previous = current_thread is not None
         if current_thread is not None:
-            orchestration_service.cancel_queued_executions(
+            stop_outcome = await orchestration_service.stop_thread(
                 current_thread.thread_target_id
             )
-            if (
-                orchestration_service.get_running_execution(
-                    current_thread.thread_target_id
-                )
-                is not None
-            ):
-                await orchestration_service.interrupt_thread(
-                    current_thread.thread_target_id
+            if stop_outcome.recovered_lost_backend:
+                log_event(
+                    self._logger,
+                    logging.INFO,
+                    "discord.thread.recovered_lost_backend",
+                    channel_id=channel_id,
+                    thread_target_id=current_thread.thread_target_id,
                 )
             orchestration_service.archive_thread_target(current_thread.thread_target_id)
         owner_kind, owner_id, normalized_repo_id = self._resource_owner_for_workspace(
@@ -11037,30 +11036,31 @@ class DiscordBotService:
             await self._respond_ephemeral(interaction_id, interaction_token, text)
             return
         try:
-            cancelled_queued = orchestration_service.cancel_queued_executions(
+            stop_outcome = await orchestration_service.stop_thread(
                 current_thread.thread_target_id
             )
-            interrupted_active = False
             if (
-                orchestration_service.get_running_execution(
-                    current_thread.thread_target_id
-                )
-                is not None
+                not stop_outcome.interrupted_active
+                and not stop_outcome.recovered_lost_backend
+                and not stop_outcome.cancelled_queued
             ):
-                await orchestration_service.interrupt_thread(
-                    current_thread.thread_target_id
-                )
-                interrupted_active = True
-            if not interrupted_active and not cancelled_queued:
                 text = format_discord_message("No active turn to interrupt.")
                 await self._respond_ephemeral(interaction_id, interaction_token, text)
                 return
             parts = []
-            if interrupted_active:
+            if stop_outcome.interrupted_active:
                 parts.append("Stopping current turn...")
-            if cancelled_queued:
-                parts.append(f"Cancelled {cancelled_queued} queued turn(s).")
-            text = format_discord_message("Stopping current turn...")
+            elif stop_outcome.recovered_lost_backend:
+                parts.append("Recovered stale session after backend thread was lost.")
+            if stop_outcome.cancelled_queued:
+                parts.append(
+                    f"Cancelled {stop_outcome.cancelled_queued} queued turn(s)."
+                )
+            text = format_discord_message(
+                "Recovered stale session after backend thread was lost."
+                if stop_outcome.recovered_lost_backend
+                else "Stopping current turn..."
+            )
             if parts:
                 text = format_discord_message(" ".join(parts))
             await self._respond_ephemeral(interaction_id, interaction_token, text)

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -380,13 +380,17 @@ async def _sync_telegram_thread_binding(
     canonical_workspace = str(workspace_root.resolve())
     normalized_repo_id = repo_id.strip() if isinstance(repo_id, str) else None
     if replace_existing and current_thread is not None:
-        orchestration_service.cancel_queued_executions(current_thread.thread_target_id)
-        if (
-            orchestration_service.get_running_execution(current_thread.thread_target_id)
-            is not None
-        ):
-            await orchestration_service.interrupt_thread(
-                current_thread.thread_target_id
+        stop_outcome = await orchestration_service.stop_thread(
+            current_thread.thread_target_id
+        )
+        if stop_outcome.recovered_lost_backend:
+            log_event(
+                handlers._logger,
+                logging.INFO,
+                "telegram.thread.recovered_lost_backend",
+                surface_key=surface_key,
+                managed_thread_id=current_thread.thread_target_id,
+                mode=mode,
             )
         orchestration_service.archive_thread_target(current_thread.thread_target_id)
         current_thread = None

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -485,21 +485,11 @@ class TelegramCommandHandlers(
                 )
             )
             if current_thread is not None:
-                interrupted_active = False
-                cancelled_queued = 0
                 pma_mode = bool(getattr(record, "pma_enabled", False))
-                running_execution = orchestration_service.get_running_execution(
-                    current_thread.thread_target_id
-                )
                 try:
-                    cancelled_queued = orchestration_service.cancel_queued_executions(
+                    stop_outcome = await orchestration_service.stop_thread(
                         current_thread.thread_target_id
                     )
-                    if running_execution is not None:
-                        await orchestration_service.interrupt_thread(
-                            current_thread.thread_target_id
-                        )
-                        interrupted_active = True
                 except Exception as exc:
                     log_event(
                         self._logger,
@@ -523,20 +513,32 @@ class TelegramCommandHandlers(
                         reply_to=reply_to,
                     )
                     return
-                if interrupted_active or cancelled_queued:
+                if (
+                    stop_outcome.interrupted_active
+                    or stop_outcome.recovered_lost_backend
+                    or stop_outcome.cancelled_queued
+                ):
                     parts = []
-                    if interrupted_active:
+                    if stop_outcome.interrupted_active:
                         parts.append(
                             "Interrupted active PMA turn."
                             if pma_mode
                             else "Interrupted active turn."
                         )
-                    if cancelled_queued:
+                    elif stop_outcome.recovered_lost_backend:
                         parts.append(
                             (
-                                f"Cancelled {cancelled_queued} queued PMA turn(s)."
+                                "Recovered stale PMA session after backend thread was lost."
                                 if pma_mode
-                                else f"Cancelled {cancelled_queued} queued turn(s)."
+                                else "Recovered stale session after backend thread was lost."
+                            )
+                        )
+                    if stop_outcome.cancelled_queued:
+                        parts.append(
+                            (
+                                f"Cancelled {stop_outcome.cancelled_queued} queued PMA turn(s)."
+                                if pma_mode
+                                else f"Cancelled {stop_outcome.cancelled_queued} queued turn(s)."
                             )
                         )
                     await self._send_message(

--- a/tests/core/orchestration/test_interfaces.py
+++ b/tests/core/orchestration/test_interfaces.py
@@ -14,6 +14,7 @@ from codex_autorunner.core.orchestration import (
     OrchestrationThreadService,
     RuntimeThreadHarness,
     ThreadExecutionStore,
+    ThreadStopOutcome,
     ThreadTarget,
 )
 
@@ -352,6 +353,12 @@ class _FakeService:
 
     async def interrupt_thread(self, thread_target_id: str) -> ExecutionRecord:
         return self.store.execution
+
+    async def stop_thread(self, thread_target_id: str) -> ThreadStopOutcome:
+        return ThreadStopOutcome(
+            thread_target_id=thread_target_id,
+            execution=self.store.execution,
+        )
 
     def get_execution(
         self, thread_target_id: str, execution_id: str

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -25,6 +25,7 @@ from codex_autorunner.core.orchestration.service import (
 )
 from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.pma_thread_store import PmaThreadStore
+from codex_autorunner.integrations.app_server.client import CodexAppServerResponseError
 
 
 @dataclass
@@ -56,6 +57,7 @@ class _FakeHarness:
     start_turn_calls: list[dict[str, Any]] = field(default_factory=list)
     start_review_calls: list[dict[str, Any]] = field(default_factory=list)
     interrupt_calls: list[tuple[Path, str, Optional[str]]] = field(default_factory=list)
+    interrupt_error: Optional[Exception] = None
 
     async def ensure_ready(self, workspace_root: Path) -> None:
         self.ensure_ready_calls.append(workspace_root)
@@ -133,6 +135,8 @@ class _FakeHarness:
         self, workspace_root: Path, conversation_id: str, turn_id: Optional[str]
     ) -> None:
         self.interrupt_calls.append((workspace_root, conversation_id, turn_id))
+        if self.interrupt_error is not None:
+            raise self.interrupt_error
 
     async def wait_for_turn(
         self,
@@ -600,6 +604,46 @@ async def test_interrupt_thread_uses_harness_and_marks_execution(
         (workspace_root, "backend-conversation-1", "backend-turn-1")
     ]
     assert interrupted.status == "interrupted"
+
+
+async def test_stop_thread_recovers_missing_backend_thread_error(
+    tmp_path: Path,
+) -> None:
+    harness = _FakeHarness(
+        interrupt_error=CodexAppServerResponseError(
+            method="turn/interrupt",
+            code=-32600,
+            message="thread not found: backend-conversation-1",
+            data=None,
+        )
+    )
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target("codex", workspace_root)
+    execution = await service.send_message(
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="Need an answer",
+        )
+    )
+
+    outcome = await service.stop_thread(thread.thread_target_id)
+
+    assert harness.interrupt_calls == [
+        (workspace_root, "backend-conversation-1", "backend-turn-1")
+    ]
+    assert outcome.interrupted_active is False
+    assert outcome.recovered_lost_backend is True
+    assert outcome.execution is not None
+    assert outcome.execution.execution_id == execution.execution_id
+    assert outcome.execution.status == "error"
+    assert outcome.execution.error == "Backend thread lost after restart"
+    refreshed_thread = service.get_thread_target(thread.thread_target_id)
+    assert refreshed_thread is not None
+    assert refreshed_thread.backend_thread_id is None
+    assert service.get_running_execution(thread.thread_target_id) is None
 
 
 async def test_cancel_queued_executions_marks_queued_rows_interrupted(

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -4364,17 +4364,13 @@ async def test_car_interrupt_uses_orchestration_thread_state(tmp_path: Path) -> 
             assert thread_target_id == "thread-1"
             return SimpleNamespace(thread_target_id="thread-1")
 
-        def cancel_queued_executions(self, thread_target_id: str) -> int:
-            assert thread_target_id == "thread-1"
-            return 2
-
-        def get_running_execution(self, thread_target_id: str) -> Any:
-            assert thread_target_id == "thread-1"
-            return SimpleNamespace(execution_id="exec-1")
-
-        async def interrupt_thread(self, thread_target_id: str) -> Any:
+        async def stop_thread(self, thread_target_id: str) -> Any:
             interrupted.append(thread_target_id)
-            return SimpleNamespace(status="interrupted")
+            return SimpleNamespace(
+                interrupted_active=True,
+                recovered_lost_backend=False,
+                cancelled_queued=2,
+            )
 
     service._discord_thread_service = lambda: _FakeThreadService()  # type: ignore[assignment]
 
@@ -4391,6 +4387,138 @@ async def test_car_interrupt_uses_orchestration_thread_state(tmp_path: Path) -> 
         assert "cancelled 2 queued turn" in content
     finally:
         await store.close()
+
+
+@pytest.mark.anyio
+async def test_car_interrupt_recovers_missing_backend_thread(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    class _FakeThreadService:
+        def get_binding(self, *, surface_kind: str, surface_key: str) -> Any:
+            assert surface_kind == "discord"
+            assert surface_key == "channel-1"
+            return SimpleNamespace(thread_target_id="thread-1", mode="repo")
+
+        def get_thread_target(self, thread_target_id: str) -> Any:
+            assert thread_target_id == "thread-1"
+            return SimpleNamespace(thread_target_id="thread-1")
+
+        async def stop_thread(self, thread_target_id: str) -> Any:
+            assert thread_target_id == "thread-1"
+            return SimpleNamespace(
+                interrupted_active=False,
+                recovered_lost_backend=True,
+                cancelled_queued=0,
+            )
+
+    service._discord_thread_service = lambda: _FakeThreadService()  # type: ignore[assignment]
+
+    try:
+        await service._handle_car_interrupt(
+            "interaction-1",
+            "token-1",
+            channel_id="channel-1",
+        )
+        assert len(rest.interaction_responses) == 1
+        content = rest.interaction_responses[0]["payload"]["data"]["content"].lower()
+        assert "recovered stale session" in content
+        assert "backend thread was lost" in content
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_reset_discord_thread_binding_archives_after_lost_backend_recovery(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    calls: list[tuple[str, str]] = []
+
+    class _FakeThreadService:
+        def get_binding(self, *, surface_kind: str, surface_key: str) -> Any:
+            assert surface_kind == "discord"
+            assert surface_key == "channel-1"
+            return SimpleNamespace(thread_target_id="thread-1", mode="repo")
+
+        def get_thread_target(self, thread_target_id: str) -> Any:
+            assert thread_target_id == "thread-1"
+            return SimpleNamespace(thread_target_id="thread-1")
+
+        async def stop_thread(self, thread_target_id: str) -> Any:
+            calls.append(("stop", thread_target_id))
+            return SimpleNamespace(recovered_lost_backend=True)
+
+        def archive_thread_target(self, thread_target_id: str) -> None:
+            calls.append(("archive", thread_target_id))
+
+        def create_thread_target(
+            self, agent: str, workspace_root: Path, **kwargs: Any
+        ) -> Any:
+            calls.append(("create", agent))
+            assert workspace_root == workspace
+            return SimpleNamespace(thread_target_id="thread-2")
+
+        def upsert_binding(self, **kwargs: Any) -> Any:
+            calls.append(("bind", str(kwargs["thread_target_id"])))
+            return SimpleNamespace(thread_target_id=kwargs["thread_target_id"])
+
+    service._discord_thread_service = lambda: _FakeThreadService()  # type: ignore[assignment]
+
+    try:
+        had_previous, new_thread_id = await service._reset_discord_thread_binding(
+            channel_id="channel-1",
+            workspace_root=workspace,
+            agent="codex",
+            repo_id="repo-1",
+            resource_kind="repo",
+            resource_id="repo-1",
+            pma_enabled=False,
+        )
+    finally:
+        await store.close()
+
+    assert had_previous is True
+    assert new_thread_id == "thread-2"
+    assert calls == [
+        ("stop", "thread-1"),
+        ("archive", "thread-1"),
+        ("create", "codex"),
+        ("bind", "thread-2"),
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
@@ -168,6 +168,17 @@ def test_managed_thread_interrupt_route_uses_orchestration_service_seam(
             store.mark_turn_interrupted(managed_turn_id)
             return SimpleNamespace(status="interrupted")
 
+        async def stop_thread(self, thread_target_id: str):
+            calls.append(thread_target_id)
+            store.mark_turn_interrupted(managed_turn_id)
+            return SimpleNamespace(
+                thread_target_id=thread_target_id,
+                execution=SimpleNamespace(status="interrupted"),
+                interrupted_active=True,
+                recovered_lost_backend=False,
+                cancelled_queued=0,
+            )
+
         def record_execution_interrupted(
             self, thread_target_id: str, execution_id: str
         ):

--- a/tests/test_telegram_pma_routing.py
+++ b/tests/test_telegram_pma_routing.py
@@ -2284,6 +2284,197 @@ async def test_pma_interrupt_uses_managed_thread_orchestration_for_text_turns(
 
 
 @pytest.mark.anyio
+async def test_pma_interrupt_recovers_missing_backend_thread_for_text_turns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    record = TelegramTopicRecord(
+        pma_enabled=True,
+        workspace_path=None,
+        repo_id="repo-1",
+        agent="codex",
+    )
+    handler = _ManagedThreadPMAHandler(record, tmp_path)
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    class _FakeHarness:
+        display_name = "Fake"
+        capabilities = frozenset(
+            {
+                "durable_threads",
+                "message_turns",
+                "interrupt",
+                "event_streaming",
+            }
+        )
+
+        def __init__(self) -> None:
+            self.interrupt_calls: list[tuple[Path, str, Optional[str]]] = []
+
+        async def ensure_ready(self, workspace_root: Path) -> None:
+            _ = workspace_root
+
+        def supports(self, capability: str) -> bool:
+            return capability in self.capabilities
+
+        async def new_conversation(
+            self, workspace_root: Path, title: Optional[str] = None
+        ) -> SimpleNamespace:
+            _ = workspace_root, title
+            return SimpleNamespace(id="telegram-backend-thread-1")
+
+        async def resume_conversation(
+            self, workspace_root: Path, conversation_id: str
+        ) -> SimpleNamespace:
+            _ = workspace_root
+            return SimpleNamespace(id=conversation_id)
+
+        async def start_turn(
+            self,
+            workspace_root: Path,
+            conversation_id: str,
+            prompt: str,
+            model: Optional[str],
+            reasoning: Optional[str],
+            *,
+            approval_mode: Optional[str],
+            sandbox_policy: Optional[Any],
+            input_items: Optional[list[dict[str, Any]]] = None,
+        ) -> SimpleNamespace:
+            _ = (
+                workspace_root,
+                conversation_id,
+                prompt,
+                model,
+                reasoning,
+                approval_mode,
+                sandbox_policy,
+                input_items,
+            )
+            turn_id = "telegram-backend-turn-1"
+            if release_first.is_set():
+                turn_id = "telegram-backend-turn-2"
+            return SimpleNamespace(conversation_id=conversation_id, turn_id=turn_id)
+
+        async def start_review(self, *args: Any, **kwargs: Any) -> SimpleNamespace:
+            raise AssertionError("review mode should not be used in this test")
+
+        async def wait_for_turn(
+            self,
+            workspace_root: Path,
+            conversation_id: str,
+            turn_id: Optional[str],
+            *,
+            timeout: Optional[float] = None,
+        ) -> SimpleNamespace:
+            _ = workspace_root, conversation_id, timeout
+            assert isinstance(turn_id, str)
+            if turn_id == "telegram-backend-turn-1":
+                first_started.set()
+                await release_first.wait()
+                return SimpleNamespace(
+                    status="error",
+                    assistant_text="",
+                    errors=["stale backend thread"],
+                )
+            return SimpleNamespace(
+                status="ok",
+                assistant_text="unexpected queued reply",
+                errors=[],
+            )
+
+        async def interrupt(
+            self, workspace_root: Path, conversation_id: str, turn_id: Optional[str]
+        ) -> None:
+            self.interrupt_calls.append((workspace_root, conversation_id, turn_id))
+            raise CodexAppServerResponseError(
+                method="turn/interrupt",
+                code=-32600,
+                message="thread not found: telegram-backend-thread-1",
+                data=None,
+            )
+
+        async def stream_events(
+            self, workspace_root: Path, conversation_id: str, turn_id: str
+        ):
+            _ = workspace_root, conversation_id, turn_id
+            if False:
+                yield ""
+
+    harness = _FakeHarness()
+    monkeypatch.setattr(
+        execution_commands_module,
+        "get_registered_agents",
+        lambda: {
+            "codex": AgentDescriptor(
+                id="codex",
+                name="Codex",
+                capabilities=harness.capabilities,
+                make_harness=lambda _ctx: harness,
+            )
+        },
+    )
+
+    message = TelegramMessage(
+        update_id=1,
+        message_id=10,
+        chat_id=-1001,
+        thread_id=101,
+        from_user_id=42,
+        text="interruptible orchestration prompt",
+        date=None,
+        is_topic_message=True,
+    )
+
+    first_task = asyncio.create_task(
+        handler._handle_normal_message(message, runtime=_RuntimeStub())
+    )
+    try:
+        await first_started.wait()
+        await handler._process_interrupt(
+            chat_id=message.chat_id,
+            thread_id=message.thread_id,
+            reply_to=message.message_id,
+            runtime=_RuntimeStub(),
+            message_id=99,
+        )
+        with anyio.fail_after(2):
+            while not any(
+                "Recovered stale PMA session" in sent for sent in handler._sent
+            ):
+                await anyio.sleep(0.05)
+        release_first.set()
+        await first_task
+
+        assert harness.interrupt_calls == [
+            (tmp_path, "telegram-backend-thread-1", "telegram-backend-turn-1")
+        ]
+        assert any(
+            "Recovered stale PMA session after backend thread was lost." in sent
+            for sent in handler._sent
+        )
+        thread_store = execution_commands_module.PmaThreadStore(tmp_path)
+        threads = thread_store.list_threads(limit=10)
+        assert len(threads) == 1
+        turns = thread_store.list_turns(threads[0]["managed_thread_id"], limit=10)
+        assert turns[0]["status"] == "error"
+        assert turns[0]["error"] == "Backend thread lost after restart"
+    finally:
+        release_first.set()
+        if not first_task.done():
+            first_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await first_task
+        remaining_tasks = list(handler._spawned_tasks)
+        for task in remaining_tasks:
+            if not task.done():
+                task.cancel()
+        for task in remaining_tasks:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
+@pytest.mark.anyio
 async def test_repo_text_turns_use_orchestration_binding_and_preserve_thread_continuity(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3127,6 +3318,78 @@ def _patch_newt_branch_reset(
         workspace_commands_module, "reset_branch_from_origin_main", _fake_reset
     )
     return calls
+
+
+@pytest.mark.anyio
+async def test_sync_telegram_thread_binding_archives_after_lost_backend_recovery() -> (
+    None
+):
+    workspace = Path("/tmp/telegram-recovery-workspace").resolve()
+    calls: list[tuple[str, str]] = []
+
+    class _FakeThreadService:
+        async def stop_thread(self, thread_target_id: str) -> Any:
+            calls.append(("stop", thread_target_id))
+            return SimpleNamespace(recovered_lost_backend=True)
+
+        def archive_thread_target(self, thread_target_id: str) -> None:
+            calls.append(("archive", thread_target_id))
+
+        def create_thread_target(
+            self, agent: str, workspace_root: Path, **kwargs: Any
+        ) -> Any:
+            calls.append(("create", agent))
+            assert workspace_root == workspace
+            return SimpleNamespace(
+                thread_target_id="thread-2",
+                agent_id=agent,
+                workspace_root=str(workspace_root),
+            )
+
+        def upsert_binding(self, **kwargs: Any) -> None:
+            calls.append(("bind", str(kwargs["thread_target_id"])))
+
+    handlers = SimpleNamespace(_logger=logging.getLogger("test"))
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        execution_commands_module,
+        "_get_telegram_thread_binding",
+        lambda *args, **kwargs: (
+            _FakeThreadService(),
+            SimpleNamespace(thread_target_id="thread-1", mode="repo"),
+            SimpleNamespace(
+                thread_target_id="thread-1",
+                agent_id="codex",
+                workspace_root=str(workspace),
+            ),
+        ),
+    )
+    try:
+        _service, thread = (
+            await execution_commands_module._sync_telegram_thread_binding(
+                handlers,
+                surface_key="topic-1",
+                workspace_root=workspace,
+                agent="codex",
+                repo_id="repo-1",
+                resource_kind="repo",
+                resource_id="repo-1",
+                backend_thread_id="backend-2",
+                mode="repo",
+                pma_enabled=False,
+                replace_existing=True,
+            )
+        )
+    finally:
+        monkeypatch.undo()
+
+    assert thread.thread_target_id == "thread-2"
+    assert calls == [
+        ("stop", "thread-1"),
+        ("archive", "thread-1"),
+        ("create", "codex"),
+        ("bind", "thread-2"),
+    ]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- add a shared orchestration `stop_thread` recovery path for stale managed threads whose backend thread disappeared
- use that recovery path in Discord reset/interrupt flows and Telegram reset/interrupt flows
- add coverage for orchestration recovery plus Discord and Telegram surface behavior

## Testing
- `.venv/bin/python -m pytest tests/core/orchestration/test_service.py tests/integrations/discord/test_service_routing.py tests/test_telegram_pma_routing.py tests/core/orchestration/test_interfaces.py tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py`
- pre-commit hook suite during `git commit` (`2977 passed, 1 skipped`)

Closes #986
