### PR TITLE
Fix managed-thread send prompt UX

### DIFF
--- a/docs/ops/pma-managed-thread-status.md
+++ b/docs/ops/pma-managed-thread-status.md
@@ -92,6 +92,9 @@ Managed-thread delivery is queue-first by default.
 
 - Sending a message to a busy thread creates a queued turn plus a durable
   orchestration queue record.
+- Prefer `car pma thread send --message-file <path>` or `--message-stdin` for
+  multiline or shell-sensitive prompts; the CLI now echoes the exact delivered
+  message after acceptance.
 - `busy_policy=interrupt` (or `car pma thread send --if-busy interrupt`) keeps
   interrupt as a first-class operation when the runtime supports it.
 - `busy_policy=reject` preserves the old fail-fast behavior for callers that

--- a/src/codex_autorunner/bootstrap.py
+++ b/src/codex_autorunner/bootstrap.py
@@ -333,6 +333,7 @@ You are an **abstraction layer, not an executor**. Coordinate tickets and flows 
 - CLI primitives:
   - `car pma thread spawn --agent codex --repo <repo_id> --name <label>`
   - `car pma thread send --id <managed_thread_id> --message "..." --watch`
+  - `car pma thread send --id <managed_thread_id> --message-file prompt.md --watch`
   - `car pma thread send --id <managed_thread_id> --message "..." --notify-on terminal --notify-lane <lane_id>`
   - `car pma thread status --id <managed_thread_id>`
   - `car pma thread compact --id <id> --summary "..."`

--- a/src/codex_autorunner/core/pma_context.py
+++ b/src/codex_autorunner/core/pma_context.py
@@ -114,6 +114,7 @@ First-turn routine:
      - `car pma thread spawn --agent codex --repo <repo_id> --name <label>`
      - `car pma thread spawn --resource-kind agent_workspace --resource-id <workspace_id> --name <label>`
      - `car pma thread send --id <managed_thread_id> --message "..." --watch`
+     - `car pma thread send --id <managed_thread_id> --message-file prompt.md --watch`
      - `car pma thread send --id <managed_thread_id> --message "..." --notify-on terminal --notify-lane <lane_id>`
      - `car pma thread status --id <managed_thread_id>`
      - `car pma thread compact --id <id> --summary "..."`

--- a/src/codex_autorunner/surfaces/cli/pma_cli.py
+++ b/src/codex_autorunner/surfaces/cli/pma_cli.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -74,6 +75,53 @@ def _resolve_hub_path(path: Optional[Path]) -> Path:
         if candidate.exists():
             return candidate.parent.parent.resolve()
     return Path.cwd()
+
+
+def _resolve_message_body(
+    *,
+    message: Optional[str],
+    message_file: Optional[Path],
+    message_stdin: bool,
+    option_hint: str,
+) -> str:
+    selected_inputs = sum(
+        1
+        for selected in (
+            message is not None,
+            message_file is not None,
+            message_stdin,
+        )
+        if selected
+    )
+    if selected_inputs != 1:
+        raise typer.BadParameter(
+            f"Provide exactly one of {option_hint}.",
+            param_hint="--message / --message-file / --message-stdin",
+        )
+
+    if message_file is not None:
+        try:
+            raw_message = message_file.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise typer.BadParameter(
+                f"Failed to read message file: {exc}",
+                param_hint="--message-file",
+            ) from exc
+    elif message_stdin:
+        raw_message = sys.stdin.read()
+    else:
+        raw_message = message or ""
+
+    if not raw_message.strip():
+        raise typer.BadParameter("Message cannot be empty.")
+    return raw_message
+
+
+def _echo_delivered_message(message: str) -> None:
+    typer.echo("delivered message:")
+    typer.echo(message, nl=False)
+    if not message.endswith("\n"):
+        typer.echo()
 
 
 def _request_json(
@@ -1263,8 +1311,14 @@ def pma_thread_send(
     managed_thread_id: str = typer.Option(
         ..., "--id", help="Managed PMA thread id", show_default=False
     ),
-    message: str = typer.Option(
-        ..., "--message", help="User message to send", show_default=False
+    message: Optional[str] = typer.Option(
+        None, "--message", help="User message to send", show_default=False
+    ),
+    message_file: Optional[Path] = typer.Option(
+        None, "--message-file", help="Read the user message from a file"
+    ),
+    message_stdin: bool = typer.Option(
+        False, "--message-stdin", help="Read the user message from stdin"
     ),
     model: Optional[str] = typer.Option(None, "--model", help="Model override"),
     reasoning: Optional[str] = typer.Option(
@@ -1297,13 +1351,19 @@ def pma_thread_send(
     path: Optional[Path] = typer.Option(None, "--path", "--hub", help="Hub root path"),
 ):
     """Send a message to a managed PMA thread."""
+    message_body = _resolve_message_body(
+        message=message,
+        message_file=message_file,
+        message_stdin=message_stdin,
+        option_hint="--message, --message-file, or --message-stdin",
+    )
     normalized_notify_on = _normalize_notify_on(notify_on)
     should_defer = watch or normalized_notify_on == "terminal"
     normalized_if_busy = (if_busy or "").strip().lower() or "queue"
     if normalized_if_busy not in {"queue", "interrupt", "reject"}:
         raise typer.BadParameter("if-busy must be queue, interrupt, or reject")
     payload: dict[str, Any] = {
-        "message": message,
+        "message": message_body,
         "busy_policy": normalized_if_busy,
         "defer_execution": should_defer,
     }
@@ -1362,6 +1422,7 @@ def pma_thread_send(
             )
         return
 
+    delivered_message = str(data.get("delivered_message") or message_body)
     execution_state = str(data.get("execution_state") or "").strip().lower()
     if execution_state == "queued" or (should_defer and execution_state == "running"):
         line = (
@@ -1375,6 +1436,7 @@ def pma_thread_send(
         if queue_depth is not None:
             line += f" queue_depth={queue_depth}"
         typer.echo(line)
+        _echo_delivered_message(delivered_message)
         if watch:
             pma_thread_tail(
                 managed_thread_id=managed_thread_id,
@@ -1400,7 +1462,17 @@ def pma_thread_send(
                 typer.echo(excerpt)
         return
 
-    typer.echo(str(data.get("assistant_text") or ""))
+    line = (
+        f"send_state={send_state or 'accepted'} "
+        f"managed_turn_id={data.get('managed_turn_id') or ''} "
+        f"execution_state={execution_state or 'completed'}"
+    )
+    typer.echo(line.strip())
+    _echo_delivered_message(delivered_message)
+    assistant_text = str(data.get("assistant_text") or "")
+    if assistant_text:
+        typer.echo("\nassistant:")
+        typer.echo(assistant_text)
 
 
 @thread_app.command("turns")

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -356,8 +356,8 @@ def build_managed_thread_runtime_routes(
     ) -> Any:
         busy_policy = _normalize_busy_policy(payload.busy_policy)
 
-        message = (payload.message or "").strip()
-        if not message:
+        message = payload.message or ""
+        if not message.strip():
             raise HTTPException(status_code=400, detail="message is required")
 
         defaults = _get_pma_config(request)
@@ -387,6 +387,7 @@ def build_managed_thread_runtime_routes(
         notify_lane = normalize_optional_text(payload.notify_lane)
         notify_once = bool(payload.notify_once)
         defer_execution = bool(payload.defer_execution)
+        delivery_payload = {"delivered_message": message}
 
         if (thread.get("status") or "") == "archived":
             return JSONResponse(
@@ -523,6 +524,7 @@ def build_managed_thread_runtime_routes(
                 "backend_thread_id": stored_backend_id or "",
                 "assistant_text": "",
                 "error": MANAGED_THREAD_PUBLIC_EXECUTION_ERROR,
+                **delivery_payload,
             }
         managed_turn_id = started_execution.execution.execution_id
         if not managed_turn_id:
@@ -556,6 +558,7 @@ def build_managed_thread_runtime_routes(
                 "backend_thread_id": backend_thread_id or "",
                 "assistant_text": "",
                 "error": detail,
+                **delivery_payload,
             }
 
         notification: Optional[dict[str, Any]] = None
@@ -696,6 +699,7 @@ def build_managed_thread_runtime_routes(
                         "backend_thread_id": resolved_backend_thread_id or "",
                         "assistant_text": "",
                         "error": detail,
+                        **delivery_payload,
                     }
                 thread_store.update_thread_after_turn(
                     managed_thread_id,
@@ -717,6 +721,7 @@ def build_managed_thread_runtime_routes(
                     "backend_thread_id": resolved_backend_thread_id or "",
                     "assistant_text": outcome.assistant_text,
                     "error": None,
+                    **delivery_payload,
                 }
 
             if outcome.status == "interrupted":
@@ -742,6 +747,7 @@ def build_managed_thread_runtime_routes(
                     "backend_thread_id": resolved_backend_thread_id or "",
                     "assistant_text": "",
                     "error": detail,
+                    **delivery_payload,
                 }
 
             detail = _sanitize_managed_thread_result_error(outcome.error)
@@ -772,6 +778,7 @@ def build_managed_thread_runtime_routes(
                 "backend_thread_id": resolved_backend_thread_id or "",
                 "assistant_text": "",
                 "error": detail,
+                **delivery_payload,
             }
 
         def _ensure_queue_worker() -> None:
@@ -826,6 +833,7 @@ def build_managed_thread_runtime_routes(
                 "backend_thread_id": backend_thread_id or "",
                 "assistant_text": "",
                 "error": None,
+                **delivery_payload,
                 "queue_depth": service.get_queue_depth(managed_thread_id),
                 "active_managed_turn_id": (
                     running_execution.execution_id
@@ -847,6 +855,7 @@ def build_managed_thread_runtime_routes(
             "backend_thread_id": backend_thread_id or "",
             "assistant_text": "",
             "error": None,
+            **delivery_payload,
         }
         if notification is not None:
             accepted_payload["notification"] = notification

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
@@ -136,6 +136,7 @@ def test_managed_thread_message_route_uses_orchestration_service_seam(
     payload = response.json()
     assert payload["status"] == "ok"
     assert payload["assistant_text"] == "assistant-output"
+    assert payload["delivered_message"] == "hello from route"
     assert captured["sandbox_policy"] == "dangerFullAccess"
     assert captured["request"].context_profile == "car_ambient"
     assert "<injected context>" not in captured["request"].metadata["runtime_prompt"]
@@ -291,6 +292,10 @@ def test_managed_thread_message_route_injects_core_context_when_profile_is_core(
             _ = thread_target_id, execution_id
             return None
 
+        def get_running_execution(self, thread_target_id: str):
+            _ = thread_target_id
+            return None
+
     async def _fake_begin(
         service, request, *, client_request_id=None, sandbox_policy=None
     ):
@@ -341,6 +346,91 @@ def test_managed_thread_message_route_injects_core_context_when_profile_is_core(
     assert response.status_code == 200
     assert captured["request"].context_profile == "car_core"
     assert "<injected context>" in captured["request"].metadata["runtime_prompt"]
+
+
+def test_managed_thread_message_route_preserves_literal_message_whitespace(
+    hub_env,
+    monkeypatch,
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+    store = PmaThreadStore(hub_env.hub_root)
+    created = store.create_thread(
+        "codex", hub_env.repo_root.resolve(), repo_id=hub_env.repo_id
+    )
+    managed_thread_id = str(created["managed_thread_id"])
+    captured: dict[str, Any] = {}
+
+    class FakeService:
+        def get_thread_target(self, thread_target_id: str):
+            return SimpleNamespace(
+                thread_target_id=thread_target_id,
+                backend_thread_id="backend-thread-1",
+            )
+
+        def record_execution_result(self, *args, **kwargs):
+            _ = args, kwargs
+            return SimpleNamespace(status="ok", error=None)
+
+        def get_execution(self, thread_target_id: str, execution_id: str):
+            _ = thread_target_id, execution_id
+            return None
+
+    async def _fake_begin(
+        service, request, *, client_request_id=None, sandbox_policy=None
+    ):
+        _ = service, client_request_id, sandbox_policy
+        captured["request"] = request
+        return SimpleNamespace(
+            execution=SimpleNamespace(
+                execution_id="managed-turn-1",
+                backend_id="backend-turn-1",
+            ),
+            thread=SimpleNamespace(backend_thread_id="backend-thread-1"),
+            workspace_root=hub_env.repo_root.resolve(),
+            request=request,
+        )
+
+    async def _fake_await(*args, **kwargs):
+        _ = args, kwargs
+        return RuntimeThreadOutcome(
+            status="ok",
+            assistant_text="assistant-output",
+            error=None,
+            backend_thread_id="backend-thread-1",
+            backend_turn_id="backend-turn-1",
+        )
+
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "_build_managed_thread_orchestration_service",
+        lambda request, *, thread_store=None: FakeService(),
+    )
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "begin_runtime_thread_execution",
+        _fake_begin,
+    )
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "await_runtime_thread_outcome",
+        _fake_await,
+    )
+
+    literal_message = "  keep literal backticks `glm-5-turbo`\nsecond line\n"
+    with TestClient(app) as client:
+        response = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/messages",
+            json={"message": literal_message},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["delivered_message"] == literal_message
+    assert captured["request"].message_text == literal_message
+    runtime_prompt = captured["request"].metadata["runtime_prompt"]
+    assert f"<user_message>\n{literal_message}" in runtime_prompt
+    assert runtime_prompt.endswith("\n</user_message>\n")
 
 
 def test_zeroclaw_managed_thread_projects_compat_agents_file_for_core_profile(

--- a/tests/test_file_chat_execution.py
+++ b/tests/test_file_chat_execution.py
@@ -9,6 +9,9 @@ import pytest
 
 from codex_autorunner.core import drafts as draft_utils
 from codex_autorunner.core.state import now_iso
+from codex_autorunner.surfaces.web.routes.file_chat_routes import (
+    execution as execution_module,
+)
 from codex_autorunner.surfaces.web.routes.file_chat_routes import runtime
 from codex_autorunner.surfaces.web.routes.file_chat_routes.drafts import (
     apply_file_patch,
@@ -81,7 +84,8 @@ async def test_execute_file_chat_writes_draft_working_copy_without_touching_live
     )
     monkeypatch.setattr(runtime, "update_turn_state", fake_update_turn_state)
     monkeypatch.setattr(
-        "codex_autorunner.surfaces.web.routes.file_chat_routes.execution.execute_app_server",
+        execution_module,
+        "execute_app_server",
         fake_execute_app_server,
     )
 
@@ -178,7 +182,8 @@ async def test_execute_file_chat_continues_from_existing_draft_working_copy(
     )
     monkeypatch.setattr(runtime, "update_turn_state", fake_update_turn_state)
     monkeypatch.setattr(
-        "codex_autorunner.surfaces.web.routes.file_chat_routes.execution.execute_app_server",
+        execution_module,
+        "execute_app_server",
         fake_execute_app_server,
     )
 

--- a/tests/test_pma_cli.py
+++ b/tests/test_pma_cli.py
@@ -92,6 +92,8 @@ def test_pma_cli_thread_send_help_shows_json_option():
     assert "--watch" in output, "PMA thread send should support --watch"
     assert "--if-busy" in output, "PMA thread send should support busy-thread policy"
     assert "--notify-on" in output, "PMA thread send should support --notify-on"
+    assert "--message-file" in output, "PMA thread send should support file input"
+    assert "--message-stdin" in output, "PMA thread send should support stdin input"
 
 
 def test_pma_cli_thread_status_help_shows_json_option():
@@ -517,6 +519,7 @@ def test_pma_cli_thread_send_reports_queued_busy_thread(
                 "managed_turn_id": "turn-2",
                 "active_managed_turn_id": "turn-1",
                 "queue_depth": 1,
+                "delivered_message": "follow up",
                 "assistant_text": "",
             },
         )
@@ -544,12 +547,187 @@ def test_pma_cli_thread_send_reports_queued_busy_thread(
     assert "send_state=queued managed_turn_id=turn-2" in result.stdout
     assert "active_managed_turn_id=turn-1" in result.stdout
     assert "queue_depth=1" in result.stdout
+    assert "delivered message:\nfollow up\n" in result.stdout
     assert captured["url"] == "http://127.0.0.1:4321/hub/pma/threads/thread-1/messages"
     assert captured["payload"] == {
         "message": "follow up",
         "busy_policy": "queue",
         "defer_execution": False,
     }
+
+
+def test_pma_cli_thread_send_reads_message_from_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_cli,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+    captured: dict[str, object] = {}
+    message_path = tmp_path / "prompt.md"
+    message_path.write_text("literal `glm-5-turbo`\nsecond line\n", encoding="utf-8")
+
+    def _fake_request_json_with_status(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        timeout=None,
+    ):
+        _ = method, url, token_env, timeout
+        captured["payload"] = payload
+        return (
+            200,
+            {
+                "status": "ok",
+                "send_state": "accepted",
+                "execution_state": "completed",
+                "managed_turn_id": "turn-3",
+                "delivered_message": payload["message"],
+                "assistant_text": "done",
+            },
+        )
+
+    monkeypatch.setattr(
+        pma_cli, "_request_json_with_status", _fake_request_json_with_status
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pma_app,
+        [
+            "thread",
+            "send",
+            "--id",
+            "thread-1",
+            "--message-file",
+            str(message_path),
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["payload"] == {
+        "message": "literal `glm-5-turbo`\nsecond line\n",
+        "busy_policy": "queue",
+        "defer_execution": False,
+    }
+    assert "delivered message:\nliteral `glm-5-turbo`\nsecond line\n" in result.stdout
+    assert "\nassistant:\ndone\n" in result.stdout
+
+
+def test_pma_cli_thread_send_reads_message_from_stdin(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_cli,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+    captured: dict[str, object] = {}
+
+    def _fake_request_json_with_status(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        timeout=None,
+    ):
+        _ = method, url, token_env, timeout
+        captured["payload"] = payload
+        return (
+            200,
+            {
+                "status": "ok",
+                "send_state": "accepted",
+                "execution_state": "running",
+                "managed_turn_id": "turn-4",
+                "delivered_message": payload["message"],
+                "assistant_text": "",
+            },
+        )
+
+    monkeypatch.setattr(
+        pma_cli, "_request_json_with_status", _fake_request_json_with_status
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pma_app,
+        [
+            "thread",
+            "send",
+            "--id",
+            "thread-1",
+            "--message-stdin",
+            "--path",
+            str(tmp_path),
+        ],
+        input="stdin payload with backticks `glm-5-turbo`\n",
+    )
+
+    assert result.exit_code == 0
+    assert captured["payload"] == {
+        "message": "stdin payload with backticks `glm-5-turbo`\n",
+        "busy_policy": "queue",
+        "defer_execution": False,
+    }
+    assert (
+        "delivered message:\nstdin payload with backticks `glm-5-turbo`\n"
+        in result.stdout
+    )
+
+
+def test_pma_cli_thread_send_requires_exactly_one_message_source(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_cli,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+    message_path = tmp_path / "prompt.md"
+    message_path.write_text("hello\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pma_app,
+        [
+            "thread",
+            "send",
+            "--id",
+            "thread-1",
+            "--message",
+            "inline",
+            "--message-file",
+            str(message_path),
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "Provide exactly one of --message, --message-file, or --message-stdin."
+        in result.output
+    )
 
 
 def test_pma_cli_thread_control_commands_use_orchestration_routes(


### PR DESCRIPTION
## Summary
- add `--message-file` and `--message-stdin` to `car pma thread send`
- preserve the literal managed-thread message body and return the exact delivered payload from the PMA route
- echo the delivered message in CLI output and cover the new behavior with CLI and route tests

## Testing
- .venv/bin/python -m pytest tests/test_pma_cli.py tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py tests/test_pma_managed_threads_messages.py tests/test_hotspot_budgets.py tests/test_file_chat_execution.py -q
- full pre-commit suite via `git commit`

Closes #992
