### PR TITLE
Auto-build PMA compaction seeds from turns

### DIFF
--- a/src/codex_autorunner/core/pma_thread_compaction.py
+++ b/src/codex_autorunner/core/pma_thread_compaction.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Optional
+
+DEFAULT_MANAGED_THREAD_COMPACT_TURNS = 6
+DEFAULT_MANAGED_THREAD_COMPACT_CHARS = 2000
+
+
+def _normalize_text(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.split()).strip()
+
+
+def _truncate(text: str, limit: int) -> str:
+    normalized = _normalize_text(text)
+    if limit <= 0 or len(normalized) <= limit:
+        return normalized
+    if limit <= 3:
+        return normalized[:limit]
+    return f"{normalized[: limit - 3].rstrip()}..."
+
+
+def build_managed_thread_compact_summary(
+    turns: Iterable[dict[str, Any]],
+    *,
+    max_chars: Optional[int] = None,
+    max_turns: int = DEFAULT_MANAGED_THREAD_COMPACT_TURNS,
+) -> Optional[str]:
+    char_budget = (
+        max_chars
+        if isinstance(max_chars, int) and max_chars > 0
+        else DEFAULT_MANAGED_THREAD_COMPACT_CHARS
+    )
+    if char_budget <= 0:
+        return None
+
+    relevant: list[dict[str, Any]] = []
+    for turn in turns:
+        prompt = _normalize_text(turn.get("prompt"))
+        assistant = _normalize_text(turn.get("assistant_text"))
+        error = _normalize_text(turn.get("error") or turn.get("error_text"))
+        status = _normalize_text(turn.get("status")).lower()
+        if not prompt and not assistant and not error:
+            continue
+        if status not in {"ok", "error", "interrupted"} and not assistant and not error:
+            continue
+        relevant.append(turn)
+
+    if not relevant:
+        return None
+
+    relevant = relevant[-max(1, max_turns) :]
+    field_limit = max(96, min(480, char_budget // 3))
+
+    def _render(candidate_turns: list[dict[str, Any]]) -> str:
+        lines = ["Compact summary of recent managed thread turns:"]
+        for index, turn in enumerate(candidate_turns, start=1):
+            prompt = _truncate(str(turn.get("prompt") or ""), field_limit)
+            assistant = _truncate(str(turn.get("assistant_text") or ""), field_limit)
+            error = _truncate(
+                str(turn.get("error") or turn.get("error_text") or ""), field_limit
+            )
+            status = _normalize_text(turn.get("status")).lower()
+            lines.append(f"Turn {index}:")
+            if prompt:
+                lines.append(f"User: {prompt}")
+            if assistant:
+                lines.append(f"Assistant: {assistant}")
+            elif error:
+                label = "Interrupted" if status == "interrupted" else "Error"
+                lines.append(f"{label}: {error}")
+        return "\n".join(lines).strip()
+
+    selected: list[dict[str, Any]] = []
+    for turn in reversed(relevant):
+        candidate = [turn, *selected]
+        rendered = _render(candidate)
+        if len(rendered) > char_budget and selected:
+            continue
+        if len(rendered) > char_budget:
+            selected = [turn]
+            break
+        selected = candidate
+
+    if not selected:
+        return None
+    return _truncate(_render(selected), char_budget)
+
+
+__all__ = [
+    "DEFAULT_MANAGED_THREAD_COMPACT_CHARS",
+    "DEFAULT_MANAGED_THREAD_COMPACT_TURNS",
+    "build_managed_thread_compact_summary",
+]

--- a/src/codex_autorunner/surfaces/cli/pma_cli.py
+++ b/src/codex_autorunner/surfaces/cli/pma_cli.py
@@ -1705,7 +1705,11 @@ def pma_thread_compact(
     managed_thread_id: str = typer.Option(
         ..., "--id", help="Managed PMA thread id", show_default=False
     ),
-    summary: str = typer.Option(..., "--summary", help="Compaction summary"),
+    summary: Optional[str] = typer.Option(
+        None,
+        "--summary",
+        help="Compaction summary (defaults to recent turn history)",
+    ),
     no_reset_backend: bool = typer.Option(
         False, "--no-reset-backend", help="Preserve backend thread/session id"
     ),

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -16,6 +16,7 @@ from .....core.managed_thread_status import derive_managed_thread_operator_statu
 from .....core.orchestration import build_harness_backed_orchestration_service
 from .....core.orchestration.catalog import RuntimeAgentDescriptor
 from .....core.orchestration.models import ThreadTarget
+from .....core.pma_thread_compaction import build_managed_thread_compact_summary
 from .....core.pma_thread_store import PmaThreadStore
 from ...schemas import (
     PmaAutomationSubscriptionCreateRequest,
@@ -714,10 +715,26 @@ def build_managed_thread_crud_routes(
         request: Request,
         payload: PmaManagedThreadCompactRequest,
     ) -> dict[str, Any]:
+        store = PmaThreadStore(request.app.state.config.root)
+        thread = store.get_thread(managed_thread_id)
+        if thread is None:
+            raise HTTPException(status_code=404, detail="Managed thread not found")
+
         summary = (payload.summary or "").strip()
-        if not summary:
-            raise HTTPException(status_code=400, detail="summary is required")
         max_text_chars = int(_get_pma_config(request).get("max_text_chars", 0) or 0)
+        if not summary:
+            summary = (
+                build_managed_thread_compact_summary(
+                    reversed(store.list_turns(managed_thread_id, limit=12)),
+                    max_chars=max_text_chars,
+                )
+                or ""
+            ).strip()
+        if not summary:
+            raise HTTPException(
+                status_code=400,
+                detail="summary is required when thread has no completed turns",
+            )
         if max_text_chars > 0 and len(summary) > max_text_chars:
             raise HTTPException(
                 status_code=400,
@@ -725,11 +742,6 @@ def build_managed_thread_crud_routes(
                     f"summary exceeds max_text_chars ({max_text_chars} characters)"
                 ),
             )
-
-        store = PmaThreadStore(request.app.state.config.root)
-        thread = store.get_thread(managed_thread_id)
-        if thread is None:
-            raise HTTPException(status_code=404, detail="Managed thread not found")
 
         old_backend_thread_id = normalize_optional_text(thread.get("backend_thread_id"))
         reset_backend = bool(payload.reset_backend)

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -676,7 +676,7 @@ class PmaManagedThreadMessageRequest(Payload):
 
 
 class PmaManagedThreadCompactRequest(Payload):
-    summary: str
+    summary: Optional[str] = None
     reset_backend: bool = True
 
 

--- a/tests/test_pma_managed_threads_lifecycle.py
+++ b/tests/test_pma_managed_threads_lifecycle.py
@@ -240,6 +240,145 @@ def test_compact_rejects_oversize_summary(hub_env) -> None:
 
 
 @pytest.mark.slow
+def test_compact_without_summary_uses_recent_turn_history(hub_env) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeTurnHandle:
+        def __init__(self, turn_id: str, assistant_text: str) -> None:
+            self.turn_id = turn_id
+            self._assistant_text = assistant_text
+
+        async def wait(self, timeout=None):
+            _ = timeout
+            return type(
+                "Result",
+                (),
+                {
+                    "agent_messages": [self._assistant_text],
+                    "raw_events": [],
+                    "errors": [],
+                },
+            )()
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.thread_start_calls = 0
+            self.turn_start_calls: list[dict[str, str]] = []
+
+        async def thread_resume(self, thread_id: str) -> None:
+            _ = thread_id
+
+        async def thread_start(self, root: str) -> dict:
+            _ = root
+            self.thread_start_calls += 1
+            return {"id": f"backend-thread-{self.thread_start_calls}"}
+
+        async def turn_start(
+            self,
+            thread_id: str,
+            prompt: str,
+            approval_policy: str,
+            sandbox_policy: str,
+            **turn_kwargs,
+        ):
+            _ = thread_id, approval_policy, sandbox_policy, turn_kwargs
+            index = len(self.turn_start_calls) + 1
+            self.turn_start_calls.append({"prompt": prompt})
+            return FakeTurnHandle(
+                turn_id=f"backend-turn-{index}",
+                assistant_text=f"assistant output {index}",
+            )
+
+    class FakeSupervisor:
+        def __init__(self) -> None:
+            self.client = FakeClient()
+
+        async def get_client(self, hub_root: Path):
+            _ = hub_root
+            return self.client
+
+    fake_supervisor = FakeSupervisor()
+    app.state.app_server_supervisor = fake_supervisor
+    app.state.app_server_events = object()
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                "resource_kind": "repo",
+                "resource_id": hub_env.repo_id,
+            },
+        )
+        assert create_resp.status_code == 200
+        managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+        first_msg = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/messages",
+            json={"message": "first user message"},
+        )
+        assert first_msg.status_code == 200
+
+        compact_resp = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/compact",
+            json={"reset_backend": True},
+        )
+        assert compact_resp.status_code == 200
+
+        store = PmaThreadStore(hub_env.hub_root)
+        compacted_thread = store.get_thread(managed_thread_id)
+        assert compacted_thread is not None
+        summary = str(compacted_thread["compact_seed"] or "")
+        assert "Compact summary of recent managed thread turns:" in summary
+        assert "User: first user message" in summary
+        assert "Assistant: assistant output 1" in summary
+
+        second_msg = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/messages",
+            json={"message": "follow-up question"},
+        )
+        assert second_msg.status_code == 200
+
+        second_prompt = fake_supervisor.client.turn_start_calls[1]["prompt"]
+        assert "Context summary (from compaction):" in second_prompt
+        assert "User: first user message" in second_prompt
+        assert "Assistant: assistant output 1" in second_prompt
+        assert "User message:\nfollow-up question" in second_prompt
+
+
+@pytest.mark.slow
+def test_compact_without_summary_rejects_threads_without_completed_turns(
+    hub_env,
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                "resource_kind": "repo",
+                "resource_id": hub_env.repo_id,
+            },
+        )
+        assert create_resp.status_code == 200
+        managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+        compact_resp = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/compact",
+            json={"reset_backend": True},
+        )
+
+    assert compact_resp.status_code == 400
+    assert (
+        compact_resp.json()["detail"]
+        == "summary is required when thread has no completed turns"
+    )
+
+
+@pytest.mark.slow
 def test_interrupt_managed_thread_sanitizes_backend_exception(hub_env) -> None:
     _enable_pma(hub_env.hub_root)
     app = create_hub_app(hub_env.hub_root)

--- a/tests/test_pma_thread_compaction.py
+++ b/tests/test_pma_thread_compaction.py
@@ -1,0 +1,52 @@
+from codex_autorunner.core.pma_thread_compaction import (
+    build_managed_thread_compact_summary,
+)
+
+
+def test_build_managed_thread_compact_summary_uses_turn_outputs_only() -> None:
+    summary = build_managed_thread_compact_summary(
+        [
+            {
+                "prompt": "first user message",
+                "assistant_text": "first assistant output",
+                "status": "ok",
+            },
+            {
+                "prompt": "second user message",
+                "assistant_text": "second assistant output",
+                "status": "ok",
+            },
+        ],
+        max_chars=400,
+    )
+
+    assert summary is not None
+    assert "Compact summary of recent managed thread turns:" in summary
+    assert "User: first user message" in summary
+    assert "Assistant: first assistant output" in summary
+    assert "User: second user message" in summary
+    assert "Assistant: second assistant output" in summary
+
+
+def test_build_managed_thread_compact_summary_prefers_recent_turns_when_trimming() -> (
+    None
+):
+    summary = build_managed_thread_compact_summary(
+        [
+            {
+                "prompt": "older user message " * 20,
+                "assistant_text": "older assistant output " * 20,
+                "status": "ok",
+            },
+            {
+                "prompt": "latest user message",
+                "assistant_text": "latest assistant output",
+                "status": "ok",
+            },
+        ],
+        max_chars=180,
+    )
+
+    assert summary is not None
+    assert "latest user message" in summary
+    assert "latest assistant output" in summary


### PR DESCRIPTION
## Summary
- auto-build PMA managed-thread compaction seeds from recent completed turns when no manual summary is provided
- keep the existing compact_seed mechanism and reset/resume flow, but derive summaries from stored user/assistant turn history instead of requiring hand-written text
- expose the new behavior through the PMA compact API and CLI, with tests covering auto-summary generation and empty-thread rejection

## Testing
- .venv/bin/pytest tests/test_pma_thread_compaction.py tests/test_pma_managed_threads_lifecycle.py tests/test_pma_managed_threads_messages.py -q -k compact
- git commit pre-commit suite (black, ruff, mypy, pnpm build/test, full pytest)
