### PR TITLE
Trim noisy PMA watch tail events

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
@@ -172,6 +172,25 @@ def _tail_event_type_from_message(message: Any) -> str:
     return "progress"
 
 
+def _should_suppress_tail_event(message: Any) -> bool:
+    payload = coerce_dict(message)
+    method = str(payload.get("method") or "").strip().lower()
+    params = coerce_dict(payload.get("params"))
+    item = coerce_dict(params.get("item"))
+
+    if method in {
+        "item/agentmessage/delta",
+        "item/plan/delta",
+        "turn/plan/updated",
+    }:
+        return True
+    if method == "item/completed":
+        item_type = str(item.get("type") or "").strip().lower()
+        if item_type == "agentmessage":
+            return True
+    return False
+
+
 _NO_STREAM_AVAILABLE_IDLE_SECONDS = 15
 _LIKELY_HUNG_IDLE_SECONDS = 90
 
@@ -606,6 +625,8 @@ def _serialize_tail_event(
     if since_ms is not None and received_at_ms and received_at_ms < since_ms:
         return None
     message = coerce_dict(event.get("message"))
+    if _should_suppress_tail_event(message):
+        return None
     lines = [
         redact_text(str(line).strip())
         for line in formatter.format_event(message)
@@ -630,6 +651,13 @@ def _serialize_tail_event(
     if level == "debug":
         payload["raw"] = _redact_nested(message)
     return payload
+
+
+def _event_received_at_iso(event: dict[str, Any]) -> Optional[str]:
+    received_at_ms = int(event.get("received_at") or 0)
+    if received_at_ms <= 0:
+        return None
+    return iso_from_event_ms(received_at_ms)
 
 
 async def _build_managed_thread_tail_snapshot(
@@ -709,6 +737,7 @@ async def _build_managed_thread_tail_snapshot(
     )
     formatter = AppServerEventFormatter(redact_enabled=True)
     tail_events: list[dict[str, Any]] = []
+    raw_last_activity_at: Optional[str] = None
     if can_stream_codex:
         raw_events = await app_server_events.list_events(
             str(backend_thread_id),
@@ -717,6 +746,9 @@ async def _build_managed_thread_tail_snapshot(
             limit=limit,
         )
         for event in raw_events:
+            activity_at = _event_received_at_iso(event)
+            if activity_at:
+                raw_last_activity_at = activity_at
             serialized = _serialize_tail_event(
                 event,
                 level=level,
@@ -737,12 +769,32 @@ async def _build_managed_thread_tail_snapshot(
         )
 
     last_event_id = int(resume_after or 0)
+    last_activity_at: Optional[str] = raw_last_activity_at
     if tail_events:
         last_event_id = int(tail_events[-1].get("event_id") or last_event_id)
+        tail_last_activity_at = normalize_optional_text(
+            tail_events[-1].get("received_at")
+        )
+        raw_last_dt = parse_iso_datetime(raw_last_activity_at)
+        tail_last_dt = parse_iso_datetime(tail_last_activity_at)
+        if raw_last_dt is None:
+            last_activity_at = tail_last_activity_at
+        elif tail_last_dt is None:
+            last_activity_at = raw_last_activity_at
+        else:
+            last_activity_at = (
+                raw_last_activity_at
+                if raw_last_dt >= tail_last_dt
+                else tail_last_activity_at
+            )
     last_event_ms = tail_events[-1].get("received_at_ms") if tail_events else None
     idle_seconds: Optional[int] = None
     if turn_status == "running":
-        if isinstance(last_event_ms, (int, float)) and last_event_ms > 0:
+        if last_activity_at:
+            last_activity_dt = parse_iso_datetime(last_activity_at)
+            if last_activity_dt is not None:
+                idle_seconds = max(0, int((now_dt - last_activity_dt).total_seconds()))
+        elif isinstance(last_event_ms, (int, float)) and last_event_ms > 0:
             idle_seconds = max(
                 0, int((now_dt.timestamp() * 1000 - last_event_ms) / 1000)
             )
@@ -786,6 +838,7 @@ async def _build_managed_thread_tail_snapshot(
         "events": tail_events,
         "last_event_id": last_event_id,
         "last_event_at": tail_events[-1].get("received_at") if tail_events else None,
+        "last_activity_at": last_activity_at,
         "stream_available": stream_available,
         "phase": phase,
         "phase_source": phase_source,
@@ -1091,10 +1144,11 @@ def build_managed_thread_tail_routes(
                     if started_dt is not None:
                         elapsed = max(0, int((now - started_dt).total_seconds()))
                     idle = None
-                    if snapshot.get("last_event_at"):
-                        last_event_dt = parse_iso_datetime(
-                            snapshot.get("last_event_at")
-                        )
+                    activity_at = snapshot.get("last_activity_at") or snapshot.get(
+                        "last_event_at"
+                    )
+                    if activity_at:
+                        last_event_dt = parse_iso_datetime(activity_at)
                         if last_event_dt is not None:
                             idle = max(0, int((now - last_event_dt).total_seconds()))
                     phase, phase_source, guidance, last_tool = _derive_progress_phase(
@@ -1128,6 +1182,9 @@ def build_managed_thread_tail_routes(
                     formatter=formatter,
                     since_ms=since_ms,
                 )
+                activity_at = _event_received_at_iso(entry)
+                if activity_at:
+                    snapshot["last_activity_at"] = activity_at
                 if serialized is None:
                     continue
                 event_id = int(serialized.get("event_id") or 0)

--- a/tests/test_pma_managed_threads_tail.py
+++ b/tests/test_pma_managed_threads_tail.py
@@ -123,6 +123,138 @@ def test_managed_thread_tail_snapshot_redacts_and_supports_cursor(hub_env) -> No
         assert [event["event_id"] for event in cursor_payload["events"]] == [2]
 
 
+def test_managed_thread_tail_snapshot_suppresses_noisy_agent_delta_events(
+    hub_env,
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+    managed_thread_id, _ = _seed_managed_thread_with_events(hub_env, app)
+
+    events = app.state.app_server_events
+
+    async def _seed() -> None:
+        await events.register_turn("backend-thread-1", "backend-turn-1")
+        await events.handle_notification(
+            {
+                "method": "item/agentMessage/delta",
+                "params": {
+                    "turnId": "backend-turn-1",
+                    "threadId": "backend-thread-1",
+                    "delta": [{"type": "output_text_delta", "text": "partial"}],
+                },
+            }
+        )
+        await events.handle_notification(
+            {
+                "method": "turn/plan/updated",
+                "params": {
+                    "turnId": "backend-turn-1",
+                    "threadId": "backend-thread-1",
+                    "plan": [{"text": "step"}],
+                },
+            }
+        )
+        await events.handle_notification(
+            {
+                "method": "item/completed",
+                "params": {
+                    "turnId": "backend-turn-1",
+                    "threadId": "backend-thread-1",
+                    "item": {
+                        "type": "agentMessage",
+                        "content": [{"type": "output_text", "text": "done"}],
+                    },
+                },
+            }
+        )
+        await events.handle_notification(
+            {
+                "method": "item/completed",
+                "params": {
+                    "turnId": "backend-turn-1",
+                    "threadId": "backend-thread-1",
+                    "item": {"type": "tool", "name": "status-check"},
+                },
+            }
+        )
+
+    import asyncio
+
+    asyncio.run(_seed())
+
+    with TestClient(app) as client:
+        resp = client.get(f"/hub/pma/threads/{managed_thread_id}/tail")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    summaries = [str(event.get("summary") or "") for event in payload["events"]]
+    assert summaries == ["tool: status-check"]
+
+
+def test_managed_thread_tail_snapshot_treats_suppressed_agent_delta_as_activity(
+    hub_env,
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+    managed_thread_id, _ = _seed_managed_thread_with_events(hub_env, app)
+
+    now = datetime.now(timezone.utc)
+    delta_received_at_ms = int((now - timedelta(seconds=5)).timestamp() * 1000)
+    tool_received_at_ms = int((now - timedelta(seconds=40)).timestamp() * 1000)
+
+    class FakeEvents:
+        async def list_events(
+            self,
+            thread_id: str,
+            turn_id: str,
+            *,
+            after_id: int = 0,
+            limit: int | None = None,
+        ):
+            _ = thread_id, turn_id, after_id, limit
+            return [
+                {
+                    "id": 1,
+                    "received_at": tool_received_at_ms,
+                    "message": {
+                        "method": "item/completed",
+                        "params": {
+                            "item": {"type": "tool", "name": "older-tool"},
+                        },
+                    },
+                },
+                {
+                    "id": 2,
+                    "received_at": delta_received_at_ms,
+                    "message": {
+                        "method": "item/agentMessage/delta",
+                        "params": {
+                            "delta": [
+                                {"type": "output_text_delta", "text": "still streaming"}
+                            ]
+                        },
+                    },
+                },
+            ]
+
+    app.state.app_server_events = FakeEvents()
+
+    with TestClient(app) as client:
+        resp = client.get(f"/hub/pma/threads/{managed_thread_id}/tail")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert [str(event.get("summary") or "") for event in payload["events"]] == [
+        "tool: older-tool"
+    ]
+    assert payload["last_activity_at"] is not None
+    assert payload["idle_seconds"] is not None
+    assert int(payload["idle_seconds"]) < 15
+    assert payload["phase"] not in {"no_stream_available", "likely_hung"}
+    assert payload["activity"] == "running"
+    assert payload["active_turn_diagnostics"]["stalled"] is False
+
+
 def test_managed_thread_status_aggregates_thread_turn_and_progress(hub_env) -> None:
     _enable_pma(hub_env.hub_root)
     app = create_hub_app(hub_env.hub_root)


### PR DESCRIPTION
## Summary
- trim low-signal PMA watch/tail events for managed Codex threads so `car pma thread send --watch` no longer echoes raw protocol noise like `item/agentMessage/delta` and `turn/plan/updated` into the watcher context
- suppress assistant delta, plan delta, and agent-message completion events in the PMA tail serializer while preserving meaningful tool/progress events and the final output excerpt shown after watch completes
- add a regression test that seeds the noisy app-server events seen in practice and verifies the PMA tail snapshot only surfaces the meaningful tool event

## Testing
- .venv/bin/pytest tests/test_pma_managed_threads_tail.py -q
- git commit pre-commit suite (black, ruff, mypy, pnpm build/test, full pytest)
