### PR TITLE
Fix bound chat delivery for managed thread outputs

### DIFF
--- a/src/codex_autorunner/core/orchestration/bindings.py
+++ b/src/codex_autorunner/core/orchestration/bindings.py
@@ -296,6 +296,7 @@ class OrchestrationBindingStore:
     def list_bindings(
         self,
         *,
+        thread_target_id: Optional[str] = None,
         repo_id: Optional[str] = None,
         resource_kind: Optional[str] = None,
         resource_id: Optional[str] = None,
@@ -308,6 +309,10 @@ class OrchestrationBindingStore:
         params: list[Any] = []
         if not include_disabled:
             filters.append("b.disabled_at IS NULL")
+        normalized_thread_target_id = _normalize_text(thread_target_id)
+        if normalized_thread_target_id is not None:
+            filters.append("b.target_id = ?")
+            params.append(normalized_thread_target_id)
         normalized_resource_kind, normalized_resource_id, normalized_repo_id = (
             normalize_resource_owner_fields(
                 resource_kind=resource_kind,

--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -424,6 +424,7 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
     def list_bindings(
         self,
         *,
+        thread_target_id: Optional[str] = None,
         repo_id: Optional[str] = None,
         resource_kind: Optional[str] = None,
         resource_id: Optional[str] = None,
@@ -435,6 +436,7 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
         if self.binding_store is None:
             return []
         return self.binding_store.list_bindings(
+            thread_target_id=thread_target_id,
             repo_id=repo_id,
             resource_kind=resource_kind,
             resource_id=resource_id,

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 from pathlib import Path
@@ -16,8 +17,13 @@ from .....core.car_context import (
     normalize_car_context_profile,
     render_injected_car_context,
 )
+from .....core.chat_bindings import (
+    DISCORD_STATE_FILE_DEFAULT,
+    TELEGRAM_STATE_FILE_DEFAULT,
+)
 from .....core.config import PMA_DEFAULT_MAX_TEXT_CHARS
 from .....core.orchestration import MessageRequest
+from .....core.orchestration.bindings import OrchestrationBindingStore
 from .....core.orchestration.runtime_threads import (
     RUNTIME_THREAD_INTERRUPTED_ERROR,
     RUNTIME_THREAD_TIMEOUT_ERROR,
@@ -35,6 +41,15 @@ from .....core.pma_thread_store import (
     PmaThreadStore,
 )
 from .....core.pma_transcripts import PmaTranscriptStore
+from .....core.time_utils import now_iso
+from .....integrations.discord.rendering import (
+    chunk_discord_message,
+    format_discord_message,
+)
+from .....integrations.discord.state import DiscordStateStore
+from .....integrations.discord.state import OutboxRecord as DiscordOutboxRecord
+from .....integrations.telegram.state import OutboxRecord as TelegramOutboxRecord
+from .....integrations.telegram.state import TelegramStateStore, parse_topic_key
 from ...schemas import PmaManagedThreadMessageRequest
 from .automation_adapter import (
     call_store_create_with_payload,
@@ -44,6 +59,11 @@ from .automation_adapter import (
 )
 from .managed_threads import (
     build_managed_thread_orchestration_service as _shared_managed_thread_orchestration_service,
+)
+from .publish import (
+    PMA_DISCORD_MESSAGE_MAX_LEN,
+    enqueue_with_retry,
+    resolve_chat_state_path,
 )
 
 if TYPE_CHECKING:
@@ -58,6 +78,7 @@ MANAGED_THREAD_INTERRUPT_FAILED_DETAIL = (
 )
 PMA_TIMEOUT_SECONDS = 7200
 PMA_MAX_TEXT = PMA_DEFAULT_MAX_TEXT_CHARS
+BOUND_CHAT_SURFACE_KINDS = frozenset({"discord", "telegram"})
 
 
 def _build_managed_thread_orchestration_service(
@@ -168,6 +189,148 @@ def _interrupt_failure_payload(
         "error": detail,
         **delivery_payload,
     }
+
+
+async def deliver_bound_chat_assistant_output(
+    request: Request,
+    *,
+    managed_thread_id: str,
+    managed_turn_id: str,
+    assistant_text: str,
+) -> None:
+    message = str(assistant_text or "").strip()
+    if not message:
+        return
+
+    hub_root = request.app.state.config.root
+    binding_store = OrchestrationBindingStore(hub_root)
+    bindings = [
+        binding
+        for binding in binding_store.list_bindings(
+            thread_target_id=managed_thread_id,
+            include_disabled=False,
+            limit=1000,
+        )
+        if binding.surface_kind in BOUND_CHAT_SURFACE_KINDS
+    ]
+    if not bindings:
+        return
+
+    discord_store: Optional[DiscordStateStore] = None
+    telegram_store: Optional[TelegramStateStore] = None
+    created_at = now_iso()
+    try:
+        for binding in bindings:
+            try:
+                if binding.surface_kind == "discord":
+                    if discord_store is None:
+                        discord_store = DiscordStateStore(
+                            resolve_chat_state_path(
+                                request,
+                                section="discord_bot",
+                                default_state_file=DISCORD_STATE_FILE_DEFAULT,
+                            )
+                        )
+                    channel_id = normalize_optional_text(binding.surface_key)
+                    if channel_id is None:
+                        continue
+                    chunks = chunk_discord_message(
+                        format_discord_message(message),
+                        max_len=PMA_DISCORD_MESSAGE_MAX_LEN,
+                        with_numbering=False,
+                    )
+                    if not chunks:
+                        chunks = [format_discord_message(message)]
+                    for index, chunk in enumerate(chunks, start=1):
+                        digest = hashlib.sha256(
+                            (
+                                f"managed-thread:{managed_turn_id}:discord:{channel_id}:{index}"
+                            ).encode("utf-8")
+                        ).hexdigest()[:24]
+                        record_id = f"managed-thread:{digest}"
+                        if await discord_store.get_outbox(record_id) is not None:
+                            continue
+                        record = DiscordOutboxRecord(
+                            record_id=record_id,
+                            channel_id=channel_id,
+                            message_id=None,
+                            operation="send",
+                            payload_json={"content": chunk},
+                            created_at=created_at,
+                        )
+                        store = discord_store
+                        await enqueue_with_retry(
+                            lambda record=record, store=store: store.enqueue_outbox(
+                                record
+                            )
+                        )
+                    continue
+
+                if binding.surface_kind != "telegram":
+                    continue
+                if telegram_store is None:
+                    telegram_store = TelegramStateStore(
+                        resolve_chat_state_path(
+                            request,
+                            section="telegram_bot",
+                            default_state_file=TELEGRAM_STATE_FILE_DEFAULT,
+                        )
+                    )
+                surface_key = normalize_optional_text(binding.surface_key)
+                if surface_key is None:
+                    continue
+                try:
+                    chat_id, thread_id, _scope = parse_topic_key(surface_key)
+                except Exception:
+                    logger.warning(
+                        "Failed to parse telegram bound-chat surface key for managed-thread delivery: %s",
+                        surface_key,
+                    )
+                    continue
+                digest = hashlib.sha256(
+                    (
+                        f"managed-thread:{managed_turn_id}:telegram:{chat_id}:{thread_id or 'root'}"
+                    ).encode("utf-8")
+                ).hexdigest()[:24]
+                record_id = f"managed-thread:{digest}"
+                if await telegram_store.get_outbox(record_id) is not None:
+                    continue
+                outbox_key = f"managed-thread:{managed_turn_id}:{chat_id}:{thread_id or 'root'}:send"
+                record = TelegramOutboxRecord(
+                    record_id=record_id,
+                    chat_id=chat_id,
+                    thread_id=thread_id,
+                    reply_to_message_id=None,
+                    placeholder_message_id=None,
+                    text=message,
+                    created_at=created_at,
+                    operation="send",
+                    message_id=None,
+                    outbox_key=outbox_key,
+                )
+                store = telegram_store
+                await enqueue_with_retry(
+                    lambda record=record, store=store: store.enqueue_outbox(record)
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to enqueue bound-chat delivery target (managed_thread_id=%s, managed_turn_id=%s, surface_kind=%s, surface_key=%s)",
+                    managed_thread_id,
+                    managed_turn_id,
+                    binding.surface_kind,
+                    binding.surface_key,
+                )
+    finally:
+        if discord_store is not None:
+            try:
+                await discord_store.close()
+            except Exception:
+                logger.exception("Failed to close discord bound-chat delivery store")
+        if telegram_store is not None:
+            try:
+                await telegram_store.close()
+            except Exception:
+                logger.exception("Failed to close telegram bound-chat delivery store")
 
 
 async def notify_managed_thread_terminal_transition(
@@ -752,6 +915,12 @@ def build_managed_thread_runtime_routes(
                     managed_thread_id,
                     last_turn_id=current_turn_id,
                     last_message_preview=current_preview,
+                )
+                await deliver_bound_chat_assistant_output(
+                    request,
+                    managed_thread_id=managed_thread_id,
+                    managed_turn_id=current_turn_id,
+                    assistant_text=outcome.assistant_text,
                 )
                 await notify_managed_thread_terminal_transition(
                     request,

--- a/tests/core/orchestration/test_bindings.py
+++ b/tests/core/orchestration/test_bindings.py
@@ -219,6 +219,35 @@ def test_binding_store_active_work_by_agent(tmp_path: Path) -> None:
     assert opencode_work[0].thread_target_id == opencode_thread_id
 
 
+def test_binding_store_filters_by_thread_target_id(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    initialize_orchestration_sqlite(hub_root)
+    bindings = OrchestrationBindingStore(hub_root)
+    first_thread_id = _create_thread(hub_root, workspace_name="repo-a-1")
+    second_thread_id = _create_thread(hub_root, workspace_name="repo-a-2")
+
+    bindings.upsert_binding(
+        surface_kind="discord",
+        surface_key="channel-1",
+        thread_target_id=first_thread_id,
+        agent_id="codex",
+        repo_id="repo-1",
+    )
+    bindings.upsert_binding(
+        surface_kind="telegram",
+        surface_key="123:root",
+        thread_target_id=second_thread_id,
+        agent_id="codex",
+        repo_id="repo-1",
+    )
+
+    listed = bindings.list_bindings(thread_target_id=first_thread_id)
+
+    assert len(listed) == 1
+    assert listed[0].thread_target_id == first_thread_id
+    assert listed[0].surface_kind == "discord"
+
+
 def test_binding_store_active_work_by_repo(tmp_path: Path) -> None:
     hub_root = tmp_path / "hub"
     initialize_orchestration_sqlite(hub_root)

--- a/tests/test_pma_managed_threads_messages.py
+++ b/tests/test_pma_managed_threads_messages.py
@@ -10,11 +10,14 @@ import pytest
 from fastapi.testclient import TestClient
 
 from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
+from codex_autorunner.core.orchestration.bindings import OrchestrationBindingStore
 from codex_autorunner.core.pma_thread_store import (
     ManagedThreadNotActiveError,
     PmaThreadStore,
 )
 from codex_autorunner.core.pma_transcripts import PmaTranscriptStore
+from codex_autorunner.integrations.discord.state import DiscordStateStore
+from codex_autorunner.integrations.telegram.state import TelegramStateStore, topic_key
 from codex_autorunner.server import create_hub_app
 from tests.conftest import write_test_config
 
@@ -42,6 +45,63 @@ def _enable_pma(
 
 def _repo_owner(hub_env) -> dict[str, str]:
     return {"resource_kind": "repo", "resource_id": hub_env.repo_id}
+
+
+async def _bind_thread_to_discord(
+    hub_env,
+    *,
+    managed_thread_id: str,
+    channel_id: str,
+) -> None:
+    OrchestrationBindingStore(hub_env.hub_root).upsert_binding(
+        surface_kind="discord",
+        surface_key=channel_id,
+        thread_target_id=managed_thread_id,
+        agent_id="codex",
+        repo_id=hub_env.repo_id,
+        mode="repo",
+    )
+    store = DiscordStateStore(
+        hub_env.hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+    )
+    try:
+        await store.upsert_binding(
+            channel_id=channel_id,
+            guild_id="guild-1",
+            workspace_path=str(hub_env.repo_root.resolve()),
+            repo_id=hub_env.repo_id,
+        )
+    finally:
+        await store.close()
+
+
+async def _bind_thread_to_telegram(
+    hub_env,
+    *,
+    managed_thread_id: str,
+    chat_id: int,
+    thread_id: int | None,
+) -> None:
+    surface_key = topic_key(chat_id, thread_id)
+    OrchestrationBindingStore(hub_env.hub_root).upsert_binding(
+        surface_kind="telegram",
+        surface_key=surface_key,
+        thread_target_id=managed_thread_id,
+        agent_id="codex",
+        repo_id=hub_env.repo_id,
+        mode="repo",
+    )
+    store = TelegramStateStore(
+        hub_env.hub_root / ".codex-autorunner" / "telegram_state.sqlite3"
+    )
+    try:
+        await store.bind_topic(
+            surface_key,
+            str(hub_env.repo_root.resolve()),
+            repo_id=hub_env.repo_id,
+        )
+    finally:
+        await store.close()
 
 
 def test_send_message_persists_turns_and_reuses_backend_thread(hub_env) -> None:
@@ -208,6 +268,214 @@ def test_send_message_persists_turns_and_reuses_backend_thread(hub_env) -> None:
     assert metadata["model"] == "model-default"
     assert metadata["reasoning"] == "high"
     assert transcript["content"].strip() == "assistant-output-1"
+
+
+@pytest.mark.anyio
+async def test_send_message_enqueues_assistant_output_to_bound_chat_outboxes(
+    hub_env,
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeTurnHandle:
+        turn_id = "backend-turn-1"
+
+        async def wait(self, timeout=None):
+            _ = timeout
+            return type(
+                "Result",
+                (),
+                {
+                    "agent_messages": ["assistant-output"],
+                    "raw_events": [],
+                    "errors": [],
+                },
+            )()
+
+    class FakeClient:
+        async def thread_start(self, root: str) -> dict:
+            _ = root
+            return {"id": "backend-thread-1"}
+
+        async def turn_start(
+            self,
+            thread_id: str,
+            prompt: str,
+            approval_policy: str,
+            sandbox_policy: str,
+            **turn_kwargs,
+        ):
+            _ = thread_id, prompt, approval_policy, sandbox_policy, turn_kwargs
+            return FakeTurnHandle()
+
+    class FakeSupervisor:
+        async def get_client(self, hub_root: Path):
+            _ = hub_root
+            return FakeClient()
+
+    app.state.app_server_supervisor = FakeSupervisor()
+    app.state.app_server_events = object()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
+        create_resp = await client.post(
+            "/hub/pma/threads",
+            json={"agent": "codex", **_repo_owner(hub_env)},
+        )
+        assert create_resp.status_code == 200
+        managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+        await _bind_thread_to_discord(
+            hub_env,
+            managed_thread_id=managed_thread_id,
+            channel_id="discord-123",
+        )
+        await _bind_thread_to_telegram(
+            hub_env,
+            managed_thread_id=managed_thread_id,
+            chat_id=1001,
+            thread_id=2002,
+        )
+
+        message_resp = await client.post(
+            f"/hub/pma/threads/{managed_thread_id}/messages",
+            json={"message": "cross-surface prompt"},
+        )
+
+    assert message_resp.status_code == 200
+    payload = message_resp.json()
+    assert payload["status"] == "ok"
+    assert payload["assistant_text"] == "assistant-output"
+
+    discord_store = DiscordStateStore(
+        hub_env.hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+    )
+    telegram_store = TelegramStateStore(
+        hub_env.hub_root / ".codex-autorunner" / "telegram_state.sqlite3"
+    )
+    try:
+        discord_outbox = await discord_store.list_outbox()
+        telegram_outbox = await telegram_store.list_outbox()
+    finally:
+        await discord_store.close()
+        await telegram_store.close()
+
+    assert any(
+        record.channel_id == "discord-123"
+        and record.payload_json.get("content") == "assistant-output"
+        for record in discord_outbox
+    )
+    assert any(
+        record.chat_id == 1001
+        and record.thread_id == 2002
+        and record.text == "assistant-output"
+        for record in telegram_outbox
+    )
+
+
+@pytest.mark.anyio
+async def test_send_message_continues_bound_chat_delivery_after_one_surface_fails(
+    hub_env,
+    monkeypatch,
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeTurnHandle:
+        turn_id = "backend-turn-1"
+
+        async def wait(self, timeout=None):
+            _ = timeout
+            return type(
+                "Result",
+                (),
+                {
+                    "agent_messages": ["assistant-output"],
+                    "raw_events": [],
+                    "errors": [],
+                },
+            )()
+
+    class FakeClient:
+        async def thread_start(self, root: str) -> dict:
+            _ = root
+            return {"id": "backend-thread-1"}
+
+        async def turn_start(
+            self,
+            thread_id: str,
+            prompt: str,
+            approval_policy: str,
+            sandbox_policy: str,
+            **turn_kwargs,
+        ):
+            _ = thread_id, prompt, approval_policy, sandbox_policy, turn_kwargs
+            return FakeTurnHandle()
+
+    class FakeSupervisor:
+        async def get_client(self, hub_root: Path):
+            _ = hub_root
+            return FakeClient()
+
+    async def _fail_discord_enqueue(self, record):
+        _ = self, record
+        raise RuntimeError("discord enqueue failed")
+
+    app.state.app_server_supervisor = FakeSupervisor()
+    app.state.app_server_events = object()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
+        create_resp = await client.post(
+            "/hub/pma/threads",
+            json={"agent": "codex", **_repo_owner(hub_env)},
+        )
+        assert create_resp.status_code == 200
+        managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+        await _bind_thread_to_discord(
+            hub_env,
+            managed_thread_id=managed_thread_id,
+            channel_id="discord-123",
+        )
+        await _bind_thread_to_telegram(
+            hub_env,
+            managed_thread_id=managed_thread_id,
+            chat_id=1001,
+            thread_id=2002,
+        )
+        monkeypatch.setattr(
+            DiscordStateStore,
+            "enqueue_outbox",
+            _fail_discord_enqueue,
+        )
+
+        message_resp = await client.post(
+            f"/hub/pma/threads/{managed_thread_id}/messages",
+            json={"message": "cross-surface prompt"},
+        )
+
+    assert message_resp.status_code == 200
+    assert message_resp.json()["status"] == "ok"
+
+    telegram_store = TelegramStateStore(
+        hub_env.hub_root / ".codex-autorunner" / "telegram_state.sqlite3"
+    )
+    try:
+        telegram_outbox = await telegram_store.list_outbox()
+    finally:
+        await telegram_store.close()
+
+    assert any(
+        record.chat_id == 1001
+        and record.thread_id == 2002
+        and record.text == "assistant-output"
+        for record in telegram_outbox
+    )
 
 
 def test_send_message_rejects_archived_thread(hub_env) -> None:
@@ -1595,6 +1863,11 @@ async def test_send_message_defer_execution_completes_in_background(hub_env) -> 
         )
         assert create_resp.status_code == 200
         managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+        await _bind_thread_to_discord(
+            hub_env,
+            managed_thread_id=managed_thread_id,
+            channel_id="discord-background",
+        )
 
         message_resp = await client.post(
             f"/hub/pma/threads/{managed_thread_id}/messages",
@@ -1641,6 +1914,23 @@ async def test_send_message_defer_execution_completes_in_background(hub_env) -> 
         with anyio.fail_after(2):
             while len(getattr(app.state, "pma_managed_thread_tasks", set())) != 0:
                 await anyio.sleep(0.05)
+
+    discord_store = DiscordStateStore(
+        hub_env.hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+    )
+    try:
+        with anyio.fail_after(2):
+            while True:
+                discord_outbox = await discord_store.list_outbox()
+                if any(
+                    record.channel_id == "discord-background"
+                    and record.payload_json.get("content") == "assistant-output"
+                    for record in discord_outbox
+                ):
+                    break
+                await anyio.sleep(0.05)
+    finally:
+        await discord_store.close()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- deliver managed-thread assistant output to active Discord/Telegram bindings when PMA completes a turn
- keep delivery keyed to the thread binding rather than the invoking surface
- add PMA managed-thread regression coverage for bound chat delivery and deferred completion

## Testing
- .venv/bin/pytest tests/test_pma_managed_threads_messages.py
- .venv/bin/pytest tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py

Fixes #1000
