### PR TITLE
Mirror OpenCode deltas in ticket flow

### DIFF
--- a/src/codex_autorunner/integrations/agents/agent_pool_impl.py
+++ b/src/codex_autorunner/integrations/agents/agent_pool_impl.py
@@ -132,27 +132,23 @@ def _runtime_message_delta(params: dict[str, Any]) -> Optional[str]:
     for key in ("delta", "text", "output"):
         value = params.get(key)
         if isinstance(value, str):
-            text = value.strip()
-            if text:
-                return text
+            if value != "":
+                return value
         if isinstance(value, dict):
             nested = value.get("text")
             if isinstance(nested, str):
-                text = nested.strip()
-                if text:
-                    return text
+                if nested != "":
+                    return nested
     properties = _runtime_message_properties(params)
     delta_raw = properties.get("delta")
     if isinstance(delta_raw, str):
-        text = delta_raw.strip()
-        if text:
-            return text
+        if delta_raw != "":
+            return delta_raw
     delta = _coerce_dict(delta_raw)
     delta_text = delta.get("text")
     if isinstance(delta_text, str):
-        text = delta_text.strip()
-        if text:
-            return text
+        if delta_text != "":
+            return delta_text
     return None
 
 

--- a/src/codex_autorunner/static/generated/agentEvents.js
+++ b/src/codex_autorunner/static/generated/agentEvents.js
@@ -357,7 +357,11 @@ export function parseAppServerEvent(payload) {
                 itemId: parsedItemId || null,
                 method,
             };
-            return delta && parsedItemId ? { event, mergeStrategy: "append" } : { event };
+            if (!parsedItemId)
+                return { event };
+            if (delta)
+                return { event, mergeStrategy: "append" };
+            return { event, mergeStrategy: "replace" };
         }
         if (partType === "reasoning") {
             const delta = extractOpenCodeDeltaText(params);

--- a/src/codex_autorunner/static/generated/docChatCore.js
+++ b/src/codex_autorunner/static/generated/docChatCore.js
@@ -134,6 +134,9 @@ export function createDocChat(config) {
             else if (mergeStrategy === "newline") {
                 existing.summary = `${existing.summary || ""}\n\n`;
             }
+            else if (mergeStrategy === "replace") {
+                existing.summary = event.summary;
+            }
             existing.time = event.time;
             return;
         }

--- a/src/codex_autorunner/static/generated/tickets.js
+++ b/src/codex_autorunner/static/generated/tickets.js
@@ -467,6 +467,9 @@ function addLiveOutputEvent(parsed) {
         else if (mergeStrategy === "newline") {
             existing.summary = `${existing.summary || ""}\n\n`;
         }
+        else if (mergeStrategy === "replace") {
+            existing.summary = event.summary;
+        }
         existing.time = event.time;
         return;
     }

--- a/src/codex_autorunner/static_src/agentEvents.ts
+++ b/src/codex_autorunner/static_src/agentEvents.ts
@@ -27,7 +27,7 @@ export interface AgentEvent {
 
 export interface ParsedAgentEvent {
   event: AgentEvent;
-  mergeStrategy?: "append" | "newline";
+  mergeStrategy?: "append" | "newline" | "replace";
 }
 
 interface CommandItem {
@@ -440,7 +440,9 @@ export function parseAppServerEvent(payload: unknown): ParsedAgentEvent | null {
         itemId: parsedItemId || null,
         method,
       };
-      return delta && parsedItemId ? { event, mergeStrategy: "append" } : { event };
+      if (!parsedItemId) return { event };
+      if (delta) return { event, mergeStrategy: "append" };
+      return { event, mergeStrategy: "replace" };
     }
 
     if (partType === "reasoning") {

--- a/src/codex_autorunner/static_src/docChatCore.ts
+++ b/src/codex_autorunner/static_src/docChatCore.ts
@@ -252,6 +252,8 @@ export function createDocChat(config: ChatConfig): DocChatInstance {
         existing.summary = `${existing.summary || ""}${event.summary}`;
       } else if (mergeStrategy === "newline") {
         existing.summary = `${existing.summary || ""}\n\n`;
+      } else if (mergeStrategy === "replace") {
+        existing.summary = event.summary;
       }
       existing.time = event.time;
       return;

--- a/src/codex_autorunner/static_src/tickets.ts
+++ b/src/codex_autorunner/static_src/tickets.ts
@@ -612,6 +612,8 @@ function addLiveOutputEvent(parsed: ParsedAgentEvent): void {
       existing.summary = `${existing.summary || ""}${event.summary}`;
     } else if (mergeStrategy === "newline") {
       existing.summary = `${existing.summary || ""}\n\n`;
+    } else if (mergeStrategy === "replace") {
+      existing.summary = event.summary;
     }
     existing.time = event.time;
     return;

--- a/tests/js/agent_events.test.js
+++ b/tests/js/agent_events.test.js
@@ -165,3 +165,46 @@ test("parses OpenCode reasoning and tool parts", () => {
   assert.match(tool.event.detail, /pwd/);
   assert.match(tool.event.detail, /running/);
 });
+
+test("replaces cumulative OpenCode text snapshots when delta is absent", () => {
+  resetOpenCodeEventState();
+
+  parseAppServerEvent({
+    id: "role-1",
+    received_at: 1000,
+    message: {
+      method: "message.updated",
+      params: {
+        properties: {
+          info: {
+            id: "assistant-1",
+            role: "assistant",
+          },
+        },
+      },
+    },
+  });
+
+  const snapshot = parseAppServerEvent({
+    id: "part-1",
+    received_at: 1001,
+    message: {
+      method: "message.part.updated",
+      params: {
+        properties: {
+          part: {
+            id: "part-text-1",
+            messageID: "assistant-1",
+            type: "text",
+            text: "hello world",
+          },
+        },
+      },
+    },
+  });
+
+  assert.ok(snapshot);
+  assert.equal(snapshot.event.itemId, "assistant-1");
+  assert.equal(snapshot.event.summary, "hello world");
+  assert.equal(snapshot.mergeStrategy, "replace");
+});

--- a/tests/test_opencode_agent_pool.py
+++ b/tests/test_opencode_agent_pool.py
@@ -321,6 +321,96 @@ async def test_run_turn_mirrors_opencode_text_parts_after_assistant_role_resolut
 
 
 @pytest.mark.asyncio
+async def test_run_turn_preserves_whitespace_in_opencode_text_part_deltas(
+    tmp_path: Path,
+):
+    harness = _FakeHarness(
+        [
+            _HarnessScript(
+                assistant_text="Debug of OpenCode  \n",
+                raw_events=[
+                    _message(
+                        "message.updated",
+                        {
+                            "properties": {
+                                "info": {
+                                    "id": "assistant-1",
+                                    "role": "assistant",
+                                }
+                            }
+                        },
+                    ),
+                    _message(
+                        "message.part.updated",
+                        {
+                            "properties": {
+                                "part": {
+                                    "id": "part-1",
+                                    "messageID": "assistant-1",
+                                    "type": "text",
+                                    "text": "Debug",
+                                },
+                                "delta": "Debug",
+                            }
+                        },
+                    ),
+                    _message(
+                        "message.part.updated",
+                        {
+                            "properties": {
+                                "part": {
+                                    "id": "part-1",
+                                    "messageID": "assistant-1",
+                                    "type": "text",
+                                    "text": "Debug of",
+                                },
+                                "delta": " of",
+                            }
+                        },
+                    ),
+                    _message(
+                        "message.part.updated",
+                        {
+                            "properties": {
+                                "part": {
+                                    "id": "part-1",
+                                    "messageID": "assistant-1",
+                                    "type": "text",
+                                    "text": "Debug of OpenCode  \n",
+                                },
+                                "delta": " OpenCode  \n",
+                            }
+                        },
+                    ),
+                ],
+            )
+        ]
+    )
+    pool = _make_pool(tmp_path, harness, approval_mode="yolo")
+
+    emitted = []
+
+    def _emit(event_type: FlowEventType, payload: dict):
+        emitted.append((event_type, payload))
+
+    await pool.run_turn(
+        AgentTurnRequest(
+            agent_id="opencode",
+            prompt="main prompt",
+            workspace_root=tmp_path,
+            emit_event=_emit,
+        )
+    )
+
+    mirrored = [
+        payload["delta"]
+        for event_type, payload in emitted
+        if event_type == FlowEventType.AGENT_STREAM_DELTA
+    ]
+    assert mirrored == ["Debug", " of", " OpenCode  \n"]
+
+
+@pytest.mark.asyncio
 async def test_run_turn_does_not_mirror_opencode_user_text_parts(tmp_path: Path):
     harness = _FakeHarness(
         [


### PR DESCRIPTION
## Summary
- mirror OpenCode assistant text deltas into delegated ticket-flow `agent_stream_delta` events once role resolution confirms they belong to the assistant
- buffer OpenCode frontend text parts until assistant/user role metadata arrives so the repo ticket page stops rendering user prompts as agent output
- add backend and frontend regression coverage for OpenCode text/reasoning/tool event handling

## Testing
- .venv/bin/python -m pytest -q tests/test_opencode_agent_pool.py
- node --test tests/js/agent_events.test.js tests/js/event_summarizer.test.js
- pre-commit hook during `git commit` ran repo validation, including full pytest: `3018 passed, 1 skipped`

## Review
- subagent review found and I fixed two medium issues before landing:
  - frontend now buffers text parts until role resolution instead of rendering unknown-role parts immediately
  - backend no longer mirrors cumulative `part.text` snapshots when OpenCode omits `delta.text`
