### PR TITLE
Fix hub lifecycle PMA queue init off event loops

### DIFF
--- a/src/codex_autorunner/core/pma_queue.py
+++ b/src/codex_autorunner/core/pma_queue.py
@@ -98,7 +98,7 @@ class PmaQueue:
         self._lane_events: dict[str, asyncio.Event] = {}
         self._lane_known_ids: dict[str, set[str]] = {}
         self._replayed_lanes: set[str] = set()
-        self._lock = asyncio.Lock()
+        self._lock: Optional[asyncio.Lock] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._initialize_canonical_state()
 
@@ -113,6 +113,13 @@ class PmaQueue:
     def _lane_queue_lock_path(self, lane_id: str) -> Path:
         path = self._lane_queue_path(lane_id)
         return path.with_suffix(path.suffix + ".lock")
+
+    def _ensure_lock(self) -> asyncio.Lock:
+        lock = self._lock
+        if lock is None:
+            lock = asyncio.Lock()
+            self._lock = lock
+        return lock
 
     def _ensure_lane_lock(self, lane_id: str) -> asyncio.Lock:
         lock = self._lane_locks.get(lane_id)
@@ -156,7 +163,7 @@ class PmaQueue:
         idempotency_key: str,
         payload: dict[str, Any],
     ) -> tuple[PmaQueueItem, Optional[str]]:
-        async with self._lock:
+        async with self._ensure_lock():
             self._record_loop()
             existing = await self._find_by_idempotency_key(lane_id, idempotency_key)
             if existing:

--- a/tests/core/test_lifecycle_event_processing.py
+++ b/tests/core/test_lifecycle_event_processing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 
 from codex_autorunner.core.config import load_hub_config
@@ -546,5 +547,59 @@ def test_drain_automation_wakeups_requests_lane_worker_start(tmp_path: Path) -> 
         drained = supervisor.drain_pma_automation_wakeups()
         assert drained == 1
         assert started_lanes == ["pma:lane-next"]
+    finally:
+        supervisor.shutdown()
+
+
+def test_drain_automation_wakeups_from_thread_without_event_loop(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _write_hub_config(
+        hub_root,
+        dispatch_interception=False,
+        extra_lines=["  reactive_enabled: false"],
+    )
+    supervisor = HubSupervisor(load_hub_config(hub_root))
+    supervisor._stop_lifecycle_event_processor()
+
+    try:
+        store = supervisor.get_pma_automation_store()
+        _, deduped = store.enqueue_wakeup(
+            source="lifecycle_subscription",
+            lane_id="pma:default",
+            repo_id="repo-1",
+            run_id="run-1",
+            from_state="running",
+            to_state="failed",
+            reason="flow_failed",
+            timestamp="2026-01-01T00:00:00Z",
+            idempotency_key="wakeup-threaded-drain",
+        )
+        assert deduped is False
+
+        drained: list[int] = []
+        errors: list[BaseException] = []
+
+        def _drain() -> None:
+            try:
+                drained.append(supervisor.drain_pma_automation_wakeups())
+            except BaseException as exc:  # pragma: no cover - characterization only
+                errors.append(exc)
+
+        thread = threading.Thread(target=_drain, name="lifecycle-event-processor")
+        thread.start()
+        thread.join(timeout=1.0)
+
+        assert thread.is_alive() is False
+        assert errors == []
+        assert drained == [1]
+
+        items = _read_queue_items(hub_root)
+        assert len(items) == 1
+        wake_up = (items[0].get("payload") or {}).get("wake_up") or {}
+        assert wake_up.get("repo_id") == "repo-1"
+        assert wake_up.get("run_id") == "run-1"
+        assert wake_up.get("source") == "lifecycle_subscription"
     finally:
         supervisor.shutdown()


### PR DESCRIPTION
## Summary
- lazily create `PmaQueue` async locks instead of allocating asyncio primitives during construction
- keep the synchronous lifecycle wake-up drain path thread-safe for the hub lifecycle worker
- add a regression test that drains automation wake-ups from a non-event-loop thread

## Testing
- `.venv/bin/pytest tests/core/test_lifecycle_event_processing.py tests/core/test_pma_queue_cross_process.py tests/core/test_pma_lane_worker.py tests/core/test_pma_reactive_pipeline.py`
- `.venv/bin/pytest tests/core/test_hub_lifecycle.py`
- full pre-commit hook suite via `git commit`

Closes #1018
