### PR TITLE
Remove intermediate output from final Discord and Telegram replies

### DIFF
--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -521,8 +521,10 @@ async def handle_message_event(
     turn_result = result.thread_result
 
     if isinstance(turn_result, DiscordMessageTurnResult):
-        response_text = turn_result.final_message
+        response_text = turn_result.final_message.strip()
         preview_message_id = turn_result.preview_message_id
+        if not response_text and isinstance(turn_result.intermediate_message, str):
+            response_text = turn_result.intermediate_message.strip()
         metrics_text = _format_turn_metrics(
             turn_result.token_usage,
             turn_result.elapsed_seconds,

--- a/src/codex_autorunner/integrations/telegram/transport.py
+++ b/src/codex_autorunner/integrations/telegram/transport.py
@@ -8,7 +8,12 @@ from ...core.logging_utils import log_event
 from ...core.state import now_iso
 from .adapter import TelegramCallbackQuery
 from .constants import PLACEHOLDER_TEXT, TELEGRAM_MAX_MESSAGE_LENGTH
-from .helpers import _format_turn_metrics, _should_trace_message, _with_conversation_id
+from .helpers import (
+    _format_turn_metrics,
+    _is_no_agent_response,
+    _should_trace_message,
+    _with_conversation_id,
+)
 from .outbox import (
     OUTBOX_OPERATION_SEND_DELETE_PLACEHOLDER,
     OUTBOX_OPERATION_SEND_KEEP_PLACEHOLDER,
@@ -19,6 +24,37 @@ from .state import OutboxRecord
 
 
 class TelegramMessageTransport:
+    @staticmethod
+    def _resolve_delivered_turn_response(
+        response: str,
+        intermediate_response: Optional[str] = None,
+    ) -> str:
+        response_text = response.strip() if isinstance(response, str) else ""
+        intermediate_text = (
+            intermediate_response.strip()
+            if isinstance(intermediate_response, str)
+            else ""
+        )
+        if not intermediate_text:
+            return response_text
+        if not response_text:
+            return intermediate_text
+
+        response_head, separator, response_tail = response_text.partition("\n\n")
+        if _is_no_agent_response(response_head):
+            if response_tail.strip():
+                return f"{intermediate_text}\n\n{response_tail.strip()}"
+            return intermediate_text
+
+        metric_lines = [
+            line.strip() for line in response_text.splitlines() if line.strip()
+        ]
+        if metric_lines and all(
+            line.startswith(("Turn time:", "Token usage:")) for line in metric_lines
+        ):
+            return f"{intermediate_text}\n\n{response_text}"
+        return response_text
+
     @staticmethod
     def _truncate_tail_text(text: str, limit: int) -> str:
         if limit <= 0:
@@ -232,9 +268,13 @@ class TelegramMessageTransport:
         intermediate_response: Optional[str] = None,
         delete_placeholder_on_delivery: bool = True,
     ) -> bool:
+        delivered_response = self._resolve_delivered_turn_response(
+            response,
+            intermediate_response=intermediate_response,
+        )
         return await self._send_message_with_outbox(
             chat_id,
-            response,
+            delivered_response,
             thread_id=thread_id,
             reply_to=reply_to,
             placeholder_id=placeholder_id,

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -2693,6 +2693,56 @@ async def test_message_create_turn_sends_only_final_attachment_when_long(
 
 
 @pytest.mark.anyio
+async def test_message_create_turn_uses_progress_snapshot_when_final_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway([("MESSAGE_CREATE", _message_create("ship it"))])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    async def _fake_run_turn(**_kwargs: Any) -> DiscordMessageTurnResult:
+        return DiscordMessageTurnResult(
+            final_message="",
+            intermediate_message="progress snapshot output",
+            preview_message_id="preview-1",
+        )
+
+    monkeypatch.setattr(service, "_run_agent_turn_for_message", _fake_run_turn)
+
+    try:
+        await service.run_forever()
+        assert any(
+            "progress snapshot output" in msg["payload"].get("content", "")
+            for msg in rest.channel_messages
+        )
+        assert not any(
+            "(No response text returned.)" in msg["payload"].get("content", "")
+            for msg in rest.channel_messages
+        )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_message_create_streaming_turn_completion_sends_final_and_deletes_preview(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_telegram_transport.py
+++ b/tests/test_telegram_transport.py
@@ -136,6 +136,58 @@ async def test_deliver_turn_response_sends_only_final_output() -> None:
     ]
 
 
+@pytest.mark.anyio
+async def test_deliver_turn_response_uses_intermediate_fallback_for_no_agent_output() -> (
+    None
+):
+    transport = _DummyTransport(parse_mode=None)
+    calls: list[dict[str, object]] = []
+
+    async def _fake_send_message_with_outbox(
+        chat_id,
+        text,
+        *,
+        thread_id,
+        reply_to,
+        placeholder_id=None,
+        delete_placeholder_on_delivery=True,
+    ):  # type: ignore[no-untyped-def]
+        calls.append(
+            {
+                "chat_id": chat_id,
+                "text": text,
+                "thread_id": thread_id,
+                "reply_to": reply_to,
+                "placeholder_id": placeholder_id,
+                "delete_placeholder_on_delivery": delete_placeholder_on_delivery,
+            }
+        )
+        return True
+
+    transport._send_message_with_outbox = _fake_send_message_with_outbox  # type: ignore[assignment]
+
+    delivered = await transport._deliver_turn_response(
+        chat_id=123,
+        thread_id=456,
+        reply_to=789,
+        placeholder_id=321,
+        intermediate_response="progress snapshot output",
+        response="No agent message produced. Check logs.\n\nTurn time: 1.0s",
+    )
+
+    assert delivered is True
+    assert calls == [
+        {
+            "chat_id": 123,
+            "text": "progress snapshot output\n\nTurn time: 1.0s",
+            "thread_id": 456,
+            "reply_to": 789,
+            "placeholder_id": 321,
+            "delete_placeholder_on_delivery": True,
+        },
+    ]
+
+
 @pytest.mark.parametrize("parse_mode", ["Markdown", "MarkdownV2"])
 def test_telegram_markdown_collapses_local_file_links(parse_mode: str) -> None:
     rendered = _format_telegram_markdown(


### PR DESCRIPTION
## Summary
- stop Discord final turn delivery from sending the persisted intermediate block and `---` separator before the final reply
- stop Telegram final turn delivery from replaying intermediate output and send only the final reply text
- update Discord and Telegram tests to assert that intermediate rendering still appears during the turn, while the final delivered message is final-only

## Verification
- `.venv/bin/pytest tests/integrations/discord/test_message_turns.py -k 'streaming_turn_accumulates_segmented_intermediate_outputs or streaming_turn_final_progress_omits_duplicate_terminal_output or sends_only_final_attachment_when_long'`
- `.venv/bin/pytest tests/test_telegram_transport.py`
- `git commit` hooks: black, ruff, mypy, pnpm build, pnpm test:markdown, full pytest
