### PR TITLE
Fix CodeQL archive path and markdown issues

### DIFF
--- a/src/codex_autorunner/static/generated/pma.js
+++ b/src/codex_autorunner/static/generated/pma.js
@@ -450,7 +450,7 @@ function getElements() {
 const decoder = new TextDecoder();
 function escapeMarkdownLinkText(text) {
     // Keep this ES2019-compatible (no String.prototype.replaceAll).
-    return text.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+    return text.replace(/\\/g, "\\\\").replace(/\[/g, "\\[").replace(/\]/g, "\\]");
 }
 function formatOutboxAttachments(listing, names) {
     if (!listing || !names.length)

--- a/src/codex_autorunner/static_src/pma.ts
+++ b/src/codex_autorunner/static_src/pma.ts
@@ -535,7 +535,7 @@ const decoder = new TextDecoder();
 
 function escapeMarkdownLinkText(text: string): string {
   // Keep this ES2019-compatible (no String.prototype.replaceAll).
-  return text.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+  return text.replace(/\\/g, "\\\\").replace(/\[/g, "\\[").replace(/\]/g, "\\]");
 }
 
 function formatOutboxAttachments(listing: FileBoxListing | null, names: string[]): string {

--- a/src/codex_autorunner/surfaces/web/routes/archive.py
+++ b/src/codex_autorunner/surfaces/web/routes/archive.py
@@ -12,7 +12,6 @@ from typing import Any, Literal, Optional
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, PlainTextResponse
 
-from ....core.flows.archive_helpers import flow_run_archive_root
 from ..schemas import (
     ArchiveSnapshotDetailResponse,
     ArchiveSnapshotsResponse,
@@ -137,12 +136,26 @@ def _resolve_snapshot_root(
 
 
 def _resolve_local_run_root(repo_root: Path, run_id: str) -> Path:
+    def _resolve_candidate(base_root: Path) -> Optional[Path]:
+        candidate = base_root / run_id
+        if not candidate.exists() or not candidate.is_dir():
+            return None
+        resolved_root = candidate.resolve(strict=False)
+        archive_root = base_root.resolve(strict=False)
+        try:
+            resolved_root.relative_to(archive_root)
+        except ValueError:
+            raise ValueError("invalid run archive path") from None
+        return resolved_root
+
     run_id = _normalize_component(run_id, "run_id")
-    primary = flow_run_archive_root(repo_root, run_id)
-    if primary.exists() and primary.is_dir():
+    primary_root = _local_run_archives_root(repo_root)
+    primary = _resolve_candidate(primary_root)
+    if primary is not None:
         return primary
-    legacy = _legacy_local_flows_root(repo_root) / run_id
-    if legacy.exists() and legacy.is_dir():
+    legacy_root = _legacy_local_flows_root(repo_root)
+    legacy = _resolve_candidate(legacy_root)
+    if legacy is not None:
         return legacy
     raise FileNotFoundError("run archive not found")
 

--- a/tests/routes/test_archive_routes.py
+++ b/tests/routes/test_archive_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from codex_autorunner.bootstrap import seed_hub_files, seed_repo_files
@@ -183,3 +184,37 @@ def test_local_archive_tree_reads_any_archived_run_content(tmp_path: Path) -> No
     )
     assert read.status_code == 200
     assert read.text.strip() == "Local archived context"
+
+
+def test_local_archive_symlink_escape_is_rejected(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    client = _client_for_repo(repo_root)
+
+    outside_root = tmp_path / "outside-run"
+    (outside_root / "contextspace").mkdir(parents=True, exist_ok=True)
+    (outside_root / "contextspace" / "active_context.md").write_text(
+        "Escaped local archived context", encoding="utf-8"
+    )
+
+    link_root = repo_root / ".codex-autorunner" / "archive" / "runs"
+    link_root.mkdir(parents=True, exist_ok=True)
+    try:
+        (link_root / "run-escape").symlink_to(outside_root, target_is_directory=True)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    tree = client.get("/api/archive/local/tree", params={"run_id": "run-escape"})
+    assert tree.status_code == 400
+
+    read = client.get(
+        "/api/archive/local/file",
+        params={"run_id": "run-escape", "path": "contextspace/active_context.md"},
+    )
+    assert read.status_code == 400
+
+    download = client.get(
+        "/api/archive/local/download",
+        params={"run_id": "run-escape", "path": "contextspace/active_context.md"},
+    )
+    assert download.status_code == 400


### PR DESCRIPTION
## Summary
- escape backslashes in PMA markdown link text so uploaded file names cannot break markdown link rendering
- re-anchor local archive run roots under repo-owned archive directories before serving tree/file/download routes
- add a regression test covering symlink escape attempts for local archive routes

## Validation
- pnpm run build
- pnpm run test:markdown
- .venv/bin/pytest tests/routes/test_archive_routes.py
- pre-commit/commit hooks also passed full validation (including full pytest)

## Notes
- false-positive CodeQL alerts were dismissed directly in GitHub after manual review
- the remaining open CodeQL alerts are the ones tied to these code changes and should close after the next scan on this branch
