### PR TITLE
Fix false managed-thread failures after completion

### DIFF
--- a/src/codex_autorunner/core/orchestration/runtime_threads.py
+++ b/src/codex_autorunner/core/orchestration/runtime_threads.py
@@ -21,10 +21,11 @@ def _raw_events_show_completion(raw_events: tuple[Any, ...]) -> bool:
     for raw_event in raw_events:
         if not isinstance(raw_event, dict):
             continue
-        message = raw_event.get("message")
-        if not isinstance(message, dict):
-            continue
-        method = str(message.get("method") or "").strip().lower()
+        method = str(raw_event.get("method") or "").strip().lower()
+        if not method:
+            message = raw_event.get("message")
+            if isinstance(message, dict):
+                method = str(message.get("method") or "").strip().lower()
         if method == "turn/completed":
             return True
     return False

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -498,6 +498,55 @@ async def test_runtime_threads_prefer_final_output_over_post_completion_errors(
     assert outcome.error is None
 
 
+async def test_runtime_threads_recovers_from_top_level_completion_raw_event(
+    tmp_path: Path,
+) -> None:
+    harness = _HarnessWithWait()
+
+    async def _wait_with_top_level_completion(
+        workspace_root: Path,
+        conversation_id: str,
+        turn_id: Optional[str],
+        *,
+        timeout: Optional[float] = None,
+    ) -> SimpleNamespace:
+        _ = timeout
+        harness.wait_calls.append((workspace_root, conversation_id, turn_id))
+        return SimpleNamespace(
+            status="completed",
+            assistant_text="assistant-output",
+            errors=["transport disconnected after completion"],
+            raw_events=[
+                {"method": "turn/completed", "params": {"status": "completed"}}
+            ],
+        )
+
+    harness.wait_for_turn = _wait_with_top_level_completion  # type: ignore[method-assign]
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target("codex", workspace_root)
+
+    started = await begin_runtime_thread_execution(
+        service,
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="user-visible prompt",
+        ),
+    )
+    outcome = await await_runtime_thread_outcome(
+        started,
+        interrupt_event=None,
+        timeout_seconds=5,
+        execution_error_message="Managed thread execution failed",
+    )
+
+    assert outcome.status == "ok"
+    assert outcome.assistant_text == "assistant-output"
+    assert outcome.error is None
+
+
 async def test_stream_runtime_thread_events_proxies_harness_stream(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- narrow managed-thread runtime recovery for post-completion transport errors
- only prefer the final assistant text when the runtime reported success and raw events confirm `turn/completed`
- add a regression test covering the Telegram false-positive path

## Validation
- `.venv/bin/pytest tests/core/orchestration/test_runtime_threads.py tests/core/orchestration/test_runtime_thread_events.py -q`
- pre-commit suite during `git commit`:
  - formatting/lint/type checks
  - `pnpm run build`
  - `pnpm test:markdown`
  - `pytest` (`3205 passed, 1 skipped`)

## Review
- mini subagent review found one issue with the initial patch being too broad
- addressed by requiring explicit success status plus a `turn/completed` raw event before recovering
