### PR TITLE
Fix PMA new/reset to clear prompt-state cache across surfaces

### DIFF
--- a/src/codex_autorunner/core/pma_context.py
+++ b/src/codex_autorunner/core/pma_context.py
@@ -7,7 +7,7 @@ import logging
 import shlex
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping, Optional, TypedDict, cast
+from typing import Any, Mapping, Optional, Sequence, TypedDict, cast
 
 from ..bootstrap import ensure_pma_docs, pma_doc_path
 from ..tickets.files import list_ticket_paths, safe_relpath
@@ -366,6 +366,71 @@ def _trim_prompt_sessions(sessions: Mapping[str, Any]) -> dict[str, Any]:
 
     trimmed = sorted(items, key=_sort_key)[-PMA_PROMPT_STATE_MAX_SESSIONS:]
     return {key: dict(value) for key, value in trimmed}
+
+
+def clear_pma_prompt_state_sessions(
+    hub_root: Path,
+    *,
+    keys: Sequence[str] = (),
+    prefixes: Sequence[str] = (),
+    exclude_prefixes: Sequence[str] = (),
+) -> list[str]:
+    """Clear PMA prompt-state sessions by exact key and/or key prefix."""
+
+    normalized_keys = {
+        str(key).strip() for key in keys if isinstance(key, str) and key.strip()
+    }
+    normalized_prefixes = tuple(
+        str(prefix).strip()
+        for prefix in prefixes
+        if isinstance(prefix, str) and prefix.strip()
+    )
+    normalized_excludes = tuple(
+        str(prefix).strip()
+        for prefix in exclude_prefixes
+        if isinstance(prefix, str) and prefix.strip()
+    )
+    if not normalized_keys and not normalized_prefixes:
+        return []
+
+    path = default_pma_prompt_state_path(hub_root)
+    lock_path = _prompt_state_lock_path(path)
+    cleared_keys: list[str] = []
+
+    def _is_excluded(session_key: str) -> bool:
+        return any(
+            session_key == excluded.rstrip(".") or session_key.startswith(excluded)
+            for excluded in normalized_excludes
+        )
+
+    with file_lock(lock_path):
+        state = _read_pma_prompt_state_unlocked(path)
+        sessions = state.get("sessions")
+        if not isinstance(sessions, Mapping):
+            return []
+
+        updated_sessions = dict(sessions)
+        for session_key in tuple(updated_sessions.keys()):
+            if not isinstance(session_key, str) or not session_key:
+                continue
+            key_match = session_key in normalized_keys
+            prefix_match = bool(normalized_prefixes) and any(
+                session_key.startswith(prefix) for prefix in normalized_prefixes
+            )
+            if not key_match and not prefix_match:
+                continue
+            if _is_excluded(session_key):
+                continue
+            updated_sessions.pop(session_key, None)
+            cleared_keys.append(session_key)
+
+        if cleared_keys:
+            state["version"] = PMA_PROMPT_STATE_VERSION
+            state["updated_at"] = now_iso()
+            state["sessions"] = _trim_prompt_sessions(updated_sessions)
+            _write_pma_prompt_state_unlocked(path, state)
+
+    return sorted(cleared_keys)
 
 
 def _merge_prompt_session_state(
@@ -1888,14 +1953,14 @@ def format_pma_prompt(
         "</current_actionable_state>\n\n"
     )
     if not use_delta:
-        prompt += "<hub_snapshot>\n" f"{snapshot_text}\n" "</hub_snapshot>\n\n"
+        prompt += f"<hub_snapshot>\n{snapshot_text}\n</hub_snapshot>\n\n"
     elif prompt_state_key:
         prompt += (
             "<hub_snapshot_ref "
             f"digest='{_digest_preview(str((sections.get('hub_snapshot') or {}).get('digest') or ''))}' "
             f"state_key='{prompt_state_key}' />\n\n"
         )
-    prompt += "<user_message>\n" f"{message}\n" "</user_message>\n"
+    prompt += f"<user_message>\n{message}\n</user_message>\n"
     return prompt
 
 

--- a/src/codex_autorunner/core/pma_lifecycle.py
+++ b/src/codex_autorunner/core/pma_lifecycle.py
@@ -29,6 +29,7 @@ from .logging_utils import log_event
 from .orchestration.migrate_legacy_state import backfill_legacy_pma_lifecycle_events
 from .orchestration.sqlite import open_orchestration_sqlite
 from .pma_audit import PmaActionType
+from .pma_context import clear_pma_prompt_state_sessions
 from .pma_queue import PmaQueue
 from .pma_safety import PmaSafetyChecker, PmaSafetyConfig
 from .time_utils import now_iso
@@ -82,6 +83,47 @@ class PmaLifecycleRouter:
         safety_config = PmaSafetyConfig()
         self._safety_checker = PmaSafetyChecker(hub_root, config=safety_config)
 
+    def _clear_runtime_state_for_agent(
+        self, agent: Optional[str]
+    ) -> tuple[list[str], list[str]]:
+        registry = AppServerThreadRegistry(
+            self._hub_root / ".codex-autorunner" / "app_server_threads.json"
+        )
+
+        cleared_thread_keys: list[str] = []
+        cleared_prompt_state_keys: list[str] = []
+        prefixes = pma_prefixes_for_reset(agent)
+        codex_prefix = pma_prefixes_for_reset("codex")[0]
+        opencode_prefix = pma_prefixes_for_reset("opencode")[0]
+        preserve_opencode = agent not in ("all", None, "")
+
+        for prefix in prefixes:
+            exclude_prefixes = (
+                (opencode_prefix,)
+                if prefix == codex_prefix and preserve_opencode
+                else ()
+            )
+            cleared_thread_keys.extend(
+                registry.reset_threads_by_prefix(
+                    prefix, exclude_prefixes=exclude_prefixes
+                )
+            )
+            base_key = prefix.rstrip(".")
+            if registry.reset_thread(base_key):
+                cleared_thread_keys.append(base_key)
+            cleared_prompt_state_keys.extend(
+                clear_pma_prompt_state_sessions(
+                    self._hub_root,
+                    keys=(base_key,),
+                    prefixes=(prefix,),
+                    exclude_prefixes=exclude_prefixes,
+                )
+            )
+
+        return list(dict.fromkeys(cleared_thread_keys)), list(
+            dict.fromkeys(cleared_prompt_state_keys)
+        )
+
     async def new(
         self,
         *,
@@ -107,28 +149,9 @@ class PmaLifecycleRouter:
         try:
             event_id = self._generate_event_id()
             timestamp = now_iso()
-
-            registry = AppServerThreadRegistry(
-                self._hub_root / ".codex-autorunner" / "app_server_threads.json"
+            cleared_keys, cleared_prompt_state_keys = (
+                self._clear_runtime_state_for_agent(agent)
             )
-
-            cleared_keys = []
-            prefixes = pma_prefixes_for_reset(agent)
-            for prefix in prefixes:
-                exclude_prefixes = (
-                    (pma_prefixes_for_reset("opencode")[0],)
-                    if prefix == pma_prefixes_for_reset("codex")[0]
-                    and agent not in ("all", None, "")
-                    else ()
-                )
-                cleared_keys.extend(
-                    registry.reset_threads_by_prefix(
-                        prefix, exclude_prefixes=exclude_prefixes
-                    )
-                )
-                base_key = prefix.rstrip(".")
-                if registry.reset_thread(base_key):
-                    cleared_keys.append(base_key)
 
             # Create artifact
             artifact = {
@@ -138,6 +161,7 @@ class PmaLifecycleRouter:
                 "agent": agent,
                 "lane_id": lane_id,
                 "cleared_threads": cleared_keys,
+                "cleared_prompt_state_keys": cleared_prompt_state_keys,
                 "metadata": metadata or {},
             }
             artifact_path = self._write_artifact(event_id, artifact)
@@ -152,6 +176,7 @@ class PmaLifecycleRouter:
                 details={
                     "command": "new",
                     "cleared_threads": cleared_keys,
+                    "cleared_prompt_state_keys": cleared_prompt_state_keys,
                     "lane_id": lane_id,
                 },
             )
@@ -165,6 +190,7 @@ class PmaLifecycleRouter:
                     "agent": agent,
                     "lane_id": lane_id,
                     "cleared_threads": cleared_keys,
+                    "cleared_prompt_state_keys": cleared_prompt_state_keys,
                     "artifact_path": str(artifact_path),
                 }
             )
@@ -177,6 +203,7 @@ class PmaLifecycleRouter:
                 agent=agent,
                 lane_id=lane_id,
                 cleared_threads=cleared_keys,
+                cleared_prompt_state_keys=cleared_prompt_state_keys,
             )
 
             return LifecycleCommandResult(
@@ -186,6 +213,7 @@ class PmaLifecycleRouter:
                 artifact_path=artifact_path,
                 details={
                     "cleared_threads": cleared_keys,
+                    "cleared_prompt_state_keys": cleared_prompt_state_keys,
                     "agent": agent,
                     "lane_id": lane_id,
                 },
@@ -226,28 +254,9 @@ class PmaLifecycleRouter:
         try:
             event_id = self._generate_event_id()
             timestamp = now_iso()
-
-            registry = AppServerThreadRegistry(
-                self._hub_root / ".codex-autorunner" / "app_server_threads.json"
+            cleared_keys, cleared_prompt_state_keys = (
+                self._clear_runtime_state_for_agent(agent)
             )
-
-            cleared_keys = []
-            prefixes = pma_prefixes_for_reset(agent)
-            for prefix in prefixes:
-                exclude_prefixes = (
-                    (pma_prefixes_for_reset("opencode")[0],)
-                    if prefix == pma_prefixes_for_reset("codex")[0]
-                    and agent not in ("all", None, "")
-                    else ()
-                )
-                cleared_keys.extend(
-                    registry.reset_threads_by_prefix(
-                        prefix, exclude_prefixes=exclude_prefixes
-                    )
-                )
-                base_key = prefix.rstrip(".")
-                if registry.reset_thread(base_key):
-                    cleared_keys.append(base_key)
 
             # Create artifact
             artifact = {
@@ -256,6 +265,7 @@ class PmaLifecycleRouter:
                 "timestamp": timestamp,
                 "agent": agent,
                 "cleared_threads": cleared_keys,
+                "cleared_prompt_state_keys": cleared_prompt_state_keys,
                 "metadata": metadata or {},
             }
             artifact_path = self._write_artifact(event_id, artifact)
@@ -270,6 +280,7 @@ class PmaLifecycleRouter:
                 details={
                     "command": "reset",
                     "cleared_threads": cleared_keys,
+                    "cleared_prompt_state_keys": cleared_prompt_state_keys,
                 },
             )
 
@@ -281,6 +292,7 @@ class PmaLifecycleRouter:
                     "timestamp": timestamp,
                     "agent": agent,
                     "cleared_threads": cleared_keys,
+                    "cleared_prompt_state_keys": cleared_prompt_state_keys,
                     "artifact_path": str(artifact_path),
                 }
             )
@@ -292,6 +304,7 @@ class PmaLifecycleRouter:
                 event_id=event_id,
                 agent=agent,
                 cleared_threads=cleared_keys,
+                cleared_prompt_state_keys=cleared_prompt_state_keys,
             )
 
             return LifecycleCommandResult(
@@ -301,6 +314,7 @@ class PmaLifecycleRouter:
                 artifact_path=artifact_path,
                 details={
                     "cleared_threads": cleared_keys,
+                    "cleared_prompt_state_keys": cleared_prompt_state_keys,
                     "agent": agent,
                 },
             )

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -13,6 +13,7 @@ from .....core.flows import FlowStore
 from .....core.flows.models import FlowRunStatus
 from .....core.git_utils import GitError, reset_branch_from_origin_main
 from .....core.logging_utils import log_event
+from .....core.pma_context import clear_pma_prompt_state_sessions
 from .....core.state import now_iso
 from .....core.utils import canonicalize_path, resolve_opencode_binary
 from .....manifest import load_manifest
@@ -1017,6 +1018,23 @@ class WorkspaceCommands(SharedHelpers):
                 pma_key = self._pma_registry_key(record, message)
                 if pma_key:
                     registry.reset_thread(pma_key)
+                    hub_root = getattr(self, "_hub_root", None)
+                    if hub_root is not None:
+                        try:
+                            clear_pma_prompt_state_sessions(
+                                Path(hub_root), keys=(pma_key,)
+                            )
+                        except Exception as exc:
+                            log_event(
+                                self._logger,
+                                logging.WARNING,
+                                "telegram.pma.prompt_state.clear_failed",
+                                topic_key=key,
+                                chat_id=message.chat_id,
+                                thread_id=message.thread_id,
+                                pma_key=pma_key,
+                                exc=exc,
+                            )
             await self._send_message(
                 message.chat_id,
                 "PMA thread reset. Send a message to start a fresh PMA turn.",
@@ -1186,6 +1204,23 @@ class WorkspaceCommands(SharedHelpers):
                 pma_key = self._pma_registry_key(record, message)
                 if pma_key:
                     registry.reset_thread(pma_key)
+                    hub_root = getattr(self, "_hub_root", None)
+                    if hub_root is not None:
+                        try:
+                            clear_pma_prompt_state_sessions(
+                                Path(hub_root), keys=(pma_key,)
+                            )
+                        except Exception as exc:
+                            log_event(
+                                self._logger,
+                                logging.WARNING,
+                                "telegram.pma.prompt_state.clear_failed",
+                                topic_key=key,
+                                chat_id=message.chat_id,
+                                thread_id=message.thread_id,
+                                pma_key=pma_key,
+                                exc=exc,
+                            )
             await self._send_message(
                 message.chat_id,
                 "PMA session reset. Send a message to start a fresh PMA turn.",

--- a/tests/test_pma_lifecycle.py
+++ b/tests/test_pma_lifecycle.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from codex_autorunner.core.pma_context import default_pma_prompt_state_path
 from codex_autorunner.core.pma_lifecycle import (
     LifecycleCommand,
     PmaLifecycleRouter,
@@ -228,6 +229,46 @@ async def test_lifecycle_router_new_clears_scoped_keys(temp_hub_root: Path) -> N
 
 
 @pytest.mark.asyncio
+async def test_lifecycle_router_new_clears_matching_prompt_state_keys(
+    temp_hub_root: Path,
+) -> None:
+    state_path = default_pma_prompt_state_path(temp_hub_root)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "updated_at": "2026-03-20T00:00:00Z",
+                "sessions": {
+                    "pma": {"version": 1},
+                    "pma.-1001.42": {"version": 1},
+                    "pma.opencode": {"version": 1},
+                    "pma.opencode.-1001.42": {"version": 1},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    router = PmaLifecycleRouter(temp_hub_root)
+    result = await router.new(agent="codex")
+
+    assert result.status == "ok"
+    cleared = result.details.get("cleared_prompt_state_keys", [])
+    assert "pma" in cleared
+    assert "pma.-1001.42" in cleared
+    assert "pma.opencode" not in cleared
+    assert "pma.opencode.-1001.42" not in cleared
+
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    sessions = payload.get("sessions", {})
+    assert "pma" not in sessions
+    assert "pma.-1001.42" not in sessions
+    assert "pma.opencode" in sessions
+    assert "pma.opencode.-1001.42" in sessions
+
+
+@pytest.mark.asyncio
 async def test_lifecycle_router_reset_clears_scoped_keys(temp_hub_root: Path) -> None:
     """Test that /reset clears both global and topic-scoped PMA keys."""
     from codex_autorunner.core.app_server_threads import AppServerThreadRegistry
@@ -247,6 +288,42 @@ async def test_lifecycle_router_reset_clears_scoped_keys(temp_hub_root: Path) ->
 
     assert registry.get_thread_id("pma.opencode") is None
     assert registry.get_thread_id("pma.opencode.-1001.42") is None
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_router_reset_all_clears_all_prompt_state_keys(
+    temp_hub_root: Path,
+) -> None:
+    state_path = default_pma_prompt_state_path(temp_hub_root)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "updated_at": "2026-03-20T00:00:00Z",
+                "sessions": {
+                    "pma": {"version": 1},
+                    "pma.-1001.1": {"version": 1},
+                    "pma.opencode": {"version": 1},
+                    "pma.opencode.-1001.2": {"version": 1},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    router = PmaLifecycleRouter(temp_hub_root)
+    result = await router.reset(agent="all")
+
+    assert result.status == "ok"
+    cleared = result.details.get("cleared_prompt_state_keys", [])
+    assert "pma" in cleared
+    assert "pma.-1001.1" in cleared
+    assert "pma.opencode" in cleared
+    assert "pma.opencode.-1001.2" in cleared
+
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    assert payload.get("sessions") == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_telegram_pma_routing.py
+++ b/tests/test_telegram_pma_routing.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import hashlib
+import json
 import logging
 from pathlib import Path
 from types import SimpleNamespace
@@ -20,6 +21,7 @@ from codex_autorunner.core.orchestration.runtime_threads import (
     RUNTIME_THREAD_INTERRUPTED_ERROR,
     RUNTIME_THREAD_TIMEOUT_ERROR,
 )
+from codex_autorunner.core.pma_context import default_pma_prompt_state_path
 from codex_autorunner.core.sse import format_sse
 from codex_autorunner.integrations.app_server.client import (
     CodexAppServerDisconnected,
@@ -3359,14 +3361,35 @@ class _PMAWorkspaceRouter:
         return self._record
 
 
+def _write_prompt_state_sessions(hub_root: Path, *keys: str) -> Path:
+    state_path = default_pma_prompt_state_path(hub_root)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "updated_at": "2026-03-20T00:00:00Z",
+                "sessions": {key: {"version": 1} for key in keys},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return state_path
+
+
 class _PMAWorkspaceHandler(WorkspaceCommands):
     def __init__(
-        self, record: TelegramTopicRecord, registry: AppServerThreadRegistry
+        self,
+        record: TelegramTopicRecord,
+        registry: AppServerThreadRegistry,
+        *,
+        hub_root: Optional[Path] = None,
     ) -> None:
         self._logger = logging.getLogger("test")
         self._config = SimpleNamespace(require_topics=False)
         self._router = _PMAWorkspaceRouter(record)
         self._hub_thread_registry = registry
+        self._hub_root = hub_root
         self._sent: list[str] = []
         self._record = record
 
@@ -3499,11 +3522,13 @@ async def test_archive_uses_shared_fresh_start_and_resets_topic(
     calls: list[dict[str, object]] = []
     monkeypatch.setattr(
         "codex_autorunner.core.archive.archive_workspace_for_fresh_start",
-        lambda **kwargs: calls.append(kwargs)
-        or SimpleNamespace(
-            snapshot_id=None,
-            archived_paths=(),
-            archived_thread_ids=("managed-thread-1",),
+        lambda **kwargs: (
+            calls.append(kwargs)
+            or SimpleNamespace(
+                snapshot_id=None,
+                archived_paths=(),
+                archived_thread_ids=("managed-thread-1",),
+            )
         ),
     )
 
@@ -3558,11 +3583,13 @@ async def test_archive_without_hub_root_does_not_substitute_workspace_root(
     calls: list[dict[str, object]] = []
     monkeypatch.setattr(
         "codex_autorunner.core.archive.archive_workspace_for_fresh_start",
-        lambda **kwargs: calls.append(kwargs)
-        or SimpleNamespace(
-            snapshot_id="snap-1",
-            archived_paths=("tickets",),
-            archived_thread_ids=(),
+        lambda **kwargs: (
+            calls.append(kwargs)
+            or SimpleNamespace(
+                snapshot_id="snap-1",
+                archived_paths=("tickets",),
+                archived_thread_ids=(),
+            )
         ),
     )
 
@@ -3643,20 +3670,21 @@ async def test_sync_telegram_thread_binding_archives_after_lost_backend_recovery
         ),
     )
     try:
-        _service, thread = (
-            await execution_commands_module._sync_telegram_thread_binding(
-                handlers,
-                surface_key="topic-1",
-                workspace_root=workspace,
-                agent="codex",
-                repo_id="repo-1",
-                resource_kind="repo",
-                resource_id="repo-1",
-                backend_thread_id="backend-2",
-                mode="repo",
-                pma_enabled=False,
-                replace_existing=True,
-            )
+        (
+            _service,
+            thread,
+        ) = await execution_commands_module._sync_telegram_thread_binding(
+            handlers,
+            surface_key="topic-1",
+            workspace_root=workspace,
+            agent="codex",
+            repo_id="repo-1",
+            resource_kind="repo",
+            resource_id="repo-1",
+            backend_thread_id="backend-2",
+            mode="repo",
+            pma_enabled=False,
+            replace_existing=True,
         )
     finally:
         monkeypatch.undo()
@@ -3675,10 +3703,11 @@ async def test_pma_new_resets_session(tmp_path: Path) -> None:
     registry = AppServerThreadRegistry(tmp_path / "threads.json")
     registry.reset_all()
     registry.set_thread_id(PMA_OPENCODE_KEY, "old-thread")
+    state_path = _write_prompt_state_sessions(tmp_path, PMA_OPENCODE_KEY)
     record = TelegramTopicRecord(
         pma_enabled=True, workspace_path=None, agent="opencode"
     )
-    handler = _PMAWorkspaceHandler(record, registry)
+    handler = _PMAWorkspaceHandler(record, registry, hub_root=tmp_path)
     message = TelegramMessage(
         update_id=1,
         message_id=2,
@@ -3693,6 +3722,8 @@ async def test_pma_new_resets_session(tmp_path: Path) -> None:
     await handler._handle_new(message)
 
     assert registry.get_thread_id(PMA_OPENCODE_KEY) is None
+    sessions = json.loads(state_path.read_text(encoding="utf-8")).get("sessions", {})
+    assert PMA_OPENCODE_KEY not in sessions
     assert handler._sent and "PMA session reset" in handler._sent[-1]
 
 
@@ -3711,11 +3742,14 @@ async def test_pma_new_resets_scoped_key_when_require_topics_enabled(
         topic_key_fn=lambda c, t: f"{c}:{t or 'root'}",
     )
     registry.set_thread_id(scoped_key, "old-scoped-thread")
+    state_path = _write_prompt_state_sessions(tmp_path, scoped_key)
 
     record = TelegramTopicRecord(
         pma_enabled=True, workspace_path=None, agent="opencode"
     )
-    handler = _PMAWorkspaceHandlerWithScopedKey(record, registry, require_topics=True)
+    handler = _PMAWorkspaceHandlerWithScopedKey(
+        record, registry, hub_root=tmp_path, require_topics=True
+    )
     message = TelegramMessage(
         update_id=1,
         message_id=2,
@@ -3730,6 +3764,8 @@ async def test_pma_new_resets_scoped_key_when_require_topics_enabled(
     await handler._handle_new(message)
 
     assert registry.get_thread_id(scoped_key) is None
+    sessions = json.loads(state_path.read_text(encoding="utf-8")).get("sessions", {})
+    assert scoped_key not in sessions
     assert handler._sent and "PMA session reset" in handler._sent[-1]
 
 
@@ -3748,9 +3784,12 @@ async def test_pma_reset_resets_scoped_key_when_require_topics_enabled(
         topic_key_fn=lambda c, t: f"{c}:{t or 'root'}",
     )
     registry.set_thread_id(scoped_key, "old-scoped-thread")
+    state_path = _write_prompt_state_sessions(tmp_path, scoped_key)
 
     record = TelegramTopicRecord(pma_enabled=True, workspace_path=None, agent="codex")
-    handler = _PMAWorkspaceHandlerWithScopedKey(record, registry, require_topics=True)
+    handler = _PMAWorkspaceHandlerWithScopedKey(
+        record, registry, hub_root=tmp_path, require_topics=True
+    )
     message = TelegramMessage(
         update_id=1,
         message_id=2,
@@ -3765,6 +3804,8 @@ async def test_pma_reset_resets_scoped_key_when_require_topics_enabled(
     await handler._handle_reset(message)
 
     assert registry.get_thread_id(scoped_key) is None
+    sessions = json.loads(state_path.read_text(encoding="utf-8")).get("sessions", {})
+    assert scoped_key not in sessions
     assert handler._sent and "PMA thread reset" in handler._sent[-1]
 
 
@@ -3774,12 +3815,14 @@ class _PMAWorkspaceHandlerWithScopedKey(WorkspaceCommands):
         record: TelegramTopicRecord,
         registry: AppServerThreadRegistry,
         *,
+        hub_root: Optional[Path] = None,
         require_topics: bool = False,
     ) -> None:
         self._logger = logging.getLogger("test")
         self._config = SimpleNamespace(require_topics=require_topics)
         self._router = _PMAWorkspaceRouter(record)
         self._hub_thread_registry = registry
+        self._hub_root = hub_root
         self._sent: list[str] = []
         self._record = record
 


### PR DESCRIPTION
## Summary
- add a shared PMA prompt-state invalidation helper that removes `prompt_state.json` sessions by exact key/prefix (with exclude-prefix support)
- update `PmaLifecycleRouter.new/reset` to clear both:
  - backend thread/session registry keys
  - PMA prompt-state cache keys
- update Telegram PMA `/new` and `/reset` handlers to clear prompt-state for the exact PMA registry key they reset, keeping scoped-topic semantics intact

## Why
Starting a new PMA session/thread only reset backend thread ids. Prompt delta cache entries remained, so the next turn could still use `mode='delta' reason='cached_context'` and carry stale context window state.

## Tests
- added lifecycle regression tests for prompt-state invalidation and codex/opencode scoping:
  - `tests/test_pma_lifecycle.py`
- added Telegram PMA `/new` and `/reset` regressions asserting prompt-state key removal:
  - `tests/test_telegram_pma_routing.py`

## Verification run
- `ruff check` on changed files
- `pytest -q tests/test_pma_lifecycle.py`
- targeted Telegram/PMA regressions in `tests/test_telegram_pma_routing.py`
- pre-commit hook suite (includes full pytest run in this repo)
