### PR TITLE
Fix Discord interaction breaker accounting

### DIFF
--- a/src/codex_autorunner/core/circuit_breaker.py
+++ b/src/codex_autorunner/core/circuit_breaker.py
@@ -6,7 +6,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import AsyncIterator, Optional
+from typing import AsyncIterator, Callable, Optional
 
 from .exceptions import CircuitOpenError
 
@@ -65,7 +65,11 @@ class CircuitBreaker:
         self._lock = asyncio.Lock()
 
     @asynccontextmanager
-    async def call(self) -> AsyncIterator[None]:
+    async def call(
+        self,
+        *,
+        should_record_failure: Optional[Callable[[Exception], bool]] = None,
+    ) -> AsyncIterator[None]:
         """
         Context manager that raises CircuitOpenError if circuit is open.
 
@@ -98,12 +102,20 @@ class CircuitBreaker:
         try:
             yield
         except Exception as exc:
-            self._logger.debug(
-                "Exception caught by circuit breaker for %s: %s",
-                self._service_name,
-                exc,
-            )
-            await self._record_failure()
+            if should_record_failure is None or should_record_failure(exc):
+                self._logger.debug(
+                    "Exception caught by circuit breaker for %s: %s",
+                    self._service_name,
+                    exc,
+                )
+                await self._record_failure()
+            else:
+                self._logger.debug(
+                    "Exception treated as successful service contact for %s: %s",
+                    self._service_name,
+                    exc,
+                )
+                await self._record_success()
             raise
         else:
             await self._record_success()

--- a/src/codex_autorunner/integrations/discord/rest.py
+++ b/src/codex_autorunner/integrations/discord/rest.py
@@ -5,16 +5,15 @@ import logging
 import random
 from contextlib import asynccontextmanager
 from io import BytesIO
-from typing import Any, AsyncIterator, Optional, cast
+from typing import Any, AsyncIterator, Callable, Optional, cast
 from urllib.parse import urlparse
 
 import httpx
 
 from codex_autorunner.core.circuit_breaker import CircuitBreaker
-from codex_autorunner.core.exceptions import CircuitOpenError
 
 from .constants import DISCORD_API_BASE_URL
-from .errors import DiscordAPIError, DiscordPermanentError
+from .errors import DiscordAPIError, DiscordPermanentError, DiscordTransientError
 
 logger = logging.getLogger(__name__)
 _DISCORD_ATTACHMENT_HOSTS = frozenset({"cdn.discordapp.com", "media.discordapp.net"})
@@ -51,13 +50,18 @@ class DiscordRestClient:
         return path.split("/")[1] if "/" in path else "default"
 
     @asynccontextmanager
-    async def _resilience_guard(self, path: str) -> AsyncIterator[None]:
+    async def _resilience_guard(
+        self,
+        path: str,
+        *,
+        should_record_failure: Optional[Callable[[Exception], bool]] = None,
+    ) -> AsyncIterator[None]:
         scope = self._circuit_breaker_scope(path)
         breaker = self._circuit_breakers.get(scope)
         if breaker is None:
             breaker = CircuitBreaker(f"Discord:{scope}", logger=logger)
             self._circuit_breakers[scope] = breaker
-        async with breaker.call():
+        async with breaker.call(should_record_failure=should_record_failure):
             yield
 
     def _calculate_retry_delay(self, attempt: int) -> float:
@@ -81,6 +85,18 @@ class DiscordRestClient:
             return 500 <= exc.response.status_code < 600
         return False
 
+    def _should_record_breaker_failure(self, exc: Exception) -> bool:
+        if isinstance(exc, DiscordTransientError):
+            cause = exc.__cause__
+            if not isinstance(cause, Exception):
+                return False
+            if isinstance(cause, httpx.HTTPStatusError):
+                return cause.response.status_code != 429 and self._is_retryable_error(
+                    cause
+                )
+            return self._is_retryable_error(cause)
+        return self._is_retryable_error(exc)
+
     async def _request(
         self,
         method: str,
@@ -92,9 +108,12 @@ class DiscordRestClient:
         rate_limit_retries = 0
         retry_attempt = 0
 
-        while True:
-            try:
-                async with self._resilience_guard(path):
+        async with self._resilience_guard(
+            path,
+            should_record_failure=self._should_record_breaker_failure,
+        ):
+            while True:
+                try:
                     response = await self._client.request(
                         method,
                         path,
@@ -102,99 +121,100 @@ class DiscordRestClient:
                         headers={"Authorization": self._authorization_header},
                     )
                     response.raise_for_status()
-            except CircuitOpenError:
-                raise
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code == 429:
-                    retry_after_raw = exc.response.headers.get("Retry-After")
+                except httpx.HTTPStatusError as exc:
+                    if exc.response.status_code == 429:
+                        retry_after_raw = exc.response.headers.get("Retry-After")
+                        if (
+                            retry_after_raw is not None
+                            and rate_limit_retries < self._max_retries
+                        ):
+                            rate_limit_retries += 1
+                            try:
+                                retry_after = max(float(retry_after_raw), 0.0)
+                            except ValueError:
+                                retry_after = 0.0
+                            logger.info(
+                                "Discord rate limited on %s %s, retrying after %.1fs (attempt %d)",
+                                method,
+                                path,
+                                retry_after,
+                                rate_limit_retries,
+                            )
+                            await asyncio.sleep(retry_after)
+                            continue
+                        raise DiscordTransientError(
+                            f"Discord API rate limit exceeded for {method} {path}"
+                        ) from exc
+
+                    status_code = exc.response.status_code
+                    body_preview = (
+                        (exc.response.text or "").strip().replace("\n", " ")[:200]
+                    )
+
+                    if 200 <= status_code < 300:
+                        response = exc.response
+                    elif 500 <= status_code < 600:
+                        if retry_attempt < self._max_retries:
+                            retry_attempt += 1
+                            delay = self._calculate_retry_delay(retry_attempt)
+                            logger.warning(
+                                "Discord server error %d on %s %s, retrying in %.1fs (attempt %d/%d)",
+                                exc.response.status_code,
+                                method,
+                                path,
+                                delay,
+                                retry_attempt,
+                                self._max_retries,
+                            )
+                            await asyncio.sleep(delay)
+                            continue
+                        raise DiscordTransientError(
+                            f"Discord API server error for {method} {path}: "
+                            f"status={status_code} body={body_preview!r}"
+                        ) from exc
+                    elif 400 <= status_code < 500:
+                        raise DiscordPermanentError(
+                            f"Discord API request failed for {method} {path}: "
+                            f"status={status_code} body={body_preview!r}"
+                        ) from exc
+                    else:
+                        raise DiscordAPIError(
+                            f"Discord API request failed for {method} {path}: "
+                            f"status={status_code} body={body_preview!r}"
+                        ) from exc
+                except httpx.HTTPError as exc:
                     if (
-                        retry_after_raw is not None
-                        and rate_limit_retries < self._max_retries
+                        self._is_retryable_error(exc)
+                        and retry_attempt < self._max_retries
                     ):
-                        rate_limit_retries += 1
-                        try:
-                            retry_after = max(float(retry_after_raw), 0.0)
-                        except ValueError:
-                            retry_after = 0.0
-                        logger.info(
-                            "Discord rate limited on %s %s, retrying after %.1fs (attempt %d)",
-                            method,
-                            path,
-                            retry_after,
-                            rate_limit_retries,
-                        )
-                        await asyncio.sleep(retry_after)
-                        continue
-                    raise DiscordAPIError(
-                        f"Discord API rate limit exceeded for {method} {path}"
-                    ) from exc
-
-                status_code = exc.response.status_code
-                body_preview = (
-                    (exc.response.text or "").strip().replace("\n", " ")[:200]
-                )
-
-                if 200 <= status_code < 300:
-                    response = exc.response
-                elif 500 <= status_code < 600:
-                    if retry_attempt < self._max_retries:
                         retry_attempt += 1
                         delay = self._calculate_retry_delay(retry_attempt)
                         logger.warning(
-                            "Discord server error %d on %s %s, retrying in %.1fs (attempt %d/%d)",
-                            exc.response.status_code,
+                            "Discord network error on %s %s: %s, retrying in %.1fs (attempt %d/%d)",
                             method,
                             path,
+                            type(exc).__name__,
                             delay,
                             retry_attempt,
                             self._max_retries,
                         )
                         await asyncio.sleep(delay)
                         continue
-                    raise DiscordAPIError(
-                        f"Discord API server error for {method} {path}: "
-                        f"status={status_code} body={body_preview!r}"
+                    raise DiscordTransientError(
+                        f"Discord API network error for {method} {path}: {exc}"
                     ) from exc
-                elif status_code in {401, 403}:
-                    raise DiscordPermanentError(
-                        f"Discord API authentication failure for {method} {path}: "
-                        f"status={status_code} body={body_preview!r}"
-                    ) from exc
-                else:
-                    raise DiscordAPIError(
-                        f"Discord API request failed for {method} {path}: "
-                        f"status={status_code} body={body_preview!r}"
-                    ) from exc
-            except httpx.HTTPError as exc:
-                if self._is_retryable_error(exc) and retry_attempt < self._max_retries:
-                    retry_attempt += 1
-                    delay = self._calculate_retry_delay(retry_attempt)
-                    logger.warning(
-                        "Discord network error on %s %s: %s, retrying in %.1fs (attempt %d/%d)",
-                        method,
-                        path,
-                        type(exc).__name__,
-                        delay,
-                        retry_attempt,
-                        self._max_retries,
-                    )
-                    await asyncio.sleep(delay)
-                    continue
-                raise DiscordAPIError(
-                    f"Discord API network error for {method} {path}: {exc}"
-                ) from exc
 
-            if 200 <= response.status_code < 300:
-                if not expect_json:
-                    return None
-                if not response.content:
-                    return {}
-                try:
-                    return response.json()
-                except ValueError as exc:
-                    raise DiscordAPIError(
-                        f"Discord API returned non-JSON success response for {method} {path}"
-                    ) from exc
+                if 200 <= response.status_code < 300:
+                    if not expect_json:
+                        return None
+                    if not response.content:
+                        return {}
+                    try:
+                        return response.json()
+                    except ValueError as exc:
+                        raise DiscordAPIError(
+                            f"Discord API returned non-JSON success response for {method} {path}"
+                        ) from exc
 
     async def get_gateway_bot(self) -> dict[str, Any]:
         payload = await self._request("GET", "/gateway/bot")
@@ -320,9 +340,12 @@ class DiscordRestClient:
         rate_limit_retries = 0
         retry_attempt = 0
 
-        while True:
-            try:
-                async with self._resilience_guard(path):
+        async with self._resilience_guard(
+            path,
+            should_record_failure=self._should_record_breaker_failure,
+        ):
+            while True:
+                try:
                     files: list[tuple[str, tuple[str, Any, Optional[str]]]] = []
                     data_fields: dict[str, str] = {}
                     for key, value in form_data.items():
@@ -341,91 +364,100 @@ class DiscordRestClient:
                         headers={"Authorization": self._authorization_header},
                     )
                     response.raise_for_status()
-            except CircuitOpenError:
-                raise
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code == 429:
-                    retry_after_raw = exc.response.headers.get("Retry-After")
-                    if (
-                        retry_after_raw is not None
-                        and rate_limit_retries < self._max_retries
-                    ):
-                        rate_limit_retries += 1
-                        try:
-                            retry_after = max(float(retry_after_raw), 0.0)
-                        except ValueError:
-                            retry_after = 0.0
-                        logger.info(
-                            "Discord rate limited on multipart %s, retrying after %.1fs (attempt %d)",
-                            path,
-                            retry_after,
-                            rate_limit_retries,
-                        )
-                        await asyncio.sleep(retry_after)
-                        continue
-                    raise DiscordAPIError(
-                        f"Discord API rate limit exceeded for multipart {path}"
-                    ) from exc
+                except httpx.HTTPStatusError as exc:
+                    if exc.response.status_code == 429:
+                        retry_after_raw = exc.response.headers.get("Retry-After")
+                        if (
+                            retry_after_raw is not None
+                            and rate_limit_retries < self._max_retries
+                        ):
+                            rate_limit_retries += 1
+                            try:
+                                retry_after = max(float(retry_after_raw), 0.0)
+                            except ValueError:
+                                retry_after = 0.0
+                            logger.info(
+                                "Discord rate limited on multipart %s, retrying after %.1fs (attempt %d)",
+                                path,
+                                retry_after,
+                                rate_limit_retries,
+                            )
+                            await asyncio.sleep(retry_after)
+                            continue
+                        raise DiscordTransientError(
+                            f"Discord API rate limit exceeded for multipart {path}"
+                        ) from exc
 
-                if 200 <= exc.response.status_code < 300:
-                    response = exc.response
-                elif 500 <= exc.response.status_code < 600:
-                    if retry_attempt < self._max_retries:
+                    if 200 <= exc.response.status_code < 300:
+                        response = exc.response
+                    elif 500 <= exc.response.status_code < 600:
+                        if retry_attempt < self._max_retries:
+                            retry_attempt += 1
+                            delay = self._calculate_retry_delay(retry_attempt)
+                            logger.warning(
+                                "Discord server error %d on multipart %s, retrying in %.1fs (attempt %d/%d)",
+                                exc.response.status_code,
+                                path,
+                                delay,
+                                retry_attempt,
+                                self._max_retries,
+                            )
+                            await asyncio.sleep(delay)
+                            continue
+                        body_preview = (
+                            (exc.response.text or "").strip().replace("\n", " ")[:200]
+                        )
+                        raise DiscordTransientError(
+                            f"Discord API server error for multipart {path}: "
+                            f"status={exc.response.status_code} body={body_preview!r}"
+                        ) from exc
+                    elif 400 <= exc.response.status_code < 500:
+                        body_preview = (
+                            (exc.response.text or "").strip().replace("\n", " ")[:200]
+                        )
+                        raise DiscordPermanentError(
+                            f"Discord API request failed for multipart {path}: "
+                            f"status={exc.response.status_code} body={body_preview!r}"
+                        ) from exc
+                    else:
+                        body_preview = (
+                            (exc.response.text or "").strip().replace("\n", " ")[:200]
+                        )
+                        raise DiscordAPIError(
+                            f"Discord API request failed for multipart {path}: "
+                            f"status={exc.response.status_code} body={body_preview!r}"
+                        ) from exc
+                except httpx.HTTPError as exc:
+                    if (
+                        self._is_retryable_error(exc)
+                        and retry_attempt < self._max_retries
+                    ):
                         retry_attempt += 1
                         delay = self._calculate_retry_delay(retry_attempt)
                         logger.warning(
-                            "Discord server error %d on multipart %s, retrying in %.1fs (attempt %d/%d)",
-                            exc.response.status_code,
+                            "Discord network error on multipart %s: %s, retrying in %.1fs (attempt %d/%d)",
                             path,
+                            type(exc).__name__,
                             delay,
                             retry_attempt,
                             self._max_retries,
                         )
                         await asyncio.sleep(delay)
                         continue
-                    body_preview = (
-                        (exc.response.text or "").strip().replace("\n", " ")[:200]
-                    )
-                    raise DiscordAPIError(
-                        f"Discord API server error for multipart {path}: "
-                        f"status={exc.response.status_code} body={body_preview!r}"
+                    raise DiscordTransientError(
+                        f"Discord API network error for multipart {path}: {exc}"
                     ) from exc
-                else:
-                    body_preview = (
-                        (exc.response.text or "").strip().replace("\n", " ")[:200]
-                    )
-                    raise DiscordAPIError(
-                        f"Discord API request failed for multipart {path}: "
-                        f"status={exc.response.status_code} body={body_preview!r}"
-                    ) from exc
-            except httpx.HTTPError as exc:
-                if self._is_retryable_error(exc) and retry_attempt < self._max_retries:
-                    retry_attempt += 1
-                    delay = self._calculate_retry_delay(retry_attempt)
-                    logger.warning(
-                        "Discord network error on multipart %s: %s, retrying in %.1fs (attempt %d/%d)",
-                        path,
-                        type(exc).__name__,
-                        delay,
-                        retry_attempt,
-                        self._max_retries,
-                    )
-                    await asyncio.sleep(delay)
-                    continue
-                raise DiscordAPIError(
-                    f"Discord API network error for multipart {path}: {exc}"
-                ) from exc
 
-            if 200 <= response.status_code < 300:
-                if not response.content:
-                    return {}
-                try:
-                    return response.json()
-                except ValueError as exc:
-                    raise DiscordAPIError(
-                        f"Discord API returned non-JSON success response for multipart {path}"
-                    ) from exc
-            return {}
+                if 200 <= response.status_code < 300:
+                    if not response.content:
+                        return {}
+                    try:
+                        return response.json()
+                    except ValueError as exc:
+                        raise DiscordAPIError(
+                            f"Discord API returned non-JSON success response for multipart {path}"
+                        ) from exc
+                return {}
 
     async def edit_original_interaction_response(
         self,
@@ -486,9 +518,12 @@ class DiscordRestClient:
         retry_attempt = 0
         path = "/attachments/download"
 
-        while True:
-            try:
-                async with self._resilience_guard(path):
+        async with self._resilience_guard(
+            path,
+            should_record_failure=self._should_record_breaker_failure,
+        ):
+            while True:
+                try:
                     async with self._client.stream("GET", url) as response:
                         response.raise_for_status()
                         size = 0
@@ -504,39 +539,49 @@ class DiscordRestClient:
                                 )
                             chunks.append(chunk)
                         return b"".join(chunks)
-            except CircuitOpenError:
-                raise
-            except httpx.HTTPStatusError as exc:
-                status_code = exc.response.status_code
-                body_preview = (
-                    (exc.response.text or "").strip().replace("\n", " ")[:200]
-                )
-                if status_code == 429:
-                    retry_after_raw = exc.response.headers.get("Retry-After")
-                    if (
-                        retry_after_raw is not None
-                        and rate_limit_retries < self._max_retries
-                    ):
-                        rate_limit_retries += 1
-                        try:
-                            retry_after = max(float(retry_after_raw), 0.0)
-                        except ValueError:
-                            retry_after = 0.0
-                        await asyncio.sleep(retry_after)
+                except httpx.HTTPStatusError as exc:
+                    status_code = exc.response.status_code
+                    body_preview = (
+                        (exc.response.text or "").strip().replace("\n", " ")[:200]
+                    )
+                    if status_code == 429:
+                        retry_after_raw = exc.response.headers.get("Retry-After")
+                        if (
+                            retry_after_raw is not None
+                            and rate_limit_retries < self._max_retries
+                        ):
+                            rate_limit_retries += 1
+                            try:
+                                retry_after = max(float(retry_after_raw), 0.0)
+                            except ValueError:
+                                retry_after = 0.0
+                            await asyncio.sleep(retry_after)
+                            continue
+                        raise DiscordTransientError(
+                            "Discord attachment download rate limit exceeded: "
+                            f"url={url!r}"
+                        ) from exc
+                    if 500 <= status_code < 600 and retry_attempt < self._max_retries:
+                        retry_attempt += 1
+                        await asyncio.sleep(self._calculate_retry_delay(retry_attempt))
                         continue
-                if 500 <= status_code < 600 and retry_attempt < self._max_retries:
-                    retry_attempt += 1
-                    await asyncio.sleep(self._calculate_retry_delay(retry_attempt))
-                    continue
-                raise DiscordAPIError(
-                    "Discord attachment download failed: "
-                    f"status={status_code} url={url!r} body={body_preview!r}"
-                ) from exc
-            except httpx.HTTPError as exc:
-                if self._is_retryable_error(exc) and retry_attempt < self._max_retries:
-                    retry_attempt += 1
-                    await asyncio.sleep(self._calculate_retry_delay(retry_attempt))
-                    continue
-                raise DiscordAPIError(
-                    f"Discord attachment download network error for {url!r}: {exc}"
-                ) from exc
+                    if 400 <= status_code < 500:
+                        raise DiscordPermanentError(
+                            "Discord attachment download failed: "
+                            f"status={status_code} url={url!r} body={body_preview!r}"
+                        ) from exc
+                    raise DiscordTransientError(
+                        "Discord attachment download failed: "
+                        f"status={status_code} url={url!r} body={body_preview!r}"
+                    ) from exc
+                except httpx.HTTPError as exc:
+                    if (
+                        self._is_retryable_error(exc)
+                        and retry_attempt < self._max_retries
+                    ):
+                        retry_attempt += 1
+                        await asyncio.sleep(self._calculate_retry_delay(retry_attempt))
+                        continue
+                    raise DiscordTransientError(
+                        f"Discord attachment download network error for {url!r}: {exc}"
+                    ) from exc

--- a/tests/core/test_circuit_breaker.py
+++ b/tests/core/test_circuit_breaker.py
@@ -375,6 +375,53 @@ class TestExceptionPropagation:
             pass
         assert circuit_breaker._state.failure_count == 1
 
+    @pytest.mark.asyncio
+    async def test_filtered_exception_does_not_count_as_failure(self, circuit_breaker):
+        try:
+            async with circuit_breaker.call(
+                should_record_failure=lambda exc: isinstance(exc, ValueError)
+            ):
+                raise RuntimeError("ignore me")
+        except RuntimeError:
+            pass
+        assert circuit_breaker._state.failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_filtered_exception_can_still_count_as_failure(self, circuit_breaker):
+        try:
+            async with circuit_breaker.call(
+                should_record_failure=lambda exc: isinstance(exc, ValueError)
+            ):
+                raise ValueError("count me")
+        except ValueError:
+            pass
+        assert circuit_breaker._state.failure_count == 1
+
+    @pytest.mark.asyncio
+    async def test_filtered_exception_closes_half_open_after_successful_contact(self):
+        config = CircuitBreakerConfig(
+            failure_threshold=1,
+            timeout_seconds=5,
+            half_open_attempts=1,
+        )
+        cb = CircuitBreaker("test-service", config=config)
+        try:
+            async with cb.call():
+                raise RuntimeError("failure")
+        except RuntimeError:
+            pass
+        with pytest.raises(CircuitOpenError):
+            async with cb.call():
+                pass
+        cb._state.last_failure_time = datetime.utcnow() - timedelta(seconds=10)
+        with pytest.raises(RuntimeError):
+            async with cb.call(
+                should_record_failure=lambda exc: isinstance(exc, ValueError)
+            ):
+                raise RuntimeError("service responded with non-breaker error")
+        assert cb._state.state == CircuitState.CLOSED
+        assert cb._state.failure_count == 0
+
 
 class TestServiceName:
     def test_service_name_stored(self, circuit_breaker):

--- a/tests/integrations/discord/test_rest_client.py
+++ b/tests/integrations/discord/test_rest_client.py
@@ -5,9 +5,11 @@ from typing import Any
 import httpx
 import pytest
 
+from codex_autorunner.core.exceptions import CircuitOpenError
 from codex_autorunner.integrations.discord.errors import (
     DiscordAPIError,
     DiscordPermanentError,
+    DiscordTransientError,
 )
 from codex_autorunner.integrations.discord.rest import DiscordRestClient
 
@@ -170,6 +172,9 @@ async def test_auth_failures_raise_permanent_error_without_retry(
         await client.close()
 
     assert attempts["count"] == 1
+    breaker = client._circuit_breakers["gateway"]
+    assert breaker._state.failure_count == 0
+    assert breaker._state.state.value == "closed"
 
 
 @pytest.mark.anyio
@@ -203,3 +208,147 @@ async def test_download_attachment_streaming_enforces_max_size() -> None:
             )
     finally:
         await client.close()
+
+
+@pytest.mark.anyio
+async def test_interaction_4xx_does_not_open_shared_breaker() -> None:
+    attempts = {"count": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        return httpx.Response(
+            404,
+            json={"message": "Unknown interaction", "code": 10062},
+        )
+
+    client = DiscordRestClient(
+        bot_token="abc123",
+        base_url="https://discord.test/api/v10",
+        max_retries=0,
+    )
+    await _configure_mock_client(client, httpx.MockTransport(handler))
+    try:
+        for _ in range(6):
+            with pytest.raises(DiscordPermanentError, match="status=404"):
+                await client.create_interaction_response(
+                    interaction_id="123",
+                    interaction_token="token",
+                    payload={"type": 5},
+                )
+    finally:
+        await client.close()
+
+    assert attempts["count"] == 6
+    breaker = client._circuit_breakers["interactions"]
+    assert breaker._state.failure_count == 0
+    assert breaker._state.state.value == "closed"
+
+
+@pytest.mark.anyio
+async def test_rate_limit_exhaustion_does_not_open_shared_breaker() -> None:
+    attempts = {"count": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        return httpx.Response(429, headers={"Retry-After": "0"}, json={})
+
+    client = DiscordRestClient(
+        bot_token="abc123",
+        base_url="https://discord.test/api/v10",
+        max_retries=0,
+    )
+    await _configure_mock_client(client, httpx.MockTransport(handler))
+    try:
+        for _ in range(6):
+            with pytest.raises(DiscordTransientError, match="rate limit"):
+                await client.create_interaction_response(
+                    interaction_id="123",
+                    interaction_token="token",
+                    payload={"type": 5},
+                )
+    finally:
+        await client.close()
+
+    assert attempts["count"] == 6
+    breaker = client._circuit_breakers["interactions"]
+    assert breaker._state.failure_count == 0
+    assert breaker._state.state.value == "closed"
+
+
+@pytest.mark.anyio
+async def test_repeated_5xx_opens_shared_breaker() -> None:
+    attempts = {"count": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        return httpx.Response(500, json={"message": "server exploded"})
+
+    client = DiscordRestClient(
+        bot_token="abc123",
+        base_url="https://discord.test/api/v10",
+        max_retries=0,
+    )
+    await _configure_mock_client(client, httpx.MockTransport(handler))
+    try:
+        for _ in range(5):
+            with pytest.raises(DiscordTransientError, match="server error"):
+                await client.create_interaction_response(
+                    interaction_id="123",
+                    interaction_token="token",
+                    payload={"type": 5},
+                )
+        with pytest.raises(CircuitOpenError):
+            await client.create_interaction_response(
+                interaction_id="123",
+                interaction_token="token",
+                payload={"type": 5},
+            )
+    finally:
+        await client.close()
+
+    assert attempts["count"] == 5
+    breaker = client._circuit_breakers["interactions"]
+    assert breaker._state.failure_count == 5
+    assert breaker._state.state.value == "open"
+
+
+@pytest.mark.anyio
+async def test_retryable_5xx_that_recovers_does_not_open_shared_breaker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = {"count": 0}
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.discord.rest.asyncio.sleep", fake_sleep
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        if attempts["count"] <= 2:
+            return httpx.Response(500, json={"message": "temporary outage"})
+        return httpx.Response(204)
+
+    client = DiscordRestClient(
+        bot_token="abc123",
+        base_url="https://discord.test/api/v10",
+        max_retries=2,
+    )
+    await _configure_mock_client(client, httpx.MockTransport(handler))
+    try:
+        await client.create_interaction_response(
+            interaction_id="123",
+            interaction_token="token",
+            payload={"type": 5},
+        )
+    finally:
+        await client.close()
+
+    assert attempts["count"] == 3
+    assert len(sleeps) == 2
+    breaker = client._circuit_breakers["interactions"]
+    assert breaker._state.failure_count == 0
+    assert breaker._state.state.value == "closed"


### PR DESCRIPTION
## Summary
- make circuit breaker filtering operate on the final classified Discord request outcome instead of each intermediate retry attempt
- treat non-breaker Discord API responses as successful service contact so shared route breakers recover cleanly in half-open mode
- add regression coverage for 4xx, 429, recovered 5xx, auth failures, and true breaker-opening 5xx behavior

## Testing
- .venv/bin/python -m pytest tests/integrations/discord/test_rest_client.py tests/core/test_circuit_breaker.py tests/integrations/discord/test_service_routing.py
- .venv/bin/python -m ruff check src/codex_autorunner/core/circuit_breaker.py src/codex_autorunner/integrations/discord/rest.py tests/core/test_circuit_breaker.py tests/integrations/discord/test_rest_client.py
- pre-commit hook suite via git commit (black, ruff, mypy, frontend build/tests, pytest)

Closes #1049
