### PR TITLE
Fix Telegram typing scope for queued topic work

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/messages.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/messages.py
@@ -216,20 +216,13 @@ async def _enqueue_or_run_topic_work(
     placeholder_id: Optional[int],
     work: Any,
 ) -> None:
-    wrapped = work
-    wrap = getattr(handlers, "_wrap_placeholder_work", None)
-    if callable(wrap):
-        wrapped = wrap(
+    async def _run_wrapped() -> None:
+        await _run_placeholder_wrapped_work(
+            handlers,
             chat_id=chat_id,
             placeholder_id=placeholder_id,
             work=work,
         )
-
-    async def _run_wrapped() -> None:
-        if callable(wrapped):
-            await wrapped()
-            return
-        await wrapped
 
     async def _run_wrapped_with_typing() -> None:
         await _run_with_typing_indicator(
@@ -244,6 +237,27 @@ async def _enqueue_or_run_topic_work(
         enqueue(key, _run_wrapped_with_typing)
         return
     await _run_wrapped_with_typing()
+
+
+async def _run_placeholder_wrapped_work(
+    handlers: Any,
+    *,
+    chat_id: int,
+    placeholder_id: Optional[int],
+    work: Any,
+) -> None:
+    wrapped = work
+    wrap = getattr(handlers, "_wrap_placeholder_work", None)
+    if callable(wrap):
+        wrapped = wrap(
+            chat_id=chat_id,
+            placeholder_id=placeholder_id,
+            work=work,
+        )
+    if callable(wrapped):
+        await wrapped()
+        return
+    await wrapped
 
 
 async def handle_message(handlers: Any, message: TelegramMessage) -> None:
@@ -562,12 +576,14 @@ async def handle_message_inner(
             await handlers._handle_command(command, message, runtime)
 
         if spec and spec.allow_during_turn:
-            wrapped = handlers._wrap_placeholder_work(
-                chat_id=message.chat_id,
-                placeholder_id=placeholder_id,
-                work=work,
+            handlers._spawn_task(
+                _run_placeholder_wrapped_work(
+                    handlers,
+                    chat_id=message.chat_id,
+                    placeholder_id=placeholder_id,
+                    work=work,
+                )
             )
-            handlers._spawn_task(wrapped())
         else:
             await _enqueue_or_run_topic_work(
                 handlers,

--- a/tests/test_telegram_handlers_messages.py
+++ b/tests/test_telegram_handlers_messages.py
@@ -475,6 +475,7 @@ async def test_enqueue_or_run_topic_work_wraps_queued_work_with_typing() -> None
 async def test_enqueue_or_run_topic_work_handles_coroutine_wrappers() -> None:
     timeline: list[tuple[object, ...]] = []
     queued: list[object] = []
+    wrapper_calls = 0
 
     async def _work() -> None:
         timeline.append(("inner",))
@@ -491,7 +492,9 @@ async def test_enqueue_or_run_topic_work_handles_coroutine_wrappers() -> None:
         placeholder_id: Optional[int],
         work: object,
     ) -> object:
+        nonlocal wrapper_calls
         _ = (chat_id, placeholder_id)
+        wrapper_calls += 1
         return work()
 
     def _enqueue_topic_work(_key: str, wrapped: object) -> None:
@@ -515,12 +518,99 @@ async def test_enqueue_or_run_topic_work_handles_coroutine_wrappers() -> None:
 
     assert timeline == []
     assert len(queued) == 1
+    assert wrapper_calls == 0
     await queued[0]()
     assert timeline == [
         ("begin", 3, 4),
         ("inner",),
         ("end", 3, 4),
     ]
+    assert wrapper_calls == 1
+
+
+@pytest.mark.anyio
+async def test_handle_message_inner_allow_during_turn_handles_coroutine_wrapper() -> (
+    None
+):
+    message = _message(
+        text="/status",
+        entities=(bot_command_entity("/status"),),
+    )
+    command_calls: list[tuple[str, bool]] = []
+    spawned_tasks: list[asyncio.Task[None]] = []
+    wrapper_calls = 0
+    runtime = object()
+
+    class _RouterStub:
+        def runtime_for(self, _key: str) -> object:
+            return runtime
+
+    async def _resolve_topic_key(*_args, **_kwargs) -> str:
+        return "topic-key"
+
+    async def _handle_pending_review_commit(*_args, **_kwargs) -> bool:
+        return False
+
+    async def _handle_pending_review_custom(*_args, **_kwargs) -> bool:
+        return False
+
+    async def _dismiss_review_custom_prompt(*_args, **_kwargs) -> None:
+        return None
+
+    async def _handle_command(
+        command: object, _message: object, runtime_arg: object
+    ) -> None:
+        command_calls.append((getattr(command, "name", ""), runtime_arg is runtime))
+
+    def _spawn_task(coro: object) -> asyncio.Task[None]:
+        task = asyncio.create_task(coro)
+        spawned_tasks.append(task)
+        return task
+
+    def _wrap_placeholder_work(
+        *,
+        chat_id: int,
+        placeholder_id: Optional[int],
+        work: object,
+    ) -> object:
+        nonlocal wrapper_calls
+        _ = (chat_id, placeholder_id)
+        wrapper_calls += 1
+        return work()
+
+    handlers = types.SimpleNamespace(
+        _bot_username="CodexBot",
+        _router=_RouterStub(),
+        _config=types.SimpleNamespace(trigger_mode="all"),
+        _resume_options={},
+        _bind_options={},
+        _flow_run_options={},
+        _agent_options={},
+        _model_options={},
+        _model_pending={},
+        _review_commit_options={},
+        _review_commit_subjects={},
+        _pending_review_custom={},
+        _handle_pending_resume=lambda *_args, **_kwargs: False,
+        _handle_pending_bind=lambda *_args, **_kwargs: False,
+        _resolve_topic_key=_resolve_topic_key,
+        _handle_pending_review_commit=_handle_pending_review_commit,
+        _handle_pending_review_custom=_handle_pending_review_custom,
+        _dismiss_review_custom_prompt=_dismiss_review_custom_prompt,
+        _command_specs={
+            "status": make_command_spec("status", "status", allow_during_turn=True)
+        },
+        _handle_command=_handle_command,
+        _wrap_placeholder_work=_wrap_placeholder_work,
+        _spawn_task=_spawn_task,
+    )
+
+    await handle_message_inner(handlers, message, placeholder_id=42)
+    assert wrapper_calls == 0
+    assert spawned_tasks
+    await asyncio.gather(*spawned_tasks)
+    assert wrapper_calls == 1
+    assert command_calls == [("status", True)]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- ensure Telegram typing indicators are scoped to actual queued topic work execution in message handlers
- route edited-message and media-batch queue paths through the same typing-aware enqueue helper
- harden helper behavior for both callable wrappers and coroutine wrappers returned by placeholder hooks
- add focused tests for queued typing wrapping behavior

## Root cause
Issue #1053 came from typing scope being attached to outer message handling boundaries that can enqueue and return before the underlying queued work executes. In that shape, typing tasks can end before meaningful work begins.

This patch keeps existing outer typing entry points and also wraps the queued work path itself, so typing coverage includes the real execution boundary.

## Tests
- pre-commit/CI hook suite during commit (full run): `3253 passed, 1 skipped`
- targeted verification (also run locally before commit):
  - `.venv/bin/pytest tests/test_telegram_handlers_messages.py -q`
  - `.venv/bin/pytest tests/test_telegram_fast_ack.py -q`
  - `.venv/bin/pytest tests/test_telegram_bot_integration.py -k typing -q`

Closes #1053
