### PR TITLE
Recover stale running turns that block queued Telegram work

### DIFF
--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -22,7 +22,6 @@ from .time_utils import now_iso
 
 PMA_THREADS_DB_FILENAME = "threads.sqlite3"
 _STALE_RUNNING_RECOVERY_ERROR = "stale_running_execution_recovered"
-_TERMINAL_RUNTIME_STATUSES = frozenset({"completed", "interrupted", "failed"})
 
 
 class ManagedThreadAlreadyHasRunningTurnError(RuntimeError):
@@ -507,11 +506,11 @@ class PmaThreadStore:
     ) -> list[str]:
         running_rows = conn.execute(
             """
-            SELECT rowid AS execution_rowid, execution_id
+            SELECT execution_id
               FROM orch_thread_executions
              WHERE thread_target_id = ?
                AND status = 'running'
-             ORDER BY rowid ASC
+             ORDER BY created_at ASC, execution_id ASC
             """,
             (managed_thread_id,),
         ).fetchall()
@@ -526,11 +525,6 @@ class PmaThreadStore:
             """,
             (managed_thread_id,),
         ).fetchone()
-        runtime_status = (
-            str(thread_row["runtime_status"]).strip().lower()
-            if thread_row is not None and thread_row["runtime_status"] is not None
-            else ""
-        )
         status_turn_id = (
             str(thread_row["status_turn_id"]).strip()
             if thread_row is not None and thread_row["status_turn_id"] is not None
@@ -540,30 +534,7 @@ class PmaThreadStore:
         stale_execution_ids: list[str] = []
         for row in running_rows:
             execution_id = str(row["execution_id"])
-            execution_rowid = int(row["execution_rowid"])
-            newer_terminal = conn.execute(
-                """
-                SELECT 1
-                  FROM orch_thread_executions AS e
-             LEFT JOIN orch_queue_items AS q
-                    ON q.source_kind = 'thread_execution'
-                   AND q.source_key = e.execution_id
-                 WHERE e.thread_target_id = ?
-                   AND e.status IN ('ok', 'error', 'interrupted')
-                   AND e.rowid > ?
-                   AND (q.queue_item_id IS NULL OR q.claimed_at IS NOT NULL)
-                 LIMIT 1
-                """,
-                (managed_thread_id, execution_rowid),
-            ).fetchone()
-            if newer_terminal is not None:
-                stale_execution_ids.append(execution_id)
-                continue
-            if (
-                runtime_status in _TERMINAL_RUNTIME_STATUSES
-                and status_turn_id
-                and status_turn_id != execution_id
-            ):
+            if status_turn_id and status_turn_id != execution_id:
                 stale_execution_ids.append(execution_id)
         return stale_execution_ids
 

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -260,6 +260,44 @@ def test_claim_next_queued_turn_recovers_stale_running_execution(
     assert stale_after["finished_at"]
 
 
+def test_recovery_does_not_interrupt_legit_queued_turn_promoted_after_newer_terminal(
+    tmp_path: Path,
+) -> None:
+    store = PmaThreadStore(tmp_path / "hub")
+    thread = store.create_thread("codex", tmp_path / "workspace")
+
+    first_running = store.create_turn(thread["managed_thread_id"], prompt="A")
+    queued_turn = store.create_turn(
+        thread["managed_thread_id"],
+        prompt="B",
+        busy_policy="queue",
+        queue_payload={"request": {"message_text": "B"}},
+    )
+    assert queued_turn["status"] == "queued"
+    assert store.mark_turn_finished(first_running["managed_turn_id"], status="ok")
+
+    newer_running = store.create_turn(thread["managed_thread_id"], prompt="C")
+    assert newer_running["status"] == "running"
+    assert store.mark_turn_finished(newer_running["managed_turn_id"], status="ok")
+
+    claimed = store.claim_next_queued_turn(thread["managed_thread_id"])
+    assert claimed is not None
+    claimed_execution, _ = claimed
+    assert claimed_execution["managed_turn_id"] == queued_turn["managed_turn_id"]
+    assert claimed_execution["status"] == "running"
+
+    running_after = store.get_running_turn(thread["managed_thread_id"])
+    assert running_after is not None
+    assert running_after["managed_turn_id"] == queued_turn["managed_turn_id"]
+
+    queued_after = store.get_turn(
+        thread["managed_thread_id"], queued_turn["managed_turn_id"]
+    )
+    assert queued_after is not None
+    assert queued_after["status"] == "running"
+    assert queued_after["error"] is None
+
+
 def test_mark_turn_finished_does_not_override_interrupted_status(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add deterministic stale-running recovery in `PmaThreadStore` for orphaned `running` executions that conflict with newer thread terminal state
- make recovery safe for interrupt flows by only treating newer terminal executions as stale evidence when they were actually claimed for execution (or had no queue item)
- run stale recovery before running-turn admission/dequeue checks in `create_turn`, `get_running_turn`, and `claim_next_queued_turn`
- add regression tests for stale-running recovery during admission and queue dequeue promotion

## Testing
- `.venv/bin/pytest tests/test_pma_thread_store.py -q`
- `.venv/bin/pytest tests/test_telegram_pma_routing.py -k "test_pma_interrupt_uses_managed_thread_orchestration_for_text_turns or test_repo_interrupt_uses_orchestration_binding_for_text_turns" -q`
- commit hooks (full suite): `3263 passed, 1 skipped`

Closes #1060
