### PR TITLE
Fix stale managed-thread interrupt recovery

### DIFF
--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Mapping, Optional
 
 from ..car_context import CarContextProfile, normalize_car_context_profile
+from ..logging_utils import log_event
 from ..pma_thread_store import PmaThreadStore
 from .bindings import ActiveWorkSummary, OrchestrationBindingStore
 from .catalog import MappingAgentDefinitionCatalog, RuntimeAgentDescriptor
@@ -40,6 +42,7 @@ _MISSING_THREAD_MARKERS = (
     "thread not found",
     "no rollout found for thread id",
 )
+logger = logging.getLogger(__name__)
 
 
 class BusyInterruptFailedError(RuntimeError):
@@ -883,6 +886,38 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
             thread_target_id, execution.execution_id
         )
 
+    def _recover_lost_backend_execution(
+        self,
+        *,
+        thread_target_id: str,
+        execution: ExecutionRecord,
+        backend_thread_id: Optional[str],
+        error_message: str,
+        reason: str,
+    ) -> ExecutionRecord:
+        recovered = self.thread_store.record_execution_result(
+            thread_target_id,
+            execution.execution_id,
+            status="error",
+            assistant_text="",
+            error=error_message,
+            backend_turn_id=execution.backend_id,
+            transcript_turn_id=None,
+        )
+        self.thread_store.set_thread_backend_id(thread_target_id, None)
+        log_event(
+            logger,
+            logging.INFO,
+            "orchestration.thread.recovered_lost_backend",
+            thread_target_id=thread_target_id,
+            execution_id=execution.execution_id,
+            backend_thread_id=backend_thread_id,
+            backend_turn_id=execution.backend_id,
+            reason=reason,
+            error=error_message,
+        )
+        return recovered
+
     async def stop_thread(self, thread_target_id: str) -> ThreadStopOutcome:
         thread = self.get_thread_target(thread_target_id)
         if thread is None:
@@ -898,16 +933,13 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
 
         backend_thread_id = thread.backend_thread_id
         if not backend_thread_id:
-            recovered = self.thread_store.record_execution_result(
-                thread_target_id,
-                execution.execution_id,
-                status="error",
-                assistant_text="",
-                error=MISSING_BACKEND_THREAD_ERROR,
-                backend_turn_id=execution.backend_id,
-                transcript_turn_id=None,
+            recovered = self._recover_lost_backend_execution(
+                thread_target_id=thread_target_id,
+                execution=execution,
+                backend_thread_id=None,
+                error_message=MISSING_BACKEND_THREAD_ERROR,
+                reason="missing_backend_thread_id",
             )
-            self.thread_store.set_thread_backend_id(thread_target_id, None)
             return ThreadStopOutcome(
                 thread_target_id=thread_target_id,
                 cancelled_queued=cancelled_queued,
@@ -920,16 +952,23 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
         except Exception as exc:
             if not _is_missing_thread_error(exc):
                 raise
-            recovered = self.thread_store.record_execution_result(
-                thread_target_id,
-                execution.execution_id,
-                status="error",
-                assistant_text="",
-                error=LOST_BACKEND_THREAD_ERROR,
+            log_event(
+                logger,
+                logging.INFO,
+                "orchestration.thread.interrupt_missing_backend",
+                thread_target_id=thread_target_id,
+                execution_id=execution.execution_id,
+                backend_thread_id=backend_thread_id,
                 backend_turn_id=execution.backend_id,
-                transcript_turn_id=None,
+                exc=exc,
             )
-            self.thread_store.set_thread_backend_id(thread_target_id, None)
+            recovered = self._recover_lost_backend_execution(
+                thread_target_id=thread_target_id,
+                execution=execution,
+                backend_thread_id=backend_thread_id,
+                error_message=LOST_BACKEND_THREAD_ERROR,
+                reason="interrupt_thread_not_found",
+            )
             return ThreadStopOutcome(
                 thread_target_id=thread_target_id,
                 cancelled_queued=cancelled_queued,

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -166,6 +166,7 @@ from ...tickets.files import (
     read_ticket_frontmatter,
     safe_relpath,
 )
+from ...tickets.frontmatter import parse_markdown_frontmatter
 from ...tickets.outbox import resolve_outbox_paths
 from ...voice import VoiceConfig, VoiceService, VoiceServiceError
 from ..chat.review_commits import _parse_review_commit_log
@@ -1719,6 +1720,7 @@ class DiscordBotService:
     def _is_user_ticket_pause(
         self, workspace_root: Path, record: FlowRunRecord
     ) -> bool:
+        resolved_workspace_root = workspace_root.resolve()
         state = getattr(record, "state", None)
         if not isinstance(state, dict):
             return False
@@ -1730,16 +1732,26 @@ class DiscordBotService:
         current_ticket = engine.get("current_ticket")
         if not isinstance(current_ticket, str) or not current_ticket.strip():
             return False
-        ticket_path = (workspace_root / current_ticket).resolve()
+        ticket_path = (resolved_workspace_root / current_ticket).resolve()
         if not ticket_path.is_file() or not is_within(
-            root=workspace_root, target=ticket_path
+            root=resolved_workspace_root,
+            target=ticket_path,
         ):
             return False
         ticket_doc, errors = read_ticket(ticket_path)
-        if errors or ticket_doc is None:
+        if not errors and ticket_doc is not None:
+            return ticket_doc.frontmatter.agent == "user" and not bool(
+                ticket_doc.frontmatter.done
+            )
+        try:
+            raw = ticket_path.read_text(encoding="utf-8")
+        except OSError:
             return False
-        return ticket_doc.frontmatter.agent == "user" and not bool(
-            ticket_doc.frontmatter.done
+        data, _body = parse_markdown_frontmatter(raw)
+        if not isinstance(data, dict):
+            return False
+        return str(data.get("agent") or "").strip().lower() == "user" and (
+            data.get("done") is False
         )
 
     async def _maybe_inject_github_context(

--- a/src/codex_autorunner/integrations/telegram/notifications.py
+++ b/src/codex_autorunner/integrations/telegram/notifications.py
@@ -38,9 +38,150 @@ from .helpers import (
 from .progress_stream import TurnProgressTracker, render_progress_text
 
 _ACTIVE_PROGRESS_LABELS = {"working", "queued", "running", "review"}
+_DEGRADED_PROGRESS_MARKERS = (
+    "reconnecting",
+    "stalled",
+    "stall timeout",
+    "session idle",
+)
+_DEGRADED_PROGRESS_MIN_EDIT_INTERVAL_SECONDS = 30.0
+_PROGRESS_EDIT_FAILURE_INITIAL_BACKOFF_SECONDS = 15.0
+_PROGRESS_EDIT_FAILURE_MAX_BACKOFF_SECONDS = 120.0
 
 
 class TelegramNotificationHandlers:
+    def _progress_tracker_is_degraded(
+        self,
+        turn_key: tuple[str, str],
+        tracker: Any,
+    ) -> bool:
+        texts: list[str] = []
+        for candidate in (
+            getattr(tracker, "transient_action", None),
+            getattr(tracker, "last_tool_trace", None),
+            getattr(tracker, "last_thinking_trace", None),
+        ):
+            text = getattr(candidate, "text", None)
+            if isinstance(text, str) and text.strip():
+                texts.append(text)
+        latest_output = getattr(tracker, "latest_output_text", None)
+        if callable(latest_output):
+            value = latest_output()
+            if isinstance(value, str) and value.strip():
+                texts.append(value)
+        rendered = self._turn_progress_rendered.get(turn_key)
+        if isinstance(rendered, str) and rendered.strip():
+            texts.append(rendered)
+        if not texts:
+            return False
+        normalized = " ".join(" ".join(texts).lower().split())
+        return any(marker in normalized for marker in _DEGRADED_PROGRESS_MARKERS)
+
+    def _progress_edit_min_interval(
+        self,
+        turn_key: tuple[str, str],
+        tracker: Any,
+    ) -> float:
+        min_interval = self._config.progress_stream.min_edit_interval_seconds
+        if TelegramNotificationHandlers._progress_tracker_is_degraded(
+            self, turn_key, tracker
+        ):
+            min_interval = max(
+                min_interval,
+                _DEGRADED_PROGRESS_MIN_EDIT_INTERVAL_SECONDS,
+            )
+        blocked_until = getattr(self, "_turn_progress_backoff_until", {}).get(
+            turn_key, 0.0
+        )
+        now = time.monotonic()
+        if blocked_until > now:
+            min_interval = max(min_interval, blocked_until - now)
+        return min_interval
+
+    def _record_progress_edit_suppressed(self, turn_key: tuple[str, str]) -> None:
+        suppressed = getattr(self, "_turn_progress_suppressed_counts", None)
+        if not isinstance(suppressed, dict):
+            suppressed = {}
+            self._turn_progress_suppressed_counts = suppressed
+        suppressed[turn_key] = int(suppressed.get(turn_key, 0)) + 1
+
+    def _record_progress_edit_failure(
+        self,
+        turn_key: tuple[str, str],
+        *,
+        ctx: Optional[Any],
+        now: float,
+        degraded: bool,
+    ) -> None:
+        failure_streaks = getattr(self, "_turn_progress_failure_streaks", None)
+        if not isinstance(failure_streaks, dict):
+            failure_streaks = {}
+            self._turn_progress_failure_streaks = failure_streaks
+        streak = int(failure_streaks.get(turn_key, 0)) + 1
+        failure_streaks[turn_key] = streak
+
+        backoff_until = getattr(self, "_turn_progress_backoff_until", None)
+        if not isinstance(backoff_until, dict):
+            backoff_until = {}
+            self._turn_progress_backoff_until = backoff_until
+        base_delay = max(
+            self._config.progress_stream.min_edit_interval_seconds,
+            _PROGRESS_EDIT_FAILURE_INITIAL_BACKOFF_SECONDS,
+        )
+        if degraded:
+            base_delay = max(
+                base_delay,
+                _DEGRADED_PROGRESS_MIN_EDIT_INTERVAL_SECONDS,
+            )
+        delay = min(
+            base_delay * (2 ** (streak - 1)),
+            _PROGRESS_EDIT_FAILURE_MAX_BACKOFF_SECONDS,
+        )
+        backoff_until[turn_key] = now + delay
+        log_event(
+            self._logger,
+            logging.INFO,
+            "telegram.progress.edit_backoff",
+            chat_id=getattr(ctx, "chat_id", None),
+            thread_id=getattr(ctx, "thread_id", None),
+            topic_key=getattr(ctx, "topic_key", None),
+            turn_id=turn_key[0],
+            backend_thread_id=turn_key[1],
+            delay_seconds=round(delay, 3),
+            failure_streak=streak,
+            degraded=degraded,
+        )
+
+    def _clear_progress_edit_failure_state(
+        self,
+        turn_key: tuple[str, str],
+        *,
+        log_recovery: bool = True,
+    ) -> None:
+        backoff_until = getattr(self, "_turn_progress_backoff_until", None)
+        if isinstance(backoff_until, dict):
+            backoff_until.pop(turn_key, None)
+        failure_streaks = getattr(self, "_turn_progress_failure_streaks", None)
+        if isinstance(failure_streaks, dict):
+            streak = int(failure_streaks.pop(turn_key, 0))
+        else:
+            streak = 0
+        suppressed = getattr(self, "_turn_progress_suppressed_counts", None)
+        if isinstance(suppressed, dict):
+            suppressed_count = int(suppressed.pop(turn_key, 0))
+        else:
+            suppressed_count = 0
+        if log_recovery and (streak > 0 or suppressed_count > 0):
+            log_event(
+                self._logger,
+                logging.INFO,
+                "telegram.progress.edit_recovered",
+                turn_id=turn_key[0],
+                backend_thread_id=turn_key[1],
+                failure_streak=streak,
+                suppressed_edits=suppressed_count,
+            )
+
     def _render_turn_progress_summary(self, turn_key: tuple[str, str]) -> str:
         tracker = self._turn_progress_trackers.get(turn_key)
         if tracker is None:
@@ -350,6 +491,11 @@ class TelegramNotificationHandlers:
         self._turn_progress_rendered.pop(turn_key, None)
         self._turn_progress_updated_at.pop(turn_key, None)
         self._turn_progress_locks.pop(turn_key, None)
+        TelegramNotificationHandlers._clear_progress_edit_failure_state(
+            self,
+            turn_key,
+            log_recovery=False,
+        )
         pending_context_usage: dict[tuple[str, str], int] = getattr(
             self, "_pending_context_usage", {}
         )
@@ -618,8 +764,26 @@ class TelegramNotificationHandlers:
                 return
             if tracker.finalized:
                 return
-            min_interval = self._config.progress_stream.min_edit_interval_seconds
             now = time.monotonic()
+            blocked_until = getattr(self, "_turn_progress_backoff_until", {}).get(
+                turn_key, 0.0
+            )
+            if blocked_until > now:
+                TelegramNotificationHandlers._record_progress_edit_suppressed(
+                    self,
+                    turn_key,
+                )
+                if turn_key in self._turn_progress_tasks:
+                    return
+                delay = max(blocked_until - now, 0.0)
+                task = self._spawn_task(self._delayed_progress_edit(turn_key, delay))
+                self._turn_progress_tasks[turn_key] = task
+                return
+            min_interval = TelegramNotificationHandlers._progress_edit_min_interval(
+                self,
+                turn_key,
+                tracker,
+            )
             last_updated = self._turn_progress_updated_at.get(turn_key, 0.0)
             if (now - last_updated) >= min_interval:
                 await self._emit_progress_edit(turn_key, ctx=ctx, now=now)
@@ -649,10 +813,7 @@ class TelegramNotificationHandlers:
                 ctx = self._turn_contexts.get(turn_key)
                 if ctx is None or ctx.placeholder_message_id is None:
                     continue
-                now = time.monotonic()
-                last_updated = self._turn_progress_updated_at.get(turn_key, 0.0)
-                if (now - last_updated) >= PROGRESS_HEARTBEAT_INTERVAL_SECONDS:
-                    await self._emit_progress_edit(turn_key, ctx=ctx, now=now)
+                await self._schedule_progress_edit(turn_key)
         finally:
             self._turn_progress_heartbeat_tasks.pop(turn_key, None)
 
@@ -674,6 +835,20 @@ class TelegramNotificationHandlers:
             return
         if now is None:
             now = time.monotonic()
+        blocked_until = getattr(self, "_turn_progress_backoff_until", {}).get(
+            turn_key, 0.0
+        )
+        if not force and blocked_until > now:
+            TelegramNotificationHandlers._record_progress_edit_suppressed(
+                self,
+                turn_key,
+            )
+            return
+        degraded = TelegramNotificationHandlers._progress_tracker_is_degraded(
+            self,
+            turn_key,
+            tracker,
+        )
         rendered = render_progress_text(
             tracker,
             max_length=TELEGRAM_MAX_MESSAGE_LENGTH,
@@ -688,16 +863,29 @@ class TelegramNotificationHandlers:
                 reply_markup = self._interrupt_keyboard()
             except Exception:
                 reply_markup = None
-        ok = await self._edit_message_text(
+        edit_result = await self._edit_message_text(
             ctx.chat_id,
             ctx.placeholder_message_id,
             rendered,
             reply_markup=reply_markup,
         )
+        ok = edit_result is not False
         if ok:
+            TelegramNotificationHandlers._clear_progress_edit_failure_state(
+                self,
+                turn_key,
+            )
             self._turn_progress_rendered[turn_key] = rendered
             self._turn_progress_updated_at[turn_key] = now
             self._touch_cache_timestamp("progress_trackers", turn_key)
+            return
+        TelegramNotificationHandlers._record_progress_edit_failure(
+            self,
+            turn_key,
+            ctx=ctx,
+            now=now,
+            degraded=degraded,
+        )
 
 
 def _extract_command_text(

--- a/src/codex_autorunner/integrations/telegram/service.py
+++ b/src/codex_autorunner/integrations/telegram/service.py
@@ -327,6 +327,9 @@ class TelegramBotService(
         self._turn_progress_final_rendered: dict[TurnKey, str] = {}
         self._turn_progress_final_summary: dict[TurnKey, str] = {}
         self._turn_progress_updated_at: dict[TurnKey, float] = {}
+        self._turn_progress_backoff_until: dict[TurnKey, float] = {}
+        self._turn_progress_failure_streaks: dict[TurnKey, int] = {}
+        self._turn_progress_suppressed_counts: dict[TurnKey, int] = {}
         self._turn_progress_tasks: dict[TurnKey, asyncio.Task[None]] = {}
         self._turn_progress_heartbeat_tasks: dict[TurnKey, asyncio.Task[None]] = {}
         self._turn_progress_locks: dict[TurnKey, asyncio.Lock] = {}
@@ -868,6 +871,9 @@ class TelegramBotService(
                 self._turn_progress_final_rendered.pop(key, None)
                 self._turn_progress_final_summary.pop(key, None)
                 self._turn_progress_updated_at.pop(key, None)
+                self._turn_progress_backoff_until.pop(key, None)
+                self._turn_progress_failure_streaks.pop(key, None)
+                self._turn_progress_suppressed_counts.pop(key, None)
                 task = self._turn_progress_tasks.pop(key, None)
                 if task and not task.done():
                     task.cancel()

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -43,7 +43,11 @@ from .....core.orchestration.runtime_threads import (
     begin_next_queued_runtime_thread_execution,
     begin_runtime_thread_execution,
 )
-from .....core.orchestration.service import BusyInterruptFailedError
+from .....core.orchestration.service import (
+    LOST_BACKEND_THREAD_ERROR,
+    MISSING_BACKEND_THREAD_ERROR,
+    BusyInterruptFailedError,
+)
 from .....core.orchestration.turn_timeline import persist_turn_timeline
 from .....core.pma_context import format_pma_discoverability_preamble
 from .....core.pma_thread_store import (
@@ -203,6 +207,178 @@ def _interrupt_failure_payload(
         "assistant_text": "",
         "error": detail,
         **delivery_payload,
+    }
+
+
+def _interrupt_recovered_lost_backend_payload(
+    *,
+    managed_thread_id: str,
+    managed_turn_id: str,
+    updated_turn: Optional[dict[str, Any]],
+    backend_error: str,
+    backend_interrupt_attempted: bool,
+) -> dict[str, Any]:
+    return {
+        "status": "ok",
+        "interrupt_state": "recovered_lost_backend",
+        "managed_thread_id": managed_thread_id,
+        "managed_turn_id": managed_turn_id,
+        "turn": updated_turn,
+        "backend_error": backend_error,
+        "detail": "Recovered stale managed-thread state after backend thread was lost.",
+        "backend_interrupt_attempted": backend_interrupt_attempted,
+        "recovered_lost_backend": True,
+    }
+
+
+async def _interrupt_managed_thread_via_orchestration(
+    *,
+    managed_thread_id: str,
+    request: Request,
+) -> dict[str, Any]:
+    from .....agents.registry import get_available_agents
+    from .....core.orchestration.catalog import map_agent_capabilities
+
+    hub_root = request.app.state.config.root
+    store = PmaThreadStore(hub_root)
+    thread = store.get_thread(managed_thread_id)
+    if thread is None:
+        raise HTTPException(status_code=404, detail="Managed thread not found")
+
+    agent = str(thread.get("agent") or "").strip().lower()
+    if agent:
+        available = get_available_agents(request.app.state)
+        descriptor = available.get(agent)
+        if descriptor is not None:
+            capabilities = map_agent_capabilities(descriptor.capabilities)
+            if "interrupt" not in capabilities:
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"Agent '{agent}' does not support interrupt (missing capability: interrupt)",
+                )
+
+    running_turn = store.get_running_turn(managed_thread_id)
+    if running_turn is None:
+        raise HTTPException(
+            status_code=409, detail="Managed thread has no running turn"
+        )
+    managed_turn_id = str(running_turn.get("managed_turn_id") or "")
+    if not managed_turn_id:
+        raise HTTPException(status_code=500, detail="Running turn is missing id")
+
+    backend_thread_id = normalize_optional_text(thread.get("backend_thread_id"))
+    backend_turn_id = normalize_optional_text(running_turn.get("backend_turn_id"))
+    backend_error: Optional[str] = None
+    backend_interrupt_attempted = bool(backend_thread_id)
+    service = _build_managed_thread_orchestration_service(
+        request,
+        thread_store=store,
+    )
+    try:
+        stop_outcome = await service.stop_thread(managed_thread_id)
+    except Exception:
+        logger.exception(
+            "Failed to interrupt managed-thread turn via orchestration service (managed_thread_id=%s, managed_turn_id=%s)",
+            managed_thread_id,
+            managed_turn_id,
+        )
+        interrupted_execution = service.get_execution(
+            managed_thread_id,
+            managed_turn_id,
+        )
+        stop_outcome = None
+        if interrupted_execution is None or interrupted_execution.status == "running":
+            backend_error = MANAGED_THREAD_PUBLIC_INTERRUPT_ERROR
+    else:
+        interrupted_execution = stop_outcome.execution
+
+    if stop_outcome and stop_outcome.interrupted_active:
+        await notify_managed_thread_terminal_transition(
+            request,
+            thread=thread,
+            managed_thread_id=managed_thread_id,
+            managed_turn_id=managed_turn_id,
+            to_state="interrupted",
+            reason=backend_error or "managed_turn_interrupted",
+        )
+        store.append_action(
+            "managed_thread_interrupt",
+            managed_thread_id=managed_thread_id,
+            payload_json=json.dumps(
+                {
+                    "agent": agent,
+                    "managed_turn_id": managed_turn_id,
+                    "backend_thread_id": backend_thread_id,
+                    "backend_turn_id": backend_turn_id,
+                    "backend_interrupt_attempted": backend_interrupt_attempted,
+                    "backend_error": backend_error,
+                },
+                ensure_ascii=True,
+            ),
+        )
+        updated_turn = store.get_turn(managed_thread_id, managed_turn_id)
+        return {
+            "status": "ok",
+            "interrupt_state": "succeeded",
+            "managed_thread_id": managed_thread_id,
+            "managed_turn_id": managed_turn_id,
+            "turn": updated_turn,
+            "backend_error": backend_error,
+        }
+
+    if stop_outcome and stop_outcome.recovered_lost_backend:
+        resolved_backend_error = (
+            interrupted_execution.error
+            if interrupted_execution is not None
+            and interrupted_execution.error
+            in {
+                LOST_BACKEND_THREAD_ERROR,
+                MISSING_BACKEND_THREAD_ERROR,
+            }
+            else backend_error or LOST_BACKEND_THREAD_ERROR
+        )
+        await notify_managed_thread_terminal_transition(
+            request,
+            thread=thread,
+            managed_thread_id=managed_thread_id,
+            managed_turn_id=managed_turn_id,
+            to_state="failed",
+            reason=resolved_backend_error,
+        )
+        store.append_action(
+            "managed_thread_interrupt",
+            managed_thread_id=managed_thread_id,
+            payload_json=json.dumps(
+                {
+                    "agent": agent,
+                    "managed_turn_id": managed_turn_id,
+                    "backend_thread_id": backend_thread_id,
+                    "backend_turn_id": backend_turn_id,
+                    "backend_interrupt_attempted": backend_interrupt_attempted,
+                    "backend_error": resolved_backend_error,
+                    "recovered_lost_backend": True,
+                },
+                ensure_ascii=True,
+            ),
+        )
+        updated_turn = store.get_turn(managed_thread_id, managed_turn_id)
+        return _interrupt_recovered_lost_backend_payload(
+            managed_thread_id=managed_thread_id,
+            managed_turn_id=managed_turn_id,
+            updated_turn=updated_turn,
+            backend_error=resolved_backend_error,
+            backend_interrupt_attempted=backend_interrupt_attempted,
+        )
+
+    updated_turn = store.get_turn(managed_thread_id, managed_turn_id)
+    return {
+        "status": "error",
+        "interrupt_state": "failed",
+        "managed_thread_id": managed_thread_id,
+        "managed_turn_id": managed_turn_id,
+        "turn": updated_turn,
+        "backend_error": backend_error or MANAGED_THREAD_PUBLIC_INTERRUPT_ERROR,
+        "detail": MANAGED_THREAD_INTERRUPT_FAILED_DETAIL,
     }
 
 
@@ -1274,110 +1450,10 @@ def build_managed_thread_runtime_routes(
         managed_thread_id: str,
         request: Request,
     ) -> dict[str, Any]:
-        from .....agents.registry import get_available_agents
-        from .....core.orchestration.catalog import map_agent_capabilities
-
-        hub_root = request.app.state.config.root
-        store = PmaThreadStore(hub_root)
-        thread = store.get_thread(managed_thread_id)
-        if thread is None:
-            raise HTTPException(status_code=404, detail="Managed thread not found")
-
-        agent = str(thread.get("agent") or "").strip().lower()
-        if agent:
-            available = get_available_agents(request.app.state)
-            descriptor = available.get(agent)
-            if descriptor is not None:
-                capabilities = map_agent_capabilities(descriptor.capabilities)
-                if "interrupt" not in capabilities:
-                    raise HTTPException(
-                        status_code=403,
-                        detail=f"Agent '{agent}' does not support interrupt (missing capability: interrupt)",
-                    )
-
-        running_turn = store.get_running_turn(managed_thread_id)
-        if running_turn is None:
-            raise HTTPException(
-                status_code=409, detail="Managed thread has no running turn"
-            )
-        managed_turn_id = str(running_turn.get("managed_turn_id") or "")
-        if not managed_turn_id:
-            raise HTTPException(status_code=500, detail="Running turn is missing id")
-
-        agent = str(thread.get("agent") or "").strip().lower()
-        backend_thread_id = normalize_optional_text(thread.get("backend_thread_id"))
-        backend_turn_id = normalize_optional_text(running_turn.get("backend_turn_id"))
-        backend_error: Optional[str] = None
-        backend_interrupt_attempted = True
-        service = _build_managed_thread_orchestration_service(
-            request,
-            thread_store=store,
+        return await _interrupt_managed_thread_via_orchestration(
+            managed_thread_id=managed_thread_id,
+            request=request,
         )
-        try:
-            interrupted_execution = await service.interrupt_thread(managed_thread_id)
-        except Exception:
-            logger.exception(
-                "Failed to interrupt managed-thread turn via orchestration service (managed_thread_id=%s, managed_turn_id=%s)",
-                managed_thread_id,
-                managed_turn_id,
-            )
-            interrupted_execution = service.get_execution(
-                managed_thread_id,
-                managed_turn_id,
-            )
-            if (
-                interrupted_execution is None
-                or interrupted_execution.status == "running"
-            ):
-                backend_error = MANAGED_THREAD_PUBLIC_INTERRUPT_ERROR
-
-        interrupted = interrupted_execution is not None and (
-            interrupted_execution.status == "interrupted"
-        )
-        if interrupted:
-            await notify_managed_thread_terminal_transition(
-                request,
-                thread=thread,
-                managed_thread_id=managed_thread_id,
-                managed_turn_id=managed_turn_id,
-                to_state="interrupted",
-                reason=backend_error or "managed_turn_interrupted",
-            )
-            store.append_action(
-                "managed_thread_interrupt",
-                managed_thread_id=managed_thread_id,
-                payload_json=json.dumps(
-                    {
-                        "agent": agent,
-                        "managed_turn_id": managed_turn_id,
-                        "backend_thread_id": backend_thread_id,
-                        "backend_turn_id": backend_turn_id,
-                        "backend_interrupt_attempted": backend_interrupt_attempted,
-                        "backend_error": backend_error,
-                    },
-                    ensure_ascii=True,
-                ),
-            )
-            updated_turn = store.get_turn(managed_thread_id, managed_turn_id)
-            return {
-                "status": "ok",
-                "interrupt_state": "succeeded",
-                "managed_thread_id": managed_thread_id,
-                "managed_turn_id": managed_turn_id,
-                "turn": updated_turn,
-                "backend_error": backend_error,
-            }
-
-        updated_turn = store.get_turn(managed_thread_id, managed_turn_id)
-        return {
-            "status": "error",
-            "interrupt_state": "failed",
-            "managed_thread_id": managed_thread_id,
-            "managed_turn_id": managed_turn_id,
-            "turn": updated_turn,
-            "backend_error": backend_error or MANAGED_THREAD_PUBLIC_INTERRUPT_ERROR,
-            "detail": MANAGED_THREAD_INTERRUPT_FAILED_DETAIL,
-        }
 
 
 __all__ = [

--- a/tests/test_pma_managed_threads_interrupt.py
+++ b/tests/test_pma_managed_threads_interrupt.py
@@ -309,3 +309,59 @@ def test_interrupt_managed_thread_skips_failed_side_effects_when_turn_already_fi
     assert updated_turn is not None
     assert updated_turn["status"] == "ok"
     assert updated_turn["assistant_text"] == "completed before interrupt persisted"
+
+
+@pytest.mark.slow
+def test_interrupt_managed_thread_recovers_stale_backend_thread(hub_env) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeClient:
+        async def turn_interrupt(
+            self, turn_id: str, *, thread_id: str | None = None
+        ) -> None:
+            _ = turn_id, thread_id
+            raise RuntimeError("thread not found: backend-thread-1")
+
+    class FakeSupervisor:
+        async def get_client(self, hub_root: Path):
+            _ = hub_root
+            return FakeClient()
+
+    app.state.app_server_supervisor = FakeSupervisor()
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                "resource_kind": "repo",
+                "resource_id": hub_env.repo_id,
+            },
+        )
+        assert create_resp.status_code == 200
+        managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+    store = PmaThreadStore(hub_env.hub_root)
+    turn = store.create_turn(managed_thread_id, prompt="running")
+    managed_turn_id = turn["managed_turn_id"]
+    store.set_thread_backend_id(managed_thread_id, "backend-thread-1")
+    store.set_turn_backend_turn_id(managed_turn_id, "backend-turn-1")
+
+    with TestClient(app) as client:
+        interrupt_resp = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/interrupt",
+        )
+
+    assert interrupt_resp.status_code == 200
+    payload = interrupt_resp.json()
+    assert payload["status"] == "ok"
+    assert payload["interrupt_state"] == "recovered_lost_backend"
+    assert payload["backend_error"] == "Backend thread lost after restart"
+    updated_turn = store.get_turn(managed_thread_id, managed_turn_id)
+    assert updated_turn is not None
+    assert updated_turn["status"] == "error"
+    assert updated_turn["error"] == "Backend thread lost after restart"
+    updated_thread = store.get_thread(managed_thread_id)
+    assert updated_thread is not None
+    assert updated_thread["backend_thread_id"] is None

--- a/tests/test_telegram_flow_status.py
+++ b/tests/test_telegram_flow_status.py
@@ -194,14 +194,31 @@ class _ProgressCadenceHarness(TelegramNotificationHandlers):
                 max_output_chars=300,
             )
         )
+        self._logger = logging.getLogger("test.telegram.progress_cadence")
         self._turn_progress_locks: dict[tuple[str, str], Any] = {}
         self._turn_progress_trackers: dict[tuple[str, str], Any] = {
-            ("turn-1", "thread-1"): SimpleNamespace(finalized=False)
+            ("turn-1", "thread-1"): TurnProgressTracker(
+                started_at=0.0,
+                agent="codex",
+                model="mock-model",
+                label="working",
+                max_actions=4,
+                max_output_chars=300,
+            )
         }
+        self._turn_progress_rendered: dict[tuple[str, str], str] = {}
         self._turn_progress_updated_at: dict[tuple[str, str], float] = {}
+        self._turn_progress_backoff_until: dict[tuple[str, str], float] = {}
+        self._turn_progress_failure_streaks: dict[tuple[str, str], int] = {}
+        self._turn_progress_suppressed_counts: dict[tuple[str, str], int] = {}
         self._turn_progress_tasks: dict[tuple[str, str], Any] = {}
         self._turn_contexts: dict[tuple[str, str], Any] = {
-            ("turn-1", "thread-1"): SimpleNamespace(placeholder_message_id=100)
+            ("turn-1", "thread-1"): SimpleNamespace(
+                chat_id=1,
+                thread_id=2,
+                topic_key="topic-1",
+                placeholder_message_id=100,
+            )
         }
         self.emitted: list[tuple[tuple[str, str], float]] = []
         self.delayed: list[tuple[tuple[str, str], float]] = []
@@ -240,6 +257,9 @@ class _StartTurnProgressHarness(TelegramNotificationHandlers):
         self._turn_progress_trackers: dict[tuple[str, str], Any] = {}
         self._turn_progress_rendered: dict[tuple[str, str], str] = {}
         self._turn_progress_updated_at: dict[tuple[str, str], float] = {}
+        self._turn_progress_backoff_until: dict[tuple[str, str], float] = {}
+        self._turn_progress_failure_streaks: dict[tuple[str, str], int] = {}
+        self._turn_progress_suppressed_counts: dict[tuple[str, str], int] = {}
         self._turn_progress_tasks: dict[tuple[str, str], Any] = {}
         self._turn_progress_heartbeat_tasks: dict[tuple[str, str], Any] = {}
         self._turn_progress_locks: dict[tuple[str, str], Any] = {}
@@ -287,6 +307,7 @@ class _TurnCompletionProgressHarness(TelegramNotificationHandlers):
             )
         )
         self._turn_key = ("turn-1", "thread-1")
+        self._logger = logging.getLogger("test.telegram.turn_completion")
         self._turn_progress_trackers: dict[tuple[str, str], Any] = {
             self._turn_key: TurnProgressTracker(
                 started_at=0.0,
@@ -297,6 +318,9 @@ class _TurnCompletionProgressHarness(TelegramNotificationHandlers):
                 max_output_chars=400,
             )
         }
+        self._turn_progress_backoff_until: dict[tuple[str, str], float] = {}
+        self._turn_progress_failure_streaks: dict[tuple[str, str], int] = {}
+        self._turn_progress_suppressed_counts: dict[tuple[str, str], int] = {}
         self._turn_contexts: dict[tuple[str, str], Any] = {self._turn_key: object()}
         self.edits: list[tuple[tuple[str, str], bool, str]] = []
         self.cleared: list[tuple[str, str]] = []
@@ -353,6 +377,15 @@ class _OutputDeltaProgressHarness(TelegramNotificationHandlers):
 class _ProgressMarkupHarness(TelegramNotificationHandlers):
     def __init__(self, *, label: str) -> None:
         self._turn_key = ("turn-1", "thread-1")
+        self._config = SimpleNamespace(
+            progress_stream=SimpleNamespace(
+                enabled=True,
+                min_edit_interval_seconds=1.0,
+                max_actions=8,
+                max_output_chars=400,
+            )
+        )
+        self._logger = logging.getLogger("test.telegram.progress_markup")
         self._turn_progress_trackers: dict[tuple[str, str], Any] = {
             self._turn_key: TurnProgressTracker(
                 started_at=0.0,
@@ -365,6 +398,9 @@ class _ProgressMarkupHarness(TelegramNotificationHandlers):
         }
         self._turn_progress_rendered: dict[tuple[str, str], str] = {}
         self._turn_progress_updated_at: dict[tuple[str, str], float] = {}
+        self._turn_progress_backoff_until: dict[tuple[str, str], float] = {}
+        self._turn_progress_failure_streaks: dict[tuple[str, str], int] = {}
+        self._turn_progress_suppressed_counts: dict[tuple[str, str], int] = {}
         self._turn_contexts: dict[tuple[str, str], Any] = {
             self._turn_key: SimpleNamespace(
                 chat_id=1,
@@ -404,6 +440,24 @@ class _ProgressMarkupHarness(TelegramNotificationHandlers):
             }
         )
         return True
+
+
+class _FailingProgressMarkupHarness(_ProgressMarkupHarness):
+    def __init__(self, *, label: str = "working") -> None:
+        super().__init__(label=label)
+        self.fail_edit = True
+
+    async def _edit_message_text(
+        self,
+        chat_id: int,
+        message_id: int,
+        text: str,
+        *,
+        message_thread_id: Optional[int] = None,
+        reply_markup: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        _ = (chat_id, message_id, text, message_thread_id, reply_markup)
+        return False
 
 
 @pytest.mark.anyio
@@ -611,6 +665,42 @@ async def test_emit_progress_edit_clears_keyboard_for_terminal_label() -> None:
 
     assert harness.edits
     assert harness.edits[-1]["reply_markup"] == {"inline_keyboard": []}
+
+
+@pytest.mark.anyio
+async def test_emit_progress_edit_records_backoff_after_failed_edit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = _FailingProgressMarkupHarness()
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.telegram.notifications.time.monotonic",
+        lambda: 10.0,
+    )
+
+    await harness._emit_progress_edit(harness._turn_key, force=False)
+
+    assert harness._turn_progress_failure_streaks[harness._turn_key] == 1
+    assert harness._turn_progress_backoff_until[harness._turn_key] == 25.0
+
+
+@pytest.mark.anyio
+async def test_progress_edit_cadence_defers_while_backoff_is_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = _ProgressCadenceHarness(min_interval=2.0)
+    key = ("turn-1", "thread-1")
+    harness._turn_progress_backoff_until[key] = 20.0
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.telegram.notifications.time.monotonic",
+        lambda: 12.0,
+    )
+
+    await harness._schedule_progress_edit(key)
+    await asyncio.sleep(0)
+
+    assert not harness.emitted
+    assert harness.delayed == [(key, 8.0)]
+    assert harness._turn_progress_suppressed_counts[key] == 1
 
 
 class _FlowStatusHandler(FlowCommands):


### PR DESCRIPTION
## Summary
- harden managed-thread interrupt recovery so stale backend thread ids are surfaced as a deterministic recovered state instead of a generic interrupt failure
- add Telegram progress edit backoff/sparse-update behavior for degraded or rate-limited runs, with regression coverage for the duck-typed PMA handlers
- fix Discord user-ticket pause detection to tolerate minimal in-workspace ticket frontmatter so the repo test suite stays green

## Testing
- .venv/bin/python -m pytest tests/test_hotspot_budgets.py tests/core/orchestration/test_service.py tests/test_pma_managed_threads_interrupt.py tests/test_telegram_flow_status.py tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py tests/test_telegram_pma_routing.py::test_repo_text_turns_use_orchestration_binding_and_preserve_thread_continuity[asyncio] tests/test_telegram_pma_routing.py::test_pma_managed_thread_turn_edits_placeholder_with_live_progress[asyncio] tests/integrations/discord/test_message_turns.py::test_is_user_ticket_pause_detects_in_workspace_user_ticket
- .venv/bin/python -m pytest -m "not integration and not slow" -n auto -x
- full pre-commit hook suite via git commit

Closes #1061
