### PR TITLE
Reduce duplicate Telegram interrupt status messages

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -169,6 +169,8 @@ class _TurnRunResult:
     transcript_message_id: Optional[int]
     transcript_text: Optional[str]
     intermediate_response: str = ""
+    interrupt_status_turn_id: Optional[str] = None
+    interrupt_status_fallback_text: Optional[str] = None
 
 
 @dataclass
@@ -1186,32 +1188,32 @@ async def _run_telegram_managed_thread_turn(
     )
     if finalized["status"] != "ok":
         failure_message = str(finalized.get("error") or public_execution_error)
+        interrupt_status_fallback_text: Optional[str] = None
         if finalized["status"] == "interrupted":
             failure_message = _compose_interrupt_response(failure_message)
             if (
                 runtime.interrupt_message_id is not None
                 and runtime.interrupt_turn_id == backend_turn_id
             ):
-                await handlers._clear_interrupt_status_message(
-                    chat_id=message.chat_id,
-                    runtime=runtime,
-                    turn_id=backend_turn_id,
-                    fallback_text="Interrupted.",
-                )
+                interrupt_status_fallback_text = "Interrupted."
         elif runtime.interrupt_turn_id == backend_turn_id:
-            await handlers._clear_interrupt_status_message(
-                chat_id=message.chat_id,
-                runtime=runtime,
-                turn_id=backend_turn_id,
-                fallback_text="Interrupt requested; turn completed.",
-            )
+            interrupt_status_fallback_text = "Interrupt requested; turn completed."
+        response_sent = False
         if send_failure_response:
-            await handlers._deliver_turn_response(
+            response_sent = await handlers._deliver_turn_response(
                 chat_id=message.chat_id,
                 thread_id=message.thread_id,
                 reply_to=message.message_id,
                 placeholder_id=prepared_placeholder_id,
                 response=failure_message,
+            )
+        if interrupt_status_fallback_text:
+            await handlers._clear_interrupt_status_message(
+                chat_id=message.chat_id,
+                runtime=runtime,
+                turn_id=backend_turn_id,
+                fallback_text=interrupt_status_fallback_text,
+                outcome_visible=response_sent,
             )
         return _TurnRunFailure(
             failure_message,
@@ -1269,13 +1271,9 @@ async def _run_telegram_managed_thread_turn(
             _apply_state,
         )
     response_text = str(finalized.get("assistant_text") or "")
+    interrupt_status_fallback_text = None
     if runtime.interrupt_turn_id == backend_turn_id:
-        await handlers._clear_interrupt_status_message(
-            chat_id=message.chat_id,
-            runtime=runtime,
-            turn_id=backend_turn_id,
-            fallback_text="Interrupt requested; turn completed.",
-        )
+        interrupt_status_fallback_text = "Interrupt requested; turn completed."
     return _TurnRunResult(
         record=record,
         thread_id=resolved_backend_thread_id,
@@ -1287,6 +1285,8 @@ async def _run_telegram_managed_thread_turn(
         transcript_message_id=transcript_message_id,
         transcript_text=transcript_text,
         intermediate_response=intermediate_response,
+        interrupt_status_turn_id=backend_turn_id or None,
+        interrupt_status_fallback_text=interrupt_status_fallback_text,
     )
 
 
@@ -3251,26 +3251,17 @@ class ExecutionCommands(SharedHelpers):
                 )
 
         turn_handle_id = turn_handle.turn_id if turn_handle else None
+        interrupt_status_fallback_text = None
         if is_interrupt_status(result.status):
             response = _compose_interrupt_response(response)
             if (
                 runtime.interrupt_message_id is not None
                 and runtime.interrupt_turn_id == turn_handle_id
             ):
-                await self._clear_interrupt_status_message(
-                    chat_id=message.chat_id,
-                    runtime=runtime,
-                    turn_id=turn_handle_id,
-                    fallback_text="Interrupted.",
-                )
+                interrupt_status_fallback_text = "Interrupted."
             runtime.interrupt_requested = False
         elif runtime.interrupt_turn_id == turn_handle_id:
-            await self._clear_interrupt_status_message(
-                chat_id=message.chat_id,
-                runtime=runtime,
-                turn_id=turn_handle_id,
-                fallback_text="Interrupt requested; turn completed.",
-            )
+            interrupt_status_fallback_text = "Interrupt requested; turn completed."
             runtime.interrupt_requested = False
 
         log_event(
@@ -3299,6 +3290,8 @@ class ExecutionCommands(SharedHelpers):
             transcript_message_id=transcript_message_id,
             transcript_text=transcript_text,
             intermediate_response=turn_delivery_state.get("intermediate_response", ""),
+            interrupt_status_turn_id=turn_handle_id,
+            interrupt_status_fallback_text=interrupt_status_fallback_text,
         )
 
     def _prepare_turn_prompt(

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/github.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/github.py
@@ -521,6 +521,7 @@ class GitHubCommands(SharedHelpers):
         turn_handle_id = (
             turn_context.turn_handle.turn_id if turn_context.turn_handle else None
         )
+        interrupt_status_fallback_text = None
         if is_interrupt_status(result.status):
             response = _compose_interrupt_response(response)
             if (
@@ -528,20 +529,10 @@ class GitHubCommands(SharedHelpers):
                 and runtime.interrupt_message_id is not None
                 and runtime.interrupt_turn_id == turn_handle_id
             ):
-                await self._clear_interrupt_status_message(
-                    chat_id=message.chat_id,
-                    runtime=runtime,
-                    turn_id=turn_handle_id,
-                    fallback_text="Interrupted.",
-                )
+                interrupt_status_fallback_text = "Interrupted."
             runtime.interrupt_requested = False
         elif runtime.interrupt_turn_id == turn_handle_id:
-            await self._clear_interrupt_status_message(
-                chat_id=message.chat_id,
-                runtime=runtime,
-                turn_id=turn_handle_id,
-                fallback_text="Interrupt requested; turn completed.",
-            )
+            interrupt_status_fallback_text = "Interrupt requested; turn completed."
             runtime.interrupt_requested = False
         log_event(
             self._logger,
@@ -568,8 +559,9 @@ class GitHubCommands(SharedHelpers):
             agent=self._effective_agent(record),
             model=getattr(record, "model", None),
         )
+        response_sent = False
         try:
-            await self._deliver_turn_response(
+            response_sent = await self._deliver_turn_response(
                 chat_id=message.chat_id,
                 thread_id=message.thread_id,
                 reply_to=message.message_id,
@@ -579,12 +571,20 @@ class GitHubCommands(SharedHelpers):
         except TypeError as exc:
             if "intermediate_response" not in str(exc):
                 raise
-            await self._deliver_turn_response(
+            response_sent = await self._deliver_turn_response(
                 chat_id=message.chat_id,
                 thread_id=message.thread_id,
                 reply_to=message.message_id,
                 placeholder_id=turn_context.placeholder_id,
                 response=response_text,
+            )
+        if interrupt_status_fallback_text and turn_handle_id:
+            await self._clear_interrupt_status_message(
+                chat_id=message.chat_id,
+                runtime=runtime,
+                turn_id=turn_handle_id,
+                fallback_text=interrupt_status_fallback_text,
+                outcome_visible=response_sent,
             )
         if turn_id:
             self._token_usage_by_turn.pop(turn_id, None)

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/shared.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/shared.py
@@ -206,12 +206,13 @@ class SharedHelpers:
         runtime: Any,
         turn_id: Optional[str],
         fallback_text: Optional[str] = None,
+        outcome_visible: bool = True,
     ) -> None:
         """Clear an interrupt status message once the turn outcome is already visible.
 
         Prefer deleting the transient "Stopping current turn..." message so Telegram
-        does not restate the same terminal outcome in a second message. Fall back to
-        editing when deletion fails.
+        does not restate the same terminal outcome in a second message. When the turn
+        outcome was not delivered, preserve a terminal signal by editing in place.
         """
 
         if runtime.interrupt_turn_id != turn_id:
@@ -220,7 +221,9 @@ class SharedHelpers:
         if message_id is None:
             runtime.interrupt_turn_id = None
             return
-        cleared = await self._delete_message(chat_id, message_id)
+        cleared = False
+        if outcome_visible:
+            cleared = await self._delete_message(chat_id, message_id)
         if not cleared and fallback_text:
             await self._edit_message_text(chat_id, message_id, fallback_text)
         runtime.interrupt_message_id = None

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -432,6 +432,18 @@ class TelegramCommandHandlers(
                 placeholder_id=outcome.placeholder_id,
                 final_response_sent_at=now_iso(),
             )
+        interrupt_status_turn_id = getattr(outcome, "interrupt_status_turn_id", None)
+        interrupt_status_fallback_text = getattr(
+            outcome, "interrupt_status_fallback_text", None
+        )
+        if interrupt_status_fallback_text and interrupt_status_turn_id:
+            await self._clear_interrupt_status_message(
+                chat_id=message.chat_id,
+                runtime=runtime,
+                turn_id=interrupt_status_turn_id,
+                fallback_text=interrupt_status_fallback_text,
+                outcome_visible=response_sent,
+            )
         if metrics and metrics_mode == "separate":
             await self._send_turn_metrics(
                 chat_id=message.chat_id,
@@ -2268,9 +2280,21 @@ class TelegramCommandHandlers(
         if isinstance(outcome, _TurnRunFailure):
             return
         summary_text = outcome.response.strip() or "(no summary)"
-        _summary_message_id, _display_text = await self._send_compact_summary_message(
+        summary_message_id, _display_text = await self._send_compact_summary_message(
             message, summary_text, reply_markup=None
         )
+        interrupt_status_turn_id = getattr(outcome, "interrupt_status_turn_id", None)
+        interrupt_status_fallback_text = getattr(
+            outcome, "interrupt_status_fallback_text", None
+        )
+        if interrupt_status_fallback_text and interrupt_status_turn_id:
+            await self._clear_interrupt_status_message(
+                chat_id=message.chat_id,
+                runtime=runtime,
+                turn_id=interrupt_status_turn_id,
+                fallback_text=interrupt_status_fallback_text,
+                outcome_visible=summary_message_id is not None,
+            )
         if outcome.turn_id:
             self._token_usage_by_turn.pop(outcome.turn_id, None)
         await self._delete_message(message.chat_id, outcome.placeholder_id)

--- a/tests/test_telegram_interrupt_cleanup.py
+++ b/tests/test_telegram_interrupt_cleanup.py
@@ -66,3 +66,22 @@ async def test_clear_interrupt_status_message_falls_back_to_edit() -> None:
     assert handler.edited == [(456, 88, "Interrupt requested; turn completed.")]
     assert runtime.interrupt_message_id is None
     assert runtime.interrupt_turn_id is None
+
+
+@pytest.mark.anyio
+async def test_clear_interrupt_status_message_edits_when_outcome_not_visible() -> None:
+    handler = _InterruptCleanupStub(delete_result=True)
+    runtime = SimpleNamespace(interrupt_message_id=99, interrupt_turn_id="turn-3")
+
+    await handler._clear_interrupt_status_message(
+        chat_id=789,
+        runtime=runtime,
+        turn_id="turn-3",
+        fallback_text="Interrupted.",
+        outcome_visible=False,
+    )
+
+    assert handler.deleted == []
+    assert handler.edited == [(789, 99, "Interrupted.")]
+    assert runtime.interrupt_message_id is None
+    assert runtime.interrupt_turn_id is None

--- a/tests/test_telegram_review_opencode.py
+++ b/tests/test_telegram_review_opencode.py
@@ -94,6 +94,7 @@ class _ReviewHandlerStub(TelegramCommandHandlers):
         *,
         record: TelegramTopicRecord,
         supervisor: _SupervisorStub,
+        deliver_result: bool = True,
     ) -> None:
         self._logger = logging.getLogger("test")
         self._config = SimpleNamespace(
@@ -128,6 +129,7 @@ class _ReviewHandlerStub(TelegramCommandHandlers):
         self._deleted: list[int] = []
         self._edited: list[tuple[int, int, str]] = []
         self._placeholder_counter = 200
+        self._deliver_result = deliver_result
 
     async def _resolve_topic_key(self, chat_id: int, thread_id: Optional[int]) -> str:
         return f"{chat_id}:{thread_id}"
@@ -218,7 +220,7 @@ class _ReviewHandlerStub(TelegramCommandHandlers):
         self._intermediate.append(intermediate_response)
         self._delivery_delete_flags.append(delete_placeholder_on_delivery)
         self._delivered.append(response)
-        return True
+        return self._deliver_result
 
     def _format_turn_metrics_text(
         self,
@@ -516,5 +518,52 @@ async def test_finalize_codex_review_success_clears_interrupt_status_message(
 
     assert handler._deleted == [333]
     assert handler._edited == []
+    assert runtime.interrupt_message_id is None
+    assert runtime.interrupt_turn_id is None
+
+
+@pytest.mark.anyio
+async def test_finalize_codex_review_success_keeps_interrupt_signal_when_delivery_fails(
+    tmp_path: Path,
+) -> None:
+    record = TelegramTopicRecord(workspace_path=str(tmp_path))
+    client = _OpenCodeClientStub(session_id="session-123")
+    supervisor = _SupervisorStub(client)
+    handler = _ReviewHandlerStub(
+        record=record,
+        supervisor=supervisor,
+        deliver_result=False,
+    )
+    runtime = SimpleNamespace(
+        interrupt_requested=True,
+        interrupt_message_id=334,
+        interrupt_turn_id="turn-2",
+    )
+    turn_context = github_commands.CodexTurnContext(
+        placeholder_id=201,
+        turn_handle=SimpleNamespace(turn_id="turn-2"),
+        turn_key=None,
+        turn_semaphore=asyncio.Semaphore(1),
+        turn_started_at=None,
+        queued=False,
+    )
+    result = SimpleNamespace(
+        final_message="",
+        agent_messages=[],
+        errors=[],
+        status="interrupted",
+    )
+
+    await handler._finalize_codex_review_success(
+        _message(),
+        record,
+        "thread-1",
+        result,
+        turn_context,
+        runtime,
+    )
+
+    assert handler._deleted == []
+    assert handler._edited == [(123, 334, "Interrupted.")]
     assert runtime.interrupt_message_id is None
     assert runtime.interrupt_turn_id is None

--- a/tests/test_telegram_turn_queue.py
+++ b/tests/test_telegram_turn_queue.py
@@ -104,6 +104,7 @@ class _HandlerStub(TelegramCommandHandlers):
         max_parallel_turns: int,
         records: dict[str, TelegramTopicRecord],
         placeholder_events: Optional[dict[int, asyncio.Event]] = None,
+        deliver_result: bool = True,
     ) -> None:
         self._logger = logging.getLogger("test")
         self._config = SimpleNamespace(
@@ -130,6 +131,7 @@ class _HandlerStub(TelegramCommandHandlers):
         self._outbox_calls: list[dict[str, object]] = []
         self._delete_calls: list[tuple[object, object]] = []
         self._placeholder_events = placeholder_events or {}
+        self._deliver_result = deliver_result
 
     async def _resolve_topic_key(self, chat_id: int, thread_id: Optional[int]) -> str:
         return f"{chat_id}:{thread_id}"
@@ -297,7 +299,7 @@ class _HandlerStub(TelegramCommandHandlers):
                 "delete_placeholder_on_delivery": delete_placeholder_on_delivery,
             }
         )
-        return True
+        return self._deliver_result
 
     async def _send_message_with_outbox(
         self,
@@ -703,6 +705,98 @@ async def test_normal_opencode_turn_drops_no_response_sentinel_when_summary_pres
         "done · agent opencode · model-x · 1s · step 3"
     )
     assert handler._deliver_calls[-1]["intermediate_response"] is None
+
+
+@pytest.mark.anyio
+async def test_normal_turn_clears_interrupt_status_after_successful_delivery() -> None:
+    wait = asyncio.Event()
+    wait.set()
+    client = _ClientStub(turn_wait_events=[wait])
+    record = _record("thread-1")
+    records = {"10:11": record}
+    handler = _HandlerStub(
+        client=client,
+        max_parallel_turns=1,
+        records=records,
+        deliver_result=True,
+    )
+    runtime = _RuntimeStub(interrupt_message_id=777, interrupt_turn_id="turn-1")
+
+    async def _fake_run_turn_and_collect_result(
+        _message: TelegramMessage,
+        _runtime: _RuntimeStub,
+        **_kwargs: object,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            record=record,
+            thread_id="thread-1",
+            turn_id="turn-1",
+            response="final output",
+            placeholder_id=456,
+            elapsed_seconds=1.0,
+            token_usage=None,
+            transcript_message_id=None,
+            transcript_text=None,
+            intermediate_response="",
+            interrupt_status_turn_id="turn-1",
+            interrupt_status_fallback_text="Interrupt requested; turn completed.",
+        )
+
+    handler._run_turn_and_collect_result = _fake_run_turn_and_collect_result  # type: ignore[assignment]
+
+    message = _message(message_id=1, thread_id=11)
+    await handler._handle_normal_message(message, runtime, record=record)
+
+    assert handler._delete_calls == [(10, 777)]
+    assert handler._edit_calls == []
+    assert runtime.interrupt_message_id is None
+    assert runtime.interrupt_turn_id is None
+
+
+@pytest.mark.anyio
+async def test_normal_turn_edits_interrupt_status_when_delivery_fails() -> None:
+    wait = asyncio.Event()
+    wait.set()
+    client = _ClientStub(turn_wait_events=[wait])
+    record = _record("thread-1")
+    records = {"10:11": record}
+    handler = _HandlerStub(
+        client=client,
+        max_parallel_turns=1,
+        records=records,
+        deliver_result=False,
+    )
+    runtime = _RuntimeStub(interrupt_message_id=778, interrupt_turn_id="turn-1")
+
+    async def _fake_run_turn_and_collect_result(
+        _message: TelegramMessage,
+        _runtime: _RuntimeStub,
+        **_kwargs: object,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            record=record,
+            thread_id="thread-1",
+            turn_id="turn-1",
+            response="final output",
+            placeholder_id=456,
+            elapsed_seconds=1.0,
+            token_usage=None,
+            transcript_message_id=None,
+            transcript_text=None,
+            intermediate_response="",
+            interrupt_status_turn_id="turn-1",
+            interrupt_status_fallback_text="Interrupted.",
+        )
+
+    handler._run_turn_and_collect_result = _fake_run_turn_and_collect_result  # type: ignore[assignment]
+
+    message = _message(message_id=1, thread_id=11)
+    await handler._handle_normal_message(message, runtime, record=record)
+
+    assert handler._delete_calls == []
+    assert handler._edit_calls == [(778, "Interrupted.")]
+    assert runtime.interrupt_message_id is None
+    assert runtime.interrupt_turn_id is None
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- remove redundant Telegram interrupt follow-up messages once the real turn outcome is already visible
- share the cleanup logic across normal turns, managed-thread turns, and review flows
- add regression coverage for interrupt status cleanup and review finalization

## Audit Notes
- Audited Telegram interrupt flows against Discord's simpler `/interrupt` UX
- Main redundancy fixed: Telegram kept a separate `Stopping current turn...` status message and then restated the terminal outcome (`Interrupted.` or `Interrupt requested; turn completed.`) even after the turn response/progress already conveyed it
- Simplification applied: prefer deleting the transient interrupt status message on successful completion/interruption, with edit fallback if deletion fails

## Testing
- `.venv/bin/pytest tests/test_telegram_interrupt_cleanup.py tests/test_telegram_review_opencode.py::test_telegram_review_opencode_sends_command tests/test_telegram_review_opencode.py::test_finalize_codex_review_success_clears_interrupt_status_message`
- full pre-commit suite via `git commit` hook (`3264 passed, 1 skipped`)

Closes #1057
