### PR TITLE
Fix Telegram PMA /new reset to clear managed thread binding

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -368,6 +368,65 @@ def _resolve_telegram_managed_thread(
     return orchestration_service, thread
 
 
+async def _reset_telegram_thread_binding(
+    handlers: Any,
+    *,
+    surface_key: str,
+    workspace_root: Path,
+    agent: str,
+    repo_id: Optional[str],
+    resource_kind: Optional[str],
+    resource_id: Optional[str],
+    mode: str,
+    pma_enabled: bool,
+) -> tuple[bool, str]:
+    orchestration_service, _binding, current_thread = _get_telegram_thread_binding(
+        handlers,
+        surface_key=surface_key,
+        mode=mode,
+    )
+    had_previous = current_thread is not None
+    normalized_repo_id = repo_id.strip() if isinstance(repo_id, str) else None
+    if current_thread is not None:
+        stop_outcome = await orchestration_service.stop_thread(
+            current_thread.thread_target_id
+        )
+        if stop_outcome.recovered_lost_backend:
+            log_event(
+                handlers._logger,
+                logging.INFO,
+                "telegram.thread.recovered_lost_backend",
+                surface_key=surface_key,
+                managed_thread_id=current_thread.thread_target_id,
+                mode=mode,
+            )
+        orchestration_service.archive_thread_target(current_thread.thread_target_id)
+    replacement = orchestration_service.create_thread_target(
+        agent,
+        workspace_root,
+        repo_id=normalized_repo_id or None,
+        resource_kind=resource_kind,
+        resource_id=resource_id,
+        display_name=f"telegram:{surface_key}",
+    )
+    orchestration_service.upsert_binding(
+        surface_kind="telegram",
+        surface_key=surface_key,
+        thread_target_id=replacement.thread_target_id,
+        agent_id=agent,
+        repo_id=normalized_repo_id or None,
+        resource_kind=resource_kind,
+        resource_id=resource_id,
+        mode=mode,
+        metadata={
+            "topic_key": surface_key,
+            "pma_enabled": pma_enabled,
+            "surface_key": surface_key,
+        },
+    )
+    return had_previous, replacement.thread_target_id
+
+
 async def _sync_telegram_thread_binding(
     handlers: Any,
     *,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -1035,6 +1035,57 @@ class WorkspaceCommands(SharedHelpers):
                                 pma_key=pma_key,
                                 exc=exc,
                             )
+            if getattr(self._config, "root", None) is not None and callable(
+                getattr(self, "_spawn_task", None)
+            ):
+                from .execution import _reset_telegram_thread_binding
+
+                hub_root = getattr(self, "_hub_root", None)
+                if hub_root is not None and record is not None:
+                    try:
+                        await _reset_telegram_thread_binding(
+                            self,
+                            surface_key=key,
+                            workspace_root=canonicalize_path(Path(hub_root)),
+                            agent=self._effective_agent(record),
+                            repo_id=(
+                                record.repo_id.strip()
+                                if isinstance(record.repo_id, str)
+                                and record.repo_id.strip()
+                                else None
+                            ),
+                            resource_kind=(
+                                record.resource_kind.strip()
+                                if isinstance(record.resource_kind, str)
+                                and record.resource_kind.strip()
+                                else None
+                            ),
+                            resource_id=(
+                                record.resource_id.strip()
+                                if isinstance(record.resource_id, str)
+                                and record.resource_id.strip()
+                                else None
+                            ),
+                            mode="pma",
+                            pma_enabled=True,
+                        )
+                    except Exception as exc:
+                        log_event(
+                            self._logger,
+                            logging.WARNING,
+                            "telegram.pma.reset.managed_thread_reset_failed",
+                            topic_key=key,
+                            chat_id=message.chat_id,
+                            thread_id=message.thread_id,
+                            exc=exc,
+                        )
+                        await self._send_message(
+                            message.chat_id,
+                            "Failed to reset PMA thread; check logs for details.",
+                            thread_id=message.thread_id,
+                            reply_to=message.message_id,
+                        )
+                        return
             await self._send_message(
                 message.chat_id,
                 "PMA thread reset. Send a message to start a fresh PMA turn.",
@@ -1221,6 +1272,57 @@ class WorkspaceCommands(SharedHelpers):
                                 pma_key=pma_key,
                                 exc=exc,
                             )
+            if getattr(self._config, "root", None) is not None and callable(
+                getattr(self, "_spawn_task", None)
+            ):
+                from .execution import _reset_telegram_thread_binding
+
+                hub_root = getattr(self, "_hub_root", None)
+                if hub_root is not None and record is not None:
+                    try:
+                        await _reset_telegram_thread_binding(
+                            self,
+                            surface_key=key,
+                            workspace_root=canonicalize_path(Path(hub_root)),
+                            agent=self._effective_agent(record),
+                            repo_id=(
+                                record.repo_id.strip()
+                                if isinstance(record.repo_id, str)
+                                and record.repo_id.strip()
+                                else None
+                            ),
+                            resource_kind=(
+                                record.resource_kind.strip()
+                                if isinstance(record.resource_kind, str)
+                                and record.resource_kind.strip()
+                                else None
+                            ),
+                            resource_id=(
+                                record.resource_id.strip()
+                                if isinstance(record.resource_id, str)
+                                and record.resource_id.strip()
+                                else None
+                            ),
+                            mode="pma",
+                            pma_enabled=True,
+                        )
+                    except Exception as exc:
+                        log_event(
+                            self._logger,
+                            logging.WARNING,
+                            "telegram.pma.new.managed_thread_reset_failed",
+                            topic_key=key,
+                            chat_id=message.chat_id,
+                            thread_id=message.thread_id,
+                            exc=exc,
+                        )
+                        await self._send_message(
+                            message.chat_id,
+                            "Failed to reset PMA session; check logs for details.",
+                            thread_id=message.thread_id,
+                            reply_to=message.message_id,
+                        )
+                        return
             await self._send_message(
                 message.chat_id,
                 "PMA session reset. Send a message to start a fresh PMA turn.",

--- a/tests/test_telegram_pma_routing.py
+++ b/tests/test_telegram_pma_routing.py
@@ -3699,6 +3699,77 @@ async def test_sync_telegram_thread_binding_archives_after_lost_backend_recovery
 
 
 @pytest.mark.anyio
+async def test_reset_telegram_thread_binding_archives_after_lost_backend_recovery() -> (
+    None
+):
+    workspace = Path("/tmp/telegram-reset-workspace").resolve()
+    calls: list[tuple[str, str]] = []
+
+    class _FakeThreadService:
+        async def stop_thread(self, thread_target_id: str) -> Any:
+            calls.append(("stop", thread_target_id))
+            return SimpleNamespace(recovered_lost_backend=True)
+
+        def archive_thread_target(self, thread_target_id: str) -> None:
+            calls.append(("archive", thread_target_id))
+
+        def create_thread_target(
+            self, agent: str, workspace_root: Path, **kwargs: Any
+        ) -> Any:
+            calls.append(("create", agent))
+            assert workspace_root == workspace
+            return SimpleNamespace(
+                thread_target_id="thread-2",
+                agent_id=agent,
+                workspace_root=str(workspace_root),
+            )
+
+        def upsert_binding(self, **kwargs: Any) -> None:
+            calls.append(("bind", str(kwargs["thread_target_id"])))
+
+    handlers = SimpleNamespace(_logger=logging.getLogger("test"))
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        execution_commands_module,
+        "_get_telegram_thread_binding",
+        lambda *args, **kwargs: (
+            _FakeThreadService(),
+            SimpleNamespace(thread_target_id="thread-1", mode="pma"),
+            SimpleNamespace(
+                thread_target_id="thread-1",
+                agent_id="codex",
+                workspace_root=str(workspace),
+            ),
+        ),
+    )
+    try:
+        had_previous, new_thread_id = (
+            await execution_commands_module._reset_telegram_thread_binding(
+                handlers,
+                surface_key="topic-1",
+                workspace_root=workspace,
+                agent="codex",
+                repo_id="repo-1",
+                resource_kind="repo",
+                resource_id="repo-1",
+                mode="pma",
+                pma_enabled=True,
+            )
+        )
+    finally:
+        monkeypatch.undo()
+
+    assert had_previous is True
+    assert new_thread_id == "thread-2"
+    assert calls == [
+        ("stop", "thread-1"),
+        ("archive", "thread-1"),
+        ("create", "codex"),
+        ("bind", "thread-2"),
+    ]
+
+
+@pytest.mark.anyio
 async def test_pma_new_resets_session(tmp_path: Path) -> None:
     registry = AppServerThreadRegistry(tmp_path / "threads.json")
     registry.reset_all()
@@ -3724,6 +3795,50 @@ async def test_pma_new_resets_session(tmp_path: Path) -> None:
     assert registry.get_thread_id(PMA_OPENCODE_KEY) is None
     sessions = json.loads(state_path.read_text(encoding="utf-8")).get("sessions", {})
     assert PMA_OPENCODE_KEY not in sessions
+    assert handler._sent and "PMA session reset" in handler._sent[-1]
+
+
+@pytest.mark.anyio
+async def test_pma_new_resets_managed_binding_when_runtime_threads_enabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = AppServerThreadRegistry(tmp_path / "threads.json")
+    registry.reset_all()
+    record = TelegramTopicRecord(pma_enabled=True, workspace_path=None, agent="codex")
+    handler = _PMAWorkspaceHandler(record, registry, hub_root=tmp_path)
+    handler._config = SimpleNamespace(require_topics=False, root=tmp_path)
+    handler._spawn_task = lambda coro: None
+    calls: list[dict[str, object]] = []
+
+    async def _fake_reset_telegram_thread_binding(
+        _handlers: Any, **kwargs: Any
+    ) -> tuple[bool, str]:
+        calls.append(kwargs)
+        return True, "thread-2"
+
+    monkeypatch.setattr(
+        execution_commands_module,
+        "_reset_telegram_thread_binding",
+        _fake_reset_telegram_thread_binding,
+    )
+    message = TelegramMessage(
+        update_id=1,
+        message_id=2,
+        chat_id=-2002,
+        thread_id=333,
+        from_user_id=99,
+        text="/new",
+        date=None,
+        is_topic_message=True,
+    )
+
+    await handler._handle_new(message)
+
+    assert calls
+    assert calls[-1]["surface_key"] == "-2002:333"
+    assert calls[-1]["mode"] == "pma"
+    assert calls[-1]["pma_enabled"] is True
     assert handler._sent and "PMA session reset" in handler._sent[-1]
 
 


### PR DESCRIPTION
## Summary
- fix Telegram PMA `/new` and `/reset` so they reset the managed-thread orchestration binding, not only legacy PMA registry/prompt-state keys
- add `_reset_telegram_thread_binding(...)` in Telegram execution helpers (parity with Discord reset behavior)
- invoke managed-thread reset from PMA branches in Telegram workspace command handlers when runtime thread orchestration is enabled

## Root Cause
Telegram PMA turns run via managed-thread orchestration bindings, but PMA `/new` only cleared legacy `AppServerThreadRegistry`/prompt-state keys. This left the active managed thread binding intact, so subsequent turns could resume the prior backend conversation.

## Validation
- `.venv/bin/python -m pytest tests/test_telegram_pma_routing.py -q`
- full pre-commit commit pipeline (black, ruff, mypy, JS build/tests, pytest): `3281 passed, 1 skipped`

## Tests Added
- `test_reset_telegram_thread_binding_archives_after_lost_backend_recovery`
- `test_pma_new_resets_managed_binding_when_runtime_threads_enabled`
