### PR TITLE
Fix Discord interrupt timeout and preserve turn failure details

### DIFF
--- a/src/codex_autorunner/core/orchestration/runtime_threads.py
+++ b/src/codex_autorunner/core/orchestration/runtime_threads.py
@@ -206,11 +206,12 @@ async def await_runtime_thread_outcome(
             )
 
         result = await collector_task
-    except Exception:
+    except Exception as exc:
+        detail = str(exc or "").strip()
         return RuntimeThreadOutcome(
             status="error",
             assistant_text="",
-            error=execution_error_message,
+            error=detail or execution_error_message,
             backend_thread_id=backend_thread_id,
             backend_turn_id=backend_turn_id,
             raw_events=(),

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -11722,6 +11722,10 @@ class DiscordBotService:
             text = format_discord_message("No active turn to interrupt.")
             await self._respond_ephemeral(interaction_id, interaction_token, text)
             return
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
         try:
             stop_outcome = await orchestration_service.stop_thread(
                 current_thread.thread_target_id
@@ -11732,7 +11736,12 @@ class DiscordBotService:
                 and not stop_outcome.cancelled_queued
             ):
                 text = format_discord_message("No active turn to interrupt.")
-                await self._respond_ephemeral(interaction_id, interaction_token, text)
+                await self._send_or_respond_ephemeral(
+                    interaction_id=interaction_id,
+                    interaction_token=interaction_token,
+                    deferred=deferred,
+                    text=text,
+                )
                 return
             parts = []
             if stop_outcome.interrupted_active:
@@ -11750,7 +11759,12 @@ class DiscordBotService:
             )
             if parts:
                 text = format_discord_message(" ".join(parts))
-            await self._respond_ephemeral(interaction_id, interaction_token, text)
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=text,
+            )
         except Exception as exc:
             log_event(
                 self._logger,
@@ -11762,7 +11776,12 @@ class DiscordBotService:
                 exc=exc,
             )
             text = format_discord_message("Interrupt failed. Please try again.")
-            await self._respond_ephemeral(interaction_id, interaction_token, text)
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=text,
+            )
 
     async def _handle_cancel_turn_button(
         self,

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -444,6 +444,48 @@ async def test_runtime_threads_allow_wait_results_without_raw_events(
     assert outcome.raw_events == ()
 
 
+async def test_runtime_threads_preserve_wait_exception_detail(
+    tmp_path: Path,
+) -> None:
+    harness = _HarnessWithWait()
+
+    async def _raising_wait(
+        workspace_root: Path,
+        conversation_id: str,
+        turn_id: Optional[str],
+        *,
+        timeout: Optional[float] = None,
+    ) -> TerminalTurnResult:
+        _ = timeout
+        harness.wait_calls.append((workspace_root, conversation_id, turn_id))
+        raise RuntimeError("transport disconnected")
+
+    harness.wait_for_turn = _raising_wait  # type: ignore[method-assign]
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target("codex", workspace_root)
+
+    started = await begin_runtime_thread_execution(
+        service,
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="user-visible prompt",
+        ),
+    )
+    outcome = await await_runtime_thread_outcome(
+        started,
+        interrupt_event=None,
+        timeout_seconds=5,
+        execution_error_message="Managed thread execution failed",
+    )
+
+    assert outcome.status == "error"
+    assert outcome.error == "transport disconnected"
+    assert outcome.raw_events == ()
+
+
 async def test_runtime_threads_prefer_final_output_over_post_completion_errors(
     tmp_path: Path,
 ) -> None:

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -4533,7 +4533,9 @@ async def test_car_interrupt_uses_orchestration_thread_state(tmp_path: Path) -> 
         )
         assert interrupted == ["thread-1"]
         assert len(rest.interaction_responses) == 1
-        content = rest.interaction_responses[0]["payload"]["data"]["content"].lower()
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        assert len(rest.followup_messages) == 1
+        content = rest.followup_messages[0]["payload"]["content"].lower()
         assert "stopping current turn" in content
         assert "cancelled 2 queued turn" in content
     finally:
@@ -4591,7 +4593,9 @@ async def test_car_interrupt_recovers_missing_backend_thread(tmp_path: Path) -> 
             channel_id="channel-1",
         )
         assert len(rest.interaction_responses) == 1
-        content = rest.interaction_responses[0]["payload"]["data"]["content"].lower()
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        assert len(rest.followup_messages) == 1
+        content = rest.followup_messages[0]["payload"]["content"].lower()
         assert "recovered stale session" in content
         assert "backend thread was lost" in content
     finally:


### PR DESCRIPTION
## Summary
- defer `/car session interrupt` responses before calling potentially slow thread-stop operations so Discord does not hit the 3-second interaction timeout
- switch interrupt result/error messaging to follow-up sends when deferred
- preserve concrete exception details from managed-thread wait failures instead of collapsing to a generic execution error string
- add regression coverage for both Discord interrupt flow and runtime-thread error detail propagation

## Validation
- `pytest tests/integrations/discord/test_service_routing.py -k "car_interrupt_uses_orchestration_thread_state or car_interrupt_recovers_missing_backend_thread"`
- `pytest tests/core/orchestration/test_runtime_threads.py -k preserve_wait_exception_detail`
- pre-commit suite during `git commit` (includes full `pytest`, 3339 passed, 1 skipped)

## User-facing impact
- Discord `/car session interrupt` no longer shows "The application did not respond" during slow stop operations
- failed turns now surface actionable backend error details instead of only "Discord turn failed"
