### PR TITLE
Clean up Discord turn footer summaries

### DIFF
--- a/src/codex_autorunner/integrations/chat/turn_metrics.py
+++ b/src/codex_autorunner/integrations/chat/turn_metrics.py
@@ -65,7 +65,11 @@ def _extract_context_usage_percent(
     return min(percent_remaining, 100)
 
 
-def _format_tui_token_usage(token_usage: Optional[dict[str, Any]]) -> Optional[str]:
+def _format_tui_token_usage(
+    token_usage: Optional[dict[str, Any]],
+    *,
+    include_context: bool = True,
+) -> Optional[str]:
     if not isinstance(token_usage, dict):
         return None
     usage = _select_context_usage_bucket(token_usage)
@@ -82,7 +86,7 @@ def _format_tui_token_usage(token_usage: Optional[dict[str, Any]]) -> Optional[s
     if isinstance(output_tokens, int):
         parts.append(f"output {output_tokens}")
     percent = _extract_context_usage_percent(token_usage)
-    if percent is not None:
+    if include_context and percent is not None:
         parts.append(f"ctx {percent}%")
     return " ".join(parts)
 
@@ -182,8 +186,6 @@ def format_turn_footer(
         elapsed_label = format_elapsed(elapsed_seconds)
 
     header_parts: list[str] = []
-    if parsed.status:
-        header_parts.append(parsed.status)
     resolved_agent = agent or parsed.agent
     if resolved_agent:
         header_parts.append(f"agent {resolved_agent}")
@@ -198,9 +200,13 @@ def format_turn_footer(
         header_parts.append(f"ctx {context_remaining_percent}%")
 
     lines: list[str] = []
-    if header_parts and _has_turn_footer_metadata(parsed):
+    rendered_header = bool(header_parts and _has_turn_footer_metadata(parsed))
+    if rendered_header:
         lines.append(" · ".join(header_parts))
-    token_line = _format_tui_token_usage(token_usage)
+    token_line = _format_tui_token_usage(
+        token_usage,
+        include_context=not (rendered_header and context_remaining_percent is not None),
+    )
     if token_line:
         lines.append(token_line)
     if not lines:

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -2943,7 +2943,7 @@ async def test_message_create_opencode_turn_sends_summary_before_final(
             str(msg["payload"].get("content", "")) for msg in rest.channel_messages
         ]
         assert any(
-            "final output\n\ndone · agent opencode · model-x · 1s · step 3" in content
+            "final output\n\nagent opencode · model-x · 1s · step 3" in content
             for content in contents
         )
         assert not any(content.strip() == "---" for content in contents)
@@ -2978,12 +2978,12 @@ async def test_message_create_opencode_turn_does_not_duplicate_summary_with_metr
         state_store=store,
         outbox_manager=_FakeOutboxManager(),
     )
-    summary = "done · agent opencode · model-x · 1s · step 3"
+    rendered_summary = "agent opencode · model-x · 1s · step 3"
 
     async def _fake_run_turn(**_kwargs: Any) -> DiscordMessageTurnResult:
         return DiscordMessageTurnResult(
             final_message="",
-            intermediate_message=summary,
+            intermediate_message="done · agent opencode · model-x · 1s · step 3",
             preview_message_id="preview-1",
             elapsed_seconds=1.0,
         )
@@ -2996,7 +2996,8 @@ async def test_message_create_opencode_turn_does_not_duplicate_summary_with_metr
             str(msg["payload"].get("content", "")) for msg in rest.channel_messages
         ]
         combined = "\n".join(contents)
-        assert combined.count(summary) == 1
+        assert combined.count(rendered_summary) == 1
+        assert "done · agent opencode · model-x · 1s · step 3" not in combined
         assert "(No response text returned.)" in combined
     finally:
         await store.close()
@@ -3487,7 +3488,8 @@ async def test_message_create_streaming_turn_appends_final_metrics(
         assert final_content
         assert "agent codex" in final_content
         assert "ctx 65%" in final_content
-        assert "Token usage: total 71173 input 400 output 245 ctx 65%" in final_content
+        assert "Token usage: total 71173 input 400 output 245" in final_content
+        assert final_content.count("ctx 65%") == 1
     finally:
         await store.close()
 
@@ -3551,7 +3553,7 @@ async def test_message_create_streaming_turn_uses_assistant_stream_when_final_em
             content = str(message.get("payload", {}).get("content", ""))
             if (
                 streamed_text in content
-                and "Token usage: total 71173 input 400 output 245 ctx 65%" in content
+                and "Token usage: total 71173 input 400 output 245" in content
             ):
                 final_content = content
                 break
@@ -3559,7 +3561,8 @@ async def test_message_create_streaming_turn_uses_assistant_stream_when_final_em
         assert streamed_text in final_content
         assert "agent codex" in final_content
         assert "ctx 65%" in final_content
-        assert "Token usage: total 71173 input 400 output 245 ctx 65%" in final_content
+        assert "Token usage: total 71173 input 400 output 245" in final_content
+        assert final_content.count("ctx 65%") == 1
         assert "(No response text returned.)" not in final_content
     finally:
         await store.close()
@@ -3615,13 +3618,14 @@ async def test_message_create_streaming_turn_empty_final_includes_text_fallback_
         final_content = ""
         for message in final_candidates:
             content = str(message.get("payload", {}).get("content", ""))
-            if "Token usage: total 71173 input 400 output 245 ctx 65%" in content:
+            if "Token usage: total 71173 input 400 output 245" in content:
                 final_content = content
                 break
         assert final_content
         assert "(No response text returned.)" in final_content
         assert "agent codex" in final_content
         assert "ctx 65%" in final_content
+        assert final_content.count("ctx 65%") == 1
     finally:
         await store.close()
 

--- a/tests/test_cross_surface_parity.py
+++ b/tests/test_cross_surface_parity.py
@@ -456,8 +456,8 @@ def test_cross_surface_shared_chat_primitive_behavior_characterization() -> None
             token_usage=token_usage,
             elapsed_seconds=None,
         )
-        == "done · agent codex · gpt-5.3-codex · 6m 19s · step 7228 · ctx 20%\n"
-        "Token usage: total 80 input 60 output 20 ctx 20%"
+        == "agent codex · gpt-5.3-codex · 6m 19s · step 7228 · ctx 20%\n"
+        "Token usage: total 80 input 60 output 20"
     )
     assert (
         compose_turn_response_with_footer(
@@ -467,8 +467,8 @@ def test_cross_surface_shared_chat_primitive_behavior_characterization() -> None
             elapsed_seconds=None,
         )
         == "Addressed and pushed.\n\n"
-        "done · agent codex · gpt-5.3-codex · 6m 19s · step 7228 · ctx 20%\n"
-        "Token usage: total 80 input 60 output 20 ctx 20%"
+        "agent codex · gpt-5.3-codex · 6m 19s · step 7228 · ctx 20%\n"
+        "Token usage: total 80 input 60 output 20"
     )
     assert (
         format_turn_footer(
@@ -476,7 +476,7 @@ def test_cross_surface_shared_chat_primitive_behavior_characterization() -> None
             token_usage=None,
             elapsed_seconds=None,
         )
-        == "done · agent codex · gpt-4.1-mini · 6m 19s · step 7"
+        == "agent codex · gpt-4.1-mini · 6m 19s · step 7"
     )
 
     assert _parse_review_commit_log("abc1234\x1fFix routing\x1e9876543\x1f") == [

--- a/tests/test_telegram_turn_queue.py
+++ b/tests/test_telegram_turn_queue.py
@@ -652,7 +652,7 @@ async def test_normal_opencode_turn_appends_summary_footer_after_final_response(
     assert handler._outbox_calls == []
     assert (
         handler._deliver_calls[-1]["response"]
-        == "final output\n\ndone · agent opencode · model-x · 1s · step 3"
+        == "final output\n\nagent opencode · model-x · 1s · step 3"
     )
     assert handler._deliver_calls[-1]["intermediate_response"] is None
 
@@ -702,7 +702,7 @@ async def test_normal_opencode_turn_drops_no_response_sentinel_when_summary_pres
 
     assert (
         handler._deliver_calls[-1]["response"] == "(No response text returned.)\n\n"
-        "done · agent opencode · model-x · 1s · step 3"
+        "agent opencode · model-x · 1s · step 3"
     )
     assert handler._deliver_calls[-1]["intermediate_response"] is None
 


### PR DESCRIPTION
## Summary
- remove the final `done` prefix from composed chat turn footers
- keep `ctx` in the footer header and omit the duplicate copy from the token-usage line
- update Discord, Telegram, and parity tests to match the cleaned footer format

## Testing
- .venv/bin/pytest tests/test_cross_surface_parity.py tests/test_telegram_turn_queue.py tests/integrations/discord/test_message_turns.py
- pre-commit hooks via `git commit` (includes full project checks and pytest suite)
