### PR TITLE
Reduce PMA automation backfill churn and log startup failures

### DIFF
--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -786,6 +786,17 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
                 or str(exc).strip()
                 or "Runtime thread execution failed"
             )
+            log_event(
+                logger,
+                logging.WARNING,
+                "orchestration.thread.start_failed",
+                exc=exc,
+                thread_target_id=thread.thread_target_id,
+                execution_id=execution.execution_id,
+                backend_thread_id=thread.backend_thread_id,
+                request_kind=request.kind,
+                reported_error=detail,
+            )
             try:
                 return self.thread_store.record_execution_result(
                     thread.thread_target_id,

--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -358,6 +358,7 @@ class PmaAutomationStore:
         self._hub_root = hub_root
         self._persistence = PmaAutomationPersistence(hub_root)
         self._path = self._persistence.path
+        self._legacy_automation_backfill_complete = False
 
     @property
     def path(self) -> Path:
@@ -370,9 +371,16 @@ class PmaAutomationStore:
         with file_lock(self._lock_path()):
             return self._load_unlocked() or default_pma_automation_state()
 
-    def _load_unlocked(self) -> Optional[dict[str, Any]]:
+    def _migrate_legacy_if_needed(self) -> None:
+        if self._legacy_automation_backfill_complete:
+            return
         with open_orchestration_sqlite(self._hub_root, durable=True) as conn:
             backfill_legacy_automation_state(self._hub_root, conn)
+        self._legacy_automation_backfill_complete = True
+
+    def _load_unlocked(self) -> Optional[dict[str, Any]]:
+        self._migrate_legacy_if_needed()
+        with open_orchestration_sqlite(self._hub_root, durable=True) as conn:
             subscriptions = self._load_subscriptions_from_sqlite(conn)
             timers = self._load_timers_from_sqlite(conn)
             wakeups = self._load_wakeups_from_sqlite(conn)
@@ -417,12 +425,12 @@ class PmaAutomationStore:
         timers: list[PmaAutomationTimer],
         wakeups: list[PmaAutomationWakeup],
     ) -> None:
+        self._migrate_legacy_if_needed()
         state["updated_at"] = _iso_now()
         state["subscriptions"] = [entry.to_dict() for entry in subscriptions]
         state["timers"] = [entry.to_dict() for entry in timers]
         state["wakeups"] = [entry.to_dict() for entry in wakeups]
         with open_orchestration_sqlite(self._hub_root, durable=True) as conn:
-            backfill_legacy_automation_state(self._hub_root, conn)
             with conn:
                 conn.execute("DELETE FROM orch_automation_wakeups")
                 conn.execute("DELETE FROM orch_automation_timers")

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
@@ -818,6 +820,7 @@ async def test_send_review_rejects_when_harness_lacks_review_capability(
 
 async def test_send_message_records_failed_execution_when_runtime_setup_fails(
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     harness = _FakeHarness(ensure_ready_error=FileNotFoundError("codex"))
     service = _build_service(tmp_path, harness)
@@ -825,22 +828,42 @@ async def test_send_message_records_failed_execution_when_runtime_setup_fails(
     workspace_root.mkdir()
     thread = service.create_thread_target("codex", workspace_root)
 
-    execution = await service.send_message(
-        MessageRequest(
-            target_id=thread.thread_target_id,
-            target_kind="thread",
-            message_text="Need an answer",
-            metadata={"execution_error_message": "Managed thread execution failed"},
+    with caplog.at_level(
+        logging.WARNING,
+        logger="codex_autorunner.core.orchestration.service",
+    ):
+        execution = await service.send_message(
+            MessageRequest(
+                target_id=thread.thread_target_id,
+                target_kind="thread",
+                message_text="Need an answer",
+                metadata={"execution_error_message": "Managed thread execution failed"},
+            )
         )
-    )
 
     running = service.get_running_execution(thread.thread_target_id)
+    payloads = [
+        json.loads(record.message)
+        for record in caplog.records
+        if record.name == "codex_autorunner.core.orchestration.service"
+    ]
+    failure_event = next(
+        payload
+        for payload in payloads
+        if payload.get("event") == "orchestration.thread.start_failed"
+    )
 
     assert harness.ensure_ready_calls == [workspace_root]
     assert harness.new_conversation_calls == []
     assert execution.status == "error"
     assert execution.error == "Managed thread execution failed"
     assert running is None
+    assert failure_event["thread_target_id"] == thread.thread_target_id
+    assert failure_event["execution_id"] == execution.execution_id
+    assert failure_event["request_kind"] == "message"
+    assert failure_event["error"] == "codex"
+    assert failure_event["error_type"] == "FileNotFoundError"
+    assert failure_event["reported_error"] == "Managed thread execution failed"
 
 
 async def test_interrupt_thread_rejects_when_harness_lacks_interrupt_capability(

--- a/tests/core/test_pma_automation_store.py
+++ b/tests/core/test_pma_automation_store.py
@@ -42,6 +42,40 @@ def test_subscription_idempotent_dedupe_and_lifecycle_matching(tmp_path) -> None
     assert matches[0]["subscription_id"] == first.subscription_id
 
 
+def test_legacy_backfill_runs_once_per_store_instance(tmp_path, monkeypatch) -> None:
+    call_count = 0
+
+    def _fake_backfill(*args, **kwargs):
+        nonlocal call_count
+        _ = args, kwargs
+        call_count += 1
+        return {"subscriptions": 0, "timers": 0, "wakeups": 0}
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.pma_automation_store.backfill_legacy_automation_state",
+        _fake_backfill,
+    )
+
+    store = PmaAutomationStore(tmp_path)
+
+    state = store.load()
+    created, deduped = store.upsert_subscription(
+        event_types=["flow_failed"],
+        thread_id="thread-1",
+        idempotency_key="sub-key-1",
+    )
+    matches = store.match_lifecycle_subscriptions(
+        event_type="flow_failed",
+        thread_id="thread-1",
+    )
+
+    assert state["subscriptions"] == []
+    assert deduped is False
+    assert created.thread_id == "thread-1"
+    assert len(matches) == 1
+    assert call_count == 1
+
+
 def test_due_timers_fire_once(tmp_path) -> None:
     store = PmaAutomationStore(tmp_path)
 


### PR DESCRIPTION
## Summary
- move PMA automation legacy backfill behind a one-time per-store guard instead of replaying it on every load/save hot path
- add structured orchestration logging for managed-thread startup failures while preserving existing public error text
- add regression coverage for both the one-time backfill behavior and the new failure log event

## Root cause this addresses
Investigation for Telegram conversation `-1003679298862:7073` showed repeated hub-side `sqlite3.OperationalError: database is locked` failures while managed turns were being processed. One contributor was `PmaAutomationStore` replaying `backfill_legacy_automation_state()` inside the hot read/write path, which widened write pressure against orchestration SQLite. This change reduces that churn and improves internal tracing when startup still fails.

## Testing
- `.venv/bin/pytest tests/core/test_pma_automation_store.py tests/core/orchestration/test_service.py -q`
- `.venv/bin/pytest tests/core/orchestration/test_runtime_threads.py -q`
- pre-commit repo gate during `git commit` including full pytest suite
