### PR TITLE
Centralize ticket_flow terminal failure classification

### DIFF
--- a/src/codex_autorunner/core/flows/failure_diagnostics.py
+++ b/src/codex_autorunner/core/flows/failure_diagnostics.py
@@ -12,6 +12,17 @@ logger = logging.getLogger(__name__)
 _MAX_STDERR_LINES = 5
 _MAX_STDERR_CHARS = 320
 _MAX_SUMMARY_CHARS = 160
+CANONICAL_FAILURE_REASON_CODE_FIELD = "failure_reason_code"
+
+_LEGACY_FAILURE_CLASS_REASON_CODES: dict[str, FailureReasonCode] = {
+    "worker_dead": FailureReasonCode.WORKER_DEAD,
+    "timeout": FailureReasonCode.TIMEOUT,
+    "network": FailureReasonCode.NETWORK_ERROR,
+}
+
+_LEGACY_ENGINE_REASON_CODES: dict[str, FailureReasonCode] = {
+    "network": FailureReasonCode.NETWORK_ERROR,
+}
 
 
 def _coerce_str(value: Any) -> Optional[str]:
@@ -288,11 +299,13 @@ def _derive_failure_reason_code(
         return FailureReasonCode.PREFLIGHT_ERROR
     if _is_repo_not_found(msg):
         return FailureReasonCode.REPO_NOT_FOUND
+    if "worker died" in msg or "worker-dead" in msg or "worker_dead" in msg:
+        return FailureReasonCode.WORKER_DEAD
     if "timeout" in msg or "timed out" in msg:
         return FailureReasonCode.TIMEOUT
     if _is_network_error(msg):
         return FailureReasonCode.NETWORK_ERROR
-    if "worker died" in msg or "crash" in msg:
+    if "crash" in msg:
         return FailureReasonCode.AGENT_CRASH
     if msg:
         return FailureReasonCode.UNCAUGHT_EXCEPTION
@@ -372,7 +385,9 @@ def build_failure_payload(
         "stderr_tail": stderr_tail,
         "retryable": retryable,
         "failure_class": failure_class,
-        "failure_reason_code": failure_reason_code.value,
+        # Downstream consumers should rely on this field as the authoritative
+        # terminal failure classification contract.
+        CANONICAL_FAILURE_REASON_CODE_FIELD: failure_reason_code.value,
         "last_event_seq": last_event_seq,
         "last_event_at": last_event_at,
     }
@@ -385,6 +400,71 @@ def get_failure_payload(record: FlowRunRecord) -> Optional[dict[str, Any]]:
     if isinstance(failure, dict) and failure:
         return failure
     return None
+
+
+def _coerce_failure_reason_code(value: Any) -> Optional[FailureReasonCode]:
+    normalized = _coerce_str(value)
+    if normalized is None:
+        return None
+    try:
+        return FailureReasonCode(normalized.lower())
+    except ValueError:
+        return None
+
+
+def _coerce_failure_reason_code_with_aliases(
+    value: Any, *, aliases: Optional[dict[str, FailureReasonCode]] = None
+) -> Optional[FailureReasonCode]:
+    canonical = _coerce_failure_reason_code(value)
+    if canonical is not None:
+        return canonical
+    normalized = _coerce_str(value)
+    if normalized is None or not aliases:
+        return None
+    return aliases.get(normalized.lower())
+
+
+def get_terminal_failure_reason_code(
+    record: FlowRunRecord,
+) -> Optional[FailureReasonCode]:
+    """Return the canonical terminal failure classification for a run record.
+
+    The authoritative contract is `state.failure.failure_reason_code`. This
+    accessor falls back to legacy terminal metadata so downstream consumers can
+    depend on one function instead of re-deriving worker-dead and related states.
+    """
+
+    failure_payload = get_failure_payload(record)
+    if isinstance(failure_payload, dict):
+        canonical = _coerce_failure_reason_code_with_aliases(
+            failure_payload.get(CANONICAL_FAILURE_REASON_CODE_FIELD)
+        )
+        if canonical is not None:
+            return canonical
+        legacy_class = _coerce_str(failure_payload.get("failure_class"))
+        if legacy_class is not None:
+            mapped = _LEGACY_FAILURE_CLASS_REASON_CODES.get(legacy_class.lower())
+            if mapped is not None:
+                return mapped
+
+    state = record.state if isinstance(record.state, dict) else {}
+    engine = state.get("ticket_engine") if isinstance(state, dict) else None
+    if isinstance(engine, dict):
+        engine_reason = _coerce_failure_reason_code_with_aliases(
+            engine.get("reason_code"),
+            aliases=_LEGACY_ENGINE_REASON_CODES,
+        )
+        if engine_reason is not None:
+            return engine_reason
+    error_message = _coerce_str(record.error_message)
+    reason_code = _derive_failure_reason_code(
+        state=state,
+        error_message=error_message,
+        note=None,
+    )
+    if reason_code == FailureReasonCode.UNKNOWN and not error_message:
+        return None
+    return reason_code
 
 
 def ensure_failure_payload(

--- a/src/codex_autorunner/core/pma_context.py
+++ b/src/codex_autorunner/core/pma_context.py
@@ -16,7 +16,11 @@ from ..tickets.outbox import parse_dispatch, resolve_outbox_paths
 from ..tickets.replies import resolve_reply_paths
 from .config import load_hub_config, load_repo_config
 from .filebox import BOXES, empty_listing, list_filebox
-from .flows.failure_diagnostics import format_failure_summary, get_failure_payload
+from .flows.failure_diagnostics import (
+    format_failure_summary,
+    get_failure_payload,
+    get_terminal_failure_reason_code,
+)
 from .flows.models import (
     FlowRunRecord,
     FlowRunStatus,
@@ -2044,33 +2048,8 @@ def _ticket_flow_has_tickets(repo_root: Path) -> Optional[bool]:
 
 
 def _terminal_ticket_flow_failure_is_worker_dead(record: FlowRunRecord) -> bool:
-    failure_payload = get_failure_payload(record)
-    if isinstance(failure_payload, Mapping):
-        failure_reason_code = str(
-            failure_payload.get("failure_reason_code") or ""
-        ).strip()
-        failure_class = str(failure_payload.get("failure_class") or "").strip()
-        if failure_reason_code.lower() == "worker_dead":
-            return True
-        if failure_class.lower() == "worker_dead":
-            return True
-
-    state_payload = record.state if isinstance(record.state, Mapping) else {}
-    ticket_engine = state_payload.get("ticket_engine")
-    if isinstance(ticket_engine, Mapping):
-        reason_code = str(ticket_engine.get("reason_code") or "").strip().lower()
-        if reason_code == "worker_dead":
-            return True
-
-    error_message = (
-        record.error_message.strip().lower()
-        if isinstance(record.error_message, str)
-        else ""
-    )
-    return any(
-        needle in error_message
-        for needle in ("worker died", "worker-dead", "worker_dead")
-    )
+    reason_code = get_terminal_failure_reason_code(record)
+    return reason_code is not None and reason_code.value == "worker_dead"
 
 
 def _stale_terminal_ticket_flow_run_reason(

--- a/tests/flows/test_failure_diagnostics.py
+++ b/tests/flows/test_failure_diagnostics.py
@@ -3,9 +3,37 @@ from __future__ import annotations
 from codex_autorunner.core.flows.failure_diagnostics import (
     _derive_failure_reason_code,
     build_failure_payload,
+    get_terminal_failure_reason_code,
 )
-from codex_autorunner.core.flows.models import FailureReasonCode, FlowEventType
+from codex_autorunner.core.flows.models import (
+    FailureReasonCode,
+    FlowEventType,
+    FlowRunRecord,
+    FlowRunStatus,
+)
 from codex_autorunner.core.flows.store import FlowStore
+
+
+def _build_record(
+    *,
+    state: dict | None = None,
+    error_message: str | None = None,
+    status: FlowRunStatus = FlowRunStatus.FAILED,
+) -> FlowRunRecord:
+    return FlowRunRecord(
+        id="run-1",
+        flow_type="ticket_flow",
+        status=status,
+        input_data={},
+        state=state or {},
+        current_step=None,
+        stop_requested=False,
+        created_at="2026-03-21T00:00:00Z",
+        started_at="2026-03-21T00:00:00Z",
+        finished_at="2026-03-21T00:00:10Z",
+        error_message=error_message,
+        metadata={},
+    )
 
 
 def test_build_failure_payload_uses_newest_app_server_events(tmp_path) -> None:
@@ -119,6 +147,17 @@ def test_derive_failure_reason_code_worker_dead() -> None:
     )
 
 
+def test_derive_failure_reason_code_worker_dead_from_error_message() -> None:
+    assert (
+        _derive_failure_reason_code(
+            state={},
+            error_message="Worker died (status=dead, pid=123, reason: lost worker)",
+            note=None,
+        )
+        == FailureReasonCode.WORKER_DEAD
+    )
+
+
 def test_derive_failure_reason_code_agent_crash() -> None:
     assert (
         _derive_failure_reason_code(
@@ -145,3 +184,64 @@ def test_derive_failure_reason_code_note_takes_precedence() -> None:
         )
         == FailureReasonCode.WORKER_DEAD
     )
+
+
+def test_get_terminal_failure_reason_code_prefers_canonical_failure_payload() -> None:
+    record = _build_record(
+        state={
+            "failure": {
+                "failure_reason_code": "worker_dead",
+                "failure_class": "error",
+            },
+            "ticket_engine": {"reason_code": "timeout"},
+        },
+        error_message="Operation timed out",
+    )
+
+    assert get_terminal_failure_reason_code(record) == FailureReasonCode.WORKER_DEAD
+
+
+def test_get_terminal_failure_reason_code_characterizes_terminal_paths() -> None:
+    cases = [
+        (
+            _build_record(
+                error_message="Worker died (status=dead, pid=123, reason: lost worker)"
+            ),
+            FailureReasonCode.WORKER_DEAD,
+        ),
+        (
+            _build_record(error_message="Operation timed out after 30s"),
+            FailureReasonCode.TIMEOUT,
+        ),
+        (
+            _build_record(error_message="Preflight check failed"),
+            FailureReasonCode.PREFLIGHT_ERROR,
+        ),
+        (
+            _build_record(error_message="Connection error to backend"),
+            FailureReasonCode.NETWORK_ERROR,
+        ),
+        (
+            _build_record(
+                state={"ticket_engine": {"reason_code": "user_stop"}},
+                status=FlowRunStatus.STOPPED,
+            ),
+            FailureReasonCode.USER_STOP,
+        ),
+        (
+            _build_record(error_message="Unhandled exception: failure"),
+            FailureReasonCode.UNCAUGHT_EXCEPTION,
+        ),
+    ]
+
+    for record, expected in cases:
+        assert get_terminal_failure_reason_code(record) == expected
+
+
+def test_get_terminal_failure_reason_code_uses_legacy_failure_class_mapping() -> None:
+    record = _build_record(
+        state={"failure": {"failure_class": "network"}},
+        error_message=None,
+    )
+
+    assert get_terminal_failure_reason_code(record) == FailureReasonCode.NETWORK_ERROR

--- a/tests/test_pma_context.py
+++ b/tests/test_pma_context.py
@@ -111,6 +111,15 @@ def _seed_failed_worker_dead_run(repo_root: Path, run_id: str) -> None:
     )
 
 
+def _seed_failed_worker_dead_legacy_run(repo_root: Path, run_id: str) -> None:
+    _seed_failed_run(
+        repo_root,
+        run_id,
+        state={"ticket_engine": {"reason_code": "worker_dead"}},
+        error_message=None,
+    )
+
+
 def _write_dispatch_history(
     repo_root: Path, run_id: str, seq: int, *, mode: str = "pause"
 ) -> None:
@@ -834,6 +843,29 @@ def test_build_hub_snapshot_suppresses_stale_failed_worker_dead_run_when_no_tick
     canonical = repo_entry.get("canonical_state_v1") or {}
     assert canonical.get("latest_run_id") == run_id
     assert canonical.get("latest_run_status") == "failed"
+
+
+def test_build_hub_snapshot_suppresses_stale_failed_worker_dead_legacy_run_when_no_tickets_remain(
+    hub_env,
+) -> None:
+    ticket_dir = hub_env.repo_root / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True, exist_ok=True)
+    for ticket in ticket_dir.glob("TICKET-*.md"):
+        ticket.unlink()
+
+    run_id = "69696969-6969-6969-6969-696969696969"
+    _seed_failed_worker_dead_legacy_run(hub_env.repo_root, run_id)
+
+    supervisor = HubSupervisor.from_path(hub_env.hub_root)
+    try:
+        snapshot = asyncio.run(
+            build_hub_snapshot(supervisor, hub_root=hub_env.hub_root)
+        )
+    finally:
+        supervisor.shutdown()
+
+    assert (snapshot.get("inbox") or []) == []
+    assert (snapshot.get("action_queue") or []) == []
 
 
 def test_build_hub_snapshot_repo_entries_include_canonical_state_v1(hub_env) -> None:


### PR DESCRIPTION
## Summary
- add a shared terminal failure reason accessor around the canonical `failure_reason_code` contract
- normalize worker-dead legacy terminal records through the shared accessor and remove PMA-specific worker-dead inference
- add characterization coverage for worker-dead, timeout, preflight, network, user-stop, generic exception, and PMA stale-run suppression

## Testing
- .venv/bin/pytest tests/flows/test_failure_diagnostics.py tests/test_pma_context.py -q
- .venv/bin/pytest tests/test_hub_messages.py -q
- git commit pre-commit suite

Closes #1085
