### PR TITLE
Fix OpenCode Discord progress event filtering

### DIFF
--- a/src/codex_autorunner/agents/opencode/harness.py
+++ b/src/codex_autorunner/agents/opencode/harness.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, AsyncIterator, Optional
 
+from ...core.logging_utils import log_event
 from ...core.sse import format_sse, parse_sse_lines
 from ..base import AgentHarness
 from ..types import (
@@ -101,6 +102,30 @@ def _collect_permission_paths(
                 _append(item)
 
     return candidates
+
+
+def _progress_event_shape_hint(payload: Any) -> Optional[str]:
+    if not isinstance(payload, dict):
+        return None
+    hints: list[str] = []
+    keys = sorted(str(key) for key in payload.keys())
+    if keys:
+        hints.append(f"keys={','.join(keys[:6])}")
+    properties = payload.get("properties")
+    if isinstance(properties, dict):
+        property_keys = sorted(str(key) for key in properties.keys())
+        if property_keys:
+            hints.append(f"properties={','.join(property_keys[:6])}")
+    item = payload.get("item")
+    if not isinstance(item, dict) and isinstance(properties, dict):
+        nested_item = properties.get("item")
+        if isinstance(nested_item, dict):
+            item = nested_item
+    if isinstance(item, dict):
+        item_keys = sorted(str(key) for key in item.keys())
+        if item_keys:
+            hints.append(f"item={','.join(item_keys[:6])}")
+    return " ".join(hints) or None
 
 
 def _workspace_permission_decision(
@@ -877,6 +902,21 @@ class OpenCodeHarness(AgentHarness):
                                 and session_id
                             ):
                                 _publish_progress_event(wrapped)
+                            elif not is_idle:
+                                log_event(
+                                    _logger,
+                                    logging.DEBUG,
+                                    "opencode.progress_event.skipped",
+                                    method=event.event,
+                                    conversation_id=conversation_id,
+                                    event_session_id=session_id,
+                                    reason=(
+                                        "missing_session_id"
+                                        if not session_id
+                                        else "session_mismatch"
+                                    ),
+                                    shape_hint=_progress_event_shape_hint(parsed),
+                                )
                         yield event
                 finally:
                     _close_progress_streams()

--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -91,46 +91,62 @@ def build_turn_id(session_id: str) -> str:
     return f"{session_id}:{int(time.time() * 1000)}"
 
 
+def _direct_session_id(
+    payload: dict[str, Any], *, allow_fallback_id: bool
+) -> Optional[str]:
+    for key in ("sessionID", "sessionId", "session_id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    if allow_fallback_id:
+        value = payload.get("id")
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _nested_session_id(
+    payload: Any, *, allow_fallback_id: bool = False
+) -> Optional[str]:
+    if not isinstance(payload, dict):
+        return None
+    session_id = _direct_session_id(payload, allow_fallback_id=allow_fallback_id)
+    if session_id:
+        return session_id
+    session = payload.get("session")
+    if isinstance(session, dict):
+        return _nested_session_id(session, allow_fallback_id=True)
+    return None
+
+
 def extract_session_id(
     payload: Any, *, allow_fallback_id: bool = False
 ) -> Optional[str]:
     if not isinstance(payload, dict):
         return None
-    for key in ("sessionID", "sessionId", "session_id"):
-        value = payload.get(key)
-        if isinstance(value, str) and value:
-            return value
+    session_id = _direct_session_id(payload, allow_fallback_id=allow_fallback_id)
+    if session_id:
+        return session_id
     info = payload.get("info")
-    if isinstance(info, dict):
-        for key in ("sessionID", "sessionId", "session_id"):
-            value = info.get(key)
-            if isinstance(value, str) and value:
-                return value
-    if allow_fallback_id:
-        value = payload.get("id")
-        if isinstance(value, str) and value:
-            return value
+    session_id = _nested_session_id(info)
+    if session_id:
+        return session_id
     properties = payload.get("properties")
     if isinstance(properties, dict):
-        for key in ("sessionID", "sessionId", "session_id"):
-            value = properties.get(key)
-            if isinstance(value, str) and value:
-                return value
-        info = properties.get("info")
-        if isinstance(info, dict):
-            for key in ("sessionID", "sessionId", "session_id"):
-                value = info.get(key)
-                if isinstance(value, str) and value:
-                    return value
-        part = properties.get("part")
-        if isinstance(part, dict):
-            for key in ("sessionID", "sessionId", "session_id"):
-                value = part.get(key)
-                if isinstance(value, str) and value:
-                    return value
+        session_id = _direct_session_id(properties, allow_fallback_id=False)
+        if session_id:
+            return session_id
+        for key in ("info", "part", "item"):
+            session_id = _nested_session_id(properties.get(key))
+            if session_id:
+                return session_id
     session = payload.get("session")
     if isinstance(session, dict):
-        return extract_session_id(session, allow_fallback_id=True)
+        return _nested_session_id(session, allow_fallback_id=True)
+    item = payload.get("item")
+    session_id = _nested_session_id(item)
+    if session_id:
+        return session_id
     return None
 
 

--- a/tests/agents/opencode/test_opencode_harness.py
+++ b/tests/agents/opencode/test_opencode_harness.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from codex_autorunner.agents.opencode import harness as harness_module
 from codex_autorunner.agents.opencode.harness import OpenCodeHarness
 from codex_autorunner.agents.registry import get_registered_agents
 from codex_autorunner.core.orchestration.runtime_thread_events import (
@@ -233,6 +234,109 @@ async def test_opencode_harness_progress_event_stream_reuses_pending_turn_collec
     assert streamed[0] == result.raw_events[0]
     assert merge_runtime_thread_raw_events(streamed, result.raw_events) == list(
         result.raw_events
+    )
+
+
+@pytest.mark.asyncio
+async def test_opencode_harness_progress_event_stream_accepts_nested_item_session_id() -> (
+    None
+):
+    workspace = Path("/tmp/workspace").resolve()
+    client = _StubClient(
+        [
+            SSEEvent(
+                event="item/agentMessage/delta",
+                data='{"item":{"sessionID":"session-1"},"itemId":"item-1","delta":"hello world"}',
+            ),
+            SSEEvent(
+                event="message.completed",
+                data='{"sessionID":"session-1","text":"hello world"}',
+            ),
+            SSEEvent(
+                event="session.status",
+                data='{"sessionID":"session-1","properties":{"status":{"type":"idle"}}}',
+            ),
+        ]
+    )
+    harness = OpenCodeHarness(_StubSupervisor(client))
+
+    turn = await harness.start_turn(
+        workspace,
+        "session-1",
+        prompt="hello",
+        model=None,
+        reasoning=None,
+        approval_mode=None,
+        sandbox_policy=None,
+    )
+
+    streamed: list[Any] = []
+
+    async def _collect_stream() -> None:
+        async for raw_event in harness.progress_event_stream(
+            workspace, "session-1", turn.turn_id
+        ):
+            streamed.append(raw_event)
+
+    stream_task = asyncio.create_task(_collect_stream())
+    result = await harness.wait_for_turn(workspace, "session-1", turn.turn_id)
+    await stream_task
+
+    assert result.status == "ok"
+    assert "item/agentMessage/delta" in [
+        event["message"]["method"] for event in streamed
+    ]
+
+
+@pytest.mark.asyncio
+async def test_opencode_harness_logs_skipped_progress_events_without_session_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = Path("/tmp/workspace").resolve()
+    client = _StubClient(
+        [
+            SSEEvent(
+                event="item/reasoning/summaryTextDelta",
+                data='{"item":{"type":"reasoning"},"delta":"thinking"}',
+            ),
+            SSEEvent(
+                event="session.status",
+                data='{"sessionID":"session-1","properties":{"status":{"type":"idle"}}}',
+            ),
+        ]
+    )
+    harness = OpenCodeHarness(_StubSupervisor(client))
+    logged_events: list[dict[str, Any]] = []
+
+    def _capture_log_event(
+        logger: Any,
+        level: int,
+        event: str,
+        **fields: Any,
+    ) -> None:
+        _ = logger
+        logged_events.append({"level": level, "event": event, **fields})
+
+    monkeypatch.setattr(harness_module, "log_event", _capture_log_event)
+
+    turn = await harness.start_turn(
+        workspace,
+        "session-1",
+        prompt="hello",
+        model=None,
+        reasoning=None,
+        approval_mode=None,
+        sandbox_policy=None,
+    )
+
+    result = await harness.wait_for_turn(workspace, "session-1", turn.turn_id)
+
+    assert result.status == "ok"
+    assert any(
+        event["event"] == "opencode.progress_event.skipped"
+        and event["reason"] == "missing_session_id"
+        and event["method"] == "item/reasoning/summaryTextDelta"
+        for event in logged_events
     )
 
 

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -23,6 +23,24 @@ def test_extract_session_id_prefers_nested_session_id() -> None:
     assert extract_session_id(payload) == "session-xyz"
 
 
+def test_extract_session_id_reads_nested_item_session_id() -> None:
+    payload = {"item": {"sessionID": "session-xyz"}}
+    assert extract_session_id(payload) == "session-xyz"
+
+
+def test_extract_session_id_reads_properties_item_nested_session_object() -> None:
+    payload = {"properties": {"item": {"session": {"id": "session-xyz"}}}}
+    assert extract_session_id(payload) == "session-xyz"
+
+
+def test_extract_session_id_preserves_existing_precedence_over_nested_item() -> None:
+    payload = {
+        "sessionID": "session-top",
+        "properties": {"item": {"sessionID": "session-item"}},
+    }
+    assert extract_session_id(payload) == "session-top"
+
+
 @pytest.mark.anyio
 async def test_collect_output_uses_delta() -> None:
     seen_deltas: list[str] = []


### PR DESCRIPTION
## Summary
- widen OpenCode session-id extraction just enough to recognize nested `item` and `properties.item` payloads without changing existing precedence
- add debug logging when non-idle OpenCode progress events are skipped because session metadata is missing or mismatched
- add regression tests for nested item session metadata and precedence preservation in the OpenCode runtime and harness

## Testing
- `.venv/bin/pytest tests/test_opencode_runtime.py tests/agents/opencode/test_opencode_harness.py`
- pre-commit hook suite during `git commit`:
  - `mypy`
  - `pnpm run build`
  - `pnpm test:markdown`
  - full `pytest` suite (`3351 passed, 1 skipped`)

Fixes #1088.
