### PR TITLE
Fix Discord pause fallback for summary-only ticket-flow runs

### DIFF
--- a/src/codex_autorunner/core/flows/pause_dispatch.py
+++ b/src/codex_autorunner/core/flows/pause_dispatch.py
@@ -82,6 +82,10 @@ def format_pause_reason(record: FlowRunRecord) -> str:
         if reason_raw
         else "Paused without details."
     )
+    reason_details_raw = engine.get("reason_details")
+    if isinstance(reason_details_raw, str) and reason_details_raw.strip():
+        details = _format_public_error(reason_details_raw, limit=500)
+        return f"Reason: {reason}\n\nDetails: {details}"
     return f"Reason: {reason}"
 
 
@@ -170,16 +174,20 @@ def list_unseen_ticket_flow_dispatches(
             )
         ]
 
+    unseen_seq_dirs = [
+        dispatch_dir
+        for dispatch_dir in seq_dirs
+        if last_seen_seq is None or int(dispatch_dir.name) > last_seen_seq
+    ]
+
     snapshots: list[TicketFlowDispatchSnapshot] = []
-    saw_notification_worthy_history = False
-    for dispatch_dir in seq_dirs:
+    saw_notification_worthy_unseen_history = False
+    for dispatch_dir in unseen_seq_dirs:
         seq = dispatch_dir.name
         dispatch_path = dispatch_dir / "DISPATCH.md"
         dispatch, errors = parse_dispatch(dispatch_path)
         if errors or dispatch is None:
-            saw_notification_worthy_history = True
-            if last_seen_seq is not None and int(seq) <= last_seen_seq:
-                continue
+            saw_notification_worthy_unseen_history = True
             snapshots.append(
                 TicketFlowDispatchSnapshot(
                     run_id=latest.id,
@@ -200,9 +208,7 @@ def list_unseen_ticket_flow_dispatches(
             )
             continue
         if dispatch.mode != "turn_summary":
-            saw_notification_worthy_history = True
-        if last_seen_seq is not None and int(seq) <= last_seen_seq:
-            continue
+            saw_notification_worthy_unseen_history = True
         if dispatch.mode == "turn_summary":
             continue
         snapshots.append(
@@ -220,8 +226,14 @@ def list_unseen_ticket_flow_dispatches(
             )
         )
 
-    if not snapshots and run_is_paused and not saw_notification_worthy_history:
-        fallback_seq = latest_dispatch_seq(paths.dispatch_history_dir) or "paused"
+    if (
+        not snapshots
+        and run_is_paused
+        and last_seen_seq is None
+        and unseen_seq_dirs
+        and not saw_notification_worthy_unseen_history
+    ):
+        fallback_seq = unseen_seq_dirs[-1].name
         snapshots.append(
             TicketFlowDispatchSnapshot(
                 run_id=latest.id,

--- a/tests/core/flows/test_pause_dispatch.py
+++ b/tests/core/flows/test_pause_dispatch.py
@@ -282,6 +282,66 @@ def test_list_unseen_ticket_flow_dispatches_does_not_repeat_after_seen_pause_the
     assert snapshots == []
 
 
+def test_list_unseen_ticket_flow_dispatches_respects_seen_summary_only_fallback(
+    tmp_path: Path,
+) -> None:
+    repo_root = _init_repo(tmp_path)
+    _create_paused_run(
+        repo_root,
+        run_id="run-seen-summary-only",
+        state={"ticket_engine": {"reason": "Investigate the stalled turn."}},
+    )
+
+    history_root = (
+        repo_root
+        / ".codex-autorunner"
+        / "runs"
+        / "run-seen-summary-only"
+        / "dispatch_history"
+    )
+    (history_root / "0001").mkdir(parents=True)
+    (history_root / "0001" / "DISPATCH.md").write_text(
+        "---\nmode: turn_summary\n---\n\nSummary that should not repeat the fallback.\n",
+        encoding="utf-8",
+    )
+
+    snapshots = list_unseen_ticket_flow_dispatches(
+        repo_root,
+        last_run_id="run-seen-summary-only",
+        last_dispatch_seq="0001",
+    )
+    assert snapshots == []
+
+
+def test_load_latest_paused_ticket_flow_dispatch_includes_reason_details(
+    tmp_path: Path,
+) -> None:
+    repo_root = _init_repo(tmp_path)
+    _create_paused_run(
+        repo_root,
+        run_id="run-error-details",
+        state={
+            "ticket_engine": {
+                "reason": "Agent turn failed. Fix the issue and resume.",
+                "reason_details": (
+                    "Error: Turn stalled and recovery exhausted: attempts=8, "
+                    "max_attempts=8, reason=resume_non_terminal, "
+                    "last_method=turn/diff/updated, status=inProgress."
+                ),
+            }
+        },
+    )
+
+    snapshot = load_latest_paused_ticket_flow_dispatch(repo_root)
+    assert snapshot is not None
+    assert snapshot.dispatch_markdown == (
+        "Reason: Agent turn failed. Fix the issue and resume.\n\n"
+        "Details: Error: Turn stalled and recovery exhausted: attempts=8, "
+        "max_attempts=8, reason=resume_non_terminal, "
+        "last_method=turn/diff/updated, status=inProgress."
+    )
+
+
 def test_latest_dispatch_seq_ignores_non_numeric_entries(tmp_path: Path) -> None:
     history = tmp_path / "dispatch_history"
     history.mkdir()

--- a/tests/integrations/discord/test_pause_bridge.py
+++ b/tests/integrations/discord/test_pause_bridge.py
@@ -526,7 +526,12 @@ async def test_pause_bridge_falls_back_when_only_turn_summary_exists(
                 input_data={},
                 state={
                     "ticket_engine": {
-                        "reason": "Investigate the stalled recovery before resuming."
+                        "reason": "Agent turn failed. Fix the issue and resume.",
+                        "reason_details": (
+                            "Error: Turn stalled and recovery exhausted: attempts=8, "
+                            "max_attempts=8, reason=resume_non_terminal, "
+                            "last_method=turn/diff/updated, status=inProgress."
+                        ),
                     }
                 },
             )
@@ -535,7 +540,12 @@ async def test_pause_bridge_falls_back_when_only_turn_summary_exists(
             FlowRunStatus.PAUSED,
             state={
                 "ticket_engine": {
-                    "reason": "Investigate the stalled recovery before resuming."
+                    "reason": "Agent turn failed. Fix the issue and resume.",
+                    "reason_details": (
+                        "Error: Turn stalled and recovery exhausted: attempts=8, "
+                        "max_attempts=8, reason=resume_non_terminal, "
+                        "last_method=turn/diff/updated, status=inProgress."
+                    ),
                 }
             },
         )
@@ -573,7 +583,12 @@ async def test_pause_bridge_falls_back_when_only_turn_summary_exists(
         assert len(queued) == 1
         content = str(queued[0].payload_json.get("content", ""))
         assert f"Ticket flow paused (run {run_id}). Latest dispatch #0001:" in content
-        assert "Reason: Investigate the stalled recovery before resuming." in content
+        assert "Reason: Agent turn failed. Fix the issue and resume." in content
+        assert (
+            "Details: Error: Turn stalled and recovery exhausted: attempts=8, "
+            "max_attempts=8, reason=resume_non_terminal, "
+            "last_method=turn/diff/updated, status=inProgress."
+        ) in content
         assert "Summary that should stay out of Discord." not in content
         assert "Use `/car flow resume` to continue." in content
 
@@ -581,6 +596,10 @@ async def test_pause_bridge_falls_back_when_only_turn_summary_exists(
         assert binding is not None
         assert binding["last_pause_run_id"] == run_id
         assert binding["last_pause_dispatch_seq"] == "0001"
+
+        await service._scan_and_enqueue_pause_notifications()
+        queued = await store.list_outbox()
+        assert len(queued) == 1
     finally:
         await store.close()
 


### PR DESCRIPTION
## Summary
- send a bound Discord pause notice when the authoritative paused run only has `turn_summary` history
- keep that fallback on the shared `list_unseen_ticket_flow_dispatches` path so Discord uses the same pause-state detection consistently
- avoid duplicate fallback notices when an actual pause dispatch was already seen and a later `turn_summary` arrives

## Why
A paused ticket-flow run could be missing a bound-chat notice if its dispatch history only contained `turn_summary` entries. Discord filters those summaries out, and the shared helper returned no snapshot at all, so the pause watcher had nothing to send.

## Testing
- `.venv/bin/python -m pytest tests/core/flows/test_pause_dispatch.py`
- `.venv/bin/python -m pytest tests/integrations/discord/test_pause_bridge.py`
- full pre-commit suite during `git commit` including repo-wide pytest (`3397 passed, 1 skipped`)
