### PR TITLE
Use 'all' for Discord update target choices

### DIFF
--- a/src/codex_autorunner/core/update_targets.py
+++ b/src/codex_autorunner/core/update_targets.py
@@ -128,7 +128,10 @@ def update_target_command_choices(
     *, include_status: bool = False
 ) -> tuple[dict[str, str], ...]:
     choices = tuple(
-        {"name": definition.label, "value": definition.value}
+        {
+            "name": definition.label,
+            "value": "all" if definition.value == "both" else definition.value,
+        }
         for definition in all_update_target_definitions()
     )
     if not include_status:

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -4961,7 +4961,7 @@ async def test_car_update_starts_worker_with_explicit_target(
         [
             _interaction(
                 name="update",
-                options=[{"type": 3, "name": "target", "value": "both"}],
+                options=[{"type": 3, "name": "target", "value": "all"}],
             )
         ]
     )
@@ -5010,7 +5010,7 @@ async def test_car_update_prompts_for_confirmation_when_sessions_active(
         [
             _interaction(
                 name="update",
-                options=[{"type": 3, "name": "target", "value": "both"}],
+                options=[{"type": 3, "name": "target", "value": "all"}],
             )
         ]
     )

--- a/tests/test_system_update_worker.py
+++ b/tests/test_system_update_worker.py
@@ -155,7 +155,7 @@ def test_update_target_helpers_share_the_same_core_definitions() -> None:
         ("discord", "Discord only"),
     )
     assert update_target_command_choices(include_status=True) == (
-        {"name": "All", "value": "both"},
+        {"name": "All", "value": "all"},
         {"name": "Web only", "value": "web"},
         {"name": "Chat apps (Telegram + Discord)", "value": "chat"},
         {"name": "Telegram only", "value": "telegram"},


### PR DESCRIPTION
## Summary
- expose `all` instead of `both` in Discord slash-command update target choices
- keep the existing internal `both` target by relying on the existing normalization alias
- update Discord routing and update-target tests to cover the new user-facing value

## Testing
- `.venv/bin/pytest tests/test_system_update_worker.py tests/integrations/discord/test_commands_payload.py tests/integrations/discord/test_components.py tests/integrations/discord/test_service_routing.py -q`
- full pre-commit checks during `git commit`, including repo-wide `pytest`
