### PR TITLE
Fix Discord update active session counting

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -6600,16 +6600,39 @@ class DiscordBotService:
 
     def _active_update_session_count(self) -> int:
         try:
-            threads = self._discord_thread_service().list_thread_targets(
+            orchestration_service = self._discord_thread_service()
+            threads = orchestration_service.list_thread_targets(
                 lifecycle_status="active"
             )
         except Exception:
             return 0
-        return sum(
-            1
-            for thread in threads
-            if str(getattr(thread, "status", "") or "").strip().lower() == "running"
+        get_running_execution = getattr(
+            orchestration_service, "get_running_execution", None
         )
+        if not callable(get_running_execution):
+            return sum(
+                1
+                for thread in threads
+                if str(getattr(thread, "status", "") or "").strip().lower() == "running"
+            )
+
+        active_count = 0
+        for thread in threads:
+            thread_target_id = str(
+                getattr(thread, "thread_target_id", "") or ""
+            ).strip()
+            if not thread_target_id:
+                continue
+            try:
+                if get_running_execution(thread_target_id) is not None:
+                    active_count += 1
+            except Exception:
+                if (
+                    str(getattr(thread, "status", "") or "").strip().lower()
+                    == "running"
+                ):
+                    active_count += 1
+        return active_count
 
     def _build_update_confirmation_components(
         self,

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -5051,6 +5051,32 @@ async def test_car_update_prompts_for_confirmation_when_sessions_active(
         await store.close()
 
 
+def test_active_update_session_count_uses_live_running_executions() -> None:
+    class _FakeThread:
+        def __init__(self, thread_target_id: str, status: str) -> None:
+            self.thread_target_id = thread_target_id
+            self.status = status
+
+    class _FakeThreadService:
+        def list_thread_targets(self, *, lifecycle_status: str) -> list[Any]:
+            assert lifecycle_status == "active"
+            return [
+                _FakeThread("thread-live", "running"),
+                _FakeThread("thread-stale", "running"),
+                _FakeThread("thread-idle", "idle"),
+            ]
+
+        def get_running_execution(self, thread_target_id: str) -> Any:
+            if thread_target_id == "thread-live":
+                return {"execution_id": "exec-live"}
+            return None
+
+    service = object.__new__(DiscordBotService)
+    service._discord_thread_service = lambda: _FakeThreadService()  # type: ignore[method-assign]
+
+    assert DiscordBotService._active_update_session_count(service) == 1
+
+
 @pytest.mark.anyio
 async def test_component_interaction_update_cancel_reports_cancelled(
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- fix Discord update warnings to count only live running executions instead of persisted running thread state
- add a regression test covering stale persisted running threads

## Testing
- .venv/bin/python -m pytest tests/integrations/discord/test_service_routing.py -k "active_update_session_count_uses_live_running_executions or car_update_prompts_for_confirmation_when_sessions_active or component_interaction_update_cancel_reports_cancelled or car_update_web_target_skips_confirmation_when_sessions_active"
