### PR TITLE
Canonicalize update target as all

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Reference docs in `docs/` (e.g., configuration, operations, debugging).
 ## Safe updates (launchd mac hub)
 - Preferred path: `scripts/safe-refresh-local-mac-hub.sh` (staged venv swap, launchd reload, `/health` + static/telegram checks, rollback on failure).
 - `/system/update` and Telegram `/update` use the safe refresh script when available.
-- Common overrides: `UPDATE_TARGET=web|chat|telegram|discord|both`, `HEALTH_CHECK_STATIC=auto|true|false`, `HEALTH_CHECK_TELEGRAM=auto|true|false`, `HEALTH_CHECK_DISCORD=auto|true|false`, `HEALTH_PATH`, `HEALTH_STATIC_PATH`.
+- Common overrides: `UPDATE_TARGET=web|chat|telegram|discord|all`, `HEALTH_CHECK_STATIC=auto|true|false`, `HEALTH_CHECK_TELEGRAM=auto|true|false`, `HEALTH_CHECK_DISCORD=auto|true|false`, `HEALTH_PATH`, `HEALTH_STATIC_PATH`.
 - Do not restart launchd services or run refresh scripts yourself; ask the user to perform restarts.
 
 ## Debugging

--- a/docs/ops/telegram-bot-runbook.md
+++ b/docs/ops/telegram-bot-runbook.md
@@ -52,7 +52,7 @@ Operate and troubleshoot the Telegram polling bot that proxies Codex app-server 
 - `/approvals yolo|safe`: toggle approval mode.
 - `/ids`: show chat/user/thread IDs plus copy-paste collaboration snippets.
 - `/status`: show current workspace/runtime state plus the effective collaboration mode for the current destination.
-- `/update [both|web|chat|telegram|discord]`: update CAR and restart selected services.
+- `/update [all|web|chat|telegram|discord]`: update CAR and restart selected services.
 - `!<cmd>`: run a bash command in the bound workspace (controlled by `telegram_bot.shell.enabled`).
 
 ## Media Support

--- a/scripts/safe-refresh-local-linux-hub.sh
+++ b/scripts/safe-refresh-local-linux-hub.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # Overrides:
 #   PACKAGE_SRC                  Path to this repo (default: scripts/..)
 #   UPDATE_STATUS_PATH           JSON status path maintained by update worker
-#   UPDATE_TARGET                both|web|chat|telegram|discord (default: both)
+#   UPDATE_TARGET                all|web|chat|telegram|discord (default: all)
 #   UPDATE_HUB_SERVICE_NAME      systemd user service for hub (default: car-hub)
 #   UPDATE_TELEGRAM_SERVICE_NAME systemd user service for telegram (default: car-telegram)
 #   UPDATE_DISCORD_SERVICE_NAME  systemd user service for discord (default: car-discord)
@@ -24,7 +24,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PACKAGE_SRC="${PACKAGE_SRC:-$SCRIPT_DIR/..}"
 UPDATE_STATUS_PATH="${UPDATE_STATUS_PATH:-}"
-UPDATE_TARGET="${UPDATE_TARGET:-both}"
+UPDATE_TARGET="${UPDATE_TARGET:-all}"
 UPDATE_HUB_SERVICE_NAME="${UPDATE_HUB_SERVICE_NAME:-car-hub}"
 UPDATE_TELEGRAM_SERVICE_NAME="${UPDATE_TELEGRAM_SERVICE_NAME:-car-telegram}"
 UPDATE_DISCORD_SERVICE_NAME="${UPDATE_DISCORD_SERVICE_NAME:-car-discord}"
@@ -111,8 +111,8 @@ normalize_update_target() {
   local raw
   raw="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
   case "${raw}" in
-    ""|both|all)
-      echo "both"
+    ""|all|both)
+      echo "all"
       ;;
     web|hub|server|ui)
       echo "web"
@@ -127,7 +127,7 @@ normalize_update_target() {
       echo "discord"
       ;;
     *)
-      fail "Unsupported UPDATE_TARGET '${raw}'. Use both, web, chat, telegram, or discord."
+      fail "Unsupported UPDATE_TARGET '${raw}'. Use all, web, chat, telegram, or discord."
       ;;
   esac
 }
@@ -243,7 +243,7 @@ restart_web=false
 restart_telegram=false
 restart_discord=false
 
-if [[ "${target}" == "both" || "${target}" == "web" ]]; then
+if [[ "${target}" == "all" || "${target}" == "web" ]]; then
   if ! service_exists "${UPDATE_HUB_SERVICE_NAME}"; then
     fail "Hub service not found: ${UPDATE_HUB_SERVICE_NAME}"
   fi
@@ -252,7 +252,7 @@ if [[ "${target}" == "both" || "${target}" == "web" ]]; then
   restart_web=true
 fi
 
-if [[ "${target}" == "both" || "${target}" == "chat" || "${target}" == "telegram" ]]; then
+if [[ "${target}" == "all" || "${target}" == "chat" || "${target}" == "telegram" ]]; then
   if service_exists "${UPDATE_TELEGRAM_SERVICE_NAME}"; then
     echo "Restarting telegram service ${UPDATE_TELEGRAM_SERVICE_NAME}..."
     systemctl --user restart "${UPDATE_TELEGRAM_SERVICE_NAME}"
@@ -264,7 +264,7 @@ if [[ "${target}" == "both" || "${target}" == "chat" || "${target}" == "telegram
   fi
 fi
 
-if [[ "${target}" == "both" || "${target}" == "chat" || "${target}" == "discord" ]]; then
+if [[ "${target}" == "all" || "${target}" == "chat" || "${target}" == "discord" ]]; then
   if service_exists "${UPDATE_DISCORD_SERVICE_NAME}"; then
     echo "Restarting discord service ${UPDATE_DISCORD_SERVICE_NAME}..."
     systemctl --user restart "${UPDATE_DISCORD_SERVICE_NAME}"

--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 #   DISCORD_LABEL          launchd label for discord bot (default: ${LABEL}.discord)
 #   DISCORD_PLIST_PATH     discord plist path (default: ~/Library/LaunchAgents/${DISCORD_LABEL}.plist)
 #   DISCORD_LOG            discord stdout/stderr log path (default: <hub_root>/.codex-autorunner/codex-autorunner-discord.log)
-#   UPDATE_TARGET          Which services to restart (both|web|chat|telegram|discord; default: both)
+#   UPDATE_TARGET          Which services to restart (all|web|chat|telegram|discord; default: all)
 #   PIPX_ROOT              pipx root (default: ~/.local/pipx)
 #   PIPX_VENV              existing pipx venv path (default: ${PIPX_ROOT}/venvs/codex-autorunner)
 #   PIPX_PYTHON            python used for new venvs (default: pyenv python3, then Homebrew)
@@ -50,7 +50,7 @@ ENABLE_TELEGRAM_BOT="${ENABLE_TELEGRAM_BOT:-auto}"
 DISCORD_LABEL="${DISCORD_LABEL:-${LABEL}.discord}"
 DISCORD_PLIST_PATH="${DISCORD_PLIST_PATH:-$HOME/Library/LaunchAgents/${DISCORD_LABEL}.plist}"
 ENABLE_DISCORD_BOT="${ENABLE_DISCORD_BOT:-auto}"
-UPDATE_TARGET="${UPDATE_TARGET:-both}"
+UPDATE_TARGET="${UPDATE_TARGET:-all}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PACKAGE_SRC="${PACKAGE_SRC:-$SCRIPT_DIR/..}"
@@ -156,8 +156,8 @@ normalize_update_target() {
   local raw
   raw="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
   case "${raw}" in
-    ""|both|all)
-      echo "both"
+    ""|all|both)
+      echo "all"
       ;;
     web|hub|server|ui)
       echo "web"
@@ -172,7 +172,7 @@ normalize_update_target() {
       echo "discord"
       ;;
     *)
-      fail "Unsupported UPDATE_TARGET '${raw}'. Use both, web, chat, telegram, or discord."
+      fail "Unsupported UPDATE_TARGET '${raw}'. Use all, web, chat, telegram, or discord."
       ;;
   esac
 }
@@ -425,7 +425,7 @@ telegram_health_checked=false
 discord_health_reason=""
 discord_health_checked=false
 case "${UPDATE_TARGET}" in
-  both)
+  all)
     should_reload_hub=true
     should_reload_telegram=true
     should_reload_discord=true

--- a/src/codex_autorunner/core/update.py
+++ b/src/codex_autorunner/core/update.py
@@ -261,8 +261,8 @@ def _default_update_target(
             linux_service_names=linux_service_names,
         )
     }
-    if "both" in values:
-        return "both"
+    if "all" in values:
+        return "all"
     return "web"
 
 
@@ -317,9 +317,9 @@ def _update_target_restarts_surface(
     if normalized_surface == "web":
         return bool(definition.includes_web)
     if normalized_surface == "telegram":
-        return definition.value in {"both", "chat", "telegram"}
+        return definition.value in {"all", "chat", "telegram"}
     if normalized_surface == "discord":
-        return definition.value in {"both", "chat", "discord"}
+        return definition.value in {"all", "chat", "discord"}
     raise ValueError(f"Unsupported update surface: {surface}")
 
 
@@ -653,7 +653,7 @@ def _system_update_worker(
     repo_ref: str,
     update_dir: Path,
     logger: logging.Logger,
-    update_target: str = "both",
+    update_target: str = "all",
     update_backend: str = "auto",
     skip_checks: bool = False,
     linux_hub_service_name: Optional[str] = None,
@@ -837,7 +837,7 @@ def _spawn_update_process(
     repo_ref: str,
     update_dir: Path,
     logger: logging.Logger,
-    update_target: str = "both",
+    update_target: str = "all",
     update_backend: str = "auto",
     skip_checks: bool = False,
     notify_chat_id: Optional[int] = None,

--- a/src/codex_autorunner/core/update_runner.py
+++ b/src/codex_autorunner/core/update_runner.py
@@ -22,7 +22,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--repo-ref", default="main")
     parser.add_argument("--update-dir", required=True)
     parser.add_argument("--log-path", required=True)
-    parser.add_argument("--target", default="both")
+    parser.add_argument("--target", default="all")
     parser.add_argument("--backend", default="auto")
     parser.add_argument("--hub-service-name")
     parser.add_argument("--telegram-service-name")

--- a/src/codex_autorunner/core/update_targets.py
+++ b/src/codex_autorunner/core/update_targets.py
@@ -13,11 +13,11 @@ class UpdateTargetDefinition:
     includes_web: bool
 
 
-_DEFAULT_UPDATE_TARGET = "both"
-_UPDATE_TARGET_ORDER = ("both", "web", "chat", "telegram", "discord")
+_DEFAULT_UPDATE_TARGET = "all"
+_UPDATE_TARGET_ORDER = ("all", "web", "chat", "telegram", "discord")
 _UPDATE_TARGET_DEFINITIONS = {
-    "both": UpdateTargetDefinition(
-        value="both",
+    "all": UpdateTargetDefinition(
+        value="all",
         label="All",
         description="Web + Telegram + Discord",
         restart_notice="The web UI, Telegram, and Discord will restart.",
@@ -54,8 +54,8 @@ _UPDATE_TARGET_DEFINITIONS = {
 }
 _UPDATE_TARGET_ALIASES = {
     "": _DEFAULT_UPDATE_TARGET,
-    "all": "both",
-    "both": "both",
+    "all": "all",
+    "both": "all",
     "web": "web",
     "hub": "web",
     "server": "web",
@@ -98,7 +98,7 @@ def _all_target_definition(
         services.append("Discord")
         restart_services.append("Discord")
     return UpdateTargetDefinition(
-        value="both",
+        value="all",
         label="All",
         description=" + ".join(services),
         restart_notice=f"The {_format_service_list(tuple(restart_services))} will restart.",
@@ -128,10 +128,7 @@ def update_target_command_choices(
     *, include_status: bool = False
 ) -> tuple[dict[str, str], ...]:
     choices = tuple(
-        {
-            "name": definition.label,
-            "value": "all" if definition.value == "both" else definition.value,
-        }
+        {"name": definition.label, "value": definition.value}
         for definition in all_update_target_definitions()
     )
     if not include_status:

--- a/src/codex_autorunner/static/generated/hub.js
+++ b/src/codex_autorunner/static/generated/hub.js
@@ -608,7 +608,7 @@ async function loadUpdateTargetOptions(selectId) {
     const { options, defaultTarget } = updateTargetOptionsFromResponse(payload);
     if (!options.length)
         return;
-    const previous = normalizeUpdateTarget(select.value || "both");
+    const previous = normalizeUpdateTarget(select.value || "all");
     const hasPrevious = options.some((item) => item.value === previous);
     const fallback = options.some((item) => item.value === defaultTarget)
         ? defaultTarget

--- a/src/codex_autorunner/static/generated/settings.js
+++ b/src/codex_autorunner/static/generated/settings.js
@@ -169,7 +169,7 @@ async function loadUpdateTargetOptions(selectId) {
     const { options, defaultTarget } = updateTargetOptionsFromResponse(payload);
     if (!options.length)
         return;
-    const previous = normalizeUpdateTarget(select.value || "both");
+    const previous = normalizeUpdateTarget(select.value || "all");
     const hasPrevious = options.some((item) => item.value === previous);
     const fallback = options.some((item) => item.value === defaultTarget)
         ? defaultTarget

--- a/src/codex_autorunner/static/generated/updateTargets.js
+++ b/src/codex_autorunner/static/generated/updateTargets.js
@@ -1,8 +1,8 @@
 // GENERATED FILE - do not edit directly. Source: static_src/
-const DEFAULT_UPDATE_TARGET = "both";
+const DEFAULT_UPDATE_TARGET = "all";
 const UPDATE_TARGET_ALIASES = new Map([
-    ["all", "both"],
-    ["both", "both"],
+    ["all", "all"],
+    ["both", "all"],
     ["web", "web"],
     ["hub", "web"],
     ["server", "web"],
@@ -30,7 +30,7 @@ function fallbackTargetOption(value) {
         value: normalized,
         label: titleCaseTarget(normalized),
         description: titleCaseTarget(normalized),
-        includesWeb: normalized === "both" || normalized === "web",
+        includesWeb: normalized === "all" || normalized === "web",
         restartNotice: "The selected services will restart.",
     };
 }

--- a/src/codex_autorunner/static_src/hub.ts
+++ b/src/codex_autorunner/static_src/hub.ts
@@ -914,7 +914,7 @@ async function loadUpdateTargetOptions(selectId: string | null): Promise<void> {
   const { options, defaultTarget } = updateTargetOptionsFromResponse(payload);
   if (!options.length) return;
 
-  const previous = normalizeUpdateTarget(select.value || "both");
+  const previous = normalizeUpdateTarget(select.value || "all");
   const hasPrevious = options.some((item) => item.value === previous);
   const fallback = options.some((item) => item.value === defaultTarget)
     ? defaultTarget

--- a/src/codex_autorunner/static_src/settings.ts
+++ b/src/codex_autorunner/static_src/settings.ts
@@ -201,7 +201,7 @@ async function loadUpdateTargetOptions(selectId: string | null): Promise<void> {
   const { options, defaultTarget } = updateTargetOptionsFromResponse(payload);
   if (!options.length) return;
 
-  const previous = normalizeUpdateTarget(select.value || "both");
+  const previous = normalizeUpdateTarget(select.value || "all");
   const hasPrevious = options.some((item) => item.value === previous);
   const fallback = options.some((item) => item.value === defaultTarget)
     ? defaultTarget

--- a/src/codex_autorunner/static_src/updateTargets.ts
+++ b/src/codex_autorunner/static_src/updateTargets.ts
@@ -21,10 +21,10 @@ export interface UpdateTargetOption {
   restartNotice: string;
 }
 
-const DEFAULT_UPDATE_TARGET = "both";
+const DEFAULT_UPDATE_TARGET = "all";
 const UPDATE_TARGET_ALIASES = new Map<string, string>([
-  ["all", "both"],
-  ["both", "both"],
+  ["all", "all"],
+  ["both", "all"],
   ["web", "web"],
   ["hub", "web"],
   ["server", "web"],
@@ -54,7 +54,7 @@ function fallbackTargetOption(value: UpdateTarget): UpdateTargetOption {
     value: normalized,
     label: titleCaseTarget(normalized),
     description: titleCaseTarget(normalized),
-    includesWeb: normalized === "both" || normalized === "web",
+    includesWeb: normalized === "all" || normalized === "web",
     restartNotice: "The selected services will restart.",
   };
 }

--- a/tests/integrations/discord/test_components.py
+++ b/tests/integrations/discord/test_components.py
@@ -233,6 +233,6 @@ class TestBuildUpdateTargetPicker:
         menu = picker["components"][0]
         assert menu["custom_id"] == "update_target_select"
         values = {opt["value"] for opt in menu["options"]}
-        assert values == {"both", "web", "chat", "telegram", "discord", "status"}
-        all_option = next(opt for opt in menu["options"] if opt["value"] == "both")
+        assert values == {"all", "web", "chat", "telegram", "discord", "status"}
+        all_option = next(opt for opt in menu["options"] if opt["value"] == "all")
         assert all_option["label"] == "All"

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -4987,7 +4987,7 @@ async def test_car_update_starts_worker_with_explicit_target(
 
     try:
         await service.run_forever()
-        assert observed["update_target"] == "both"
+        assert observed["update_target"] == "all"
         assert observed["repo_ref"] == "main"
         assert "codex-autorunner.git" in observed["repo_url"]
         assert observed["notify_platform"] == "discord"
@@ -5045,8 +5045,8 @@ async def test_car_update_prompts_for_confirmation_when_sessions_active(
         components = data.get("components") or []
         assert components
         buttons = components[0]["components"]
-        assert buttons[0]["custom_id"] == "update_confirm:both"
-        assert buttons[1]["custom_id"] == "update_cancel:both"
+        assert buttons[0]["custom_id"] == "update_confirm:all"
+        assert buttons[1]["custom_id"] == "update_cancel:all"
     finally:
         await store.close()
 
@@ -5059,7 +5059,7 @@ async def test_component_interaction_update_cancel_reports_cancelled(
     await store.initialize()
     rest = _FakeRest()
     gateway = _FakeGateway(
-        [_component_interaction(custom_id="update_cancel:both", values=["both"])]
+        [_component_interaction(custom_id="update_cancel:all", values=["all"])]
     )
     service = DiscordBotService(
         _config(tmp_path, allow_user_ids=frozenset({"user-1"})),

--- a/tests/routes/test_system_update_routes.py
+++ b/tests/routes/test_system_update_routes.py
@@ -49,7 +49,7 @@ def test_system_update_warns_when_terminal_sessions_are_active(
     )
 
     with TestClient(app) as client:
-        response = client.post("/system/update", json={"target": "both"})
+        response = client.post("/system/update", json={"target": "all"})
 
     assert response.status_code == 200
     payload = response.json()
@@ -82,13 +82,13 @@ def test_system_update_force_bypasses_active_session_warning(
     )
 
     with TestClient(app) as client:
-        response = client.post("/system/update", json={"target": "both", "force": True})
+        response = client.post("/system/update", json={"target": "all", "force": True})
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["status"] == "ok"
     assert payload["requires_confirmation"] is False
-    assert observed["update_target"] == "both"
+    assert observed["update_target"] == "all"
 
 
 def test_system_update_chat_target_skips_terminal_warning(

--- a/tests/test_system_update_worker.py
+++ b/tests/test_system_update_worker.py
@@ -18,9 +18,10 @@ from codex_autorunner.core.update_targets import (
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
-        (None, "both"),
-        ("", "both"),
-        ("ALL", "both"),
+        (None, "all"),
+        ("", "all"),
+        ("ALL", "all"),
+        ("both", "all"),
         ("web", "web"),
         ("ui", "web"),
         ("chat", "chat"),
@@ -86,7 +87,7 @@ def test_available_update_target_options_include_telegram_when_enableable(
         linux_service_names={"hub": "car-hub"},
     )
     assert options == (
-        ("both", "All"),
+        ("all", "All"),
         ("web", "Web only"),
         ("telegram", "Telegram only"),
     )
@@ -122,7 +123,7 @@ def test_available_update_target_options_include_discord_when_active(
         linux_service_names={"hub": "car-hub", "discord": "car-discord"},
     )
     assert options == (
-        ("both", "All"),
+        ("all", "All"),
         ("web", "Web only"),
         ("discord", "Discord only"),
     )
@@ -140,7 +141,7 @@ def test_available_update_target_options_include_discord_when_active(
 
 def test_update_target_helpers_share_the_same_core_definitions() -> None:
     assert update_target_values(include_status=True) == (
-        "both",
+        "all",
         "web",
         "chat",
         "telegram",
@@ -148,7 +149,7 @@ def test_update_target_helpers_share_the_same_core_definitions() -> None:
         "status",
     )
     assert update_target_label_pairs() == (
-        ("both", "All"),
+        ("all", "All"),
         ("web", "Web only"),
         ("chat", "Chat apps (Telegram + Discord)"),
         ("telegram", "Telegram only"),

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -735,7 +735,7 @@ def test_build_keyboards() -> None:
     bind_keyboard = build_bind_keyboard([("repo_a", "1) repo-a")])
     assert bind_keyboard["inline_keyboard"][0][0]["callback_data"].startswith("bind:")
     update_keyboard = build_update_keyboard(
-        [("both", "Both"), ("web", "Web only")],
+        [("all", "All"), ("web", "Web only")],
         include_cancel=True,
     )
     assert update_keyboard["inline_keyboard"][0][0]["callback_data"].startswith(

--- a/tests/test_telegram_bot_integration.py
+++ b/tests/test_telegram_bot_integration.py
@@ -1377,7 +1377,7 @@ async def test_update_with_explicit_target_prompts_for_confirmation_when_turn_ac
     finally:
         await service._app_server_supervisor.close_all()
 
-    assert captured == {"message_id": 20, "update_target": "both"}
+    assert captured == {"message_id": 20, "update_target": "all"}
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- canonicalize the update target domain model to `all` and keep `both` as a backward-compatible input alias only
- update Discord, Telegram, web TS helpers, and safe refresh scripts so emitted values, labels, and confirmation component ids all use `all`
- refresh the generated static assets and update focused tests/docs to match the new canonical value

## Testing
- `.venv/bin/python -m pytest tests/test_system_update_worker.py tests/routes/test_system_update_routes.py tests/integrations/discord/test_components.py tests/integrations/discord/test_service_routing.py -k 'update'`
- `.venv/bin/python -m pytest tests/test_telegram_bot_integration.py tests/test_telegram_adapter.py -k 'update or keyboards'`
- `pnpm run build`
- pre-commit suite via `git commit` (`3410 passed, 1 skipped`)

## Notes
- While investigating the live Discord update issue, the runtime log at `/Users/dazheng/car-workspace/.codex-autorunner/codex-autorunner-discord.log` showed repeated `OSError: [Errno 28] No space left on device`. That looks like a separate operational problem that can cause Discord interactions to fail or behave inconsistently even when the update script reports a successful restart.
