### PR TITLE
Fix Discord compaction completion

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -11602,6 +11602,8 @@ class DiscordBotService:
         )
 
         interaction_text: Optional[str] = None
+        previous_thread_id = current_thread.thread_target_id
+        next_thread_id: Optional[str] = None
         try:
             try:
                 turn_result = await self._run_agent_turn_for_message(
@@ -11688,7 +11690,83 @@ class DiscordBotService:
                     seed_text=build_compact_seed_prompt(response_text),
                     session_key=next_thread_id,
                 )
+            except Exception as exc:
+                log_event(
+                    self._logger,
+                    logging.WARNING,
+                    "discord.compact.seed_save_failed",
+                    channel_id=channel_id,
+                    workspace_root=str(workspace_root),
+                    next_thread_id=next_thread_id,
+                    previous_thread_id=previous_thread_id,
+                    exc=exc,
+                )
+                rollback_failed = False
+                try:
+                    orchestration_service = self._discord_thread_service()
+                    if next_thread_id:
+                        with contextlib.suppress(Exception):
+                            orchestration_service.archive_thread_target(next_thread_id)
+                    restored = orchestration_service.resume_thread_target(
+                        previous_thread_id
+                    )
+                    self._attach_discord_thread_binding(
+                        channel_id=channel_id,
+                        thread_target_id=restored.thread_target_id,
+                        agent=agent,
+                        repo_id=(
+                            str(binding.get("repo_id")).strip()
+                            if isinstance(binding.get("repo_id"), str)
+                            and str(binding.get("repo_id")).strip()
+                            else None
+                        ),
+                        resource_kind=(
+                            str(binding.get("resource_kind")).strip()
+                            if isinstance(binding.get("resource_kind"), str)
+                            and str(binding.get("resource_kind")).strip()
+                            else None
+                        ),
+                        resource_id=(
+                            str(binding.get("resource_id")).strip()
+                            if isinstance(binding.get("resource_id"), str)
+                            and str(binding.get("resource_id")).strip()
+                            else None
+                        ),
+                        workspace_root=workspace_root,
+                        pma_enabled=pma_enabled,
+                    )
+                except Exception as rollback_exc:
+                    rollback_failed = True
+                    log_event(
+                        self._logger,
+                        logging.ERROR,
+                        "discord.compact.seed_save_rollback_failed",
+                        channel_id=channel_id,
+                        workspace_root=str(workspace_root),
+                        next_thread_id=next_thread_id,
+                        previous_thread_id=previous_thread_id,
+                        exc=rollback_exc,
+                    )
+                await self._send_channel_message_safe(
+                    channel_id,
+                    {
+                        "content": (
+                            "Compaction summary generated, but saving the compacted context failed. "
+                            "Restored the previous thread; please retry."
+                            if not rollback_failed
+                            else "Compaction summary generated, but saving the compacted context failed and restoring the previous thread also failed."
+                        )
+                    },
+                )
+                interaction_text = (
+                    "Compaction summary generated, but saving the compacted context failed. "
+                    "Restored the previous thread; please retry."
+                    if not rollback_failed
+                    else "Compaction summary generated, but saving the compacted context failed and restoring the previous thread also failed."
+                )
+                return
 
+            try:
                 chunks = chunk_discord_message(
                     f"**Conversation Summary:**\n\n{response_text}",
                     max_len=self._config.max_message_length,

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -984,6 +984,129 @@ async def test_car_session_compact_finishes_interaction_when_finalize_fails(
 
 
 @pytest.mark.anyio
+async def test_car_session_compact_restores_previous_thread_when_seed_save_fails(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, max_message_length=120),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    orchestration_service = service._discord_thread_service()
+    current_thread = orchestration_service.create_thread_target(
+        "codex",
+        workspace.resolve(),
+        display_name="discord:channel-1",
+    )
+    service._attach_discord_thread_binding(
+        channel_id="channel-1",
+        thread_target_id=current_thread.thread_target_id,
+        agent="codex",
+        repo_id=None,
+        pma_enabled=False,
+    )
+
+    async def _fake_run_turn(
+        *,
+        workspace_root: Path,
+        prompt_text: str,
+        agent: str,
+        model_override: Optional[str],
+        reasoning_effort: Optional[str],
+        session_key: str,
+        orchestrator_channel_key: str,
+    ) -> DiscordMessageTurnResult:
+        _ = (
+            workspace_root,
+            prompt_text,
+            agent,
+            model_override,
+            reasoning_effort,
+            session_key,
+            orchestrator_channel_key,
+        )
+        return DiscordMessageTurnResult(
+            final_message="summary text",
+            preview_message_id=None,
+        )
+
+    async def _failing_set_pending_compact_seed(
+        *, channel_id: str, seed_text: str, session_key: str
+    ) -> None:
+        _ = channel_id, seed_text, session_key
+        raise RuntimeError("sqlite locked")
+
+    service._run_agent_turn_for_message = _fake_run_turn  # type: ignore[assignment]
+    store.set_pending_compact_seed = _failing_set_pending_compact_seed  # type: ignore[assignment]
+
+    try:
+        await service._handle_car_compact(
+            "interaction-1",
+            "token-1",
+            channel_id="channel-1",
+        )
+        assert rest.original_interaction_edits
+        assert (
+            rest.original_interaction_edits[-1]["payload"]["content"]
+            == "Compaction summary generated, but saving the compacted context failed. Restored the previous thread; please retry."
+        )
+        assert rest.channel_messages
+        assert (
+            rest.channel_messages[-1]["payload"]["content"]
+            == "Compaction summary generated, but saving the compacted context failed. Restored the previous thread; please retry."
+        )
+
+        restored_thread = orchestration_service.get_thread_target(
+            current_thread.thread_target_id
+        )
+        assert restored_thread is not None
+        assert restored_thread.lifecycle_status == "active"
+
+        active_threads = orchestration_service.list_thread_targets(
+            lifecycle_status="active"
+        )
+        assert [thread.thread_target_id for thread in active_threads] == [
+            current_thread.thread_target_id
+        ]
+
+        archived_threads = orchestration_service.list_thread_targets(
+            lifecycle_status="archived"
+        )
+        assert len(archived_threads) == 1
+        assert archived_threads[0].thread_target_id != current_thread.thread_target_id
+
+        binding = orchestration_service.get_binding(
+            surface_kind="discord",
+            surface_key="channel-1",
+        )
+        assert binding is not None
+        assert binding.thread_target_id == current_thread.thread_target_id
+
+        state_binding = await store.get_binding(channel_id="channel-1")
+        assert state_binding is not None
+        assert state_binding["pending_compact_seed"] is None
+        assert state_binding["pending_compact_session_key"] is None
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_message_event_submits_through_surface_orchestration_ingress(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- finish deferred Discord `/car session compact` interactions with a terminal confirmation so the slash command no longer hangs on "thinking"
- cover post-summary finalization failures so a seed write or outbox flush error still completes the interaction with a clear failure message
- add Discord regression coverage for the success path and the post-summary failure path

## Testing
- `.venv/bin/pytest tests/integrations/discord/test_message_turns.py`
- `git commit -m "Fix Discord compaction completion"` (passed repo hooks, including repo-wide checks)
