### PR TITLE
Auto-assign missing ticket IDs during flow startup

### DIFF
--- a/src/codex_autorunner/core/file_chat_keys.py
+++ b/src/codex_autorunner/core/file_chat_keys.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ..tickets.frontmatter import parse_markdown_frontmatter, sanitize_ticket_id
+from ..tickets.frontmatter import (
+    deterministic_ticket_id,
+    parse_markdown_frontmatter,
+    sanitize_ticket_id,
+)
 
 
 def ticket_stable_id(path: Path) -> str | None:
-    """Return explicit frontmatter ticket_id when present."""
+    """Return the ticket's stable identity token."""
     if not path.exists():
         return None
     try:
@@ -14,14 +18,17 @@ def ticket_stable_id(path: Path) -> str | None:
     except OSError:
         return None
     data, _ = parse_markdown_frontmatter(content)
-    return sanitize_ticket_id(data.get("ticket_id"))
+    explicit_ticket_id = sanitize_ticket_id(data.get("ticket_id"))
+    if explicit_ticket_id:
+        return explicit_ticket_id
+    return deterministic_ticket_id(path)
 
 
 def ticket_instance_token(path: Path) -> str:
     """Return a stable ticket identity token.
 
-    Uses explicit frontmatter `ticket_id` so normal saves (which use atomic_write)
-    do not churn identity.
+    Uses explicit frontmatter `ticket_id` when present, otherwise a deterministic
+    fallback derived from the ticket path.
     """
     ticket_id = ticket_stable_id(path)
     if ticket_id:

--- a/src/codex_autorunner/core/ticket_linter_cli.py
+++ b/src/codex_autorunner/core/ticket_linter_cli.py
@@ -17,7 +17,8 @@ _SCRIPT = dedent(
 
     - Validates ticket filenames (TICKET-<number>[suffix].md, e.g. TICKET-001-foo.md)
     - Parses YAML frontmatter for each .codex-autorunner/tickets/TICKET-*.md
-    - Validates required keys: ticket_id, agent, and done
+    - Validates required keys: agent and done
+    - Validates ticket_id when present
     - Validates agent ids against the runtime agents that seeded this repo
     - Exits non-zero on any error
     \"\"\"

--- a/src/codex_autorunner/ticket_helper_script_common.py
+++ b/src/codex_autorunner/ticket_helper_script_common.py
@@ -6,7 +6,7 @@ from .agents.registry import get_registered_agents
 
 PORTABLE_TICKET_ID_PATTERN = r"^[A-Za-z0-9._-]{6,128}$"
 PORTABLE_TICKET_ID_ERROR = (
-    "frontmatter.ticket_id is required and must match [A-Za-z0-9._-]{6,128}."
+    "frontmatter.ticket_id must match [A-Za-z0-9._-]{6,128} when provided."
 )
 PORTABLE_TICKET_AGENT_REQUIRED_ERROR = (
     "frontmatter.agent is required (e.g. 'codex' or 'opencode')."
@@ -54,8 +54,9 @@ def portable_ticket_validation_source() -> str:
         def _lint_frontmatter(data: dict[str, Any]) -> List[str]:
             errors: List[str] = []
 
-            ticket_id = _sanitize_ticket_id(data.get("ticket_id"))
-            if not ticket_id:
+            raw_ticket_id = data.get("ticket_id")
+            ticket_id = _sanitize_ticket_id(raw_ticket_id)
+            if raw_ticket_id is not None and not ticket_id:
                 errors.append("{PORTABLE_TICKET_ID_ERROR}")
 
             _agent, agent_error = _normalize_agent(data.get("agent"))

--- a/src/codex_autorunner/tickets/files.py
+++ b/src/codex_autorunner/tickets/files.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
-from .frontmatter import parse_markdown_frontmatter
+from .frontmatter import deterministic_ticket_id, parse_markdown_frontmatter
 from .lint import lint_ticket_frontmatter, parse_ticket_index
 from .models import TicketDoc, TicketFrontmatter
 
@@ -42,7 +42,10 @@ def read_ticket(path: Path) -> tuple[Optional[TicketDoc], list[str]]:
             "Invalid ticket filename; expected TICKET-<number>[suffix].md (e.g. TICKET-001-foo.md)"
         ]
 
-    frontmatter, errors = lint_ticket_frontmatter(data)
+    frontmatter, errors = lint_ticket_frontmatter(
+        data,
+        fallback_ticket_id=deterministic_ticket_id(path),
+    )
     if errors:
         return None, errors
     assert frontmatter is not None
@@ -57,7 +60,10 @@ def read_ticket_frontmatter(
     except OSError as exc:
         return None, [f"Failed to read ticket: {exc}"]
     data, _ = parse_markdown_frontmatter(raw)
-    frontmatter, errors = lint_ticket_frontmatter(data)
+    frontmatter, errors = lint_ticket_frontmatter(
+        data,
+        fallback_ticket_id=deterministic_ticket_id(path),
+    )
     return frontmatter, errors
 
 

--- a/src/codex_autorunner/tickets/frontmatter.py
+++ b/src/codex_autorunner/tickets/frontmatter.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import hashlib
 import re
 import uuid
 from collections.abc import MutableMapping
+from pathlib import Path, PurePosixPath
 from typing import Any, Optional, Tuple
 
 import yaml
@@ -60,6 +62,25 @@ def parse_markdown_frontmatter(text: str) -> tuple[dict[str, Any], str]:
 
 def generate_ticket_id() -> str:
     return f"tkt_{uuid.uuid4().hex}"
+
+
+def deterministic_ticket_id(ticket_path: Path) -> str:
+    """Derive a stable ticket_id from the ticket path."""
+    identity_path = _ticket_identity_path(ticket_path)
+    digest = hashlib.sha256(identity_path.encode("utf-8")).hexdigest()[:32]
+    return f"tkt_auto_{digest}"
+
+
+def _ticket_identity_path(ticket_path: Path) -> str:
+    parts = ticket_path.parts
+    if not parts:
+        return ticket_path.as_posix()
+    if not ticket_path.is_absolute():
+        return PurePosixPath(*parts).as_posix()
+    for idx, part in enumerate(parts):
+        if part == ".codex-autorunner":
+            return PurePosixPath(*parts[idx:]).as_posix()
+    return PurePosixPath(ticket_path.name).as_posix()
 
 
 def sanitize_ticket_id(raw: object) -> str | None:

--- a/src/codex_autorunner/tickets/lint.py
+++ b/src/codex_autorunner/tickets/lint.py
@@ -6,7 +6,10 @@ from pathlib import Path
 from typing import Any, Optional, Tuple
 
 from ..agents.registry import validate_agent_id
-from .frontmatter import parse_markdown_frontmatter, sanitize_ticket_id
+from .frontmatter import (
+    parse_markdown_frontmatter,
+    sanitize_ticket_id,
+)
 from .models import TicketContextEntry, TicketFrontmatter
 
 # Accept TICKET-###.md or TICKET-###<suffix>.md (suffix optional), case-insensitive.
@@ -91,11 +94,13 @@ def _parse_context_entries(
 
 def lint_ticket_frontmatter(
     data: dict[str, Any],
+    *,
+    fallback_ticket_id: str | None = None,
 ) -> Tuple[Optional[TicketFrontmatter], list[str]]:
     """Validate and normalize ticket frontmatter.
 
     Required keys:
-    - ticket_id: stable opaque ticket identity
+    - ticket_id: stable opaque ticket identity (or a caller-supplied fallback)
     - agent: string (or the special value "user")
     - done: bool
     """
@@ -106,7 +111,14 @@ def lint_ticket_frontmatter(
 
     extra = {k: v for k, v in data.items()}
 
-    ticket_id = sanitize_ticket_id(data.get("ticket_id"))
+    raw_ticket_id = data.get("ticket_id")
+    ticket_id = sanitize_ticket_id(raw_ticket_id)
+    if raw_ticket_id is not None and ticket_id is None:
+        errors.append(
+            "frontmatter.ticket_id must match [A-Za-z0-9._-]{6,128} when provided."
+        )
+    if ticket_id is None:
+        ticket_id = sanitize_ticket_id(fallback_ticket_id)
     if not ticket_id:
         errors.append(
             "frontmatter.ticket_id is required and must match [A-Za-z0-9._-]{6,128}."

--- a/src/codex_autorunner/tickets/runner_post_turn.py
+++ b/src/codex_autorunner/tickets/runner_post_turn.py
@@ -7,8 +7,7 @@ from typing import Any, Optional
 from ..core.file_chat_keys import ticket_instance_token
 from ..core.flows.models import FlowEventType
 from ..core.git_utils import git_diff_stats, run_git
-from .frontmatter import parse_markdown_frontmatter
-from .lint import lint_ticket_frontmatter
+from .files import read_ticket_frontmatter
 from .outbox import (
     archive_dispatch,
     create_turn_summary,
@@ -104,13 +103,14 @@ def check_ticket_frontmatter(
     ticket_path: Path,
 ) -> tuple[Optional[Any], Optional[list[str]]]:
     """Check ticket frontmatter after turn execution."""
-    try:
-        raw = ticket_path.read_text(encoding="utf-8")
-    except OSError as exc:
-        return None, [f"Failed to read ticket after turn: {exc}"]
-
-    data, _ = parse_markdown_frontmatter(raw)
-    fm, errors = lint_ticket_frontmatter(data)
+    fm, errors = read_ticket_frontmatter(ticket_path)
+    if errors and any(err.startswith("Failed to read ticket:") for err in errors):
+        return None, [
+            err.replace(
+                "Failed to read ticket:", "Failed to read ticket after turn:", 1
+            )
+            for err in errors
+        ]
     return fm, errors
 
 

--- a/tests/routes/test_flow_bootstrap_guard.py
+++ b/tests/routes/test_flow_bootstrap_guard.py
@@ -465,14 +465,14 @@ def test_ticket_flow_start_rejects_when_ticket_path_is_file(tmp_path, monkeypatc
 
 
 def test_ticket_flow_start_allows_with_tickets(tmp_path, monkeypatch):
-    """Starting ticket_flow with force_new should succeed when tickets exist."""
+    """Starting ticket_flow with force_new should succeed when tickets omit ticket_id."""
     _reset_state()
     monkeypatch.setattr(flow_routes, "find_repo_root", lambda: Path(tmp_path))
 
     ticket_dir = tmp_path / ".codex-autorunner" / "tickets"
     ticket_dir.mkdir(parents=True, exist_ok=True)
     (ticket_dir / "TICKET-001.md").write_text(
-        '---\nticket_id: "tkt_guard002"\nagent: codex\ndone: false\n---\n',
+        "---\nagent: codex\ndone: false\n---\n",
         encoding="utf-8",
     )
 

--- a/tests/test_ticket_linter_cli.py
+++ b/tests/test_ticket_linter_cli.py
@@ -96,7 +96,7 @@ def test_linter_flags_invalid_yaml_with_suffix(repo: Path) -> None:
     assert "OK" in result_good.stdout
 
 
-def test_linter_requires_ticket_id(repo: Path) -> None:
+def test_linter_allows_missing_ticket_id(repo: Path) -> None:
     tickets_dir = repo / ".codex-autorunner" / "tickets"
     tickets_dir.mkdir(parents=True, exist_ok=True)
 
@@ -106,8 +106,8 @@ def test_linter_requires_ticket_id(repo: Path) -> None:
     )
 
     result = _run_linter(repo)
-    assert result.returncode == 1
-    assert "frontmatter.ticket_id is required" in result.stderr
+    assert result.returncode == 0
+    assert "OK" in result.stdout
 
 
 def test_linter_rejects_unknown_agent(repo: Path) -> None:

--- a/tests/tickets/test_files_relaxed.py
+++ b/tests/tickets/test_files_relaxed.py
@@ -7,6 +7,7 @@ from codex_autorunner.tickets.files import (
     parse_ticket_index,
     read_ticket,
 )
+from codex_autorunner.tickets.frontmatter import deterministic_ticket_id
 
 
 def test_parse_ticket_index_accepts_suffix() -> None:
@@ -39,3 +40,22 @@ def test_read_ticket_rejects_invalid_filename(tmp_path: Path) -> None:
     doc, errors = read_ticket(ticket_path)
     assert doc is None
     assert any("Invalid ticket filename" in e for e in errors)
+
+
+def test_read_ticket_assigns_stable_ticket_id_when_missing(tmp_path: Path) -> None:
+    ticket_path = tmp_path / ".codex-autorunner" / "tickets" / "TICKET-001-no-id.md"
+    ticket_path.parent.mkdir(parents=True)
+    ticket_path.write_text(
+        "---\nagent: codex\ndone: false\n---\nBody\n",
+        encoding="utf-8",
+    )
+
+    first_doc, first_errors = read_ticket(ticket_path)
+    second_doc, second_errors = read_ticket(ticket_path)
+
+    assert first_errors == []
+    assert second_errors == []
+    assert first_doc is not None
+    assert second_doc is not None
+    assert first_doc.frontmatter.ticket_id == deterministic_ticket_id(ticket_path)
+    assert second_doc.frontmatter.ticket_id == first_doc.frontmatter.ticket_id

--- a/tests/tickets/test_lint.py
+++ b/tests/tickets/test_lint.py
@@ -53,6 +53,25 @@ def test_lint_ticket_frontmatter_accepts_known_agents_and_user() -> None:
     assert any("invalid" in e for e in errors)
 
 
+def test_lint_ticket_frontmatter_accepts_fallback_ticket_id() -> None:
+    fm, errors = lint_ticket_frontmatter(
+        {"agent": "codex", "done": False},
+        fallback_ticket_id="tkt_fallback123",
+    )
+    assert errors == []
+    assert fm is not None
+    assert fm.ticket_id == "tkt_fallback123"
+
+
+def test_lint_ticket_frontmatter_rejects_invalid_provided_ticket_id() -> None:
+    fm, errors = lint_ticket_frontmatter(
+        {"ticket_id": "bad id", "agent": "codex", "done": False},
+        fallback_ticket_id="tkt_fallback123",
+    )
+    assert fm is None
+    assert any("ticket_id must match" in e for e in errors)
+
+
 def test_lint_ticket_frontmatter_preserves_extra() -> None:
     fm, errors = lint_ticket_frontmatter(
         {


### PR DESCRIPTION
## Summary
- derive deterministic fallback ticket IDs from ticket file paths and inject them during backend ticket reads
- allow the portable ticket linter to accept omitted `ticket_id` values while still rejecting invalid provided IDs
- add regressions covering flow start without explicit ticket IDs and stable normalized IDs

## Testing
- `.venv/bin/python -m pytest tests/tickets/test_lint.py tests/tickets/test_files_relaxed.py tests/test_ticket_linter_cli.py tests/routes/test_flow_bootstrap_guard.py tests/routes/test_ticket_first_contracts.py tests/core/flows/test_start_policy.py`
- full pre-commit suite via `git commit` hook (`3421 passed, 1 skipped`)

Closes #1114
