### PR TITLE
Unify shared chat status command details

### DIFF
--- a/src/codex_autorunner/integrations/chat/status_diagnostics.py
+++ b/src/codex_autorunner/integrations/chat/status_diagnostics.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class StatusBlockContext:
+    """Shared status fields that both chat surfaces can render."""
+
+    agent: Optional[str] = None
+    resume: Optional[str] = None
+    model: Optional[str] = None
+    effort: Optional[str] = None
+    approval_mode: Optional[str] = None
+    approval_policy: Optional[str] = None
+    sandbox_policy: Any = None
+    rate_limits: Optional[dict[str, Any]] = None
+    thread_id: Optional[str] = None
+    turn_id: Optional[str] = None
+    extra_lines: tuple[str, ...] = ()
+
+
+def _clean_line(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _append_status_line(lines: list[str], label: str, value: Any) -> None:
+    text = _clean_line(value)
+    if text is not None:
+        lines.append(f"{label}: {text}")
+
+
+def format_sandbox_policy(sandbox_policy: Any) -> str:
+    if sandbox_policy is None:
+        return "default"
+    if isinstance(sandbox_policy, str):
+        return sandbox_policy
+    if isinstance(sandbox_policy, dict):
+        sandbox_type = sandbox_policy.get("type")
+        if isinstance(sandbox_type, str):
+            suffix = ""
+            if "networkAccess" in sandbox_policy:
+                suffix = f", network={sandbox_policy.get('networkAccess')}"
+            return f"{sandbox_type}{suffix}"
+    return str(sandbox_policy)
+
+
+def _coerce_number(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _compute_used_percent(entry: dict[str, Any]) -> Optional[float]:
+    remaining = _coerce_number(entry.get("remaining"))
+    limit = _coerce_number(entry.get("limit"))
+    if remaining is None or limit is None or limit <= 0:
+        return None
+    used = (limit - remaining) / limit * 100
+    return max(min(used, 100.0), 0.0)
+
+
+def _format_percent(value: Any) -> Optional[str]:
+    number = _coerce_number(value)
+    if number is None:
+        return None
+    if number.is_integer():
+        return f"{int(number)}%"
+    return f"{number:.1f}%"
+
+
+def _rate_limit_window_minutes(
+    entry: dict[str, Any],
+    section: Optional[str] = None,
+) -> Optional[int]:
+    for key in (
+        "window_minutes",
+        "windowMinutes",
+        "window_mins",
+        "windowMins",
+        "period_minutes",
+        "periodMinutes",
+        "duration_minutes",
+        "durationMinutes",
+    ):
+        value = entry.get(key)
+        number = _coerce_number(value)
+        if number is not None:
+            return max(int(round(number)), 1)
+    window_seconds = _coerce_number(
+        entry.get("window_seconds", entry.get("windowSeconds"))
+    )
+    if window_seconds is not None:
+        return max(int(round(window_seconds / 60)), 1)
+    if section in ("primary", "secondary"):
+        return 300 if section == "primary" else 10080
+    return None
+
+
+def _format_rate_limit_window(window_minutes: Optional[int]) -> Optional[str]:
+    if not isinstance(window_minutes, int) or window_minutes <= 0:
+        return None
+    if window_minutes == 300:
+        return "5h"
+    if window_minutes % 1440 == 0:
+        return f"{window_minutes // 1440}d"
+    if window_minutes % 60 == 0:
+        return f"{window_minutes // 60}h"
+    return f"{window_minutes}m"
+
+
+def _parse_iso_timestamp(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _coerce_datetime(value: Any) -> Optional[datetime]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        seconds = float(value)
+        if seconds > 1e12:
+            seconds /= 1000.0
+        try:
+            return datetime.fromtimestamp(seconds, tz=timezone.utc)
+        except Exception:
+            return None
+    if isinstance(value, str):
+        parsed = _parse_iso_timestamp(value)
+        if parsed is not None:
+            return parsed
+        try:
+            return _coerce_datetime(float(value))
+        except Exception:
+            return None
+    return None
+
+
+def _format_friendly_time(value: datetime) -> str:
+    month = value.strftime("%b")
+    day = value.day
+    hour = value.strftime("%I").lstrip("0") or "12"
+    minute = value.strftime("%M")
+    ampm = value.strftime("%p").lower()
+    return f"{month} {day}, {hour}:{minute}{ampm}"
+
+
+def _extract_rate_limit_timestamp(rate_limits: dict[str, Any]) -> Optional[datetime]:
+    candidates: list[tuple[int, datetime]] = []
+    for section in ("primary", "secondary"):
+        entry = rate_limits.get(section)
+        if not isinstance(entry, dict):
+            continue
+        window_minutes = _rate_limit_window_minutes(entry, section) or 0
+        for key in (
+            "resets_at",
+            "resetsAt",
+            "reset_at",
+            "resetAt",
+            "refresh_at",
+            "refreshAt",
+            "updated_at",
+            "updatedAt",
+        ):
+            if key in entry:
+                timestamp = _coerce_datetime(entry.get(key))
+                if timestamp is not None:
+                    candidates.append((window_minutes, timestamp))
+    if candidates:
+        return max(candidates, key=lambda item: (item[0], item[1]))[1]
+    for key in (
+        "refreshed_at",
+        "refreshedAt",
+        "refresh_at",
+        "refreshAt",
+        "updated_at",
+        "updatedAt",
+        "timestamp",
+        "time",
+        "as_of",
+        "asOf",
+    ):
+        if key in rate_limits:
+            return _coerce_datetime(rate_limits.get(key))
+    return None
+
+
+def _format_rate_limit_refresh(rate_limits: dict[str, Any]) -> Optional[str]:
+    refresh_dt = _extract_rate_limit_timestamp(rate_limits)
+    if refresh_dt is None:
+        return None
+    return _format_friendly_time(refresh_dt.astimezone())
+
+
+def format_rate_limit_lines(rate_limits: Optional[dict[str, Any]]) -> list[str]:
+    if not isinstance(rate_limits, dict):
+        return []
+    parts: list[str] = []
+    for key in ("primary", "secondary"):
+        entry = rate_limits.get(key)
+        if not isinstance(entry, dict):
+            continue
+        used_value = entry.get("used_percent", entry.get("usedPercent"))
+        used = _coerce_number(used_value)
+        if used is None:
+            used = _compute_used_percent(entry)
+        used_text = _format_percent(used)
+        window_minutes = _rate_limit_window_minutes(entry, key)
+        label = _format_rate_limit_window(window_minutes) or key
+        if used_text:
+            parts.append(f"[{label}: {used_text}]")
+    if not parts:
+        return []
+    refresh_label = _format_rate_limit_refresh(rate_limits)
+    if refresh_label:
+        parts.append(f"[refresh: {refresh_label}]")
+    return [f"Limits: {' '.join(parts)}"]
+
+
+def extract_rate_limits(payload: Any) -> Optional[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return None
+    for key in ("rateLimits", "rate_limits", "limits"):
+        value = payload.get(key)
+        if isinstance(value, dict):
+            return value
+    if "primary" in payload or "secondary" in payload:
+        return payload
+    return None
+
+
+def build_status_block_lines(context: StatusBlockContext) -> list[str]:
+    """Render the shared runtime status block used by chat surfaces."""
+
+    lines: list[str] = []
+    _append_status_line(lines, "Agent", context.agent)
+    _append_status_line(lines, "Resume", context.resume)
+    _append_status_line(lines, "Model", context.model)
+    _append_status_line(lines, "Effort", context.effort)
+    _append_status_line(lines, "Approval mode", context.approval_mode)
+    _append_status_line(lines, "Approval policy", context.approval_policy)
+    lines.append(f"Sandbox policy: {format_sandbox_policy(context.sandbox_policy)}")
+    lines.extend(format_rate_limit_lines(context.rate_limits))
+    _append_status_line(lines, "Active thread", context.thread_id)
+    _append_status_line(lines, "Active turn", context.turn_id)
+    lines.extend(line for line in context.extra_lines if _clean_line(line))
+    return lines

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -131,6 +131,10 @@ from ...integrations.chat.collaboration_policy import (
     evaluate_collaboration_admission,
     evaluate_collaboration_policy,
 )
+from ...integrations.chat.command_diagnostics import (
+    ActiveFlowInfo,
+    build_status_text,
+)
 from ...integrations.chat.command_ingress import canonicalize_command_ingress
 from ...integrations.chat.compaction import build_compact_seed_prompt
 from ...integrations.chat.dispatcher import (
@@ -172,6 +176,11 @@ from ...integrations.chat.picker_filter import (
     resolve_picker_query,
 )
 from ...integrations.chat.run_mirror import ChatRunMirror
+from ...integrations.chat.status_diagnostics import (
+    StatusBlockContext,
+    build_status_block_lines,
+    extract_rate_limits,
+)
 from ...integrations.chat.turn_policy import (
     PlainTextTurnContext,
     should_trigger_plain_text_turn,
@@ -196,7 +205,11 @@ from ...tickets.files import (
 from ...tickets.frontmatter import parse_markdown_frontmatter
 from ...tickets.outbox import resolve_outbox_paths
 from ...voice import VoiceConfig, VoiceService, VoiceServiceError
-from ..chat.approval_modes import APPROVAL_MODE_USAGE, normalize_approval_mode
+from ..chat.approval_modes import (
+    APPROVAL_MODE_USAGE,
+    normalize_approval_mode,
+    resolve_approval_mode_policies,
+)
 from ..chat.review_commits import _parse_review_commit_log
 from ..chat.thread_summaries import (
     _coerce_thread_list,
@@ -4728,6 +4741,51 @@ class DiscordBotService:
             or self.DEFAULT_AGENT
         )
 
+    def _agent_supports_effort(self, agent: str) -> bool:
+        return agent == "codex"
+
+    def _agent_supports_resume(self, agent: str) -> bool:
+        return agent in {"codex", "opencode"}
+
+    def _status_model_label(self, binding: dict[str, Any]) -> str:
+        model = binding.get("model_override")
+        if isinstance(model, str):
+            model = model.strip()
+            if model:
+                return model
+        return "default"
+
+    def _status_effort_label(self, binding: dict[str, Any], agent: str) -> str:
+        if not self._agent_supports_effort(agent):
+            return "n/a"
+        effort = binding.get("reasoning_effort")
+        if isinstance(effort, str):
+            effort = effort.strip()
+            if effort:
+                return effort
+        return "default"
+
+    async def _read_status_rate_limits(
+        self, workspace_path: Optional[str], *, agent: str
+    ) -> Optional[dict[str, Any]]:
+        if not self._agent_supports_effort(agent):
+            return None
+        try:
+            client = await self._client_for_workspace(workspace_path)
+        except AppServerUnavailableError:
+            return None
+        if client is None:
+            return None
+        for method in ("account/rateLimits/read", "account/read"):
+            try:
+                result = await client.request(method, params=None, timeout=5.0)
+            except Exception:
+                continue
+            rate_limits = extract_rate_limits(result)
+            if rate_limits:
+                return rate_limits
+        return None
+
     async def _list_model_items_for_binding(
         self,
         *,
@@ -4997,70 +5055,71 @@ class DiscordBotService:
                 user_id=user_id,
             ),
         )
-        if binding is None:
-            lines = [
-                "This channel is not bound.",
-                "Use /car bind workspace:<workspace> or /pma on to enable plain-text turns here.",
-                *collaboration_summary_lines(
-                    channel_id=channel_id,
-                    command_result=command_result,
-                    plain_text_result=plain_text_result,
-                    binding=None,
-                ),
-                "Then use /car flow status once flow commands are enabled.",
-            ]
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                "\n".join(lines),
-            )
-            return
-
-        lines = []
-        is_pma = binding.get("pma_enabled", False)
-        workspace_path = binding.get("workspace_path", "unknown")
-        repo_id = binding.get("repo_id")
-        guild_id = binding.get("guild_id")
-        updated_at = binding.get("updated_at", "unknown")
-
-        if is_pma:
-            lines.append("Mode: PMA (hub)")
-            prev_workspace = binding.get("pma_prev_workspace_path")
-            if prev_workspace:
-                lines.append(f"Previous binding: {prev_workspace}")
-                lines.append("Use /pma off to restore previous binding.")
-        else:
-            lines.append("Mode: workspace")
-            lines.append("Channel is bound.")
-
-        lines.extend(
-            [
-                f"Workspace: {workspace_path}",
-                f"Repo ID: {repo_id or 'none'}",
-                f"Guild ID: {guild_id or 'none'}",
-                f"Channel ID: {channel_id}",
-                f"Last updated: {updated_at}",
-            ]
-        )
-
-        active_flow_info = await self._get_active_flow_info(workspace_path)
-        if active_flow_info:
-            lines.append(f"Active flow: {active_flow_info}")
-
-        lines.extend(
+        active_flow = None
+        workspace_path = None
+        if isinstance(binding, dict):
+            workspace_raw = binding.get("workspace_path")
+            if isinstance(workspace_raw, str) and workspace_raw.strip():
+                workspace_path = workspace_raw.strip()
+                active_flow = await self._get_active_flow_info(workspace_path)
+        lines = build_status_text(
+            binding,
             collaboration_summary_lines(
                 channel_id=channel_id,
                 command_result=command_result,
                 plain_text_result=plain_text_result,
                 binding=binding,
-            )
+            ),
+            active_flow,
+            channel_id,
+            include_flow_hint=False,
         )
+        if binding is None:
+            await self._respond_ephemeral(
+                interaction_id, interaction_token, "\n".join(lines)
+            )
+            return
+
+        agent = self._normalize_agent(binding.get("agent"))
+        rate_limits = await self._read_status_rate_limits(workspace_path, agent=agent)
+        approval_mode = normalize_approval_mode(
+            binding.get("approval_mode"),
+            default="yolo",
+            include_command_aliases=True,
+        )
+        if approval_mode is None:
+            approval_mode = "yolo"
+        approval_policy, sandbox_policy = resolve_approval_mode_policies(approval_mode)
+        explicit_approval_policy = binding.get("approval_policy")
+        if (
+            isinstance(explicit_approval_policy, str)
+            and explicit_approval_policy.strip()
+        ):
+            approval_policy = explicit_approval_policy.strip()
+        explicit_sandbox_policy = binding.get("sandbox_policy")
+        if explicit_sandbox_policy is not None:
+            sandbox_policy = explicit_sandbox_policy
+        model_label = self._status_model_label(binding)
+        effort_label = self._status_effort_label(binding, agent)
+        status_block = StatusBlockContext(
+            agent=agent,
+            resume="supported" if self._agent_supports_resume(agent) else "unsupported",
+            model=model_label,
+            effort=effort_label,
+            approval_mode=approval_mode,
+            approval_policy=approval_policy or "default",
+            sandbox_policy=sandbox_policy,
+            rate_limits=rate_limits,
+        )
+        lines.extend(build_status_block_lines(status_block))
         lines.append("Use /car flow status for ticket flow details.")
         await self._respond_ephemeral(
             interaction_id, interaction_token, "\n".join(lines)
         )
 
-    async def _get_active_flow_info(self, workspace_path: str) -> Optional[str]:
+    async def _get_active_flow_info(
+        self, workspace_path: str
+    ) -> Optional[ActiveFlowInfo]:
         if not workspace_path or workspace_path == "unknown":
             return None
         try:
@@ -5072,9 +5131,9 @@ class DiscordBotService:
                 runs = store.list_flow_runs(flow_type="ticket_flow")
                 for record in runs:
                     if record.status == FlowRunStatus.RUNNING:
-                        return f"{record.id} (running)"
+                        return ActiveFlowInfo(flow_id=record.id, status="running")
                     if record.status == FlowRunStatus.PAUSED:
-                        return f"{record.id} (paused)"
+                        return ActiveFlowInfo(flow_id=record.id, status="paused")
             finally:
                 store.close()
         except Exception:

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -24,6 +24,10 @@ from ....chat.agents import (
     chat_agent_supports_effort,
     normalize_chat_agent,
 )
+from ....chat.status_diagnostics import (
+    StatusBlockContext,
+    build_status_block_lines,
+)
 from ...adapter import (
     TelegramCallbackQuery,
     TelegramMessage,
@@ -53,9 +57,7 @@ from ...helpers import (
     _extract_thread_list_cursor,
     _extract_thread_preview_parts,
     _format_missing_thread_label,
-    _format_rate_limits,
     _format_resume_summary,
-    _format_sandbox_policy,
     _format_thread_preview,
     _format_token_usage,
     _local_workspace_threads,
@@ -111,6 +113,42 @@ class ResumeThreadData:
     threads: list[dict[str, Any]]
     unscoped_entries: list[dict[str, Any]]
     saw_path: bool
+
+
+def _telegram_status_base_lines(
+    *,
+    message: TelegramMessage,
+    record: "TelegramTopicRecord",
+    runtime: Any,
+    command_policy: Any,
+    plain_text_policy: Any,
+) -> list[str]:
+    workspace_label = record.workspace_path or (
+        "hub" if record.pma_enabled else "unbound"
+    )
+    lines: list[str] = []
+    if record.pma_enabled:
+        lines.append("Mode: PMA (hub)")
+        if record.pma_prev_workspace_path:
+            lines.append(f"Previous binding: {record.pma_prev_workspace_path}")
+            lines.append("Use /pma off to restore previous binding.")
+    elif record.workspace_path:
+        lines.append("Mode: workspace")
+        lines.append("Topic is bound.")
+    lines.extend(
+        [
+            f"Workspace: {workspace_label}",
+            f"Workspace ID: {record.workspace_id or 'unknown'}",
+            f"Active thread: {record.active_thread_id or 'none'}",
+            f"Active turn: {runtime.current_turn_id or 'none'}",
+            *collaboration_summary_lines(
+                message,
+                command_result=command_policy,
+                plain_text_result=plain_text_policy,
+            ),
+        ]
+    )
+    return lines
 
 
 class WorkspaceCommands(SharedHelpers):
@@ -3085,36 +3123,34 @@ class WorkspaceCommands(SharedHelpers):
             message,
             command_text="/status",
         )
-        workspace_label = record.workspace_path or ("hub" if is_pma else "unbound")
+        lines = _telegram_status_base_lines(
+            message=message,
+            record=record,
+            runtime=runtime,
+            command_policy=command_policy,
+            plain_text_policy=plain_text_policy,
+        )
         effort_label = (
             record.effort or "default" if self._agent_supports_effort(agent) else "n/a"
         )
-        lines = []
-        if is_pma:
-            lines.append("Mode: PMA (hub)")
-            # Show previous binding if available
-            if record.pma_prev_workspace_path:
-                lines.append(f"Previous binding: {record.pma_prev_workspace_path}")
-                lines.append("Use /pma off to restore previous binding.")
+        rate_limits = await self._read_rate_limits(record.workspace_path, agent=agent)
         lines.extend(
-            [
-                f"Workspace: {workspace_label}",
-                f"Workspace ID: {record.workspace_id or 'unknown'}",
-                f"Active thread: {record.active_thread_id or 'none'}",
-                f"Active turn: {runtime.current_turn_id or 'none'}",
-                *collaboration_summary_lines(
-                    message,
-                    command_result=command_policy,
-                    plain_text_result=plain_text_policy,
-                ),
-                f"Agent: {agent}",
-                f"Resume: {'supported' if self._agent_supports_resume(agent) else 'unsupported'}",
-                f"Model: {record.model or 'default'}",
-                f"Effort: {effort_label}",
-                f"Approval mode: {record.approval_mode}",
-                f"Approval policy: {approval_policy or 'default'}",
-                f"Sandbox policy: {_format_sandbox_policy(sandbox_policy)}",
-            ]
+            build_status_block_lines(
+                StatusBlockContext(
+                    agent=agent,
+                    resume=(
+                        "supported"
+                        if self._agent_supports_resume(agent)
+                        else "unsupported"
+                    ),
+                    model=record.model or "default",
+                    effort=effort_label,
+                    approval_mode=record.approval_mode,
+                    approval_policy=approval_policy or "default",
+                    sandbox_policy=sandbox_policy,
+                    rate_limits=rate_limits,
+                )
+            )
         )
         pending = await self._store.pending_approvals_for_key(key)
         if pending:
@@ -3132,8 +3168,6 @@ class WorkspaceCommands(SharedHelpers):
         if record.active_thread_id:
             token_usage = self._token_usage_by_thread.get(record.active_thread_id)
             lines.extend(_format_token_usage(token_usage))
-        rate_limits = await self._read_rate_limits(record.workspace_path, agent=agent)
-        lines.extend(_format_rate_limits(rate_limits))
 
         manifest_path = getattr(self, "_manifest_path", None)
         hub_root = getattr(self, "_hub_root", None)

--- a/src/codex_autorunner/integrations/telegram/helpers.py
+++ b/src/codex_autorunner/integrations/telegram/helpers.py
@@ -28,6 +28,10 @@ from ...integrations.chat.review_commits import (  # noqa: F401
     _format_review_commit_label,
     _parse_review_commit_log,
 )
+from ...integrations.chat.status_diagnostics import (
+    extract_rate_limits,
+    format_sandbox_policy,
+)
 from ...integrations.chat.thread_summaries import (  # noqa: F401
     _coerce_thread_list,
     _extract_thread_list_cursor,
@@ -325,18 +329,7 @@ def _format_persist_note(message: str, *, persist: bool) -> str:
 
 
 def _format_sandbox_policy(sandbox_policy: Any) -> str:
-    if sandbox_policy is None:
-        return "default"
-    if isinstance(sandbox_policy, str):
-        return sandbox_policy
-    if isinstance(sandbox_policy, dict):
-        sandbox_type = sandbox_policy.get("type")
-        if isinstance(sandbox_type, str):
-            suffix = ""
-            if "networkAccess" in sandbox_policy:
-                suffix = f", network={sandbox_policy.get('networkAccess')}"
-            return f"{sandbox_type}{suffix}"
-    return str(sandbox_policy)
+    return format_sandbox_policy(sandbox_policy)
 
 
 def _format_token_usage(token_usage: Optional[dict[str, Any]]) -> list[str]:
@@ -362,40 +355,7 @@ def _format_token_usage(token_usage: Optional[dict[str, Any]]) -> list[str]:
 
 
 def _extract_rate_limits(payload: Any) -> Optional[dict[str, Any]]:
-    if not isinstance(payload, dict):
-        return None
-    for key in ("rateLimits", "rate_limits", "limits"):
-        value = payload.get(key)
-        if isinstance(value, dict):
-            return value
-    if "primary" in payload or "secondary" in payload:
-        return payload
-    return None
-
-
-def _format_rate_limits(rate_limits: Optional[dict[str, Any]]) -> list[str]:
-    if not isinstance(rate_limits, dict):
-        return []
-    parts: list[str] = []
-    for key in ("primary", "secondary"):
-        entry = rate_limits.get(key)
-        if not isinstance(entry, dict):
-            continue
-        used_value = entry.get("used_percent", entry.get("usedPercent"))
-        used = _coerce_number(used_value)
-        if used is None:
-            used = _compute_used_percent(entry)
-        used_text = _format_percent(used)
-        window_minutes = _rate_limit_window_minutes(entry, key)
-        label = _format_rate_limit_window(window_minutes) or key
-        if used_text:
-            parts.append(f"[{label}: {used_text}]")
-    if not parts:
-        return []
-    refresh_label = _format_rate_limit_refresh(rate_limits)
-    if refresh_label:
-        parts.append(f"[refresh: {refresh_label}]")
-    return [f"Limits: {' '.join(parts)}"]
+    return extract_rate_limits(payload)
 
 
 def _rate_limit_window_minutes(

--- a/tests/integrations/chat/test_status_diagnostics.py
+++ b/tests/integrations/chat/test_status_diagnostics.py
@@ -1,0 +1,77 @@
+from codex_autorunner.integrations.chat.status_diagnostics import (
+    StatusBlockContext,
+    build_status_block_lines,
+    extract_rate_limits,
+)
+
+
+class TestBuildStatusBlockLines:
+    def test_renders_shared_runtime_fields_in_order(self) -> None:
+        context = StatusBlockContext(
+            agent="codex",
+            resume="supported",
+            model="gpt-5.4",
+            effort="high",
+            approval_mode="yolo",
+            approval_policy="never",
+            sandbox_policy={"type": "dangerFullAccess", "networkAccess": True},
+            rate_limits={"primary": {"used_percent": 5, "window_minutes": 300}},
+            thread_id="thread-123",
+            turn_id="turn-456",
+            extra_lines=("Summary: ready", " ", ""),
+        )
+
+        lines = build_status_block_lines(context)
+
+        assert lines == [
+            "Agent: codex",
+            "Resume: supported",
+            "Model: gpt-5.4",
+            "Effort: high",
+            "Approval mode: yolo",
+            "Approval policy: never",
+            "Sandbox policy: dangerFullAccess, network=True",
+            "Limits: [5h: 5%]",
+            "Active thread: thread-123",
+            "Active turn: turn-456",
+            "Summary: ready",
+        ]
+
+    def test_skips_blank_shared_values(self) -> None:
+        context = StatusBlockContext(
+            agent="  ",
+            resume=None,
+            model="gpt-5.4",
+            effort="",
+            sandbox_policy=None,
+            rate_limits=None,
+            thread_id=None,
+            turn_id=None,
+            extra_lines=("  ", "Notes: included"),
+        )
+
+        lines = build_status_block_lines(context)
+
+        assert lines == [
+            "Model: gpt-5.4",
+            "Sandbox policy: default",
+            "Notes: included",
+        ]
+
+
+class TestExtractRateLimits:
+    def test_prefers_nested_rate_limit_mappings(self) -> None:
+        assert extract_rate_limits(
+            {"rateLimits": {"primary": {"used_percent": 5}}}
+        ) == {"primary": {"used_percent": 5}}
+        assert extract_rate_limits(
+            {"rate_limits": {"primary": {"used_percent": 6}}}
+        ) == {"primary": {"used_percent": 6}}
+        assert extract_rate_limits({"limits": {"primary": {"used_percent": 7}}}) == {
+            "primary": {"used_percent": 7}
+        }
+
+    def test_accepts_flat_primary_secondary_payloads(self) -> None:
+        payload = {"primary": {"used_percent": 5}, "secondary": {"used_percent": 8}}
+
+        assert extract_rate_limits(payload) == payload

--- a/tests/integrations/discord/test_status.py
+++ b/tests/integrations/discord/test_status.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Optional
+from unittest.mock import AsyncMock
+
+import pytest
+
+from codex_autorunner.integrations.chat.command_diagnostics import ActiveFlowInfo
+from codex_autorunner.integrations.discord.service import DiscordBotService
+
+
+class _StoreStub:
+    def __init__(self, binding: Optional[dict[str, Any]]) -> None:
+        self._binding = binding
+
+    async def get_binding(self, *, channel_id: str) -> Optional[dict[str, Any]]:
+        _ = channel_id
+        return self._binding
+
+
+class _ClientStub:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+        self.requests: list[tuple[str, Optional[dict[str, Any]], float]] = []
+
+    async def request(
+        self,
+        method: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        timeout: float,
+    ) -> dict[str, Any]:
+        self.requests.append((method, params, timeout))
+        return self.payload
+
+
+def _collaboration_result() -> SimpleNamespace:
+    return SimpleNamespace(
+        command_allowed=True,
+        destination_mode="active",
+        plain_text_trigger="always",
+        reason="allowed",
+        matched_destination=None,
+    )
+
+
+def _capture_message(
+    sent_messages: list[str],
+):
+    async def _capture(
+        _interaction_id: str,
+        _interaction_token: str,
+        content: str,
+    ) -> None:
+        sent_messages.append(content)
+
+    return _capture
+
+
+@pytest.mark.anyio
+async def test_status_bound_channel_includes_shared_and_discord_specific_details(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    binding = {
+        "workspace_path": str(workspace),
+        "repo_id": "repo-123",
+        "guild_id": "guild-456",
+        "pma_enabled": False,
+        "updated_at": "2026-03-24T08:00:00Z",
+        "agent": "codex",
+        "model_override": "gpt-5.4",
+        "reasoning_effort": "high",
+        "approval_mode": "yolo",
+        "approval_policy": "never",
+        "sandbox_policy": {"type": "dangerFullAccess", "networkAccess": True},
+    }
+    service = object.__new__(DiscordBotService)
+    sent_messages: list[str] = []
+    service._store = _StoreStub(binding)
+    service._respond_ephemeral = AsyncMock(side_effect=_capture_message(sent_messages))
+    service._evaluate_channel_collaboration_summary = lambda **_kwargs: (
+        _collaboration_result(),
+        _collaboration_result(),
+    )
+    service._get_active_flow_info = AsyncMock(
+        return_value=ActiveFlowInfo(flow_id="flow-123", status="running")
+    )
+    service._read_status_rate_limits = AsyncMock(
+        return_value={"primary": {"used_percent": 5, "window_minutes": 300}}
+    )
+
+    await DiscordBotService._handle_status(
+        service,
+        "interaction-1",
+        "token-1",
+        channel_id="channel-789",
+        guild_id="guild-456",
+        user_id="user-999",
+    )
+
+    assert len(sent_messages) == 1
+    content = sent_messages[0]
+    assert "Mode: workspace" in content
+    assert "Channel is bound." in content
+    assert f"Workspace: {workspace}" in content
+    assert "Repo ID: repo-123" in content
+    assert "Guild ID: guild-456" in content
+    assert "Channel ID: channel-789" in content
+    assert "Active flow: flow-123 (running)" in content
+    assert "Agent: codex" in content
+    assert "Resume: supported" in content
+    assert "Model: gpt-5.4" in content
+    assert "Effort: high" in content
+    assert "Approval mode: yolo" in content
+    assert "Approval policy: never" in content
+    assert "Sandbox policy: dangerFullAccess, network=True" in content
+    assert "Limits: [5h: 5%]" in content
+    assert "Use /car flow status for ticket flow details." in content
+    service._get_active_flow_info.assert_awaited_once_with(str(workspace))
+    service._read_status_rate_limits.assert_awaited_once_with(
+        str(workspace), agent="codex"
+    )
+
+
+@pytest.mark.anyio
+async def test_status_unbound_channel_keeps_flow_hint() -> None:
+    service = object.__new__(DiscordBotService)
+    sent_messages: list[str] = []
+    service._store = _StoreStub(None)
+    service._respond_ephemeral = AsyncMock(side_effect=_capture_message(sent_messages))
+    service._evaluate_channel_collaboration_summary = lambda **_kwargs: (
+        _collaboration_result(),
+        _collaboration_result(),
+    )
+    service._get_active_flow_info = AsyncMock()
+    service._read_status_rate_limits = AsyncMock()
+
+    await DiscordBotService._handle_status(
+        service,
+        "interaction-1",
+        "token-1",
+        channel_id="channel-789",
+        guild_id="guild-456",
+        user_id="user-999",
+    )
+
+    assert len(sent_messages) == 1
+    content = sent_messages[0]
+    assert "This channel is not bound." in content
+    assert "Agent:" not in content
+    assert "Then use /car flow status once flow commands are enabled." in content
+    service._get_active_flow_info.assert_not_awaited()
+    service._read_status_rate_limits.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_read_status_rate_limits_uses_app_server_client() -> None:
+    service = object.__new__(DiscordBotService)
+    client = _ClientStub(
+        {"rateLimits": {"primary": {"used_percent": 4, "window_minutes": 300}}}
+    )
+    service._client_for_workspace = AsyncMock(return_value=client)
+
+    rate_limits = await DiscordBotService._read_status_rate_limits(
+        service,
+        "/workspace",
+        agent="codex",
+    )
+
+    assert rate_limits == {"primary": {"used_percent": 4, "window_minutes": 300}}
+    assert client.requests == [("account/rateLimits/read", None, 5.0)]

--- a/tests/test_telegram_status_rate_limits.py
+++ b/tests/test_telegram_status_rate_limits.py
@@ -118,6 +118,14 @@ async def test_status_opencode_skips_rate_limits() -> None:
     await handler._handle_status(_message(), runtime=runtime)
 
     assert handler._client_calls == 0
+    text = handler._sent_messages[-1]
+    assert "Workspace ID: unknown" in text
+    assert "Active thread: none" in text
+    assert "Agent: opencode" in text
+    assert "Resume: supported" in text
+    assert "Model: default" in text
+    assert "Channel is bound." not in text
+    assert "/car flow status" not in text
     assert "Limits:" not in handler._sent_messages[-1]
 
 
@@ -130,7 +138,19 @@ async def test_status_codex_includes_rate_limits() -> None:
     await handler._handle_status(_message(), runtime=runtime)
 
     assert handler._client_calls == 1
-    assert "Limits:" in handler._sent_messages[-1]
+    text = handler._sent_messages[-1]
+    assert "Mode: workspace" in text
+    assert "Topic is bound." in text
+    assert "Workspace ID: unknown" in text
+    assert "Active thread: none" in text
+    assert "Agent: codex" in text
+    assert "Resume: supported" in text
+    assert "Model: default" in text
+    assert "Approval mode: yolo" in text
+    assert "Sandbox policy: default" in text
+    assert "Limits:" in text
+    assert "Channel is bound." not in text
+    assert "/car flow status" not in text
 
 
 @pytest.mark.anyio
@@ -143,5 +163,8 @@ async def test_status_pma_mode_skips_bind_hint() -> None:
 
     assert handler._sent_messages
     text = handler._sent_messages[-1]
-    assert "PMA" in text
+    assert "Mode: PMA (hub)" in text
+    assert "Workspace: hub" in text
+    assert "Workspace ID: unknown" in text
+    assert "/car flow status" not in text
     assert "Use /bind" not in text


### PR DESCRIPTION
## Summary
This narrows the cross-platform command parity work to the highest-value shared surface first: `/status` / `/car status`.

The main change is to extract a shared status diagnostics formatter and have both Discord and Telegram compose their status responses from the same common block for agent/model/resume/approval/sandbox/rate-limit details, while still allowing platform-specific lines like Telegram topics vs Discord channels.

## Drift inventory scouted
Scouting across the chat surfaces found broader command drift beyond status:
- `status` content drift: shared runtime details were inconsistent across Telegram and Discord.
- Help text drift: overlapping commands describe different capabilities and naming.
- Namespace drift: flow/session/files commands are not presented uniformly across surfaces.
- Output/detail drift: model, agent, approval, and limit reporting varies by surface.

This PR intentionally fixes the shared `status` path and leaves the rest as follow-up parity work.

## What changed
- Added shared chat status diagnostics helpers under `integrations/chat/status_diagnostics.py`.
- Updated Discord status rendering to include the shared status block.
- Updated Telegram workspace status rendering to use the same shared status block while preserving topic/PMA-specific lines.
- Added focused tests for the new shared helpers and Discord/Telegram status behavior.

## Subagent review notes
Scout agents were used to inventory command drift and identify the shared extraction point.
Review agents caught two concrete issues during implementation:
- a bad import split / missing shared-module wiring
- a Telegram regression where the explicit bound-topic marker disappeared

Both issues were fixed before merge.

## Testing
- `.venv/bin/python -m pytest tests/integrations/chat/test_status_diagnostics.py tests/integrations/discord/test_status.py tests/test_telegram_status_rate_limits.py tests/test_telegram_bot_integration.py -k status`
- `.venv/bin/python scripts/deadcode.py --check`
- full pre-commit hook via `git commit`:
  - black
  - ruff
  - injected context / command resolution / import boundary / interface / contract checks
  - mypy
  - eslint
  - `pnpm run build`
  - `pnpm test:markdown`
  - repo pytest (`3425 passed, 1 skipped`)
