### PR TITLE
Defer Discord and Telegram interaction responses before slow work

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -2938,6 +2938,7 @@ class DiscordBotService:
         *,
         workspace_root: Path,
         action: str,
+        deferred: bool = False,
     ) -> None:
         try:
             store = self._open_flow_store(workspace_root)
@@ -2958,20 +2959,22 @@ class DiscordBotService:
 
         filtered = [run for run in runs if _flow_run_matches_action(run, action)]
         if not filtered:
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                f"No ticket_flow runs available for {flow_action_label(action)}.",
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=f"No ticket_flow runs available for {flow_action_label(action)}.",
             )
             return
         run_tuples = [(record.id, record.status.value) for record in filtered]
         custom_id = f"{FLOW_ACTION_SELECT_PREFIX}:{action}"
         prompt = f"Select a run to {flow_action_label(action)}:"
-        await self._respond_with_components(
-            interaction_id,
-            interaction_token,
-            prompt,
-            [
+        await self._send_or_respond_with_components_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=prompt,
+            components=[
                 build_flow_runs_picker(
                     run_tuples,
                     custom_id=custom_id,
@@ -2988,6 +2991,7 @@ class DiscordBotService:
         workspace_root: Path,
         action: str,
         run_id_opt: Any,
+        deferred: bool = False,
     ) -> Optional[str]:
         if not (isinstance(run_id_opt, str) and run_id_opt.strip()):
             if action == "status":
@@ -2997,6 +3001,7 @@ class DiscordBotService:
                 interaction_token,
                 workspace_root=workspace_root,
                 action=action,
+                deferred=deferred,
             )
             return None
 
@@ -3034,11 +3039,12 @@ class DiscordBotService:
                 f"Matched {len(filtered_items)} runs for `{query_text}`. "
                 f"Select a run to {flow_action_label(action)}:"
             )
-            await self._respond_with_components(
-                interaction_id,
-                interaction_token,
-                prompt,
-                [
+            await self._send_or_respond_with_components_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=prompt,
+                components=[
                     build_flow_runs_picker(
                         filtered_items,
                         custom_id=custom_id,
@@ -5354,6 +5360,10 @@ class DiscordBotService:
             except Exception:
                 cwd = workspace_root
 
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
         git_check = ["git", "rev-parse", "--is-inside-work-tree"]
         try:
             result = await asyncio.to_thread(
@@ -5365,24 +5375,27 @@ class DiscordBotService:
                 timeout=5,
             )
             if result.returncode != 0:
-                await self._respond_ephemeral(
-                    interaction_id,
-                    interaction_token,
-                    "Not a git repository.",
+                await self._send_or_respond_ephemeral(
+                    interaction_id=interaction_id,
+                    interaction_token=interaction_token,
+                    deferred=deferred,
+                    text="Not a git repository.",
                 )
                 return
         except subprocess.TimeoutExpired:
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                "Git check timed out.",
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text="Git check timed out.",
             )
             return
         except Exception as exc:
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                f"Git check failed: {exc}",
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=f"Git check failed: {exc}",
             )
             return
 
@@ -5412,7 +5425,12 @@ class DiscordBotService:
         from .rendering import truncate_for_discord
 
         output = truncate_for_discord(output, self._config.max_message_length - 100)
-        await self._respond_ephemeral(interaction_id, interaction_token, output)
+        await self._send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=output,
+        )
 
     async def _handle_skills(
         self,
@@ -6591,6 +6609,10 @@ class DiscordBotService:
                 )
                 return
 
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
         repo_url = (self._update_repo_url or DEFAULT_UPDATE_REPO_URL).strip()
         if not repo_url:
             repo_url = DEFAULT_UPDATE_REPO_URL
@@ -6636,10 +6658,11 @@ class DiscordBotService:
             text = format_discord_message(
                 f"{exc} Use `/car update target:status` for current state."
             )
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                text,
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=text,
             )
             return
         except Exception as exc:
@@ -6650,10 +6673,11 @@ class DiscordBotService:
                 update_target=update_target,
                 exc=exc,
             )
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                "Update failed to start. Check logs for details.",
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text="Update failed to start. Check logs for details.",
             )
             return
 
@@ -6663,10 +6687,11 @@ class DiscordBotService:
             "I will post completion status in this channel. "
             "Use `/car update target:status` for progress."
         )
-        await self._respond_ephemeral(
-            interaction_id,
-            interaction_token,
-            text,
+        await self._send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=text,
         )
         self._update_status_notifier.schedule_watch({"chat_id": channel_id})
 
@@ -6787,13 +6812,18 @@ class DiscordBotService:
         interaction_id: str,
         interaction_token: str,
     ) -> None:
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
         status = await asyncio.to_thread(_read_update_status)
         if not isinstance(status, dict):
             status = None
-        await self._respond_ephemeral(
-            interaction_id,
-            interaction_token,
-            self._format_update_status_message(status),
+        await self._send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=self._format_update_status_message(status),
         )
 
     VALID_AGENT_VALUES = VALID_CHAT_AGENT_VALUES
@@ -7667,12 +7697,19 @@ class DiscordBotService:
         guild_id: Optional[str] = None,
         update_message: bool = False,
     ) -> None:
+        deferred_public = False
+        if not update_message:
+            deferred_public = await self._defer_public(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+            )
         run_id_opt = await self._resolve_flow_run_input(
             interaction_id,
             interaction_token,
             workspace_root=workspace_root,
             action="status",
             run_id_opt=options.get("run_id"),
+            deferred=deferred_public,
         )
         if run_id_opt is None:
             return
@@ -7757,8 +7794,11 @@ class DiscordBotService:
                     if explicit_run_requested
                     else "No ticket_flow runs found."
                 )
-                await self._respond_ephemeral(
-                    interaction_id, interaction_token, message
+                await self._send_or_respond_ephemeral(
+                    interaction_id=interaction_id,
+                    interaction_token=interaction_token,
+                    deferred=deferred_public,
+                    text=message,
                 )
                 return
             try:
@@ -7766,10 +7806,11 @@ class DiscordBotService:
                     workspace_root, record, store
                 )
                 if locked:
-                    await self._respond_ephemeral(
-                        interaction_id,
-                        interaction_token,
-                        f"Run {record.id} is locked for reconcile; try again.",
+                    await self._send_or_respond_ephemeral(
+                        interaction_id=interaction_id,
+                        interaction_token=interaction_token,
+                        deferred=deferred_public,
+                        text=f"Run {record.id} is locked for reconcile; try again.",
                     )
                     return
             except (sqlite3.Error, OSError) as exc:
@@ -7840,11 +7881,12 @@ class DiscordBotService:
                     components=status_buttons,
                 )
             else:
-                await self._respond_with_components_public(
-                    interaction_id,
-                    interaction_token,
-                    response_text,
-                    status_buttons,
+                await self._send_or_respond_with_components_public(
+                    interaction_id=interaction_id,
+                    interaction_token=interaction_token,
+                    deferred=deferred_public,
+                    text=response_text,
+                    components=status_buttons,
                 )
         else:
             if update_message:
@@ -7855,8 +7897,11 @@ class DiscordBotService:
                     components=[],
                 )
             else:
-                await self._respond_public(
-                    interaction_id, interaction_token, response_text
+                await self._send_or_respond_public(
+                    interaction_id=interaction_id,
+                    interaction_token=interaction_token,
+                    deferred=deferred_public,
+                    text=response_text,
                 )
 
     async def _handle_flow_runs(
@@ -7867,6 +7912,10 @@ class DiscordBotService:
         workspace_root: Path,
         options: dict[str, Any],
     ) -> None:
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
         raw_limit = options.get("limit")
         limit = FLOW_RUNS_DEFAULT_LIMIT
         if isinstance(raw_limit, int):
@@ -7906,8 +7955,11 @@ class DiscordBotService:
             store.close()
 
         if not runs:
-            await self._respond_ephemeral(
-                interaction_id, interaction_token, "No ticket_flow runs found."
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text="No ticket_flow runs found.",
             )
             return
 
@@ -7916,8 +7968,12 @@ class DiscordBotService:
         lines = [f"Recent ticket_flow runs (limit={limit}):"]
         for record in runs:
             lines.append(f"- {record.id} [{record.status.value}]")
-        await self._respond_with_components(
-            interaction_id, interaction_token, "\n".join(lines), components
+        await self._send_or_respond_with_components_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text="\n".join(lines),
+            components=components,
         )
 
     async def _handle_flow_issue(
@@ -7940,34 +7996,55 @@ class DiscordBotService:
             )
             return
         issue_ref = issue_ref.strip()
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
         try:
-            seed = seed_issue_from_github(
-                workspace_root,
-                issue_ref,
-                github_service_factory=lambda repo_root: cast(
-                    GitHubServiceProtocol, GitHubService(repo_root)
-                ),
+
+            def _seed_issue() -> Any:
+                seeded = seed_issue_from_github(
+                    workspace_root,
+                    issue_ref,
+                    github_service_factory=lambda repo_root: cast(
+                        GitHubServiceProtocol, GitHubService(repo_root)
+                    ),
+                )
+                atomic_write(issue_md_path(workspace_root), seeded.content)
+                return seeded
+
+            seed = await asyncio.to_thread(
+                _seed_issue,
             )
-            atomic_write(issue_md_path(workspace_root), seed.content)
         except GitHubError as exc:
-            await self._respond_ephemeral(
-                interaction_id, interaction_token, f"GitHub error: {exc}"
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=f"GitHub error: {exc}",
             )
             return
         except RuntimeError as exc:
-            await self._respond_ephemeral(interaction_id, interaction_token, str(exc))
-            return
-        except Exception as exc:
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                f"Failed to fetch issue: {exc}",
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=str(exc),
             )
             return
-        await self._respond_ephemeral(
-            interaction_id,
-            interaction_token,
-            f"Seeded ISSUE.md from GitHub issue {seed.issue_number}.",
+        except Exception as exc:
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=f"Failed to fetch issue: {exc}",
+            )
+            return
+        await self._send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=f"Seeded ISSUE.md from GitHub issue {seed.issue_number}.",
         )
 
     async def _handle_flow_plan(
@@ -8004,10 +8081,16 @@ class DiscordBotService:
         *,
         workspace_root: Path,
         options: dict[str, Any],
+        deferred_public: Optional[bool] = None,
     ) -> None:
         force_new = bool(options.get("force_new"))
         restart_from = options.get("restart_from")
         flow_service = self._ticket_flow_orchestration_service(workspace_root)
+        if deferred_public is None:
+            deferred_public = await self._defer_public(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+            )
 
         try:
             store = self._open_flow_store(workspace_root)
@@ -8088,10 +8171,11 @@ class DiscordBotService:
                             user_message="Unable to query flow database. Please try again later.",
                         ) from None
                     if record is None:
-                        await self._respond_ephemeral(
-                            interaction_id,
-                            interaction_token,
-                            (
+                        await self._send_or_respond_public(
+                            interaction_id=interaction_id,
+                            interaction_token=interaction_token,
+                            deferred=deferred_public,
+                            text=(
                                 "Reusing ticket_flow run "
                                 f"{active_or_paused.id} ({active_or_paused.status.value})."
                             ),
@@ -8102,10 +8186,11 @@ class DiscordBotService:
                             workspace_root, record, store
                         )
                         if locked:
-                            await self._respond_ephemeral(
-                                interaction_id,
-                                interaction_token,
-                                f"Run {record.id} is locked for reconcile; try again.",
+                            await self._send_or_respond_ephemeral(
+                                interaction_id=interaction_id,
+                                interaction_token=interaction_token,
+                                deferred=deferred_public,
+                                text=f"Run {record.id} is locked for reconcile; try again.",
                             )
                             return
                     except (sqlite3.Error, OSError) as exc:
@@ -8148,15 +8233,19 @@ class DiscordBotService:
                     ),
                 )
                 if status_buttons:
-                    await self._respond_with_components_public(
-                        interaction_id,
-                        interaction_token,
-                        response_text,
-                        status_buttons,
+                    await self._send_or_respond_with_components_public(
+                        interaction_id=interaction_id,
+                        interaction_token=interaction_token,
+                        deferred=deferred_public,
+                        text=response_text,
+                        components=status_buttons,
                     )
                 else:
-                    await self._respond_public(
-                        interaction_id, interaction_token, response_text
+                    await self._send_or_respond_public(
+                        interaction_id=interaction_id,
+                        interaction_token=interaction_token,
+                        deferred=deferred_public,
+                        text=response_text,
                     )
                 return
 
@@ -8171,7 +8260,12 @@ class DiscordBotService:
                 metadata=metadata,
             )
         except ValueError as exc:
-            await self._respond_ephemeral(interaction_id, interaction_token, str(exc))
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred_public,
+                text=str(exc),
+            )
             return
 
         try:
@@ -8206,10 +8300,11 @@ class DiscordBotService:
                 ) from None
             if record is None:
                 prefix = "Started new" if force_new else "Started"
-                await self._respond_ephemeral(
-                    interaction_id,
-                    interaction_token,
-                    f"{prefix} ticket_flow run {started.run_id}.",
+                await self._send_or_respond_public(
+                    interaction_id=interaction_id,
+                    interaction_token=interaction_token,
+                    deferred=deferred_public,
+                    text=f"{prefix} ticket_flow run {started.run_id}.",
                 )
                 return
             try:
@@ -8217,10 +8312,11 @@ class DiscordBotService:
                     workspace_root, record, store
                 )
                 if locked:
-                    await self._respond_ephemeral(
-                        interaction_id,
-                        interaction_token,
-                        f"Run {record.id} is locked for reconcile; try again.",
+                    await self._send_or_respond_ephemeral(
+                        interaction_id=interaction_id,
+                        interaction_token=interaction_token,
+                        deferred=deferred_public,
+                        text=f"Run {record.id} is locked for reconcile; try again.",
                     )
                     return
             except (sqlite3.Error, OSError) as exc:
@@ -8260,14 +8356,20 @@ class DiscordBotService:
             prefix=f"{prefix} ticket_flow run {record.id}.",
         )
         if status_buttons:
-            await self._respond_with_components_public(
-                interaction_id,
-                interaction_token,
-                response_text,
-                status_buttons,
+            await self._send_or_respond_with_components_public(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred_public,
+                text=response_text,
+                components=status_buttons,
             )
         else:
-            await self._respond_public(interaction_id, interaction_token, response_text)
+            await self._send_or_respond_public(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred_public,
+                text=response_text,
+            )
 
     async def _handle_flow_restart(
         self,
@@ -8276,13 +8378,20 @@ class DiscordBotService:
         *,
         workspace_root: Path,
         options: dict[str, Any],
+        deferred_public: Optional[bool] = None,
     ) -> None:
+        if deferred_public is None:
+            deferred_public = await self._defer_public(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+            )
         run_id_opt = await self._resolve_flow_run_input(
             interaction_id,
             interaction_token,
             workspace_root=workspace_root,
             action="restart",
             run_id_opt=options.get("run_id"),
+            deferred=deferred_public,
         )
         if run_id_opt is None:
             return
@@ -8341,10 +8450,11 @@ class DiscordBotService:
             store.close()
 
         if isinstance(run_id_opt, str) and run_id_opt.strip() and target is None:
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                f"No ticket_flow run found for run_id {run_id_opt.strip()}.",
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred_public,
+                text=f"No ticket_flow run found for run_id {run_id_opt.strip()}.",
             )
             return
 
@@ -8353,8 +8463,11 @@ class DiscordBotService:
             try:
                 await flow_service.stop_flow_run(target.id)
             except ValueError as exc:
-                await self._respond_ephemeral(
-                    interaction_id, interaction_token, str(exc)
+                await self._send_or_respond_ephemeral(
+                    interaction_id=interaction_id,
+                    interaction_token=interaction_token,
+                    deferred=deferred_public,
+                    text=str(exc),
                 )
                 return
             latest = await flow_service.wait_for_flow_run_terminal(target.id)
@@ -8364,10 +8477,11 @@ class DiscordBotService:
                 "failed",
             }:
                 status_value = latest.status if latest is not None else "unknown"
-                await self._respond_ephemeral(
-                    interaction_id,
-                    interaction_token,
-                    (
+                await self._send_or_respond_public(
+                    interaction_id=interaction_id,
+                    interaction_token=interaction_token,
+                    deferred=deferred_public,
+                    text=(
                         f"Run {target.id} is still active ({status_value}); "
                         "restart aborted to avoid concurrent workers. Try again after it stops."
                     ),
@@ -8382,6 +8496,7 @@ class DiscordBotService:
                 "force_new": True,
                 "restart_from": target.id if target is not None else None,
             },
+            deferred_public=deferred_public,
         )
 
     async def _handle_flow_recover(
@@ -8392,12 +8507,17 @@ class DiscordBotService:
         workspace_root: Path,
         options: dict[str, Any],
     ) -> None:
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
         run_id_opt = await self._resolve_flow_run_input(
             interaction_id,
             interaction_token,
             workspace_root=workspace_root,
             action="recover",
             run_id_opt=options.get("run_id"),
+            deferred=deferred,
         )
         if run_id_opt is None:
             return
@@ -8455,27 +8575,30 @@ class DiscordBotService:
                 )
 
             if target is None:
-                await self._respond_ephemeral(
-                    interaction_id,
-                    interaction_token,
-                    "No active ticket_flow run found.",
+                await self._send_or_respond_ephemeral(
+                    interaction_id=interaction_id,
+                    interaction_token=interaction_token,
+                    deferred=deferred,
+                    text="No active ticket_flow run found.",
                 )
                 return
 
             flow_service = self._ticket_flow_orchestration_service(workspace_root)
             target_run, updated, locked = flow_service.reconcile_flow_run(target.id)
             if locked:
-                await self._respond_ephemeral(
-                    interaction_id,
-                    interaction_token,
-                    f"Run {target_run.run_id} is locked for reconcile; try again.",
+                await self._send_or_respond_ephemeral(
+                    interaction_id=interaction_id,
+                    interaction_token=interaction_token,
+                    deferred=deferred,
+                    text=f"Run {target_run.run_id} is locked for reconcile; try again.",
                 )
                 return
             verdict = "Recovered" if updated else "No changes needed"
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                f"{verdict} for run {target_run.run_id} ({target_run.status}).",
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=f"{verdict} for run {target_run.run_id} ({target_run.status}).",
             )
         finally:
             store.close()
@@ -8490,12 +8613,17 @@ class DiscordBotService:
         channel_id: Optional[str] = None,
         guild_id: Optional[str] = None,
     ) -> None:
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
         run_id_opt = await self._resolve_flow_run_input(
             interaction_id,
             interaction_token,
             workspace_root=workspace_root,
             action="resume",
             run_id_opt=options.get("run_id"),
+            deferred=deferred,
         )
         if run_id_opt is None:
             return
@@ -8558,10 +8686,11 @@ class DiscordBotService:
             store.close()
 
         if target is None:
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                "No paused ticket_flow run found to resume.",
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text="No paused ticket_flow run found to resume.",
             )
             return
 
@@ -8581,14 +8710,20 @@ class DiscordBotService:
         try:
             updated = await flow_service.resume_flow_run(target.id)
         except ValueError as exc:
-            await self._respond_ephemeral(interaction_id, interaction_token, str(exc))
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=str(exc),
+            )
             return
 
         outbound_text = f"Resumed run {updated.run_id}."
-        await self._respond_ephemeral(
-            interaction_id,
-            interaction_token,
-            outbound_text,
+        await self._send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=outbound_text,
         )
         run_mirror.mirror_outbound(
             run_id=updated.run_id,
@@ -8611,12 +8746,17 @@ class DiscordBotService:
         channel_id: Optional[str] = None,
         guild_id: Optional[str] = None,
     ) -> None:
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
         run_id_opt = await self._resolve_flow_run_input(
             interaction_id,
             interaction_token,
             workspace_root=workspace_root,
             action="stop",
             run_id_opt=options.get("run_id"),
+            deferred=deferred,
         )
         if run_id_opt is None:
             return
@@ -8675,10 +8815,11 @@ class DiscordBotService:
             store.close()
 
         if target is None:
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                "No active ticket_flow run found to stop.",
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text="No active ticket_flow run found to stop.",
             )
             return
 
@@ -8698,14 +8839,20 @@ class DiscordBotService:
         try:
             updated = await flow_service.stop_flow_run(target.id)
         except ValueError as exc:
-            await self._respond_ephemeral(interaction_id, interaction_token, str(exc))
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=str(exc),
+            )
             return
 
         outbound_text = f"Stop requested for run {updated.run_id} ({updated.status})."
-        await self._respond_ephemeral(
-            interaction_id,
-            interaction_token,
-            outbound_text,
+        await self._send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=outbound_text,
         )
         run_mirror.mirror_outbound(
             run_id=updated.run_id,
@@ -8902,6 +9049,10 @@ class DiscordBotService:
             )
             return
 
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
         run_id_opt = options.get("run_id")
         if not (isinstance(run_id_opt, str) and run_id_opt.strip()) and channel_id:
             pending_key = self._pending_interaction_scope_key(
@@ -8914,6 +9065,7 @@ class DiscordBotService:
                 interaction_token,
                 workspace_root=workspace_root,
                 action="reply",
+                deferred=deferred,
             )
             return
         if isinstance(run_id_opt, str) and run_id_opt.strip():
@@ -8923,6 +9075,7 @@ class DiscordBotService:
                 workspace_root=workspace_root,
                 action="reply",
                 run_id_opt=run_id_opt,
+                deferred=deferred,
             )
             if run_id_opt is None:
                 return
@@ -8987,10 +9140,11 @@ class DiscordBotService:
             store.close()
 
         if target is None:
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                "No paused ticket_flow run found for reply.",
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text="No paused ticket_flow run found for reply.",
             )
             return
 
@@ -9012,16 +9166,22 @@ class DiscordBotService:
         try:
             updated = await flow_service.resume_flow_run(target.id)
         except ValueError as exc:
-            await self._respond_ephemeral(interaction_id, interaction_token, str(exc))
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=str(exc),
+            )
             return
 
         outbound_text = (
             f"Reply saved to {reply_path.name} and resumed run {updated.run_id}."
         )
-        await self._respond_ephemeral(
-            interaction_id,
-            interaction_token,
-            outbound_text,
+        await self._send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=outbound_text,
         )
         run_mirror.mirror_outbound(
             run_id=updated.run_id,
@@ -9527,6 +9687,28 @@ class DiscordBotService:
                 return
         await self._respond_ephemeral(interaction_id, interaction_token, text)
 
+    async def _send_or_respond_with_components_ephemeral(
+        self,
+        *,
+        interaction_id: str,
+        interaction_token: str,
+        deferred: bool,
+        text: str,
+        components: list[dict[str, Any]],
+    ) -> None:
+        if deferred:
+            max_len = max(int(self._config.max_message_length), 32)
+            sent = await self._send_followup_ephemeral(
+                interaction_token=interaction_token,
+                content=truncate_for_discord(text, max_len=max_len),
+                components=components,
+            )
+            if sent:
+                return
+        await self._respond_with_components(
+            interaction_id, interaction_token, text, components
+        )
+
     async def _respond_with_components(
         self,
         interaction_id: str,
@@ -9758,6 +9940,28 @@ class DiscordBotService:
             if sent:
                 return
         await self._respond_public(interaction_id, interaction_token, text)
+
+    async def _send_or_respond_with_components_public(
+        self,
+        *,
+        interaction_id: str,
+        interaction_token: str,
+        deferred: bool,
+        text: str,
+        components: list[dict[str, Any]],
+    ) -> None:
+        if deferred:
+            max_len = max(int(self._config.max_message_length), 32)
+            sent = await self._send_followup_public(
+                interaction_token=interaction_token,
+                content=truncate_for_discord(text, max_len=max_len),
+                components=components,
+            )
+            if sent:
+                return
+        await self._respond_with_components_public(
+            interaction_id, interaction_token, text, components
+        )
 
     async def _respond_with_components_public(
         self,
@@ -10948,6 +11152,7 @@ class DiscordBotService:
                 interaction_token,
                 workspace_root=workspace_root,
                 options={"run_id": run_id},
+                deferred_public=False,
             )
         elif action == "refresh":
             await self._handle_flow_status(
@@ -11076,6 +11281,10 @@ class DiscordBotService:
             )
             return
 
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
         target_arg = options.get("target", "")
         target_type = "uncommittedChanges"
         target_value: Optional[str] = None
@@ -11112,14 +11321,15 @@ class DiscordBotService:
                             (commit_sha, commit_subjects.get(commit_sha, ""))
                             for commit_sha, _label in filtered_search_items
                         ]
-                        await self._respond_with_components(
-                            interaction_id,
-                            interaction_token,
-                            (
+                        await self._send_or_respond_with_components_ephemeral(
+                            interaction_id=interaction_id,
+                            interaction_token=interaction_token,
+                            deferred=deferred,
+                            text=(
                                 f"Matched {len(filtered_commits)} commits for `{query_text}`. "
                                 "Select a commit to review:"
                             ),
-                            [
+                            components=[
                                 build_review_commit_picker(
                                     filtered_commits,
                                     custom_id=REVIEW_COMMIT_SELECT_ID,
@@ -11147,21 +11357,27 @@ class DiscordBotService:
             elif target_lower in ("uncommitted", ""):
                 pass
             elif target_lower == "custom":
-                await self._respond_ephemeral(
-                    interaction_id,
-                    interaction_token,
-                    "Provide custom review instructions after `custom`, for example: "
-                    "`/car review target:custom focus on security regressions`.",
+                await self._send_or_respond_ephemeral(
+                    interaction_id=interaction_id,
+                    interaction_token=interaction_token,
+                    deferred=deferred,
+                    text=(
+                        "Provide custom review instructions after `custom`, for example: "
+                        "`/car review target:custom focus on security regressions`."
+                    ),
                 )
                 return
             elif target_lower.startswith("custom "):
                 custom_instructions = target_text[7:].strip()
                 if not custom_instructions:
-                    await self._respond_ephemeral(
-                        interaction_id,
-                        interaction_token,
-                        "Provide custom review instructions after `custom`, for example: "
-                        "`/car review target:custom focus on security regressions`.",
+                    await self._send_or_respond_ephemeral(
+                        interaction_id=interaction_id,
+                        interaction_token=interaction_token,
+                        deferred=deferred,
+                        text=(
+                            "Provide custom review instructions after `custom`, for example: "
+                            "`/car review target:custom focus on security regressions`."
+                        ),
                     )
                     return
                 target_type = "custom"
@@ -11173,28 +11389,25 @@ class DiscordBotService:
         if prompt_commit_picker:
             commits = await self._list_recent_commits_for_picker(workspace_root)
             if not commits:
-                await self._respond_ephemeral(
-                    interaction_id,
-                    interaction_token,
-                    "No recent commits found. Use `/car review target:commit <sha>`.",
+                await self._send_or_respond_ephemeral(
+                    interaction_id=interaction_id,
+                    interaction_token=interaction_token,
+                    deferred=deferred,
+                    text="No recent commits found. Use `/car review target:commit <sha>`.",
                 )
                 return
-            await self._respond_with_components(
-                interaction_id,
-                interaction_token,
-                "Select a commit to review:",
-                [
+            await self._send_or_respond_with_components_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text="Select a commit to review:",
+                components=[
                     build_review_commit_picker(
                         commits, custom_id=REVIEW_COMMIT_SELECT_ID
                     )
                 ],
             )
             return
-
-        await self._defer_ephemeral(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
-        )
 
         prompt_parts: list[str] = ["Please perform a code review."]
         if target_type == "uncommittedChanges":
@@ -11442,31 +11655,38 @@ class DiscordBotService:
             )
             return
 
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
         max_bytes = 100000
         try:
             data = path.read_bytes()
         except Exception:
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                "Failed to read file.",
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text="Failed to read file.",
             )
             return
 
         if len(data) > max_bytes:
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                f"File too large (max {max_bytes} bytes).",
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=f"File too large (max {max_bytes} bytes).",
             )
             return
 
         null_count = data.count(b"\x00")
         if null_count > 0 and null_count > len(data) * 0.1:
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                "File appears to be binary; refusing to include it.",
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text="File appears to be binary; refusing to include it.",
             )
             return
 
@@ -11478,17 +11698,20 @@ class DiscordBotService:
         if not isinstance(request_arg, str) or not request_arg.strip():
             request_arg = "Please review this file."
 
-        await self._respond_ephemeral(
-            interaction_id,
-            interaction_token,
-            f"File `{display_path}` ready for mention.\n\n"
-            f"To include it in a request, send a message starting with:\n"
-            f"```\n"
-            f'<file path="{display_path}">\n'
-            f"...\n"
-            f"</file>\n"
-            f"```\n\n"
-            f"Your request: {request_arg}",
+        await self._send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=(
+                f"File `{display_path}` ready for mention.\n\n"
+                f"To include it in a request, send a message starting with:\n"
+                f"```\n"
+                f'<file path="{display_path}">\n'
+                f"...\n"
+                f"</file>\n"
+                f"```\n\n"
+                f"Your request: {request_arg}"
+            ),
         )
 
     async def _handle_car_experimental(
@@ -11945,12 +12168,17 @@ class DiscordBotService:
         *,
         workspace_root: Path,
     ) -> None:
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
         client = await self._client_for_workspace(str(workspace_root))
         if client is None:
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                format_discord_message(
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=format_discord_message(
                     "Topic not bound. Use `/car bind path:<workspace>` first."
                 ),
             )
@@ -11965,16 +12193,18 @@ class DiscordBotService:
                 workspace_root=str(workspace_root),
                 exc=exc,
             )
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                format_discord_message("Logout failed; check logs for details."),
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=format_discord_message("Logout failed; check logs for details."),
             )
             return
-        await self._respond_ephemeral(
-            interaction_id,
-            interaction_token,
-            "Logged out.",
+        await self._send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text="Logged out.",
         )
 
     async def _handle_car_feedback(
@@ -11999,12 +12229,17 @@ class DiscordBotService:
             )
             return
 
+        deferred = await self._defer_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+        )
         client = await self._client_for_workspace(str(workspace_root))
         if client is None:
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                format_discord_message(
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=format_discord_message(
                     "Topic not bound. Use `/car bind path:<workspace>` first."
                 ),
             )
@@ -12032,10 +12267,11 @@ class DiscordBotService:
                 workspace_root=str(workspace_root),
                 exc=exc,
             )
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                format_discord_message(
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=format_discord_message(
                     "Feedback upload failed; check logs for details."
                 ),
             )
@@ -12047,10 +12283,11 @@ class DiscordBotService:
         message_text = "Feedback sent."
         if isinstance(report_id, str):
             message_text = f"Feedback sent (report {report_id})."
-        await self._respond_ephemeral(
-            interaction_id,
-            interaction_token,
-            message_text,
+        await self._send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=message_text,
         )
 
     async def _handle_car_archive(

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
@@ -643,6 +643,15 @@ class FlowCommands(SharedHelpers):
     async def _handle_flow_callback(
         self, callback: TelegramCallbackQuery, parsed: FlowCallback
     ) -> None:
+        callback_answered = False
+
+        async def _answer_once(text: str) -> None:
+            nonlocal callback_answered
+            if callback_answered:
+                return
+            await self._answer_callback(callback, text)
+            callback_answered = True
+
         if callback.chat_id is None:
             return
         key = await self._resolve_topic_key(callback.chat_id, callback.thread_id)
@@ -658,7 +667,7 @@ class FlowCommands(SharedHelpers):
         if repo_root is None and record and record.workspace_path:
             repo_root = canonicalize_path(Path(record.workspace_path))
         if repo_root is None:
-            await self._answer_callback(callback, "No workspace bound")
+            await _answer_once("No workspace bound")
             await self._edit_callback_message(
                 callback,
                 "No workspace bound. Use /flow <repo-id> <worktree-id>, or /bind to bind this topic to a repo first.",
@@ -670,7 +679,7 @@ class FlowCommands(SharedHelpers):
         run_id_raw = parsed.run_id
 
         if action in {"refresh", "status"}:
-            await self._answer_callback(callback, "Refreshing...")
+            await _answer_once("Refreshing...")
             await self._render_flow_status_callback(
                 callback, repo_root, run_id_raw, repo_id=effective_repo_id
             )
@@ -699,6 +708,7 @@ class FlowCommands(SharedHelpers):
                 store.close()
             if error is None:
                 try:
+                    await _answer_once("Working...")
                     updated = await flow_service.resume_flow_run(record.id)
                 except (KeyError, ValueError) as exc:
                     error = str(exc)
@@ -723,6 +733,7 @@ class FlowCommands(SharedHelpers):
             finally:
                 store.close()
             if error is None:
+                await _answer_once("Working...")
                 await flow_service.stop_flow_run(record.id)
                 notice = "Stopped."
         elif action == "recover":
@@ -740,6 +751,7 @@ class FlowCommands(SharedHelpers):
                 if error is None and record is None:
                     error = "No active ticket flow run found."
                 if error is None:
+                    await _answer_once("Working...")
                     record, updated, locked = flow_service.reconcile_flow_run(record.id)
                     if locked:
                         error = (
@@ -757,7 +769,7 @@ class FlowCommands(SharedHelpers):
             "archive_cancel_prompt",
         }:
             if action == "archive_cancel":
-                await self._answer_callback(callback, "Archive cancelled")
+                await _answer_once("Archive cancelled")
                 await self._render_flow_status_callback(
                     callback,
                     repo_root,
@@ -766,7 +778,7 @@ class FlowCommands(SharedHelpers):
                 )
                 return
             if action == "archive_cancel_prompt":
-                await self._answer_callback(callback, "Archive cancelled")
+                await _answer_once("Archive cancelled")
                 await self._edit_callback_message(
                     callback,
                     "Archive cancelled.",
@@ -789,7 +801,7 @@ class FlowCommands(SharedHelpers):
                         "Stop or pause it before archiving."
                     )
                 elif action == "archive" and archive_mode == "confirm":
-                    await self._answer_callback(callback, "Confirm archive?")
+                    await _answer_once("Confirm archive?")
                     await self._edit_callback_message(
                         callback,
                         self._flow_archive_prompt_text(record),
@@ -802,6 +814,7 @@ class FlowCommands(SharedHelpers):
                     return
                 else:
                     try:
+                        await _answer_once("Working...")
                         summary = flow_service.archive_flow_run(
                             record.id,
                             force=ticket_flow_archive_requires_force(record),
@@ -814,13 +827,13 @@ class FlowCommands(SharedHelpers):
                     except ValueError as exc:
                         error = str(exc)
         else:
-            await self._answer_callback(callback, "Unknown action")
+            await _answer_once("Unknown action")
             return
 
         if error:
-            await self._answer_callback(callback, error)
+            await _answer_once(error)
         elif notice:
-            await self._answer_callback(callback, notice)
+            await _answer_once(notice)
         await self._render_flow_status_callback(
             callback, repo_root, run_id_raw, repo_id=effective_repo_id
         )

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -2693,6 +2693,15 @@ class WorkspaceCommands(SharedHelpers):
         thread_id: str,
         callback: Optional[TelegramCallbackQuery] = None,
     ) -> None:
+        callback_answered = False
+
+        async def _answer_once(text: str) -> None:
+            nonlocal callback_answered
+            if callback_answered or callback is None:
+                return
+            await self._answer_callback(callback, text)
+            callback_answered = True
+
         chat_id, thread_id_val = _split_topic_key(key)
         self._resume_options.pop(key, None)
         record = await self._router.get_topic(key)
@@ -2701,7 +2710,7 @@ class WorkspaceCommands(SharedHelpers):
             return
         workspace_path, error = self._resolve_workspace_path(record, allow_pma=True)
         if workspace_path is None:
-            await self._answer_callback(callback, "Resume aborted")
+            await _answer_once("Resume aborted")
             await self._finalize_selection(
                 key,
                 callback,
@@ -2714,6 +2723,7 @@ class WorkspaceCommands(SharedHelpers):
             return
         record = self._record_with_workspace_path(record, workspace_path)
         try:
+            await _answer_once("Resuming...")
             client = await self._client_for_workspace(record.workspace_path)
         except AppServerUnavailableError as exc:
             log_event(
@@ -2724,7 +2734,7 @@ class WorkspaceCommands(SharedHelpers):
                 thread_id=thread_id_val,
                 exc=exc,
             )
-            await self._answer_callback(callback, "Resume aborted")
+            await _answer_once("Resume aborted")
             await self._finalize_selection(
                 key,
                 callback,
@@ -2736,7 +2746,7 @@ class WorkspaceCommands(SharedHelpers):
             )
             return
         if client is None:
-            await self._answer_callback(callback, "Resume aborted")
+            await _answer_once("Resume aborted")
             await self._finalize_selection(
                 key,
                 callback,
@@ -2767,7 +2777,7 @@ class WorkspaceCommands(SharedHelpers):
                     record.thread_summaries.pop(thread_id, None)
 
                 await self._store.update_topic(key, clear_stale)
-                await self._answer_callback(callback, "Thread missing")
+                await _answer_once("Thread missing")
                 await self._finalize_selection(
                     key,
                     callback,
@@ -2786,7 +2796,7 @@ class WorkspaceCommands(SharedHelpers):
                 thread_id=thread_id,
                 exc=exc,
             )
-            await self._answer_callback(callback, "Resume failed")
+            await _answer_once("Resume failed")
             chat_id, thread_id_val = _split_topic_key(key)
             await self._finalize_selection(
                 key,
@@ -2801,7 +2811,7 @@ class WorkspaceCommands(SharedHelpers):
         info = _extract_thread_info(result)
         resumed_path = info.get("workspace_path")
         if record is None or not record.workspace_path:
-            await self._answer_callback(callback, "Resume aborted")
+            await _answer_once("Resume aborted")
             await self._finalize_selection(
                 key,
                 callback,
@@ -2813,7 +2823,7 @@ class WorkspaceCommands(SharedHelpers):
             )
             return
         if not isinstance(resumed_path, str):
-            await self._answer_callback(callback, "Resume aborted")
+            await _answer_once("Resume aborted")
             await self._finalize_selection(
                 key,
                 callback,
@@ -2828,7 +2838,7 @@ class WorkspaceCommands(SharedHelpers):
             workspace_root = Path(record.workspace_path).expanduser().resolve()
             resumed_root = Path(resumed_path).expanduser().resolve()
         except Exception:
-            await self._answer_callback(callback, "Resume aborted")
+            await _answer_once("Resume aborted")
             await self._finalize_selection(
                 key,
                 callback,
@@ -2840,7 +2850,7 @@ class WorkspaceCommands(SharedHelpers):
             )
             return
         if not _paths_compatible(workspace_root, resumed_root):
-            await self._answer_callback(callback, "Resume aborted")
+            await _answer_once("Resume aborted")
             await self._finalize_selection(
                 key,
                 callback,
@@ -2853,7 +2863,7 @@ class WorkspaceCommands(SharedHelpers):
             return
         conflict_key = await self._find_thread_conflict(thread_id, key=key)
         if conflict_key:
-            await self._answer_callback(callback, "Resume aborted")
+            await _answer_once("Resume aborted")
             await self._finalize_selection(
                 key,
                 callback,
@@ -2879,7 +2889,7 @@ class WorkspaceCommands(SharedHelpers):
             active_thread_id=thread_id,
             overwrite_defaults=True,
         )
-        await self._answer_callback(callback, "Resumed thread")
+        await _answer_once("Resumed thread")
         message = _format_resume_summary(
             thread_id,
             result,
@@ -2895,12 +2905,21 @@ class WorkspaceCommands(SharedHelpers):
         thread_id: str,
         callback: Optional[TelegramCallbackQuery] = None,
     ) -> None:
+        callback_answered = False
+
+        async def _answer_once(text: str) -> None:
+            nonlocal callback_answered
+            if callback_answered or callback is None:
+                return
+            await self._answer_callback(callback, text)
+            callback_answered = True
+
         chat_id, thread_id_val = _split_topic_key(key)
         self._resume_options.pop(key, None)
         record = await self._router.get_topic(key)
         workspace_path, error = self._resolve_workspace_path(record, allow_pma=True)
         if workspace_path is None:
-            await self._answer_callback(callback, "Resume aborted")
+            await _answer_once("Resume aborted")
             await self._finalize_selection(
                 key,
                 callback,
@@ -2914,7 +2933,7 @@ class WorkspaceCommands(SharedHelpers):
         record = self._record_with_workspace_path(record, workspace_path)
         supervisor = getattr(self, "_opencode_supervisor", None)
         if supervisor is None:
-            await self._answer_callback(callback, "Resume aborted")
+            await _answer_once("Resume aborted")
             await self._finalize_selection(
                 key,
                 callback,
@@ -2927,7 +2946,7 @@ class WorkspaceCommands(SharedHelpers):
             return
         workspace_root = self._canonical_workspace_root(record.workspace_path)
         if workspace_root is None:
-            await self._answer_callback(callback, "Resume aborted")
+            await _answer_once("Resume aborted")
             await self._finalize_selection(
                 key,
                 callback,
@@ -2939,6 +2958,7 @@ class WorkspaceCommands(SharedHelpers):
             )
             return
         try:
+            await _answer_once("Resuming...")
             client = await supervisor.get_client(workspace_root)
             session = await client.get_session(thread_id)
         except Exception as exc:
@@ -2960,7 +2980,7 @@ class WorkspaceCommands(SharedHelpers):
                     record.thread_summaries.pop(thread_id, None)
 
                 await self._store.update_topic(key, clear_stale)
-                await self._answer_callback(callback, "Thread missing")
+                await _answer_once("Thread missing")
                 await self._finalize_selection(
                     key,
                     callback,
@@ -2979,7 +2999,7 @@ class WorkspaceCommands(SharedHelpers):
                 thread_id=thread_id,
                 exc=exc,
             )
-            await self._answer_callback(callback, "Resume failed")
+            await _answer_once("Resume failed")
             await self._finalize_selection(
                 key,
                 callback,
@@ -2996,7 +3016,7 @@ class WorkspaceCommands(SharedHelpers):
                 workspace_root = Path(record.workspace_path).expanduser().resolve()
                 resumed_root = Path(resumed_path).expanduser().resolve()
             except Exception:
-                await self._answer_callback(callback, "Resume aborted")
+                await _answer_once("Resume aborted")
                 await self._finalize_selection(
                     key,
                     callback,
@@ -3008,7 +3028,7 @@ class WorkspaceCommands(SharedHelpers):
                 )
                 return
             if not _paths_compatible(workspace_root, resumed_root):
-                await self._answer_callback(callback, "Resume aborted")
+                await _answer_once("Resume aborted")
                 await self._finalize_selection(
                     key,
                     callback,
@@ -3021,7 +3041,7 @@ class WorkspaceCommands(SharedHelpers):
                 return
         conflict_key = await self._find_thread_conflict(thread_id, key=key)
         if conflict_key:
-            await self._answer_callback(callback, "Resume aborted")
+            await _answer_once("Resume aborted")
             await self._finalize_selection(
                 key,
                 callback,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -2633,6 +2633,10 @@ Summary applied.""",
             reply_to=notify_reply_to,
             include_legacy_telegram_keys=True,
         )
+        callback_answered = False
+        if callback is not None:
+            await self._answer_callback(callback, "Starting update...")
+            callback_answered = True
         try:
             _spawn_update_process(
                 repo_url=repo_url,
@@ -2673,7 +2677,8 @@ Summary applied.""",
                 thread_id=thread_id,
             )
             if callback and selection_key:
-                await self._answer_callback(callback, "Update failed")
+                if not callback_answered:
+                    await self._answer_callback(callback, "Update failed")
                 await self._finalize_selection(selection_key, callback, failure)
             else:
                 await self._send_message(
@@ -2685,7 +2690,8 @@ Summary applied.""",
             f"Update started ({target_label}). The selected service(s) will restart."
         )
         if callback and selection_key:
-            await self._answer_callback(callback, "Update started")
+            if not callback_answered:
+                await self._answer_callback(callback, "Update started")
             await self._finalize_selection(selection_key, callback, message)
         else:
             await self._send_message(

--- a/tests/integrations/discord/test_flow_handlers.py
+++ b/tests/integrations/discord/test_flow_handlers.py
@@ -303,11 +303,11 @@ async def test_flow_status_and_runs_render_expected_output(tmp_path: Path) -> No
 
     try:
         await service.run_forever()
-        assert len(rest.interaction_responses) == 2
-        status_data = rest.interaction_responses[0]["payload"]["data"]
-        status_payload = status_data["content"]
-        runs_payload = rest.interaction_responses[1]["payload"]["data"]["content"]
-        assert "flags" not in status_data
+        assert len(rest.interaction_responses) == 4
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        assert rest.interaction_responses[2]["payload"]["type"] == 5
+        status_payload = rest.interaction_responses[1]["payload"]["data"]["content"]
+        runs_payload = rest.interaction_responses[3]["payload"]["data"]["content"]
 
         assert f"Run: {paused_run_id}" in status_payload
         assert "Status: paused" in status_payload
@@ -375,11 +375,11 @@ async def test_flow_status_without_run_id_uses_current_run_and_includes_picker(
 
     try:
         await service.run_forever()
-        assert len(rest.interaction_responses) == 1
-        payload = rest.interaction_responses[0]["payload"]["data"]
+        assert len(rest.interaction_responses) == 2
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        payload = rest.interaction_responses[1]["payload"]["data"]
         content = payload["content"]
         components = payload["components"]
-        assert "flags" not in payload
 
         assert f"Run: {paused_run_id}" in content
         assert "Status: paused" in content
@@ -432,8 +432,9 @@ async def test_flow_status_without_run_id_shows_no_current_run_for_history_only(
 
     try:
         await service.run_forever()
-        assert len(rest.interaction_responses) == 1
-        payload = rest.interaction_responses[0]["payload"]["data"]
+        assert len(rest.interaction_responses) == 2
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        payload = rest.interaction_responses[1]["payload"]["data"]
         content = payload["content"]
         components = payload["components"]
 
@@ -496,7 +497,8 @@ async def test_flow_status_shows_elapsed_for_completed_run(tmp_path: Path) -> No
 
     try:
         await service.run_forever()
-        content = _latest_status_message(rest)["content"]
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        content = rest.interaction_responses[1]["payload"]["data"]["content"]
         assert "Status: completed" in content
         assert "Elapsed: 2h 30m" in content
     finally:
@@ -541,8 +543,9 @@ async def test_flow_status_with_missing_explicit_run_id_reports_not_found(
 
     try:
         await service.run_forever()
-        assert len(rest.interaction_responses) == 1
-        content = rest.interaction_responses[0]["payload"]["data"]["content"]
+        assert len(rest.interaction_responses) == 2
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        content = rest.interaction_responses[1]["payload"]["data"]["content"]
         assert content == f"Ticket_flow run {missing_run_id} not found."
     finally:
         await store.close()
@@ -603,10 +606,12 @@ async def test_flow_refresh_button_updates_existing_status_message(
 
     try:
         await service.run_forever()
-        assert len(rest.interaction_responses) == 2
-        initial_payload = rest.interaction_responses[0]["payload"]
-        refresh_payload = rest.interaction_responses[1]["payload"]
+        assert len(rest.interaction_responses) == 3
+        initial_defer = rest.interaction_responses[0]["payload"]
+        initial_payload = rest.interaction_responses[1]["payload"]
+        refresh_payload = rest.interaction_responses[2]["payload"]
 
+        assert initial_defer["type"] == 5
         assert initial_payload["type"] == 4
         assert "flags" not in initial_payload["data"]
         assert "Status: running" in initial_payload["data"]["content"]
@@ -662,7 +667,8 @@ async def test_flow_issue_seeds_issue_md(
         issue_path = workspace / ".codex-autorunner" / "ISSUE.md"
         assert issue_path.exists()
         assert "Issue 123" in issue_path.read_text(encoding="utf-8")
-        content = rest.interaction_responses[0]["payload"]["data"]["content"]
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        content = rest.interaction_responses[1]["payload"]["data"]["content"]
         assert "Seeded ISSUE.md from GitHub issue 123." in content
     finally:
         await store.close()
@@ -744,13 +750,13 @@ async def test_flow_start_reuses_active_or_paused_run(
     try:
         await service.run_forever()
         assert flow_service.ensure_calls == [(paused_run_id, False)]
-        payload = rest.interaction_responses[0]["payload"]["data"]
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        payload = rest.interaction_responses[1]["payload"]["data"]
         content = payload["content"]
         assert f"Reusing ticket_flow run {paused_run_id} (paused)." in content
         assert f"Run: {paused_run_id}" in content
         assert "Status: paused" in content
         assert "components" in payload
-        assert "flags" not in payload
     finally:
         await store.close()
 
@@ -821,13 +827,13 @@ async def test_flow_restart_starts_new_run_for_failed_flow(
         assert len(flow_service.start_calls) == 1
         assert flow_service.start_calls[0]["metadata"]["force_new"] is True
         assert flow_service.start_calls[0]["metadata"]["origin"] == "discord"
-        payload = rest.interaction_responses[0]["payload"]["data"]
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        payload = rest.interaction_responses[1]["payload"]["data"]
         content = payload["content"]
         assert f"Started new ticket_flow run {new_run_id}." in content
         assert f"Run: {new_run_id}" in content
         assert "Status:" in content
         assert "components" in payload
-        assert "flags" not in payload
     finally:
         await store.close()
 
@@ -877,8 +883,78 @@ async def test_flow_restart_aborts_when_active_run_does_not_terminate(
         await service.run_forever()
         assert flow_service.stop_calls == [running_run_id]
         assert flow_service.start_calls == []
-        content = rest.interaction_responses[0]["payload"]["data"]["content"]
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        content = rest.interaction_responses[1]["payload"]["data"]["content"]
         assert "restart aborted to avoid concurrent workers" in content
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_flow_restart_button_uses_component_safe_response_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _workspace(tmp_path)
+    failed_run_id = str(uuid.uuid4())
+    new_run_id = str(uuid.uuid4())
+    _create_run(workspace, failed_run_id, status=FlowRunStatus.FAILED)
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+
+    flow_service = _FlowServiceStub()
+
+    async def _start_flow_run(
+        _flow_target_id: str,
+        *,
+        input_data: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+        run_id: str | None = None,
+    ) -> SimpleNamespace:
+        flow_service.start_calls.append(
+            {
+                "input_data": input_data or {},
+                "metadata": metadata or {},
+                "run_id": run_id,
+            }
+        )
+        _create_run(workspace, new_run_id, status=FlowRunStatus.RUNNING)
+        return SimpleNamespace(run_id=new_run_id, status="running")
+
+    flow_service.start_flow_run = _start_flow_run  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.discord.service.build_ticket_flow_orchestration_service",
+        lambda *, workspace_root: flow_service,
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [_flow_component_interaction(f"flow:{failed_run_id}:restart")]
+    )
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await service.run_forever()
+        assert len(flow_service.start_calls) == 1
+        assert len(rest.interaction_responses) == 1
+        payload = rest.interaction_responses[0]["payload"]
+        assert payload["type"] == 4
+        assert (
+            f"Started new ticket_flow run {new_run_id}." in payload["data"]["content"]
+        )
     finally:
         await store.close()
 
@@ -926,7 +1002,8 @@ async def test_flow_recover_reconciles_active_run(
     try:
         await service.run_forever()
         assert flow_service.reconcile_calls == [running_run_id]
-        content = rest.interaction_responses[0]["payload"]["data"]["content"]
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        content = rest.interaction_responses[1]["payload"]["data"]["content"]
         assert f"Recovered for run {running_run_id}" in content
     finally:
         await store.close()
@@ -984,8 +1061,9 @@ async def test_flow_reply_writes_user_reply_and_resumes(
         )
         assert reply_path.exists()
         assert reply_path.read_text(encoding="utf-8").strip() == "Please continue"
-        assert len(rest.interaction_responses) == 1
-        content = rest.interaction_responses[0]["payload"]["data"]["content"]
+        assert len(rest.interaction_responses) == 2
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        content = rest.interaction_responses[1]["payload"]["data"]["content"]
         assert paused_run_id in content
         assert "resumed run" in content.lower()
 
@@ -1544,7 +1622,8 @@ async def test_flow_recover_uses_explicit_run_id(
     try:
         await service.run_forever()
         assert flow_service.reconcile_calls == [target_run_id]
-        content = rest.interaction_responses[0]["payload"]["data"]["content"]
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        content = rest.interaction_responses[1]["payload"]["data"]["content"]
         assert f"Recovered for run {target_run_id}" in content
     finally:
         await store.close()

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -2871,11 +2871,12 @@ async def test_car_flow_resume_with_partial_run_id_prompts_filtered_picker(
 
     try:
         await service.run_forever()
-        payload = rest.interaction_responses[0]["payload"]
-        assert payload["type"] == 4
-        content = payload["data"]["content"].lower()
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        assert len(rest.followup_messages) == 1
+        payload = rest.followup_messages[0]["payload"]
+        content = payload["content"].lower()
         assert "matched 2 runs" in content
-        select = payload["data"]["components"][0]["components"][0]
+        select = payload["components"][0]["components"][0]
         values = [option["value"] for option in select["options"]]
         assert values == ["run-alpha", "run-beta"]
     finally:
@@ -2935,11 +2936,12 @@ async def test_car_flow_resume_status_text_prompts_picker_instead_of_auto_resolv
 
     try:
         await service.run_forever()
-        payload = rest.interaction_responses[0]["payload"]
-        assert payload["type"] == 4
-        content = payload["data"]["content"].lower()
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        assert len(rest.followup_messages) == 1
+        payload = rest.followup_messages[0]["payload"]
+        content = payload["content"].lower()
         assert "matched 2 runs" in content
-        select = payload["data"]["components"][0]["components"][0]
+        select = payload["components"][0]["components"][0]
         values = [option["value"] for option in select["options"]]
         assert values == ["run-paused-a", "run-paused-b"]
     finally:
@@ -3441,8 +3443,9 @@ async def test_normalized_interaction_flow_restart_without_run_id_uses_picker(
         *,
         workspace_root: Path,
         action: str,
+        deferred: bool = False,
     ) -> None:
-        _ = interaction_id, interaction_token, workspace_root
+        _ = interaction_id, interaction_token, workspace_root, deferred
         captured["action"] = action
 
     service._prompt_flow_action_picker = _fake_prompt  # type: ignore[assignment]
@@ -3486,8 +3489,9 @@ async def test_normalized_interaction_flow_reply_without_run_id_sets_pending_tex
         *,
         workspace_root: Path,
         action: str,
+        deferred: bool = False,
     ) -> None:
-        _ = interaction_id, interaction_token, workspace_root, action
+        _ = interaction_id, interaction_token, workspace_root, action, deferred
         return
 
     service._prompt_flow_action_picker = _fake_prompt  # type: ignore[assignment]
@@ -3653,7 +3657,9 @@ async def test_car_review_commit_without_sha_returns_picker(tmp_path: Path) -> N
     try:
         await service.run_forever()
         assert len(rest.interaction_responses) == 1
-        data = rest.interaction_responses[0]["payload"]["data"]
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        assert len(rest.followup_messages) == 1
+        data = rest.followup_messages[0]["payload"]
         components = data.get("components") or []
         assert components
         menu = components[0]["components"][0]
@@ -3708,11 +3714,12 @@ async def test_car_review_partial_commit_value_returns_filtered_picker(
     try:
         await service.run_forever()
         assert len(rest.interaction_responses) == 1
-        payload = rest.interaction_responses[0]["payload"]
-        assert payload["type"] == 4
-        content = payload["data"]["content"].lower()
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        assert len(rest.followup_messages) == 1
+        payload = rest.followup_messages[0]["payload"]
+        content = payload["content"].lower()
         assert "matched 2 commits" in content
-        menu = payload["data"]["components"][0]["components"][0]
+        menu = payload["components"][0]["components"][0]
         values = [option["value"] for option in menu["options"]]
         assert values == ["abcdef1234567890", "0123456789abcdef"]
     finally:
@@ -3800,17 +3807,19 @@ async def test_car_review_custom_without_instructions_returns_guidance(
     )
     deferred = False
 
-    async def _fake_defer_ephemeral(*_args: Any, **_kwargs: Any) -> None:
+    async def _fake_defer_ephemeral(*_args: Any, **_kwargs: Any) -> bool:
         nonlocal deferred
         deferred = True
+        return True
 
     service._defer_ephemeral = _fake_defer_ephemeral  # type: ignore[assignment]
 
     try:
         await service.run_forever()
-        assert deferred is False
-        assert len(rest.interaction_responses) == 1
-        content = rest.interaction_responses[0]["payload"]["data"]["content"].lower()
+        assert deferred is True
+        assert len(rest.interaction_responses) == 0
+        assert len(rest.followup_messages) == 1
+        content = rest.followup_messages[0]["payload"]["content"].lower()
         assert "provide custom review instructions" in content
     finally:
         await store.close()
@@ -4944,7 +4953,9 @@ async def test_car_update_status_reports_absent_status(
     try:
         await service.run_forever()
         assert len(rest.interaction_responses) == 1
-        content = rest.interaction_responses[0]["payload"]["data"]["content"].lower()
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        assert len(rest.followup_messages) == 1
+        content = rest.followup_messages[0]["payload"]["content"].lower()
         assert "no update status recorded" in content
     finally:
         await store.close()
@@ -4993,7 +5004,9 @@ async def test_car_update_starts_worker_with_explicit_target(
         assert observed["notify_platform"] == "discord"
         assert observed["notify_context"] == {"chat_id": "channel-1"}
         assert len(rest.interaction_responses) == 1
-        content = rest.interaction_responses[0]["payload"]["data"]["content"].lower()
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        assert len(rest.followup_messages) == 1
+        content = rest.followup_messages[0]["payload"]["content"].lower()
         assert "update started (all)" in content
     finally:
         await store.close()
@@ -5145,7 +5158,9 @@ async def test_car_update_web_target_skips_confirmation_when_sessions_active(
         await service.run_forever()
         assert observed["update_target"] == "web"
         assert len(rest.interaction_responses) == 1
-        content = rest.interaction_responses[0]["payload"]["data"]["content"].lower()
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        assert len(rest.followup_messages) == 1
+        content = rest.followup_messages[0]["payload"]["content"].lower()
         assert "update started (web only)" in content
     finally:
         await store.close()

--- a/tests/test_telegram_bot_integration.py
+++ b/tests/test_telegram_bot_integration.py
@@ -7,12 +7,16 @@ from typing import Optional
 import pytest
 
 from codex_autorunner.integrations.telegram.adapter import (
+    TelegramCallbackQuery,
     TelegramDocument,
     TelegramMessage,
     TelegramMessageEntity,
     TelegramPhotoSize,
 )
 from codex_autorunner.integrations.telegram.config import TelegramBotConfig
+from codex_autorunner.integrations.telegram.handlers import (
+    commands_runtime as telegram_commands_runtime,
+)
 from codex_autorunner.integrations.telegram.service import TelegramBotService
 from codex_autorunner.integrations.telegram.types import PendingQuestion, SelectionState
 
@@ -1484,6 +1488,68 @@ async def test_update_web_target_skips_confirmation_when_turn_active(
         "update_target": "web",
         "reply_to": 21,
     }
+
+
+@pytest.mark.anyio
+async def test_update_callback_acknowledged_before_spawn(tmp_path: Path) -> None:
+    config = make_config(tmp_path, fixture_command("basic"))
+    service = TelegramBotService(config, hub_root=tmp_path)
+    callback = TelegramCallbackQuery(
+        update_id=1,
+        callback_id="cb-1",
+        from_user_id=456,
+        data="update:discord",
+        message_id=22,
+        chat_id=123,
+        thread_id=None,
+    )
+    events: list[tuple[str, str]] = []
+
+    async def _fake_answer_callback(
+        cb: Optional[TelegramCallbackQuery], text: str
+    ) -> None:
+        assert cb == callback
+        events.append(("answer", text))
+
+    async def _fake_finalize_selection(
+        key: str,
+        cb: Optional[TelegramCallbackQuery],
+        text: str,
+    ) -> None:
+        assert key == "topic-key"
+        assert cb == callback
+        events.append(("finalize", text))
+
+    def _fake_spawn_update_process(**kwargs: object) -> None:
+        assert kwargs["update_target"] == "discord"
+        events.append(("spawn", "discord"))
+
+    service._answer_callback = _fake_answer_callback  # type: ignore[assignment]
+    service._finalize_selection = _fake_finalize_selection  # type: ignore[assignment]
+
+    original_spawn = telegram_commands_runtime._spawn_update_process
+    telegram_commands_runtime._spawn_update_process = _fake_spawn_update_process  # type: ignore[assignment]
+
+    try:
+        await service._start_update(
+            chat_id=123,
+            thread_id=None,
+            update_target="discord",
+            callback=callback,
+            selection_key="topic-key",
+        )
+    finally:
+        telegram_commands_runtime._spawn_update_process = original_spawn  # type: ignore[assignment]
+        await service._app_server_supervisor.close_all()
+
+    assert events == [
+        ("answer", "Starting update..."),
+        ("spawn", "discord"),
+        (
+            "finalize",
+            "Update started (Discord only). The selected service(s) will restart.",
+        ),
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_flow_callback_actions.py
+++ b/tests/test_telegram_flow_callback_actions.py
@@ -161,7 +161,7 @@ async def test_flow_callback_resume_latest_paused(
     await handler._handle_flow_callback(_callback(), FlowCallback(action="resume"))
 
     assert flow_service.resume_calls == [run_id]
-    assert "Resumed." in handler.answers
+    assert handler.answers == ["Working..."]
     assert handler.rendered
 
 
@@ -185,7 +185,7 @@ async def test_flow_callback_stop_latest_active(
     await handler._handle_flow_callback(_callback(), FlowCallback(action="stop"))
 
     assert flow_service.stop_calls == [run_id]
-    assert "Stopped." in handler.answers
+    assert handler.answers == ["Working..."]
     assert handler.rendered
 
 
@@ -209,7 +209,7 @@ async def test_flow_callback_recover_latest_active(
     await handler._handle_flow_callback(_callback(), FlowCallback(action="recover"))
 
     assert flow_service.reconcile_calls == [run_id]
-    assert "Recovered." in handler.answers
+    assert handler.answers == ["Working..."]
     assert handler.rendered
 
 

--- a/tests/test_telegram_pma_routing.py
+++ b/tests/test_telegram_pma_routing.py
@@ -5458,7 +5458,7 @@ async def test_resume_opencode_missing_session_clears_stale_topic_state(
     assert record.active_thread_id is None
     assert stale_session not in record.thread_ids
     assert stale_session not in record.thread_summaries
-    assert handler.answers and handler.answers[-1] == "Thread missing"
+    assert handler.answers == []
     assert any("Thread no longer exists." in text for text in handler.final_messages)
 
 


### PR DESCRIPTION
## Summary
- defer Discord slash-command responses before flow/database/app-server work so interactions are acknowledged before slow paths run
- defer Telegram update and flow callbacks before restart/reconcile/resume work, and guard callback answers so they only fire once
- cover the new defer-first behavior in Discord and Telegram tests, including a regression test for restart buttons using the component-safe response path

## Verification
- `.venv/bin/python -m pytest tests/integrations/discord/test_flow_handlers.py tests/integrations/discord/test_service_routing.py tests/test_telegram_flow_callback_actions.py tests/test_telegram_bot_integration.py tests/test_telegram_pma_routing.py -k 'flow_status or flow_runs or flow_start or flow_restart or flow_recover or flow_reply or flow_issue or car_review_commit_without_sha or car_review_partial_commit_value or car_review_custom_without_instructions or car_update or normalized_interaction_flow_restart_without_run_id_uses_picker or normalized_interaction_flow_reply_without_run_id_sets_pending_text or flow_callback or update_callback_acknowledged_before_spawn or resume_missing_thread_clears_stale_topic_state or resume_opencode_missing_session_clears_stale_topic_state'`
- `git commit -m "Defer chat interaction responses before slow work"` (repo hooks passed: black, ruff, mypy, eslint, pnpm build/test, fast-test suite, deadcode)

## Review
- spark subagent review flagged a component-path regression risk in flow restart defer handling; fixed by keeping slash commands on public defers while restart buttons stay on the component-safe response path
- second review pass found no remaining functional issues; residual gap is direct callback-present coverage for Telegram resume callbacks
