### PR TITLE
Standardize update target on all

### DIFF
--- a/scripts/safe-refresh-local-linux-hub.sh
+++ b/scripts/safe-refresh-local-linux-hub.sh
@@ -111,7 +111,7 @@ normalize_update_target() {
   local raw
   raw="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
   case "${raw}" in
-    ""|all|both)
+    ""|all)
       echo "all"
       ;;
     web|hub|server|ui)

--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -156,7 +156,7 @@ normalize_update_target() {
   local raw
   raw="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
   case "${raw}" in
-    ""|all|both)
+    ""|all)
       echo "all"
       ;;
     web|hub|server|ui)

--- a/src/codex_autorunner/core/update_targets.py
+++ b/src/codex_autorunner/core/update_targets.py
@@ -55,7 +55,6 @@ _UPDATE_TARGET_DEFINITIONS = {
 _UPDATE_TARGET_ALIASES = {
     "": _DEFAULT_UPDATE_TARGET,
     "all": "all",
-    "both": "all",
     "web": "web",
     "hub": "web",
     "server": "web",
@@ -128,10 +127,7 @@ def update_target_command_choices(
     *, include_status: bool = False
 ) -> tuple[dict[str, str], ...]:
     choices = tuple(
-        {
-            "name": definition.label,
-            "value": "all" if definition.value == "both" else definition.value,
-        }
+        {"name": definition.label, "value": definition.value}
         for definition in all_update_target_definitions()
     )
     if not include_status:

--- a/src/codex_autorunner/integrations/discord/commands.py
+++ b/src/codex_autorunner/integrations/discord/commands.py
@@ -234,7 +234,7 @@ def build_application_commands() -> list[dict[str, Any]]:
                         {
                             "type": STRING,
                             "name": "target",
-                            "description": "Target service group or status",
+                            "description": "Target: all, web, chat, telegram, discord, or status",
                             "required": False,
                             "choices": list(
                                 update_target_command_choices(include_status=True)

--- a/src/codex_autorunner/static/generated/updateTargets.js
+++ b/src/codex_autorunner/static/generated/updateTargets.js
@@ -2,7 +2,6 @@
 const DEFAULT_UPDATE_TARGET = "all";
 const UPDATE_TARGET_ALIASES = new Map([
     ["all", "all"],
-    ["both", "all"],
     ["web", "web"],
     ["hub", "web"],
     ["server", "web"],

--- a/src/codex_autorunner/static_src/updateTargets.ts
+++ b/src/codex_autorunner/static_src/updateTargets.ts
@@ -24,7 +24,6 @@ export interface UpdateTargetOption {
 const DEFAULT_UPDATE_TARGET = "all";
 const UPDATE_TARGET_ALIASES = new Map<string, string>([
   ["all", "all"],
-  ["both", "all"],
   ["web", "web"],
   ["hub", "web"],
   ["server", "web"],

--- a/tests/integrations/discord/test_commands_payload.py
+++ b/tests/integrations/discord/test_commands_payload.py
@@ -173,7 +173,10 @@ def test_agent_and_effort_options_include_choices() -> None:
 
     update = _find_option(car_options, "update")
     update_target = _find_option(update["options"], "target")
-    assert update_target["description"] == "Target service group or status"
+    assert (
+        update_target["description"]
+        == "Target: all, web, chat, telegram, discord, or status"
+    )
     assert update_target.get("choices", []) == list(
         update_target_command_choices(include_status=True)
     )

--- a/tests/test_system_update_worker.py
+++ b/tests/test_system_update_worker.py
@@ -21,7 +21,6 @@ from codex_autorunner.core.update_targets import (
         (None, "all"),
         ("", "all"),
         ("ALL", "all"),
-        ("both", "all"),
         ("web", "web"),
         ("ui", "web"),
         ("chat", "chat"),
@@ -34,6 +33,11 @@ from codex_autorunner.core.update_targets import (
 )
 def test_normalize_update_target(raw: str | None, expected: str) -> None:
     assert system._normalize_update_target(raw) == expected
+
+
+def test_normalize_update_target_rejects_legacy_both_alias() -> None:
+    with pytest.raises(ValueError, match="Unsupported update target"):
+        system._normalize_update_target("both")
 
 
 def test_available_update_target_options_web_only_when_no_chat_available(

--- a/tests/test_telegram_bot_integration.py
+++ b/tests/test_telegram_bot_integration.py
@@ -1420,12 +1420,12 @@ async def test_resume_paginates_thread_list(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
-async def test_update_with_explicit_target_prompts_for_confirmation_when_turn_active(
+async def test_update_with_all_target_prompts_for_confirmation_when_turn_active(
     tmp_path: Path,
 ) -> None:
     config = make_config(tmp_path, fixture_command("basic"))
     service = TelegramBotService(config, hub_root=tmp_path)
-    message = build_message("/update both", message_id=20)
+    message = build_message("/update all", message_id=20)
     captured: dict[str, object] = {}
 
     async def _fake_prompt_update_confirmation(
@@ -1438,7 +1438,7 @@ async def test_update_with_explicit_target_prompts_for_confirmation_when_turn_ac
     service._prompt_update_confirmation = _fake_prompt_update_confirmation  # type: ignore[assignment]
 
     try:
-        await service._handle_update(message, "both", None)
+        await service._handle_update(message, "all", None)
     finally:
         await service._app_server_supervisor.close_all()
 


### PR DESCRIPTION
## Summary
- remove the legacy `both` update-target alias so `all` is the only supported domain value
- update Discord command metadata, frontend normalization, and safe refresh scripts to use the same canonical target vocabulary
- tighten regression coverage so `both` is now rejected instead of silently normalized

## Testing
- `.venv/bin/python -m pytest -q tests/test_system_update_worker.py tests/integrations/discord/test_commands_payload.py tests/test_telegram_bot_integration.py -k "update_target or update_with_all_target_prompts_for_confirmation_when_turn_active or normalize_update_target or helpers_share_the_same_core_definitions"`
- `pnpm run build`
- repo pre-commit hooks, including strict mypy, JS tests, and full pytest (`3438 passed, 1 skipped`)
