### PR TITLE
Align flow status across web, Discord, and Telegram

### DIFF
--- a/src/codex_autorunner/core/flows/ux_helpers.py
+++ b/src/codex_autorunner/core/flows/ux_helpers.py
@@ -11,7 +11,13 @@ from ..ticket_flow_projection import (
     build_canonical_state_v1,
     select_authoritative_run_record,
 )
-from .models import FlowEventType, FlowRunRecord, FlowRunStatus
+from .models import (
+    FlowEventType,
+    FlowRunRecord,
+    FlowRunStatus,
+    flow_run_duration_seconds,
+    format_flow_duration,
+)
 from .store import FlowStore
 from .worker_process import (
     check_worker_health,
@@ -340,6 +346,90 @@ def summarize_flow_freshness(payload: Any) -> Optional[str]:
     return " · ".join(parts)
 
 
+def _format_ticket_flow_archive_status(record: FlowRunRecord) -> str:
+    mode = resolve_ticket_flow_archive_mode(record)
+    if mode == "ready":
+        return "ready"
+    if mode == "confirm":
+        return "confirm required"
+    return "blocked until run stops"
+
+
+def _flow_status_current_step(record: FlowRunRecord) -> Optional[str]:
+    current_step = getattr(record, "current_step", None)
+    if isinstance(current_step, str) and current_step.strip():
+        return current_step.strip()
+    if isinstance(current_step, int):
+        return str(current_step)
+
+    state = record.state if isinstance(record.state, Mapping) else {}
+    ticket_engine = state.get("ticket_engine") if isinstance(state, Mapping) else {}
+    if not isinstance(ticket_engine, Mapping):
+        return None
+
+    for key in ("total_turns", "current_step", "step"):
+        value = ticket_engine.get(key)
+        if isinstance(value, int):
+            return str(value)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def format_ticket_flow_status_lines(
+    record: FlowRunRecord,
+    snapshot: Mapping[str, Any],
+) -> list[str]:
+    worker = snapshot.get("worker_health")
+    worker_status = getattr(worker, "status", "unknown")
+    worker_pid = getattr(worker, "pid", None)
+    worker_text = (
+        f"{worker_status} (pid={worker_pid})"
+        if isinstance(worker_pid, int)
+        else str(worker_status)
+    )
+    last_event_seq = snapshot.get("last_event_seq")
+    last_event_at = snapshot.get("last_event_at")
+    current_ticket = snapshot.get("effective_current_ticket")
+    ticket_progress_payload = snapshot.get("ticket_progress")
+    progress_label = None
+    if isinstance(ticket_progress_payload, Mapping):
+        done = ticket_progress_payload.get("done")
+        total = ticket_progress_payload.get("total")
+        if isinstance(done, int) and isinstance(total, int) and total >= 0:
+            progress_label = f"{done}/{total}"
+
+    lines = [
+        f"Run: {record.id}",
+        f"Status: {record.status.value}",
+    ]
+    if progress_label:
+        lines.append(f"Tickets: {progress_label}")
+
+    current_step = _flow_status_current_step(record)
+    if current_step:
+        lines.append(f"Step: {current_step}")
+
+    duration_label = format_flow_duration(flow_run_duration_seconds(record))
+    if duration_label:
+        lines.append(f"Elapsed: {duration_label}")
+
+    lines.extend(
+        [
+            f"Last event: {last_event_seq if last_event_seq is not None else '-'} at {last_event_at or '-'}",
+            f"Worker: {worker_text}",
+            f"Current ticket: {current_ticket or '-'}",
+        ]
+    )
+
+    freshness_summary = summarize_flow_freshness(snapshot.get("freshness"))
+    if freshness_summary:
+        lines.append(f"Freshness: {freshness_summary}")
+
+    lines.append(f"Archive: {_format_ticket_flow_archive_status(record)}")
+    return lines
+
+
 def build_flow_status_snapshot(
     repo_root: Path, record: FlowRunRecord, store: Optional[FlowStore]
 ) -> dict:
@@ -422,6 +512,7 @@ __all__ = [
     "bootstrap_check",
     "build_flow_status_snapshot",
     "ensure_worker",
+    "format_ticket_flow_status_lines",
     "format_issue_as_markdown",
     "issue_md_has_content",
     "issue_md_path",

--- a/src/codex_autorunner/integrations/chat/command_contract.py
+++ b/src/codex_autorunner/integrations/chat/command_contract.py
@@ -194,7 +194,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         requires_bound_workspace=False,
         status="partial",
         telegram_commands=("flow",),
-        discord_paths=(("car", "flow", "status"),),
+        discord_paths=(("car", "flow", "status"), ("flow", "status")),
         required_capabilities=("ticket_flow",),
     ),
     CommandContractEntry(
@@ -203,7 +203,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         requires_bound_workspace=False,
         status="partial",
         telegram_commands=("flow",),
-        discord_paths=(("car", "flow", "runs"),),
+        discord_paths=(("car", "flow", "runs"), ("flow", "runs")),
         required_capabilities=("ticket_flow",),
     ),
     CommandContractEntry(
@@ -212,7 +212,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         requires_bound_workspace=True,
         status="partial",
         telegram_commands=("flow",),
-        discord_paths=(("car", "flow", "issue"),),
+        discord_paths=(("car", "flow", "issue"), ("flow", "issue")),
         required_capabilities=("ticket_flow", "github_cli"),
     ),
     CommandContractEntry(
@@ -221,7 +221,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         requires_bound_workspace=True,
         status="partial",
         telegram_commands=("flow",),
-        discord_paths=(("car", "flow", "plan"),),
+        discord_paths=(("car", "flow", "plan"), ("flow", "plan")),
         required_capabilities=("ticket_flow",),
     ),
     CommandContractEntry(
@@ -230,7 +230,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         requires_bound_workspace=True,
         status="partial",
         telegram_commands=("flow",),
-        discord_paths=(("car", "flow", "start"),),
+        discord_paths=(("car", "flow", "start"), ("flow", "start")),
         required_capabilities=("ticket_flow",),
     ),
     CommandContractEntry(
@@ -239,7 +239,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         requires_bound_workspace=True,
         status="partial",
         telegram_commands=("flow",),
-        discord_paths=(("car", "flow", "restart"),),
+        discord_paths=(("car", "flow", "restart"), ("flow", "restart")),
         required_capabilities=("ticket_flow",),
     ),
     CommandContractEntry(
@@ -248,7 +248,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         requires_bound_workspace=True,
         status="partial",
         telegram_commands=("flow",),
-        discord_paths=(("car", "flow", "resume"),),
+        discord_paths=(("car", "flow", "resume"), ("flow", "resume")),
         required_capabilities=("ticket_flow",),
     ),
     CommandContractEntry(
@@ -257,7 +257,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         requires_bound_workspace=True,
         status="partial",
         telegram_commands=("flow",),
-        discord_paths=(("car", "flow", "stop"),),
+        discord_paths=(("car", "flow", "stop"), ("flow", "stop")),
         required_capabilities=("ticket_flow",),
     ),
     CommandContractEntry(
@@ -266,7 +266,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         requires_bound_workspace=True,
         status="partial",
         telegram_commands=("flow",),
-        discord_paths=(("car", "flow", "archive"),),
+        discord_paths=(("car", "flow", "archive"), ("flow", "archive")),
         required_capabilities=("ticket_flow",),
     ),
     CommandContractEntry(
@@ -275,7 +275,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         requires_bound_workspace=True,
         status="partial",
         telegram_commands=("flow",),
-        discord_paths=(("car", "flow", "recover"),),
+        discord_paths=(("car", "flow", "recover"), ("flow", "recover")),
         required_capabilities=("ticket_flow",),
     ),
     CommandContractEntry(
@@ -284,7 +284,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         requires_bound_workspace=True,
         status="partial",
         telegram_commands=("flow", "reply"),
-        discord_paths=(("car", "flow", "reply"),),
+        discord_paths=(("car", "flow", "reply"), ("flow", "reply")),
         required_capabilities=("ticket_flow",),
     ),
     CommandContractEntry(

--- a/src/codex_autorunner/integrations/chat/command_diagnostics.py
+++ b/src/codex_autorunner/integrations/chat/command_diagnostics.py
@@ -26,7 +26,7 @@ def build_status_text(
         ]
         if collaboration_summary_lines:
             lines.extend(collaboration_summary_lines)
-        lines.append("Then use /car flow status once flow commands are enabled.")
+        lines.append("Then use /flow status once flow commands are enabled.")
         return lines
 
     lines = []
@@ -63,7 +63,7 @@ def build_status_text(
         lines.extend(collaboration_summary_lines)
 
     if include_flow_hint:
-        lines.append("Use /car flow status for ticket flow details.")
+        lines.append("Use /flow status for ticket flow details.")
 
     return lines
 

--- a/src/codex_autorunner/integrations/chat/help_catalog.py
+++ b/src/codex_autorunner/integrations/chat/help_catalog.py
@@ -419,7 +419,7 @@ def build_discord_help_lines() -> list[str]:
         [
             "",
             "**Flow Commands:**",
-            *flow_help_lines(prefix="/car flow", usage_overrides={"runs": "[limit]"}),
+            *flow_help_lines(prefix="/flow", usage_overrides={"runs": "[limit]"}),
             "",
             "Direct shell:",
             "!<cmd> - run a bash command in the bound workspace",

--- a/src/codex_autorunner/integrations/discord/car_autocomplete.py
+++ b/src/codex_autorunner/integrations/discord/car_autocomplete.py
@@ -315,6 +315,8 @@ async def handle_command_autocomplete(
     focused_value: str,
 ) -> None:
     _ = options
+    if command_path[:1] == ("flow",):
+        command_path = ("car", "flow", *command_path[1:])
     choices: list[dict[str, str]] = []
     if command_path == ("car", "bind") and focused_name == "workspace":
         choices = build_bind_autocomplete_choices(service, focused_value)

--- a/src/codex_autorunner/integrations/discord/commands.py
+++ b/src/codex_autorunner/integrations/discord/commands.py
@@ -501,4 +501,10 @@ def build_application_commands() -> list[dict[str, Any]]:
                 },
             ],
         },
+        {
+            "type": 1,
+            "name": "flow",
+            "description": "Ticket flow commands",
+            "options": _build_flow_subcommand_options(),
+        },
     ]

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -69,6 +69,7 @@ from ...core.flows.ux_helpers import (
     GitHubServiceProtocol,
     build_flow_status_snapshot,
     ensure_worker,
+    format_ticket_flow_status_lines,
     issue_md_path,
     resolve_ticket_flow_archive_mode,
     seed_issue_from_github,
@@ -86,7 +87,6 @@ from ...core.managed_processes import reap_managed_processes
 from ...core.orchestration import build_ticket_flow_orchestration_service
 from ...core.state import RunnerState
 from ...core.state_roots import resolve_global_state_root
-from ...core.ticket_flow_projection import select_authoritative_run_record
 from ...core.ticket_flow_summary import build_ticket_flow_display
 from ...core.update import (
     UpdateInProgressError,
@@ -1292,6 +1292,11 @@ class DiscordBotService:
                 "I could not parse this interaction. Please retry the command.",
             )
             return
+
+        ingress = replace(
+            ingress,
+            command_path=self._normalize_discord_command_path(ingress.command_path),
+        )
 
         try:
             if ingress.command_path[:1] == ("car",):
@@ -3643,7 +3648,7 @@ class DiscordBotService:
                 dispatch_seq=dispatch_seq,
                 content=content,
                 source=source,
-                resume_hint="`/car flow resume`" if allow_resume_hint else "",
+                resume_hint="`/flow resume`" if allow_resume_hint else "",
             )
         body = content.strip() or "(no dispatch message)"
         header_lines = [
@@ -4177,6 +4182,11 @@ class DiscordBotService:
                 "I could not parse this interaction. Please retry the command.",
             )
             return
+
+        ingress = replace(
+            ingress,
+            command_path=self._normalize_discord_command_path(ingress.command_path),
+        )
 
         try:
             if ingress.command_path[:1] == ("car",):
@@ -4940,6 +4950,7 @@ class DiscordBotService:
         focused_name: Optional[str],
         focused_value: str,
     ) -> None:
+        command_path = self._normalize_discord_command_path(command_path)
         await handle_car_command_autocomplete(
             self,
             interaction_id,
@@ -4950,6 +4961,14 @@ class DiscordBotService:
             focused_name=focused_name,
             focused_value=focused_value,
         )
+
+    @staticmethod
+    def _normalize_discord_command_path(
+        command_path: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        if command_path[:1] != ("flow",):
+            return command_path
+        return ("car", "flow", *command_path[1:])
 
     async def _bind_with_path(
         self,
@@ -5123,7 +5142,7 @@ class DiscordBotService:
             rate_limits=rate_limits,
         )
         lines.extend(build_status_block_lines(status_block))
-        lines.append("Use /car flow status for ticket flow details.")
+        lines.append("Use /flow status for ticket flow details.")
         await self._respond_ephemeral(
             interaction_id, interaction_token, "\n".join(lines)
         )
@@ -7610,15 +7629,7 @@ class DiscordBotService:
     ) -> Optional[FlowRunRecord]:
         if not records:
             return None
-        live_records = [
-            record
-            for record in records
-            if not record.status.is_terminal()
-            and record.status != FlowRunStatus.SUPERSEDED
-        ]
-        if not live_records:
-            return None
-        return select_authoritative_run_record(live_records)
+        return select_ticket_flow_run_record(records, selection="authoritative")
 
     @staticmethod
     def _build_historical_runs_picker(
@@ -7660,47 +7671,7 @@ class DiscordBotService:
         record: FlowRunRecord,
         snapshot: dict[str, Any],
     ) -> str:
-        worker = snapshot.get("worker_health")
-        worker_status = getattr(worker, "status", "unknown")
-        worker_pid = getattr(worker, "pid", None)
-        worker_text = (
-            f"{worker_status} (pid={worker_pid})"
-            if isinstance(worker_pid, int)
-            else str(worker_status)
-        )
-        last_event_seq = snapshot.get("last_event_seq")
-        last_event_at = snapshot.get("last_event_at")
-        current_ticket = snapshot.get("effective_current_ticket")
-        ticket_progress = snapshot.get("ticket_progress")
-        progress_label = None
-        if isinstance(ticket_progress, dict):
-            done = ticket_progress.get("done")
-            total = ticket_progress.get("total")
-            if isinstance(done, int) and isinstance(total, int) and total >= 0:
-                progress_label = f"{done}/{total}"
-        lines = [
-            f"Run: {record.id}",
-            f"Status: {record.status.value}",
-        ]
-        if progress_label:
-            lines.append(f"Tickets: {progress_label}")
-        duration_label = format_flow_duration(flow_run_duration_seconds(record))
-        if duration_label:
-            lines.append(f"Elapsed: {duration_label}")
-        freshness_summary = summarize_flow_freshness(snapshot.get("freshness"))
-        freshness_line = (
-            f"Freshness: {freshness_summary}" if freshness_summary else None
-        )
-        lines.extend(
-            [
-                f"Last event: {last_event_seq if last_event_seq is not None else '-'} at {last_event_at or '-'}",
-                f"Worker: {worker_text}",
-                f"Current ticket: {current_ticket or '-'}",
-            ]
-        )
-        if freshness_line:
-            lines.append(freshness_line)
-        return "\n".join(lines)
+        return "\n".join(format_ticket_flow_status_lines(record, snapshot))
 
     def _build_flow_status_message(
         self,
@@ -7799,7 +7770,7 @@ class DiscordBotService:
             if record is None:
                 if runs and not explicit_run_requested:
                     content = (
-                        "No current ticket_flow run.\n\n"
+                        "No ticket_flow run found.\n\n"
                         "Use the picker below to inspect historical runs."
                     )
                     components = self._build_historical_runs_picker(runs)
@@ -7883,7 +7854,7 @@ class DiscordBotService:
             event_type="flow_status_command",
             kind="command",
             actor="user",
-            text="/car flow status",
+            text="/flow status",
             chat_id=channel_id,
             thread_id=guild_id,
             message_id=interaction_id,
@@ -8021,7 +7992,7 @@ class DiscordBotService:
             await self._respond_ephemeral(
                 interaction_id,
                 interaction_token,
-                "Provide an issue reference: `/car flow issue issue_ref:<issue#|url>`",
+                "Provide an issue reference: `/flow issue issue_ref:<issue#|url>`",
             )
             return
         issue_ref = issue_ref.strip()
@@ -8092,7 +8063,7 @@ class DiscordBotService:
             await self._respond_ephemeral(
                 interaction_id,
                 interaction_token,
-                "Provide a plan: `/car flow plan text:<plan>`",
+                "Provide a plan: `/flow plan text:<plan>`",
             )
             return
         content = seed_issue_from_text(plan_text.strip())
@@ -8718,7 +8689,7 @@ class DiscordBotService:
             event_type="flow_resume_command",
             kind="command",
             actor="user",
-            text="/car flow resume",
+            text="/flow resume",
             chat_id=channel_id,
             thread_id=guild_id,
             message_id=interaction_id,
@@ -8844,7 +8815,7 @@ class DiscordBotService:
             event_type="flow_stop_command",
             kind="command",
             actor="user",
-            text="/car flow stop",
+            text="/flow stop",
             chat_id=channel_id,
             thread_id=guild_id,
             message_id=interaction_id,
@@ -8993,7 +8964,7 @@ class DiscordBotService:
             event_type="flow_archive_command",
             kind="command",
             actor="user",
-            text="/car flow archive",
+            text="/flow archive",
             chat_id=channel_id,
             thread_id=guild_id,
             message_id=interaction_id,
@@ -9017,7 +8988,7 @@ class DiscordBotService:
                 deferred=deferred,
                 text=(
                     f"Run {target.id} no longer exists. "
-                    "Use /car flow status or /car flow runs to inspect historical runs."
+                    "Use /flow status or /flow runs to inspect historical runs."
                 ),
             )
             return
@@ -10401,7 +10372,7 @@ class DiscordBotService:
                         await self._respond_ephemeral(
                             interaction_id,
                             interaction_token,
-                            "Reply selection expired. Re-run `/car flow reply text:<...>`.",
+                            "Reply selection expired. Re-run `/flow reply text:<...>`.",
                         )
                         return
                     await self._handle_flow_reply(
@@ -10782,7 +10753,7 @@ class DiscordBotService:
                         await self._respond_ephemeral(
                             interaction_id,
                             interaction_token,
-                            "Reply selection expired. Re-run `/car flow reply text:<...>`.",
+                            "Reply selection expired. Re-run `/flow reply text:<...>`.",
                         )
                         return
                     await self._handle_flow_reply(
@@ -11103,7 +11074,7 @@ class DiscordBotService:
             if target is None:
                 stale_text = (
                     f"Run {run_id} no longer exists. "
-                    "Use /car flow status or /car flow runs to inspect historical runs."
+                    "Use /flow status or /flow runs to inspect historical runs."
                 )
                 await self._respond_ephemeral(
                     interaction_id, interaction_token, stale_text
@@ -11154,7 +11125,7 @@ class DiscordBotService:
             except KeyError:
                 stale_text = (
                     f"Run {run_id} no longer exists. "
-                    "Use /car flow status or /car flow runs to inspect historical runs."
+                    "Use /flow status or /flow runs to inspect historical runs."
                 )
                 if deferred:
                     updated = await self._edit_original_component_message(
@@ -11182,7 +11153,7 @@ class DiscordBotService:
                 f"(tickets={summary['archived_tickets']}, "
                 f"runs_archived={summary['archived_runs']}, "
                 f"contextspace={summary['archived_contextspace']}).\n\n"
-                "Use /car flow status or /car flow runs to inspect historical runs."
+                "Use /flow status or /flow runs to inspect historical runs."
             )
             if deferred:
                 updated = await self._edit_original_component_message(

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
@@ -23,6 +23,7 @@ from .....core.flows.surface_defaults import should_route_flow_read_to_hub_overv
 from .....core.flows.ux_helpers import (
     bootstrap_check,
     build_flow_status_snapshot,
+    format_ticket_flow_status_lines,
     issue_md_has_content,
     issue_md_path,
     resolve_ticket_flow_archive_mode,
@@ -885,19 +886,7 @@ class FlowCommands(SharedHelpers):
         run = record
         status = getattr(run, "status", None)
         status_value = status.value if status else "unknown"
-        progress = snapshot.get("ticket_progress") if snapshot else None
-        progress_label = None
-        if isinstance(progress, dict):
-            done = progress.get("done")
-            total = progress.get("total")
-            if isinstance(done, int) and isinstance(total, int) and total >= 0:
-                progress_label = f"{done}/{total}"
-        lines = [f"Run: {_code(run.id)}", f"Status: {status_value}"]
-        if progress_label:
-            lines.append(f"Tickets: {progress_label}")
-        flow_type = getattr(run, "flow_type", None)
-        if flow_type:
-            lines.append(f"Flow: {flow_type}")
+        lines = format_ticket_flow_status_lines(run, snapshot)
         created_at = getattr(run, "created_at", None)
         if created_at:
             lines.append(f"Created: {created_at}")
@@ -911,16 +900,12 @@ class FlowCommands(SharedHelpers):
             flow_duration_seconds(started_at, finished_at, status_value)
         )
         if duration_label:
-            lines.append(f"Elapsed: {duration_label}")
-        current_step = getattr(run, "current_step", None)
-        if current_step:
-            lines.append(f"Step: {current_step}")
+            elapsed_line = f"Elapsed: {duration_label}"
+            if elapsed_line not in lines:
+                lines.append(elapsed_line)
         state = run.state or {}
         engine = state.get("ticket_engine") if isinstance(state, dict) else None
         engine = engine if isinstance(engine, dict) else {}
-        current = snapshot.get("effective_current_ticket") if snapshot else None
-        if isinstance(current, str) and current.strip():
-            lines.append(f"Current: {current.strip()}")
         reason_summary = None
         if isinstance(state, dict):
             value = state.get("reason_summary")
@@ -937,16 +922,6 @@ class FlowCommands(SharedHelpers):
         error_message = getattr(run, "error_message", None)
         if isinstance(error_message, str) and error_message.strip():
             lines.append(f"Error: {_truncate_text(error_message.strip(), 300)}")
-        if snapshot:
-            last_seq = snapshot.get("last_event_seq")
-            last_at = snapshot.get("last_event_at")
-            if last_seq or last_at:
-                seq_label = str(last_seq) if last_seq is not None else "?"
-                at_label = last_at or "unknown time"
-                lines.append(f"Last event: {seq_label} @ {at_label}")
-            freshness_summary = summarize_flow_freshness(snapshot.get("freshness"))
-            if freshness_summary:
-                lines.append(f"Freshness: {freshness_summary}")
         if health is None:
             health = snapshot.get("worker_health") if snapshot else None
         if health is None:
@@ -958,12 +933,6 @@ class FlowCommands(SharedHelpers):
                     health = None
         if health is None:
             return lines
-        worker_line = f"Worker: {health.status}"
-        if health.pid:
-            worker_line += f" (pid {health.pid})"
-        if health.message and health.status not in {"alive"}:
-            worker_line += f" - {health.message}"
-        lines.append(worker_line)
         if status == FlowRunStatus.PAUSED:
             lines.append(
                 "Paused: use `/flow reply <message>` (or send a message in chat) to resume."

--- a/tests/integrations/chat/test_command_diagnostics.py
+++ b/tests/integrations/chat/test_command_diagnostics.py
@@ -130,7 +130,7 @@ class TestBuildStatusText:
         )
         lines_str = "\n".join(lines)
 
-        assert "Use /car flow status" in lines_str
+        assert "Use /flow status" in lines_str
 
     def test_excludes_flow_hint_when_disabled(self):
         binding = {
@@ -154,7 +154,7 @@ class TestBuildStatusText:
         )
         lines_str = "\n".join(lines)
 
-        assert "Use /car flow status" not in lines_str
+        assert "Use /flow status" not in lines_str
 
 
 class TestBuildDebugText:

--- a/tests/integrations/chat/test_help_catalog.py
+++ b/tests/integrations/chat/test_help_catalog.py
@@ -37,5 +37,5 @@ def test_discord_help_lists_session_file_and_flow_sections() -> None:
     assert "/car session resume [thread_id] - Resume a previous chat thread" in text
     assert "/car files inbox - List files in inbox" in text
     assert "/car files clear [target] - Clear inbox/outbox" in text
-    assert "/car flow runs [limit]" in text
+    assert "/flow runs [limit]" in text
     assert "/pma on - Enable PMA mode" in text

--- a/tests/integrations/discord/test_commands_payload.py
+++ b/tests/integrations/discord/test_commands_payload.py
@@ -22,9 +22,9 @@ def _find_option(options: list[dict], name: str) -> dict:
 
 def test_build_application_commands_structure_is_stable() -> None:
     commands = build_application_commands()
-    assert len(commands) == 2
+    assert len(commands) == 3
     command_names = {cmd["name"] for cmd in commands}
-    assert command_names == {"car", "pma"}
+    assert command_names == {"car", "flow", "pma"}
 
     car = next(cmd for cmd in commands if cmd["name"] == "car")
     assert car["type"] == 1
@@ -74,6 +74,14 @@ def test_build_application_commands_structure_is_stable() -> None:
     flow_options = flow["options"]
     assert [opt["name"] for opt in flow_options] == list(FLOW_ACTION_NAMES)
     assert [(opt["name"], opt["description"]) for opt in flow_options] == [
+        (spec.name, spec.description) for spec in FLOW_ACTION_SPECS
+    ]
+
+    flow_root = next(cmd for cmd in commands if cmd["name"] == "flow")
+    assert flow_root["type"] == 1
+    flow_root_options = flow_root["options"]
+    assert [opt["name"] for opt in flow_root_options] == list(FLOW_ACTION_NAMES)
+    assert [(opt["name"], opt["description"]) for opt in flow_root_options] == [
         (spec.name, spec.description) for spec in FLOW_ACTION_SPECS
     ]
 
@@ -151,7 +159,13 @@ def test_required_options_are_marked_required() -> None:
     assert run_id_option["required"] is False
     assert run_id_option["autocomplete"] is True
 
-    pma_options = commands[1]["options"]
+    flow_root = next(cmd for cmd in commands if cmd["name"] == "flow")
+    flow_root_status = _find_option(flow_root["options"], "status")
+    flow_root_run_id = _find_option(flow_root_status["options"], "run_id")
+    assert flow_root_run_id["required"] is False
+    assert flow_root_run_id["autocomplete"] is True
+
+    pma_options = next(cmd for cmd in commands if cmd["name"] == "pma")["options"]
     assert [opt["name"] for opt in pma_options] == ["on", "off", "status"]
 
 

--- a/tests/integrations/discord/test_flow_handlers.py
+++ b/tests/integrations/discord/test_flow_handlers.py
@@ -177,14 +177,19 @@ def _workspace(tmp_path: Path) -> Path:
     return workspace
 
 
-def _flow_interaction(name: str, options: list[dict[str, Any]]) -> dict[str, Any]:
-    return {
-        "id": str(uuid.uuid4()),
-        "token": "token-1",
-        "channel_id": "channel-1",
-        "guild_id": "guild-1",
-        "member": {"user": {"id": "user-1"}},
-        "data": {
+def _flow_interaction(
+    name: str,
+    options: list[dict[str, Any]],
+    *,
+    root: str = "car",
+) -> dict[str, Any]:
+    if root == "flow":
+        data = {
+            "name": "flow",
+            "options": [{"type": 1, "name": name, "options": options}],
+        }
+    else:
+        data = {
             "name": "car",
             "options": [
                 {
@@ -193,7 +198,14 @@ def _flow_interaction(name: str, options: list[dict[str, Any]]) -> dict[str, Any
                     "options": [{"type": 1, "name": name, "options": options}],
                 }
             ],
-        },
+        }
+    return {
+        "id": str(uuid.uuid4()),
+        "token": "token-1",
+        "channel_id": "channel-1",
+        "guild_id": "guild-1",
+        "member": {"user": {"id": "user-1"}},
+        "data": data,
     }
 
 
@@ -344,7 +356,7 @@ async def test_flow_status_and_runs_render_expected_output(tmp_path: Path) -> No
 
 
 @pytest.mark.anyio
-async def test_flow_status_without_run_id_uses_current_run_and_includes_picker(
+async def test_flow_status_without_run_id_uses_authoritative_run_and_includes_picker(
     tmp_path: Path,
 ) -> None:
     workspace = _workspace(tmp_path)
@@ -438,8 +450,9 @@ async def test_flow_status_without_run_id_shows_no_current_run_for_history_only(
         content = payload["content"]
         components = payload["components"]
 
-        assert "No current ticket_flow run." in content
-        assert "Run: " not in content
+        assert f"Run: {newest_completed_run_id}" in content
+        assert "Status: completed" in content
+        assert "Archive: ready" in content
         picker_rows = [
             row
             for row in components
@@ -451,7 +464,44 @@ async def test_flow_status_without_run_id_shows_no_current_run_for_history_only(
             newest_completed_run_id,
             older_stopped_run_id,
         ]
-        assert all(option.get("default") is False for option in picker_options)
+        assert picker_options[0]["default"] is True
+        assert picker_options[1]["default"] is False
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_flow_root_alias_routes_to_authoritative_status(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    completed_run_id = str(uuid.uuid4())
+    _create_run(workspace, completed_run_id, status=FlowRunStatus.COMPLETED)
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway([_flow_interaction(name="status", options=[], root="flow")])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await service.run_forever()
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        content = rest.interaction_responses[1]["payload"]["data"]["content"]
+        assert f"Run: {completed_run_id}" in content
+        assert "Status: completed" in content
     finally:
         await store.close()
 

--- a/tests/integrations/discord/test_pause_bridge.py
+++ b/tests/integrations/discord/test_pause_bridge.py
@@ -179,7 +179,7 @@ async def test_pause_bridge_dedupes_by_run_and_dispatch_seq(tmp_path: Path) -> N
         assert f"Ticket flow paused (run {run_id}). Latest dispatch #0001:" in content
         assert f"Source: {workspace}" in content
         assert "Paused: need reply" in content
-        assert "Use `/car flow resume` to continue." in content
+        assert "Use `/flow resume` to continue." in content
         mirror_path = (
             workspace
             / ".codex-autorunner"
@@ -250,7 +250,7 @@ async def test_pause_bridge_chunked_messages_have_no_part_prefix(
             content = str(record.payload_json.get("content", ""))
             assert not content.startswith("Part ")
         assert any(
-            "Use `/car flow resume` to continue."
+            "Use `/flow resume` to continue."
             in str(record.payload_json.get("content", ""))
             for record in queued
         )
@@ -310,7 +310,7 @@ async def test_pause_bridge_prefers_pause_dispatch_over_turn_summary(
         assert f"Source: {workspace}" in content
         assert "Need input" in content
         assert "Please answer the blocker before I continue." in content
-        assert "Use `/car flow resume` to continue." in content
+        assert "Use `/flow resume` to continue." in content
         assert "turn_summary" not in content
         assert "This summary should not be mirrored to Discord." not in content
     finally:
@@ -371,7 +371,7 @@ async def test_dispatch_bridge_sends_notify_then_incremental_pause(
         assert f"Source: {workspace}" in content
         assert "Progress update" in content
         assert "Finished the repo scan and moving to implementation." in content
-        assert "Use `/car flow resume` to continue." not in content
+        assert "Use `/flow resume` to continue." not in content
         assert "turn_summary" not in content
 
         binding = await store.get_binding(channel_id="channel-1")
@@ -397,7 +397,7 @@ async def test_dispatch_bridge_sends_notify_then_incremental_pause(
         assert f"Ticket flow paused (run {run_id}). Latest dispatch #0003:" in content
         assert "Need guidance" in content
         assert "Please confirm the migration target before I continue." in content
-        assert "Use `/car flow resume` to continue." in content
+        assert "Use `/flow resume` to continue." in content
 
         binding = await store.get_binding(channel_id="channel-1")
         assert binding is not None
@@ -451,7 +451,7 @@ async def test_pause_bridge_surfaces_latest_invalid_dispatch_notice(
             content
         )
         assert "Fix DISPATCH.md for that paused turn before resuming." in content
-        assert "Use `/car flow resume` to continue." not in content
+        assert "Use `/flow resume` to continue." not in content
     finally:
         await store.close()
 
@@ -499,7 +499,7 @@ async def test_pause_bridge_keeps_reason_fallback_when_history_is_empty(
         content = str(queued[0].payload_json.get("content", ""))
         assert f"Ticket flow paused (run {run_id}). Latest dispatch #paused:" in content
         assert "Reason: Waiting for the user to reply." in content
-        assert "Use `/car flow resume` to continue." in content
+        assert "Use `/flow resume` to continue." in content
 
         binding = await store.get_binding(channel_id="channel-1")
         assert binding is not None
@@ -590,7 +590,7 @@ async def test_pause_bridge_falls_back_when_only_turn_summary_exists(
             "last_method=turn/diff/updated, status=inProgress."
         ) in content
         assert "Summary that should stay out of Discord." not in content
-        assert "Use `/car flow resume` to continue." in content
+        assert "Use `/flow resume` to continue." in content
 
         binding = await store.get_binding(channel_id="channel-1")
         assert binding is not None

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -2259,7 +2259,7 @@ async def test_service_syncs_commands_on_startup(tmp_path: Path) -> None:
         assert sync_call["application_id"] == "app-1"
         assert sync_call["guild_id"] == "guild-1"
         command_names = {cmd.get("name") for cmd in sync_call["commands"]}
-        assert command_names == {"car", "pma"}
+        assert command_names == {"car", "flow", "pma"}
     finally:
         await store.close()
 

--- a/tests/integrations/discord/test_status.py
+++ b/tests/integrations/discord/test_status.py
@@ -119,7 +119,7 @@ async def test_status_bound_channel_includes_shared_and_discord_specific_details
     assert "Approval policy: never" in content
     assert "Sandbox policy: dangerFullAccess, network=True" in content
     assert "Limits: [5h: 5%]" in content
-    assert "Use /car flow status for ticket flow details." in content
+    assert "Use /flow status for ticket flow details." in content
     service._get_active_flow_info.assert_awaited_once_with(str(workspace))
     service._read_status_rate_limits.assert_awaited_once_with(
         str(workspace), agent="codex"
@@ -152,7 +152,7 @@ async def test_status_unbound_channel_keeps_flow_hint() -> None:
     content = sent_messages[0]
     assert "This channel is not bound." in content
     assert "Agent:" not in content
-    assert "Then use /car flow status once flow commands are enabled." in content
+    assert "Then use /flow status once flow commands are enabled." in content
     service._get_active_flow_info.assert_not_awaited()
     service._read_status_rate_limits.assert_not_awaited()
 

--- a/tests/test_telegram_flow_bootstrap.py
+++ b/tests/test_telegram_flow_bootstrap.py
@@ -177,7 +177,7 @@ async def test_flow_bootstrap_skips_prompt_when_tickets_exist(
     assert outbound_records[-1]["event_type"] == "flow_bootstrap_started_notice"
     assert outbound_records[-1]["kind"] == "notice"
     assert "Started ticket flow run `run-1`." in handler.sent[-1]
-    assert "Run: `run-1`" in handler.sent[-1]
+    assert "Run: run-1" in handler.sent[-1]
     assert "Status: running" in handler.sent[-1]
     assert handler.markups[-1] is not None
 

--- a/tests/test_telegram_flow_status.py
+++ b/tests/test_telegram_flow_status.py
@@ -92,7 +92,7 @@ def test_flow_status_includes_effective_current_ticket(
     handler = FlowCommands()
     lines = handler._format_flow_status_lines(tmp_path, record, store)
 
-    assert any(line == "Current: TICKET-002" for line in lines)
+    assert any(line == "Current ticket: TICKET-002" for line in lines)
     store.close()
 
 


### PR DESCRIPTION
## Summary
- align Discord flow status with the authoritative run selection already used by web and Telegram, so terminal runs still show up when they are the latest run
- add a top-level Discord `/flow` command alias and update Discord help/hints to point users at `/flow ...` as the canonical flow surface
- share flow-status formatting across Discord and Telegram, including step, freshness, and archive readiness metadata

## Problem
The web UI was showing the latest ticket-flow metadata for a worktree, but Discord status defaulted to "current non-terminal run only". That meant a completed or stopped latest run looked invisible in chat unless the operator manually opened the historical picker, which made it hard to tell when the workspace should be archived before starting new tickets or a new run.

## Testing
- `.venv/bin/python -m pytest tests/integrations/discord/test_commands_payload.py tests/integrations/discord/test_flow_handlers.py tests/integrations/discord/test_service_routing.py tests/integrations/discord/test_pause_bridge.py tests/integrations/discord/test_status.py tests/integrations/chat/test_command_contract.py tests/integrations/chat/test_command_diagnostics.py tests/integrations/chat/test_help_catalog.py tests/test_telegram_flow_status.py`
- pre-commit `git commit` hooks, including repo-wide pytest, mypy, ruff, build, and JS tests
