### PR TITLE
Fix stale OpenCode thread rebinding via runtime instance identity

### DIFF
--- a/src/codex_autorunner/agents/opencode/harness.py
+++ b/src/codex_autorunner/agents/opencode/harness.py
@@ -627,6 +627,20 @@ class OpenCodeHarness(AgentHarness):
     async def ensure_ready(self, workspace_root: Path) -> None:
         await self._supervisor.get_client(workspace_root)
 
+    async def backend_runtime_instance_id(self, workspace_root: Path) -> Optional[str]:
+        resolver = getattr(
+            self._supervisor,
+            "backend_runtime_instance_id_for_workspace",
+            None,
+        )
+        if not callable(resolver):
+            return None
+        runtime_instance_id = await resolver(workspace_root)
+        if not isinstance(runtime_instance_id, str):
+            return None
+        normalized = runtime_instance_id.strip()
+        return normalized or None
+
     async def model_catalog(self, workspace_root: Path) -> ModelCatalog:
         client = await self._supervisor.get_client(workspace_root)
         payload = await client.providers(directory=str(workspace_root))

--- a/src/codex_autorunner/agents/opencode/supervisor.py
+++ b/src/codex_autorunner/agents/opencode/supervisor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import os
 import re
@@ -207,6 +208,34 @@ class OpenCodeSupervisor:
         if handle.client is None:
             raise OpenCodeSupervisorError("OpenCode client not initialized")
         return handle.client
+
+    async def backend_runtime_instance_id_for_workspace(
+        self, workspace_root: Path
+    ) -> Optional[str]:
+        canonical_root = canonical_workspace_root(workspace_root)
+        workspace_id = workspace_id_for_path(canonical_root)
+        handle_id = (
+            _GLOBAL_HANDLE_ID if self._server_scope == _SCOPE_GLOBAL else workspace_id
+        )
+        handle = await self._ensure_handle(handle_id, canonical_root)
+        await self._ensure_started(handle)
+        handle.last_used_at = time.monotonic()
+
+        record = handle.managed_process_record
+        if record is None:
+            record = self._read_registry_record(canonical_root, handle.workspace_id)
+        if record is not None:
+            runtime_instance_id = self._runtime_instance_id_from_record(record)
+            if runtime_instance_id is not None:
+                return runtime_instance_id
+
+        process = handle.process
+        if process is not None and process.pid is not None:
+            return self._runtime_instance_id_from_pid(process.pid)
+
+        if handle.base_url:
+            return self._runtime_instance_id_from_base_url(handle.base_url)
+        return None
 
     async def close_all(self) -> None:
         async with self._get_lock():
@@ -971,6 +1000,41 @@ class OpenCodeSupervisor:
 
     def _current_record_timestamp(self) -> str:
         return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    def _read_registry_record(
+        self, workspace_root: Path, workspace_id: str
+    ) -> Optional[ProcessRecord]:
+        try:
+            record = read_process_record(
+                self._registry_root(workspace_root), _PROCESS_KIND, workspace_id
+            )
+        except Exception:
+            return None
+        if record is None or not self._record_is_running(record):
+            return None
+        return record
+
+    def _runtime_instance_id_from_record(self, record: ProcessRecord) -> Optional[str]:
+        if record.pid is not None:
+            started_at = record.started_at.strip() if record.started_at else ""
+            if started_at:
+                return (
+                    "opencode:"
+                    f"scope={self._server_scope}:"
+                    f"pid={record.pid}:"
+                    f"started_at={started_at}"
+                )
+            return self._runtime_instance_id_from_pid(record.pid)
+        if record.base_url:
+            return self._runtime_instance_id_from_base_url(record.base_url)
+        return None
+
+    def _runtime_instance_id_from_pid(self, pid: int) -> str:
+        return f"opencode:scope={self._server_scope}:pid={pid}"
+
+    def _runtime_instance_id_from_base_url(self, base_url: str) -> str:
+        digest = hashlib.sha256(base_url.encode("utf-8")).hexdigest()[:16]
+        return f"opencode:scope={self._server_scope}:url_sha256={digest}"
 
     def _record_metadata(
         self,

--- a/src/codex_autorunner/agents/opencode/supervisor_protocol.py
+++ b/src/codex_autorunner/agents/opencode/supervisor_protocol.py
@@ -8,6 +8,10 @@ from typing import Any, Optional, Protocol, runtime_checkable
 class OpenCodeHarnessSupervisorProtocol(Protocol):
     async def get_client(self, workspace_root: Path) -> Any: ...
 
+    async def backend_runtime_instance_id_for_workspace(
+        self, workspace_root: Path
+    ) -> Optional[str]: ...
+
     async def session_stall_timeout_seconds_for_workspace(
         self, workspace_root: Path
     ) -> Optional[float]: ...

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -520,6 +520,26 @@ class _DiscordOpenCodeSupervisorAdapter:
             raise RuntimeError("OpenCode supervisor unavailable")
         return await supervisor.get_client(canonical_root)
 
+    async def backend_runtime_instance_id_for_workspace(
+        self, workspace_root: Path
+    ) -> Optional[str]:
+        canonical_root = canonicalize_path(Path(workspace_root))
+        supervisor = await self._service._opencode_supervisor_for_workspace(
+            canonical_root
+        )
+        if supervisor is None:
+            return None
+        resolver = getattr(
+            supervisor, "backend_runtime_instance_id_for_workspace", None
+        )
+        if not callable(resolver):
+            return None
+        runtime_instance_id = await resolver(canonical_root)
+        if not isinstance(runtime_instance_id, str):
+            return None
+        normalized = runtime_instance_id.strip()
+        return normalized or None
+
     async def session_stall_timeout_seconds_for_workspace(
         self, workspace_root: Path
     ) -> Optional[float]:

--- a/tests/agents/opencode/test_opencode_harness.py
+++ b/tests/agents/opencode/test_opencode_harness.py
@@ -86,11 +86,17 @@ class _StubClient:
 
 class _StubSupervisor:
     def __init__(
-        self, client: _StubClient, *, session_stall_timeout_seconds: float | None = None
+        self,
+        client: _StubClient,
+        *,
+        session_stall_timeout_seconds: float | None = None,
+        runtime_instance_id: str | None = None,
     ) -> None:
         self._client = client
         self.session_stall_timeout_seconds = session_stall_timeout_seconds
+        self.runtime_instance_id = runtime_instance_id
         self.timeout_workspace_roots: list[Path] = []
+        self.runtime_workspace_roots: list[Path] = []
 
     async def get_client(self, _workspace_root: Path) -> _StubClient:
         return self._client
@@ -100,6 +106,12 @@ class _StubSupervisor:
     ) -> float | None:
         self.timeout_workspace_roots.append(workspace_root)
         return self.session_stall_timeout_seconds
+
+    async def backend_runtime_instance_id_for_workspace(
+        self, workspace_root: Path
+    ) -> str | None:
+        self.runtime_workspace_roots.append(workspace_root)
+        return self.runtime_instance_id
 
 
 @pytest.mark.asyncio
@@ -115,6 +127,38 @@ async def test_opencode_harness_reports_capabilities_from_contract() -> None:
     assert harness.allows_parallel_event_stream() is False
     assert harness.supports("approvals") is False
     assert report.capabilities == harness.capabilities
+
+
+@pytest.mark.asyncio
+async def test_opencode_harness_exposes_backend_runtime_instance_id() -> None:
+    workspace_root = Path("/tmp/workspace").resolve()
+    supervisor = _StubSupervisor(
+        _StubClient([]),
+        runtime_instance_id=" opencode:scope=workspace:pid=4242 ",
+    )
+    harness = OpenCodeHarness(supervisor)
+
+    runtime_instance_id = await harness.backend_runtime_instance_id(workspace_root)
+
+    assert runtime_instance_id == "opencode:scope=workspace:pid=4242"
+    assert supervisor.runtime_workspace_roots == [workspace_root]
+
+
+@pytest.mark.asyncio
+async def test_opencode_harness_backend_runtime_instance_id_is_optional() -> None:
+    class _SupervisorWithoutRuntimeId:
+        async def get_client(self, _workspace_root: Path) -> _StubClient:
+            return _StubClient([])
+
+        async def session_stall_timeout_seconds_for_workspace(
+            self, workspace_root: Path
+        ) -> float | None:
+            _ = workspace_root
+            return None
+
+    harness = OpenCodeHarness(_SupervisorWithoutRuntimeId())
+
+    assert await harness.backend_runtime_instance_id(Path(".")) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_opencode_supervisor_registry_reuse.py
+++ b/tests/test_opencode_supervisor_registry_reuse.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +36,78 @@ def _handle(workspace_root: Path, workspace_id: str = "ws-1") -> OpenCodeHandle:
 def _expected_registry_lock_path(registry_root: Path, handle_id: str) -> Path:
     return (
         registry_root / ".codex-autorunner" / "locks" / "opencode" / f"{handle_id}.lock"
+    )
+
+
+@pytest.mark.anyio
+async def test_backend_runtime_instance_id_prefers_process_record_identity(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    supervisor = OpenCodeSupervisor(["opencode", "serve"])
+    handle = _handle(tmp_path)
+    handle.managed_process_record = ProcessRecord(
+        kind="opencode",
+        workspace_id="ws-1",
+        pid=4242,
+        pgid=4242,
+        base_url="http://127.0.0.1:9001",
+        command=["opencode", "serve"],
+        owner_pid=111,
+        started_at="2026-02-15T00:00:00Z",
+        metadata={},
+    )
+    handle.started = True
+
+    async def _fake_ensure_handle(
+        _handle_id: str, _workspace_root: Path
+    ) -> OpenCodeHandle:
+        return handle
+
+    async def _fake_ensure_started(_handle: OpenCodeHandle) -> None:
+        return
+
+    monkeypatch.setattr(supervisor, "_ensure_handle", _fake_ensure_handle)
+    monkeypatch.setattr(supervisor, "_ensure_started", _fake_ensure_started)
+
+    runtime_instance_id = await supervisor.backend_runtime_instance_id_for_workspace(
+        tmp_path
+    )
+
+    assert (
+        runtime_instance_id
+        == "opencode:scope=workspace:pid=4242:started_at=2026-02-15T00:00:00Z"
+    )
+
+
+@pytest.mark.anyio
+async def test_backend_runtime_instance_id_hashes_external_base_url(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    supervisor = OpenCodeSupervisor(["opencode", "serve"])
+    handle = _handle(tmp_path)
+    handle.base_url = "https://example.com/opencode"
+    handle.started = True
+
+    async def _fake_ensure_handle(
+        _handle_id: str, _workspace_root: Path
+    ) -> OpenCodeHandle:
+        return handle
+
+    async def _fake_ensure_started(_handle: OpenCodeHandle) -> None:
+        return
+
+    monkeypatch.setattr(supervisor, "_ensure_handle", _fake_ensure_handle)
+    monkeypatch.setattr(supervisor, "_ensure_started", _fake_ensure_started)
+
+    runtime_instance_id = await supervisor.backend_runtime_instance_id_for_workspace(
+        tmp_path
+    )
+
+    expected_digest = hashlib.sha256(
+        "https://example.com/opencode".encode("utf-8")
+    ).hexdigest()[:16]
+    assert (
+        runtime_instance_id == f"opencode:scope=workspace:url_sha256={expected_digest}"
     )
 
 


### PR DESCRIPTION
## Summary
This PR addresses Telegram turn failures caused by stale OpenCode session bindings after runtime churn/restarts.

Root cause from incident trace (`conversation -1003679298862:7073`): orchestration could not reliably detect OpenCode runtime instance changes because OpenCode harness did not expose a runtime instance identity. That left thread bindings attached to invalid backend sessions until a 400 surfaced during turn start.

## What changed
- Added `backend_runtime_instance_id_for_workspace(...)` to the OpenCode supervisor protocol.
- Implemented runtime identity resolution in `OpenCodeSupervisor`.
  - Prefers process-record identity (`pid + started_at`) when available.
  - Falls back to `pid` if needed.
  - Falls back to hashed `base_url` for externally managed servers.
- Exposed `backend_runtime_instance_id(...)` in `OpenCodeHarness` with safe fallback when a supervisor lacks the method.
- Added Discord OpenCode supervisor adapter support for the new runtime identity accessor.
- Added focused tests for harness and supervisor runtime identity behavior.

## Why this fixes the incident class
With runtime identities available for OpenCode, orchestration’s existing stale-binding checks can proactively clear/rebind when the backend runtime instance changes, instead of attempting to continue on a dead/rotated session and failing mid-run.

## Validation
- Targeted tests before commit:
  - `tests/agents/opencode/test_opencode_harness.py`
  - `tests/test_opencode_supervisor_registry_reuse.py`
  - `tests/integrations/discord/test_opencode_lifecycle.py`
  - `tests/core/orchestration/test_service.py -k "stale or fresh_conversation"`
- Full pre-commit gate (auto-run by repo hooks):
  - black, ruff, strict mypy
  - frontend build/tests
  - full pytest: `3480 passed, 1 skipped`
