### PR TITLE
fix: remove dead code and unused imports

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -707,9 +707,9 @@ class DiscordBotService:
         self._typing_sessions: dict[str, int] = {}
         self._typing_tasks: dict[str, asyncio.Task[Any]] = {}
         self._typing_lock: Optional[asyncio.Lock] = None
-        self._discord_turn_approval_contexts: dict[
-            str, _DiscordTurnApprovalContext
-        ] = {}
+        self._discord_turn_approval_contexts: dict[str, _DiscordTurnApprovalContext] = (
+            {}
+        )
         self._discord_pending_approvals: dict[str, _DiscordPendingApproval] = {}
         self._update_status_notifier = ChatUpdateStatusNotifier(
             platform="discord",

--- a/src/codex_autorunner/integrations/telegram/adapter.py
+++ b/src/codex_autorunner/integrations/telegram/adapter.py
@@ -27,7 +27,6 @@ from ..chat.collaboration_policy import (
     evaluate_collaboration_admission,
 )
 from ..chat.text_chunking import chunk_text
-from ..chat.text_sanitization import collapse_local_markdown_links
 from .api_schemas import (
     TelegramAudioSchema,
     TelegramDocumentSchema,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import uuid
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 from .....core.config import ConfigError, load_repo_config
 from .....core.flows import (
@@ -122,15 +122,6 @@ def _worktree_suffix(repo_id: str) -> Optional[str]:
     if len(parts) <= 1:
         return None
     return parts[-1]
-
-
-def _select_latest_run(
-    store: FlowStore, predicate: Callable[[object], bool]
-) -> Optional[object]:
-    for record in store.list_flow_runs(flow_type="ticket_flow"):
-        if predicate(record):
-            return record
-    return None
 
 
 class FlowCommands(TelegramCommandSupportMixin):


### PR DESCRIPTION
## Summary
Hotfix to address CI failures in main from PR #1123.

- Remove unused `_select_latest_run` function from `flows.py` (dead-code check failure)
- Remove unused `collapse_local_markdown_links` import from `adapter.py` (ruff failure)
- Format `discord/service.py` with black (black failure)

## Test Plan
- All 3479 tests pass
- Pre-commit hooks pass locally