### PR TITLE
Align chat flow status with web metadata fallback

### DIFF
--- a/src/codex_autorunner/core/ticket_flow_summary.py
+++ b/src/codex_autorunner/core/ticket_flow_summary.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 from ..tickets.files import list_ticket_paths
 from ..tickets.frontmatter import parse_markdown_frontmatter
@@ -87,6 +87,35 @@ def build_ticket_flow_display(
         "total_count": total,
         "run_id": run_id,
     }
+
+
+def format_ticket_flow_summary_lines(summary: Mapping[str, Any]) -> list[str]:
+    lines: list[str] = []
+
+    status_label = summary.get("status_label")
+    if isinstance(status_label, str) and status_label.strip():
+        lines.append(f"Status: {status_label.strip()}")
+
+    done_count = summary.get("done_count")
+    total_count = summary.get("total_count")
+    if (
+        isinstance(done_count, int)
+        and isinstance(total_count, int)
+        and total_count >= 0
+    ):
+        lines.append(f"Tickets: {done_count}/{total_count}")
+
+    current_step = summary.get("current_step")
+    if isinstance(current_step, int):
+        lines.append(f"Step: {current_step}")
+    elif isinstance(current_step, str) and current_step.strip():
+        lines.append(f"Step: {current_step.strip()}")
+
+    run_id = summary.get("run_id")
+    if isinstance(run_id, str) and run_id.strip():
+        lines.append(f"Run: {run_id.strip()}")
+
+    return lines
 
 
 def build_ticket_flow_summary(

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -87,7 +87,10 @@ from ...core.managed_processes import reap_managed_processes
 from ...core.orchestration import build_ticket_flow_orchestration_service
 from ...core.state import RunnerState
 from ...core.state_roots import resolve_global_state_root
-from ...core.ticket_flow_summary import build_ticket_flow_display
+from ...core.ticket_flow_summary import (
+    build_ticket_flow_display,
+    format_ticket_flow_summary_lines,
+)
 from ...core.update import (
     UpdateInProgressError,
     _available_update_target_definitions,
@@ -7820,6 +7823,25 @@ class DiscordBotService:
             response_text = f"{prefix.strip()}\n\n{response_text}"
         return response_text, self._build_flow_status_components(record, runs)
 
+    @staticmethod
+    def _build_flow_status_summary_fallback(
+        workspace_root: Path,
+    ) -> Optional[str]:
+        progress = ticket_progress(workspace_root)
+        if int(progress.get("total", 0)) <= 0:
+            return None
+        display = build_ticket_flow_display(
+            status=None,
+            done_count=int(progress.get("done", 0)),
+            total_count=int(progress.get("total", 0)),
+            run_id=None,
+        )
+        summary: Mapping[str, Any] = {**display, "current_step": None}
+        lines = format_ticket_flow_summary_lines(summary)
+        if not lines:
+            return None
+        return "\n".join(lines)
+
     async def _handle_flow_status(
         self,
         interaction_id: str,
@@ -7923,6 +7945,27 @@ class DiscordBotService:
                             components,
                         )
                     return
+                if not explicit_run_requested:
+                    summary_text = self._build_flow_status_summary_fallback(
+                        workspace_root
+                    )
+                    if summary_text:
+                        if update_message:
+                            await self._update_component_message(
+                                interaction_id=interaction_id,
+                                interaction_token=interaction_token,
+                                text=summary_text,
+                                components=[],
+                            )
+                        else:
+                            await self._send_or_respond_with_components_public(
+                                interaction_id=interaction_id,
+                                interaction_token=interaction_token,
+                                deferred=deferred_public,
+                                text=summary_text,
+                                components=[],
+                            )
+                        return
                 message = (
                     f"Ticket_flow run {run_id_opt.strip()} not found."
                     if explicit_run_requested

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
@@ -39,7 +39,10 @@ from .....core.flows.worker_process import FlowWorkerHealth, check_worker_health
 from .....core.logging_utils import log_event
 from .....core.orchestration import build_ticket_flow_orchestration_service
 from .....core.state import now_iso
-from .....core.ticket_flow_summary import build_ticket_flow_display
+from .....core.ticket_flow_summary import (
+    build_ticket_flow_display,
+    format_ticket_flow_summary_lines,
+)
 from .....core.utils import atomic_write, canonicalize_path
 from .....manifest import load_manifest
 from .....tickets.files import list_ticket_paths
@@ -613,6 +616,15 @@ class FlowCommands(TelegramCommandSupportMixin):
             store.initialize()
             record, error = self._resolve_status_record(store, run_id_raw)
             if error:
+                if not run_id_raw:
+                    summary_text = self._build_flow_status_summary_fallback(repo_root)
+                    if summary_text:
+                        await self._edit_callback_message(
+                            callback,
+                            summary_text,
+                            reply_markup={"inline_keyboard": []},
+                        )
+                        return
                 await self._edit_callback_message(
                     callback, error, reply_markup={"inline_keyboard": []}
                 )
@@ -869,6 +881,22 @@ class FlowCommands(TelegramCommandSupportMixin):
                 "No ticket flow run found. Use /pma to start a new flow via web app.",
             )
         return record, None
+
+    def _build_flow_status_summary_fallback(self, repo_root: Path) -> Optional[str]:
+        progress = ticket_progress(repo_root)
+        if int(progress.get("total", 0)) <= 0:
+            return None
+        display = build_ticket_flow_display(
+            status=None,
+            done_count=int(progress.get("done", 0)),
+            total_count=int(progress.get("total", 0)),
+            run_id=None,
+        )
+        summary = {**display, "current_step": None}
+        lines = format_ticket_flow_summary_lines(summary)
+        if not lines:
+            return None
+        return "\n".join(lines)
 
     def _format_flow_status_lines(
         self,
@@ -1262,6 +1290,17 @@ class FlowCommands(TelegramCommandSupportMixin):
             run_id_raw = self._first_non_flag(argv)
             record, error = self._resolve_status_record(store, run_id_raw)
             if error:
+                if not run_id_raw:
+                    summary_text = self._build_flow_status_summary_fallback(repo_root)
+                    if summary_text:
+                        await self._send_message(
+                            message.chat_id,
+                            summary_text,
+                            thread_id=message.thread_id,
+                            reply_to=message.message_id,
+                            parse_mode="Markdown",
+                        )
+                        return
                 await self._send_message(
                     message.chat_id,
                     error,

--- a/tests/integrations/discord/test_flow_handlers.py
+++ b/tests/integrations/discord/test_flow_handlers.py
@@ -254,6 +254,21 @@ def _create_run(
         )
 
 
+def _write_ticket(workspace: Path, name: str, *, done: bool) -> None:
+    ticket_dir = workspace / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True, exist_ok=True)
+    ticket_path = ticket_dir / name
+    ticket_path.write_text(
+        "---\n"
+        "agent: codex\n"
+        f"done: {'true' if done else 'false'}\n"
+        "title: Ticket\n"
+        "---\n\n"
+        "Body\n",
+        encoding="utf-8",
+    )
+
+
 def _write_manifest(root: Path, *, repo_id: str, repo_path: str) -> Path:
     manifest_path = root / ".codex-autorunner" / "manifest.yml"
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
@@ -466,6 +481,46 @@ async def test_flow_status_without_run_id_shows_no_current_run_for_history_only(
         ]
         assert picker_options[0]["default"] is True
         assert picker_options[1]["default"] is False
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_flow_status_without_run_uses_ticket_summary_fallback(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path)
+    _write_ticket(workspace, "TICKET-001-a.md", done=True)
+    _write_ticket(workspace, "TICKET-002-b.md", done=True)
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway([_flow_interaction(name="status", options=[])])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 2
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        payload = rest.interaction_responses[1]["payload"]["data"]
+        content = payload["content"]
+        assert content == "Status: Done\nTickets: 2/2"
+        assert payload.get("components") == []
     finally:
         await store.close()
 

--- a/tests/test_telegram_flow_status.py
+++ b/tests/test_telegram_flow_status.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 import pytest
 
+from codex_autorunner.bootstrap import seed_repo_files
 from codex_autorunner.core.flows import FlowStore
 from codex_autorunner.core.flows import hub_overview as hub_overview_module
 from codex_autorunner.core.flows.models import (
@@ -20,6 +21,7 @@ from codex_autorunner.core.flows.models import (
 from codex_autorunner.core.flows.worker_process import FlowWorkerHealth
 from codex_autorunner.integrations.telegram.adapter import (
     FlowCallback,
+    TelegramCallbackQuery,
     TelegramMessage,
     build_model_keyboard,
     parse_callback_data,
@@ -65,6 +67,20 @@ def _record(
         finished_at=finished_at,
         error_message=None,
         metadata={},
+    )
+
+
+def _write_ticket(repo_root: Path, name: str, *, done: bool) -> None:
+    ticket_dir = repo_root / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True, exist_ok=True)
+    (ticket_dir / name).write_text(
+        "---\n"
+        "agent: codex\n"
+        f"done: {'true' if done else 'false'}\n"
+        "title: Ticket\n"
+        "---\n\n"
+        "Body\n",
+        encoding="utf-8",
     )
 
 
@@ -755,6 +771,22 @@ class _FlowStatusHandler(FlowCommands):
         self.markups.append(reply_markup)
 
 
+class _FlowStatusCallbackHandler(FlowCommands):
+    def __init__(self) -> None:
+        self.edits: list[tuple[str, dict[str, object] | None]] = []
+
+    async def _edit_callback_message(
+        self,
+        _callback: TelegramCallbackQuery,
+        text: str,
+        *,
+        reply_markup: dict[str, object] | None = None,
+        parse_mode: str | None = None,
+    ) -> None:
+        _ = parse_mode
+        self.edits.append((text, reply_markup))
+
+
 @pytest.mark.anyio
 async def test_flow_status_action_sends_keyboard(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -802,6 +834,56 @@ async def test_flow_status_action_sends_keyboard(
     assert handler.sent
     assert any("Run:" in line for line in handler.sent[0].splitlines())
     assert handler.markups[0] is not None
+
+
+@pytest.mark.anyio
+async def test_flow_status_action_without_run_uses_ticket_summary_fallback(
+    tmp_path: Path,
+) -> None:
+    seed_repo_files(tmp_path, git_required=False)
+    _write_ticket(tmp_path, "TICKET-001-a.md", done=True)
+    _write_ticket(tmp_path, "TICKET-002-b.md", done=True)
+
+    handler = _FlowStatusHandler()
+    message = TelegramMessage(
+        update_id=1,
+        message_id=2,
+        chat_id=3,
+        thread_id=4,
+        from_user_id=5,
+        text="/flow status",
+        date=None,
+        is_topic_message=True,
+    )
+
+    await handler._handle_flow_status_action(message, tmp_path, argv=[])
+
+    assert handler.sent == ["Status: Done\nTickets: 2/2"]
+    assert handler.markups == [None]
+
+
+@pytest.mark.anyio
+async def test_flow_status_callback_without_run_uses_ticket_summary_fallback(
+    tmp_path: Path,
+) -> None:
+    seed_repo_files(tmp_path, git_required=False)
+    _write_ticket(tmp_path, "TICKET-001-a.md", done=True)
+    _write_ticket(tmp_path, "TICKET-002-b.md", done=True)
+
+    handler = _FlowStatusCallbackHandler()
+    callback = TelegramCallbackQuery(
+        update_id=1,
+        callback_id="cb-1",
+        from_user_id=5,
+        data="refresh",
+        message_id=2,
+        chat_id=3,
+        thread_id=4,
+    )
+
+    await handler._render_flow_status_callback(callback, tmp_path, None)
+
+    assert handler.edits == [("Status: Done\nTickets: 2/2", {"inline_keyboard": []})]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- add a shared ticket-flow summary formatter for chat surfaces
- make Discord `/flow status` fall back to ticket-derived metadata when no run record exists
- make Telegram status and refresh callbacks use the same fallback, with regression coverage

## Why
Web hub cards already show ticket progress as the source of truth even when chat status cannot resolve a run record. This aligns Discord and Telegram with that behavior so chat no longer reports `No ticket_flow runs found` for completed worktrees that still have ticket metadata.

## Testing
- `.venv/bin/python -m pytest tests/test_telegram_flow_status.py tests/integrations/discord/test_flow_handlers.py tests/core/test_ticket_flow_summary.py`
- pre-commit pipeline via `git commit`:
  - repo-wide `mypy`
  - frontend build and JS tests
  - full pytest suite (`3493 passed, 1 skipped`)
