### PR TITLE
Refactor Telegram command surface policy

### DIFF
--- a/src/codex_autorunner/integrations/chat/command_contract.py
+++ b/src/codex_autorunner/integrations/chat/command_contract.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from typing import Literal, Optional
 
 CommandStatus = Literal["stable", "partial", "unsupported"]
+TelegramExposure = Literal["public", "hidden", "legacy_alias"]
+TelegramResponsePolicy = Literal["typing"]
 DiscordAckPolicy = Literal[
     "immediate",
     "defer_ephemeral",
@@ -28,6 +30,13 @@ class CommandContractEntry:
     discord_ack_timing: DiscordAckTiming = "dispatch"
     discord_exposure: Optional[DiscordExposure] = None
     required_capabilities: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class TelegramCommandMetadata:
+    exposure: TelegramExposure
+    response_policy: TelegramResponsePolicy
+    allow_during_turn: bool
 
 
 COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
@@ -512,6 +521,164 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
     ),
 )
 
+_TELEGRAM_COMMAND_METADATA: dict[str, TelegramCommandMetadata] = {
+    "repos": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "bind": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "new": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "newt": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "archive": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "reset": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "resume": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "review": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "flow": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "reply": TelegramCommandMetadata(
+        exposure="legacy_alias",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "agent": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "model": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "approvals": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "pma": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "status": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "files": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "debug": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "ids": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "diff": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "mention": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "skills": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "mcp": TelegramCommandMetadata(
+        exposure="hidden",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "experimental": TelegramCommandMetadata(
+        exposure="hidden",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "init": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "compact": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "rollout": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "update": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "logout": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=False,
+    ),
+    "feedback": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "interrupt": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "help": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+}
+
 
 def command_contract_entry_for_path(
     path: tuple[str, ...],
@@ -520,3 +687,24 @@ def command_contract_entry_for_path(
         if entry.path == path:
             return entry
     return None
+
+
+def telegram_command_metadata_for_name(
+    name: str,
+) -> Optional[TelegramCommandMetadata]:
+    return _TELEGRAM_COMMAND_METADATA.get(name.strip())
+
+
+def telegram_runtime_command_names_from_contract(
+    contract: tuple[CommandContractEntry, ...] = COMMAND_CONTRACT,
+) -> tuple[str, ...]:
+    names: list[str] = []
+    seen: set[str] = set()
+    for entry in contract:
+        for name in entry.telegram_commands:
+            normalized = name.strip()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            names.append(normalized)
+    return tuple(names)

--- a/src/codex_autorunner/integrations/chat/help_catalog.py
+++ b/src/codex_autorunner/integrations/chat/help_catalog.py
@@ -428,17 +428,19 @@ def build_discord_help_lines() -> list[str]:
     return lines
 
 
-def build_telegram_help_text(command_names: Collection[str]) -> str:
+def build_telegram_help_text(
+    command_names: Collection[str],
+    *,
+    legacy_command_names: Collection[str] = (),
+) -> str:
     available = set(command_names)
+    legacy_available = set(legacy_command_names)
     lines = ["Commands:"]
     for command_name in _TELEGRAM_COMMAND_ORDER:
         if command_name not in available:
             continue
         if command_name == "flow":
             lines.append("/flow - ticket flow controls")
-            continue
-        if command_name == "reply":
-            lines.append("/reply <message> - reply to a paused ticket flow dispatch")
             continue
         line = _render_telegram_line(command_name)
         if line is not None:
@@ -470,7 +472,7 @@ def build_telegram_help_text(command_names: Collection[str]) -> str:
                 "(Use /pma for full flow controls via web app)",
             ]
         )
-        if "reply" in available:
+        if "reply" in legacy_available:
             lines.append("/reply <message> (legacy)")
 
     file_lines = _telegram_file_help_lines(available)

--- a/src/codex_autorunner/integrations/chat/parity_checker.py
+++ b/src/codex_autorunner/integrations/chat/parity_checker.py
@@ -7,7 +7,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterable, Sequence
 
-from .command_contract import COMMAND_CONTRACT, CommandContractEntry
+from .command_contract import (
+    COMMAND_CONTRACT,
+    CommandContractEntry,
+    telegram_command_metadata_for_name,
+    telegram_runtime_command_names_from_contract,
+)
 
 _DISCORD_SERVICE_PATH = Path("src/codex_autorunner/integrations/discord/service.py")
 _DISCORD_CAR_DISPATCH_PATH = Path(
@@ -89,6 +94,7 @@ def run_parity_checks(
 
     return (
         _check_contract_discord_metadata_complete(contract=contract),
+        _check_contract_telegram_metadata_complete(contract=contract),
         _check_contract_registry_entries_cataloged(
             contract=contract,
             discord_commands_ast=discord_commands_ast,
@@ -178,6 +184,12 @@ def _source_unavailable_results(
             metadata=metadata,
         ),
         ParityCheckResult(
+            id="contract.telegram_metadata_complete",
+            passed=True,
+            message=message,
+            metadata=metadata,
+        ),
+        ParityCheckResult(
             id="contract.registry_entries_cataloged",
             passed=True,
             message=message,
@@ -246,6 +258,47 @@ def _check_contract_discord_metadata_complete(
         metadata={
             "missing_ack_policy": missing_ack_policy,
             "missing_exposure": missing_exposure,
+        },
+    )
+
+
+def _check_contract_telegram_metadata_complete(
+    *,
+    contract: Sequence[CommandContractEntry],
+) -> ParityCheckResult:
+    missing_exposure: list[str] = []
+    missing_response_policy: list[str] = []
+    missing_allow_during_turn: list[str] = []
+    for name in telegram_runtime_command_names_from_contract(tuple(contract)):
+        metadata = telegram_command_metadata_for_name(name)
+        if metadata is None:
+            missing_exposure.append(name)
+            missing_response_policy.append(name)
+            missing_allow_during_turn.append(name)
+            continue
+        if not metadata.exposure:
+            missing_exposure.append(name)
+        if not metadata.response_policy:
+            missing_response_policy.append(name)
+        if not isinstance(metadata.allow_during_turn, bool):
+            missing_allow_during_turn.append(name)
+    passed = (
+        not missing_exposure
+        and not missing_response_policy
+        and not missing_allow_during_turn
+    )
+    if passed:
+        message = "Registered Telegram commands declare exposure, response, and turn policy metadata."
+    else:
+        message = "One or more Telegram commands are missing contract metadata."
+    return ParityCheckResult(
+        id="contract.telegram_metadata_complete",
+        passed=passed,
+        message=message,
+        metadata={
+            "missing_exposure": missing_exposure,
+            "missing_response_policy": missing_response_policy,
+            "missing_allow_during_turn": missing_allow_during_turn,
         },
     )
 

--- a/src/codex_autorunner/integrations/telegram/commands_registry.py
+++ b/src/codex_autorunner/integrations/telegram/commands_registry.py
@@ -31,6 +31,8 @@ def build_command_payloads(
     commands: list[dict[str, str]] = []
     invalid: list[str] = []
     for spec in command_specs.values():
+        if not spec.exposed:
+            continue
         name = _validate_command_name(spec.name)
         if not name:
             invalid.append(spec.name)

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_spec.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_spec.py
@@ -5,6 +5,10 @@ from typing import Any, Awaitable, Callable
 
 from ....core.flows import flow_action_summary
 from ....core.update_targets import update_target_values
+from ...chat.command_contract import (
+    TelegramResponsePolicy,
+    telegram_command_metadata_for_name,
+)
 from ..adapter import TelegramMessage
 
 
@@ -14,154 +18,162 @@ class CommandSpec:
     description: str
     handler: Callable[[TelegramMessage, str, Any], Awaitable[None]]
     allow_during_turn: bool = False
+    exposed: bool = True
+    legacy_alias: bool = False
+    response_policy: TelegramResponsePolicy = "typing"
 
 
 def build_command_specs(handlers: Any) -> dict[str, CommandSpec]:
+    def _spec(
+        name: str,
+        description: str,
+        handler: Callable[[TelegramMessage, str, Any], Awaitable[None]],
+    ) -> CommandSpec:
+        policy = telegram_command_metadata_for_name(name)
+        if policy is None:
+            raise ValueError(f"missing Telegram command metadata for {name}")
+        return CommandSpec(
+            name=name,
+            description=description,
+            handler=handler,
+            allow_during_turn=policy.allow_during_turn,
+            exposed=policy.exposure == "public",
+            legacy_alias=policy.exposure == "legacy_alias",
+            response_policy=policy.response_policy,
+        )
+
     return {
-        "repos": CommandSpec(
+        "repos": _spec(
             "repos",
             "list available repositories in the hub",
             handlers._handle_repos,
-            allow_during_turn=True,
         ),
-        "bind": CommandSpec(
+        "bind": _spec(
             "bind",
             "bind this topic to a workspace",
             lambda message, args, _runtime: handlers._handle_bind(message, args),
         ),
-        "new": CommandSpec(
+        "new": _spec(
             "new",
             "start a new PMA session",
             lambda message, _args, _runtime: handlers._handle_new(message),
         ),
-        "newt": CommandSpec(
+        "newt": _spec(
             "newt",
             "reset current workspace branch from origin default branch and start a new session",
             lambda message, _args, _runtime: handlers._handle_newt(message),
         ),
-        "archive": CommandSpec(
+        "archive": _spec(
             "archive",
             "archive workspace state for a fresh start",
             lambda message, _args, _runtime: handlers._handle_archive(message),
         ),
-        "reset": CommandSpec(
+        "reset": _spec(
             "reset",
             "reset PMA thread state (clear volatile state)",
             lambda message, _args, _runtime: handlers._handle_reset(message),
         ),
-        "resume": CommandSpec(
+        "resume": _spec(
             "resume",
             "list or resume a previous session",
             lambda message, args, _runtime: handlers._handle_resume(message, args),
         ),
-        "review": CommandSpec(
+        "review": _spec(
             "review",
             "run a code review",
             handlers._handle_review,
         ),
-        "flow": CommandSpec(
+        "flow": _spec(
             "flow",
             f"ticket flow controls ({flow_action_summary()})",
             lambda message, args, _runtime: handlers._handle_flow(message, args),
-            allow_during_turn=True,
         ),
-        "reply": CommandSpec(
+        "reply": _spec(
             "reply",
             "reply to a paused ticket flow dispatch (prefer /flow reply)",
             lambda message, args, _runtime: handlers._handle_reply(message, args),
-            allow_during_turn=True,
         ),
-        "agent": CommandSpec(
+        "agent": _spec(
             "agent",
             "show or set the active agent",
             handlers._handle_agent,
         ),
-        "model": CommandSpec(
+        "model": _spec(
             "model",
             "list or set the model",
             handlers._handle_model,
         ),
-        "approvals": CommandSpec(
+        "approvals": _spec(
             "approvals",
             "set approval and sandbox policy",
             handlers._handle_approvals,
         ),
-        "pma": CommandSpec(
+        "pma": _spec(
             "pma",
             "PMA mode controls (on/off/status)",
             handlers._handle_pma,
-            allow_during_turn=True,
         ),
-        "status": CommandSpec(
+        "status": _spec(
             "status",
             "show current binding, thread, and collaboration status",
             handlers._handle_status,
-            allow_during_turn=True,
         ),
-        "files": CommandSpec(
+        "files": _spec(
             "files",
             "list or manage Telegram file inbox/outbox",
             handlers._handle_files,
-            allow_during_turn=True,
         ),
-        "debug": CommandSpec(
+        "debug": _spec(
             "debug",
             "show topic debug info and effective collaboration policy",
             handlers._handle_debug,
-            allow_during_turn=True,
         ),
-        "ids": CommandSpec(
+        "ids": _spec(
             "ids",
             "show chat/user/thread IDs and collaboration snippets",
             handlers._handle_ids,
-            allow_during_turn=True,
         ),
-        "diff": CommandSpec(
+        "diff": _spec(
             "diff",
             "show git diff for the bound workspace",
             handlers._handle_diff,
-            allow_during_turn=True,
         ),
-        "mention": CommandSpec(
+        "mention": _spec(
             "mention",
             "include a file in a new request",
             handlers._handle_mention,
-            allow_during_turn=True,
         ),
-        "skills": CommandSpec(
+        "skills": _spec(
             "skills",
             "list available skills",
             handlers._handle_skills,
-            allow_during_turn=True,
         ),
-        "mcp": CommandSpec(
+        "mcp": _spec(
             "mcp",
             "list MCP server status",
             handlers._handle_mcp,
-            allow_during_turn=True,
         ),
-        "experimental": CommandSpec(
+        "experimental": _spec(
             "experimental",
             "toggle experimental features",
             handlers._handle_experimental,
         ),
-        "init": CommandSpec(
+        "init": _spec(
             "init",
             "generate AGENTS.md guidance",
             handlers._handle_init,
         ),
-        "compact": CommandSpec(
+        "compact": _spec(
             "compact",
             "compact the conversation (summary)",
             handlers._handle_compact,
         ),
-        "rollout": CommandSpec(
+        "rollout": _spec(
             "rollout",
             "show current thread rollout path",
             handlers._handle_rollout,
-            allow_during_turn=True,
         ),
-        "update": CommandSpec(
+        "update": _spec(
             "update",
             (
                 "update CAR (prompt or "
@@ -169,29 +181,26 @@ def build_command_specs(handlers: Any) -> dict[str, CommandSpec]:
             ),
             handlers._handle_update,
         ),
-        "logout": CommandSpec(
+        "logout": _spec(
             "logout",
             "log out of the Codex account",
             handlers._handle_logout,
         ),
-        "feedback": CommandSpec(
+        "feedback": _spec(
             "feedback",
             "send feedback and logs",
             handlers._handle_feedback,
-            allow_during_turn=True,
         ),
-        "interrupt": CommandSpec(
+        "interrupt": _spec(
             "interrupt",
             "stop the active turn",
             lambda message, _args, runtime: handlers._handle_interrupt(
                 message, runtime
             ),
-            allow_during_turn=True,
         ),
-        "help": CommandSpec(
+        "help": _spec(
             "help",
             "show this help message",
             handlers._handle_help,
-            allow_during_turn=True,
         ),
     }

--- a/src/codex_autorunner/integrations/telegram/helpers.py
+++ b/src/codex_autorunner/integrations/telegram/helpers.py
@@ -342,7 +342,12 @@ def _format_token_row(label: str, usage: dict[str, Any]) -> Optional[str]:
 
 
 def _format_help_text(command_specs: dict[str, CommandSpec]) -> str:
-    return build_telegram_help_text(command_specs.keys())
+    return build_telegram_help_text(
+        [name for name, spec in command_specs.items() if spec.exposed],
+        legacy_command_names=[
+            name for name, spec in command_specs.items() if spec.legacy_alias
+        ],
+    )
 
 
 def _should_trace_message(text: str) -> bool:

--- a/tests/fixtures/telegram_command_helpers.py
+++ b/tests/fixtures/telegram_command_helpers.py
@@ -31,10 +31,14 @@ def make_command_spec(
     *,
     handler: CommandHandler = noop_handler,
     allow_during_turn: bool = False,
+    exposed: bool = True,
+    legacy_alias: bool = False,
 ) -> CommandSpec:
     return CommandSpec(
         name=name,
         description=description,
         handler=handler,
         allow_during_turn=allow_during_turn,
+        exposed=exposed,
+        legacy_alias=legacy_alias,
     )

--- a/tests/integrations/chat/test_command_contract.py
+++ b/tests/integrations/chat/test_command_contract.py
@@ -2,11 +2,18 @@ from __future__ import annotations
 
 from typing import Any
 
-from codex_autorunner.integrations.chat.command_contract import COMMAND_CONTRACT
+from codex_autorunner.integrations.chat.command_contract import (
+    COMMAND_CONTRACT,
+    telegram_command_metadata_for_name,
+    telegram_runtime_command_names_from_contract,
+)
 from codex_autorunner.integrations.discord.commands import (
     SUB_COMMAND,
     SUB_COMMAND_GROUP,
     build_application_commands,
+)
+from codex_autorunner.integrations.telegram.commands_registry import (
+    build_command_payloads,
 )
 from codex_autorunner.integrations.telegram.handlers.commands_spec import (
     build_command_specs,
@@ -55,7 +62,9 @@ def _discord_registered_paths() -> set[tuple[str, ...]]:
 
 def _telegram_registered_commands() -> set[str]:
     specs = build_command_specs(_HandlerStub())
-    return set(specs.keys())
+    commands, invalid = build_command_payloads(specs)
+    assert invalid == []
+    return {entry["command"] for entry in commands}
 
 
 def test_command_contract_has_unique_ids_and_paths() -> None:
@@ -71,7 +80,9 @@ def test_command_contract_catalogs_all_registered_surface_commands() -> None:
         path for entry in COMMAND_CONTRACT for path in entry.discord_paths
     }
     contract_telegram_commands = {
-        name for entry in COMMAND_CONTRACT for name in entry.telegram_commands
+        name
+        for name in telegram_runtime_command_names_from_contract()
+        if telegram_command_metadata_for_name(name).exposure == "public"
     }
 
     assert contract_discord_paths == _discord_registered_paths()
@@ -120,3 +131,16 @@ def test_command_contract_discord_metadata_is_present_for_registered_paths() -> 
     assert by_id["car.flow.status"].discord_ack_timing == "post_private_preflight"
     assert by_id["car.flow.start"].discord_ack_timing == "post_private_preflight"
     assert by_id["car.flow.restart"].discord_ack_timing == "post_private_preflight"
+
+
+def test_command_contract_telegram_metadata_is_present_for_runtime_commands() -> None:
+    for name in telegram_runtime_command_names_from_contract():
+        metadata = telegram_command_metadata_for_name(name)
+        assert metadata is not None
+        assert metadata.exposure in {"public", "hidden", "legacy_alias"}
+        assert metadata.response_policy == "typing"
+        assert isinstance(metadata.allow_during_turn, bool)
+
+    assert telegram_command_metadata_for_name("mcp").exposure == "hidden"
+    assert telegram_command_metadata_for_name("experimental").exposure == "hidden"
+    assert telegram_command_metadata_for_name("reply").exposure == "legacy_alias"

--- a/tests/integrations/chat/test_help_catalog.py
+++ b/tests/integrations/chat/test_help_catalog.py
@@ -27,6 +27,9 @@ def test_telegram_help_lists_shared_commands_without_discord_only_entries() -> N
     assert "/files clear inbox|outbox|all" in text
     assert "/files send <filename>" in text
     assert "/pma - PMA mode controls (on/off/status)" in text
+    assert "/mcp -" not in text
+    assert "/experimental -" not in text
+    assert "/reply <message> (legacy)" in text
     assert "/tickets" not in text
 
 

--- a/tests/integrations/chat/test_parity_checker.py
+++ b/tests/integrations/chat/test_parity_checker.py
@@ -81,6 +81,27 @@ def test_parity_checker_fails_when_registered_discord_metadata_is_missing() -> N
     assert "car.future" in metadata_check.metadata["missing_exposure"]
 
 
+def test_parity_checker_fails_when_registered_telegram_metadata_is_missing() -> None:
+    contract = (
+        CommandContractEntry(
+            id="car.future",
+            path=("car", "future"),
+            requires_bound_workspace=False,
+            status="partial",
+            telegram_commands=("future",),
+        ),
+    )
+    results_by_id = {
+        result.id: result for result in run_parity_checks(contract=contract)
+    }
+
+    metadata_check = results_by_id["contract.telegram_metadata_complete"]
+    assert not metadata_check.passed
+    assert "future" in metadata_check.metadata["missing_exposure"]
+    assert "future" in metadata_check.metadata["missing_response_policy"]
+    assert "future" in metadata_check.metadata["missing_allow_during_turn"]
+
+
 def test_parity_checker_fails_when_contract_route_is_missing(tmp_path: Path) -> None:
     repo_root = _write_fixture_repo(tmp_path, include_car_model_route=False)
 

--- a/tests/test_cross_surface_parity.py
+++ b/tests/test_cross_surface_parity.py
@@ -227,7 +227,9 @@ def test_cross_surface_parity_report(hub_env) -> None:
         )
     )
 
-    telegram_ticket_flow = '"flow": CommandSpec(' in spec_text
+    telegram_ticket_flow = (
+        '"flow": _spec(' in spec_text and "handlers._handle_flow" in spec_text
+    )
     checks.append(
         ParityCheck(
             entrypoint="telegram",

--- a/tests/test_telegram_command_contract.py
+++ b/tests/test_telegram_command_contract.py
@@ -9,6 +9,9 @@ from codex_autorunner.integrations.telegram.adapter import (
 from codex_autorunner.integrations.telegram.commands_registry import (
     build_command_payloads,
 )
+from codex_autorunner.integrations.telegram.handlers.commands_spec import (
+    build_command_specs,
+)
 from tests.fixtures.telegram_command_helpers import (
     README_REVISIT_GUIDANCE_MIN_MODULE_THRESHOLD,
     bot_command_entity,
@@ -17,6 +20,14 @@ from tests.fixtures.telegram_command_helpers import (
 
 # Helper usage: this file owns cross-cutting Telegram command invariants, so use
 # shared helpers for setup and keep assertions focused on behavior contracts.
+
+
+class _HandlerStub:
+    def __getattr__(self, _name: str):
+        async def _noop(*_args, **_kwargs):
+            return None
+
+        return _noop
 
 
 def test_contract_runtime_entity_and_fallback_parity_for_mention_validation() -> None:
@@ -52,6 +63,16 @@ def test_contract_registration_rejects_invalid_names() -> None:
     commands, invalid = build_command_payloads(specs)
     assert commands == []
     assert invalid == ["foo-bar", "foo bar", "foo@codexbot", "a" * 33]
+
+
+def test_contract_build_command_specs_applies_shared_surface_policy() -> None:
+    specs = build_command_specs(_HandlerStub())
+
+    assert specs["status"].allow_during_turn is True
+    assert specs["new"].allow_during_turn is False
+    assert specs["mcp"].exposed is False
+    assert specs["experimental"].exposed is False
+    assert specs["reply"].legacy_alias is True
 
 
 def test_contract_readme_revisit_threshold_policy_minimum() -> None:

--- a/tests/test_telegram_command_registry.py
+++ b/tests/test_telegram_command_registry.py
@@ -37,6 +37,22 @@ def test_build_command_payloads_rejects_invalid_names() -> None:
     assert invalid == ["foo-bar", "foo bar", "foo@codexbot", "a" * 33]
 
 
+def test_build_command_payloads_skips_hidden_and_legacy_specs() -> None:
+    specs = {
+        "status": make_command_spec("status", "Show status"),
+        "mcp": make_command_spec("mcp", "MCP", exposed=False),
+        "reply": make_command_spec(
+            "reply",
+            "Legacy reply",
+            exposed=False,
+            legacy_alias=True,
+        ),
+    }
+    commands, invalid = build_command_payloads(specs)
+    assert invalid == []
+    assert commands == [{"command": "status", "description": "Show status"}]
+
+
 def test_diff_command_lists_detects_changes() -> None:
     desired = [
         {"command": "run", "description": "Start a task"},


### PR DESCRIPTION
## Summary
- move Telegram command surface metadata into the shared command contract
- derive Telegram `allow_during_turn`, exposure, and response policy from that contract
- hide Telegram-only dead or unsupported commands from registration/help and demote `/reply` to a legacy alias
- add parity and contract tests so Telegram command exposure cannot drift silently again

## What changed
- added Telegram metadata in the shared command contract for exposure, response policy, and turn-availability
- updated Telegram command spec construction to read those policies centrally instead of duplicating them locally
- removed `/mcp` and `/experimental` from Telegram registration/help while keeping `/reply` documented as a legacy flow alias
- added parity coverage for Telegram metadata completeness and registration/help behavior

## Validation
- `tests/test_telegram_command_contract.py`
- `tests/test_telegram_command_registry.py`
- `tests/test_cross_surface_parity.py`
- `tests/integrations/chat/test_command_contract.py`
- `tests/integrations/chat/test_help_catalog.py`
- `tests/integrations/chat/test_parity_checker.py`
- `tests/test_telegram_handlers_messages.py`
- `tests/test_telegram_pma_routing.py`
- pre-commit hook sweep passed, including strict mypy, frontend build/tests, and pytest: `3606 passed, 1 skipped`

Closes #1143
