### PR TITLE
Guard Discord opencode prune against active turns

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -7051,7 +7051,9 @@ class DiscordBotService:
         try:
             orchestration_service = self._discord_thread_service()
             threads = orchestration_service.list_thread_targets(
-                lifecycle_status="active"
+                agent_id="opencode",
+                lifecycle_status="active",
+                limit=10_000,
             )
         except Exception:
             return None
@@ -7060,8 +7062,6 @@ class DiscordBotService:
         )
         canonical_workspace = str(canonicalize_path(Path(workspace_root)).resolve())
         for thread in threads:
-            if str(getattr(thread, "agent_id", "") or "").strip().lower() != "opencode":
-                continue
             thread_workspace = str(getattr(thread, "workspace_root", "") or "").strip()
             if not thread_workspace:
                 continue

--- a/tests/integrations/discord/test_opencode_lifecycle.py
+++ b/tests/integrations/discord/test_opencode_lifecycle.py
@@ -235,8 +235,16 @@ async def test_opencode_prune_sweep_defers_workspace_with_running_opencode_execu
             self.status = "running"
 
     class _FakeThreadService:
-        def list_thread_targets(self, *, lifecycle_status: str) -> list[Any]:
+        def list_thread_targets(
+            self,
+            *,
+            agent_id: str | None = None,
+            lifecycle_status: str,
+            limit: int = 200,
+        ) -> list[Any]:
+            assert agent_id == "opencode"
             assert lifecycle_status == "active"
+            assert limit == 10_000
             return [_FakeThread("thread-active", workspace_active)]
 
         def get_running_execution(self, thread_target_id: str) -> Any:


### PR DESCRIPTION
## Summary
- defer Discord opencode idle pruning when orchestration still reports a running opencode execution for the workspace
- fail closed when execution-state lookup is unavailable, and preserve lifecycle snapshot telemetry for deferred workspaces
- add Discord lifecycle regressions covering both active executions and lookup failures during prune sweeps

## Testing
- ./.venv/bin/pytest tests/integrations/discord/test_opencode_lifecycle.py tests/integrations/discord/test_service_routing.py::test_active_update_session_count_uses_live_running_executions -q
- git commit hook: black, ruff, mypy, frontend build/tests, full pytest suite (`3738 passed, 1 skipped`)
