### PR TITLE
[codex] align update target option labels

### DIFF
--- a/src/codex_autorunner/core/update_targets.py
+++ b/src/codex_autorunner/core/update_targets.py
@@ -18,35 +18,35 @@ _UPDATE_TARGET_ORDER = ("all", "web", "chat", "telegram", "discord")
 _UPDATE_TARGET_DEFINITIONS = {
     "all": UpdateTargetDefinition(
         value="all",
-        label="All",
+        label="all",
         description="Web + Telegram + Discord",
         restart_notice="The web UI, Telegram, and Discord will restart.",
         includes_web=True,
     ),
     "web": UpdateTargetDefinition(
         value="web",
-        label="Web only",
+        label="web",
         description="Web UI only",
         restart_notice="The web UI will restart.",
         includes_web=True,
     ),
     "chat": UpdateTargetDefinition(
         value="chat",
-        label="Chat apps (Telegram + Discord)",
+        label="chat",
         description="Telegram + Discord",
         restart_notice="Telegram and Discord will restart.",
         includes_web=False,
     ),
     "telegram": UpdateTargetDefinition(
         value="telegram",
-        label="Telegram only",
+        label="telegram",
         description="Telegram only",
         restart_notice="Telegram will restart.",
         includes_web=False,
     ),
     "discord": UpdateTargetDefinition(
         value="discord",
-        label="Discord only",
+        label="discord",
         description="Discord only",
         restart_notice="Discord will restart.",
         includes_web=False,
@@ -72,7 +72,7 @@ _UPDATE_TARGET_ALIASES = {
 }
 _UPDATE_TARGET_STATUS = UpdateTargetDefinition(
     value="status",
-    label="Status",
+    label="status",
     description="Show update status",
     restart_notice="",
     includes_web=False,
@@ -100,7 +100,7 @@ def _all_target_definition(
         restart_services.append("Discord")
     return UpdateTargetDefinition(
         value="all",
-        label="All",
+        label="all",
         description=" + ".join(services),
         restart_notice=f"The {_format_service_list(tuple(restart_services))} will restart.",
         includes_web=True,

--- a/src/codex_autorunner/integrations/discord/components.py
+++ b/src/codex_autorunner/integrations/discord/components.py
@@ -385,7 +385,7 @@ def build_update_target_picker(
         for definition in definitions[: DISCORD_SELECT_OPTION_MAX_OPTIONS - 1]
     ]
     options.append(
-        build_select_option("Status", "status", description="Show update status")
+        build_select_option("status", "status", description="Show update status")
     )
     return build_action_row(
         [build_select_menu(custom_id, options, placeholder=placeholder)]

--- a/tests/integrations/discord/test_components.py
+++ b/tests/integrations/discord/test_components.py
@@ -235,4 +235,4 @@ class TestBuildUpdateTargetPicker:
         values = {opt["value"] for opt in menu["options"]}
         assert values == {"all", "web", "chat", "telegram", "discord", "status"}
         all_option = next(opt for opt in menu["options"] if opt["value"] == "all")
-        assert all_option["label"] == "All"
+        assert all_option["label"] == "all"

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -5937,7 +5937,7 @@ async def test_car_update_acknowledges_before_spawning_restart_target(
         observed.update(kwargs)
         assert len(rest.followup_messages) == 1
         content = rest.followup_messages[0]["payload"]["content"].lower()
-        assert "preparing update (discord only)" in content
+        assert "preparing update (discord)" in content
 
     monkeypatch.setattr(
         discord_service_module,
@@ -5979,7 +5979,7 @@ async def test_component_update_acknowledges_before_spawning_restart_target(
         content = rest.edited_original_interaction_responses[0]["payload"][
             "content"
         ].lower()
-        assert "preparing update (discord only)" in content
+        assert "preparing update (discord)" in content
 
     monkeypatch.setattr(
         discord_service_module,
@@ -6039,7 +6039,7 @@ async def test_car_update_web_target_skips_confirmation_when_sessions_active(
         assert rest.interaction_responses[0]["payload"]["type"] == 5
         assert len(rest.followup_messages) == 1
         content = rest.followup_messages[0]["payload"]["content"].lower()
-        assert "update started (web only)" in content
+        assert "update started (web)" in content
     finally:
         await store.close()
 
@@ -6082,7 +6082,7 @@ async def test_car_update_restart_target_reports_lock_error_after_neutral_prep_t
         assert len(rest.followup_messages) == 2
         prep_text = rest.followup_messages[0]["payload"]["content"].lower()
         error_text = rest.followup_messages[1]["payload"]["content"].lower()
-        assert "preparing update (discord only)" in prep_text
+        assert "preparing update (discord)" in prep_text
         assert "starting update" not in prep_text
         assert "update already in progress" in error_text
     finally:

--- a/tests/test_system_update_worker.py
+++ b/tests/test_system_update_worker.py
@@ -55,7 +55,7 @@ def test_available_update_target_options_web_only_when_no_chat_available(
         update_backend="systemd-user",
         linux_service_names={"hub": "car-hub"},
     )
-    assert options == (("web", "Web only"),)
+    assert options == (("web", "web"),)
     assert (
         system._default_update_target(
             raw_config={
@@ -90,9 +90,9 @@ def test_available_update_target_options_include_telegram_when_enableable(
         linux_service_names={"hub": "car-hub"},
     )
     assert options == (
-        ("all", "All"),
-        ("web", "Web only"),
-        ("telegram", "Telegram only"),
+        ("all", "all"),
+        ("web", "web"),
+        ("telegram", "telegram"),
     )
     definitions = system._available_update_target_definitions(
         raw_config={
@@ -126,9 +126,9 @@ def test_available_update_target_options_include_discord_when_active(
         linux_service_names={"hub": "car-hub", "discord": "car-discord"},
     )
     assert options == (
-        ("all", "All"),
-        ("web", "Web only"),
-        ("discord", "Discord only"),
+        ("all", "all"),
+        ("web", "web"),
+        ("discord", "discord"),
     )
     definitions = system._available_update_target_definitions(
         raw_config={
@@ -152,19 +152,19 @@ def test_update_target_helpers_share_the_same_core_definitions() -> None:
         "status",
     )
     assert update_target_label_pairs() == (
-        ("all", "All"),
-        ("web", "Web only"),
-        ("chat", "Chat apps (Telegram + Discord)"),
-        ("telegram", "Telegram only"),
-        ("discord", "Discord only"),
+        ("all", "all"),
+        ("web", "web"),
+        ("chat", "chat"),
+        ("telegram", "telegram"),
+        ("discord", "discord"),
     )
     assert update_target_command_choices(include_status=True) == (
-        {"name": "All", "value": "all"},
-        {"name": "Web only", "value": "web"},
-        {"name": "Chat apps (Telegram + Discord)", "value": "chat"},
-        {"name": "Telegram only", "value": "telegram"},
-        {"name": "Discord only", "value": "discord"},
-        {"name": "Status", "value": "status"},
+        {"name": "all", "value": "all"},
+        {"name": "web", "value": "web"},
+        {"name": "chat", "value": "chat"},
+        {"name": "telegram", "value": "telegram"},
+        {"name": "discord", "value": "discord"},
+        {"name": "status", "value": "status"},
     )
 
 

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -823,7 +823,7 @@ def test_build_keyboards() -> None:
     bind_keyboard = build_bind_keyboard([("repo_a", "1) repo-a")])
     assert bind_keyboard["inline_keyboard"][0][0]["callback_data"].startswith("bind:")
     update_keyboard = build_update_keyboard(
-        [("all", "All"), ("web", "Web only")],
+        [("all", "all"), ("web", "web")],
         include_cancel=True,
     )
     assert update_keyboard["inline_keyboard"][0][0]["callback_data"].startswith(

--- a/tests/test_telegram_bot_integration.py
+++ b/tests/test_telegram_bot_integration.py
@@ -1547,7 +1547,7 @@ async def test_update_callback_acknowledged_before_spawn(tmp_path: Path) -> None
         ("spawn", "discord"),
         (
             "finalize",
-            "Update started (Discord only). The selected service(s) will restart.",
+            "Update started (discord). The selected service(s) will restart.",
         ),
     ]
 


### PR DESCRIPTION
## Summary
- change shared update-target choice labels to use the literal lowercase tokens (`all`, `web`, `chat`, `telegram`, `discord`, `status`)
- keep the existing descriptions/restart notices so the option scope stays clear while the selectable values match the command hint text
- update Discord and Telegram tests that asserted the previous humanized labels

## Why
The update command hints already tell users to use lowercase targets like `all` and `web`, but the actual surfaced choices were shown as labels like `All` and `Web only`. That mismatch makes the options less ergonomic to type and search for in chat surfaces.

## Impact
Users now see the same lowercase target strings in the shared helpers, Discord picker/command choices, and related chat flows that they are expected to type.

## Validation
- pre-commit hooks during `git commit`
- `./.venv/bin/pytest tests/test_system_update_worker.py tests/integrations/discord/test_components.py tests/integrations/discord/test_commands_payload.py tests/test_telegram_adapter.py`
- full repo pytest suite from the commit hooks (`3820 passed, 1 skipped`)
