### PR TITLE
[codex] fix PR draft defaults

### DIFF
--- a/codex-autorunner.yml
+++ b/codex-autorunner.yml
@@ -80,8 +80,8 @@ repo_defaults:
   github:
     # Enable GitHub integration endpoints.
     enabled: true
-    # Default to draft PRs.
-    pr_draft_default: true
+    # Default to ready-for-review PRs unless the user explicitly asks for draft.
+    pr_draft_default: false
     # none|auto|always
     sync_commit_mode: auto
     # Bounds the agentic sync step (seconds).

--- a/src/codex_autorunner/core/config.py
+++ b/src/codex_autorunner/core/config.py
@@ -627,7 +627,7 @@ DEFAULT_REPO_CONFIG: Dict[str, Any] = {
     },
     "github": {
         "enabled": True,
-        "pr_draft_default": True,
+        "pr_draft_default": False,
         "sync_commit_mode": "auto",  # none|auto|always
         # Bounds the agentic sync step in GitHubService.sync_pr (seconds).
         "sync_agent_timeout_seconds": 1800,

--- a/src/codex_autorunner/integrations/github/service.py
+++ b/src/codex_autorunner/integrations/github/service.py
@@ -1050,7 +1050,7 @@ class GitHubService:
     def sync_pr(
         self,
         *,
-        draft: bool = True,
+        draft: Optional[bool] = None,
         title: Optional[str] = None,
         body: Optional[str] = None,
     ) -> dict:
@@ -1077,6 +1077,11 @@ class GitHubService:
             (self.raw_config.get("github") or {})
             if isinstance(self.raw_config, dict)
             else {}
+        )
+        resolved_draft = (
+            draft
+            if draft is not None
+            else bool(github_cfg.get("pr_draft_default", False))
         )
         commit_mode = str(github_cfg.get("sync_commit_mode", "auto")).lower()
         if commit_mode not in ("none", "auto", "always"):
@@ -1113,7 +1118,7 @@ class GitHubService:
         pr = self.pr_for_branch(branch=head_branch, cwd=cwd)
         if not pr:
             args = ["pr", "create", "--base", base]
-            if draft:
+            if resolved_draft:
                 args.append("--draft")
             if title:
                 args += ["--title", title]
@@ -1133,7 +1138,7 @@ class GitHubService:
             pr = {
                 "url": url,
                 "state": "OPEN",
-                "isDraft": bool(draft),
+                "isDraft": bool(resolved_draft),
                 "headRefName": head_branch,
                 "baseRefName": base,
             }

--- a/tests/fixtures/default_hub_config.v2.json
+++ b/tests/fixtures/default_hub_config.v2.json
@@ -293,7 +293,7 @@
         }
       },
       "enabled": true,
-      "pr_draft_default": true,
+      "pr_draft_default": false,
       "sync_agent_timeout_seconds": 1800,
       "sync_commit_mode": "auto"
     },

--- a/tests/fixtures/default_repo_config.v2.json
+++ b/tests/fixtures/default_repo_config.v2.json
@@ -145,7 +145,7 @@
       }
     },
     "enabled": true,
-    "pr_draft_default": true,
+    "pr_draft_default": false,
     "sync_agent_timeout_seconds": 1800,
     "sync_commit_mode": "auto"
   },

--- a/tests/test_github_service_pr_discovery.py
+++ b/tests/test_github_service_pr_discovery.py
@@ -170,6 +170,159 @@ def test_sync_pr_does_not_append_duplicate_close_keyword(
     assert edit_calls == []
 
 
+def test_sync_pr_defaults_to_ready_for_review_when_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = GitHubService(tmp_path, raw_config={})
+    create_calls: list[list[str]] = []
+
+    monkeypatch.setattr(service, "gh_authenticated", lambda: True)
+    monkeypatch.setattr(
+        service,
+        "repo_info",
+        lambda: RepoInfo(
+            name_with_owner="acme/widgets",
+            url="https://github.com/acme/widgets",
+            default_branch="main",
+        ),
+    )
+    monkeypatch.setattr(service, "read_link_state", lambda: {})
+    monkeypatch.setattr(service, "current_branch", lambda *, cwd=None: "feature/login")
+    monkeypatch.setattr(service, "is_clean", lambda *, cwd=None: True)
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.github.service._run_codex_sync_agent",
+        lambda **_: None,
+    )
+
+    pr_lookup_count = {"value": 0}
+
+    def _fake_pr_for_branch(
+        *, branch: str, cwd: Path | None = None
+    ) -> dict[str, object] | None:
+        pr_lookup_count["value"] += 1
+        if pr_lookup_count["value"] == 1:
+            return None
+        return {
+            "url": "https://github.com/acme/widgets/pull/17",
+            "number": 17,
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefName": branch,
+            "baseRefName": "main",
+            "title": "Login flow",
+        }
+
+    monkeypatch.setattr(service, "pr_for_branch", _fake_pr_for_branch)
+
+    def _fake_gh(
+        args: list[str], *, cwd=None, check=True, timeout_seconds=None
+    ):  # type: ignore[no-untyped-def]
+        if args[:2] == ["pr", "create"]:
+            create_calls.append(list(args))
+            return type(
+                "Proc", (), {"stdout": "https://github.com/acme/widgets/pull/17\n"}
+            )()
+        if args[:3] == ["pr", "view", "https://github.com/acme/widgets/pull/17"]:
+            return type("Proc", (), {"stdout": json.dumps({"body": ""})})()
+        raise AssertionError(f"unexpected gh args: {args}")
+
+    monkeypatch.setattr(service, "_gh", _fake_gh)
+    monkeypatch.setattr(service, "write_link_state", lambda state: state)
+
+    result = service.sync_pr(title="Login flow", body="Initial body")
+
+    assert create_calls == [
+        [
+            "pr",
+            "create",
+            "--base",
+            "main",
+            "--title",
+            "Login flow",
+            "--body",
+            "Initial body",
+        ]
+    ]
+    assert result["links"]["url"] == "https://github.com/acme/widgets/pull/17"
+
+
+def test_sync_pr_uses_configured_draft_default_when_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = GitHubService(tmp_path, raw_config={"github": {"pr_draft_default": True}})
+    create_calls: list[list[str]] = []
+
+    monkeypatch.setattr(service, "gh_authenticated", lambda: True)
+    monkeypatch.setattr(
+        service,
+        "repo_info",
+        lambda: RepoInfo(
+            name_with_owner="acme/widgets",
+            url="https://github.com/acme/widgets",
+            default_branch="main",
+        ),
+    )
+    monkeypatch.setattr(service, "read_link_state", lambda: {})
+    monkeypatch.setattr(service, "current_branch", lambda *, cwd=None: "feature/login")
+    monkeypatch.setattr(service, "is_clean", lambda *, cwd=None: True)
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.github.service._run_codex_sync_agent",
+        lambda **_: None,
+    )
+
+    pr_lookup_count = {"value": 0}
+
+    def _fake_pr_for_branch(
+        *, branch: str, cwd: Path | None = None
+    ) -> dict[str, object] | None:
+        pr_lookup_count["value"] += 1
+        if pr_lookup_count["value"] == 1:
+            return None
+        return {
+            "url": "https://github.com/acme/widgets/pull/18",
+            "number": 18,
+            "state": "OPEN",
+            "isDraft": True,
+            "headRefName": branch,
+            "baseRefName": "main",
+            "title": "Login flow",
+        }
+
+    monkeypatch.setattr(service, "pr_for_branch", _fake_pr_for_branch)
+
+    def _fake_gh(
+        args: list[str], *, cwd=None, check=True, timeout_seconds=None
+    ):  # type: ignore[no-untyped-def]
+        if args[:2] == ["pr", "create"]:
+            create_calls.append(list(args))
+            return type(
+                "Proc", (), {"stdout": "https://github.com/acme/widgets/pull/18\n"}
+            )()
+        if args[:3] == ["pr", "view", "https://github.com/acme/widgets/pull/18"]:
+            return type("Proc", (), {"stdout": json.dumps({"body": ""})})()
+        raise AssertionError(f"unexpected gh args: {args}")
+
+    monkeypatch.setattr(service, "_gh", _fake_gh)
+    monkeypatch.setattr(service, "write_link_state", lambda state: state)
+
+    result = service.sync_pr(title="Login flow", body="Initial body")
+
+    assert create_calls == [
+        [
+            "pr",
+            "create",
+            "--base",
+            "main",
+            "--draft",
+            "--title",
+            "Login flow",
+            "--body",
+            "Initial body",
+        ]
+    ]
+    assert result["links"]["url"] == "https://github.com/acme/widgets/pull/18"
+
+
 def _write_manifest(hub_root: Path, *, repo_rel: str, repo_id: str = "repo-1") -> None:
     manifest_path = hub_root / ".codex-autorunner" / "manifest.yml"
     manifest_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- default CAR repo GitHub config to ready-for-review PRs instead of draft PRs
- make `GitHubService.sync_pr()` honor `github.pr_draft_default` when callers do not explicitly pass `draft`
- add regression coverage for both the default ready-for-review path and an explicit configured draft default

## Root cause
The repo had two long-lived in-repo draft defaults that diverged from the intended config-driven behavior:

- `codex-autorunner.yml` and `src/codex_autorunner/core/config.py` both defaulted `github.pr_draft_default` to `true`
- `src/codex_autorunner/integrations/github/service.py` still hardcoded `sync_pr(..., draft=True)` and ignored `github.pr_draft_default` entirely when a caller omitted `draft`

That meant the in-repo GitHub sync path was biased toward draft PR creation even though the setting was supposed to be the policy control point.

Recent-history note: git blame/log show those draft defaults are longstanding, not newly added in the last few days. The recent Mar 26 SCM automation work touched `service.py`, but it did not introduce the hardcoded draft default or add a new in-repo `sync_pr` caller.

## Why this change
Repo-bound CAR behavior should default to ready-for-review PRs unless the user or config explicitly asks for a draft. This change makes the config and service behavior line up with that policy.

## Validation
- `./.venv/bin/pytest tests/test_github_service_pr_discovery.py tests/test_config_default_snapshots.py -q`
- `./.venv/bin/pytest tests/test_config_resolution.py -q -k 'load_repo_config or load_hub_config'`
- `./.venv/bin/black src/codex_autorunner/core/config.py src/codex_autorunner/integrations/github/service.py tests/test_github_service_pr_discovery.py`
- pre-commit hook suite during `git commit`:
  - repo-wide `ruff`
  - repo-wide strict `mypy`
  - `pnpm run build`
  - frontend JS tests
  - full pytest suite: `3822 passed, 1 skipped`
