### PR TITLE
[codex] Restore raw-user context hints

### DIFF
--- a/src/codex_autorunner/core/context_awareness.py
+++ b/src/codex_autorunner/core/context_awareness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from typing import Literal
 
 from .car_context import (
@@ -24,6 +25,10 @@ PROMPT_WRITING_HINT = (
 _PROMPT_CONTEXT_RE = re.compile(r"\bprompt\b", re.IGNORECASE)
 _FILE_CONTEXT_SIGNAL_RE = re.compile(
     r"(?:<file\s+path=|Inbound Discord attachments:|PMA File Inbox:)",
+    re.IGNORECASE,
+)
+_FILEBOX_HINT_KEYWORD_RE = re.compile(
+    r"\b(?:filebox|inbox|outbox)\b",
     re.IGNORECASE,
 )
 
@@ -53,13 +58,18 @@ def maybe_inject_car_awareness(
     return f"{injection}\n\n{prompt_text}", True
 
 
-def maybe_inject_prompt_writing_hint(prompt_text: str) -> tuple[str, bool]:
+def maybe_inject_prompt_writing_hint(
+    prompt_text: str,
+    *,
+    trigger_text: str | None = None,
+) -> tuple[str, bool]:
     """Inject prompt-writing formatting hint when the message is about prompts."""
     if not prompt_text or not prompt_text.strip():
         return prompt_text, False
     if PROMPT_WRITING_HINT in prompt_text:
         return prompt_text, False
-    if not _PROMPT_CONTEXT_RE.search(prompt_text):
+    trigger_text = trigger_text if isinstance(trigger_text, str) else prompt_text
+    if not _PROMPT_CONTEXT_RE.search(trigger_text):
         return prompt_text, False
     return _append_injected_context(
         prompt_text,
@@ -74,17 +84,32 @@ def has_file_context_signal(prompt_text: str) -> bool:
     return bool(_FILE_CONTEXT_SIGNAL_RE.search(prompt_text))
 
 
+def has_user_filebox_hint_request(
+    user_input_texts: Sequence[str | None] | None,
+) -> bool:
+    """Return True when raw user-supplied text explicitly mentions FileBox terms."""
+    if not user_input_texts:
+        return False
+    for text in user_input_texts:
+        if not isinstance(text, str):
+            continue
+        if _FILEBOX_HINT_KEYWORD_RE.search(text):
+            return True
+    return False
+
+
 def should_inject_filebox_hint(
     prompt_text: str,
     *,
     has_file_context: bool = False,
+    user_input_texts: Sequence[str | None] | None = None,
 ) -> bool:
-    """Gate filebox hints to turns with concrete file context."""
+    """Gate filebox hints to raw user requests or turns with concrete file context."""
     if not prompt_text or not prompt_text.strip():
         return False
     if "Outbox (pending):" in prompt_text or "Inbox:" in prompt_text:
         return False
-    if not has_file_context and not has_file_context_signal(prompt_text):
+    if not has_file_context and not has_user_filebox_hint_request(user_input_texts):
         return False
     return True
 
@@ -94,11 +119,13 @@ def maybe_inject_filebox_hint(
     *,
     hint_text: str,
     has_file_context: bool = False,
+    user_input_texts: Sequence[str | None] | None = None,
 ) -> tuple[str, bool]:
-    """Inject filebox guidance only when file context is available."""
+    """Inject filebox guidance for explicit user requests or real file context."""
     if not should_inject_filebox_hint(
         prompt_text,
         has_file_context=has_file_context,
+        user_input_texts=user_input_texts,
     ):
         return prompt_text, False
     return _append_injected_context(prompt_text, hint_text)

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -19,8 +19,11 @@ from ...agents.base import (
 from ...agents.registry import get_registered_agents
 from ...core.context_awareness import (
     maybe_inject_car_awareness,
+    maybe_inject_filebox_hint,
     maybe_inject_prompt_writing_hint,
 )
+from ...core.filebox import inbox_dir, outbox_dir, outbox_pending_dir
+from ...core.injected_context import wrap_injected_context
 from ...core.orchestration import (
     FlowTarget,
     MessageRequest,
@@ -228,6 +231,30 @@ def _stash_discord_reusable_progress_message(
             channel_id=normalized_channel_id,
             message_id=normalized_message_id,
         )
+    )
+
+
+def _maybe_inject_discord_filebox_hint(
+    prompt_text: str,
+    *,
+    user_text: str,
+    workspace_root: Path,
+) -> tuple[str, bool]:
+    """Inject repo FileBox paths when the raw Discord turn requests them."""
+    hint_text = wrap_injected_context(
+        "\n".join(
+            [
+                f"Inbox: {inbox_dir(workspace_root)}",
+                f"Outbox: {outbox_dir(workspace_root)}",
+                f"Outbox (pending): {outbox_pending_dir(workspace_root)}",
+                "Use inbox files as local inputs and place reply files in outbox.",
+            ]
+        )
+    )
+    return maybe_inject_filebox_hint(
+        prompt_text,
+        hint_text=hint_text,
+        user_input_texts=[user_text],
     )
 
 
@@ -649,12 +676,28 @@ async def handle_message_event(
                     channel_id=channel_id,
                     message_id=event.message.message_id,
                 )
-            prompt_text, injected = maybe_inject_prompt_writing_hint(prompt_text)
+            prompt_text, injected = maybe_inject_prompt_writing_hint(
+                prompt_text,
+                trigger_text=text,
+            )
             if injected:
                 log_event_fn(
                     service._logger,
                     logging.INFO,
                     "discord.prompt_context.injected",
+                    channel_id=channel_id,
+                    message_id=event.message.message_id,
+                )
+            prompt_text, injected = _maybe_inject_discord_filebox_hint(
+                prompt_text,
+                user_text=text,
+                workspace_root=workspace_root,
+            )
+            if injected:
+                log_event_fn(
+                    service._logger,
+                    logging.INFO,
+                    "discord.filebox_context.injected",
                     channel_id=channel_id,
                     message_id=event.message.message_id,
                 )

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -1561,8 +1561,16 @@ class ExecutionCommands(TelegramCommandSupportMixin):
             allow_cross_repo=allow_cross_repo,
         )
 
-    def _maybe_inject_prompt_context(self, prompt_text: str) -> tuple[str, bool]:
-        return maybe_inject_prompt_writing_hint(prompt_text)
+    def _maybe_inject_prompt_context(
+        self,
+        prompt_text: str,
+        *,
+        trigger_text: Optional[str] = None,
+    ) -> tuple[str, bool]:
+        return maybe_inject_prompt_writing_hint(
+            prompt_text,
+            trigger_text=trigger_text,
+        )
 
     def _maybe_inject_car_context(self, prompt_text: str) -> tuple[str, bool]:
         return maybe_inject_car_awareness(
@@ -1576,6 +1584,8 @@ class ExecutionCommands(TelegramCommandSupportMixin):
         *,
         record: "TelegramTopicRecord",
         topic_key: str,
+        has_file_context: bool = False,
+        user_input_text: Optional[str] = None,
     ) -> tuple[str, bool]:
         inbox_dir = self._files_inbox_dir(record.workspace_path, topic_key)
         outbox_dir = self._files_outbox_pending_dir(record.workspace_path, topic_key)
@@ -1591,7 +1601,8 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                     max_bytes=self._config.media.max_file_bytes,
                 )
             ),
-            has_file_context=True,
+            has_file_context=has_file_context,
+            user_input_texts=[user_input_text],
         )
 
     def _has_turn_file_context(
@@ -1599,8 +1610,11 @@ class ExecutionCommands(TelegramCommandSupportMixin):
         message: TelegramMessage,
         prompt_text: str,
         input_items: Optional[list[dict[str, Any]]],
+        *,
+        user_input_text: Optional[str] = None,
     ) -> bool:
-        if has_file_context_signal(prompt_text):
+        source_text = user_input_text if user_input_text is not None else prompt_text
+        if has_file_context_signal(source_text):
             return True
         if message.photos or message.document or message.audio or message.voice:
             return True
@@ -3588,11 +3602,17 @@ class ExecutionCommands(TelegramCommandSupportMixin):
         record: "TelegramTopicRecord",
         *,
         input_items: Optional[list[dict[str, Any]]] = None,
+        user_input_text: Optional[str] = None,
     ) -> tuple[str, str]:
         key = await self._resolve_topic_key(message.chat_id, message.thread_id)
+        raw_user_input = (
+            user_input_text if user_input_text is not None else message.text
+        )
 
         prompt_text, injected = await self._maybe_inject_github_context(
-            prompt_text, record
+            prompt_text,
+            record,
+            link_source_text=raw_user_input,
         )
         if injected:
             await self._send_message(
@@ -3613,7 +3633,10 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 message_id=message.message_id,
             )
 
-        prompt_text, injected = self._maybe_inject_prompt_context(prompt_text)
+        prompt_text, injected = self._maybe_inject_prompt_context(
+            prompt_text,
+            trigger_text=raw_user_input,
+        )
         if injected:
             log_event(
                 self._logger,
@@ -3624,19 +3647,28 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 message_id=message.message_id,
             )
 
-        if self._has_turn_file_context(message, prompt_text, input_items):
-            prompt_text, injected = self._maybe_inject_outbox_context(
-                prompt_text, record=record, topic_key=key
+        has_file_context = self._has_turn_file_context(
+            message,
+            prompt_text,
+            input_items,
+            user_input_text=user_input_text,
+        )
+        prompt_text, injected = self._maybe_inject_outbox_context(
+            prompt_text,
+            record=record,
+            topic_key=key,
+            has_file_context=has_file_context,
+            user_input_text=raw_user_input,
+        )
+        if injected:
+            log_event(
+                self._logger,
+                logging.INFO,
+                "telegram.outbox_context.injected",
+                chat_id=message.chat_id,
+                thread_id=message.thread_id,
+                message_id=message.message_id,
             )
-            if injected:
-                log_event(
-                    self._logger,
-                    logging.INFO,
-                    "telegram.outbox_context.injected",
-                    chat_id=message.chat_id,
-                    thread_id=message.thread_id,
-                    message_id=message.message_id,
-                )
 
         return prompt_text, key
 
@@ -3802,7 +3834,13 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 )
         else:
             prompt_text, key = await self._prepare_turn_context(
-                message, prompt_text, record, input_items=input_items
+                message,
+                prompt_text,
+                record,
+                input_items=input_items,
+                user_input_text=(
+                    text_override if text_override is not None else message.text
+                ),
             )
 
         if (

--- a/tests/core/test_car_context.py
+++ b/tests/core/test_car_context.py
@@ -10,6 +10,10 @@ from codex_autorunner.core.car_context import (
     render_runtime_compat_agents_md,
     resolve_effective_car_context_profile,
 )
+from codex_autorunner.core.context_awareness import (
+    CAR_AWARENESS_BLOCK,
+    maybe_inject_filebox_hint,
+)
 
 
 def test_default_managed_thread_context_profile_for_repo_threads() -> None:
@@ -68,6 +72,30 @@ def test_runtime_projection_for_core_profile_mentions_car_artifacts() -> None:
     assert "# AGENTS" in rendered
     assert ".codex-autorunner/ABOUT_CAR.md" in rendered
     assert ".codex-autorunner/tickets/" in rendered
+
+
+def test_filebox_hint_uses_raw_user_input_not_injected_context() -> None:
+    prompt, injected = maybe_inject_filebox_hint(
+        CAR_AWARENESS_BLOCK,
+        hint_text="hint",
+        user_input_texts=["please summarize"],
+    )
+
+    assert injected is False
+    assert prompt == CAR_AWARENESS_BLOCK
+
+
+def test_filebox_hint_triggers_from_raw_user_keyword_even_with_injected_context() -> (
+    None
+):
+    prompt, injected = maybe_inject_filebox_hint(
+        CAR_AWARENESS_BLOCK,
+        hint_text="hint",
+        user_input_texts=["check outbox"],
+    )
+
+    assert injected is True
+    assert prompt.endswith("hint")
 
 
 def test_normalize_car_context_profile_rejects_unknown_values() -> None:

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -1253,8 +1253,9 @@ def _message_create(
     guild_id: str = "guild-1",
     channel_id: str = "channel-1",
     attachments: Optional[list[dict[str, Any]]] = None,
+    extra_payload: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
-    return {
+    payload = {
         "id": message_id,
         "channel_id": channel_id,
         "guild_id": guild_id,
@@ -1262,6 +1263,9 @@ def _message_create(
         "author": {"id": "user-1", "bot": False},
         "attachments": attachments or [],
     }
+    if extra_payload:
+        payload.update(extra_payload)
+    return payload
 
 
 @pytest.mark.anyio
@@ -2056,6 +2060,223 @@ async def test_message_create_non_pma_injects_prompt_context_hints(
         assert CAR_AWARENESS_BLOCK not in captured_prompts[0]
         assert PROMPT_WRITING_HINT in captured_prompts[0]
         assert "please write a prompt for triage" in captured_prompts[0]
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_message_create_non_pma_prompt_hint_ignores_reply_context_prompt_text(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            (
+                "MESSAGE_CREATE",
+                _message_create(
+                    "please review this",
+                    extra_payload={
+                        "message_reference": {
+                            "message_id": "parent-1",
+                            "channel_id": "channel-1",
+                        },
+                        "referenced_message": {
+                            "content": "write a prompt for this later",
+                            "author": {"id": "user-2", "username": "alice"},
+                        },
+                    },
+                ),
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    captured_prompts: list[str] = []
+
+    async def _fake_run_turn(
+        self,
+        *,
+        workspace_root: Path,
+        prompt_text: str,
+        agent: str,
+        model_override: Optional[str],
+        reasoning_effort: Optional[str],
+        session_key: str,
+        orchestrator_channel_key: str,
+    ) -> str:
+        _ = (
+            workspace_root,
+            agent,
+            model_override,
+            reasoning_effort,
+            session_key,
+            orchestrator_channel_key,
+        )
+        captured_prompts.append(prompt_text)
+        return "Done from fake turn"
+
+    service._run_agent_turn_for_message = _fake_run_turn.__get__(
+        service, DiscordBotService
+    )
+
+    try:
+        await service.run_forever()
+        assert captured_prompts
+        prompt = captured_prompts[0]
+        assert "please review this" in prompt
+        assert "Replying to message" in prompt
+        assert "write a prompt for this later" in prompt
+        assert PROMPT_WRITING_HINT not in prompt
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_message_create_non_pma_injects_filebox_hint_for_outbox_keyword(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway([("MESSAGE_CREATE", _message_create("outbox me"))])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    captured_prompts: list[str] = []
+
+    async def _fake_run_turn(
+        self,
+        *,
+        workspace_root: Path,
+        prompt_text: str,
+        agent: str,
+        model_override: Optional[str],
+        reasoning_effort: Optional[str],
+        session_key: str,
+        orchestrator_channel_key: str,
+    ) -> str:
+        _ = (
+            workspace_root,
+            agent,
+            model_override,
+            reasoning_effort,
+            session_key,
+            orchestrator_channel_key,
+        )
+        captured_prompts.append(prompt_text)
+        return "Done from fake turn"
+
+    service._run_agent_turn_for_message = _fake_run_turn.__get__(
+        service, DiscordBotService
+    )
+
+    try:
+        await service.run_forever()
+        assert captured_prompts
+        prompt = captured_prompts[0]
+        assert "outbox me" in prompt
+        assert str(inbox_dir(workspace.resolve())) in prompt
+        assert str(outbox_dir(workspace.resolve())) in prompt
+        assert str(outbox_pending_dir(workspace.resolve())) in prompt
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_message_create_non_pma_injects_filebox_hint_for_inbox_keyword(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway([("MESSAGE_CREATE", _message_create("check inbox"))])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    captured_prompts: list[str] = []
+
+    async def _fake_run_turn(
+        self,
+        *,
+        workspace_root: Path,
+        prompt_text: str,
+        agent: str,
+        model_override: Optional[str],
+        reasoning_effort: Optional[str],
+        session_key: str,
+        orchestrator_channel_key: str,
+    ) -> str:
+        _ = (
+            workspace_root,
+            agent,
+            model_override,
+            reasoning_effort,
+            session_key,
+            orchestrator_channel_key,
+        )
+        captured_prompts.append(prompt_text)
+        return "Done from fake turn"
+
+    service._run_agent_turn_for_message = _fake_run_turn.__get__(
+        service, DiscordBotService
+    )
+
+    try:
+        await service.run_forever()
+        assert captured_prompts
+        prompt = captured_prompts[0]
+        assert "check inbox" in prompt
+        assert str(inbox_dir(workspace.resolve())) in prompt
+        assert str(outbox_dir(workspace.resolve())) in prompt
+        assert str(outbox_pending_dir(workspace.resolve())) in prompt
     finally:
         await store.close()
 

--- a/tests/test_context_awareness.py
+++ b/tests/test_context_awareness.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from codex_autorunner.core.context_awareness import (
+    CAR_AWARENESS_BLOCK,
+    maybe_inject_filebox_hint,
+)
+
+
+def test_filebox_hint_injected_for_raw_user_keyword() -> None:
+    prompt, injected = maybe_inject_filebox_hint(
+        "please handle this",
+        hint_text="<injected context>\nInbox: /tmp/inbox\n</injected context>",
+        user_input_texts=["check outbox"],
+    )
+
+    assert injected is True
+    assert "Inbox: /tmp/inbox" in prompt
+
+
+def test_filebox_hint_not_injected_from_car_context_keyword_only() -> None:
+    prompt, injected = maybe_inject_filebox_hint(
+        CAR_AWARENESS_BLOCK,
+        hint_text="<injected context>\nInbox: /tmp/inbox\n</injected context>",
+    )
+
+    assert injected is False
+    assert prompt == CAR_AWARENESS_BLOCK

--- a/tests/test_telegram_car_context.py
+++ b/tests/test_telegram_car_context.py
@@ -6,6 +6,10 @@ from types import SimpleNamespace
 
 import pytest
 
+from codex_autorunner.core.context_awareness import (
+    CAR_AWARENESS_BLOCK,
+    PROMPT_WRITING_HINT,
+)
 from codex_autorunner.integrations.telegram.adapter import (
     TelegramDocument,
     TelegramMessage,
@@ -21,6 +25,7 @@ class _ContextExecutionStub(ExecutionCommands):
         self._logger = logging.getLogger("test")
         self._config = SimpleNamespace(media=SimpleNamespace(max_file_bytes=1024))
         self._workspace_path = workspace_path
+        self.sent_messages: list[dict[str, object]] = []
 
     async def _resolve_topic_key(self, chat_id: int, thread_id: int | None) -> str:
         return f"{chat_id}:{thread_id}"
@@ -44,6 +49,23 @@ class _ContextExecutionStub(ExecutionCommands):
 
     def _files_outbox_pending_dir(self, workspace_path: str, topic_key: str) -> Path:
         return self._files_topic_dir(workspace_path, topic_key) / "outbox" / "pending"
+
+    async def _send_message(
+        self,
+        chat_id: int,
+        text: str,
+        *,
+        thread_id: int | None = None,
+        reply_to: int | None = None,
+    ) -> None:
+        self.sent_messages.append(
+            {
+                "chat_id": chat_id,
+                "text": text,
+                "thread_id": thread_id,
+                "reply_to": reply_to,
+            }
+        )
 
 
 def test_telegram_car_context_not_injected_for_plain_repo_turn() -> None:
@@ -70,7 +92,7 @@ def test_telegram_car_context_injected_for_car_trigger() -> None:
 
 
 @pytest.mark.anyio
-async def test_telegram_file_hints_not_injected_for_plain_text_keywords(
+async def test_telegram_file_hints_injected_for_plain_text_outbox_keyword(
     tmp_path: Path,
 ) -> None:
     handler = _ContextExecutionStub(tmp_path)
@@ -91,6 +113,63 @@ async def test_telegram_file_hints_not_injected_for_plain_text_keywords(
         "check outbox for report.txt",
         record,
         input_items=None,
+    )
+
+    assert "Outbox (pending):" in prompt
+    assert "Inbox:" in prompt
+
+
+@pytest.mark.anyio
+async def test_telegram_file_hints_injected_for_plain_text_inbox_keyword(
+    tmp_path: Path,
+) -> None:
+    handler = _ContextExecutionStub(tmp_path)
+    record = TelegramTopicRecord(workspace_path=str(tmp_path))
+    message = TelegramMessage(
+        update_id=6,
+        message_id=7,
+        chat_id=8,
+        thread_id=9,
+        from_user_id=10,
+        text="check inbox",
+        date=None,
+        is_topic_message=True,
+    )
+
+    prompt, _topic_key = await handler._prepare_turn_context(
+        message,
+        "check inbox",
+        record,
+        input_items=None,
+    )
+
+    assert "Outbox (pending):" in prompt
+    assert "Inbox:" in prompt
+
+
+@pytest.mark.anyio
+async def test_telegram_file_hints_do_not_trigger_from_injected_car_context(
+    tmp_path: Path,
+) -> None:
+    handler = _ContextExecutionStub(tmp_path)
+    record = TelegramTopicRecord(workspace_path=str(tmp_path))
+    message = TelegramMessage(
+        update_id=11,
+        message_id=12,
+        chat_id=13,
+        thread_id=14,
+        from_user_id=15,
+        text="summarize the notes",
+        date=None,
+        is_topic_message=True,
+    )
+
+    prompt, _topic_key = await handler._prepare_turn_context(
+        message,
+        CAR_AWARENESS_BLOCK,
+        record,
+        input_items=None,
+        user_input_text="summarize the notes",
     )
 
     assert "Outbox (pending):" not in prompt
@@ -131,3 +210,85 @@ async def test_telegram_file_hints_injected_when_file_context_exists(
     assert "Inbox:" in prompt
     assert "Outbox (pending):" in prompt
     assert topic_key in prompt
+
+
+@pytest.mark.anyio
+async def test_telegram_prompt_hint_uses_raw_user_text_not_github_injection(
+    tmp_path: Path,
+) -> None:
+    handler = _ContextExecutionStub(tmp_path)
+    record = TelegramTopicRecord(workspace_path=str(tmp_path))
+    message = TelegramMessage(
+        update_id=31,
+        message_id=32,
+        chat_id=33,
+        thread_id=34,
+        from_user_id=35,
+        text="review this issue",
+        date=None,
+        is_topic_message=True,
+    )
+
+    async def _fake_github_context(
+        prompt_text: str,
+        _record: object,
+        *,
+        link_source_text: str | None = None,
+        allow_cross_repo: bool = False,
+    ) -> tuple[str, bool]:
+        _ = (link_source_text, allow_cross_repo)
+        return f"{prompt_text}\n\n<injected context>\nprompt\n</injected context>", True
+
+    handler._maybe_inject_github_context = _fake_github_context  # type: ignore[method-assign]
+
+    prompt, _topic_key = await handler._prepare_turn_context(
+        message,
+        "review this issue",
+        record,
+        input_items=None,
+    )
+
+    assert "<injected context>\nprompt\n</injected context>" in prompt
+    assert PROMPT_WRITING_HINT not in prompt
+
+
+@pytest.mark.anyio
+async def test_telegram_github_context_uses_raw_user_text_as_link_source(
+    tmp_path: Path,
+) -> None:
+    handler = _ContextExecutionStub(tmp_path)
+    record = TelegramTopicRecord(workspace_path=str(tmp_path))
+    message = TelegramMessage(
+        update_id=41,
+        message_id=42,
+        chat_id=43,
+        thread_id=44,
+        from_user_id=45,
+        text="plain user text",
+        date=None,
+        is_topic_message=True,
+    )
+    captured_link_sources: list[str | None] = []
+
+    async def _fake_github_context(
+        prompt_text: str,
+        _record: object,
+        *,
+        link_source_text: str | None = None,
+        allow_cross_repo: bool = False,
+    ) -> tuple[str, bool]:
+        _ = (prompt_text, allow_cross_repo)
+        captured_link_sources.append(link_source_text)
+        return prompt_text, False
+
+    handler._maybe_inject_github_context = _fake_github_context  # type: ignore[method-assign]
+
+    await handler._prepare_turn_context(
+        message,
+        "mutated prompt text",
+        record,
+        input_items=None,
+        user_input_text="https://github.com/example/repo/issues/123",
+    )
+
+    assert captured_link_sources == ["https://github.com/example/repo/issues/123"]

--- a/tests/test_telegram_pma_routing.py
+++ b/tests/test_telegram_pma_routing.py
@@ -1207,12 +1207,25 @@ class _PMAHandler(TelegramCommandHandlers):
     def _maybe_inject_car_context(self, prompt_text: str) -> tuple[str, bool]:
         return prompt_text, False
 
-    def _maybe_inject_prompt_context(self, prompt_text: str) -> tuple[str, bool]:
+    def _maybe_inject_prompt_context(
+        self,
+        prompt_text: str,
+        *,
+        trigger_text: Optional[str] = None,
+    ) -> tuple[str, bool]:
+        _ = trigger_text
         return prompt_text, False
 
     def _maybe_inject_outbox_context(
-        self, prompt_text: str, *, record: object, topic_key: str
+        self,
+        prompt_text: str,
+        *,
+        record: object,
+        topic_key: str,
+        has_file_context: bool = False,
+        user_input_text: Optional[str] = None,
     ) -> tuple[str, bool]:
+        _ = record, topic_key, has_file_context, user_input_text
         return prompt_text, False
 
     async def _prepare_turn_placeholder(

--- a/tests/test_telegram_turn_queue.py
+++ b/tests/test_telegram_turn_queue.py
@@ -180,12 +180,25 @@ class _HandlerStub(TelegramCommandHandlers):
     def _maybe_inject_car_context(self, prompt_text: str) -> tuple[str, bool]:
         return prompt_text, False
 
-    def _maybe_inject_prompt_context(self, prompt_text: str) -> tuple[str, bool]:
+    def _maybe_inject_prompt_context(
+        self,
+        prompt_text: str,
+        *,
+        trigger_text: Optional[str] = None,
+    ) -> tuple[str, bool]:
+        _ = trigger_text
         return prompt_text, False
 
     def _maybe_inject_outbox_context(
-        self, prompt_text: str, *, record: object, topic_key: str
+        self,
+        prompt_text: str,
+        *,
+        record: object,
+        topic_key: str,
+        has_file_context: bool = False,
+        user_input_text: Optional[str] = None,
     ) -> tuple[str, bool]:
+        _ = record, topic_key, has_file_context, user_input_text
         return prompt_text, False
 
     def _effective_policies(self, _record: TelegramTopicRecord) -> tuple[None, None]:


### PR DESCRIPTION
## What changed
- restored Discord and Telegram filebox context hints when the raw user message explicitly mentions `inbox`, `outbox`, or `filebox`
- moved the trigger logic into shared context-awareness helpers so injected CAR/system context no longer trips these hints
- aligned adjacent prompt/GitHub context triggers to use raw user input where needed and added regression coverage

## Why
A regression removed the user-keyword-driven filebox hint path, so agents lost the repo-local inbox/outbox guidance unless there was already attachment context. Discord and Telegram had also drifted slightly in how neighboring prompt/GitHub triggers used mutated prompt text.

## Impact
- users can again ask for inbox/outbox handling directly from chat without making agents always assume outbox behavior
- Discord and Telegram now share the same raw-user-input-based filebox hint behavior
- prompt-writing and GitHub-link injection are less likely to be triggered by forwarded, replied, or injected context

## Validation
- targeted context and chat integration tests
- full pre-commit suite via `git commit`, including repo-wide checks and pytest
- latest focused rerun: `93 passed, 94 deselected`
