### PR TITLE
[codex] Fix ACP prompt event ordering

### DIFF
--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -635,7 +635,7 @@ class ACPClient:
             if state is None:
                 self._orphan_events[event.turn_id].append(event)
             else:
-                await self._record_prompt_event(state, event)
+                await self._record_prompt_event_in_order(state, event)
 
     async def _handle_server_request(
         self, message: dict[str, Any], *, request_id: str
@@ -648,7 +648,7 @@ class ACPClient:
             if state is None:
                 self._orphan_events[event.turn_id].append(event)
             else:
-                await self._record_prompt_event(state, event)
+                await self._record_prompt_event_in_order(state, event)
         if self._notification_handler is not None:
             await self._notification_handler(event)
 
@@ -723,6 +723,21 @@ class ACPClient:
     ) -> None:
         for event in events:
             await self._record_prompt_event(state, event)
+
+    async def _record_prompt_event_in_order(
+        self,
+        state: _PromptState,
+        event: ACPEvent,
+    ) -> None:
+        replay_task = state.replay_task
+        current_task = asyncio.current_task()
+        if (
+            replay_task is not None
+            and replay_task is not current_task
+            and not replay_task.done()
+        ):
+            await asyncio.shield(replay_task)
+        await self._record_prompt_event(state, event)
 
     def _log_background_task_result(self, task: asyncio.Task[Any]) -> None:
         try:


### PR DESCRIPTION
## Summary
Fix ACP prompt event ordering by waiting for orphan-event replay to finish before recording newly arrived prompt events for the same turn.

## Root Cause
`ACPClient.start_prompt()` can create prompt state after some turn events have already arrived. Those early events are replayed from `_orphan_events` in a background task, while later live events are recorded immediately. That made event order depend on task scheduling, which is exactly what made `test_client_prompt_streams_updates_and_calls_permission_hook` flaky.

## What Changed
- route live prompt events through `_record_prompt_event_in_order()`
- block live recording on `state.replay_task` when orphan replay is still in progress
- preserve the existing event stream and test expectations without reclassifying the test as slow or integration

## Validation
- `.venv/bin/pytest -q tests/agents/acp/test_client.py -k prompt_streams_updates_and_calls_permission_hook`
- `.venv/bin/python -m pytest -q tests/agents/acp/test_client.py`
- repeated the flaky test 30 times successfully
- repo pre-commit checks passed, including repo-wide pytest (3830 passed, 1 skipped)