### PR TITLE
[codex] fix repo-owned PR publish defaults

### DIFF
--- a/src/codex_autorunner/integrations/github/context_injection.py
+++ b/src/codex_autorunner/integrations/github/context_injection.py
@@ -22,6 +22,9 @@ _ISSUE_ONLY_LINK_WRAPPERS = (
 _ISSUE_ONLY_LEADING_MENTION_RE = re.compile(
     r"^(?:(?:<@!?\d+>|<@&\d+>|<#\d+>)\s*[:,]?\s*)+"
 )
+READY_FOR_REVIEW_PR_DEFAULT_HINT = (
+    "Default to a ready-for-review PR unless the user explicitly asks for a draft."
+)
 
 
 def issue_only_link(prompt_text: str, links: list[str]) -> Optional[str]:
@@ -47,6 +50,7 @@ def issue_only_workflow_hint(issue_number: int) -> str:
         "Create a new branch from the latest head branch, "
         "sync with the current origin default branch first,\n"
         "implement the fix, and open a PR.\n"
+        f"{READY_FOR_REVIEW_PR_DEFAULT_HINT}\n"
         f"Ensure the PR description includes `Closes #{issue_number}` "
         "so GitHub auto-closes the issue when merged."
     )

--- a/src/codex_autorunner/surfaces/cli/commands/hub_tickets.py
+++ b/src/codex_autorunner/surfaces/cli/commands/hub_tickets.py
@@ -125,6 +125,7 @@ def _append_setup_pack_final_tickets(
     }
     pr_body = (
         "Open or update the pull request.\n"
+        "Default to a ready-for-review PR unless the user explicitly asked for a draft.\n"
         "Add `pr_url` to this ticket frontmatter after the PR exists so hub summaries can surface it."
     )
     atomic_write(pr_path, render_ticket_markdown(pr_frontmatter, pr_body))

--- a/tests/test_cli_hub_tickets_tools.py
+++ b/tests/test_cli_hub_tickets_tools.py
@@ -124,3 +124,16 @@ def test_hub_tickets_setup_pack_creates_final_tickets(
     assert "final-review" in payload
     assert "open-pr" in payload
     assert "preflight" in payload
+
+    pr_ticket = (
+        hub_env.hub_root
+        / "worktrees"
+        / f"{hub_env.repo_id}--feature/setup-pack"
+        / ".codex-autorunner"
+        / "tickets"
+        / "TICKET-003-open-pr.md"
+    )
+    _frontmatter, body = parse_markdown_frontmatter(
+        pr_ticket.read_text(encoding="utf-8")
+    )
+    assert "ready-for-review PR unless the user explicitly asked for a draft" in body

--- a/tests/test_github_context_injection.py
+++ b/tests/test_github_context_injection.py
@@ -91,6 +91,7 @@ async def test_pma_injection_falls_back_to_workspace_when_repo_not_found(
     assert injected is True
     assert "Context: injected" in injected_prompt
     assert "Issue-only GitHub message detected" in injected_prompt
+    assert "Default to a ready-for-review PR" in injected_prompt
     assert "Closes #123" in injected_prompt
 
 
@@ -119,6 +120,7 @@ async def test_pma_injection_issue_only_with_discord_mention_prefix(
 
     assert injected is True
     assert "Issue-only GitHub message detected" in injected_prompt
+    assert "Default to a ready-for-review PR" in injected_prompt
     assert "Closes #123" in injected_prompt
 
 

--- a/tests/test_telegram_github_context_injection.py
+++ b/tests/test_telegram_github_context_injection.py
@@ -71,6 +71,7 @@ async def test_issue_only_link_injects_branch_and_pr_workflow_hint(
     )
     assert "Issue-only GitHub message detected" in injected_prompt
     assert "latest head branch" in injected_prompt
+    assert "ready-for-review PR" in injected_prompt
     assert "Closes #321" in injected_prompt
 
 


### PR DESCRIPTION
## Summary
- default repo-owned GitHub issue-only workflow guidance to ready-for-review PRs unless the user explicitly asks for a draft
- update generated `Open PR` tickets to carry the same ready-for-review default
- add regression coverage for the injected GitHub hint and setup-pack PR ticket text

## Validation
- `pytest tests/test_github_context_injection.py tests/test_telegram_github_context_injection.py tests/test_cli_hub_tickets_tools.py -q`
- repo commit hooks passed during `git commit`, including repo-wide formatting/lint/type/build/test checks
