### PR TITLE
[codex] Fix Hermes-linked command capability mapping

### DIFF
--- a/src/codex_autorunner/agents/types.py
+++ b/src/codex_autorunner/agents/types.py
@@ -10,6 +10,11 @@ RuntimeCapability = NewType("RuntimeCapability", str)
 _RUNTIME_CAPABILITY_ALIASES = {
     "threads": "durable_threads",
     "turns": "message_turns",
+    "session_resume": "durable_threads",
+    "pma_thread_reset": "durable_threads",
+    "conversation_compaction": "message_turns",
+    "code_review": "review",
+    "turn_control": "interrupt",
 }
 
 

--- a/src/codex_autorunner/core/orchestration/catalog.py
+++ b/src/codex_autorunner/core/orchestration/catalog.py
@@ -15,6 +15,11 @@ RuntimeCapability = str
 _RUNTIME_CAPABILITY_ALIASES = {
     "threads": "durable_threads",
     "turns": "message_turns",
+    "session_resume": "durable_threads",
+    "pma_thread_reset": "durable_threads",
+    "conversation_compaction": "message_turns",
+    "code_review": "review",
+    "turn_control": "interrupt",
 }
 
 

--- a/src/codex_autorunner/integrations/chat/command_contract.py
+++ b/src/codex_autorunner/integrations/chat/command_contract.py
@@ -411,7 +411,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         discord_paths=(("car", "session", "resume"),),
         discord_ack_policy="defer_ephemeral",
         discord_exposure="public",
-        required_capabilities=("session_resume",),
+        required_capabilities=("durable_threads",),
     ),
     CommandContractEntry(
         id="car.reset",
@@ -422,7 +422,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         discord_paths=(("car", "session", "reset"),),
         discord_ack_policy="defer_ephemeral",
         discord_exposure="public",
-        required_capabilities=("pma_thread_reset",),
+        required_capabilities=("durable_threads",),
     ),
     CommandContractEntry(
         id="car.review",
@@ -433,7 +433,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         discord_paths=(("car", "review"),),
         discord_ack_policy="defer_ephemeral",
         discord_exposure="public",
-        required_capabilities=("code_review",),
+        required_capabilities=("review",),
     ),
     CommandContractEntry(
         id="car.approvals",
@@ -474,7 +474,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         discord_paths=(("car", "session", "compact"),),
         discord_ack_policy="defer_ephemeral",
         discord_exposure="public",
-        required_capabilities=("conversation_compaction",),
+        required_capabilities=("message_turns",),
     ),
     CommandContractEntry(
         id="car.rollout",
@@ -517,7 +517,7 @@ COMMAND_CONTRACT: tuple[CommandContractEntry, ...] = (
         discord_paths=(("car", "session", "interrupt"),),
         discord_ack_policy="defer_ephemeral",
         discord_exposure="public",
-        required_capabilities=("turn_control",),
+        required_capabilities=("interrupt",),
     ),
 )
 

--- a/tests/agents/test_registry_capabilities.py
+++ b/tests/agents/test_registry_capabilities.py
@@ -21,7 +21,15 @@ def _make_descriptor(capabilities: frozenset[str]) -> AgentDescriptor:
 
 def test_normalize_agent_capabilities_canonicalizes_legacy_aliases() -> None:
     capabilities = normalize_agent_capabilities(
-        ["threads", "turns", "interrupt", "active_thread_discovery"]
+        [
+            "threads",
+            "turns",
+            "session_resume",
+            "conversation_compaction",
+            "code_review",
+            "turn_control",
+            "active_thread_discovery",
+        ]
     )
 
     assert capabilities == frozenset(
@@ -29,6 +37,7 @@ def test_normalize_agent_capabilities_canonicalizes_legacy_aliases() -> None:
             "durable_threads",
             "message_turns",
             "interrupt",
+            "review",
             "active_thread_discovery",
         ]
     )

--- a/tests/integrations/chat/test_command_contract.py
+++ b/tests/integrations/chat/test_command_contract.py
@@ -133,6 +133,18 @@ def test_command_contract_discord_metadata_is_present_for_registered_paths() -> 
     assert by_id["car.flow.restart"].discord_ack_timing == "post_private_preflight"
 
 
+def test_command_contract_uses_canonical_runtime_capabilities_for_agent_linked_commands() -> (
+    None
+):
+    by_id = {entry.id: entry for entry in COMMAND_CONTRACT}
+
+    assert by_id["car.resume"].required_capabilities == ("durable_threads",)
+    assert by_id["car.reset"].required_capabilities == ("durable_threads",)
+    assert by_id["car.review"].required_capabilities == ("review",)
+    assert by_id["car.compact"].required_capabilities == ("message_turns",)
+    assert by_id["car.interrupt"].required_capabilities == ("interrupt",)
+
+
 def test_command_contract_telegram_metadata_is_present_for_runtime_commands() -> None:
     for name in telegram_runtime_command_names_from_contract():
         metadata = telegram_command_metadata_for_name(name)

--- a/tests/integrations/discord/test_capability_gating.py
+++ b/tests/integrations/discord/test_capability_gating.py
@@ -107,6 +107,12 @@ class TestCapabilityHelpers:
         )
 
         assert service._agent_supports_capability("hermes", "message_turns") is True
+        assert (
+            service._agent_supports_capability("hermes", "conversation_compaction")
+            is True
+        )
+        assert service._agent_supports_capability("hermes", "session_resume") is True
+        assert service._agent_supports_capability("hermes", "turn_control") is True
         assert service._agent_supports_capability("hermes", "model_listing") is False
         assert service._agent_supports_capability("hermes", "review") is False
         assert service._agent_supports_capability("codex", "model_listing") is True


### PR DESCRIPTION
## Summary

Fix the Discord/Telegram command-contract capability drift that made Hermes-linked session commands look unsupported even though Hermes already supports the underlying runtime features.

## What Changed

- Canonicalized the agent-linked command contract entries for:
  - `/car session resume`
  - `/car session reset`
  - `/car review`
  - `/car session compact`
  - `/car session interrupt`
- Added backward-compatible runtime capability aliases so older capability names still normalize to the canonical runtime vocabulary.
- Added regression coverage for:
  - capability alias normalization
  - canonical command-contract mappings
  - Hermes capability checks for compact/resume/interrupt aliases

## Why

`/car session compact` was being treated as unsupported for Hermes at the metadata/capability-linking layer even though the Hermes runtime supports `message_turns` and the Discord compact flow is implemented as a normal message-turn summary plus thread reset. The root cause was contract drift between legacy command capability names and the runtime capability vocabulary.

## Impact

- Hermes now resolves the linked session command capabilities consistently with Codex/OpenCode for the commands it actually supports.
- Unsupported Hermes actions remain unchanged and explicit:
  - review remains unsupported at runtime
  - model catalog listing remains unsupported
- `/car model` and `/car approvals` remain available under their existing surface-specific semantics.

## Validation

- `.venv/bin/python -m pytest tests/agents/test_registry_capabilities.py tests/integrations/chat/test_command_contract.py tests/integrations/discord/test_capability_gating.py tests/integrations/discord/test_message_turns.py -k 'car_session_compact or test_command_contract or test_normalize_agent_capabilities or test_agent_supports_capability_for_hermes'`
- Full pre-commit hooks passed during `git commit`, including repo-wide checks and pytest.

## Notes

This change fixes the command-capability linkage issue. It does not attempt to change the live Discord interaction transport/timeout path behind the separate "application did not respond" symptom.