### PR TITLE
Fix PMA passive managed-thread prioritization

### DIFF
--- a/src/codex_autorunner/core/pma_context.py
+++ b/src/codex_autorunner/core/pma_context.py
@@ -898,15 +898,17 @@ def _thread_followup_semantics(entry: Mapping[str, Any]) -> dict[str, Any]:
             or status_reason == "thread_resumed"
         ) and not is_stale:
             return {
-                "followup_state": "awaiting_followup",
-                "operator_need": "normal",
-                "recommended_action": "resume_managed_thread",
+                "followup_state": "reusable",
+                "operator_need": "optional",
+                "recommended_action": "consider_resuming_managed_thread",
                 "why_selected": (
-                    "Managed thread was recently created or resumed and likely "
-                    "needs its next turn"
+                    "Managed thread was recently created or resumed, but there is "
+                    "no explicit wake-up or continuity signal that PMA needs to "
+                    "act on it now"
                 ),
                 "recommended_detail_template": (
-                    'car pma thread send --id {managed_thread_id} --message "..." --watch'
+                    "Optional reuse: car pma thread send --id {managed_thread_id} "
+                    '--message "..." --watch'
                 ),
             }
         if is_stale:
@@ -1390,6 +1392,30 @@ def _build_automation_queue_items(
     return items
 
 
+def _is_strong_action_queue_item(item: Mapping[str, Any]) -> bool:
+    if bool(item.get("likely_false_positive")):
+        return False
+
+    item_type = str(item.get("item_type") or "").strip().lower()
+    followup_state = str(item.get("followup_state") or "").strip().lower()
+    operator_need = str(item.get("operator_need") or "").strip().lower()
+
+    if item_type in {
+        "managed_thread_followup_summary",
+        "pma_file_summary",
+    }:
+        return False
+    if item_type == "managed_thread_followup":
+        return followup_state in {"attention_required", "awaiting_followup"}
+    if item_type == "pma_file":
+        return True
+    if item_type == "automation_wakeup":
+        return True
+    if item.get("queue_source") == "ticket_flow_inbox":
+        return True
+    return operator_need in {"urgent", "normal"}
+
+
 def build_pma_action_queue(
     *,
     inbox: list[dict[str, Any]],
@@ -1426,7 +1452,14 @@ def build_pma_action_queue(
 
     winning_scope: dict[str, dict[str, Any]] = {}
     winning_repo_blocker: dict[str, dict[str, Any]] = {}
-    primary_queue_id = str(items[0].get("action_queue_id") or "") if items else None
+    primary_queue_id = next(
+        (
+            str(item.get("action_queue_id") or "")
+            for item in items
+            if _is_strong_action_queue_item(item)
+        ),
+        None,
+    )
     for index, item in enumerate(items, start=1):
         scope = item.get("scope") or {}
         scope_key = str(scope.get("key") or "")
@@ -1457,7 +1490,11 @@ def build_pma_action_queue(
                 reason=(
                     "Highest-priority actionable item in the queue"
                     if is_primary
-                    else "Actionable, but lower priority than the current primary item"
+                    else (
+                        "Actionable, but lower priority than the current primary item"
+                        if primary_queue_id
+                        else "Inventory or hygiene item; no strong next action currently"
+                    )
                 ),
             )
         if (
@@ -1677,6 +1714,13 @@ def _render_hub_snapshot(
     action_queue = snapshot.get("action_queue") or []
     if action_queue:
         lines.append("PMA Action Queue:")
+        has_primary = any(
+            (item.get("supersession") or {}).get("status") == "primary"
+            for item in action_queue
+            if isinstance(item, Mapping)
+        )
+        if not has_primary:
+            lines.append("- No strong next-action item right now")
         for item in list(action_queue)[: max(0, max_messages)]:
             queue_id = _truncate(
                 str(item.get("action_queue_id") or ""), max_field_chars

--- a/tests/test_pma_context.py
+++ b/tests/test_pma_context.py
@@ -746,11 +746,13 @@ def test_build_hub_snapshot_includes_action_queue_with_supersession(hub_env) -> 
     thread_item = next(
         item
         for item in queue
-        if item.get("managed_thread_id") == thread["managed_thread_id"]
+        if item.get("item_type") == "managed_thread_followup_summary"
+        and item.get("followup_state") == "reusable"
     )
     assert thread_item["queue_source"] == "managed_thread_followup"
-    assert thread_item["followup_state"] == "awaiting_followup"
-    assert thread_item["recommended_action"] == "resume_managed_thread"
+    assert thread_item["followup_state"] == "reusable"
+    assert thread["managed_thread_id"] in (thread_item.get("managed_thread_ids") or [])
+    assert thread_item["recommended_action"] == "show_reusable_threads"
     assert thread_item["supersession"]["status"] == "superseded"
     assert thread_item["supersession"]["superseded_by"] == queue[0]["action_queue_id"]
 
@@ -2460,7 +2462,7 @@ class TestIssue975CharacterizationMixedPmaState:
         assert "thread-idle-1" in (reusable_item.get("managed_thread_ids") or [])
         assert "thread-unowned-1" in (reusable_item.get("managed_thread_ids") or [])
 
-    def test_recently_resumed_thread_with_history_stays_awaiting_followup(
+    def test_recently_resumed_thread_with_history_stays_reusable_inventory(
         self, tmp_path: Path
     ) -> None:
         seed_hub_files(tmp_path, force=True)
@@ -2491,13 +2493,40 @@ class TestIssue975CharacterizationMixedPmaState:
             stale_threshold_seconds=3600,
         )
         resumed_item = next(
-            item for item in queue if item.get("managed_thread_id") == "thread-idle-1"
+            item
+            for item in queue
+            if item.get("item_type") == "managed_thread_followup_summary"
+            and item.get("followup_state") == "reusable"
+            and "thread-idle-1" in (item.get("managed_thread_ids") or [])
         )
 
-        assert resumed_item["followup_state"] == "awaiting_followup"
-        assert resumed_item["operator_need"] == "normal"
-        assert resumed_item["recommended_action"] == "resume_managed_thread"
-        assert "needs its next turn" in (resumed_item.get("why_selected") or "")
+        assert resumed_item["followup_state"] == "reusable"
+        assert resumed_item["operator_need"] == "optional"
+        assert resumed_item["recommended_action"] == "show_reusable_threads"
+        assert "thread-idle-1" in (resumed_item.get("managed_thread_ids") or [])
+
+    def test_low_signal_inventory_queue_has_no_primary_next_action(
+        self, tmp_path: Path
+    ) -> None:
+        from codex_autorunner.core.pma_context import _render_hub_snapshot
+
+        seed_hub_files(tmp_path, force=True)
+        snapshot = self.build_mixed_pma_snapshot(
+            include_dispatch=False,
+            include_failed_run=False,
+            include_completed_run=False,
+            include_pma_file=False,
+        )
+
+        queue = snapshot.get("action_queue") or []
+        assert queue
+        assert all(
+            (item.get("supersession") or {}).get("status") != "primary"
+            for item in queue
+        )
+
+        rendered = _render_hub_snapshot(snapshot)
+        assert "No strong next-action item right now" in rendered
 
     def test_stale_completed_thread_queue_item_becomes_cleanup_candidate(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary
- demote passive `thread_created` and `thread_resumed` managed-thread followups into reusable inventory instead of promoting them as active PMA follow-up work
- only assign a primary PMA next-action item when the queue contains a strong actionable signal; otherwise keep inventory/hygiene buckets non-primary
- render an explicit `No strong next-action item right now` line when the queue only contains low-signal buckets

## Testing
- .venv/bin/python -m pytest tests/test_pma_context.py -q
- pre-commit hook (`scripts/check.sh`): black, ruff, mypy, eslint, `pnpm run build`, `pnpm test:markdown`, fast-test budget, dead-code check, pytest

Closes #1171
