### PR TITLE
[codex] Harden Hermes ACP turn handling

### DIFF
--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -52,6 +52,7 @@ _PERMISSION_NOTIFICATION_METHODS = (
 )
 _ACP_PROTOCOL_VERSION = 1
 _OFFICIAL_ACP_INIT_KEYS = frozenset({"agentInfo", "agentCapabilities"})
+_ACP_STDOUT_NOISE_PREFIXES = ("┊", "╎", "│")
 
 
 @dataclass(frozen=True)
@@ -176,6 +177,18 @@ def _build_transport_error_message(
     if stderr_tail:
         message = f"{message}: {' | '.join(stderr_tail)}"
     return message
+
+
+def _coerce_stdout_text(line: bytes) -> str:
+    return line.decode("utf-8", errors="replace").strip()
+
+
+def _is_ignorable_stdout_noise(line: bytes) -> bool:
+    text = _coerce_stdout_text(line)
+    if not text:
+        return True
+    stripped = text.lstrip()
+    return stripped.startswith(_ACP_STDOUT_NOISE_PREFIXES)
 
 
 class ACPPromptHandle:
@@ -554,9 +567,17 @@ class ACPClient:
             line = await process.stdout.readline()
             if not line:
                 return
+            text = _coerce_stdout_text(line)
             try:
-                message = json.loads(line.decode("utf-8"))
+                message = json.loads(text)
             except json.JSONDecodeError as exc:
+                if _is_ignorable_stdout_noise(line):
+                    if text:
+                        self._logger.warning(
+                            "Ignoring non-JSON ACP stdout noise: %s",
+                            text[:200],
+                        )
+                    continue
                 error = ACPProtocolError(
                     f"ACP subprocess emitted invalid JSON: {line[:200]!r}"
                 )

--- a/src/codex_autorunner/core/orchestration/runtime_threads.py
+++ b/src/codex_autorunner/core/orchestration/runtime_threads.py
@@ -12,6 +12,9 @@ RuntimeThreadOutcomeStatus = Literal["ok", "error", "interrupted"]
 _INTERRUPT_POLL_INTERVAL_SECONDS = 0.05
 RUNTIME_THREAD_TIMEOUT_ERROR = "Runtime thread timed out"
 RUNTIME_THREAD_INTERRUPTED_ERROR = "Runtime thread interrupted"
+RUNTIME_THREAD_MISSING_BACKEND_IDS_ERROR = (
+    "Runtime thread execution is missing backend ids"
+)
 _SUCCESSFUL_COMPLETION_STATUSES = frozenset(
     {"ok", "completed", "complete", "done", "success"}
 )
@@ -153,6 +156,15 @@ async def await_runtime_thread_outcome(
 
     backend_thread_id = execution.thread.backend_thread_id or ""
     backend_turn_id = execution.execution.backend_id
+    if not backend_thread_id or not backend_turn_id:
+        return RuntimeThreadOutcome(
+            status="error",
+            assistant_text="",
+            error=RUNTIME_THREAD_MISSING_BACKEND_IDS_ERROR,
+            backend_thread_id=backend_thread_id,
+            backend_turn_id=backend_turn_id,
+            raw_events=(),
+        )
     collector_task = asyncio.create_task(
         execution.harness.wait_for_turn(
             execution.workspace_root,
@@ -296,6 +308,7 @@ async def _wait_for_interrupt(interrupt_event: asyncio.Event) -> None:
 
 __all__ = [
     "RUNTIME_THREAD_INTERRUPTED_ERROR",
+    "RUNTIME_THREAD_MISSING_BACKEND_IDS_ERROR",
     "RUNTIME_THREAD_TIMEOUT_ERROR",
     "RuntimeThreadExecution",
     "RuntimeThreadOutcome",

--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -926,6 +926,11 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
                             sandbox_policy=sandbox_policy,
                             input_items=request.input_items,
                         )
+                    resolved_turn_id = str(getattr(turn, "turn_id", "") or "").strip()
+                    if not resolved_turn_id:
+                        raise RuntimeError(
+                            f"Agent '{thread.agent_id}' returned an empty turn id"
+                        )
                     break
                 except FreshConversationRequiredError as exc:
                     if (
@@ -1004,7 +1009,9 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
                 resolved_conversation_id,
                 backend_runtime_instance_id=runtime_instance_id,
             )
-        self.thread_store.set_execution_backend_id(execution.execution_id, turn.turn_id)
+        self.thread_store.set_execution_backend_id(
+            execution.execution_id, resolved_turn_id
+        )
         refreshed = self.get_execution(thread.thread_target_id, execution.execution_id)
         if refreshed is None:
             raise KeyError(

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -190,6 +190,20 @@ async def test_client_reports_subprocess_crash_during_prompt(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
+async def test_client_ignores_known_cli_noise_on_stdout(tmp_path: Path) -> None:
+    client = ACPClient(fixture_command("basic"), cwd=tmp_path)
+    try:
+        session = await client.create_session(cwd=str(tmp_path))
+        handle = await client.start_prompt(session.session_id, "stdout noise")
+        result = await handle.wait()
+
+        assert result.status == "completed"
+        assert result.final_output == "fixture reply"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
 async def test_client_logs_background_permission_notification_task_failures(
     tmp_path: Path,
 ) -> None:

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Optional
@@ -16,6 +16,7 @@ from codex_autorunner.core.orchestration import (
     PmaThreadExecutionStore,
 )
 from codex_autorunner.core.orchestration.runtime_threads import (
+    RUNTIME_THREAD_MISSING_BACKEND_IDS_ERROR,
     await_runtime_thread_outcome,
     begin_runtime_thread_execution,
     stream_runtime_thread_events,
@@ -398,6 +399,39 @@ async def test_runtime_threads_allow_missing_interrupt_event(
 
     assert outcome.status == "ok"
     assert outcome.assistant_text == "assistant-output"
+
+
+async def test_runtime_threads_fail_cleanly_when_backend_ids_are_missing(
+    tmp_path: Path,
+) -> None:
+    harness = _HarnessWithWait()
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target("codex", workspace_root)
+
+    started = await begin_runtime_thread_execution(
+        service,
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="user-visible prompt",
+        ),
+    )
+    broken_started = replace(
+        started,
+        execution=replace(started.execution, backend_id=None),
+    )
+    outcome = await await_runtime_thread_outcome(
+        broken_started,
+        interrupt_event=None,
+        timeout_seconds=5,
+        execution_error_message="Managed thread execution failed",
+    )
+
+    assert outcome.status == "error"
+    assert outcome.error == RUNTIME_THREAD_MISSING_BACKEND_IDS_ERROR
+    assert harness.wait_calls == []
 
 
 async def test_runtime_threads_stream_events_support_hermes_harness(

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -407,6 +407,35 @@ async def test_send_message_creates_conversation_and_execution(tmp_path: Path) -
     assert running.execution_id == execution.execution_id
 
 
+async def test_send_message_rejects_empty_backend_turn_id(tmp_path: Path) -> None:
+    harness = _FakeHarness(next_turn_id="")
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target(
+        "codex",
+        workspace_root,
+        repo_id="repo-1",
+        display_name="Backlog",
+    )
+
+    execution = await service.send_message(
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="Ship it",
+        ),
+    )
+
+    refreshed_thread = service.get_thread_target(thread.thread_target_id)
+
+    assert execution.status == "error"
+    assert execution.backend_id is None
+    assert execution.error == "Agent 'codex' returned an empty turn id"
+    assert refreshed_thread is not None
+    assert refreshed_thread.backend_thread_id == "backend-conversation-1"
+
+
 async def test_send_review_resumes_existing_backend_thread(tmp_path: Path) -> None:
     harness = _FakeHarness(next_conversation_id="unused", next_turn_id="review-turn-1")
     service = _build_service(tmp_path, harness)

--- a/tests/fixtures/fake_acp_server.py
+++ b/tests/fixtures/fake_acp_server.py
@@ -16,6 +16,12 @@ def _write_line(lock: threading.Lock, payload: dict[str, Any]) -> None:
         sys.stdout.flush()
 
 
+def _write_raw_stdout(lock: threading.Lock, line: str) -> None:
+    with lock:
+        sys.stdout.write(line)
+        sys.stdout.flush()
+
+
 class FakeACPServer:
     def __init__(self, scenario: str) -> None:
         self._scenario = scenario
@@ -57,6 +63,11 @@ class FakeACPServer:
                 },
             }
         )
+        if prompt == "stdout noise":
+            _write_raw_stdout(
+                self._lock,
+                "  ┊ 💻 $ curl -fsS http://127.0.0.1:4517/car/hub... 0.3s\n",
+            )
         cancel_event = self._cancel_events[turn_id]
         if prompt == "needs permission":
             permission_id = f"perm-{self._next_permission}"


### PR DESCRIPTION
## What changed

This PR hardens CAR against two related Hermes-managed turn failures.

1. ACP stdout contamination containment
- Ignore known Hermes-style decorated CLI noise lines on ACP stdout instead of treating them as fatal protocol frames.
- Add a regression fixture/test that injects a `┊ 💻 $ ...` line before valid ACP output.

2. Managed runtime turn-id hardening
- Reject empty turn ids immediately after `start_turn` / `start_review` instead of persisting a broken execution.
- Refuse to call `wait_for_turn` when a runtime execution is already missing backend ids, returning a managed error instead of leaking a Hermes-specific exception.
- Add regression tests for both paths.

## Why

A Discord Hermes turn failed because Hermes ACP emitted human-readable tool progress on stdout, which CAR correctly parsed as invalid JSON.

After that, a follow-up Discord message hit a second failure path where CAR attempted to wait on a managed execution without a valid backend turn id, surfacing `Hermes wait_for_turn requires a turn id`.

This PR contains the first issue locally and hardens the second path so broken execution state fails deterministically.

## Impact

- Discord / PMA runtime turns are more resilient to Hermes ACP stdout contamination.
- Managed thread execution no longer degrades into a raw harness error when backend ids are missing.
- Future invalid runtime turn handles are caught at execution start.

## Validation

- `.venv/bin/python -m pytest tests/agents/acp/test_client.py tests/core/orchestration/test_runtime_threads.py tests/core/orchestration/test_service.py -q`
- Full pre-commit hook suite via `git commit`, including:
  - `black --check`
  - `ruff`
  - strict `mypy`
  - `pnpm run build`
  - `pnpm test:markdown`
  - repo pytest suite (`3851 passed, 1 skipped`)

## Root cause

Hermes ACP mode promises JSON-only stdout for ACP transport, but Hermes quiet-mode tool execution can still emit CLI display lines such as `┊ 💻 $ ...` on stdout. CAR treated that as malformed ACP JSON, which is correct protocol behavior.

The second error was a follow-on state issue: a managed execution without a valid backend turn id was allowed to flow into `wait_for_turn`.
