### PR TITLE
[codex] Harden shared ACP stdout noise filtering

### DIFF
--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -71,7 +71,7 @@ _ACP_STDOUT_NOISE_PREFIXES = (
     "╰",
     "╯",
 )
-_ACP_STDOUT_BRACKETED_STATUS_RE = re.compile(r"^\[[^\]\s]{1,32}\]\s+\S")
+_ACP_STDOUT_BRACKETED_STATUS_RE = re.compile(r"^\[[^\]\s]{1,32}\]\s+(?![\[{])\S")
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -222,6 +222,23 @@ async def test_client_rejects_unclassified_non_json_stdout(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
+async def test_client_rejects_bracketed_json_like_stdout(tmp_path: Path) -> None:
+    client = ACPClient(fixture_command("basic"), cwd=tmp_path)
+    try:
+        session = await client.create_session(cwd=str(tmp_path))
+        handle = await client.start_prompt(
+            session.session_id, "stdout invalid bracketed"
+        )
+
+        with pytest.raises(
+            ACPProtocolError, match="ACP subprocess emitted invalid JSON"
+        ):
+            await handle.wait()
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
 async def test_client_logs_background_permission_notification_task_failures(
     tmp_path: Path,
 ) -> None:

--- a/tests/fixtures/fake_acp_server.py
+++ b/tests/fixtures/fake_acp_server.py
@@ -76,6 +76,12 @@ class FakeACPServer:
         if prompt == "stdout invalid":
             _write_raw_stdout(self._lock, "ACP dependencies not installed.\n")
             return
+        if prompt == "stdout invalid bracketed":
+            _write_raw_stdout(
+                self._lock,
+                '[tool] {"id":"1","method":"prompt/completed"}\n',
+            )
+            return
         cancel_event = self._cancel_events[turn_id]
         if prompt == "needs permission":
             permission_id = f"perm-{self._next_permission}"


### PR DESCRIPTION
## Summary
This hardens CAR's shared ACP subprocess transport against incidental human-readable stdout noise without adding another agent-specific patch.

## What changed
- broadened `ACPClient` stdout noise detection to ignore obvious terminal display lines after JSON parsing fails
- kept the matcher structural and narrow: blank lines, box-drawing UI prefixes, and bracketed status labels like `[tool] ...`
- stripped ANSI control sequences before classifying stdout noise so colored status lines are also ignored
- preserved hard failure behavior for unclassified non-JSON stdout so real protocol breakage still surfaces
- consumed completed ACP transport task exceptions during shutdown so protocol-error cases do not leave `Task exception was never retrieved` warnings behind
- expanded the fake ACP fixture and client tests to cover glyph noise, bracketed status noise, blank lines, and a negative non-JSON stdout case

## Why
Hermes previously leaked multiple kinds of human-readable CLI/status output onto ACP stdout. CAR had already contained one concrete line shape, but the follow-up `[tool] ... deliberating...` failure showed the parser hardening was still too specific.

The shared ACP client is the right choke point because it is the only stdout JSON parser used by CAR's ACP subprocess supervisor. Hardening that layer protects all current ACP-backed agents instead of chasing backend-specific strings.

## Impact
- ACP-backed agents are more resilient to incidental terminal UI noise on stdout
- real malformed ACP frames still fail normally
- shutdown is cleaner after protocol failures

## Validation
- `.venv/bin/python -m pytest tests/agents/acp/test_client.py -q`
- commit hook suite:
  - `black --check`
  - `ruff check`
  - strict `mypy`
  - `pnpm run build`
  - `pnpm test:markdown`
  - repo `pytest` (`3855 passed, 1 skipped`)
