### PR TITLE
[codex] Surface Discord runtime start errors

### DIFF
--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -1320,6 +1320,10 @@ async def _finalize_discord_thread_execution(
         or started.thread.backend_thread_id
         or ""
     ).strip()
+    started_execution_status = str(
+        getattr(started.execution, "status", "") or ""
+    ).strip()
+    started_execution_error = str(getattr(started.execution, "error", "") or "").strip()
     event_state = runtime_event_state or RuntimeThreadRunEventState()
     stream_task: Optional[asyncio.Task[None]] = None
 
@@ -1377,17 +1381,34 @@ async def _finalize_discord_thread_execution(
         stream_task = asyncio.create_task(_pump_runtime_events())
 
     try:
-        outcome = await await_runtime_thread_outcome(
-            started,
-            interrupt_event=None,
-            timeout_seconds=DISCORD_PMA_TIMEOUT_SECONDS,
-            execution_error_message=public_execution_error,
-        )
+        if started_execution_status == "error":
+            outcome = RuntimeThreadOutcome(
+                status="error",
+                assistant_text="",
+                error=started_execution_error or public_execution_error,
+                backend_thread_id=current_backend_thread_id,
+                backend_turn_id=started.execution.backend_id,
+            )
+        elif started_execution_status == "interrupted":
+            outcome = RuntimeThreadOutcome(
+                status="interrupted",
+                assistant_text="",
+                error=interrupted_error,
+                backend_thread_id=current_backend_thread_id,
+                backend_turn_id=started.execution.backend_id,
+            )
+        else:
+            outcome = await await_runtime_thread_outcome(
+                started,
+                interrupt_event=None,
+                timeout_seconds=DISCORD_PMA_TIMEOUT_SECONDS,
+                execution_error_message=public_execution_error,
+            )
     except Exception:
         outcome = RuntimeThreadOutcome(
             status="error",
             assistant_text="",
-            error=public_execution_error,
+            error=started_execution_error or public_execution_error,
             backend_thread_id=current_backend_thread_id,
             backend_turn_id=started.execution.backend_id,
         )

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -7478,6 +7478,80 @@ async def test_discord_managed_thread_queue_worker_formats_local_file_links(
 
 
 @pytest.mark.anyio
+async def test_finalize_discord_thread_execution_prefers_started_execution_error(
+    tmp_path: Path,
+) -> None:
+    seed_hub_files(tmp_path, force=True)
+
+    service = SimpleNamespace(
+        _config=SimpleNamespace(root=tmp_path),
+        _logger=logging.getLogger("test.discord.finalize"),
+    )
+
+    captured_result: dict[str, Any] = {}
+
+    class _OrchestrationServiceStub:
+        def get_thread_target(self, managed_thread_id: str) -> Any:
+            _ = managed_thread_id
+            return SimpleNamespace(backend_thread_id=None)
+
+        def record_execution_result(
+            self,
+            managed_thread_id: str,
+            managed_turn_id: str,
+            *,
+            status: str,
+            assistant_text: str,
+            error: Optional[str],
+            backend_turn_id: Optional[str],
+            transcript_turn_id: Optional[str],
+        ) -> Any:
+            _ = (
+                managed_thread_id,
+                managed_turn_id,
+                assistant_text,
+                backend_turn_id,
+                transcript_turn_id,
+            )
+            captured_result["status"] = status
+            captured_result["error"] = error
+            return SimpleNamespace(status=status, error=error)
+
+    started = SimpleNamespace(
+        thread=SimpleNamespace(
+            thread_target_id="managed-thread-1",
+            backend_thread_id=None,
+        ),
+        execution=SimpleNamespace(
+            execution_id="turn-1",
+            status="error",
+            backend_id=None,
+            error=(
+                "ACP subprocess emitted invalid JSON: " "b'  [tool] deliberating...\\n'"
+            ),
+        ),
+        request=SimpleNamespace(message_text="What did we do in this session so far?"),
+        workspace_root=tmp_path,
+        harness=object(),
+    )
+
+    result = await discord_message_turns_module._finalize_discord_thread_execution(
+        service,
+        orchestration_service=_OrchestrationServiceStub(),
+        started=started,
+        channel_id="channel-1",
+        public_execution_error="Discord PMA turn failed",
+        timeout_error="Discord PMA turn timed out",
+        interrupted_error="Discord PMA turn interrupted",
+    )
+
+    assert result["status"] == "error"
+    assert "ACP subprocess emitted invalid JSON" in str(result["error"])
+    assert captured_result["status"] == "error"
+    assert "ACP subprocess emitted invalid JSON" in str(captured_result["error"])
+
+
+@pytest.mark.anyio
 async def test_car_review_single_chunk_deletes_preview_and_sends_chunk_when_flush_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## What changed
Discord managed-thread finalization now preserves and reports the original execution start failure when startup already failed, instead of replacing it with the downstream `Runtime thread execution is missing backend ids` error. A regression test covers the case where the start path has already marked the execution as failed.

## Why
A resumed archived Hermes PMA thread may legitimately have no live backend binding and need to start a fresh backend conversation. In the failing case, that fresh Hermes start emitted invalid ACP JSON. Discord was surfacing the later backend-id follow-on error instead of the real startup failure, which made debugging misleading.

## Impact
Discord now shows the real Hermes startup error, which should make resume/start debugging much more direct.

## Validation
- `.venv/bin/pytest tests/integrations/discord/test_message_turns.py -k "prefers_started_execution_error"`
- `.venv/bin/pytest tests/integrations/discord/test_message_turns.py -k "formats_local_file_links or queued_placeholder"`
- repo pre-commit checks via `git commit` hook, including strict typecheck, frontend build/tests, and pytest

## Review
- Mini subagent review: no findings
