### PR TITLE
[codex] Retry CAR update after cleaning stale build artifacts

### DIFF
--- a/src/codex_autorunner/core/update.py
+++ b/src/codex_autorunner/core/update.py
@@ -31,12 +31,6 @@ _UPDATE_LOCK_STARTUP_GRACE_SECONDS = 10.0
 _UPDATE_LOCK_CMD_HINTS = ("codex_autorunner.core.update_runner",)
 _UPDATE_BUILD_ARTIFACT_DIRS = ("build", "dist", ".eggs")
 _UPDATE_BUILD_ARTIFACT_GLOBS = ("*.egg-info", "src/*.egg-info")
-_RETRYABLE_REFRESH_FAILURE_MARKERS = (
-    "failed building wheel",
-    "failed-wheel-build-for-install",
-    "building wheel for codex-autorunner",
-    "no such file or directory: 'build/",
-)
 
 
 def _run_cmd(cmd: list[str], cwd: Path) -> None:
@@ -92,7 +86,16 @@ def _refresh_failure_is_retryable(output_lines: list[str]) -> bool:
     if not output_lines:
         return False
     haystack = "\n".join(output_lines).lower()
-    return any(marker in haystack for marker in _RETRYABLE_REFRESH_FAILURE_MARKERS)
+    if "codex-autorunner" not in haystack:
+        return False
+    if "no such file or directory" not in haystack:
+        return False
+    if "build/" not in haystack and "build\\" not in haystack:
+        return False
+    return (
+        "failed building wheel for codex-autorunner" in haystack
+        or "building wheel for codex-autorunner" in haystack
+    )
 
 
 def _reset_update_cache_for_retry(
@@ -108,11 +111,11 @@ def _reset_update_cache_for_retry(
         return False
     try:
         logger.warning(
-            "Refresh failed with a retryable packaging error; cleaning ignored cache artifacts in %s and retrying once.",
+            "Refresh failed with a retryable stale-build-artifact error; resetting tracked files and cleaning build artifacts in %s before retrying once.",
             update_dir,
         )
         _run_cmd(["git", "reset", "--hard", "FETCH_HEAD"], cwd=update_dir)
-        _run_cmd(["git", "clean", "-fdX"], cwd=update_dir)
+        _cleanup_update_build_artifacts(update_dir, logger)
     except Exception as exc:
         logger.warning(
             "Aggressive update cache cleanup failed; refresh retry skipped. %s",
@@ -904,7 +907,6 @@ def _system_update_worker(
             and _refresh_failure_is_retryable(output_tail)
             and _reset_update_cache_for_retry(update_dir, logger=logger)
         ):
-            _cleanup_update_build_artifacts(update_dir, logger)
             returncode, output_tail = _run_refresh_script(
                 refresh_script=refresh_script,
                 update_dir=update_dir,

--- a/tests/test_system_update_worker.py
+++ b/tests/test_system_update_worker.py
@@ -535,10 +535,12 @@ def test_system_update_worker_retries_refresh_after_packaging_failure(
             return self.returncode
 
     popen_calls = 0
+    build_exists_at_refresh: list[bool] = []
 
     def fake_popen(cmd, cwd, env, stdout, stderr, text):  # type: ignore[no-untyped-def]
         nonlocal popen_calls
         popen_calls += 1
+        build_exists_at_refresh.append((update_dir / "build").exists())
         if popen_calls == 1:
             return _Proc(
                 [
@@ -566,5 +568,124 @@ def test_system_update_worker_retries_refresh_after_packaging_failure(
     payload = json.loads(system._update_status_path().read_text(encoding="utf-8"))
     assert payload["status"] == "ok"
     assert popen_calls == 2
-    assert ["git", "clean", "-fdX"] in run_cmd_calls
+    assert build_exists_at_refresh == [False, False]
+    assert ["git", "reset", "--hard", "FETCH_HEAD"] in run_cmd_calls
+    assert not (update_dir / "build").exists()
+
+
+def test_system_update_worker_does_not_retry_non_packaging_refresh_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    update_dir = tmp_path / "update"
+    (update_dir / ".git").mkdir(parents=True)
+    refresh_script = update_dir / "scripts" / "safe-refresh-local-linux-hub.sh"
+    refresh_script.parent.mkdir(parents=True, exist_ok=True)
+    refresh_script.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+
+    monkeypatch.setattr(system.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(system.update_core, "_is_valid_git_repo", lambda _path: True)
+
+    run_cmd_calls: list[list[str]] = []
+
+    def fake_run_cmd(cmd: list[str], cwd: Path) -> None:
+        run_cmd_calls.append(cmd)
+
+    monkeypatch.setattr(system.update_core, "_run_cmd", fake_run_cmd)
+
+    class _Proc:
+        def __init__(self) -> None:
+            self.stdout = ["Hub health check failed.\n"]
+            self.returncode = 1
+
+        def wait(self) -> int:
+            return self.returncode
+
+    popen_calls = 0
+
+    def fake_popen(cmd, cwd, env, stdout, stderr, text):  # type: ignore[no-untyped-def]
+        nonlocal popen_calls
+        popen_calls += 1
+        return _Proc()
+
+    monkeypatch.setattr(system.subprocess, "Popen", fake_popen)
+    logger = logging.getLogger("test")
+
+    system._system_update_worker(
+        repo_url="https://example.com/repo.git",
+        repo_ref="main",
+        update_dir=update_dir,
+        logger=logger,
+        update_target="web",
+        update_backend="systemd-user",
+        skip_checks=True,
+    )
+
+    payload = json.loads(system._update_status_path().read_text(encoding="utf-8"))
+    assert payload["status"] == "rollback"
+    assert payload["exit_code"] == 1
+    assert popen_calls == 1
+    assert run_cmd_calls.count(["git", "reset", "--hard", "FETCH_HEAD"]) == 1
+
+
+def test_system_update_worker_rolls_back_when_retryable_refresh_failure_persists(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    update_dir = tmp_path / "update"
+    (update_dir / ".git").mkdir(parents=True)
+    (update_dir / "build").mkdir()
+    refresh_script = update_dir / "scripts" / "safe-refresh-local-linux-hub.sh"
+    refresh_script.parent.mkdir(parents=True, exist_ok=True)
+    refresh_script.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+
+    monkeypatch.setattr(system.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(system.update_core, "_is_valid_git_repo", lambda _path: True)
+
+    run_cmd_calls: list[list[str]] = []
+
+    def fake_run_cmd(cmd: list[str], cwd: Path) -> None:
+        run_cmd_calls.append(cmd)
+
+    monkeypatch.setattr(system.update_core, "_run_cmd", fake_run_cmd)
+
+    class _Proc:
+        def __init__(self) -> None:
+            self.stdout = [
+                "error: subprocess-exited-with-error\n",
+                "Failed building wheel for codex-autorunner\n",
+                "error: [Errno 2] No such file or directory: 'build/bdist...'\n",
+            ]
+            self.returncode = 1
+
+        def wait(self) -> int:
+            return self.returncode
+
+    popen_calls = 0
+
+    def fake_popen(cmd, cwd, env, stdout, stderr, text):  # type: ignore[no-untyped-def]
+        nonlocal popen_calls
+        popen_calls += 1
+        return _Proc()
+
+    monkeypatch.setattr(system.subprocess, "Popen", fake_popen)
+    logger = logging.getLogger("test")
+
+    system._system_update_worker(
+        repo_url="https://example.com/repo.git",
+        repo_ref="main",
+        update_dir=update_dir,
+        logger=logger,
+        update_target="web",
+        update_backend="systemd-user",
+        skip_checks=True,
+    )
+
+    payload = json.loads(system._update_status_path().read_text(encoding="utf-8"))
+    assert payload["status"] == "rollback"
+    assert payload["exit_code"] == 1
+    assert popen_calls == 2
+    assert ["git", "reset", "--hard", "FETCH_HEAD"] in run_cmd_calls
     assert not (update_dir / "build").exists()


### PR DESCRIPTION
## Summary
This changes CAR update behavior in the shared update core so all update surfaces inherit the same recovery path.

## What changed
- remove cheap packaging build outputs from `update_cache` before every refresh attempt
- detect wheel/build-style refresh failures from the shared refresh subprocess output
- retry the refresh exactly once after an aggressive `git reset --hard FETCH_HEAD` + `git clean -fdX`
- keep the cached clone by default instead of deleting the whole update cache
- add focused tests for artifact cleanup, retryable failure detection, and worker retry behavior

## Why
A CAR update failed because the staged install in the safe refresh flow hit a stale wheel build artifact in `~/.codex-autorunner/update_cache/build`, even though the source file existed in the cached repo. The old behavior treated that as a generic refresh failure and rolled back immediately.

## Impact
- normal updates stay fast because the git cache is preserved
- cheap, disposable build outputs are rebuilt cleanly on each run
- stale packaging artifacts get one automatic recovery attempt instead of forcing a manual cache cleanup
- Discord, Telegram, and web update entrypoints all share this logic because they already converge in `src/codex_autorunner/core/update.py`

## Validation
- `.venv/bin/python -m pytest tests/test_system_update_worker.py -q`
- `.venv/bin/python -m pytest tests/routes/test_system_update_routes.py tests/test_update_paths.py -q`
- `python3 -m compileall src/codex_autorunner/core/update.py tests/test_system_update_worker.py`
- repo pre-commit gate during `git commit`:
  - black
  - ruff
  - mypy
  - pnpm build
  - frontend JS tests
  - repo pytest suite (`3859 passed, 1 skipped`)
