### PR TITLE
[codex] Fix managed OpenCode event streaming

### DIFF
--- a/src/codex_autorunner/agents/opencode/harness.py
+++ b/src/codex_autorunner/agents/opencode/harness.py
@@ -915,7 +915,10 @@ class OpenCodeHarness(AgentHarness):
         self, workspace_root: Path, conversation_id: str, turn_id: str
     ) -> AsyncIterator[str]:
         client = await self._supervisor.get_client(workspace_root)
-        async for event in client.stream_events(directory=str(workspace_root)):
+        async for event in client.stream_events(
+            directory=str(workspace_root),
+            session_id=conversation_id,
+        ):
             payload = event.data
             try:
                 parsed = json.loads(payload) if payload else {}
@@ -1019,7 +1022,8 @@ class OpenCodeHarness(AgentHarness):
             async def _event_stream() -> AsyncIterator[Any]:
                 try:
                     async for event in client.stream_events(
-                        directory=str(workspace_root)
+                        directory=str(workspace_root),
+                        session_id=conversation_id,
                     ):
                         payload = event.data
                         try:

--- a/tests/agents/opencode/test_opencode_harness.py
+++ b/tests/agents/opencode/test_opencode_harness.py
@@ -24,6 +24,7 @@ class _StubClient:
     ) -> None:
         self._events = events
         self._stream_error = stream_error
+        self.stream_calls: list[dict[str, object]] = []
         self.permission_replies: list[tuple[str, str]] = []
         self.question_replies: list[tuple[str, list[list[str]]]] = []
         self.question_rejections: list[str] = []
@@ -34,8 +35,21 @@ class _StubClient:
         self.send_command_error: Exception | None = None
 
     async def stream_events(
-        self, *, directory: str | None = None, ready_event: object = None
+        self,
+        *,
+        directory: str | None = None,
+        ready_event: object = None,
+        session_id: str | None = None,
+        paths: object = None,
     ):
+        self.stream_calls.append(
+            {
+                "directory": directory,
+                "ready_event": ready_event,
+                "session_id": session_id,
+                "paths": paths,
+            }
+        )
         _ = directory
         if ready_event is not None:
             ready_event.set()
@@ -680,6 +694,94 @@ async def test_opencode_harness_progress_event_stream_is_empty_after_pending_tur
     ]
 
     assert streamed == []
+
+
+@pytest.mark.asyncio
+async def test_opencode_harness_wait_for_turn_uses_session_scoped_event_stream() -> (
+    None
+):
+    workspace = Path("/tmp/workspace").resolve()
+
+    class _SessionScopedClient(_StubClient):
+        async def stream_events(
+            self,
+            *,
+            directory: str | None = None,
+            ready_event: object = None,
+            session_id: str | None = None,
+            paths: object = None,
+        ):
+            self.stream_calls.append(
+                {
+                    "directory": directory,
+                    "ready_event": ready_event,
+                    "session_id": session_id,
+                    "paths": paths,
+                }
+            )
+            if ready_event is not None:
+                ready_event.set()
+            if session_id != "session-1":
+                return
+            for event in self._events:
+                yield event
+
+    client = _SessionScopedClient(
+        [
+            SSEEvent(
+                event="message.part.updated",
+                data='{"sessionID":"session-1","properties":{"part":{"type":"text","text":"OK"}}}',
+            ),
+            SSEEvent(
+                event="session.status",
+                data='{"sessionID":"session-1","properties":{"status":{"type":"idle"}}}',
+            ),
+        ]
+    )
+    harness = OpenCodeHarness(_StubSupervisor(client))
+
+    turn = await harness.start_turn(
+        workspace,
+        "session-1",
+        prompt="hello",
+        model=None,
+        reasoning=None,
+        approval_mode=None,
+        sandbox_policy=None,
+    )
+
+    result = await harness.wait_for_turn(workspace, "session-1", turn.turn_id)
+
+    assert result.status == "ok"
+    assert result.assistant_text == "OK"
+    assert any(call["session_id"] == "session-1" for call in client.stream_calls)
+
+
+@pytest.mark.asyncio
+async def test_opencode_harness_stream_events_uses_session_scoped_event_stream() -> (
+    None
+):
+    workspace = Path("/tmp/workspace").resolve()
+    client = _StubClient(
+        [
+            SSEEvent(
+                event="message.part.updated",
+                data='{"sessionID":"session-1","properties":{"part":{"type":"text","text":"OK"}}}',
+            ),
+            SSEEvent(
+                event="session.status",
+                data='{"sessionID":"session-1","properties":{"status":{"type":"idle"}}}',
+            ),
+        ]
+    )
+    harness = OpenCodeHarness(_StubSupervisor(client))
+
+    events = [
+        event async for event in harness.stream_events(workspace, "session-1", "turn-1")
+    ]
+
+    assert events
+    assert client.stream_calls[0]["session_id"] == "session-1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

This updates the managed `OpenCodeHarness` to subscribe to the session-scoped OpenCode event stream when reading turn output and progress events.

Previously the harness was opening the directory/global event stream and then filtering events by session after the fact. On OpenCode servers that only emit turn events from `/session/{id}/event`, managed turns could start successfully but never receive any progress or output events.

## Root cause

The direct OpenCode backend path already passed `session_id` into `client.stream_events(...)`, but the managed harness path did not.

That created an inconsistency:

- direct OpenCode execution used the session-scoped event endpoint first
- managed PMA / Discord / Telegram OpenCode turns listened on the directory/global stream instead

When the server only produced events on the session endpoint, the managed path saw no events at all. PMA then surfaced the turn as `no_events_yet` / `likely_hung`, and Discord / Telegram bound chats did not receive OpenCode output.

## User impact

This should restore streamed and final OpenCode output for managed surfaces that rely on `OpenCodeHarness`, including PMA-managed turns and the Discord / Telegram bound chat flows that consume the same harness event stream.

## Validation

Pre-commit hooks ran successfully, including:

- `black`
- `ruff`
- `mypy src/codex_autorunner`
- `pnpm run build`
- `pnpm test:markdown`
- full `pytest` suite (`3865 passed, 1 skipped`)

I also added targeted regressions covering the session-scoped harness stream behavior.