### PR TITLE
[codex] Fix PMA wakeup publish repo matching

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/publish.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/publish.py
@@ -120,6 +120,31 @@ def resolve_binding_repo_id(
     return None
 
 
+def resolve_binding_repo_candidates(
+    *,
+    repo_id: Any,
+    workspace_path: Any,
+    prev_repo_id: Any,
+    prev_workspace_path: Any,
+    repo_id_by_workspace: dict[str, str],
+    hub_root: Path,
+) -> set[str]:
+    candidates: set[str] = set()
+    for candidate_repo_id, candidate_workspace_path in (
+        (repo_id, workspace_path),
+        (prev_repo_id, prev_workspace_path),
+    ):
+        resolved = resolve_binding_repo_id(
+            repo_id=candidate_repo_id,
+            workspace_path=candidate_workspace_path,
+            repo_id_by_workspace=repo_id_by_workspace,
+            hub_root=hub_root,
+        )
+        if resolved:
+            candidates.add(resolved)
+    return candidates
+
+
 def resolve_publish_repo_id(
     *,
     request: Request,
@@ -328,17 +353,15 @@ async def publish_automation_result(
                 channel_id = normalize_optional_text(binding.get("channel_id"))
                 if not channel_id or channel_id in seen_channels:
                     continue
-                binding_repo_id = resolve_binding_repo_id(
+                binding_repo_ids = resolve_binding_repo_candidates(
                     repo_id=binding.get("repo_id"),
                     workspace_path=binding.get("workspace_path"),
+                    prev_repo_id=binding.get("pma_prev_repo_id"),
+                    prev_workspace_path=binding.get("pma_prev_workspace_path"),
                     repo_id_by_workspace=repo_id_by_workspace,
                     hub_root=hub_root,
                 )
-                prev_repo_id = normalize_optional_text(binding.get("pma_prev_repo_id"))
-                if target_repo_id and target_repo_id not in {
-                    binding_repo_id,
-                    prev_repo_id,
-                }:
+                if target_repo_id and target_repo_id not in binding_repo_ids:
                     continue
                 seen_channels.add(channel_id)
                 targets += 1
@@ -405,19 +428,15 @@ async def publish_automation_result(
                 identity = (chat_id, thread_id)
                 if identity in seen_topics:
                     continue
-                binding_repo_id = resolve_binding_repo_id(
+                binding_repo_ids = resolve_binding_repo_candidates(
                     repo_id=getattr(topic, "repo_id", None),
                     workspace_path=getattr(topic, "workspace_path", None),
+                    prev_repo_id=getattr(topic, "pma_prev_repo_id", None),
+                    prev_workspace_path=getattr(topic, "pma_prev_workspace_path", None),
                     repo_id_by_workspace=repo_id_by_workspace,
                     hub_root=hub_root,
                 )
-                prev_repo_id = normalize_optional_text(
-                    getattr(topic, "pma_prev_repo_id", None)
-                )
-                if target_repo_id and target_repo_id not in {
-                    binding_repo_id,
-                    prev_repo_id,
-                }:
+                if target_repo_id and target_repo_id not in binding_repo_ids:
                     continue
                 seen_topics.add(identity)
                 targets += 1

--- a/tests/test_pma_routes.py
+++ b/tests/test_pma_routes.py
@@ -1472,6 +1472,127 @@ async def test_pma_wakeup_publish_retries_transient_telegram_enqueue_failure(
     assert "automation summary complete" in matching[0].text
 
 
+@pytest.mark.anyio
+async def test_pma_wakeup_turn_publishes_using_prev_workspace_repo_context(
+    hub_env,
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+    _install_fake_successful_chat_supervisor(
+        app,
+        turn_id="turn-wakeup-prev-workspace",
+        message="automation summary complete",
+    )
+    app.state.app_server_events = object()
+
+    unrelated_workspace = hub_env.hub_root / "unrelated-pma-workspace"
+    unrelated_workspace.mkdir(parents=True, exist_ok=True)
+
+    discord_store = DiscordStateStore(
+        hub_env.hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+    )
+    telegram_store = TelegramStateStore(
+        hub_env.hub_root / ".codex-autorunner" / "telegram_state.sqlite3"
+    )
+    try:
+        await discord_store.upsert_binding(
+            channel_id="discord-prev-workspace",
+            guild_id="guild-1",
+            workspace_path=str(unrelated_workspace.resolve()),
+            repo_id=None,
+        )
+        await discord_store.update_pma_state(
+            channel_id="discord-prev-workspace",
+            pma_enabled=True,
+            pma_prev_workspace_path=str(hub_env.repo_root.resolve()),
+            pma_prev_repo_id=None,
+        )
+
+        telegram_key = topic_key(7007, 8008)
+        await telegram_store.bind_topic(
+            telegram_key,
+            str(unrelated_workspace.resolve()),
+            repo_id=None,
+        )
+
+        def _enable(record: Any) -> None:
+            record.pma_enabled = True
+            record.repo_id = None
+            record.workspace_path = str(unrelated_workspace.resolve())
+            record.pma_prev_repo_id = None
+            record.pma_prev_workspace_path = str(hub_env.repo_root.resolve())
+
+        await telegram_store.update_topic(telegram_key, _enable)
+    finally:
+        await discord_store.close()
+        await telegram_store.close()
+
+    queue = PmaQueue(hub_env.hub_root)
+    lane_id = "pma:test-publish-prev-workspace"
+    start_lane_worker = app.state.pma_lane_worker_start
+    stop_lane_worker = app.state.pma_lane_worker_stop
+    assert callable(start_lane_worker)
+    assert callable(stop_lane_worker)
+
+    item, _ = await queue.enqueue(
+        lane_id,
+        "pma:test-publish-prev-workspace:key-1",
+        {
+            "message": "Automation wake-up received.",
+            "agent": "codex",
+            "client_turn_id": "wakeup-prev-workspace-123",
+            "wake_up": {
+                "wakeup_id": "wakeup-prev-workspace-123",
+                "repo_id": hub_env.repo_id,
+                "event_type": "managed_thread_completed",
+                "source": "lifecycle_subscription",
+                "run_id": "run-prev-workspace-123",
+            },
+        },
+    )
+
+    try:
+        await start_lane_worker(app, lane_id)
+        result: dict[str, Any] | None = None
+        with anyio.fail_after(3):
+            while True:
+                items = await queue.list_items(lane_id)
+                match = next(
+                    (entry for entry in items if entry.item_id == item.item_id), None
+                )
+                assert match is not None
+                if match.state in (QueueItemState.COMPLETED, QueueItemState.FAILED):
+                    result = dict(match.result or {})
+                    break
+                await anyio.sleep(0.05)
+        assert result is not None
+        assert result.get("status") == "ok"
+        assert result.get("delivery_status") == "success"
+    finally:
+        await stop_lane_worker(app, lane_id)
+
+    discord_store = DiscordStateStore(
+        hub_env.hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+    )
+    telegram_store = TelegramStateStore(
+        hub_env.hub_root / ".codex-autorunner" / "telegram_state.sqlite3"
+    )
+    try:
+        discord_outbox = await discord_store.list_outbox()
+        telegram_outbox = await telegram_store.list_outbox()
+    finally:
+        await discord_store.close()
+        await telegram_store.close()
+
+    assert any(
+        record.channel_id == "discord-prev-workspace" for record in discord_outbox
+    )
+    assert any(
+        record.chat_id == 7007 and record.thread_id == 8008
+        for record in telegram_outbox
+    )
+
+
 def test_pma_active_clears_on_prompt_build_error(hub_env, monkeypatch) -> None:
     _enable_pma(hub_env.hub_root)
 


### PR DESCRIPTION
## Summary
- teach PMA automation publish target matching to resolve repo ownership from both current and preserved PMA workspace context
- use that candidate set for Discord and Telegram PMA-enabled bindings instead of requiring an explicit stored repo id
- add a regression test covering PMA wake-up delivery when the binding only retains `pma_prev_workspace_path`

## Root Cause
PMA wake-up publish delivery filtered PMA-enabled bindings by repo id, but PMA mode can preserve the originating repo only through `pma_prev_workspace_path`. When `repo_id` and `pma_prev_repo_id` were absent, the wake-up executed successfully but the publish step skipped the bound chat thread entirely.

## Validation
- `.venv/bin/python -m pytest -q tests/test_pma_routes.py -k 'wakeup and (publishes or prev_workspace)'`
- `.venv/bin/python -m ruff check src/codex_autorunner/surfaces/web/routes/pma_routes/publish.py tests/test_pma_routes.py`
- full pre-commit suite via `git commit` hook (`3865 passed, 1 skipped`)

Closes #1191
