### PR TITLE
[codex] Fix OpenCode backend turn IDs for managed threads

### DIFF
--- a/src/codex_autorunner/agents/opencode/harness.py
+++ b/src/codex_autorunner/agents/opencode/harness.py
@@ -25,7 +25,6 @@ from ..types import (
     TurnRef,
 )
 from .runtime import (
-    build_turn_id,
     collect_opencode_output_from_events,
     extract_session_id,
     extract_turn_id,
@@ -811,9 +810,8 @@ class OpenCodeHarness(AgentHarness):
         if model is None:
             model = DEFAULT_CHAT_AGENT_MODELS.get("opencode")
         model_payload = split_model_id(model)
-        turn_id = build_turn_id(conversation_id)
         try:
-            await client.prompt_async(
+            result = await client.prompt_async(
                 conversation_id,
                 message=prompt,
                 model=model_payload,
@@ -826,6 +824,9 @@ class OpenCodeHarness(AgentHarness):
                 conversation_id=conversation_id,
                 operation="start_turn",
             )
+        turn_id = extract_turn_id(conversation_id, result)
+        if turn_id:
+            _logger.debug("OpenCode turn started: %s", turn_id)
         self._pending_turns[(conversation_id, turn_id)] = _PendingTurnConfig(
             model_payload=model_payload,
             approval_mode=approval_mode,
@@ -868,7 +869,6 @@ class OpenCodeHarness(AgentHarness):
         if model is None:
             model = DEFAULT_CHAT_AGENT_MODELS.get("opencode")
         arguments = prompt if prompt else ""
-        turn_id = build_turn_id(conversation_id)
         try:
             result = await client.send_command(
                 conversation_id,
@@ -883,9 +883,9 @@ class OpenCodeHarness(AgentHarness):
                 conversation_id=conversation_id,
                 operation="start_review",
             )
-        started_turn_id = extract_turn_id(conversation_id, result)
-        if started_turn_id:
-            _logger.debug("OpenCode review started: %s", started_turn_id)
+        turn_id = extract_turn_id(conversation_id, result)
+        if turn_id:
+            _logger.debug("OpenCode review started: %s", turn_id)
 
         self._pending_turns[(conversation_id, turn_id)] = _PendingTurnConfig(
             model_payload=split_model_id(model),

--- a/tests/agents/opencode/test_opencode_harness.py
+++ b/tests/agents/opencode/test_opencode_harness.py
@@ -325,6 +325,68 @@ async def test_opencode_harness_keeps_turn_guard_through_resume_start_and_wait()
 
 
 @pytest.mark.asyncio
+async def test_opencode_harness_start_turn_uses_backend_turn_id_from_prompt_response() -> (
+    None
+):
+    workspace = Path("/tmp/workspace").resolve()
+    client = _StubClient([])
+
+    async def _prompt_async(session_id: str, **kwargs: object) -> dict[str, object]:
+        return {
+            "info": {"id": "backend-turn-1"},
+            "sessionID": session_id,
+            **kwargs,
+        }
+
+    client.prompt_async = _prompt_async  # type: ignore[method-assign]
+    harness = OpenCodeHarness(_StubSupervisor(client))
+
+    turn = await harness.start_turn(
+        workspace,
+        "session-1",
+        prompt="hello",
+        model=None,
+        reasoning=None,
+        approval_mode=None,
+        sandbox_policy=None,
+    )
+
+    assert turn.turn_id == "backend-turn-1"
+    assert ("session-1", "backend-turn-1") in harness._pending_turns
+
+
+@pytest.mark.asyncio
+async def test_opencode_harness_start_review_uses_backend_turn_id_from_command_response() -> (
+    None
+):
+    workspace = Path("/tmp/workspace").resolve()
+    client = _StubClient([])
+
+    async def _send_command(session_id: str, **kwargs: object) -> dict[str, object]:
+        return {
+            "id": "backend-review-1",
+            "sessionID": session_id,
+            **kwargs,
+        }
+
+    client.send_command = _send_command  # type: ignore[method-assign]
+    harness = OpenCodeHarness(_StubSupervisor(client))
+
+    turn = await harness.start_review(
+        workspace,
+        "session-1",
+        prompt="review this",
+        model=None,
+        reasoning=None,
+        approval_mode=None,
+        sandbox_policy=None,
+    )
+
+    assert turn.turn_id == "backend-review-1"
+    assert ("session-1", "backend-review-1") in harness._pending_turns
+
+
+@pytest.mark.asyncio
 async def test_opencode_harness_releases_reserved_turn_when_start_turn_setup_fails() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- use the backend turn id returned by OpenCode message/review startup when it is available
- stop seeding PMA-managed executions with synthetic local turn ids that block stream-capable observability
- add harness regressions covering backend turn id propagation for both message and review starts

## Root Cause
OpenCode harness startup was ignoring the `prompt_async()` / `send_command()` response payload and always returning a synthetic local turn id. PMA managed-thread status and tail streaming depend on a real backend turn id, so OpenCode turns could run while PMA degraded into `no_stream_available` / `likely_hung`.

## Validation
- `.venv/bin/pytest tests/agents/opencode/test_opencode_harness.py`
- `.venv/bin/pytest tests/core/orchestration/test_service.py -k 'new_backend_thread_and_records_running_execution or rejects_empty_backend_turn_id or send_review_resumes_existing_backend_thread'`
- repo pre-commit hooks, including strict mypy, frontend build/tests, and full pytest (`3873 passed, 1 skipped`)

Closes #1194