### PR TITLE
fix(chat): propagate Hermes profiles through Discord/Telegram (#1197)

### DIFF
--- a/src/codex_autorunner/integrations/chat/agents.py
+++ b/src/codex_autorunner/integrations/chat/agents.py
@@ -135,6 +135,22 @@ def valid_chat_agent_values(context: Any = None) -> tuple[str, ...]:
     return _valid_chat_agent_values(context)
 
 
+def _config_hermes_profiles(context: Any) -> dict[str, Any]:
+    try:
+        from ...agents.registry import _resolve_runtime_agent_config
+
+        config = _resolve_runtime_agent_config(context)
+        if config is None:
+            return {}
+        getter = getattr(config, "agent_profiles", None)
+        if not callable(getter):
+            return {}
+        profiles = getter("hermes")
+        return dict(profiles) if isinstance(profiles, dict) else {}
+    except Exception:
+        return {}
+
+
 def chat_hermes_profile_options(
     context: Any = None,
 ) -> tuple[ChatAgentProfileOption, ...]:
@@ -159,6 +175,22 @@ def chat_hermes_profile_options(
             )
         )
         seen_profiles.add(profile)
+    for profile_id, profile_cfg in sorted(_config_hermes_profiles(context).items()):
+        normalized_id = str(profile_id or "").strip().lower()
+        if not normalized_id or normalized_id in seen_profiles:
+            continue
+        display = getattr(profile_cfg, "display_name", None)
+        if not isinstance(display, str) or not display.strip():
+            display = normalized_id
+        options.append(
+            ChatAgentProfileOption(
+                agent="hermes",
+                profile=normalized_id,
+                runtime_agent="hermes",
+                description=display,
+            )
+        )
+        seen_profiles.add(normalized_id)
     return tuple(options)
 
 

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -16,7 +16,7 @@ from ...agents.base import (
     harness_progress_event_stream,
     harness_supports_progress_event_stream,
 )
-from ...agents.registry import get_registered_agents
+from ...agents.registry import get_registered_agents, wrap_requested_agent_context
 from ...core.context_awareness import (
     maybe_inject_car_awareness,
     maybe_inject_filebox_hint,
@@ -1213,13 +1213,15 @@ def build_discord_thread_orchestration_service(service: Any) -> Any:
             raise
         descriptors = get_registered_agents()
 
-    def _make_harness(agent_id: str) -> Any:
+    def _make_harness(agent_id: str, profile: Optional[str] = None) -> Any:
         if _should_use_legacy_orchestrator_harness(service):
             return _LegacyOrchestratorRuntimeHarness(service, agent_id)
         descriptor = descriptors.get(agent_id)
         if descriptor is None:
             raise KeyError(f"Unknown agent definition '{agent_id}'")
-        return descriptor.make_harness(service)
+        return descriptor.make_harness(
+            wrap_requested_agent_context(service, agent_id=agent_id, profile=profile)
+        )
 
     created = build_harness_backed_orchestration_service(
         descriptors=cast(Any, descriptors),
@@ -1237,6 +1239,7 @@ def resolve_discord_thread_target(
     channel_id: str,
     workspace_root: Path,
     agent: str,
+    agent_profile: Optional[str] = None,
     repo_id: Optional[str],
     resource_kind: Optional[str],
     resource_id: Optional[str],
@@ -1262,6 +1265,7 @@ def resolve_discord_thread_target(
     reusable_thread = (
         thread is not None
         and thread.agent_id == agent
+        and (thread.agent_profile or None) == (agent_profile or None)
         and str(thread.workspace_root or "").strip() == canonical_workspace
     )
     owner_kind, owner_id, normalized_repo_id = service._resource_owner_for_workspace(
@@ -1276,6 +1280,9 @@ def resolve_discord_thread_target(
     ):
         thread = orchestration_service.resume_thread_target(thread.thread_target_id)
     elif not reusable_thread:
+        thread_metadata: Optional[dict[str, Any]] = (
+            {"agent_profile": agent_profile} if agent_profile else None
+        )
         thread = orchestration_service.create_thread_target(
             agent,
             workspace_root,
@@ -1283,6 +1290,7 @@ def resolve_discord_thread_target(
             resource_kind=owner_kind,
             resource_id=owner_id,
             display_name=f"discord:{channel_id}",
+            metadata=thread_metadata,
         )
     orchestration_service.upsert_binding(
         surface_kind="discord",
@@ -1736,6 +1744,7 @@ async def _run_discord_orchestrated_turn_for_message(
     )
     binding = await service._store.get_binding(channel_id=channel_id)
     runtime_agent = service._runtime_agent_for_binding(binding)
+    _agent, agent_profile = service._resolve_agent_state(binding)
     repo_id = binding.get("repo_id") if isinstance(binding, dict) else None
     resource_kind = binding.get("resource_kind") if isinstance(binding, dict) else None
     resource_id = binding.get("resource_id") if isinstance(binding, dict) else None
@@ -1744,6 +1753,7 @@ async def _run_discord_orchestrated_turn_for_message(
         channel_id=channel_id,
         workspace_root=workspace_root,
         agent=runtime_agent,
+        agent_profile=agent_profile,
         repo_id=repo_id if isinstance(repo_id, str) and repo_id.strip() else None,
         resource_kind=(
             resource_kind.strip()

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -28,7 +28,7 @@ from .....agents.opencode.runtime import (
     opencode_missing_env,
     split_model_id,
 )
-from .....agents.registry import get_registered_agents
+from .....agents.registry import get_registered_agents, wrap_requested_agent_context
 from .....core.context_awareness import (
     has_file_context_signal,
     maybe_inject_car_awareness,
@@ -260,11 +260,13 @@ def _build_telegram_thread_orchestration_service(handlers: Any) -> Any:
             raise
         descriptors = get_registered_agents()
 
-    def _make_harness(agent_id: str) -> Any:
+    def _make_harness(agent_id: str, profile: Optional[str] = None) -> Any:
         descriptor = descriptors.get(agent_id)
         if descriptor is None:
             raise KeyError(f"Unknown agent definition '{agent_id}'")
-        return descriptor.make_harness(handlers)
+        return descriptor.make_harness(
+            wrap_requested_agent_context(handlers, agent_id=agent_id, profile=profile)
+        )
 
     state_root = getattr(getattr(handlers, "_config", None), "root", None)
     if state_root is None:
@@ -324,6 +326,7 @@ async def _resolve_telegram_managed_thread(
     surface_key: str,
     workspace_root: Path,
     agent: str,
+    agent_profile: Optional[str] = None,
     repo_id: Optional[str],
     resource_kind: Optional[str] = None,
     resource_id: Optional[str] = None,
@@ -386,6 +389,7 @@ async def _resolve_telegram_managed_thread(
     reusable_thread = (
         thread is not None
         and thread.agent_id == agent
+        and (thread.agent_profile or None) == (agent_profile or None)
         and str(thread.workspace_root or "").strip() == canonical_workspace
     )
     effective_backend_thread_id = normalized_backend_thread_id
@@ -408,6 +412,11 @@ async def _resolve_telegram_managed_thread(
     elif not reusable_thread:
         if not allow_new_thread and not effective_backend_thread_id:
             return orchestration_service, None
+        thread_metadata: Optional[dict[str, Any]] = {}
+        if agent_profile:
+            thread_metadata["agent_profile"] = agent_profile
+        if backend_runtime_instance_id is not None:
+            thread_metadata["backend_runtime_instance_id"] = backend_runtime_instance_id
         thread = orchestration_service.create_thread_target(
             agent,
             workspace_root,
@@ -416,13 +425,7 @@ async def _resolve_telegram_managed_thread(
             resource_id=resource_id,
             display_name=f"telegram:{surface_key}",
             backend_thread_id=effective_backend_thread_id,
-            metadata=(
-                {
-                    "backend_runtime_instance_id": backend_runtime_instance_id,
-                }
-                if backend_runtime_instance_id is not None
-                else None
-            ),
+            metadata=thread_metadata or None,
         )
     orchestration_service.upsert_binding(
         surface_kind="telegram",
@@ -448,6 +451,7 @@ async def _reset_telegram_thread_binding(
     surface_key: str,
     workspace_root: Path,
     agent: str,
+    agent_profile: Optional[str] = None,
     repo_id: Optional[str],
     resource_kind: Optional[str],
     resource_id: Optional[str],
@@ -482,6 +486,7 @@ async def _reset_telegram_thread_binding(
         resource_kind=resource_kind,
         resource_id=resource_id,
         display_name=f"telegram:{surface_key}",
+        metadata={"agent_profile": agent_profile} if agent_profile else None,
     )
     orchestration_service.upsert_binding(
         surface_kind="telegram",
@@ -1057,6 +1062,7 @@ async def _run_telegram_managed_thread_turn(
     )
     workspace_root = canonicalize_path(Path(record.workspace_path or ""))
     agent = handlers._effective_agent(record)
+    agent_profile = handlers._effective_agent_profile(record)
     runtime_agent = handlers._effective_runtime_agent(record)
     repo_id = record.repo_id.strip() if isinstance(record.repo_id, str) else None
     current_backend_thread_id = (
@@ -1187,6 +1193,7 @@ async def _run_telegram_managed_thread_turn(
         surface_key=topic_key,
         workspace_root=workspace_root,
         agent=runtime_agent,
+        agent_profile=agent_profile,
         repo_id=repo_id or None,
         resource_kind=getattr(record, "resource_kind", None),
         resource_id=getattr(record, "resource_id", None),

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -1174,6 +1174,7 @@ class WorkspaceCommands(TelegramCommandSupportMixin):
                             surface_key=key,
                             workspace_root=canonicalize_path(Path(hub_root)),
                             agent=self._effective_runtime_agent(record),
+                            agent_profile=self._effective_agent_profile(record),
                             repo_id=(
                                 record.repo_id.strip()
                                 if isinstance(record.repo_id, str)
@@ -1414,6 +1415,7 @@ class WorkspaceCommands(TelegramCommandSupportMixin):
                             surface_key=key,
                             workspace_root=canonicalize_path(Path(hub_root)),
                             agent=self._effective_runtime_agent(record),
+                            agent_profile=self._effective_agent_profile(record),
                             repo_id=(
                                 record.repo_id.strip()
                                 if isinstance(record.repo_id, str)

--- a/tests/integrations/chat/test_agents.py
+++ b/tests/integrations/chat/test_agents.py
@@ -208,3 +208,94 @@ def test_normalize_hermes_profile_fallback_without_context() -> None:
     assert normalize_hermes_profile("hermes-m4-pma") == "m4-pma"
     assert normalize_hermes_profile("hermes_m4_pma") == "m4_pma"
     assert normalize_hermes_profile("m4-pma") is None
+
+
+def test_chat_hermes_profile_options_discovers_config_profiles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "codex_autorunner.agents.registry.get_registered_agents",
+        lambda context=None: {},
+    )
+
+    config = SimpleNamespace(
+        agent_profiles=lambda agent_id: (
+            {
+                "m4-pma": SimpleNamespace(display_name="M4 PMA"),
+                "fast": SimpleNamespace(display_name=None),
+            }
+            if agent_id == "hermes"
+            else {}
+        ),
+        agent_binary=lambda agent_id, **kw: "hermes",
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.agents.registry._resolve_runtime_agent_config",
+        lambda ctx: config,
+    )
+
+    opts = chat_hermes_profile_options("ctx")
+    profiles = {o.profile: o for o in opts}
+    assert "m4-pma" in profiles
+    assert "fast" in profiles
+    assert profiles["m4-pma"].runtime_agent == "hermes"
+    assert profiles["m4-pma"].description == "M4 PMA"
+    assert profiles["fast"].runtime_agent == "hermes"
+    assert profiles["fast"].description == "fast"
+
+
+def test_config_profile_normalizes_and_resolves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "codex_autorunner.agents.registry.get_registered_agents",
+        lambda context=None: {},
+    )
+
+    config = SimpleNamespace(
+        agent_profiles=lambda agent_id: (
+            {"m4-pma": SimpleNamespace(display_name="M4 PMA")}
+            if agent_id == "hermes"
+            else {}
+        ),
+        agent_binary=lambda agent_id, **kw: "hermes",
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.agents.registry._resolve_runtime_agent_config",
+        lambda ctx: config,
+    )
+
+    assert normalize_hermes_profile("m4-pma", context="ctx") == "m4-pma"
+    assert resolve_chat_runtime_agent("hermes", "m4-pma", context="ctx") == "hermes"
+    agent, profile = resolve_chat_agent_and_profile("hermes", "m4-pma", context="ctx")
+    assert agent == "hermes"
+    assert profile == "m4-pma"
+
+
+def test_config_profiles_deferred_to_alias_profiles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "codex_autorunner.agents.registry.get_registered_agents",
+        lambda context=None: {
+            "hermes-m4-pma": SimpleNamespace(name="Hermes Alias"),
+        },
+    )
+
+    config = SimpleNamespace(
+        agent_profiles=lambda agent_id: (
+            {"m4-pma": SimpleNamespace(display_name="Config Version")}
+            if agent_id == "hermes"
+            else {}
+        ),
+        agent_binary=lambda agent_id, **kw: "hermes",
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.agents.registry._resolve_runtime_agent_config",
+        lambda ctx: config,
+    )
+
+    opts = chat_hermes_profile_options("ctx")
+    assert len(opts) == 1
+    assert opts[0].runtime_agent == "hermes-m4-pma"
+    assert opts[0].description == "Hermes Alias"

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -398,6 +398,14 @@ async def test_orchestrated_turn_interrupt_send_hands_off_progress_message(
         def _clear_discord_turn_approval_context(self, **kwargs: Any) -> None:
             _ = kwargs
 
+        def _resolve_agent_state(self, binding: Any) -> tuple[str, Optional[str]]:
+            _ = binding
+            return "codex", None
+
+        def _runtime_agent_for_binding(self, binding: Any) -> str:
+            _ = binding
+            return "codex"
+
     async def _fake_begin(*args: Any, **kwargs: Any) -> Any:
         _ = args, kwargs
         return started_execution
@@ -515,6 +523,14 @@ async def test_orchestrated_turn_interrupt_send_reuses_existing_progress_message
         def _clear_discord_turn_approval_context(self, **kwargs: Any) -> None:
             _ = kwargs
 
+        def _resolve_agent_state(self, binding: Any) -> tuple[str, Optional[str]]:
+            _ = binding
+            return "codex", None
+
+        def _runtime_agent_for_binding(self, binding: Any) -> str:
+            _ = binding
+            return "codex"
+
     async def _fake_begin(*args: Any, **kwargs: Any) -> Any:
         _ = args, kwargs
         return started_execution
@@ -629,6 +645,14 @@ async def test_orchestrated_turn_interrupt_send_acknowledges_when_progress_messa
         def _clear_discord_turn_approval_context(self, **kwargs: Any) -> None:
             _ = kwargs
 
+        def _resolve_agent_state(self, binding: Any) -> tuple[str, Optional[str]]:
+            _ = binding
+            return "codex", None
+
+        def _runtime_agent_for_binding(self, binding: Any) -> str:
+            _ = binding
+            return "codex"
+
     async def _fake_begin(*args: Any, **kwargs: Any) -> Any:
         _ = args, kwargs
         return started_execution
@@ -741,6 +765,14 @@ async def test_orchestrated_turn_interrupt_send_falls_back_when_progress_ack_edi
 
         def _clear_discord_turn_approval_context(self, **kwargs: Any) -> None:
             _ = kwargs
+
+        def _resolve_agent_state(self, binding: Any) -> tuple[str, Optional[str]]:
+            _ = binding
+            return "codex", None
+
+        def _runtime_agent_for_binding(self, binding: Any) -> str:
+            _ = binding
+            return "codex"
 
     async def _fake_begin(*args: Any, **kwargs: Any) -> Any:
         _ = args, kwargs
@@ -8101,5 +8133,94 @@ async def test_car_session_compact_places_continue_button_on_last_chunk_without_
         )
         assert archived_thread is not None
         assert archived_thread.lifecycle_status == "archived"
+    finally:
+        await store.close()
+
+
+def test_discord_harness_factory_accepts_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[tuple[str, Any]] = []
+
+    def _fake_make_harness(ctx: Any) -> SimpleNamespace:
+        agent_id = getattr(ctx, "_requested_agent_id", None)
+        profile = getattr(ctx, "_requested_agent_profile", None)
+        captured.append((agent_id, profile))
+        return SimpleNamespace()
+
+    descriptor = AgentDescriptor(
+        id="hermes",
+        name="Hermes",
+        capabilities=("durable_threads",),
+        make_harness=_fake_make_harness,
+        healthcheck=lambda: True,
+        runtime_kind="hermes",
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "get_registered_agents",
+        lambda context=None: {"hermes": descriptor},
+    )
+
+    store = DiscordStateStore(tmp_path / "state.sqlite3")
+    service = DiscordBotService(
+        _config(tmp_path, max_message_length=100),
+        logger=logging.getLogger("test"),
+        rest_client=_FakeRest(),
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    service._discord_thread_orchestration_service = None
+    service._discord_managed_thread_orchestration_service = None
+
+    orch = discord_message_turns_module.build_discord_thread_orchestration_service(
+        service
+    )
+    orch._harness_for_agent("hermes", "m4-pma")
+    assert len(captured) == 1
+    assert captured[0] == ("hermes", "m4-pma")
+
+
+@pytest.mark.anyio
+async def test_resolve_discord_thread_target_stores_agent_profile_in_metadata(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    service = DiscordBotService(
+        _config(tmp_path, max_message_length=120),
+        logger=logging.getLogger("test"),
+        rest_client=_FakeRest(),
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        _orch, thread = discord_message_turns_module.resolve_discord_thread_target(
+            service,
+            channel_id="channel-1",
+            workspace_root=workspace.resolve(),
+            agent="hermes",
+            agent_profile="m4-pma",
+            repo_id=None,
+            resource_kind=None,
+            resource_id=None,
+            mode="repo",
+            pma_enabled=False,
+        )
+        assert thread.agent_id == "hermes"
+        assert thread.agent_profile == "m4-pma"
     finally:
         await store.close()

--- a/tests/test_telegram_pma_routing.py
+++ b/tests/test_telegram_pma_routing.py
@@ -2480,6 +2480,7 @@ async def test_resolve_telegram_managed_thread_ignores_backend_thread_id_binding
             return SimpleNamespace(
                 thread_target_id=thread_target_id,
                 agent_id="codex",
+                agent_profile=None,
                 workspace_root=str(workspace),
                 lifecycle_status="active",
                 backend_thread_id=None,
@@ -2500,6 +2501,7 @@ async def test_resolve_telegram_managed_thread_ignores_backend_thread_id_binding
             SimpleNamespace(
                 thread_target_id="thread-1",
                 agent_id="codex",
+                agent_profile=None,
                 workspace_root=str(workspace),
                 lifecycle_status="archived",
                 backend_thread_id="legacy-backend",
@@ -4933,6 +4935,7 @@ async def test_resolve_telegram_managed_thread_rejects_rebind_when_runtime_missi
     thread = SimpleNamespace(
         thread_target_id="thread-existing",
         agent_id="opencode",
+        agent_profile=None,
         workspace_root=str(workspace),
         backend_thread_id="backend-old",
         lifecycle_status="active",
@@ -4997,6 +5000,7 @@ async def test_resolve_telegram_managed_thread_keeps_requested_backend_thread_id
     thread = SimpleNamespace(
         thread_target_id="thread-existing",
         agent_id="opencode",
+        agent_profile=None,
         workspace_root=str(other_workspace),
         backend_thread_id="backend-old",
         lifecycle_status="active",
@@ -5017,6 +5021,7 @@ async def test_resolve_telegram_managed_thread_keeps_requested_backend_thread_id
             return SimpleNamespace(
                 thread_target_id="thread-new",
                 agent_id=agent,
+                agent_profile=None,
                 workspace_root=str(workspace_root),
                 backend_thread_id=kwargs.get("backend_thread_id"),
                 lifecycle_status="active",


### PR DESCRIPTION
## Summary
Completes Hermes profile support for chat surfaces by propagating the selected profile into harness creation and durable thread metadata.

## Changes
- Discover Type B (config) Hermes profiles in `chat_hermes_profile_options`
- Pass `profile` through `wrap_requested_agent_context` when building Discord/Telegram harnesses
- Persist `agent_profile` on thread targets and treat profile changes as non-reusable for existing threads
- Test updates: Discord interrupt-send mocks, Telegram PMA routing thread stubs

## Issue
Fixes #1197

Made with [Cursor](https://cursor.com)