### PR TITLE
Improve voice provider error handling and env resolution

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -228,6 +228,8 @@ from ...tickets.files import (
 from ...tickets.frontmatter import parse_markdown_frontmatter
 from ...tickets.outbox import resolve_outbox_paths
 from ...voice import VoiceConfig, VoiceService, VoiceServiceError
+from ...voice.provider_catalog import normalize_voice_provider
+from ...voice.service import VoiceTransientError
 from ..chat.approval_modes import (
     APPROVAL_MODE_USAGE,
     normalize_approval_mode,
@@ -1715,6 +1717,34 @@ class DiscordBotService:
             kind=kind if isinstance(kind, str) else None,
         )
 
+    def _transcription_filename_for_attachment(
+        self,
+        attachment: Any,
+        *,
+        saved_name: str,
+        mime_type: Optional[str],
+    ) -> str:
+        raw_name = getattr(attachment, "file_name", None)
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            return saved_name
+
+        candidate = Path(raw_name).name.strip()
+        if not candidate:
+            return saved_name
+        if not self._is_audio_attachment(attachment, mime_type):
+            return candidate
+
+        # Discord voice notes can arrive with generic names like ".bin". Reuse the
+        # normalized inbox filename so transcription providers get a recognizable
+        # audio extension/content type.
+        if audio_content_type_for_input(
+            mime_type=None,
+            file_name=candidate,
+            source_url=None,
+        ):
+            return candidate
+        return saved_name
+
     async def _transcribe_voice_attachment(
         self,
         *,
@@ -1765,6 +1795,16 @@ class DiscordBotService:
                 file_id=getattr(attachment, "file_id", None),
                 reason=exc.reason,
             )
+            if isinstance(exc, VoiceTransientError):
+                detail = getattr(exc, "detail", None)
+                if isinstance(detail, str) and detail.strip():
+                    return None, detail.strip()
+            user_message = getattr(exc, "user_message", None)
+            if isinstance(user_message, str) and user_message.strip():
+                return None, user_message.strip()
+            detail = getattr(exc, "detail", None)
+            if isinstance(detail, str) and detail.strip():
+                return None, detail.strip()
             return None, f"Voice transcript unavailable ({exc.reason})."
         except Exception as exc:
             log_event(
@@ -1831,12 +1871,14 @@ class DiscordBotService:
                 path = inbox / file_name
                 path.write_bytes(data)
                 original_name = getattr(attachment, "file_name", None) or path.name
-                transcription_name = str(original_name)
-                if not Path(transcription_name).suffix:
-                    transcription_name = path.name
                 mime_type = getattr(attachment, "mime_type", None)
                 is_audio = self._is_audio_attachment(
                     attachment, mime_type if isinstance(mime_type, str) else None
+                )
+                transcription_name = self._transcription_filename_for_attachment(
+                    attachment,
+                    saved_name=path.name,
+                    mime_type=mime_type if isinstance(mime_type, str) else None,
                 )
                 is_image = is_image_mime_or_path(
                     mime_type if isinstance(mime_type, str) else None,
@@ -1913,14 +1955,19 @@ class DiscordBotService:
                 details.append(f"  Transcript: {item.transcript_warning}")
 
         if any(item.transcript_text for item in saved):
-            _voice_service, voice_config = self._voice_service_for_workspace(
+            voice_service, voice_config = self._voice_service_for_workspace(
                 workspace_root
             )
-            provider_name = (
-                voice_config.provider.strip()
-                if voice_config and isinstance(voice_config.provider, str)
-                else ""
-            )
+            provider_name = ""
+            if voice_service is not None:
+                with contextlib.suppress(Exception):
+                    provider_name = voice_service.effective_provider_name()
+            if (
+                not provider_name
+                and voice_config
+                and isinstance(voice_config.provider, str)
+            ):
+                provider_name = normalize_voice_provider(voice_config.provider)
             if provider_name == "openai_whisper":
                 details.append("")
                 details.append(
@@ -1995,21 +2042,24 @@ class DiscordBotService:
                     "application/pdf": ".pdf",
                     "text/plain": ".txt",
                 }.get(mime_key, "")
-        if not suffix:
-            source_url = getattr(attachment, "source_url", None)
-            is_audio = is_audio_mime_or_path(
+        source_url = getattr(attachment, "source_url", None)
+        is_audio = is_audio_mime_or_path(
+            mime_type=getattr(attachment, "mime_type", None),
+            file_name=getattr(attachment, "file_name", None),
+            source_url=source_url if isinstance(source_url, str) else None,
+            kind=getattr(attachment, "kind", None),
+        )
+        if is_audio and not audio_content_type_for_input(
+            mime_type=None,
+            file_name=f"attachment{suffix}" if suffix else None,
+            source_url=None,
+        ):
+            suffix = audio_extension_for_input(
                 mime_type=getattr(attachment, "mime_type", None),
                 file_name=getattr(attachment, "file_name", None),
                 source_url=source_url if isinstance(source_url, str) else None,
-                kind=getattr(attachment, "kind", None),
+                default=".ogg",
             )
-            if is_audio:
-                suffix = audio_extension_for_input(
-                    mime_type=getattr(attachment, "mime_type", None),
-                    file_name=getattr(attachment, "file_name", None),
-                    source_url=source_url if isinstance(source_url, str) else None,
-                    default=".ogg",
-                )
         return f"{stem[:64]}-{uuid.uuid4().hex[:8]}{suffix}"
 
     async def _find_paused_flow_run(

--- a/src/codex_autorunner/surfaces/web/routes/voice.py
+++ b/src/codex_autorunner/surfaces/web/routes/voice.py
@@ -108,6 +108,13 @@ def build_voice_routes() -> APIRouter:
                 status = 413
             elif exc.reason == "rate_limited":
                 status = 429
+            elif exc.reason in (
+                "missing_api_key",
+                "provider_unavailable",
+                "local_provider_unavailable",
+                "local_runtime_dependency_missing",
+            ):
+                status = 503
             else:
                 status = (
                     400

--- a/src/codex_autorunner/voice/providers/openai_whisper.py
+++ b/src/codex_autorunner/voice/providers/openai_whisper.py
@@ -150,7 +150,7 @@ class OpenAIWhisperProvider(SpeechProvider):
         request_fn: Optional[RequestFn] = None,
     ) -> None:
         self._settings = settings
-        self._env = env or os.environ
+        self._env = env if env is not None else os.environ
         self._warn_on_remote_api = warn_on_remote_api
         self._logger = logger or logging.getLogger(__name__)
         self._request_fn: RequestFn = request_fn or self._default_request

--- a/src/codex_autorunner/voice/resolver.py
+++ b/src/codex_autorunner/voice/resolver.py
@@ -37,7 +37,7 @@ def resolve_speech_provider(
         return build_speech_provider(
             provider_configs.get(provider_name, {}),
             warn_on_remote_api=voice_config.warn_on_remote_api,
-            env=env or os.environ,
+            env=env if env is not None else os.environ,
             logger=logger,
         )
     if provider_name == LocalWhisperProvider.name:

--- a/src/codex_autorunner/voice/service.py
+++ b/src/codex_autorunner/voice/service.py
@@ -86,10 +86,14 @@ class VoiceService:
 
     def config_payload(self) -> dict:
         """Expose safe config fields to the UI."""
+        configured_provider = self._configured_provider_name()
+        try:
+            effective_provider = self.effective_provider_name()
+        except Exception:
+            effective_provider = configured_provider
+
         # Providers that do not use remote APIs may not require any API key.
-        provider_cfg = self.config.providers.get(
-            self.config.provider or "openai_whisper", {}
-        )
+        provider_cfg = self.config.providers.get(effective_provider, {})
         api_key_env = provider_cfg.get("api_key_env")
         api_key_env_name = api_key_env.strip() if isinstance(api_key_env, str) else ""
         requires_api_key = bool(api_key_env_name)
@@ -100,6 +104,7 @@ class VoiceService:
         return {
             "enabled": self.config.enabled,
             "provider": self.config.provider,
+            "effective_provider": effective_provider,
             "latency_mode": self.config.latency_mode,
             "chunk_ms": self.config.chunk_ms,
             "sample_rate": self.config.sample_rate,
@@ -128,7 +133,10 @@ class VoiceService:
         if not audio_bytes:
             raise VoiceServiceError("empty_audio", "No audio received")
 
-        provider = self._resolve_provider()
+        try:
+            provider = self._resolve_provider()
+        except ValueError as exc:
+            raise self._provider_resolution_error(exc) from exc
         buffer = _TranscriptionBuffer()
         capture = PushToTalkCapture(
             provider=provider,
@@ -192,9 +200,7 @@ class VoiceService:
                     user_message="Voice transcription rate limited. Retrying...",
                 )
             if buffer.error_reason == "local_runtime_dependency_missing":
-                provider = normalize_voice_provider(
-                    self.config.provider or "local_whisper"
-                )
+                provider = self.effective_provider_name()
                 raise VoicePermanentError(
                     "local_runtime_dependency_missing",
                     "Local voice runtime dependencies are unavailable. Ensure ffmpeg "
@@ -205,9 +211,7 @@ class VoiceService:
                     ),
                 )
             if buffer.error_reason == "local_provider_unavailable":
-                provider = normalize_voice_provider(
-                    self.config.provider or "local_whisper"
-                )
+                provider = self.effective_provider_name()
                 provider_spec = local_voice_provider_spec(provider)
                 extra = provider_spec[2] if provider_spec is not None else "voice-local"
                 raise VoicePermanentError(
@@ -268,6 +272,52 @@ class VoiceService:
                 except TypeError:
                     self._provider = self._provider_resolver(self.config)
         return self._provider
+
+    def _configured_provider_name(self) -> str:
+        provider_name = normalize_voice_provider(self.config.provider or "")
+        return provider_name or "openai_whisper"
+
+    def effective_provider_name(self) -> str:
+        configured_provider = self._configured_provider_name()
+        provider = self._provider
+        if provider is None:
+            try:
+                provider = self._resolve_provider()
+            except ValueError:
+                return configured_provider
+        provider_name = getattr(provider, "name", None)
+        if isinstance(provider_name, str):
+            normalized_provider = normalize_voice_provider(provider_name)
+            if normalized_provider == "openai_whisper":
+                return normalized_provider
+            if local_voice_provider_spec(normalized_provider) is not None:
+                return normalized_provider
+        return configured_provider
+
+    def _provider_resolution_error(self, exc: ValueError) -> VoiceServiceError:
+        message = str(exc).strip() or "Voice provider is unavailable"
+        provider_name = self._configured_provider_name()
+        provider_cfg = self.config.providers.get(provider_name, {})
+        api_key_env_name = "OPENAI_API_KEY"
+        if isinstance(provider_cfg, Mapping):
+            raw_api_key_env = provider_cfg.get("api_key_env")
+            if isinstance(raw_api_key_env, str) and raw_api_key_env.strip():
+                api_key_env_name = raw_api_key_env.strip()
+
+        if "api key env" in message.lower():
+            return VoicePermanentError(
+                "missing_api_key",
+                message,
+                user_message=(
+                    "Voice transcription failed: missing API key. "
+                    f"Set {api_key_env_name} or install a local whisper provider."
+                ),
+            )
+        return VoicePermanentError(
+            "provider_unavailable",
+            message,
+            user_message=message,
+        )
 
     def _build_session_metadata(
         self,

--- a/tests/test_discord_voice_input.py
+++ b/tests/test_discord_voice_input.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from codex_autorunner.voice.service import VoicePermanentError, VoiceTransientError
+
+
+def _load_discord_service_module():
+    root = Path(__file__).resolve().parents[1] / "src" / "codex_autorunner"
+
+    for name, path in (
+        ("codex_autorunner.integrations.chat", root / "integrations" / "chat"),
+        ("codex_autorunner.integrations.discord", root / "integrations" / "discord"),
+    ):
+        package = types.ModuleType(name)
+        package.__path__ = [str(path)]
+        sys.modules[name] = package
+
+    return importlib.import_module("codex_autorunner.integrations.discord.service")
+
+
+def _make_service(*, voice_service):
+    discord_service = _load_discord_service_module()
+    service = object.__new__(discord_service.DiscordBotService)
+    service._logger = logging.getLogger("test.discord.voice")
+    service._config = SimpleNamespace(
+        media=SimpleNamespace(enabled=True, voice=True, max_voice_bytes=10_000),
+        max_message_length=2_000,
+    )
+    service._voice_service_for_workspace = lambda workspace_root: (
+        voice_service,
+        SimpleNamespace(provider="openai_whisper"),
+    )
+    return service
+
+
+def test_build_attachment_filename_normalizes_generic_audio_suffix():
+    service = _make_service(voice_service=None)
+    attachment = SimpleNamespace(
+        kind="audio",
+        file_name="voice-message.bin",
+        mime_type="application/octet-stream",
+        source_url="https://cdn.discordapp.com/attachments/1/2",
+    )
+
+    file_name = service._build_attachment_filename(attachment, index=1)
+
+    assert file_name.endswith(".ogg")
+
+
+@pytest.mark.asyncio
+async def test_with_attachment_context_normalizes_discord_voice_transcription_metadata(
+    tmp_path: Path,
+):
+    class _FakeRest:
+        async def download_attachment(
+            self,
+            *,
+            url: str,
+            max_size_bytes: int | None = None,
+        ):
+            return b"voice-bytes"
+
+    class _FakeVoiceService:
+        def __init__(self):
+            self.calls: list[dict[str, object]] = []
+
+        async def transcribe_async(self, data: bytes, **kwargs):
+            self.calls.append({"data": data, **kwargs})
+            return {"text": "hello from discord"}
+
+    voice_service = _FakeVoiceService()
+    service = _make_service(voice_service=voice_service)
+    service._rest = _FakeRest()
+
+    attachment = SimpleNamespace(
+        kind="audio",
+        file_id="voice-1",
+        file_name="voice-message.bin",
+        mime_type="application/octet-stream",
+        size_bytes=11,
+        source_url="https://cdn.discordapp.com/attachments/1/2",
+    )
+
+    prompt_text, saved_count, failed_count, transcript_message, native_input_items = (
+        await service._with_attachment_context(
+            prompt_text="",
+            workspace_root=tmp_path,
+            attachments=(attachment,),
+            channel_id="123",
+        )
+    )
+
+    assert saved_count == 1
+    assert failed_count == 0
+    assert native_input_items is None
+    assert "hello from discord" in (transcript_message or "")
+    assert "Transcript: hello from discord" in prompt_text
+
+    assert len(voice_service.calls) == 1
+    call = voice_service.calls[0]
+    assert call["data"] == b"voice-bytes"
+    assert str(call["filename"]).endswith(".ogg")
+    assert call["content_type"] == "audio/ogg"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_attachment_returns_voice_user_message(tmp_path: Path):
+    class _FailingVoiceService:
+        async def transcribe_async(self, data: bytes, **kwargs):
+            raise VoicePermanentError(
+                "missing_api_key",
+                "OpenAI Whisper provider requires API key env 'OPENAI_API_KEY' to be set.",
+                user_message=(
+                    "Voice transcription failed: missing API key. "
+                    "Set OPENAI_API_KEY or install a local whisper provider."
+                ),
+            )
+
+    service = _make_service(voice_service=_FailingVoiceService())
+    transcript, warning = await service._transcribe_voice_attachment(
+        workspace_root=tmp_path,
+        channel_id="123",
+        attachment=SimpleNamespace(
+            kind="audio",
+            file_id="voice-2",
+            file_name="voice-message.ogg",
+            mime_type="audio/ogg",
+            source_url="https://cdn.discordapp.com/attachments/1/2",
+        ),
+        data=b"voice-bytes",
+        file_name="voice-message.ogg",
+        mime_type="audio/ogg",
+    )
+
+    assert transcript is None
+    assert (
+        warning
+        == "Voice transcription failed: missing API key. Set OPENAI_API_KEY or install a local whisper provider."
+    )
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_attachment_uses_detail_for_transient_errors(
+    tmp_path: Path,
+):
+    class _FailingVoiceService:
+        async def transcribe_async(self, data: bytes, **kwargs):
+            raise VoiceTransientError(
+                "rate_limited",
+                "OpenAI rate limited the request; wait a moment and try again.",
+                user_message="Voice transcription rate limited. Retrying...",
+            )
+
+    service = _make_service(voice_service=_FailingVoiceService())
+    transcript, warning = await service._transcribe_voice_attachment(
+        workspace_root=tmp_path,
+        channel_id="123",
+        attachment=SimpleNamespace(
+            kind="audio",
+            file_id="voice-3",
+            file_name="voice-message.ogg",
+            mime_type="audio/ogg",
+            source_url="https://cdn.discordapp.com/attachments/1/2",
+        ),
+        data=b"voice-bytes",
+        file_name="voice-message.ogg",
+        mime_type="audio/ogg",
+    )
+
+    assert transcript is None
+    assert warning == "OpenAI rate limited the request; wait a moment and try again."
+
+
+@pytest.mark.asyncio
+async def test_with_attachment_context_uses_effective_provider_for_disclaimer(
+    tmp_path: Path,
+):
+    discord_service = _load_discord_service_module()
+
+    class _FakeRest:
+        async def download_attachment(
+            self,
+            *,
+            url: str,
+            max_size_bytes: int | None = None,
+        ):
+            return b"voice-bytes"
+
+    class _FakeVoiceService:
+        async def transcribe_async(self, data: bytes, **kwargs):
+            return {"text": "hello from local whisper"}
+
+        def effective_provider_name(self) -> str:
+            return "local_whisper"
+
+    service = _make_service(voice_service=_FakeVoiceService())
+    service._rest = _FakeRest()
+
+    attachment = SimpleNamespace(
+        kind="audio",
+        file_id="voice-4",
+        file_name="voice-message.bin",
+        mime_type="application/octet-stream",
+        size_bytes=11,
+        source_url="https://cdn.discordapp.com/attachments/1/2",
+    )
+
+    prompt_text, saved_count, failed_count, transcript_message, native_input_items = (
+        await service._with_attachment_context(
+            prompt_text="",
+            workspace_root=tmp_path,
+            attachments=(attachment,),
+            channel_id="123",
+        )
+    )
+
+    assert saved_count == 1
+    assert failed_count == 0
+    assert native_input_items is None
+    assert transcript_message == "User:\nhello from local whisper"
+    assert discord_service.DISCORD_WHISPER_TRANSCRIPT_DISCLAIMER not in prompt_text

--- a/tests/test_voice_routes.py
+++ b/tests/test_voice_routes.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from codex_autorunner.surfaces.web.routes.voice import build_voice_routes
+from codex_autorunner.voice.config import VoiceConfig
+from codex_autorunner.voice.service import VoicePermanentError
+
+
+def _build_app(*, voice_service) -> FastAPI:
+    app = FastAPI()
+    app.include_router(build_voice_routes())
+    app.state.voice_service = voice_service
+    app.state.voice_config = VoiceConfig.from_raw(
+        {"enabled": True, "provider": "openai_whisper"},
+        env={},
+    )
+    app.state.voice_missing_reason = None
+    app.state.logger = logging.getLogger("test.voice.routes")
+    return app
+
+
+@pytest.mark.parametrize(
+    ("reason", "detail"),
+    [
+        (
+            "missing_api_key",
+            "Voice transcription failed: missing API key. Set OPENAI_API_KEY.",
+        ),
+        (
+            "provider_unavailable",
+            "Voice provider is unavailable.",
+        ),
+        (
+            "local_provider_unavailable",
+            "Local Whisper provider is unavailable.",
+        ),
+        (
+            "local_runtime_dependency_missing",
+            "Local voice runtime dependencies are unavailable.",
+        ),
+    ],
+)
+def test_voice_transcribe_returns_503_for_provider_setup_errors(
+    reason: str,
+    detail: str,
+):
+    class _FailingVoiceService:
+        def transcribe(self, audio_bytes: bytes, **kwargs):
+            raise VoicePermanentError(reason, detail)
+
+    client = TestClient(_build_app(voice_service=_FailingVoiceService()))
+
+    response = client.post("/api/voice/transcribe", content=b"voice-bytes")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": detail}

--- a/tests/test_voice_runtime.py
+++ b/tests/test_voice_runtime.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from codex_autorunner.voice.config import VoiceConfig
+from codex_autorunner.voice.provider import SpeechSessionMetadata
+from codex_autorunner.voice.providers import build_speech_provider
+from codex_autorunner.voice.service import VoicePermanentError, VoiceService
+
+
+def test_openai_whisper_provider_respects_explicit_empty_env(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("OPENAI_API_KEY", "process-key")
+    provider = build_speech_provider({}, env={})
+
+    with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+        provider.start_stream(
+            SpeechSessionMetadata(
+                session_id="session-1",
+                provider="openai_whisper",
+                latency_mode="balanced",
+            )
+        )
+
+
+def test_voice_service_transcribe_surfaces_missing_openai_api_key():
+    config = VoiceConfig.from_raw(
+        {"enabled": True, "provider": "openai_whisper"},
+        env={},
+    )
+
+    def _resolver(config, *, logger=None, env=None):
+        raise ValueError(
+            "OpenAI Whisper provider requires API key env 'OPENAI_API_KEY' to be set."
+        )
+
+    service = VoiceService(config, provider_resolver=_resolver, env={})
+
+    with pytest.raises(VoicePermanentError) as exc_info:
+        service.transcribe(b"voice-bytes", client="discord")
+
+    assert exc_info.value.reason == "missing_api_key"
+    assert exc_info.value.user_message == (
+        "Voice transcription failed: missing API key. "
+        "Set OPENAI_API_KEY or install a local whisper provider."
+    )
+
+
+def test_voice_service_config_payload_uses_effective_fallback_provider():
+    config = VoiceConfig.from_raw(
+        {"enabled": True, "provider": "openai_whisper"},
+        env={},
+    )
+    sentinel = SimpleNamespace(name="local_whisper")
+    service = VoiceService(
+        config,
+        provider_resolver=lambda config, *, logger=None, env=None: sentinel,
+        env={},
+    )
+
+    payload = service.config_payload()
+
+    assert payload["provider"] == "openai_whisper"
+    assert payload["effective_provider"] == "local_whisper"
+    assert payload["has_api_key"] is True
+    assert payload["api_key_env"] is None


### PR DESCRIPTION
## Summary

Selective backport of clean improvements from #1200 by @Lange1337.

This PR takes the error handling, env resolution fixes, and Discord voice improvements from #1200 without the silent provider fallback mechanism.

Changes:
- Fix explicit empty env mapping (`env or os.environ` -> `env if env is not None else os.environ`) in OpenAI Whisper provider
- Expose effective resolved voice provider in `VoiceService.config_payload()` via `effective_provider` field
- Surface actionable missing-key / provider-unavailable errors from `VoiceService` with user-friendly messages
- Return 503 (not 502) from web voice transcribe route for provider setup/runtime failures
- Prefer `user_message` over generic reason in Discord voice error warnings
- Use effective provider when deciding whether to inject OpenAI Whisper transcript disclaimer in Discord
- Normalize Discord voice attachment filenames so generic audio metadata (e.g. `.bin`) produces valid transcription filenames

## Testing

- `python -m py_compile` passes for all changed files
- `pytest tests/test_voice_runtime.py tests/test_voice_routes.py tests/test_discord_voice_input.py` - all passing

## Credit

Based on #1200 by @Lange1337. Thank you for the thorough contribution!
