### PR TITLE
fix(hub): make Cleanup all actionable and resilient

### DIFF
--- a/src/codex_autorunner/static/generated/hub.js
+++ b/src/codex_autorunner/static/generated/hub.js
@@ -69,8 +69,10 @@ const pmaVersionEl = document.getElementById("pma-version");
 const hubRepoSearchInput = document.getElementById("hub-repo-search");
 const hubFlowFilterEl = document.getElementById("hub-flow-filter");
 const hubSortOrderEl = document.getElementById("hub-sort-order");
-const hubCleanupAllThreadsBtn = document.getElementById("hub-cleanup-all-threads");
 const hubRepoPanelEl = document.getElementById("hub-repo-panel");
+function getHubCleanupAllThreadsBtn() {
+    return document.getElementById("hub-cleanup-all-threads");
+}
 const hubAgentPanelEl = document.getElementById("hub-agent-panel");
 const hubShellEl = document.getElementById("hub-shell");
 const hubRepoPanelSummaryEl = document.getElementById("hub-repo-panel-summary");
@@ -86,6 +88,8 @@ let hubUsageIndex = {};
 let hubUsageUnmatched = null;
 let hubChannelEntries = [];
 let hubOpenPanel = loadHubOpenPanel();
+/** True while bulk cleanup POST is in flight; keeps the button disabled across hub re-renders. */
+let cleanupAllRepoThreadsInFlight = false;
 function saveSessionCache(key, value) {
     try {
         const payload = { at: Date.now(), value };
@@ -431,23 +435,41 @@ async function pollHubJob(jobId, { timeoutMs = HUB_JOB_TIMEOUT_MS } = {}) {
     }
 }
 function updateCleanupAllThreadsButton(repos) {
-    if (!hubCleanupAllThreadsBtn)
+    const btn = getHubCleanupAllThreadsBtn();
+    if (!btn)
         return;
     const cleanupRepos = baseReposWithUnboundThreads(repos);
     const totalThreads = totalUnboundManagedThreadCount(cleanupRepos);
     const dirtyRepos = dirtyBaseReposWithUnboundThreads(repos);
-    hubCleanupAllThreadsBtn.textContent =
+    const empty = totalThreads <= 0;
+    btn.textContent =
         totalThreads > 0 ? `Cleanup all (${totalThreads})` : "Cleanup all";
-    hubCleanupAllThreadsBtn.disabled = totalThreads <= 0;
+    if (cleanupAllRepoThreadsInFlight) {
+        btn.disabled = true;
+        btn.classList.remove("hub-cleanup-all--empty");
+        btn.removeAttribute("aria-disabled");
+        btn.title = "Cleaning up stale threads…";
+        return;
+    }
+    // Do not use the native `disabled` attribute when empty: it swallows clicks
+    // with no feedback; use aria + styling so the handler can flash a toast.
+    btn.disabled = false;
+    if (empty) {
+        btn.setAttribute("aria-disabled", "true");
+    }
+    else {
+        btn.removeAttribute("aria-disabled");
+    }
+    btn.classList.toggle("hub-cleanup-all--empty", empty);
     if (totalThreads <= 0) {
-        hubCleanupAllThreadsBtn.title =
-            "No stale non-chat-bound managed threads across base repos";
+        btn.title =
+            "No stale non-chat-bound managed threads across base repos (click for confirmation)";
         return;
     }
     const dirtySummary = dirtyRepos.length
         ? ` Includes ${dirtyRepos.length} dirty repo${dirtyRepos.length === 1 ? "" : "s"}.`
         : "";
-    hubCleanupAllThreadsBtn.title =
+    btn.title =
         `Archive ${totalThreads} stale non-chat-bound managed thread${totalThreads === 1 ? "" : "s"} across ${cleanupRepos.length} base repo${cleanupRepos.length === 1 ? "" : "s"}.` +
             dirtySummary;
 }
@@ -2654,8 +2676,11 @@ async function handleRepoAction(repoId, action) {
     }
 }
 async function handleCleanupAllRepoThreads() {
-    if (!hubCleanupAllThreadsBtn)
+    const btn = getHubCleanupAllThreadsBtn();
+    if (!btn) {
+        flash("Cleanup control is missing from the page.", "error");
         return;
+    }
     const cleanupRepos = baseReposWithUnboundThreads(hubData.repos || []);
     const totalThreads = totalUnboundManagedThreadCount(cleanupRepos);
     if (totalThreads <= 0) {
@@ -2671,7 +2696,8 @@ async function handleCleanupAllRepoThreads() {
     const ok = await confirmModal(`Clean up stale non-chat threads across ${cleanupRepos.length} base repo${cleanupRepos.length === 1 ? "" : "s"}?\n\nCAR will archive ${totalThreads} unbound managed thread${totalThreads === 1 ? "" : "s"}. Discord and Telegram-bound threads will stay active.${dirtyWarning}`, { confirmText: "Cleanup all" });
     if (!ok)
         return;
-    hubCleanupAllThreadsBtn.disabled = true;
+    cleanupAllRepoThreadsInFlight = true;
+    updateCleanupAllThreadsButton(hubData.repos || []);
     try {
         const response = (await api("/hub/repos/cleanup-threads", {
             method: "POST",
@@ -2686,6 +2712,7 @@ async function handleCleanupAllRepoThreads() {
         flash(err.message || "Bulk cleanup failed", "error");
     }
     finally {
+        cleanupAllRepoThreadsInFlight = false;
         updateCleanupAllThreadsButton(hubData.repos || []);
     }
 }
@@ -2707,11 +2734,13 @@ function attachHubHandlers() {
     if (hubUsageRefresh) {
         hubUsageRefresh.addEventListener("click", () => loadHubUsage());
     }
-    if (hubCleanupAllThreadsBtn) {
-        hubCleanupAllThreadsBtn.addEventListener("click", () => {
-            void handleCleanupAllRepoThreads();
-        });
-    }
+    hubRepoPanelEl?.addEventListener("click", (e) => {
+        const target = e.target;
+        const el = target instanceof Element ? target : target.parentElement;
+        if (!el?.closest("#hub-cleanup-all-threads"))
+            return;
+        void handleCleanupAllRepoThreads();
+    });
     if (hubRepoSearchInput) {
         hubRepoSearchInput.addEventListener("input", () => {
             renderReposWithScroll(hubData.repos || []);

--- a/src/codex_autorunner/static/generated/utils.js
+++ b/src/codex_autorunner/static/generated/utils.js
@@ -497,6 +497,7 @@ export function confirmModal(message, options = {}) {
         const okBtn = document.getElementById("confirm-modal-ok");
         const cancelBtn = document.getElementById("confirm-modal-cancel");
         if (!overlay || !messageEl || !okBtn || !cancelBtn) {
+            flash("Confirmation dialog is unavailable (expected #confirm-modal markup is missing).", "error");
             resolve(false);
             return;
         }

--- a/src/codex_autorunner/static/styles.css
+++ b/src/codex_autorunner/static/styles.css
@@ -1416,6 +1416,12 @@ main {
   padding: var(--sp-1) 0;
 }
 
+/* Matches button:disabled look but keeps clicks (handler shows a toast). */
+button#hub-cleanup-all-threads.hub-cleanup-all--empty {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .hub-repo-control {
   display: inline-flex;
   align-items: center;

--- a/src/codex_autorunner/static_src/hub.ts
+++ b/src/codex_autorunner/static_src/hub.ts
@@ -333,10 +333,13 @@ const hubFlowFilterEl = document.getElementById(
 const hubSortOrderEl = document.getElementById(
   "hub-sort-order"
 ) as HTMLSelectElement | null;
-const hubCleanupAllThreadsBtn = document.getElementById(
-  "hub-cleanup-all-threads"
-) as HTMLButtonElement | null;
 const hubRepoPanelEl = document.getElementById("hub-repo-panel");
+
+function getHubCleanupAllThreadsBtn(): HTMLButtonElement | null {
+  return document.getElementById(
+    "hub-cleanup-all-threads"
+  ) as HTMLButtonElement | null;
+}
 const hubAgentPanelEl = document.getElementById("hub-agent-panel");
 const hubShellEl = document.getElementById("hub-shell");
 const hubRepoPanelSummaryEl = document.getElementById(
@@ -357,6 +360,8 @@ let hubUsageIndex: Record<string, HubUsageRepo> = {};
 let hubUsageUnmatched: HubUsageData["unmatched"] | null = null;
 let hubChannelEntries: HubChannelEntry[] = [];
 let hubOpenPanel: HubOpenPanel = loadHubOpenPanel();
+/** True while bulk cleanup POST is in flight; keeps the button disabled across hub re-renders. */
+let cleanupAllRepoThreadsInFlight = false;
 
 function saveSessionCache<T>(key: string, value: T): void {
   try {
@@ -725,16 +730,33 @@ async function pollHubJob(jobId: string, { timeoutMs = HUB_JOB_TIMEOUT_MS }: Pol
 }
 
 function updateCleanupAllThreadsButton(repos: HubRepo[]): void {
-  if (!hubCleanupAllThreadsBtn) return;
+  const btn = getHubCleanupAllThreadsBtn();
+  if (!btn) return;
   const cleanupRepos = baseReposWithUnboundThreads(repos);
   const totalThreads = totalUnboundManagedThreadCount(cleanupRepos);
   const dirtyRepos = dirtyBaseReposWithUnboundThreads(repos);
-  hubCleanupAllThreadsBtn.textContent =
+  const empty = totalThreads <= 0;
+  btn.textContent =
     totalThreads > 0 ? `Cleanup all (${totalThreads})` : "Cleanup all";
-  hubCleanupAllThreadsBtn.disabled = totalThreads <= 0;
+  if (cleanupAllRepoThreadsInFlight) {
+    btn.disabled = true;
+    btn.classList.remove("hub-cleanup-all--empty");
+    btn.removeAttribute("aria-disabled");
+    btn.title = "Cleaning up stale threads…";
+    return;
+  }
+  // Do not use the native `disabled` attribute when empty: it swallows clicks
+  // with no feedback; use aria + styling so the handler can flash a toast.
+  btn.disabled = false;
+  if (empty) {
+    btn.setAttribute("aria-disabled", "true");
+  } else {
+    btn.removeAttribute("aria-disabled");
+  }
+  btn.classList.toggle("hub-cleanup-all--empty", empty);
   if (totalThreads <= 0) {
-    hubCleanupAllThreadsBtn.title =
-      "No stale non-chat-bound managed threads across base repos";
+    btn.title =
+      "No stale non-chat-bound managed threads across base repos (click for confirmation)";
     return;
   }
   const dirtySummary = dirtyRepos.length
@@ -742,7 +764,7 @@ function updateCleanupAllThreadsButton(repos: HubRepo[]): void {
         dirtyRepos.length === 1 ? "" : "s"
       }.`
     : "";
-  hubCleanupAllThreadsBtn.title =
+  btn.title =
     `Archive ${totalThreads} stale non-chat-bound managed thread${
       totalThreads === 1 ? "" : "s"
     } across ${cleanupRepos.length} base repo${cleanupRepos.length === 1 ? "" : "s"}.` +
@@ -3346,7 +3368,11 @@ async function handleRepoAction(repoId: string, action: string): Promise<void> {
 }
 
 async function handleCleanupAllRepoThreads(): Promise<void> {
-  if (!hubCleanupAllThreadsBtn) return;
+  const btn = getHubCleanupAllThreadsBtn();
+  if (!btn) {
+    flash("Cleanup control is missing from the page.", "error");
+    return;
+  }
   const cleanupRepos = baseReposWithUnboundThreads(hubData.repos || []);
   const totalThreads = totalUnboundManagedThreadCount(cleanupRepos);
   if (totalThreads <= 0) {
@@ -3371,7 +3397,8 @@ async function handleCleanupAllRepoThreads(): Promise<void> {
   );
   if (!ok) return;
 
-  hubCleanupAllThreadsBtn.disabled = true;
+  cleanupAllRepoThreadsInFlight = true;
+  updateCleanupAllThreadsButton(hubData.repos || []);
   try {
     const response = (await api("/hub/repos/cleanup-threads", {
       method: "POST",
@@ -3385,6 +3412,7 @@ async function handleCleanupAllRepoThreads(): Promise<void> {
   } catch (err) {
     flash((err as Error).message || "Bulk cleanup failed", "error");
   } finally {
+    cleanupAllRepoThreadsInFlight = false;
     updateCleanupAllThreadsButton(hubData.repos || []);
   }
 }
@@ -3415,11 +3443,13 @@ function attachHubHandlers(): void {
   if (hubUsageRefresh) {
     hubUsageRefresh.addEventListener("click", () => loadHubUsage());
   }
-  if (hubCleanupAllThreadsBtn) {
-    hubCleanupAllThreadsBtn.addEventListener("click", () => {
-      void handleCleanupAllRepoThreads();
-    });
-  }
+  hubRepoPanelEl?.addEventListener("click", (e) => {
+    const target = e.target;
+    const el =
+      target instanceof Element ? target : (target as Node).parentElement;
+    if (!el?.closest("#hub-cleanup-all-threads")) return;
+    void handleCleanupAllRepoThreads();
+  });
   if (hubRepoSearchInput) {
     hubRepoSearchInput.addEventListener("input", () => {
       renderReposWithScroll(hubData.repos || []);

--- a/src/codex_autorunner/static_src/utils.ts
+++ b/src/codex_autorunner/static_src/utils.ts
@@ -527,6 +527,10 @@ export function confirmModal(message: string, options: ConfirmModalOptions = {})
     const cancelBtn = document.getElementById("confirm-modal-cancel") as HTMLButtonElement | null;
 
     if (!overlay || !messageEl || !okBtn || !cancelBtn) {
+      flash(
+        "Confirmation dialog is unavailable (expected #confirm-modal markup is missing).",
+        "error"
+      );
       resolve(false);
       return;
     }


### PR DESCRIPTION
## Problem
The Hub **Cleanup all** control could appear interactive while doing nothing: no toast, no confirm dialog, and no network request.

## Causes
- **Native `disabled`** when there were zero unbound threads to archive — disabled buttons do not fire `click`, so users saw no feedback.
- **Confirm modal** could resolve `false` immediately if `#confirm-modal` markup was missing, with no visible error.
- **Re-renders during POST** could clear the temporary disabled state and allow overlapping requests.

## Changes
- Use `aria-disabled` + `hub-cleanup-all--empty` styling for the empty state; keep the control clickable so we can show a toast explaining there is nothing to clean.
- Delegate clicks from `#hub-repo-panel` for `#hub-cleanup-all-threads`.
- `confirmModal`: flash an error when confirmation DOM is missing.
- `cleanupAllRepoThreadsInFlight`: keep the button disabled for the whole bulk-cleanup request even if the hub list re-renders mid-flight.

## Testing
- Pre-commit: eslint, `pnpm build`, JS tests, full pytest suite.


Made with [Cursor](https://cursor.com)