### PR TITLE
[codex] Add polling parity for PR comments

### DIFF
--- a/src/codex_autorunner/integrations/github/polling.py
+++ b/src/codex_autorunner/integrations/github/polling.py
@@ -240,11 +240,10 @@ def _build_snapshot(
 
     current_review_thread_comments: dict[str, Any] = {}
     for thread in review_threads:
-        if bool(thread.get("isResolved")):
-            continue
         comments = thread.get("comments")
         if not isinstance(comments, list):
             continue
+        thread_resolved = bool(thread.get("isResolved"))
         for comment in comments:
             if not isinstance(comment, Mapping):
                 continue
@@ -260,6 +259,7 @@ def _build_snapshot(
                 ),
                 "issue_number": binding.pr_number,
                 "issue_author_login": pr_author_login,
+                "thread_resolved": thread_resolved,
                 "line": (
                     comment.get("line")
                     if isinstance(comment.get("line"), int)
@@ -517,6 +517,8 @@ class GitHubScmPollingService:
             emitted += 1
 
         for key, payload in current_review_thread_comments.items():
+            if bool(payload.get("thread_resolved")):
+                continue
             if key in previous_review_thread_comments:
                 continue
             event = self._event_store.record_event(

--- a/src/codex_autorunner/integrations/github/service.py
+++ b/src/codex_autorunner/integrations/github/service.py
@@ -974,7 +974,7 @@ class GitHubService:
         repo: str,
         number: Optional[int] = None,
         since: Optional[str] = None,
-        limit: int = 100,
+        limit: Optional[int] = None,
         cwd: Optional[Path] = None,
     ) -> list[dict[str, Any]]:
         endpoint = (
@@ -982,25 +982,39 @@ class GitHubService:
             if number is not None
             else f"repos/{owner}/{repo}/issues/comments"
         )
-        args = [
-            "api",
-            endpoint,
-            "-F",
-            f"per_page={int(limit)}",
-        ]
-        if since:
-            args += ["-F", f"since={since}"]
-        proc = self._gh(
-            args, cwd=cwd or self.repo_root, check=False, timeout_seconds=30
-        )
-        if proc.returncode != 0:
+        issue_number = int(number) if number is not None else None
+        remaining = None if limit is None else max(int(limit), 0)
+        if remaining == 0:
             return []
-        try:
-            payload = json.loads(proc.stdout or "[]")
-        except json.JSONDecodeError:
-            return []
-        if isinstance(payload, list):
-            comments: list[dict[str, Any]] = []
+
+        comments: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            page_size = 100 if remaining is None else min(100, remaining)
+            args = [
+                "api",
+                endpoint,
+                "-F",
+                f"per_page={page_size}",
+                "-F",
+                f"page={page}",
+            ]
+            if since:
+                args += ["-F", f"since={since}"]
+            proc = self._gh(
+                args, cwd=cwd or self.repo_root, check=False, timeout_seconds=30
+            )
+            if proc.returncode != 0:
+                return []
+            try:
+                payload = json.loads(proc.stdout or "[]")
+            except json.JSONDecodeError:
+                return []
+            if not isinstance(payload, list):
+                return []
+            if not payload:
+                break
+
             for item in payload:
                 if not isinstance(item, dict):
                     continue
@@ -1029,7 +1043,7 @@ class GitHubService:
                             "author_association": _normalize_optional_text(
                                 item.get("author_association")
                             ),
-                            "issue_number": int(number) if number is not None else None,
+                            "issue_number": issue_number,
                             "path": _normalize_optional_text(item.get("path")),
                             "line": _normalize_positive_int(item.get("line")),
                             "pull_request_review_id": (
@@ -1050,8 +1064,16 @@ class GitHubService:
                         if value is not None
                     }
                 )
-            return comments
-        return []
+
+            if remaining is not None:
+                remaining = max(0, remaining - page_size)
+                if remaining == 0:
+                    break
+            if len(payload) < page_size:
+                break
+            page += 1
+
+        return comments
 
     def create_issue_comment(
         self,

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -463,6 +463,104 @@ def test_process_due_watches_emits_new_pr_comment_and_inline_review_comment(
     }
 
 
+def test_process_due_watches_does_not_reemit_when_thread_is_reopened_without_new_comments(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding = PrBindingStore(tmp_path).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        pr_number=17,
+        pr_state="open",
+        head_branch="feature/scm-polling",
+        base_branch="main",
+    )
+    watch_store = ScmPollingWatchStore(tmp_path)
+    watch_store.upsert_watch(
+        provider="github",
+        binding_id=binding.binding_id,
+        repo_slug=binding.repo_slug,
+        pr_number=binding.pr_number,
+        workspace_root=str((tmp_path / "repo").resolve()),
+        poll_interval_seconds=90,
+        next_poll_at="2026-03-30T00:00:00Z",
+        expires_at="2099-03-30T01:00:00Z",
+        reaction_config={"enabled": True},
+        snapshot={
+            "head_sha": "oldsha",
+            "pr_state": "open",
+            "review_thread_comments": {
+                "review-comment-1": {
+                    "action": "created",
+                    "comment_id": "review-comment-1",
+                    "author_login": "reviewer",
+                    "issue_author_login": "pr-author",
+                    "body": "Existing inline thread comment.",
+                    "path": "src/codex_autorunner/integrations/github/polling.py",
+                    "line": 140,
+                    "thread_resolved": True,
+                    "updated_at": "2026-03-30T00:02:00Z",
+                }
+            },
+        },
+    )
+
+    def _factory(repo_root: Path, raw_config=None) -> _GitHubServiceStub:
+        return _GitHubServiceStub(
+            repo_root,
+            raw_config,
+            pr_view_payload={
+                "state": "OPEN",
+                "isDraft": False,
+                "headRefOid": "newsha",
+                "author": {"login": "pr-author"},
+            },
+            reviews_payload=[],
+            checks_payload=[],
+            review_threads_payload=[
+                {
+                    "thread_id": "thread-1",
+                    "isResolved": False,
+                    "comments": [
+                        {
+                            "comment_id": "review-comment-1",
+                            "body": "Existing inline thread comment.",
+                            "author_login": "reviewer",
+                            "author_type": "User",
+                            "path": "src/codex_autorunner/integrations/github/polling.py",
+                            "line": 140,
+                            "updated_at": "2026-03-30T00:02:00Z",
+                        }
+                    ],
+                }
+            ],
+        )
+
+    _AutomationServiceFake.ingested_events = []
+    _AutomationServiceFake.process_calls = 0
+    monkeypatch.setattr(
+        GitHubScmPollingService,
+        "_build_automation_service",
+        lambda self, reaction_config=None: _AutomationServiceFake(  # type: ignore[misc]
+            tmp_path,
+            reaction_config=reaction_config,
+        ),
+    )
+
+    service = GitHubScmPollingService(
+        tmp_path,
+        raw_config=_polling_config(),
+        github_service_factory=_factory,
+        watch_store=watch_store,
+        event_store=ScmEventStore(tmp_path),
+    )
+
+    result = service.process_due_watches(limit=10)
+
+    assert result["events_emitted"] == 0
+    assert _AutomationServiceFake.ingested_events == []
+
+
 def test_process_due_watches_uses_first_successful_poll_as_baseline(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_github_service_comments.py
+++ b/tests/test_github_service_comments.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_autorunner.integrations.github.service import GitHubService
+
+
+def test_issue_comments_pages_through_all_pr_comment_results(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = GitHubService(tmp_path, raw_config={})
+    page_calls: list[int] = []
+
+    def _fake_gh(
+        args: list[str], *, cwd=None, check=True, timeout_seconds=None
+    ):  # type: ignore[no-untyped-def]
+        _ = cwd, check, timeout_seconds
+        assert args[:2] == ["api", "repos/acme/widgets/issues/17/comments"]
+        page = int(
+            next(arg.split("=", 1)[1] for arg in args if arg.startswith("page="))
+        )
+        per_page = int(
+            next(arg.split("=", 1)[1] for arg in args if arg.startswith("per_page="))
+        )
+        page_calls.append(page)
+        if page == 1:
+            payload = [
+                {
+                    "id": index,
+                    "body": f"comment {index}",
+                    "html_url": f"https://example.invalid/comments/{index}",
+                    "author_association": "MEMBER",
+                    "updated_at": f"2026-03-30T00:{index:02d}:00Z",
+                    "user": {"login": f"user-{index}", "type": "User"},
+                }
+                for index in range(1, per_page + 1)
+            ]
+        elif page == 2:
+            payload = [
+                {
+                    "id": 101,
+                    "body": "comment 101",
+                    "html_url": "https://example.invalid/comments/101",
+                    "author_association": "MEMBER",
+                    "updated_at": "2026-03-30T01:41:00Z",
+                    "user": {"login": "user-101", "type": "User"},
+                }
+            ]
+        else:
+            payload = []
+        return type(
+            "Proc",
+            (),
+            {"returncode": 0, "stdout": json.dumps(payload)},
+        )()
+
+    monkeypatch.setattr(service, "_gh", _fake_gh)
+
+    comments = service.issue_comments(owner="acme", repo="widgets", number=17)
+
+    assert page_calls == [1, 2]
+    assert len(comments) == 101
+    assert comments[0]["comment_id"] == "1"
+    assert comments[-1]["comment_id"] == "101"
+    assert comments[-1]["issue_number"] == 17


### PR DESCRIPTION
## Summary
- add PR conversation comments and unresolved inline review thread comments to the GitHub polling snapshot
- normalize polled comment payloads to match the webhook-driven review comment routing path
- add polling coverage for baseline snapshots plus new PR comment and inline review comment wake-ups

## Why
Polling-only GitHub setups could detect changes-requested reviews and failed checks, but they could not wake the agent up on new PR comments or inline review comments. This closes that parity gap with webhook ingress.

## Validation
- `./.venv/bin/python -m pytest tests/integrations/github/test_polling.py -q`
- `./.venv/bin/python -m pytest tests/test_github_service_context_files.py -q`
- `./.venv/bin/python -m pytest tests/core/test_scm_reaction_router.py tests/core/test_scm_reaction_state.py -q`
- `git commit` pre-commit suite (`3975 passed, 1 skipped`)

Closes #1227
