### PR TITLE
[codex] Support polling-only GitHub SCM automation

### DIFF
--- a/docs/AGENT_SETUP_GUIDE.md
+++ b/docs/AGENT_SETUP_GUIDE.md
@@ -11,7 +11,7 @@ Use these only after base setup is complete:
 - Telegram interactive bot onboarding: `docs/AGENT_SETUP_TELEGRAM_GUIDE.md`
 - Discord interactive bot onboarding: `docs/AGENT_SETUP_DISCORD_GUIDE.md`
 - GitHub SCM automation: auto-address PR review feedback and CI failures on
-  bound PRs via webhook ingress and managed-thread follow-up.
+  bound PRs via polling-only or webhook-backed managed-thread follow-up.
 
 These are optional integrations, not required for baseline CAR setup.
 

--- a/src/codex_autorunner/core/capability_hints.py
+++ b/src/codex_autorunner/core/capability_hints.py
@@ -196,13 +196,18 @@ def _build_scm_hint(
     enabled = _explicit_bool(automation, "enabled")
     ingress = _mapping(automation.get("webhook_ingress"))
     ingress_enabled = _explicit_bool(ingress, "enabled")
+    polling = _mapping(automation.get("polling"))
+    polling_enabled = _explicit_bool(polling, "enabled")
 
     if enabled is False:
         reason_code = "scm_automation_disabled"
         prerequisite = "Enable `github.automation.enabled`."
-    elif enabled is True and ingress_enabled is False:
-        reason_code = "scm_webhook_ingress_disabled"
-        prerequisite = "Enable `github.automation.webhook_ingress.enabled`."
+    elif enabled is True and ingress_enabled is False and polling_enabled is False:
+        reason_code = "scm_automation_transport_disabled"
+        prerequisite = (
+            "Enable `github.automation.polling.enabled` or "
+            "`github.automation.webhook_ingress.enabled`."
+        )
     else:
         return None
 
@@ -214,11 +219,11 @@ def _build_scm_hint(
             "PMA prompt:",
             (
                 "Enable GitHub SCM automation for this repo. Turn on "
-                "`github.automation.enabled` and "
-                "`github.automation.webhook_ingress.enabled`, configure the "
-                "webhook secret, and confirm PRs are bound to a managed "
-                "thread so review feedback and CI failures can be routed into "
-                "follow-up work. Report back any remaining prerequisites."
+                "`github.automation.enabled`, choose either polling or "
+                "webhook ingress as the transport, and confirm PRs are bound "
+                "to a managed thread so review feedback and CI failures can "
+                "be routed into follow-up work. Report back any remaining "
+                "prerequisites."
             ),
         ]
     )

--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -2607,6 +2607,10 @@ class HubSupervisor:
                 "expired": 0,
                 "closed": 0,
                 "errors": 0,
+                "candidate_workspaces": 0,
+                "bindings_discovered": 0,
+                "watches_armed": 0,
+                "discovery_errors": 0,
             }
         try:
             return processor(limit)
@@ -2619,6 +2623,10 @@ class HubSupervisor:
                 "expired": 0,
                 "closed": 0,
                 "errors": 1,
+                "candidate_workspaces": 0,
+                "bindings_discovered": 0,
+                "watches_armed": 0,
+                "discovery_errors": 1,
             }
 
     def _start_lifecycle_event_processor(self) -> None:

--- a/src/codex_autorunner/core/orchestration/migrations.py
+++ b/src/codex_autorunner/core/orchestration/migrations.py
@@ -1166,7 +1166,7 @@ _TABLE_DEFINITIONS = (
     OrchestrationTableDefinition(
         name="orch_scm_polling_watches",
         role="authoritative",
-        description="Bounded SCM polling watches for outbound-only PR follow-up automation.",
+        description="Bounded SCM polling watches for GitHub PR follow-up automation, including outbound-only deployments.",
     ),
     OrchestrationTableDefinition(
         name="orch_notification_conversations",

--- a/src/codex_autorunner/core/scm_polling_watches.py
+++ b/src/codex_autorunner/core/scm_polling_watches.py
@@ -149,6 +149,26 @@ class ScmPollingWatchStore:
     def __init__(self, hub_root: Path) -> None:
         self._hub_root = Path(hub_root)
 
+    def get_watch(
+        self,
+        *,
+        provider: str,
+        binding_id: str,
+    ) -> Optional[ScmPollingWatch]:
+        normalized_provider = _normalize_text(provider)
+        normalized_binding_id = _normalize_text(binding_id)
+        if normalized_provider is None:
+            raise ValueError("provider is required")
+        if normalized_binding_id is None:
+            raise ValueError("binding_id is required")
+        with open_orchestration_sqlite(self._hub_root, durable=True) as conn:
+            row = self._load_watch_row(
+                conn,
+                provider=normalized_provider,
+                binding_id=normalized_binding_id,
+            )
+        return _watch_from_row(row) if row is not None else None
+
     def upsert_watch(
         self,
         *,

--- a/src/codex_autorunner/integrations/github/polling.py
+++ b/src/codex_autorunner/integrations/github/polling.py
@@ -7,11 +7,13 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional
 
+from ...core.pma_thread_store import PmaThreadStore
 from ...core.pr_bindings import PrBinding, PrBindingStore
 from ...core.scm_events import ScmEventStore
 from ...core.scm_polling_watches import ScmPollingWatch, ScmPollingWatchStore
 from ...core.scm_reaction_types import ScmReactionConfig
 from ...core.time_utils import now_iso
+from ...manifest import ManifestError, load_manifest
 
 _FAILED_CHECK_CONCLUSIONS = frozenset(
     {"action_required", "cancelled", "failure", "startup_failure", "stale", "timed_out"}
@@ -351,6 +353,94 @@ class GitHubScmPollingService:
             snapshot=snapshot,
         )
 
+    def discover_and_arm_missing_watches(self, *, limit: int = 20) -> dict[str, int]:
+        counts = {
+            "candidate_workspaces": 0,
+            "bindings_discovered": 0,
+            "watches_armed": 0,
+            "discovery_errors": 0,
+        }
+        polling_config = GitHubPollingConfig.from_mapping(self._raw_config)
+        if not polling_config.enabled:
+            return counts
+
+        candidate_roots, workspaces_by_repo_id, workspaces_by_thread_id = (
+            self._candidate_workspace_roots()
+        )
+        counts["candidate_workspaces"] = len(candidate_roots)
+
+        active_bindings = self._active_bindings(limit=max(100, limit * 10))
+        for workspace_root in candidate_roots:
+            try:
+                github = self._github_service_factory(
+                    workspace_root,
+                    self._raw_config if isinstance(self._raw_config, dict) else None,
+                )
+                binding = github.discover_pr_binding(cwd=workspace_root)
+            except Exception:
+                _LOGGER.warning(
+                    "Failed discovering polling binding for workspace %s",
+                    workspace_root,
+                    exc_info=True,
+                )
+                counts["discovery_errors"] += 1
+                continue
+            if binding is None or binding.pr_state not in _ACTIVE_PR_STATES:
+                continue
+            if binding.binding_id not in active_bindings:
+                counts["bindings_discovered"] += 1
+            active_bindings[binding.binding_id] = binding
+
+        repo_slug_cache: dict[str, Optional[str]] = {}
+        for binding in active_bindings.values():
+            watch = self._watch_store.get_watch(
+                provider="github",
+                binding_id=binding.binding_id,
+            )
+
+            resolved_workspace_root = self._resolve_workspace_root_for_binding(
+                binding=binding,
+                existing_watch=watch,
+                candidate_roots=candidate_roots,
+                workspaces_by_repo_id=workspaces_by_repo_id,
+                workspaces_by_thread_id=workspaces_by_thread_id,
+                repo_slug_cache=repo_slug_cache,
+            )
+            if resolved_workspace_root is None:
+                continue
+            if (
+                watch is not None
+                and watch.state == "active"
+                and Path(watch.workspace_root).resolve()
+                == resolved_workspace_root.resolve()
+            ):
+                continue
+            try:
+                armed: Optional[ScmPollingWatch]
+                if watch is not None and watch.state == "active":
+                    armed = self._repair_active_watch(
+                        binding=binding,
+                        watch=watch,
+                        workspace_root=resolved_workspace_root,
+                    )
+                else:
+                    armed = self.arm_watch(
+                        binding=binding,
+                        workspace_root=resolved_workspace_root,
+                    )
+            except Exception:
+                _LOGGER.warning(
+                    "Failed arming discovered SCM polling watch for %s#%s",
+                    binding.repo_slug,
+                    binding.pr_number,
+                    exc_info=True,
+                )
+                counts["discovery_errors"] += 1
+                continue
+            if armed is not None:
+                counts["watches_armed"] += 1
+        return counts
+
     def process_due_watches(self, *, limit: int = 20) -> dict[str, int]:
         counts = {
             "due": 0,
@@ -434,6 +524,166 @@ class GitHubScmPollingService:
             counts["polled"] += 1
             counts["events_emitted"] += emitted
         return counts
+
+    def process(self, *, limit: int = 20) -> dict[str, int]:
+        counts = {
+            "due": 0,
+            "polled": 0,
+            "events_emitted": 0,
+            "expired": 0,
+            "closed": 0,
+            "errors": 0,
+            "candidate_workspaces": 0,
+            "bindings_discovered": 0,
+            "watches_armed": 0,
+            "discovery_errors": 0,
+        }
+        discovery_counts = self.discover_and_arm_missing_watches(limit=limit)
+        due_counts = self.process_due_watches(limit=limit)
+        for key, value in discovery_counts.items():
+            counts[key] = counts.get(key, 0) + int(value)
+        for key, value in due_counts.items():
+            counts[key] = counts.get(key, 0) + int(value)
+        return counts
+
+    def _active_bindings(self, *, limit: int) -> dict[str, PrBinding]:
+        binding_store = PrBindingStore(self._hub_root)
+        active_bindings: dict[str, PrBinding] = {}
+        for state in sorted(_ACTIVE_PR_STATES):
+            for binding in binding_store.list_bindings(
+                provider="github",
+                pr_state=state,
+                limit=limit,
+            ):
+                active_bindings[binding.binding_id] = binding
+        return active_bindings
+
+    def _repair_active_watch(
+        self,
+        *,
+        binding: PrBinding,
+        watch: ScmPollingWatch,
+        workspace_root: Path,
+    ) -> ScmPollingWatch:
+        return self._watch_store.upsert_watch(
+            provider="github",
+            binding_id=binding.binding_id,
+            repo_slug=binding.repo_slug,
+            repo_id=binding.repo_id,
+            pr_number=binding.pr_number,
+            workspace_root=str(workspace_root.resolve()),
+            thread_target_id=binding.thread_target_id,
+            poll_interval_seconds=watch.poll_interval_seconds,
+            next_poll_at=watch.next_poll_at,
+            expires_at=watch.expires_at,
+            reaction_config=watch.reaction_config,
+            snapshot=watch.snapshot,
+        )
+
+    def _candidate_workspace_roots(
+        self,
+    ) -> tuple[list[Path], dict[str, list[Path]], dict[str, Path]]:
+        roots: list[Path] = []
+        seen_roots: set[Path] = set()
+        workspaces_by_repo_id: dict[str, list[Path]] = {}
+        workspaces_by_thread_id: dict[str, Path] = {}
+
+        def add_root(
+            workspace_root: Path,
+            *,
+            repo_id: Optional[str] = None,
+            thread_target_id: Optional[str] = None,
+        ) -> None:
+            resolved_root = workspace_root.resolve()
+            if not resolved_root.exists() or not resolved_root.is_dir():
+                return
+            if resolved_root not in seen_roots:
+                seen_roots.add(resolved_root)
+                roots.append(resolved_root)
+            normalized_repo_id = _normalize_text(repo_id)
+            if normalized_repo_id is not None:
+                bucket = workspaces_by_repo_id.setdefault(normalized_repo_id, [])
+                if resolved_root not in bucket:
+                    bucket.append(resolved_root)
+            normalized_thread_target_id = _normalize_text(thread_target_id)
+            if normalized_thread_target_id is not None:
+                workspaces_by_thread_id[normalized_thread_target_id] = resolved_root
+
+        manifest_path = self._hub_root / ".codex-autorunner" / "manifest.yml"
+        if manifest_path.exists():
+            try:
+                manifest = load_manifest(manifest_path, self._hub_root)
+            except ManifestError:
+                manifest = None
+            if manifest is not None:
+                for repo in manifest.repos:
+                    if not repo.enabled:
+                        continue
+                    add_root(self._hub_root / repo.path, repo_id=repo.id)
+
+        try:
+            threads = PmaThreadStore(self._hub_root).list_threads(
+                status="active",
+                limit=500,
+            )
+        except Exception:
+            threads = []
+        for thread in threads:
+            workspace_root = _normalize_text(thread.get("workspace_root"))
+            if workspace_root is None:
+                continue
+            add_root(
+                Path(workspace_root),
+                repo_id=_normalize_text(thread.get("repo_id")),
+                thread_target_id=_normalize_text(thread.get("managed_thread_id")),
+            )
+        return roots, workspaces_by_repo_id, workspaces_by_thread_id
+
+    def _resolve_workspace_root_for_binding(
+        self,
+        *,
+        binding: PrBinding,
+        existing_watch: Optional[ScmPollingWatch],
+        candidate_roots: list[Path],
+        workspaces_by_repo_id: Mapping[str, list[Path]],
+        workspaces_by_thread_id: Mapping[str, Path],
+        repo_slug_cache: dict[str, Optional[str]],
+    ) -> Optional[Path]:
+        if existing_watch is not None:
+            existing_watch_root = Path(existing_watch.workspace_root).resolve()
+            if existing_watch_root.exists() and existing_watch_root.is_dir():
+                return existing_watch_root
+
+        if binding.thread_target_id is not None:
+            thread_root = workspaces_by_thread_id.get(binding.thread_target_id)
+            if thread_root is not None:
+                return thread_root
+
+        if binding.repo_id is not None:
+            repo_roots = workspaces_by_repo_id.get(binding.repo_id) or []
+            if repo_roots:
+                return repo_roots[0]
+
+        for candidate_root in candidate_roots:
+            candidate_key = str(candidate_root)
+            if candidate_key not in repo_slug_cache:
+                try:
+                    github = self._github_service_factory(
+                        candidate_root,
+                        (
+                            self._raw_config
+                            if isinstance(self._raw_config, dict)
+                            else None
+                        ),
+                    )
+                    repo_slug_cache[candidate_key] = _normalize_text(
+                        github.repo_info().name_with_owner
+                    )
+                except Exception:
+                    repo_slug_cache[candidate_key] = None
+            if repo_slug_cache.get(candidate_key) == binding.repo_slug:
+                return candidate_root
+        return None
 
     def _emit_new_conditions(
         self,
@@ -564,7 +814,7 @@ def build_hub_scm_poll_processor(
         return GitHubScmPollingService(
             hub_root,
             raw_config=raw_config,
-        ).process_due_watches(limit=limit)
+        ).process(limit=limit)
 
     return processor
 

--- a/src/codex_autorunner/integrations/github/service.py
+++ b/src/codex_autorunner/integrations/github/service.py
@@ -557,13 +557,22 @@ class GitHubService:
         hub_root, repo_id = self._binding_context()
         store = PrBindingStore(hub_root) if hub_root is not None else None
         if store is not None and repo_id is not None:
-            canonical_bindings = store.list_bindings(
-                provider="github",
-                repo_id=repo_id,
-                head_branch=resolved_branch,
-                limit=1,
-            )
+            canonical_bindings: list[PrBinding] = []
+            for pr_state in ("open", "draft"):
+                canonical_bindings.extend(
+                    store.list_bindings(
+                        provider="github",
+                        repo_id=repo_id,
+                        pr_state=pr_state,
+                        head_branch=resolved_branch,
+                        limit=1,
+                    )
+                )
             if canonical_bindings:
+                canonical_bindings.sort(
+                    key=lambda binding: (binding.updated_at, binding.pr_number),
+                    reverse=True,
+                )
                 return binding_summary(canonical_bindings[0])
 
         pr = self.pr_for_branch(branch=resolved_branch, cwd=cwd)
@@ -591,6 +600,38 @@ class GitHubService:
                 else None
             )
         return summary
+
+    def discover_pr_binding(
+        self, *, branch: Optional[str] = None, cwd: Optional[Path] = None
+    ) -> Optional[PrBinding]:
+        summary = self.discover_pr_binding_summary(branch=branch, cwd=cwd)
+        if summary is None:
+            return None
+
+        binding_store = self._pr_binding_store()
+        existing_binding: Optional[PrBinding] = None
+        repo_slug = _normalize_optional_text(summary.get("repo_slug"))
+        head_branch = _normalize_optional_text(summary.get("head_branch"))
+        if (
+            binding_store is not None
+            and repo_slug is not None
+            and head_branch is not None
+        ):
+            existing_binding = binding_store.find_active_binding_for_branch(
+                provider="github",
+                repo_slug=repo_slug,
+                branch_name=head_branch,
+            )
+
+        return (
+            self._persist_pr_binding(
+                repo_slug=str(summary["repo_slug"]),
+                summary=summary,
+                existing_binding=existing_binding,
+            )
+            if repo_slug is not None
+            else None
+        )
 
     def list_open_issues(
         self, *, limit: int = 10, cwd: Optional[Path] = None

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -79,6 +79,77 @@ class _AutomationServiceFake:
         return []
 
 
+class _DiscoveringGitHubServiceStub(_GitHubServiceStub):
+    def __init__(
+        self,
+        repo_root: Path,
+        raw_config: dict | None = None,
+        *,
+        hub_root: Path,
+        repo_id: str,
+        repo_slug: str,
+        pr_number: int,
+        head_branch: str,
+        base_branch: str = "main",
+        pr_state: str = "open",
+        discover: bool = True,
+    ) -> None:
+        super().__init__(
+            repo_root,
+            raw_config,
+            pr_view_payload={
+                "state": "OPEN",
+                "isDraft": pr_state == "draft",
+                "headRefOid": "abc123",
+                "author": {"login": "pr-author"},
+            },
+            reviews_payload=[],
+            checks_payload=[],
+        )
+        self._hub_root = hub_root
+        self._repo_id = repo_id
+        self._repo_slug = repo_slug
+        self._pr_number = pr_number
+        self._head_branch = head_branch
+        self._base_branch = base_branch
+        self._pr_state = pr_state
+        self._discover = discover
+
+    def discover_pr_binding(self, *, branch=None, cwd=None):
+        _ = branch, cwd
+        if not self._discover:
+            return None
+        return PrBindingStore(self._hub_root).upsert_binding(
+            provider="github",
+            repo_slug=self._repo_slug,
+            repo_id=self._repo_id,
+            pr_number=self._pr_number,
+            pr_state=self._pr_state,
+            head_branch=self._head_branch,
+            base_branch=self._base_branch,
+        )
+
+
+def _write_manifest(hub_root: Path, *, repo_rel: str, repo_id: str = "repo-1") -> None:
+    manifest_path = hub_root / ".codex-autorunner" / "manifest.yml"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        "\n".join(
+            [
+                "version: 3",
+                "repos:",
+                f"  - id: {repo_id}",
+                f"    path: {repo_rel}",
+                "    enabled: true",
+                "    auto_run: false",
+                "    kind: base",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 def _polling_config(*, profile: str | None = None) -> dict[str, object]:
     reactions: dict[str, object] = {}
     if profile is not None:
@@ -676,3 +747,160 @@ def test_claim_due_watches_prevents_duplicate_claims(
         )
         == []
     )
+
+
+def test_process_discovers_external_pr_binding_and_arms_watch_from_manifest_workspace(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "workspace" / "repo"
+    repo_root.mkdir(parents=True)
+    _write_manifest(hub_root, repo_rel="workspace/repo")
+
+    def _factory(repo_root_arg: Path, raw_config=None) -> _DiscoveringGitHubServiceStub:
+        return _DiscoveringGitHubServiceStub(
+            repo_root_arg,
+            raw_config,
+            hub_root=hub_root,
+            repo_id="repo-1",
+            repo_slug="acme/widgets",
+            pr_number=42,
+            head_branch="feature/external-pr",
+            discover=True,
+        )
+
+    watch_store = ScmPollingWatchStore(hub_root)
+    service = GitHubScmPollingService(
+        hub_root,
+        raw_config=_polling_config(),
+        github_service_factory=_factory,
+        watch_store=watch_store,
+        event_store=ScmEventStore(hub_root),
+    )
+
+    result = service.process(limit=10)
+
+    assert result["candidate_workspaces"] == 1
+    assert result["bindings_discovered"] == 1
+    assert result["watches_armed"] == 1
+    binding = PrBindingStore(hub_root).get_binding_by_pr(
+        provider="github",
+        repo_slug="acme/widgets",
+        pr_number=42,
+    )
+    assert binding is not None
+    watch = watch_store.get_watch(provider="github", binding_id=binding.binding_id)
+    assert watch is not None
+    assert watch.state == "active"
+    assert watch.workspace_root == str(repo_root.resolve())
+
+
+def test_process_arms_watch_for_existing_binding_without_discovery(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "workspace" / "repo"
+    repo_root.mkdir(parents=True)
+    _write_manifest(hub_root, repo_rel="workspace/repo")
+    binding = PrBindingStore(hub_root).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        repo_id="repo-1",
+        pr_number=43,
+        pr_state="open",
+        head_branch="feature/missing-watch",
+        base_branch="main",
+    )
+
+    def _factory(repo_root_arg: Path, raw_config=None) -> _DiscoveringGitHubServiceStub:
+        return _DiscoveringGitHubServiceStub(
+            repo_root_arg,
+            raw_config,
+            hub_root=hub_root,
+            repo_id="repo-1",
+            repo_slug="acme/widgets",
+            pr_number=43,
+            head_branch="feature/missing-watch",
+            discover=False,
+        )
+
+    watch_store = ScmPollingWatchStore(hub_root)
+    service = GitHubScmPollingService(
+        hub_root,
+        raw_config=_polling_config(),
+        github_service_factory=_factory,
+        watch_store=watch_store,
+        event_store=ScmEventStore(hub_root),
+    )
+
+    result = service.process(limit=10)
+
+    assert result["bindings_discovered"] == 0
+    assert result["watches_armed"] == 1
+    watch = watch_store.get_watch(provider="github", binding_id=binding.binding_id)
+    assert watch is not None
+    assert watch.state == "active"
+    assert watch.workspace_root == str(repo_root.resolve())
+
+
+def test_process_repairs_active_watch_workspace_root_without_resetting_snapshot(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "workspace" / "repo"
+    repo_root.mkdir(parents=True)
+    _write_manifest(hub_root, repo_rel="workspace/repo")
+    binding = PrBindingStore(hub_root).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        repo_id="repo-1",
+        pr_number=44,
+        pr_state="open",
+        head_branch="feature/repair-watch",
+        base_branch="main",
+    )
+    stale_root = hub_root / "workspace" / "missing"
+
+    def _factory(repo_root_arg: Path, raw_config=None) -> _DiscoveringGitHubServiceStub:
+        return _DiscoveringGitHubServiceStub(
+            repo_root_arg,
+            raw_config,
+            hub_root=hub_root,
+            repo_id="repo-1",
+            repo_slug="acme/widgets",
+            pr_number=44,
+            head_branch="feature/repair-watch",
+            discover=False,
+        )
+
+    watch_store = ScmPollingWatchStore(hub_root)
+    watch_store.upsert_watch(
+        provider="github",
+        binding_id=binding.binding_id,
+        repo_slug=binding.repo_slug,
+        repo_id=binding.repo_id,
+        pr_number=binding.pr_number,
+        workspace_root=str(stale_root),
+        thread_target_id=binding.thread_target_id,
+        poll_interval_seconds=90,
+        next_poll_at="2099-03-30T00:00:00Z",
+        expires_at="2099-03-30T01:00:00Z",
+        reaction_config={"enabled": True},
+        snapshot={"head_sha": "abc123", "pr_state": "open"},
+    )
+
+    service = GitHubScmPollingService(
+        hub_root,
+        raw_config=_polling_config(),
+        github_service_factory=_factory,
+        watch_store=watch_store,
+        event_store=ScmEventStore(hub_root),
+    )
+
+    result = service.process(limit=10)
+
+    assert result["watches_armed"] == 1
+    watch = watch_store.get_watch(provider="github", binding_id=binding.binding_id)
+    assert watch is not None
+    assert watch.workspace_root == str(repo_root.resolve())
+    assert watch.snapshot == {"head_sha": "abc123", "pr_state": "open"}

--- a/tests/test_github_service_pr_discovery.py
+++ b/tests/test_github_service_pr_discovery.py
@@ -431,6 +431,54 @@ def test_discover_pr_binding_summary_prefers_canonical_binding_for_hub_repo(
     }
 
 
+def test_discover_pr_binding_summary_ignores_closed_canonical_binding_and_uses_live_pr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "workspace" / "repo"
+    repo_root.mkdir(parents=True)
+    _write_manifest(hub_root, repo_rel="workspace/repo")
+    PrBindingStore(hub_root).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        repo_id="repo-1",
+        pr_number=88,
+        pr_state="closed",
+        head_branch="feature/login",
+        base_branch="main",
+    )
+
+    service = GitHubService(repo_root, raw_config={})
+    monkeypatch.setattr(
+        service,
+        "pr_for_branch",
+        lambda *, branch, cwd=None: {
+            "number": 99,
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefName": branch,
+            "baseRefName": "main",
+        },
+    )
+    monkeypatch.setattr(
+        service,
+        "repo_info",
+        lambda: RepoInfo(
+            name_with_owner="acme/widgets",
+            url="https://github.com/acme/widgets",
+            default_branch="main",
+        ),
+    )
+
+    assert service.discover_pr_binding_summary(branch="feature/login") == {
+        "repo_slug": "acme/widgets",
+        "pr_number": 99,
+        "pr_state": "open",
+        "head_branch": "feature/login",
+        "base_branch": "main",
+    }
+
+
 def test_sync_pr_persists_binding_and_keeps_link_state_as_session_cache(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

This makes GitHub SCM automation fully supported for polling-only deployments where CAR cannot receive inbound webhook traffic.

## What changed

- add polling-side PR discovery so the hub can discover open PRs from CAR-managed workspaces and persist bindings without relying on `/pr` or webhook ingress
- arm missing polling watches automatically during the SCM poll cycle
- repair active watches whose stored `workspace_root` has gone stale without resetting the existing polling snapshot/baseline
- prevent stale closed canonical bindings from shadowing live active PR discovery
- update operator-facing docs and capability hints so polling-only is documented as a supported transport, with webhook ingress optional
- add regression coverage for:
  - externally created PR discovery from manifest workspaces
  - arming watches for existing bindings without discovery
  - repairing active watch workspace roots
  - ignoring stale closed canonical bindings during discovery

## Root cause

Polling watch arming previously depended on code paths that already had a binding in hand, especially `/pr` sync. In polling-only environments there was no equivalent hub-side discovery path to bind open PRs from managed workspaces and arm watches autonomously.

## Validation

- spark review for polling/discovery correctness, then fixes applied for the findings
- spark review for docs/operator-facing consistency
- `.venv/bin/python -m pytest -q tests/integrations/github/test_polling.py tests/test_github_service_pr_discovery.py tests/core/test_pr_binding_resolver.py tests/routes/test_scm_webhooks.py tests/test_hub_messages.py tests/core/test_scm_automation_service.py`
- pre-commit/full repo gate on commit, including:
  - `black`
  - `ruff`
  - strict repo-wide `mypy`
  - frontend build/tests
  - full pytest suite via the repo commit hook

## Impact

CAR instances that have outbound GitHub access but no inbound traffic support can now discover and monitor PR review activity through polling as a first-class supported mode.