### PR TITLE
Fix [object Object] status summaries in event stream

### DIFF
--- a/src/codex_autorunner/static/generated/agentEvents.js
+++ b/src/codex_autorunner/static/generated/agentEvents.js
@@ -253,6 +253,49 @@ function extractErrorMessage(params) {
         return params.message;
     return "";
 }
+function normalizeStatusSummary(statusValue) {
+    if (typeof statusValue === "string")
+        return statusValue.trim();
+    if (typeof statusValue === "number" || typeof statusValue === "boolean") {
+        return String(statusValue);
+    }
+    const statusObj = asRecord(statusValue);
+    if (!statusObj)
+        return "";
+    const statusType = statusObj.type;
+    if (typeof statusType === "string" && statusType.trim())
+        return statusType.trim();
+    const nestedStatus = statusObj.status;
+    if (typeof nestedStatus === "string" && nestedStatus.trim())
+        return nestedStatus.trim();
+    const nestedStatusObj = asRecord(nestedStatus);
+    if (nestedStatusObj) {
+        const nestedType = nestedStatusObj.type;
+        if (typeof nestedType === "string" && nestedType.trim())
+            return nestedType.trim();
+        const nestedState = nestedStatusObj.state;
+        if (typeof nestedState === "string" && nestedState.trim())
+            return nestedState.trim();
+    }
+    const state = statusObj.state;
+    if (typeof state === "string" && state.trim())
+        return state.trim();
+    const message = statusObj.message;
+    if (typeof message === "string" && message.trim())
+        return message.trim();
+    const reason = statusObj.reason;
+    if (typeof reason === "string" && reason.trim())
+        return reason.trim();
+    try {
+        const encoded = JSON.stringify(statusObj);
+        if (encoded && encoded !== "{}")
+            return encoded;
+    }
+    catch {
+        // Ignore serialization failures and fall back to default status text.
+    }
+    return "";
+}
 function hasMeaningfulText(summary, detail) {
     return Boolean(summary.trim() || detail.trim());
 }
@@ -600,7 +643,7 @@ export function parseAppServerEvent(payload) {
     // Handle generic status updates
     if (method === "status" || params.status) {
         title = "Status";
-        summary = params.status || "Processing";
+        summary = normalizeStatusSummary(params.status) || "Processing";
         kind = "status";
     }
     else if (method === "item/completed") {
@@ -651,7 +694,7 @@ export function parseAppServerEvent(payload) {
     }
     else if (method === "turn/completed") {
         title = "Turn completed";
-        summary = params.status || "completed";
+        summary = normalizeStatusSummary(params.status) || "completed";
         kind = "status";
     }
     else if (method === "error") {

--- a/src/codex_autorunner/static_src/agentEvents.ts
+++ b/src/codex_autorunner/static_src/agentEvents.ts
@@ -48,7 +48,7 @@ interface PayloadParams {
   delta?: string;
   text?: string;
   output?: string;
-  status?: string;
+  status?: unknown;
   message?: string;
   files?: Array<string | { path?: string; file?: string; name?: string }>;
   fileChanges?: Array<string | { path?: string; file?: string; name?: string }>;
@@ -322,6 +322,43 @@ function extractErrorMessage(params: PayloadParams | null | undefined): string {
   }
   if (typeof err === "string") return err;
   if (typeof params.message === "string") return params.message;
+  return "";
+}
+
+function normalizeStatusSummary(statusValue: unknown): string {
+  if (typeof statusValue === "string") return statusValue.trim();
+  if (typeof statusValue === "number" || typeof statusValue === "boolean") {
+    return String(statusValue);
+  }
+  const statusObj = asRecord(statusValue);
+  if (!statusObj) return "";
+
+  const statusType = statusObj.type;
+  if (typeof statusType === "string" && statusType.trim()) return statusType.trim();
+
+  const nestedStatus = statusObj.status;
+  if (typeof nestedStatus === "string" && nestedStatus.trim()) return nestedStatus.trim();
+  const nestedStatusObj = asRecord(nestedStatus);
+  if (nestedStatusObj) {
+    const nestedType = nestedStatusObj.type;
+    if (typeof nestedType === "string" && nestedType.trim()) return nestedType.trim();
+    const nestedState = nestedStatusObj.state;
+    if (typeof nestedState === "string" && nestedState.trim()) return nestedState.trim();
+  }
+
+  const state = statusObj.state;
+  if (typeof state === "string" && state.trim()) return state.trim();
+  const message = statusObj.message;
+  if (typeof message === "string" && message.trim()) return message.trim();
+  const reason = statusObj.reason;
+  if (typeof reason === "string" && reason.trim()) return reason.trim();
+
+  try {
+    const encoded = JSON.stringify(statusObj);
+    if (encoded && encoded !== "{}") return encoded;
+  } catch {
+    // Ignore serialization failures and fall back to default status text.
+  }
   return "";
 }
 
@@ -679,7 +716,7 @@ export function parseAppServerEvent(payload: unknown): ParsedAgentEvent | null {
   // Handle generic status updates
   if (method === "status" || params.status) {
     title = "Status";
-    summary = params.status || "Processing";
+    summary = normalizeStatusSummary(params.status) || "Processing";
     kind = "status";
   } else if (method === "item/completed") {
     const itemType = (item as CommandItem).type;
@@ -722,7 +759,7 @@ export function parseAppServerEvent(payload: unknown): ParsedAgentEvent | null {
     kind = "file";
   } else if (method === "turn/completed") {
     title = "Turn completed";
-    summary = params.status || "completed";
+    summary = normalizeStatusSummary(params.status) || "completed";
     kind = "status";
   } else if (method === "error") {
     title = "Error";

--- a/tests/js/agent_events.test.js
+++ b/tests/js/agent_events.test.js
@@ -459,3 +459,24 @@ test("caps raw session.diff file extraction work for large payloads", () => {
   assert.equal(parsed.event.summary, "src/0.ts, src/1.ts, src/2.ts, src/3.ts +46 more");
   assert.equal(parsed.event.detail, "50 file changes");
 });
+
+test("renders object-based status values without object coercion noise", () => {
+  resetOpenCodeEventState();
+  const parsed = parseAppServerEvent({
+    id: "status-object",
+    received_at: 2000,
+    message: {
+      method: "session.status",
+      params: {
+        status: {
+          type: "busy",
+        },
+      },
+    },
+  });
+
+  assert.ok(parsed);
+  assert.equal(parsed.event.kind, "status");
+  assert.equal(parsed.event.title, "Status");
+  assert.equal(parsed.event.summary, "busy");
+});


### PR DESCRIPTION
## Summary
Fix event-stream status summaries rendering as `[object Object]` in ticket/doc chat compact headers and event rows.

## Root cause
`parseAppServerEvent` in `static_src/agentEvents.ts` treated any truthy `params.status` as summary text and relied on JS coercion. For object-shaped statuses (for example OpenCode `session.status` emits `{ "type": "busy" }`), this became `[object Object]`.

## Changes
- Added `normalizeStatusSummary()` to parse object/primitive status values into readable text (`type`, `status`, `state`, `message`, etc.) and safely serialize only as fallback.
- Updated generic status handling and `turn/completed` handling to use normalized status text instead of raw coercion.
- Added JS regression test for object status payloads.
- Rebuilt generated frontend asset (`static/generated/agentEvents.js`).

## Scope check: OpenCode vs Codex/Hermes
- **Repro today:** OpenCode (`session.status` with object status payloads).
- **Current Codex/Hermes:** tests indicate they stream different methods and do not currently emit this object status shape in this UI path.
- **Future-proofing:** parser is shared by ticket + doc chat UIs for all agents, so any future backend that emits object status would now render correctly.

## Verification
- `pnpm run build`
- `pnpm run test:markdown`
- full pre-commit suite (ruff, mypy, eslint/build, js tests, pytest) passed during commit.
