### PR TITLE
[codex] Skip startup recovery for chat-bound threads

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -97,6 +97,7 @@ MANAGED_THREAD_INTERRUPT_FAILED_DETAIL = (
 PMA_TIMEOUT_SECONDS = 7200
 PMA_MAX_TEXT = PMA_DEFAULT_MAX_TEXT_CHARS
 BOUND_CHAT_SURFACE_KINDS = frozenset({"discord", "telegram"})
+BOUND_CHAT_CLIENT_TURN_PREFIXES = ("discord:", "telegram:")
 
 
 def _build_managed_thread_orchestration_service(
@@ -934,6 +935,21 @@ def _has_bound_chat_surface(
     )
 
 
+def _is_chat_origin_running_execution(
+    thread_store: PmaThreadStore, managed_thread_id: str
+) -> bool:
+    running_turn = thread_store.get_running_turn(managed_thread_id)
+    client_turn_id = normalize_optional_text(
+        running_turn.get("client_turn_id") if running_turn is not None else None
+    )
+    if not client_turn_id:
+        return False
+    client_turn_id = client_turn_id.lower()
+    return any(
+        client_turn_id.startswith(prefix) for prefix in BOUND_CHAT_CLIENT_TURN_PREFIXES
+    )
+
+
 async def recover_orphaned_managed_thread_executions(app: Any) -> None:
     thread_store = PmaThreadStore(app.state.config.root)
     binding_store = OrchestrationBindingStore(app.state.config.root)
@@ -950,7 +966,9 @@ async def recover_orphaned_managed_thread_executions(app: Any) -> None:
             execution = service.get_running_execution(managed_thread_id)
             if thread is None or execution is None:
                 continue
-            if _has_bound_chat_surface(binding_store, managed_thread_id):
+            if _has_bound_chat_surface(
+                binding_store, managed_thread_id
+            ) and _is_chat_origin_running_execution(thread_store, managed_thread_id):
                 continue
             has_turn = getattr(app_server_events, "has_turn", None)
             if (

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
@@ -126,7 +126,11 @@ async def test_recover_orphaned_managed_thread_executions_skips_chat_bound_threa
         repo_id=hub_env.repo_id,
     )
     managed_thread_id = str(created["managed_thread_id"])
-    running = store.create_turn(managed_thread_id, prompt="running")
+    running = store.create_turn(
+        managed_thread_id,
+        prompt="running",
+        client_turn_id="discord:channel-123:run-1",
+    )
     bindings.upsert_binding(
         surface_kind="discord",
         surface_key="channel-123",
@@ -154,6 +158,59 @@ async def test_recover_orphaned_managed_thread_executions_skips_chat_bound_threa
     assert updated_running is not None
     assert updated_running["status"] == "running"
     assert updated_running["error"] is None
+
+
+@pytest.mark.anyio
+async def test_recover_orphaned_managed_thread_executions_recovers_pma_runs_on_chat_bound_threads(
+    hub_env,
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+    store = PmaThreadStore(hub_env.hub_root)
+    bindings = OrchestrationBindingStore(hub_env.hub_root)
+    created = store.create_thread(
+        "codex",
+        hub_env.repo_root.resolve(),
+        repo_id=hub_env.repo_id,
+    )
+    managed_thread_id = str(created["managed_thread_id"])
+    running = store.create_turn(managed_thread_id, prompt="running")
+    queued = store.create_turn(managed_thread_id, prompt="queued", busy_policy="queue")
+    bindings.upsert_binding(
+        surface_kind="discord",
+        surface_key="channel-123",
+        thread_target_id=managed_thread_id,
+        agent_id="codex",
+        repo_id=hub_env.repo_id,
+    )
+    store.set_thread_backend_id(managed_thread_id, "backend-thread-1")
+    clear_runtime_thread_binding(hub_env.hub_root, managed_thread_id)
+    with open_orchestration_sqlite(hub_env.hub_root) as conn:
+        with conn:
+            conn.execute(
+                """
+                UPDATE orch_thread_targets
+                   SET runtime_status = 'idle',
+                       status_turn_id = NULL
+                 WHERE thread_target_id = ?
+                """,
+                (managed_thread_id,),
+            )
+
+    await managed_thread_runtime.recover_orphaned_managed_thread_executions(app)
+
+    updated_running = store.get_turn(managed_thread_id, running["managed_turn_id"])
+    updated_queued = store.get_turn(managed_thread_id, queued["managed_turn_id"])
+    assert updated_running is not None
+    assert updated_running["status"] == "error"
+    assert updated_running["error"] == "Backend thread missing from orchestration state"
+    assert updated_queued is not None
+    assert updated_queued["status"] == "queued"
+
+    claimed = store.claim_next_queued_turn(managed_thread_id)
+    assert claimed is not None
+    claimed_turn, _queue_payload = claimed
+    assert claimed_turn["managed_turn_id"] == queued["managed_turn_id"]
 
 
 def test_managed_thread_message_route_uses_orchestration_service_seam(


### PR DESCRIPTION
## Summary
- skip startup orphan-recovery for managed threads that are actively bound to Discord or Telegram
- keep the existing recovery behavior for PMA-only managed threads
- add a regression test proving chat-bound threads remain running across restart recovery

## Root cause
Startup recovery treated every running managed thread as PMA-owned work and immediately marked it as lost when the in-memory app-server event buffer was empty after restart. Discord and Telegram managed threads already have their own chat re-dispatch path, so this recovery path poisoned their execution state and surfaced `Backend thread lost after restart` to users.

## Validation
- `.venv/bin/python -m pytest tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py -q`
- repo pre-commit hooks during `git commit` including full pytest (`4053 passed, 1 skipped`)
