### PR TITLE
[codex] Fix PR binding lookup for recent terminal managed threads

### DIFF
--- a/src/codex_autorunner/core/pr_binding_runtime.py
+++ b/src/codex_autorunner/core/pr_binding_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -11,6 +12,7 @@ from .pr_bindings import PrBinding, PrBindingStore
 _BRANCH_METADATA_KEYS = ("head_branch", "branch", "git_branch")
 _THREAD_TARGET_ID_KEYS = ("thread_target_id", "managed_thread_id")
 _CONTEXT_MAPPING_KEYS = ("manual_context", "scm", "scm_context", "context")
+_RECENT_TERMINAL_THREAD_LOOKBACK = timedelta(hours=24)
 
 
 def _normalize_text(value: Any) -> Optional[str]:
@@ -22,6 +24,27 @@ def _normalize_text(value: Any) -> Optional[str]:
 
 def _mapping(value: Any) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
+
+
+def _parse_timestamp(value: Any) -> Optional[datetime]:
+    text = _normalize_text(value)
+    if text is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _thread_changed_at(thread: Mapping[str, Any]) -> Optional[datetime]:
+    for key in ("status_updated_at", "updated_at", "created_at"):
+        parsed = _parse_timestamp(thread.get(key))
+        if parsed is not None:
+            return parsed
+    return None
 
 
 def find_hub_binding_context(repo_root: Path) -> tuple[Optional[Path], Optional[str]]:
@@ -103,6 +126,19 @@ def resolve_thread_target_id(
     for thread in store.list_threads(status="active", repo_id=repo_id, limit=100):
         candidate_thread_id = _normalize_text(thread.get("managed_thread_id"))
         if candidate_thread_id is None:
+            continue
+        if thread_matches_branch(thread, head_branch=head_branch):
+            return candidate_thread_id
+
+    cutoff = datetime.now(timezone.utc) - _RECENT_TERMINAL_THREAD_LOOKBACK
+    for thread in store.list_threads(repo_id=repo_id, limit=100):
+        candidate_thread_id = _normalize_text(thread.get("managed_thread_id"))
+        if candidate_thread_id is None:
+            continue
+        if not bool(thread.get("status_terminal")):
+            continue
+        changed_at = _thread_changed_at(thread)
+        if changed_at is None or changed_at < cutoff:
             continue
         if thread_matches_branch(thread, head_branch=head_branch):
             return candidate_thread_id

--- a/tests/core/test_pr_binding_resolver.py
+++ b/tests/core/test_pr_binding_resolver.py
@@ -6,6 +6,7 @@ from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.pma_thread_store import PmaThreadStore
 from codex_autorunner.core.pr_binding_resolver import resolve_binding_for_scm_event
 from codex_autorunner.core.scm_events import ScmEvent
+from codex_autorunner.core.sqlite_utils import open_sqlite
 
 
 def _make_event(
@@ -61,6 +62,30 @@ def _create_repo_thread(
         metadata={"head_branch": head_branch},
     )
     return str(created["managed_thread_id"])
+
+
+def _create_terminal_repo_thread(
+    hub_root: Path,
+    *,
+    repo_id: str = "repo-1",
+    head_branch: str = "feature/login",
+    archive: bool = False,
+) -> str:
+    workspace_root = hub_root / "worktrees" / head_branch.replace("/", "-")
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    store = PmaThreadStore(hub_root)
+    created = store.create_thread(
+        "codex",
+        workspace_root,
+        repo_id=repo_id,
+        metadata={"head_branch": head_branch},
+    )
+    managed_thread_id = str(created["managed_thread_id"])
+    turn = store.create_turn(managed_thread_id, prompt="create pr")
+    assert store.mark_turn_finished(turn["managed_turn_id"], status="ok") is True
+    if archive:
+        store.archive_thread(managed_thread_id)
+    return managed_thread_id
 
 
 def test_resolve_binding_for_pr_event_creates_binding_and_attaches_matching_thread(
@@ -152,3 +177,59 @@ def test_resolve_binding_for_closed_or_merged_pr_updates_existing_binding_state(
     assert merged.pr_state == "merged"
     assert merged.closed_at is not None
     assert merged.thread_target_id == thread_target_id
+
+
+def test_resolve_binding_for_pr_event_attaches_recent_archived_matching_thread(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    thread_target_id = _create_terminal_repo_thread(hub_root, archive=True)
+
+    binding = resolve_binding_for_scm_event(hub_root, _make_event())
+
+    assert binding is not None
+    assert binding.thread_target_id == thread_target_id
+
+
+def test_resolve_binding_for_pr_event_ignores_stale_archived_matching_thread(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    thread_target_id = _create_terminal_repo_thread(hub_root, archive=True)
+
+    with open_sqlite(PmaThreadStore(hub_root).path) as legacy_conn:
+        with legacy_conn:
+            legacy_conn.execute(
+                """
+                UPDATE pma_managed_threads
+                   SET updated_at = ?,
+                       status_updated_at = ?
+                 WHERE managed_thread_id = ?
+                """,
+                (
+                    "2025-01-01T00:00:00Z",
+                    "2025-01-01T00:00:00Z",
+                    thread_target_id,
+                ),
+            )
+
+    with open_orchestration_sqlite(hub_root) as conn:
+        with conn:
+            conn.execute(
+                """
+                UPDATE orch_thread_targets
+                   SET updated_at = ?,
+                       status_updated_at = ?
+                 WHERE thread_target_id = ?
+                """,
+                (
+                    "2025-01-01T00:00:00Z",
+                    "2025-01-01T00:00:00Z",
+                    thread_target_id,
+                ),
+            )
+
+    binding = resolve_binding_for_scm_event(hub_root, _make_event())
+
+    assert binding is not None
+    assert binding.thread_target_id is None


### PR DESCRIPTION
## Summary
- keep the existing active-thread lookup for PR bindings
- add a bounded fallback that can reattach a PR to a recently updated terminal managed thread on the same repo and head branch
- cover both the recent archived-thread recovery case and a stale archived-thread guard in resolver tests

## Why
`resolve_thread_target_id()` only relied on the active-thread scan, so PR discovery could persist bindings with a null `thread_target_id` after the creating managed thread had already moved into a terminal state. That broke review-comment routing because reactions fell back to `notify_chat` instead of waking the managed thread.

## Impact
Managed-thread-created PRs can now recover their thread association during discovery even after the originating thread has completed or been archived recently, which allows review comment reactions to enqueue managed turns again.

## Validation
- `.venv/bin/pytest tests/core/test_pr_binding_resolver.py tests/integrations/github/test_polling.py`
- pre-commit hook suite during `git commit` (`4056 passed, 1 skipped`)

Closes #1250