### PR TITLE
[codex] Fix pytest temp leak cleanup

### DIFF
--- a/src/codex_autorunner/agents/opencode/supervisor.py
+++ b/src/codex_autorunner/agents/opencode/supervisor.py
@@ -661,12 +661,26 @@ class OpenCodeSupervisor:
             )
         except Exception:
             handle.started = False
-            process.terminate()
-            try:
-                await asyncio.wait_for(process.wait(), timeout=5)
-            except asyncio.TimeoutError:
-                process.kill()
-                await process.wait()
+            pid = process.pid
+            pgid = self._record_pid_and_pgid(pid)[1] if pid is not None else None
+            terminated = False
+            if pid is not None:
+                terminated = await asyncio.to_thread(
+                    terminate_record,
+                    pid,
+                    pgid,
+                    grace_seconds=0.5,
+                    kill_seconds=0.5,
+                    logger=self._logger,
+                    event_prefix="opencode.supervisor.startup_cleanup",
+                )
+            if not terminated:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=5)
+                except asyncio.TimeoutError:
+                    process.kill()
+                    await process.wait()
             raise
 
     async def _ensure_started_from_registry(self, handle: OpenCodeHandle) -> bool:

--- a/src/codex_autorunner/core/pytest_temp_cleanup.py
+++ b/src/codex_autorunner/core/pytest_temp_cleanup.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+_PYTEST_RUNTIME_TEMP_SUBDIR = "t"
+_DEFAULT_LSOF_TIMEOUT_SECONDS = 10.0
+_TEMP_ENV_KEYS = ("TMPDIR", "TMP", "TEMP")
+
+
+@dataclass(frozen=True)
+class TempRootProcess:
+    pid: int
+    command: str
+    descriptor: str | None = None
+    path: str | None = None
+
+
+@dataclass(frozen=True)
+class TempPathScanResult:
+    path: Path
+    bytes: int
+    active_processes: tuple[TempRootProcess, ...] = ()
+    scan_error: str | None = None
+
+
+@dataclass(frozen=True)
+class TempCleanupSummary:
+    scanned: int
+    deleted: int
+    active: int
+    failed: int
+    bytes_before: int
+    bytes_after: int
+    deleted_paths: tuple[Path, ...] = ()
+    active_paths: tuple[Path, ...] = ()
+    failed_paths: tuple[str, ...] = ()
+    active_processes: tuple[TempRootProcess, ...] = ()
+
+
+def repo_pytest_runtime_root(repo_root: Path, *, temp_base: Path | None = None) -> Path:
+    key = hashlib.sha1(
+        str(Path(repo_root).expanduser().resolve(strict=False)).encode("utf-8")
+    ).hexdigest()[:10]
+    base_root = (
+        Path(temp_base).expanduser().resolve(strict=False)
+        if temp_base is not None
+        else system_temp_root()
+    )
+    return base_root / f"cp-{key}"
+
+
+def repo_pytest_temp_root(repo_root: Path, *, temp_base: Path | None = None) -> Path:
+    return (
+        repo_pytest_runtime_root(repo_root, temp_base=temp_base)
+        / _PYTEST_RUNTIME_TEMP_SUBDIR
+    )
+
+
+def cleanup_repo_pytest_temp_runs(
+    repo_root: Path,
+    *,
+    keep_run_tokens: set[str] | None = None,
+    dry_run: bool = False,
+    temp_base: Path | None = None,
+) -> TempCleanupSummary:
+    temp_root = repo_pytest_temp_root(repo_root, temp_base=temp_base)
+    keep = {token for token in (keep_run_tokens or set()) if token}
+    if not temp_root.exists():
+        return TempCleanupSummary(
+            scanned=0,
+            deleted=0,
+            active=0,
+            failed=0,
+            bytes_before=0,
+            bytes_after=0,
+        )
+    paths = [
+        path
+        for path in sorted(temp_root.iterdir())
+        if path.name not in keep and path.is_dir()
+    ]
+    summary = cleanup_temp_paths(paths, dry_run=dry_run)
+    if not dry_run:
+        _remove_empty_parent_dirs(
+            temp_root,
+            stop_before=repo_pytest_runtime_root(repo_root, temp_base=temp_base).parent,
+        )
+    return summary
+
+
+def cleanup_temp_paths(
+    paths: Iterable[Path],
+    *,
+    dry_run: bool = False,
+    scan_fn: Callable[[Path], TempPathScanResult] | None = None,
+) -> TempCleanupSummary:
+    scanner = scan_fn or scan_temp_path
+    deleted_paths: list[Path] = []
+    active_paths: list[Path] = []
+    failed_paths: list[str] = []
+    active_processes: list[TempRootProcess] = []
+    scanned = deleted = active = failed = 0
+    bytes_before = bytes_after = 0
+
+    for candidate in paths:
+        path = Path(candidate)
+        if not path.exists():
+            continue
+        scanned += 1
+        scan = scanner(path)
+        bytes_before += scan.bytes
+        if scan.scan_error is not None:
+            failed += 1
+            bytes_after += scan.bytes
+            failed_paths.append(f"{path}: {scan.scan_error}")
+            continue
+        if scan.active_processes:
+            active += 1
+            bytes_after += scan.bytes
+            active_paths.append(path)
+            active_processes.extend(scan.active_processes)
+            continue
+        if dry_run:
+            deleted += 1
+            deleted_paths.append(path)
+            continue
+        try:
+            shutil.rmtree(path)
+        except OSError as exc:
+            failed += 1
+            remaining_bytes = _tree_size_bytes(path)
+            bytes_after += remaining_bytes
+            failed_paths.append(f"{path}: {exc}")
+            continue
+        deleted += 1
+        deleted_paths.append(path)
+        _remove_empty_parent_dirs(path.parent, stop_before=path.anchor)
+
+    return TempCleanupSummary(
+        scanned=scanned,
+        deleted=deleted,
+        active=active,
+        failed=failed,
+        bytes_before=bytes_before,
+        bytes_after=bytes_after,
+        deleted_paths=tuple(deleted_paths),
+        active_paths=tuple(active_paths),
+        failed_paths=tuple(failed_paths),
+        active_processes=tuple(_dedupe_processes(active_processes)),
+    )
+
+
+def scan_temp_path(
+    path: Path, *, lsof_timeout_seconds: float = _DEFAULT_LSOF_TIMEOUT_SECONDS
+) -> TempPathScanResult:
+    root = Path(path)
+    bytes_used = _tree_size_bytes(root)
+    if not root.exists():
+        return TempPathScanResult(path=root, bytes=0)
+    try:
+        active_processes = find_processes_using_path(
+            root, timeout_seconds=lsof_timeout_seconds
+        )
+    except RuntimeError as exc:
+        return TempPathScanResult(path=root, bytes=bytes_used, scan_error=str(exc))
+    return TempPathScanResult(
+        path=root,
+        bytes=bytes_used,
+        active_processes=active_processes,
+    )
+
+
+def find_processes_using_path(
+    root: Path, *, timeout_seconds: float = _DEFAULT_LSOF_TIMEOUT_SECONDS
+) -> tuple[TempRootProcess, ...]:
+    path = Path(root)
+    if not path.exists():
+        return ()
+    try:
+        result = subprocess.run(
+            ["lsof", "-n", "-P", "-F0pcfn", "+D", str(path)],
+            capture_output=True,
+            text=False,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except FileNotFoundError:
+        return ()
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"lsof timed out after {timeout_seconds:.1f}s") from exc
+    except OSError as exc:
+        raise RuntimeError(f"lsof failed: {exc}") from exc
+
+    if result.returncode not in (0, 1):
+        stderr = (result.stderr or b"").decode("utf-8", errors="replace").strip()
+        detail = stderr or f"exit code {result.returncode}"
+        raise RuntimeError(f"lsof failed: {detail}")
+
+    if result.returncode == 1 or not result.stdout:
+        return ()
+
+    current_pid: int | None = None
+    current_command = ""
+    current_fd: str | None = None
+    processes: list[TempRootProcess] = []
+    for field in result.stdout.split(b"\0"):
+        if not field:
+            continue
+        code = chr(field[0])
+        value = field[1:].decode("utf-8", errors="replace")
+        if code == "p":
+            current_pid = int(value)
+            current_command = ""
+            current_fd = None
+        elif code == "c":
+            current_command = value
+        elif code == "f":
+            current_fd = value
+        elif code == "n" and current_pid is not None:
+            processes.append(
+                TempRootProcess(
+                    pid=current_pid,
+                    command=current_command or "?",
+                    descriptor=current_fd,
+                    path=value,
+                )
+            )
+    return tuple(_dedupe_processes(processes))
+
+
+def system_temp_root() -> Path:
+    original_tempdir = tempfile.tempdir
+    original_env = {key: os.environ.get(key) for key in _TEMP_ENV_KEYS}
+    try:
+        for key in _TEMP_ENV_KEYS:
+            os.environ.pop(key, None)
+        tempfile.tempdir = None
+        return Path(tempfile.gettempdir()).resolve(strict=False)
+    finally:
+        tempfile.tempdir = original_tempdir
+        for key, value in original_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _tree_size_bytes(root: Path) -> int:
+    if not root.exists():
+        return 0
+    if root.is_file():
+        try:
+            return root.stat().st_size
+        except OSError:
+            return 0
+    total = 0
+    for candidate in root.rglob("*"):
+        try:
+            if candidate.is_file():
+                total += candidate.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _remove_empty_parent_dirs(start: Path, *, stop_before: str | Path) -> None:
+    stop = Path(stop_before)
+    current = Path(start)
+    while True:
+        if current == stop or str(current) == str(stop):
+            return
+        try:
+            current.rmdir()
+        except OSError:
+            return
+        parent = current.parent
+        if parent == current:
+            return
+        current = parent
+
+
+def _dedupe_processes(
+    processes: Iterable[TempRootProcess],
+) -> list[TempRootProcess]:
+    seen: set[tuple[int, str, str | None]] = set()
+    deduped: list[TempRootProcess] = []
+    for process in sorted(
+        processes,
+        key=lambda item: (
+            item.pid,
+            item.command,
+            item.path or "",
+            item.descriptor or "",
+        ),
+    ):
+        key = (process.pid, process.command, process.path)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(process)
+    return deduped

--- a/src/codex_autorunner/integrations/app_server/client.py
+++ b/src/codex_autorunner/integrations/app_server/client.py
@@ -2084,6 +2084,11 @@ class CodexAppServerClient:
             )
 
     async def _force_kill_process(self, process: asyncio.subprocess.Process) -> None:
+        if os.name != "nt" and hasattr(os, "killpg"):
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except Exception:
+                pass
         try:
             os.kill(process.pid, signal.SIGKILL)
         except Exception:

--- a/src/codex_autorunner/surfaces/cli/commands/cleanup.py
+++ b/src/codex_autorunner/surfaces/cli/commands/cleanup.py
@@ -26,6 +26,7 @@ from ....core.force_attestation import FORCE_ATTESTATION_REQUIRED_PHRASE
 from ....core.locks import process_alive, process_command_matches
 from ....core.managed_processes import reap_managed_processes
 from ....core.managed_processes.registry import list_process_records
+from ....core.pytest_temp_cleanup import cleanup_repo_pytest_temp_runs
 from ....core.report_retention import (
     DEFAULT_REPORT_MAX_HISTORY_FILES,
     DEFAULT_REPORT_MAX_TOTAL_BYTES,
@@ -224,6 +225,39 @@ def register_cleanup_commands(
                 ]
             )
         )
+
+    @cleanup_app.command("pytest-tmp")
+    def cleanup_pytest_tmp(
+        repo: Optional[Path] = typer.Option(None, "--repo", help="Repo path"),
+        hub: Optional[Path] = typer.Option(None, "--hub", help="Hub root path"),
+        dry_run: bool = typer.Option(
+            False,
+            "--dry-run",
+            help="Preview pytest temp cleanup without deleting inactive roots.",
+        ),
+    ) -> None:
+        """Prune inactive repo-specific pytest temp roots under the shared cp-* tree."""
+        engine = require_repo_config(repo, hub)
+        summary = cleanup_repo_pytest_temp_runs(engine.repo_root, dry_run=dry_run)
+        prefix = "Dry run: " if dry_run else ""
+        typer.echo(
+            prefix
+            + "pytest tmp cleanup: "
+            + " ".join(
+                [
+                    f"scanned={summary.scanned}",
+                    f"deleted={summary.deleted}",
+                    f"active={summary.active}",
+                    f"failed={summary.failed}",
+                    f"bytes_before={summary.bytes_before}",
+                    f"bytes_after={summary.bytes_after}",
+                ]
+            )
+        )
+        for path in summary.active_paths:
+            typer.echo(f"ACTIVE {path}")
+        for detail in summary.failed_paths:
+            typer.echo(f"FAILED {detail}")
 
     @cleanup_app.command("state")
     def cleanup_state(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import importlib
 import json
 import os
 import shutil
@@ -27,11 +28,14 @@ import yaml
 DEFAULT_NON_INTEGRATION_TIMEOUT_SECONDS = 120
 _OPENCODE_PROCESS_KIND = "opencode"
 _REPO_ROOT = Path(__file__).resolve().parents[1]
-_PYTEST_RUNTIME_KEY = hashlib.sha1(str(_REPO_ROOT).encode("utf-8")).hexdigest()[:10]
-_PYTEST_RUNTIME_ROOT = Path("/tmp") / f"cp-{_PYTEST_RUNTIME_KEY}"
-_PYTEST_TEMP_ROOT = _PYTEST_RUNTIME_ROOT / "t"
+_PYTEST_RUNTIME_KEY = hashlib.sha1(
+    str(_REPO_ROOT.expanduser().resolve(strict=False)).encode("utf-8")
+).hexdigest()[:10]
 _PYTEST_OPENCODE_STATE_ROOT = _REPO_ROOT / ".codex-autorunner" / "pytest-opencode-state"
 _PYTEST_RUN_TOKEN = os.environ.setdefault("CAR_PYTEST_RUN_TOKEN", uuid.uuid4().hex[:8])
+_PYTEST_TEMP_ROOT_MAX_BYTES = int(
+    os.environ.get("CAR_PYTEST_TEMP_ROOT_MAX_BYTES", str(5 * 1024 * 1024 * 1024))
+)
 os.environ.setdefault("CODEX_DISABLE_APP_SERVER_AUTORESTART_FOR_TESTS", "1")
 
 
@@ -43,11 +47,28 @@ def _pytest_process_token() -> str:
 
 
 def _pytest_temp_env_root() -> Path:
-    return _PYTEST_TEMP_ROOT / _PYTEST_RUN_TOKEN / _pytest_process_token()
+    return _pytest_temp_run_root() / _pytest_process_token()
+
+
+def _pytest_temp_run_root() -> Path:
+    return _PYTEST_TEMP_ROOT / _PYTEST_RUN_TOKEN
 
 
 def _pytest_global_state_root() -> Path:
     return _PYTEST_OPENCODE_STATE_ROOT / _PYTEST_RUN_TOKEN / _pytest_process_token()
+
+
+def _load_pytest_temp_cleanup_module():
+    src_dir = _REPO_ROOT / "src"
+    src_path = str(src_dir)
+    if sys.path[:1] != [src_path] and src_path not in sys.path:
+        sys.path.insert(0, src_path)
+    return importlib.import_module("codex_autorunner.core.pytest_temp_cleanup")
+
+
+def _system_temp_root() -> Path:
+    cleanup_module = _load_pytest_temp_cleanup_module()
+    return cleanup_module.system_temp_root()
 
 
 def _prepare_repo_local_tmpdir() -> None:
@@ -56,6 +77,10 @@ def _prepare_repo_local_tmpdir() -> None:
     for key in ("TMPDIR", "TMP", "TEMP"):
         os.environ[key] = str(temp_root)
     tempfile.tempdir = None
+
+
+_PYTEST_RUNTIME_ROOT = _system_temp_root() / f"cp-{_PYTEST_RUNTIME_KEY}"
+_PYTEST_TEMP_ROOT = _PYTEST_RUNTIME_ROOT / "t"
 
 
 def _prune_old_runtime_dirs(
@@ -75,10 +100,29 @@ def _prune_old_runtime_dirs(
         shutil.rmtree(path, ignore_errors=True)
 
 
+def _prune_inactive_pytest_temp_runs(*, keep: set[str]) -> None:
+    cleanup_module = _load_pytest_temp_cleanup_module()
+    cleanup_module.cleanup_repo_pytest_temp_runs(_REPO_ROOT, keep_run_tokens=keep)
+
+
+def _format_temp_processes(processes: tuple[object, ...]) -> str:
+    parts: list[str] = []
+    for process in processes[:10]:
+        pid = getattr(process, "pid", "?")
+        command = getattr(process, "command", "?")
+        path = getattr(process, "path", None)
+        if path:
+            parts.append(f"pid={pid} command={command} path={path}")
+        else:
+            parts.append(f"pid={pid} command={command}")
+    remaining = len(processes) - len(parts)
+    if remaining > 0:
+        parts.append(f"... plus {remaining} more")
+    return "; ".join(parts)
+
+
 _prepare_repo_local_tmpdir()
-_prune_old_runtime_dirs(
-    _PYTEST_TEMP_ROOT, keep={_PYTEST_RUN_TOKEN}, max_age_seconds=86400
-)
+_prune_inactive_pytest_temp_runs(keep={_PYTEST_RUN_TOKEN})
 _prune_old_runtime_dirs(
     _PYTEST_OPENCODE_STATE_ROOT, keep={_PYTEST_RUN_TOKEN}, max_age_seconds=86400
 )
@@ -332,7 +376,7 @@ def _configure_opencode_global_state_root(
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _cleanup_codex_app_server_clients() -> None:
+def _cleanup_codex_app_server_clients(_cleanup_pytest_temp_runs_session) -> None:
     """
     Ensure any CodexAppServerClient restart tasks are cancelled after the suite.
 
@@ -351,7 +395,7 @@ def _cleanup_codex_app_server_clients() -> None:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _cleanup_opencode_processes_session() -> None:
+def _cleanup_opencode_processes_session(_cleanup_pytest_temp_runs_session) -> None:
     """
     Reap stale prior-run OpenCode records and fail if this run leaks any.
     """
@@ -372,6 +416,32 @@ def _cleanup_opencode_processes_session() -> None:
             "Leaked OpenCode managed processes remained after the test session: "
             + "; ".join(failures)
         )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_pytest_temp_runs_session() -> None:
+    yield
+    cleanup_module = _load_pytest_temp_cleanup_module()
+    env_root = _pytest_temp_env_root()
+    summary = cleanup_module.cleanup_temp_paths((env_root,))
+    failures: list[str] = []
+    if summary.active_paths:
+        failures.append(
+            "active processes remained under pytest temp root: "
+            + _format_temp_processes(summary.active_processes)
+        )
+    if summary.failed_paths:
+        failures.append("; ".join(summary.failed_paths))
+    if summary.bytes_before > _PYTEST_TEMP_ROOT_MAX_BYTES:
+        gib = summary.bytes_before / float(1024**3)
+        failures.append(
+            "pytest temp root exceeded size guard "
+            f"({gib:.2f} GiB > {_PYTEST_TEMP_ROOT_MAX_BYTES / float(1024**3):.2f} GiB)"
+        )
+    if env_root.exists():
+        failures.append(f"pytest temp env root still exists after cleanup: {env_root}")
+    if failures:
+        raise AssertionError(" ; ".join(failures))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/core/test_pytest_temp_cleanup.py
+++ b/tests/core/test_pytest_temp_cleanup.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_autorunner.core.pytest_temp_cleanup import (
+    TempPathScanResult,
+    TempRootProcess,
+    cleanup_repo_pytest_temp_runs,
+    cleanup_temp_paths,
+    repo_pytest_temp_root,
+)
+
+
+def test_cleanup_repo_pytest_temp_runs_deletes_inactive_run_dirs(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    temp_root = repo_pytest_temp_root(repo_root, temp_base=tmp_path / "tmp")
+    stale_run = temp_root / "stale"
+    keep_run = temp_root / "keep"
+    (stale_run / "data").mkdir(parents=True)
+    (stale_run / "data" / "artifact.bin").write_bytes(b"1234")
+    keep_run.mkdir(parents=True)
+
+    summary = cleanup_repo_pytest_temp_runs(
+        repo_root,
+        keep_run_tokens={"keep"},
+        temp_base=tmp_path / "tmp",
+    )
+
+    assert summary.scanned == 1
+    assert summary.deleted == 1
+    assert summary.active == 0
+    assert stale_run.exists() is False
+    assert keep_run.exists() is True
+
+
+def test_cleanup_temp_paths_skips_active_roots(tmp_path: Path) -> None:
+    active_root = tmp_path / "active"
+    active_root.mkdir()
+    (active_root / "payload.txt").write_text("payload", encoding="utf-8")
+
+    def _scan(path: Path) -> TempPathScanResult:
+        return TempPathScanResult(
+            path=path,
+            bytes=7,
+            active_processes=(
+                TempRootProcess(
+                    pid=123,
+                    command="node",
+                    descriptor="cwd",
+                    path=str(path),
+                ),
+            ),
+        )
+
+    summary = cleanup_temp_paths((active_root,), scan_fn=_scan)
+
+    assert summary.scanned == 1
+    assert summary.deleted == 0
+    assert summary.active == 1
+    assert summary.failed == 0
+    assert active_root.exists() is True
+    assert summary.active_processes[0].command == "node"

--- a/tests/test_app_server_registry.py
+++ b/tests/test_app_server_registry.py
@@ -170,3 +170,37 @@ async def test_app_server_supervisor_passes_workspace_id_to_client(
     await supervisor.get_client(workspace)
 
     assert isinstance(captured.get("workspace_id"), str)
+
+
+@pytest.mark.anyio
+async def test_force_kill_process_escalates_to_process_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeProcess:
+        pid = 32103
+
+        async def wait(self) -> int:
+            return 0
+
+        def kill(self) -> None:
+            return
+
+    killpg_calls: list[tuple[int, int]] = []
+    kill_calls: list[tuple[int, int]] = []
+
+    monkeypatch.setattr(
+        app_server_client.os,
+        "killpg",
+        lambda pgid, sig: killpg_calls.append((pgid, sig)),
+    )
+    monkeypatch.setattr(
+        app_server_client.os,
+        "kill",
+        lambda pid, sig: kill_calls.append((pid, sig)),
+    )
+
+    client = CodexAppServerClient(["python", "-m", "codex_autorunner"])
+    await client._force_kill_process(_FakeProcess())
+
+    assert killpg_calls == [(32103, signal.SIGKILL)]
+    assert kill_calls == [(32103, signal.SIGKILL)]

--- a/tests/test_cli_cleanup_pytest_tmp.py
+++ b/tests/test_cli_cleanup_pytest_tmp.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+from codex_autorunner.core.pytest_temp_cleanup import TempCleanupSummary
+from codex_autorunner.surfaces.cli.commands import cleanup as cleanup_cmd
+
+runner = CliRunner()
+
+
+def test_cleanup_pytest_tmp_reports_summary(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        cleanup_cmd,
+        "cleanup_repo_pytest_temp_runs",
+        lambda repo_root, dry_run=False: TempCleanupSummary(
+            scanned=3,
+            deleted=2,
+            active=1,
+            failed=0,
+            bytes_before=300,
+            bytes_after=100,
+            deleted_paths=(),
+            active_paths=(tmp_path / "active-run",),
+            failed_paths=(),
+            active_processes=(),
+        ),
+    )
+
+    cleanup_app = typer.Typer()
+    cleanup_cmd.register_cleanup_commands(
+        cleanup_app,
+        require_repo_config=lambda _repo, _hub: types.SimpleNamespace(  # type: ignore[arg-type]
+            repo_root=tmp_path,
+            config=types.SimpleNamespace(pma=types.SimpleNamespace()),
+        ),
+    )
+
+    result = runner.invoke(cleanup_app, ["pytest-tmp", "--repo", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "pytest tmp cleanup:" in result.output
+    assert "scanned=3" in result.output
+    assert "deleted=2" in result.output
+    assert "active=1" in result.output
+    assert f"ACTIVE {tmp_path / 'active-run'}" in result.output

--- a/tests/test_opencode_supervisor_registry_reuse.py
+++ b/tests/test_opencode_supervisor_registry_reuse.py
@@ -205,6 +205,52 @@ async def test_start_process_writes_registry_record(
     assert written_paths[1].name == "4242.json"
 
 
+@pytest.mark.anyio
+async def test_start_process_failure_reaps_spawned_process_group(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    supervisor = OpenCodeSupervisor(["opencode", "serve"])
+    handle = _handle(tmp_path)
+
+    class _FakeProcess:
+        pid = 5252
+        returncode = None
+        stdout = None
+
+        def terminate(self) -> None:
+            raise AssertionError(
+                "terminate() should not be used when group reap succeeds"
+            )
+
+        def kill(self) -> None:
+            raise AssertionError("kill() should not be used when group reap succeeds")
+
+        async def wait(self) -> int:
+            raise AssertionError("wait() should not be used when group reap succeeds")
+
+    async def _fake_create_subprocess_exec(*_args, **_kwargs):
+        return _FakeProcess()
+
+    async def _fake_read_base_url(_process):
+        raise RuntimeError("boom")
+
+    terminate_calls: list[tuple[int, int | None, str]] = []
+
+    def _fake_terminate_record(pid, pgid, **kwargs):
+        terminate_calls.append((pid, pgid, kwargs["event_prefix"]))
+        return True
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+    monkeypatch.setattr(supervisor, "_read_base_url", _fake_read_base_url)
+    monkeypatch.setattr(supervisor_module, "terminate_record", _fake_terminate_record)
+    monkeypatch.setattr(supervisor_module.os, "getpgid", lambda _pid: 5253)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await supervisor._start_process(handle)
+
+    assert terminate_calls == [(5252, 5253, "opencode.supervisor.startup_cleanup")]
+
+
 def test_refresh_registry_ownership_marks_registry_reuse(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- add shared pytest temp-root cleanup utilities and a `cleanup pytest-tmp` command for repo-scoped `cp-*` hygiene
- explicitly clean each worker's pytest temp environment at session end with active-process and oversize guards
- harden app-server and OpenCode startup teardown so temp-rooted child process groups are killed, not just the parent pid

## Root Cause
The test harness redirected temp files into repo-scoped `cp-*` roots, but it did not explicitly remove each worker's temp root at session end. Some teardown paths also only killed the parent process, which let child helpers keep large temp trees pinned.

## Validation
- `.venv/bin/python -m pytest tests/core/test_pytest_temp_cleanup.py tests/test_cli_cleanup_pytest_tmp.py tests/test_app_server_registry.py tests/test_opencode_supervisor_registry_reuse.py tests/test_cli_cleanup_state.py tests/test_app_server_client.py tests/test_process_termination.py tests/test_lifecycle_events.py tests/test_housekeeping.py tests/unit/test_text_delta_coalescer.py tests/unit/test_locks.py`
- pre-commit/commit hook suite including repo-wide mypy, frontend build/tests, and full pytest suite (`4061 passed, 1 skipped`)

Closes #1252
