### PR TITLE
[codex] Fix hub web UI refresh overhead

### DIFF
--- a/src/codex_autorunner/static/generated/app.js
+++ b/src/codex_autorunner/static/generated/app.js
@@ -1,27 +1,66 @@
 // GENERATED FILE - do not edit directly. Source: static_src/
 import { REPO_ID, HUB_BASE } from "./env.js";
-import { initHub } from "./hub.js";
-import { initTabs, registerTab, registerHamburgerAction } from "./tabs.js";
-import { initTerminal } from "./terminal.js";
-import { initTicketFlow } from "./tickets.js";
-import { initMessages, initMessageBell } from "./messages.js";
-import { initMobileCompact } from "./mobileCompact.js";
-import { subscribe } from "./bus.js";
-import { initRepoSettingsPanel, openRepoSettings } from "./settings.js";
 import { flash, getAuthToken, repairModalBackgroundIfStuck, resolvePath, updateUrlParams, } from "./utils.js";
-import { initLiveUpdates } from "./liveUpdates.js";
-import { initHealthGate } from "./health.js";
-import { initContextspace } from "./contextspace.js";
-import { initDashboard } from "./dashboard.js";
-import { initArchive } from "./archive.js";
-import { initPMA, setPMARefreshActive } from "./pma.js";
-import { initNotifications } from "./notifications.js";
 let pmaInitialized = false;
+let hubModulePromise = null;
+let pmaModulePromise = null;
+let notificationsModulePromise = null;
+let repoShellModulesPromise = null;
+function loadHubModule() {
+    hubModulePromise ?? (hubModulePromise = import("./hub.js"));
+    return hubModulePromise;
+}
+function loadPMAModule() {
+    pmaModulePromise ?? (pmaModulePromise = import("./pma.js"));
+    return pmaModulePromise;
+}
+function loadNotificationsModule() {
+    notificationsModulePromise ?? (notificationsModulePromise = import("./notifications.js"));
+    return notificationsModulePromise;
+}
+function loadRepoShellModules() {
+    repoShellModulesPromise ?? (repoShellModulesPromise = Promise.all([
+        import("./archive.js"),
+        import("./bus.js"),
+        import("./contextspace.js"),
+        import("./dashboard.js"),
+        import("./health.js"),
+        import("./liveUpdates.js"),
+        import("./messages.js"),
+        import("./mobileCompact.js"),
+        import("./settings.js"),
+        import("./tabs.js"),
+        import("./terminal.js"),
+        import("./tickets.js"),
+    ]).then(([archive, bus, contextspace, dashboard, health, liveUpdates, messages, mobileCompact, settings, tabs, terminal, tickets,]) => ({
+        archive,
+        bus,
+        contextspace,
+        dashboard,
+        health,
+        liveUpdates,
+        messages,
+        mobileCompact,
+        settings,
+        tabs,
+        terminal,
+        tickets,
+    })));
+    return repoShellModulesPromise;
+}
 async function initPMAView() {
     if (!pmaInitialized) {
+        const { initPMA } = await loadPMAModule();
         await initPMA();
         pmaInitialized = true;
     }
+}
+function setPMARefreshActiveIfLoaded(active) {
+    if (!pmaInitialized && pmaModulePromise === null)
+        return;
+    void loadPMAModule().then(({ setPMARefreshActive }) => {
+        setPMARefreshActive(active);
+    });
 }
 function showHubView() {
     const hubShell = document.getElementById("hub-shell");
@@ -30,7 +69,7 @@ function showHubView() {
         hubShell.classList.remove("hidden");
     if (pmaShell)
         pmaShell.classList.add("hidden");
-    setPMARefreshActive(false);
+    setPMARefreshActiveIfLoaded(false);
     updateModeToggle("manual");
     updateUrlParams({ view: null });
 }
@@ -43,7 +82,7 @@ function showPMAView() {
         pmaShell.classList.remove("hidden");
     updateModeToggle("pma");
     void initPMAView().then(() => {
-        setPMARefreshActive(true);
+        setPMARefreshActiveIfLoaded(true);
     });
     updateUrlParams({ view: "pma" });
 }
@@ -87,6 +126,10 @@ async function initHubShell() {
         hubShell.classList.remove("hidden");
     if (repoShell)
         repoShell.classList.add("hidden");
+    const [{ initHub }, { initNotifications }] = await Promise.all([
+        loadHubModule(),
+        loadNotificationsModule(),
+    ]);
     initHub();
     initNotifications();
     manualBtns.forEach((btn) => {
@@ -121,6 +164,19 @@ async function initHubShell() {
     }
 }
 async function initRepoShell() {
+    const { archive, bus, contextspace, dashboard, health, liveUpdates, messages, mobileCompact, settings, tabs, terminal, tickets, } = await loadRepoShellModules();
+    const { initHealthGate } = health;
+    const { initArchive } = archive;
+    const { subscribe } = bus;
+    const { initContextspace } = contextspace;
+    const { initDashboard } = dashboard;
+    const { initMessages, initMessageBell } = messages;
+    const { initMobileCompact } = mobileCompact;
+    const { initRepoSettingsPanel, openRepoSettings } = settings;
+    const { initTabs, registerTab, registerHamburgerAction } = tabs;
+    const { initTerminal } = terminal;
+    const { initTicketFlow } = tickets;
+    const { initLiveUpdates } = liveUpdates;
     await initHealthGate();
     if (REPO_ID) {
         const navBar = document.querySelector(".nav-bar");

--- a/src/codex_autorunner/static/generated/hub.js
+++ b/src/codex_autorunner/static/generated/hub.js
@@ -2889,8 +2889,10 @@ async function silentRefreshHub() {
         renderSummary(hubData.repos || []);
         renderReposWithScroll(hubData.repos || []);
         renderAgentWorkspaces(hubData.agent_workspaces || []);
-        await loadHubUsage({ silent: true, allowRetry: false });
-        await loadHubChannelDirectory({ silent: true });
+        await Promise.allSettled([
+            loadHubUsage({ silent: true, allowRetry: false }),
+            loadHubChannelDirectory({ silent: true }),
+        ]);
     }
     catch (err) {
         console.error("Auto-refresh hub failed:", err);
@@ -2972,8 +2974,7 @@ export function initHub() {
     }
     loadHubChannelDirectory({ silent: true }).catch(() => { });
     refreshHub();
-    loadHubVersion();
-    checkUpdateStatus();
+    void Promise.allSettled([loadHubVersion(), checkUpdateStatus()]);
     registerAutoRefresh("hub-repos", {
         callback: async (ctx) => {
             void ctx;

--- a/src/codex_autorunner/static_src/app.ts
+++ b/src/codex_autorunner/static_src/app.ts
@@ -1,12 +1,4 @@
 import { REPO_ID, HUB_BASE } from "./env.js";
-import { initHub } from "./hub.js";
-import { initTabs, registerTab, registerHamburgerAction } from "./tabs.js";
-import { initTerminal } from "./terminal.js";
-import { initTicketFlow } from "./tickets.js";
-import { initMessages, initMessageBell } from "./messages.js";
-import { initMobileCompact } from "./mobileCompact.js";
-import { subscribe } from "./bus.js";
-import { initRepoSettingsPanel, openRepoSettings } from "./settings.js";
 import {
   flash,
   getAuthToken,
@@ -14,21 +6,101 @@ import {
   resolvePath,
   updateUrlParams,
 } from "./utils.js";
-import { initLiveUpdates } from "./liveUpdates.js";
-import { initHealthGate } from "./health.js";
-import { initContextspace } from "./contextspace.js";
-import { initDashboard } from "./dashboard.js";
-import { initArchive } from "./archive.js";
-import { initPMA, setPMARefreshActive } from "./pma.js";
-import { initNotifications } from "./notifications.js";
 
 let pmaInitialized = false;
+let hubModulePromise: Promise<typeof import("./hub.js")> | null = null;
+let pmaModulePromise: Promise<typeof import("./pma.js")> | null = null;
+let notificationsModulePromise: Promise<typeof import("./notifications.js")> | null =
+  null;
+let repoShellModulesPromise: Promise<{
+  archive: typeof import("./archive.js");
+  bus: typeof import("./bus.js");
+  contextspace: typeof import("./contextspace.js");
+  dashboard: typeof import("./dashboard.js");
+  health: typeof import("./health.js");
+  liveUpdates: typeof import("./liveUpdates.js");
+  messages: typeof import("./messages.js");
+  mobileCompact: typeof import("./mobileCompact.js");
+  settings: typeof import("./settings.js");
+  tabs: typeof import("./tabs.js");
+  terminal: typeof import("./terminal.js");
+  tickets: typeof import("./tickets.js");
+}> | null = null;
+
+function loadHubModule(): Promise<typeof import("./hub.js")> {
+  hubModulePromise ??= import("./hub.js");
+  return hubModulePromise;
+}
+
+function loadPMAModule(): Promise<typeof import("./pma.js")> {
+  pmaModulePromise ??= import("./pma.js");
+  return pmaModulePromise;
+}
+
+function loadNotificationsModule(): Promise<typeof import("./notifications.js")> {
+  notificationsModulePromise ??= import("./notifications.js");
+  return notificationsModulePromise;
+}
+
+function loadRepoShellModules() {
+  repoShellModulesPromise ??= Promise.all([
+    import("./archive.js"),
+    import("./bus.js"),
+    import("./contextspace.js"),
+    import("./dashboard.js"),
+    import("./health.js"),
+    import("./liveUpdates.js"),
+    import("./messages.js"),
+    import("./mobileCompact.js"),
+    import("./settings.js"),
+    import("./tabs.js"),
+    import("./terminal.js"),
+    import("./tickets.js"),
+  ]).then(
+    ([
+      archive,
+      bus,
+      contextspace,
+      dashboard,
+      health,
+      liveUpdates,
+      messages,
+      mobileCompact,
+      settings,
+      tabs,
+      terminal,
+      tickets,
+    ]) => ({
+      archive,
+      bus,
+      contextspace,
+      dashboard,
+      health,
+      liveUpdates,
+      messages,
+      mobileCompact,
+      settings,
+      tabs,
+      terminal,
+      tickets,
+    })
+  );
+  return repoShellModulesPromise;
+}
 
 async function initPMAView(): Promise<void> {
   if (!pmaInitialized) {
+    const { initPMA } = await loadPMAModule();
     await initPMA();
     pmaInitialized = true;
   }
+}
+
+function setPMARefreshActiveIfLoaded(active: boolean): void {
+  if (!pmaInitialized && pmaModulePromise === null) return;
+  void loadPMAModule().then(({ setPMARefreshActive }) => {
+    setPMARefreshActive(active);
+  });
 }
 
 function showHubView(): void {
@@ -36,7 +108,7 @@ function showHubView(): void {
   const pmaShell = document.getElementById("pma-shell");
   if (hubShell) hubShell.classList.remove("hidden");
   if (pmaShell) pmaShell.classList.add("hidden");
-  setPMARefreshActive(false);
+  setPMARefreshActiveIfLoaded(false);
   updateModeToggle("manual");
   updateUrlParams({ view: null });
 }
@@ -48,7 +120,7 @@ function showPMAView(): void {
   if (pmaShell) pmaShell.classList.remove("hidden");
   updateModeToggle("pma");
   void initPMAView().then(() => {
-    setPMARefreshActive(true);
+    setPMARefreshActiveIfLoaded(true);
   });
   updateUrlParams({ view: "pma" });
 }
@@ -101,6 +173,10 @@ async function initHubShell(): Promise<void> {
 
   if (hubShell) hubShell.classList.remove("hidden");
   if (repoShell) repoShell.classList.add("hidden");
+  const [{ initHub }, { initNotifications }] = await Promise.all([
+    loadHubModule(),
+    loadNotificationsModule(),
+  ]);
   initHub();
   initNotifications();
 
@@ -141,6 +217,33 @@ async function initHubShell(): Promise<void> {
 }
 
 async function initRepoShell(): Promise<void> {
+  const {
+    archive,
+    bus,
+    contextspace,
+    dashboard,
+    health,
+    liveUpdates,
+    messages,
+    mobileCompact,
+    settings,
+    tabs,
+    terminal,
+    tickets,
+  } = await loadRepoShellModules();
+  const { initHealthGate } = health;
+  const { initArchive } = archive;
+  const { subscribe } = bus;
+  const { initContextspace } = contextspace;
+  const { initDashboard } = dashboard;
+  const { initMessages, initMessageBell } = messages;
+  const { initMobileCompact } = mobileCompact;
+  const { initRepoSettingsPanel, openRepoSettings } = settings;
+  const { initTabs, registerTab, registerHamburgerAction } = tabs;
+  const { initTerminal } = terminal;
+  const { initTicketFlow } = tickets;
+  const { initLiveUpdates } = liveUpdates;
+
   await initHealthGate();
 
   if (REPO_ID) {

--- a/src/codex_autorunner/static_src/hub.ts
+++ b/src/codex_autorunner/static_src/hub.ts
@@ -3614,8 +3614,10 @@ async function silentRefreshHub(): Promise<void> {
     renderSummary(hubData.repos || []);
     renderReposWithScroll(hubData.repos || []);
     renderAgentWorkspaces(hubData.agent_workspaces || []);
-    await loadHubUsage({ silent: true, allowRetry: false });
-    await loadHubChannelDirectory({ silent: true });
+    await Promise.allSettled([
+      loadHubUsage({ silent: true, allowRetry: false }),
+      loadHubChannelDirectory({ silent: true }),
+    ]);
   } catch (err) {
     console.error("Auto-refresh hub failed:", err);
   }
@@ -3691,8 +3693,7 @@ export function initHub(): void {
   }
   loadHubChannelDirectory({ silent: true }).catch(() => {});
   refreshHub();
-  loadHubVersion();
-  checkUpdateStatus();
+  void Promise.allSettled([loadHubVersion(), checkUpdateStatus()]);
 
   registerAutoRefresh("hub-repos", {
     callback: async (ctx) => {

--- a/src/codex_autorunner/surfaces/web/routes/hub_messages.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_messages.py
@@ -163,6 +163,7 @@ def build_hub_messages_routes(context: HubAppContext) -> APIRouter:
             )
             dismissed_at = str(dismissed.get("resolved_at") or "")
             dismissed["dismissed_at"] = dismissed_at
+        hub_gather_service.invalidate_hub_message_snapshot_cache(context)
         return {
             "status": "ok",
             "dismissed": dismissed,
@@ -264,6 +265,7 @@ def build_hub_messages_routes(context: HubAppContext) -> APIRouter:
                 hint_id=hint_id,
                 scope_key=scope_key,
             )
+        hub_gather_service.invalidate_hub_message_snapshot_cache(context)
         return {"status": "ok", "resolved": resolved}
 
     return router

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/services.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/services.py
@@ -1,11 +1,24 @@
 from __future__ import annotations
 
+import copy
 import time
-from typing import TYPE_CHECKING, Optional
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from ...app_state import HubAppContext
     from .mount_manager import HubMountManager
+
+
+_REPO_ENRICH_CACHE_TTL_SECONDS = 2.0
+
+
+@dataclass(frozen=True)
+class _RepoEnrichmentCacheEntry:
+    fingerprint: tuple[Any, ...]
+    expires_at: float
+    payload: dict[str, Any]
 
 
 class HubRepoEnricher:
@@ -14,10 +27,12 @@ class HubRepoEnricher:
         self._mount_manager = mount_manager
         self._unbound_thread_counts_cache: Optional[dict[str, int]] = None
         self._unbound_thread_counts_cached_at = 0.0
+        self._repo_state_cache: dict[str, _RepoEnrichmentCacheEntry] = {}
 
     def invalidate_runtime_caches(self) -> None:
         self._unbound_thread_counts_cache = None
         self._unbound_thread_counts_cached_at = 0.0
+        self._repo_state_cache.clear()
 
     def _unbound_repo_thread_counts(self) -> dict[str, int]:
         now = time.monotonic()
@@ -34,15 +49,46 @@ class HubRepoEnricher:
         self._unbound_thread_counts_cached_at = now
         return dict(counts)
 
-    def enrich_repo(
+    def _path_stat_fingerprint(
+        self, path: Path
+    ) -> tuple[bool, Optional[int], Optional[int]]:
+        try:
+            stat = path.stat()
+        except OSError:
+            return (False, None, None)
+        return (True, int(stat.st_mtime_ns), int(stat.st_size))
+
+    def _repo_state_fingerprint(
         self,
         snapshot,
-        chat_binding_counts: Optional[dict[str, int]] = None,
-        chat_binding_counts_by_source: Optional[dict[str, dict[str, int]]] = None,
-    ) -> dict:
+        *,
+        stale_threshold_seconds: Optional[int],
+    ) -> tuple[Any, ...]:
+        repo_root = snapshot.path
+        car_root = repo_root / ".codex-autorunner"
+        return (
+            str(snapshot.id),
+            str(repo_root),
+            bool(snapshot.exists_on_disk),
+            bool(snapshot.initialized),
+            snapshot.last_run_id,
+            snapshot.last_run_started_at,
+            snapshot.last_run_finished_at,
+            int(stale_threshold_seconds or 0),
+            self._path_stat_fingerprint(car_root),
+            self._path_stat_fingerprint(car_root / "tickets"),
+            self._path_stat_fingerprint(car_root / "flows.db"),
+            self._path_stat_fingerprint(car_root / "runs"),
+        )
+
+    def _compute_repo_state_payload(
+        self,
+        snapshot,
+        *,
+        stale_threshold_seconds: Optional[int],
+    ) -> dict[str, Any]:
         from .....core.archive import has_car_state
         from .....core.flows.models import flow_run_duration_seconds
-        from .....core.freshness import resolve_stale_threshold_seconds
         from .....core.pma_context import (
             get_latest_ticket_flow_run_state_with_record,
         )
@@ -51,6 +97,105 @@ class HubRepoEnricher:
             build_ticket_flow_display,
             build_ticket_flow_summary,
         )
+
+        payload: dict[str, Any] = {
+            "has_car_state": (
+                has_car_state(self._context.config.root / snapshot.path)
+                if snapshot.exists_on_disk
+                else False
+            ),
+            "ticket_flow": None,
+            "ticket_flow_display": None,
+            "run_state": None,
+            "canonical_state_v1": None,
+        }
+        if not (snapshot.initialized and snapshot.exists_on_disk):
+            return payload
+
+        ticket_flow = build_ticket_flow_summary(snapshot.path, include_failure=True)
+        payload["ticket_flow"] = ticket_flow
+        if isinstance(ticket_flow, dict):
+            payload["ticket_flow_display"] = build_ticket_flow_display(
+                status=(
+                    str(ticket_flow.get("status"))
+                    if ticket_flow.get("status") is not None
+                    else None
+                ),
+                done_count=int(ticket_flow.get("done_count") or 0),
+                total_count=int(ticket_flow.get("total_count") or 0),
+                run_id=(
+                    str(ticket_flow.get("run_id"))
+                    if ticket_flow.get("run_id")
+                    else None
+                ),
+            )
+        else:
+            payload["ticket_flow_display"] = build_ticket_flow_display(
+                status=None,
+                done_count=0,
+                total_count=0,
+                run_id=None,
+            )
+        run_state, run_record = get_latest_ticket_flow_run_state_with_record(
+            snapshot.path, snapshot.id
+        )
+        payload["run_state"] = run_state
+        if run_record is not None:
+            if str(snapshot.last_run_id) != str(run_record.id):
+                payload["last_exit_code"] = None
+            payload["last_run_id"] = run_record.id
+            payload["last_run_started_at"] = run_record.started_at
+            payload["last_run_finished_at"] = run_record.finished_at
+            payload["last_run_duration_seconds"] = flow_run_duration_seconds(run_record)
+        payload["canonical_state_v1"] = build_canonical_state_v1(
+            repo_root=snapshot.path,
+            repo_id=snapshot.id,
+            run_state=payload["run_state"],
+            record=run_record,
+            preferred_run_id=(
+                str(snapshot.last_run_id) if snapshot.last_run_id is not None else None
+            ),
+            stale_threshold_seconds=stale_threshold_seconds,
+        )
+        return payload
+
+    def _repo_state_payload(
+        self,
+        snapshot,
+        *,
+        stale_threshold_seconds: Optional[int],
+    ) -> dict[str, Any]:
+        now = time.monotonic()
+        cache_key = str(snapshot.id)
+        fingerprint = self._repo_state_fingerprint(
+            snapshot,
+            stale_threshold_seconds=stale_threshold_seconds,
+        )
+        cached = self._repo_state_cache.get(cache_key)
+        if (
+            cached is not None
+            and cached.expires_at > now
+            and cached.fingerprint == fingerprint
+        ):
+            return copy.deepcopy(cached.payload)
+        payload = self._compute_repo_state_payload(
+            snapshot,
+            stale_threshold_seconds=stale_threshold_seconds,
+        )
+        self._repo_state_cache[cache_key] = _RepoEnrichmentCacheEntry(
+            fingerprint=fingerprint,
+            expires_at=now + _REPO_ENRICH_CACHE_TTL_SECONDS,
+            payload=copy.deepcopy(payload),
+        )
+        return payload
+
+    def enrich_repo(
+        self,
+        snapshot,
+        chat_binding_counts: Optional[dict[str, int]] = None,
+        chat_binding_counts_by_source: Optional[dict[str, dict[str, int]]] = None,
+    ) -> dict:
+        from .....core.freshness import resolve_stale_threshold_seconds
 
         repo_dict = snapshot.to_dict(self._context.config.root)
         repo_dict = self._mount_manager.add_mount_info(repo_dict)
@@ -80,65 +225,11 @@ class HubRepoEnricher:
                 self._unbound_repo_thread_counts().get(snapshot.id, 0)
             )
         repo_dict["unbound_managed_thread_count"] = max(0, unbound_thread_count)
-        repo_dict["has_car_state"] = (
-            has_car_state(self._context.config.root / snapshot.path)
-            if snapshot.exists_on_disk
-            else False
-        )
-        if snapshot.initialized and snapshot.exists_on_disk:
-            ticket_flow = build_ticket_flow_summary(snapshot.path, include_failure=True)
-            repo_dict["ticket_flow"] = ticket_flow
-            if isinstance(ticket_flow, dict):
-                repo_dict["ticket_flow_display"] = build_ticket_flow_display(
-                    status=(
-                        str(ticket_flow.get("status"))
-                        if ticket_flow.get("status") is not None
-                        else None
-                    ),
-                    done_count=int(ticket_flow.get("done_count") or 0),
-                    total_count=int(ticket_flow.get("total_count") or 0),
-                    run_id=(
-                        str(ticket_flow.get("run_id"))
-                        if ticket_flow.get("run_id")
-                        else None
-                    ),
-                )
-            else:
-                repo_dict["ticket_flow_display"] = build_ticket_flow_display(
-                    status=None,
-                    done_count=0,
-                    total_count=0,
-                    run_id=None,
-                )
-            run_state, run_record = get_latest_ticket_flow_run_state_with_record(
-                snapshot.path, snapshot.id
-            )
-            repo_dict["run_state"] = run_state
-            if run_record is not None:
-                if str(repo_dict.get("last_run_id")) != str(run_record.id):
-                    repo_dict["last_exit_code"] = None
-                repo_dict["last_run_id"] = run_record.id
-                repo_dict["last_run_started_at"] = run_record.started_at
-                repo_dict["last_run_finished_at"] = run_record.finished_at
-                repo_dict["last_run_duration_seconds"] = flow_run_duration_seconds(
-                    run_record
-                )
-            repo_dict["canonical_state_v1"] = build_canonical_state_v1(
-                repo_root=snapshot.path,
-                repo_id=snapshot.id,
-                run_state=repo_dict["run_state"],
-                record=run_record,
-                preferred_run_id=(
-                    str(snapshot.last_run_id)
-                    if snapshot.last_run_id is not None
-                    else None
-                ),
+        repo_dict.update(
+            self._repo_state_payload(
+                snapshot,
                 stale_threshold_seconds=stale_threshold_seconds,
             )
-        else:
-            repo_dict["ticket_flow"] = None
-            repo_dict["ticket_flow_display"] = None
-            repo_dict["run_state"] = None
-            repo_dict["canonical_state_v1"] = None
+        )
         repo_dict.setdefault("last_run_duration_seconds", None)
         return repo_dict

--- a/src/codex_autorunner/surfaces/web/services/hub_gather.py
+++ b/src/codex_autorunner/surfaces/web/services/hub_gather.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import copy
+import threading
+import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
@@ -29,10 +33,73 @@ from ....core.pma_context import (
     build_pma_action_queue,
     enrich_pma_file_inbox_entry,
 )
+from ....core.pma_thread_store import default_pma_threads_db_path
 from ....tickets.files import safe_relpath
 from ....tickets.models import Dispatch
 from ....tickets.outbox import parse_dispatch, resolve_outbox_paths
 from ..app_state import HubAppContext
+
+_HUB_SNAPSHOT_CACHE_TTL_SECONDS = 2.0
+_hub_snapshot_cache_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class _HubSnapshotCacheEntry:
+    fingerprint: tuple[Any, ...]
+    expires_at: float
+    snapshot: dict[str, Any]
+
+
+_hub_snapshot_cache: dict[tuple[int, str], _HubSnapshotCacheEntry] = {}
+
+
+def _path_stat_fingerprint(path: Path) -> tuple[bool, Optional[int], Optional[int]]:
+    try:
+        stat = path.stat()
+    except OSError:
+        return (False, None, None)
+    return (True, int(stat.st_mtime_ns), int(stat.st_size))
+
+
+def _hub_snapshot_fingerprint(
+    context: HubAppContext,
+    *,
+    limit: int,
+    scope_key: Optional[str],
+    requested: set[str],
+) -> tuple[Any, ...]:
+    config_root = getattr(getattr(context, "config", None), "root", None)
+    root_path = config_root if isinstance(config_root, Path) else None
+    supervisor_state = getattr(getattr(context, "supervisor", None), "state", None)
+    fingerprint: list[Any] = [
+        tuple(sorted(requested)),
+        int(limit),
+        scope_key or "",
+        getattr(supervisor_state, "last_scan_at", None),
+    ]
+    if root_path is not None:
+        fingerprint.extend(
+            [
+                str(root_path),
+                _path_stat_fingerprint(root_path / ".codex-autorunner"),
+                _path_stat_fingerprint(root_path / ".codex-autorunner" / "filebox"),
+                _path_stat_fingerprint(default_pma_threads_db_path(root_path)),
+            ]
+        )
+    return tuple(fingerprint)
+
+
+def invalidate_hub_message_snapshot_cache(
+    context: Optional[HubAppContext] = None,
+) -> None:
+    with _hub_snapshot_cache_lock:
+        if context is None:
+            _hub_snapshot_cache.clear()
+            return
+        context_id = id(context)
+        stale_keys = [key for key in _hub_snapshot_cache if key[0] == context_id]
+        for key in stale_keys:
+            _hub_snapshot_cache.pop(key, None)
 
 
 def latest_dispatch(repo_root: Path, run_id: str, input_data: dict) -> Optional[dict]:
@@ -153,6 +220,22 @@ def gather_hub_message_snapshot(
         if sections is not None
         else {"inbox", "pma_threads", "pma_files_detail", "automation", "action_queue"}
     )
+    cache_key = (id(context), "|".join(sorted(requested)))
+    fingerprint = _hub_snapshot_fingerprint(
+        context,
+        limit=limit,
+        scope_key=scope_key,
+        requested=requested,
+    )
+    now = time.monotonic()
+    with _hub_snapshot_cache_lock:
+        cached = _hub_snapshot_cache.get(cache_key)
+        if (
+            cached is not None
+            and cached.expires_at > now
+            and cached.fingerprint == fingerprint
+        ):
+            return copy.deepcopy(cached.snapshot)
     include_action_queue = bool(requested & {"inbox", "action_queue"})
     pma_config = getattr(getattr(context, "config", None), "pma", None)
     stale_threshold_seconds = resolve_stale_threshold_seconds(
@@ -397,4 +480,16 @@ def gather_hub_message_snapshot(
         snapshot["automation"] = automation
     if "action_queue" in requested:
         snapshot["action_queue"] = filtered_action_queue
+    store_fingerprint = _hub_snapshot_fingerprint(
+        context,
+        limit=limit,
+        scope_key=scope_key,
+        requested=requested,
+    )
+    with _hub_snapshot_cache_lock:
+        _hub_snapshot_cache[cache_key] = _HubSnapshotCacheEntry(
+            fingerprint=store_fingerprint,
+            expires_at=now + _HUB_SNAPSHOT_CACHE_TTL_SECONDS,
+            snapshot=copy.deepcopy(snapshot),
+        )
     return snapshot

--- a/tests/surfaces/web/routes/test_hub_performance_caches.py
+++ b/tests/surfaces/web/routes/test_hub_performance_caches.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from codex_autorunner.core.hub import LockStatus, RepoSnapshot, RepoStatus
+from codex_autorunner.surfaces.web.routes.hub_repo_routes.services import (
+    HubRepoEnricher,
+)
+from codex_autorunner.surfaces.web.services import hub_gather as hub_gather_service
+
+
+class _MountManager:
+    def add_mount_info(self, repo_dict: dict) -> dict:
+        repo_dict["mounted"] = True
+        return repo_dict
+
+
+def _repo_snapshot(repo_root: Path) -> RepoSnapshot:
+    return RepoSnapshot(
+        id="demo",
+        path=repo_root,
+        display_name="demo",
+        enabled=True,
+        auto_run=False,
+        worktree_setup_commands=None,
+        kind="base",
+        worktree_of=None,
+        branch="main",
+        exists_on_disk=True,
+        is_clean=True,
+        initialized=True,
+        init_error=None,
+        status=RepoStatus.IDLE,
+        lock_status=LockStatus.UNLOCKED,
+        last_run_id=1,
+        last_run_started_at=None,
+        last_run_finished_at=None,
+        last_exit_code=0,
+        runner_pid=None,
+    )
+
+
+def test_hub_repo_enricher_reuses_cached_repo_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "demo"
+    tickets_dir = repo_root / ".codex-autorunner" / "tickets"
+    tickets_dir.mkdir(parents=True, exist_ok=True)
+    snapshot = _repo_snapshot(repo_root)
+    context = SimpleNamespace(
+        config=SimpleNamespace(
+            root=hub_root,
+            pma=SimpleNamespace(freshness_stale_threshold_seconds=None),
+        ),
+        supervisor=SimpleNamespace(unbound_repo_thread_counts=lambda: {"demo": 0}),
+    )
+    enricher = HubRepoEnricher(context, _MountManager())  # type: ignore[arg-type]
+    calls = {
+        "has_car_state": 0,
+        "ticket_flow_summary": 0,
+        "run_state": 0,
+        "canonical_state": 0,
+    }
+
+    def fake_has_car_state(_path: Path) -> bool:
+        calls["has_car_state"] += 1
+        return True
+
+    def fake_ticket_flow_summary(
+        _path: Path, *, include_failure: bool
+    ) -> dict[str, object]:
+        assert include_failure is True
+        calls["ticket_flow_summary"] += 1
+        return {
+            "status": "running",
+            "done_count": 1,
+            "total_count": 2,
+            "run_id": "r1",
+        }
+
+    def fake_run_state(
+        _repo_root: Path, _repo_id: str
+    ) -> tuple[dict[str, object], None]:
+        calls["run_state"] += 1
+        return ({"state": "running", "flow_status": "running", "run_id": "r1"}, None)
+
+    def fake_canonical_state(**_kwargs) -> dict[str, object]:
+        calls["canonical_state"] += 1
+        return {"status": "running"}
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.archive.has_car_state", fake_has_car_state
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.ticket_flow_summary.build_ticket_flow_summary",
+        fake_ticket_flow_summary,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.pma_context.get_latest_ticket_flow_run_state_with_record",
+        fake_run_state,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.ticket_flow_projection.build_canonical_state_v1",
+        fake_canonical_state,
+    )
+
+    first = enricher.enrich_repo(snapshot)
+    second = enricher.enrich_repo(snapshot)
+
+    assert first["canonical_state_v1"] == {"status": "running"}
+    assert second["canonical_state_v1"] == {"status": "running"}
+    assert calls == {
+        "has_car_state": 1,
+        "ticket_flow_summary": 1,
+        "run_state": 1,
+        "canonical_state": 1,
+    }
+
+
+def test_hub_repo_enricher_invalidates_cache_on_flow_db_change(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "demo"
+    car_root = repo_root / ".codex-autorunner"
+    tickets_dir = car_root / "tickets"
+    tickets_dir.mkdir(parents=True, exist_ok=True)
+    flows_db = car_root / "flows.db"
+    flows_db.write_text("v1", encoding="utf-8")
+    snapshot = _repo_snapshot(repo_root)
+    context = SimpleNamespace(
+        config=SimpleNamespace(
+            root=hub_root,
+            pma=SimpleNamespace(freshness_stale_threshold_seconds=None),
+        ),
+        supervisor=SimpleNamespace(unbound_repo_thread_counts=lambda: {"demo": 0}),
+    )
+    enricher = HubRepoEnricher(context, _MountManager())  # type: ignore[arg-type]
+    calls = {"ticket_flow_summary": 0}
+
+    def fake_ticket_flow_summary(
+        _path: Path, *, include_failure: bool
+    ) -> dict[str, object]:
+        assert include_failure is True
+        calls["ticket_flow_summary"] += 1
+        return {
+            "status": "running",
+            "done_count": 1,
+            "total_count": 2,
+            "run_id": f"r{calls['ticket_flow_summary']}",
+        }
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.archive.has_car_state", lambda _path: True
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.ticket_flow_summary.build_ticket_flow_summary",
+        fake_ticket_flow_summary,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.pma_context.get_latest_ticket_flow_run_state_with_record",
+        lambda _repo_root, _repo_id: (
+            {"state": "running", "flow_status": "running"},
+            None,
+        ),
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.ticket_flow_projection.build_canonical_state_v1",
+        lambda **_kwargs: {"status": "running"},
+    )
+
+    enricher.enrich_repo(snapshot)
+    flows_db.write_text("v2", encoding="utf-8")
+    enricher.enrich_repo(snapshot)
+
+    assert calls["ticket_flow_summary"] == 2
+
+
+def test_gather_hub_message_snapshot_reuses_short_ttl_cache(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir(parents=True, exist_ok=True)
+    calls = {"list_repos": 0}
+
+    def list_repos() -> list[object]:
+        calls["list_repos"] += 1
+        return []
+
+    context = SimpleNamespace(
+        supervisor=SimpleNamespace(
+            list_repos=list_repos,
+            state=SimpleNamespace(last_scan_at="2026-04-05T00:00:00Z"),
+        ),
+        config=SimpleNamespace(root=hub_root),
+    )
+
+    monkeypatch.setattr(
+        hub_gather_service, "_gather_inbox", lambda *_args, **_kwargs: []
+    )
+    monkeypatch.setattr(
+        hub_gather_service, "build_hub_capability_hints", lambda **_kwargs: []
+    )
+    monkeypatch.setattr(
+        hub_gather_service, "build_repo_capability_hints", lambda **_kwargs: []
+    )
+    monkeypatch.setattr(
+        hub_gather_service, "load_hub_inbox_dismissals", lambda _root: {}
+    )
+
+    first = hub_gather_service.gather_hub_message_snapshot(context, sections={"inbox"})
+    second = hub_gather_service.gather_hub_message_snapshot(context, sections={"inbox"})
+
+    assert first["items"] == []
+    assert second["items"] == []
+    assert calls["list_repos"] == 1


### PR DESCRIPTION
## Summary
- add short-TTL, shallow-fingerprint caches around expensive hub repo enrichment and hub message snapshot assembly
- lazy-load hub, PMA, and repo-shell modules from `app.ts` so the hub entrypoint stops pulling every view module on first paint
- parallelize independent hub refresh/version calls and invalidate the hub message cache immediately after dismiss/resolve mutations

## Root Cause
The hub UI was repeatedly paying full backend recomputation costs for unchanged repo/message data, while the frontend eagerly imported view code that was not needed for the current screen.

## Validation
- `pnpm run build`
- `.venv/bin/python -m pytest tests/surfaces/web/routes/test_hub_performance_caches.py tests/surfaces/web/test_hub_gather_service.py`
- `.venv/bin/python -m pytest tests/test_hub_messages.py -k 'hub_messages_action_queue_sections_honor_dismissals or hub_messages_dismiss_filters_and_persists'`
- pre-commit hook suite: `4059 passed, 1 skipped`

Closes #1253
