### PR TITLE
[codex] Fix opencode final output assembly

### DIFF
--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -1717,16 +1717,22 @@ async def collect_opencode_output_from_events(
                             continue
                         _append_text_for_message(part_message_id, delta_text)
                         # Update dedupe bookkeeping for text deltas to prevent re-adding later
-                        if isinstance(part_dict, dict):
-                            part_id = part_dict.get("id") or part_dict.get("partId")
+                        if isinstance(part_id, str) and part_id:
+                            if isinstance(part_dict, dict):
+                                text = part_dict.get("text")
+                                if isinstance(text, str):
+                                    part_lengths[part_id] = len(text)
+                                else:
+                                    part_lengths[part_id] = part_lengths.get(
+                                        part_id, 0
+                                    ) + len(delta_text)
+                            else:
+                                part_lengths[part_id] = part_lengths.get(
+                                    part_id, 0
+                                ) + len(delta_text)
+                        elif isinstance(part_dict, dict):
                             text = part_dict.get("text")
-                            if (
-                                isinstance(part_id, str)
-                                and part_id
-                                and isinstance(text, str)
-                            ):
-                                part_lengths[part_id] = len(text)
-                            elif isinstance(text, str):
+                            if isinstance(text, str):
                                 last_full_text = text
                         if part_handler and part_with_session:
                             await part_handler("text", part_with_session, delta_text)

--- a/src/codex_autorunner/core/orchestration/opencode_event_fields.py
+++ b/src/codex_autorunner/core/orchestration/opencode_event_fields.py
@@ -64,6 +64,31 @@ def extract_message_role(params: dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _normalize_message_phase(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"commentary", "final_answer"}:
+        return normalized
+    return None
+
+
+def extract_message_phase(params: dict[str, Any]) -> Optional[str]:
+    phase = _normalize_message_phase(params.get("phase"))
+    if phase is not None:
+        return phase
+    for source in (
+        extract_message_info(params),
+        extract_message_properties(params),
+        coerce_dict(params.get("message")),
+        coerce_dict(params.get("item")),
+    ):
+        phase = _normalize_message_phase(source.get("phase"))
+        if phase is not None:
+            return phase
+    return None
+
+
 def extract_part_message_id(params: dict[str, Any]) -> Optional[str]:
     properties = extract_message_properties(params)
     part = extract_message_part(params)

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -30,6 +30,9 @@ from .opencode_event_fields import (
     extract_message_part as _event_extract_message_part,
 )
 from .opencode_event_fields import (
+    extract_message_phase as _event_extract_message_phase,
+)
+from .opencode_event_fields import (
     extract_message_role as _event_extract_message_role,
 )
 from .opencode_event_fields import (
@@ -543,7 +546,7 @@ def normalize_runtime_thread_message(
             return []
         if item_type == "agentMessage":
             content = _extract_agent_message_text(item)
-            if not content:
+            if not content or _extract_message_phase(params) == "commentary":
                 return []
             state.note_message_text(content)
             return [
@@ -668,6 +671,8 @@ def normalize_runtime_thread_message(
         if not content:
             return role_events
         if _extract_message_role(params) == "user":
+            return role_events
+        if _extract_message_phase(params) == "commentary":
             return role_events
         state.note_message_text(content)
         return role_events + [
@@ -903,6 +908,10 @@ def _coerce_dict(value: Any) -> dict[str, Any]:
 
 def _extract_message_part(params: dict[str, Any]) -> dict[str, Any]:
     return _event_extract_message_part(params)
+
+
+def _extract_message_phase(params: dict[str, Any]) -> Optional[str]:
+    return _event_extract_message_phase(params)
 
 
 def _extract_output_delta(params: dict[str, Any]) -> str:

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -580,6 +580,50 @@ async def test_normalize_runtime_thread_raw_event_handles_opencode_message_part_
     assert state.best_assistant_text() == "OK"
 
 
+async def test_normalize_runtime_thread_raw_event_ignores_commentary_completed_messages() -> (
+    None
+):
+    state = RuntimeThreadRunEventState()
+
+    commentary = await normalize_runtime_thread_raw_event(
+        format_sse(
+            "app-server",
+            {
+                "message": {
+                    "method": "item/completed",
+                    "params": {
+                        "itemId": "item-1",
+                        "item": {
+                            "type": "agentMessage",
+                            "text": "draft reply",
+                            "phase": "commentary",
+                        },
+                    },
+                }
+            },
+        ),
+        state,
+    )
+    final_stream = await normalize_runtime_thread_raw_event(
+        format_sse(
+            "app-server",
+            {
+                "message": {
+                    "method": "item/agentMessage/delta",
+                    "params": {"itemId": "item-2", "delta": "final reply"},
+                }
+            },
+        ),
+        state,
+    )
+
+    assert commentary == []
+    assert len(final_stream) == 1
+    assert isinstance(final_stream[0], OutputDelta)
+    assert final_stream[0].content == "final reply"
+    assert state.best_assistant_text() == "final reply"
+
+
 async def test_normalize_runtime_thread_raw_event_maps_opencode_reasoning_parts_to_thinking() -> (
     None
 ):

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -4733,6 +4733,74 @@ async def test_message_create_streaming_turn_ignores_late_failed_with_stream_fal
 
 
 @pytest.mark.anyio
+async def test_message_create_streaming_turn_ignores_commentary_when_stream_falls_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway([("MESSAGE_CREATE", _message_create("ship it"))])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    commentary_text = "draft release summary"
+    final_text = "final release summary"
+    _patch_streaming_harness(
+        monkeypatch,
+        [
+            {
+                "message": {
+                    "method": "item/completed",
+                    "params": {
+                        "itemId": "item-1",
+                        "item": {
+                            "type": "agentMessage",
+                            "text": commentary_text,
+                            "phase": "commentary",
+                        },
+                    },
+                }
+            },
+            OutputDelta(
+                timestamp="2026-01-01T00:00:01Z",
+                content=final_text,
+                delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
+            ),
+            Completed(timestamp="2026-01-01T00:00:02Z", final_message=""),
+        ],
+        assistant_text="",
+        wait_for_stream=True,
+    )
+
+    try:
+        await service.run_forever()
+        contents = [
+            str(msg["payload"].get("content", "")) for msg in rest.channel_messages
+        ]
+        assert any(final_text in content for content in contents)
+        assert not any(commentary_text in content for content in contents)
+        assert not any(
+            "(No response text returned.)" in content for content in contents
+        )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_message_create_streaming_turn_recovers_if_wait_disconnects_after_completion(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_opencode_integration.py
+++ b/tests/test_opencode_integration.py
@@ -14,6 +14,10 @@ from codex_autorunner.agents.opencode.supervisor import (
     OpenCodeSupervisorError,
 )
 from codex_autorunner.core.managed_processes.registry import read_process_record
+from codex_autorunner.core.orchestration.runtime_thread_events import (
+    RuntimeThreadRunEventState,
+    normalize_runtime_thread_raw_event,
+)
 from codex_autorunner.core.sse import parse_sse_lines
 from codex_autorunner.workspace import canonical_workspace_root, workspace_id_for_path
 
@@ -502,6 +506,40 @@ async def test_harness_stream_turn_events(workspace: Path) -> None:
                 pass
     finally:
         await supervisor.close_all()
+
+
+@pytest.mark.asyncio
+async def test_harness_wait_for_turn_matches_runtime_event_fallback(
+    supervisor: OpenCodeSupervisor,
+    workspace: Path,
+) -> None:
+    """Real OpenCode turns should agree with runtime-event fallback text."""
+
+    harness = OpenCodeHarness(supervisor)
+    conv = await harness.new_conversation(workspace)
+    turn = await harness.start_turn(
+        workspace,
+        conv.id,
+        prompt="What is 2+2? Think carefully first, then answer in one short sentence.",
+        model=None,
+        reasoning=None,
+        approval_mode=None,
+        sandbox_policy=None,
+    )
+
+    result = await asyncio.wait_for(
+        harness.wait_for_turn(workspace, conv.id, turn.turn_id),
+        timeout=90.0,
+    )
+
+    state = RuntimeThreadRunEventState()
+    for raw_event in result.raw_events:
+        await normalize_runtime_thread_raw_event(raw_event, state)
+
+    assert result.status == "ok"
+    assert result.assistant_text.strip()
+    assert state.best_assistant_text().strip()
+    assert result.assistant_text.strip() == state.best_assistant_text().strip()
 
 
 @pytest.mark.asyncio

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -149,6 +149,45 @@ async def test_collect_output_supports_message_part_delta_with_direct_ids() -> N
 
 
 @pytest.mark.anyio
+async def test_collect_output_dedupes_delta_then_full_text_update_for_same_part() -> (
+    None
+):
+    events = [
+        SSEEvent(
+            event="message.updated",
+            data='{"sessionID":"s1","properties":{"info":{"id":"assistant-1","role":"assistant"}}}',
+        ),
+        SSEEvent(
+            event="message.part.updated",
+            data='{"sessionID":"s1","properties":{"part":{"id":"p1","messageID":"assistant-1","type":"text","text":""}}}',
+        ),
+        SSEEvent(
+            event="message.part.delta",
+            data='{"sessionID":"s1","properties":{"partID":"p1","messageID":"assistant-1","delta":"2"}}',
+        ),
+        SSEEvent(
+            event="message.part.delta",
+            data='{"sessionID":"s1","properties":{"partID":"p1","messageID":"assistant-1","delta":" + 2"}}',
+        ),
+        SSEEvent(
+            event="message.part.delta",
+            data='{"sessionID":"s1","properties":{"partID":"p1","messageID":"assistant-1","delta":" = 4."}}',
+        ),
+        SSEEvent(
+            event="message.part.updated",
+            data='{"sessionID":"s1","properties":{"part":{"id":"p1","messageID":"assistant-1","type":"text","text":"2 + 2 = 4."}}}',
+        ),
+        SSEEvent(event="session.idle", data='{"sessionID":"s1"}'),
+    ]
+    output = await collect_opencode_output_from_events(
+        _iter_events(events),
+        session_id="s1",
+    )
+    assert output.text == "2 + 2 = 4."
+    assert output.error is None
+
+
+@pytest.mark.anyio
 async def test_collect_output_uses_part_type_memory_for_reasoning_delta_events() -> (
     None
 ):


### PR DESCRIPTION
## Summary
Fix OpenCode final-response assembly so Discord-managed turns do not leak commentary-style fallback text and real OpenCode text parts are not duplicated when the runtime sends both `message.part.delta` chunks and a later full `message.part.updated` snapshot for the same part.

## Root Cause
There were two separate issues in the current codebase:

1. The shared managed-thread runtime normalizer treated OpenCode `commentary` agent messages as canonical assistant output, even though the OpenCode harness and app-server client already distinguish `commentary` from the final answer.
2. The OpenCode output collector did not advance per-part dedupe state for delta-only text events with a known `partID`, so when OpenCode later emitted the full text snapshot for that same part it re-appended the whole answer.

The second issue was reproduced with the real authenticated `opencode` binary. Before the fix, a live canary returned duplicated text such as `2 + 2 = 4.2 + 2 = 4.` while the runtime-event fallback reconstructed the correct single answer.

## Changes
- Add shared OpenCode message-phase extraction in `core/orchestration/opencode_event_fields.py`.
- Teach `core/orchestration/runtime_thread_events.py` to ignore `commentary` agent messages for canonical final-text selection.
- Fix `agents/opencode/runtime.py` so text deltas update `part_lengths` even when the event only contains `partID` plus a delta, preventing a later full-text snapshot from being appended again.
- Add regression coverage for:
  - commentary being excluded from runtime-thread fallback text
  - Discord managed-thread fallback preferring the real final stream over commentary
  - delta-then-full-text dedupe for the same OpenCode text part
  - a real OpenCode integration canary that asserts the harness final text matches the runtime-event fallback final text

## Validation
- `pytest tests/test_opencode_runtime.py tests/test_opencode_backend_streaming.py tests/agents/opencode/test_opencode_harness.py tests/core/orchestration/test_runtime_thread_events.py tests/integrations/discord/test_message_turns.py -k 'dedupes_delta_then_full_text_update_for_same_part or supports_message_part_delta_with_direct_ids or commentary or real_events_ignore_user_prompt or stream_falls_back'`
- `pytest tests/test_opencode_integration.py -k 'matches_runtime_event_fallback'`
- pre-commit hook suite during `git commit`, including full repo pytest: `4075 passed, 1 skipped`

## Notes
The new live canary is added under `tests/test_opencode_integration.py`, which already carries `pytest.mark.integration`, so it remains opt-in and does not run in the default non-integration test selection.