### PR TITLE
[codex] Recover stale running turns when status_turn_id matches

### DIFF
--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -556,7 +556,15 @@ class PmaThreadStore:
     ) -> list[str]:
         running_rows = conn.execute(
             """
-            SELECT execution_id, started_at, created_at
+            SELECT
+                execution_id,
+                started_at,
+                created_at,
+                (
+                    SELECT MAX(ep.timestamp)
+                      FROM orch_event_projections AS ep
+                     WHERE ep.execution_id = orch_thread_executions.execution_id
+                ) AS last_event_at
               FROM orch_thread_executions
              WHERE thread_target_id = ?
                AND status = 'running'
@@ -589,12 +597,14 @@ class PmaThreadStore:
                 stale_execution_ids.append(execution_id)
                 continue
 
-            started_at = parse_iso_datetime(row["started_at"]) or parse_iso_datetime(
-                row["created_at"]
+            last_activity_at = (
+                parse_iso_datetime(row["last_event_at"])
+                or parse_iso_datetime(row["started_at"])
+                or parse_iso_datetime(row["created_at"])
             )
-            if started_at is None:
+            if last_activity_at is None:
                 continue
-            age_seconds = max(0, int((now_dt - started_at).total_seconds()))
+            age_seconds = max(0, int((now_dt - last_activity_at).total_seconds()))
             if age_seconds > self._stale_running_threshold_seconds:
                 stale_execution_ids.append(execution_id)
         return stale_execution_ids

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -468,6 +468,61 @@ def test_claim_next_queued_turn_recovers_old_running_execution_when_status_turn_
     assert stale_after["finished_at"]
 
 
+def test_create_turn_keeps_old_running_execution_with_recent_activity(
+    tmp_path: Path,
+) -> None:
+    store = PmaThreadStore(
+        tmp_path / "hub",
+        stale_running_threshold_seconds=60,
+    )
+    thread = store.create_thread("codex", tmp_path / "workspace")
+
+    active_turn = store.create_turn(thread["managed_thread_id"], prompt="first")
+
+    with store._write_conn() as conn:
+        with conn:
+            conn.execute(
+                """
+                UPDATE orch_thread_executions
+                   SET started_at = '2000-01-01T00:00:00Z',
+                       created_at = '2000-01-01T00:00:00Z'
+                 WHERE execution_id = ?
+                """,
+                (active_turn["managed_turn_id"],),
+            )
+            conn.execute(
+                """
+                INSERT INTO orch_event_projections (
+                    event_id,
+                    event_family,
+                    event_type,
+                    execution_id,
+                    timestamp,
+                    status,
+                    payload_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    f"test-activity:{active_turn['managed_turn_id']}",
+                    "turn.timeline",
+                    "output_delta",
+                    active_turn["managed_turn_id"],
+                    "2999-01-01T00:00:00Z",
+                    "recorded",
+                    "{}",
+                ),
+            )
+
+    with pytest.raises(ManagedThreadAlreadyHasRunningTurnError):
+        store.create_turn(thread["managed_thread_id"], prompt="second")
+
+    turn_after = store.get_turn(
+        thread["managed_thread_id"], active_turn["managed_turn_id"]
+    )
+    assert turn_after is not None
+    assert turn_after["status"] == "running"
+
+
 def test_recovery_does_not_interrupt_legit_queued_turn_promoted_after_newer_terminal(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add time-based stale detection for running thread executions in `PmaThreadStore`
- keep existing mismatch-based stale recovery, and also recover long-running executions even when `execution_id == status_turn_id`
- source the stale threshold from PMA config (`pma.freshness_stale_threshold_seconds`, default 1800s) with optional constructor override for tests
- add regression tests for both `create_turn` and `claim_next_queued_turn` paths when the stale running execution is also the thread status turn

## Root Cause
Stale recovery only considered a running execution stale when its id differed from `status_turn_id`. A zombie execution that remained `running` and also matched `status_turn_id` was never recovered.

## User Impact
Managed chat threads can self-heal from stale/zombie running executions instead of remaining blocked behind an unrecoverable `running` turn.

## Validation
- pre-commit pipeline executed during commit (black, ruff, mypy, frontend build/tests, repo pytest)
- focused local regression verification:
  - `.venv/bin/python -m pytest tests/test_pma_thread_store.py`
  - `.venv/bin/python -m pytest tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py -k "recover_orphaned_managed_thread_executions_unblocks_restart_queue or recover_orphaned_managed_thread_executions_skips_chat_bound_threads"`

Closes #1262