### PR TITLE
[codex] Fix passive PMA stale recovery interrupting active turns

### DIFF
--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -552,7 +552,11 @@ class PmaThreadStore:
         return self._fetch_thread(conn, managed_thread_id)
 
     def _find_stale_running_turn_ids(
-        self, conn: Any, managed_thread_id: str
+        self,
+        conn: Any,
+        managed_thread_id: str,
+        *,
+        include_status_turn_age_recovery: bool = True,
     ) -> list[str]:
         running_rows = conn.execute(
             """
@@ -596,6 +600,8 @@ class PmaThreadStore:
             if status_turn_id and status_turn_id != execution_id:
                 stale_execution_ids.append(execution_id)
                 continue
+            if not include_status_turn_age_recovery and status_turn_id == execution_id:
+                continue
 
             last_activity_at = (
                 parse_iso_datetime(row["last_event_at"])
@@ -609,8 +615,18 @@ class PmaThreadStore:
                 stale_execution_ids.append(execution_id)
         return stale_execution_ids
 
-    def _recover_stale_running_turns(self, conn: Any, managed_thread_id: str) -> int:
-        stale_execution_ids = self._find_stale_running_turn_ids(conn, managed_thread_id)
+    def _recover_stale_running_turns(
+        self,
+        conn: Any,
+        managed_thread_id: str,
+        *,
+        include_status_turn_age_recovery: bool = True,
+    ) -> int:
+        stale_execution_ids = self._find_stale_running_turn_ids(
+            conn,
+            managed_thread_id,
+            include_status_turn_age_recovery=include_status_turn_age_recovery,
+        )
         if not stale_execution_ids:
             return 0
         recovered_at = now_iso()
@@ -1320,7 +1336,13 @@ class PmaThreadStore:
 
     def get_running_turn(self, managed_thread_id: str) -> Optional[dict[str, Any]]:
         with self._write_conn() as conn:
-            self._recover_stale_running_turns(conn, managed_thread_id)
+            # Status checks can be polled frequently; avoid age-based interruption of
+            # the currently-tracked status turn during passive reads.
+            self._recover_stale_running_turns(
+                conn,
+                managed_thread_id,
+                include_status_turn_age_recovery=False,
+            )
             row = conn.execute(
                 """
                 SELECT *

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -407,6 +407,11 @@ def test_create_turn_recovers_old_running_execution_when_status_turn_matches(
                 (stale_running_turn["managed_turn_id"],),
             )
 
+    # Passive status reads should not age-interrupt the active status turn.
+    running_snapshot = store.get_running_turn(thread["managed_thread_id"])
+    assert running_snapshot is not None
+    assert running_snapshot["managed_turn_id"] == stale_running_turn["managed_turn_id"]
+
     recovered_running_turn = store.create_turn(
         thread["managed_thread_id"],
         prompt="fresh execution",


### PR DESCRIPTION
## Summary
- fix a regression introduced in #1263 where passive `get_running_turn()` reads could age-interrupt the active `status_turn_id` execution
- keep mismatch-based stale recovery in passive reads, but disable age-based stale recovery for the currently tracked `status_turn_id`
- preserve age-based stale recovery for explicit admission/requeue paths (`create_turn` and `claim_next_queued_turn`)
- add regression coverage to ensure passive status reads do not interrupt active turns

## Root cause
`get_running_turn()` calls stale-recovery and is polled frequently by Discord queue/status paths. After #1263, stale recovery could mark the active `status_turn_id` execution as stale purely by elapsed time, which flips healthy long-running turns to `interrupted` and makes finalization fail.

## User impact
Discord managed threads could report turn failures and appear stuck after being queued because active turns were being interrupted during passive status polling.

## Validation
- pre-commit suite run by commit hook:
  - black, ruff, mypy
  - frontend build + JS tests
  - repo pytest (`4084 passed, 1 skipped`)
- focused local checks run before commit:
  - `.venv/bin/python -m pytest tests/test_pma_thread_store.py`
  - `.venv/bin/python -m pytest tests/integrations/discord/test_message_turns.py -k "repeated_messages_through_orchestration_thread"`
