### PR TITLE
[codex] Persist live managed-thread timelines for PMA tail

### DIFF
--- a/src/codex_autorunner/core/orchestration/turn_timeline.py
+++ b/src/codex_autorunner/core/orchestration/turn_timeline.py
@@ -73,6 +73,7 @@ def persist_turn_timeline(
     resource_id: Optional[str] = None,
     metadata: Optional[dict[str, Any]] = None,
     events: Iterable[RunEvent],
+    start_index: int = 1,
 ) -> int:
     normalized_execution_id = str(execution_id or "").strip()
     if not normalized_execution_id:
@@ -80,8 +81,10 @@ def persist_turn_timeline(
 
     base_metadata = dict(metadata or {})
     count = 0
+    next_index = max(int(start_index or 1), 1)
     with open_orchestration_sqlite(hub_root) as conn:
-        for index, event in enumerate(events, start=1):
+        for event in events:
+            index = next_index + count
             event_type, status = _event_type_and_status(event)
             event_payload = {
                 **base_metadata,

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -44,6 +44,7 @@ from ...core.orchestration.runtime_threads import (
     begin_next_queued_runtime_thread_execution,
     begin_runtime_thread_execution,
 )
+from ...core.orchestration.turn_timeline import persist_turn_timeline
 from ...core.pma_context import (
     build_hub_snapshot,
     format_pma_discoverability_preamble,
@@ -1164,6 +1165,54 @@ async def _finalize_discord_thread_execution(
     started_execution_error = str(getattr(started.execution, "error", "") or "").strip()
     event_state = runtime_event_state or RuntimeThreadRunEventState()
     stream_task: Optional[asyncio.Task[None]] = None
+    timeline_events: list[Any] = []
+    live_timeline_count = 0
+    live_timeline_error_logged = False
+
+    def _persist_live_timeline_events(events: list[Any]) -> None:
+        nonlocal live_timeline_count
+        nonlocal live_timeline_error_logged
+        if not events:
+            return
+        try:
+            persist_turn_timeline(
+                service._config.root,
+                execution_id=managed_turn_id,
+                target_kind="thread_target",
+                target_id=managed_thread_id,
+                repo_id=str(current_thread_row.get("repo_id") or "").strip() or None,
+                resource_kind=(
+                    str(current_thread_row.get("resource_kind") or "").strip() or None
+                ),
+                resource_id=(
+                    str(current_thread_row.get("resource_id") or "").strip() or None
+                ),
+                metadata={
+                    "agent": getattr(started.thread, "agent_id", None),
+                    "execution_id": managed_turn_id,
+                    "thread_target_id": managed_thread_id,
+                    "backend_thread_id": current_backend_thread_id or None,
+                    "backend_turn_id": started.execution.backend_id,
+                    "model": started.request.model,
+                    "reasoning": started.request.reasoning,
+                    "request_kind": getattr(started.request, "kind", None),
+                    "status": "running",
+                    "surface_kind": "discord",
+                    "surface_key": channel_id,
+                },
+                events=events,
+                start_index=live_timeline_count + 1,
+            )
+        except Exception:
+            if not live_timeline_error_logged:
+                live_timeline_error_logged = True
+                _logger.exception(
+                    "Failed to persist live Discord thread timeline (thread=%s turn=%s)",
+                    managed_thread_id,
+                    managed_turn_id,
+                )
+        else:
+            live_timeline_count += len(events)
 
     stream_backend_thread_id = current_backend_thread_id
     stream_backend_turn_id = str(started.execution.backend_id or "").strip()
@@ -1215,6 +1264,8 @@ async def _finalize_discord_thread_execution(
                             raw_event,
                             event_state,
                         )
+                    timeline_events.extend(run_events)
+                    _persist_live_timeline_events(run_events)
                     if on_progress_event is None:
                         continue
                     for run_event in run_events:
@@ -1302,12 +1353,50 @@ async def _finalize_discord_thread_execution(
         outcome = recovered_outcome
 
     if on_progress_event is not None:
+        terminal_event = terminal_run_event_from_outcome(outcome, event_state)
+        timeline_events.append(terminal_event)
         try:
-            await on_progress_event(
-                terminal_run_event_from_outcome(outcome, event_state)
-            )
+            await on_progress_event(terminal_event)
         except Exception:
             _logger.debug("Discord terminal progress event failed", exc_info=True)
+    else:
+        timeline_events.append(terminal_run_event_from_outcome(outcome, event_state))
+
+    try:
+        persist_turn_timeline(
+            service._config.root,
+            execution_id=managed_turn_id,
+            target_kind="thread_target",
+            target_id=managed_thread_id,
+            repo_id=str(current_thread_row.get("repo_id") or "").strip() or None,
+            resource_kind=(
+                str(current_thread_row.get("resource_kind") or "").strip() or None
+            ),
+            resource_id=(
+                str(current_thread_row.get("resource_id") or "").strip() or None
+            ),
+            metadata={
+                "agent": getattr(started.thread, "agent_id", None),
+                "execution_id": managed_turn_id,
+                "thread_target_id": managed_thread_id,
+                "backend_thread_id": current_backend_thread_id or None,
+                "backend_turn_id": outcome.backend_turn_id
+                or started.execution.backend_id,
+                "model": started.request.model,
+                "reasoning": started.request.reasoning,
+                "request_kind": getattr(started.request, "kind", None),
+                "status": outcome.status,
+                "surface_kind": "discord",
+                "surface_key": channel_id,
+            },
+            events=timeline_events,
+        )
+    except Exception:
+        _logger.exception(
+            "Failed to persist Discord thread timeline (thread=%s turn=%s)",
+            managed_thread_id,
+            managed_turn_id,
+        )
 
     resolved_assistant_text = (
         outcome.assistant_text or event_state.best_assistant_text()

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -55,6 +55,7 @@ from .....core.orchestration.runtime_threads import (
     begin_next_queued_runtime_thread_execution,
     begin_runtime_thread_execution,
 )
+from .....core.orchestration.turn_timeline import persist_turn_timeline
 from .....core.pma_context import (
     build_hub_snapshot,
     format_pma_discoverability_preamble,
@@ -687,6 +688,56 @@ async def _finalize_telegram_managed_thread_execution(
     ).strip()
     event_state = runtime_event_state or RuntimeThreadRunEventState()
     stream_task: Optional[asyncio.Task[None]] = None
+    timeline_events: list[Any] = []
+    live_timeline_count = 0
+    live_timeline_error_logged = False
+
+    def _persist_live_timeline_events(events: list[Any]) -> None:
+        nonlocal live_timeline_count
+        nonlocal live_timeline_error_logged
+        if not events:
+            return
+        try:
+            persist_turn_timeline(
+                state_root,
+                execution_id=managed_turn_id,
+                target_kind="thread_target",
+                target_id=managed_thread_id,
+                repo_id=str(current_thread_row.get("repo_id") or "").strip() or None,
+                resource_kind=(
+                    str(current_thread_row.get("resource_kind") or "").strip() or None
+                ),
+                resource_id=(
+                    str(current_thread_row.get("resource_id") or "").strip() or None
+                ),
+                metadata={
+                    "agent": getattr(started.thread, "agent_id", None),
+                    "execution_id": managed_turn_id,
+                    "thread_target_id": managed_thread_id,
+                    "backend_thread_id": current_backend_thread_id or None,
+                    "backend_turn_id": started.execution.backend_id,
+                    "model": started.request.model,
+                    "reasoning": started.request.reasoning,
+                    "request_kind": getattr(started.request, "kind", None),
+                    "status": "running",
+                    "surface_kind": "telegram",
+                    "surface_key": surface_key,
+                    "chat_id": chat_id,
+                    "thread_id": thread_id,
+                },
+                events=events,
+                start_index=live_timeline_count + 1,
+            )
+        except Exception:
+            if not live_timeline_error_logged:
+                live_timeline_error_logged = True
+                handlers._logger.exception(
+                    "Failed to persist live Telegram thread timeline (thread=%s turn=%s)",
+                    managed_thread_id,
+                    managed_turn_id,
+                )
+        else:
+            live_timeline_count += len(events)
 
     stream_backend_thread_id = current_backend_thread_id
     stream_backend_turn_id = str(started.execution.backend_id or "").strip()
@@ -720,6 +771,8 @@ async def _finalize_telegram_managed_thread_execution(
                         raw_event,
                         event_state,
                     )
+                    timeline_events.extend(run_events)
+                    _persist_live_timeline_events(run_events)
                     if on_progress_event is None:
                         continue
                     for run_event in run_events:
@@ -792,14 +845,54 @@ async def _finalize_telegram_managed_thread_execution(
         outcome = recovered_outcome
 
     if on_progress_event is not None:
+        terminal_event = terminal_run_event_from_outcome(outcome, event_state)
+        timeline_events.append(terminal_event)
         try:
-            await on_progress_event(
-                terminal_run_event_from_outcome(outcome, event_state)
-            )
+            await on_progress_event(terminal_event)
         except Exception:
             handlers._logger.debug(
                 "Telegram terminal progress event failed", exc_info=True
             )
+    else:
+        timeline_events.append(terminal_run_event_from_outcome(outcome, event_state))
+
+    try:
+        persist_turn_timeline(
+            state_root,
+            execution_id=managed_turn_id,
+            target_kind="thread_target",
+            target_id=managed_thread_id,
+            repo_id=str(current_thread_row.get("repo_id") or "").strip() or None,
+            resource_kind=(
+                str(current_thread_row.get("resource_kind") or "").strip() or None
+            ),
+            resource_id=(
+                str(current_thread_row.get("resource_id") or "").strip() or None
+            ),
+            metadata={
+                "agent": getattr(started.thread, "agent_id", None),
+                "execution_id": managed_turn_id,
+                "thread_target_id": managed_thread_id,
+                "backend_thread_id": current_backend_thread_id or None,
+                "backend_turn_id": outcome.backend_turn_id
+                or started.execution.backend_id,
+                "model": started.request.model,
+                "reasoning": started.request.reasoning,
+                "request_kind": getattr(started.request, "kind", None),
+                "status": outcome.status,
+                "surface_kind": "telegram",
+                "surface_key": surface_key,
+                "chat_id": chat_id,
+                "thread_id": thread_id,
+            },
+            events=timeline_events,
+        )
+    except Exception:
+        handlers._logger.exception(
+            "Failed to persist Telegram thread timeline (thread=%s turn=%s)",
+            managed_thread_id,
+            managed_turn_id,
+        )
 
     resolved_assistant_text = (
         outcome.assistant_text or event_state.best_assistant_text()

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -556,6 +556,52 @@ async def _run_managed_thread_execution(
     hub_root = request.app.state.config.root
     transcripts = PmaTranscriptStore(hub_root)
     response_payload = dict(delivery_payload or {})
+    live_timeline_count = 0
+    live_timeline_error_logged = False
+    live_timeline_metadata = _build_managed_thread_turn_metadata(
+        managed_thread_id=managed_thread_id,
+        managed_turn_id=current_turn_id,
+        thread_row=current_thread_row,
+        backend_thread_id=current_backend_thread_id,
+        backend_turn_id=started.execution.backend_id,
+        workspace_root=started.workspace_root,
+        model=started.request.model,
+        reasoning=started.request.reasoning,
+        status="running",
+    )
+
+    def _persist_live_timeline_events(events: list[RunEvent]) -> None:
+        nonlocal live_timeline_count
+        nonlocal live_timeline_error_logged
+        if not events:
+            return
+        try:
+            persist_turn_timeline(
+                hub_root,
+                execution_id=current_turn_id,
+                target_kind="thread_target",
+                target_id=managed_thread_id,
+                repo_id=normalize_optional_text(current_thread_row.get("repo_id")),
+                resource_kind=normalize_optional_text(
+                    current_thread_row.get("resource_kind")
+                ),
+                resource_id=normalize_optional_text(
+                    current_thread_row.get("resource_id")
+                ),
+                metadata=live_timeline_metadata,
+                events=events,
+                start_index=live_timeline_count + 1,
+            )
+        except Exception:
+            if not live_timeline_error_logged:
+                live_timeline_error_logged = True
+                logger.exception(
+                    "Failed to persist live managed-thread timeline (managed_thread_id=%s, managed_turn_id=%s)",
+                    managed_thread_id,
+                    current_turn_id,
+                )
+        else:
+            live_timeline_count += len(events)
 
     if (
         harness is not None
@@ -573,13 +619,13 @@ async def _run_managed_thread_execution(
                 live_backend_turn_id,
             ):
                 streamed_raw_events.append(raw_event)
-                timeline_events.extend(
-                    await normalize_runtime_thread_raw_event(
-                        raw_event,
-                        timeline_state,
-                        timestamp=now_iso(),
-                    )
+                new_events = await normalize_runtime_thread_raw_event(
+                    raw_event,
+                    timeline_state,
+                    timestamp=now_iso(),
                 )
+                timeline_events.extend(new_events)
+                _persist_live_timeline_events(new_events)
 
         stream_task = asyncio.create_task(_collect_timeline())
     try:

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
@@ -17,6 +17,7 @@ from .....core.orchestration.runtime_thread_events import (
     RuntimeThreadRunEventState,
     normalize_runtime_thread_raw_event,
 )
+from .....core.orchestration.turn_timeline import list_turn_timeline
 from .....core.pma_thread_store import PmaThreadStore
 from .....core.ports.run_event import (
     ApprovalRequested,
@@ -650,6 +651,107 @@ def _tail_event_from_run_event(
     }
 
 
+def _run_event_from_timeline_entry(entry: dict[str, Any]) -> Any | None:
+    event_type = str(entry.get("event_type") or "").strip().lower()
+    event = coerce_dict(entry.get("event"))
+    timestamp = normalize_optional_text(
+        event.get("timestamp")
+    ) or normalize_optional_text(entry.get("timestamp"))
+    if timestamp is None:
+        return None
+    if event_type == "output_delta":
+        return OutputDelta(
+            timestamp=timestamp,
+            content=str(event.get("content") or ""),
+            delta_type=str(event.get("delta_type") or "text"),
+        )
+    if event_type == "tool_call":
+        return ToolCall(
+            timestamp=timestamp,
+            tool_name=str(event.get("tool_name") or ""),
+            tool_input=coerce_dict(event.get("tool_input")),
+        )
+    if event_type == "tool_result":
+        return ToolResult(
+            timestamp=timestamp,
+            tool_name=str(event.get("tool_name") or ""),
+            status=str(event.get("status") or ""),
+            result=event.get("result"),
+            error=event.get("error"),
+        )
+    if event_type == "approval_requested":
+        return ApprovalRequested(
+            timestamp=timestamp,
+            request_id=str(event.get("request_id") or ""),
+            description=str(event.get("description") or ""),
+            context=coerce_dict(event.get("context")),
+        )
+    if event_type == "token_usage":
+        usage = event.get("usage")
+        return TokenUsage(
+            timestamp=timestamp,
+            usage=usage if isinstance(usage, dict) else {},
+        )
+    if event_type == "run_notice":
+        return RunNotice(
+            timestamp=timestamp,
+            kind=str(event.get("kind") or ""),
+            message=str(event.get("message") or ""),
+            data=coerce_dict(event.get("data")),
+        )
+    if event_type == "turn_completed":
+        return Completed(
+            timestamp=timestamp,
+            final_message=str(event.get("final_message") or ""),
+        )
+    if event_type == "turn_failed":
+        return Failed(
+            timestamp=timestamp,
+            error_message=str(event.get("error_message") or "Turn failed"),
+        )
+    return None
+
+
+def _serialize_persisted_timeline_tail_events(
+    timeline_entries: list[dict[str, Any]],
+    *,
+    level: str,
+    since_ms: Optional[int],
+    resume_after: Optional[int],
+) -> tuple[list[dict[str, Any]], Optional[str]]:
+    serialized: list[dict[str, Any]] = []
+    last_activity_at: Optional[str] = None
+    min_event_id = int(resume_after or 0)
+    for entry in timeline_entries:
+        if not isinstance(entry, dict):
+            continue
+        event_id = int(entry.get("event_index") or 0)
+        if event_id <= 0 or event_id <= min_event_id:
+            continue
+        timestamp = normalize_optional_text(entry.get("timestamp"))
+        if timestamp is None:
+            continue
+        if since_ms is not None:
+            dt = parse_iso_datetime(timestamp)
+            if dt is not None and int(dt.timestamp() * 1000) < since_ms:
+                continue
+        run_event = _run_event_from_timeline_entry(entry)
+        if run_event is None:
+            continue
+        payload = _tail_event_from_run_event(
+            run_event,
+            event_id=event_id,
+            received_at=timestamp,
+        )
+        if payload is None:
+            continue
+        if level == "debug":
+            payload["raw"] = _redact_nested(entry)
+        serialized.append(payload)
+        last_activity_at = timestamp
+    return serialized, last_activity_at
+
+
 async def _serialize_runtime_raw_tail_events(
     raw_event: Any,
     state: RuntimeThreadRunEventState,
@@ -786,7 +888,17 @@ async def _build_managed_thread_tail_snapshot(
     )
     tail_events: list[dict[str, Any]] = []
     raw_last_activity_at: Optional[str] = None
-    if has_backend_binding and harness is not None:
+    persisted_timeline_entries = list_turn_timeline(
+        request.app.state.config.root,
+        execution_id=managed_turn_id,
+    )
+    tail_events, raw_last_activity_at = _serialize_persisted_timeline_tail_events(
+        persisted_timeline_entries,
+        level=level,
+        since_ms=since_ms,
+        resume_after=resume_after,
+    )
+    if not tail_events and has_backend_binding and harness is not None:
         list_fn = getattr(harness, "list_progress_events", None)
         if callable(list_fn):
             try:

--- a/tests/core/orchestration/test_turn_timeline.py
+++ b/tests/core/orchestration/test_turn_timeline.py
@@ -58,3 +58,54 @@ def test_persist_turn_timeline_round_trips_events(tmp_path: Path) -> None:
     assert timeline[1]["event"]["tool_name"] == "shell"
     assert timeline[2]["event"]["result"] == {"stdout": "/tmp"}
     assert timeline[3]["event"]["final_message"] == "done"
+
+
+def test_persist_turn_timeline_appends_from_start_index(tmp_path: Path) -> None:
+    first_count = persist_turn_timeline(
+        tmp_path,
+        execution_id="turn-append",
+        target_kind="thread_target",
+        target_id="thread-1",
+        events=[
+            RunNotice(
+                timestamp="2026-03-19T00:00:00Z",
+                kind="thinking",
+                message="planning",
+            ),
+            ToolCall(
+                timestamp="2026-03-19T00:00:01Z",
+                tool_name="shell",
+                tool_input={"cmd": "pwd"},
+            ),
+        ],
+    )
+    second_count = persist_turn_timeline(
+        tmp_path,
+        execution_id="turn-append",
+        target_kind="thread_target",
+        target_id="thread-1",
+        events=[
+            ToolResult(
+                timestamp="2026-03-19T00:00:02Z",
+                tool_name="shell",
+                status="completed",
+                result={"stdout": "/tmp"},
+            ),
+            Completed(
+                timestamp="2026-03-19T00:00:03Z",
+                final_message="done",
+            ),
+        ],
+        start_index=3,
+    )
+
+    assert first_count == 2
+    assert second_count == 2
+    timeline = list_turn_timeline(tmp_path, execution_id="turn-append")
+    assert [entry["event_index"] for entry in timeline] == [1, 2, 3, 4]
+    assert [entry["event_type"] for entry in timeline] == [
+        "run_notice",
+        "tool_call",
+        "tool_result",
+        "turn_completed",
+    ]

--- a/tests/test_pma_managed_threads_tail.py
+++ b/tests/test_pma_managed_threads_tail.py
@@ -10,7 +10,9 @@ from fastapi.testclient import TestClient
 
 from codex_autorunner.agents.hermes.harness import HermesHarness
 from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
+from codex_autorunner.core.orchestration.turn_timeline import persist_turn_timeline
 from codex_autorunner.core.pma_thread_store import PmaThreadStore
+from codex_autorunner.core.ports.run_event import OutputDelta
 from codex_autorunner.integrations.app_server.event_buffer import AppServerEventBuffer
 from codex_autorunner.server import create_hub_app
 from codex_autorunner.surfaces.web.routes.pma_routes import tail_stream
@@ -574,6 +576,81 @@ def test_managed_thread_tail_snapshot_includes_opencode_list_progress_events(
     first = payload["events"][0]
     assert first.get("event_type") == "assistant_update"
     assert "Working" in str(first.get("summary") or "")
+
+
+def test_managed_thread_tail_snapshot_prefers_persisted_live_timeline_for_opencode(
+    hub_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_pma(hub_env.hub_root)
+
+    class _OpenCodeHarnessWithoutBufferedProgress:
+        def supports(self, capability: str) -> bool:
+            return capability == "event_streaming"
+
+        def allows_parallel_event_stream(self) -> bool:
+            return True
+
+        async def list_progress_events(
+            self, conversation_id: str, turn_id: str, **kwargs: Any
+        ) -> list[dict[str, Any]]:
+            _ = conversation_id, turn_id, kwargs
+            return []
+
+        def stream_events(
+            self,
+            workspace_root: Path,
+            conversation_id: str,
+            turn_id: str,
+        ):
+            _ = workspace_root, conversation_id, turn_id
+
+            async def _stream():
+                if False:
+                    yield None
+
+            return _stream()
+
+    monkeypatch.setattr(
+        tail_stream,
+        "_managed_thread_harness",
+        lambda service, agent_id: _OpenCodeHarnessWithoutBufferedProgress(),
+    )
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        managed_thread_id, managed_turn_id = _seed_running_managed_thread(
+            hub_env,
+            app,
+            agent="opencode",
+            backend_thread_id="opencode-session-live",
+            backend_turn_id="opencode-turn-live",
+            name="opencode persisted timeline",
+        )
+        persist_turn_timeline(
+            hub_env.hub_root,
+            execution_id=managed_turn_id,
+            target_kind="thread_target",
+            target_id=managed_thread_id,
+            repo_id=hub_env.repo_id,
+            metadata={"agent": "opencode", "status": "running"},
+            events=[
+                OutputDelta(
+                    timestamp="2026-04-06T10:00:00Z",
+                    content="Working through the issue...",
+                    delta_type="assistant_message",
+                )
+            ],
+        )
+        resp = client.get(f"/hub/pma/threads/{managed_thread_id}/tail")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["stream_available"] is True
+    assert [event["event_id"] for event in payload["events"]] == [1]
+    assert payload["events"][0]["event_type"] == "assistant_update"
+    assert "Working through the issue" in str(payload["events"][0]["summary"] or "")
+    assert payload["last_event_id"] == 1
+    assert payload["last_event_at"] == "2026-04-06T10:00:00Z"
 
 
 def test_managed_thread_tail_snapshot_stream_available_when_backend_binding_appears(


### PR DESCRIPTION
## Summary
- persist managed-thread runtime timeline events while a turn is still running instead of waiting for final completion persistence
- teach PMA tail snapshots to read the durable turn timeline first, then fall back to harness-local progress buffers when needed
- add coverage for incremental timeline writes and for opencode PMA tail snapshots backed by persisted live progress

## Root Cause
Issue #1268 exposed a mismatch between where live progress was observed and where PMA looked for it.

For opencode managed threads, Discord and Telegram were receiving live `RunEvent` progress through their local harness stream, but PMA tail snapshots only queried harness-local buffered progress. That buffer is process-local and ephemeral, so the hub could see `turn_started` and `turn_completed` while missing the intermediate progress entirely.

Codex, Hermes, and other agents already had stronger buffering paths, but the deeper problem was the same architectural assumption: PMA live observability should not depend on whichever harness instance happened to execute the turn.

## What Changed
- `persist_turn_timeline()` now supports incremental append indices so live execution paths can publish events as they arrive.
- Discord, Telegram, and hub managed-thread execution paths now write live normalized run events into the shared turn timeline during execution, then persist the full final timeline at completion.
- PMA tail snapshots now read those persisted timeline entries before consulting harness-local progress snapshots, which lets the hub see live progress even when the executing surface is a different process.

## Validation
- targeted pytest:
  - `tests/core/orchestration/test_turn_timeline.py`
  - `tests/test_pma_managed_threads_tail.py`
  - `tests/integrations/discord/test_message_turns.py -k finalize_discord_thread_execution_prefers_started_execution_error`
  - `tests/test_telegram_pma_routing.py -k pma_managed_thread_turn_edits_placeholder_with_live_progress`
  - `tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py -k raw_events`
- pre-commit hook suite:
  - black
  - ruff
  - mypy
  - frontend build/tests
  - full pytest (`4097 passed, 1 skipped`)

Closes #1268.
