### PR TITLE
[codex] Fix Discord interaction dispatch timeouts

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -1299,9 +1299,29 @@ class DiscordBotService:
             )
         return result.command_allowed
 
+    def _uses_background_command_dispatch(self, command_path: tuple[str, ...]) -> bool:
+        normalized_path = self._normalize_discord_command_path(command_path)
+        return normalized_path == ("car", "session", "compact")
+
     def _bypass_predicate(self, event: ChatEvent, context: DispatchContext) -> bool:
         if isinstance(event, ChatInteractionEvent):
-            return True
+            import json
+
+            payload_str = event.payload or "{}"
+            try:
+                payload_data = json.loads(payload_str)
+            except json.JSONDecodeError:
+                return True
+            payload_type = payload_data.get("type")
+            if not isinstance(payload_type, str) or payload_type != "command":
+                return True
+            command_raw = payload_data.get("command")
+            command_path = (
+                tuple(part for part in str(command_raw).split(":") if part)
+                if isinstance(command_raw, str)
+                else ()
+            )
+            return not self._uses_background_command_dispatch(command_path)
         return False
 
     async def _handle_normalized_interaction(
@@ -4273,9 +4293,39 @@ class DiscordBotService:
         if event_type == "INTERACTION_CREATE":
             interaction_event = self._chat_adapter.parse_interaction_event(payload)
             if interaction_event is not None:
-                await self._dispatcher.dispatch(
-                    interaction_event, self._handle_chat_event
-                )
+                if (
+                    not is_component_interaction(payload)
+                    and not is_modal_submit_interaction(payload)
+                    and not is_autocomplete_interaction(payload)
+                ):
+                    interaction_id = extract_interaction_id(payload)
+                    interaction_token = extract_interaction_token(payload)
+                    command_path, options = extract_command_path_and_options(payload)
+                    ingress = canonicalize_command_ingress(
+                        command_path=command_path,
+                        options=options,
+                    )
+                    if (
+                        interaction_id
+                        and interaction_token
+                        and ingress is not None
+                        and self._uses_background_command_dispatch(ingress.command_path)
+                    ):
+                        ingress = replace(
+                            ingress,
+                            command_path=self._normalize_discord_command_path(
+                                ingress.command_path
+                            ),
+                        )
+                        prepared = await self._prepare_command_interaction_or_abort(
+                            interaction_id=interaction_id,
+                            interaction_token=interaction_token,
+                            command_path=ingress.command_path,
+                            timing="dispatch",
+                        )
+                        if not prepared:
+                            return
+                await self._dispatch_chat_event(interaction_event)
         elif event_type == "MESSAGE_CREATE":
             await self._record_channel_directory_seen_from_message_payload(payload)
             message_event = self._chat_adapter.parse_message_event(payload)

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -5150,6 +5150,51 @@ async def test_unknown_pma_subcommand_has_explicit_unknown_message(
 
 
 @pytest.mark.anyio
+async def test_on_dispatch_backgrounds_interaction_handling(
+    tmp_path: Path,
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_handle(_event: Any, _context: Any) -> None:
+        started.set()
+        await release.wait()
+
+    service._handle_chat_event = _slow_handle  # type: ignore[assignment]
+
+    try:
+        dispatch_task = asyncio.create_task(
+            service._on_dispatch(
+                "INTERACTION_CREATE",
+                _interaction_path(
+                    command_path=("car", "session", "compact"),
+                    options=[],
+                ),
+            )
+        )
+        await asyncio.wait_for(dispatch_task, timeout=1.0)
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        release.set()
+        await asyncio.wait_for(service._dispatcher.wait_idle(), timeout=1.0)
+    finally:
+        await service._shutdown()
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_malformed_interaction_payload_returns_ephemeral_response(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- keep `/car session compact` from blocking later Discord interaction frames on the gateway dispatch path
- pre-defer that command on dispatch, then let the chat dispatcher run the actual compaction work asynchronously
- add a regression test proving compact interactions acknowledge immediately while execution continues in the dispatcher

## Root Cause
Discord slash-command interactions are delivered on the gateway dispatch loop. The compact command can run for a long time because it asks the active agent to summarize the current session and then resets the thread state. That work was running inline on the same dispatch path, so a long-running compact could delay later `INTERACTION_CREATE` events long enough for Discord to show `The application did not respond`.

The fix narrows the change to `/car session compact`: it now acknowledges the interaction at dispatch time and routes the actual command through the existing dispatcher queue instead of keeping the gateway loop occupied.

## Validation
- full pre-commit hook suite passed (`4097 passed, 1 skipped`)
- `.venv/bin/pytest tests/integrations/discord/test_flow_handlers.py -k "flow_refresh_button_updates_existing_status_message"`
- `.venv/bin/pytest tests/integrations/discord/test_service_routing.py -k "service_enforces_allowlist_and_denies_command or car_tickets_search_filters_picker_and_persists_across_filter_changes or backgrounds_interaction_handling"`
- `.venv/bin/pytest tests/integrations/discord/test_pma_commands.py -k "pma_on_enables_pma_mode or pma_off_disables_pma_mode_and_restores_binding or pma_on_unbound_channel_auto_binds_for_pma or pma_off_after_unbound_pma_on_returns_to_unbound"`
- `.venv/bin/pytest tests/integrations/discord/test_message_turns.py -k "car_session_compact_finishes_interaction_when_finalize_fails or car_session_compact_reuses_preview_without_part_numbering or car_session_compact_places_continue_button_on_last_chunk_without_preview"`