### PR TITLE
Fix managed-thread completion after gap recovery

### DIFF
--- a/src/codex_autorunner/integrations/app_server/client.py
+++ b/src/codex_autorunner/integrations/app_server/client.py
@@ -281,6 +281,7 @@ class CodexAppServerClient:
         self._process_registry_key: Optional[str] = None
         self._reader_task: Optional[asyncio.Task] = None
         self._stderr_task: Optional[asyncio.Task] = None
+        self._background_tasks: set[asyncio.Task[None]] = set()
         self._start_lock: Optional[asyncio.Lock] = None
         self._write_lock: Optional[asyncio.Lock] = None
         self._data_lock: Optional[asyncio.Lock] = None
@@ -362,6 +363,7 @@ class CodexAppServerClient:
             except asyncio.CancelledError:
                 pass
             self._restart_task = None
+        await self._cancel_background_tasks()
         await self._terminate_process()
         self._fail_pending(CodexAppServerDisconnected("Client closed"))
         _CLIENT_INSTANCES.discard(self)
@@ -870,17 +872,33 @@ class CodexAppServerClient:
         self._apply_turn_completed(state, message, params)
         if self._notification_handler is None:
             return
-        try:
-            await _maybe_await(self._notification_handler(message))
-        except Exception as exc:
-            log_event(
-                self._logger,
-                logging.WARNING,
-                "app_server.notification_handler.failed",
-                method="turn/completed",
-                handled=True,
-                exc=exc,
-            )
+        self._schedule_notification_handler(message, method="turn/completed")
+
+    def _schedule_notification_handler(
+        self, message: Dict[str, Any], *, method: str, handled: bool = True
+    ) -> None:
+        handler = self._notification_handler
+        if handler is None:
+            return
+
+        async def _invoke_notification_handler() -> None:
+            try:
+                await _maybe_await(handler(message))
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                log_event(
+                    self._logger,
+                    logging.WARNING,
+                    "app_server.notification_handler.failed",
+                    method=method,
+                    handled=handled,
+                    exc=exc,
+                )
+
+        task = asyncio.create_task(_invoke_notification_handler())
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     def _maybe_fail_stalled_turn(
         self,
@@ -2183,6 +2201,17 @@ class CodexAppServerClient:
             await task
         except asyncio.CancelledError:
             pass
+
+    async def _cancel_background_tasks(self) -> None:
+        tasks = [task for task in self._background_tasks if not task.done()]
+        self._background_tasks.clear()
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
     async def _terminate_running_process(
         self, process: asyncio.subprocess.Process

--- a/tests/test_app_server_client.py
+++ b/tests/test_app_server_client.py
@@ -890,9 +890,13 @@ async def test_completion_gap_recovery_emits_synthetic_turn_completed_notificati
     tmp_path: Path,
 ) -> None:
     notifications: list[dict[str, object]] = []
+    handler_started = asyncio.Event()
+    release_handler = asyncio.Event()
 
     async def on_notification(message: dict[str, object]) -> None:
         notifications.append(message)
+        handler_started.set()
+        await release_handler.wait()
 
     client = CodexAppServerClient(
         fixture_command("basic"),
@@ -931,7 +935,11 @@ async def test_completion_gap_recovery_emits_synthetic_turn_completed_notificati
 
         client.thread_resume = _resume  # type: ignore[method-assign]
 
-        result = await client.wait_for_turn("turn-1", thread_id="thread-1", timeout=1.0)
+        result = await asyncio.wait_for(
+            client.wait_for_turn("turn-1", thread_id="thread-1", timeout=1.0),
+            timeout=0.2,
+        )
+        await asyncio.wait_for(handler_started.wait(), timeout=0.5)
 
         assert result.status == "completed"
         assert state.turn_completed_seen is True
@@ -950,6 +958,7 @@ async def test_completion_gap_recovery_emits_synthetic_turn_completed_notificati
             for event in result.raw_events
         )
     finally:
+        release_handler.set()
         await client.close()
 
 


### PR DESCRIPTION
## Summary
- propagate a synthetic `turn/completed` notification when `thread/resume` recovery finds a terminal turn
- record the recovered completion in raw events and mark the turn as completed locally so downstream consumers stay in sync
- add a regression test covering completion-gap recovery fan-out

## Testing
- `.venv/bin/pytest tests/test_app_server_client.py -k "missing_turn_completed or completion_gap"`
- `git commit` pre-commit hook suite (repo checks, mypy, frontend build/tests, full pytest)

Closes #1273
