### PR TITLE
Cache GitHub SCM polling quota checks across cycles

### DIFF
--- a/src/codex_autorunner/integrations/github/polling.py
+++ b/src/codex_autorunner/integrations/github/polling.py
@@ -137,6 +137,63 @@ class _CachedQuotaState:
     expires_at: datetime
 
 
+def _cached_quota_state_from_mapping(value: Any) -> Optional[_CachedQuotaState]:
+    payload = _mapping(value)
+    expires_at_raw = _normalize_text(payload.get("expires_at"))
+    if expires_at_raw is None:
+        return None
+    try:
+        expires_at = _parse_iso(expires_at_raw)
+    except ValueError:
+        return None
+    quota_state_payload = _mapping(payload.get("value"))
+    resource = _normalize_text(quota_state_payload.get("resource"))
+    remaining = _normalize_non_negative_int(quota_state_payload.get("remaining"))
+    limit = _normalize_positive_int(quota_state_payload.get("limit"))
+    reset_epoch = _normalize_positive_int(quota_state_payload.get("reset_epoch"))
+    near_limit_raw = quota_state_payload.get("near_limit")
+    if not quota_state_payload:
+        return _CachedQuotaState(value=None, expires_at=expires_at)
+    if (
+        resource is None
+        or remaining is None
+        or limit is None
+        or not isinstance(near_limit_raw, bool)
+    ):
+        return None
+    return _CachedQuotaState(
+        value=_GitHubQuotaState(
+            resource=resource,
+            remaining=remaining,
+            limit=limit,
+            reset_epoch=reset_epoch,
+            near_limit=near_limit_raw,
+        ),
+        expires_at=expires_at,
+    )
+
+
+def _cached_quota_state_to_mapping(
+    value: Optional[_CachedQuotaState],
+) -> Optional[dict[str, Any]]:
+    if value is None:
+        return None
+    quota_state = value.value
+    payload: dict[str, Any] = {
+        "expires_at": value.expires_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "value": None,
+    }
+    if quota_state is not None:
+        payload["value"] = {
+            "resource": quota_state.resource,
+            "remaining": quota_state.remaining,
+            "limit": quota_state.limit,
+            "reset_epoch": quota_state.reset_epoch,
+            "near_limit": quota_state.near_limit,
+        }
+    return payload
+
+
 def _quota_state_from_payload(
     payload: Mapping[str, Any],
 ) -> Optional[_GitHubQuotaState]:
@@ -496,7 +553,6 @@ class GitHubScmPollingService:
         self._polling_state_path = (
             self._hub_root / ".codex-autorunner" / "github_polling_state.json"
         )
-        self._quota_state_cache: dict[str, _CachedQuotaState] = {}
 
     def arm_watch(
         self,
@@ -1015,12 +1071,12 @@ class GitHubScmPollingService:
         if cache_key in cache:
             return cache[cache_key]
         now = _utc_now()
-        persisted = self._quota_state_cache.get(cache_key)
+        persisted = self._read_cached_quota_state(cache_key=cache_key)
         if persisted is not None:
             if persisted.expires_at > now:
                 cache[cache_key] = persisted.value
                 return persisted.value
-            self._quota_state_cache.pop(cache_key, None)
+            self._invalidate_quota_state_cache(cache_key=cache_key)
         try:
             github = self._github_service_factory(
                 workspace_root,
@@ -1029,9 +1085,12 @@ class GitHubScmPollingService:
             cache[cache_key] = _quota_state_from_payload(github.rate_limit_status())
         except Exception:
             cache[cache_key] = None
-        self._quota_state_cache[cache_key] = _CachedQuotaState(
-            value=cache[cache_key],
-            expires_at=self._quota_state_cache_expiry(cache[cache_key], now=now),
+        self._write_cached_quota_state(
+            cache_key=cache_key,
+            value=_CachedQuotaState(
+                value=cache[cache_key],
+                expires_at=self._quota_state_cache_expiry(cache[cache_key], now=now),
+            ),
         )
         return cache[cache_key]
 
@@ -1061,7 +1120,48 @@ class GitHubScmPollingService:
         )
 
     def _invalidate_quota_state_cache(self, *, cache_key: str = "global") -> None:
-        self._quota_state_cache.pop(cache_key, None)
+        state = self._read_polling_state()
+        quota_state_cache = _mapping(state.get("quota_state_cache"))
+        if cache_key not in quota_state_cache:
+            return
+        updated_cache = dict(quota_state_cache)
+        updated_cache.pop(cache_key, None)
+        state["quota_state_cache"] = updated_cache
+        self._write_polling_state(state)
+
+    def _read_polling_state(self) -> dict[str, Any]:
+        state = read_json(self._polling_state_path) or {}
+        return dict(state) if isinstance(state, dict) else {}
+
+    def _write_polling_state(self, state: Mapping[str, Any]) -> None:
+        self._polling_state_path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write(
+            self._polling_state_path,
+            json.dumps(state, indent=2, sort_keys=True) + "\n",
+        )
+
+    def _read_cached_quota_state(
+        self, *, cache_key: str
+    ) -> Optional[_CachedQuotaState]:
+        state = self._read_polling_state()
+        quota_state_cache = _mapping(state.get("quota_state_cache"))
+        return _cached_quota_state_from_mapping(quota_state_cache.get(cache_key))
+
+    def _write_cached_quota_state(
+        self,
+        *,
+        cache_key: str,
+        value: _CachedQuotaState,
+    ) -> None:
+        state = self._read_polling_state()
+        quota_state_cache = dict(_mapping(state.get("quota_state_cache")))
+        serialized = _cached_quota_state_to_mapping(value)
+        if serialized is None:
+            quota_state_cache.pop(cache_key, None)
+        else:
+            quota_state_cache[cache_key] = serialized
+        state["quota_state_cache"] = quota_state_cache
+        self._write_polling_state(state)
 
     def _prioritized_discovery_roots(
         self,
@@ -1338,23 +1438,13 @@ class GitHubScmPollingService:
     def _claim_discovery_cycle(self, *, polling_config: GitHubPollingConfig) -> bool:
         discovery_interval_seconds = max(1, polling_config.discovery_interval_seconds)
         cycle_slot = int(_utc_now().timestamp()) // discovery_interval_seconds
-        state = read_json(self._polling_state_path) or {}
+        state = self._read_polling_state()
         last_cycle_slot = state.get("last_discovery_cycle_slot")
         if isinstance(last_cycle_slot, int) and last_cycle_slot == cycle_slot:
             return False
-        self._polling_state_path.parent.mkdir(parents=True, exist_ok=True)
-        atomic_write(
-            self._polling_state_path,
-            json.dumps(
-                {
-                    "last_discovery_cycle_slot": cycle_slot,
-                    "last_discovery_claimed_at": now_iso(),
-                },
-                indent=2,
-                sort_keys=True,
-            )
-            + "\n",
-        )
+        state["last_discovery_cycle_slot"] = cycle_slot
+        state["last_discovery_claimed_at"] = now_iso()
+        self._write_polling_state(state)
         return True
 
 

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -10,7 +10,10 @@ from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.pr_bindings import PrBindingStore
 from codex_autorunner.core.scm_events import ScmEventStore
 from codex_autorunner.core.scm_polling_watches import ScmPollingWatchStore
-from codex_autorunner.integrations.github.polling import GitHubScmPollingService
+from codex_autorunner.integrations.github.polling import (
+    GitHubPollingConfig,
+    GitHubScmPollingService,
+)
 from codex_autorunner.integrations.github.service import GitHubError
 
 
@@ -1098,27 +1101,31 @@ def test_quota_state_cache_persists_across_poll_cycles(
             rate_limit_payload=_rate_limit_payload(graphql_remaining=5000),
         )
 
-    service = GitHubScmPollingService(
-        hub_root,
-        raw_config=_polling_config(),
-        github_service_factory=_factory,
-        watch_store=ScmPollingWatchStore(hub_root),
-        event_store=ScmEventStore(hub_root),
-    )
-
     monkeypatch.setattr(
         github_polling,
         "_utc_now",
         lambda: datetime(2026, 4, 7, 10, 0, 0, tzinfo=timezone.utc),
     )
-    first = service._quota_state_for_workspace(workspace_root=repo_root, cache={})
+    first = GitHubScmPollingService(
+        hub_root,
+        raw_config=_polling_config(),
+        github_service_factory=_factory,
+        watch_store=ScmPollingWatchStore(hub_root),
+        event_store=ScmEventStore(hub_root),
+    )._quota_state_for_workspace(workspace_root=repo_root, cache={})
 
     monkeypatch.setattr(
         github_polling,
         "_utc_now",
         lambda: datetime(2026, 4, 7, 10, 1, 30, tzinfo=timezone.utc),
     )
-    second = service._quota_state_for_workspace(workspace_root=repo_root, cache={})
+    second = GitHubScmPollingService(
+        hub_root,
+        raw_config=_polling_config(),
+        github_service_factory=_factory,
+        watch_store=ScmPollingWatchStore(hub_root),
+        event_store=ScmEventStore(hub_root),
+    )._quota_state_for_workspace(workspace_root=repo_root, cache={})
 
     assert first is not None
     assert second == first
@@ -1188,7 +1195,7 @@ def test_rate_limit_error_invalidates_cached_quota_state(
             pr_view_exception=pr_view_exception,
         )
 
-    service = GitHubScmPollingService(
+    first_service = GitHubScmPollingService(
         hub_root,
         raw_config=_polling_config(),
         github_service_factory=_factory,
@@ -1201,7 +1208,7 @@ def test_rate_limit_error_invalidates_cached_quota_state(
         "_utc_now",
         lambda: datetime(2026, 4, 7, 10, 0, 0, tzinfo=timezone.utc),
     )
-    first = service.process_due_watches(limit=10)
+    first = first_service.process_due_watches(limit=10)
 
     watch_store.refresh_watch(
         watch_id=watch.watch_id,
@@ -1214,11 +1221,64 @@ def test_rate_limit_error_invalidates_cached_quota_state(
         "_utc_now",
         lambda: datetime(2026, 4, 7, 10, 1, 30, tzinfo=timezone.utc),
     )
-    second = service.process_due_watches(limit=10)
+    second = GitHubScmPollingService(
+        hub_root,
+        raw_config=_polling_config(),
+        github_service_factory=_factory,
+        watch_store=watch_store,
+        event_store=ScmEventStore(hub_root),
+    ).process_due_watches(limit=10)
 
     assert first["rate_limited_skipped"] == 1
     assert second["polled"] == 1
     assert calls["rate_limit_status"] == 2
+
+
+def test_quota_cache_persistence_preserves_discovery_cycle_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "workspace" / "repo"
+    repo_root.mkdir(parents=True)
+
+    def _factory(repo_root_arg: Path, raw_config=None) -> _GitHubServiceStub:
+        return _GitHubServiceStub(
+            repo_root_arg,
+            raw_config,
+            pr_view_payload={},
+            reviews_payload=[],
+            checks_payload=[],
+            rate_limit_payload=_rate_limit_payload(graphql_remaining=5000),
+        )
+
+    monkeypatch.setattr(
+        github_polling,
+        "_utc_now",
+        lambda: datetime(2026, 4, 7, 10, 0, 0, tzinfo=timezone.utc),
+    )
+    service = GitHubScmPollingService(
+        hub_root,
+        raw_config=_polling_config(),
+        github_service_factory=_factory,
+        watch_store=ScmPollingWatchStore(hub_root),
+        event_store=ScmEventStore(hub_root),
+    )
+
+    assert service._claim_discovery_cycle(
+        polling_config=GitHubPollingConfig.from_mapping(_polling_config())
+    )
+    assert (
+        service._quota_state_for_workspace(workspace_root=repo_root, cache={})
+        is not None
+    )
+
+    state = github_polling.read_json(
+        hub_root / ".codex-autorunner" / "github_polling_state.json"
+    )
+    assert isinstance(state, dict)
+    assert isinstance(state.get("last_discovery_cycle_slot"), int)
+    assert state.get("quota_state_cache") is not None
 
 
 def test_process_rotates_discovery_across_candidate_workspaces(


### PR DESCRIPTION
## Summary
- cache GitHub SCM polling quota state across poll cycles for 10 minutes when healthy
- keep low-budget quota state conservative by expiring at reset time or a short fallback window
- invalidate the cached quota state when a real rate-limit error happens during polling or baseline establishment

## Testing
- .venv/bin/pytest tests/integrations/github/test_polling.py tests/integrations/github/test_broker.py
- repo commit hooks (black, ruff, mypy, asset build/tests, full pytest)

Closes #1275
