### PR TITLE
Fix hub repo and channel listing latency

### DIFF
--- a/src/codex_autorunner/core/pma_ticket_flow_state.py
+++ b/src/codex_autorunner/core/pma_ticket_flow_state.py
@@ -476,45 +476,55 @@ def build_ticket_flow_run_state(
 
 
 def get_latest_ticket_flow_run_state_with_record(
-    repo_root: Path, repo_id: str
+    repo_root: Path,
+    repo_id: str,
+    *,
+    store: Optional[FlowStore] = None,
 ) -> tuple[Optional[TicketFlowRunState], Optional[FlowRunRecord]]:
+    def _load_from_store(
+        active_store: FlowStore,
+    ) -> tuple[Optional[TicketFlowRunState], Optional[FlowRunRecord]]:
+        records = active_store.list_flow_runs(flow_type="ticket_flow")
+        if not records:
+            return None, None
+        record = select_authoritative_run_record(records)
+        if record is None:
+            return None, None
+        latest = _latest_dispatch(
+            repo_root,
+            str(record.id),
+            dict(record.input_data or {}),
+            max_text_chars=PMA_MAX_TEXT,
+        )
+        reply_seq = _latest_reply_history_seq(
+            repo_root, str(record.id), dict(record.input_data or {})
+        )
+        latest_payload = latest if isinstance(latest, dict) else {}
+        has_dispatch, reason = _resolve_paused_dispatch_state(
+            repo_root=repo_root,
+            record_status=record.status,
+            latest_payload=latest_payload,
+            latest_reply_seq=reply_seq,
+        )
+        run_state = build_ticket_flow_run_state(
+            repo_root=repo_root,
+            repo_id=repo_id,
+            record=record,
+            store=active_store,
+            has_pending_dispatch=has_dispatch,
+            dispatch_state_reason=reason,
+        )
+        return run_state, record
+
     db_path = repo_root / ".codex-autorunner" / "flows.db"
-    if not db_path.exists():
+    if store is None and not db_path.exists():
         return None, None
     try:
+        if store is not None:
+            return _load_from_store(store)
         config = load_repo_config(repo_root)
-        with FlowStore(db_path, durable=config.durable_writes) as store:
-            records = store.list_flow_runs(flow_type="ticket_flow")
-            if not records:
-                return None, None
-            record = select_authoritative_run_record(records)
-            if record is None:
-                return None, None
-            latest = _latest_dispatch(
-                repo_root,
-                str(record.id),
-                dict(record.input_data or {}),
-                max_text_chars=PMA_MAX_TEXT,
-            )
-            reply_seq = _latest_reply_history_seq(
-                repo_root, str(record.id), dict(record.input_data or {})
-            )
-            latest_payload = latest if isinstance(latest, dict) else {}
-            has_dispatch, reason = _resolve_paused_dispatch_state(
-                repo_root=repo_root,
-                record_status=record.status,
-                latest_payload=latest_payload,
-                latest_reply_seq=reply_seq,
-            )
-            run_state = build_ticket_flow_run_state(
-                repo_root=repo_root,
-                repo_id=repo_id,
-                record=record,
-                store=store,
-                has_pending_dispatch=has_dispatch,
-                dispatch_state_reason=reason,
-            )
-            return run_state, record
+        with FlowStore(db_path, durable=config.durable_writes) as local_store:
+            return _load_from_store(local_store)
     except (
         Exception
     ) as exc:  # intentional: top-level guard spanning config, db, fs, and validation errors

--- a/src/codex_autorunner/core/ticket_flow_summary.py
+++ b/src/codex_autorunner/core/ticket_flow_summary.py
@@ -59,6 +59,12 @@ def _load_latest_ticket_flow_run(repo_path: Path) -> Optional[FlowRunRecord]:
         return get_latest_ticket_flow_run(store)
 
 
+def _load_latest_ticket_flow_run_from_store(
+    store: FlowStore,
+) -> Optional[FlowRunRecord]:
+    return get_latest_ticket_flow_run(store)
+
+
 def build_ticket_flow_display(
     *,
     status: Optional[str],
@@ -122,6 +128,7 @@ def build_ticket_flow_summary(
     repo_path: Path,
     *,
     include_failure: bool,
+    store: Optional[FlowStore] = None,
 ) -> Optional[dict[str, Any]]:
     ticket_dir = repo_path / ".codex-autorunner" / "tickets"
     ticket_paths = list_ticket_paths(ticket_dir)
@@ -163,7 +170,11 @@ def build_ticket_flow_summary(
     pr_url = open_pr_ticket_url
 
     try:
-        latest = _load_latest_ticket_flow_run(repo_path)
+        latest = (
+            _load_latest_ticket_flow_run_from_store(store)
+            if store is not None
+            else _load_latest_ticket_flow_run(repo_path)
+        )
     except (
         Exception
     ):  # intentional: summary degrades gracefully on any data-access failure

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/channels.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/channels.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 import sqlite3
+import time
 from collections.abc import Iterable
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
@@ -42,9 +45,19 @@ if TYPE_CHECKING:
     from ...app_state import HubAppContext
 
 
+_CHANNEL_DIR_CACHE_TTL_SECONDS = 10.0
+
+
+@dataclass(frozen=True)
+class _ChannelDirectoryCacheEntry:
+    expires_at: float
+    rows: list[dict[str, Any]]
+
+
 class HubChannelService:
     def __init__(self, context: HubAppContext) -> None:
         self._context = context
+        self._channel_dir_cache: Optional[_ChannelDirectoryCacheEntry] = None
 
     def _state_db_path(self, section: str, default_path: str) -> Path:
         raw = (
@@ -985,7 +998,9 @@ class HubChannelService:
         return payload
 
     async def list_chat_channels(
-        self, query: Optional[str] = None, limit: int = 100
+        self,
+        query: Optional[str] = None,
+        limit: int = 100,
     ) -> dict[str, Any]:
         from fastapi import HTTPException
 
@@ -994,6 +1009,17 @@ class HubChannelService:
         if limit > 1000:
             raise HTTPException(status_code=400, detail="limit must be <= 1000")
 
+        rows = await self._list_cached_channel_rows()
+        query_text = (query or "").strip().lower()
+        if query_text:
+            rows = [
+                row for row in rows if self._channel_row_matches_query(row, query_text)
+            ]
+        if limit >= 0:
+            rows = rows[:limit]
+        return {"entries": rows}
+
+    async def _build_channel_rows(self) -> list[dict[str, Any]]:
         store = ChannelDirectoryStore(self._context.config.root)
         entries = await asyncio.to_thread(store.list_entries, query=None, limit=None)
         snapshots: list[Any] = []
@@ -1348,17 +1374,23 @@ class HubChannelService:
                             "timestamp": usage_payload.get("timestamp"),
                         }
             rows.append(thread_row)
-        query_text = (query or "").strip().lower()
-        if query_text:
-            rows = [
-                row for row in rows if self._channel_row_matches_query(row, query_text)
-            ]
         rows.sort(
             key=lambda item: self._timestamp_rank(item.get("seen_at")), reverse=True
         )
-        if limit >= 0:
-            rows = rows[:limit]
-        return {"entries": rows}
+        return rows
+
+    async def _list_cached_channel_rows(self) -> list[dict[str, Any]]:
+        now = time.monotonic()
+        cached = self._channel_dir_cache
+        if cached is not None and cached.expires_at > now:
+            return copy.deepcopy(cached.rows)
+
+        rows = await self._build_channel_rows()
+        self._channel_dir_cache = _ChannelDirectoryCacheEntry(
+            expires_at=time.monotonic() + _CHANNEL_DIR_CACHE_TTL_SECONDS,
+            rows=copy.deepcopy(rows),
+        )
+        return rows
 
 
 def build_hub_channel_router(context: HubAppContext) -> APIRouter:

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/repo_listing.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/repo_listing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from .....core.chat_bindings import active_chat_binding_counts_by_source
 from .....core.freshness import (
@@ -50,6 +50,23 @@ class HubRepoListingService:
         self._mount_manager = mount_manager
         self._enricher = enricher
 
+    async def _enrich_repos(
+        self,
+        snapshots: list[Any],
+        chat_binding_counts: dict[str, int],
+        chat_binding_counts_by_source: dict[str, dict[str, int]],
+    ) -> list[dict[str, Any]]:
+        tasks = [
+            asyncio.to_thread(
+                self._enricher.enrich_repo,
+                snap,
+                chat_binding_counts,
+                chat_binding_counts_by_source,
+            )
+            for snap in snapshots
+        ]
+        return cast(list[dict[str, Any]], await asyncio.gather(*tasks))
+
     def _active_chat_binding_counts_by_source(self) -> dict[str, dict[str, int]]:
         try:
             return active_chat_binding_counts_by_source(
@@ -95,12 +112,11 @@ class HubRepoListingService:
                 for repo_id, source_counts in chat_binding_counts_by_source.items()
             }
             await self._mount_manager.refresh_mounts(snapshots)
-            repos = [
-                self._enricher.enrich_repo(
-                    snap, chat_binding_counts, chat_binding_counts_by_source
-                )
-                for snap in snapshots
-            ]
+            repos = await self._enrich_repos(
+                snapshots,
+                chat_binding_counts,
+                chat_binding_counts_by_source,
+            )
             if needs_agent_workspaces:
                 agent_workspace_snapshots = results[2]
                 agent_workspaces = [
@@ -173,12 +189,11 @@ class HubRepoListingService:
             for repo_id, source_counts in chat_binding_counts_by_source.items()
         }
         await self._mount_manager.refresh_mounts(snapshots)
-        repos = [
-            self._enricher.enrich_repo(
-                snap, chat_binding_counts, chat_binding_counts_by_source
-            )
-            for snap in snapshots
-        ]
+        repos = await self._enrich_repos(
+            snapshots,
+            chat_binding_counts,
+            chat_binding_counts_by_source,
+        )
         agent_workspaces = [
             workspace.to_dict(self._context.config.root)
             for workspace in agent_workspace_snapshots

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/services.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/services.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -27,27 +28,32 @@ class HubRepoEnricher:
         self._mount_manager = mount_manager
         self._unbound_thread_counts_cache: Optional[dict[str, int]] = None
         self._unbound_thread_counts_cached_at = 0.0
+        self._unbound_thread_counts_lock = threading.Lock()
         self._repo_state_cache: dict[str, _RepoEnrichmentCacheEntry] = {}
+        self._repo_state_cache_lock = threading.Lock()
 
     def invalidate_runtime_caches(self) -> None:
-        self._unbound_thread_counts_cache = None
-        self._unbound_thread_counts_cached_at = 0.0
-        self._repo_state_cache.clear()
+        with self._unbound_thread_counts_lock:
+            self._unbound_thread_counts_cache = None
+            self._unbound_thread_counts_cached_at = 0.0
+        with self._repo_state_cache_lock:
+            self._repo_state_cache.clear()
 
     def _unbound_repo_thread_counts(self) -> dict[str, int]:
-        now = time.monotonic()
-        if (
-            self._unbound_thread_counts_cache is not None
-            and now - self._unbound_thread_counts_cached_at < 1.0
-        ):
-            return dict(self._unbound_thread_counts_cache)
-        try:
-            counts = self._context.supervisor.unbound_repo_thread_counts()
-        except Exception:  # intentional: supervisor query failure is non-critical
-            counts = {}
-        self._unbound_thread_counts_cache = dict(counts)
-        self._unbound_thread_counts_cached_at = now
-        return dict(counts)
+        with self._unbound_thread_counts_lock:
+            now = time.monotonic()
+            if (
+                self._unbound_thread_counts_cache is not None
+                and now - self._unbound_thread_counts_cached_at < 1.0
+            ):
+                return dict(self._unbound_thread_counts_cache)
+            try:
+                counts = self._context.supervisor.unbound_repo_thread_counts()
+            except Exception:  # intentional: supervisor query failure is non-critical
+                counts = {}
+            self._unbound_thread_counts_cache = dict(counts)
+            self._unbound_thread_counts_cached_at = now
+            return dict(counts)
 
     def _path_stat_fingerprint(
         self, path: Path
@@ -88,7 +94,9 @@ class HubRepoEnricher:
         stale_threshold_seconds: Optional[int],
     ) -> dict[str, Any]:
         from .....core.archive import has_car_state
+        from .....core.config import load_repo_config
         from .....core.flows.models import flow_run_duration_seconds
+        from .....core.flows.store import FlowStore
         from .....core.pma_context import (
             get_latest_ticket_flow_run_state_with_record,
         )
@@ -112,51 +120,79 @@ class HubRepoEnricher:
         if not (snapshot.initialized and snapshot.exists_on_disk):
             return payload
 
-        ticket_flow = build_ticket_flow_summary(snapshot.path, include_failure=True)
-        payload["ticket_flow"] = ticket_flow
-        if isinstance(ticket_flow, dict):
-            payload["ticket_flow_display"] = build_ticket_flow_display(
-                status=(
-                    str(ticket_flow.get("status"))
-                    if ticket_flow.get("status") is not None
+        db_path = snapshot.path / ".codex-autorunner" / "flows.db"
+        store: Optional[FlowStore] = None
+        if db_path.exists():
+            try:
+                config = load_repo_config(snapshot.path)
+                store = FlowStore(db_path, durable=config.durable_writes)
+                store.initialize()
+            except Exception:  # intentional: best-effort store reuse only
+                store = None
+
+        try:
+            ticket_flow = build_ticket_flow_summary(
+                snapshot.path,
+                include_failure=True,
+                store=store,
+            )
+            payload["ticket_flow"] = ticket_flow
+            if isinstance(ticket_flow, dict):
+                payload["ticket_flow_display"] = build_ticket_flow_display(
+                    status=(
+                        str(ticket_flow.get("status"))
+                        if ticket_flow.get("status") is not None
+                        else None
+                    ),
+                    done_count=int(ticket_flow.get("done_count") or 0),
+                    total_count=int(ticket_flow.get("total_count") or 0),
+                    run_id=(
+                        str(ticket_flow.get("run_id"))
+                        if ticket_flow.get("run_id")
+                        else None
+                    ),
+                )
+            else:
+                payload["ticket_flow_display"] = build_ticket_flow_display(
+                    status=None,
+                    done_count=0,
+                    total_count=0,
+                    run_id=None,
+                )
+            run_state, run_record = get_latest_ticket_flow_run_state_with_record(
+                snapshot.path,
+                snapshot.id,
+                store=store,
+            )
+            payload["run_state"] = run_state
+            if run_record is not None:
+                if str(snapshot.last_run_id) != str(run_record.id):
+                    payload["last_exit_code"] = None
+                payload["last_run_id"] = run_record.id
+                payload["last_run_started_at"] = run_record.started_at
+                payload["last_run_finished_at"] = run_record.finished_at
+                payload["last_run_duration_seconds"] = flow_run_duration_seconds(
+                    run_record
+                )
+            payload["canonical_state_v1"] = build_canonical_state_v1(
+                repo_root=snapshot.path,
+                repo_id=snapshot.id,
+                run_state=payload["run_state"],
+                record=run_record,
+                store=store,
+                preferred_run_id=(
+                    str(snapshot.last_run_id)
+                    if snapshot.last_run_id is not None
                     else None
                 ),
-                done_count=int(ticket_flow.get("done_count") or 0),
-                total_count=int(ticket_flow.get("total_count") or 0),
-                run_id=(
-                    str(ticket_flow.get("run_id"))
-                    if ticket_flow.get("run_id")
-                    else None
-                ),
+                stale_threshold_seconds=stale_threshold_seconds,
             )
-        else:
-            payload["ticket_flow_display"] = build_ticket_flow_display(
-                status=None,
-                done_count=0,
-                total_count=0,
-                run_id=None,
-            )
-        run_state, run_record = get_latest_ticket_flow_run_state_with_record(
-            snapshot.path, snapshot.id
-        )
-        payload["run_state"] = run_state
-        if run_record is not None:
-            if str(snapshot.last_run_id) != str(run_record.id):
-                payload["last_exit_code"] = None
-            payload["last_run_id"] = run_record.id
-            payload["last_run_started_at"] = run_record.started_at
-            payload["last_run_finished_at"] = run_record.finished_at
-            payload["last_run_duration_seconds"] = flow_run_duration_seconds(run_record)
-        payload["canonical_state_v1"] = build_canonical_state_v1(
-            repo_root=snapshot.path,
-            repo_id=snapshot.id,
-            run_state=payload["run_state"],
-            record=run_record,
-            preferred_run_id=(
-                str(snapshot.last_run_id) if snapshot.last_run_id is not None else None
-            ),
-            stale_threshold_seconds=stale_threshold_seconds,
-        )
+        finally:
+            if store is not None:
+                try:
+                    store.close()
+                except Exception:
+                    pass
         return payload
 
     def _repo_state_payload(
@@ -171,22 +207,24 @@ class HubRepoEnricher:
             snapshot,
             stale_threshold_seconds=stale_threshold_seconds,
         )
-        cached = self._repo_state_cache.get(cache_key)
-        if (
-            cached is not None
-            and cached.expires_at > now
-            and cached.fingerprint == fingerprint
-        ):
-            return copy.deepcopy(cached.payload)
+        with self._repo_state_cache_lock:
+            cached = self._repo_state_cache.get(cache_key)
+            if (
+                cached is not None
+                and cached.expires_at > now
+                and cached.fingerprint == fingerprint
+            ):
+                return copy.deepcopy(cached.payload)
         payload = self._compute_repo_state_payload(
             snapshot,
             stale_threshold_seconds=stale_threshold_seconds,
         )
-        self._repo_state_cache[cache_key] = _RepoEnrichmentCacheEntry(
-            fingerprint=fingerprint,
-            expires_at=now + _REPO_ENRICH_CACHE_TTL_SECONDS,
-            payload=copy.deepcopy(payload),
-        )
+        with self._repo_state_cache_lock:
+            self._repo_state_cache[cache_key] = _RepoEnrichmentCacheEntry(
+                fingerprint=fingerprint,
+                expires_at=now + _REPO_ENRICH_CACHE_TTL_SECONDS,
+                payload=copy.deepcopy(payload),
+            )
         return payload
 
     def enrich_repo(

--- a/tests/surfaces/web/routes/test_hub_performance_caches.py
+++ b/tests/surfaces/web/routes/test_hub_performance_caches.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
+import asyncio
+import logging
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 
 from codex_autorunner.core.hub import LockStatus, RepoSnapshot, RepoStatus
+from codex_autorunner.surfaces.web.routes.hub_repo_routes import (
+    channels as hub_channels_module,
+)
+from codex_autorunner.surfaces.web.routes.hub_repo_routes.channels import (
+    HubChannelService,
+)
+from codex_autorunner.surfaces.web.routes.hub_repo_routes.repo_listing import (
+    HubRepoListingService,
+)
 from codex_autorunner.surfaces.web.routes.hub_repo_routes.services import (
     HubRepoEnricher,
 )
@@ -16,11 +28,11 @@ class _MountManager:
         return repo_dict
 
 
-def _repo_snapshot(repo_root: Path) -> RepoSnapshot:
+def _repo_snapshot(repo_root: Path, repo_id: str = "demo") -> RepoSnapshot:
     return RepoSnapshot(
-        id="demo",
+        id=repo_id,
         path=repo_root,
-        display_name="demo",
+        display_name=repo_id,
         enabled=True,
         auto_run=False,
         worktree_setup_commands=None,
@@ -70,7 +82,7 @@ def test_hub_repo_enricher_reuses_cached_repo_state(
         return True
 
     def fake_ticket_flow_summary(
-        _path: Path, *, include_failure: bool
+        _path: Path, *, include_failure: bool, store=None
     ) -> dict[str, object]:
         assert include_failure is True
         calls["ticket_flow_summary"] += 1
@@ -82,7 +94,7 @@ def test_hub_repo_enricher_reuses_cached_repo_state(
         }
 
     def fake_run_state(
-        _repo_root: Path, _repo_id: str
+        _repo_root: Path, _repo_id: str, *, store=None
     ) -> tuple[dict[str, object], None]:
         calls["run_state"] += 1
         return ({"state": "running", "flow_status": "running", "run_id": "r1"}, None)
@@ -143,7 +155,7 @@ def test_hub_repo_enricher_invalidates_cache_on_flow_db_change(
     calls = {"ticket_flow_summary": 0}
 
     def fake_ticket_flow_summary(
-        _path: Path, *, include_failure: bool
+        _path: Path, *, include_failure: bool, store=None
     ) -> dict[str, object]:
         assert include_failure is True
         calls["ticket_flow_summary"] += 1
@@ -163,7 +175,7 @@ def test_hub_repo_enricher_invalidates_cache_on_flow_db_change(
     )
     monkeypatch.setattr(
         "codex_autorunner.core.pma_context.get_latest_ticket_flow_run_state_with_record",
-        lambda _repo_root, _repo_id: (
+        lambda _repo_root, _repo_id, store=None: (
             {"state": "running", "flow_status": "running"},
             None,
         ),
@@ -178,6 +190,177 @@ def test_hub_repo_enricher_invalidates_cache_on_flow_db_change(
     enricher.enrich_repo(snapshot)
 
     assert calls["ticket_flow_summary"] == 2
+
+
+def test_hub_repo_enricher_reuses_single_flow_store_per_repo_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "demo"
+    car_root = repo_root / ".codex-autorunner"
+    (car_root / "tickets").mkdir(parents=True, exist_ok=True)
+    (car_root / "flows.db").touch()
+    snapshot = _repo_snapshot(repo_root)
+    context = SimpleNamespace(
+        config=SimpleNamespace(
+            root=hub_root,
+            pma=SimpleNamespace(freshness_stale_threshold_seconds=None),
+        ),
+        supervisor=SimpleNamespace(unbound_repo_thread_counts=lambda: {"demo": 0}),
+    )
+    enricher = HubRepoEnricher(context, _MountManager())  # type: ignore[arg-type]
+    store_ids: dict[str, int] = {}
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.archive.has_car_state", lambda _path: True
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.config.load_repo_config",
+        lambda _repo_root: SimpleNamespace(durable_writes=False),
+    )
+
+    def fake_ticket_flow_summary(
+        _path: Path, *, include_failure: bool, store=None
+    ) -> dict[str, object]:
+        assert include_failure is True
+        assert store is not None
+        store_ids["summary"] = id(store)
+        return {
+            "status": "running",
+            "done_count": 1,
+            "total_count": 2,
+            "run_id": "r1",
+        }
+
+    def fake_run_state(
+        _repo_root: Path, _repo_id: str, *, store=None
+    ) -> tuple[dict[str, object], None]:
+        assert store is not None
+        store_ids["run_state"] = id(store)
+        return ({"state": "running", "flow_status": "running", "run_id": "r1"}, None)
+
+    def fake_canonical_state(**kwargs) -> dict[str, object]:
+        store = kwargs.get("store")
+        assert store is not None
+        store_ids["canonical"] = id(store)
+        return {"status": "running"}
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.ticket_flow_summary.build_ticket_flow_summary",
+        fake_ticket_flow_summary,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.pma_context.get_latest_ticket_flow_run_state_with_record",
+        fake_run_state,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.ticket_flow_projection.build_canonical_state_v1",
+        fake_canonical_state,
+    )
+
+    enriched = enricher.enrich_repo(snapshot)
+
+    assert enriched["canonical_state_v1"] == {"status": "running"}
+    assert store_ids["summary"] == store_ids["run_state"] == store_ids["canonical"]
+
+
+def test_hub_repo_listing_service_enriches_repos_in_parallel(tmp_path: Path) -> None:
+    class _AsyncMountManager:
+        async def refresh_mounts(self, _snapshots) -> None:
+            return None
+
+    snapshots = [
+        _repo_snapshot(tmp_path / "repo-1", repo_id="repo-1"),
+        _repo_snapshot(tmp_path / "repo-2", repo_id="repo-2"),
+    ]
+    barrier = threading.Barrier(2, timeout=0.5)
+    failures: list[Exception] = []
+    thread_ids: set[int] = set()
+
+    def enrich_repo(
+        snapshot, chat_binding_counts: dict[str, int], chat_binding_counts_by_source
+    ) -> dict[str, object]:
+        assert chat_binding_counts == {}
+        assert chat_binding_counts_by_source == {}
+        thread_ids.add(threading.get_ident())
+        try:
+            barrier.wait(timeout=0.5)
+        except threading.BrokenBarrierError as exc:
+            failures.append(exc)
+        return {"repo_id": snapshot.id}
+
+    context = SimpleNamespace(
+        config=SimpleNamespace(
+            root=tmp_path,
+            raw={},
+            pma=SimpleNamespace(freshness_stale_threshold_seconds=None),
+        ),
+        supervisor=SimpleNamespace(
+            list_repos=lambda: snapshots,
+            state=SimpleNamespace(last_scan_at=None, pinned_parent_repo_ids=[]),
+        ),
+        logger=logging.getLogger(__name__),
+    )
+    listing_service = HubRepoListingService(
+        context,
+        _AsyncMountManager(),  # type: ignore[arg-type]
+        SimpleNamespace(enrich_repo=enrich_repo),
+    )
+
+    payload = asyncio.run(listing_service.list_repos(sections={"repos"}))
+
+    assert failures == []
+    assert len(thread_ids) == 2
+    assert [repo["repo_id"] for repo in payload["repos"]] == ["repo-1", "repo-2"]
+
+
+def test_hub_channel_service_reuses_ttl_cache(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir(parents=True, exist_ok=True)
+    context = SimpleNamespace(
+        config=SimpleNamespace(root=hub_root, raw={}),
+        supervisor=SimpleNamespace(list_repos=lambda: []),
+        logger=logging.getLogger(__name__),
+    )
+    service = HubChannelService(context)  # type: ignore[arg-type]
+    calls = {"build_rows": 0}
+    now = {"value": 100.0}
+
+    monkeypatch.setattr(
+        hub_channels_module.time,
+        "monotonic",
+        lambda: now["value"],
+    )
+
+    async def fake_build_channel_rows() -> list[dict[str, object]]:
+        calls["build_rows"] += 1
+        return [
+            {
+                "key": "discord:chan-123:guild-1",
+                "display": "CAR HQ / #ops",
+                "seen_at": "2026-04-01T00:00:00Z",
+                "meta": {},
+                "entry": {},
+                "source": "discord",
+                "provenance": {"source": "discord"},
+            }
+        ]
+
+    monkeypatch.setattr(service, "_build_channel_rows", fake_build_channel_rows)
+
+    first = asyncio.run(service.list_chat_channels(limit=100))
+    second = asyncio.run(service.list_chat_channels(query="ops", limit=10))
+    now["value"] = 111.0
+    third = asyncio.run(service.list_chat_channels(limit=100))
+
+    assert [entry["key"] for entry in first["entries"]] == ["discord:chan-123:guild-1"]
+    assert [entry["key"] for entry in second["entries"]] == ["discord:chan-123:guild-1"]
+    assert [entry["key"] for entry in third["entries"]] == ["discord:chan-123:guild-1"]
+    assert calls["build_rows"] == 2
 
 
 def test_gather_hub_message_snapshot_reuses_short_ttl_cache(


### PR DESCRIPTION
## Summary
- parallelize repo enrichment for `/hub/repos` and `/hub/repos/scan` so per-repo state work runs concurrently
- reuse a single `FlowStore` during repo enrichment to avoid repeated SQLite open/close cycles for the same repo
- cache enriched `/hub/chat/channels` rows for 10 seconds and add focused coverage for the new concurrency and cache behavior

## Testing
- `.venv/bin/python -m pytest tests/surfaces/web/routes/test_hub_performance_caches.py tests/surfaces/web/test_hub_destination_and_channels.py tests/core/test_ticket_flow_summary.py tests/core/test_ticket_flow_projection.py -q`
- repo commit hook suite (`4380 passed`)

Closes #1281
