### PR TITLE
Fix completion-gap recovery during active streaming

### DIFF
--- a/src/codex_autorunner/integrations/app_server/client.py
+++ b/src/codex_autorunner/integrations/app_server/client.py
@@ -179,6 +179,7 @@ class _TurnState:
     completion_settle_task: Optional[asyncio.Task[None]] = None
     item_completed_count: int = 0
     completion_gap_started_at: Optional[float] = None
+    last_stream_delta_at: float = 0.0
     completion_gap_recovery_attempts: int = 0
     last_completion_gap_recovery_at: float = 0.0
 
@@ -633,6 +634,11 @@ class CodexAppServerClient:
         if completion_gap_started_at is None:
             return
         now = time.monotonic()
+        if (
+            state.last_stream_delta_at
+            and now - state.last_stream_delta_at < completion_gap_timeout
+        ):
+            return
         completion_gap_seconds = now - completion_gap_started_at
         if completion_gap_seconds < completion_gap_timeout:
             return
@@ -1732,6 +1738,7 @@ class CodexAppServerClient:
             state.agent_message_deltas[item_id] = (
                 state.agent_message_deltas.get(item_id, "") + delta
             )
+        state.last_stream_delta_at = time.monotonic()
         self._mark_notification_event(state=state, method="item/agentMessage/delta")
         _record_raw_event(state, message)
         if state.turn_completed_seen and not state.future.done():
@@ -1925,6 +1932,10 @@ class CodexAppServerClient:
                 target.completion_gap_started_at,
                 source.completion_gap_started_at,
             )
+        target.last_stream_delta_at = max(
+            target.last_stream_delta_at,
+            source.last_stream_delta_at,
+        )
         target.completion_gap_recovery_attempts = max(
             target.completion_gap_recovery_attempts,
             source.completion_gap_recovery_attempts,

--- a/tests/test_app_server_client.py
+++ b/tests/test_app_server_client.py
@@ -1050,6 +1050,64 @@ async def test_live_progress_refreshes_completion_gap_window(
 
 
 @pytest.mark.anyio
+async def test_recent_stream_delta_blocks_completion_gap_recovery(
+    tmp_path: Path,
+) -> None:
+    client = CodexAppServerClient(
+        fixture_command("basic"),
+        cwd=tmp_path,
+        turn_stall_timeout_seconds=10.0,
+        turn_stall_poll_interval_seconds=0.02,
+        turn_stall_recovery_min_interval_seconds=0.0,
+        turn_completion_gap_timeout_seconds=0.05,
+    )
+    try:
+        state = client._ensure_turn_state("turn-1", "thread-1")
+        state.status = "running"
+        state.item_completed_count = 3
+        state.completion_gap_started_at = time.monotonic() - 1.0
+        resume_calls = 0
+
+        async def _resume(thread_id: str, **kwargs: object) -> dict[str, object]:
+            nonlocal resume_calls
+            _ = thread_id, kwargs
+            resume_calls += 1
+            return {}
+
+        client.thread_resume = _resume  # type: ignore[method-assign]
+
+        await client._handle_notification_agent_message_delta(
+            {
+                "method": "item/agentMessage/delta",
+                "params": {
+                    "turnId": "turn-1",
+                    "threadId": "thread-1",
+                    "itemId": "msg-1",
+                    "delta": "still streaming",
+                },
+            },
+            {
+                "turnId": "turn-1",
+                "threadId": "thread-1",
+                "itemId": "msg-1",
+                "delta": "still streaming",
+            },
+        )
+
+        assert state.last_stream_delta_at > 0.0
+
+        await client._maybe_reconcile_turn_completion_gap(
+            state,
+            turn_id="turn-1",
+            thread_id="thread-1",
+        )
+
+        assert resume_calls == 0
+    finally:
+        await client.close()
+
+
+@pytest.mark.anyio
 async def test_turn_hint_progress_refreshes_completion_gap_window(
     tmp_path: Path,
 ) -> None:
@@ -1091,6 +1149,27 @@ async def test_turn_hint_progress_refreshes_completion_gap_window(
         )
 
         assert resume_calls == 0
+    finally:
+        await client.close()
+
+
+@pytest.mark.anyio
+async def test_merge_turn_state_keeps_latest_stream_delta_timestamp(
+    tmp_path: Path,
+) -> None:
+    client = CodexAppServerClient(
+        fixture_command("basic"),
+        cwd=tmp_path,
+    )
+    try:
+        target = client._ensure_turn_state("turn-1", "thread-1")
+        source = client._ensure_pending_turn_state("turn-1")
+        target.last_stream_delta_at = time.monotonic() - 5.0
+        source.last_stream_delta_at = time.monotonic() - 1.0
+
+        client._merge_turn_state(target, source)
+
+        assert target.last_stream_delta_at == source.last_stream_delta_at
     finally:
         await client.close()
 


### PR DESCRIPTION
## Summary
- track the most recent agent stream delta timestamp in app-server turn state
- skip completion-gap recovery while streaming activity is still recent, even if item completion has already started the gap window
- preserve the latest stream-delta timestamp across pending-to-bound turn state merges and cover the regression in unit tests

## Testing
- .venv/bin/python -m pytest tests/test_app_server_client.py -k 'completion_gap or stream_delta'
- .venv/bin/python -m pytest tests/test_app_server_client.py

Closes #1282
