### PR TITLE
[codex] Show archive progress in chat flows

### DIFF
--- a/src/codex_autorunner/integrations/discord/flow_commands.py
+++ b/src/codex_autorunner/integrations/discord/flow_commands.py
@@ -67,6 +67,10 @@ def flow_archive_prompt_text(record: FlowRunRecord) -> str:
     )
 
 
+def flow_archive_in_progress_text(run_id: str) -> str:
+    return f"Archiving run {run_id}... This can take a few seconds."
+
+
 def build_flow_archive_confirmation_components(
     run_id: str,
     *,
@@ -2070,6 +2074,10 @@ async def handle_flow_button(
             )
             return
 
+        await service._send_followup_ephemeral(
+            interaction_token=interaction_token,
+            content=flow_archive_in_progress_text(target.id),
+        )
         try:
             summary = await asyncio.to_thread(
                 flow_service.archive_flow_run,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
@@ -152,6 +152,10 @@ class FlowCommands(TelegramCommandSupportMixin):
             "archive. Archive it anyway?"
         )
 
+    @staticmethod
+    def _flow_archive_in_progress_text(run_id: object) -> str:
+        return f"Archiving run {_code(run_id)}. This can take a few seconds."
+
     def _build_flow_archive_confirmation_keyboard(
         self,
         run_id: str,
@@ -816,6 +820,11 @@ class FlowCommands(TelegramCommandSupportMixin):
                 else:
                     try:
                         await _answer_once("Working...")
+                        await self._edit_callback_message(
+                            callback,
+                            self._flow_archive_in_progress_text(record.id),
+                            reply_markup={"inline_keyboard": []},
+                        )
                         summary = flow_service.archive_flow_run(
                             record.id,
                             force=ticket_flow_archive_requires_force(record),

--- a/tests/integrations/discord/test_flow_archive.py
+++ b/tests/integrations/discord/test_flow_archive.py
@@ -372,6 +372,8 @@ async def test_flow_archive_button_deletes_run_record_by_default(
         {"run_id": run_id, "force": False, "delete_run": True}
     ]
     assert rest.interaction_responses[0]["payload"]["type"] == 6
+    assert len(rest.followup_messages) == 1
+    assert "Archiving run" in rest.followup_messages[0]["payload"]["content"]
     edited = rest.edited_original_interaction_responses[0]["payload"]
     assert "Archived run" in edited["content"]
     assert edited["components"] == []
@@ -504,9 +506,10 @@ async def test_flow_archive_button_keeps_original_card_on_validation_error(
 
     assert rest.interaction_responses[0]["payload"]["type"] == 6
     assert rest.edited_original_interaction_responses == []
-    assert len(rest.followup_messages) == 1
+    assert len(rest.followup_messages) == 2
+    assert "Archiving run" in rest.followup_messages[0]["payload"]["content"]
     assert (
-        rest.followup_messages[0]["payload"]["content"]
+        rest.followup_messages[1]["payload"]["content"]
         == "Can only archive completed/stopped/failed flows"
     )
 

--- a/tests/test_telegram_flow_callback_actions.py
+++ b/tests/test_telegram_flow_callback_actions.py
@@ -61,6 +61,7 @@ class _FlowServiceStub:
         self.resume_calls: list[str] = []
         self.stop_calls: list[str] = []
         self.reconcile_calls: list[str] = []
+        self.archive_calls: list[dict[str, object]] = []
 
     async def resume_flow_run(
         self, run_id: str, *, force: bool = False
@@ -76,6 +77,19 @@ class _FlowServiceStub:
         self.reconcile_calls.append(run_id)
         return SimpleNamespace(run_id=run_id, status="running"), True, False
 
+    def archive_flow_run(
+        self, run_id: str, *, force: bool = False, delete_run: bool = True
+    ) -> dict[str, object]:
+        self.archive_calls.append(
+            {"run_id": run_id, "force": force, "delete_run": delete_run}
+        )
+        return {
+            "run_id": run_id,
+            "archived_tickets": 0,
+            "archived_runs": True,
+            "archived_contextspace": False,
+        }
+
 
 class _FlowCallbackHandler(FlowCommands):
     def __init__(
@@ -88,6 +102,7 @@ class _FlowCallbackHandler(FlowCommands):
         self._store = _TopicStoreStub(repo_root)
         self.answers: list[str] = []
         self.rendered: list[tuple[Path, str | None, str | None]] = []
+        self.edits: list[tuple[str, dict[str, object] | None]] = []
 
     async def _resolve_topic_key(self, _chat_id: int, _thread_id: int | None) -> str:
         return "topic"
@@ -114,6 +129,16 @@ class _FlowCallbackHandler(FlowCommands):
         }:
             return str(self._repo_root), arg
         return None
+
+    async def _edit_callback_message(
+        self,
+        _callback: TelegramCallbackQuery,
+        text: str,
+        *,
+        reply_markup: dict[str, object] | None = None,
+    ) -> bool:
+        self.edits.append((text, reply_markup))
+        return True
 
 
 def _init_store(repo_root: Path) -> FlowStore:
@@ -211,6 +236,38 @@ async def test_flow_callback_recover_latest_active(
     assert flow_service.reconcile_calls == [run_id]
     assert handler.answers == ["Working..."]
     assert handler.rendered
+
+
+@pytest.mark.anyio
+async def test_flow_callback_archive_updates_message_while_archiving(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _init_store(tmp_path)
+    run_id = str(uuid.uuid4())
+    _create_run(store, run_id, FlowRunStatus.COMPLETED)
+    store.close()
+
+    flow_service = _FlowServiceStub()
+    monkeypatch.setattr(
+        flows_module,
+        "build_ticket_flow_orchestration_service",
+        lambda *, workspace_root: flow_service,
+    )
+
+    handler = _FlowCallbackHandler(tmp_path)
+    await handler._handle_flow_callback(_callback(), FlowCallback(action="archive"))
+
+    assert flow_service.archive_calls == [
+        {"run_id": run_id, "force": False, "delete_run": True}
+    ]
+    assert handler.answers == ["Working..."]
+    assert handler.edits == [
+        (
+            f"Archiving run `{run_id}`. This can take a few seconds.",
+            {"inline_keyboard": []},
+        )
+    ]
+    assert handler.rendered == [(tmp_path, None, None)]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## What changed
- added an immediate in-progress notice for Discord flow-status archive button clicks before the archive work completes
- added the same visible in-progress state for Telegram flow archive callbacks by editing the status message to an `Archiving...` placeholder before rerendering the final state
- extended Discord and Telegram tests to cover the new progress behavior

## Why
Archive actions can take a few seconds. Before this change, Discord only acknowledged the button interaction without showing visible progress, and Telegram only showed a transient callback toast. In both cases the user could reasonably think nothing was happening.

## Impact
Users now get immediate feedback that CAR is working after they trigger archive from flow status on both chat surfaces.

## Validation
- `.venv/bin/python -m pytest tests/integrations/discord/test_flow_archive.py tests/test_telegram_flow_callback_actions.py tests/test_telegram_flow_lifecycle.py`
- repo pre-commit checks during `git commit`, including formatting, linting, mypy, frontend build/tests, and full pytest