### PR TITLE
Fix completion-gap recovery during active tool execution

### DIFF
--- a/src/codex_autorunner/integrations/app_server/client.py
+++ b/src/codex_autorunner/integrations/app_server/client.py
@@ -2048,6 +2048,7 @@ class CodexAppServerClient:
     ) -> None:
         item = params.get("item") if isinstance(params, dict) else None
         item_id = _extract_notification_item_id(params, decoded)
+        matched_active_item_id = item_id if isinstance(item_id, str) else None
         if item_id is not None:
             state.active_item_ids.discard(item_id)
         text: Optional[str] = None
@@ -2059,12 +2060,17 @@ class CodexAppServerClient:
             if isinstance(item_id, str):
                 delta_text = state.agent_message_deltas.pop(item_id, None)
             elif text:
-                _prune_unambiguous_stale_delta(
+                matched_active_item_id = _prune_unambiguous_stale_delta(
                     state.agent_message_deltas, completed_text=text
                 )
             if not text:
                 text = delta_text
             _append_agent_message_for_phase(state, text, phase=phase)
+        if item_id is None:
+            _discard_completed_active_item(
+                state.active_item_ids,
+                matched_item_id=matched_active_item_id,
+            )
         review_text = _extract_review_text(item)
         if review_text and review_text != text:
             _append_agent_message(state.agent_messages, review_text)
@@ -2680,10 +2686,10 @@ def _agent_message_deltas_as_list(agent_message_deltas: Dict[str, str]) -> list[
 
 def _prune_unambiguous_stale_delta(
     agent_message_deltas: Dict[str, str], *, completed_text: str
-) -> None:
+) -> Optional[str]:
     cleaned_completed = completed_text.strip()
     if not cleaned_completed:
-        return
+        return None
     matching_keys = [
         item_id
         for item_id, delta_text in agent_message_deltas.items()
@@ -2692,7 +2698,20 @@ def _prune_unambiguous_stale_delta(
         and cleaned_completed.startswith(delta_text.strip())
     ]
     if len(matching_keys) == 1:
-        agent_message_deltas.pop(matching_keys[0], None)
+        matched_item_id = matching_keys[0]
+        agent_message_deltas.pop(matched_item_id, None)
+        return matched_item_id
+    return None
+
+
+def _discard_completed_active_item(
+    active_item_ids: set[str], *, matched_item_id: Optional[str]
+) -> None:
+    if matched_item_id is not None:
+        active_item_ids.discard(matched_item_id)
+        return
+    if len(active_item_ids) == 1:
+        active_item_ids.clear()
 
 
 def _agent_messages_for_result(state: _TurnState) -> list[str]:

--- a/tests/test_app_server_client.py
+++ b/tests/test_app_server_client.py
@@ -384,6 +384,74 @@ async def test_item_completed_without_item_id_prunes_matching_stale_delta(
 
 
 @pytest.mark.anyio
+async def test_item_completed_without_item_id_clears_matching_active_item(
+    tmp_path: Path,
+) -> None:
+    client = CodexAppServerClient(fixture_command("basic"), cwd=tmp_path)
+    try:
+        state = client._ensure_turn_state("turn-1", "thread-1")
+        state.active_item_ids.update({"item-1", "item-2"})
+        partial_delta = {
+            "turnId": "turn-1",
+            "threadId": "thread-1",
+            "itemId": "item-1",
+            "delta": "final",
+        }
+        completed_item_without_id = {
+            "turnId": "turn-1",
+            "threadId": "thread-1",
+            "item": {"type": "agentMessage", "text": "final reply"},
+        }
+
+        await client._handle_notification_agent_message_delta(
+            {"method": "item/agentMessage/delta", "params": partial_delta},
+            partial_delta,
+        )
+        await client._handle_notification_item_completed(
+            {"method": "item/completed", "params": completed_item_without_id},
+            completed_item_without_id,
+        )
+
+        assert state.active_item_ids == {"item-2"}
+        assert state.agent_message_deltas == {}
+    finally:
+        await client.close()
+
+
+@pytest.mark.anyio
+async def test_item_completed_without_item_id_clears_lone_active_item(
+    tmp_path: Path,
+) -> None:
+    client = CodexAppServerClient(fixture_command("basic"), cwd=tmp_path)
+    try:
+        state = client._ensure_turn_state("turn-1", "thread-1")
+        started_item = {
+            "turnId": "turn-1",
+            "threadId": "thread-1",
+            "itemId": "tool-1",
+            "item": {"type": "commandExecution"},
+        }
+        completed_item_without_id = {
+            "turnId": "turn-1",
+            "threadId": "thread-1",
+            "item": {"type": "commandExecution"},
+        }
+
+        await client._handle_notification_item_started(
+            {"method": "item/started", "params": started_item},
+            started_item,
+        )
+        await client._handle_notification_item_completed(
+            {"method": "item/completed", "params": completed_item_without_id},
+            completed_item_without_id,
+        )
+
+        assert state.active_item_ids == set()
+    finally:
+        await client.close()
+
+
+@pytest.mark.anyio
 async def test_turn_completed_settles_before_returning_final_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Problem

PR #1284 added a `last_stream_delta_at` guard to prevent completion-gap recovery from killing actively-streaming turns. However, the guard only checks for `item/agentMessage/delta` notifications. The codex CLI does NOT send these deltas while a tool is executing — it sends `item/started` when the tool begins, then goes silent until `item/completed` when the tool finishes.

During this silent period (which can easily exceed the 15s `completion_gap_timeout` for long-running tools), the completion-gap timer fires, calls `thread_resume`, gets `status=inProgress` (tool is still running), and counts it as a failed recovery. After 8 attempts, the turn is killed.

Evidence from production logs:
- `last_method=item/started` in every completion-gap recovery event
- `item_completed_count` stays constant between recoveries (no items completing)
- Zero `item/agentMessage/delta` notifications in any log during these periods

## Fix

Replace the `last_stream_delta_at`-only guard with two guards:

1. **`active_item_ids` tracking** — if any item has started but not yet completed, suppress recovery entirely (strong signal: tool is running)
2. **`last_event_at` freshness** — if any notification arrived within the timeout window, suppress recovery (catches all event types: token usage, diff updates, etc.)

Also adds an `_handle_notification_item_started` handler that tracks active item IDs, and cleans them up on `item/completed` and `turn/completed`.

Closes #1290