### PR TITLE
Fix #1296: subscription creation silently drops event_type

### DIFF
--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -835,6 +835,33 @@ class PmaAutomationStore:
         return merged
 
     @staticmethod
+    def _normalize_subscription_event_types(
+        value: Any,
+        *,
+        singular: Any = None,
+    ) -> list[str]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+
+        def _append(candidate: Any) -> None:
+            text = _normalize_text(candidate)
+            if text is None:
+                return
+            lowered = text.lower()
+            if lowered in seen:
+                return
+            seen.add(lowered)
+            normalized.append(lowered)
+
+        if isinstance(value, (list, tuple, set)):
+            for item in value:
+                _append(item)
+        else:
+            _append(value)
+        _append(singular)
+        return normalized
+
+    @staticmethod
     def _coerce_limit(value: Any) -> Optional[int]:
         if value is None:
             return None
@@ -863,6 +890,11 @@ class PmaAutomationStore:
         metadata: Optional[dict[str, Any]] = None,
     ) -> tuple[PmaLifecycleSubscription, bool]:
         key = _normalize_text(idempotency_key)
+        normalized_event_types = self._normalize_subscription_event_types(event_types)
+        if not normalized_event_types:
+            logger.warning(
+                "Creating PMA subscription with empty event_types; subscription will match all events"
+            )
         with file_lock(self._lock_path()):
             state, subscriptions, timers, wakeups = self._load_structured_unlocked()
             if key is not None:
@@ -872,7 +904,7 @@ class PmaAutomationStore:
                     if existing.idempotency_key == key:
                         return existing, True
             created = PmaLifecycleSubscription.create(
-                event_types=event_types,
+                event_types=normalized_event_types,
                 repo_id=repo_id,
                 run_id=run_id,
                 thread_id=thread_id,
@@ -894,7 +926,11 @@ class PmaAutomationStore:
     ) -> dict[str, Any]:
         data = self._coerce_payload(payload, kwargs)
         created, deduped = self.upsert_subscription(
-            event_types=_normalize_text_list(data.get("event_types")) or None,
+            event_types=self._normalize_subscription_event_types(
+                data.get("event_types"),
+                singular=data.get("event_type"),
+            )
+            or None,
             repo_id=_normalize_text(data.get("repo_id")),
             run_id=_normalize_text(data.get("run_id")),
             thread_id=_normalize_text(data.get("thread_id")),

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -17,6 +17,7 @@ from pydantic import (
 )
 
 from ...core.car_context import CarContextProfile
+from ...core.text_utils import _normalize_text
 from ...integrations.chat.approval_modes import normalize_approval_mode
 
 
@@ -798,6 +799,44 @@ class PmaAutomationSubscriptionCreateRequest(Payload):
     )
     reason: Optional[str] = None
     timestamp: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_event_type_inputs(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+        data = dict(value)
+        normalized_event_types: list[str] = []
+        seen: set[str] = set()
+
+        def _append(candidate: Any) -> None:
+            text = _normalize_text(candidate)
+            if text is None:
+                return
+            lowered = text.lower()
+            if lowered in seen:
+                return
+            seen.add(lowered)
+            normalized_event_types.append(lowered)
+
+        plural_value = data.get("event_types", data.get("eventTypes"))
+        if isinstance(plural_value, (list, tuple, set)):
+            for item in plural_value:
+                _append(item)
+        else:
+            _append(plural_value)
+
+        _append(data.get("event_type"))
+        _append(data.get("eventType"))
+
+        data.pop("event_type", None)
+        data.pop("eventType", None)
+        data.pop("eventTypes", None)
+        if normalized_event_types:
+            data["event_types"] = normalized_event_types
+        elif "event_types" in data:
+            data["event_types"] = []
+        return data
 
 
 class PmaAutomationTimerCreateRequest(Payload):

--- a/tests/core/test_pma_automation_store.py
+++ b/tests/core/test_pma_automation_store.py
@@ -271,6 +271,57 @@ def test_subscription_lane_id_flows_into_transition_wakeup(tmp_path) -> None:
     assert pending[0]["lane_id"] == "pma:lane-next"
 
 
+def test_create_subscription_accepts_singular_event_type_and_triggers_transition(
+    tmp_path,
+) -> None:
+    store = PmaAutomationStore(tmp_path)
+    subscription = store.create_subscription(
+        {
+            "event_type": "managed_thread_completed",
+            "thread_id": "thread-1",
+            "lane_id": "pma:lane-next",
+        }
+    )["subscription"]
+
+    assert subscription["event_types"] == ["managed_thread_completed"]
+
+    result = store.notify_transition(
+        {
+            "event_type": "managed_thread_completed",
+            "thread_id": "thread-1",
+            "from_state": "running",
+            "to_state": "completed",
+            "transition_id": "managed-thread-1:completed",
+        }
+    )
+
+    assert result["matched"] == 1
+    assert result["created"] == 1
+    pending = store.list_pending_wakeups(limit=10)
+    assert len(pending) == 1
+    assert pending[0]["subscription_id"] == subscription["subscription_id"]
+    assert pending[0]["event_type"] == "managed_thread_completed"
+
+
+def test_create_subscription_warns_when_event_types_empty(
+    tmp_path, caplog: pytest.LogCaptureFixture
+) -> None:
+    store = PmaAutomationStore(tmp_path)
+
+    with caplog.at_level(
+        logging.WARNING, logger="codex_autorunner.core.pma_automation_store"
+    ):
+        subscription = store.create_subscription({"thread_id": "thread-empty"})[
+            "subscription"
+        ]
+
+    assert subscription["event_types"] == []
+    assert any(
+        "Creating PMA subscription with empty event_types" in record.getMessage()
+        for record in caplog.records
+    )
+
+
 def test_notify_once_subscription_cancels_after_first_match(tmp_path) -> None:
     store = PmaAutomationStore(tmp_path)
     subscription = store.create_subscription(

--- a/tests/test_pma_routes.py
+++ b/tests/test_pma_routes.py
@@ -2875,7 +2875,7 @@ def test_pma_automation_subscription_endpoints(hub_env) -> None:
             self.list_filters.append(dict(filters))
             return [{"subscription_id": "sub-1", "thread_id": "thread-1"}]
 
-        def delete_subscription(self, subscription_id: str) -> dict[str, Any]:
+        def cancel_subscription(self, subscription_id: str) -> dict[str, Any]:
             self.deleted_ids.append(subscription_id)
             return {"deleted": True}
 
@@ -2919,6 +2919,59 @@ def test_pma_automation_subscription_endpoints(hub_env) -> None:
         and fake_store.list_filters[0]["thread_id"] == "thread-1"
     )
     assert fake_store.deleted_ids == ["sub-1"]
+
+
+@pytest.mark.parametrize(
+    ("request_body", "expected_event_types"),
+    [
+        (
+            {
+                "event_type": "managed_thread_completed",
+                "thread_id": "thread-1",
+            },
+            ["managed_thread_completed"],
+        ),
+        (
+            {
+                "event_types": [
+                    "managed_thread_completed",
+                    "managed_thread_failed",
+                ],
+                "thread_id": "thread-2",
+            },
+            ["managed_thread_completed", "managed_thread_failed"],
+        ),
+    ],
+)
+def test_pma_automation_subscription_create_normalizes_event_type_aliases(
+    hub_env,
+    request_body: dict[str, Any],
+    expected_event_types: list[str],
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeAutomationStore:
+        def __init__(self) -> None:
+            self.created_payloads: list[dict[str, Any]] = []
+
+        def create_subscription(self, payload: dict[str, Any]) -> dict[str, Any]:
+            self.created_payloads.append(dict(payload))
+            return {"subscription_id": "sub-event-types-1", **payload}
+
+    fake_store = FakeAutomationStore()
+    app.state.hub_supervisor.get_pma_automation_store = lambda: fake_store
+
+    with TestClient(app) as client:
+        create_resp = client.post("/hub/pma/subscriptions", json=request_body)
+
+    assert create_resp.status_code == 200
+    assert fake_store.created_payloads == [
+        {
+            "thread_id": request_body["thread_id"],
+            "event_types": expected_event_types,
+        }
+    ]
 
 
 def test_pma_automation_timer_endpoints(hub_env) -> None:
@@ -3027,7 +3080,7 @@ def test_pma_automation_subscription_alias_endpoint_supports_kwargs_only_store(
                 "lane_id": lane_id,
             }
 
-        def delete_subscription(self, subscription_id: str) -> bool:
+        def cancel_subscription(self, subscription_id: str) -> bool:
             self.deleted_ids.append(subscription_id)
             return True
 


### PR DESCRIPTION
## Summary
- accept both `event_type` and `event_types` for PMA subscription creation and normalize to the canonical `event_types` list
- persist normalized event types in the automation store and warn when a subscription is created with an empty event type filter
- add coverage for singular/plural request payloads and for wake-up matching from a singular `event_type` subscription

## Testing
- `.venv/bin/python -m pytest tests/core/test_pma_automation_store.py -q`
- `.venv/bin/python -m pytest tests/test_pma_routes.py -q -k "automation_subscription or normalizes_event_type_aliases"`
- repo pre-commit suite: `4534 passed`
