### PR TITLE
[codex] Handle Telegram app-server response errors

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -20,7 +20,7 @@ from .....core.state import now_iso
 from .....core.utils import canonicalize_path, resolve_opencode_binary
 from .....manifest import load_manifest
 from ....app_server import is_missing_thread_error
-from ....app_server.client import CodexAppServerClient
+from ....app_server.client import CodexAppServerClient, CodexAppServerError
 from ....chat.agents import (
     build_agent_switch_state,
     chat_agent_supports_effort,
@@ -437,7 +437,7 @@ class WorkspaceCommands(TelegramCommandSupportMixin):
             return None
         try:
             result = await client.thread_resume(thread_id)
-        except (OSError, RuntimeError, ValueError) as exc:
+        except (OSError, RuntimeError, ValueError, CodexAppServerError) as exc:
             if is_missing_thread_error(exc):
                 log_event(
                     self._logger,
@@ -1625,7 +1625,7 @@ class WorkspaceCommands(TelegramCommandSupportMixin):
                     record.workspace_path,
                     **self._thread_start_kwargs(record),
                 )
-            except (OSError, RuntimeError, ValueError) as exc:
+            except (OSError, RuntimeError, ValueError, CodexAppServerError) as exc:
                 log_event(
                     self._logger,
                     logging.WARNING,
@@ -2928,7 +2928,7 @@ class WorkspaceCommands(TelegramCommandSupportMixin):
             return
         try:
             result = await client.thread_resume(thread_id)
-        except (OSError, RuntimeError, ValueError) as exc:
+        except (OSError, RuntimeError, ValueError, CodexAppServerError) as exc:
             if is_missing_thread_error(exc):
                 log_event(
                     self._logger,

--- a/tests/test_telegram_bot_integration.py
+++ b/tests/test_telegram_bot_integration.py
@@ -161,6 +161,7 @@ class FakeBot:
     def __init__(self) -> None:
         self.messages: list[dict[str, object]] = []
         self.documents: list[dict[str, object]] = []
+        self.deleted_messages: list[dict[str, object]] = []
 
     async def send_message(
         self,
@@ -250,6 +251,22 @@ class FakeBot:
         disable_web_page_preview: bool = True,
     ) -> dict[str, object]:
         return {}
+
+    async def delete_message(
+        self,
+        chat_id: int,
+        message_id: int,
+        *,
+        message_thread_id: Optional[int] = None,
+    ) -> bool:
+        self.deleted_messages.append(
+            {
+                "chat_id": chat_id,
+                "thread_id": message_thread_id,
+                "message_id": message_id,
+            }
+        )
+        return True
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- catch `CodexAppServerError` in Telegram codex thread verification so stale rollout/thread ids clear gracefully instead of killing the turn
- apply the same response-error handling to explicit Telegram `/resume` and `/new` flows in the same command module
- extend the Telegram integration test bot stub with `delete_message()` so the recovered turn path can complete in tests

## Root cause
Telegram workspace command handlers only rescued `OSError`, `RuntimeError`, and `ValueError`, but `thread_resume()` and `thread_start()` surface stale app-server failures as `CodexAppServerResponseError`, which inherits from `CodexAppServerError`. That meant the intended fallback logic never ran.

## Validation
- `.venv/bin/pytest tests/test_telegram_bot_integration.py`
- pre-commit hook suite during `git commit` (including repo-wide pytest)

Closes #1310