### PR TITLE
[codex] Fix Discord interaction ack starvation

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -594,6 +594,8 @@ class DiscordBotService:
         self._channel_directory_store = ChannelDirectoryStore(self._config.root)
         self._guild_name_cache: dict[str, str] = {}
         self._channel_name_cache: dict[str, str] = {}
+        self._guild_name_lookups: dict[str, asyncio.Task[Optional[str]]] = {}
+        self._channel_name_lookups: dict[str, asyncio.Task[Optional[str]]] = {}
         self._hub_raw_config_cache: Optional[dict[str, Any]] = None
         self._hub_config_path: Optional[Path] = None
         generated_hub_config = self._config.root / ".codex-autorunner" / "config.yml"
@@ -3490,56 +3492,79 @@ class DiscordBotService:
         if not callable(fetch):
             self._channel_name_cache[channel_id] = ""
             return None
-        try:
-            payload = await fetch(channel_id=channel_id)
-        except (DiscordAPIError, OSError) as exc:
-            log_event(
-                self._logger,
-                logging.WARNING,
-                "discord.channel_directory.channel_lookup_failed",
-                channel_id=channel_id,
-                exc=exc,
-            )
-            self._channel_name_cache[channel_id] = ""
-            return None
-        if not isinstance(payload, dict):
-            self._channel_name_cache[channel_id] = ""
-            return None
-        channel_label = self._first_non_empty_text(payload.get("name"))
-        if channel_label is None:
-            self._channel_name_cache[channel_id] = ""
-            return None
-        normalized = channel_label.lstrip("#")
-        self._channel_name_cache[channel_id] = normalized
+        in_flight = self._channel_name_lookups.get(channel_id)
+        if in_flight is None:
 
-        return normalized
+            async def _load_channel_name() -> Optional[str]:
+                try:
+                    payload = await fetch(channel_id=channel_id)
+                except (DiscordAPIError, OSError) as exc:
+                    log_event(
+                        self._logger,
+                        logging.WARNING,
+                        "discord.channel_directory.channel_lookup_failed",
+                        channel_id=channel_id,
+                        exc=exc,
+                    )
+                    self._channel_name_cache[channel_id] = ""
+                    return None
+                if not isinstance(payload, dict):
+                    self._channel_name_cache[channel_id] = ""
+                    return None
+                channel_label = self._first_non_empty_text(payload.get("name"))
+                if channel_label is None:
+                    self._channel_name_cache[channel_id] = ""
+                    return None
+                normalized = channel_label.lstrip("#")
+                self._channel_name_cache[channel_id] = normalized
+                return normalized
+
+            in_flight = asyncio.create_task(_load_channel_name())
+            self._channel_name_lookups[channel_id] = in_flight
+        try:
+            return await in_flight
+        finally:
+            if self._channel_name_lookups.get(channel_id) is in_flight:
+                self._channel_name_lookups.pop(channel_id, None)
 
     async def _resolve_guild_name(self, guild_id: str) -> Optional[str]:
         fetch = getattr(self._rest, "get_guild", None)
         if not callable(fetch):
             self._guild_name_cache[guild_id] = ""
             return None
+        in_flight = self._guild_name_lookups.get(guild_id)
+        if in_flight is None:
+
+            async def _load_guild_name() -> Optional[str]:
+                try:
+                    payload = await fetch(guild_id=guild_id)
+                except (DiscordAPIError, OSError) as exc:
+                    log_event(
+                        self._logger,
+                        logging.WARNING,
+                        "discord.channel_directory.guild_lookup_failed",
+                        guild_id=guild_id,
+                        exc=exc,
+                    )
+                    self._guild_name_cache[guild_id] = ""
+                    return None
+                if not isinstance(payload, dict):
+                    self._guild_name_cache[guild_id] = ""
+                    return None
+                guild_label = self._first_non_empty_text(payload.get("name"))
+                if guild_label is None:
+                    self._guild_name_cache[guild_id] = ""
+                    return None
+                self._guild_name_cache[guild_id] = guild_label
+                return guild_label
+
+            in_flight = asyncio.create_task(_load_guild_name())
+            self._guild_name_lookups[guild_id] = in_flight
         try:
-            payload = await fetch(guild_id=guild_id)
-        except (DiscordAPIError, OSError) as exc:
-            log_event(
-                self._logger,
-                logging.WARNING,
-                "discord.channel_directory.guild_lookup_failed",
-                guild_id=guild_id,
-                exc=exc,
-            )
-            self._guild_name_cache[guild_id] = ""
-            return None
-        if not isinstance(payload, dict):
-            self._guild_name_cache[guild_id] = ""
-            return None
-        guild_label = self._first_non_empty_text(payload.get("name"))
-        if guild_label is None:
-            self._guild_name_cache[guild_id] = ""
-            return None
-        self._guild_name_cache[guild_id] = guild_label
-        return guild_label
+            return await in_flight
+        finally:
+            if self._guild_name_lookups.get(guild_id) is in_flight:
+                self._guild_name_lookups.pop(guild_id, None)
 
     @staticmethod
     def _nested_text(payload: dict[str, Any], key: str, field: str) -> Optional[str]:

--- a/tests/integrations/discord/test_channel_directory_ingest.py
+++ b/tests/integrations/discord/test_channel_directory_ingest.py
@@ -216,6 +216,56 @@ async def test_message_create_uses_negative_lookup_cache_for_missing_names(
 
 
 @pytest.mark.anyio
+async def test_message_create_concurrent_rest_resolution_deduplicates_lookups(
+    tmp_path: Path,
+) -> None:
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway(),
+    )
+
+    async def _slow_get_channel(*, channel_id: str) -> dict[str, Any]:
+        rest.get_channel_calls.append(channel_id)
+        await asyncio.sleep(0.01)
+        return {
+            "id": channel_id,
+            "guild_id": "guild-9",
+            "name": "renamed-room",
+        }
+
+    async def _slow_get_guild(*, guild_id: str) -> dict[str, Any]:
+        rest.get_guild_calls.append(guild_id)
+        await asyncio.sleep(0.01)
+        return {"id": guild_id, "name": "CAR HQ"}
+
+    rest.get_channel = _slow_get_channel  # type: ignore[assignment]
+    rest.get_guild = _slow_get_guild  # type: ignore[assignment]
+
+    payload = {
+        "id": "m-5",
+        "channel_id": "channel-9",
+        "guild_id": "guild-9",
+        "content": "hello",
+        "author": {"id": "user-1", "bot": False},
+    }
+
+    await asyncio.gather(
+        service._record_channel_directory_seen_from_message_payload(dict(payload)),
+        service._record_channel_directory_seen_from_message_payload(dict(payload)),
+    )
+
+    entries = ChannelDirectoryStore(tmp_path).list_entries(limit=None)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["display"] == "CAR HQ / #renamed-room"
+    assert rest.get_channel_calls == ["channel-9"]
+    assert rest.get_guild_calls == ["guild-9"]
+
+
+@pytest.mark.anyio
 async def test_message_create_dispatch_does_not_wait_for_channel_directory_lookup(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## What changed
- moved Discord `MESSAGE_CREATE` channel-directory recording off the gateway hot path so it no longer blocks later interaction callbacks
- kept the existing directory enrichment behavior, but scheduled it as background work instead of awaiting it inline
- updated the channel-directory tests to call the recording helper directly where appropriate
- added a regression test proving slow channel-directory lookup does not delay message dispatch

## Why
Discord slash commands must acknowledge within roughly 3 seconds. The `MESSAGE_CREATE` dispatch path was awaiting channel and guild directory enrichment, and that enrichment can perform REST lookups to Discord. Under message traffic, that serialized gateway work could delay a later slash command long enough for Discord to show `The application did not respond`, even though the command handler itself correctly defers.

## Impact
- reduces intermittent Discord slash-command failures caused by gateway callback starvation
- specifically protects commands like `/car newt` that should acknowledge immediately before doing slower work
- preserves the channel-directory feature without making it part of the interaction deadline path

## Root cause
The root cause was synchronous REST-backed channel-directory enrichment inside the gateway `MESSAGE_CREATE` callback. Because gateway dispatch is serialized, a slow message-side lookup could consume the same dispatch lane needed for a subsequent interaction ack.

## Validation
- `python3 -m compileall src/codex_autorunner/integrations/discord/service.py tests/integrations/discord/test_channel_directory_ingest.py`
- `.venv/bin/python -m pytest tests/integrations/discord/test_channel_directory_ingest.py tests/integrations/discord/test_reliability.py -q`
- repo pre-commit hook, including strict typecheck, frontend build/tests, and pytest fast suite
