### PR TITLE
[codex] Fix Discord interaction callback retry budget

### DIFF
--- a/src/codex_autorunner/integrations/discord/rest.py
+++ b/src/codex_autorunner/integrations/discord/rest.py
@@ -20,8 +20,10 @@ _DISCORD_ATTACHMENT_HOSTS = frozenset({"cdn.discordapp.com", "media.discordapp.n
 # Initial interaction callback must reach Discord before the ~3s interaction
 # deadline. A 2s read timeout caused avoidable "application did not respond"
 # when the API or network was slightly slow; stay under 3s but allow headroom.
+# These callbacks must not retry: a second attempt can push the ack past
+# Discord's hard deadline even if it uses zero backoff.
 DISCORD_INTERACTION_CALLBACK_TIMEOUT_SECONDS = 2.85
-DISCORD_INTERACTION_CALLBACK_MAX_RETRIES = 1
+DISCORD_INTERACTION_CALLBACK_MAX_RETRIES = 0
 
 
 class DiscordRestClient:
@@ -106,7 +108,7 @@ class DiscordRestClient:
         self, *, path: str, max_retries: int
     ) -> bool:
         return (
-            max_retries <= DISCORD_INTERACTION_CALLBACK_MAX_RETRIES
+            max_retries == DISCORD_INTERACTION_CALLBACK_MAX_RETRIES
             and path.startswith("/interactions/")
             and path.endswith("/callback")
         )

--- a/tests/integrations/discord/test_rest_client.py
+++ b/tests/integrations/discord/test_rest_client.py
@@ -245,7 +245,7 @@ async def test_interaction_4xx_does_not_open_shared_breaker() -> None:
 
 
 @pytest.mark.anyio
-async def test_interaction_callback_retries_fast_transient_network_error(
+async def test_interaction_callback_does_not_retry_transient_network_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     attempts = {"count": 0}
@@ -272,15 +272,16 @@ async def test_interaction_callback_retries_fast_transient_network_error(
     )
     await _configure_mock_client(client, httpx.MockTransport(handler))
     try:
-        await client.create_interaction_response(
-            interaction_id="123",
-            interaction_token="token",
-            payload={"type": 5},
-        )
+        with pytest.raises(DiscordTransientError, match="network error"):
+            await client.create_interaction_response(
+                interaction_id="123",
+                interaction_token="token",
+                payload={"type": 5},
+            )
     finally:
         await client.close()
 
-    assert attempts["count"] == 2
+    assert attempts["count"] == 1
     assert sleeps == []
 
 


### PR DESCRIPTION
## What changed
- stop retrying initial Discord interaction callbacks (`/interactions/.../callback`)
- keep the 2.85s callback timeout but enforce a single-attempt ack path
- update the REST client test to assert transient network errors do not retry on the initial callback path

## Why
Discord slash commands have a hard initial acknowledgement window of about 3 seconds. On April 9, 2026, commit `8e18c905` changed the callback path to allow one fast retry. That retry had zero backoff, but it still doubled the wall-clock budget for the initial ack path when the first attempt stalled or timed out.

That creates the exact user-visible failure we are still seeing:
- Discord shows `The application did not respond`
- the command body can still finish later and post a success message

`/car newt` is a good example because the handler itself defers immediately and only does git/setup work after that. The remaining timeout source is the callback boundary, not the command body.

## Impact
- transient callback failures now fail fast instead of retrying past Discord's ack deadline
- this should reduce false timeout banners for slash commands, components, modals, and autocomplete interactions that depend on the same callback endpoint

## Validation
- `.venv/bin/pytest tests/integrations/discord/test_rest_client.py -q`
- `.venv/bin/pytest tests/integrations/discord/test_rest_client.py tests/integrations/discord/test_reliability.py -q`
- repository commit hooks passed, including full validation and `4607` pytest cases
