### PR TITLE
[codex] Fix Hermes PMA profile launch handling

### DIFF
--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
+from os.path import basename
 from pathlib import Path
 from typing import Any, AsyncIterator, Awaitable, Callable, Mapping, Optional, Sequence
 
@@ -567,6 +568,61 @@ def _workspace_key(workspace_root: Path) -> str:
     return str(canonical_workspace_root(workspace_root))
 
 
+def _configured_hermes_binary(
+    config: RepoConfig | HubConfig,
+    *,
+    agent_id: str,
+    profile: Optional[str] = None,
+) -> Optional[str]:
+    try:
+        try:
+            return config.agent_binary(agent_id, profile=profile).strip()
+        except TypeError as exc:
+            if "profile" not in str(exc):
+                raise
+            return config.agent_binary(agent_id).strip()
+    except (
+        KeyError,
+        AttributeError,
+        ValueError,
+        TypeError,
+        RuntimeError,
+    ):  # intentional: config lookup may raise various errors
+        return None
+
+
+def _resolve_hermes_launch(
+    config: RepoConfig | HubConfig,
+    *,
+    agent_id: str,
+    profile: Optional[str] = None,
+) -> tuple[list[str], str]:
+    normalized_agent_id = str(agent_id or "").strip().lower() or HERMES_RUNTIME_ID
+    normalized_profile = _normalize_optional_text(profile)
+    configured_binary = _configured_hermes_binary(
+        config,
+        agent_id=normalized_agent_id,
+        profile=normalized_profile,
+    )
+    configured_name = basename(configured_binary) if configured_binary else ""
+    if (
+        normalized_agent_id != HERMES_RUNTIME_ID
+        and normalized_profile is None
+        and configured_name == normalized_agent_id
+    ):
+        base_binary = _configured_hermes_binary(config, agent_id=HERMES_RUNTIME_ID)
+        if base_binary:
+            return [
+                base_binary,
+                "-p",
+                normalized_agent_id,
+                HERMES_ACP_COMMAND,
+            ], base_binary
+    if configured_binary:
+        return [configured_binary, HERMES_ACP_COMMAND], configured_binary
+    raise KeyError(normalized_agent_id)
+
+
 def build_hermes_supervisor_from_config(
     config: RepoConfig | HubConfig,
     *,
@@ -577,12 +633,11 @@ def build_hermes_supervisor_from_config(
     logger: Optional[logging.Logger] = None,
 ) -> Optional[HermesSupervisor]:
     try:
-        try:
-            binary = config.agent_binary(agent_id, profile=profile).strip()
-        except TypeError as exc:
-            if "profile" not in str(exc):
-                raise
-            binary = config.agent_binary(agent_id).strip()
+        command, _binary = _resolve_hermes_launch(
+            config,
+            agent_id=agent_id,
+            profile=profile,
+        )
     except (
         KeyError,
         AttributeError,
@@ -591,10 +646,8 @@ def build_hermes_supervisor_from_config(
         RuntimeError,
     ):  # intentional: config lookup may raise various errors
         return None
-    if not binary:
-        return None
     return HermesSupervisor(
-        [binary, HERMES_ACP_COMMAND],
+        command,
         approval_handler=approval_handler,
         default_approval_decision=default_approval_decision,
         logger=logger,
@@ -610,19 +663,12 @@ def hermes_binary_available(
     if config is None:
         return False
     try:
-        try:
-            binary = config.agent_binary(agent_id, profile=profile).strip()
-        except TypeError as exc:
-            if "profile" not in str(exc):
-                raise
-            binary = config.agent_binary(agent_id).strip()
-    except (
-        KeyError,
-        AttributeError,
-        ValueError,
-        TypeError,
-        RuntimeError,
-    ):  # intentional: config lookup may raise various errors
+        _command, binary = _resolve_hermes_launch(
+            config,
+            agent_id=agent_id,
+            profile=profile,
+        )
+    except (KeyError, AttributeError, ValueError, TypeError, RuntimeError):
         return False
     if not binary:
         return False
@@ -652,15 +698,11 @@ def hermes_runtime_preflight(
             fix=f"Set {binary_key} in the repo or hub config.",
         )
     try:
-        try:
-            binary = config.agent_binary(
-                normalized_agent_id,
-                profile=normalized_profile or None,
-            ).strip()
-        except TypeError as exc:
-            if "profile" not in str(exc):
-                raise
-            binary = config.agent_binary(normalized_agent_id).strip()
+        command, binary = _resolve_hermes_launch(
+            config,
+            agent_id=normalized_agent_id,
+            profile=normalized_profile or None,
+        )
     except (
         KeyError,
         AttributeError,
@@ -709,7 +751,7 @@ def hermes_runtime_preflight(
         version = None
     try:
         result = subprocess.run(
-            [binary, HERMES_ACP_COMMAND, "--help"],
+            [*command, "--help"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/tests/agents/hermes/test_hermes_supervisor.py
+++ b/tests/agents/hermes/test_hermes_supervisor.py
@@ -14,6 +14,7 @@ from codex_autorunner.agents.acp.errors import (
 from codex_autorunner.agents.hermes.supervisor import (
     HermesSupervisor,
     HermesSupervisorError,
+    build_hermes_supervisor_from_config,
     hermes_runtime_preflight,
 )
 
@@ -28,6 +29,26 @@ class _HermesPreflightConfig:
     def agent_binary(self, agent_id: str) -> str:
         assert agent_id == "hermes"
         return "hermes"
+
+
+class _HermesAliasConfig:
+    def agent_binary(self, agent_id: str, *, profile: str | None = None) -> str:
+        assert profile is None
+        if agent_id == "hermes":
+            return "hermes"
+        if agent_id == "hermes-m4-pma":
+            return "hermes-m4-pma"
+        raise AssertionError(f"unexpected agent_id: {agent_id}")
+
+
+class _HermesCustomAliasConfig:
+    def agent_binary(self, agent_id: str, *, profile: str | None = None) -> str:
+        assert profile is None
+        if agent_id == "hermes":
+            return "hermes"
+        if agent_id == "hermes-special":
+            return "/opt/hermes/special-launcher"
+        raise AssertionError(f"unexpected agent_id: {agent_id}")
 
 
 async def _collect_events(
@@ -127,6 +148,105 @@ def test_hermes_runtime_preflight_accepts_plain_acp_help(
     assert result.launch_mode is None
     assert result.version == "hermes 1.2.3"
     assert "Hermes-native durable sessions" in result.message
+
+
+def test_build_hermes_supervisor_prefers_base_binary_for_alias_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+
+    class _FakeHermesSupervisor:
+        def __init__(self, command, **kwargs):  # type: ignore[no-untyped-def]
+            observed["command"] = list(command)
+            observed["kwargs"] = dict(kwargs)
+
+    monkeypatch.setattr(
+        "codex_autorunner.agents.hermes.supervisor.HermesSupervisor",
+        _FakeHermesSupervisor,
+    )
+
+    supervisor = build_hermes_supervisor_from_config(
+        _HermesAliasConfig(),
+        agent_id="hermes-m4-pma",
+    )
+
+    assert supervisor is not None
+    assert observed["command"] == [
+        "hermes",
+        "-p",
+        "hermes-m4-pma",
+        "acp",
+    ]
+
+
+def test_hermes_runtime_preflight_prefers_base_binary_for_alias_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        "codex_autorunner.agents.hermes.supervisor.resolve_executable",
+        lambda _name: "/usr/bin/hermes",
+    )
+
+    def fake_run(cmd, capture_output, text, timeout):  # type: ignore[no-untyped-def]
+        observed_commands.append(list(cmd))
+        if cmd == ["hermes", "--version"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="hermes 1.2.3\n",
+                stderr="",
+            )
+        if cmd == ["hermes", "-p", "hermes-m4-pma", "acp", "--help"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="",
+                stderr="Usage: hermes acp [OPTIONS]\n  Start the ACP server.\n",
+            )
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = hermes_runtime_preflight(
+        _HermesAliasConfig(),
+        agent_id="hermes-m4-pma",
+    )
+
+    assert observed_commands == [
+        ["hermes", "--version"],
+        ["hermes", "-p", "hermes-m4-pma", "acp", "--help"],
+    ]
+    assert result.status == "ready"
+    assert result.version == "hermes 1.2.3"
+
+
+def test_build_hermes_supervisor_preserves_custom_alias_binary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+
+    class _FakeHermesSupervisor:
+        def __init__(self, command, **kwargs):  # type: ignore[no-untyped-def]
+            observed["command"] = list(command)
+            observed["kwargs"] = dict(kwargs)
+
+    monkeypatch.setattr(
+        "codex_autorunner.agents.hermes.supervisor.HermesSupervisor",
+        _FakeHermesSupervisor,
+    )
+
+    supervisor = build_hermes_supervisor_from_config(
+        _HermesCustomAliasConfig(),
+        agent_id="hermes-special",
+    )
+
+    assert supervisor is not None
+    assert observed["command"] == [
+        "/opt/hermes/special-launcher",
+        "acp",
+    ]
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## What changed
This PR hardens Hermes PMA launch resolution for wrapper-style Hermes aliases such as `hermes-m4-pma`.

It updates the Hermes supervisor to:
- prefer launching wrapper-shaped Hermes aliases via the base `hermes` binary plus `-p <alias>`
- keep using the configured alias binary when the alias points at a genuinely distinct launcher
- run preflight against the same resolved launch command used at runtime

It also adds regression coverage for:
- wrapper-style alias launch resolution
- preserving custom alias binaries
- Hermes PMA profile validation through the existing PMA route tests

## Why
During reproduction, Hermes ACP initialization succeeded but `session/new` failed immediately for the PMA profile path. The backend error from Hermes was an internal error with profile-specific provider details.

The immediate production failure was caused by local Hermes profile credential drift outside this repo: the `hermes-m4-pma` profile expected `ZAI_API_KEY` after the Hermes update, while the local profile env still only exposed the older `GLM_API_KEY` name.

Separately, CAR was still treating Hermes aliases as standalone ACP binaries. This PR makes CAR's launch behavior match the profile-style Hermes alias model used by PMA without breaking custom alias binaries.

## Impact
- Hermes PMA alias launches are more robust against wrapper-script behavior changes.
- Future custom Hermes alias binaries still keep their own launch path.
- The failure mode is now covered by focused regression tests.

## Validation
- `./car pma chat --path /Users/dazheng/car-workspace 'Echo hello world for me'`
- `.venv/bin/pytest tests/agents/hermes/test_hermes_supervisor.py tests/test_agents_registry.py tests/test_pma_routes.py -q -k 'hermes or hermes_profile'`
- Pre-commit hooks during `git commit` ran repo checks including mypy, frontend build/tests, and full pytest.