### PR TITLE
[codex] Speed up Discord turn handoff

### DIFF
--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -349,6 +349,15 @@ def _claim_discord_reusable_progress_message(
     return None
 
 
+def _managed_thread_surface_key_for_notification_reply(
+    notification_reply: Any,
+) -> Optional[str]:
+    notification_id = getattr(notification_reply, "notification_id", None)
+    if isinstance(notification_id, str) and notification_id.strip():
+        return notification_surface_key(notification_id)
+    return None
+
+
 async def _acknowledge_discord_progress_reuse(
     service: Any,
     *,
@@ -619,6 +628,10 @@ async def _submit_discord_thread_message(
     *,
     dispatch: _DiscordMessageTurnDispatch,
 ) -> DiscordMessageTurnResult:
+    managed_thread_surface_key = _managed_thread_surface_key_for_notification_reply(
+        dispatch.notification_reply
+    )
+
     async def _send_initial_progress_placeholder() -> Optional[str]:
         try:
             response = await dispatch.service._send_channel_message(
@@ -650,6 +663,7 @@ async def _submit_discord_thread_message(
         _orchestration_service, thread = resolve_discord_thread_target(
             dispatch.service,
             channel_id=dispatch.channel_id,
+            managed_thread_surface_key=managed_thread_surface_key,
             workspace_root=request.workspace_root,
             agent=logical_agent,
             agent_profile=agent_profile,
@@ -671,7 +685,12 @@ async def _submit_discord_thread_message(
         return thread_target_id or None
 
     async def _run_in_background() -> None:
-        turn_result = await _execute_discord_thread_message(request, dispatch=dispatch)
+        turn_result = await _execute_discord_thread_message(
+            request,
+            dispatch=dispatch,
+            initial_progress_message_id=progress_message_id,
+            managed_thread_surface_key=managed_thread_surface_key,
+        )
         await _deliver_discord_turn_result(
             dispatch,
             workspace_root=request.workspace_root,
@@ -705,6 +724,8 @@ async def _execute_discord_thread_message(
     request: SurfaceThreadMessageRequest,
     *,
     dispatch: _DiscordMessageTurnDispatch,
+    initial_progress_message_id: Optional[str] = None,
+    managed_thread_surface_key: Optional[str] = None,
 ) -> DiscordMessageTurnResult:
     request_workspace_root = request.workspace_root
     prompt_text = dispatch.turn_text
@@ -748,7 +769,11 @@ async def _execute_discord_thread_message(
                     ),
                 },
             )
-        return DiscordMessageTurnResult(final_message="", send_final_message=False)
+        return DiscordMessageTurnResult(
+            final_message="",
+            preview_message_id=initial_progress_message_id,
+            send_final_message=False,
+        )
 
     if not dispatch.effective_pma_enabled:
         prompt_text, injected = maybe_inject_car_awareness(
@@ -819,7 +844,11 @@ async def _execute_discord_thread_message(
                 dispatch.channel_id,
                 {"content": "Failed to build PMA context. Please try again."},
             )
-            return DiscordMessageTurnResult(final_message="", send_final_message=False)
+            return DiscordMessageTurnResult(
+                final_message="",
+                preview_message_id=initial_progress_message_id,
+                send_final_message=False,
+            )
 
     prompt_text, _github_injected = await dispatch.service._maybe_inject_github_context(
         prompt_text,
@@ -850,9 +879,15 @@ async def _execute_discord_thread_message(
         ),
         "source_message_id": dispatch.event.message.message_id,
     }
-    if dispatch.notification_reply is not None:
-        run_turn_kwargs["managed_thread_surface_key"] = notification_surface_key(
-            dispatch.notification_reply.notification_id
+    resolved_managed_thread_surface_key = (
+        managed_thread_surface_key
+        or _managed_thread_surface_key_for_notification_reply(
+            dispatch.notification_reply
+        )
+    )
+    if resolved_managed_thread_surface_key is not None:
+        run_turn_kwargs["managed_thread_surface_key"] = (
+            resolved_managed_thread_surface_key
         )
     if turn_input_items:
         run_turn_kwargs["input_items"] = turn_input_items
@@ -889,7 +924,11 @@ async def _execute_discord_thread_message(
                 )
             },
         )
-        return DiscordMessageTurnResult(final_message="", send_final_message=False)
+        return DiscordMessageTurnResult(
+            final_message="",
+            preview_message_id=initial_progress_message_id,
+            send_final_message=False,
+        )
 
 
 async def _handle_discord_notification_turn(

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -114,6 +114,7 @@ class DiscordMessageTurnResult:
     token_usage: Optional[dict[str, Any]] = None
     elapsed_seconds: Optional[float] = None
     send_final_message: bool = True
+    deferred_delivery: bool = False
 
 
 @dataclass(frozen=True)
@@ -333,11 +334,10 @@ def _claim_discord_reusable_progress_message(
         return None
     requests = _get_discord_progress_reuse_requests(service)
     request = requests.get(normalized_thread_target_id)
-    if not isinstance(request, _DiscordProgressReuseRequest):
-        return None
-    if request.source_message_id != normalized_source_message_id:
-        return None
-    requests.pop(normalized_thread_target_id, None)
+    if isinstance(request, _DiscordProgressReuseRequest):
+        if request.source_message_id != normalized_source_message_id:
+            return None
+        requests.pop(normalized_thread_target_id, None)
     reusable = _get_discord_reusable_progress_messages(service).pop(
         normalized_thread_target_id, None
     )
@@ -619,6 +619,93 @@ async def _submit_discord_thread_message(
     *,
     dispatch: _DiscordMessageTurnDispatch,
 ) -> DiscordMessageTurnResult:
+    async def _send_initial_progress_placeholder() -> Optional[str]:
+        try:
+            response = await dispatch.service._send_channel_message(
+                dispatch.channel_id,
+                {"content": "Received. Preparing turn..."},
+            )
+        except (RuntimeError, ConnectionError, OSError):
+            dispatch.service._logger.warning(
+                "Discord initial progress placeholder send failed for channel=%s",
+                dispatch.channel_id,
+                exc_info=True,
+            )
+            return None
+        message_id = response.get("id")
+        return message_id if isinstance(message_id, str) and message_id else None
+
+    async def _resolve_managed_thread_id() -> Optional[str]:
+        binding = await dispatch.service._store.get_binding(
+            channel_id=dispatch.channel_id
+        )
+        logical_agent, agent_profile = dispatch.service._resolve_agent_state(binding)
+        if not isinstance(logical_agent, str) or not logical_agent.strip():
+            logical_agent = dispatch.agent
+        repo_id = binding.get("repo_id") if isinstance(binding, dict) else None
+        resource_kind = (
+            binding.get("resource_kind") if isinstance(binding, dict) else None
+        )
+        resource_id = binding.get("resource_id") if isinstance(binding, dict) else None
+        _orchestration_service, thread = resolve_discord_thread_target(
+            dispatch.service,
+            channel_id=dispatch.channel_id,
+            workspace_root=request.workspace_root,
+            agent=logical_agent,
+            agent_profile=agent_profile,
+            repo_id=repo_id if isinstance(repo_id, str) and repo_id.strip() else None,
+            resource_kind=(
+                resource_kind.strip()
+                if isinstance(resource_kind, str) and resource_kind.strip()
+                else None
+            ),
+            resource_id=(
+                resource_id.strip()
+                if isinstance(resource_id, str) and resource_id.strip()
+                else None
+            ),
+            mode="pma" if request.pma_enabled else "repo",
+            pma_enabled=request.pma_enabled,
+        )
+        thread_target_id = str(getattr(thread, "thread_target_id", "") or "").strip()
+        return thread_target_id or None
+
+    async def _run_in_background() -> None:
+        turn_result = await _execute_discord_thread_message(request, dispatch=dispatch)
+        await _deliver_discord_turn_result(
+            dispatch,
+            workspace_root=request.workspace_root,
+            turn_result=turn_result,
+        )
+
+    progress_message_id = await _send_initial_progress_placeholder()
+    if (
+        progress_message_id is not None
+        and isinstance(dispatch.event.message.message_id, str)
+        and dispatch.event.message.message_id
+    ):
+        thread_target_id = await _resolve_managed_thread_id()
+        if thread_target_id:
+            _stash_discord_reusable_progress_message(
+                dispatch.service,
+                thread_target_id=thread_target_id,
+                source_message_id=dispatch.event.message.message_id,
+                channel_id=dispatch.channel_id,
+                message_id=progress_message_id,
+            )
+    dispatch.service._spawn_task(_run_in_background())
+    return DiscordMessageTurnResult(
+        final_message="",
+        send_final_message=False,
+        deferred_delivery=True,
+    )
+
+
+async def _execute_discord_thread_message(
+    request: SurfaceThreadMessageRequest,
+    *,
+    dispatch: _DiscordMessageTurnDispatch,
+) -> DiscordMessageTurnResult:
     request_workspace_root = request.workspace_root
     prompt_text = dispatch.turn_text
     (
@@ -834,6 +921,64 @@ async def _handle_discord_notification_turn(
     return turn_result
 
 
+async def _deliver_discord_turn_result(
+    dispatch: _DiscordMessageTurnDispatch,
+    *,
+    workspace_root: Path,
+    turn_result: Any,
+) -> None:
+    if isinstance(turn_result, DiscordMessageTurnResult):
+        if turn_result.deferred_delivery:
+            return
+        response_text = turn_result.final_message
+        preview_message_id = turn_result.preview_message_id
+        send_final_message = turn_result.send_final_message
+        intermediate_text = (
+            turn_result.intermediate_message.strip()
+            if isinstance(turn_result.intermediate_message, str)
+            else ""
+        )
+        response_text = compose_turn_response_with_footer(
+            response_text,
+            summary_text=intermediate_text,
+            token_usage=turn_result.token_usage,
+            elapsed_seconds=turn_result.elapsed_seconds,
+            agent=dispatch.agent,
+            model=dispatch.model_override,
+        )
+    else:
+        response_text = str(turn_result or "")
+        preview_message_id = None
+        send_final_message = True
+
+    if isinstance(preview_message_id, str) and preview_message_id:
+        await dispatch.service._delete_channel_message_safe(
+            channel_id=dispatch.channel_id,
+            message_id=preview_message_id,
+            record_id=(
+                f"turn:delete_progress:{dispatch.session_key}:{uuid.uuid4().hex[:8]}"
+            ),
+        )
+    if send_final_message:
+        await _send_discord_turn_section(
+            dispatch.service,
+            channel_id=dispatch.channel_id,
+            text=response_text or "(No response text returned.)",
+            record_prefix=f"turn:final:{dispatch.session_key}",
+            attachment_filename="final-response.md",
+            attachment_caption="Final response too long; attached as final-response.md.",
+        )
+    if dispatch.pending_compact_seed is not None:
+        await dispatch.service._store.clear_pending_compact_seed(
+            channel_id=dispatch.channel_id
+        )
+    if send_final_message:
+        await dispatch.service._flush_outbox_files(
+            workspace_root=workspace_root,
+            channel_id=dispatch.channel_id,
+        )
+
+
 async def handle_message_event(
     service: Any,
     event: ChatMessageEvent,
@@ -954,51 +1099,11 @@ async def handle_message_event(
             return
         turn_result = result.thread_result
 
-    if isinstance(turn_result, DiscordMessageTurnResult):
-        response_text = turn_result.final_message
-        preview_message_id = turn_result.preview_message_id
-        send_final_message = turn_result.send_final_message
-        intermediate_text = (
-            turn_result.intermediate_message.strip()
-            if isinstance(turn_result.intermediate_message, str)
-            else ""
-        )
-        response_text = compose_turn_response_with_footer(
-            response_text,
-            summary_text=intermediate_text,
-            token_usage=turn_result.token_usage,
-            elapsed_seconds=turn_result.elapsed_seconds,
-            agent=agent,
-            model=model_override,
-        )
-    else:
-        response_text = str(turn_result or "")
-        preview_message_id = None
-        send_final_message = True
-        intermediate_text = ""
-
-    if isinstance(preview_message_id, str) and preview_message_id:
-        await service._delete_channel_message_safe(
-            channel_id=channel_id,
-            message_id=preview_message_id,
-            record_id=f"turn:delete_progress:{session_key}:{uuid.uuid4().hex[:8]}",
-        )
-    if send_final_message:
-        await _send_discord_turn_section(
-            service,
-            channel_id=channel_id,
-            text=response_text or "(No response text returned.)",
-            record_prefix=f"turn:final:{session_key}",
-            attachment_filename="final-response.md",
-            attachment_caption="Final response too long; attached as final-response.md.",
-        )
-    if pending_compact_seed is not None:
-        await service._store.clear_pending_compact_seed(channel_id=channel_id)
-    if send_final_message:
-        await service._flush_outbox_files(
-            workspace_root=workspace_root,
-            channel_id=channel_id,
-        )
+    await _deliver_discord_turn_result(
+        dispatch,
+        workspace_root=workspace_root,
+        turn_result=turn_result,
+    )
 
 
 async def run_agent_turn_for_message(
@@ -1216,7 +1321,7 @@ def _build_discord_queue_worker_hooks(
                 channel_id,
                 {"content": message},
                 record_id=(
-                    "discord-queued:" f"{managed_thread_id}:{finalized.managed_turn_id}"
+                    f"discord-queued:{managed_thread_id}:{finalized.managed_turn_id}"
                 ),
             )
             return
@@ -1224,8 +1329,7 @@ def _build_discord_queue_worker_hooks(
             channel_id,
             {"content": (f"Turn failed: {finalized.error or public_execution_error}")},
             record_id=(
-                "discord-queued-error:"
-                f"{managed_thread_id}:{finalized.managed_turn_id}"
+                f"discord-queued-error:{managed_thread_id}:{finalized.managed_turn_id}"
             ),
         )
 
@@ -1581,14 +1685,18 @@ async def _run_discord_orchestrated_turn_for_message(
             ensure_queue_worker=ensure_queue_worker,
             direct_hooks=ManagedThreadExecutionHooks(
                 on_execution_started=(
-                    lambda active_execution: service._register_discord_turn_approval_context(
-                        started_execution=active_execution,
-                        channel_id=channel_id,
+                    lambda active_execution: (
+                        service._register_discord_turn_approval_context(
+                            started_execution=active_execution,
+                            channel_id=channel_id,
+                        )
                     )
                 ),
                 on_execution_finished=(
-                    lambda active_execution: service._clear_discord_turn_approval_context(
-                        started_execution=active_execution
+                    lambda active_execution: (
+                        service._clear_discord_turn_approval_context(
+                            started_execution=active_execution
+                        )
                     )
                 ),
                 on_progress_event=lambda run_event: _apply_discord_progress_run_event(

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -8,7 +8,7 @@ import uuid
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import Any, Awaitable, Optional, cast
 
 from ...agents.registry import get_registered_agents, wrap_requested_agent_context
 from ...core.context_awareness import (
@@ -356,6 +356,26 @@ def _managed_thread_surface_key_for_notification_reply(
     if isinstance(notification_id, str) and notification_id.strip():
         return notification_surface_key(notification_id)
     return None
+
+
+def _spawn_discord_background_task(
+    service: Any,
+    coro: Awaitable[None],
+    *,
+    await_on_shutdown: bool = False,
+) -> asyncio.Task[Any]:
+    spawn_task = service._spawn_task
+    if not await_on_shutdown:
+        return cast(asyncio.Task[Any], spawn_task(coro))
+    try:
+        return cast(
+            asyncio.Task[Any],
+            spawn_task(coro, await_on_shutdown=True),
+        )
+    except TypeError as exc:
+        if "await_on_shutdown" not in str(exc):
+            raise
+        return cast(asyncio.Task[Any], spawn_task(coro))
 
 
 async def _acknowledge_discord_progress_reuse(
@@ -712,7 +732,11 @@ async def _submit_discord_thread_message(
                 channel_id=dispatch.channel_id,
                 message_id=progress_message_id,
             )
-    dispatch.service._spawn_task(_run_in_background())
+    _spawn_discord_background_task(
+        dispatch.service,
+        _run_in_background(),
+        await_on_shutdown=True,
+    )
     return DiscordMessageTurnResult(
         final_message="",
         send_final_message=False,
@@ -1569,7 +1593,9 @@ async def _run_discord_orchestrated_turn_for_message(
         coordinator.ensure_queue_worker(
             task_map=_get_discord_thread_queue_task_map(service),
             managed_thread_id=managed_thread_id,
-            spawn_task=service._spawn_task,
+            spawn_task=lambda coro: _spawn_discord_background_task(
+                service, coro, await_on_shutdown=True
+            ),
             hooks=_build_discord_queue_worker_hooks(
                 service,
                 channel_id=channel_id,

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -305,6 +305,7 @@ DISCORD_TURN_PROGRESS_MIN_EDIT_INTERVAL_SECONDS = 1.0
 DISCORD_TURN_PROGRESS_HEARTBEAT_INTERVAL_SECONDS = 2.0
 DISCORD_TURN_PROGRESS_MAX_ACTIONS = 12
 DISCORD_TYPING_HEARTBEAT_INTERVAL_SECONDS = 5.0
+DISCORD_BACKGROUND_TASK_SHUTDOWN_GRACE_SECONDS = 10.0
 SHELL_OUTPUT_TRUNCATION_SUFFIX = "\n...[truncated]..."
 DISCORD_ATTACHMENT_MAX_BYTES = 100_000_000
 THREAD_LIST_MAX_PAGES = 5
@@ -629,6 +630,7 @@ class DiscordBotService:
         self._discord_turn_progress_reuse_requests: dict[str, Any] = {}
         self._discord_reusable_progress_messages: dict[str, Any] = {}
         self._background_tasks: set[asyncio.Task[Any]] = set()
+        self._background_shutdown_wait_tasks: set[asyncio.Task[Any]] = set()
         self._typing_sessions: dict[str, int] = {}
         self._typing_tasks: dict[str, asyncio.Task[Any]] = {}
         self._typing_lock: Optional[asyncio.Lock] = None
@@ -2945,11 +2947,31 @@ class DiscordBotService:
             )
 
     async def _shutdown(self) -> None:
+        drainable_tasks = [
+            task
+            for task in list(self._background_shutdown_wait_tasks)
+            if not task.done()
+        ]
+        if drainable_tasks:
+            done, pending = await asyncio.wait(
+                drainable_tasks,
+                timeout=DISCORD_BACKGROUND_TASK_SHUTDOWN_GRACE_SECONDS,
+            )
+            self._background_shutdown_wait_tasks.difference_update(done)
+            if pending:
+                log_event(
+                    self._logger,
+                    logging.WARNING,
+                    "discord.background_task.shutdown_timeout",
+                    timeout_seconds=DISCORD_BACKGROUND_TASK_SHUTDOWN_GRACE_SECONDS,
+                    pending_count=len(pending),
+                )
         if self._background_tasks:
             for task in list(self._background_tasks):
                 task.cancel()
             await asyncio.gather(*list(self._background_tasks), return_exceptions=True)
             self._background_tasks.clear()
+        self._background_shutdown_wait_tasks.clear()
         await self._command_runner.shutdown()
         if self._owns_gateway:
             with contextlib.suppress(Exception):  # intentional: shutdown cleanup
@@ -3141,14 +3163,19 @@ class DiscordBotService:
                     exc=enqueue_exc,
                 )
 
-    def _spawn_task(self, coro: Awaitable[None]) -> asyncio.Task[Any]:
+    def _spawn_task(
+        self, coro: Awaitable[None], *, await_on_shutdown: bool = False
+    ) -> asyncio.Task[Any]:
         task = cast(asyncio.Task[Any], asyncio.ensure_future(coro))
         self._background_tasks.add(task)
+        if await_on_shutdown:
+            self._background_shutdown_wait_tasks.add(task)
         task.add_done_callback(self._on_background_task_done)
         return task
 
     def _on_background_task_done(self, task: asyncio.Task[Any]) -> None:
         self._background_tasks.discard(task)
+        self._background_shutdown_wait_tasks.discard(task)
         try:
             task.result()
         except asyncio.CancelledError:

--- a/tests/discord_message_turns_support.py
+++ b/tests/discord_message_turns_support.py
@@ -53,6 +53,7 @@ from codex_autorunner.integrations.chat.collaboration_policy import (
     build_discord_collaboration_policy,
 )
 from codex_autorunner.integrations.chat.compaction import build_compact_seed_prompt
+from codex_autorunner.integrations.chat.dispatcher import build_dispatch_context
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
     DiscordBotMediaConfig,
@@ -2320,20 +2321,26 @@ async def test_message_event_submits_through_surface_orchestration_ingress(
         repo_id="repo-1",
     )
     rest = _FakeRest()
-    gateway = _FakeGateway([("MESSAGE_CREATE", _message_create("route via ingress"))])
     service = DiscordBotService(
         _config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
         logger=logging.getLogger("test"),
         rest_client=rest,
-        gateway_client=gateway,
+        gateway_client=_FakeGateway([]),
         state_store=store,
         outbox_manager=_FakeOutboxManager(),
     )
     captured: dict[str, object] = {}
+    turn_started = asyncio.Event()
+    release_turn = asyncio.Event()
 
     async def _fake_run_turn(**kwargs: Any) -> DiscordMessageTurnResult:
         captured["session_key"] = kwargs["session_key"]
-        return DiscordMessageTurnResult(final_message="handled by ingress")
+        turn_started.set()
+        await release_turn.wait()
+        return DiscordMessageTurnResult(
+            final_message="handled by ingress",
+            preview_message_id="msg-1",
+        )
 
     class _FakeIngress:
         async def submit_message(
@@ -2358,15 +2365,38 @@ async def test_message_event_submits_through_surface_orchestration_ingress(
     service._run_agent_turn_for_message = _fake_run_turn  # type: ignore[assignment]
 
     try:
-        await service.run_forever()
+        event = service._chat_adapter.parse_message_event(
+            _message_create("route via ingress")
+        )
+        assert event is not None
+        await discord_message_turns_module.handle_message_event(
+            service,
+            event,
+            build_dispatch_context(event),
+            channel_id="channel-1",
+            text="route via ingress",
+            has_attachments=False,
+            policy_result=None,
+            log_event_fn=discord_service_module.log_event,
+            build_ticket_flow_controller_fn=discord_service_module.build_ticket_flow_controller,
+            ensure_worker_fn=discord_service_module.ensure_worker,
+        )
+        await asyncio.wait_for(turn_started.wait(), timeout=1)
         assert captured["surface_kind"] == "discord"
         assert captured["prompt_text"] == "route via ingress"
         assert isinstance(captured["session_key"], str)
+        assert any(
+            message["payload"]["content"] == "Received. Preparing turn..."
+            for message in rest.channel_messages
+        )
+        release_turn.set()
+        await asyncio.gather(*list(service._background_tasks), return_exceptions=True)
         assert any(
             message["payload"]["content"] == "handled by ingress"
             for message in rest.channel_messages
         )
     finally:
+        release_turn.set()
         await store.close()
 
 
@@ -9699,17 +9729,18 @@ async def test_reset_discord_thread_binding_preserves_logical_hermes_profile(
             pma_enabled=False,
         )
 
-        had_previous, replacement_thread_id = (
-            await service._reset_discord_thread_binding(
-                channel_id="channel-1",
-                workspace_root=workspace.resolve(),
-                agent="hermes",
-                agent_profile="m4-pma",
-                repo_id=None,
-                resource_kind=None,
-                resource_id=None,
-                pma_enabled=False,
-            )
+        (
+            had_previous,
+            replacement_thread_id,
+        ) = await service._reset_discord_thread_binding(
+            channel_id="channel-1",
+            workspace_root=workspace.resolve(),
+            agent="hermes",
+            agent_profile="m4-pma",
+            repo_id=None,
+            resource_kind=None,
+            resource_id=None,
+            pma_enabled=False,
         )
 
         assert had_previous is True

--- a/tests/integrations/chat/test_orchestration_guardrails.py
+++ b/tests/integrations/chat/test_orchestration_guardrails.py
@@ -139,14 +139,17 @@ def test_discord_ordinary_turn_entrypoint_routes_only_via_shared_ingress() -> No
     path = REPO_ROOT / "src/codex_autorunner/integrations/discord/message_turns.py"
     function_node = _parse_function(path, "handle_message_event")
     submit_helper = _parse_function(path, "_submit_discord_thread_message")
+    execute_helper = _parse_function(path, "_execute_discord_thread_message")
 
     entrypoint_calls = _collect_reachable_call_names(function_node)
-    helper_calls = _collect_reachable_call_names(submit_helper)
+    submit_helper_calls = _collect_reachable_call_names(submit_helper)
+    execute_helper_calls = _collect_reachable_call_names(execute_helper)
 
     assert "_build_discord_surface_ingress" in entrypoint_calls
     assert "ingress.submit_message" in entrypoint_calls
     assert "service._run_agent_turn_for_message" not in entrypoint_calls
-    assert "dispatch.service._run_agent_turn_for_message" in helper_calls
+    assert "_execute_discord_thread_message" in submit_helper_calls
+    assert "dispatch.service._run_agent_turn_for_message" in execute_helper_calls
 
 
 def test_telegram_ordinary_turn_entrypoint_routes_only_via_shared_ingress() -> None:

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -450,6 +450,7 @@ async def test_discord_notification_reply_routes_to_pma_thread_with_context(
             self._logger = logging.getLogger("test")
             self._config = SimpleNamespace(root=tmp_path)
             self._hub_supervisor = object()
+            self._background_tasks: set[asyncio.Task[Any]] = set()
 
         def _resolve_agent_state(self, binding: dict[str, object]) -> tuple[str, None]:
             return str(binding.get("agent") or "codex"), None
@@ -501,6 +502,17 @@ async def test_discord_notification_reply_routes_to_pma_thread_with_context(
         ) -> None:
             return
 
+        async def _send_channel_message(
+            self, _channel_id: str, _payload: dict[str, object]
+        ) -> dict[str, object]:
+            return {"id": "msg-1"}
+
+        def _spawn_task(self, coro: Any) -> asyncio.Task[Any]:
+            task = asyncio.create_task(coro)
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+            return task
+
         async def _delete_channel_message_safe(
             self, *, channel_id: str, message_id: str, record_id: str
         ) -> None:
@@ -550,6 +562,14 @@ async def test_discord_notification_reply_routes_to_pma_thread_with_context(
             )
         ),
     )
+    monkeypatch.setattr(
+        discord_message_turns,
+        "resolve_discord_thread_target",
+        lambda *_args, **_kwargs: (
+            object(),
+            SimpleNamespace(thread_target_id="thread-target-123"),
+        ),
+    )
 
     thread = ChatThreadRef(platform="discord", chat_id="channel-1", thread_id=None)
     event = ChatMessageEvent(
@@ -562,8 +582,9 @@ async def test_discord_notification_reply_routes_to_pma_thread_with_context(
     )
     context = build_dispatch_context(event)
 
+    service = _ServiceStub()
     await discord_message_turns.handle_message_event(
-        _ServiceStub(),
+        service,
         event,
         context,
         channel_id="channel-1",
@@ -574,6 +595,7 @@ async def test_discord_notification_reply_routes_to_pma_thread_with_context(
         build_ticket_flow_controller_fn=lambda *_args, **_kwargs: None,
         ensure_worker_fn=lambda *_args, **_kwargs: None,
     )
+    await asyncio.gather(*list(service._background_tasks), return_exceptions=True)
 
     run_turn_kwargs = captured.get("run_turn_kwargs")
     assert isinstance(run_turn_kwargs, dict)

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -385,6 +385,146 @@ async def test_discord_message_turns_include_reply_context_in_prompt(
 
 
 @pytest.mark.anyio
+async def test_discord_message_turns_delete_immediate_placeholder_when_background_turn_exits_early(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    sent_messages: list[dict[str, object]] = []
+    deleted_messages: list[dict[str, str]] = []
+
+    class _StoreStub:
+        async def get_binding(self, *, channel_id: str) -> dict[str, object] | None:
+            assert channel_id == "channel-1"
+            return {
+                "workspace_path": str(workspace),
+                "agent": "codex",
+                "pma_enabled": False,
+                "model_override": None,
+                "reasoning_effort": None,
+            }
+
+    class _ServiceStub:
+        def __init__(self) -> None:
+            self._store = _StoreStub()
+            self._logger = logging.getLogger("test")
+            self._config = SimpleNamespace(root=tmp_path)
+            self._background_tasks: set[asyncio.Task[Any]] = set()
+
+        def _resolve_agent_state(self, binding: dict[str, object]) -> tuple[str, None]:
+            return str(binding.get("agent") or "codex"), None
+
+        def _runtime_agent_for_binding(self, binding: dict[str, object]) -> str:
+            return str(binding.get("agent") or "codex")
+
+        def _normalize_agent(self, value: object) -> str:
+            return str(value or "codex")
+
+        def _build_message_session_key(self, **_kwargs: object) -> str:
+            return "session-key"
+
+        async def _with_attachment_context(
+            self, *, prompt_text: str, **_kwargs: object
+        ) -> tuple[str, int, int, None, list[dict[str, object]]]:
+            _ = prompt_text
+            return "", 0, 1, None, []
+
+        async def _send_channel_message(
+            self, channel_id: str, payload: dict[str, object]
+        ) -> dict[str, object]:
+            sent_messages.append({"channel_id": channel_id, "payload": dict(payload)})
+            return {"id": f"msg-{len(sent_messages)}"}
+
+        async def _send_channel_message_safe(
+            self, channel_id: str, payload: dict[str, object]
+        ) -> None:
+            sent_messages.append({"channel_id": channel_id, "payload": dict(payload)})
+
+        async def _delete_channel_message_safe(
+            self, *, channel_id: str, message_id: str, record_id: str
+        ) -> None:
+            _ = record_id
+            deleted_messages.append(
+                {"channel_id": channel_id, "message_id": message_id}
+            )
+
+        async def _run_agent_turn_for_message(self, **_kwargs: object) -> object:
+            raise AssertionError("background turn should exit before submission")
+
+        def _spawn_task(self, coro: Any) -> asyncio.Task[Any]:
+            task = asyncio.create_task(coro)
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+            return task
+
+    class _IngressStub:
+        async def submit_message(
+            self,
+            request,
+            *,
+            resolve_paused_flow_target,
+            submit_flow_reply,
+            submit_thread_message,
+        ):
+            _ = resolve_paused_flow_target, submit_flow_reply
+            thread_result = await submit_thread_message(request)
+            return SimpleNamespace(route="thread", thread_result=thread_result)
+
+    monkeypatch.setattr(
+        discord_message_turns,
+        "build_surface_orchestration_ingress",
+        lambda **_: _IngressStub(),
+    )
+    monkeypatch.setattr(
+        discord_message_turns,
+        "resolve_discord_thread_target",
+        lambda *_args, **_kwargs: (
+            object(),
+            SimpleNamespace(thread_target_id="thread-target-123"),
+        ),
+    )
+
+    thread = ChatThreadRef(platform="discord", chat_id="channel-1", thread_id=None)
+    event = ChatMessageEvent(
+        update_id="update-2b",
+        thread=thread,
+        message=ChatMessageRef(thread=thread, message_id="msg-2"),
+        from_user_id="user-1",
+        text="",
+        attachments=[
+            {
+                "id": "att-1",
+                "filename": "note.txt",
+                "url": "https://example.invalid/note.txt",
+            }
+        ],
+    )
+    context = build_dispatch_context(event)
+
+    service = _ServiceStub()
+    await discord_message_turns.handle_message_event(
+        service,
+        event,
+        context,
+        channel_id="channel-1",
+        text="",
+        has_attachments=True,
+        policy_result=None,
+        log_event_fn=lambda *args, **kwargs: None,
+        build_ticket_flow_controller_fn=lambda *_args, **_kwargs: None,
+        ensure_worker_fn=lambda *_args, **_kwargs: None,
+    )
+    await asyncio.gather(*list(service._background_tasks), return_exceptions=True)
+
+    assert [message["payload"]["content"] for message in sent_messages] == [
+        "Received. Preparing turn...",
+        "Some Discord attachments could not be downloaded. Continuing with available inputs.",
+        "Failed to download attachments from Discord. Please retry.",
+    ]
+    assert deleted_messages == [{"channel_id": "channel-1", "message_id": "msg-1"}]
+
+
+@pytest.mark.anyio
 async def test_discord_notification_reply_routes_to_pma_thread_with_context(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -393,6 +533,7 @@ async def test_discord_notification_reply_routes_to_pma_thread_with_context(
     rebound_workspace = tmp_path / "rebound-workspace"
     rebound_workspace.mkdir()
     captured: dict[str, object] = {}
+    resolved_thread_target_calls: list[dict[str, object]] = []
     bind_calls: list[dict[str, str]] = []
 
     notification_reply = SimpleNamespace(
@@ -562,13 +703,15 @@ async def test_discord_notification_reply_routes_to_pma_thread_with_context(
             )
         ),
     )
+
+    def _fake_resolve_discord_thread_target(*_args: object, **kwargs: object) -> object:
+        resolved_thread_target_calls.append(dict(kwargs))
+        return object(), SimpleNamespace(thread_target_id="thread-target-123")
+
     monkeypatch.setattr(
         discord_message_turns,
         "resolve_discord_thread_target",
-        lambda *_args, **_kwargs: (
-            object(),
-            SimpleNamespace(thread_target_id="thread-target-123"),
-        ),
+        _fake_resolve_discord_thread_target,
     )
 
     thread = ChatThreadRef(platform="discord", chat_id="channel-1", thread_id=None)
@@ -604,6 +747,11 @@ async def test_discord_notification_reply_routes_to_pma_thread_with_context(
     assert run_turn_kwargs["orchestrator_channel_key"] == "pma:channel-1"
     assert run_turn_kwargs["workspace_root"] == notification_workspace
     assert captured["github_workspace_root"] == notification_workspace
+    assert resolved_thread_target_calls
+    assert (
+        resolved_thread_target_calls[-1]["managed_thread_surface_key"]
+        == "notification:notif-123"
+    )
     assert "<notification_context>" in str(run_turn_kwargs["prompt_text"])
     assert '"dispatch_paused"' in str(run_turn_kwargs["prompt_text"])
     assert "please triage this" in str(run_turn_kwargs["prompt_text"])


### PR DESCRIPTION
## Summary
- send an immediate reusable Discord placeholder when a thread turn is accepted so users see progress right away
- hand off Discord managed-thread execution to a background task after ingress submission so the outer dispatcher is not blocked for the full turn lifetime
- update Discord routing/message-flow guardrails and support tests for the deferred execution path

## Why
Discord ordinary turns were effectively paying for queueing twice: once in the chat dispatcher and again in managed-thread execution. On top of that, the first visible progress message was created too deep in the startup path, so users saw dead air before any intermediate response appeared.

This keeps ordering and durable queue semantics in the managed-thread layer, but makes the UX feel immediate by acknowledging receipt up front and moving long-running turn work out of the dispatcher critical section.

## Validation
- `.venv/bin/python -m ruff check src/codex_autorunner/integrations/discord/message_turns.py tests/discord_message_turns_support.py tests/integrations/discord/test_service_routing.py tests/integrations/chat/test_orchestration_guardrails.py`
- `.venv/bin/python -m pytest -q tests/integrations/discord/test_message_turns_message_flow.py tests/integrations/discord/test_message_turns.py tests/integrations/discord/test_service_routing.py`
- `git commit` hook suite passed, including repo-wide checks and pytest
