### PR TITLE
[codex] Fix Hermes PMA idle completion

### DIFF
--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -74,6 +74,27 @@ _ACP_STDOUT_NOISE_PREFIXES = (
 )
 _ACP_STDOUT_BRACKETED_STATUS_RE = re.compile(r"^\[[^\]\s]{1,32}\]\s+(?![\[{])\S")
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_SESSION_TURN_ID_FALLBACK_METHODS = frozenset(
+    {
+        "session/update",
+        "session/request_permission",
+        "session.status",
+        "session/status",
+        "session.idle",
+        "prompt/output",
+        "prompt/delta",
+        "prompt/progress",
+        "prompt/message",
+        "prompt/completed",
+        "prompt/failed",
+        "prompt/cancelled",
+        "turn/progress",
+        "turn/message",
+        "turn/completed",
+        "turn/failed",
+        "turn/cancelled",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -655,6 +676,8 @@ class ACPClient:
                 error = self._response_error(method, error_payload)
                 future.set_exception(error)
                 return
+            if self._pending_methods.get(request_id) == "prompt/start":
+                self._prime_prompt_state_from_start_result(message.get("result"))
             future.set_result(message.get("result"))
             return
 
@@ -761,6 +784,14 @@ class ACPClient:
                 state.replay_task = task
                 task.add_done_callback(self._log_background_task_result)
         return state
+
+    def _prime_prompt_state_from_start_result(self, payload: Any) -> None:
+        try:
+            prompt = ACPPromptDescriptor.from_result(payload)
+        except ValueError:
+            return
+        self._session_active_turns[prompt.session_id] = prompt.turn_id
+        self._ensure_prompt_state(prompt.session_id, prompt.turn_id)
 
     async def _replay_orphan_prompt_events(
         self,
@@ -950,7 +981,7 @@ class ACPClient:
 
     def _message_with_mapped_turn_id(self, message: dict[str, Any]) -> dict[str, Any]:
         method = _normalize_optional_text(message.get("method"))
-        if method not in {"session/update", "session/request_permission"}:
+        if method not in _SESSION_TURN_ID_FALLBACK_METHODS:
             return message
         params = _coerce_mapping(message.get("params"))
         if _normalize_optional_text(params.get("turnId") or params.get("turn_id")):

--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -85,9 +85,6 @@ _SESSION_TURN_ID_FALLBACK_METHODS = frozenset(
         "prompt/delta",
         "prompt/progress",
         "prompt/message",
-        "prompt/completed",
-        "prompt/failed",
-        "prompt/cancelled",
         "turn/progress",
         "turn/message",
         "turn/completed",
@@ -293,6 +290,7 @@ class ACPClient:
         self._closing = False
         self._turn_counter = 0
         self._session_active_turns: dict[str, str] = {}
+        self._pending_prompt_start_sessions: dict[str, str] = {}
         self._background_tasks: set[asyncio.Task[Any]] = set()
 
     @property
@@ -370,6 +368,10 @@ class ACPClient:
         future: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
         self._pending[request_id] = future
         self._pending_methods[request_id] = method
+        if method == "prompt/start":
+            session_id = _normalize_optional_text((params or {}).get("sessionId"))
+            if session_id:
+                self._pending_prompt_start_sessions[request_id] = session_id
         try:
             await self._write_message(
                 {
@@ -391,6 +393,7 @@ class ACPClient:
         finally:
             self._pending.pop(request_id, None)
             self._pending_methods.pop(request_id, None)
+            self._pending_prompt_start_sessions.pop(request_id, None)
 
     async def notify(
         self, method: str, params: Optional[dict[str, Any]] = None
@@ -677,7 +680,12 @@ class ACPClient:
                 future.set_exception(error)
                 return
             if self._pending_methods.get(request_id) == "prompt/start":
-                self._prime_prompt_state_from_start_result(message.get("result"))
+                self._prime_prompt_state_from_start_result(
+                    message.get("result"),
+                    fallback_session_id=self._pending_prompt_start_sessions.get(
+                        request_id
+                    ),
+                )
             future.set_result(message.get("result"))
             return
 
@@ -785,9 +793,17 @@ class ACPClient:
                 task.add_done_callback(self._log_background_task_result)
         return state
 
-    def _prime_prompt_state_from_start_result(self, payload: Any) -> None:
+    def _prime_prompt_state_from_start_result(
+        self,
+        payload: Any,
+        *,
+        fallback_session_id: Optional[str] = None,
+    ) -> None:
         try:
-            prompt = ACPPromptDescriptor.from_result(payload)
+            prompt = ACPPromptDescriptor.from_result(
+                payload,
+                session_id=fallback_session_id,
+            )
         except ValueError:
             return
         self._session_active_turns[prompt.session_id] = prompt.turn_id

--- a/src/codex_autorunner/agents/acp/events.py
+++ b/src/codex_autorunner/agents/acp/events.py
@@ -56,6 +56,28 @@ def _permission_description(payload: Mapping[str, Any]) -> str:
     return kind or ""
 
 
+def _session_status_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    status = payload.get("status")
+    if isinstance(status, Mapping):
+        return status
+    properties = payload.get("properties")
+    if isinstance(properties, Mapping):
+        nested_status = properties.get("status")
+        if isinstance(nested_status, Mapping):
+            return nested_status
+    return {}
+
+
+def _session_status_type(payload: Mapping[str, Any]) -> Optional[str]:
+    status = _session_status_payload(payload)
+    if status:
+        for key in ("type", "status", "state"):
+            normalized = _normalize_optional_text(status.get(key))
+            if normalized:
+                return normalized
+    return _normalize_optional_text(payload.get("status"))
+
+
 @dataclass(frozen=True)
 class ACPEventEnvelope:
     kind: str
@@ -159,6 +181,47 @@ def normalize_notification(message: Mapping[str, Any]) -> ACPEvent:
             raw_notification=raw_notification,
             action=action,
             session=session,
+        )
+
+    if method == "session.idle":
+        return ACPTurnTerminalEvent(
+            kind="turn_terminal",
+            method=method,
+            session_id=session_id,
+            turn_id=turn_id,
+            payload=payload,
+            raw_notification=raw_notification,
+            status="completed",
+            final_output=_extract_text(
+                payload, "finalOutput", "final_output", "message"
+            )
+            or "",
+        )
+
+    if method in {"session.status", "session/status"}:
+        status_type = _session_status_type(payload)
+        if status_type == "idle":
+            return ACPTurnTerminalEvent(
+                kind="turn_terminal",
+                method=method,
+                session_id=session_id,
+                turn_id=turn_id,
+                payload=payload,
+                raw_notification=raw_notification,
+                status="completed",
+                final_output=_extract_text(
+                    payload, "finalOutput", "final_output", "message"
+                )
+                or "",
+            )
+        return ACPProgressEvent(
+            kind="progress",
+            method=method,
+            session_id=session_id,
+            turn_id=turn_id,
+            payload=payload,
+            raw_notification=raw_notification,
+            message=status_type or "",
         )
 
     if method == "session/update":

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -25,6 +25,38 @@ def fixture_command(scenario: str) -> list[str]:
     return [sys.executable, "-u", str(FIXTURE_PATH), "--scenario", scenario]
 
 
+def test_client_does_not_map_prompt_terminal_notifications_without_turn_id() -> None:
+    client = ACPClient(fixture_command("basic"))
+    client._session_active_turns["session-1"] = "turn-2"
+
+    message = client._message_with_mapped_turn_id(
+        {
+            "method": "prompt/completed",
+            "params": {
+                "sessionId": "session-1",
+                "status": "completed",
+            },
+        }
+    )
+
+    assert "turnId" not in message["params"]
+
+
+@pytest.mark.asyncio
+async def test_client_primes_prompt_state_with_fallback_session_id() -> None:
+    client = ACPClient(fixture_command("basic"))
+    try:
+        client._prime_prompt_state_from_start_result(
+            {"turnId": "turn-1"},
+            fallback_session_id="session-1",
+        )
+
+        assert client._session_active_turns == {"session-1": "turn-1"}
+        assert "turn-1" in client._prompts
+    finally:
+        await client.close()
+
+
 @pytest.mark.asyncio
 async def test_client_initialize_and_session_roundtrip(tmp_path: Path) -> None:
     client = ACPClient(fixture_command("basic"), cwd=tmp_path)

--- a/tests/agents/acp/test_event_normalization.py
+++ b/tests/agents/acp/test_event_normalization.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from codex_autorunner.agents.acp import (
     ACPOutputDeltaEvent,
     ACPPermissionRequestEvent,
+    ACPProgressEvent,
     ACPTurnTerminalEvent,
     normalize_notification,
 )
@@ -108,3 +109,53 @@ def test_normalize_notification_maps_session_update_message_chunk() -> None:
     assert event.session_id == "session-1"
     assert event.turn_id == "turn-1"
     assert event.delta == "hello"
+
+
+def test_normalize_notification_maps_session_idle_to_terminal_event() -> None:
+    event = normalize_notification(
+        {
+            "method": "session.idle",
+            "params": {
+                "sessionId": "session-1",
+                "turnId": "turn-1",
+            },
+        }
+    )
+
+    assert isinstance(event, ACPTurnTerminalEvent)
+    assert event.status == "completed"
+    assert event.turn_id == "turn-1"
+
+
+def test_normalize_notification_maps_idle_session_status_to_terminal_event() -> None:
+    event = normalize_notification(
+        {
+            "method": "session.status",
+            "params": {
+                "sessionId": "session-1",
+                "turnId": "turn-1",
+                "status": {"type": "idle"},
+            },
+        }
+    )
+
+    assert isinstance(event, ACPTurnTerminalEvent)
+    assert event.status == "completed"
+    assert event.turn_id == "turn-1"
+
+
+def test_normalize_notification_maps_busy_session_status_to_progress_event() -> None:
+    event = normalize_notification(
+        {
+            "method": "session.status",
+            "params": {
+                "sessionId": "session-1",
+                "turnId": "turn-1",
+                "status": {"type": "running"},
+            },
+        }
+    )
+
+    assert isinstance(event, ACPProgressEvent)
+    assert event.message == "running"
+    assert event.turn_id == "turn-1"

--- a/tests/agents/hermes/test_hermes_supervisor_idle_completion_gap.py
+++ b/tests/agents/hermes/test_hermes_supervisor_idle_completion_gap.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from tests.chat_surface_harness.hermes import (
+    SESSION_STATUS_IDLE_COMPLETION_GAP,
+    fake_acp_command,
+)
+
+from codex_autorunner.agents.hermes.supervisor import HermesSupervisor
+
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_hermes_supervisor_completes_turn_when_runtime_goes_idle_without_prompt_completed(
+    tmp_path: Path,
+) -> None:
+    supervisor = HermesSupervisor(fake_acp_command(SESSION_STATUS_IDLE_COMPLETION_GAP))
+    try:
+        session = await supervisor.create_session(tmp_path)
+        turn_id = await supervisor.start_turn(tmp_path, session.session_id, "hello")
+
+        result = await asyncio.wait_for(
+            supervisor.wait_for_turn(tmp_path, session.session_id, turn_id),
+            timeout=1.0,
+        )
+
+        assert result.status == "completed"
+        assert result.assistant_text == "fixture reply"
+        assert any(
+            event.get("method") == "session.status"
+            and event.get("params", {}).get("status", {}).get("type") == "idle"
+            for event in result.raw_events
+        )
+    finally:
+        await supervisor.close_all()

--- a/tests/chat_surface_harness/README.md
+++ b/tests/chat_surface_harness/README.md
@@ -1,0 +1,27 @@
+# Chat Surface Harness
+
+Reusable integration fixtures for cross-surface PMA regressions.
+
+Use this package when a bug needs to be exercised through the real Discord or
+Telegram services instead of unit-level stubs.
+
+Available helpers:
+
+- `tests.chat_surface_harness.hermes`
+  - Registers a real `HermesHarness` backed by `tests/fixtures/fake_acp_server.py`
+  - Includes the `session_status_idle_completion_gap` scenario used to model the
+    "surface shows working forever" failure mode
+- `tests.chat_surface_harness.discord`
+  - Builds a `DiscordBotService` with fake gateway/rest transports and PMA state
+- `tests.chat_surface_harness.telegram`
+  - Builds a `TelegramBotService` with a fake bot and PMA topic state
+
+Recommended focused runs:
+
+```bash
+pytest tests/agents/hermes/test_hermes_supervisor_idle_completion_gap.py -q
+pytest tests/integrations/chat/test_hermes_idle_completion.py -q
+```
+
+The harness is intentionally in `tests/chat_surface_harness/` so future agents
+can discover it without mining large support files.

--- a/tests/chat_surface_harness/__init__.py
+++ b/tests/chat_surface_harness/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable cross-surface chat integration fixtures for tests."""

--- a/tests/chat_surface_harness/discord.py
+++ b/tests/chat_surface_harness/discord.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from codex_autorunner.bootstrap import seed_hub_files
+from codex_autorunner.integrations.chat.collaboration_policy import CollaborationPolicy
+from codex_autorunner.integrations.discord.config import (
+    DiscordBotConfig,
+    DiscordBotMediaConfig,
+    DiscordBotShellConfig,
+    DiscordCommandRegistration,
+)
+from codex_autorunner.integrations.discord.service import DiscordBotService
+from codex_autorunner.integrations.discord.state import DiscordStateStore
+
+from .hermes import logger_for
+
+
+class FakeDiscordRest:
+    def __init__(self) -> None:
+        self.channel_messages: list[dict[str, Any]] = []
+        self.edited_channel_messages: list[dict[str, Any]] = []
+        self.deleted_channel_messages: list[dict[str, Any]] = []
+        self.typing_calls: list[str] = []
+
+    async def create_channel_message(
+        self, *, channel_id: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        message = {
+            "channel_id": channel_id,
+            "payload": dict(payload),
+            "id": f"msg-{len(self.channel_messages) + 1}",
+        }
+        self.channel_messages.append(message)
+        return {"id": message["id"]}
+
+    async def edit_channel_message(
+        self, *, channel_id: str, message_id: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.edited_channel_messages.append(
+            {
+                "channel_id": channel_id,
+                "message_id": message_id,
+                "payload": dict(payload),
+            }
+        )
+        return {"id": message_id}
+
+    async def delete_channel_message(self, *, channel_id: str, message_id: str) -> None:
+        self.deleted_channel_messages.append(
+            {"channel_id": channel_id, "message_id": message_id}
+        )
+
+    async def trigger_typing(self, *, channel_id: str) -> None:
+        self.typing_calls.append(channel_id)
+
+    async def bulk_overwrite_application_commands(
+        self,
+        *,
+        application_id: str,
+        commands: list[dict[str, Any]],
+        guild_id: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
+        _ = application_id, guild_id
+        return commands
+
+
+class FakeDiscordGateway:
+    def __init__(self, events: list[tuple[str, dict[str, Any]]]) -> None:
+        self._events = list(events)
+
+    async def run(self, on_dispatch: Any) -> None:
+        for event_type, payload in self._events:
+            await on_dispatch(event_type, payload)
+        await asyncio.sleep(0.05)
+
+    async def stop(self) -> None:
+        return None
+
+
+class FakeDiscordOutboxManager:
+    def start(self) -> None:
+        return None
+
+    async def run_loop(self) -> None:
+        await asyncio.Event().wait()
+
+
+def discord_config(
+    root: Path,
+    *,
+    pma_enabled: bool = True,
+    collaboration_policy: CollaborationPolicy | None = None,
+) -> DiscordBotConfig:
+    return DiscordBotConfig(
+        root=root,
+        enabled=True,
+        bot_token_env="TOKEN_ENV",
+        app_id_env="APP_ENV",
+        bot_token="token",
+        application_id="app-1",
+        allowed_guild_ids=frozenset({"guild-1"}),
+        allowed_channel_ids=frozenset({"channel-1"}),
+        allowed_user_ids=frozenset(),
+        command_registration=DiscordCommandRegistration(
+            enabled=False,
+            scope="guild",
+            guild_ids=("guild-1",),
+        ),
+        state_file=root / ".codex-autorunner" / "discord_state.sqlite3",
+        intents=1,
+        max_message_length=2000,
+        message_overflow="split",
+        pma_enabled=pma_enabled,
+        shell=DiscordBotShellConfig(
+            enabled=True,
+            timeout_ms=120000,
+            max_output_chars=3800,
+        ),
+        media=DiscordBotMediaConfig(
+            enabled=True,
+            voice=True,
+            max_voice_bytes=10 * 1024 * 1024,
+        ),
+        collaboration_policy=collaboration_policy,
+    )
+
+
+def discord_message_create(
+    content: str,
+    *,
+    message_id: str = "m-1",
+    guild_id: str = "guild-1",
+    channel_id: str = "channel-1",
+) -> dict[str, Any]:
+    return {
+        "id": message_id,
+        "channel_id": channel_id,
+        "guild_id": guild_id,
+        "content": content,
+        "author": {"id": "user-1", "bot": False},
+        "attachments": [],
+    }
+
+
+@dataclass
+class DiscordPmaEnvironment:
+    service: DiscordBotService
+    rest: FakeDiscordRest
+    store: DiscordStateStore
+
+    async def close(self) -> None:
+        await self.store.close()
+
+
+async def build_discord_pma_environment(
+    root: Path,
+    *,
+    message_content: str,
+    agent: str = "hermes",
+) -> DiscordPmaEnvironment:
+    seed_hub_files(root, force=True)
+    workspace = root / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(root / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+    await store.update_pma_state(channel_id="channel-1", pma_enabled=True)
+    await store.update_agent_state(channel_id="channel-1", agent=agent)
+
+    rest = FakeDiscordRest()
+    gateway = FakeDiscordGateway(
+        [("MESSAGE_CREATE", discord_message_create(message_content))]
+    )
+    service = DiscordBotService(
+        discord_config(root),
+        logger=logger_for("discord"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=FakeDiscordOutboxManager(),
+    )
+    return DiscordPmaEnvironment(service=service, rest=rest, store=store)

--- a/tests/chat_surface_harness/hermes.py
+++ b/tests/chat_surface_harness/hermes.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import codex_autorunner.agents.registry as registry_module
+from codex_autorunner.agents.hermes.harness import HermesHarness
+from codex_autorunner.agents.hermes.supervisor import HermesSupervisor
+from codex_autorunner.agents.registry import AgentDescriptor
+
+FAKE_ACP_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "fake_acp_server.py"
+)
+SESSION_STATUS_IDLE_COMPLETION_GAP = "session_status_idle_completion_gap"
+
+
+def fake_acp_command(scenario: str) -> list[str]:
+    return [sys.executable, "-u", str(FAKE_ACP_FIXTURE_PATH), "--scenario", scenario]
+
+
+@dataclass
+class HermesFixtureRuntime:
+    harness: HermesHarness
+    supervisor: HermesSupervisor
+
+    async def close(self) -> None:
+        await self.supervisor.close_all()
+
+
+def patch_hermes_registry(
+    monkeypatch: Any,
+    *,
+    scenario: str,
+    targets: Sequence[Any],
+) -> HermesFixtureRuntime:
+    supervisor = HermesSupervisor(fake_acp_command(scenario))
+    harness = HermesHarness(supervisor)
+    descriptor = AgentDescriptor(
+        id="hermes",
+        name="Hermes",
+        capabilities=harness.capabilities,
+        make_harness=lambda _ctx: harness,
+    )
+
+    def _registry(_context: Any = None) -> dict[str, AgentDescriptor]:
+        return {"hermes": descriptor}
+
+    monkeypatch.setattr(registry_module, "get_registered_agents", _registry)
+    for target in targets:
+        monkeypatch.setattr(target, "get_registered_agents", _registry)
+    return HermesFixtureRuntime(harness=harness, supervisor=supervisor)
+
+
+def logger_for(name: str) -> logging.Logger:
+    return logging.getLogger(f"test.chat_surface_harness.{name}")

--- a/tests/chat_surface_harness/telegram.py
+++ b/tests/chat_surface_harness/telegram.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from codex_autorunner.bootstrap import seed_hub_files
+from codex_autorunner.integrations.telegram.adapter import (
+    TelegramMessage,
+    TelegramUpdatePoller,
+)
+from codex_autorunner.integrations.telegram.chat_adapter import TelegramChatAdapter
+from codex_autorunner.integrations.telegram.config import TelegramBotConfig
+from codex_autorunner.integrations.telegram.service import TelegramBotService
+
+from .hermes import logger_for
+
+APP_SERVER_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "app_server_fixture.py"
+)
+
+
+def app_server_fixture_command(scenario: str = "basic") -> list[str]:
+    return [sys.executable, "-u", str(APP_SERVER_FIXTURE_PATH), "--scenario", scenario]
+
+
+class FakeTelegramBot:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, object]] = []
+        self.documents: list[dict[str, object]] = []
+        self.deleted_messages: list[dict[str, object]] = []
+
+    async def send_message(
+        self,
+        chat_id: int,
+        text: str,
+        *,
+        message_thread_id: Optional[int] = None,
+        reply_to_message_id: Optional[int] = None,
+        parse_mode: Optional[str] = None,
+        disable_web_page_preview: bool = True,
+        reply_markup: Optional[dict[str, object]] = None,
+    ) -> dict[str, object]:
+        _ = parse_mode, disable_web_page_preview
+        self.messages.append(
+            {
+                "chat_id": chat_id,
+                "thread_id": message_thread_id,
+                "text": text,
+                "reply_to": reply_to_message_id,
+                "reply_markup": reply_markup,
+            }
+        )
+        return {"message_id": len(self.messages)}
+
+    async def send_message_chunks(
+        self,
+        chat_id: int,
+        text: str,
+        *,
+        message_thread_id: Optional[int] = None,
+        reply_to_message_id: Optional[int] = None,
+        reply_markup: Optional[dict[str, object]] = None,
+        parse_mode: Optional[str] = None,
+        disable_web_page_preview: bool = True,
+        max_len: int = 4096,
+    ) -> list[dict[str, object]]:
+        _ = parse_mode, disable_web_page_preview, max_len
+        self.messages.append(
+            {
+                "chat_id": chat_id,
+                "thread_id": message_thread_id,
+                "text": text,
+                "reply_to": reply_to_message_id,
+                "reply_markup": reply_markup,
+            }
+        )
+        return [{"message_id": len(self.messages)}]
+
+    async def send_document(
+        self,
+        chat_id: int,
+        document: bytes,
+        *,
+        filename: str,
+        message_thread_id: Optional[int] = None,
+        reply_to_message_id: Optional[int] = None,
+        caption: Optional[str] = None,
+        parse_mode: Optional[str] = None,
+    ) -> dict[str, object]:
+        _ = document, parse_mode
+        self.documents.append(
+            {
+                "chat_id": chat_id,
+                "thread_id": message_thread_id,
+                "reply_to": reply_to_message_id,
+                "filename": filename,
+                "caption": caption,
+            }
+        )
+        return {"message_id": len(self.documents)}
+
+    async def answer_callback_query(
+        self,
+        _callback_query_id: str,
+        *,
+        text: Optional[str] = None,
+        show_alert: bool = False,
+    ) -> dict[str, object]:
+        _ = text, show_alert
+        return {}
+
+    async def edit_message_text(
+        self,
+        _chat_id: int,
+        _message_id: int,
+        _text: str,
+        *,
+        reply_markup: Optional[dict[str, object]] = None,
+        parse_mode: Optional[str] = None,
+        disable_web_page_preview: bool = True,
+    ) -> dict[str, object]:
+        _ = reply_markup, parse_mode, disable_web_page_preview
+        return {}
+
+    async def delete_message(
+        self,
+        chat_id: int,
+        message_id: int,
+        *,
+        message_thread_id: Optional[int] = None,
+    ) -> bool:
+        self.deleted_messages.append(
+            {
+                "chat_id": chat_id,
+                "thread_id": message_thread_id,
+                "message_id": message_id,
+            }
+        )
+        return True
+
+
+def telegram_config(root: Path) -> TelegramBotConfig:
+    return TelegramBotConfig.from_raw(
+        {
+            "enabled": True,
+            "mode": "polling",
+            "allowed_chat_ids": [123],
+            "allowed_user_ids": [456],
+            "require_topics": False,
+            "app_server_command": app_server_fixture_command(),
+        },
+        root=root,
+        env={
+            "CAR_TELEGRAM_BOT_TOKEN": "test-token",
+            "CAR_TELEGRAM_CHAT_ID": "123",
+        },
+    )
+
+
+def telegram_message(
+    text: str,
+    *,
+    chat_id: int = 123,
+    thread_id: Optional[int] = None,
+    user_id: int = 456,
+    message_id: int = 1,
+    update_id: int = 1,
+) -> TelegramMessage:
+    return TelegramMessage(
+        update_id=update_id,
+        message_id=message_id,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        from_user_id=user_id,
+        text=text,
+        date=0,
+        is_topic_message=thread_id is not None,
+    )
+
+
+async def drain_spawned_tasks(service: TelegramBotService) -> None:
+    while True:
+        while service._spawned_tasks:
+            await asyncio.gather(*tuple(service._spawned_tasks))
+        for runtime in service._router._topics.values():
+            await runtime.queue.join_idle()
+        if not service._spawned_tasks:
+            return
+
+
+@dataclass
+class TelegramPmaEnvironment:
+    service: TelegramBotService
+    bot: FakeTelegramBot
+
+    async def close(self) -> None:
+        await self.service._app_server_supervisor.close_all()
+
+
+async def build_telegram_pma_environment(
+    root: Path,
+    *,
+    agent: str = "hermes",
+) -> TelegramPmaEnvironment:
+    seed_hub_files(root, force=True)
+    service = TelegramBotService(telegram_config(root), hub_root=root)
+    bot = FakeTelegramBot()
+    service._bot = bot
+    service._poller = TelegramUpdatePoller(bot)
+    service._chat_adapter = TelegramChatAdapter(bot, poller=service._poller)
+    service._chat_core._adapter = service._chat_adapter
+
+    def apply(record) -> None:
+        record.pma_enabled = True
+        record.agent = agent
+
+    await service._router.update_topic(123, None, apply)
+    service._logger = logger_for("telegram")
+    return TelegramPmaEnvironment(service=service, bot=bot)

--- a/tests/fixtures/fake_acp_server.py
+++ b/tests/fixtures/fake_acp_server.py
@@ -192,15 +192,28 @@ class FakeACPServer:
                 },
             }
         )
+        if self._scenario == "session_status_idle_completion_gap":
+            self.send(
+                {
+                    "method": "session.status",
+                    "params": {
+                        "sessionId": session_id,
+                        "status": {"type": "idle"},
+                    },
+                }
+            )
+            return
+        completed_params = {
+            "sessionId": session_id,
+            "status": "completed",
+            "finalOutput": "fixture reply",
+        }
+        if self._scenario != "terminal_missing_turn_id":
+            completed_params["turnId"] = turn_id
         self.send(
             {
                 "method": "prompt/completed",
-                "params": {
-                    "sessionId": session_id,
-                    "turnId": turn_id,
-                    "status": "completed",
-                    "finalOutput": "fixture reply",
-                },
+                "params": completed_params,
             }
         )
 

--- a/tests/integrations/chat/test_hermes_idle_completion.py
+++ b/tests/integrations/chat/test_hermes_idle_completion.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+
+import anyio
+import pytest
+from tests.chat_surface_harness.discord import build_discord_pma_environment
+from tests.chat_surface_harness.hermes import (
+    SESSION_STATUS_IDLE_COMPLETION_GAP,
+    patch_hermes_registry,
+)
+from tests.chat_surface_harness.telegram import (
+    build_telegram_pma_environment,
+    drain_spawned_tasks,
+    telegram_message,
+)
+
+import codex_autorunner.integrations.discord.message_turns as discord_message_turns_module
+from codex_autorunner.integrations.telegram.handlers.commands import (
+    execution as telegram_execution_module,
+)
+from codex_autorunner.integrations.telegram.handlers.commands import (
+    shared as telegram_shared_module,
+)
+
+
+@pytest.mark.anyio
+async def test_discord_pma_turn_completes_when_hermes_only_emits_idle_status(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = patch_hermes_registry(
+        monkeypatch,
+        scenario=SESSION_STATUS_IDLE_COMPLETION_GAP,
+        targets=[discord_message_turns_module],
+    )
+    env = await build_discord_pma_environment(
+        tmp_path,
+        message_content="echo hello world",
+    )
+    try:
+        await asyncio.wait_for(env.service.run_forever(), timeout=3)
+        with anyio.fail_after(2):
+            while not any(
+                "fixture reply" in message["payload"].get("content", "")
+                for message in env.rest.channel_messages
+            ):
+                await anyio.sleep(0.05)
+
+        assert env.rest.deleted_channel_messages
+        assert any(
+            "working" in edit["payload"].get("content", "")
+            for edit in env.rest.edited_channel_messages
+        )
+        assert any(
+            "fixture reply" in message["payload"].get("content", "")
+            for message in env.rest.channel_messages
+        )
+    finally:
+        await runtime.close()
+        await env.close()
+
+
+@pytest.mark.anyio
+async def test_telegram_pma_turn_completes_when_hermes_only_emits_idle_status(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = patch_hermes_registry(
+        monkeypatch,
+        scenario=SESSION_STATUS_IDLE_COMPLETION_GAP,
+        targets=[telegram_execution_module, telegram_shared_module],
+    )
+    env = await build_telegram_pma_environment(tmp_path)
+    try:
+        message = telegram_message("echo hello world")
+        await asyncio.wait_for(env.service._handle_message_inner(message), timeout=3)
+        await asyncio.wait_for(drain_spawned_tasks(env.service), timeout=3)
+
+        assert any(
+            "fixture reply" in str(sent.get("text") or "") for sent in env.bot.messages
+        )
+    finally:
+        await runtime.close()
+        await env.close()


### PR DESCRIPTION
## Summary

This PR adds a reusable cross-surface chat integration harness for Discord and Telegram PMA flows, reproduces the Discord/Telegram Hermes "working forever" failure mode, and fixes Hermes ACP completion handling when the runtime goes idle without emitting `prompt/completed`.

## Root Cause

Hermes completion depended on terminal ACP events that carried a `turnId`. In the failing path, the ACP runtime emitted session-scoped idle status (`session.status` / `session.idle`) instead of `prompt/completed`. Those notifications were neither mapped onto the active turn nor normalized into a terminal event, so `HermesSupervisor.wait_for_turn()` never resolved and PMA surfaces kept showing the working placeholder indefinitely.

## What Changed

- add `tests/chat_surface_harness/` as a discoverable reusable harness for Discord and Telegram PMA integration coverage
- extend `tests/fixtures/fake_acp_server.py` with a `session_status_idle_completion_gap` scenario that reproduces the hang
- add narrow Hermes and cross-surface regression tests that exercise the real service layer with fake transports
- treat idle session notifications as terminal completion events in ACP normalization
- map session-scoped idle/status notifications back onto the active turn so Hermes can resolve the pending turn
- tighten the harness after reproduction by patching the canonical agent registry and rebuilding the Telegram adapter stack around the fake bot

## Impact

Discord and Telegram PMA managed-thread turns now complete when Hermes goes idle without a `prompt/completed` notification, and future agents have a realistic fixture they can use to debug similar end-to-end regressions before shipping.

## Validation

- `.venv/bin/pytest tests/agents/acp/test_event_normalization.py tests/agents/hermes/test_hermes_supervisor_idle_completion_gap.py tests/integrations/chat/test_hermes_idle_completion.py -q`
- repo commit hook suite during `git commit`:
  - repo Python lint/type checks
  - frontend build and JS tests
  - full pytest sweep: `4652 passed`
