### PR TITLE
[codex] Fix SCM review comment wakeup flow

### DIFF
--- a/src/codex_autorunner/core/publish_journal.py
+++ b/src/codex_autorunner/core/publish_journal.py
@@ -177,6 +177,12 @@ class PublishJournalStore:
                  WHERE state = 'pending'
                    AND COALESCE(next_attempt_at, created_at) <= ?
                  ORDER BY COALESCE(next_attempt_at, created_at) ASC,
+                          CASE operation_kind
+                              WHEN 'react_pr_review_comment' THEN 0
+                              WHEN 'enqueue_managed_turn' THEN 1
+                              WHEN 'notify_chat' THEN 2
+                              ELSE 50
+                          END ASC,
                           created_at ASC,
                           operation_id ASC
                  LIMIT ?

--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -32,7 +32,11 @@ from .scm_observability import (
 )
 from .scm_reaction_router import route_scm_reactions
 from .scm_reaction_state import ScmReactionStateStore
-from .scm_reaction_types import ReactionIntent, ScmReactionConfig
+from .scm_reaction_types import (
+    ReactionIntent,
+    ScmReactionConfig,
+    stable_reaction_operation_key,
+)
 from .text_utils import _normalize_text
 
 _LOGGER = logging.getLogger(__name__)
@@ -225,6 +229,84 @@ def _stable_escalation_operation_key(
     return f"scm-reaction-escalation:{reason}:{digest}"
 
 
+def _intent_priority(intent: ReactionIntent) -> tuple[int, str]:
+    priorities = {
+        "react_pr_review_comment": 0,
+        "enqueue_managed_turn": 1,
+        "notify_chat": 2,
+    }
+    return (
+        priorities.get(intent.operation_kind, 50),
+        intent.operation_key,
+    )
+
+
+def _publish_notice_payload(
+    *,
+    thread_target_id: str,
+    message: str,
+) -> dict[str, Any]:
+    return {
+        "delivery": "bound",
+        "thread_target_id": thread_target_id,
+        "message": message,
+    }
+
+
+def _event_payload(event: ScmEvent) -> Mapping[str, Any]:
+    payload = event.payload
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def _collapse_whitespace(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    text = " ".join(value.split())
+    return text or None
+
+
+def _trimmed_summary(value: Any, *, limit: int = 120) -> Optional[str]:
+    text = _collapse_whitespace(value)
+    if text is None:
+        return None
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 3].rstrip()}..."
+
+
+def _review_comment_location(payload: Mapping[str, Any]) -> Optional[str]:
+    path = _collapse_whitespace(payload.get("path"))
+    line = payload.get("line")
+    if path is None:
+        return None
+    if isinstance(line, int):
+        return f"{path}:{line}"
+    return path
+
+
+def _review_comment_wakeup_message(
+    *,
+    event: ScmEvent,
+    binding: PrBinding,
+) -> str:
+    payload = _event_payload(event)
+    subject = f"{binding.repo_slug}#{binding.pr_number}"
+    commenter_login = _collapse_whitespace(payload.get("author_login"))
+    location = _review_comment_location(payload)
+    comment_summary = _trimmed_summary(payload.get("body"))
+
+    summary = f"Received PR review feedback on {subject}"
+    if commenter_login is not None:
+        summary = f"{summary} from {commenter_login}"
+    if location is not None:
+        summary = f"{summary} at {location}"
+    if comment_summary is not None:
+        summary = f"{summary}: {comment_summary}"
+    if not summary.endswith((".", "!", "?")):
+        summary = f"{summary}."
+    return f"{summary} The bound agent thread is taking a look."
+
+
 def _reaction_subject(tracking: Mapping[str, Any]) -> str:
     repo_slug = _normalize_text(tracking.get("repo_slug"))
     pr_number = tracking.get("pr_number")
@@ -399,6 +481,69 @@ class ScmAutomationService:
             raise LookupError(f"SCM event '{event_id}' was not found")
         return event
 
+    def _review_comment_notice_key(
+        self,
+        *,
+        event: ScmEvent,
+        binding: PrBinding,
+    ) -> str:
+        return stable_reaction_operation_key(
+            provider=event.provider,
+            event_id=event.event_id,
+            reaction_kind="review_comment",
+            operation_kind="notify_chat",
+            repo_slug=binding.repo_slug,
+            repo_id=binding.repo_id or event.repo_id,
+            pr_number=binding.pr_number,
+            binding_id=binding.binding_id,
+            thread_target_id=binding.thread_target_id,
+        )
+
+    def _create_review_comment_notice_operation(
+        self,
+        *,
+        event: ScmEvent,
+        binding: PrBinding,
+        correlation_id: str,
+        seen_operation_keys: set[str],
+        publish_operations: list[PublishOperation],
+    ) -> None:
+        thread_target_id = _normalize_text(binding.thread_target_id)
+        if thread_target_id is None:
+            return
+        operation_key = self._review_comment_notice_key(event=event, binding=binding)
+        if operation_key in seen_operation_keys:
+            return
+        seen_operation_keys.add(operation_key)
+        payload = with_correlation_id(
+            _publish_notice_payload(
+                thread_target_id=thread_target_id,
+                message=_review_comment_wakeup_message(
+                    event=event,
+                    binding=binding,
+                ),
+            ),
+            correlation_id=correlation_id,
+        )
+        operation, deduped = self._journal.create_operation(
+            operation_key=operation_key,
+            operation_kind="notify_chat",
+            payload=payload,
+        )
+        self._audit_recorder.record(
+            action_type=SCM_AUDIT_PUBLISH_CREATED,
+            correlation_id=correlation_id,
+            event=event,
+            binding=binding,
+            operation=operation,
+            payload={
+                "deduped": deduped,
+                "auxiliary": True,
+                "wake_notice": True,
+            },
+        )
+        publish_operations.append(operation)
+
     def ingest_event(
         self,
         event_or_id: ScmEvent | str,
@@ -416,10 +561,13 @@ class ScmAutomationService:
             payload={"binding_found": binding is not None},
         )
         reaction_intents = tuple(
-            self._reaction_router(
-                event,
-                binding=binding,
-                config=self._reaction_config,
+            sorted(
+                self._reaction_router(
+                    event,
+                    binding=binding,
+                    config=self._reaction_config,
+                ),
+                key=_intent_priority,
             )
         )
 
@@ -558,6 +706,18 @@ class ScmAutomationService:
                     metadata=tracking,
                 )
             publish_operations.append(operation)
+            if (
+                binding is not None
+                and intent.reaction_kind == "review_comment"
+                and intent.operation_kind == "enqueue_managed_turn"
+            ):
+                self._create_review_comment_notice_operation(
+                    event=event,
+                    binding=binding,
+                    correlation_id=correlation_id,
+                    seen_operation_keys=seen_operation_keys,
+                    publish_operations=publish_operations,
+                )
 
         return ScmAutomationIngestResult(
             event=event,

--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -253,6 +253,11 @@ def _publish_notice_payload(
     }
 
 
+def _auxiliary_correlation_id(*, correlation_id: str, operation_key: str) -> str:
+    digest = hashlib.sha256(operation_key.encode("utf-8")).hexdigest()[:12]
+    return f"{correlation_id}:aux:{digest}"
+
+
 def _event_payload(event: ScmEvent) -> Mapping[str, Any]:
     payload = event.payload
     return payload if isinstance(payload, Mapping) else {}
@@ -515,6 +520,10 @@ class ScmAutomationService:
         if operation_key in seen_operation_keys:
             return
         seen_operation_keys.add(operation_key)
+        notice_correlation_id = _auxiliary_correlation_id(
+            correlation_id=correlation_id,
+            operation_key=operation_key,
+        )
         payload = with_correlation_id(
             _publish_notice_payload(
                 thread_target_id=thread_target_id,
@@ -523,7 +532,7 @@ class ScmAutomationService:
                     binding=binding,
                 ),
             ),
-            correlation_id=correlation_id,
+            correlation_id=notice_correlation_id,
         )
         operation, deduped = self._journal.create_operation(
             operation_key=operation_key,

--- a/tests/core/test_scm_automation_service.py
+++ b/tests/core/test_scm_automation_service.py
@@ -797,31 +797,34 @@ def test_ingest_event_tracks_review_comment_operations_in_separate_state_namespa
     result = service.ingest_event(event.event_id)
 
     assert [operation.operation_kind for operation in result.publish_operations] == [
-        "enqueue_managed_turn",
         "react_pr_review_comment",
+        "enqueue_managed_turn",
+        "notify_chat",
     ]
     assert state_store.should_calls == [
-        (
-            "binding-1",
-            "review_comment:enqueue_managed_turn",
-            "review_comment:github:event-inline-comment:enqueue_managed_turn",
-        ),
         (
             "binding-1",
             "review_comment:react_pr_review_comment",
             "review_comment:github:event-inline-comment:react_pr_review_comment",
         ),
+        (
+            "binding-1",
+            "review_comment:enqueue_managed_turn",
+            "review_comment:github:event-inline-comment:enqueue_managed_turn",
+        ),
     ]
     tracking_payloads = [
-        operation.payload["scm_reaction"] for operation in result.publish_operations
+        operation.payload["scm_reaction"]
+        for operation in result.publish_operations
+        if "scm_reaction" in operation.payload
     ]
     assert [payload["reaction_kind"] for payload in tracking_payloads] == [
         "review_comment",
         "review_comment",
     ]
     assert [payload["reaction_state_kind"] for payload in tracking_payloads] == [
-        "review_comment:enqueue_managed_turn",
         "review_comment:react_pr_review_comment",
+        "review_comment:enqueue_managed_turn",
     ]
 
 

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -1126,6 +1126,216 @@ def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
     )
 
 
+def test_process_due_watches_keeps_distinct_bound_notices_for_multiple_review_comments(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    workspace_root = hub_root / "repo"
+    workspace_root.mkdir(parents=True)
+    write_test_config(
+        hub_root / CONFIG_FILENAME,
+        DEFAULT_HUB_CONFIG,
+    )
+    _write_manifest(hub_root, repo_rel="repo")
+
+    async def _bind_discord() -> None:
+        store = DiscordStateStore(
+            hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+        )
+        try:
+            await store.initialize()
+            await store.upsert_binding(
+                channel_id="repo-discord",
+                guild_id=None,
+                workspace_path=str(workspace_root),
+                repo_id="repo-1",
+            )
+        finally:
+            await store.close()
+
+    asyncio.run(_bind_discord())
+    thread = PmaThreadStore(hub_root).create_thread(
+        "codex",
+        workspace_root,
+        repo_id="repo-1",
+        metadata={"head_branch": "feature/scm-polling"},
+    )
+    binding = PrBindingStore(hub_root).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        repo_id="repo-1",
+        pr_number=17,
+        pr_state="open",
+        head_branch="feature/scm-polling",
+        base_branch="main",
+        thread_target_id=str(thread["managed_thread_id"]),
+    )
+    watch_store = ScmPollingWatchStore(hub_root)
+    watch_store.upsert_watch(
+        provider="github",
+        binding_id=binding.binding_id,
+        repo_slug=binding.repo_slug,
+        repo_id=binding.repo_id,
+        pr_number=binding.pr_number,
+        workspace_root=str(workspace_root.resolve()),
+        thread_target_id=str(thread["managed_thread_id"]),
+        poll_interval_seconds=90,
+        next_poll_at="2026-03-30T00:00:00Z",
+        expires_at="2099-03-30T01:00:00Z",
+        reaction_config={"enabled": True},
+        snapshot={
+            "head_sha": "oldsha",
+            "pr_state": "open",
+            "review_thread_comments": {},
+        },
+    )
+
+    def _factory(repo_root: Path, raw_config=None) -> _GitHubServiceStub:
+        return _GitHubServiceStub(
+            repo_root,
+            raw_config,
+            pr_view_payload={
+                "state": "OPEN",
+                "isDraft": False,
+                "headRefOid": "newsha",
+                "author": {"login": "pr-author"},
+            },
+            reviews_payload=[],
+            checks_payload=[],
+            issue_comments_payload=[],
+            review_threads_payload=[
+                {
+                    "thread_id": "thread-1",
+                    "isResolved": False,
+                    "comments": [
+                        {
+                            "comment_id": "2844",
+                            "body": "Please cover the inline review wakeup path too.",
+                            "author_login": "reviewer",
+                            "author_type": "User",
+                            "path": "src/codex_autorunner/integrations/github/polling.py",
+                            "line": 196,
+                            "updated_at": "2026-03-30T00:04:00Z",
+                        },
+                        {
+                            "comment_id": "2845",
+                            "body": "Also verify the bound notification does not dedupe away later comments.",
+                            "author_login": "reviewer",
+                            "author_type": "User",
+                            "path": "src/codex_autorunner/core/scm_automation_service.py",
+                            "line": 526,
+                            "updated_at": "2026-03-30T00:04:01Z",
+                        },
+                    ],
+                }
+            ],
+        )
+
+    automation_config = _polling_config()
+    automation_config["github"]["automation"]["policy"] = {
+        "react_pr_review_comment": "allow"
+    }
+
+    class _ReactionGitHubService:
+        def __init__(self, repo_root: Path, raw_config=None) -> None:
+            _ = repo_root, raw_config
+
+        def create_pull_request_review_comment_reaction(
+            self,
+            *,
+            owner: str,
+            repo: str,
+            comment_id: int,
+            content: str,
+            cwd=None,
+        ) -> dict[str, object]:
+            _ = owner, repo, cwd
+            return {
+                "id": comment_id,
+                "content": content,
+                "url": f"https://api.github.com/reactions/{comment_id}",
+            }
+
+    journal = PublishJournalStore(hub_root)
+    processor = PublishOperationProcessor(
+        journal,
+        executors={
+            "react_pr_review_comment": build_react_pr_review_comment_executor(
+                repo_root=hub_root,
+                raw_config=automation_config,
+                github_service_factory=_ReactionGitHubService,
+            ),
+            "enqueue_managed_turn": build_enqueue_managed_turn_executor(
+                hub_root=hub_root
+            ),
+            "notify_chat": build_notify_chat_executor(hub_root=hub_root),
+        },
+    )
+    processed_operations = []
+    automation = ScmAutomationService(
+        hub_root,
+        reaction_config=automation_config,
+        publish_processor=processor,
+    )
+
+    class _AutomationWrapper:
+        def ingest_event(self, event) -> None:
+            automation.ingest_event(event)
+
+        def process_now(self, limit: int = 10):
+            result = automation.process_now(limit=limit)
+            processed_operations.extend(result)
+            return result
+
+    monkeypatch.setattr(
+        GitHubScmPollingService,
+        "_build_automation_service",
+        lambda self, reaction_config=None: _AutomationWrapper(),  # type: ignore[misc]
+    )
+
+    service = GitHubScmPollingService(
+        hub_root,
+        raw_config=automation_config,
+        github_service_factory=_factory,
+        watch_store=watch_store,
+        event_store=ScmEventStore(hub_root),
+    )
+
+    result = service.process_due_watches(limit=10)
+
+    assert result["events_emitted"] == 2
+    notify_results = [
+        operation
+        for operation in processed_operations
+        if operation.operation_kind == "notify_chat"
+    ]
+    assert len(notify_results) == 2
+    assert all(operation.state == "succeeded" for operation in notify_results)
+    assert (
+        len({operation.payload["correlation_id"] for operation in notify_results}) == 2
+    )
+
+    async def _load_outbox() -> list[object]:
+        store = DiscordStateStore(
+            hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+        )
+        try:
+            return await store.list_outbox()
+        finally:
+            await store.close()
+
+    outbox = asyncio.run(_load_outbox())
+    contents = [
+        str(record.payload_json.get("content", "")).lower()
+        for record in outbox
+        if record.channel_id == "repo-discord"
+    ]
+    assert len(contents) == 2
+    assert any("inline review wakeup path" in content for content in contents)
+    assert any("does not dedupe away later comments" in content for content in contents)
+
+
 def test_process_due_watches_does_not_reemit_when_thread_is_reopened_without_new_comments(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -1,22 +1,36 @@
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from tests.conftest import write_test_config
 
 import codex_autorunner.core.scm_polling_watches as scm_polling_watches
 import codex_autorunner.integrations.github.polling as github_polling
+from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
 from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.pma_thread_store import PmaThreadStore
 from codex_autorunner.core.pr_binding_runtime import upsert_pr_binding
 from codex_autorunner.core.pr_bindings import PrBindingStore
+from codex_autorunner.core.publish_executor import PublishOperationProcessor
+from codex_autorunner.core.publish_journal import PublishJournalStore
+from codex_autorunner.core.publish_operation_executors import (
+    build_enqueue_managed_turn_executor,
+    build_notify_chat_executor,
+)
+from codex_autorunner.core.scm_automation_service import ScmAutomationService
 from codex_autorunner.core.scm_events import ScmEventStore
 from codex_autorunner.core.scm_polling_watches import ScmPollingWatchStore
+from codex_autorunner.integrations.discord.state import DiscordStateStore
 from codex_autorunner.integrations.github.polling import (
     GitHubPollingConfig,
     GitHubScmPollingService,
+)
+from codex_autorunner.integrations.github.publisher import (
+    build_react_pr_review_comment_executor,
 )
 from codex_autorunner.integrations.github.service import GitHubError, RepoInfo
 
@@ -902,6 +916,214 @@ def test_process_due_watches_emits_new_pr_comment_and_inline_review_comment(
         "issue_comment",
         "pull_request_review_comment",
     }
+
+
+def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    workspace_root = hub_root / "repo"
+    workspace_root.mkdir(parents=True)
+    write_test_config(
+        hub_root / CONFIG_FILENAME,
+        DEFAULT_HUB_CONFIG,
+    )
+    _write_manifest(hub_root, repo_rel="repo")
+
+    async def _bind_discord() -> None:
+        store = DiscordStateStore(
+            hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+        )
+        try:
+            await store.initialize()
+            await store.upsert_binding(
+                channel_id="repo-discord",
+                guild_id=None,
+                workspace_path=str(workspace_root),
+                repo_id="repo-1",
+            )
+        finally:
+            await store.close()
+
+    asyncio.run(_bind_discord())
+    thread = PmaThreadStore(hub_root).create_thread(
+        "codex",
+        workspace_root,
+        repo_id="repo-1",
+        metadata={"head_branch": "feature/scm-polling"},
+    )
+    binding = PrBindingStore(hub_root).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        repo_id="repo-1",
+        pr_number=17,
+        pr_state="open",
+        head_branch="feature/scm-polling",
+        base_branch="main",
+        thread_target_id=str(thread["managed_thread_id"]),
+    )
+    watch_store = ScmPollingWatchStore(hub_root)
+    watch_store.upsert_watch(
+        provider="github",
+        binding_id=binding.binding_id,
+        repo_slug=binding.repo_slug,
+        repo_id=binding.repo_id,
+        pr_number=binding.pr_number,
+        workspace_root=str(workspace_root.resolve()),
+        thread_target_id=str(thread["managed_thread_id"]),
+        poll_interval_seconds=90,
+        next_poll_at="2026-03-30T00:00:00Z",
+        expires_at="2099-03-30T01:00:00Z",
+        reaction_config={"enabled": True},
+        snapshot={
+            "head_sha": "oldsha",
+            "pr_state": "open",
+            "review_thread_comments": {},
+        },
+    )
+
+    def _factory(repo_root: Path, raw_config=None) -> _GitHubServiceStub:
+        return _GitHubServiceStub(
+            repo_root,
+            raw_config,
+            pr_view_payload={
+                "state": "OPEN",
+                "isDraft": False,
+                "headRefOid": "newsha",
+                "author": {"login": "pr-author"},
+            },
+            reviews_payload=[],
+            checks_payload=[],
+            issue_comments_payload=[],
+            review_threads_payload=[
+                {
+                    "thread_id": "thread-1",
+                    "isResolved": False,
+                    "comments": [
+                        {
+                            "comment_id": "2844",
+                            "body": "Please cover the inline review wakeup path too.",
+                            "author_login": "reviewer",
+                            "author_type": "User",
+                            "path": "src/codex_autorunner/integrations/github/polling.py",
+                            "line": 196,
+                            "updated_at": "2026-03-30T00:04:00Z",
+                        }
+                    ],
+                }
+            ],
+        )
+
+    automation_config = _polling_config()
+    automation_config["github"]["automation"]["policy"] = {
+        "react_pr_review_comment": "allow"
+    }
+    reaction_calls: list[tuple[str, str, str, int, str]] = []
+
+    class _ReactionGitHubService:
+        def __init__(self, repo_root: Path, raw_config=None) -> None:
+            _ = raw_config
+            self.repo_root = repo_root
+
+        def create_pull_request_review_comment_reaction(
+            self,
+            *,
+            owner: str,
+            repo: str,
+            comment_id: int,
+            content: str,
+            cwd=None,
+        ) -> dict[str, object]:
+            reaction_calls.append((owner, repo, str(cwd), comment_id, content))
+            return {
+                "id": 88,
+                "content": content,
+                "url": "https://api.github.com/reactions/88",
+            }
+
+    journal = PublishJournalStore(hub_root)
+    processor = PublishOperationProcessor(
+        journal,
+        executors={
+            "react_pr_review_comment": build_react_pr_review_comment_executor(
+                repo_root=hub_root,
+                raw_config=automation_config,
+                github_service_factory=_ReactionGitHubService,
+            ),
+            "enqueue_managed_turn": build_enqueue_managed_turn_executor(
+                hub_root=hub_root
+            ),
+            "notify_chat": build_notify_chat_executor(hub_root=hub_root),
+        },
+    )
+    processed_operations = []
+    automation = ScmAutomationService(
+        hub_root,
+        reaction_config=automation_config,
+        publish_processor=processor,
+    )
+
+    class _AutomationWrapper:
+        def ingest_event(self, event) -> None:
+            automation.ingest_event(event)
+
+        def process_now(self, limit: int = 10):
+            result = automation.process_now(limit=limit)
+            processed_operations.extend(result)
+            return result
+
+    monkeypatch.setattr(
+        GitHubScmPollingService,
+        "_build_automation_service",
+        lambda self, reaction_config=None: _AutomationWrapper(),  # type: ignore[misc]
+    )
+
+    service = GitHubScmPollingService(
+        hub_root,
+        raw_config=automation_config,
+        github_service_factory=_factory,
+        watch_store=watch_store,
+        event_store=ScmEventStore(hub_root),
+    )
+
+    result = service.process_due_watches(limit=10)
+
+    assert result["events_emitted"] == 1
+    assert [operation.operation_kind for operation in processed_operations] == [
+        "react_pr_review_comment",
+        "enqueue_managed_turn",
+        "notify_chat",
+    ]
+    notify_result = processed_operations[2]
+    assert notify_result.state == "succeeded"
+    assert notify_result.response["delivery"] == "bound"
+    assert notify_result.response["repo_id"] == "repo-1"
+    assert notify_result.response["route"] == "bound"
+    assert notify_result.response["targets"] == 1
+    assert notify_result.response["published"] == 1
+    assert reaction_calls == [("acme", "widgets", str(hub_root), 2844, "eyes")]
+
+    turns = PmaThreadStore(hub_root).list_turns(thread["managed_thread_id"], limit=10)
+    assert len(turns) == 1
+
+    async def _load_outbox() -> list[object]:
+        store = DiscordStateStore(
+            hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+        )
+        try:
+            return await store.list_outbox()
+        finally:
+            await store.close()
+
+    outbox = asyncio.run(_load_outbox())
+    assert any(
+        record.channel_id == "repo-discord"
+        and "taking a look" in str(record.payload_json.get("content", "")).lower()
+        and "inline review wakeup path"
+        in str(record.payload_json.get("content", "")).lower()
+        for record in outbox
+    )
 
 
 def test_process_due_watches_does_not_reemit_when_thread_is_reopened_without_new_comments(


### PR DESCRIPTION
## Summary
- make SCM inline review-comment handling acknowledge GitHub review feedback before delegating follow-up work
- enqueue a bound chat notice for Discord/Telegram threads so users see that the review comment was received and the agent is taking a look
- add integration coverage for the polling path so review-comment wakeup, 👀 reaction, managed-thread enqueue, and bound-chat notification are exercised together

## Root Cause
The review-comment automation path had two gaps. First, the publish queue did not prioritize the GitHub `react_pr_review_comment` operation ahead of the managed-thread wakeup, so the intended 👀 acknowledgement was not guaranteed to happen before delegation. Second, waking the bound thread did not emit a companion bound-chat notification, so Discord/Telegram users got no visible acknowledgement that review feedback had been received.

## What Changed
- sort SCM reaction intents and publish-queue claims so `react_pr_review_comment` runs before `enqueue_managed_turn`, followed by any bound `notify_chat` wakeup notice
- add a review-comment wakeup notice in the SCM automation service that targets the bound chat thread with `delivery="bound"`
- add focused coverage for the extra `notify_chat` operation in SCM automation tests
- add an end-to-end GitHub polling integration test that verifies review-comment polling creates the 👀 reaction, wakes the managed thread, and notifies the bound Discord chat

## Validation
- `git commit` hook suite passed, including:
- `black`
- `ruff`
- repo import-boundary and contract checks
- strict mypy: `Success: no issues found in 600 source files`
- frontend build and JS tests
- full pytest sweep: `4653 passed`
- targeted verification rerun during development:
- `.venv/bin/pytest -q tests/core/test_scm_automation_service.py tests/core/test_publish_executor.py tests/integrations/github/test_polling.py`