### PR TITLE
[codex] Harden official Hermes ACP handling

### DIFF
--- a/src/codex_autorunner/agents/acp/AGENTS.md
+++ b/src/codex_autorunner/agents/acp/AGENTS.md
@@ -1,0 +1,131 @@
+# ACP Module — Agent Guide
+
+This package is CAR's generic ACP client/supervisor layer.
+
+Use this guide before changing `client.py`, `events.py`, `protocol.py`, or
+`supervisor.py`.
+
+## Why this guide exists
+
+ACP has two materially different shapes in this codebase:
+
+- Legacy / notification-heavy adapters
+- Official ACP session protocol adapters
+
+Several Hermes regressions came from treating those two shapes as interchangeable.
+The main risk is assuming a notification-based terminal contract in places where
+official ACP is actually request/response based.
+
+## Core split: legacy vs official ACP
+
+`ACPClient._uses_official_session_protocol()` is the branch point.
+
+- Legacy ACP:
+  - session creation uses `session/create`
+  - prompts start via `prompt/start`
+  - prompt lifecycle can be driven by terminal notifications such as
+    `prompt/completed`, `prompt/failed`, `prompt/cancelled`
+- Official ACP session protocol:
+  - session creation uses `session/new`
+  - prompts run via `session/prompt`
+  - streaming progress arrives through `session/update`
+  - turn completion is the `session/prompt` RPC response
+
+Do not assume fixes for one side automatically apply to the other.
+
+## Invariants to preserve
+
+### Official ACP turn completion
+
+For official ACP, CAR must not invent a notification-based completion contract.
+
+- `session/update` is progress, not terminal completion.
+- The `session/prompt` response is the completion boundary.
+- CAR synthesizes a local terminal event only after that RPC returns.
+
+If `session/prompt` never returns, the turn is still open from ACP's point of
+view, even if many `session/update` notifications have arrived.
+
+### Sparse official `session/load` responses
+
+Official ACP `session/load` responses may be sparse.
+
+- `null` should be treated as a missing-session failure.
+- `{}` or other object responses without a session identifier should still be
+  accepted when the caller already knows the requested `session_id`.
+
+Do not require `sessionId` in official `session/load` success payloads unless
+the protocol itself changes and the code/tests are updated together.
+
+### Legacy terminal fallback logic
+
+Legacy adapters may emit prompt-scoped terminal notifications without `turnId`,
+or may emit idle/status before a canonical completion event.
+
+- Session-level fallback mapping for missing `turnId` is legacy-only defensive
+  behavior.
+- Idle-terminal grace logic exists to prefer explicit completion when both idle
+  and prompt completion signals appear close together.
+
+Do not copy those heuristics into official ACP logic unless you have a concrete
+protocol reason.
+
+## File responsibilities
+
+| File | Responsibility |
+|---|---|
+| `client.py` | Transport, request/response tracking, official-vs-legacy branching, prompt state |
+| `events.py` | Notification normalization into CAR event types |
+| `protocol.py` | Coercion/parsing of ACP initialize/session/prompt payloads |
+| `supervisor.py` | Workspace-scoped client lifecycle and higher-level handle management |
+| `errors.py` | ACP-specific error surface |
+
+## Before changing behavior
+
+Answer these questions explicitly:
+
+1. Is this change for legacy ACP, official ACP, or both?
+2. Is the completion boundary notification-driven or RPC-response-driven?
+3. Are you changing protocol interpretation, or just hardening around malformed
+   adapters?
+4. What test proves the exact boundary being changed?
+
+If the answer is unclear, stop and add a fixture/test first.
+
+## Required tests for ACP behavior changes
+
+At minimum, update or add focused tests in:
+
+- `tests/agents/acp/test_client.py`
+
+Use `tests/fixtures/fake_acp_server.py` to model protocol behavior directly.
+
+If the change affects surface behavior, add or update a cross-surface test such
+as:
+
+- `tests/chat_surface_integration/test_hermes_pma_official_timeout.py`
+
+## Existing regression coverage to preserve
+
+These tests cover real historical failure modes:
+
+- legacy terminal notification without `turnId`
+- idle-status then explicit completion ordering
+- official `session/prompt` hang remaining non-terminal until RPC return
+- official sparse `session/load` success payloads
+- official `null` `session/load` failure payloads
+
+If you remove or weaken one of these, document why in the PR.
+
+## When integrating a new ACP-backed agent
+
+Before relying on the shared ACP client, determine:
+
+1. Does it advertise the official ACP session protocol (`agentInfo` +
+   `agentCapabilities`)?
+2. Does `session/prompt` always return terminally?
+3. Are `session/load` responses sparse?
+4. Does the agent emit any non-standard terminal notifications anyway?
+
+Add a fixture scenario for any non-default behavior before wiring the agent into
+Discord/Telegram/PMA surfaces.

--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -452,10 +452,13 @@ class ACPClient:
                     "sessionId": session_id,
                 },
             )
-            return ACPSessionDescriptor(
-                session_id=session_id,
-                raw=_coerce_mapping(result),
-            )
+            if not _coerce_mapping(result):
+                raise ACPResponseError(
+                    method="session/load",
+                    code=-32004,
+                    message=f"session not found: {session_id}",
+                )
+            return ACPSessionDescriptor.from_result(result)
         result = await self.request("session/load", {"sessionId": session_id})
         return ACPSessionDescriptor.from_result(result)
 

--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -452,13 +452,20 @@ class ACPClient:
                     "sessionId": session_id,
                 },
             )
-            if not _coerce_mapping(result):
+            if result is None:
                 raise ACPResponseError(
                     method="session/load",
                     code=-32004,
                     message=f"session not found: {session_id}",
                 )
-            return ACPSessionDescriptor.from_result(result)
+            payload = _coerce_mapping(result)
+            try:
+                return ACPSessionDescriptor.from_result(payload)
+            except ValueError:
+                return ACPSessionDescriptor(
+                    session_id=session_id,
+                    raw=payload,
+                )
         result = await self.request("session/load", {"sessionId": session_id})
         return ACPSessionDescriptor.from_result(result)
 

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -15,6 +15,7 @@ from codex_autorunner.agents.acp import (
 from codex_autorunner.agents.acp.errors import (
     ACPProcessCrashedError,
     ACPProtocolError,
+    ACPResponseError,
 )
 
 FIXTURE_PATH = Path(__file__).resolve().parents[2] / "fixtures" / "fake_acp_server.py"
@@ -169,6 +170,46 @@ async def test_client_supports_official_acp_session_and_prompt_flow(
             "progress",
             "output_delta",
             "turn_terminal",
+        ]
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_client_rejects_official_load_session_empty_result(
+    tmp_path: Path,
+) -> None:
+    client = ACPClient(fixture_command("official_missing_load_result"), cwd=tmp_path)
+    try:
+        await client.start()
+        with pytest.raises(
+            ACPResponseError, match="session not found: missing-session"
+        ):
+            await client.load_session("missing-session")
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_client_official_prompt_stays_non_terminal_until_request_returns(
+    tmp_path: Path,
+) -> None:
+    client = ACPClient(fixture_command("official_prompt_hang"), cwd=tmp_path)
+    try:
+        created = await client.create_session(cwd=str(tmp_path))
+        handle = await client.start_prompt(created.session_id, "Reply with exactly OK.")
+        for _ in range(20):
+            if len(handle.snapshot_events()) >= 3:
+                break
+            await asyncio.sleep(0.01)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(handle.wait(), timeout=0.1)
+
+        assert [event.kind for event in handle.snapshot_events()] == [
+            "turn_started",
+            "progress",
+            "output_delta",
         ]
     finally:
         await client.close()

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -176,7 +176,22 @@ async def test_client_supports_official_acp_session_and_prompt_flow(
 
 
 @pytest.mark.asyncio
-async def test_client_rejects_official_load_session_empty_result(
+async def test_client_accepts_official_load_session_empty_object_result(
+    tmp_path: Path,
+) -> None:
+    client = ACPClient(fixture_command("official_empty_load_result"), cwd=tmp_path)
+    try:
+        created = await client.create_session(cwd=str(tmp_path))
+        loaded = await client.load_session(created.session_id)
+
+        assert loaded.session_id == created.session_id
+        assert loaded.raw == {}
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_client_rejects_official_load_session_null_result(
     tmp_path: Path,
 ) -> None:
     client = ACPClient(fixture_command("official_missing_load_result"), cwd=tmp_path)

--- a/tests/chat_surface_integration/test_hermes_pma_official_timeout.py
+++ b/tests/chat_surface_integration/test_hermes_pma_official_timeout.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from codex_autorunner.integrations.discord import message_turns as discord_message_turns
+
+from .harness import DiscordSurfaceHarness, HermesFixtureRuntime, patch_hermes_runtime
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.anyio
+async def test_discord_hermes_pma_times_out_for_official_prompt_hang(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = HermesFixtureRuntime("official_prompt_hang")
+    patch_hermes_runtime(monkeypatch, runtime)
+    monkeypatch.setattr(discord_message_turns, "DISCORD_PMA_TIMEOUT_SECONDS", 0.05)
+    harness = DiscordSurfaceHarness(tmp_path / "discord")
+    await harness.setup(agent="hermes")
+    try:
+        rest = await harness.run_message("echo hello world")
+
+        assert any(
+            op["op"] == "edit"
+            and "failed" in str(op["payload"].get("content", "")).lower()
+            for op in rest.message_ops
+        )
+        assert any(
+            op["op"] == "send"
+            and "discord pma turn timed out"
+            in str(op["payload"].get("content", "")).lower()
+            for op in rest.message_ops
+        )
+    finally:
+        await harness.close()
+        await runtime.close()

--- a/tests/fixtures/fake_acp_server.py
+++ b/tests/fixtures/fake_acp_server.py
@@ -40,7 +40,7 @@ class FakeACPServer:
     def send(self, payload: dict[str, Any]) -> None:
         _write_line(self._lock, payload)
 
-    def _send_result(self, request_id: Any, result: dict[str, Any]) -> None:
+    def _send_result(self, request_id: Any, result: Any) -> None:
         self.send({"id": request_id, "result": result})
 
     def _send_error(self, request_id: Any, code: int, message: str) -> None:
@@ -244,6 +244,7 @@ class FakeACPServer:
         request_id = message.get("id")
         method = message.get("method")
         params = message.get("params") or {}
+        is_official = self._scenario.startswith("official")
         if method != "initialize" and not self._initialized:
             self._send_error(request_id, -32000, "not initialized")
             return
@@ -251,11 +252,11 @@ class FakeACPServer:
             if self._scenario == "initialize_error":
                 self._send_error(request_id, -32001, "initialize failed")
                 return
-            if self._scenario == "official" and "protocolVersion" not in params:
+            if is_official and "protocolVersion" not in params:
                 self._send_error(request_id, -32602, "Invalid params")
                 return
             self._initialized = True
-            if self._scenario == "official":
+            if is_official:
                 self._send_result(
                     request_id,
                     {
@@ -303,13 +304,16 @@ class FakeACPServer:
         if method == "session/load":
             session_id = str(params.get("sessionId") or "")
             session = self._sessions.get(session_id)
+            if self._scenario == "official_missing_load_result" and session is None:
+                self._send_result(request_id, None)
+                return
             if session is None:
                 self._send_error(request_id, -32004, "session not found")
                 return
             self._send_result(request_id, {"session": session})
             return
         if method == "session/list":
-            if self._scenario == "official":
+            if is_official:
                 self._send_error(request_id, -32601, "Method not found: session/list")
                 return
             self._send_result(
@@ -356,6 +360,8 @@ class FakeACPServer:
                     },
                 }
             )
+            if self._scenario == "official_prompt_hang":
+                return
             self._send_result(request_id, {"stopReason": "end_turn"})
             return
         if method == "prompt/start":

--- a/tests/fixtures/fake_acp_server.py
+++ b/tests/fixtures/fake_acp_server.py
@@ -310,6 +310,9 @@ class FakeACPServer:
             if session is None:
                 self._send_error(request_id, -32004, "session not found")
                 return
+            if self._scenario == "official_empty_load_result":
+                self._send_result(request_id, {})
+                return
             self._send_result(request_id, {"session": session})
             return
         if method == "session/list":


### PR DESCRIPTION
## Summary
This hardens CAR's official Hermes ACP path around the failure mode described in the expert review: official `session/prompt` requests can stream updates without ever returning terminally, and official `session/load` can fail by returning an empty result instead of an explicit ACP error.

## What changed
- treat empty official `session/load` results as `session not found` instead of constructing a bogus session descriptor
- extend the fake ACP fixture with official-path scenarios for:
  - a hanging `session/prompt` request that never returns
  - an empty `session/load` result
- add ACP client coverage proving official prompt updates remain non-terminal until the request returns
- add Discord PMA integration coverage proving an official prompt hang transitions to explicit timeout failure instead of hanging indefinitely

## Why
The recent Hermes fixes mostly targeted idle-terminal notification gaps. The expert take points at a different production boundary for official ACP mode: CAR only finalizes when the `session/prompt` RPC returns. This PR adds the CAR-side hardening and regression coverage that matches that official-path behavior.

## Impact
- stale official Hermes session bindings fail fast and can be cleared instead of masquerading as successful loads
- official ACP hangs are covered by regression fixtures and Discord PMA timeout behavior is now locked in by test
- this does not replace the primary Hermes-side fix; it hardens CAR around the observed contract mismatch

## Validation
- `.venv/bin/python -m pytest -q tests/agents/acp/test_client.py tests/chat_surface_integration/test_hermes_pma_official_timeout.py`
- pre-commit commit hook suite, including repo-wide mypy, frontend build/tests, and repo-wide pytest (`4657 passed`)

## Root cause
The best-supported root cause from the attached expert analysis is that Hermes hangs at the official ACP prompt-completion boundary, while CAR's recent fixes were aimed at idle-terminal notification gaps. This PR addresses the CAR-side gaps that analysis surfaced without claiming to solve the Hermes-side prompt return issue itself.