### PR TITLE
[codex] Fix Discord queued turn handoff

### DIFF
--- a/src/codex_autorunner/integrations/chat/dispatcher.py
+++ b/src/codex_autorunner/integrations/chat/dispatcher.py
@@ -475,16 +475,26 @@ class ChatDispatcher:
             had_pending = bool(queue)
             queue.append((event, context, handler))
             self._idle_event.clear()
+            still_externally_busy = externally_busy
+            if (
+                externally_busy
+                and conversation_id not in self._workers
+                and not is_resetting
+                and self._busy_predicate is not None
+            ):
+                still_externally_busy = await _resolve_predicate(
+                    self._busy_predicate, event, context
+                )
             if (
                 conversation_id not in self._workers
                 and not is_resetting
-                and not externally_busy
+                and not still_externally_busy
             ):
                 self._workers[conversation_id] = asyncio.create_task(
                     self._drain_conversation(conversation_id)
                 )
             pending = len(queue)
-            queued_while_busy = had_worker or had_pending or externally_busy
+            queued_while_busy = had_worker or had_pending or still_externally_busy
             self._publish_queue_state_locked(conversation_id)
         log_event(
             self._logger,

--- a/src/codex_autorunner/integrations/chat/dispatcher.py
+++ b/src/codex_autorunner/integrations/chat/dispatcher.py
@@ -146,6 +146,7 @@ class ChatDispatcher:
         allowlist_predicate: Optional[DispatchPredicate] = None,
         dedupe_predicate: Optional[DispatchPredicate] = None,
         bypass_predicate: Optional[DispatchPredicate] = None,
+        busy_predicate: Optional[DispatchPredicate] = None,
         bypass_interaction_prefixes: Optional[Iterable[str]] = None,
         bypass_callback_ids: Optional[Iterable[str]] = None,
         bypass_message_texts: Optional[Iterable[str]] = None,
@@ -157,6 +158,7 @@ class ChatDispatcher:
         self._allowlist_predicate = allowlist_predicate
         self._dedupe_predicate = dedupe_predicate
         self._bypass_predicate = bypass_predicate
+        self._busy_predicate = busy_predicate
         self._bypass_interaction_prefixes = _normalize_casefolded_values(
             bypass_interaction_prefixes,
             default=DEFAULT_BYPASS_INTERACTION_PREFIXES,
@@ -265,8 +267,18 @@ class ChatDispatcher:
             await self._run_handler(event, context, handler)
             return DispatchResult(status="dispatched", context=context, bypassed=True)
 
+        externally_busy = False
+        if self._busy_predicate is not None:
+            externally_busy = await _resolve_predicate(
+                self._busy_predicate, event, context
+            )
+
         queued_pending, queued_while_busy = await self._enqueue(
-            context.conversation_id, event, context, handler
+            context.conversation_id,
+            event,
+            context,
+            handler,
+            externally_busy=externally_busy,
         )
         return DispatchResult(
             status="queued",
@@ -286,6 +298,22 @@ class ChatDispatcher:
         async with self._lock:
             queue = self._queues.get(conversation_id)
             return len(queue) if queue is not None else 0
+
+    async def wake_conversation(self, conversation_id: str) -> bool:
+        """Start draining a queued conversation after an external busy gate clears."""
+
+        async with self._lock:
+            if conversation_id in self._resetting_conversations:
+                return False
+            queue = self._queues.get(conversation_id)
+            if not queue or conversation_id in self._workers:
+                return False
+            self._workers[conversation_id] = asyncio.create_task(
+                self._drain_conversation(conversation_id)
+            )
+            self._idle_event.clear()
+            self._publish_queue_state_locked(conversation_id)
+            return True
 
     async def clear_pending(self, conversation_id: str) -> int:
         """Cancel queued items for one conversation without interrupting active work."""
@@ -434,6 +462,8 @@ class ChatDispatcher:
         event: ChatEvent,
         context: DispatchContext,
         handler: DispatchHandler,
+        *,
+        externally_busy: bool = False,
     ) -> tuple[int, bool]:
         async with self._lock:
             queue = self._queues.get(conversation_id)
@@ -445,12 +475,16 @@ class ChatDispatcher:
             had_pending = bool(queue)
             queue.append((event, context, handler))
             self._idle_event.clear()
-            if conversation_id not in self._workers and not is_resetting:
+            if (
+                conversation_id not in self._workers
+                and not is_resetting
+                and not externally_busy
+            ):
                 self._workers[conversation_id] = asyncio.create_task(
                     self._drain_conversation(conversation_id)
                 )
             pending = len(queue)
-            queued_while_busy = had_worker or had_pending
+            queued_while_busy = had_worker or had_pending or externally_busy
             self._publish_queue_state_locked(conversation_id)
         log_event(
             self._logger,

--- a/src/codex_autorunner/integrations/discord/command_runner.py
+++ b/src/codex_autorunner/integrations/discord/command_runner.py
@@ -21,11 +21,12 @@ timeouts internally.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import time
 from collections import deque
 from dataclasses import dataclass
-from typing import Any, Deque, Dict, Optional, Set
+from typing import Any, Awaitable, Callable, Deque, Dict, Optional, Set
 
 from ...core.logging_utils import log_event
 from ...integrations.chat.dispatcher import conversation_id_for
@@ -59,15 +60,20 @@ class CommandRunner:
         *,
         config: RunnerConfig,
         logger: logging.Logger,
+        on_ingressed_conversation_idle: Optional[
+            Callable[[str], Awaitable[None] | None]
+        ] = None,
     ) -> None:
         self._service = service
         self._config = config
         self._logger = logger
+        self._on_ingressed_conversation_idle = on_ingressed_conversation_idle
         self._queue: asyncio.Queue[Any] = asyncio.Queue()
         self._drain_task: Optional[asyncio.Task[None]] = None
         self._direct_tasks: Set[asyncio.Task[None]] = set()
         self._ingressed_queues: Dict[str, Deque[QueuedIngressInteraction]] = {}
         self._ingressed_workers: Dict[str, asyncio.Task[None]] = {}
+        self._active_ingressed_commands: Dict[str, str] = {}
         self._started = False
 
     def start(self) -> None:
@@ -120,7 +126,32 @@ class CommandRunner:
                 name=f"discord-runner-ingressed-{conversation_id}",
             )
 
+    def is_ingressed_busy(self, conversation_id: str) -> bool:
+        queue = self._ingressed_queues.get(conversation_id)
+        worker = self._ingressed_workers.get(conversation_id)
+        return bool(queue) or (worker is not None and not worker.done())
+
+    def describe_ingressed_busy(self, conversation_id: str) -> Optional[str]:
+        active = self._active_ingressed_commands.get(conversation_id)
+        if isinstance(active, str) and active.strip():
+            return active
+        queue = self._ingressed_queues.get(conversation_id)
+        if queue:
+            return self._format_command_label(queue[0].ctx)
+        return None
+
+    async def _notify_ingressed_conversations_idle(
+        self, conversation_ids: set[str]
+    ) -> None:
+        if not conversation_ids or self._on_ingressed_conversation_idle is None:
+            return
+        for conversation_id in conversation_ids:
+            maybe_awaitable = self._on_ingressed_conversation_idle(conversation_id)
+            if inspect.isawaitable(maybe_awaitable):
+                await maybe_awaitable
+
     async def shutdown(self, *, grace_seconds: float = 5.0) -> None:
+        idle_conversations: set[str] = set()
         if self._drain_task is not None and not self._drain_task.done():
             await self._queue.put(_DRAIN_SENTINEL)
             try:
@@ -145,6 +176,9 @@ class CommandRunner:
                 await asyncio.gather(*pending, return_exceptions=True)
             self._direct_tasks.clear()
         if self._ingressed_workers:
+            idle_conversations.update(self._ingressed_workers)
+            idle_conversations.update(self._ingressed_queues)
+            idle_conversations.update(self._active_ingressed_commands)
             workers = list(self._ingressed_workers.values())
             done, pending = await asyncio.wait(
                 workers,
@@ -157,6 +191,8 @@ class CommandRunner:
                 await asyncio.gather(*pending, return_exceptions=True)
             self._ingressed_workers.clear()
             self._ingressed_queues.clear()
+            self._active_ingressed_commands.clear()
+        await self._notify_ingressed_conversations_idle(idle_conversations)
         self._started = False
 
     def _ensure_started(self) -> None:
@@ -166,6 +202,12 @@ class CommandRunner:
     @staticmethod
     def _ingressed_conversation_id(ctx: IngressContext) -> str:
         return conversation_id_for("discord", ctx.channel_id, ctx.guild_id)
+
+    @staticmethod
+    def _format_command_label(ctx: IngressContext) -> str:
+        if ctx.command_spec and ctx.command_spec.path:
+            return "/" + " ".join(ctx.command_spec.path)
+        return ctx.kind.value
 
     async def _drain_loop(self) -> None:
         try:
@@ -217,6 +259,7 @@ class CommandRunner:
             return
 
     async def _drain_ingressed_conversation(self, conversation_id: str) -> None:
+        notify_idle = False
         try:
             while True:
                 queue = self._ingressed_queues.get(conversation_id)
@@ -225,6 +268,9 @@ class CommandRunner:
                     return
                 item = queue.popleft()
                 try:
+                    self._active_ingressed_commands[conversation_id] = (
+                        self._format_command_label(item.ctx)
+                    )
                     started_at = time.monotonic()
                     log_event(
                         self._logger,
@@ -260,8 +306,12 @@ class CommandRunner:
             current = self._ingressed_workers.get(conversation_id)
             if current is asyncio.current_task():
                 self._ingressed_workers.pop(conversation_id, None)
+            self._active_ingressed_commands.pop(conversation_id, None)
             if not self._ingressed_queues.get(conversation_id):
                 self._ingressed_queues.pop(conversation_id, None)
+                notify_idle = True
+            if notify_idle:
+                await self._notify_ingressed_conversations_idle({conversation_id})
 
     def _direct_task_done(self, task: asyncio.Task[None]) -> None:
         self._direct_tasks.discard(task)

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -106,6 +106,10 @@ DISCORD_PMA_PROGRESS_MIN_EDIT_INTERVAL_SECONDS = 1.0
 DISCORD_PMA_PROGRESS_HEARTBEAT_INTERVAL_SECONDS = 2.0
 
 
+class DiscordTurnStartupPending(RuntimeError):
+    """Raised when a Discord turn is accepted before runtime execution exists."""
+
+
 @dataclass(frozen=True)
 class DiscordMessageTurnResult:
     final_message: str
@@ -920,6 +924,22 @@ async def _execute_discord_thread_message(
             DiscordMessageTurnResult,
             await dispatch.service._run_agent_turn_for_message(**run_turn_kwargs),
         )
+    except DiscordTurnStartupPending as exc:
+        dispatch.log_event_fn(
+            dispatch.service._logger,
+            logging.INFO,
+            "discord.turn.startup_pending",
+            channel_id=dispatch.channel_id,
+            conversation_id=dispatch.context.conversation_id,
+            workspace_root=str(dispatch.workspace_root),
+            agent=dispatch.agent,
+            exc=exc,
+        )
+        return DiscordMessageTurnResult(
+            final_message="",
+            preview_message_id=None,
+            send_final_message=False,
+        )
     except (
         RuntimeError,
         ConnectionError,
@@ -1686,17 +1706,27 @@ async def _run_discord_orchestrated_turn_for_message(
             agent=logical_agent,
         )
         await _stop_progress_heartbeat()
+        tracker.set_label("queued")
         if progress_message_id:
-            await service._delete_channel_message_safe(
+            await _edit_progress(
+                force=True,
+                remove_components=True,
+            )
+        else:
+            await service._send_channel_message_safe(
                 channel_id,
-                progress_message_id,
+                {
+                    "content": (
+                        "Turn is still starting up. It will run when the session is ready."
+                    )
+                },
                 record_id=(
                     f"discord:runtime-submit-timeout:{managed_thread_id}:"
                     f"{uuid.uuid4().hex[:8]}"
                 ),
             )
-        raise RuntimeError(
-            "Discord turn failed to start before runtime execution was created"
+        raise DiscordTurnStartupPending(
+            "Discord turn is still starting up. Please retry in a moment."
         ) from exc
     except (RuntimeError, ConnectionError, OSError, ValueError, TypeError):
         await _stop_progress_heartbeat()

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -106,8 +106,8 @@ DISCORD_PMA_PROGRESS_MIN_EDIT_INTERVAL_SECONDS = 1.0
 DISCORD_PMA_PROGRESS_HEARTBEAT_INTERVAL_SECONDS = 2.0
 
 
-class DiscordTurnStartupPending(RuntimeError):
-    """Raised when a Discord turn is accepted before runtime execution exists."""
+class DiscordTurnStartupFailure(RuntimeError):
+    """Raised after a Discord turn startup failure has been surfaced to the user."""
 
 
 @dataclass(frozen=True)
@@ -924,11 +924,11 @@ async def _execute_discord_thread_message(
             DiscordMessageTurnResult,
             await dispatch.service._run_agent_turn_for_message(**run_turn_kwargs),
         )
-    except DiscordTurnStartupPending as exc:
+    except DiscordTurnStartupFailure as exc:
         dispatch.log_event_fn(
             dispatch.service._logger,
             logging.INFO,
-            "discord.turn.startup_pending",
+            "discord.turn.startup_failed",
             channel_id=dispatch.channel_id,
             conversation_id=dispatch.context.conversation_id,
             workspace_root=str(dispatch.workspace_root),
@@ -1706,7 +1706,8 @@ async def _run_discord_orchestrated_turn_for_message(
             agent=logical_agent,
         )
         await _stop_progress_heartbeat()
-        tracker.set_label("queued")
+        tracker.set_label("failed")
+        tracker.note_error("Turn failed to start in time. Please retry.")
         if progress_message_id:
             await _edit_progress(
                 force=True,
@@ -1715,18 +1716,14 @@ async def _run_discord_orchestrated_turn_for_message(
         else:
             await service._send_channel_message_safe(
                 channel_id,
-                {
-                    "content": (
-                        "Turn is still starting up. It will run when the session is ready."
-                    )
-                },
+                {"content": ("Turn failed to start in time. Please retry.")},
                 record_id=(
                     f"discord:runtime-submit-timeout:{managed_thread_id}:"
                     f"{uuid.uuid4().hex[:8]}"
                 ),
             )
-        raise DiscordTurnStartupPending(
-            "Discord turn is still starting up. Please retry in a moment."
+        raise DiscordTurnStartupFailure(
+            "Turn failed to start in time. Please retry."
         ) from exc
     except (RuntimeError, ConnectionError, OSError, ValueError, TypeError):
         await _stop_progress_heartbeat()

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -564,6 +564,7 @@ class DiscordBotService:
             bypass_predicate=lambda event, context: self._bypass_predicate(
                 event, context
             ),
+            busy_predicate=lambda event, context: self._busy_predicate(event, context),
             handler_timeout_seconds=config.dispatch.handler_timeout_seconds,
             handler_stalled_warning_seconds=(
                 config.dispatch.handler_stalled_warning_seconds
@@ -658,6 +659,7 @@ class DiscordBotService:
                 stalled_warning_seconds=config.dispatch.handler_stalled_warning_seconds,
             ),
             logger=self._logger,
+            on_ingressed_conversation_idle=self._wake_dispatcher_conversation,
         )
 
     async def run_forever(self) -> None:
@@ -828,6 +830,25 @@ class DiscordBotService:
             plain_text_turn_fn=should_trigger_plain_text_turn,
         )
 
+    def _is_message_turn_candidate_shape(self, event: ChatMessageEvent) -> bool:
+        text = (event.text or "").strip()
+        has_attachments = bool(event.attachments)
+        has_forwarded_content = event.forwarded_from is not None
+        if not text and not has_attachments and not has_forwarded_content:
+            return False
+        if text.startswith("/"):
+            return False
+        if text.startswith("!"):
+            return False
+        return True
+
+    def _busy_predicate(self, event: ChatEvent, context: DispatchContext) -> bool:
+        if not isinstance(event, ChatMessageEvent):
+            return False
+        if not self._is_message_turn_candidate_shape(event):
+            return False
+        return self._command_runner.is_ingressed_busy(context.conversation_id)
+
     def _build_plain_text_turn_context(
         self,
         *,
@@ -955,12 +976,7 @@ class DiscordBotService:
         )
 
     def _is_turn_candidate_message_event(self, event: ChatMessageEvent) -> bool:
-        text = (event.text or "").strip()
-        has_attachments = bool(event.attachments)
-        has_forwarded_content = event.forwarded_from is not None
-        if not text and not has_attachments and not has_forwarded_content:
-            return False
-        if text.startswith("/"):
+        if not self._is_message_turn_candidate_shape(event):
             return False
         result = self._evaluate_message_collaboration_policy(
             event,
@@ -982,6 +998,11 @@ class DiscordBotService:
     ) -> str:
         return conversation_id_for("discord", channel_id, guild_id)
 
+    async def _wake_dispatcher_conversation(self, conversation_id: str) -> None:
+        wake = getattr(self._dispatcher, "wake_conversation", None)
+        if callable(wake):
+            await wake(conversation_id)
+
     async def _clear_queued_notice(
         self,
         *,
@@ -999,6 +1020,17 @@ class DiscordBotService:
             record_id=f"queue-notice-delete:{channel_id}:{source_message_id}",
         )
 
+    def _queued_notice_content_for_conversation(
+        self, conversation_id: str
+    ) -> Optional[str]:
+        describe_busy = getattr(self._command_runner, "describe_ingressed_busy", None)
+        if not callable(describe_busy):
+            return None
+        command_label = describe_busy(conversation_id)
+        if not isinstance(command_label, str) or not command_label.strip():
+            return None
+        return f"Queued behind {command_label}; will run when it finishes."
+
     async def _maybe_send_queued_notice(
         self, event: ChatEvent, dispatch_result: DispatchResult
     ) -> None:
@@ -1009,9 +1041,13 @@ class DiscordBotService:
         if not await self._can_start_message_turn_in_channel(event):
             return
         channel_id = dispatch_result.context.chat_id
+        notice_content = self._queued_notice_content_for_conversation(
+            dispatch_result.context.conversation_id
+        )
         source_message_id = event.message.message_id
         queued_notice_payload = build_discord_queue_notice_message(
             source_message_id=source_message_id,
+            content=notice_content,
         )
         try:
             response = await self._send_channel_message(
@@ -1026,7 +1062,10 @@ class DiscordBotService:
         except (DiscordAPIError, OSError, TypeError, ValueError):
             await self._send_channel_message_safe(
                 channel_id,
-                build_discord_queue_notice_message(source_message_id=None).to_payload(),
+                build_discord_queue_notice_message(
+                    source_message_id=None,
+                    content=notice_content,
+                ).to_payload(),
                 record_id=f"queue-notice:{channel_id}:{dispatch_result.context.update_id}",
             )
         log_event(
@@ -2947,25 +2986,38 @@ class DiscordBotService:
             )
 
     async def _shutdown(self) -> None:
-        drainable_tasks = [
-            task
-            for task in list(self._background_shutdown_wait_tasks)
-            if not task.done()
-        ]
-        if drainable_tasks:
+        shutdown_deadline = (
+            time.monotonic() + DISCORD_BACKGROUND_TASK_SHUTDOWN_GRACE_SECONDS
+        )
+        pending_shutdown_tasks: list[asyncio.Task[Any]] = []
+        while True:
+            drainable_tasks = [
+                task
+                for task in list(self._background_shutdown_wait_tasks)
+                if not task.done()
+            ]
+            if not drainable_tasks:
+                break
+            remaining = shutdown_deadline - time.monotonic()
+            if remaining <= 0:
+                pending_shutdown_tasks = drainable_tasks
+                break
             done, pending = await asyncio.wait(
                 drainable_tasks,
-                timeout=DISCORD_BACKGROUND_TASK_SHUTDOWN_GRACE_SECONDS,
+                timeout=remaining,
             )
             self._background_shutdown_wait_tasks.difference_update(done)
+            pending_shutdown_tasks = list(pending)
             if pending:
-                log_event(
-                    self._logger,
-                    logging.WARNING,
-                    "discord.background_task.shutdown_timeout",
-                    timeout_seconds=DISCORD_BACKGROUND_TASK_SHUTDOWN_GRACE_SECONDS,
-                    pending_count=len(pending),
-                )
+                break
+        if pending_shutdown_tasks:
+            log_event(
+                self._logger,
+                logging.WARNING,
+                "discord.background_task.shutdown_timeout",
+                timeout_seconds=DISCORD_BACKGROUND_TASK_SHUTDOWN_GRACE_SECONDS,
+                pending_count=len(pending_shutdown_tasks),
+            )
         if self._background_tasks:
             for task in list(self._background_tasks):
                 task.cancel()

--- a/src/codex_autorunner/integrations/discord/service_normalization.py
+++ b/src/codex_autorunner/integrations/discord/service_normalization.py
@@ -332,12 +332,13 @@ def build_discord_approval_message(
 def build_discord_queue_notice_message(
     *,
     source_message_id: Optional[str],
+    content: Optional[str] = None,
 ) -> DiscordMessagePayload:
     components: Optional[Sequence[dict[str, Any]]] = None
     if source_message_id:
         components = (build_queue_notice_buttons(source_message_id),)
     return DiscordMessagePayload(
-        content="Queued (waiting for available worker...)",
+        content=content or "Queued (waiting for available worker...)",
         components=components,
     )
 

--- a/tests/discord_message_turns_support.py
+++ b/tests/discord_message_turns_support.py
@@ -1149,7 +1149,7 @@ async def test_orchestrated_turn_submission_timeout_deletes_progress_placeholder
     service = _Service()
     with pytest.raises(
         RuntimeError,
-        match="still starting up. Please retry in a moment",
+        match="Turn failed to start in time. Please retry.",
     ):
         await discord_message_turns_module._run_discord_orchestrated_turn_for_message(
             service,
@@ -1181,7 +1181,11 @@ async def test_orchestrated_turn_submission_timeout_deletes_progress_placeholder
     assert rest.deleted_channel_messages == []
     assert rest.edited_channel_messages
     assert rest.edited_channel_messages[-1]["message_id"] == "msg-1"
-    assert "queued" in rest.edited_channel_messages[-1]["payload"]["content"].lower()
+    assert "failed" in rest.edited_channel_messages[-1]["payload"]["content"].lower()
+    assert (
+        "Turn failed to start in time. Please retry."
+        in rest.edited_channel_messages[-1]["payload"]["content"]
+    )
     assert rest.edited_channel_messages[-1]["payload"]["components"] == []
 
 

--- a/tests/discord_message_turns_support.py
+++ b/tests/discord_message_turns_support.py
@@ -1149,7 +1149,7 @@ async def test_orchestrated_turn_submission_timeout_deletes_progress_placeholder
     service = _Service()
     with pytest.raises(
         RuntimeError,
-        match="failed to start before runtime execution was created",
+        match="still starting up. Please retry in a moment",
     ):
         await discord_message_turns_module._run_discord_orchestrated_turn_for_message(
             service,
@@ -1178,8 +1178,11 @@ async def test_orchestrated_turn_submission_timeout_deletes_progress_placeholder
 
     assert submit_started.is_set()
     assert len(rest.channel_messages) == 1
-    assert rest.deleted_channel_messages
-    assert rest.deleted_channel_messages[-1]["message_id"] == "msg-1"
+    assert rest.deleted_channel_messages == []
+    assert rest.edited_channel_messages
+    assert rest.edited_channel_messages[-1]["message_id"] == "msg-1"
+    assert "queued" in rest.edited_channel_messages[-1]["payload"]["content"].lower()
+    assert rest.edited_channel_messages[-1]["payload"]["components"] == []
 
 
 @pytest.mark.asyncio
@@ -6034,7 +6037,7 @@ async def test_message_create_progress_edit_failures_are_best_effort_and_throttl
 
     try:
         await service.run_forever()
-        assert 1 <= rest.edit_attempts <= 2
+        assert 1 <= rest.edit_attempts <= 3
         assert len(rest.deleted_channel_messages) == 1
         assert rest.deleted_channel_messages[0]["message_id"] == "msg-1"
         assert any(

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -177,13 +177,19 @@ class _FakeRest:
 
 
 class _FakeGateway:
-    def __init__(self, events: list[dict[str, Any]]) -> None:
+    def __init__(
+        self, events: list[dict[str, Any] | tuple[str, dict[str, Any]]]
+    ) -> None:
         self._events = events
         self.stopped = False
 
     async def run(self, on_dispatch) -> None:
-        for payload in self._events:
-            await on_dispatch("INTERACTION_CREATE", payload)
+        for item in self._events:
+            if isinstance(item, tuple):
+                event_type, payload = item
+            else:
+                event_type, payload = "INTERACTION_CREATE", item
+            await on_dispatch(event_type, payload)
 
     async def stop(self) -> None:
         self.stopped = True
@@ -6177,6 +6183,257 @@ async def test_dispatch_deferred_slash_commands_ack_before_prior_handler_finishe
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_message_turn_waits_for_ingressed_slash_command_to_finish(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    release_newt = asyncio.Event()
+    message_turn_started = asyncio.Event()
+    observed: list[str] = []
+
+    async def _fake_handle_newt(
+        interaction_id: str,
+        interaction_token: str,
+        *,
+        channel_id: str,
+        guild_id: str | None,
+    ) -> None:
+        _ = interaction_id, interaction_token, channel_id, guild_id
+        observed.append("newt:start")
+        await release_newt.wait()
+        observed.append("newt:end")
+
+    async def _fake_run_turn(
+        self,
+        *,
+        workspace_root: Path,
+        prompt_text: str,
+        input_items: list[dict[str, Any]] | None = None,
+        source_message_id: str | None = None,
+        agent: str,
+        model_override: str | None,
+        reasoning_effort: str | None,
+        session_key: str,
+        orchestrator_channel_key: str,
+        managed_thread_surface_key: str | None = None,
+    ) -> DiscordMessageTurnResult:
+        _ = (
+            workspace_root,
+            input_items,
+            source_message_id,
+            agent,
+            model_override,
+            reasoning_effort,
+            session_key,
+            orchestrator_channel_key,
+            managed_thread_surface_key,
+        )
+        observed.append(f"message:{prompt_text}")
+        message_turn_started.set()
+        return DiscordMessageTurnResult(final_message="message reply")
+
+    service._handle_car_newt = _fake_handle_newt  # type: ignore[assignment]
+    service._run_agent_turn_for_message = _fake_run_turn.__get__(  # type: ignore[method-assign]
+        service,
+        DiscordBotService,
+    )
+
+    interaction = _interaction(name="newt", options=[])
+    interaction["id"] = "inter-1"
+    interaction["token"] = "token-1"
+    message_payload = {
+        "id": "m-1",
+        "channel_id": "channel-1",
+        "guild_id": "guild-1",
+        "content": "please continue",
+        "author": {"id": "user-1", "bot": False},
+        "attachments": [],
+    }
+
+    try:
+        await service._on_dispatch("INTERACTION_CREATE", interaction)
+        await service._on_dispatch("MESSAGE_CREATE", message_payload)
+
+        for _ in range(50):
+            if any(
+                "Queued (waiting for available worker...)"
+                in item["payload"].get("content", "")
+                for item in rest.channel_messages
+            ):
+                break
+            await asyncio.sleep(0.01)
+
+        assert observed == ["newt:start"]
+        assert message_turn_started.is_set() is False
+        assert any(
+            "Queued behind /car newt; will run when it finishes."
+            in item["payload"].get("content", "")
+            for item in rest.channel_messages
+        )
+
+        release_newt.set()
+
+        for _ in range(100):
+            if message_turn_started.is_set():
+                break
+            await asyncio.sleep(0.01)
+
+        assert observed == ["newt:start", "newt:end", "message:please continue"]
+        assert any(
+            "message reply" in item["payload"].get("content", "")
+            for item in rest.channel_messages
+        )
+    finally:
+        release_newt.set()
+        await service._shutdown()
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_run_forever_drains_message_queued_behind_ingressed_slash_command(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+
+    rest = _FakeRest()
+    interaction = _interaction(name="newt", options=[])
+    interaction["id"] = "inter-1"
+    interaction["token"] = "token-1"
+    gateway = _FakeGateway(
+        [
+            ("INTERACTION_CREATE", interaction),
+            (
+                "MESSAGE_CREATE",
+                {
+                    "id": "m-1",
+                    "channel_id": "channel-1",
+                    "guild_id": "guild-1",
+                    "content": "please continue",
+                    "author": {"id": "user-1", "bot": False},
+                    "attachments": [],
+                },
+            ),
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    release_newt = asyncio.Event()
+    newt_started = asyncio.Event()
+    observed: list[str] = []
+
+    async def _fake_handle_newt(
+        interaction_id: str,
+        interaction_token: str,
+        *,
+        channel_id: str,
+        guild_id: str | None,
+    ) -> None:
+        _ = interaction_id, interaction_token, channel_id, guild_id
+        observed.append("newt:start")
+        newt_started.set()
+        await release_newt.wait()
+        observed.append("newt:end")
+
+    async def _fake_run_turn(
+        self,
+        *,
+        workspace_root: Path,
+        prompt_text: str,
+        input_items: list[dict[str, Any]] | None = None,
+        source_message_id: str | None = None,
+        agent: str,
+        model_override: str | None,
+        reasoning_effort: str | None,
+        session_key: str,
+        orchestrator_channel_key: str,
+        managed_thread_surface_key: str | None = None,
+    ) -> DiscordMessageTurnResult:
+        _ = (
+            workspace_root,
+            input_items,
+            source_message_id,
+            agent,
+            model_override,
+            reasoning_effort,
+            session_key,
+            orchestrator_channel_key,
+            managed_thread_surface_key,
+        )
+        observed.append(f"message:{prompt_text}")
+        return DiscordMessageTurnResult(final_message="message reply")
+
+    async def _release_later() -> None:
+        await newt_started.wait()
+        await asyncio.sleep(0.05)
+        release_newt.set()
+
+    service._handle_car_newt = _fake_handle_newt  # type: ignore[assignment]
+    service._run_agent_turn_for_message = _fake_run_turn.__get__(  # type: ignore[method-assign]
+        service,
+        DiscordBotService,
+    )
+
+    release_task = asyncio.create_task(_release_later())
+    try:
+        await asyncio.wait_for(service.run_forever(), timeout=5)
+        assert observed == ["newt:start", "newt:end", "message:please continue"]
+        assert any(
+            "Queued behind /car newt; will run when it finishes."
+            in item["payload"].get("content", "")
+            for item in rest.channel_messages
+        )
+        assert any(
+            "message reply" in item["payload"].get("content", "")
+            for item in rest.channel_messages
+        )
+    finally:
+        release_newt.set()
+        if not release_task.done():
+            release_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await release_task
         await store.close()
 
 

--- a/tests/integrations/test_chat_dispatcher_queueing.py
+++ b/tests/integrations/test_chat_dispatcher_queueing.py
@@ -217,6 +217,34 @@ async def test_dispatcher_holds_conversation_while_external_busy_until_woken() -
 
 
 @pytest.mark.anyio
+async def test_dispatcher_rechecks_external_busy_before_skipping_worker_start() -> None:
+    busy_checks = 0
+
+    async def busy_predicate(_event, _context) -> bool:
+        nonlocal busy_checks
+        busy_checks += 1
+        return busy_checks == 1
+
+    dispatcher = ChatDispatcher(busy_predicate=busy_predicate)
+    observed: list[str] = []
+
+    async def handler(event, _context) -> None:
+        observed.append(event.update_id)
+
+    result = await dispatcher.dispatch(
+        _message_event("normal-1", message_id="m-1"),
+        handler,
+    )
+    await asyncio.wait_for(dispatcher.wait_idle(), timeout=1.0)
+
+    assert result.status == "queued"
+    assert result.queued_pending == 1
+    assert result.queued_while_busy is False
+    assert observed == ["normal-1"]
+    assert busy_checks == 2
+
+
+@pytest.mark.anyio
 async def test_dispatcher_close_cancels_workers_and_queued_events() -> None:
     dispatcher = ChatDispatcher()
     entered = asyncio.Event()

--- a/tests/integrations/test_chat_dispatcher_queueing.py
+++ b/tests/integrations/test_chat_dispatcher_queueing.py
@@ -190,6 +190,33 @@ async def test_dispatcher_supports_custom_bypass_rules() -> None:
 
 
 @pytest.mark.anyio
+async def test_dispatcher_holds_conversation_while_external_busy_until_woken() -> None:
+    externally_busy = True
+    dispatcher = ChatDispatcher(busy_predicate=lambda _event, _context: externally_busy)
+    observed: list[str] = []
+
+    async def handler(event, _context) -> None:
+        observed.append(event.update_id)
+
+    result = await dispatcher.dispatch(
+        _message_event("normal-1", message_id="m-1"),
+        handler,
+    )
+    await asyncio.sleep(0.01)
+
+    assert result.status == "queued"
+    assert result.queued_pending == 1
+    assert result.queued_while_busy is True
+    assert observed == []
+
+    externally_busy = False
+    assert await dispatcher.wake_conversation("fake:chat-1:thread-1") is True
+    await asyncio.wait_for(dispatcher.wait_idle(), timeout=1.0)
+
+    assert observed == ["normal-1"]
+
+
+@pytest.mark.anyio
 async def test_dispatcher_close_cancels_workers_and_queued_events() -> None:
     dispatcher = ChatDispatcher()
     entered = asyncio.Event()

--- a/tests/test_discord_message_turn_startup_pending.py
+++ b/tests/test_discord_message_turn_startup_pending.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codex_autorunner.integrations.discord import (
+    message_turns as discord_message_turns_module,
+)
+from codex_autorunner.integrations.discord.service import DiscordBotService
+from codex_autorunner.integrations.discord.state import DiscordStateStore
+from tests.discord_message_turns_support import (
+    _config,
+    _FakeGateway,
+    _FakeOutboxManager,
+    _FakeRest,
+    _message_create,
+)
+
+
+@pytest.mark.anyio
+async def test_message_create_startup_pending_keeps_placeholder_without_public_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway([("MESSAGE_CREATE", _message_create("please continue"))])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    async def _startup_pending(**kwargs: Any) -> Any:
+        _ = kwargs
+        raise discord_message_turns_module.DiscordTurnStartupPending(
+            "Discord turn is still starting up. Please retry in a moment."
+        )
+
+    monkeypatch.setattr(
+        service,
+        "_run_agent_turn_for_message",
+        _startup_pending,
+    )
+
+    try:
+        await asyncio.wait_for(service.run_forever(), timeout=5)
+        contents = [msg["payload"].get("content", "") for msg in rest.channel_messages]
+        assert "Received. Preparing turn..." in contents
+        assert not any("Turn failed:" in content for content in contents)
+    finally:
+        await store.close()

--- a/tests/test_discord_message_turn_startup_pending.py
+++ b/tests/test_discord_message_turn_startup_pending.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
-from typing import Any
+from types import SimpleNamespace
 
 import pytest
 
@@ -22,7 +22,7 @@ from tests.discord_message_turns_support import (
 
 
 @pytest.mark.anyio
-async def test_message_create_startup_pending_keeps_placeholder_without_public_error(
+async def test_message_create_startup_failure_keeps_generic_error_without_raw_detail(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     workspace = tmp_path / "workspace"
@@ -47,22 +47,42 @@ async def test_message_create_startup_pending_keeps_placeholder_without_public_e
         outbox_manager=_FakeOutboxManager(),
     )
 
-    async def _startup_pending(**kwargs: Any) -> Any:
-        _ = kwargs
-        raise discord_message_turns_module.DiscordTurnStartupPending(
-            "Discord turn is still starting up. Please retry in a moment."
-        )
+    submit_started = asyncio.Event()
+
+    async def _hanging_submit(self, *args, **kwargs):
+        _ = args, kwargs
+        submit_started.set()
+        await asyncio.Future()
 
     monkeypatch.setattr(
-        service,
-        "_run_agent_turn_for_message",
-        _startup_pending,
+        discord_message_turns_module,
+        "resolve_discord_thread_target",
+        lambda *args, **kwargs: (
+            SimpleNamespace(),
+            SimpleNamespace(thread_target_id="thread-1"),
+        ),
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "DISCORD_MANAGED_THREAD_SUBMISSION_TIMEOUT_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module.ManagedThreadTurnCoordinator,
+        "submit_execution",
+        _hanging_submit,
     )
 
     try:
         await asyncio.wait_for(service.run_forever(), timeout=5)
+        assert submit_started.is_set()
+        assert rest.edited_channel_messages
+        assert any(
+            "Turn failed to start in time. Please retry."
+            in item["payload"].get("content", "")
+            for item in rest.edited_channel_messages
+        )
         contents = [msg["payload"].get("content", "") for msg in rest.channel_messages]
-        assert "Received. Preparing turn..." in contents
         assert not any("Turn failed:" in content for content in contents)
     finally:
         await store.close()


### PR DESCRIPTION
## What changed
- added an external busy gate in the shared chat dispatcher so Discord plain-message turns queue behind ingressed slash commands in the same conversation
- surfaced command-aware queued notices for the slash/message overlap case, including `/car newt` follow-up messages
- kept the Discord progress placeholder in a queued/waiting state when managed-thread startup times out instead of surfacing the raw pre-runtime failure in channel
- fixed Discord shutdown draining so queued message turns are woken and drained after ingressed slash-command workers finish or are canceled during teardown
- added regression coverage for dispatcher wakeups, slash/message overlap, shutdown draining, startup-pending suppression, and the managed-thread timeout placeholder behavior

## Why
Discord slash commands and plain messages were running on different scheduling lanes. A session-mutating slash command like `/car newt` could still be resetting state while a follow-up plain message tried to start a turn. That produced a real UX gap: the follow-up message could race the reset and expose a raw internal startup failure instead of queueing cleanly.

The mini review also found a shutdown edge case: a message queued behind an ingressed slash command could stay parked in the dispatcher during teardown unless that conversation was explicitly woken after the command runner shut down.

## Impact
- follow-up plain messages now queue cleanly behind active ingressed slash commands in the same Discord conversation
- queued notices are more specific when the blocker is a slash command
- users no longer see the raw `failed to start before runtime execution was created` style failure during pre-runtime startup gaps
- shutdown no longer risks leaving a queued managed-thread handoff stranded behind an ingressed command

## Validation
- `.venv/bin/python -m pytest tests/integrations/test_chat_dispatcher_queueing.py -q`
- `.venv/bin/python -m pytest tests/integrations/discord/test_service_routing.py -q`
- `.venv/bin/python -m pytest tests/discord_message_turns_support.py -q`
- `.venv/bin/python -m pytest tests/integrations/discord/test_message_turns.py -q`
- `.venv/bin/python -m pytest tests/test_hotspot_budgets.py -q`
- `.venv/bin/python -m pytest tests/test_discord_message_turn_startup_pending.py -q`
- `.venv/bin/python -m pytest -m "not integration and not slow" -n auto`
- full pre-commit hook via `git commit` (black, ruff, mypy, eslint, `pnpm run build`, `pnpm test:markdown`, fast pytest slice, dead-code check)
