### PR TITLE
[codex] Improve review notification formatting

### DIFF
--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import html
 import importlib
 import json
 import logging
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -40,6 +42,11 @@ from .scm_reaction_types import (
 from .text_utils import _normalize_text
 
 _LOGGER = logging.getLogger(__name__)
+_MARKDOWN_LINK_RE = re.compile(r"!\[([^\]\n]*)\]\([^)]+\)|\[([^\]\n]+)\]\([^)]+\)")
+_REVIEW_BADGE_RE = re.compile(r"!\s*(P\d+)\s+Badge\b", re.IGNORECASE)
+_REVIEW_HTML_TAG_RE = re.compile(
+    r"</?(?:sub|sup|strong|b|em|i|code|br)\b[^>\n]*>", re.IGNORECASE
+)
 
 
 class ScmEventLookup(Protocol):
@@ -270,8 +277,21 @@ def _collapse_whitespace(value: Any) -> Optional[str]:
     return text or None
 
 
+def _plain_text_review_summary(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    text = html.unescape(value)
+    text = _MARKDOWN_LINK_RE.sub(
+        lambda match: match.group(1) or match.group(2) or " ", text
+    )
+    text = _REVIEW_HTML_TAG_RE.sub(" ", text)
+    text = text.replace("*", " ").replace("`", " ").replace("~", " ")
+    text = _REVIEW_BADGE_RE.sub(r"\1", text)
+    return _collapse_whitespace(text)
+
+
 def _trimmed_summary(value: Any, *, limit: int = 120) -> Optional[str]:
-    text = _collapse_whitespace(value)
+    text = _plain_text_review_summary(value)
     if text is None:
         return None
     if len(text) <= limit:
@@ -289,6 +309,13 @@ def _review_comment_location(payload: Mapping[str, Any]) -> Optional[str]:
     return path
 
 
+def _review_comment_url(payload: Mapping[str, Any]) -> Optional[str]:
+    url = _collapse_whitespace(payload.get("html_url"))
+    if url is None or not url.startswith(("http://", "https://")):
+        return None
+    return url
+
+
 def _review_comment_wakeup_message(
     *,
     event: ScmEvent,
@@ -299,17 +326,19 @@ def _review_comment_wakeup_message(
     commenter_login = _collapse_whitespace(payload.get("author_login"))
     location = _review_comment_location(payload)
     comment_summary = _trimmed_summary(payload.get("body"))
+    review_url = _review_comment_url(payload)
 
-    summary = f"Received PR review feedback on {subject}"
+    lines = [f"PR review feedback on {subject}"]
     if commenter_login is not None:
-        summary = f"{summary} from {commenter_login}"
+        lines.append(f"From: {commenter_login}")
     if location is not None:
-        summary = f"{summary} at {location}"
+        lines.append(f"Location: {location}")
     if comment_summary is not None:
-        summary = f"{summary}: {comment_summary}"
-    if not summary.endswith((".", "!", "?")):
-        summary = f"{summary}."
-    return f"{summary} The bound agent thread is taking a look."
+        lines.append(f"Summary: {comment_summary}")
+    if review_url is not None:
+        lines.append(f"Link: <{review_url}>")
+    lines.append("The bound agent thread is taking a look.")
+    return "\n".join(lines)
 
 
 def _reaction_subject(tracking: Mapping[str, Any]) -> str:

--- a/src/codex_autorunner/integrations/discord/rendering.py
+++ b/src/codex_autorunner/integrations/discord/rendering.py
@@ -12,6 +12,7 @@ _CODE_BLOCK_RE = re.compile(r"```([^\n`]*)\n(.*?)```", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
 _BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
 _ITALIC_RE = re.compile(r"\*(.+?)\*")
+_AUTOLINK_RE = re.compile(r"<https?://[^>\s]+>")
 _DISCORD_ESCAPE_RE = re.compile(r"([*_~`>|{}\\])")
 
 
@@ -85,6 +86,7 @@ def _format_discord_inline(text: str) -> str:
     code_placeholders: list[str] = []
     bold_placeholders: list[str] = []
     italic_placeholders: list[str] = []
+    autolink_placeholders: list[str] = []
 
     def _replace_code(match: re.Match[str]) -> str:
         code_placeholders.append(escape_discord_code(match.group(1)))
@@ -98,12 +100,20 @@ def _format_discord_inline(text: str) -> str:
         italic_placeholders.append(escape_discord_markdown(match.group(1)))
         return f"\x00ITALIC{len(italic_placeholders) - 1}\x00"
 
+    def _replace_autolink(match: re.Match[str]) -> str:
+        autolink_placeholders.append(match.group(0))
+        return f"\x00AUTOLINK{len(autolink_placeholders) - 1}\x00"
+
     text = _INLINE_CODE_RE.sub(_replace_code, text)
     text = _BOLD_RE.sub(_replace_bold, text)
     text = _ITALIC_RE.sub(_replace_italic, text)
+    text = _AUTOLINK_RE.sub(_replace_autolink, text)
 
     escaped = escape_discord_markdown(text)
 
+    for idx, autolink in enumerate(autolink_placeholders):
+        token = f"\x00AUTOLINK{idx}\x00"
+        escaped = escaped.replace(token, autolink)
     for idx, italic in enumerate(italic_placeholders):
         token = f"\x00ITALIC{idx}\x00"
         escaped = escaped.replace(token, f"*{italic}*")

--- a/tests/core/test_scm_automation_service.py
+++ b/tests/core/test_scm_automation_service.py
@@ -828,6 +828,110 @@ def test_ingest_event_tracks_review_comment_operations_in_separate_state_namespa
     ]
 
 
+def test_ingest_event_formats_review_comment_notice_with_link_and_clean_summary(
+    tmp_path: Path,
+) -> None:
+    event = ScmEvent(
+        event_id="github:event-inline-comment-formatted",
+        provider="github",
+        event_type="pull_request_review_comment",
+        occurred_at="2026-03-26T00:00:00Z",
+        received_at="2026-03-26T00:00:01Z",
+        created_at="2026-03-26T00:00:02Z",
+        repo_slug="acme/widgets",
+        repo_id="repo-1",
+        pr_number=42,
+        delivery_id="delivery-1",
+        payload={
+            "action": "created",
+            "comment_id": "2844",
+            "author_login": "reviewer",
+            "author_type": "User",
+            "issue_author_login": "pr-author",
+            "body": "**<sub><sub>!P1 Badge</sub></sub>** Surface startup timeouts as fallback regressions.",
+            "path": "src/codex_autorunner/integrations/discord/message_turns.py",
+            "line": 942,
+            "html_url": "https://github.com/acme/widgets/pull/42#discussion_r2844",
+        },
+        raw_payload=None,
+    )
+    binding = _binding()
+    service = ScmAutomationService(
+        tmp_path,
+        event_store=_EventStoreFake(event),
+        binding_resolver=_BindingResolverFake(binding),
+        reaction_router=route_scm_reactions,
+        reaction_state_store=_PermissiveReactionStateFake(),
+        journal=_JournalFake(),
+        publish_processor=_ProcessorFake(processed=[]),
+    )
+
+    result = service.ingest_event(event.event_id)
+
+    notify_op = next(
+        operation
+        for operation in result.publish_operations
+        if operation.operation_kind == "notify_chat"
+    )
+    assert notify_op.payload["message"] == (
+        "PR review feedback on acme/widgets#42\n"
+        "From: reviewer\n"
+        "Location: src/codex_autorunner/integrations/discord/message_turns.py:942\n"
+        "Summary: P1 Surface startup timeouts as fallback regressions.\n"
+        "Link: <https://github.com/acme/widgets/pull/42#discussion_r2844>\n"
+        "The bound agent thread is taking a look."
+    )
+
+
+def test_ingest_event_preserves_angle_bracket_content_in_review_summary(
+    tmp_path: Path,
+) -> None:
+    event = ScmEvent(
+        event_id="github:event-inline-comment-generics",
+        provider="github",
+        event_type="pull_request_review_comment",
+        occurred_at="2026-03-26T00:00:00Z",
+        received_at="2026-03-26T00:00:01Z",
+        created_at="2026-03-26T00:00:02Z",
+        repo_slug="acme/widgets",
+        repo_id="repo-1",
+        pr_number=42,
+        delivery_id="delivery-1",
+        payload={
+            "action": "created",
+            "comment_id": "2845",
+            "author_login": "reviewer",
+            "author_type": "User",
+            "issue_author_login": "pr-author",
+            "body": "Keep Response<T> and <foo> examples intact while removing <sub>badge</sub> wrappers.",
+            "path": "src/codex_autorunner/core/scm_automation_service.py",
+            "line": 300,
+        },
+        raw_payload=None,
+    )
+    binding = _binding()
+    service = ScmAutomationService(
+        tmp_path,
+        event_store=_EventStoreFake(event),
+        binding_resolver=_BindingResolverFake(binding),
+        reaction_router=route_scm_reactions,
+        reaction_state_store=_PermissiveReactionStateFake(),
+        journal=_JournalFake(),
+        publish_processor=_ProcessorFake(processed=[]),
+    )
+
+    result = service.ingest_event(event.event_id)
+
+    notify_op = next(
+        operation
+        for operation in result.publish_operations
+        if operation.operation_kind == "notify_chat"
+    )
+    assert "Response<T>" in notify_op.payload["message"]
+    assert "<foo>" in notify_op.payload["message"]
+    assert "<sub>" not in notify_op.payload["message"]
+
+
 def test_handle_processed_operations_uses_reaction_state_kind_tracking_key(
     tmp_path: Path,
 ) -> None:

--- a/tests/integrations/discord/test_rendering.py
+++ b/tests/integrations/discord/test_rendering.py
@@ -123,6 +123,13 @@ class TestFormatDiscordMessage:
         assert "docs" in result
         assert "https://example.com/docs" in result
 
+    def test_preserves_autolinks_without_escaping_markdown_characters(self) -> None:
+        text = "Link: <https://github.com/acme/widgets/pull/42#discussion_r2844>"
+
+        result = format_discord_message(text)
+
+        assert result == text
+
 
 class TestTruncateForDiscord:
     def test_keeps_short_text(self) -> None:

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -1006,6 +1006,7 @@ def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
                             "body": "Please cover the inline review wakeup path too.",
                             "author_login": "reviewer",
                             "author_type": "User",
+                            "html_url": "https://github.com/acme/widgets/pull/17#discussion_r2844",
                             "path": "src/codex_autorunner/integrations/github/polling.py",
                             "line": 196,
                             "updated_at": "2026-03-30T00:04:00Z",
@@ -1122,6 +1123,7 @@ def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
         and "taking a look" in str(record.payload_json.get("content", "")).lower()
         and "inline review wakeup path"
         in str(record.payload_json.get("content", "")).lower()
+        and "discussion_r2844" in str(record.payload_json.get("content", ""))
         for record in outbox
     )
 
@@ -1214,6 +1216,7 @@ def test_process_due_watches_keeps_distinct_bound_notices_for_multiple_review_co
                             "body": "Please cover the inline review wakeup path too.",
                             "author_login": "reviewer",
                             "author_type": "User",
+                            "html_url": "https://github.com/acme/widgets/pull/17#discussion_r2844",
                             "path": "src/codex_autorunner/integrations/github/polling.py",
                             "line": 196,
                             "updated_at": "2026-03-30T00:04:00Z",
@@ -1223,6 +1226,7 @@ def test_process_due_watches_keeps_distinct_bound_notices_for_multiple_review_co
                             "body": "Also verify the bound notification does not dedupe away later comments.",
                             "author_login": "reviewer",
                             "author_type": "User",
+                            "html_url": "https://github.com/acme/widgets/pull/17#discussion_r2845",
                             "path": "src/codex_autorunner/core/scm_automation_service.py",
                             "line": 526,
                             "updated_at": "2026-03-30T00:04:01Z",
@@ -1327,12 +1331,17 @@ def test_process_due_watches_keeps_distinct_bound_notices_for_multiple_review_co
 
     outbox = asyncio.run(_load_outbox())
     contents = [
-        str(record.payload_json.get("content", "")).lower()
+        str(record.payload_json.get("content", ""))
         for record in outbox
         if record.channel_id == "repo-discord"
     ]
     assert len(contents) == 2
-    assert any("inline review wakeup path" in content for content in contents)
+    normalized_contents = [content.lower() for content in contents]
+    assert any(
+        "inline review wakeup path" in content for content in normalized_contents
+    )
+    assert any("discussion_r2844" in content for content in contents)
+    assert any("discussion_r2845" in content for content in contents)
     assert any("does not dedupe away later comments" in content for content in contents)
 
 


### PR DESCRIPTION
## Summary

Improve bound PR review notifications so Discord messages are easier to scan and include a clickable link back to the underlying GitHub review comment.

## What Changed

- reformatted review wake-up notifications into a short multi-line layout with subject, author, location, summary, and link
- sanitized noisy GitHub badge and inline formatting markup out of review summaries without stripping legitimate angle-bracket content such as `Response<T>`
- preserved Discord autolinks so review links remain clickable without broad URL escaping changes across unrelated messages
- added unit and integration coverage for formatting, sanitization, and polling-driven Discord delivery

## Why

The previous notification text was dense, leaked raw GitHub badge markup into Discord, and did not give the user a reliable clickable path back to the review thread for more detail.

## Validation

- full commit hook suite passed, including repo-wide `pytest` (4665 passed), `black`, `ruff`, `mypy`, frontend build, and JS tests
- `.venv/bin/pytest tests/core/test_scm_automation_service.py -q --basetemp=<isolated temp dir>`
- `TMPDIR=$PWD/.codex-autorunner/tmp .venv/bin/pytest tests/integrations/discord/test_rendering.py -q`
- `TMPDIR=$PWD/.codex-autorunner/tmp .venv/bin/pytest tests/integrations/github/test_polling.py -q`

## Review Notes

A mini subagent review flagged two issues during the first pass:

- overly broad HTML tag stripping in review summaries
- overly broad bare-URL preservation in Discord rendering

Both were fixed before publishing by narrowing the sanitizer to known formatting tags and limiting URL preservation to Discord autolinks used by the review notice formatter.