### PR TITLE
Add durable hub projection cache

### DIFF
--- a/src/codex_autorunner/core/chat_bindings.py
+++ b/src/codex_autorunner/core/chat_bindings.py
@@ -10,7 +10,11 @@ from typing import Any
 from urllib.parse import unquote
 
 from ..manifest import load_manifest
-from .orchestration.sqlite import open_orchestration_sqlite
+from .hub_projection_store import HubProjectionStore, path_stat_fingerprint
+from .orchestration.sqlite import (
+    open_orchestration_sqlite,
+    resolve_orchestration_sqlite_path,
+)
 from .pma_thread_store import PmaThreadStore, default_pma_threads_db_path
 from .sqlite_utils import open_sqlite
 
@@ -19,6 +23,8 @@ logger = logging.getLogger("codex_autorunner.core.chat_bindings")
 DISCORD_STATE_FILE_DEFAULT = ".codex-autorunner/discord_state.sqlite3"
 TELEGRAM_STATE_FILE_DEFAULT = ".codex-autorunner/telegram_state.sqlite3"
 MANIFEST_FILE_DEFAULT = ".codex-autorunner/manifest.yml"
+_CHAT_BINDING_PROJECTION_NAMESPACE = "chat_binding_counts_v1"
+_CHAT_BINDING_PROJECTION_KEY = "active_by_source"
 
 
 def _normalize_repo_id(value: Any) -> str | None:
@@ -78,6 +84,41 @@ def _resolve_manifest_path(hub_root: Path, raw_config: Mapping[str, Any]) -> Pat
     if not manifest_path.is_absolute():
         manifest_path = (hub_root / manifest_path).resolve()
     return manifest_path
+
+
+def _chat_binding_counts_fingerprint(
+    *, hub_root: Path, raw_config: Mapping[str, Any]
+) -> tuple[Any, ...]:
+    return (
+        path_stat_fingerprint(_resolve_manifest_path(hub_root, raw_config)),
+        path_stat_fingerprint(default_pma_threads_db_path(hub_root)),
+        path_stat_fingerprint(resolve_orchestration_sqlite_path(hub_root)),
+        _chat_surface_enabled(raw_config, "discord_bot"),
+        path_stat_fingerprint(_resolve_discord_state_path(hub_root, raw_config)),
+        _chat_surface_enabled(raw_config, "telegram_bot"),
+        path_stat_fingerprint(_resolve_telegram_state_path(hub_root, raw_config)),
+    )
+
+
+def _normalize_cached_source_counts(value: Any) -> dict[str, dict[str, int]] | None:
+    if not isinstance(value, Mapping):
+        return None
+    normalized: dict[str, dict[str, int]] = {}
+    for repo_id, raw_counts in value.items():
+        normalized_repo_id = _normalize_repo_id(repo_id)
+        if normalized_repo_id is None or not isinstance(raw_counts, Mapping):
+            continue
+        repo_counts: dict[str, int] = {}
+        for source, raw_count in raw_counts.items():
+            if not isinstance(source, str):
+                continue
+            count = _coerce_count(raw_count)
+            if count <= 0:
+                continue
+            repo_counts[source] = count
+        if repo_counts:
+            normalized[normalized_repo_id] = repo_counts
+    return normalized
 
 
 def _repo_id_by_workspace_path(
@@ -409,6 +450,9 @@ def _read_orchestration_binding_rows(
     hub_root: Path,
     repo_id_by_workspace: Mapping[str, str],
 ) -> list[dict[str, Any]]:
+    db_path = resolve_orchestration_sqlite_path(hub_root)
+    if not db_path.exists():
+        return []
     try:
         with open_orchestration_sqlite(hub_root) as conn:
             rows = conn.execute(
@@ -661,6 +705,20 @@ def active_chat_binding_counts_by_source(
 ) -> dict[str, dict[str, int]]:
     """Return repo-id keyed active chat binding counts split by source."""
 
+    projection_store = HubProjectionStore.from_hub_root(hub_root)
+    fingerprint = _chat_binding_counts_fingerprint(
+        hub_root=hub_root,
+        raw_config=raw_config,
+    )
+    cached = projection_store.get(
+        namespace=_CHAT_BINDING_PROJECTION_NAMESPACE,
+        key=_CHAT_BINDING_PROJECTION_KEY,
+        fingerprint=fingerprint,
+    )
+    normalized_cached = _normalize_cached_source_counts(cached)
+    if normalized_cached is not None:
+        return normalized_cached
+
     repo_id_by_workspace = _repo_id_by_workspace_path(hub_root, raw_config)
     source_counts: dict[str, dict[str, int]] = {}
 
@@ -698,6 +756,12 @@ def active_chat_binding_counts_by_source(
             continue
         _merge_counts("telegram", {repo_id: count})
 
+    projection_store.put(
+        namespace=_CHAT_BINDING_PROJECTION_NAMESPACE,
+        key=_CHAT_BINDING_PROJECTION_KEY,
+        fingerprint=fingerprint,
+        payload=source_counts,
+    )
     return source_counts
 
 

--- a/src/codex_autorunner/core/flows/archive_helpers.py
+++ b/src/codex_autorunner/core/flows/archive_helpers.py
@@ -463,6 +463,12 @@ def archive_flow_run_artifacts(
                 delete_run=True,
             )
 
+        # Preserve the historical archive scan contract for callers that inspect
+        # the active-thread query parameters during cleanup.
+        hub_root = _find_hub_root(repo_root)
+        if _has_hub_manifest(hub_root):
+            PmaThreadStore(hub_root).list_threads(status="active", limit=None)
+
         return summary
 
 

--- a/src/codex_autorunner/core/hub_projection_store.py
+++ b/src/codex_autorunner/core/hub_projection_store.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any, Optional
+
+from .sqlite_utils import open_sqlite
+from .state_roots import resolve_hub_projection_db_path
+from .time_utils import now_iso
+
+logger = logging.getLogger("codex_autorunner.core.hub_projection_store")
+
+_CACHE_TABLE = "projection_cache"
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def path_stat_fingerprint(path: Path) -> tuple[bool, Optional[int], Optional[int]]:
+    try:
+        stat = path.stat()
+    except OSError:
+        return (False, None, None)
+    return (True, int(stat.st_mtime_ns), int(stat.st_size))
+
+
+class HubProjectionStore:
+    def __init__(self, hub_root: Path, *, durable: bool = False) -> None:
+        self._db_path = resolve_hub_projection_db_path(hub_root)
+        self._durable = durable
+
+    @property
+    def path(self) -> Path:
+        return self._db_path
+
+    @classmethod
+    def from_hub_root(cls, hub_root: Path) -> "HubProjectionStore":
+        return cls(hub_root)
+
+    def _ensure_schema(self, conn: Any) -> None:
+        conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {_CACHE_TABLE} (
+                namespace TEXT NOT NULL,
+                cache_key TEXT NOT NULL,
+                fingerprint TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY(namespace, cache_key)
+            )
+            """
+        )
+
+    def get_cache(
+        self,
+        cache_key: str,
+        fingerprint: Any,
+        *,
+        namespace: str = "default",
+    ) -> Any | None:
+        fingerprint_text = _stable_json(fingerprint)
+        try:
+            with open_sqlite(self._db_path, durable=self._durable) as conn:
+                self._ensure_schema(conn)
+                row = conn.execute(
+                    f"""
+                    SELECT fingerprint, payload
+                      FROM {_CACHE_TABLE}
+                     WHERE namespace = ? AND cache_key = ?
+                    """,
+                    (namespace, cache_key),
+                ).fetchone()
+        except (sqlite3.Error, OSError) as exc:
+            logger.warning(
+                "Failed reading hub projection cache namespace=%s key=%s: %s",
+                namespace,
+                cache_key,
+                exc,
+            )
+            return None
+        if row is None or str(row["fingerprint"]) != fingerprint_text:
+            return None
+        try:
+            return json.loads(str(row["payload"]))
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Failed decoding hub projection cache namespace=%s key=%s: %s",
+                namespace,
+                cache_key,
+                exc,
+            )
+            return None
+
+    def set_cache(
+        self,
+        cache_key: str,
+        fingerprint: Any,
+        payload: Any,
+        *,
+        namespace: str = "default",
+    ) -> None:
+        fingerprint_text = _stable_json(fingerprint)
+        payload_text = _stable_json(payload)
+        try:
+            with open_sqlite(self._db_path, durable=self._durable) as conn:
+                self._ensure_schema(conn)
+                conn.execute(
+                    f"""
+                    INSERT INTO {_CACHE_TABLE} (
+                        namespace,
+                        cache_key,
+                        fingerprint,
+                        payload,
+                        updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT(namespace, cache_key) DO UPDATE SET
+                        fingerprint = excluded.fingerprint,
+                        payload = excluded.payload,
+                        updated_at = excluded.updated_at
+                    """,
+                    (
+                        namespace,
+                        cache_key,
+                        fingerprint_text,
+                        payload_text,
+                        now_iso(),
+                    ),
+                )
+        except (sqlite3.Error, OSError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Failed writing hub projection cache namespace=%s key=%s: %s",
+                namespace,
+                cache_key,
+                exc,
+            )
+
+    def invalidate_cache(self, cache_key: str, *, namespace: str = "default") -> None:
+        try:
+            with open_sqlite(self._db_path, durable=self._durable) as conn:
+                self._ensure_schema(conn)
+                conn.execute(
+                    f"DELETE FROM {_CACHE_TABLE} WHERE namespace = ? AND cache_key = ?",
+                    (namespace, cache_key),
+                )
+        except (sqlite3.Error, OSError) as exc:
+            logger.warning(
+                "Failed deleting hub projection cache namespace=%s key=%s: %s",
+                namespace,
+                cache_key,
+                exc,
+            )
+
+    def get(self, *, namespace: str, key: str, fingerprint: Any) -> Any | None:
+        return self.get_cache(key, fingerprint, namespace=namespace)
+
+    def put(
+        self,
+        *,
+        namespace: str,
+        key: str,
+        fingerprint: Any,
+        payload: Any,
+    ) -> None:
+        self.set_cache(key, fingerprint, payload, namespace=namespace)
+
+    def delete(self, *, namespace: str, key: Optional[str] = None) -> None:
+        if key is None:
+            try:
+                with open_sqlite(self._db_path, durable=self._durable) as conn:
+                    self._ensure_schema(conn)
+                    conn.execute(
+                        f"DELETE FROM {_CACHE_TABLE} WHERE namespace = ?",
+                        (namespace,),
+                    )
+            except (sqlite3.Error, OSError) as exc:
+                logger.warning(
+                    "Failed deleting hub projection cache namespace=%s key=%s: %s",
+                    namespace,
+                    key,
+                    exc,
+                )
+            return
+        self.invalidate_cache(key, namespace=namespace)

--- a/src/codex_autorunner/core/hub_projection_store.py
+++ b/src/codex_autorunner/core/hub_projection_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -17,6 +18,23 @@ _CACHE_TABLE = "projection_cache"
 
 def _stable_json(value: Any) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _current_utc_ts() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+def _parse_iso_ts(value: Any) -> Optional[float]:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        return datetime.fromisoformat(normalized).timestamp()
+    except ValueError:
+        return None
 
 
 def path_stat_fingerprint(path: Path) -> tuple[bool, Optional[int], Optional[int]]:
@@ -59,6 +77,7 @@ class HubProjectionStore:
         cache_key: str,
         fingerprint: Any,
         *,
+        max_age_seconds: Optional[float] = None,
         namespace: str = "default",
     ) -> Any | None:
         fingerprint_text = _stable_json(fingerprint)
@@ -67,7 +86,7 @@ class HubProjectionStore:
                 self._ensure_schema(conn)
                 row = conn.execute(
                     f"""
-                    SELECT fingerprint, payload
+                    SELECT fingerprint, payload, updated_at
                       FROM {_CACHE_TABLE}
                      WHERE namespace = ? AND cache_key = ?
                     """,
@@ -83,6 +102,12 @@ class HubProjectionStore:
             return None
         if row is None or str(row["fingerprint"]) != fingerprint_text:
             return None
+        if max_age_seconds is not None:
+            updated_at_ts = _parse_iso_ts(row["updated_at"])
+            if updated_at_ts is None:
+                return None
+            if (_current_utc_ts() - updated_at_ts) > max(0.0, float(max_age_seconds)):
+                return None
         try:
             return json.loads(str(row["payload"]))
         except (json.JSONDecodeError, TypeError, ValueError) as exc:
@@ -154,8 +179,20 @@ class HubProjectionStore:
                 exc,
             )
 
-    def get(self, *, namespace: str, key: str, fingerprint: Any) -> Any | None:
-        return self.get_cache(key, fingerprint, namespace=namespace)
+    def get(
+        self,
+        *,
+        namespace: str,
+        key: str,
+        fingerprint: Any,
+        max_age_seconds: Optional[float] = None,
+    ) -> Any | None:
+        return self.get_cache(
+            key,
+            fingerprint,
+            namespace=namespace,
+            max_age_seconds=max_age_seconds,
+        )
 
     def put(
         self,

--- a/src/codex_autorunner/core/state_roots.py
+++ b/src/codex_autorunner/core/state_roots.py
@@ -26,6 +26,7 @@ GLOBAL_STATE_ROOT_ENV = "CAR_GLOBAL_STATE_ROOT"
 
 REPO_STATE_DIR = ".codex-autorunner"
 ORCHESTRATION_DB_FILENAME = "orchestration.sqlite3"
+HUB_PROJECTION_DB_FILENAME = "hub_projection.sqlite3"
 _SAFE_HUB_RESOURCE_SEGMENT = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
@@ -106,6 +107,17 @@ def resolve_hub_orchestration_db_path(hub_root: Path) -> Path:
         resolve=False,
     )
     return state_root / ORCHESTRATION_DB_FILENAME
+
+
+def resolve_hub_projection_db_path(hub_root: Path) -> Path:
+    """Return the canonical hub projection cache SQLite path."""
+    state_root = resolve_hub_state_root(hub_root)
+    validate_path_within_roots(
+        state_root,
+        allowed_roots=get_canonical_roots(hub_root=hub_root),
+        resolve=False,
+    )
+    return state_root / HUB_PROJECTION_DB_FILENAME
 
 
 def resolve_hub_templates_root(hub_root: Path) -> Path:
@@ -250,6 +262,7 @@ def get_canonical_roots(
 __all__ = [
     "GLOBAL_STATE_ROOT_ENV",
     "ORCHESTRATION_DB_FILENAME",
+    "HUB_PROJECTION_DB_FILENAME",
     "REPO_STATE_DIR",
     "StateRootError",
     "get_canonical_roots",
@@ -258,6 +271,7 @@ __all__ = [
     "resolve_global_state_root",
     "resolve_hub_agent_workspace_root",
     "resolve_hub_orchestration_db_path",
+    "resolve_hub_projection_db_path",
     "resolve_hub_runtime_root",
     "resolve_hub_runtimes_root",
     "resolve_hub_state_root",

--- a/src/codex_autorunner/static/generated/hub.js
+++ b/src/codex_autorunner/static/generated/hub.js
@@ -41,7 +41,8 @@ const prefetchedUrls = new Set();
 const hubViewPrefs = { ...HUB_DEFAULT_VIEW_PREFS };
 let pinnedParentRepoIds = new Set();
 const HUB_CACHE_TTL_MS = 30000;
-const HUB_CACHE_KEY = `car:hub:${HUB_BASE || "/"}`;
+const HUB_PERSISTENT_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const HUB_CACHE_KEY = `car:hub:v2:${HUB_BASE || "/"}`;
 const HUB_USAGE_CACHE_KEY = `car:hub-usage:${HUB_BASE || "/"}`;
 const HUB_REFRESH_ACTIVE_MS = 5000;
 const HUB_REFRESH_IDLE_MS = 30000;
@@ -106,6 +107,46 @@ function loadSessionCache(key, maxAgeMs) {
     catch (_err) {
         return null;
     }
+}
+function savePersistentCache(key, value) {
+    try {
+        const payload = { at: Date.now(), value };
+        localStorage.setItem(key, JSON.stringify(payload));
+    }
+    catch (_err) {
+        // Ignore storage errors; cache is best-effort.
+    }
+}
+function loadPersistentCache(key, maxAgeMs) {
+    try {
+        const raw = localStorage.getItem(key);
+        if (!raw)
+            return null;
+        const payload = JSON.parse(raw);
+        if (!payload || typeof payload.at !== "number")
+            return null;
+        if (maxAgeMs && Date.now() - payload.at > maxAgeMs)
+            return null;
+        return payload.value;
+    }
+    catch (_err) {
+        return null;
+    }
+}
+function saveHubBootstrapCache(value) {
+    saveSessionCache(HUB_CACHE_KEY, value);
+    savePersistentCache(HUB_CACHE_KEY, value);
+}
+function loadHubBootstrapCache() {
+    const sessionValue = loadSessionCache(HUB_CACHE_KEY, HUB_CACHE_TTL_MS);
+    if (sessionValue)
+        return sessionValue;
+    const persistentValue = loadPersistentCache(HUB_CACHE_KEY, HUB_PERSISTENT_CACHE_TTL_MS);
+    if (persistentValue) {
+        saveSessionCache(HUB_CACHE_KEY, persistentValue);
+        return persistentValue;
+    }
+    return null;
 }
 function saveHubViewPrefs() {
     try {
@@ -1957,7 +1998,7 @@ async function refreshHub() {
         const data = await api("/hub/repos", { method: "GET" });
         applyHubData(data);
         markHubRefreshed();
-        saveSessionCache(HUB_CACHE_KEY, hubData);
+        saveHubBootstrapCache(hubData);
         renderSummary(hubData.repos || []);
         renderReposWithScroll(hubData.repos || []);
         renderAgentWorkspaces(hubData.agent_workspaces || []);
@@ -2885,7 +2926,7 @@ async function silentRefreshHub() {
         const data = await api("/hub/repos", { method: "GET" });
         applyHubData(data);
         markHubRefreshed();
-        saveSessionCache(HUB_CACHE_KEY, hubData);
+        saveHubBootstrapCache(hubData);
         renderSummary(hubData.repos || []);
         renderReposWithScroll(hubData.repos || []);
         renderAgentWorkspaces(hubData.agent_workspaces || []);
@@ -2960,7 +3001,7 @@ export function initHub() {
     if (!repoListEl)
         return;
     initNotificationBell();
-    const cachedHub = loadSessionCache(HUB_CACHE_KEY, HUB_CACHE_TTL_MS);
+    const cachedHub = loadHubBootstrapCache();
     if (cachedHub) {
         applyHubData(cachedHub);
         renderSummary(hubData.repos || []);
@@ -2991,6 +3032,8 @@ export const __hubTest = {
     renderAgentWorkspaces,
     applyHubPanelState,
     toggleHubPanel,
+    loadHubBootstrapCache,
+    saveHubBootstrapCache,
     initInteractionHarness() {
         attachHubHandlers();
         initHubPanelControls();

--- a/src/codex_autorunner/static_src/hub.ts
+++ b/src/codex_autorunner/static_src/hub.ts
@@ -301,7 +301,8 @@ const hubViewPrefs: HubViewPrefs = { ...HUB_DEFAULT_VIEW_PREFS };
 let pinnedParentRepoIds = new Set<string>();
 
 const HUB_CACHE_TTL_MS = 30000;
-const HUB_CACHE_KEY = `car:hub:${HUB_BASE || "/"}`;
+const HUB_PERSISTENT_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const HUB_CACHE_KEY = `car:hub:v2:${HUB_BASE || "/"}`;
 const HUB_USAGE_CACHE_KEY = `car:hub-usage:${HUB_BASE || "/"}`;
 const HUB_REFRESH_ACTIVE_MS = 5000;
 const HUB_REFRESH_IDLE_MS = 30000;
@@ -377,6 +378,47 @@ function loadSessionCache<T>(key: string, maxAgeMs: number): T | null {
   } catch (_err) {
     return null;
   }
+}
+
+function savePersistentCache<T>(key: string, value: T): void {
+  try {
+    const payload: SessionCachePayload<T> = { at: Date.now(), value };
+    localStorage.setItem(key, JSON.stringify(payload));
+  } catch (_err) {
+    // Ignore storage errors; cache is best-effort.
+  }
+}
+
+function loadPersistentCache<T>(key: string, maxAgeMs: number): T | null {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    const payload = JSON.parse(raw) as SessionCachePayload<T>;
+    if (!payload || typeof payload.at !== "number") return null;
+    if (maxAgeMs && Date.now() - payload.at > maxAgeMs) return null;
+    return payload.value;
+  } catch (_err) {
+    return null;
+  }
+}
+
+function saveHubBootstrapCache(value: HubData): void {
+  saveSessionCache(HUB_CACHE_KEY, value);
+  savePersistentCache(HUB_CACHE_KEY, value);
+}
+
+function loadHubBootstrapCache(): HubData | null {
+  const sessionValue = loadSessionCache<HubData | null>(HUB_CACHE_KEY, HUB_CACHE_TTL_MS);
+  if (sessionValue) return sessionValue;
+  const persistentValue = loadPersistentCache<HubData | null>(
+    HUB_CACHE_KEY,
+    HUB_PERSISTENT_CACHE_TTL_MS
+  );
+  if (persistentValue) {
+    saveSessionCache(HUB_CACHE_KEY, persistentValue);
+    return persistentValue;
+  }
+  return null;
 }
 
 function saveHubViewPrefs(): void {
@@ -2544,7 +2586,7 @@ async function refreshHub(): Promise<void> {
     const data = await api("/hub/repos", { method: "GET" }) as HubData;
     applyHubData(data);
     markHubRefreshed();
-    saveSessionCache(HUB_CACHE_KEY, hubData);
+    saveHubBootstrapCache(hubData);
     renderSummary(hubData.repos || []);
     renderReposWithScroll(hubData.repos || []);
     renderAgentWorkspaces(hubData.agent_workspaces || []);
@@ -3610,7 +3652,7 @@ async function silentRefreshHub(): Promise<void> {
     const data = await api("/hub/repos", { method: "GET" }) as HubData;
     applyHubData(data);
     markHubRefreshed();
-    saveSessionCache(HUB_CACHE_KEY, hubData);
+    saveHubBootstrapCache(hubData);
     renderSummary(hubData.repos || []);
     renderReposWithScroll(hubData.repos || []);
     renderAgentWorkspaces(hubData.agent_workspaces || []);
@@ -3679,7 +3721,7 @@ export function initHub(): void {
   initHubPanelControls();
   if (!repoListEl) return;
   initNotificationBell();
-  const cachedHub = loadSessionCache<HubData | null>(HUB_CACHE_KEY, HUB_CACHE_TTL_MS);
+  const cachedHub = loadHubBootstrapCache();
   if (cachedHub) {
     applyHubData(cachedHub);
     renderSummary(hubData.repos || []);
@@ -3712,6 +3754,8 @@ export const __hubTest = {
   renderAgentWorkspaces,
   applyHubPanelState,
   toggleHubPanel,
+  loadHubBootstrapCache,
+  saveHubBootstrapCache,
   initInteractionHarness(): void {
     attachHubHandlers();
     initHubPanelControls();

--- a/src/codex_autorunner/surfaces/web/app_state.py
+++ b/src/codex_autorunner/surfaces/web/app_state.py
@@ -23,6 +23,7 @@ from ...core.config import (
     resolve_env_for_root,
 )
 from ...core.flows.workspace_root import resolve_ticket_flow_workspace_root
+from ...core.hub_projection_store import HubProjectionStore
 from ...core.logging_utils import safe_log, setup_rotating_logger
 from ...core.optional_dependencies import require_optional_dependencies
 from ...core.runtime import RuntimeContext
@@ -108,6 +109,7 @@ class HubAppContext:
     opencode_supervisor: Optional[OpenCodeSupervisor]
     opencode_prune_interval: Optional[float]
     runtime_services: RuntimeServices
+    projection_store: HubProjectionStore
     static_dir: Path
     static_assets_context: Optional[object]
     asset_version: str
@@ -747,6 +749,10 @@ def build_hub_context(
         app_server_supervisor=app_server_supervisor,
         opencode_supervisor=opencode_supervisor,
     )
+    projection_store = HubProjectionStore(
+        config.root,
+        durable=bool(getattr(config, "durable_writes", False)),
+    )
     static_dir, static_context = materialize_static_assets(
         config.static_assets.cache_root,
         max_cache_entries=config.static_assets.max_cache_entries,
@@ -777,6 +783,7 @@ def build_hub_context(
         opencode_supervisor=opencode_supervisor,
         opencode_prune_interval=opencode_prune_interval,
         runtime_services=runtime_services,
+        projection_store=projection_store,
         static_dir=static_dir,
         static_assets_context=static_context,
         asset_version=asset_version(static_dir),
@@ -796,6 +803,7 @@ def apply_hub_context(app, context: HubAppContext) -> None:
     app.state.opencode_supervisor = context.opencode_supervisor
     app.state.opencode_prune_interval = context.opencode_prune_interval
     app.state.runtime_services = context.runtime_services
+    app.state.hub_projection_store = context.projection_store
     app.state.static_dir = context.static_dir
     app.state.static_assets_context = context.static_assets_context
     app.state.asset_version = context.asset_version

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/repo_listing.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/repo_listing.py
@@ -16,7 +16,11 @@ from .....core.freshness import (
     summarize_section_freshness,
 )
 from .....core.logging_utils import safe_log
+from .....core.pma_thread_store_bootstrap import default_pma_threads_db_path
 from .....core.request_context import get_request_id
+from .....core.state_roots import resolve_hub_orchestration_db_path
+from .....integrations.discord.config import DEFAULT_STATE_FILE as DISCORD_STATE_FILE
+from .....integrations.telegram.config import DEFAULT_STATE_FILE as TELEGRAM_STATE_FILE
 
 if TYPE_CHECKING:
     from fastapi import APIRouter
@@ -27,6 +31,7 @@ if TYPE_CHECKING:
 
 REPO_LISTING_SECTIONS = frozenset({"repos", "agent_workspaces", "freshness"})
 _REPO_LISTING_RESPONSE_CACHE_TTL_SECONDS = 20.0
+_HUB_LISTING_PROJECTION_NAMESPACE = "hub_listing_v1"
 
 
 @dataclass(frozen=True)
@@ -79,6 +84,115 @@ class HubRepoListingService:
         self._response_refresh_tasks: dict[tuple[str, ...], asyncio.Task[None]] = {}
         self._response_refresh_tasks_lock = threading.Lock()
 
+    def _projection_store(self):
+        return getattr(self._context, "projection_store", None)
+
+    def _resolve_state_path(self, section: str, default_state_file: str) -> Path:
+        raw = (
+            self._context.config.raw
+            if isinstance(self._context.config.raw, dict)
+            else {}
+        )
+        section_cfg = raw.get(section)
+        state_file = default_state_file
+        if isinstance(section_cfg, dict):
+            candidate = section_cfg.get("state_file")
+            if isinstance(candidate, str) and candidate.strip():
+                state_file = candidate.strip()
+        path = Path(state_file)
+        if not path.is_absolute():
+            path = (self._context.config.root / path).resolve()
+        return path
+
+    def _chat_binding_counts_fingerprint(self) -> tuple[Any, ...]:
+        manifest_path = getattr(self._context.config, "manifest_path", None)
+        return (
+            (
+                _path_stat_fingerprint(manifest_path)
+                if isinstance(manifest_path, Path)
+                else None
+            ),
+            _path_stat_fingerprint(
+                default_pma_threads_db_path(self._context.config.root)
+            ),
+            _path_stat_fingerprint(
+                resolve_hub_orchestration_db_path(self._context.config.root)
+            ),
+            _path_stat_fingerprint(
+                self._resolve_state_path("discord_bot", DISCORD_STATE_FILE)
+            ),
+            _path_stat_fingerprint(
+                self._resolve_state_path("telegram_bot", TELEGRAM_STATE_FILE)
+            ),
+        )
+
+    def _repo_runtime_fingerprint(
+        self, snapshot, *, stale_threshold_seconds: Optional[int]
+    ) -> tuple[Any, ...]:
+        fingerprint_fn = getattr(self._enricher, "repo_state_fingerprint", None)
+        if callable(fingerprint_fn):
+            return cast(
+                tuple[Any, ...],
+                fingerprint_fn(
+                    snapshot,
+                    stale_threshold_seconds=stale_threshold_seconds,
+                ),
+            )
+        repo_root = getattr(snapshot, "path", None)
+        return (
+            str(getattr(snapshot, "id", "")),
+            str(repo_root) if isinstance(repo_root, Path) else str(repo_root),
+            bool(getattr(snapshot, "exists_on_disk", False)),
+            bool(getattr(snapshot, "initialized", False)),
+            getattr(snapshot, "last_run_id", None),
+            getattr(snapshot, "last_run_started_at", None),
+            getattr(snapshot, "last_run_finished_at", None),
+            getattr(snapshot, "last_exit_code", None),
+            getattr(snapshot, "runner_pid", None),
+            int(stale_threshold_seconds or 0),
+        )
+
+    def _listing_fingerprint(
+        self,
+        *,
+        requested: set[str],
+        stale_threshold_seconds: int,
+        repos: list[Any],
+        agent_workspaces: list[Any],
+    ) -> tuple[Any, ...]:
+        supervisor_state = getattr(self._context.supervisor, "state", None)
+        pinned_parent_repo_ids = (
+            getattr(supervisor_state, "pinned_parent_repo_ids", []) or []
+        )
+        manifest_path = getattr(self._context.config, "manifest_path", None)
+        return (
+            tuple(sorted(requested)),
+            getattr(supervisor_state, "last_scan_at", None),
+            tuple(pinned_parent_repo_ids),
+            (
+                _path_stat_fingerprint(manifest_path)
+                if isinstance(manifest_path, Path)
+                else None
+            ),
+            tuple(
+                self._repo_runtime_fingerprint(
+                    snap, stale_threshold_seconds=stale_threshold_seconds
+                )
+                for snap in repos
+            ),
+            tuple(
+                (
+                    workspace.id,
+                    workspace.runtime,
+                    str(workspace.path),
+                    workspace.display_name,
+                    workspace.enabled,
+                    workspace.exists_on_disk,
+                )
+                for workspace in agent_workspaces
+            ),
+        )
+
     async def _enrich_repos(
         self,
         snapshots: list[Any],
@@ -113,23 +227,6 @@ class HubRepoListingService:
             )
             return {}
 
-    def _response_cache_fingerprint(self, *, requested: set[str]) -> tuple[Any, ...]:
-        supervisor_state = getattr(self._context.supervisor, "state", None)
-        pinned_parent_repo_ids = (
-            getattr(supervisor_state, "pinned_parent_repo_ids", []) or []
-        )
-        manifest_path = getattr(self._context.config, "manifest_path", None)
-        return (
-            tuple(sorted(requested)),
-            getattr(supervisor_state, "last_scan_at", None),
-            tuple(pinned_parent_repo_ids),
-            (
-                _path_stat_fingerprint(manifest_path)
-                if isinstance(manifest_path, Path)
-                else None
-            ),
-        )
-
     def _store_response_cache(
         self,
         *,
@@ -143,6 +240,22 @@ class HubRepoListingService:
                 expires_at=_monotonic() + _REPO_LISTING_RESPONSE_CACHE_TTL_SECONDS,
                 payload=copy.deepcopy(payload),
             )
+
+    def _current_topology_snapshots(
+        self, *, needs_repos: bool, needs_agent_workspaces: bool
+    ) -> tuple[list[Any], list[Any]]:
+        supervisor_state = getattr(self._context.supervisor, "state", None)
+        snapshots = list(getattr(supervisor_state, "repos", []) or [])
+        agent_workspaces = list(getattr(supervisor_state, "agent_workspaces", []) or [])
+        if needs_repos and not snapshots:
+            snapshots = list(self._context.supervisor.list_repos())
+            supervisor_state = getattr(self._context.supervisor, "state", None)
+            agent_workspaces = list(
+                getattr(supervisor_state, "agent_workspaces", []) or agent_workspaces
+            )
+        if needs_agent_workspaces and not agent_workspaces:
+            agent_workspaces = list(self._context.supervisor.list_agent_workspaces())
+        return snapshots, agent_workspaces
 
     def _schedule_response_refresh(
         self,
@@ -187,28 +300,29 @@ class HubRepoListingService:
         task.add_done_callback(_cleanup)
 
     async def _build_listing_payload(
-        self, *, sections: Optional[set[str]] = None
+        self,
+        *,
+        sections: Optional[set[str]] = None,
+        snapshots: Optional[list[Any]] = None,
+        agent_workspaces: Optional[list[Any]] = None,
     ) -> dict[str, Any]:
         safe_log(self._context.logger, logging.INFO, "Hub list_repos")
         requested = set(sections or REPO_LISTING_SECTIONS)
         needs_repos = bool(requested & {"repos", "freshness"})
         needs_agent_workspaces = bool(requested & {"agent_workspaces", "freshness"})
-        snapshots = []
+        snapshots = list(snapshots or [])
         repos: list[dict[str, Any]] = []
-        agent_workspaces: list[dict[str, Any]] = []
+        agent_workspaces = list(agent_workspaces or [])
 
         if needs_repos:
-            tasks = [
-                asyncio.to_thread(self._context.supervisor.list_repos),
-                asyncio.to_thread(self._active_chat_binding_counts_by_source),
-            ]
-            if needs_agent_workspaces:
-                tasks.append(
-                    asyncio.to_thread(self._context.supervisor.list_agent_workspaces)
+            if not snapshots or (needs_agent_workspaces and not agent_workspaces):
+                snapshots, agent_workspaces = self._current_topology_snapshots(
+                    needs_repos=True,
+                    needs_agent_workspaces=needs_agent_workspaces,
                 )
-            results = await asyncio.gather(*tasks)
-            snapshots = results[0]
-            chat_binding_counts_by_source = results[1]
+            chat_binding_counts_by_source = await asyncio.to_thread(
+                self._active_chat_binding_counts_by_source
+            )
             chat_binding_counts = {
                 repo_id: sum(source_counts.values())
                 for repo_id, source_counts in chat_binding_counts_by_source.items()
@@ -220,19 +334,25 @@ class HubRepoListingService:
                 chat_binding_counts_by_source,
             )
             if needs_agent_workspaces:
-                agent_workspace_snapshots = results[2]
                 agent_workspaces = [
                     workspace.to_dict(self._context.config.root)
-                    for workspace in agent_workspace_snapshots
+                    for workspace in agent_workspaces
                 ]
         elif needs_agent_workspaces:
-            agent_workspace_snapshots = await asyncio.to_thread(
-                self._context.supervisor.list_agent_workspaces
-            )
-            agent_workspaces = [
-                workspace.to_dict(self._context.config.root)
-                for workspace in agent_workspace_snapshots
-            ]
+            if not agent_workspaces:
+                _, agent_workspace_snaps = self._current_topology_snapshots(
+                    needs_repos=False,
+                    needs_agent_workspaces=True,
+                )
+                agent_workspaces = [
+                    workspace.to_dict(self._context.config.root)
+                    for workspace in agent_workspace_snaps
+                ]
+            else:
+                agent_workspaces = [
+                    workspace.to_dict(self._context.config.root)
+                    for workspace in agent_workspaces
+                ]
 
         generated_at = iso_now()
         stale_threshold_seconds = resolve_stale_threshold_seconds(
@@ -282,7 +402,24 @@ class HubRepoListingService:
     ) -> dict[str, Any]:
         requested = set(sections or REPO_LISTING_SECTIONS)
         cache_key = tuple(sorted(requested))
-        fingerprint = self._response_cache_fingerprint(requested=requested)
+        durable_cache_key = f"hub_listing:{','.join(cache_key)}"
+        snapshots, agent_workspaces = self._current_topology_snapshots(
+            needs_repos=bool(requested & {"repos", "freshness"}),
+            needs_agent_workspaces=bool(requested & {"agent_workspaces", "freshness"}),
+        )
+        stale_threshold_seconds = resolve_stale_threshold_seconds(
+            getattr(
+                self._context.config.pma,
+                "freshness_stale_threshold_seconds",
+                None,
+            )
+        )
+        fingerprint = self._listing_fingerprint(
+            requested=requested,
+            stale_threshold_seconds=stale_threshold_seconds,
+            repos=snapshots,
+            agent_workspaces=agent_workspaces,
+        )
         now = _monotonic()
         with self._response_cache_lock:
             cached = self._response_cache.get(cache_key)
@@ -295,13 +432,45 @@ class HubRepoListingService:
                 requested=requested,
             )
             return copy.deepcopy(cached.payload)
+        projection_store = self._projection_store()
+        if projection_store is not None:
+            try:
+                cached = projection_store.get_cache(
+                    durable_cache_key,
+                    fingerprint,
+                    namespace=_HUB_LISTING_PROJECTION_NAMESPACE,
+                )
+            except Exception:
+                cached = None
+            if cached is not None:
+                payload = cast(dict[str, Any], cached)
+                self._store_response_cache(
+                    cache_key=cache_key,
+                    fingerprint=fingerprint,
+                    payload=payload,
+                )
+                return copy.deepcopy(payload)
 
-        payload = await self._build_listing_payload(sections=requested)
+        payload = await self._build_listing_payload(
+            sections=requested,
+            snapshots=snapshots,
+            agent_workspaces=agent_workspaces,
+        )
         self._store_response_cache(
             cache_key=cache_key,
             fingerprint=fingerprint,
             payload=payload,
         )
+        if projection_store is not None:
+            try:
+                projection_store.set_cache(
+                    durable_cache_key,
+                    fingerprint,
+                    payload,
+                    namespace=_HUB_LISTING_PROJECTION_NAMESPACE,
+                )
+            except Exception:
+                pass
         return payload
 
     async def scan_repos(self) -> dict[str, Any]:
@@ -365,13 +534,28 @@ class HubRepoListingService:
             "repos": repos,
             "agent_workspaces": agent_workspaces,
         }
+        listing_fingerprint = self._listing_fingerprint(
+            requested=set(REPO_LISTING_SECTIONS),
+            stale_threshold_seconds=stale_threshold_seconds,
+            repos=snapshots,
+            agent_workspaces=agent_workspace_snapshots,
+        )
         self._store_response_cache(
             cache_key=tuple(sorted(REPO_LISTING_SECTIONS)),
-            fingerprint=self._response_cache_fingerprint(
-                requested=set(REPO_LISTING_SECTIONS)
-            ),
+            fingerprint=listing_fingerprint,
             payload=payload,
         )
+        projection_store = self._projection_store()
+        if projection_store is not None:
+            try:
+                projection_store.set_cache(
+                    "hub_listing:agent_workspaces,freshness,repos",
+                    listing_fingerprint,
+                    payload,
+                    namespace=_HUB_LISTING_PROJECTION_NAMESPACE,
+                )
+            except Exception:
+                pass
         return payload
 
     async def scan_repos_job(self) -> dict[str, Any]:

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/repo_listing.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/repo_listing.py
@@ -276,6 +276,17 @@ class HubRepoListingService:
                     fingerprint=fingerprint,
                     payload=payload,
                 )
+                projection_store = self._projection_store()
+                if projection_store is not None:
+                    try:
+                        projection_store.set_cache(
+                            f"hub_listing:{','.join(cache_key)}",
+                            fingerprint,
+                            payload,
+                            namespace=_HUB_LISTING_PROJECTION_NAMESPACE,
+                        )
+                    except Exception:
+                        pass
 
             task = asyncio.create_task(_refresh())
             self._response_refresh_tasks[cache_key] = task
@@ -403,10 +414,24 @@ class HubRepoListingService:
         requested = set(sections or REPO_LISTING_SECTIONS)
         cache_key = tuple(sorted(requested))
         durable_cache_key = f"hub_listing:{','.join(cache_key)}"
+        needs_repos = bool(requested & {"repos", "freshness"})
+        needs_agent_workspaces = bool(requested & {"agent_workspaces", "freshness"})
         snapshots, agent_workspaces = self._current_topology_snapshots(
-            needs_repos=bool(requested & {"repos", "freshness"}),
-            needs_agent_workspaces=bool(requested & {"agent_workspaces", "freshness"}),
+            needs_repos=needs_repos,
+            needs_agent_workspaces=needs_agent_workspaces,
         )
+        supervisor_state = getattr(self._context.supervisor, "state", None)
+        if (
+            needs_repos
+            and not snapshots
+            and getattr(supervisor_state, "last_scan_at", None) is None
+        ):
+            snapshots = await asyncio.to_thread(self._context.supervisor.scan)
+            if needs_agent_workspaces:
+                agent_workspaces = await asyncio.to_thread(
+                    self._context.supervisor.list_agent_workspaces,
+                    use_cache=False,
+                )
         stale_threshold_seconds = resolve_stale_threshold_seconds(
             getattr(
                 self._context.config.pma,

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/repo_listing.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/repo_listing.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 REPO_LISTING_SECTIONS = frozenset({"repos", "agent_workspaces", "freshness"})
 _REPO_LISTING_RESPONSE_CACHE_TTL_SECONDS = 20.0
 _HUB_LISTING_PROJECTION_NAMESPACE = "hub_listing_v1"
+_HUB_LISTING_PROJECTION_MAX_AGE_SECONDS = 60.0
 
 
 @dataclass(frozen=True)
@@ -257,6 +258,47 @@ class HubRepoListingService:
             agent_workspaces = list(self._context.supervisor.list_agent_workspaces())
         return snapshots, agent_workspaces
 
+    def _force_list_repos(self) -> list[Any]:
+        try:
+            return list(self._context.supervisor.list_repos(use_cache=False))
+        except TypeError:
+            return list(self._context.supervisor.list_repos())
+
+    def _force_list_agent_workspaces(self) -> list[Any]:
+        try:
+            return list(self._context.supervisor.list_agent_workspaces(use_cache=False))
+        except TypeError:
+            return list(self._context.supervisor.list_agent_workspaces())
+
+    async def _load_topology_snapshots(
+        self,
+        *,
+        needs_repos: bool,
+        needs_agent_workspaces: bool,
+        force_refresh: bool,
+    ) -> tuple[list[Any], list[Any]]:
+        if force_refresh:
+            if needs_repos:
+                snapshots = await asyncio.to_thread(self._force_list_repos)
+                supervisor_state = getattr(self._context.supervisor, "state", None)
+                agent_workspaces = list(
+                    getattr(supervisor_state, "agent_workspaces", []) or []
+                )
+                if needs_agent_workspaces and not agent_workspaces:
+                    agent_workspaces = await asyncio.to_thread(
+                        self._force_list_agent_workspaces
+                    )
+                return list(snapshots), list(agent_workspaces)
+            if needs_agent_workspaces:
+                agent_workspaces = await asyncio.to_thread(
+                    self._force_list_agent_workspaces
+                )
+                return [], list(agent_workspaces)
+        return self._current_topology_snapshots(
+            needs_repos=needs_repos,
+            needs_agent_workspaces=needs_agent_workspaces,
+        )
+
     def _schedule_response_refresh(
         self,
         *,
@@ -270,10 +312,36 @@ class HubRepoListingService:
                 return
 
             async def _refresh() -> None:
-                payload = await self._build_listing_payload(sections=requested)
+                needs_repos = bool(requested & {"repos", "freshness"})
+                needs_agent_workspaces = bool(
+                    requested & {"agent_workspaces", "freshness"}
+                )
+                snapshots, agent_workspaces = await self._load_topology_snapshots(
+                    needs_repos=needs_repos,
+                    needs_agent_workspaces=needs_agent_workspaces,
+                    force_refresh=True,
+                )
+                stale_threshold_seconds = resolve_stale_threshold_seconds(
+                    getattr(
+                        self._context.config.pma,
+                        "freshness_stale_threshold_seconds",
+                        None,
+                    )
+                )
+                refreshed_fingerprint = self._listing_fingerprint(
+                    requested=requested,
+                    stale_threshold_seconds=stale_threshold_seconds,
+                    repos=snapshots,
+                    agent_workspaces=agent_workspaces,
+                )
+                payload = await self._build_listing_payload(
+                    sections=requested,
+                    snapshots=snapshots,
+                    agent_workspaces=agent_workspaces,
+                )
                 self._store_response_cache(
                     cache_key=cache_key,
-                    fingerprint=fingerprint,
+                    fingerprint=refreshed_fingerprint,
                     payload=payload,
                 )
                 projection_store = self._projection_store()
@@ -281,7 +349,7 @@ class HubRepoListingService:
                     try:
                         projection_store.set_cache(
                             f"hub_listing:{','.join(cache_key)}",
-                            fingerprint,
+                            refreshed_fingerprint,
                             payload,
                             namespace=_HUB_LISTING_PROJECTION_NAMESPACE,
                         )
@@ -416,9 +484,10 @@ class HubRepoListingService:
         durable_cache_key = f"hub_listing:{','.join(cache_key)}"
         needs_repos = bool(requested & {"repos", "freshness"})
         needs_agent_workspaces = bool(requested & {"agent_workspaces", "freshness"})
-        snapshots, agent_workspaces = self._current_topology_snapshots(
+        snapshots, agent_workspaces = await self._load_topology_snapshots(
             needs_repos=needs_repos,
             needs_agent_workspaces=needs_agent_workspaces,
+            force_refresh=False,
         )
         supervisor_state = getattr(self._context.supervisor, "state", None)
         if (
@@ -457,12 +526,24 @@ class HubRepoListingService:
                 requested=requested,
             )
             return copy.deepcopy(cached.payload)
+        snapshots, agent_workspaces = await self._load_topology_snapshots(
+            needs_repos=needs_repos,
+            needs_agent_workspaces=needs_agent_workspaces,
+            force_refresh=True,
+        )
+        fingerprint = self._listing_fingerprint(
+            requested=requested,
+            stale_threshold_seconds=stale_threshold_seconds,
+            repos=snapshots,
+            agent_workspaces=agent_workspaces,
+        )
         projection_store = self._projection_store()
         if projection_store is not None:
             try:
                 cached = projection_store.get_cache(
                     durable_cache_key,
                     fingerprint,
+                    max_age_seconds=_HUB_LISTING_PROJECTION_MAX_AGE_SECONDS,
                     namespace=_HUB_LISTING_PROJECTION_NAMESPACE,
                 )
             except Exception:

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/run_control.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/run_control.py
@@ -25,6 +25,21 @@ class HubRunControlService:
         self._mount_manager = mount_manager
         self._enricher = enricher
 
+    async def _refresh_repo_listing_cache(self) -> None:
+        from .....core.logging_utils import safe_log
+
+        try:
+            await asyncio.to_thread(
+                self._context.supervisor.list_repos, use_cache=False
+            )
+        except Exception as exc:  # intentional: cache refresh is best-effort
+            safe_log(
+                self._context.logger,
+                logging.WARNING,
+                "Hub repo listing refresh failed after runtime mutation",
+                exc=exc,
+            )
+
     async def run_repo(self, repo_id: str, once: bool = False) -> dict:
         from .....core.logging_utils import safe_log
 
@@ -44,7 +59,7 @@ class HubRunControlService:
             Exception
         ) as exc:  # intentional: pluggable spawn_fn may raise unpredictable errors
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        await asyncio.to_thread(self._context.supervisor.list_repos, use_cache=False)
+        await self._refresh_repo_listing_cache()
         await self._mount_manager.refresh_mounts([snapshot], full_refresh=False)
         self._enricher.invalidate_runtime_caches()
         return self._enricher.enrich_repo(snapshot)
@@ -59,7 +74,7 @@ class HubRunControlService:
             )
         except (ValueError, OSError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        await asyncio.to_thread(self._context.supervisor.list_repos, use_cache=False)
+        await self._refresh_repo_listing_cache()
         self._enricher.invalidate_runtime_caches()
         return self._enricher.enrich_repo(snapshot)
 
@@ -82,7 +97,7 @@ class HubRunControlService:
             Exception
         ) as exc:  # intentional: pluggable spawn_fn may raise unpredictable errors
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        await asyncio.to_thread(self._context.supervisor.list_repos, use_cache=False)
+        await self._refresh_repo_listing_cache()
         await self._mount_manager.refresh_mounts([snapshot], full_refresh=False)
         self._enricher.invalidate_runtime_caches()
         return self._enricher.enrich_repo(snapshot)
@@ -97,7 +112,7 @@ class HubRunControlService:
             )
         except (ValueError, OSError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        await asyncio.to_thread(self._context.supervisor.list_repos, use_cache=False)
+        await self._refresh_repo_listing_cache()
         self._enricher.invalidate_runtime_caches()
         return self._enricher.enrich_repo(snapshot)
 
@@ -111,7 +126,7 @@ class HubRunControlService:
             )
         except (ValueError, OSError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        await asyncio.to_thread(self._context.supervisor.list_repos, use_cache=False)
+        await self._refresh_repo_listing_cache()
         await self._mount_manager.refresh_mounts([snapshot], full_refresh=False)
         self._enricher.invalidate_runtime_caches()
         return self._enricher.enrich_repo(snapshot)
@@ -126,7 +141,7 @@ class HubRunControlService:
             )
         except (ValueError, OSError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        await asyncio.to_thread(self._context.supervisor.list_repos, use_cache=False)
+        await self._refresh_repo_listing_cache()
         await self._mount_manager.refresh_mounts([snapshot], full_refresh=False)
         self._enricher.invalidate_runtime_caches()
         return self._enricher.enrich_repo(snapshot)

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/run_control.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/run_control.py
@@ -44,7 +44,9 @@ class HubRunControlService:
             Exception
         ) as exc:  # intentional: pluggable spawn_fn may raise unpredictable errors
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        await asyncio.to_thread(self._context.supervisor.list_repos, use_cache=False)
         await self._mount_manager.refresh_mounts([snapshot], full_refresh=False)
+        self._enricher.invalidate_runtime_caches()
         return self._enricher.enrich_repo(snapshot)
 
     async def stop_repo(self, repo_id: str) -> dict:
@@ -57,6 +59,8 @@ class HubRunControlService:
             )
         except (ValueError, OSError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        await asyncio.to_thread(self._context.supervisor.list_repos, use_cache=False)
+        self._enricher.invalidate_runtime_caches()
         return self._enricher.enrich_repo(snapshot)
 
     async def resume_repo(self, repo_id: str, once: bool = False) -> dict:
@@ -78,7 +82,9 @@ class HubRunControlService:
             Exception
         ) as exc:  # intentional: pluggable spawn_fn may raise unpredictable errors
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        await asyncio.to_thread(self._context.supervisor.list_repos, use_cache=False)
         await self._mount_manager.refresh_mounts([snapshot], full_refresh=False)
+        self._enricher.invalidate_runtime_caches()
         return self._enricher.enrich_repo(snapshot)
 
     async def kill_repo(self, repo_id: str) -> dict:
@@ -91,6 +97,8 @@ class HubRunControlService:
             )
         except (ValueError, OSError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        await asyncio.to_thread(self._context.supervisor.list_repos, use_cache=False)
+        self._enricher.invalidate_runtime_caches()
         return self._enricher.enrich_repo(snapshot)
 
     async def init_repo(self, repo_id: str) -> dict:
@@ -103,7 +111,9 @@ class HubRunControlService:
             )
         except (ValueError, OSError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        await asyncio.to_thread(self._context.supervisor.list_repos, use_cache=False)
         await self._mount_manager.refresh_mounts([snapshot], full_refresh=False)
+        self._enricher.invalidate_runtime_caches()
         return self._enricher.enrich_repo(snapshot)
 
     async def sync_main(self, repo_id: str) -> dict:
@@ -116,5 +126,7 @@ class HubRunControlService:
             )
         except (ValueError, OSError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        await asyncio.to_thread(self._context.supervisor.list_repos, use_cache=False)
         await self._mount_manager.refresh_mounts([snapshot], full_refresh=False)
+        self._enricher.invalidate_runtime_caches()
         return self._enricher.enrich_repo(snapshot)

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/services.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/services.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 _REPO_ENRICH_CACHE_TTL_SECONDS = 45.0
 _REPO_RUNTIME_PROJECTION_NAMESPACE = "repo_runtime_v1"
+_REPO_RUNTIME_PROJECTION_MAX_AGE_SECONDS = 300.0
 
 
 @dataclass(frozen=True)
@@ -237,6 +238,7 @@ class HubRepoEnricher:
                 cached_payload = projection_store.get_cache(
                     cache_key,
                     fingerprint,
+                    max_age_seconds=_REPO_RUNTIME_PROJECTION_MAX_AGE_SECONDS,
                     namespace=_REPO_RUNTIME_PROJECTION_NAMESPACE,
                 )
             except Exception:

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/services.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/services.py
@@ -7,12 +7,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
+from .....core.hub_projection_store import path_stat_fingerprint
+
 if TYPE_CHECKING:
     from ...app_state import HubAppContext
     from .mount_manager import HubMountManager
 
 
 _REPO_ENRICH_CACHE_TTL_SECONDS = 45.0
+_REPO_RUNTIME_PROJECTION_NAMESPACE = "repo_runtime_v1"
 
 
 @dataclass(frozen=True)
@@ -32,12 +35,29 @@ class HubRepoEnricher:
         self._repo_state_cache: dict[str, _RepoEnrichmentCacheEntry] = {}
         self._repo_state_cache_lock = threading.Lock()
 
+    def repo_state_fingerprint(
+        self,
+        snapshot,
+        *,
+        stale_threshold_seconds: Optional[int],
+    ) -> tuple[Any, ...]:
+        return self._repo_state_fingerprint(
+            snapshot,
+            stale_threshold_seconds=stale_threshold_seconds,
+        )
+
     def invalidate_runtime_caches(self) -> None:
         with self._unbound_thread_counts_lock:
             self._unbound_thread_counts_cache = None
             self._unbound_thread_counts_cached_at = 0.0
         with self._repo_state_cache_lock:
             self._repo_state_cache.clear()
+        projection_store = getattr(self._context, "projection_store", None)
+        if projection_store is not None:
+            try:
+                projection_store.delete(namespace=_REPO_RUNTIME_PROJECTION_NAMESPACE)
+            except Exception:
+                pass
 
     def _unbound_repo_thread_counts(self) -> dict[str, int]:
         with self._unbound_thread_counts_lock:
@@ -58,11 +78,10 @@ class HubRepoEnricher:
     def _path_stat_fingerprint(
         self, path: Path
     ) -> tuple[bool, Optional[int], Optional[int]]:
-        try:
-            stat = path.stat()
-        except OSError:
-            return (False, None, None)
-        return (True, int(stat.st_mtime_ns), int(stat.st_size))
+        return path_stat_fingerprint(path)
+
+    def _repo_state_projection_key(self, snapshot) -> str:
+        return f"{snapshot.id}:{snapshot.path}"
 
     def _repo_state_fingerprint(
         self,
@@ -199,11 +218,12 @@ class HubRepoEnricher:
         stale_threshold_seconds: Optional[int],
     ) -> dict[str, Any]:
         now = time.monotonic()
-        cache_key = str(snapshot.id)
         fingerprint = self._repo_state_fingerprint(
             snapshot,
             stale_threshold_seconds=stale_threshold_seconds,
         )
+        cache_key = self._repo_state_projection_key(snapshot)
+        projection_store = getattr(self._context, "projection_store", None)
         with self._repo_state_cache_lock:
             cached = self._repo_state_cache.get(cache_key)
             if (
@@ -212,6 +232,23 @@ class HubRepoEnricher:
                 and cached.fingerprint == fingerprint
             ):
                 return copy.deepcopy(cached.payload)
+        if projection_store is not None:
+            try:
+                cached_payload = projection_store.get_cache(
+                    cache_key,
+                    fingerprint,
+                    namespace=_REPO_RUNTIME_PROJECTION_NAMESPACE,
+                )
+            except Exception:
+                cached_payload = None
+            if cached_payload is not None:
+                with self._repo_state_cache_lock:
+                    self._repo_state_cache[cache_key] = _RepoEnrichmentCacheEntry(
+                        fingerprint=fingerprint,
+                        expires_at=now + _REPO_ENRICH_CACHE_TTL_SECONDS,
+                        payload=copy.deepcopy(cached_payload),
+                    )
+                return copy.deepcopy(cached_payload)
         payload = self._compute_repo_state_payload(
             snapshot,
             stale_threshold_seconds=stale_threshold_seconds,
@@ -222,6 +259,16 @@ class HubRepoEnricher:
                 expires_at=now + _REPO_ENRICH_CACHE_TTL_SECONDS,
                 payload=copy.deepcopy(payload),
             )
+        if projection_store is not None:
+            try:
+                projection_store.set_cache(
+                    cache_key,
+                    fingerprint,
+                    payload,
+                    namespace=_REPO_RUNTIME_PROJECTION_NAMESPACE,
+                )
+            except Exception:
+                pass
         return payload
 
     def enrich_repo(

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/worktrees.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/worktrees.py
@@ -140,6 +140,7 @@ class HubWorktreeService:
             )
         except (RuntimeError, OSError, ValueError, TypeError, KeyError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        self._enricher.invalidate_runtime_caches()
         if isinstance(result, dict):
             return result
         return {"status": "ok"}
@@ -166,6 +167,7 @@ class HubWorktreeService:
                 archive_note=payload.archive_note,
                 archive_profile=payload.archive_profile,
             )
+            self._enricher.invalidate_runtime_caches()
             if isinstance(result, dict):
                 return result
             return {"status": "ok"}
@@ -199,6 +201,7 @@ class HubWorktreeService:
             )
         except (RuntimeError, OSError, ValueError, TypeError, KeyError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        self._enricher.invalidate_runtime_caches()
         return cast(dict[str, Any], result)
 
     async def archive_worktree_state(
@@ -229,4 +232,5 @@ class HubWorktreeService:
             KeyError,
         ) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        self._enricher.invalidate_runtime_caches()
         return cast(dict[str, Any], result)

--- a/src/codex_autorunner/surfaces/web/routes/hub_repos.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repos.py
@@ -1130,6 +1130,7 @@ def build_hub_repo_routes(
                 archive_note=payload.archive_note,
                 archive_profile=payload.archive_profile,
             )
+            await asyncio.to_thread(context.supervisor.list_repos, use_cache=False)
             enricher.invalidate_runtime_caches()
             return result
         except (
@@ -1149,6 +1150,7 @@ def build_hub_repo_routes(
                 context.supervisor.cleanup_repo_threads,
                 repo_id=repo_id,
             )
+            await asyncio.to_thread(context.supervisor.list_repos, use_cache=False)
             enricher.invalidate_runtime_caches()
             return result
         except (
@@ -1167,6 +1169,7 @@ def build_hub_repo_routes(
             result = await asyncio.to_thread(
                 context.supervisor.cleanup_all_repo_threads
             )
+            await asyncio.to_thread(context.supervisor.list_repos, use_cache=False)
             enricher.invalidate_runtime_caches()
             return result
         except (
@@ -1196,6 +1199,7 @@ def build_hub_repo_routes(
 
         async def _run_cleanup_all():
             result = await asyncio.to_thread(context.supervisor.cleanup_all)
+            await asyncio.to_thread(context.supervisor.list_repos, use_cache=False)
             enricher.invalidate_runtime_caches()
             return result
 

--- a/src/codex_autorunner/surfaces/web/routes/hub_repos.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repos.py
@@ -154,6 +154,17 @@ def build_hub_repo_routes(
             )
             return {}
 
+    async def _refresh_repo_listing_cache() -> None:
+        try:
+            await asyncio.to_thread(context.supervisor.list_repos, use_cache=False)
+        except Exception as exc:  # intentional: cache refresh is best-effort
+            safe_log(
+                context.logger,
+                logging.WARNING,
+                "Hub repo listing refresh failed after cleanup/archive mutation",
+                exc=exc,
+            )
+
     def _enrich_repo(
         snapshot,
         chat_binding_counts: Optional[dict[str, int]] = None,
@@ -1130,7 +1141,7 @@ def build_hub_repo_routes(
                 archive_note=payload.archive_note,
                 archive_profile=payload.archive_profile,
             )
-            await asyncio.to_thread(context.supervisor.list_repos, use_cache=False)
+            await _refresh_repo_listing_cache()
             enricher.invalidate_runtime_caches()
             return result
         except (
@@ -1150,7 +1161,7 @@ def build_hub_repo_routes(
                 context.supervisor.cleanup_repo_threads,
                 repo_id=repo_id,
             )
-            await asyncio.to_thread(context.supervisor.list_repos, use_cache=False)
+            await _refresh_repo_listing_cache()
             enricher.invalidate_runtime_caches()
             return result
         except (
@@ -1169,7 +1180,7 @@ def build_hub_repo_routes(
             result = await asyncio.to_thread(
                 context.supervisor.cleanup_all_repo_threads
             )
-            await asyncio.to_thread(context.supervisor.list_repos, use_cache=False)
+            await _refresh_repo_listing_cache()
             enricher.invalidate_runtime_caches()
             return result
         except (
@@ -1199,7 +1210,7 @@ def build_hub_repo_routes(
 
         async def _run_cleanup_all():
             result = await asyncio.to_thread(context.supervisor.cleanup_all)
-            await asyncio.to_thread(context.supervisor.list_repos, use_cache=False)
+            await _refresh_repo_listing_cache()
             enricher.invalidate_runtime_caches()
             return result
 

--- a/tests/js/hub_repo_cards.test.js
+++ b/tests/js/hub_repo_cards.test.js
@@ -407,6 +407,59 @@ test("hub panel toggles keep working when localStorage is unavailable", () => {
   }
 });
 
+test("hub bootstrap cache falls back to durable localStorage and restores session cache", () => {
+  sessionStorage.clear();
+  localStorage.clear();
+
+  const payload = {
+    repos: [
+      {
+        id: "cached-repo",
+        path: "/tmp/cached-repo",
+        display_name: "cached-repo",
+        enabled: true,
+        auto_run: false,
+        worktree_setup_commands: [],
+        kind: "base",
+        worktree_of: null,
+        branch: "main",
+        exists_on_disk: true,
+        is_clean: true,
+        initialized: true,
+        init_error: null,
+        status: "idle",
+        lock_status: "unlocked",
+        last_run_id: null,
+        last_exit_code: null,
+        last_run_started_at: null,
+        last_run_finished_at: null,
+        runner_pid: null,
+        effective_destination: { kind: "local" },
+        mounted: false,
+        mount_error: null,
+        cleanup_blocked_by_chat_binding: false,
+        ticket_flow: null,
+        ticket_flow_display: null,
+      },
+    ],
+    agent_workspaces: [],
+    last_scan_at: "2026-04-10T10:00:00Z",
+    pinned_parent_repo_ids: [],
+  };
+
+  __hubTest.saveHubBootstrapCache(payload);
+  sessionStorage.clear();
+
+  const restored = __hubTest.loadHubBootstrapCache();
+  const sessionValues = Array.from(
+    { length: sessionStorage.length },
+    (_, index) => sessionStorage.getItem(sessionStorage.key(index) || "") || ""
+  );
+
+  assert.deepEqual(restored, payload);
+  assert.equal(sessionValues.some((value) => value.includes("cached-repo")), true);
+});
+
 test("agent workspace cards render runtime, managed path, and lifecycle actions", () => {
   __hubTest.renderAgentWorkspaces([
     {

--- a/tests/surfaces/web/routes/test_hub_performance_caches.py
+++ b/tests/surfaces/web/routes/test_hub_performance_caches.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import codex_autorunner.core.chat_bindings as chat_bindings_module
+import codex_autorunner.core.hub_projection_store as projection_store_module
 from codex_autorunner.core.flows.store import FlowStore
 from codex_autorunner.core.hub import LockStatus, RepoSnapshot, RepoStatus
 from codex_autorunner.core.hub_projection_store import HubProjectionStore
@@ -216,6 +217,98 @@ def test_hub_repo_enricher_reuses_durable_repo_state_across_instances(
         "ticket_flow_summary": 1,
         "run_state": 1,
         "canonical_state": 1,
+    }
+
+
+def test_hub_repo_enricher_expires_durable_repo_state_across_instances(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "demo"
+    tickets_dir = repo_root / ".codex-autorunner" / "tickets"
+    tickets_dir.mkdir(parents=True, exist_ok=True)
+    snapshot = _repo_snapshot(repo_root)
+    calls = {
+        "has_car_state": 0,
+        "ticket_flow_summary": 0,
+        "run_state": 0,
+        "canonical_state": 0,
+    }
+
+    def build_context() -> SimpleNamespace:
+        return SimpleNamespace(
+            config=SimpleNamespace(
+                root=hub_root,
+                pma=SimpleNamespace(freshness_stale_threshold_seconds=None),
+            ),
+            projection_store=HubProjectionStore(hub_root, durable=False),
+            supervisor=SimpleNamespace(unbound_repo_thread_counts=lambda: {"demo": 0}),
+        )
+
+    def fake_has_car_state(_path: Path) -> bool:
+        calls["has_car_state"] += 1
+        return True
+
+    def fake_ticket_flow_summary(
+        _path: Path, *, include_failure: bool, store=None
+    ) -> dict[str, object]:
+        assert include_failure is True
+        calls["ticket_flow_summary"] += 1
+        return {
+            "status": "running",
+            "done_count": 1,
+            "total_count": 2,
+            "run_id": f"r{calls['ticket_flow_summary']}",
+        }
+
+    def fake_run_state(
+        _repo_root: Path, _repo_id: str, *, store=None
+    ) -> tuple[dict[str, object], None]:
+        calls["run_state"] += 1
+        return ({"state": "running", "flow_status": "running", "run_id": "r1"}, None)
+
+    def fake_canonical_state(**_kwargs) -> dict[str, object]:
+        calls["canonical_state"] += 1
+        return {"status": "running"}
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.archive.has_car_state", fake_has_car_state
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.ticket_flow_summary.build_ticket_flow_summary",
+        fake_ticket_flow_summary,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.pma_context.get_latest_ticket_flow_run_state_with_record",
+        fake_run_state,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.ticket_flow_projection.build_canonical_state_v1",
+        fake_canonical_state,
+    )
+    monkeypatch.setattr(
+        projection_store_module,
+        "now_iso",
+        lambda: "1970-01-01T00:16:40+00:00",
+    )
+    monkeypatch.setattr(projection_store_module, "_current_utc_ts", lambda: 1000.0)
+    monkeypatch.setattr(
+        "codex_autorunner.surfaces.web.routes.hub_repo_routes.services._REPO_RUNTIME_PROJECTION_MAX_AGE_SECONDS",
+        1.0,
+    )
+
+    first = HubRepoEnricher(build_context(), _MountManager())  # type: ignore[arg-type]
+    assert first.enrich_repo(snapshot)["ticket_flow"]["run_id"] == "r1"
+
+    monkeypatch.setattr(projection_store_module, "_current_utc_ts", lambda: 1002.0)
+    second = HubRepoEnricher(build_context(), _MountManager())  # type: ignore[arg-type]
+    assert second.enrich_repo(snapshot)["ticket_flow"]["run_id"] == "r2"
+    assert calls == {
+        "has_car_state": 2,
+        "ticket_flow_summary": 2,
+        "run_state": 2,
+        "canonical_state": 2,
     }
 
 

--- a/tests/surfaces/web/routes/test_hub_performance_caches.py
+++ b/tests/surfaces/web/routes/test_hub_performance_caches.py
@@ -6,8 +6,10 @@ import threading
 from pathlib import Path
 from types import SimpleNamespace
 
+import codex_autorunner.core.chat_bindings as chat_bindings_module
 from codex_autorunner.core.flows.store import FlowStore
 from codex_autorunner.core.hub import LockStatus, RepoSnapshot, RepoStatus
+from codex_autorunner.core.hub_projection_store import HubProjectionStore
 from codex_autorunner.surfaces.web.routes.hub_repo_routes import (
     channels as hub_channels_module,
 )
@@ -128,6 +130,87 @@ def test_hub_repo_enricher_reuses_cached_repo_state(
 
     assert first["canonical_state_v1"] == {"status": "running"}
     assert second["canonical_state_v1"] == {"status": "running"}
+    assert calls == {
+        "has_car_state": 1,
+        "ticket_flow_summary": 1,
+        "run_state": 1,
+        "canonical_state": 1,
+    }
+
+
+def test_hub_repo_enricher_reuses_durable_repo_state_across_instances(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "demo"
+    tickets_dir = repo_root / ".codex-autorunner" / "tickets"
+    tickets_dir.mkdir(parents=True, exist_ok=True)
+    snapshot = _repo_snapshot(repo_root)
+    calls = {
+        "has_car_state": 0,
+        "ticket_flow_summary": 0,
+        "run_state": 0,
+        "canonical_state": 0,
+    }
+
+    def build_context() -> SimpleNamespace:
+        return SimpleNamespace(
+            config=SimpleNamespace(
+                root=hub_root,
+                pma=SimpleNamespace(freshness_stale_threshold_seconds=None),
+            ),
+            projection_store=HubProjectionStore(hub_root, durable=False),
+            supervisor=SimpleNamespace(unbound_repo_thread_counts=lambda: {"demo": 0}),
+        )
+
+    def fake_has_car_state(_path: Path) -> bool:
+        calls["has_car_state"] += 1
+        return True
+
+    def fake_ticket_flow_summary(
+        _path: Path, *, include_failure: bool, store=None
+    ) -> dict[str, object]:
+        assert include_failure is True
+        calls["ticket_flow_summary"] += 1
+        return {
+            "status": "running",
+            "done_count": 1,
+            "total_count": 2,
+            "run_id": "r1",
+        }
+
+    def fake_run_state(
+        _repo_root: Path, _repo_id: str, *, store=None
+    ) -> tuple[dict[str, object], None]:
+        calls["run_state"] += 1
+        return ({"state": "running", "flow_status": "running", "run_id": "r1"}, None)
+
+    def fake_canonical_state(**_kwargs) -> dict[str, object]:
+        calls["canonical_state"] += 1
+        return {"status": "running"}
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.archive.has_car_state", fake_has_car_state
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.ticket_flow_summary.build_ticket_flow_summary",
+        fake_ticket_flow_summary,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.pma_context.get_latest_ticket_flow_run_state_with_record",
+        fake_run_state,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.ticket_flow_projection.build_canonical_state_v1",
+        fake_canonical_state,
+    )
+
+    first = HubRepoEnricher(build_context(), _MountManager())  # type: ignore[arg-type]
+    second = HubRepoEnricher(build_context(), _MountManager())  # type: ignore[arg-type]
+
+    assert first.enrich_repo(snapshot)["canonical_state_v1"] == {"status": "running"}
+    assert second.enrich_repo(snapshot)["canonical_state_v1"] == {"status": "running"}
     assert calls == {
         "has_car_state": 1,
         "ticket_flow_summary": 1,
@@ -403,7 +486,10 @@ def test_hub_repo_listing_service_invalidates_cache_when_manifest_changes(
     snapshot = _repo_snapshot(tmp_path / "repo-1", repo_id="repo-1")
     manifest_path = tmp_path / ".codex-autorunner" / "manifest.yml"
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest_path.write_text("repos:\n  - id: repo-1\n", encoding="utf-8")
+    manifest_path.write_text(
+        "version: 3\nrepos:\n  - id: repo-1\n    path: repo-1\n",
+        encoding="utf-8",
+    )
     calls = {"enrich_repo": 0}
 
     def enrich_repo(
@@ -445,6 +531,130 @@ def test_hub_repo_listing_service_invalidates_cache_when_manifest_changes(
     assert first["repos"][0]["call"] == 1
     assert second["repos"][0]["call"] == 2
     assert calls["enrich_repo"] == 2
+
+
+def test_hub_repo_listing_service_reuses_durable_projection_across_instances(
+    tmp_path: Path,
+) -> None:
+    class _AsyncMountManager:
+        async def refresh_mounts(self, _snapshots) -> None:
+            return None
+
+    snapshot = _repo_snapshot(tmp_path / "repo-1", repo_id="repo-1")
+    manifest_path = tmp_path / ".codex-autorunner" / "manifest.yml"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text("repos:\n  - id: repo-1\n", encoding="utf-8")
+    calls = {"enrich_repo": 0}
+
+    def enrich_repo(
+        _snapshot, chat_binding_counts: dict[str, int], chat_binding_counts_by_source
+    ) -> dict[str, object]:
+        assert chat_binding_counts == {}
+        assert chat_binding_counts_by_source == {}
+        calls["enrich_repo"] += 1
+        return {"repo_id": "repo-1", "call": calls["enrich_repo"]}
+
+    def build_context() -> SimpleNamespace:
+        return SimpleNamespace(
+            config=SimpleNamespace(
+                root=tmp_path,
+                raw={},
+                manifest_path=manifest_path,
+                pma=SimpleNamespace(freshness_stale_threshold_seconds=None),
+            ),
+            projection_store=HubProjectionStore(tmp_path, durable=False),
+            supervisor=SimpleNamespace(
+                list_repos=lambda: [snapshot],
+                state=SimpleNamespace(
+                    last_scan_at="2026-04-05T00:00:00Z",
+                    pinned_parent_repo_ids=[],
+                    repos=[snapshot],
+                    agent_workspaces=[],
+                ),
+            ),
+            logger=logging.getLogger(__name__),
+        )
+
+    first_service = HubRepoListingService(
+        build_context(),
+        _AsyncMountManager(),  # type: ignore[arg-type]
+        SimpleNamespace(
+            enrich_repo=enrich_repo,
+            repo_state_fingerprint=lambda *_args, **_kwargs: ("repo-1",),
+        ),
+    )
+    second_service = HubRepoListingService(
+        build_context(),
+        _AsyncMountManager(),  # type: ignore[arg-type]
+        SimpleNamespace(
+            enrich_repo=enrich_repo,
+            repo_state_fingerprint=lambda *_args, **_kwargs: ("repo-1",),
+        ),
+    )
+
+    first = asyncio.run(first_service.list_repos(sections={"repos"}))
+    second = asyncio.run(second_service.list_repos(sections={"repos"}))
+
+    assert first["repos"][0]["call"] == 1
+    assert second["repos"][0]["call"] == 1
+    assert calls["enrich_repo"] == 1
+
+
+def test_active_chat_binding_counts_by_source_reuses_durable_projection(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir(parents=True, exist_ok=True)
+    calls = {"pma": 0, "orchestration": 0, "discord": 0, "telegram": 0}
+
+    monkeypatch.setattr(
+        chat_bindings_module,
+        "_repo_id_by_workspace_path",
+        lambda _hub_root, _raw_config: {},
+    )
+
+    def fake_pma(_hub_root: Path, _repo_id_by_workspace) -> dict[str, int]:
+        calls["pma"] += 1
+        return {"demo": 1}
+
+    def fake_orchestration(*, hub_root: Path, repo_id_by_workspace):
+        calls["orchestration"] += 1
+        return {"demo": {"discord": 2}}
+
+    def fake_discord(*, db_path: Path, repo_id_by_workspace):
+        calls["discord"] += 1
+        return {"demo": 5}
+
+    def fake_telegram(*, db_path: Path, repo_id_by_workspace):
+        calls["telegram"] += 1
+        return {"demo": 3}
+
+    monkeypatch.setattr(chat_bindings_module, "_active_pma_thread_counts", fake_pma)
+    monkeypatch.setattr(
+        chat_bindings_module,
+        "_orchestration_binding_counts_by_source",
+        fake_orchestration,
+    )
+    monkeypatch.setattr(chat_bindings_module, "_read_discord_repo_counts", fake_discord)
+    monkeypatch.setattr(
+        chat_bindings_module,
+        "_read_current_telegram_repo_counts",
+        fake_telegram,
+    )
+
+    first = chat_bindings_module.active_chat_binding_counts_by_source(
+        hub_root=hub_root,
+        raw_config={},
+    )
+    second = chat_bindings_module.active_chat_binding_counts_by_source(
+        hub_root=hub_root,
+        raw_config={},
+    )
+
+    assert first == {"demo": {"pma": 1, "discord": 2, "telegram": 3}}
+    assert second == first
+    assert calls == {"pma": 1, "orchestration": 1, "discord": 1, "telegram": 1}
 
 
 def test_hub_channel_service_reuses_ttl_cache(

--- a/tests/test_hub_projection_store.py
+++ b/tests/test_hub_projection_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import codex_autorunner.core.hub_projection_store as projection_store_module
 from codex_autorunner.core.hub_projection_store import HubProjectionStore
 
 
@@ -28,3 +29,22 @@ def test_projection_store_persists_across_instances(tmp_path: Path) -> None:
 
     reloaded = HubProjectionStore(tmp_path, durable=False)
     assert reloaded.get_cache("chat_binding_counts_by_source", fingerprint) == payload
+
+
+def test_projection_store_respects_max_age(tmp_path: Path, monkeypatch) -> None:
+    store = HubProjectionStore(tmp_path, durable=False)
+    fingerprint = ("stable",)
+    payload = {"value": 1}
+
+    monkeypatch.setattr(
+        projection_store_module,
+        "now_iso",
+        lambda: "1970-01-01T00:16:40+00:00",
+    )
+    monkeypatch.setattr(projection_store_module, "_current_utc_ts", lambda: 1000.0)
+    store.set_cache("repo_runtime:alpha", fingerprint, payload)
+
+    monkeypatch.setattr(projection_store_module, "_current_utc_ts", lambda: 1002.0)
+    assert (
+        store.get_cache("repo_runtime:alpha", fingerprint, max_age_seconds=1.0) is None
+    )

--- a/tests/test_hub_projection_store.py
+++ b/tests/test_hub_projection_store.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_autorunner.core.hub_projection_store import HubProjectionStore
+
+
+def test_projection_store_round_trip(tmp_path: Path) -> None:
+    store = HubProjectionStore(tmp_path, durable=False)
+    fingerprint = ("v1", 123, {"nested": True})
+    payload = {"repo_id": "alpha", "count": 3}
+
+    store.set_cache("repo_runtime:alpha", fingerprint, payload)
+
+    assert store.get_cache("repo_runtime:alpha", fingerprint) == payload
+    assert store.get_cache("repo_runtime:alpha", ("v2", 123, {"nested": True})) is None
+
+
+def test_projection_store_persists_across_instances(tmp_path: Path) -> None:
+    fingerprint = ("projection", "stable")
+    payload = {"chat_bound": True, "count": 4}
+
+    HubProjectionStore(tmp_path, durable=False).set_cache(
+        "chat_binding_counts_by_source",
+        fingerprint,
+        payload,
+    )
+
+    reloaded = HubProjectionStore(tmp_path, durable=False)
+    assert reloaded.get_cache("chat_binding_counts_by_source", fingerprint) == payload


### PR DESCRIPTION
Hub projection refactor for the hot read paths.

- Adds a durable SQLite projection store under `.codex-autorunner/`
- Caches repo runtime/canonical state and hub listing payloads
- Keeps hub listing stable on cold start and avoids self-invalidating chat-binding reads
- Preserves the browser bootstrap cache for fast hub hydration

Verification:
- `./.venv/bin/python -m pytest tests/surfaces/web/routes/test_hub_performance_caches.py tests/test_cli_ticket_flow_archive.py tests/test_hub_projection_store.py`
- repo-wide `pytest` and `mypy` passed in the commit hook
