### PR TITLE
[codex] Fix Discord flow refresh interaction ack timing

### DIFF
--- a/src/codex_autorunner/integrations/discord/interaction_dispatch.py
+++ b/src/codex_autorunner/integrations/discord/interaction_dispatch.py
@@ -21,6 +21,17 @@ UPDATE_CONFIRM_PREFIX = "update_confirm"
 UPDATE_CANCEL_PREFIX = "update_cancel"
 REVIEW_COMMIT_SELECT_ID = "review_commit_select"
 FLOW_ACTION_SELECT_PREFIX = "flow_action_select"
+FLOW_COMPONENT_PREPARE_ACTIONS = frozenset(
+    {
+        "archive",
+        "archive_cancel",
+        "archive_cancel_prompt",
+        "archive_confirm",
+        "archive_confirm_prompt",
+        "refresh",
+        "restart",
+    }
+)
 
 
 async def handle_normalized_interaction(
@@ -471,6 +482,20 @@ async def handle_component_interaction(
             return
 
         if custom_id.startswith("flow:"):
+            flow_parts = custom_id.split(":")
+            flow_action = flow_parts[2].strip().lower() if len(flow_parts) >= 3 else ""
+            if flow_action in FLOW_COMPONENT_PREPARE_ACTIONS:
+                prepared = await service._defer_component_update(
+                    interaction_id=interaction_id,
+                    interaction_token=interaction_token,
+                )
+                if not prepared:
+                    await service._respond_ephemeral(
+                        interaction_id,
+                        interaction_token,
+                        "Discord interaction did not acknowledge. Please retry.",
+                    )
+                    return
             workspace_root = await service._require_bound_workspace(
                 interaction_id, interaction_token, channel_id=channel_id
             )

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -5498,25 +5498,28 @@ class DiscordBotService:
         *,
         channel_id: str,
     ) -> Optional[Path]:
+        deferred = self._prepared_interaction_policy(interaction_token) is not None
         binding = await self._store.get_binding(channel_id=channel_id)
         if binding is None:
             text = format_discord_message(
                 "This channel is not bound. Run `/car bind path:<...>` first."
             )
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                text,
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=text,
             )
             return None
         if bool(binding.get("pma_enabled", False)):
             text = format_discord_message(
                 "PMA mode is enabled for this channel. Run `/pma off` to use workspace-scoped `/car` commands."
             )
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                text,
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=text,
             )
             return None
         workspace_raw = binding.get("workspace_path")
@@ -5524,10 +5527,11 @@ class DiscordBotService:
             text = format_discord_message(
                 "Binding is invalid. Run `/car bind path:<...>` first."
             )
-            await self._respond_ephemeral(
-                interaction_id,
-                interaction_token,
-                text,
+            await self._send_or_respond_ephemeral(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=text,
             )
             return None
         return canonicalize_path(Path(workspace_raw))

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -5703,6 +5703,104 @@ async def test_normalized_component_empty_values_returns_error(
 
 
 @pytest.mark.anyio
+async def test_normalized_flow_refresh_component_defers_before_workspace_lookup(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    captured: dict[str, Any] = {}
+
+    async def _fake_require_bound_workspace(
+        interaction_id: str,
+        interaction_token: str,
+        *,
+        channel_id: str,
+    ) -> Path:
+        captured["require_args"] = (
+            interaction_id,
+            interaction_token,
+            channel_id,
+        )
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
+        return workspace
+
+    async def _fake_handle_flow_button(
+        interaction_id: str,
+        interaction_token: str,
+        *,
+        workspace_root: Path,
+        custom_id: str,
+        channel_id: str | None = None,
+        guild_id: str | None = None,
+    ) -> None:
+        captured["button_args"] = {
+            "interaction_id": interaction_id,
+            "interaction_token": interaction_token,
+            "workspace_root": workspace_root,
+            "custom_id": custom_id,
+            "channel_id": channel_id,
+            "guild_id": guild_id,
+        }
+
+    service._require_bound_workspace = _fake_require_bound_workspace  # type: ignore[assignment]
+    service._handle_flow_button = _fake_handle_flow_button  # type: ignore[assignment]
+
+    try:
+        event = _normalized_component_event(component_id="flow:run-1:refresh")
+        context = build_dispatch_context(event)
+        await service._handle_normalized_interaction(event, context)
+        assert captured["button_args"]["custom_id"] == "flow:run-1:refresh"
+        assert captured["button_args"]["workspace_root"] == workspace
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_normalized_flow_refresh_component_binding_error_uses_followup(
+    tmp_path: Path,
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        event = _normalized_component_event(component_id="flow:run-1:refresh")
+        context = build_dispatch_context(event)
+        await service._handle_normalized_interaction(event, context)
+
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
+        assert len(rest.followup_messages) == 1
+        assert (
+            "not bound"
+            in str(rest.followup_messages[0]["payload"].get("content", "")).lower()
+        )
+        assert rest.edited_original_interaction_responses == []
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_unknown_car_subcommand_has_explicit_unknown_message(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What changed
Fix the Discord flow status refresh button so component interactions are acknowledged before workspace binding lookup runs.

## Why
The refresh button sometimes failed with Discord's interaction timeout even though rerunning `/flow status` worked. The component path was doing work before sending the component defer, so a slow binding lookup could miss Discord's acknowledgement deadline.

## Root cause
`flow:*` component actions such as `refresh` reached `_require_bound_workspace()` before the component interaction was deferred. If the Discord state store or SQLite path was slow, the later `type=6` component acknowledgement could arrive too late.

## Fix
- Defer selected `flow:*` component actions immediately in the dispatcher before workspace lookup.
- Preserve the existing status panel on post-defer binding errors by sending a followup ephemeral error instead of editing the original component message.
- Add regression tests for both the success path and the deferred-error path.

## Impact
Discord refreshes for flow status are more reliable under transient binding-store delays and no longer risk wiping the status panel when a deferred component hits a binding error.

## Validation
- Focused pytest: `tests/integrations/discord/test_service_routing.py -k "test_normalized_flow_refresh_component_defers_before_workspace_lookup or test_normalized_flow_refresh_component_binding_error_uses_followup"`
- Focused pytest: `tests/integrations/discord/test_flow_handlers.py -k test_flow_refresh_button_updates_existing_status_message`
- Pre-commit hook suite during commit, including repo-wide mypy, frontend build/tests, and repo pytest suite