### PR TITLE
Fix stale Telegram terminal notifications after archive

### DIFF
--- a/src/codex_autorunner/integrations/telegram/state_types.py
+++ b/src/codex_autorunner/integrations/telegram/state_types.py
@@ -173,6 +173,7 @@ class TelegramTopicRecord:
     last_active_at: Optional[str] = None
     last_ticket_dispatch_seq: Optional[str] = None
     last_terminal_run_id: Optional[str] = None
+    last_terminal_finished_at: Optional[str] = None
 
     @classmethod
     def from_dict(
@@ -325,6 +326,11 @@ class TelegramTopicRecord:
         )
         if not isinstance(last_terminal_run_id, str):
             last_terminal_run_id = None
+        last_terminal_finished_at = payload.get(
+            "last_terminal_finished_at"
+        ) or payload.get("lastTerminalFinishedAt")
+        if not isinstance(last_terminal_finished_at, str):
+            last_terminal_finished_at = None
         return cls(
             repo_id=repo_id,
             resource_kind=resource_kind,
@@ -356,6 +362,7 @@ class TelegramTopicRecord:
             last_active_at=last_active_at,
             last_ticket_dispatch_seq=last_ticket_dispatch_seq,
             last_terminal_run_id=last_terminal_run_id,
+            last_terminal_finished_at=last_terminal_finished_at,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -393,6 +400,7 @@ class TelegramTopicRecord:
             "last_active_at": self.last_active_at,
             "last_ticket_dispatch_seq": self.last_ticket_dispatch_seq,
             "last_terminal_run_id": self.last_terminal_run_id,
+            "last_terminal_finished_at": self.last_terminal_finished_at,
         }
 
 

--- a/src/codex_autorunner/integrations/telegram/ticket_flow_bridge.py
+++ b/src/codex_autorunner/integrations/telegram/ticket_flow_bridge.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Optional
 
@@ -35,6 +35,8 @@ from .state import parse_topic_key
 
 class TelegramTicketFlowBridge:
     """Encapsulate ticket_flow pause/resume plumbing for Telegram service."""
+
+    _LEGACY_STALE_TERMINAL_FALLBACK_SECONDS = 30.0
 
     def __init__(
         self,
@@ -100,9 +102,65 @@ class TelegramTicketFlowBridge:
         if not isinstance(raw, str):
             return float("-inf")
         try:
-            return datetime.strptime(raw, "%Y-%m-%dT%H:%M:%SZ").timestamp()
+            parsed = datetime.strptime(raw, "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+            return parsed.timestamp()
         except ValueError:
             return float("-inf")
+
+    @staticmethod
+    def _parse_iso_timestamp(raw: Optional[str]) -> Optional[float]:
+        if not isinstance(raw, str):
+            return None
+        text = raw.strip()
+        if not text:
+            return None
+        try:
+            return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+
+    def _should_notify_terminal(
+        self,
+        *,
+        record: object,
+        run_id: str,
+        status: str,
+        terminal_at: Optional[str],
+    ) -> bool:
+        last_run_id = getattr(record, "last_terminal_run_id", None)
+        if last_run_id == run_id:
+            return False
+
+        current_ts = self._parse_iso_timestamp(terminal_at)
+        if current_ts is None:
+            return True
+
+        seen_ts = self._parse_iso_timestamp(
+            getattr(record, "last_terminal_finished_at", None)
+        )
+        if seen_ts is not None and current_ts < seen_ts:
+            return False
+
+        # Backward compatibility for existing topic records that only have run_id:
+        # suppress stale terminal notices that predate the topic's last activity.
+        if (
+            seen_ts is None
+            and status == FlowRunStatus.STOPPED.value
+            and isinstance(last_run_id, str)
+            and last_run_id.strip()
+        ):
+            last_active_ts = self._parse_last_active(
+                getattr(record, "last_active_at", None)
+            )
+            if (
+                current_ts
+                <= last_active_ts - self._LEGACY_STALE_TERMINAL_FALLBACK_SECONDS
+            ):
+                return False
+
+        return True
 
     async def watch_ticket_flow_pauses(self, interval_seconds: float) -> None:
         interval = max(interval_seconds, 1.0)
@@ -740,11 +798,16 @@ class TelegramTicketFlowBridge:
         self._clear_scan_failure_marker("terminal", workspace_root)
         if terminal_run is None:
             return
-        run_id, status, error_message = terminal_run
+        run_id, status, error_message, terminal_at = terminal_run
         pending = [
             (key, record)
             for key, record in entries
-            if getattr(record, "last_terminal_run_id", None) != run_id
+            if self._should_notify_terminal(
+                record=record,
+                run_id=run_id,
+                status=status,
+                terminal_at=terminal_at,
+            )
         ]
         if not pending:
             return
@@ -787,7 +850,10 @@ class TelegramTicketFlowBridge:
             )
             return
         for key, _record in pending:
-            await self._store.update_topic(key, self._set_terminal_run_marker(run_id))
+            await self._store.update_topic(
+                key,
+                self._set_terminal_run_marker(run_id, finished_at=terminal_at),
+            )
         log_event(
             self._logger,
             logging.INFO,
@@ -799,7 +865,7 @@ class TelegramTicketFlowBridge:
 
     def _load_latest_terminal_run(
         self, workspace_root: Path
-    ) -> Optional[tuple[str, str, Optional[str]]]:
+    ) -> Optional[tuple[str, str, Optional[str], Optional[str]]]:
         db_path = workspace_root / ".codex-autorunner" / "flows.db"
         if not db_path.exists():
             return None
@@ -831,7 +897,13 @@ class TelegramTicketFlowBridge:
             store.close()
         if latest_run is None:
             return None
-        return (latest_run.id, latest_run.status.value, latest_run.error_message)
+        terminal_at = latest_run.finished_at or latest_run.created_at
+        return (
+            latest_run.id,
+            latest_run.status.value,
+            latest_run.error_message,
+            terminal_at,
+        )
 
     def _format_terminal_notification(
         self, *, run_id: str, status: str, error_message: Optional[str]
@@ -854,9 +926,11 @@ class TelegramTicketFlowBridge:
         return normalized
 
     @staticmethod
-    def _set_terminal_run_marker(value: Optional[str]):
+    def _set_terminal_run_marker(value: Optional[str], *, finished_at: Optional[str]):
         def apply(topic) -> None:
             topic.last_terminal_run_id = value
+            if hasattr(topic, "last_terminal_finished_at"):
+                topic.last_terminal_finished_at = finished_at
 
         return apply
 

--- a/tests/test_telegram_ticket_flow_bridge.py
+++ b/tests/test_telegram_ticket_flow_bridge.py
@@ -18,6 +18,9 @@ class _DummyRecord:
     def __init__(self, workspace_path: Path) -> None:
         self.workspace_path = str(workspace_path)
         self.last_ticket_dispatch_seq = None
+        self.last_terminal_run_id = None
+        self.last_terminal_finished_at = None
+        self.last_active_at = None
 
 
 class _DummyStore:
@@ -583,6 +586,208 @@ async def test_terminal_scan_failure_sends_degraded_notice_once_until_recovery(
     await bridge._notify_terminal_for_workspace(workspace, [("123:456", record)])
 
     assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_terminal_scan_skips_stale_run_when_newer_terminal_was_already_marked(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "tg-terminal-stale"
+    workspace.mkdir()
+    record = _DummyRecord(workspace)
+    record.last_terminal_run_id = "run-completed"
+    record.last_terminal_finished_at = "2026-04-10T10:00:00Z"
+    calls: list[str] = []
+
+    async def send_message_with_outbox(
+        chat_id: int, text: str, thread_id=None, reply_to=None
+    ):
+        calls.append(text)
+        return True
+
+    async def send_document(**kwargs):
+        return True
+
+    bridge = TelegramTicketFlowBridge(
+        logger=logging.getLogger("test"),
+        store=_DummyStore({"123:456": record}),
+        pause_targets={},
+        send_message_with_outbox=send_message_with_outbox,
+        send_document=send_document,
+        pause_config=PauseDispatchNotifications(
+            enabled=True,
+            send_attachments=False,
+            max_file_size_bytes=10,
+            chunk_long_messages=False,
+        ),
+        default_notification_chat_id=None,
+        hub_root=None,
+        manifest_path=None,
+        config_root=workspace,
+    )
+    bridge._load_latest_terminal_run = lambda _path: (  # type: ignore[assignment]
+        "run-stopped",
+        FlowRunStatus.STOPPED.value,
+        None,
+        "2026-04-10T09:00:00Z",
+    )
+
+    await bridge._notify_terminal_for_workspace(workspace, [("123:456", record)])
+
+    assert calls == []
+    assert record.last_terminal_run_id == "run-completed"
+    assert record.last_terminal_finished_at == "2026-04-10T10:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_terminal_scan_uses_last_active_fallback_for_legacy_marker(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "tg-terminal-legacy"
+    workspace.mkdir()
+    record = _DummyRecord(workspace)
+    record.last_terminal_run_id = "run-completed"
+    record.last_terminal_finished_at = None
+    record.last_active_at = "2026-04-10T10:00:00Z"
+    calls: list[str] = []
+
+    async def send_message_with_outbox(
+        chat_id: int, text: str, thread_id=None, reply_to=None
+    ):
+        calls.append(text)
+        return True
+
+    async def send_document(**kwargs):
+        return True
+
+    bridge = TelegramTicketFlowBridge(
+        logger=logging.getLogger("test"),
+        store=_DummyStore({"123:456": record}),
+        pause_targets={},
+        send_message_with_outbox=send_message_with_outbox,
+        send_document=send_document,
+        pause_config=PauseDispatchNotifications(
+            enabled=True,
+            send_attachments=False,
+            max_file_size_bytes=10,
+            chunk_long_messages=False,
+        ),
+        default_notification_chat_id=None,
+        hub_root=None,
+        manifest_path=None,
+        config_root=workspace,
+    )
+    bridge._load_latest_terminal_run = lambda _path: (  # type: ignore[assignment]
+        "run-stopped",
+        FlowRunStatus.STOPPED.value,
+        None,
+        "2026-04-10T09:00:00Z",
+    )
+
+    await bridge._notify_terminal_for_workspace(workspace, [("123:456", record)])
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_terminal_scan_does_not_suppress_same_second_new_run(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "tg-terminal-same-second"
+    workspace.mkdir()
+    record = _DummyRecord(workspace)
+    record.last_terminal_run_id = "run-older"
+    record.last_terminal_finished_at = "2026-04-10T10:00:00Z"
+    calls: list[str] = []
+
+    async def send_message_with_outbox(
+        chat_id: int, text: str, thread_id=None, reply_to=None
+    ):
+        calls.append(text)
+        return True
+
+    async def send_document(**kwargs):
+        return True
+
+    bridge = TelegramTicketFlowBridge(
+        logger=logging.getLogger("test"),
+        store=_DummyStore({"123:456": record}),
+        pause_targets={},
+        send_message_with_outbox=send_message_with_outbox,
+        send_document=send_document,
+        pause_config=PauseDispatchNotifications(
+            enabled=True,
+            send_attachments=False,
+            max_file_size_bytes=10,
+            chunk_long_messages=False,
+        ),
+        default_notification_chat_id=None,
+        hub_root=None,
+        manifest_path=None,
+        config_root=workspace,
+    )
+    bridge._load_latest_terminal_run = lambda _path: (  # type: ignore[assignment]
+        "run-new",
+        FlowRunStatus.COMPLETED.value,
+        None,
+        "2026-04-10T10:00:00Z",
+    )
+
+    await bridge._notify_terminal_for_workspace(workspace, [("123:456", record)])
+
+    assert len(calls) == 1
+    assert "completed successfully (run run-new)" in calls[0]
+
+
+@pytest.mark.asyncio
+async def test_terminal_scan_legacy_fallback_keeps_fresh_stopped_notice(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "tg-terminal-legacy-fresh"
+    workspace.mkdir()
+    record = _DummyRecord(workspace)
+    record.last_terminal_run_id = "run-completed"
+    record.last_terminal_finished_at = None
+    record.last_active_at = "2026-04-10T10:00:00Z"
+    calls: list[str] = []
+
+    async def send_message_with_outbox(
+        chat_id: int, text: str, thread_id=None, reply_to=None
+    ):
+        calls.append(text)
+        return True
+
+    async def send_document(**kwargs):
+        return True
+
+    bridge = TelegramTicketFlowBridge(
+        logger=logging.getLogger("test"),
+        store=_DummyStore({"123:456": record}),
+        pause_targets={},
+        send_message_with_outbox=send_message_with_outbox,
+        send_document=send_document,
+        pause_config=PauseDispatchNotifications(
+            enabled=True,
+            send_attachments=False,
+            max_file_size_bytes=10,
+            chunk_long_messages=False,
+        ),
+        default_notification_chat_id=None,
+        hub_root=None,
+        manifest_path=None,
+        config_root=workspace,
+    )
+    bridge._load_latest_terminal_run = lambda _path: (  # type: ignore[assignment]
+        "run-stopped-fresh",
+        FlowRunStatus.STOPPED.value,
+        None,
+        "2026-04-10T09:59:45Z",
+    )
+
+    await bridge._notify_terminal_for_workspace(workspace, [("123:456", record)])
+
+    assert len(calls) == 1
+    assert "Ticket flow stopped (run run-stopped-fresh)." in calls[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- prevent Telegram terminal watcher from emitting stale `Ticket flow stopped` notices after archive by tracking and comparing terminal timestamps
- keep backward compatibility for legacy topic records by adding `last_terminal_finished_at` and using a conservative stale-stop fallback window
- fix UTC parsing for `last_active_at` timestamps in terminal-notification logic
- address reviewer-noted edge cases: same-second terminal runs and legacy fallback over-suppression

## Testing
- `.venv/bin/python -m pytest tests/test_telegram_ticket_flow_bridge.py -q`
- `.venv/bin/python -m pytest tests/test_telegram_state.py -q`
- pre-commit checks from `git commit` (repo-wide hooks, mypy, JS tests, pytest suite)
