### PR TITLE
[codex] Fix Discord flow archive status UX

### DIFF
--- a/src/codex_autorunner/integrations/discord/flow_commands.py
+++ b/src/codex_autorunner/integrations/discord/flow_commands.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional, cast
@@ -91,6 +92,13 @@ def flow_archive_in_progress_text(run_id: str) -> str:
     return f"Archiving run {run_id}... This can take a few seconds."
 
 
+def _normalize_run_id(value: str) -> Optional[str]:
+    try:
+        return str(uuid.UUID(str(value)))
+    except ValueError:
+        return None
+
+
 def _legacy_flow_archive_root(workspace_root: Path, run_id: str) -> Path:
     return workspace_root / ".codex-autorunner" / "flows" / run_id
 
@@ -99,9 +107,12 @@ def _describe_archived_flow_run(
     workspace_root: Path,
     run_id: str,
 ) -> Optional[dict[str, Any]]:
+    normalized_run_id = _normalize_run_id(run_id)
+    if normalized_run_id is None:
+        return None
     roots = (
-        (flow_run_archive_root(workspace_root, run_id), True),
-        (_legacy_flow_archive_root(workspace_root, run_id), False),
+        (flow_run_archive_root(workspace_root, normalized_run_id), True),
+        (_legacy_flow_archive_root(workspace_root, normalized_run_id), False),
     )
     for archive_root, treat_any_child_as_archive in roots:
         if not archive_root.exists() or not archive_root.is_dir():
@@ -157,7 +168,7 @@ def _describe_archived_flow_run(
         except ValueError:
             archive_path = str(archive_root)
         return {
-            "run_id": run_id,
+            "run_id": normalized_run_id,
             "archive_path": archive_path,
             "archived_at": archived_at,
             "has_tickets": has_tickets,

--- a/src/codex_autorunner/integrations/discord/flow_commands.py
+++ b/src/codex_autorunner/integrations/discord/flow_commands.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional, cast
 
@@ -12,6 +13,7 @@ from ...core.flows import (
     FlowRunStatus,
     flow_action_label,
 )
+from ...core.flows.archive_helpers import flow_run_archive_root
 from ...core.flows.reconciler import reconcile_flow_run
 from ...core.flows.ux_helpers import (
     GitHubServiceProtocol,
@@ -45,6 +47,9 @@ from .errors import DiscordTransientError
 FLOW_ACTION_SELECT_PREFIX = "flow_action_select"
 FLOW_RUNS_DEFAULT_LIMIT = 5
 FLOW_RUNS_MAX_LIMIT = DISCORD_SELECT_OPTION_MAX_OPTIONS
+_LEGACY_FLOW_ARCHIVE_MARKERS = frozenset(
+    {"archived_tickets", "archived_runs", "contextspace", "flow_state"}
+)
 
 
 async def _public_interaction_deferred(
@@ -84,6 +89,134 @@ def flow_archive_prompt_text(record: FlowRunRecord) -> str:
 
 def flow_archive_in_progress_text(run_id: str) -> str:
     return f"Archiving run {run_id}... This can take a few seconds."
+
+
+def _legacy_flow_archive_root(workspace_root: Path, run_id: str) -> Path:
+    return workspace_root / ".codex-autorunner" / "flows" / run_id
+
+
+def _describe_archived_flow_run(
+    workspace_root: Path,
+    run_id: str,
+) -> Optional[dict[str, Any]]:
+    roots = (
+        (flow_run_archive_root(workspace_root, run_id), True),
+        (_legacy_flow_archive_root(workspace_root, run_id), False),
+    )
+    for archive_root, treat_any_child_as_archive in roots:
+        if not archive_root.exists() or not archive_root.is_dir():
+            continue
+        tickets_dir = archive_root / "archived_tickets"
+        runs_dirs = [
+            child
+            for child in archive_root.iterdir()
+            if child.is_dir() and child.name.startswith("archived_runs")
+        ]
+        flow_state_dirs = [
+            child
+            for child in archive_root.iterdir()
+            if child.is_dir() and child.name.startswith("flow_state")
+        ]
+        contextspace_dir = archive_root / "contextspace"
+        has_tickets = tickets_dir.exists() and tickets_dir.is_dir()
+        has_runs = bool(runs_dirs)
+        has_contextspace = contextspace_dir.exists() and contextspace_dir.is_dir()
+        has_flow_state = bool(flow_state_dirs)
+        if not any((has_tickets, has_runs, has_contextspace, has_flow_state)):
+            continue
+        artifact_children: list[Path] = []
+        if has_tickets:
+            artifact_children.append(tickets_dir)
+        artifact_children.extend(runs_dirs)
+        if has_contextspace:
+            artifact_children.append(contextspace_dir)
+        artifact_children.extend(flow_state_dirs)
+        if not treat_any_child_as_archive:
+            artifact_children = [
+                child
+                for child in artifact_children
+                if child.name in _LEGACY_FLOW_ARCHIVE_MARKERS
+                or child.name.startswith("archived_runs")
+                or child.name.startswith("flow_state")
+            ]
+        if not artifact_children:
+            continue
+        mtime_candidates = []
+        for child in artifact_children:
+            try:
+                mtime_candidates.append(child.stat().st_mtime)
+            except OSError:
+                continue
+        archived_at = None
+        if mtime_candidates:
+            archived_at = datetime.fromtimestamp(
+                max(mtime_candidates), tz=timezone.utc
+            ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        try:
+            archive_path = archive_root.relative_to(workspace_root).as_posix()
+        except ValueError:
+            archive_path = str(archive_root)
+        return {
+            "run_id": run_id,
+            "archive_path": archive_path,
+            "archived_at": archived_at,
+            "has_tickets": has_tickets,
+            "has_runs": has_runs,
+            "has_contextspace": has_contextspace,
+            "has_flow_state": has_flow_state,
+        }
+    return None
+
+
+def _format_archived_flow_status_text(
+    run_id: str,
+    archived_summary: dict[str, Any],
+    *,
+    prefix: Optional[str] = None,
+) -> str:
+    lines: list[str] = []
+    if isinstance(prefix, str) and prefix.strip():
+        lines.append(prefix.strip())
+        lines.append("")
+    else:
+        lines.append(f"Run {run_id} has already been archived.")
+        lines.append("")
+    lines.append(f"Run: {run_id}")
+    lines.append("Status: archived")
+    archived_at = archived_summary.get("archived_at")
+    if isinstance(archived_at, str) and archived_at.strip():
+        lines.append(f"Archived at: {archived_at.strip()}")
+    archive_path = archived_summary.get("archive_path")
+    if isinstance(archive_path, str) and archive_path.strip():
+        lines.append(f"Archive path: {archive_path.strip()}")
+    lines.append(
+        "Tickets archived: " f"{'yes' if archived_summary.get('has_tickets') else 'no'}"
+    )
+    lines.append(
+        "Run artifacts archived: "
+        f"{'yes' if archived_summary.get('has_runs') else 'no'}"
+    )
+    lines.append(
+        "Contextspace archived: "
+        f"{'yes' if archived_summary.get('has_contextspace') else 'no'}"
+    )
+    lines.append(
+        "Flow state archived: "
+        f"{'yes' if archived_summary.get('has_flow_state') else 'no'}"
+    )
+    lines.append(
+        "Use /flow status to inspect the current run or /flow runs for history."
+    )
+    return "\n".join(lines)
+
+
+def _format_flow_archive_completion_text(summary: dict[str, Any]) -> str:
+    return (
+        f"Archived run {summary['run_id']} "
+        f"(tickets={summary['archived_tickets']}, "
+        f"runs_archived={summary['archived_runs']}, "
+        f"contextspace={summary['archived_contextspace']})."
+    )
 
 
 def build_flow_archive_confirmation_components(
@@ -397,6 +530,7 @@ async def handle_flow_status(
     channel_id: Optional[str] = None,
     guild_id: Optional[str] = None,
     update_message: bool = False,
+    prefix: Optional[str] = None,
 ) -> None:
     deferred_public = False
     deferred_component = False
@@ -484,6 +618,33 @@ async def handle_flow_status(
             run_id_opt.strip()
         )
         if record is None:
+            archived_summary = None
+            if explicit_run_requested:
+                archived_summary = _describe_archived_flow_run(
+                    workspace_root, run_id_opt.strip()
+                )
+            if archived_summary is not None:
+                archived_text = _format_archived_flow_status_text(
+                    run_id_opt.strip(),
+                    archived_summary,
+                    prefix=prefix,
+                )
+                if update_message:
+                    await service._update_component_message(
+                        interaction_id=interaction_id,
+                        interaction_token=interaction_token,
+                        text=archived_text,
+                        components=[],
+                    )
+                else:
+                    await service._send_or_respond_with_components_public(
+                        interaction_id=interaction_id,
+                        interaction_token=interaction_token,
+                        deferred=deferred_public,
+                        text=archived_text,
+                        components=[],
+                    )
+                return
             if runs and not explicit_run_requested:
                 content = (
                     "No ticket_flow run found.\n\n"
@@ -579,6 +740,7 @@ async def handle_flow_status(
         record=record,
         runs=runs,
         snapshot=snapshot,
+        prefix=prefix,
     )
     run_mirror = service._flow_run_mirror(workspace_root)
     run_mirror.mirror_inbound(
@@ -1743,12 +1905,7 @@ async def handle_flow_archive(
         )
         return
 
-    outbound_text = (
-        f"Archived run {summary['run_id']} "
-        f"(tickets={summary['archived_tickets']}, "
-        f"runs_archived={summary['archived_runs']}, "
-        f"contextspace={summary['archived_contextspace']})."
-    )
+    outbound_text = _format_flow_archive_completion_text(summary)
     await service._send_or_respond_ephemeral(
         interaction_id=interaction_id,
         interaction_token=interaction_token,
@@ -2119,27 +2276,18 @@ async def handle_flow_button(
             )
             return
 
-        archived_text = (
-            f"Archived run {summary['run_id']} "
-            f"(tickets={summary['archived_tickets']}, "
-            f"runs_archived={summary['archived_runs']}, "
-            f"contextspace={summary['archived_contextspace']}).\n\n"
-            "Use /flow status or /flow runs to inspect historical runs."
+        await handle_flow_status(
+            service,
+            interaction_id,
+            interaction_token,
+            workspace_root=workspace_root,
+            options={"run_id": summary["run_id"]},
+            channel_id=channel_id,
+            guild_id=guild_id,
+            update_message=True,
+            prefix=_format_flow_archive_completion_text(summary),
         )
-        if deferred:
-            updated = await service._edit_original_component_message(
-                interaction_token=interaction_token,
-                text=archived_text,
-                components=[],
-            )
-            if updated:
-                return
-        await service._update_component_message(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
-            text=archived_text,
-            components=[],
-        )
+        return
     elif action == "restart":
         deferred = await service._defer_component_update(
             interaction_id=interaction_id,

--- a/tests/integrations/discord/test_flow_archive.py
+++ b/tests/integrations/discord/test_flow_archive.py
@@ -412,6 +412,53 @@ async def test_flow_archive_button_deletes_run_record_by_default(
     assert "Archiving run" in rest.followup_messages[0]["payload"]["content"]
     edited = rest.edited_original_interaction_responses[0]["payload"]
     assert "Archived run" in edited["content"]
+
+
+@pytest.mark.anyio
+async def test_flow_archive_button_real_archive_renders_archived_state(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path)
+    run_id = str(uuid.uuid4())
+    _create_run(workspace, run_id, FlowRunStatus.COMPLETED)
+
+    tickets_dir = workspace / ".codex-autorunner" / "tickets"
+    tickets_dir.mkdir(parents=True, exist_ok=True)
+    (tickets_dir / "TICKET-001.md").write_text("ticket", encoding="utf-8")
+
+    context_dir = workspace / ".codex-autorunner" / "contextspace"
+    context_dir.mkdir(parents=True, exist_ok=True)
+    (context_dir / "active_context.md").write_text("Active context\n", encoding="utf-8")
+
+    run_dir = workspace / ".codex-autorunner" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "DISPATCH.md").write_text("dispatch", encoding="utf-8")
+    live_flow_dir = workspace / ".codex-autorunner" / "flows" / run_id / "chat"
+    live_flow_dir.mkdir(parents=True, exist_ok=True)
+    (live_flow_dir / "outbound.jsonl").write_text("{}", encoding="utf-8")
+
+    rest = _FakeRest()
+    service = _service(tmp_path, rest)
+
+    try:
+        await service._handle_flow_button(
+            "interaction-2-real",
+            "token-2-real",
+            workspace_root=workspace,
+            custom_id=f"flow:{run_id}:archive",
+            channel_id="channel-1",
+            guild_id="guild-1",
+        )
+    finally:
+        await service._store.close()
+
+    assert rest.interaction_responses[0]["payload"]["type"] == 6
+    assert len(rest.followup_messages) == 1
+    assert "Archiving run" in rest.followup_messages[0]["payload"]["content"]
+    edited = rest.edited_original_interaction_responses[0]["payload"]
+    assert "Archived run" in edited["content"]
+    assert "Status: archived" in edited["content"]
+    assert f"Archive path: .codex-autorunner/archive/runs/{run_id}" in edited["content"]
     assert edited["components"] == []
 
 

--- a/tests/integrations/discord/test_flow_handlers.py
+++ b/tests/integrations/discord/test_flow_handlers.py
@@ -799,6 +799,52 @@ async def test_flow_status_with_stray_archive_dir_still_reports_not_found(
 
 
 @pytest.mark.anyio
+async def test_flow_status_with_path_traversal_run_id_does_not_render_archived_state(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path)
+    malicious_run_id = "../../../"
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _flow_interaction(
+                name="status",
+                options=[{"type": 3, "name": "run_id", "value": malicious_run_id}],
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        content = rest.followup_messages[0]["payload"]["content"]
+        assert content == f"Ticket_flow run {malicious_run_id} not found."
+        assert "Status: archived" not in content
+        assert "Archive path:" not in content
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_flow_refresh_button_updates_existing_status_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/integrations/discord/test_flow_handlers.py
+++ b/tests/integrations/discord/test_flow_handlers.py
@@ -699,6 +699,106 @@ async def test_flow_status_with_missing_explicit_run_id_reports_not_found(
 
 
 @pytest.mark.anyio
+async def test_flow_status_with_archived_explicit_run_id_renders_archived_state(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path)
+    run_id = str(uuid.uuid4())
+    archive_root = workspace / ".codex-autorunner" / "archive" / "runs" / run_id
+    (archive_root / "archived_tickets").mkdir(parents=True, exist_ok=True)
+    (archive_root / "flow_state").mkdir(parents=True, exist_ok=True)
+    (archive_root / "archived_tickets" / "TICKET-001.md").write_text(
+        "ticket",
+        encoding="utf-8",
+    )
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _flow_interaction(
+                name="status",
+                options=[{"type": 3, "name": "run_id", "value": run_id}],
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        content = rest.followup_messages[0]["payload"]["content"]
+        assert f"Run {run_id} has already been archived." in content
+        assert "Status: archived" in content
+        assert f"Archive path: .codex-autorunner/archive/runs/{run_id}" in content
+        assert "not found" not in content
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_flow_status_with_stray_archive_dir_still_reports_not_found(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path)
+    run_id = str(uuid.uuid4())
+    archive_root = workspace / ".codex-autorunner" / "archive" / "runs" / run_id
+    (archive_root / "scratch").mkdir(parents=True, exist_ok=True)
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _flow_interaction(
+                name="status",
+                options=[{"type": 3, "name": "run_id", "value": run_id}],
+            )
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        content = rest.followup_messages[0]["payload"]["content"]
+        assert content == f"Ticket_flow run {run_id} not found."
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_flow_refresh_button_updates_existing_status_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## What changed
Fix the Discord flow archive UX so an archived run no longer falls back to `Ticket_flow run … not found` after the live run record is deleted.

## Why it changed
The archive action succeeds, but the Discord status card and refresh path still resolve by live run id. Once the archive deletes that run record, a later refresh would render a confusing not-found state instead of a completion state.

## User impact
Discord users now see a stable archived-state card after archive completes, including archive metadata, instead of a stale error. The status path also distinguishes real archived artifacts from stray leftover directories.

## Root cause
The status renderer only understood live flow rows in `flows.db`. Archive completion removed the live row, but the UI kept asking for that run id.

## Validation
- `.venv/bin/python -m pytest tests/integrations/discord/test_flow_archive.py tests/integrations/discord/test_flow_handlers.py -q`
- `.venv/bin/python -m ruff check src/codex_autorunner/integrations/discord/flow_commands.py tests/integrations/discord/test_flow_archive.py tests/integrations/discord/test_flow_handlers.py`
- Repo pre-commit hook during `git commit`, including repo-wide checks and pytest

## Review notes
A mini sub-agent review found two issues in the first draft:
- archived-run detection was too permissive and could treat stray leftover directories as a successful archive
- coverage did not exercise the real archive-completion button path

Both were fixed before publishing this PR.