### PR TITLE
Improve GitHub PR review reactivity and restore inline eyes reactions

### DIFF
--- a/src/codex_autorunner/core/scm_reaction_router.py
+++ b/src/codex_autorunner/core/scm_reaction_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from typing import Any, Optional
 
@@ -19,6 +20,7 @@ from .text_utils import _mapping, _normalize_text
 _FAILED_CHECK_CONCLUSIONS = frozenset(
     {"action_required", "cancelled", "failure", "startup_failure", "stale", "timed_out"}
 )
+_REVIEW_COMMENT_ID_IN_URL = re.compile(r"(?:#discussion_r|/pulls/comments/)(\d+)")
 
 
 def _normalize_lower_text(value: Any) -> Optional[str]:
@@ -135,7 +137,7 @@ def _build_review_comment_reaction_payload(
     binding: Optional[PrBinding],
 ) -> Optional[dict[str, Any]]:
     payload = _event_payload(event)
-    comment_id = _normalize_text(payload.get("comment_id"))
+    comment_id = _resolve_review_comment_id(payload)
     repo_slug = _resolved_repo_slug(event, binding)
     if comment_id is None or repo_slug is None:
         return None
@@ -156,6 +158,27 @@ def _build_review_comment_reaction_payload(
     if binding is not None:
         reaction_payload["binding_id"] = binding.binding_id
     return reaction_payload
+
+
+def _review_comment_id_from_url(value: Any) -> Optional[str]:
+    url = _normalize_text(value)
+    if url is None:
+        return None
+    match = _REVIEW_COMMENT_ID_IN_URL.search(url)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _resolve_review_comment_id(payload: Mapping[str, Any]) -> Optional[str]:
+    raw_comment_id = _normalize_text(payload.get("comment_id"))
+    if raw_comment_id is not None and raw_comment_id.isdigit():
+        return str(int(raw_comment_id))
+    for key in ("html_url", "url"):
+        resolved = _review_comment_id_from_url(payload.get(key))
+        if resolved is not None:
+            return resolved
+    return None
 
 
 def _match_reaction_kind(

--- a/src/codex_autorunner/integrations/github/polling.py
+++ b/src/codex_autorunner/integrations/github/polling.py
@@ -34,6 +34,9 @@ _HOT_THREAD_WINDOW_MINUTES = 60
 _RECENT_THREAD_WINDOW_MINUTES = 24 * 60
 _WARM_INTERVAL_SECONDS_FLOOR = 15 * 60
 _COLD_INTERVAL_SECONDS_FLOOR = 60 * 60
+_DEFAULT_POST_OPEN_BOOST_MINUTES = 20
+_DEFAULT_POST_OPEN_BOOST_INTERVAL_SECONDS = 30
+_POST_OPEN_BOOST_UNTIL_SNAPSHOT_KEY = "post_open_boost_until"
 _RATE_LIMIT_MIN_REMAINING = 100
 _RATE_LIMIT_RATIO_FLOOR = 0.02
 _RATE_LIMIT_BACKOFF_SECONDS = 15 * 60
@@ -313,6 +316,8 @@ class GitHubPollingConfig:
     enabled: bool = False
     watch_window_minutes: int = 30
     interval_seconds: int = 90
+    post_open_boost_minutes: int = _DEFAULT_POST_OPEN_BOOST_MINUTES
+    post_open_boost_interval_seconds: int = _DEFAULT_POST_OPEN_BOOST_INTERVAL_SECONDS
     discovery_interval_seconds: int = 6 * 60
     discovery_workspace_limit: int = 1
 
@@ -324,6 +329,10 @@ class GitHubPollingConfig:
         enabled = polling.get("enabled")
         watch_window_minutes = polling.get("watch_window_minutes")
         interval_seconds = polling.get("interval_seconds")
+        post_open_boost_minutes = polling.get("post_open_boost_minutes")
+        post_open_boost_interval_seconds = polling.get(
+            "post_open_boost_interval_seconds"
+        )
         discovery_interval_seconds = polling.get("discovery_interval_seconds")
         discovery_workspace_limit = polling.get("discovery_workspace_limit")
         return cls(
@@ -337,6 +346,22 @@ class GitHubPollingConfig:
                 int(interval_seconds)
                 if isinstance(interval_seconds, int) and interval_seconds > 0
                 else 90
+            ),
+            post_open_boost_minutes=(
+                int(post_open_boost_minutes)
+                if (
+                    isinstance(post_open_boost_minutes, int)
+                    and post_open_boost_minutes >= 0
+                )
+                else _DEFAULT_POST_OPEN_BOOST_MINUTES
+            ),
+            post_open_boost_interval_seconds=(
+                int(post_open_boost_interval_seconds)
+                if (
+                    isinstance(post_open_boost_interval_seconds, int)
+                    and post_open_boost_interval_seconds >= 0
+                )
+                else _DEFAULT_POST_OPEN_BOOST_INTERVAL_SECONDS
             ),
             discovery_interval_seconds=(
                 int(discovery_interval_seconds)
@@ -359,6 +384,47 @@ class GitHubPollingConfig:
     @property
     def comment_backfill_window_seconds(self) -> int:
         return self.watch_window_minutes * 60
+
+
+def _initial_post_open_boost_until(
+    *,
+    binding: PrBinding,
+    snapshot: Mapping[str, Any],
+    polling_config: GitHubPollingConfig,
+) -> Optional[str]:
+    boost_minutes = polling_config.post_open_boost_minutes
+    if boost_minutes <= 0:
+        return None
+    now = _utc_now()
+    pr_created_at = _parse_optional_iso(snapshot.get("pr_created_at"))
+    if pr_created_at is not None:
+        expires_at = pr_created_at + timedelta(minutes=boost_minutes)
+        if expires_at > now:
+            return expires_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return None
+    binding_created_at = _parse_optional_iso(binding.created_at)
+    if binding_created_at is not None:
+        expires_at = binding_created_at + timedelta(minutes=boost_minutes)
+        if expires_at > now:
+            return expires_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return None
+    return _iso_after_seconds(boost_minutes * 60)
+
+
+def _snapshot_with_polling_metadata(
+    *,
+    snapshot: Mapping[str, Any],
+    previous_snapshot: Mapping[str, Any] | None = None,
+    post_open_boost_until: Optional[str] = None,
+) -> dict[str, Any]:
+    merged = dict(snapshot)
+    inherited_boost = _normalize_text(
+        _mapping(previous_snapshot or {}).get(_POST_OPEN_BOOST_UNTIL_SNAPSHOT_KEY)
+    )
+    resolved_boost = post_open_boost_until or inherited_boost
+    if resolved_boost is not None:
+        merged[_POST_OPEN_BOOST_UNTIL_SNAPSHOT_KEY] = resolved_boost
+    return merged
 
 
 def _reaction_state_from_pr(pr: Mapping[str, Any]) -> str:
@@ -716,6 +782,28 @@ class GitHubScmPollingService:
                     if _is_rate_limit_error(exc)
                     else now_timestamp
                 )
+        post_open_boost_until = _initial_post_open_boost_until(
+            binding=binding,
+            snapshot=snapshot,
+            polling_config=polling_config,
+        )
+        snapshot = _snapshot_with_polling_metadata(
+            snapshot=snapshot,
+            post_open_boost_until=post_open_boost_until,
+        )
+        boost_interval_seconds = polling_config.post_open_boost_interval_seconds
+        if (
+            post_open_boost_until is not None
+            and boost_interval_seconds > 0
+            and _parse_iso(post_open_boost_until) > _utc_now()
+        ):
+            boosted_next_poll_at = _iso_after_seconds(boost_interval_seconds)
+            current_next_poll_at = _parse_optional_iso(scheduled_next_poll_at)
+            if (
+                current_next_poll_at is None
+                or _parse_iso(boosted_next_poll_at) < current_next_poll_at
+            ):
+                scheduled_next_poll_at = boosted_next_poll_at
 
         watch = self._watch_store.upsert_watch(
             provider="github",
@@ -1040,14 +1128,29 @@ class GitHubScmPollingService:
                     previous_snapshot=previous_snapshot,
                     snapshot=snapshot,
                 )
+            post_open_boost_until = _normalize_text(
+                _mapping(previous_snapshot).get(_POST_OPEN_BOOST_UNTIL_SNAPSHOT_KEY)
+            )
+            if post_open_boost_until is None:
+                post_open_boost_until = _initial_post_open_boost_until(
+                    binding=binding,
+                    snapshot=snapshot,
+                    polling_config=polling_config,
+                )
+            snapshot = _snapshot_with_polling_metadata(
+                snapshot=snapshot,
+                previous_snapshot=previous_snapshot,
+                post_open_boost_until=post_open_boost_until,
+            )
 
             self._watch_store.refresh_watch(
                 watch_id=watch.watch_id,
                 snapshot=snapshot,
                 next_poll_at=_iso_after_seconds(
-                    self._poll_interval_for_tier(
+                    self._poll_interval_for_watch(
                         activity_tier=activity_tier,
                         polling_config=polling_config,
+                        snapshot=snapshot,
                     )
                 ),
                 last_polled_at=now_iso(),
@@ -1225,6 +1328,41 @@ class GitHubScmPollingService:
             polling_config.interval_seconds * 10,
             _WARM_INTERVAL_SECONDS_FLOOR,
         )
+
+    def _post_open_boost_interval_for_snapshot(
+        self,
+        *,
+        snapshot: Mapping[str, Any],
+        polling_config: GitHubPollingConfig,
+    ) -> Optional[int]:
+        boost_interval_seconds = polling_config.post_open_boost_interval_seconds
+        if boost_interval_seconds <= 0:
+            return None
+        boost_until = _parse_optional_iso(
+            _mapping(snapshot).get(_POST_OPEN_BOOST_UNTIL_SNAPSHOT_KEY)
+        )
+        if boost_until is None or boost_until <= _utc_now():
+            return None
+        return boost_interval_seconds
+
+    def _poll_interval_for_watch(
+        self,
+        *,
+        activity_tier: str,
+        polling_config: GitHubPollingConfig,
+        snapshot: Mapping[str, Any],
+    ) -> int:
+        tier_interval = self._poll_interval_for_tier(
+            activity_tier=activity_tier,
+            polling_config=polling_config,
+        )
+        boost_interval = self._post_open_boost_interval_for_snapshot(
+            snapshot=snapshot,
+            polling_config=polling_config,
+        )
+        if boost_interval is None:
+            return tier_interval
+        return min(tier_interval, boost_interval)
 
     def _quota_state_for_workspace(
         self,

--- a/src/codex_autorunner/integrations/github/polling.py
+++ b/src/codex_autorunner/integrations/github/polling.py
@@ -760,6 +760,7 @@ class GitHubScmPollingService:
         scheduled_next_poll_at = next_poll_at or _iso_after_seconds(
             polling_config.interval_seconds
         )
+        schedule_forced_by_rate_limit = False
         snapshot: dict[str, Any] = {"baseline_pending": True}
         if establish_baseline:
             try:
@@ -782,6 +783,7 @@ class GitHubScmPollingService:
                     if _is_rate_limit_error(exc)
                     else now_timestamp
                 )
+                schedule_forced_by_rate_limit = _is_rate_limit_error(exc)
         post_open_boost_until = _initial_post_open_boost_until(
             binding=binding,
             snapshot=snapshot,
@@ -793,7 +795,8 @@ class GitHubScmPollingService:
         )
         boost_interval_seconds = polling_config.post_open_boost_interval_seconds
         if (
-            post_open_boost_until is not None
+            not schedule_forced_by_rate_limit
+            and post_open_boost_until is not None
             and boost_interval_seconds > 0
             and _parse_iso(post_open_boost_until) > _utc_now()
         ):

--- a/tests/core/test_scm_reaction_router.py
+++ b/tests/core/test_scm_reaction_router.py
@@ -384,6 +384,54 @@ def test_route_scm_reactions_routes_pull_request_review_comment() -> None:
     }
 
 
+def test_route_scm_reactions_parses_review_comment_id_from_discussion_url() -> None:
+    event = _event(
+        "pull_request_review_comment",
+        event_id="github:event-inline-comment-url-id",
+        payload={
+            "action": "created",
+            "comment_id": "PRRC_kwDOAcmeNodeId",
+            "html_url": "https://github.com/acme/widgets/pull/42#discussion_r99331",
+            "author_login": "reviewer",
+            "author_type": "User",
+            "issue_author_login": "pr-author",
+            "body": "Please preserve inline reaction support.",
+        },
+    )
+
+    intents = route_scm_reactions(
+        event, binding=_binding(thread_target_id="thread-inline")
+    )
+
+    assert len(intents) == 2
+    assert intents[1].operation_kind == "react_pr_review_comment"
+    assert intents[1].payload["comment_id"] == "99331"
+
+
+def test_route_scm_reactions_parses_review_comment_id_from_api_url() -> None:
+    event = _event(
+        "pull_request_review_comment",
+        event_id="github:event-inline-comment-api-url-id",
+        payload={
+            "action": "created",
+            "comment_id": "PRRC_kwDOAcmeNodeId",
+            "url": "https://api.github.com/repos/acme/widgets/pulls/comments/77123",
+            "author_login": "reviewer",
+            "author_type": "User",
+            "issue_author_login": "pr-author",
+            "body": "Please preserve inline reaction support.",
+        },
+    )
+
+    intents = route_scm_reactions(
+        event, binding=_binding(thread_target_id="thread-inline")
+    )
+
+    assert len(intents) == 2
+    assert intents[1].operation_kind == "react_pr_review_comment"
+    assert intents[1].payload["comment_id"] == "77123"
+
+
 def test_route_scm_reactions_routes_bot_pull_request_review_comment() -> None:
     event = _event(
         "pull_request_review_comment",

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -234,6 +234,8 @@ def _polling_config(
     profile: str | None = None,
     discovery_interval_seconds: int = 360,
     discovery_workspace_limit: int = 1,
+    post_open_boost_minutes: int = 20,
+    post_open_boost_interval_seconds: int = 30,
 ) -> dict[str, object]:
     reactions: dict[str, object] = {}
     if profile is not None:
@@ -247,6 +249,10 @@ def _polling_config(
                     "discovery_workspace_limit": discovery_workspace_limit,
                     "watch_window_minutes": 30,
                     "interval_seconds": 90,
+                    "post_open_boost_minutes": post_open_boost_minutes,
+                    "post_open_boost_interval_seconds": (
+                        post_open_boost_interval_seconds
+                    ),
                 },
                 "reactions": reactions,
             }
@@ -464,6 +470,233 @@ def test_arm_watch_backfills_recent_review_comments_immediately(
         "comment-new",
         "review-comment-new",
     }
+
+
+def test_arm_watch_applies_post_open_boost_interval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding = PrBindingStore(tmp_path).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        pr_number=17,
+        pr_state="open",
+        head_branch="feature/scm-polling",
+        base_branch="main",
+    )
+
+    def _factory(repo_root: Path, raw_config=None) -> _GitHubServiceStub:
+        return _GitHubServiceStub(
+            repo_root,
+            raw_config,
+            pr_view_payload={
+                "state": "OPEN",
+                "isDraft": False,
+                "headRefOid": "abc123",
+                "createdAt": "2026-03-30T00:55:00Z",
+                "author": {"login": "pr-author"},
+            },
+            reviews_payload=[],
+            checks_payload=[],
+        )
+
+    monkeypatch.setattr(
+        github_polling,
+        "_utc_now",
+        lambda: datetime(2026, 3, 30, 1, 0, 0, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(github_polling, "now_iso", lambda: "2026-03-30T01:00:00Z")
+    monkeypatch.setattr(scm_polling_watches, "now_iso", lambda: "2026-03-30T01:00:00Z")
+    _AutomationServiceFake.ingested_events = []
+    _AutomationServiceFake.process_calls = 0
+    monkeypatch.setattr(
+        GitHubScmPollingService,
+        "_build_automation_service",
+        lambda self, reaction_config=None: _AutomationServiceFake(  # type: ignore[misc]
+            tmp_path,
+            reaction_config=reaction_config,
+        ),
+    )
+
+    service = GitHubScmPollingService(
+        tmp_path,
+        raw_config=_polling_config(
+            post_open_boost_minutes=20,
+            post_open_boost_interval_seconds=30,
+        ),
+        github_service_factory=_factory,
+        event_store=ScmEventStore(tmp_path),
+    )
+
+    watch = service.arm_watch(binding=binding, workspace_root=tmp_path / "repo")
+
+    assert watch is not None
+    assert watch.next_poll_at == "2026-03-30T01:00:30Z"
+    assert watch.snapshot["post_open_boost_until"] == "2026-03-30T01:15:00Z"
+
+
+def test_process_due_watches_uses_post_open_boost_interval_while_window_active(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding = PrBindingStore(tmp_path).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        pr_number=17,
+        pr_state="open",
+        head_branch="feature/scm-polling",
+        base_branch="main",
+    )
+    watch_store = ScmPollingWatchStore(tmp_path)
+    watch = watch_store.upsert_watch(
+        provider="github",
+        binding_id=binding.binding_id,
+        repo_slug=binding.repo_slug,
+        pr_number=binding.pr_number,
+        workspace_root=str((tmp_path / "repo").resolve()),
+        poll_interval_seconds=90,
+        next_poll_at="2026-03-30T00:00:00Z",
+        expires_at="2099-03-30T01:00:00Z",
+        reaction_config={"enabled": True},
+        snapshot={
+            "head_sha": "oldsha",
+            "pr_state": "open",
+            "post_open_boost_until": "2026-03-30T01:15:00Z",
+        },
+    )
+    assert watch is not None
+
+    def _factory(repo_root: Path, raw_config=None) -> _GitHubServiceStub:
+        return _GitHubServiceStub(
+            repo_root,
+            raw_config,
+            pr_view_payload={
+                "state": "OPEN",
+                "isDraft": False,
+                "headRefOid": "newsha",
+                "createdAt": "2026-03-30T00:55:00Z",
+                "author": {"login": "pr-author"},
+            },
+            reviews_payload=[],
+            checks_payload=[],
+        )
+
+    monkeypatch.setattr(
+        github_polling,
+        "_utc_now",
+        lambda: datetime(2026, 3, 30, 1, 0, 0, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(github_polling, "now_iso", lambda: "2026-03-30T01:00:00Z")
+    monkeypatch.setattr(scm_polling_watches, "now_iso", lambda: "2026-03-30T01:00:00Z")
+    _AutomationServiceFake.ingested_events = []
+    _AutomationServiceFake.process_calls = 0
+    monkeypatch.setattr(
+        GitHubScmPollingService,
+        "_build_automation_service",
+        lambda self, reaction_config=None: _AutomationServiceFake(  # type: ignore[misc]
+            tmp_path,
+            reaction_config=reaction_config,
+        ),
+    )
+
+    service = GitHubScmPollingService(
+        tmp_path,
+        raw_config=_polling_config(
+            post_open_boost_minutes=20,
+            post_open_boost_interval_seconds=30,
+        ),
+        github_service_factory=_factory,
+        watch_store=watch_store,
+        event_store=ScmEventStore(tmp_path),
+    )
+
+    result = service.process_due_watches(limit=10)
+
+    assert result["polled"] == 1
+    refreshed = watch_store.get_watch(provider="github", binding_id=binding.binding_id)
+    assert refreshed is not None
+    assert refreshed.next_poll_at == "2026-03-30T01:00:30Z"
+    assert refreshed.snapshot["post_open_boost_until"] == "2026-03-30T01:15:00Z"
+
+
+def test_process_due_watches_initializes_post_open_boost_for_baseline_pending_watch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding = PrBindingStore(tmp_path).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        pr_number=17,
+        pr_state="open",
+        head_branch="feature/scm-polling",
+        base_branch="main",
+    )
+    watch_store = ScmPollingWatchStore(tmp_path)
+    watch = watch_store.upsert_watch(
+        provider="github",
+        binding_id=binding.binding_id,
+        repo_slug=binding.repo_slug,
+        pr_number=binding.pr_number,
+        workspace_root=str((tmp_path / "repo").resolve()),
+        poll_interval_seconds=90,
+        next_poll_at="2026-03-30T00:00:00Z",
+        expires_at="2099-03-30T01:00:00Z",
+        reaction_config={"enabled": True},
+        snapshot={"baseline_pending": True},
+    )
+    assert watch is not None
+
+    def _factory(repo_root: Path, raw_config=None) -> _GitHubServiceStub:
+        return _GitHubServiceStub(
+            repo_root,
+            raw_config,
+            pr_view_payload={
+                "state": "OPEN",
+                "isDraft": False,
+                "headRefOid": "newsha",
+                "createdAt": "2026-03-30T00:55:00Z",
+                "author": {"login": "pr-author"},
+            },
+            reviews_payload=[],
+            checks_payload=[],
+        )
+
+    monkeypatch.setattr(
+        github_polling,
+        "_utc_now",
+        lambda: datetime(2026, 3, 30, 1, 0, 0, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(github_polling, "now_iso", lambda: "2026-03-30T01:00:00Z")
+    monkeypatch.setattr(scm_polling_watches, "now_iso", lambda: "2026-03-30T01:00:00Z")
+    _AutomationServiceFake.ingested_events = []
+    _AutomationServiceFake.process_calls = 0
+    monkeypatch.setattr(
+        GitHubScmPollingService,
+        "_build_automation_service",
+        lambda self, reaction_config=None: _AutomationServiceFake(  # type: ignore[misc]
+            tmp_path,
+            reaction_config=reaction_config,
+        ),
+    )
+
+    service = GitHubScmPollingService(
+        tmp_path,
+        raw_config=_polling_config(
+            post_open_boost_minutes=20,
+            post_open_boost_interval_seconds=30,
+        ),
+        github_service_factory=_factory,
+        watch_store=watch_store,
+        event_store=ScmEventStore(tmp_path),
+    )
+
+    result = service.process_due_watches(limit=10)
+
+    assert result["polled"] == 1
+    refreshed = watch_store.get_watch(provider="github", binding_id=binding.binding_id)
+    assert refreshed is not None
+    assert refreshed.next_poll_at == "2026-03-30T01:00:30Z"
+    assert refreshed.snapshot["post_open_boost_until"] == "2026-03-30T01:15:00Z"
 
 
 def test_arm_watch_backfill_uses_current_arm_time_for_reactivated_watch(
@@ -1002,7 +1235,7 @@ def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
                     "isResolved": False,
                     "comments": [
                         {
-                            "comment_id": "2844",
+                            "comment_id": "PRRC_kwDOAcmeNonNumeric",
                             "body": "Please cover the inline review wakeup path too.",
                             "author_login": "reviewer",
                             "author_type": "User",
@@ -2178,7 +2411,8 @@ def test_process_defers_baseline_when_rate_limit_budget_is_low(
     assert result["rate_limited_skipped"] == 1
     watch = watch_store.get_watch(provider="github", binding_id=binding.binding_id)
     assert watch is not None
-    assert watch.snapshot == {"baseline_pending": True}
+    assert watch.snapshot["baseline_pending"] is True
+    assert watch.snapshot.get("post_open_boost_until") is not None
     assert watch.last_error_text == "GitHub rate-limit budget low; baseline deferred"
 
 

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -699,6 +699,57 @@ def test_process_due_watches_initializes_post_open_boost_for_baseline_pending_wa
     assert refreshed.snapshot["post_open_boost_until"] == "2026-03-30T01:15:00Z"
 
 
+def test_arm_watch_preserves_rate_limit_backoff_even_when_post_open_boost_enabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding = PrBindingStore(tmp_path).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        pr_number=17,
+        pr_state="open",
+        head_branch="feature/scm-polling",
+        base_branch="main",
+    )
+
+    def _factory(repo_root: Path, raw_config=None) -> _GitHubServiceStub:
+        return _GitHubServiceStub(
+            repo_root,
+            raw_config,
+            pr_view_payload={},
+            reviews_payload=[],
+            checks_payload=[],
+            pr_view_exception=GitHubError(
+                "API rate limit exceeded for graphql",
+                status_code=429,
+            ),
+        )
+
+    monkeypatch.setattr(
+        github_polling,
+        "_utc_now",
+        lambda: datetime(2026, 3, 30, 1, 0, 0, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(github_polling, "now_iso", lambda: "2026-03-30T01:00:00Z")
+    monkeypatch.setattr(scm_polling_watches, "now_iso", lambda: "2026-03-30T01:00:00Z")
+
+    service = GitHubScmPollingService(
+        tmp_path,
+        raw_config=_polling_config(
+            post_open_boost_minutes=20,
+            post_open_boost_interval_seconds=30,
+        ),
+        github_service_factory=_factory,
+        event_store=ScmEventStore(tmp_path),
+    )
+
+    watch = service.arm_watch(binding=binding, workspace_root=tmp_path / "repo")
+
+    assert watch is not None
+    assert watch.snapshot["baseline_pending"] is True
+    assert watch.next_poll_at == "2026-03-30T01:15:00Z"
+
+
 def test_arm_watch_backfill_uses_current_arm_time_for_reactivated_watch(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- add a configurable post-open polling boost window for GitHub PR watches (defaults: 20 minutes at 30s cadence)
- persist and honor boost metadata in watch snapshots so subsequent polls stay fast while the window is active
- initialize boost metadata when baseline-pending watches become fully baselined, so deferred watches still get post-open acceleration
- harden review-comment reaction routing to resolve numeric comment IDs from discussion/api URLs when webhook payload comment IDs are non-numeric
- add regression tests for boost scheduling and both html_url/url fallback ID parsing paths

## Why
Review feedback could take too long to be picked up after PR open, and some processed inline review comments were not getting the `eyes` reaction due to non-numeric comment IDs.

## Validation
- `.venv/bin/python -m pytest -q tests/integrations/github/test_polling.py`
- `.venv/bin/python -m pytest -q tests/core/test_scm_reaction_router.py`
- pre-commit suite during `git commit` passed (repo checks + full pytest)
