### PR TITLE
[codex] Gate Discord queue interrupts for slash-command backpressure

### DIFF
--- a/src/codex_autorunner/integrations/discord/components.py
+++ b/src/codex_autorunner/integrations/discord/components.py
@@ -539,21 +539,27 @@ def parse_cancel_turn_custom_id(custom_id: str) -> tuple[str | None, str | None]
     return normalized_thread_target_id, normalized_execution_id or None
 
 
-def build_queue_notice_buttons(source_message_id: str) -> dict[str, Any]:
+def build_queue_notice_buttons(
+    source_message_id: str,
+    *,
+    allow_interrupt: bool = True,
+) -> dict[str, Any]:
     source = str(source_message_id or "").strip()
     if not source:
         raise ValueError("source_message_id required")
-    return build_action_row(
-        [
-            build_button(
-                "Cancel",
-                f"queue_cancel:{source}",
-                style=DISCORD_BUTTON_STYLE_DANGER,
-            ),
+    buttons = [
+        build_button(
+            "Cancel",
+            f"queue_cancel:{source}",
+            style=DISCORD_BUTTON_STYLE_DANGER,
+        )
+    ]
+    if allow_interrupt:
+        buttons.append(
             build_button(
                 "Interrupt + Send",
                 f"queue_interrupt_send:{source}",
                 style=DISCORD_BUTTON_STYLE_PRIMARY,
-            ),
-        ]
-    )
+            )
+        )
+    return build_action_row(buttons)

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -1020,7 +1020,7 @@ class DiscordBotService:
             record_id=f"queue-notice-delete:{channel_id}:{source_message_id}",
         )
 
-    def _queued_notice_config_for_conversation(
+    async def _queued_notice_config_for_conversation(
         self, conversation_id: str
     ) -> tuple[Optional[str], bool]:
         describe_busy = getattr(self._command_runner, "describe_ingressed_busy", None)
@@ -1029,9 +1029,13 @@ class DiscordBotService:
         command_label = describe_busy(conversation_id)
         if not isinstance(command_label, str) or not command_label.strip():
             return None, True
+        queue_status = await self._dispatcher.queue_status(conversation_id)
+        has_active_message_turn = bool(
+            queue_status.get("active") if isinstance(queue_status, dict) else False
+        )
         return (
             f"Queued behind {command_label}; will run when it finishes.",
-            False,
+            has_active_message_turn,
         )
 
     async def _maybe_send_queued_notice(
@@ -1044,8 +1048,10 @@ class DiscordBotService:
         if not await self._can_start_message_turn_in_channel(event):
             return
         channel_id = dispatch_result.context.chat_id
-        notice_content, allow_interrupt = self._queued_notice_config_for_conversation(
-            dispatch_result.context.conversation_id
+        notice_content, allow_interrupt = (
+            await self._queued_notice_config_for_conversation(
+                dispatch_result.context.conversation_id
+            )
         )
         source_message_id = event.message.message_id
         queued_notice_payload = build_discord_queue_notice_message(

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -1020,16 +1020,19 @@ class DiscordBotService:
             record_id=f"queue-notice-delete:{channel_id}:{source_message_id}",
         )
 
-    def _queued_notice_content_for_conversation(
+    def _queued_notice_config_for_conversation(
         self, conversation_id: str
-    ) -> Optional[str]:
+    ) -> tuple[Optional[str], bool]:
         describe_busy = getattr(self._command_runner, "describe_ingressed_busy", None)
         if not callable(describe_busy):
-            return None
+            return None, True
         command_label = describe_busy(conversation_id)
         if not isinstance(command_label, str) or not command_label.strip():
-            return None
-        return f"Queued behind {command_label}; will run when it finishes."
+            return None, True
+        return (
+            f"Queued behind {command_label}; will run when it finishes.",
+            False,
+        )
 
     async def _maybe_send_queued_notice(
         self, event: ChatEvent, dispatch_result: DispatchResult
@@ -1041,13 +1044,14 @@ class DiscordBotService:
         if not await self._can_start_message_turn_in_channel(event):
             return
         channel_id = dispatch_result.context.chat_id
-        notice_content = self._queued_notice_content_for_conversation(
+        notice_content, allow_interrupt = self._queued_notice_config_for_conversation(
             dispatch_result.context.conversation_id
         )
         source_message_id = event.message.message_id
         queued_notice_payload = build_discord_queue_notice_message(
             source_message_id=source_message_id,
             content=notice_content,
+            allow_interrupt=allow_interrupt,
         )
         try:
             response = await self._send_channel_message(
@@ -1065,6 +1069,7 @@ class DiscordBotService:
                 build_discord_queue_notice_message(
                     source_message_id=None,
                     content=notice_content,
+                    allow_interrupt=allow_interrupt,
                 ).to_payload(),
                 record_id=f"queue-notice:{channel_id}:{dispatch_result.context.update_id}",
             )

--- a/src/codex_autorunner/integrations/discord/service_normalization.py
+++ b/src/codex_autorunner/integrations/discord/service_normalization.py
@@ -333,10 +333,16 @@ def build_discord_queue_notice_message(
     *,
     source_message_id: Optional[str],
     content: Optional[str] = None,
+    allow_interrupt: bool = True,
 ) -> DiscordMessagePayload:
     components: Optional[Sequence[dict[str, Any]]] = None
     if source_message_id:
-        components = (build_queue_notice_buttons(source_message_id),)
+        components = (
+            build_queue_notice_buttons(
+                source_message_id,
+                allow_interrupt=allow_interrupt,
+            ),
+        )
     return DiscordMessagePayload(
         content=content or "Queued (waiting for available worker...)",
         components=components,

--- a/tests/integrations/discord/test_components.py
+++ b/tests/integrations/discord/test_components.py
@@ -18,6 +18,7 @@ from codex_autorunner.integrations.discord.components import (
     build_flow_status_buttons,
     build_model_effort_picker,
     build_model_picker,
+    build_queue_notice_buttons,
     build_review_commit_picker,
     build_select_menu,
     build_select_option,
@@ -68,6 +69,23 @@ class TestCancelTurnCustomId:
 
         assert thread_target_id == "thread-1"
         assert execution_id == "turn-1"
+
+
+class TestBuildQueueNoticeButtons:
+    def test_includes_interrupt_button_by_default(self) -> None:
+        row = build_queue_notice_buttons("message-1")
+
+        assert [button["custom_id"] for button in row["components"]] == [
+            "queue_cancel:message-1",
+            "queue_interrupt_send:message-1",
+        ]
+
+    def test_can_omit_interrupt_button(self) -> None:
+        row = build_queue_notice_buttons("message-1", allow_interrupt=False)
+
+        assert [button["custom_id"] for button in row["components"]] == [
+            "queue_cancel:message-1"
+        ]
 
 
 class TestBuildSelectMenu:

--- a/tests/integrations/discord/test_service_normalization.py
+++ b/tests/integrations/discord/test_service_normalization.py
@@ -42,12 +42,20 @@ def test_build_discord_queue_notice_message_serializes_optional_components() -> 
     with_buttons = build_discord_queue_notice_message(
         source_message_id="message-1",
     ).to_payload()
+    without_interrupt = build_discord_queue_notice_message(
+        source_message_id="message-1",
+        allow_interrupt=False,
+    ).to_payload()
     without_buttons = build_discord_queue_notice_message(
         source_message_id=None,
     ).to_payload()
 
     assert with_buttons["content"] == "Queued (waiting for available worker...)"
     assert with_buttons["components"][0]["components"]
+    assert [
+        button["custom_id"]
+        for button in without_interrupt["components"][0]["components"]
+    ] == ["queue_cancel:message-1"]
     assert "components" not in without_buttons
 
 

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -3053,6 +3053,90 @@ async def test_component_interaction_queue_interrupt_send_promotes_and_interrupt
 
 
 @pytest.mark.anyio
+async def test_queued_notice_keeps_interrupt_when_message_turn_active(
+    tmp_path: Path,
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        conversation_id = service._dispatcher_conversation_id(
+            channel_id="channel-1",
+            guild_id="guild-1",
+        )
+
+        service._command_runner.describe_ingressed_busy = (  # type: ignore[method-assign]
+            lambda _conversation_id: "/car newt"
+        )
+
+        async def _queue_status(_conversation_id: str) -> dict[str, Any]:
+            assert _conversation_id == conversation_id
+            return {"active": True}
+
+        service._dispatcher.queue_status = _queue_status  # type: ignore[method-assign]
+
+        content, allow_interrupt = await service._queued_notice_config_for_conversation(
+            conversation_id
+        )
+
+        assert content == "Queued behind /car newt; will run when it finishes."
+        assert allow_interrupt is True
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_queued_notice_hides_interrupt_when_only_ingressed_busy(
+    tmp_path: Path,
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        conversation_id = service._dispatcher_conversation_id(
+            channel_id="channel-1",
+            guild_id="guild-1",
+        )
+
+        service._command_runner.describe_ingressed_busy = (  # type: ignore[method-assign]
+            lambda _conversation_id: "/car newt"
+        )
+
+        async def _queue_status(_conversation_id: str) -> dict[str, Any]:
+            assert _conversation_id == conversation_id
+            return {"active": False}
+
+        service._dispatcher.queue_status = _queue_status  # type: ignore[method-assign]
+
+        content, allow_interrupt = await service._queued_notice_config_for_conversation(
+            conversation_id
+        )
+
+        assert content == "Queued behind /car newt; will run when it finishes."
+        assert allow_interrupt is False
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_service_malformed_direct_payload_returns_parse_error(
     tmp_path: Path,
 ) -> None:

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -6388,11 +6388,20 @@ async def test_message_turn_waits_for_ingressed_slash_command_to_finish(
 
         assert observed == ["newt:start"]
         assert message_turn_started.is_set() is False
-        assert any(
-            "Queued behind /car newt; will run when it finishes."
-            in item["payload"].get("content", "")
-            for item in rest.channel_messages
+        queued_notice = next(
+            (
+                item["payload"]
+                for item in rest.channel_messages
+                if "Queued behind /car newt; will run when it finishes."
+                in item["payload"].get("content", "")
+            ),
+            None,
         )
+        assert queued_notice is not None
+        assert [
+            button["custom_id"]
+            for button in queued_notice["components"][0]["components"]
+        ] == ["queue_cancel:m-1"]
 
         release_newt.set()
 
@@ -6517,11 +6526,20 @@ async def test_run_forever_drains_message_queued_behind_ingressed_slash_command(
     try:
         await asyncio.wait_for(service.run_forever(), timeout=5)
         assert observed == ["newt:start", "newt:end", "message:please continue"]
-        assert any(
-            "Queued behind /car newt; will run when it finishes."
-            in item["payload"].get("content", "")
-            for item in rest.channel_messages
+        queued_notice = next(
+            (
+                item["payload"]
+                for item in rest.channel_messages
+                if "Queued behind /car newt; will run when it finishes."
+                in item["payload"].get("content", "")
+            ),
+            None,
         )
+        assert queued_notice is not None
+        assert [
+            button["custom_id"]
+            for button in queued_notice["components"][0]["components"]
+        ] == ["queue_cancel:m-1"]
         assert any(
             "message reply" in item["payload"].get("content", "")
             for item in rest.channel_messages


### PR DESCRIPTION
## What changed
- Discord queue notices now omit `Interrupt + Send` when the busy state comes from an ingressed slash command.
- Queue notice rendering now accepts an explicit `allow_interrupt` flag and uses it to render a `Cancel`-only button row in that case.
- Added tests covering the Discord component builder, queue notice serialization, and the slash-command queue path.

## Why
- The previous Discord queue notice offered an interrupt action even when the active blocker was a slash-command turn that cannot be interrupted from that surface.

## Validation
- `pytest tests/integrations/discord/test_components.py tests/integrations/discord/test_service_normalization.py tests/integrations/discord/test_service_routing.py -q`
- Repo commit hooks ran the full checks, including `black`, `ruff`, `mypy`, frontend build, and `pytest`.