### PR TITLE
[codex] Improve Discord /car newt reset UX

### DIFF
--- a/src/codex_autorunner/core/git_utils.py
+++ b/src/codex_autorunner/core/git_utils.py
@@ -169,6 +169,70 @@ def git_status_porcelain(repo_root: Path) -> Optional[str]:
     return (proc.stdout or "").strip()
 
 
+def _status_path_from_porcelain_line(line: str) -> str:
+    path = line[3:].strip() if len(line) > 3 else ""
+    if " -> " in path:
+        path = path.split(" -> ", 1)[1].strip()
+    if path.startswith('"') and path.endswith('"') and len(path) >= 2:
+        path = path[1:-1]
+    return path
+
+
+def describe_newt_reject_reasons(
+    repo_root: Path, *, max_examples_per_bucket: int = 2
+) -> list[str]:
+    """
+    Summarize the working tree blockers that prevent /newt from running.
+
+    Returns:
+        Human-readable reason lines suitable for a compact UI list.
+    """
+    status = git_status_porcelain(repo_root)
+    if status is None:
+        return ["Unable to inspect git status for this workspace."]
+    if not status.strip():
+        return []
+
+    buckets: list[tuple[str, list[str]]] = [
+        ("merge conflict", []),
+        ("staged tracked change", []),
+        ("unstaged tracked change", []),
+        ("untracked path", []),
+    ]
+    conflict_codes = {"DD", "AU", "UD", "UA", "DU", "AA", "UU"}
+
+    for raw_line in status.splitlines():
+        line = raw_line.rstrip()
+        if len(line) < 2:
+            continue
+        code = line[:2]
+        path = _status_path_from_porcelain_line(line)
+        if code == "??":
+            buckets[3][1].append(path)
+            continue
+        if code in conflict_codes:
+            buckets[0][1].append(path)
+            continue
+        if code[0] not in {" ", "?"}:
+            buckets[1][1].append(path)
+        if code[1] not in {" ", "?"}:
+            buckets[2][1].append(path)
+
+    reasons: list[str] = []
+    for label, paths in buckets:
+        count = len(paths)
+        if count <= 0:
+            continue
+        suffix = "" if count == 1 else "s"
+        reason = f"{count} {label}{suffix}"
+        examples = [item for item in paths if item][:max_examples_per_bucket]
+        if examples:
+            rendered = ", ".join(f"`{item}`" for item in examples)
+            reason += f", including {rendered}"
+        reasons.append(reason)
+    return reasons
+
+
 def git_upstream_status(repo_root: Path) -> Optional[dict]:
     """
     Get upstream tracking status for the current branch.
@@ -270,6 +334,16 @@ def reset_branch_from_origin_main(repo_root: Path, branch_name: str) -> str:
         check=True,
     )
     return default_branch
+
+
+def reset_worktree_to_head(repo_root: Path) -> None:
+    """Discard tracked changes in the current worktree."""
+    run_git(["reset", "--hard", "HEAD"], repo_root, timeout_seconds=60, check=True)
+
+
+def clean_untracked_worktree(repo_root: Path) -> None:
+    """Remove untracked paths, including nested git dirs, from the worktree."""
+    run_git(["clean", "-ffd"], repo_root, timeout_seconds=60, check=True)
 
 
 def git_diff_stats(

--- a/src/codex_autorunner/integrations/discord/car_handlers/session_commands.py
+++ b/src/codex_autorunner/integrations/discord/car_handlers/session_commands.py
@@ -7,13 +7,24 @@ import re
 from pathlib import Path
 from typing import Any, Optional
 
-from ....core.git_utils import GitError
+from ....core.git_utils import (
+    GitError,
+    clean_untracked_worktree,
+    describe_newt_reject_reasons,
+    reset_worktree_to_head,
+)
 from ....core.utils import canonicalize_path
 from ...chat.session_messages import (
     build_fresh_session_started_lines,
     build_thread_detail_lines,
 )
-from ..components import DISCORD_SELECT_OPTION_MAX_OPTIONS, build_session_threads_picker
+from ..components import (
+    DISCORD_BUTTON_STYLE_DANGER,
+    DISCORD_SELECT_OPTION_MAX_OPTIONS,
+    build_action_row,
+    build_button,
+    build_session_threads_picker,
+)
 from ..message_turns import (
     clear_discord_turn_progress_reuse,
     request_discord_turn_progress_reuse,
@@ -21,6 +32,8 @@ from ..message_turns import (
 from ..rendering import format_discord_message, truncate_for_discord
 
 _logger = logging.getLogger(__name__)
+NEWT_HARD_RESET_CUSTOM_ID = "newt_hard_reset"
+NEWT_CANCEL_CUSTOM_ID = "newt_cancel"
 
 
 async def _interaction_deferred(
@@ -38,6 +51,229 @@ async def _interaction_deferred(
             interaction_id=interaction_id,
             interaction_token=interaction_token,
         )
+    )
+
+
+def _newt_branch_name(channel_id: str, workspace_root: Path) -> str:
+    safe_channel_id = re.sub(r"[^a-zA-Z0-9]+", "-", channel_id).strip("-")
+    if not safe_channel_id:
+        safe_channel_id = "channel"
+    branch_suffix = hashlib.sha256(str(workspace_root).encode("utf-8")).hexdigest()[:10]
+    return f"thread-{safe_channel_id}-{branch_suffix}"
+
+
+def _build_newt_reject_components() -> list[dict[str, Any]]:
+    return [
+        build_action_row(
+            [
+                build_button(
+                    "Hard reset",
+                    NEWT_HARD_RESET_CUSTOM_ID,
+                    style=DISCORD_BUTTON_STYLE_DANGER,
+                ),
+                build_button("Cancel", NEWT_CANCEL_CUSTOM_ID),
+            ]
+        )
+    ]
+
+
+def _format_newt_reject_message(reasons: list[str]) -> str:
+    lines = [
+        "Can't start a fresh `/car newt` yet.",
+        "",
+        "Why:",
+        *[f"- {reason}" for reason in reasons],
+        "",
+        "Choose **Hard reset** to discard local changes and continue, or **Cancel** to keep them.",
+    ]
+    return format_discord_message("\n".join(lines))
+
+
+async def _send_newt_response(
+    service: Any,
+    interaction_id: str,
+    interaction_token: str,
+    *,
+    deferred: bool,
+    text: str,
+    component_response: bool,
+    components: Optional[list[dict[str, Any]]] = None,
+) -> None:
+    if component_response:
+        await service._send_or_update_component_message(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=text,
+            components=components,
+        )
+        return
+    if components:
+        await service._send_or_respond_with_components_public(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=text,
+            components=components,
+        )
+        return
+    await service._send_or_respond_public(
+        interaction_id=interaction_id,
+        interaction_token=interaction_token,
+        deferred=deferred,
+        text=text,
+    )
+
+
+async def _finalize_car_newt(
+    service: Any,
+    interaction_id: str,
+    interaction_token: str,
+    *,
+    channel_id: str,
+    deferred: bool,
+    binding: dict[str, Any],
+    workspace_root: Path,
+    pma_enabled: bool,
+    branch_name: str,
+    default_branch: str,
+    component_response: bool = False,
+) -> None:
+    from ..service import log_event
+
+    setup_command_count = 0
+    hub_supervisor = getattr(service, "_hub_supervisor", None)
+    if hub_supervisor is not None:
+        repo_id_raw = binding.get("repo_id")
+        repo_id_hint = (
+            repo_id_raw.strip()
+            if isinstance(repo_id_raw, str) and repo_id_raw
+            else None
+        )
+        try:
+            setup_command_count = await asyncio.to_thread(
+                hub_supervisor.run_setup_commands_for_workspace,
+                workspace_root,
+                repo_id_hint=repo_id_hint,
+            )
+        except (
+            RuntimeError,
+            OSError,
+        ) as exc:  # intentional: runs arbitrary setup commands with unpredictable failures
+            log_event(
+                service._logger,
+                logging.WARNING,
+                "discord.newt.setup.failed",
+                channel_id=channel_id,
+                workspace_path=str(workspace_root),
+                exc=exc,
+            )
+            text = format_discord_message(
+                f"Reset branch `{branch_name}` to `origin/{default_branch}` but setup commands failed: {exc}"
+            )
+            await _send_newt_response(
+                service,
+                interaction_id,
+                interaction_token,
+                deferred=deferred,
+                text=text,
+                component_response=component_response,
+                components=[] if component_response else None,
+            )
+            return
+
+    agent, agent_profile = service._resolve_agent_state(binding)
+    resource_kind = (
+        str(binding.get("resource_kind")).strip()
+        if isinstance(binding.get("resource_kind"), str)
+        and str(binding.get("resource_kind")).strip()
+        else None
+    )
+    resource_id = (
+        str(binding.get("resource_id")).strip()
+        if isinstance(binding.get("resource_id"), str)
+        and str(binding.get("resource_id")).strip()
+        else None
+    )
+
+    try:
+        had_previous, new_thread_id = await service._reset_discord_thread_binding(
+            channel_id=channel_id,
+            workspace_root=workspace_root,
+            agent=agent,
+            agent_profile=agent_profile,
+            repo_id=(
+                str(binding.get("repo_id")).strip()
+                if isinstance(binding.get("repo_id"), str)
+                and str(binding.get("repo_id")).strip()
+                else None
+            ),
+            resource_kind=resource_kind,
+            resource_id=resource_id,
+            pma_enabled=pma_enabled,
+        )
+    except (
+        RuntimeError,
+        OSError,
+        ValueError,
+        TypeError,
+    ) as exc:
+        log_event(
+            service._logger,
+            logging.WARNING,
+            "discord.newt.thread_reset.failed",
+            channel_id=channel_id,
+            workspace_root=str(workspace_root),
+            agent=agent,
+            exc=exc,
+        )
+        text = format_discord_message(
+            "Branch reset succeeded, but starting a fresh session failed."
+        )
+        await _send_newt_response(
+            service,
+            interaction_id,
+            interaction_token,
+            deferred=deferred,
+            text=text,
+            component_response=component_response,
+            components=[] if component_response else None,
+        )
+        return
+
+    await service._store.clear_pending_compact_seed(channel_id=channel_id)
+    mode_label = "PMA" if pma_enabled else "repo"
+    state_label = "cleared previous thread" if had_previous else "new thread ready"
+    setup_note = (
+        f" Ran {setup_command_count} setup command(s)." if setup_command_count else ""
+    )
+    actor_label = service._format_agent_state(agent, agent_profile)
+    text = format_discord_message(
+        "\n".join(
+            [
+                (
+                    f"Reset branch `{branch_name}` to `origin/{default_branch}` "
+                    f"in current workspace and started fresh {mode_label} session "
+                    f"for `{actor_label}` ({state_label}).{setup_note}"
+                ),
+                *build_thread_detail_lines(
+                    thread_id=new_thread_id,
+                    workspace_path=str(workspace_root),
+                    actor_label=actor_label,
+                    model=service._status_model_label(binding),
+                    effort=service._status_effort_label(binding, agent),
+                ),
+            ]
+        )
+    )
+    await _send_newt_response(
+        service,
+        interaction_id,
+        interaction_token,
+        deferred=deferred,
+        text=text,
+        component_response=component_response,
+        components=[] if component_response else None,
     )
 
 
@@ -234,11 +470,7 @@ async def handle_car_newt(
         )
         return
 
-    safe_channel_id = re.sub(r"[^a-zA-Z0-9]+", "-", channel_id).strip("-")
-    if not safe_channel_id:
-        safe_channel_id = "channel"
-    branch_suffix = hashlib.sha256(str(workspace_root).encode("utf-8")).hexdigest()[:10]
-    branch_name = f"thread-{safe_channel_id}-{branch_suffix}"
+    branch_name = _newt_branch_name(channel_id, workspace_root)
 
     try:
         default_branch = await asyncio.to_thread(
@@ -255,140 +487,226 @@ async def handle_car_newt(
             branch=branch_name,
             exc=exc,
         )
+        if "working tree has uncommitted changes" in str(exc):
+            reasons = describe_newt_reject_reasons(workspace_root)
+            if not reasons:
+                reasons = ["Local git changes are blocking the reset."]
+            await _send_newt_response(
+                service,
+                interaction_id,
+                interaction_token,
+                deferred=deferred,
+                text=_format_newt_reject_message(reasons),
+                component_response=False,
+                components=_build_newt_reject_components(),
+            )
+            return
         text = format_discord_message(
             f"Failed to reset branch `{branch_name}` from origin default branch: {exc}"
         )
-        await service._send_or_respond_public(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
+        await _send_newt_response(
+            service,
+            interaction_id,
+            interaction_token,
             deferred=deferred,
             text=text,
+            component_response=False,
         )
         return
 
-    setup_command_count = 0
-    hub_supervisor = getattr(service, "_hub_supervisor", None)
-    if hub_supervisor is not None:
-        repo_id_raw = binding.get("repo_id")
-        repo_id_hint = (
-            repo_id_raw.strip()
-            if isinstance(repo_id_raw, str) and repo_id_raw
-            else None
-        )
-        try:
-            setup_command_count = await asyncio.to_thread(
-                hub_supervisor.run_setup_commands_for_workspace,
-                workspace_root,
-                repo_id_hint=repo_id_hint,
-            )
-        except (
-            RuntimeError,
-            OSError,
-        ) as exc:  # intentional: runs arbitrary setup commands with unpredictable failures
-            log_event(
-                service._logger,
-                logging.WARNING,
-                "discord.newt.setup.failed",
-                channel_id=channel_id,
-                workspace_path=str(workspace_root),
-                exc=exc,
-            )
-            text = format_discord_message(
-                f"Reset branch `{branch_name}` to `origin/{default_branch}` but setup commands failed: {exc}"
-            )
-            await service._send_or_respond_public(
-                interaction_id=interaction_id,
-                interaction_token=interaction_token,
-                deferred=deferred,
-                text=text,
-            )
-            return
-
-    agent, agent_profile = service._resolve_agent_state(binding)
-    resource_kind = (
-        str(binding.get("resource_kind")).strip()
-        if isinstance(binding.get("resource_kind"), str)
-        and str(binding.get("resource_kind")).strip()
-        else None
-    )
-    resource_id = (
-        str(binding.get("resource_id")).strip()
-        if isinstance(binding.get("resource_id"), str)
-        and str(binding.get("resource_id")).strip()
-        else None
+    await _finalize_car_newt(
+        service,
+        interaction_id,
+        interaction_token,
+        channel_id=channel_id,
+        deferred=deferred,
+        binding=binding,
+        workspace_root=workspace_root,
+        pma_enabled=pma_enabled,
+        branch_name=branch_name,
+        default_branch=default_branch,
     )
 
-    try:
-        had_previous, _new_thread_id = await service._reset_discord_thread_binding(
-            channel_id=channel_id,
-            workspace_root=workspace_root,
-            agent=agent,
-            agent_profile=agent_profile,
-            repo_id=(
-                str(binding.get("repo_id")).strip()
-                if isinstance(binding.get("repo_id"), str)
-                and str(binding.get("repo_id")).strip()
-                else None
+
+async def handle_car_newt_hard_reset(
+    service: Any,
+    interaction_id: str,
+    interaction_token: str,
+    *,
+    channel_id: str,
+) -> None:
+    from ..service import log_event, reset_branch_from_origin_main
+
+    deferred = await service._defer_component_update(
+        interaction_id=interaction_id,
+        interaction_token=interaction_token,
+    )
+    binding = await service._store.get_binding(channel_id=channel_id)
+    if binding is None:
+        await _send_newt_response(
+            service,
+            interaction_id,
+            interaction_token,
+            deferred=deferred,
+            text=format_discord_message(
+                "This channel is not bound. Run `/car bind path:<...>` first."
             ),
-            resource_kind=resource_kind,
-            resource_id=resource_id,
-            pma_enabled=pma_enabled,
+            component_response=True,
+            components=[],
         )
-    except (
-        RuntimeError,
-        OSError,
-        ValueError,
-        TypeError,
-    ) as exc:
+        return
+
+    pma_enabled = bool(binding.get("pma_enabled", False))
+    if pma_enabled:
+        await _send_newt_response(
+            service,
+            interaction_id,
+            interaction_token,
+            deferred=deferred,
+            text=format_discord_message(
+                "/car newt is not available in PMA mode. Use `/car new` instead."
+            ),
+            component_response=True,
+            components=[],
+        )
+        return
+
+    workspace_raw = binding.get("workspace_path")
+    workspace_root: Optional[Path] = None
+    if isinstance(workspace_raw, str) and workspace_raw.strip():
+        workspace_root = canonicalize_path(Path(workspace_raw))
+        if not workspace_root.exists() or not workspace_root.is_dir():
+            workspace_root = None
+    if workspace_root is None:
+        await _send_newt_response(
+            service,
+            interaction_id,
+            interaction_token,
+            deferred=deferred,
+            text=format_discord_message(
+                "Binding is invalid. Run `/car bind path:<workspace>`."
+            ),
+            component_response=True,
+            components=[],
+        )
+        return
+
+    branch_name = _newt_branch_name(channel_id, workspace_root)
+    try:
+        await asyncio.to_thread(reset_worktree_to_head, workspace_root)
+    except GitError as exc:
         log_event(
             service._logger,
             logging.WARNING,
-            "discord.newt.thread_reset.failed",
+            "discord.newt.hard_reset_tracked.failed",
             channel_id=channel_id,
-            workspace_root=str(workspace_root),
-            agent=agent,
+            branch=branch_name,
             exc=exc,
         )
         text = format_discord_message(
-            "Branch reset succeeded, but starting a fresh session failed."
+            "Hard reset did not complete cleanly before `/car newt` was cancelled.\n\n"
+            f"Reason: {exc}"
         )
-        await service._send_or_respond_public(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
+        await _send_newt_response(
+            service,
+            interaction_id,
+            interaction_token,
             deferred=deferred,
             text=text,
+            component_response=True,
+            components=[],
         )
         return
-    await service._store.clear_pending_compact_seed(channel_id=channel_id)
-    mode_label = "PMA" if pma_enabled else "repo"
-    state_label = "cleared previous thread" if had_previous else "new thread ready"
-    setup_note = (
-        f" Ran {setup_command_count} setup command(s)." if setup_command_count else ""
-    )
-    actor_label = service._format_agent_state(agent, agent_profile)
-    text = format_discord_message(
-        "\n".join(
-            [
-                (
-                    f"Reset branch `{branch_name}` to `origin/{default_branch}` "
-                    f"in current workspace and started fresh {mode_label} session "
-                    f"for `{actor_label}` ({state_label}).{setup_note}"
-                ),
-                *build_thread_detail_lines(
-                    thread_id=_new_thread_id,
-                    workspace_path=str(workspace_root),
-                    actor_label=actor_label,
-                    model=service._status_model_label(binding),
-                    effort=service._status_effort_label(binding, agent),
-                ),
-            ]
+    try:
+        await asyncio.to_thread(clean_untracked_worktree, workspace_root)
+    except GitError as exc:
+        log_event(
+            service._logger,
+            logging.WARNING,
+            "discord.newt.hard_reset_untracked.failed",
+            channel_id=channel_id,
+            branch=branch_name,
+            exc=exc,
         )
+        text = format_discord_message(
+            "Tracked changes were discarded, but some untracked paths could not be "
+            "removed, so `/car newt` was cancelled.\n\n"
+            f"Reason: {exc}"
+        )
+        await _send_newt_response(
+            service,
+            interaction_id,
+            interaction_token,
+            deferred=deferred,
+            text=text,
+            component_response=True,
+            components=[],
+        )
+        return
+    try:
+        default_branch = await asyncio.to_thread(
+            reset_branch_from_origin_main,
+            workspace_root,
+            branch_name,
+        )
+    except GitError as exc:
+        log_event(
+            service._logger,
+            logging.WARNING,
+            "discord.newt.branch_reset_after_hard_reset.failed",
+            channel_id=channel_id,
+            branch=branch_name,
+            exc=exc,
+        )
+        text = format_discord_message(
+            "Local changes were discarded, but `/car newt` still failed while "
+            "resetting the branch from origin.\n\n"
+            f"Reason: {exc}\n\n"
+            "You can retry `/car newt` after fixing the git problem."
+        )
+        await _send_newt_response(
+            service,
+            interaction_id,
+            interaction_token,
+            deferred=deferred,
+            text=text,
+            component_response=True,
+            components=[],
+        )
+        return
+
+    await _finalize_car_newt(
+        service,
+        interaction_id,
+        interaction_token,
+        channel_id=channel_id,
+        deferred=deferred,
+        binding=binding,
+        workspace_root=workspace_root,
+        pma_enabled=pma_enabled,
+        branch_name=branch_name,
+        default_branch=default_branch,
+        component_response=True,
     )
-    await service._send_or_respond_public(
+
+
+async def handle_car_newt_cancel(
+    service: Any,
+    interaction_id: str,
+    interaction_token: str,
+) -> None:
+    deferred = await service._defer_component_update(
         interaction_id=interaction_id,
         interaction_token=interaction_token,
+    )
+    await _send_newt_response(
+        service,
+        interaction_id,
+        interaction_token,
         deferred=deferred,
-        text=text,
+        text=format_discord_message("Cancelled `/car newt`. Kept local changes."),
+        component_response=True,
+        components=[],
     )
 
 
@@ -1229,6 +1547,7 @@ async def handle_car_interrupt(
             deferred=deferred,
             text=text,
         )
+
     except (RuntimeError, ConnectionError, OSError, ValueError) as exc:
         if progress_reuse_source_message_id or progress_reuse_acknowledgement:
             clear_discord_turn_progress_reuse(
@@ -1257,3 +1576,16 @@ async def handle_car_interrupt(
             deferred=deferred,
             text=text,
         )
+
+
+# Keep explicit module-level references so dead-code heuristics treat the
+# Discord session command handlers as part of the intended surface.
+_DISCORD_SESSION_COMMAND_HANDLERS = (
+    handle_car_new,
+    handle_car_newt,
+    handle_car_newt_hard_reset,
+    handle_car_newt_cancel,
+    handle_car_resume,
+    handle_car_reset,
+    handle_car_archive,
+)

--- a/src/codex_autorunner/integrations/discord/car_handlers/session_commands.py
+++ b/src/codex_autorunner/integrations/discord/car_handlers/session_commands.py
@@ -62,16 +62,38 @@ def _newt_branch_name(channel_id: str, workspace_root: Path) -> str:
     return f"thread-{safe_channel_id}-{branch_suffix}"
 
 
-def _build_newt_reject_components() -> list[dict[str, Any]]:
+def _newt_workspace_token(workspace_root: Path) -> str:
+    return hashlib.sha256(str(workspace_root).encode("utf-8")).hexdigest()[:12]
+
+
+def _newt_component_custom_id(prefix: str, workspace_root: Path) -> str:
+    return f"{prefix}:{_newt_workspace_token(workspace_root)}"
+
+
+def _parse_newt_component_custom_id(custom_id: str, prefix: str) -> Optional[str]:
+    if custom_id == prefix:
+        return ""
+    if not custom_id.startswith(f"{prefix}:"):
+        return None
+    token = custom_id.split(":", 1)[1].strip()
+    return token or None
+
+
+def _build_newt_reject_components(workspace_root: Path) -> list[dict[str, Any]]:
     return [
         build_action_row(
             [
                 build_button(
                     "Hard reset",
-                    NEWT_HARD_RESET_CUSTOM_ID,
+                    _newt_component_custom_id(
+                        NEWT_HARD_RESET_CUSTOM_ID, workspace_root
+                    ),
                     style=DISCORD_BUTTON_STYLE_DANGER,
                 ),
-                build_button("Cancel", NEWT_CANCEL_CUSTOM_ID),
+                build_button(
+                    "Cancel",
+                    _newt_component_custom_id(NEWT_CANCEL_CUSTOM_ID, workspace_root),
+                ),
             ]
         )
     ]
@@ -498,7 +520,7 @@ async def handle_car_newt(
                 deferred=deferred,
                 text=_format_newt_reject_message(reasons),
                 component_response=False,
-                components=_build_newt_reject_components(),
+                components=_build_newt_reject_components(workspace_root),
             )
             return
         text = format_discord_message(
@@ -534,6 +556,7 @@ async def handle_car_newt_hard_reset(
     interaction_token: str,
     *,
     channel_id: str,
+    expected_workspace_token: Optional[str],
 ) -> None:
     from ..service import log_event, reset_branch_from_origin_main
 
@@ -585,6 +608,24 @@ async def handle_car_newt_hard_reset(
             deferred=deferred,
             text=format_discord_message(
                 "Binding is invalid. Run `/car bind path:<workspace>`."
+            ),
+            component_response=True,
+            components=[],
+        )
+        return
+    current_workspace_token = _newt_workspace_token(workspace_root)
+    if (
+        not expected_workspace_token
+        or expected_workspace_token != current_workspace_token
+    ):
+        await _send_newt_response(
+            service,
+            interaction_id,
+            interaction_token,
+            deferred=deferred,
+            text=format_discord_message(
+                "This `/car newt` action no longer matches the channel's current "
+                "workspace binding. Run `/car newt` again from the current workspace."
             ),
             component_response=True,
             components=[],
@@ -694,7 +735,10 @@ async def handle_car_newt_cancel(
     service: Any,
     interaction_id: str,
     interaction_token: str,
+    *,
+    expected_workspace_token: Optional[str] = None,
 ) -> None:
+    _ = expected_workspace_token
     deferred = await service._defer_component_update(
         interaction_id=interaction_id,
         interaction_token=interaction_token,

--- a/src/codex_autorunner/integrations/discord/interaction_dispatch.py
+++ b/src/codex_autorunner/integrations/discord/interaction_dispatch.py
@@ -7,6 +7,10 @@ from typing import Any, Optional
 
 from ...core.logging_utils import log_event
 from ...integrations.chat.command_ingress import canonicalize_command_ingress
+from .car_handlers.session_commands import (
+    NEWT_CANCEL_CUSTOM_ID,
+    NEWT_HARD_RESET_CUSTOM_ID,
+)
 from .errors import DiscordTransientError
 from .ingress import CommandSpec, IngressContext, IngressTiming, InteractionKind
 
@@ -451,6 +455,21 @@ async def handle_component_interaction(
                 interaction_token=interaction_token,
                 text="Update cancelled.",
                 components=[],
+            )
+            return
+
+        if custom_id == NEWT_HARD_RESET_CUSTOM_ID:
+            await service._handle_car_newt_hard_reset(
+                interaction_id,
+                interaction_token,
+                channel_id=channel_id,
+            )
+            return
+
+        if custom_id == NEWT_CANCEL_CUSTOM_ID:
+            await service._handle_car_newt_cancel(
+                interaction_id,
+                interaction_token,
             )
             return
 

--- a/src/codex_autorunner/integrations/discord/interaction_dispatch.py
+++ b/src/codex_autorunner/integrations/discord/interaction_dispatch.py
@@ -10,6 +10,7 @@ from ...integrations.chat.command_ingress import canonicalize_command_ingress
 from .car_handlers.session_commands import (
     NEWT_CANCEL_CUSTOM_ID,
     NEWT_HARD_RESET_CUSTOM_ID,
+    _parse_newt_component_custom_id,
 )
 from .errors import DiscordTransientError
 from .ingress import CommandSpec, IngressContext, IngressTiming, InteractionKind
@@ -458,18 +459,24 @@ async def handle_component_interaction(
             )
             return
 
-        if custom_id == NEWT_HARD_RESET_CUSTOM_ID:
+        hard_reset_token = _parse_newt_component_custom_id(
+            custom_id, NEWT_HARD_RESET_CUSTOM_ID
+        )
+        if hard_reset_token is not None:
             await service._handle_car_newt_hard_reset(
                 interaction_id,
                 interaction_token,
                 channel_id=channel_id,
+                expected_workspace_token=hard_reset_token,
             )
             return
 
-        if custom_id == NEWT_CANCEL_CUSTOM_ID:
+        cancel_token = _parse_newt_component_custom_id(custom_id, NEWT_CANCEL_CUSTOM_ID)
+        if cancel_token is not None:
             await service._handle_car_newt_cancel(
                 interaction_id,
                 interaction_token,
+                expected_workspace_token=cancel_token,
             )
             return
 

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -4942,6 +4942,35 @@ class DiscordBotService:
             guild_id=guild_id,
         )
 
+    async def _handle_car_newt_hard_reset(
+        self,
+        interaction_id: str,
+        interaction_token: str,
+        *,
+        channel_id: str,
+    ) -> None:
+        from .car_handlers.session_commands import handle_car_newt_hard_reset
+
+        await handle_car_newt_hard_reset(
+            self,
+            interaction_id,
+            interaction_token,
+            channel_id=channel_id,
+        )
+
+    async def _handle_car_newt_cancel(
+        self,
+        interaction_id: str,
+        interaction_token: str,
+    ) -> None:
+        from .car_handlers.session_commands import handle_car_newt_cancel
+
+        await handle_car_newt_cancel(
+            self,
+            interaction_id,
+            interaction_token,
+        )
+
     async def _handle_car_resume(
         self,
         interaction_id: str,

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -4948,6 +4948,7 @@ class DiscordBotService:
         interaction_token: str,
         *,
         channel_id: str,
+        expected_workspace_token: str | None,
     ) -> None:
         from .car_handlers.session_commands import handle_car_newt_hard_reset
 
@@ -4956,12 +4957,15 @@ class DiscordBotService:
             interaction_id,
             interaction_token,
             channel_id=channel_id,
+            expected_workspace_token=expected_workspace_token,
         )
 
     async def _handle_car_newt_cancel(
         self,
         interaction_id: str,
         interaction_token: str,
+        *,
+        expected_workspace_token: str | None = None,
     ) -> None:
         from .car_handlers.session_commands import handle_car_newt_cancel
 
@@ -4969,6 +4973,7 @@ class DiscordBotService:
             self,
             interaction_id,
             interaction_token,
+            expected_workspace_token=expected_workspace_token,
         )
 
     async def _handle_car_resume(

--- a/tests/core/test_git_utils.py
+++ b/tests/core/test_git_utils.py
@@ -97,3 +97,20 @@ def test_reset_branch_from_origin_main_raises_when_worktree_dirty(
         match="working tree has uncommitted changes; commit or stash before /newt",
     ):
         git_utils.reset_branch_from_origin_main(Path("/tmp/repo"), "thread-123")
+
+
+def test_describe_newt_reject_reasons_summarizes_git_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        git_utils,
+        "git_status_porcelain",
+        lambda _repo_root: "M  staged.py\n M unstaged.py\n?? .tmp/\nUU conflict.txt\n",
+    )
+
+    assert git_utils.describe_newt_reject_reasons(Path("/tmp/repo")) == [
+        "1 merge conflict, including `conflict.txt`",
+        "1 staged tracked change, including `staged.py`",
+        "1 unstaged tracked change, including `unstaged.py`",
+        "1 untracked path, including `.tmp/`",
+    ]

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -6699,14 +6699,17 @@ async def test_car_newt_dirty_worktree_shows_hard_reset_prompt(
         assert "changed.txt" in payload["content"]
         assert ".tmp/" in payload["content"]
         buttons = payload["components"][0]["components"]
+        expected_token = discord_session_commands_module._newt_workspace_token(
+            workspace.resolve()
+        )
         assert [button["label"] for button in buttons] == ["Hard reset", "Cancel"]
         assert (
             buttons[0]["custom_id"]
-            == discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID
+            == f"{discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID}:{expected_token}"
         )
         assert (
             buttons[1]["custom_id"]
-            == discord_session_commands_module.NEWT_CANCEL_CUSTOM_ID
+            == f"{discord_session_commands_module.NEWT_CANCEL_CUSTOM_ID}:{expected_token}"
         )
     finally:
         await store.close()
@@ -6729,11 +6732,14 @@ async def test_car_newt_hard_reset_button_discards_changes_and_retries(
     )
 
     rest = _FakeRest()
+    workspace_token = discord_session_commands_module._newt_workspace_token(
+        workspace.resolve()
+    )
     gateway = _FakeGateway(
         [
             _interaction(name="newt", options=[]),
             _component_interaction(
-                custom_id=discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID
+                custom_id=f"{discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID}:{workspace_token}"
             ),
         ]
     )
@@ -6818,11 +6824,14 @@ async def test_car_newt_hard_reset_reports_discard_when_retry_reset_fails(
     )
 
     rest = _FakeRest()
+    workspace_token = discord_session_commands_module._newt_workspace_token(
+        workspace.resolve()
+    )
     gateway = _FakeGateway(
         [
             _interaction(name="newt", options=[]),
             _component_interaction(
-                custom_id=discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID
+                custom_id=f"{discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID}:{workspace_token}"
             ),
         ]
     )
@@ -6898,11 +6907,14 @@ async def test_car_newt_hard_reset_reports_when_tracked_discard_step_fails(
     )
 
     rest = _FakeRest()
+    workspace_token = discord_session_commands_module._newt_workspace_token(
+        workspace.resolve()
+    )
     gateway = _FakeGateway(
         [
             _interaction(name="newt", options=[]),
             _component_interaction(
-                custom_id=discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID
+                custom_id=f"{discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID}:{workspace_token}"
             ),
         ]
     )
@@ -6969,11 +6981,14 @@ async def test_car_newt_hard_reset_reports_when_untracked_cleanup_fails(
     )
 
     rest = _FakeRest()
+    workspace_token = discord_session_commands_module._newt_workspace_token(
+        workspace.resolve()
+    )
     gateway = _FakeGateway(
         [
             _interaction(name="newt", options=[]),
             _component_interaction(
-                custom_id=discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID
+                custom_id=f"{discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID}:{workspace_token}"
             ),
         ]
     )
@@ -7024,6 +7039,89 @@ async def test_car_newt_hard_reset_reports_when_untracked_cleanup_fails(
         assert "some untracked paths could not be removed" in content
         assert "simulated failure" in content
         assert edited_payload["components"] == []
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_car_newt_hard_reset_rejects_stale_workspace_binding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace-a"
+    workspace.mkdir()
+    rebound_workspace = tmp_path / "workspace-b"
+    rebound_workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+    stale_token = discord_session_commands_module._newt_workspace_token(
+        workspace.resolve()
+    )
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(rebound_workspace),
+        repo_id="repo-2",
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _component_interaction(
+                custom_id=f"{discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID}:{stale_token}"
+            ),
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    branch_calls: list[dict[str, Any]] = []
+    reset_calls: list[Path] = []
+    clean_calls: list[Path] = []
+
+    def _reset_branch(repo_root: Path, branch_name: str) -> str:
+        branch_calls.append({"repo_root": repo_root, "branch_name": branch_name})
+        return "main"
+
+    monkeypatch.setattr(
+        discord_service_module, "reset_branch_from_origin_main", _reset_branch
+    )
+    monkeypatch.setattr(
+        discord_session_commands_module,
+        "reset_worktree_to_head",
+        lambda repo_root: reset_calls.append(repo_root),
+    )
+    monkeypatch.setattr(
+        discord_session_commands_module,
+        "clean_untracked_worktree",
+        lambda repo_root: clean_calls.append(repo_root),
+    )
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
+        assert len(rest.edited_original_interaction_responses) == 1
+        edited_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert "no longer matches the channel's current workspace binding" in (
+            edited_payload["content"].lower()
+        )
+        assert edited_payload["components"] == []
+        assert branch_calls == []
+        assert reset_calls == []
+        assert clean_calls == []
     finally:
         await store.close()
 

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -41,6 +41,9 @@ from codex_autorunner.integrations.discord.car_autocomplete import (
     repo_autocomplete_value,
     workspace_autocomplete_value,
 )
+from codex_autorunner.integrations.discord.car_handlers import (
+    session_commands as discord_session_commands_module,
+)
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
     DiscordCommandRegistration,
@@ -6637,6 +6640,390 @@ async def test_car_newt_reports_branch_reset_errors(
         assert len(rest.followup_messages) == 1
         content = rest.followup_messages[0]["payload"]["content"].lower()
         assert "failed to reset branch" in content
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_car_newt_dirty_worktree_shows_hard_reset_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway([_interaction(name="newt", options=[])])
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    def _reject_reset_branch(_repo_root: Path, _branch_name: str) -> None:
+        raise discord_service_module.GitError(
+            "working tree has uncommitted changes; commit or stash before /newt"
+        )
+
+    monkeypatch.setattr(
+        discord_service_module, "reset_branch_from_origin_main", _reject_reset_branch
+    )
+    monkeypatch.setattr(
+        discord_session_commands_module,
+        "describe_newt_reject_reasons",
+        lambda _repo_root: [
+            "1 unstaged tracked change, including `changed.txt`",
+            "1 untracked path, including `.tmp/`",
+        ],
+    )
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        assert len(rest.followup_messages) == 1
+        payload = rest.followup_messages[0]["payload"]
+        content = payload["content"].lower()
+        assert "can't start a fresh" in content
+        assert "changed.txt" in payload["content"]
+        assert ".tmp/" in payload["content"]
+        buttons = payload["components"][0]["components"]
+        assert [button["label"] for button in buttons] == ["Hard reset", "Cancel"]
+        assert (
+            buttons[0]["custom_id"]
+            == discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID
+        )
+        assert (
+            buttons[1]["custom_id"]
+            == discord_session_commands_module.NEWT_CANCEL_CUSTOM_ID
+        )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_car_newt_hard_reset_button_discards_changes_and_retries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _interaction(name="newt", options=[]),
+            _component_interaction(
+                custom_id=discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID
+            ),
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    branch_calls: list[dict[str, Any]] = []
+    hard_reset_calls: list[Path] = []
+
+    def _reset_branch(repo_root: Path, branch_name: str) -> str:
+        branch_calls.append({"repo_root": repo_root, "branch_name": branch_name})
+        if len(branch_calls) == 1:
+            raise discord_service_module.GitError(
+                "working tree has uncommitted changes; commit or stash before /newt"
+            )
+        return "master"
+
+    monkeypatch.setattr(
+        discord_service_module, "reset_branch_from_origin_main", _reset_branch
+    )
+    monkeypatch.setattr(
+        discord_session_commands_module,
+        "describe_newt_reject_reasons",
+        lambda _repo_root: ["1 untracked path, including `.tmp/`"],
+    )
+    monkeypatch.setattr(
+        discord_session_commands_module,
+        "reset_worktree_to_head",
+        lambda repo_root: hard_reset_calls.append(repo_root),
+    )
+    monkeypatch.setattr(
+        discord_session_commands_module,
+        "clean_untracked_worktree",
+        lambda _repo_root: None,
+    )
+
+    try:
+        await service.run_forever()
+        expected_branch = (
+            "thread-channel-1-"
+            f"{hashlib.sha256(str(workspace.resolve()).encode('utf-8')).hexdigest()[:10]}"
+        )
+        assert branch_calls == [
+            {"repo_root": workspace.resolve(), "branch_name": expected_branch},
+            {"repo_root": workspace.resolve(), "branch_name": expected_branch},
+        ]
+        assert hard_reset_calls == [workspace.resolve()]
+        assert [item["payload"]["type"] for item in rest.interaction_responses] == [
+            5,
+            6,
+        ]
+        assert len(rest.followup_messages) == 1
+        assert len(rest.edited_original_interaction_responses) == 1
+        edited_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert "reset branch" in edited_payload["content"].lower()
+        assert "origin/master" in edited_payload["content"].lower()
+        assert edited_payload["components"] == []
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_car_newt_hard_reset_reports_discard_when_retry_reset_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _interaction(name="newt", options=[]),
+            _component_interaction(
+                custom_id=discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID
+            ),
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    branch_calls: list[dict[str, Any]] = []
+    hard_reset_calls: list[Path] = []
+
+    def _reset_branch(repo_root: Path, branch_name: str) -> str:
+        branch_calls.append({"repo_root": repo_root, "branch_name": branch_name})
+        if len(branch_calls) == 1:
+            raise discord_service_module.GitError(
+                "working tree has uncommitted changes; commit or stash before /newt"
+            )
+        raise discord_service_module.GitError("git fetch failed: simulated failure")
+
+    monkeypatch.setattr(
+        discord_service_module, "reset_branch_from_origin_main", _reset_branch
+    )
+    monkeypatch.setattr(
+        discord_session_commands_module,
+        "describe_newt_reject_reasons",
+        lambda _repo_root: ["1 untracked path, including `.tmp/`"],
+    )
+    monkeypatch.setattr(
+        discord_session_commands_module,
+        "reset_worktree_to_head",
+        lambda repo_root: hard_reset_calls.append(repo_root),
+    )
+    monkeypatch.setattr(
+        discord_session_commands_module,
+        "clean_untracked_worktree",
+        lambda _repo_root: None,
+    )
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 2
+        assert rest.interaction_responses[1]["payload"]["type"] == 6
+        assert hard_reset_calls == [workspace.resolve()]
+        assert len(rest.edited_original_interaction_responses) == 1
+        edited_payload = rest.edited_original_interaction_responses[0]["payload"]
+        content = edited_payload["content"].lower()
+        assert "local changes were discarded" in content
+        assert "retry `/car newt`" in content
+        assert "simulated failure" in content
+        assert edited_payload["components"] == []
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_car_newt_hard_reset_reports_when_tracked_discard_step_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _interaction(name="newt", options=[]),
+            _component_interaction(
+                custom_id=discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID
+            ),
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    def _reset_branch(repo_root: Path, branch_name: str) -> str:
+        _ = repo_root, branch_name
+        raise discord_service_module.GitError(
+            "working tree has uncommitted changes; commit or stash before /newt"
+        )
+
+    monkeypatch.setattr(
+        discord_service_module, "reset_branch_from_origin_main", _reset_branch
+    )
+    monkeypatch.setattr(
+        discord_session_commands_module,
+        "describe_newt_reject_reasons",
+        lambda _repo_root: ["1 untracked path, including `.tmp/`"],
+    )
+
+    def _fail_reset_worktree(_repo_root: Path) -> None:
+        raise discord_service_module.GitError("git reset failed: simulated failure")
+
+    monkeypatch.setattr(
+        discord_session_commands_module, "reset_worktree_to_head", _fail_reset_worktree
+    )
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 2
+        assert rest.interaction_responses[1]["payload"]["type"] == 6
+        assert len(rest.edited_original_interaction_responses) == 1
+        edited_payload = rest.edited_original_interaction_responses[0]["payload"]
+        content = edited_payload["content"].lower()
+        assert "did not complete cleanly" in content
+        assert "simulated failure" in content
+        assert "were discarded" not in content
+        assert edited_payload["components"] == []
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_car_newt_hard_reset_reports_when_untracked_cleanup_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [
+            _interaction(name="newt", options=[]),
+            _component_interaction(
+                custom_id=discord_session_commands_module.NEWT_HARD_RESET_CUSTOM_ID
+            ),
+        ]
+    )
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    def _reset_branch(repo_root: Path, branch_name: str) -> str:
+        _ = repo_root, branch_name
+        raise discord_service_module.GitError(
+            "working tree has uncommitted changes; commit or stash before /newt"
+        )
+
+    monkeypatch.setattr(
+        discord_service_module, "reset_branch_from_origin_main", _reset_branch
+    )
+    monkeypatch.setattr(
+        discord_session_commands_module,
+        "describe_newt_reject_reasons",
+        lambda _repo_root: ["1 untracked path, including `.tmp/`"],
+    )
+    monkeypatch.setattr(
+        discord_session_commands_module,
+        "reset_worktree_to_head",
+        lambda _repo_root: None,
+    )
+
+    def _fail_clean(_repo_root: Path) -> None:
+        raise discord_service_module.GitError("git clean failed: simulated failure")
+
+    monkeypatch.setattr(
+        discord_session_commands_module, "clean_untracked_worktree", _fail_clean
+    )
+
+    try:
+        await service.run_forever()
+        assert len(rest.interaction_responses) == 2
+        assert rest.interaction_responses[1]["payload"]["type"] == 6
+        assert len(rest.edited_original_interaction_responses) == 1
+        edited_payload = rest.edited_original_interaction_responses[0]["payload"]
+        content = edited_payload["content"].lower()
+        assert "tracked changes were discarded" in content
+        assert "some untracked paths could not be removed" in content
+        assert "simulated failure" in content
+        assert edited_payload["components"] == []
     finally:
         await store.close()
 


### PR DESCRIPTION
## What changed
- replace the plain `/car newt` dirty-worktree failure with a compact Discord action card that lists reset blockers and offers `Hard reset` and `Cancel`
- add component handlers so the hard-reset button discards local tracked and untracked changes, retries `/car newt`, and updates the original message with the result
- tighten the reset flow so tracked-reset failure, untracked-cleanup failure, and post-discard branch-reset failure each report the correct outcome
- add git helper coverage plus Discord routing regressions for the reject card and each hard-reset failure path

## Why
`/car newt` previously dead-ended on a raw git error when the workspace was dirty. The new flow gives users a direct recovery path from Discord while keeping the destructive step explicit and accurately reported.

## Impact
Discord users now get a clearer reset UX for dirty worktrees, with a single-click hard reset path when they intentionally want to throw away local changes.

## Validation
- mini sub-agent review completed with findings addressed before publish
- `.venv/bin/pytest tests/core/test_git_utils.py -q`
- `.venv/bin/pytest tests/integrations/discord/test_service_routing.py -q -k 'car_newt'`
- `.venv/bin/ruff check src/codex_autorunner/core/git_utils.py src/codex_autorunner/integrations/discord/car_handlers/session_commands.py src/codex_autorunner/integrations/discord/interaction_dispatch.py src/codex_autorunner/integrations/discord/service.py tests/core/test_git_utils.py tests/integrations/discord/test_service_routing.py`
- full pre-commit gate during `git commit`, including repo-wide mypy, frontend build/tests, dead-code check, and full pytest (`4699 passed`)
