### PR TITLE
[codex] Improve Discord attachment prep status

### DIFF
--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -146,6 +146,7 @@ class _DiscordMessageTurnDispatch:
     service: Any
     event: ChatMessageEvent
     context: DispatchContext
+    binding: dict[str, object]
     channel_id: str
     text: str
     has_attachments: bool
@@ -655,12 +656,25 @@ async def _submit_discord_thread_message(
     managed_thread_surface_key = _managed_thread_surface_key_for_notification_reply(
         dispatch.notification_reply
     )
+    managed_thread_status = _resolve_discord_managed_thread_status(
+        dispatch,
+        workspace_root=request.workspace_root,
+        managed_thread_surface_key=managed_thread_surface_key,
+        pma_enabled=request.pma_enabled,
+    )
 
     async def _send_initial_progress_placeholder() -> Optional[str]:
+        initial_content = "Received. Preparing turn..."
+        if dispatch.has_attachments:
+            initial_content = "Preparing attachments..."
+            if managed_thread_status.busy:
+                initial_content = (
+                    "Busy. Preparing attachments while the current turn finishes..."
+                )
         try:
             response = await dispatch.service._send_channel_message(
                 dispatch.channel_id,
-                {"content": "Received. Preparing turn..."},
+                {"content": initial_content},
             )
         except (RuntimeError, ConnectionError, OSError):
             dispatch.service._logger.warning(
@@ -727,7 +741,9 @@ async def _submit_discord_thread_message(
         and isinstance(dispatch.event.message.message_id, str)
         and dispatch.event.message.message_id
     ):
-        thread_target_id = await _resolve_managed_thread_id()
+        thread_target_id = managed_thread_status.thread_target_id
+        if not thread_target_id:
+            thread_target_id = await _resolve_managed_thread_id()
         if thread_target_id:
             _stash_discord_reusable_progress_message(
                 dispatch.service,
@@ -1143,6 +1159,7 @@ async def handle_message_event(
         service=service,
         event=event,
         context=context,
+        binding=binding,
         channel_id=channel_id,
         text=text,
         has_attachments=has_attachments,
@@ -1327,6 +1344,64 @@ def resolve_discord_thread_target(
             reusable_agent_ids=(runtime_agent,),
         ),
     )
+
+
+@dataclass(frozen=True)
+class _DiscordManagedThreadStatus:
+    thread_target_id: Optional[str]
+    busy: bool
+
+
+def _resolve_discord_managed_thread_status(
+    dispatch: _DiscordMessageTurnDispatch,
+    *,
+    workspace_root: Path,
+    managed_thread_surface_key: Optional[str],
+    pma_enabled: bool,
+) -> _DiscordManagedThreadStatus:
+    orchestration_service = build_discord_thread_orchestration_service(dispatch.service)
+    surface_key = managed_thread_surface_key or dispatch.channel_id
+    get_binding = getattr(orchestration_service, "get_binding", None)
+    get_thread_target = getattr(orchestration_service, "get_thread_target", None)
+    if not callable(get_binding) or not callable(get_thread_target):
+        return _DiscordManagedThreadStatus(thread_target_id=None, busy=False)
+    try:
+        binding = get_binding(surface_kind="discord", surface_key=surface_key)
+    except (RuntimeError, ValueError, TypeError, KeyError, AttributeError):
+        return _DiscordManagedThreadStatus(thread_target_id=None, busy=False)
+    normalized_mode = "pma" if pma_enabled else "repo"
+    if str(getattr(binding, "mode", "") or "").strip().lower() != normalized_mode:
+        return _DiscordManagedThreadStatus(thread_target_id=None, busy=False)
+    thread_target_id = (
+        str(getattr(binding, "thread_target_id", "") or "").strip() or None
+    )
+    if not thread_target_id:
+        return _DiscordManagedThreadStatus(thread_target_id=None, busy=False)
+    try:
+        thread = get_thread_target(thread_target_id)
+    except (RuntimeError, ValueError, TypeError, KeyError, AttributeError):
+        return _DiscordManagedThreadStatus(thread_target_id=None, busy=False)
+    canonical_workspace = str(canonicalize_path(workspace_root))
+    if str(getattr(thread, "workspace_root", "") or "").strip() != canonical_workspace:
+        return _DiscordManagedThreadStatus(thread_target_id=None, busy=False)
+
+    busy = False
+    get_running_execution = getattr(
+        orchestration_service, "get_running_execution", None
+    )
+    if callable(get_running_execution):
+        with contextlib.suppress(RuntimeError, ValueError, TypeError, AttributeError):
+            busy = get_running_execution(thread_target_id) is not None
+    if not busy:
+        list_queued_executions = getattr(
+            orchestration_service, "list_queued_executions", None
+        )
+        if callable(list_queued_executions):
+            with contextlib.suppress(
+                RuntimeError, ValueError, TypeError, AttributeError
+            ):
+                busy = bool(list_queued_executions(thread_target_id, limit=1))
+    return _DiscordManagedThreadStatus(thread_target_id=thread_target_id, busy=busy)
 
 
 def _build_discord_managed_thread_coordinator(

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -741,9 +741,7 @@ async def _submit_discord_thread_message(
         and isinstance(dispatch.event.message.message_id, str)
         and dispatch.event.message.message_id
     ):
-        thread_target_id = managed_thread_status.thread_target_id
-        if not thread_target_id:
-            thread_target_id = await _resolve_managed_thread_id()
+        thread_target_id = await _resolve_managed_thread_id()
         if thread_target_id:
             _stash_discord_reusable_progress_message(
                 dispatch.service,

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -537,6 +537,7 @@ async def test_discord_message_turns_show_busy_placeholder_for_attachment_prep(
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     sent_messages: list[dict[str, object]] = []
+    stashed_progress_messages: list[dict[str, str]] = []
 
     class _StoreStub:
         async def get_binding(self, *, channel_id: str) -> dict[str, object] | None:
@@ -648,8 +649,23 @@ async def test_discord_message_turns_show_busy_placeholder_for_attachment_prep(
     monkeypatch.setattr(
         discord_message_turns,
         "resolve_discord_thread_target",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("status inspection should not create or resolve a thread")
+        lambda *_args, **_kwargs: (
+            object(),
+            SimpleNamespace(thread_target_id="thread-target-456"),
+        ),
+    )
+    monkeypatch.setattr(
+        discord_message_turns,
+        "_stash_discord_reusable_progress_message",
+        lambda service, *, thread_target_id, source_message_id, channel_id, message_id: (
+            stashed_progress_messages.append(
+                {
+                    "thread_target_id": thread_target_id,
+                    "source_message_id": source_message_id,
+                    "channel_id": channel_id,
+                    "message_id": message_id,
+                }
+            )
         ),
     )
 
@@ -688,6 +704,14 @@ async def test_discord_message_turns_show_busy_placeholder_for_attachment_prep(
     assert sent_messages[0]["payload"]["content"] == (
         "Busy. Preparing attachments while the current turn finishes..."
     )
+    assert stashed_progress_messages == [
+        {
+            "thread_target_id": "thread-target-456",
+            "source_message_id": "msg-2",
+            "channel_id": "channel-1",
+            "message_id": "msg-1",
+        }
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -523,11 +523,171 @@ async def test_discord_message_turns_delete_immediate_placeholder_when_backgroun
     await asyncio.gather(*list(service._background_tasks), return_exceptions=True)
 
     assert [message["payload"]["content"] for message in sent_messages] == [
-        "Received. Preparing turn...",
+        "Preparing attachments...",
         "Some Discord attachments could not be downloaded. Continuing with available inputs.",
         "Failed to download attachments from Discord. Please retry.",
     ]
     assert deleted_messages == [{"channel_id": "channel-1", "message_id": "msg-1"}]
+
+
+@pytest.mark.anyio
+async def test_discord_message_turns_show_busy_placeholder_for_attachment_prep(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    sent_messages: list[dict[str, object]] = []
+
+    class _StoreStub:
+        async def get_binding(self, *, channel_id: str) -> dict[str, object] | None:
+            assert channel_id == "channel-1"
+            return {
+                "workspace_path": str(workspace),
+                "agent": "codex",
+                "pma_enabled": False,
+                "model_override": None,
+                "reasoning_effort": None,
+            }
+
+    class _ServiceStub:
+        def __init__(self) -> None:
+            self._store = _StoreStub()
+            self._logger = logging.getLogger("test")
+            self._config = SimpleNamespace(root=tmp_path)
+            self._background_tasks: set[asyncio.Task[Any]] = set()
+
+        def _resolve_agent_state(self, binding: dict[str, object]) -> tuple[str, None]:
+            return str(binding.get("agent") or "codex"), None
+
+        def _runtime_agent_for_binding(self, binding: dict[str, object]) -> str:
+            return str(binding.get("agent") or "codex")
+
+        def _normalize_agent(self, value: object) -> str:
+            return str(value or "codex")
+
+        def _build_message_session_key(self, **_kwargs: object) -> str:
+            return "session-key"
+
+        async def _with_attachment_context(
+            self, *, prompt_text: str, **_kwargs: object
+        ) -> tuple[str, int, int, None, list[dict[str, object]]]:
+            _ = prompt_text
+            return "", 0, 1, None, []
+
+        async def _send_channel_message(
+            self, channel_id: str, payload: dict[str, object]
+        ) -> dict[str, object]:
+            sent_messages.append({"channel_id": channel_id, "payload": dict(payload)})
+            return {"id": f"msg-{len(sent_messages)}"}
+
+        async def _send_channel_message_safe(
+            self, channel_id: str, payload: dict[str, object]
+        ) -> None:
+            sent_messages.append({"channel_id": channel_id, "payload": dict(payload)})
+
+        async def _delete_channel_message_safe(
+            self, *, channel_id: str, message_id: str, record_id: str
+        ) -> None:
+            _ = channel_id, message_id, record_id
+
+        async def _run_agent_turn_for_message(self, **_kwargs: object) -> object:
+            raise AssertionError("background turn should exit before submission")
+
+        def _spawn_task(self, coro: Any) -> asyncio.Task[Any]:
+            task = asyncio.create_task(coro)
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+            return task
+
+    class _IngressStub:
+        async def submit_message(
+            self,
+            request,
+            *,
+            resolve_paused_flow_target,
+            submit_flow_reply,
+            submit_thread_message,
+        ):
+            _ = resolve_paused_flow_target, submit_flow_reply
+            thread_result = await submit_thread_message(request)
+            return SimpleNamespace(route="thread", thread_result=thread_result)
+
+    class _BusyOrchestrationService:
+        def get_binding(self, *, surface_kind: str, surface_key: str) -> object | None:
+            assert surface_kind == "discord"
+            assert surface_key == "channel-1"
+            return SimpleNamespace(mode="repo", thread_target_id="thread-target-123")
+
+        def get_thread_target(self, thread_target_id: str) -> object | None:
+            assert thread_target_id == "thread-target-123"
+            return SimpleNamespace(
+                thread_target_id=thread_target_id, workspace_root=str(workspace)
+            )
+
+        def get_running_execution(self, thread_target_id: str) -> object | None:
+            assert thread_target_id == "thread-target-123"
+            return object()
+
+        def list_queued_executions(
+            self, thread_target_id: str, *, limit: int | None = None
+        ) -> list[object]:
+            _ = limit
+            assert thread_target_id == "thread-target-123"
+            return []
+
+    monkeypatch.setattr(
+        discord_message_turns,
+        "build_surface_orchestration_ingress",
+        lambda **_: _IngressStub(),
+    )
+    monkeypatch.setattr(
+        discord_message_turns,
+        "build_discord_thread_orchestration_service",
+        lambda *_args, **_kwargs: _BusyOrchestrationService(),
+    )
+    monkeypatch.setattr(
+        discord_message_turns,
+        "resolve_discord_thread_target",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("status inspection should not create or resolve a thread")
+        ),
+    )
+
+    thread = ChatThreadRef(platform="discord", chat_id="channel-1", thread_id=None)
+    event = ChatMessageEvent(
+        update_id="update-2c",
+        thread=thread,
+        message=ChatMessageRef(thread=thread, message_id="msg-2"),
+        from_user_id="user-1",
+        text="voice note",
+        attachments=[
+            {
+                "id": "att-1",
+                "filename": "voice.ogg",
+                "url": "https://example.invalid/voice.ogg",
+            }
+        ],
+    )
+    context = build_dispatch_context(event)
+
+    service = _ServiceStub()
+    await discord_message_turns.handle_message_event(
+        service,
+        event,
+        context,
+        channel_id="channel-1",
+        text="voice note",
+        has_attachments=True,
+        policy_result=None,
+        log_event_fn=lambda *args, **kwargs: None,
+        build_ticket_flow_controller_fn=lambda *_args, **_kwargs: None,
+        ensure_worker_fn=lambda *_args, **_kwargs: None,
+    )
+    await asyncio.gather(*list(service._background_tasks), return_exceptions=True)
+
+    assert sent_messages[0]["payload"]["content"] == (
+        "Busy. Preparing attachments while the current turn finishes..."
+    )
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## What changed

This updates Discord message-turn handling so attachment-heavy turns, including voice uploads, show clearer progress while attachment download and transcription are happening.

- show `Preparing attachments...` for attachment-backed turns before runtime submission starts
- show `Busy. Preparing attachments while the current turn finishes...` when the bound managed thread is already occupied
- reuse existing managed-thread bindings for status inspection instead of resolving/creating a thread just to check queue state
- add Discord routing coverage for the new placeholder behavior and the non-creating status lookup path

## Why

Voice and other attachment-backed turns could look stuck because Discord only showed a generic `Received. Preparing turn...` placeholder while the system was still downloading attachments and transcribing audio.

## User impact

Discord users now get a more accurate status message during attachment preprocessing, especially for voice messages, and busy channels communicate that the current turn is still finishing.

## Root cause

The Discord surface only surfaced queue state after attachment preprocessing completed. In the earlier patch iteration, status inspection also resolved the managed thread too early, which risked creating thread state before a turn was actually submitted.

## Validation

- `.venv/bin/pytest tests/integrations/discord/test_service_routing.py -q -k 'busy_placeholder_for_attachment_prep or delete_immediate_placeholder_when_background_turn_exits_early'`
- `.venv/bin/ruff check src/codex_autorunner/integrations/discord/message_turns.py tests/integrations/discord/test_service_routing.py`
- pre-commit hook suite during `git commit`:
  - black
  - ruff
  - mypy
  - static asset build
  - frontend JS tests
  - full pytest run (`4694 passed`)
  - repo contract and hygiene checks

## Review

Mini subagent review completed on the final diff with no findings.