### PR TITLE
[codex] Harden Hermes Discord PMA session update handling

### DIFF
--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -1189,7 +1189,8 @@ class ACPClient:
             text_length=state.last_session_update_text_length,
         )
         if (
-            state.last_session_update_kind in {"agent_message_chunk", "agent_thought_chunk"}
+            state.last_session_update_kind
+            in {"agent_message_chunk", "agent_thought_chunk"}
             and not extracted_text
         ):
             self._log_trace_event(

--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -109,6 +109,9 @@ class _PromptState:
     request_started_at: Optional[float] = None
     last_session_update_kind: Optional[str] = None
     last_session_update_excerpt: Optional[str] = None
+    last_session_update_content_kind: Optional[str] = None
+    last_session_update_part_types: tuple[str, ...] = ()
+    last_session_update_text_length: Optional[int] = None
     last_session_update_at: Optional[float] = None
 
 
@@ -127,6 +130,55 @@ def _text_excerpt(value: Any, *, limit: int = 120) -> Optional[str]:
     if len(normalized) <= limit:
         return normalized
     return normalized[: limit - 3] + "..."
+
+
+def _extract_text_content(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        for key in ("text", "message"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate:
+                return candidate
+        return _extract_text_content(value.get("content"))
+    if isinstance(value, list):
+        text_parts: list[str] = []
+        for item in value:
+            if isinstance(item, str) and item:
+                text_parts.append(item)
+                continue
+            if not isinstance(item, dict):
+                continue
+            item_type = _normalize_optional_text(item.get("type"))
+            if item_type and item_type not in {"text", "output_text", "message"}:
+                continue
+            text = _extract_text_content(item)
+            if text:
+                text_parts.append(text)
+        return "".join(text_parts)
+    return ""
+
+
+def _session_update_content_summary(update: dict[str, Any]) -> dict[str, Any]:
+    content = update.get("content")
+    part_types: list[str] = []
+    if isinstance(content, list):
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            item_type = _normalize_optional_text(item.get("type"))
+            if item_type:
+                part_types.append(item_type)
+    extracted_text = _extract_text_content(content)
+    if not extracted_text:
+        fallback_message = update.get("message")
+        if isinstance(fallback_message, str):
+            extracted_text = fallback_message
+    return {
+        "content_kind": type(content).__name__ if content is not None else "missing",
+        "content_part_types": tuple(part_types),
+        "text": extracted_text,
+    }
 
 
 def _stringify(value: Any) -> str:
@@ -1096,6 +1148,9 @@ class ACPClient:
         return {
             "last_session_update_kind": state.last_session_update_kind,
             "last_session_update_excerpt": state.last_session_update_excerpt,
+            "last_session_update_content_kind": state.last_session_update_content_kind,
+            "last_session_update_part_types": state.last_session_update_part_types,
+            "last_session_update_text_length": state.last_session_update_text_length,
             "last_session_update_elapsed_ms": self._elapsed_ms(
                 state.last_session_update_at
             ),
@@ -1105,15 +1160,22 @@ class ACPClient:
         if event.method != "session/update":
             return
         update = _coerce_mapping(event.payload.get("update"))
-        content = _coerce_mapping(update.get("content"))
+        content_summary = _session_update_content_summary(update)
+        extracted_text = str(content_summary.get("text") or "")
         state.last_session_update_kind = _normalize_optional_text(
             update.get("sessionUpdate") or update.get("session_update")
         )
-        state.last_session_update_excerpt = _text_excerpt(
-            content.get("text")
-            or update.get("message")
-            or event.payload.get("message")
-            or ""
+        state.last_session_update_excerpt = _text_excerpt(extracted_text)
+        state.last_session_update_content_kind = _normalize_optional_text(
+            content_summary.get("content_kind")
+        )
+        state.last_session_update_part_types = tuple(
+            str(item)
+            for item in (content_summary.get("content_part_types") or ())
+            if str(item).strip()
+        )
+        state.last_session_update_text_length = (
+            len(extracted_text) if extracted_text else 0
         )
         state.last_session_update_at = time.monotonic()
         self._log_trace_event(
@@ -1122,7 +1184,23 @@ class ACPClient:
             turn_id=state.turn_id,
             session_update=state.last_session_update_kind,
             text_excerpt=state.last_session_update_excerpt,
+            content_kind=state.last_session_update_content_kind,
+            content_part_types=state.last_session_update_part_types,
+            text_length=state.last_session_update_text_length,
         )
+        if (
+            state.last_session_update_kind in {"agent_message_chunk", "agent_thought_chunk"}
+            and not extracted_text
+        ):
+            self._log_trace_event(
+                "acp.prompt.session_update.unparsed",
+                session_id=state.session_id,
+                turn_id=state.turn_id,
+                session_update=state.last_session_update_kind,
+                content_kind=state.last_session_update_content_kind,
+                content_part_types=state.last_session_update_part_types,
+                raw_update=update,
+            )
 
     def _response_error(
         self, method: Optional[str], payload: dict[str, Any]

--- a/src/codex_autorunner/agents/acp/events.py
+++ b/src/codex_autorunner/agents/acp/events.py
@@ -29,6 +29,32 @@ def _extract_text(payload: Mapping[str, Any], *keys: str) -> Optional[str]:
     return None
 
 
+def _extract_text_content(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        text = _extract_text(value, "text", "message")
+        if text:
+            return text
+        return _extract_text_content(value.get("content"))
+    if isinstance(value, list):
+        text_parts: list[str] = []
+        for item in value:
+            if isinstance(item, str) and item:
+                text_parts.append(item)
+                continue
+            if not isinstance(item, Mapping):
+                continue
+            item_type = _normalize_optional_text(item.get("type"))
+            if item_type and item_type not in {"text", "output_text", "message"}:
+                continue
+            part_text = _extract_text_content(item)
+            if part_text:
+                text_parts.append(part_text)
+        return "".join(text_parts)
+    return ""
+
+
 def _session_update_kind(payload: Mapping[str, Any]) -> Optional[str]:
     value = payload.get("sessionUpdate")
     if value is None:
@@ -227,8 +253,9 @@ def normalize_notification(message: Mapping[str, Any]) -> ACPEvent:
     if method == "session/update":
         update = _coerce_mapping(payload.get("update"))
         update_kind = _session_update_kind(update) or ""
-        content = _coerce_mapping(update.get("content"))
-        text = _extract_text(content, "text") or ""
+        text = _extract_text_content(update.get("content")) or ""
+        if not text:
+            text = _extract_text(update, "message") or ""
         if update_kind == "agent_message_chunk":
             return ACPOutputDeltaEvent(
                 kind="output_delta",

--- a/src/codex_autorunner/core/orchestration/opencode_event_fields.py
+++ b/src/codex_autorunner/core/orchestration/opencode_event_fields.py
@@ -10,6 +10,39 @@ def coerce_dict(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def _extract_text_content(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        text = value.get("text")
+        if isinstance(text, str) and text:
+            return text
+        message = value.get("message")
+        if isinstance(message, str) and message:
+            return message
+        return _extract_text_content(value.get("content"))
+    if isinstance(value, list):
+        parts: list[str] = []
+        for entry in value:
+            if isinstance(entry, str) and entry:
+                parts.append(entry)
+                continue
+            if not isinstance(entry, dict):
+                continue
+            entry_type = entry.get("type")
+            if isinstance(entry_type, str) and entry_type not in (
+                "text",
+                "output_text",
+                "message",
+            ):
+                continue
+            text = _extract_text_content(entry)
+            if text:
+                parts.append(text)
+        return "".join(parts)
+    return ""
+
+
 def extract_message_properties(params: dict[str, Any]) -> dict[str, Any]:
     return coerce_dict(params.get("properties"))
 
@@ -108,12 +141,9 @@ def extract_output_delta(
 ) -> str:
     for key in ("content", "delta", "text", "output"):
         value = params.get(key)
-        if isinstance(value, str) and value:
-            return value
-        if isinstance(value, dict):
-            nested_text = value.get("text")
-            if isinstance(nested_text, str) and nested_text:
-                return nested_text
+        extracted = _extract_text_content(value)
+        if extracted:
+            return extracted
     properties = extract_message_properties(params)
     delta_raw = properties.get("delta")
     if isinstance(delta_raw, str) and delta_raw:

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -406,10 +406,7 @@ def normalize_runtime_thread_message(
         update_kind = _extract_session_update_kind(update)
         if update_kind == "agent_message_chunk":
             return _assistant_stream_events(
-                {
-                    "content": update.get("content"),
-                    "message": update.get("message"),
-                },
+                _extract_session_update_message_params(update),
                 state,
                 timestamp=event_timestamp,
             )
@@ -925,15 +922,35 @@ def _extract_session_update_kind(update: dict[str, Any]) -> str:
     return ""
 
 
+def _extract_session_update_message_params(update: dict[str, Any]) -> dict[str, Any]:
+    content = update.get("content")
+    if isinstance(content, dict):
+        params = dict(content)
+        message = update.get("message")
+        if isinstance(message, str) and message.strip() and "message" not in params:
+            params["message"] = message
+        return params
+    return {
+        "content": content,
+        "message": update.get("message"),
+    }
+
+
 def _extract_session_update_text(update: dict[str, Any]) -> str:
     content = update.get("content")
     if isinstance(content, str) and content.strip():
         return content
     if isinstance(content, dict):
-        for key in ("text", "message"):
+        for key in ("text", "message", "status"):
             value = content.get(key)
             if isinstance(value, str) and value.strip():
                 return value
+        progress_message = _extract_acp_progress_message(content)
+        if progress_message:
+            return progress_message
+        output_delta = _extract_output_delta(content)
+        if output_delta:
+            return output_delta
     if isinstance(content, list):
         text_parts: list[str] = []
         for entry in content:
@@ -949,12 +966,19 @@ def _extract_session_update_text(update: dict[str, Any]) -> str:
                 "message",
             ):
                 continue
-            entry_text = entry.get("text")
-            if isinstance(entry_text, str) and entry_text:
+            entry_text = ""
+            message_text = entry.get("message")
+            if isinstance(message_text, str) and message_text:
+                entry_text = message_text
+            if not entry_text:
+                entry_text = _extract_output_delta(entry)
+            if not entry_text:
+                entry_text = _extract_acp_progress_message(entry)
+            if entry_text:
                 text_parts.append(entry_text)
         if text_parts:
             return "".join(text_parts)
-    return str(update.get("message") or "").strip()
+    return _extract_acp_progress_message(update)
 
 
 def _extract_acp_progress_message(params: dict[str, Any]) -> str:

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -405,17 +405,16 @@ def normalize_runtime_thread_message(
         update = _extract_session_update(params)
         update_kind = _extract_session_update_kind(update)
         if update_kind == "agent_message_chunk":
-            session_update_content = _extract_session_update_content(update)
             return _assistant_stream_events(
-                session_update_content,
+                {
+                    "content": update.get("content"),
+                    "message": update.get("message"),
+                },
                 state,
                 timestamp=event_timestamp,
             )
         if update_kind == "agent_thought_chunk":
-            session_update_content = _extract_session_update_content(update)
-            progress_message = _extract_acp_progress_message(
-                session_update_content
-            ) or _extract_output_delta(session_update_content)
+            progress_message = _extract_session_update_text(update)
             if not progress_message:
                 return []
             return [
@@ -925,9 +924,36 @@ def _extract_session_update_kind(update: dict[str, Any]) -> str:
             return value.strip()
     return ""
 
-
-def _extract_session_update_content(update: dict[str, Any]) -> dict[str, Any]:
-    return _coerce_dict(update.get("content"))
+def _extract_session_update_text(update: dict[str, Any]) -> str:
+    content = update.get("content")
+    if isinstance(content, str) and content.strip():
+        return content
+    if isinstance(content, dict):
+        for key in ("text", "message"):
+            value = content.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+    if isinstance(content, list):
+        text_parts: list[str] = []
+        for entry in content:
+            if isinstance(entry, str) and entry:
+                text_parts.append(entry)
+                continue
+            if not isinstance(entry, dict):
+                continue
+            entry_type = entry.get("type")
+            if isinstance(entry_type, str) and entry_type not in (
+                "text",
+                "output_text",
+                "message",
+            ):
+                continue
+            entry_text = entry.get("text")
+            if isinstance(entry_text, str) and entry_text:
+                text_parts.append(entry_text)
+        if text_parts:
+            return "".join(text_parts)
+    return str(update.get("message") or "").strip()
 
 
 def _extract_acp_progress_message(params: dict[str, Any]) -> str:

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -924,6 +924,7 @@ def _extract_session_update_kind(update: dict[str, Any]) -> str:
             return value.strip()
     return ""
 
+
 def _extract_session_update_text(update: dict[str, Any]) -> str:
     content = update.get("content")
     if isinstance(content, str) and content.strip():

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -103,6 +103,52 @@ _DIRECT_RUN_EVENT_TYPES = (
 )
 
 
+def _runtime_raw_event_message(raw_event: Any) -> dict[str, Any]:
+    if not isinstance(raw_event, dict):
+        return {}
+    message = raw_event.get("message")
+    if isinstance(message, dict):
+        return message
+    return raw_event
+
+
+def _runtime_raw_event_method(raw_event: Any) -> str:
+    message = _runtime_raw_event_message(raw_event)
+    return str(message.get("method") or "").strip()
+
+
+def _runtime_raw_event_session_update(raw_event: Any) -> dict[str, Any]:
+    message = _runtime_raw_event_message(raw_event)
+    params = message.get("params")
+    if not isinstance(params, dict):
+        return {}
+    update = params.get("update")
+    if isinstance(update, dict):
+        return update
+    return {}
+
+
+def _runtime_raw_event_content_summary(raw_event: Any) -> dict[str, Any]:
+    update = _runtime_raw_event_session_update(raw_event)
+    content = update.get("content")
+    part_types: list[str] = []
+    if isinstance(content, list):
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            item_type = str(item.get("type") or "").strip()
+            if item_type:
+                part_types.append(item_type)
+    return {
+        "session_update_kind": str(
+            update.get("sessionUpdate") or update.get("session_update") or ""
+        ).strip(),
+        "content_kind": type(content).__name__ if content is not None else "missing",
+        "content_part_count": len(content) if isinstance(content, list) else None,
+        "content_part_types": tuple(part_types),
+    }
+
+
 @dataclass(frozen=True)
 class ManagedThreadErrorMessages:
     public_execution_error: str
@@ -1159,6 +1205,8 @@ async def finalize_managed_thread_execution(
         async def _pump_runtime_events() -> None:
             raw_events_received = 0
             run_events_dispatched = 0
+            empty_session_update_events = 0
+            empty_session_update_kinds: dict[str, int] = {}
             try:
                 async for raw_event in harness_progress_event_stream(
                     started.harness,
@@ -1171,6 +1219,35 @@ async def finalize_managed_thread_execution(
                         raw_event,
                         event_state,
                     )
+                    raw_method = _runtime_raw_event_method(raw_event)
+                    if not run_events and raw_method == "session/update":
+                        content_summary = _runtime_raw_event_content_summary(raw_event)
+                        summary_kind = str(
+                            content_summary.get("session_update_kind") or "unknown"
+                        ).strip() or "unknown"
+                        if summary_kind in {"agent_message_chunk", "agent_thought_chunk"}:
+                            empty_session_update_events += 1
+                            empty_session_update_kinds[summary_kind] = (
+                                empty_session_update_kinds.get(summary_kind, 0) + 1
+                            )
+                            log_event(
+                                logger,
+                                logging.WARNING,
+                                "chat.managed_thread.session_update_unparsed",
+                                **_managed_thread_trace_fields(
+                                    managed_thread_id=managed_thread_id,
+                                    managed_turn_id=managed_turn_id,
+                                    backend_thread_id=stream_backend_thread_id or None,
+                                    backend_turn_id=stream_backend_turn_id or None,
+                                    surface=surface,
+                                ),
+                                raw_event=raw_event,
+                                event_state_completed=event_state.completed_seen,
+                                event_state_best_assistant_chars=len(
+                                    event_state.best_assistant_text()
+                                ),
+                                content_summary=content_summary,
+                            )
                     timeline_events.extend(run_events)
                     _persist_live_timeline_events(run_events)
                     if on_progress_event is None:
@@ -1222,6 +1299,8 @@ async def finalize_managed_thread_execution(
                     ),
                     raw_events_received=raw_events_received,
                     run_events_dispatched=run_events_dispatched,
+                    empty_session_update_events=empty_session_update_events,
+                    empty_session_update_kinds=empty_session_update_kinds,
                 )
 
         stream_task = asyncio.create_task(_pump_runtime_events())

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -1222,10 +1222,16 @@ async def finalize_managed_thread_execution(
                     raw_method = _runtime_raw_event_method(raw_event)
                     if not run_events and raw_method == "session/update":
                         content_summary = _runtime_raw_event_content_summary(raw_event)
-                        summary_kind = str(
-                            content_summary.get("session_update_kind") or "unknown"
-                        ).strip() or "unknown"
-                        if summary_kind in {"agent_message_chunk", "agent_thought_chunk"}:
+                        summary_kind = (
+                            str(
+                                content_summary.get("session_update_kind") or "unknown"
+                            ).strip()
+                            or "unknown"
+                        )
+                        if summary_kind in {
+                            "agent_message_chunk",
+                            "agent_thought_chunk",
+                        }:
                             empty_session_update_events += 1
                             empty_session_update_kinds[summary_kind] = (
                                 empty_session_update_kinds.get(summary_kind, 0) + 1

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -1034,6 +1034,19 @@ async def _deliver_discord_turn_result(
         preview_message_id = None
         send_final_message = True
 
+    log_event(
+        dispatch.service._logger,
+        logging.INFO,
+        "discord.turn.delivery_started",
+        channel_id=dispatch.channel_id,
+        session_key=dispatch.session_key,
+        preview_message_id=preview_message_id,
+        send_final_message=send_final_message,
+        response_chars=len(response_text or ""),
+        workspace_root=str(workspace_root),
+        agent=dispatch.agent,
+    )
+
     if isinstance(preview_message_id, str) and preview_message_id:
         await dispatch.service._delete_channel_message_safe(
             channel_id=dispatch.channel_id,
@@ -1060,6 +1073,19 @@ async def _deliver_discord_turn_result(
             workspace_root=workspace_root,
             channel_id=dispatch.channel_id,
         )
+    log_event(
+        dispatch.service._logger,
+        logging.INFO,
+        "discord.turn.delivery_finished",
+        channel_id=dispatch.channel_id,
+        session_key=dispatch.session_key,
+        preview_message_deleted=isinstance(preview_message_id, str)
+        and bool(preview_message_id),
+        send_final_message=send_final_message,
+        response_chars=len(response_text or ""),
+        flushed_outbox_files=send_final_message,
+        agent=dispatch.agent,
+    )
 
 
 async def handle_message_event(
@@ -1754,6 +1780,18 @@ async def _run_discord_orchestrated_turn_for_message(
             )
 
     if submission.queued:
+        log_event(
+            service._logger,
+            logging.INFO,
+            "discord.turn.managed_thread_submission",
+            channel_id=channel_id,
+            managed_thread_id=managed_thread_id,
+            execution_id=getattr(started_execution.execution, "execution_id", None),
+            backend_turn_id=getattr(started_execution.execution, "backend_id", None),
+            queued=True,
+            progress_message_id=progress_message_id,
+            agent=logical_agent,
+        )
         await _stop_progress_heartbeat()
         tracker.set_label("queued")
         try:
@@ -1769,6 +1807,18 @@ async def _run_discord_orchestrated_turn_for_message(
         return DiscordMessageTurnResult(
             final_message="Queued (waiting for available worker...)"
         )
+    log_event(
+        service._logger,
+        logging.INFO,
+        "discord.turn.managed_thread_submission",
+        channel_id=channel_id,
+        managed_thread_id=managed_thread_id,
+        execution_id=getattr(started_execution.execution, "execution_id", None),
+        backend_turn_id=getattr(started_execution.execution, "backend_id", None),
+        queued=False,
+        progress_message_id=progress_message_id,
+        agent=logical_agent,
+    )
 
     try:
         finalized_flow = await complete_managed_thread_execution(
@@ -1805,6 +1855,20 @@ async def _run_discord_orchestrated_turn_for_message(
 
     finalized = coerce_managed_thread_finalization_result(finalized_flow.finalized)
     assert finalized is not None
+    log_event(
+        service._logger,
+        logging.INFO,
+        "discord.turn.managed_thread_finalized",
+        channel_id=channel_id,
+        managed_thread_id=managed_thread_id,
+        status=finalized.status,
+        backend_thread_id=finalized.backend_thread_id,
+        preview_message_id=progress_message_id,
+        assistant_chars=len(str(finalized.assistant_text or "")),
+        token_usage_present=isinstance(finalized.token_usage, dict),
+        elapsed_ms=max(int((time.monotonic() - tracker.started_at) * 1000), 0),
+        agent=logical_agent,
+    )
     if finalized.status != "ok":
         if finalized.status == "interrupted":
             reuse_request = _peek_discord_progress_reuse_request(

--- a/tests/agents/acp/test_event_normalization.py
+++ b/tests/agents/acp/test_event_normalization.py
@@ -111,6 +111,75 @@ def test_normalize_notification_maps_session_update_message_chunk() -> None:
     assert event.delta == "hello"
 
 
+def test_normalize_notification_maps_session_update_message_chunk_with_content_parts() -> (
+    None
+):
+    event = normalize_notification(
+        {
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "turnId": "turn-1",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": [
+                        {"type": "text", "text": "hello"},
+                        {"type": "output_text", "text": " world"},
+                    ],
+                },
+            },
+        }
+    )
+
+    assert isinstance(event, ACPOutputDeltaEvent)
+    assert event.delta == "hello world"
+
+
+def test_normalize_notification_maps_session_update_message_chunk_with_message_parts() -> (
+    None
+):
+    event = normalize_notification(
+        {
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "turnId": "turn-1",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": [
+                        {"type": "message", "message": "hello"},
+                        {"type": "message", "text": " world"},
+                    ],
+                },
+            },
+        }
+    )
+
+    assert isinstance(event, ACPOutputDeltaEvent)
+    assert event.delta == "hello world"
+
+
+def test_normalize_notification_maps_session_update_thought_chunk_with_string_content() -> (
+    None
+):
+    event = normalize_notification(
+        {
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "turnId": "turn-1",
+                "update": {
+                    "sessionUpdate": "agent_thought_chunk",
+                    "content": "thinking hard",
+                },
+            },
+        }
+    )
+
+    assert isinstance(event, ACPProgressEvent)
+    assert event.message == "thinking hard"
+
+
 def test_normalize_notification_maps_session_idle_to_terminal_event() -> None:
     event = normalize_notification(
         {

--- a/tests/chat_surface_integration/test_hermes_pma_surfaces.py
+++ b/tests/chat_surface_integration/test_hermes_pma_surfaces.py
@@ -85,3 +85,50 @@ async def test_telegram_hermes_pma_uses_official_turn_delivery_flow(
     finally:
         await harness.close()
         await runtime.close()
+
+
+@pytest.mark.anyio
+async def test_discord_hermes_pma_handles_official_session_update_content_parts(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = HermesFixtureRuntime("official_content_parts")
+    patch_hermes_runtime(monkeypatch, runtime)
+    harness = DiscordSurfaceHarness(tmp_path / "discord")
+    await harness.setup(agent="hermes")
+    try:
+        rest = await harness.run_message("echo hello world")
+
+        assert any(
+            op["op"] == "send"
+            and "fixture reply" in str(op["payload"].get("content", ""))
+            for op in rest.message_ops
+        )
+        assert any(
+            op["op"] == "edit"
+            and "done" in str(op["payload"].get("content", "")).lower()
+            for op in rest.message_ops
+        )
+    finally:
+        await harness.close()
+        await runtime.close()
+
+
+@pytest.mark.anyio
+async def test_telegram_hermes_pma_handles_official_session_update_content_parts(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = HermesFixtureRuntime("official_content_parts")
+    patch_hermes_runtime(monkeypatch, runtime)
+    harness = TelegramSurfaceHarness(tmp_path / "telegram")
+    await harness.setup(agent="hermes")
+    try:
+        bot = await harness.run_message("echo hello world")
+
+        sent_texts = [str(item["text"]) for item in bot.messages]
+        assert sent_texts[0] == "Working..."
+        assert any("fixture reply" in text for text in sent_texts[1:])
+    finally:
+        await harness.close()
+        await runtime.close()

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -417,6 +417,71 @@ async def test_normalize_runtime_thread_raw_event_handles_official_session_updat
     assert state.token_usage == {"total_tokens": 42}
 
 
+async def test_normalize_runtime_thread_raw_event_preserves_session_update_object_shapes() -> (
+    None
+):
+    state = RuntimeThreadRunEventState()
+
+    progress = await normalize_runtime_thread_raw_event(
+        {
+            "message": {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "session-1",
+                    "turnId": "turn-1",
+                    "update": {
+                        "sessionUpdate": "agent_thought_chunk",
+                        "content": {"status": "thinking"},
+                    },
+                },
+            }
+        },
+        state,
+    )
+    output = await normalize_runtime_thread_raw_event(
+        {
+            "message": {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "session-1",
+                    "turnId": "turn-1",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"delta": "hello"},
+                    },
+                },
+            }
+        },
+        state,
+    )
+    output_with_output_key = await normalize_runtime_thread_raw_event(
+        {
+            "message": {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "session-1",
+                    "turnId": "turn-1",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"output": " world"},
+                    },
+                },
+            }
+        },
+        state,
+    )
+
+    assert len(progress) == 1
+    assert isinstance(progress[0], RunNotice)
+    assert progress[0].message == "thinking"
+    assert len(output) == 1
+    assert isinstance(output[0], OutputDelta)
+    assert output[0].content == "hello"
+    assert len(output_with_output_key) == 1
+    assert isinstance(output_with_output_key[0], OutputDelta)
+    assert output_with_output_key[0].content == " world"
+
+
 async def test_normalize_runtime_thread_raw_event_handles_official_session_update_content_parts() -> (
     None
 ):
@@ -433,7 +498,7 @@ async def test_normalize_runtime_thread_raw_event_handles_official_session_updat
                         "sessionUpdate": "agent_thought_chunk",
                         "content": [
                             {"type": "text", "text": "thinking"},
-                            {"type": "output_text", "text": " more"},
+                            {"type": "message", "message": " more"},
                         ],
                     },
                 },

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -417,6 +417,58 @@ async def test_normalize_runtime_thread_raw_event_handles_official_session_updat
     assert state.token_usage == {"total_tokens": 42}
 
 
+async def test_normalize_runtime_thread_raw_event_handles_official_session_update_content_parts() -> (
+    None
+):
+    state = RuntimeThreadRunEventState()
+
+    thinking = await normalize_runtime_thread_raw_event(
+        {
+            "message": {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "session-1",
+                    "turnId": "turn-1",
+                    "update": {
+                        "sessionUpdate": "agent_thought_chunk",
+                        "content": [
+                            {"type": "text", "text": "thinking"},
+                            {"type": "output_text", "text": " more"},
+                        ],
+                    },
+                },
+            }
+        },
+        state,
+    )
+    output = await normalize_runtime_thread_raw_event(
+        {
+            "message": {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "session-1",
+                    "turnId": "turn-1",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": [
+                            {"type": "text", "text": "hello"},
+                            {"type": "output_text", "text": " world"},
+                        ],
+                    },
+                },
+            }
+        },
+        state,
+    )
+
+    assert len(thinking) == 1
+    assert isinstance(thinking[0], RunNotice)
+    assert thinking[0].message == "thinking more"
+    assert len(output) == 1
+    assert isinstance(output[0], OutputDelta)
+    assert output[0].content == "hello world"
+
+
 async def test_recover_post_completion_outcome_uses_streamed_output_after_completion() -> (
     None
 ):

--- a/tests/fixtures/fake_acp_server.py
+++ b/tests/fixtures/fake_acp_server.py
@@ -249,6 +249,17 @@ class FakeACPServer:
         prompt: str,
     ) -> None:
         cancel_event = self._session_cancel_events[session_id]
+        thought_content: Any = {"type": "text", "text": "thinking"}
+        reply_content: Any = {"type": "text", "text": "fixture reply"}
+        if self._scenario == "official_content_parts":
+            thought_content = [
+                {"type": "text", "text": "thinking"},
+                {"type": "output_text", "text": " more"},
+            ]
+            reply_content = [
+                {"type": "text", "text": "fixture"},
+                {"type": "output_text", "text": " reply"},
+            ]
         self.send(
             {
                 "method": "session/update",
@@ -256,7 +267,7 @@ class FakeACPServer:
                     "sessionId": session_id,
                     "update": {
                         "sessionUpdate": "agent_thought_chunk",
-                        "content": {"type": "text", "text": "thinking"},
+                        "content": thought_content,
                     },
                 },
             }
@@ -347,7 +358,7 @@ class FakeACPServer:
                     "sessionId": session_id,
                     "update": {
                         "sessionUpdate": "agent_message_chunk",
-                        "content": {"type": "text", "text": "fixture reply"},
+                        "content": reply_content,
                     },
                 },
             }


### PR DESCRIPTION
## What changed

This hardens the Hermes official ACP path used by PMA turns so Discord and Telegram both handle richer `session/update` payloads correctly.

It also adds telemetry around the ACP ingress, managed-thread progress pump, and Discord PMA delivery lifecycle so we can tell whether a turn stalled during event normalization, managed-thread finalization, or Discord delivery.

## Why

Discord PMA turns were hanging indefinitely while Telegram showed progress and completed normally. The integration harness was not reproducing the issue because newer Hermes `session/update` payload shapes were not covered.

## Root cause

Hermes can emit `session/update` content as strings, dicts, or multi-part lists including `output_text` and `message` parts. The Discord PMA path was dropping those richer payloads during normalization, which meant progress and final assistant output could be lost even though the underlying session continued.

## Impact

Discord PMA is now resilient to the newer Hermes payload shapes, Telegram and Discord are covered by the same repro scenario, and the new structured logs should make future regressions much faster to triage.

## Validation

- `.venv/bin/pytest tests/agents/acp/test_event_normalization.py tests/core/orchestration/test_runtime_thread_events.py -q`
- `.venv/bin/pytest tests/chat_surface_integration/test_hermes_pma_surfaces.py -q`
- `.venv/bin/pytest tests/agents/acp/test_client.py -q`
- `.venv/bin/pytest tests/integrations/chat/test_hermes_official_completion.py -q`
- `python -m py_compile src/codex_autorunner/agents/acp/client.py src/codex_autorunner/integrations/chat/managed_thread_turns.py src/codex_autorunner/integrations/discord/message_turns.py`
- Full pre-commit suite during `git commit` including mypy, frontend build/tests, and `pytest` repo-wide (`4701 passed`)

## Review

A mini subagent review found two follow-ups before publish:

- accept `type: "message"` parts in ACP event normalization
- avoid noisy managed-thread warnings for unrelated no-op `session/update` traffic

Both were fixed in this branch before push.