### PR TITLE
[codex] Handle transient Discord PMA progress failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ test-managed-thread-cutover:
 		tests/test_telegram_status_rate_limits.py \
 		tests/integrations/discord/test_service_routing.py \
 		tests/integrations/discord/test_message_turns.py \
+		tests/integrations/discord/test_message_turns_transient_progress.py \
 		tests/test_redaction.py
 
 test-integration:

--- a/docs/ops/collaboration-verification.md
+++ b/docs/ops/collaboration-verification.md
@@ -33,6 +33,7 @@ Or run the collaboration-specific subset:
   tests/test_telegram_bot_integration.py \
   tests/test_doctor_checks.py \
   tests/integrations/discord/test_message_turns.py \
+  tests/integrations/discord/test_message_turns_transient_progress.py \
   tests/integrations/discord/test_service_routing.py \
   tests/integrations/discord/test_doctor_checks.py \
   tests/integrations/discord/test_config.py \

--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -1189,7 +1189,8 @@ class ACPClient:
             text_length=state.last_session_update_text_length,
         )
         if (
-            state.last_session_update_kind in {"agent_message_chunk", "agent_thought_chunk"}
+            state.last_session_update_kind
+            in {"agent_message_chunk", "agent_thought_chunk"}
             and not extracted_text
         ):
             self._log_trace_event(

--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -109,6 +109,9 @@ class _PromptState:
     request_started_at: Optional[float] = None
     last_session_update_kind: Optional[str] = None
     last_session_update_excerpt: Optional[str] = None
+    last_session_update_content_kind: Optional[str] = None
+    last_session_update_part_types: tuple[str, ...] = ()
+    last_session_update_text_length: Optional[int] = None
     last_session_update_at: Optional[float] = None
 
 
@@ -127,6 +130,55 @@ def _text_excerpt(value: Any, *, limit: int = 120) -> Optional[str]:
     if len(normalized) <= limit:
         return normalized
     return normalized[: limit - 3] + "..."
+
+
+def _extract_text_content(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        for key in ("text", "message"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate:
+                return candidate
+        return _extract_text_content(value.get("content"))
+    if isinstance(value, list):
+        text_parts: list[str] = []
+        for item in value:
+            if isinstance(item, str) and item:
+                text_parts.append(item)
+                continue
+            if not isinstance(item, dict):
+                continue
+            item_type = _normalize_optional_text(item.get("type"))
+            if item_type and item_type not in {"text", "output_text", "message"}:
+                continue
+            text = _extract_text_content(item)
+            if text:
+                text_parts.append(text)
+        return "".join(text_parts)
+    return ""
+
+
+def _session_update_content_summary(update: dict[str, Any]) -> dict[str, Any]:
+    content = update.get("content")
+    part_types: list[str] = []
+    if isinstance(content, list):
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            item_type = _normalize_optional_text(item.get("type"))
+            if item_type:
+                part_types.append(item_type)
+    extracted_text = _extract_text_content(content)
+    if not extracted_text:
+        fallback_message = update.get("message")
+        if isinstance(fallback_message, str):
+            extracted_text = fallback_message
+    return {
+        "content_kind": type(content).__name__ if content is not None else "missing",
+        "content_part_types": tuple(part_types),
+        "text": extracted_text,
+    }
 
 
 def _stringify(value: Any) -> str:
@@ -1096,6 +1148,9 @@ class ACPClient:
         return {
             "last_session_update_kind": state.last_session_update_kind,
             "last_session_update_excerpt": state.last_session_update_excerpt,
+            "last_session_update_content_kind": state.last_session_update_content_kind,
+            "last_session_update_part_types": state.last_session_update_part_types,
+            "last_session_update_text_length": state.last_session_update_text_length,
             "last_session_update_elapsed_ms": self._elapsed_ms(
                 state.last_session_update_at
             ),
@@ -1105,15 +1160,22 @@ class ACPClient:
         if event.method != "session/update":
             return
         update = _coerce_mapping(event.payload.get("update"))
-        content = _coerce_mapping(update.get("content"))
+        content_summary = _session_update_content_summary(update)
+        extracted_text = str(content_summary.get("text") or "")
         state.last_session_update_kind = _normalize_optional_text(
             update.get("sessionUpdate") or update.get("session_update")
         )
-        state.last_session_update_excerpt = _text_excerpt(
-            content.get("text")
-            or update.get("message")
-            or event.payload.get("message")
-            or ""
+        state.last_session_update_excerpt = _text_excerpt(extracted_text)
+        state.last_session_update_content_kind = _normalize_optional_text(
+            content_summary.get("content_kind")
+        )
+        state.last_session_update_part_types = tuple(
+            str(item)
+            for item in (content_summary.get("content_part_types") or ())
+            if str(item).strip()
+        )
+        state.last_session_update_text_length = (
+            len(extracted_text) if extracted_text else 0
         )
         state.last_session_update_at = time.monotonic()
         self._log_trace_event(
@@ -1122,7 +1184,23 @@ class ACPClient:
             turn_id=state.turn_id,
             session_update=state.last_session_update_kind,
             text_excerpt=state.last_session_update_excerpt,
+            content_kind=state.last_session_update_content_kind,
+            content_part_types=state.last_session_update_part_types,
+            text_length=state.last_session_update_text_length,
         )
+        if (
+            state.last_session_update_kind in {"agent_message_chunk", "agent_thought_chunk"}
+            and not extracted_text
+        ):
+            self._log_trace_event(
+                "acp.prompt.session_update.unparsed",
+                session_id=state.session_id,
+                turn_id=state.turn_id,
+                session_update=state.last_session_update_kind,
+                content_kind=state.last_session_update_content_kind,
+                content_part_types=state.last_session_update_part_types,
+                raw_update=update,
+            )
 
     def _response_error(
         self, method: Optional[str], payload: dict[str, Any]

--- a/src/codex_autorunner/agents/acp/events.py
+++ b/src/codex_autorunner/agents/acp/events.py
@@ -29,6 +29,32 @@ def _extract_text(payload: Mapping[str, Any], *keys: str) -> Optional[str]:
     return None
 
 
+def _extract_text_content(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        text = _extract_text(value, "text", "message")
+        if text:
+            return text
+        return _extract_text_content(value.get("content"))
+    if isinstance(value, list):
+        text_parts: list[str] = []
+        for item in value:
+            if isinstance(item, str) and item:
+                text_parts.append(item)
+                continue
+            if not isinstance(item, Mapping):
+                continue
+            item_type = _normalize_optional_text(item.get("type"))
+            if item_type and item_type not in {"text", "output_text", "message"}:
+                continue
+            part_text = _extract_text_content(item)
+            if part_text:
+                text_parts.append(part_text)
+        return "".join(text_parts)
+    return ""
+
+
 def _session_update_kind(payload: Mapping[str, Any]) -> Optional[str]:
     value = payload.get("sessionUpdate")
     if value is None:
@@ -227,8 +253,9 @@ def normalize_notification(message: Mapping[str, Any]) -> ACPEvent:
     if method == "session/update":
         update = _coerce_mapping(payload.get("update"))
         update_kind = _session_update_kind(update) or ""
-        content = _coerce_mapping(update.get("content"))
-        text = _extract_text(content, "text") or ""
+        text = _extract_text_content(update.get("content")) or ""
+        if not text:
+            text = _extract_text(update, "message") or ""
         if update_kind == "agent_message_chunk":
             return ACPOutputDeltaEvent(
                 kind="output_delta",

--- a/src/codex_autorunner/core/orchestration/opencode_event_fields.py
+++ b/src/codex_autorunner/core/orchestration/opencode_event_fields.py
@@ -10,6 +10,39 @@ def coerce_dict(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def _extract_text_content(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        text = value.get("text")
+        if isinstance(text, str) and text:
+            return text
+        message = value.get("message")
+        if isinstance(message, str) and message:
+            return message
+        return _extract_text_content(value.get("content"))
+    if isinstance(value, list):
+        parts: list[str] = []
+        for entry in value:
+            if isinstance(entry, str) and entry:
+                parts.append(entry)
+                continue
+            if not isinstance(entry, dict):
+                continue
+            entry_type = entry.get("type")
+            if isinstance(entry_type, str) and entry_type not in (
+                "text",
+                "output_text",
+                "message",
+            ):
+                continue
+            text = _extract_text_content(entry)
+            if text:
+                parts.append(text)
+        return "".join(parts)
+    return ""
+
+
 def extract_message_properties(params: dict[str, Any]) -> dict[str, Any]:
     return coerce_dict(params.get("properties"))
 
@@ -108,12 +141,9 @@ def extract_output_delta(
 ) -> str:
     for key in ("content", "delta", "text", "output"):
         value = params.get(key)
-        if isinstance(value, str) and value:
-            return value
-        if isinstance(value, dict):
-            nested_text = value.get("text")
-            if isinstance(nested_text, str) and nested_text:
-                return nested_text
+        extracted = _extract_text_content(value)
+        if extracted:
+            return extracted
     properties = extract_message_properties(params)
     delta_raw = properties.get("delta")
     if isinstance(delta_raw, str) and delta_raw:

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -406,10 +406,7 @@ def normalize_runtime_thread_message(
         update_kind = _extract_session_update_kind(update)
         if update_kind == "agent_message_chunk":
             return _assistant_stream_events(
-                {
-                    "content": update.get("content"),
-                    "message": update.get("message"),
-                },
+                _extract_session_update_message_params(update),
                 state,
                 timestamp=event_timestamp,
             )
@@ -925,15 +922,35 @@ def _extract_session_update_kind(update: dict[str, Any]) -> str:
     return ""
 
 
+def _extract_session_update_message_params(update: dict[str, Any]) -> dict[str, Any]:
+    content = update.get("content")
+    if isinstance(content, dict):
+        params = dict(content)
+        message = update.get("message")
+        if isinstance(message, str) and message.strip() and "message" not in params:
+            params["message"] = message
+        return params
+    return {
+        "content": content,
+        "message": update.get("message"),
+    }
+
+
 def _extract_session_update_text(update: dict[str, Any]) -> str:
     content = update.get("content")
     if isinstance(content, str) and content.strip():
         return content
     if isinstance(content, dict):
-        for key in ("text", "message"):
+        for key in ("text", "message", "status"):
             value = content.get(key)
             if isinstance(value, str) and value.strip():
                 return value
+        progress_message = _extract_acp_progress_message(content)
+        if progress_message:
+            return progress_message
+        output_delta = _extract_output_delta(content)
+        if output_delta:
+            return output_delta
     if isinstance(content, list):
         text_parts: list[str] = []
         for entry in content:
@@ -949,12 +966,19 @@ def _extract_session_update_text(update: dict[str, Any]) -> str:
                 "message",
             ):
                 continue
-            entry_text = entry.get("text")
-            if isinstance(entry_text, str) and entry_text:
+            entry_text = ""
+            message_text = entry.get("message")
+            if isinstance(message_text, str) and message_text:
+                entry_text = message_text
+            if not entry_text:
+                entry_text = _extract_output_delta(entry)
+            if not entry_text:
+                entry_text = _extract_acp_progress_message(entry)
+            if entry_text:
                 text_parts.append(entry_text)
         if text_parts:
             return "".join(text_parts)
-    return str(update.get("message") or "").strip()
+    return _extract_acp_progress_message(update)
 
 
 def _extract_acp_progress_message(params: dict[str, Any]) -> str:

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -405,17 +405,16 @@ def normalize_runtime_thread_message(
         update = _extract_session_update(params)
         update_kind = _extract_session_update_kind(update)
         if update_kind == "agent_message_chunk":
-            session_update_content = _extract_session_update_content(update)
             return _assistant_stream_events(
-                session_update_content,
+                {
+                    "content": update.get("content"),
+                    "message": update.get("message"),
+                },
                 state,
                 timestamp=event_timestamp,
             )
         if update_kind == "agent_thought_chunk":
-            session_update_content = _extract_session_update_content(update)
-            progress_message = _extract_acp_progress_message(
-                session_update_content
-            ) or _extract_output_delta(session_update_content)
+            progress_message = _extract_session_update_text(update)
             if not progress_message:
                 return []
             return [
@@ -925,9 +924,36 @@ def _extract_session_update_kind(update: dict[str, Any]) -> str:
             return value.strip()
     return ""
 
-
-def _extract_session_update_content(update: dict[str, Any]) -> dict[str, Any]:
-    return _coerce_dict(update.get("content"))
+def _extract_session_update_text(update: dict[str, Any]) -> str:
+    content = update.get("content")
+    if isinstance(content, str) and content.strip():
+        return content
+    if isinstance(content, dict):
+        for key in ("text", "message"):
+            value = content.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+    if isinstance(content, list):
+        text_parts: list[str] = []
+        for entry in content:
+            if isinstance(entry, str) and entry:
+                text_parts.append(entry)
+                continue
+            if not isinstance(entry, dict):
+                continue
+            entry_type = entry.get("type")
+            if isinstance(entry_type, str) and entry_type not in (
+                "text",
+                "output_text",
+                "message",
+            ):
+                continue
+            entry_text = entry.get("text")
+            if isinstance(entry_text, str) and entry_text:
+                text_parts.append(entry_text)
+        if text_parts:
+            return "".join(text_parts)
+    return str(update.get("message") or "").strip()
 
 
 def _extract_acp_progress_message(params: dict[str, Any]) -> str:

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -924,6 +924,7 @@ def _extract_session_update_kind(update: dict[str, Any]) -> str:
             return value.strip()
     return ""
 
+
 def _extract_session_update_text(update: dict[str, Any]) -> str:
     content = update.get("content")
     if isinstance(content, str) and content.strip():

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -103,6 +103,52 @@ _DIRECT_RUN_EVENT_TYPES = (
 )
 
 
+def _runtime_raw_event_message(raw_event: Any) -> dict[str, Any]:
+    if not isinstance(raw_event, dict):
+        return {}
+    message = raw_event.get("message")
+    if isinstance(message, dict):
+        return message
+    return raw_event
+
+
+def _runtime_raw_event_method(raw_event: Any) -> str:
+    message = _runtime_raw_event_message(raw_event)
+    return str(message.get("method") or "").strip()
+
+
+def _runtime_raw_event_session_update(raw_event: Any) -> dict[str, Any]:
+    message = _runtime_raw_event_message(raw_event)
+    params = message.get("params")
+    if not isinstance(params, dict):
+        return {}
+    update = params.get("update")
+    if isinstance(update, dict):
+        return update
+    return {}
+
+
+def _runtime_raw_event_content_summary(raw_event: Any) -> dict[str, Any]:
+    update = _runtime_raw_event_session_update(raw_event)
+    content = update.get("content")
+    part_types: list[str] = []
+    if isinstance(content, list):
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            item_type = str(item.get("type") or "").strip()
+            if item_type:
+                part_types.append(item_type)
+    return {
+        "session_update_kind": str(
+            update.get("sessionUpdate") or update.get("session_update") or ""
+        ).strip(),
+        "content_kind": type(content).__name__ if content is not None else "missing",
+        "content_part_count": len(content) if isinstance(content, list) else None,
+        "content_part_types": tuple(part_types),
+    }
+
+
 @dataclass(frozen=True)
 class ManagedThreadErrorMessages:
     public_execution_error: str
@@ -1159,6 +1205,8 @@ async def finalize_managed_thread_execution(
         async def _pump_runtime_events() -> None:
             raw_events_received = 0
             run_events_dispatched = 0
+            empty_session_update_events = 0
+            empty_session_update_kinds: dict[str, int] = {}
             try:
                 async for raw_event in harness_progress_event_stream(
                     started.harness,
@@ -1171,6 +1219,35 @@ async def finalize_managed_thread_execution(
                         raw_event,
                         event_state,
                     )
+                    raw_method = _runtime_raw_event_method(raw_event)
+                    if not run_events and raw_method == "session/update":
+                        content_summary = _runtime_raw_event_content_summary(raw_event)
+                        summary_kind = str(
+                            content_summary.get("session_update_kind") or "unknown"
+                        ).strip() or "unknown"
+                        if summary_kind in {"agent_message_chunk", "agent_thought_chunk"}:
+                            empty_session_update_events += 1
+                            empty_session_update_kinds[summary_kind] = (
+                                empty_session_update_kinds.get(summary_kind, 0) + 1
+                            )
+                            log_event(
+                                logger,
+                                logging.WARNING,
+                                "chat.managed_thread.session_update_unparsed",
+                                **_managed_thread_trace_fields(
+                                    managed_thread_id=managed_thread_id,
+                                    managed_turn_id=managed_turn_id,
+                                    backend_thread_id=stream_backend_thread_id or None,
+                                    backend_turn_id=stream_backend_turn_id or None,
+                                    surface=surface,
+                                ),
+                                raw_event=raw_event,
+                                event_state_completed=event_state.completed_seen,
+                                event_state_best_assistant_chars=len(
+                                    event_state.best_assistant_text()
+                                ),
+                                content_summary=content_summary,
+                            )
                     timeline_events.extend(run_events)
                     _persist_live_timeline_events(run_events)
                     if on_progress_event is None:
@@ -1222,6 +1299,8 @@ async def finalize_managed_thread_execution(
                     ),
                     raw_events_received=raw_events_received,
                     run_events_dispatched=run_events_dispatched,
+                    empty_session_update_events=empty_session_update_events,
+                    empty_session_update_kinds=empty_session_update_kinds,
                 )
 
         stream_task = asyncio.create_task(_pump_runtime_events())

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -1222,10 +1222,16 @@ async def finalize_managed_thread_execution(
                     raw_method = _runtime_raw_event_method(raw_event)
                     if not run_events and raw_method == "session/update":
                         content_summary = _runtime_raw_event_content_summary(raw_event)
-                        summary_kind = str(
-                            content_summary.get("session_update_kind") or "unknown"
-                        ).strip() or "unknown"
-                        if summary_kind in {"agent_message_chunk", "agent_thought_chunk"}:
+                        summary_kind = (
+                            str(
+                                content_summary.get("session_update_kind") or "unknown"
+                            ).strip()
+                            or "unknown"
+                        )
+                        if summary_kind in {
+                            "agent_message_chunk",
+                            "agent_thought_chunk",
+                        }:
                             empty_session_update_events += 1
                             empty_session_update_kinds[summary_kind] = (
                                 empty_session_update_kinds.get(summary_kind, 0) + 1

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -1034,6 +1034,19 @@ async def _deliver_discord_turn_result(
         preview_message_id = None
         send_final_message = True
 
+    log_event(
+        dispatch.service._logger,
+        logging.INFO,
+        "discord.turn.delivery_started",
+        channel_id=dispatch.channel_id,
+        session_key=dispatch.session_key,
+        preview_message_id=preview_message_id,
+        send_final_message=send_final_message,
+        response_chars=len(response_text or ""),
+        workspace_root=str(workspace_root),
+        agent=dispatch.agent,
+    )
+
     if isinstance(preview_message_id, str) and preview_message_id:
         await dispatch.service._delete_channel_message_safe(
             channel_id=dispatch.channel_id,
@@ -1060,6 +1073,19 @@ async def _deliver_discord_turn_result(
             workspace_root=workspace_root,
             channel_id=dispatch.channel_id,
         )
+    log_event(
+        dispatch.service._logger,
+        logging.INFO,
+        "discord.turn.delivery_finished",
+        channel_id=dispatch.channel_id,
+        session_key=dispatch.session_key,
+        preview_message_deleted=isinstance(preview_message_id, str)
+        and bool(preview_message_id),
+        send_final_message=send_final_message,
+        response_chars=len(response_text or ""),
+        flushed_outbox_files=send_final_message,
+        agent=dispatch.agent,
+    )
 
 
 async def handle_message_event(
@@ -1754,6 +1780,18 @@ async def _run_discord_orchestrated_turn_for_message(
             )
 
     if submission.queued:
+        log_event(
+            service._logger,
+            logging.INFO,
+            "discord.turn.managed_thread_submission",
+            channel_id=channel_id,
+            managed_thread_id=managed_thread_id,
+            execution_id=getattr(started_execution.execution, "execution_id", None),
+            backend_turn_id=getattr(started_execution.execution, "backend_id", None),
+            queued=True,
+            progress_message_id=progress_message_id,
+            agent=logical_agent,
+        )
         await _stop_progress_heartbeat()
         tracker.set_label("queued")
         try:
@@ -1769,6 +1807,18 @@ async def _run_discord_orchestrated_turn_for_message(
         return DiscordMessageTurnResult(
             final_message="Queued (waiting for available worker...)"
         )
+    log_event(
+        service._logger,
+        logging.INFO,
+        "discord.turn.managed_thread_submission",
+        channel_id=channel_id,
+        managed_thread_id=managed_thread_id,
+        execution_id=getattr(started_execution.execution, "execution_id", None),
+        backend_turn_id=getattr(started_execution.execution, "backend_id", None),
+        queued=False,
+        progress_message_id=progress_message_id,
+        agent=logical_agent,
+    )
 
     try:
         finalized_flow = await complete_managed_thread_execution(
@@ -1805,6 +1855,20 @@ async def _run_discord_orchestrated_turn_for_message(
 
     finalized = coerce_managed_thread_finalization_result(finalized_flow.finalized)
     assert finalized is not None
+    log_event(
+        service._logger,
+        logging.INFO,
+        "discord.turn.managed_thread_finalized",
+        channel_id=channel_id,
+        managed_thread_id=managed_thread_id,
+        status=finalized.status,
+        backend_thread_id=finalized.backend_thread_id,
+        preview_message_id=progress_message_id,
+        assistant_chars=len(str(finalized.assistant_text or "")),
+        token_usage_present=isinstance(finalized.token_usage, dict),
+        elapsed_ms=max(int((time.monotonic() - tracker.started_at) * 1000), 0),
+        agent=logical_agent,
+    )
     if finalized.status != "ok":
         if finalized.status == "interrupted":
             reuse_request = _peek_discord_progress_reuse_request(

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -88,6 +88,7 @@ from ..chat.turn_metrics import (
     compose_turn_response_with_footer,
 )
 from .components import build_cancel_turn_button, build_cancel_turn_custom_id
+from .errors import DiscordTransientError
 from .rendering import (
     chunk_discord_message,
     format_discord_message,
@@ -401,7 +402,7 @@ async def _acknowledge_discord_progress_reuse(
                 "components": [],
             },
         )
-    except (RuntimeError, ConnectionError, OSError):
+    except (DiscordTransientError, RuntimeError, ConnectionError, OSError):
         return False
     return True
 
@@ -1588,7 +1589,7 @@ async def _run_discord_orchestrated_turn_for_message(
                 message_id=progress_message_id,
                 payload=payload,
             )
-        except (RuntimeError, ConnectionError, OSError):
+        except (DiscordTransientError, RuntimeError, ConnectionError, OSError):
             _logger.debug(
                 "Discord progress edit failed for message=%s",
                 progress_message_id,
@@ -1688,7 +1689,7 @@ async def _run_discord_orchestrated_turn_for_message(
                 progress_rendered = initial_content
                 progress_last_updated = time.monotonic()
                 progress_heartbeat_task = asyncio.create_task(_progress_heartbeat())
-    except (RuntimeError, ConnectionError, OSError):
+    except (DiscordTransientError, RuntimeError, ConnectionError, OSError):
         service._logger.warning(
             "Discord progress placeholder send failed for channel=%s",
             channel_id,

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -170,6 +170,36 @@ async def test_client_official_prompt_stays_non_terminal_until_request_returns(
 
 
 @pytest.mark.asyncio
+async def test_client_official_prompt_hang_tracks_last_session_update_state(
+    tmp_path: Path,
+) -> None:
+    client = ACPClient(fixture_command("official_prompt_hang"), cwd=tmp_path)
+    try:
+        created = await client.create_session(cwd=str(tmp_path))
+        handle = await client.start_prompt(created.session_id, "Reply with exactly OK.")
+        for _ in range(20):
+            state = client._prompts.get(handle.turn_id)
+            if (
+                state is not None
+                and state.last_session_update_kind == "agent_message_chunk"
+            ):
+                break
+            await asyncio.sleep(0.01)
+
+        state = client._prompts[handle.turn_id]
+
+        assert client._session_active_turns[created.session_id] == handle.turn_id
+        assert state.last_session_update_kind == "agent_message_chunk"
+        assert state.last_session_update_excerpt == "fixture reply"
+        assert state.last_session_update_content_kind == "dict"
+        assert state.last_session_update_part_types == ()
+        assert state.last_session_update_text_length == len("fixture reply")
+        assert state.last_session_update_at is not None
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
 async def test_client_logs_official_prompt_lifecycle_trace(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/agents/acp/test_event_normalization.py
+++ b/tests/agents/acp/test_event_normalization.py
@@ -111,6 +111,75 @@ def test_normalize_notification_maps_session_update_message_chunk() -> None:
     assert event.delta == "hello"
 
 
+def test_normalize_notification_maps_session_update_message_chunk_with_content_parts() -> (
+    None
+):
+    event = normalize_notification(
+        {
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "turnId": "turn-1",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": [
+                        {"type": "text", "text": "hello"},
+                        {"type": "output_text", "text": " world"},
+                    ],
+                },
+            },
+        }
+    )
+
+    assert isinstance(event, ACPOutputDeltaEvent)
+    assert event.delta == "hello world"
+
+
+def test_normalize_notification_maps_session_update_message_chunk_with_message_parts() -> (
+    None
+):
+    event = normalize_notification(
+        {
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "turnId": "turn-1",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": [
+                        {"type": "message", "message": "hello"},
+                        {"type": "message", "text": " world"},
+                    ],
+                },
+            },
+        }
+    )
+
+    assert isinstance(event, ACPOutputDeltaEvent)
+    assert event.delta == "hello world"
+
+
+def test_normalize_notification_maps_session_update_thought_chunk_with_string_content() -> (
+    None
+):
+    event = normalize_notification(
+        {
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "turnId": "turn-1",
+                "update": {
+                    "sessionUpdate": "agent_thought_chunk",
+                    "content": "thinking hard",
+                },
+            },
+        }
+    )
+
+    assert isinstance(event, ACPProgressEvent)
+    assert event.message == "thinking hard"
+
+
 def test_normalize_notification_maps_session_idle_to_terminal_event() -> None:
     event = normalize_notification(
         {

--- a/tests/chat_surface_integration/test_hermes_pma_surfaces.py
+++ b/tests/chat_surface_integration/test_hermes_pma_surfaces.py
@@ -85,3 +85,50 @@ async def test_telegram_hermes_pma_uses_official_turn_delivery_flow(
     finally:
         await harness.close()
         await runtime.close()
+
+
+@pytest.mark.anyio
+async def test_discord_hermes_pma_handles_official_session_update_content_parts(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = HermesFixtureRuntime("official_content_parts")
+    patch_hermes_runtime(monkeypatch, runtime)
+    harness = DiscordSurfaceHarness(tmp_path / "discord")
+    await harness.setup(agent="hermes")
+    try:
+        rest = await harness.run_message("echo hello world")
+
+        assert any(
+            op["op"] == "send"
+            and "fixture reply" in str(op["payload"].get("content", ""))
+            for op in rest.message_ops
+        )
+        assert any(
+            op["op"] == "edit"
+            and "done" in str(op["payload"].get("content", "")).lower()
+            for op in rest.message_ops
+        )
+    finally:
+        await harness.close()
+        await runtime.close()
+
+
+@pytest.mark.anyio
+async def test_telegram_hermes_pma_handles_official_session_update_content_parts(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = HermesFixtureRuntime("official_content_parts")
+    patch_hermes_runtime(monkeypatch, runtime)
+    harness = TelegramSurfaceHarness(tmp_path / "telegram")
+    await harness.setup(agent="hermes")
+    try:
+        bot = await harness.run_message("echo hello world")
+
+        sent_texts = [str(item["text"]) for item in bot.messages]
+        assert sent_texts[0] == "Working..."
+        assert any("fixture reply" in text for text in sent_texts[1:])
+    finally:
+        await harness.close()
+        await runtime.close()

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -417,6 +417,71 @@ async def test_normalize_runtime_thread_raw_event_handles_official_session_updat
     assert state.token_usage == {"total_tokens": 42}
 
 
+async def test_normalize_runtime_thread_raw_event_preserves_session_update_object_shapes() -> (
+    None
+):
+    state = RuntimeThreadRunEventState()
+
+    progress = await normalize_runtime_thread_raw_event(
+        {
+            "message": {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "session-1",
+                    "turnId": "turn-1",
+                    "update": {
+                        "sessionUpdate": "agent_thought_chunk",
+                        "content": {"status": "thinking"},
+                    },
+                },
+            }
+        },
+        state,
+    )
+    output = await normalize_runtime_thread_raw_event(
+        {
+            "message": {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "session-1",
+                    "turnId": "turn-1",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"delta": "hello"},
+                    },
+                },
+            }
+        },
+        state,
+    )
+    output_with_output_key = await normalize_runtime_thread_raw_event(
+        {
+            "message": {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "session-1",
+                    "turnId": "turn-1",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"output": " world"},
+                    },
+                },
+            }
+        },
+        state,
+    )
+
+    assert len(progress) == 1
+    assert isinstance(progress[0], RunNotice)
+    assert progress[0].message == "thinking"
+    assert len(output) == 1
+    assert isinstance(output[0], OutputDelta)
+    assert output[0].content == "hello"
+    assert len(output_with_output_key) == 1
+    assert isinstance(output_with_output_key[0], OutputDelta)
+    assert output_with_output_key[0].content == " world"
+
+
 async def test_normalize_runtime_thread_raw_event_handles_official_session_update_content_parts() -> (
     None
 ):
@@ -433,7 +498,7 @@ async def test_normalize_runtime_thread_raw_event_handles_official_session_updat
                         "sessionUpdate": "agent_thought_chunk",
                         "content": [
                             {"type": "text", "text": "thinking"},
-                            {"type": "output_text", "text": " more"},
+                            {"type": "message", "message": " more"},
                         ],
                     },
                 },

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -417,6 +417,58 @@ async def test_normalize_runtime_thread_raw_event_handles_official_session_updat
     assert state.token_usage == {"total_tokens": 42}
 
 
+async def test_normalize_runtime_thread_raw_event_handles_official_session_update_content_parts() -> (
+    None
+):
+    state = RuntimeThreadRunEventState()
+
+    thinking = await normalize_runtime_thread_raw_event(
+        {
+            "message": {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "session-1",
+                    "turnId": "turn-1",
+                    "update": {
+                        "sessionUpdate": "agent_thought_chunk",
+                        "content": [
+                            {"type": "text", "text": "thinking"},
+                            {"type": "output_text", "text": " more"},
+                        ],
+                    },
+                },
+            }
+        },
+        state,
+    )
+    output = await normalize_runtime_thread_raw_event(
+        {
+            "message": {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "session-1",
+                    "turnId": "turn-1",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": [
+                            {"type": "text", "text": "hello"},
+                            {"type": "output_text", "text": " world"},
+                        ],
+                    },
+                },
+            }
+        },
+        state,
+    )
+
+    assert len(thinking) == 1
+    assert isinstance(thinking[0], RunNotice)
+    assert thinking[0].message == "thinking more"
+    assert len(output) == 1
+    assert isinstance(output[0], OutputDelta)
+    assert output[0].content == "hello world"
+
+
 async def test_recover_post_completion_outcome_uses_streamed_output_after_completion() -> (
     None
 ):

--- a/tests/discord_message_turns_support.py
+++ b/tests/discord_message_turns_support.py
@@ -386,6 +386,7 @@ async def test_orchestrated_turn_interrupt_send_hands_off_progress_message(
             self._config = _config(tmp_path)
             self._store = _Store()
             self._rest = rest
+            self._logger = logging.getLogger(__name__)
             self._spawn_task = asyncio.create_task
 
         async def _send_channel_message(
@@ -512,6 +513,7 @@ async def test_orchestrated_turn_interrupt_send_reuses_existing_progress_message
             self._config = _config(tmp_path)
             self._store = _Store()
             self._rest = rest
+            self._logger = logging.getLogger(__name__)
             self._spawn_task = asyncio.create_task
 
         async def _send_channel_message(
@@ -757,6 +759,7 @@ async def test_orchestrated_turn_interrupt_send_falls_back_when_progress_ack_edi
             self._config = _config(tmp_path)
             self._store = _Store()
             self._rest = rest
+            self._logger = logging.getLogger(__name__)
 
         async def _send_channel_message(
             self, channel_id: str, payload: dict[str, Any]
@@ -886,6 +889,7 @@ async def test_orchestrated_turn_placeholder_sent_before_runtime_begin(
             self._config = _config(tmp_path)
             self._store = _Store()
             self._rest = rest
+            self._logger = logging.getLogger(__name__)
 
         async def _send_channel_message(
             self, channel_id: str, payload: dict[str, Any]
@@ -1227,6 +1231,7 @@ async def test_orchestrated_turn_queued_updates_placeholder_skips_finalize(
             self._config = _config(tmp_path)
             self._store = _Store()
             self._rest = rest
+            self._logger = logging.getLogger(__name__)
             self._spawn_task = asyncio.create_task
 
         async def _send_channel_message(

--- a/tests/fixtures/fake_acp_server.py
+++ b/tests/fixtures/fake_acp_server.py
@@ -249,6 +249,17 @@ class FakeACPServer:
         prompt: str,
     ) -> None:
         cancel_event = self._session_cancel_events[session_id]
+        thought_content: Any = {"type": "text", "text": "thinking"}
+        reply_content: Any = {"type": "text", "text": "fixture reply"}
+        if self._scenario == "official_content_parts":
+            thought_content = [
+                {"type": "text", "text": "thinking"},
+                {"type": "output_text", "text": " more"},
+            ]
+            reply_content = [
+                {"type": "text", "text": "fixture"},
+                {"type": "output_text", "text": " reply"},
+            ]
         self.send(
             {
                 "method": "session/update",
@@ -256,7 +267,7 @@ class FakeACPServer:
                     "sessionId": session_id,
                     "update": {
                         "sessionUpdate": "agent_thought_chunk",
-                        "content": {"type": "text", "text": "thinking"},
+                        "content": thought_content,
                     },
                 },
             }
@@ -347,7 +358,7 @@ class FakeACPServer:
                     "sessionId": session_id,
                     "update": {
                         "sessionUpdate": "agent_message_chunk",
-                        "content": {"type": "text", "text": "fixture reply"},
+                        "content": reply_content,
                     },
                 },
             }

--- a/tests/integrations/discord/test_message_turns_transient_progress.py
+++ b/tests/integrations/discord/test_message_turns_transient_progress.py
@@ -1,0 +1,266 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import pytest
+from tests import discord_message_turns_support as support
+
+from codex_autorunner.integrations.discord.errors import DiscordTransientError
+
+pytestmark = pytest.mark.slow
+
+
+class _TransientEditProgressRest(support._FakeRest):
+    def __init__(self) -> None:
+        super().__init__()
+        self.edit_attempts = 0
+
+    async def edit_channel_message(
+        self, *, channel_id: str, message_id: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        _ = channel_id, message_id, payload
+        self.edit_attempts += 1
+        raise DiscordTransientError("simulated transient progress edit failure")
+
+
+@pytest.mark.asyncio
+async def test_orchestrated_turn_interrupt_send_falls_back_when_progress_ack_edit_is_transient(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    thread = SimpleNamespace(thread_target_id="thread-1")
+    started_execution = SimpleNamespace(
+        execution=SimpleNamespace(status="running"),
+        thread=thread,
+    )
+
+    class _Rest(support._FakeRest):
+        async def edit_channel_message(
+            self, *, channel_id: str, message_id: str, payload: dict[str, Any]
+        ) -> dict[str, Any]:
+            _ = channel_id, message_id, payload
+            raise DiscordTransientError("transient edit failure")
+
+    rest = _Rest()
+
+    class _Store:
+        async def get_binding(self, *, channel_id: str) -> dict[str, Any]:
+            assert channel_id == "channel-1"
+            return {}
+
+    class _Service:
+        def __init__(self) -> None:
+            self._config = support._config(tmp_path)
+            self._store = _Store()
+            self._rest = rest
+            self._logger = logging.getLogger(__name__)
+
+        async def _send_channel_message(
+            self, channel_id: str, payload: dict[str, Any]
+        ) -> dict[str, Any]:
+            return await rest.create_channel_message(
+                channel_id=channel_id,
+                payload=payload,
+            )
+
+        def _register_discord_turn_approval_context(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+        def _clear_discord_turn_approval_context(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+        def _resolve_agent_state(self, binding: Any) -> tuple[str, Optional[str]]:
+            _ = binding
+            return "codex", None
+
+        def _runtime_agent_for_binding(self, binding: Any) -> str:
+            _ = binding
+            return "codex"
+
+    async def _fake_begin(*args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        return started_execution
+
+    async def _fake_finalize(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        _ = args, kwargs
+        return {"status": "interrupted", "error": "Discord PMA turn interrupted"}
+
+    async def _fake_complete(*args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        return SimpleNamespace(finalized=await _fake_finalize())
+
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "resolve_discord_thread_target",
+        lambda *args, **kwargs: (SimpleNamespace(), thread),
+    )
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "begin_runtime_thread_execution",
+        _fake_begin,
+    )
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "complete_managed_thread_execution",
+        _fake_complete,
+    )
+
+    service = _Service()
+    support.discord_message_turns_module.request_discord_turn_progress_reuse(
+        service,
+        thread_target_id="thread-1",
+        source_message_id="m-2",
+        acknowledgement="Message received. Switching to it now...",
+    )
+
+    result = await support.discord_message_turns_module._run_discord_orchestrated_turn_for_message(
+        service,
+        workspace_root=tmp_path,
+        prompt_text="first prompt",
+        source_message_id="m-1",
+        agent="codex",
+        model_override=None,
+        reasoning_effort=None,
+        session_key="session-1",
+        orchestrator_channel_key="channel-1",
+        managed_thread_surface_key=None,
+        mode="pma",
+        pma_enabled=True,
+        execution_prompt="<user_message>\nfirst prompt\n</user_message>\n",
+        public_execution_error="Discord PMA turn failed",
+        timeout_error="Discord PMA turn timed out",
+        interrupted_error="Discord PMA turn interrupted",
+        approval_mode="never",
+        sandbox_policy="dangerFullAccess",
+        max_actions=12,
+        min_edit_interval_seconds=1.0,
+        heartbeat_interval_seconds=2.0,
+    )
+
+    assert result.send_final_message is True
+    assert result.final_message == "Message received. Switching to it now..."
+    assert len(rest.channel_messages) == 1
+    assert service._discord_turn_progress_reuse_requests == {}
+    assert service._discord_reusable_progress_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_orchestrated_turn_ignores_transient_progress_edit_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    rest = _TransientEditProgressRest()
+    thread = SimpleNamespace(thread_target_id="thread-1")
+    started_execution = SimpleNamespace(
+        execution=SimpleNamespace(status="running"),
+        thread=thread,
+    )
+
+    class _Store:
+        async def get_binding(self, *, channel_id: str) -> dict[str, Any]:
+            assert channel_id == "channel-1"
+            return {}
+
+    class _Service:
+        def __init__(self) -> None:
+            self._config = support._config(tmp_path)
+            self._store = _Store()
+            self._rest = rest
+            self._logger = logging.getLogger(__name__)
+
+        async def _send_channel_message(
+            self, channel_id: str, payload: dict[str, Any]
+        ) -> dict[str, Any]:
+            return await rest.create_channel_message(
+                channel_id=channel_id,
+                payload=payload,
+            )
+
+        def _register_discord_turn_approval_context(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+        def _clear_discord_turn_approval_context(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+        def _resolve_agent_state(self, binding: Any) -> tuple[str, Optional[str]]:
+            _ = binding
+            return "codex", None
+
+        def _runtime_agent_for_binding(self, binding: Any) -> str:
+            _ = binding
+            return "codex"
+
+    async def _fake_begin(*args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        return started_execution
+
+    async def _fake_complete(*args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        await asyncio.sleep(0.03)
+        return SimpleNamespace(
+            finalized={
+                "status": "ok",
+                "assistant_text": "done",
+                "token_usage": None,
+            }
+        )
+
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "resolve_discord_thread_target",
+        lambda *args, **kwargs: (SimpleNamespace(), thread),
+    )
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "begin_runtime_thread_execution",
+        _fake_begin,
+    )
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "complete_managed_thread_execution",
+        _fake_complete,
+    )
+
+    loop = asyncio.get_running_loop()
+    loop_errors: list[dict[str, Any]] = []
+    previous_handler = loop.get_exception_handler()
+
+    def _capture_exception(
+        _loop: asyncio.AbstractEventLoop, context: dict[str, Any]
+    ) -> None:
+        loop_errors.append(context)
+
+    loop.set_exception_handler(_capture_exception)
+    try:
+        result = await support.discord_message_turns_module._run_discord_orchestrated_turn_for_message(
+            _Service(),
+            workspace_root=tmp_path,
+            prompt_text="hi",
+            input_items=None,
+            source_message_id=None,
+            agent="codex",
+            model_override=None,
+            reasoning_effort=None,
+            session_key="s1",
+            orchestrator_channel_key="channel-1",
+            managed_thread_surface_key=None,
+            mode="pma",
+            pma_enabled=True,
+            execution_prompt="<user_message>\nhi\n</user_message>\n",
+            public_execution_error="err",
+            timeout_error="timeout",
+            interrupted_error="interrupt",
+            approval_mode="never",
+            sandbox_policy="dangerFullAccess",
+            max_actions=12,
+            min_edit_interval_seconds=0.0,
+            heartbeat_interval_seconds=0.01,
+        )
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert result.final_message == "done"
+    assert rest.edit_attempts >= 1
+    assert loop_errors == []


### PR DESCRIPTION
## What changed
- treat transient Discord progress edit/send failures as non-fatal in the Discord PMA message-turn flow
- cover transient progress-heartbeat and interrupted acknowledgement edit failures with dedicated Discord regressions
- keep the large Discord support file and thin wrapper file under their hotspot caps by placing the new regressions in a dedicated integration test file
- wire `make test-managed-thread-cutover` and the collaboration verification runbook to include the new transient-progress test file

## Why
Live deployed Discord PMA logs showed an unhandled `DiscordTransientError` escaping the progress heartbeat PATCH path. That can derail the managed-thread return path even when Hermes runtime processing itself succeeds.

## Root cause
Discord PMA progress updates only treated generic runtime/network failures as recoverable in a few places. Retry-exhaustion from Discord REST calls surfaces as `DiscordTransientError`, so transient PATCH failures could still escape and abort the turn path instead of degrading the progress UI.

## Impact
Discord PMA turns should now continue to completion when transient Discord progress-message edits fail. The progress UI may degrade for that turn, but the final managed-thread response should still be delivered.

## Validation
- `./.venv/bin/pytest tests/integrations/discord/test_message_turns.py tests/integrations/discord/test_message_turns_transient_progress.py tests/test_hotspot_budgets.py -q`
- `./.venv/bin/python -m black --check src/codex_autorunner/integrations/discord/message_turns.py tests/discord_message_turns_support.py tests/integrations/discord/test_message_turns.py tests/integrations/discord/test_message_turns_transient_progress.py`
- `git commit` hook suite: `4702 passed`

## Notes
- `make test-managed-thread-cutover` still reports unrelated existing failures in hub/Telegram tests and temp-root cleanup, outside the files changed in this PR.