### PR TITLE
[codex] Harden Discord PMA background failure cleanup

### DIFF
--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -189,6 +189,20 @@ class _DiscordMessageTurnDispatch:
 _sanitize_runtime_thread_result_error = sanitize_runtime_thread_error
 
 
+def _discord_surface_error_messages(*, pma_enabled: bool) -> tuple[str, str, str]:
+    if pma_enabled:
+        return (
+            DISCORD_PMA_PUBLIC_EXECUTION_ERROR,
+            "Discord PMA turn timed out",
+            "Discord PMA turn interrupted",
+        )
+    return (
+        DISCORD_REPO_PUBLIC_EXECUTION_ERROR,
+        "Discord turn timed out",
+        "Discord turn interrupted",
+    )
+
+
 def _get_discord_progress_reuse_requests(
     service: Any,
 ) -> dict[str, _DiscordProgressReuseRequest]:
@@ -663,6 +677,50 @@ async def _submit_discord_thread_message(
         managed_thread_surface_key=managed_thread_surface_key,
         pma_enabled=request.pma_enabled,
     )
+    thread_target_id: Optional[str] = None
+
+    async def _cleanup_background_failure(exc: Exception) -> None:
+        public_error, timeout_error, interrupted_error = (
+            _discord_surface_error_messages(pma_enabled=dispatch.effective_pma_enabled)
+        )
+        failure_message = _sanitize_runtime_thread_result_error(
+            exc,
+            public_error=public_error,
+            timeout_error=timeout_error,
+            interrupted_error=interrupted_error,
+        )
+        dispatch.log_event_fn(
+            dispatch.service._logger,
+            logging.WARNING,
+            "discord.turn.background_failed",
+            channel_id=dispatch.channel_id,
+            conversation_id=dispatch.context.conversation_id,
+            workspace_root=str(dispatch.workspace_root),
+            agent=dispatch.agent,
+            exc=exc,
+        )
+        if thread_target_id:
+            clear_discord_turn_progress_reuse(
+                dispatch.service,
+                thread_target_id=thread_target_id,
+            )
+        if progress_message_id:
+            await dispatch.service._delete_channel_message_safe(
+                channel_id=dispatch.channel_id,
+                message_id=progress_message_id,
+                record_id=(
+                    "turn:background_cleanup:"
+                    f"{dispatch.session_key}:{uuid.uuid4().hex[:8]}"
+                ),
+            )
+        await dispatch.service._send_channel_message_safe(
+            dispatch.channel_id,
+            {"content": f"Turn failed: {failure_message}"},
+            record_id=(
+                f"turn:background_failure:{dispatch.session_key}:"
+                f"{uuid.uuid4().hex[:8]}"
+            ),
+        )
 
     async def _send_initial_progress_placeholder() -> Optional[str]:
         initial_content = "Received. Preparing turn..."
@@ -724,38 +782,48 @@ async def _submit_discord_thread_message(
         return thread_target_id or None
 
     async def _run_in_background() -> None:
-        turn_result = await _execute_discord_thread_message(
-            request,
-            dispatch=dispatch,
-            initial_progress_message_id=progress_message_id,
-            managed_thread_surface_key=managed_thread_surface_key,
-        )
-        await _deliver_discord_turn_result(
-            dispatch,
-            workspace_root=request.workspace_root,
-            turn_result=turn_result,
-        )
+        try:
+            turn_result = await _execute_discord_thread_message(
+                request,
+                dispatch=dispatch,
+                initial_progress_message_id=progress_message_id,
+                managed_thread_surface_key=managed_thread_surface_key,
+            )
+            await _deliver_discord_turn_result(
+                dispatch,
+                workspace_root=request.workspace_root,
+                turn_result=turn_result,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # intentional: background task must clean up visibly
+            await _cleanup_background_failure(exc)
 
     progress_message_id = await _send_initial_progress_placeholder()
-    if (
-        progress_message_id is not None
-        and isinstance(dispatch.event.message.message_id, str)
-        and dispatch.event.message.message_id
-    ):
-        thread_target_id = await _resolve_managed_thread_id()
-        if thread_target_id:
-            _stash_discord_reusable_progress_message(
-                dispatch.service,
-                thread_target_id=thread_target_id,
-                source_message_id=dispatch.event.message.message_id,
-                channel_id=dispatch.channel_id,
-                message_id=progress_message_id,
-            )
-    _spawn_discord_background_task(
-        dispatch.service,
-        _run_in_background(),
-        await_on_shutdown=True,
-    )
+    try:
+        if (
+            progress_message_id is not None
+            and isinstance(dispatch.event.message.message_id, str)
+            and dispatch.event.message.message_id
+        ):
+            thread_target_id = await _resolve_managed_thread_id()
+            if thread_target_id:
+                _stash_discord_reusable_progress_message(
+                    dispatch.service,
+                    thread_target_id=thread_target_id,
+                    source_message_id=dispatch.event.message.message_id,
+                    channel_id=dispatch.channel_id,
+                    message_id=progress_message_id,
+                )
+        _spawn_discord_background_task(
+            dispatch.service,
+            _run_in_background(),
+            await_on_shutdown=True,
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        await _cleanup_background_failure(exc)
     return DiscordMessageTurnResult(
         final_message="",
         send_final_message=False,
@@ -1079,14 +1147,27 @@ async def _deliver_discord_turn_result(
             attachment_filename="final-response.md",
             attachment_caption="Final response too long; attached as final-response.md.",
         )
-    if dispatch.pending_compact_seed is not None:
-        await dispatch.service._store.clear_pending_compact_seed(
-            channel_id=dispatch.channel_id
-        )
-    if send_final_message:
-        await dispatch.service._flush_outbox_files(
-            workspace_root=workspace_root,
+    try:
+        if dispatch.pending_compact_seed is not None:
+            await dispatch.service._store.clear_pending_compact_seed(
+                channel_id=dispatch.channel_id
+            )
+        if send_final_message:
+            await dispatch.service._flush_outbox_files(
+                workspace_root=workspace_root,
+                channel_id=dispatch.channel_id,
+            )
+    except Exception as exc:  # intentional: do not surface cleanup failures after reply
+        log_event(
+            dispatch.service._logger,
+            logging.WARNING,
+            "discord.turn.delivery_cleanup_failed",
             channel_id=dispatch.channel_id,
+            session_key=dispatch.session_key,
+            workspace_root=str(workspace_root),
+            send_final_message=send_final_message,
+            agent=dispatch.agent,
+            exc=exc,
         )
     log_event(
         dispatch.service._logger,

--- a/tests/discord_message_turns_support.py
+++ b/tests/discord_message_turns_support.py
@@ -2412,7 +2412,6 @@ async def test_message_event_submits_through_surface_orchestration_ingress(
         await store.close()
 
 
-@pytest.mark.anyio
 async def test_message_create_after_compact_uses_pending_seed_and_clears_it(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_discord_message_turn_background_failures.py
+++ b/tests/test_discord_message_turn_background_failures.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import codex_autorunner.integrations.discord.message_turns as discord_message_turns_module
+import codex_autorunner.integrations.discord.service as discord_service_module
+from codex_autorunner.integrations.chat.dispatcher import build_dispatch_context
+from codex_autorunner.integrations.discord.service import (
+    DiscordBotService,
+    DiscordMessageTurnResult,
+)
+from codex_autorunner.integrations.discord.state import DiscordStateStore
+from tests.discord_message_turns_support import (
+    _config,
+    _FakeGateway,
+    _FakeOutboxManager,
+    _FakeRest,
+    _message_create,
+)
+
+
+class _FakeIngress:
+    async def submit_message(
+        self,
+        request,
+        *,
+        resolve_paused_flow_target,
+        submit_flow_reply,
+        submit_thread_message,
+    ):
+        _ = request, resolve_paused_flow_target, submit_flow_reply
+        thread_result = await submit_thread_message(request)
+        return SimpleNamespace(route="thread", thread_result=thread_result)
+
+
+@pytest.mark.anyio
+async def test_message_event_background_failure_cleans_up_placeholder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    async def _fail_execute(*args: Any, **kwargs: Any) -> DiscordMessageTurnResult:
+        _ = args, kwargs
+        raise Exception("background boom")
+
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "build_surface_orchestration_ingress",
+        lambda **_: _FakeIngress(),
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "resolve_discord_thread_target",
+        lambda *args, **kwargs: (
+            SimpleNamespace(),
+            SimpleNamespace(thread_target_id="thread-1"),
+        ),
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "_execute_discord_thread_message",
+        _fail_execute,
+    )
+
+    try:
+        event = service._chat_adapter.parse_message_event(
+            _message_create("route via ingress")
+        )
+        assert event is not None
+        await discord_message_turns_module.handle_message_event(
+            service,
+            event,
+            build_dispatch_context(event),
+            channel_id="channel-1",
+            text="route via ingress",
+            has_attachments=False,
+            policy_result=None,
+            log_event_fn=discord_service_module.log_event,
+            build_ticket_flow_controller_fn=discord_service_module.build_ticket_flow_controller,
+            ensure_worker_fn=discord_service_module.ensure_worker,
+        )
+        task_results = await asyncio.gather(
+            *list(service._background_tasks), return_exceptions=True
+        )
+        assert task_results
+        assert all(result is None for result in task_results)
+        assert any(
+            message["payload"]["content"] == "Received. Preparing turn..."
+            for message in rest.channel_messages
+        )
+        assert any(
+            message["message_id"] == "msg-1"
+            for message in rest.deleted_channel_messages
+        )
+        assert any(
+            message["payload"]["content"] == "Turn failed: background boom"
+            for message in rest.channel_messages
+        )
+        assert service._discord_reusable_progress_messages == {}
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_message_event_pre_spawn_failure_cleans_up_placeholder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "build_surface_orchestration_ingress",
+        lambda **_: _FakeIngress(),
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "resolve_discord_thread_target",
+        lambda *args, **kwargs: (_ for _ in ()).throw(Exception("pre-spawn boom")),
+    )
+
+    try:
+        event = service._chat_adapter.parse_message_event(
+            _message_create("route via ingress")
+        )
+        assert event is not None
+        await discord_message_turns_module.handle_message_event(
+            service,
+            event,
+            build_dispatch_context(event),
+            channel_id="channel-1",
+            text="route via ingress",
+            has_attachments=False,
+            policy_result=None,
+            log_event_fn=discord_service_module.log_event,
+            build_ticket_flow_controller_fn=discord_service_module.build_ticket_flow_controller,
+            ensure_worker_fn=discord_service_module.ensure_worker,
+        )
+        assert not service._background_tasks
+        assert any(
+            message["payload"]["content"] == "Received. Preparing turn..."
+            for message in rest.channel_messages
+        )
+        assert any(
+            message["message_id"] == "msg-1"
+            for message in rest.deleted_channel_messages
+        )
+        assert any(
+            message["payload"]["content"] == "Turn failed: pre-spawn boom"
+            for message in rest.channel_messages
+        )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_message_event_cleanup_failure_does_not_send_false_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    async def _fake_execute(*args: Any, **kwargs: Any) -> DiscordMessageTurnResult:
+        _ = args, kwargs
+        return DiscordMessageTurnResult(
+            final_message="handled by ingress",
+            preview_message_id="msg-1",
+        )
+
+    async def _fail_flush_outbox_files(*args: Any, **kwargs: Any) -> None:
+        _ = args, kwargs
+        raise RuntimeError("outbox boom")
+
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "build_surface_orchestration_ingress",
+        lambda **_: _FakeIngress(),
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "_execute_discord_thread_message",
+        _fake_execute,
+    )
+    service._flush_outbox_files = _fail_flush_outbox_files  # type: ignore[assignment]
+
+    try:
+        event = service._chat_adapter.parse_message_event(
+            _message_create("route via ingress")
+        )
+        assert event is not None
+        await discord_message_turns_module.handle_message_event(
+            service,
+            event,
+            build_dispatch_context(event),
+            channel_id="channel-1",
+            text="route via ingress",
+            has_attachments=False,
+            policy_result=None,
+            log_event_fn=discord_service_module.log_event,
+            build_ticket_flow_controller_fn=discord_service_module.build_ticket_flow_controller,
+            ensure_worker_fn=discord_service_module.ensure_worker,
+        )
+        await asyncio.gather(*list(service._background_tasks), return_exceptions=True)
+        assert any(
+            message["payload"]["content"] == "handled by ingress"
+            for message in rest.channel_messages
+        )
+        assert not any(
+            message["payload"]["content"].startswith("Turn failed:")
+            for message in rest.channel_messages
+        )
+    finally:
+        await store.close()


### PR DESCRIPTION
## Summary
This follow-up hardens Discord PMA message turns when Hermes fails in the detached `MESSAGE_CREATE` path.

## What changed
- added a top-level Discord background failure cleanup path for detached PMA turns
- clean up the `Received. Preparing turn...` placeholder and surface a user-visible failure instead of leaving Discord stuck on `working`
- covered the pre-spawn failure window before the background task is created
- prevented late delivery-cleanup errors from emitting a bogus `Turn failed` after a successful final response
- moved the new Discord regressions into a dedicated test file to stay within the repo hotspot budget

## Root cause
Telegram surfaces managed-thread failures in a foreground path, but Discord detaches PMA `MESSAGE_CREATE` work into a background task. If an exception escaped before or during Discord-specific delivery cleanup, the only fallback was a generic background-task logger, which left the progress placeholder stranded. A separate late-cleanup path could also turn a successful reply into a misleading failure follow-up.

## Impact
Discord Hermes PMA turns should now either complete normally or show the actual failure, rather than hanging indefinitely on the placeholder. The fix is scoped to Discord background PMA handling and does not reduce turn timeouts.

## Validation
- `.venv/bin/pytest tests/test_discord_message_turn_background_failures.py -q`
- `.venv/bin/pytest tests/discord_message_turns_support.py -q -k 'message_event_submits_through_surface_orchestration_ingress'`
- `.venv/bin/pytest tests/chat_surface_integration/test_hermes_pma_surfaces.py -q`
- `.venv/bin/pytest tests/test_hotspot_budgets.py -q -k hotspot_file_budgets`
- full pre-commit hook suite during `git commit` including repo-wide `pytest` (`4705 passed`)
