### PR TITLE
docs: Add VM/container caveats to docs/ops/running-in-a-vm.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,8 @@ Reference docs in `docs/` (e.g., configuration, operations, debugging).
 
 ## Cursor Cloud specific instructions
 - See `docs/ops/running-in-a-vm.md` for VM/cloud-agent startup caveats, service commands, and known test quirks.
+- **First-time setup**: `sudo apt-get install -y python3.12-venv` then `make setup`. After that, run `CAR_DEV_INCLUDE_ROOT_REPO=1 .venv/bin/car init --mode hub` to bootstrap `.codex-autorunner/`.
+- **Dev server**: `CAR_DEV_INCLUDE_ROOT_REPO=1 make serve-dev HOST=0.0.0.0` (port 4173). Use `HOST=0.0.0.0` so the UI is accessible outside the VM.
+- **Tests**: `make test` runs non-integration tests. Use `-m "not integration and not slow"` for the pre-commit subset. Two tests are expected to fail in containerized VMs: `test_process_termination.py` (PID namespace constraints) and occasionally `test_text_delta_coalescer.py`.
+- **Lint**: `make check` runs the full pre-commit suite (black, ruff, mypy, eslint, custom scripts, build, pytest). Individual checks: `black --check src tests`, `ruff check src tests`, `pnpm lint`, `make typecheck-strict`.
+- **Build**: `make build` compiles TypeScript (`static_src/*.ts` → `static/generated/*.js`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,3 @@ Reference docs in `docs/` (e.g., configuration, operations, debugging).
 
 ## Cursor Cloud specific instructions
 - See `docs/ops/running-in-a-vm.md` for VM/cloud-agent startup caveats, service commands, and known test quirks.
-- **First-time setup**: `sudo apt-get install -y python3.12-venv` then `make setup`. After that, run `CAR_DEV_INCLUDE_ROOT_REPO=1 .venv/bin/car init --mode hub` to bootstrap `.codex-autorunner/`.
-- **Dev server**: `CAR_DEV_INCLUDE_ROOT_REPO=1 make serve-dev HOST=0.0.0.0` (port 4173). Use `HOST=0.0.0.0` so the UI is accessible outside the VM.
-- **Tests**: `make test` runs non-integration tests. Use `-m "not integration and not slow"` for the pre-commit subset. Two tests are expected to fail in containerized VMs: `test_process_termination.py` (PID namespace constraints) and occasionally `test_text_delta_coalescer.py`.
-- **Lint**: `make check` runs the full pre-commit suite (black, ruff, mypy, eslint, custom scripts, build, pytest). Individual checks: `black --check src tests`, `ruff check src tests`, `pnpm lint`, `make typecheck-strict`.
-- **Build**: `make build` compiles TypeScript (`static_src/*.ts` → `static/generated/*.js`).

--- a/docs/ops/running-in-a-vm.md
+++ b/docs/ops/running-in-a-vm.md
@@ -18,7 +18,10 @@ Notes for running codex-autorunner inside containerized or cloud-provisioned VMs
 - **Hub init**: Before running the dev server for the first time, run `CAR_DEV_INCLUDE_ROOT_REPO=1 .venv/bin/car init --mode hub` to bootstrap `.codex-autorunner/`.
 - **Dev server binding**: Use `--host 0.0.0.0` (not the default `127.0.0.1`) to make the UI accessible outside the VM.
 - **Process termination tests**: A few tests in `tests/test_opencode_supervisor_process_management.py` and `tests/test_process_termination.py` may fail in containerized environments due to PID namespace / signal handling constraints. These are environment-specific, not code bugs.
+- **Text delta coalescer**: `tests/unit/test_text_delta_coalescer.py::test_multibyte_unicode_newline` may occasionally error in containerized VMs. This is environment-specific.
 - **No external services required**: SQLite is embedded (stdlib); no Postgres/Redis/Docker needed for core dev workflows.
+- **Pre-commit subset**: The pre-commit hook (`scripts/check.sh`) runs `pytest -m "not integration and not slow"`. Use the same marker set when iterating locally to match pre-commit behavior.
+- **Individual lint commands**: `black --check src tests`, `ruff check src tests`, `pnpm lint`, `make typecheck-strict`. The full suite is `make check`.
 
 ## Optional Docker Profile Probe
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds non-obvious VM/container caveats discovered during cloud agent environment setup to `docs/ops/running-in-a-vm.md` (the canonical location for this information). `AGENTS.md` keeps its single-line pointer to that doc.

## Changes

**`docs/ops/running-in-a-vm.md`** — added to the Startup caveats section:
- `test_text_delta_coalescer.py` occasional container-specific error
- Pre-commit subset marker (`-m "not integration and not slow"`) for matching pre-commit behavior
- Individual lint command quick reference (`black`, `ruff`, `pnpm lint`, `make typecheck-strict`)

**`AGENTS.md`** — reverted to the original single-line reference (no inline duplication).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-323496b6-e8d7-45a7-b768-88832a68035b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-323496b6-e8d7-45a7-b768-88832a68035b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

