### PR TITLE
[codex] Fix canonical Hermes profile resolution

### DIFF
--- a/docs/ops/hermes-acp.md
+++ b/docs/ops/hermes-acp.md
@@ -52,8 +52,23 @@ agents:
 CAR does not install Hermes for you. The configured binary must already exist
 and be executable on the host that runs CAR.
 
-You can also expose multiple named CAR agents over the Hermes backend by adding
-aliases with `backend: hermes`:
+Prefer the canonical profile shape for user-facing Hermes selection:
+
+```yaml
+agents:
+  hermes:
+    binary: hermes
+    default_profile: m4-pma
+    profiles:
+      m4-pma:
+        display_name: M4 PMA
+        binary: hermes-m4-pma
+```
+
+CAR treats the logical identity as `agent + profile` and persists Hermes PMA
+threads in that canonical shape.
+
+Legacy alias agents remain supported as an internal compatibility path:
 
 ```yaml
 agents:
@@ -64,8 +79,10 @@ agents:
     binary: hermes-m4-pma
 ```
 
-Each configured alias is validated independently by `car doctor` and can be
-targeted explicitly by PMA, tickets, and other registry-driven CAR surfaces.
+When a logical request such as `agent=hermes, profile=m4-pma` has no canonical
+`agents.hermes.profiles.m4-pma` entry, CAR can still resolve the matching
+runtime alias for compatibility. Prefer migrating configs and examples toward
+the canonical profile shape over time.
 
 ## Launch Expectations
 

--- a/src/codex_autorunner/agents/registry.py
+++ b/src/codex_autorunner/agents/registry.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional, cast
 
-from ..core.config import load_hub_config, load_repo_config
+from ..core.config import ResolvedAgentTarget, load_hub_config, load_repo_config
 from ..core.config_contract import ConfigError
 from ..plugin_api import CAR_AGENT_ENTRYPOINT_GROUP, CAR_PLUGIN_API_VERSION
 from .aliased_harness import AliasedAgentHarness
@@ -78,6 +78,15 @@ class _RequestedAgentContext:
 
     def __setattr__(self, name: str, value: Any) -> None:
         setattr(self._delegate, name, value)
+
+
+@dataclass(frozen=True)
+class AgentRuntimeResolution:
+    logical_agent_id: str
+    logical_profile: Optional[str]
+    runtime_agent_id: str
+    runtime_profile: Optional[str]
+    resolution_kind: str
 
 
 def normalize_agent_capabilities(
@@ -319,6 +328,124 @@ def _resolve_context_root(ctx: Any) -> Optional[Path]:
         if isinstance(root, Path):
             return root
     return None
+
+
+def _normalize_optional_text(value: object) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _agent_runtime_kind(agent_id: str, descriptor: Any) -> str:
+    raw_runtime_kind = getattr(descriptor, "runtime_kind", None)
+    if isinstance(raw_runtime_kind, str) and raw_runtime_kind.strip():
+        return raw_runtime_kind.strip().lower()
+    normalized_agent_id = str(agent_id or "").strip().lower()
+    for separator in ("-", "_"):
+        if separator not in normalized_agent_id:
+            continue
+        prefix = normalized_agent_id.split(separator, 1)[0].strip()
+        if prefix and prefix in _all_agents():
+            return prefix
+    return normalized_agent_id
+
+
+def _strip_runtime_kind_prefix(agent_id: str, runtime_kind: str) -> str:
+    aid = str(agent_id or "").strip().lower()
+    rk = str(runtime_kind or "").strip().lower()
+    if not rk:
+        return aid
+    dash = f"{rk}-"
+    under = f"{rk}_"
+    if aid.startswith(dash):
+        suffix = aid[len(dash) :].strip()
+        return suffix if suffix else aid
+    if aid.startswith(under):
+        suffix = aid[len(under) :].strip()
+        return suffix if suffix else aid
+    return aid
+
+
+def _coerce_resolved_agent_target(value: object) -> Optional[ResolvedAgentTarget]:
+    if isinstance(value, ResolvedAgentTarget):
+        return value
+    return None
+
+
+def resolve_agent_runtime(
+    agent_id: str,
+    profile: Optional[str] = None,
+    *,
+    context: Any = None,
+) -> AgentRuntimeResolution:
+    normalized_agent_id = str(agent_id or "").strip().lower()
+    normalized_profile = _normalize_optional_text(profile)
+    if not normalized_agent_id:
+        raise ValueError("agent_id is required")
+
+    descriptors = get_registered_agents(context)
+    logical_agent_id = normalized_agent_id
+    logical_profile = normalized_profile
+
+    descriptor = descriptors.get(normalized_agent_id)
+    if descriptor is not None:
+        runtime_kind = _agent_runtime_kind(normalized_agent_id, descriptor)
+        if runtime_kind != normalized_agent_id:
+            derived_profile = _strip_runtime_kind_prefix(
+                normalized_agent_id,
+                runtime_kind,
+            )
+            if derived_profile != normalized_agent_id:
+                logical_agent_id = runtime_kind
+                if logical_profile is None:
+                    logical_profile = derived_profile
+
+    config = _resolve_runtime_agent_config(context)
+    resolver = getattr(config, "resolve_runtime_agent_target", None)
+    if callable(resolver):
+        try:
+            resolved_target = _coerce_resolved_agent_target(
+                resolver(logical_agent_id, profile=logical_profile)
+            )
+        except (ValueError, TypeError, RuntimeError, ConfigError):
+            resolved_target = None
+        if resolved_target is not None:
+            return AgentRuntimeResolution(
+                logical_agent_id=resolved_target.logical_agent_id,
+                logical_profile=resolved_target.logical_profile,
+                runtime_agent_id=resolved_target.runtime_agent_id,
+                runtime_profile=resolved_target.runtime_profile,
+                resolution_kind=resolved_target.resolution_kind,
+            )
+
+    if logical_profile is not None:
+        for candidate_id, candidate_descriptor in descriptors.items():
+            if candidate_id == logical_agent_id:
+                continue
+            if (
+                _agent_runtime_kind(candidate_id, candidate_descriptor)
+                != logical_agent_id
+            ):
+                continue
+            derived_profile = _strip_runtime_kind_prefix(candidate_id, logical_agent_id)
+            if derived_profile != logical_profile:
+                continue
+            return AgentRuntimeResolution(
+                logical_agent_id=logical_agent_id,
+                logical_profile=logical_profile,
+                runtime_agent_id=candidate_id,
+                runtime_profile=None,
+                resolution_kind="alias_profile",
+            )
+
+    return AgentRuntimeResolution(
+        logical_agent_id=logical_agent_id,
+        logical_profile=logical_profile,
+        runtime_agent_id=logical_agent_id,
+        runtime_profile=logical_profile,
+        resolution_kind="passthrough",
+    )
 
 
 def wrap_requested_agent_context(
@@ -693,6 +820,7 @@ def has_capability(agent_id: str, capability: str, context: Any = None) -> bool:
 
 
 __all__ = [
+    "AgentRuntimeResolution",
     "CAR_AGENT_ENTRYPOINT_GROUP",
     "CAR_PLUGIN_API_VERSION",
     "AgentCapability",
@@ -703,6 +831,7 @@ __all__ = [
     "has_capability",
     "normalize_agent_capabilities",
     "reload_agents",
+    "resolve_agent_runtime",
     "validate_agent_id",
     "wrap_requested_agent_context",
 ]

--- a/src/codex_autorunner/core/config.py
+++ b/src/codex_autorunner/core/config.py
@@ -1078,6 +1078,15 @@ class AgentConfig:
 
 
 @dataclasses.dataclass(frozen=True)
+class ResolvedAgentTarget:
+    logical_agent_id: str
+    logical_profile: Optional[str]
+    runtime_agent_id: str
+    runtime_profile: Optional[str]
+    resolution_kind: Literal["passthrough", "canonical_profile", "alias_profile"]
+
+
+@dataclasses.dataclass(frozen=True)
 class TemplateRepoConfig:
     id: str
     url: str
@@ -1151,19 +1160,92 @@ def _parse_optional_int(value: Any) -> Optional[int]:
 class AgentConfigMixin:
     agents: Dict[str, AgentConfig]
 
+    @staticmethod
+    def _normalize_agent_token(value: object) -> str:
+        return str(value or "").strip().lower()
+
+    @classmethod
+    def _strip_agent_prefix(cls, agent_id: str, runtime_kind: str) -> Optional[str]:
+        normalized_agent_id = cls._normalize_agent_token(agent_id)
+        normalized_runtime_kind = cls._normalize_agent_token(runtime_kind)
+        if not normalized_agent_id or not normalized_runtime_kind:
+            return None
+        for prefix in (
+            f"{normalized_runtime_kind}-",
+            f"{normalized_runtime_kind}_",
+        ):
+            if normalized_agent_id.startswith(prefix):
+                suffix = normalized_agent_id[len(prefix) :].strip()
+                return suffix or None
+        return None
+
+    def resolve_runtime_agent_target(
+        self, agent_id: str, *, profile: Optional[str] = None
+    ) -> ResolvedAgentTarget:
+        logical_agent_id = self._normalize_agent_token(agent_id)
+        logical_profile = self._normalize_agent_token(profile) or None
+        if not logical_agent_id:
+            raise ConfigError("agent_id is required")
+
+        if logical_profile is not None:
+            agent = self.agents.get(logical_agent_id)
+            configured_profiles = agent.profiles if agent is not None else None
+            if (
+                isinstance(configured_profiles, dict)
+                and logical_profile in configured_profiles
+            ):
+                return ResolvedAgentTarget(
+                    logical_agent_id=logical_agent_id,
+                    logical_profile=logical_profile,
+                    runtime_agent_id=logical_agent_id,
+                    runtime_profile=logical_profile,
+                    resolution_kind="canonical_profile",
+                )
+
+            for raw_runtime_agent_id, runtime_agent in self.agents.items():
+                runtime_agent_id = self._normalize_agent_token(raw_runtime_agent_id)
+                if runtime_agent_id == logical_agent_id:
+                    continue
+                runtime_kind = self._normalize_agent_token(
+                    runtime_agent.backend or runtime_agent_id
+                )
+                if runtime_kind != logical_agent_id:
+                    continue
+                derived_profile = self._strip_agent_prefix(
+                    runtime_agent_id, logical_agent_id
+                )
+                if derived_profile != logical_profile:
+                    continue
+                return ResolvedAgentTarget(
+                    logical_agent_id=logical_agent_id,
+                    logical_profile=logical_profile,
+                    runtime_agent_id=runtime_agent_id,
+                    runtime_profile=None,
+                    resolution_kind="alias_profile",
+                )
+
+        return ResolvedAgentTarget(
+            logical_agent_id=logical_agent_id,
+            logical_profile=logical_profile,
+            runtime_agent_id=logical_agent_id,
+            runtime_profile=logical_profile,
+            resolution_kind="passthrough",
+        )
+
     def resolved_agent_config(
         self, agent_id: str, *, profile: Optional[str] = None
     ) -> AgentConfig:
-        agent = self.agents.get(agent_id)
+        resolved_target = self.resolve_runtime_agent_target(agent_id, profile=profile)
+        agent = self.agents.get(resolved_target.runtime_agent_id)
         if agent is None:
             raise ConfigError(f"agents.{agent_id}.binary is required")
-        normalized_profile = str(profile or "").strip().lower()
+        normalized_profile = str(resolved_target.runtime_profile or "").strip().lower()
         if not normalized_profile:
             return agent
         profile_config = (agent.profiles or {}).get(normalized_profile)
         if profile_config is None:
             raise ConfigError(
-                f"agents.{agent_id}.profiles.{normalized_profile} is not configured"
+                f"agents.{resolved_target.runtime_agent_id}.profiles.{normalized_profile} is not configured"
             )
         return AgentConfig(
             backend=profile_config.backend or agent.backend,

--- a/src/codex_autorunner/integrations/chat/agents.py
+++ b/src/codex_autorunner/integrations/chat/agents.py
@@ -265,18 +265,19 @@ def resolve_chat_runtime_agent(
     default: Optional[str] = DEFAULT_CHAT_AGENT,
     context: Any = None,
 ) -> str:
+    from ...agents.registry import resolve_agent_runtime
+
     normalized_agent, normalized_profile = resolve_chat_agent_and_profile(
         agent,
         profile,
         default=default,
         context=context,
     )
-    if normalized_agent != "hermes" or normalized_profile is None:
-        return normalized_agent
-    for option in chat_hermes_profile_options(context):
-        if option.profile == normalized_profile:
-            return option.runtime_agent
-    return normalized_agent
+    return resolve_agent_runtime(
+        normalized_agent,
+        normalized_profile,
+        context=context,
+    ).runtime_agent_id
 
 
 def format_chat_agent_selection(agent: object, profile: object = None) -> str:

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -10,7 +10,11 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Awaitable, Optional, cast
 
-from ...agents.registry import get_registered_agents, wrap_requested_agent_context
+from ...agents.registry import (
+    get_registered_agents,
+    resolve_agent_runtime,
+    wrap_requested_agent_context,
+)
 from ...core.context_awareness import (
     maybe_inject_car_awareness,
     maybe_inject_filebox_hint,
@@ -2003,11 +2007,16 @@ def build_discord_thread_orchestration_service(service: Any) -> Any:
     descriptors = get_registered_agents(service)
 
     def _make_harness(agent_id: str, profile: Optional[str] = None) -> Any:
-        descriptor = descriptors.get(agent_id)
+        resolution = resolve_agent_runtime(agent_id, profile, context=service)
+        descriptor = descriptors.get(resolution.runtime_agent_id)
         if descriptor is None:
-            raise KeyError(f"Unknown agent definition '{agent_id}'")
+            raise KeyError(f"Unknown agent definition '{resolution.runtime_agent_id}'")
         return descriptor.make_harness(
-            wrap_requested_agent_context(service, agent_id=agent_id, profile=profile)
+            wrap_requested_agent_context(
+                service,
+                agent_id=resolution.runtime_agent_id,
+                profile=resolution.runtime_profile,
+            )
         )
 
     created = build_harness_backed_orchestration_service(

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -24,7 +24,11 @@ from .....agents.opencode.runtime import (
     opencode_stream_timeouts,
     split_model_id,
 )
-from .....agents.registry import get_registered_agents, wrap_requested_agent_context
+from .....agents.registry import (
+    get_registered_agents,
+    resolve_agent_runtime,
+    wrap_requested_agent_context,
+)
 from .....core.config_contract import ConfigError
 from .....core.context_awareness import (
     has_file_context_signal,
@@ -350,11 +354,16 @@ def _build_telegram_thread_orchestration_service(handlers: Any) -> Any:
     descriptors = get_registered_agents(handlers)
 
     def _make_harness(agent_id: str, profile: Optional[str] = None) -> Any:
-        descriptor = descriptors.get(agent_id)
+        resolution = resolve_agent_runtime(agent_id, profile, context=handlers)
+        descriptor = descriptors.get(resolution.runtime_agent_id)
         if descriptor is None:
-            raise KeyError(f"Unknown agent definition '{agent_id}'")
+            raise KeyError(f"Unknown agent definition '{resolution.runtime_agent_id}'")
         return descriptor.make_harness(
-            wrap_requested_agent_context(handlers, agent_id=agent_id, profile=profile)
+            wrap_requested_agent_context(
+                handlers,
+                agent_id=resolution.runtime_agent_id,
+                profile=resolution.runtime_profile,
+            )
         )
 
     state_root = _telegram_state_root(handlers)

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime.py
@@ -16,7 +16,11 @@ from .....agents.base import (
 )
 from .....agents.codex.harness import CodexHarness
 from .....agents.opencode.harness import OpenCodeHarness
-from .....agents.registry import get_registered_agents, wrap_requested_agent_context
+from .....agents.registry import (
+    get_registered_agents,
+    resolve_agent_runtime,
+    wrap_requested_agent_context,
+)
 from .....core.orchestration import (
     FreshConversationRequiredError,
     SurfaceThreadMessageRequest,
@@ -632,24 +636,9 @@ def _build_runtime_harness(
         if "positional argument" not in str(exc):
             raise
         descriptors = get_registered_agents()
-    effective_agent_id = agent_id
-    effective_profile = profile
-    if agent_id == "hermes":
-        try:
-            from .....integrations.chat.agents import resolve_chat_runtime_agent
-
-            runtime_agent = resolve_chat_runtime_agent(
-                "hermes", profile, context=request.app.state
-            )
-        except (
-            ImportError,
-            AttributeError,
-            RuntimeError,
-        ):  # intentional: import and call of optional integration
-            runtime_agent = agent_id
-        if runtime_agent != "hermes":
-            effective_agent_id = runtime_agent
-            effective_profile = None
+    resolution = resolve_agent_runtime(agent_id, profile, context=request.app.state)
+    effective_agent_id = resolution.runtime_agent_id
+    effective_profile = resolution.runtime_profile
     descriptor = descriptors.get(effective_agent_id)
     if descriptor is None:
         raise HTTPException(

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
@@ -8,6 +8,7 @@ from typing import Any, Optional
 
 from fastapi import HTTPException, Request
 
+from .....agents.registry import resolve_agent_runtime, validate_agent_id
 from .....core.car_context import (
     default_managed_thread_context_profile,
     normalize_car_context_profile,
@@ -395,9 +396,8 @@ def _resolve_requested_profile(
     request: Request,
     *,
     agent_id: str,
-    payload: PmaManagedThreadCreateRequest,
+    requested_profile: Optional[str],
 ) -> Optional[str]:
-    requested_profile = normalize_optional_text(payload.profile)
     config = getattr(request.app.state, "config", None)
     profile_getter = getattr(config, "agent_profiles", None)
     default_profile_getter = getattr(config, "agent_default_profile", None)
@@ -428,7 +428,17 @@ def _resolve_requested_profile(
                 exc_info=True,
             )
     if requested_profile is not None and requested_profile not in valid_profiles:
-        raise HTTPException(status_code=400, detail="profile is invalid")
+        resolved = resolve_agent_runtime(
+            agent_id,
+            requested_profile,
+            context=request.app.state,
+        )
+        if (
+            resolved.logical_agent_id != agent_id
+            or resolved.logical_profile != requested_profile
+            or resolved.resolution_kind == "passthrough"
+        ):
+            raise HTTPException(status_code=400, detail="profile is invalid")
     return requested_profile
 
 
@@ -438,7 +448,21 @@ def resolve_managed_thread_create_resolution(
 ) -> ManagedThreadCreateResolution:
     hub_root = request.app.state.config.root
     pma_config = request.app.state.config.pma
-    agent_id = normalize_optional_text(payload.agent)
+    raw_agent_id = normalize_optional_text(payload.agent)
+    raw_profile = normalize_optional_text(payload.profile)
+    if raw_agent_id is not None:
+        try:
+            validate_agent_id(raw_agent_id, request.app.state)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+    runtime_resolution = (
+        resolve_agent_runtime(raw_agent_id, raw_profile, context=request.app.state)
+        if raw_agent_id is not None
+        else None
+    )
+    agent_id = (
+        runtime_resolution.logical_agent_id if runtime_resolution is not None else None
+    )
     resource_kind, resource_id, resolved_repo_id = _normalize_resource_owner(
         resource_kind=payload.resource_kind,
         resource_id=payload.resource_id,
@@ -510,7 +534,11 @@ def resolve_managed_thread_create_resolution(
     requested_profile = _resolve_requested_profile(
         request,
         agent_id=agent_id,
-        payload=payload,
+        requested_profile=(
+            runtime_resolution.logical_profile
+            if runtime_resolution is not None
+            else raw_profile
+        ),
     )
     context_profile = normalize_car_context_profile(
         payload.context_profile,

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -6,7 +6,11 @@ from typing import TYPE_CHECKING, Annotated, Any, Optional, cast
 
 from fastapi import APIRouter, Body, HTTPException, Request
 
-from .....agents.registry import get_registered_agents, wrap_requested_agent_context
+from .....agents.registry import (
+    get_registered_agents,
+    resolve_agent_runtime,
+    wrap_requested_agent_context,
+)
 from .....core.chat_bindings import active_chat_binding_metadata_by_thread
 from .....core.orchestration import build_harness_backed_orchestration_service
 from .....core.orchestration.catalog import RuntimeAgentDescriptor
@@ -76,18 +80,21 @@ def build_managed_thread_orchestration_service(request: Request):
         if not isinstance(cache, dict):
             cache = {}
             request.app.state._managed_thread_harness_cache = cache
-        cache_key = (agent_id, profile or "")
+        resolution = resolve_agent_runtime(agent_id, profile, context=request.app.state)
+        runtime_agent_id = resolution.runtime_agent_id
+        runtime_profile = resolution.runtime_profile
+        cache_key = (runtime_agent_id, runtime_profile or "")
         cached = cache.get(cache_key)
         if cached is not None:
             return cached
-        descriptor = descriptors.get(agent_id)
+        descriptor = descriptors.get(runtime_agent_id)
         if descriptor is None:
-            raise KeyError(f"Unknown agent definition '{agent_id}'")
+            raise KeyError(f"Unknown agent definition '{runtime_agent_id}'")
         harness = descriptor.make_harness(
             wrap_requested_agent_context(
                 request.app.state,
-                agent_id=agent_id,
-                profile=profile,
+                agent_id=runtime_agent_id,
+                profile=runtime_profile,
             )
         )
         cache[cache_key] = harness

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -262,7 +262,7 @@ class AppServerThreadArchiveRequest(Payload):
 class PmaManagedThreadCreateRequest(Payload):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
-    agent: Optional[Literal["codex", "hermes", "opencode", "zeroclaw"]] = None
+    agent: Optional[str] = None
     profile: Optional[str] = None
     resource_kind: Optional[Literal["repo", "agent_workspace"]] = Field(
         default=None, validation_alias=AliasChoices("resource_kind", "resourceKind")

--- a/tests/test_agents_registry.py
+++ b/tests/test_agents_registry.py
@@ -13,10 +13,11 @@ from codex_autorunner.agents.registry import (
     get_registered_agents,
     has_capability,
     reload_agents,
+    resolve_agent_runtime,
     validate_agent_id,
     wrap_requested_agent_context,
 )
-from codex_autorunner.core.config import AgentConfig
+from codex_autorunner.core.config import AgentConfig, ResolvedAgentTarget
 
 
 @pytest.fixture
@@ -558,3 +559,50 @@ class TestHermesHarness:
 
         assert wrapped._requested_agent_id == "hermes"
         assert wrapped._requested_agent_profile == "m4"
+
+    def test_resolve_agent_runtime_maps_alias_input_to_logical_profile(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "codex_autorunner.agents.registry.get_registered_agents",
+            lambda context=None: {
+                "hermes": AgentDescriptor(
+                    id="hermes",
+                    name="Hermes",
+                    capabilities=frozenset(),
+                    make_harness=lambda _ctx: None,  # type: ignore[return-value]
+                    runtime_kind="hermes",
+                ),
+                "hermes-m4-pma": AgentDescriptor(
+                    id="hermes-m4-pma",
+                    name="Hermes Alias",
+                    capabilities=frozenset(),
+                    make_harness=lambda _ctx: None,  # type: ignore[return-value]
+                    runtime_kind="hermes",
+                ),
+            },
+        )
+        monkeypatch.setattr(
+            "codex_autorunner.agents.registry._resolve_runtime_agent_config",
+            lambda _ctx: SimpleNamespace(
+                resolve_runtime_agent_target=lambda agent_id, profile=None: (
+                    ResolvedAgentTarget(
+                        logical_agent_id=agent_id,
+                        logical_profile=profile,
+                        runtime_agent_id="hermes-m4-pma",
+                        runtime_profile=None,
+                        resolution_kind="alias_profile",
+                    )
+                    if agent_id == "hermes" and profile == "m4-pma"
+                    else None
+                )
+            ),
+        )
+
+        resolved = resolve_agent_runtime("hermes-m4-pma", context="ctx")
+
+        assert resolved.logical_agent_id == "hermes"
+        assert resolved.logical_profile == "m4-pma"
+        assert resolved.runtime_agent_id == "hermes-m4-pma"
+        assert resolved.runtime_profile is None
+        assert resolved.resolution_kind == "alias_profile"

--- a/tests/test_pma_managed_threads_messages.py
+++ b/tests/test_pma_managed_threads_messages.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import anyio
 import httpx
@@ -272,6 +273,126 @@ def test_send_message_persists_turns_and_reuses_backend_thread(hub_env) -> None:
     assert metadata["model"] == "model-default"
     assert metadata["reasoning"] == "high"
     assert transcript["content"].strip() == "assistant-output-1"
+
+
+def test_send_message_resolves_alias_backed_hermes_profile_runtime(
+    hub_env, monkeypatch
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg.setdefault("pma", {})
+    cfg["pma"]["enabled"] = True
+    cfg.setdefault("agents", {})
+    cfg["agents"]["hermes"] = {"binary": "hermes"}
+    cfg["agents"]["hermes-m4-pma"] = {
+        "backend": "hermes",
+        "binary": "hermes-m4-pma",
+    }
+    write_test_config(hub_env.hub_root / CONFIG_FILENAME, cfg)
+
+    observed_supervisor_args: list[tuple[str, str | None]] = []
+
+    class _FakeHermesSupervisor:
+        async def ensure_ready(self, workspace_root: Path) -> None:
+            _ = workspace_root
+
+        async def create_session(self, workspace_root: Path, title: str | None = None):
+            _ = workspace_root, title
+            return SimpleNamespace(session_id="hermes-session-1")
+
+        async def resume_session(self, workspace_root: Path, conversation_id: str):
+            _ = workspace_root
+            return SimpleNamespace(session_id=conversation_id)
+
+        async def start_turn(
+            self,
+            workspace_root: Path,
+            conversation_id: str,
+            prompt: str,
+            *,
+            model: str | None = None,
+            approval_mode: str | None = None,
+        ) -> str:
+            _ = workspace_root, conversation_id, prompt, model, approval_mode
+            return "hermes-turn-1"
+
+        async def wait_for_turn(
+            self,
+            workspace_root: Path,
+            conversation_id: str,
+            turn_id: str,
+            *,
+            timeout: float | None = None,
+        ):
+            _ = workspace_root, conversation_id, turn_id, timeout
+            return SimpleNamespace(
+                status="ok",
+                assistant_text="hermes-output",
+                raw_events=[],
+                errors=[],
+            )
+
+        async def interrupt_turn(
+            self, workspace_root: Path, conversation_id: str, turn_id: str | None
+        ) -> None:
+            _ = workspace_root, conversation_id, turn_id
+
+        async def stream_turn_events(
+            self, workspace_root: Path, conversation_id: str, turn_id: str
+        ):
+            _ = workspace_root, conversation_id, turn_id
+            if False:
+                yield {}
+
+        async def list_turn_events_snapshot(
+            self, turn_id: str
+        ) -> list[dict[str, object]]:
+            _ = turn_id
+            return []
+
+    def _fake_build_supervisor(
+        _config,
+        *,
+        agent_id: str = "hermes",
+        profile: str | None = None,
+        **_kwargs,
+    ):
+        observed_supervisor_args.append((agent_id, profile))
+        return _FakeHermesSupervisor()
+
+    monkeypatch.setattr(
+        "codex_autorunner.agents.registry.build_hermes_supervisor_from_config",
+        _fake_build_supervisor,
+    )
+
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "hermes",
+                "profile": "m4-pma",
+                **_repo_owner(hub_env),
+            },
+        )
+        assert create_resp.status_code == 200
+        thread = create_resp.json()["thread"]
+        assert thread["agent"] == "hermes"
+        assert thread["agent_profile"] == "m4-pma"
+        managed_thread_id = thread["managed_thread_id"]
+
+        message_resp = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/messages",
+            json={"message": "hello hermes"},
+        )
+
+    assert message_resp.status_code == 200
+    payload = message_resp.json()
+    assert payload["status"] == "ok"
+    assert payload["assistant_text"] == "hermes-output"
+    assert payload["backend_thread_id"] == "hermes-session-1"
+    assert observed_supervisor_args == [("hermes-m4-pma", None)]
 
 
 @pytest.mark.anyio

--- a/tests/test_pma_managed_threads_routes.py
+++ b/tests/test_pma_managed_threads_routes.py
@@ -264,6 +264,39 @@ def test_create_managed_thread_persists_agent_profile(hub_env) -> None:
     assert stored["metadata"]["agent_profile"] == "m4"
 
 
+def test_create_managed_thread_canonicalizes_alias_agent_input(hub_env) -> None:
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg.setdefault("agents", {})
+    cfg["agents"]["hermes"] = {"binary": "hermes"}
+    cfg["agents"]["hermes-m4-pma"] = {
+        "backend": "hermes",
+        "binary": "hermes-m4-pma",
+    }
+    write_test_config(hub_env.hub_root / CONFIG_FILENAME, cfg)
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "hermes-m4-pma",
+                **_repo_owner(hub_env),
+                "name": "Hermes alias thread",
+            },
+        )
+
+    assert resp.status_code == 200
+    thread = resp.json()["thread"]
+    assert thread["agent"] == "hermes"
+    assert thread["agent_profile"] == "m4-pma"
+
+    store = PmaThreadStore(hub_env.hub_root)
+    stored = store.get_thread(thread["managed_thread_id"])
+    assert stored is not None
+    assert stored["agent"] == "hermes"
+    assert stored["metadata"]["agent_profile"] == "m4-pma"
+
+
 def test_create_managed_thread_accepts_explicit_approval_mode(hub_env) -> None:
     app = create_hub_app(hub_env.hub_root)
 
@@ -392,9 +425,8 @@ def test_create_managed_thread_rejects_unknown_agent(hub_env) -> None:
             },
         )
 
-    assert resp.status_code == 422
-    assert "codex" in str(resp.json())
-    assert "zeroclaw" in str(resp.json())
+    assert resp.status_code == 400
+    assert "unknown agent" in str(resp.json()).lower()
 
 
 def test_create_managed_thread_rejects_invalid_notify_on_without_side_effect(


### PR DESCRIPTION
## Summary

- add a shared logical-agent/profile to runtime-target resolver in the agent/config layer
- normalize managed-thread creation back to canonical logical `agent + profile`, while still resolving alias agents for runtime compatibility
- route chat, PMA managed threads, Discord, and Telegram harness creation through the same runtime resolution path
- document the canonical Hermes profile config shape and keep alias agents as compatibility-only config

## Root Cause

PMA chat already resolved Hermes profile `m4-pma` to the runtime alias target before harness construction, but managed-thread harness creation passed `agent=hermes, profile=m4-pma` straight into config lookup. That failed when the local config only exposed the alias form (`hermes-m4-pma`) instead of a canonical `agents.hermes.profiles.m4-pma` block.

## Validation

- `python3 -m pytest tests/integrations/chat/test_agents.py tests/test_agents_registry.py tests/test_pma_managed_threads_routes.py tests/test_pma_managed_threads_messages.py tests/integrations/discord/test_service_routing.py::test_list_discord_thread_targets_for_picker_supports_logical_and_legacy_hermes_ids tests/telegram_pma_routing_support.py::test_pma_registry_key_matches_logical_hermes_profile -q`
- `python3 -m pytest tests/agents/hermes/test_hermes_supervisor.py::test_build_hermes_supervisor_prefers_base_binary_for_alias_profile tests/agents/hermes/test_hermes_supervisor.py::test_hermes_runtime_preflight_prefers_base_binary_for_alias_profile tests/agents/hermes/test_hermes_supervisor.py::test_build_hermes_supervisor_preserves_custom_alias_binary -q`
- pre-commit hook suite during `git commit`, including repo-wide checks and full pytest (`4803 passed`)
