### PR TITLE
Default PMA managed-thread sends to async terminal followup

### DIFF
--- a/src/codex_autorunner/bootstrap.py
+++ b/src/codex_autorunner/bootstrap.py
@@ -334,9 +334,9 @@ You are an **abstraction layer, not an executor**. Coordinate tickets and flows 
   intended hub config instead of relying on the current working directory.
 - CLI primitives:
   - `car pma thread spawn --agent codex --repo <repo_id> --name <label> --path <hub_root>`
-  - `car pma thread send --id <managed_thread_id> --message "..." --watch --path <hub_root>`
-  - `car pma thread send --id <managed_thread_id> --message-file prompt.md --watch --path <hub_root>`
-  - `car pma thread send --id <managed_thread_id> --message "..." --notify-on terminal --notify-lane <lane_id> --path <hub_root>`
+  - `car pma thread send --id <managed_thread_id> --message "..." --path <hub_root>`
+  - `car pma thread send --id <managed_thread_id> --message-file prompt.md --path <hub_root>`
+  - `car pma thread send --id <managed_thread_id> --message "..." --watch --path <hub_root>` only when you intentionally want synchronous foreground babysitting
   - `car pma thread status --id <managed_thread_id> --path <hub_root>`
   - `car pma thread compact --id <id> --summary "..." --path <hub_root>`
   - `car pma thread archive --id <id> --path <hub_root>`

--- a/src/codex_autorunner/core/pma_action_queue.py
+++ b/src/codex_autorunner/core/pma_action_queue.py
@@ -125,9 +125,9 @@ def _thread_followup_semantics(entry: Mapping[str, Any]) -> dict[str, Any]:
             "operator_need": "normal",
             "recommended_action": "resume_managed_thread",
             "why_selected": "Managed thread is paused and likely waiting for the next turn",
-            "recommended_detail_template": (
-                'car pma thread send --id {managed_thread_id} --message "..." --watch --path <hub_root>'
-            ),
+                "recommended_detail_template": (
+                    'car pma thread send --id {managed_thread_id} --message "..." --path <hub_root>'
+                ),
         }
     if status in {"completed", "interrupted"}:
         if is_stale:
@@ -158,7 +158,7 @@ def _thread_followup_semantics(entry: Mapping[str, Any]) -> dict[str, Any]:
                 "recommended_detail_template": (
                     "Review before cleanup: car pma thread archive --id "
                     "{managed_thread_id} --path <hub_root> if dormant, or reuse it with "
-                    'car pma thread send --id {managed_thread_id} --message "..." --watch --path <hub_root>'
+                    'car pma thread send --id {managed_thread_id} --message "..." --path <hub_root>'
                 ),
             }
         return {
@@ -171,7 +171,7 @@ def _thread_followup_semantics(entry: Mapping[str, Any]) -> dict[str, Any]:
             ),
             "recommended_detail_template": (
                 "Optional reuse: car pma thread send --id {managed_thread_id} "
-                '--message "..." --watch --path <hub_root>'
+                '--message "..." --path <hub_root>'
             ),
         }
     if status == "idle":
@@ -190,7 +190,7 @@ def _thread_followup_semantics(entry: Mapping[str, Any]) -> dict[str, Any]:
                 ),
                 "recommended_detail_template": (
                     "Optional reuse: car pma thread send --id {managed_thread_id} "
-                    '--message "..." --watch --path <hub_root>'
+                    '--message "..." --path <hub_root>'
                 ),
             }
         if is_stale:
@@ -221,7 +221,7 @@ def _thread_followup_semantics(entry: Mapping[str, Any]) -> dict[str, Any]:
                 "recommended_detail_template": (
                     "Review before cleanup: car pma thread archive --id "
                     "{managed_thread_id} --path <hub_root> if dormant, or reuse it with "
-                    'car pma thread send --id {managed_thread_id} --message "..." --watch --path <hub_root>'
+                    'car pma thread send --id {managed_thread_id} --message "..." --path <hub_root>'
                 ),
             }
         return {
@@ -234,7 +234,7 @@ def _thread_followup_semantics(entry: Mapping[str, Any]) -> dict[str, Any]:
             ),
             "recommended_detail_template": (
                 "Optional reuse: car pma thread send --id {managed_thread_id} "
-                '--message "..." --watch --path <hub_root>'
+                '--message "..." --path <hub_root>'
             ),
         }
     return {
@@ -244,7 +244,7 @@ def _thread_followup_semantics(entry: Mapping[str, Any]) -> dict[str, Any]:
         "why_selected": "Managed thread can accept another turn if PMA needs it",
         "recommended_detail_template": (
             "Optional reuse: car pma thread send --id {managed_thread_id} "
-            '--message "..." --watch --path <hub_root>'
+            '--message "..." --path <hub_root>'
         ),
     }
 

--- a/src/codex_autorunner/core/pma_action_queue.py
+++ b/src/codex_autorunner/core/pma_action_queue.py
@@ -125,9 +125,9 @@ def _thread_followup_semantics(entry: Mapping[str, Any]) -> dict[str, Any]:
             "operator_need": "normal",
             "recommended_action": "resume_managed_thread",
             "why_selected": "Managed thread is paused and likely waiting for the next turn",
-                "recommended_detail_template": (
-                    'car pma thread send --id {managed_thread_id} --message "..." --path <hub_root>'
-                ),
+            "recommended_detail_template": (
+                'car pma thread send --id {managed_thread_id} --message "..." --path <hub_root>'
+            ),
         }
     if status in {"completed", "interrupted"}:
         if is_stale:

--- a/src/codex_autorunner/core/pma_prompt_builder.py
+++ b/src/codex_autorunner/core/pma_prompt_builder.py
@@ -52,9 +52,9 @@ First-turn routine:
     - If no suitable thread exists, spawn one, run work, and keep it compact:
       - `car pma thread spawn --agent codex --repo <repo_id> --name <label> --path <hub_root>`
       - `car pma thread spawn --resource-kind agent_workspace --resource-id <workspace_id> --name <label> --path <hub_root>`
-      - `car pma thread send --id <managed_thread_id> --message "..." --watch --path <hub_root>`
-      - `car pma thread send --id <managed_thread_id> --message-file prompt.md --watch --path <hub_root>`
-      - `car pma thread send --id <managed_thread_id> --message "..." --notify-on terminal --notify-lane <lane_id> --path <hub_root>`
+      - `car pma thread send --id <managed_thread_id> --message "..." --path <hub_root>`
+      - `car pma thread send --id <managed_thread_id> --message-file prompt.md --path <hub_root>`
+      - `car pma thread send --id <managed_thread_id> --message "..." --watch --path <hub_root>` only when you intentionally want synchronous foreground babysitting
       - `car pma thread status --id <managed_thread_id> --path <hub_root>`
       - `car pma thread compact --id <id> --summary "..." --path <hub_root>`
       - `car pma thread archive --id <id> --path <hub_root>`

--- a/src/codex_autorunner/surfaces/cli/pma_cli.py
+++ b/src/codex_autorunner/surfaces/cli/pma_cli.py
@@ -769,6 +769,8 @@ class _ManagedThreadSendResponse:
     detail: str
     error: str
     next_step: str
+    notification_mode: str
+    notification_lane: str
 
     @classmethod
     def from_http(
@@ -790,6 +792,15 @@ class _ManagedThreadSendResponse:
             detail=str(payload.get("detail") or "").strip(),
             error=str(payload.get("error") or "").strip(),
             next_step=str(payload.get("next_step") or "").strip(),
+            notification_mode=str(
+                ((payload.get("notification") or {}).get("mode") or "")
+            ).strip(),
+            notification_lane=str(
+                (((payload.get("notification") or {}).get("subscription") or {}).get(
+                    "lane_id"
+                )
+                or "")
+            ).strip(),
         )
 
     @property
@@ -808,6 +819,10 @@ class _ManagedThreadSendResponse:
             line += f" active_managed_turn_id={self.active_managed_turn_id}"
         if self.queue_depth is not None:
             line += f" queue_depth={self.queue_depth}"
+        if self.notification_mode:
+            line += f" wakeup={self.notification_mode}"
+            if self.notification_lane:
+                line += f" lane={self.notification_lane}"
         return line
 
     def completion_line(self) -> str:
@@ -839,6 +854,14 @@ def _normalize_notify_on(value: Optional[str]) -> Optional[str]:
     if text != "terminal":
         raise typer.BadParameter("notify-on must be 'terminal'")
     return text
+
+
+def _default_managed_thread_send_notify_on(config: Any) -> Optional[str]:
+    pma_config = getattr(config, "pma", None)
+    if pma_config is None:
+        return "terminal"
+    enabled = getattr(pma_config, "managed_thread_terminal_followup_default", True)
+    return "terminal" if bool(enabled) else None
 
 
 _CAPABILITY_REQUIREMENTS = {
@@ -2013,7 +2036,7 @@ def pma_thread_send(
     watch: bool = typer.Option(
         False,
         "--watch",
-        help="Follow tail/events until the turn reaches terminal state",
+        help="Opt into synchronous foreground tailing until terminal state",
     ),
     notify_on: Optional[str] = typer.Option(
         None,
@@ -2045,20 +2068,21 @@ def pma_thread_send(
     normalized_if_busy = (if_busy or "").strip().lower() or "queue"
     if normalized_if_busy not in {"queue", "interrupt", "reject"}:
         raise typer.BadParameter("if-busy must be queue, interrupt, or reject")
-    request_payload = _ManagedThreadSendRequest(
-        message=message_body,
-        busy_policy=normalized_if_busy,
-        defer_execution=should_defer,
-        model=model,
-        reasoning=reasoning,
-        notify_on=normalized_notify_on,
-        notify_lane=notify_lane,
-        notify_once=notify_once,
-    )
-
     hub_root = _resolve_hub_path(path)
     try:
         config = load_hub_config(hub_root)
+        if normalized_notify_on is None:
+            normalized_notify_on = _default_managed_thread_send_notify_on(config)
+        request_payload = _ManagedThreadSendRequest(
+            message=message_body,
+            busy_policy=normalized_if_busy,
+            defer_execution=should_defer,
+            model=model,
+            reasoning=reasoning,
+            notify_on=normalized_notify_on,
+            notify_lane=notify_lane,
+            notify_once=notify_once,
+        )
         status_code, data = _request_json_with_status(
             "POST",
             _build_pma_url(config, f"/threads/{managed_thread_id}/messages"),

--- a/src/codex_autorunner/surfaces/cli/pma_cli.py
+++ b/src/codex_autorunner/surfaces/cli/pma_cli.py
@@ -796,10 +796,12 @@ class _ManagedThreadSendResponse:
                 ((payload.get("notification") or {}).get("mode") or "")
             ).strip(),
             notification_lane=str(
-                (((payload.get("notification") or {}).get("subscription") or {}).get(
-                    "lane_id"
+                (
+                    ((payload.get("notification") or {}).get("subscription") or {}).get(
+                        "lane_id"
+                    )
+                    or ""
                 )
-                or "")
             ).strip(),
         )
 
@@ -854,14 +856,6 @@ def _normalize_notify_on(value: Optional[str]) -> Optional[str]:
     if text != "terminal":
         raise typer.BadParameter("notify-on must be 'terminal'")
     return text
-
-
-def _default_managed_thread_send_notify_on(config: Any) -> Optional[str]:
-    pma_config = getattr(config, "pma", None)
-    if pma_config is None:
-        return "terminal"
-    enabled = getattr(pma_config, "managed_thread_terminal_followup_default", True)
-    return "terminal" if bool(enabled) else None
 
 
 _CAPABILITY_REQUIREMENTS = {
@@ -2071,8 +2065,6 @@ def pma_thread_send(
     hub_root = _resolve_hub_path(path)
     try:
         config = load_hub_config(hub_root)
-        if normalized_notify_on is None:
-            normalized_notify_on = _default_managed_thread_send_notify_on(config)
         request_payload = _ManagedThreadSendRequest(
             message=message_body,
             busy_policy=normalized_if_busy,

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -911,7 +911,7 @@ def build_managed_thread_runtime_routes(
                         if options.notify_once
                         else None
                     ),
-                    required=True,
+                    required=options.notify_required,
                 )
             except ManagedThreadAutomationUnavailable as exc:
                 raise HTTPException(

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime_payloads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime_payloads.py
@@ -22,6 +22,9 @@ from .....core.pma_thread_store import ManagedThreadNotActiveError
 from .....integrations.chat.approval_modes import resolve_approval_mode_policies
 from ...schemas import PmaManagedThreadMessageRequest
 from ...services.pma.common import pma_config_from_raw as shared_pma_config_from_raw
+from ...services.pma.managed_thread_followup import (
+    resolve_managed_thread_followup_policy,
+)
 from .automation_adapter import normalize_optional_text
 
 MANAGED_THREAD_PUBLIC_EXECUTION_ERROR = "Managed thread execution failed"
@@ -34,6 +37,7 @@ class ManagedThreadMessageOptions:
     notify_on: Optional[str]
     notify_lane: Optional[str]
     notify_once: bool
+    notify_required: bool
     defer_execution: bool
     model: Optional[str]
     reasoning: Optional[str]
@@ -45,6 +49,7 @@ class ManagedThreadMessageOptions:
     live_backend_thread_id: str
     execution_prompt: str
     delivery_payload: dict[str, Any]
+
 
 def get_pma_route_config(request: Request) -> dict[str, Any]:
     raw = getattr(request.app.state.config, "raw", {})
@@ -189,16 +194,15 @@ def resolve_managed_thread_message_options(
             detail=f"message exceeds max_text_chars ({max_text_chars} characters)",
         )
 
-    notify_on = normalize_optional_text(payload.notify_on)
-    if not notify_on and bool(defaults.get("managed_thread_terminal_followup_default")):
-        notify_on = "terminal"
-    if notify_on and notify_on != "terminal":
-        raise HTTPException(
-            status_code=400, detail="notify_on must be 'terminal' when provided"
-        )
-
-    notify_lane = normalize_optional_text(payload.notify_lane)
-    notify_once = bool(payload.notify_once)
+    followup_policy = resolve_managed_thread_followup_policy(
+        payload,
+        default_terminal_followup=bool(
+            defaults.get("managed_thread_terminal_followup_default")
+        ),
+    )
+    notify_on = followup_policy.event_mode
+    notify_lane = followup_policy.lane_id
+    notify_once = followup_policy.notify_once
     defer_execution = bool(payload.defer_execution)
     model = normalize_optional_text(payload.model) or defaults.get("model")
     reasoning = normalize_optional_text(payload.reasoning) or defaults.get("reasoning")
@@ -240,6 +244,7 @@ def resolve_managed_thread_message_options(
         notify_on=notify_on,
         notify_lane=notify_lane,
         notify_once=notify_once,
+        notify_required=followup_policy.required,
         defer_execution=defer_execution,
         model=model,
         reasoning=reasoning,

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime_payloads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime_payloads.py
@@ -13,7 +13,6 @@ from .....core.car_context import (
     normalize_car_context_profile,
     render_injected_car_context,
 )
-from .....core.config import PMA_DEFAULT_MAX_TEXT_CHARS
 from .....core.orchestration.runtime_threads import (
     RUNTIME_THREAD_INTERRUPTED_ERROR,
     RUNTIME_THREAD_TIMEOUT_ERROR,
@@ -22,6 +21,7 @@ from .....core.pma_context import format_pma_discoverability_preamble
 from .....core.pma_thread_store import ManagedThreadNotActiveError
 from .....integrations.chat.approval_modes import resolve_approval_mode_policies
 from ...schemas import PmaManagedThreadMessageRequest
+from ...services.pma.common import pma_config_from_raw as shared_pma_config_from_raw
 from .automation_adapter import normalize_optional_text
 
 MANAGED_THREAD_PUBLIC_EXECUTION_ERROR = "Managed thread execution failed"
@@ -46,23 +46,9 @@ class ManagedThreadMessageOptions:
     execution_prompt: str
     delivery_payload: dict[str, Any]
 
-
-def pma_config_from_raw(raw: dict[str, Any]) -> dict[str, Any]:
-    defaults: dict[str, Any] = {
-        "enabled": True,
-        "max_text_chars": PMA_DEFAULT_MAX_TEXT_CHARS,
-    }
-    if not isinstance(raw, dict):
-        return defaults
-    pma = raw.get("pma")
-    if not isinstance(pma, dict):
-        return defaults
-    return {**defaults, **pma}
-
-
 def get_pma_route_config(request: Request) -> dict[str, Any]:
     raw = getattr(request.app.state.config, "raw", {})
-    return pma_config_from_raw(raw)
+    return shared_pma_config_from_raw(raw)
 
 
 def _resolve_managed_thread_policies(
@@ -204,6 +190,8 @@ def resolve_managed_thread_message_options(
         )
 
     notify_on = normalize_optional_text(payload.notify_on)
+    if not notify_on and bool(defaults.get("managed_thread_terminal_followup_default")):
+        notify_on = "terminal"
     if notify_on and notify_on != "terminal":
         raise HTTPException(
             status_code=400, detail="notify_on must be 'terminal' when provided"
@@ -340,8 +328,8 @@ def build_running_turn_exists_payload(
         "reason": "running_turn_exists",
         "detail": f"Managed thread {managed_thread_id} already has a running turn",
         "next_step": (
-            "Wait for the running turn to finish, use --watch, "
-            "or subscribe with --notify-on terminal."
+            "Wait for the running turn to finish or let the default terminal "
+            "wakeup fire; use --watch only for foreground babysitting."
         ),
         "managed_thread_id": managed_thread_id,
         "managed_turn_id": str((running_turn or {}).get("managed_turn_id") or "")

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -828,12 +828,40 @@ class PmaManagedThreadMessageRequest(Payload):
     notify_on: Optional[Literal["terminal"]] = Field(
         default=None, validation_alias=AliasChoices("notify_on", "notifyOn")
     )
+    terminal_followup: Optional[bool] = Field(
+        default=None,
+        validation_alias=AliasChoices("terminal_followup", "terminalFollowup"),
+    )
     notify_lane: Optional[str] = Field(
         default=None, validation_alias=AliasChoices("notify_lane", "notifyLane")
     )
     notify_once: bool = Field(
         default=True, validation_alias=AliasChoices("notify_once", "notifyOnce")
     )
+    notify_on_explicit: bool = Field(default=False, exclude=True)
+    terminal_followup_explicit: bool = Field(default=False, exclude=True)
+    notify_lane_explicit: bool = Field(default=False, exclude=True)
+    notify_once_explicit: bool = Field(default=False, exclude=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _capture_followup_intent(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+        payload = dict(value)
+        payload["notify_on_explicit"] = any(
+            key in value for key in ("notify_on", "notifyOn")
+        )
+        payload["terminal_followup_explicit"] = any(
+            key in value for key in ("terminal_followup", "terminalFollowup")
+        )
+        payload["notify_lane_explicit"] = any(
+            key in value for key in ("notify_lane", "notifyLane")
+        )
+        payload["notify_once_explicit"] = any(
+            key in value for key in ("notify_once", "notifyOnce")
+        )
+        return payload
 
 
 class PmaManagedThreadCompactRequest(Payload):

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
@@ -144,5 +144,5 @@ class ManagedThreadAutomationClient:
             raise
 
         if isinstance(created, dict) and "subscription" in created:
-            return created
-        return {"subscription": created}
+            return {"mode": "terminal", **created}
+        return {"mode": "terminal", "subscription": created}

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
@@ -10,7 +10,7 @@ from ...routes.pma_routes.automation_adapter import (
     call_store_create_with_payload,
     get_automation_store,
 )
-from ...schemas import PmaManagedThreadCreateRequest
+from ...schemas import PmaManagedThreadCreateRequest, PmaManagedThreadMessageRequest
 from ...services.pma.common import normalize_optional_text
 
 
@@ -51,12 +51,12 @@ def build_managed_thread_terminal_notify_payload(
 
 
 def resolve_managed_thread_followup_policy(
-    payload: PmaManagedThreadCreateRequest,
+    payload: PmaManagedThreadCreateRequest | PmaManagedThreadMessageRequest,
     *,
     default_terminal_followup: bool,
 ) -> ManagedThreadFollowupPolicy:
     notify_on = payload.notify_on
-    terminal_followup = payload.terminal_followup
+    terminal_followup = getattr(payload, "terminal_followup", None)
     if terminal_followup is False and notify_on == "terminal":
         raise HTTPException(
             status_code=400,
@@ -77,9 +77,9 @@ def resolve_managed_thread_followup_policy(
         enabled=enabled,
         required=enabled
         and (
-            payload.notify_on_explicit
-            or payload.notify_lane_explicit
-            or payload.notify_once_explicit
+            getattr(payload, "notify_on_explicit", False)
+            or getattr(payload, "notify_lane_explicit", False)
+            or getattr(payload, "notify_once_explicit", False)
             or terminal_followup is True
         ),
         event_mode="terminal" if enabled else None,

--- a/tests/test_pma_cli.py
+++ b/tests/test_pma_cli.py
@@ -1123,9 +1123,6 @@ def test_pma_cli_thread_send_reports_queued_busy_thread(
         "message": "follow up",
         "busy_policy": "queue",
         "defer_execution": True,
-        "notify_on": "terminal",
-        "notify_lane": None,
-        "notify_once": True,
     }
 
 
@@ -1191,9 +1188,6 @@ def test_pma_cli_thread_send_reads_message_from_file(
         "message": "literal `glm-5-turbo`\nsecond line\n",
         "busy_policy": "queue",
         "defer_execution": True,
-        "notify_on": "terminal",
-        "notify_lane": None,
-        "notify_once": True,
     }
     assert "delivered message:\nliteral `glm-5-turbo`\nsecond line\n" in result.stdout
     assert "\nassistant:\n" not in result.stdout
@@ -1259,9 +1253,6 @@ def test_pma_cli_thread_send_reads_message_from_stdin(
         "message": "stdin payload with backticks `glm-5-turbo`\n",
         "busy_policy": "queue",
         "defer_execution": True,
-        "notify_on": "terminal",
-        "notify_lane": None,
-        "notify_once": True,
     }
     assert (
         "delivered message:\nstdin payload with backticks `glm-5-turbo`\n"

--- a/tests/test_pma_cli.py
+++ b/tests/test_pma_cli.py
@@ -414,6 +414,10 @@ def test_pma_thread_send_request_and_response_helpers() -> None:
             "active_managed_turn_id": "turn-1",
             "queue_depth": "1",
             "delivered_message": "follow up",
+            "notification": {
+                "mode": "terminal",
+                "subscription": {"lane_id": "lane-1"},
+            },
         },
         default_message="fallback",
     )
@@ -431,7 +435,8 @@ def test_pma_thread_send_request_and_response_helpers() -> None:
     assert response.is_ok is True
     assert response.accepted_line() == (
         "send_state=accepted managed_turn_id=turn-2 "
-        "active_managed_turn_id=turn-1 queue_depth=1"
+        "active_managed_turn_id=turn-1 queue_depth=1 "
+        "wakeup=terminal lane=lane-1"
     )
     assert response.delivered_message == "follow up"
     assert error_response.is_ok is False
@@ -1081,6 +1086,10 @@ def test_pma_cli_thread_send_reports_queued_busy_thread(
                 "queue_depth": 1,
                 "delivered_message": "follow up",
                 "assistant_text": "",
+                "notification": {
+                    "mode": "terminal",
+                    "subscription": {"lane_id": "pma:default"},
+                },
             },
         )
 
@@ -1107,12 +1116,16 @@ def test_pma_cli_thread_send_reports_queued_busy_thread(
     assert "send_state=accepted managed_turn_id=turn-2" in result.stdout
     assert "active_managed_turn_id=turn-1" in result.stdout
     assert "queue_depth=1" in result.stdout
+    assert "wakeup=terminal lane=pma:default" in result.stdout
     assert "delivered message:\nfollow up\n" in result.stdout
     assert captured["url"] == "http://127.0.0.1:4321/hub/pma/threads/thread-1/messages"
     assert captured["payload"] == {
         "message": "follow up",
         "busy_policy": "queue",
         "defer_execution": True,
+        "notify_on": "terminal",
+        "notify_lane": None,
+        "notify_once": True,
     }
 
 
@@ -1178,6 +1191,9 @@ def test_pma_cli_thread_send_reads_message_from_file(
         "message": "literal `glm-5-turbo`\nsecond line\n",
         "busy_policy": "queue",
         "defer_execution": True,
+        "notify_on": "terminal",
+        "notify_lane": None,
+        "notify_once": True,
     }
     assert "delivered message:\nliteral `glm-5-turbo`\nsecond line\n" in result.stdout
     assert "\nassistant:\n" not in result.stdout
@@ -1243,6 +1259,9 @@ def test_pma_cli_thread_send_reads_message_from_stdin(
         "message": "stdin payload with backticks `glm-5-turbo`\n",
         "busy_policy": "queue",
         "defer_execution": True,
+        "notify_on": "terminal",
+        "notify_lane": None,
+        "notify_once": True,
     }
     assert (
         "delivered message:\nstdin payload with backticks `glm-5-turbo`\n"

--- a/tests/test_pma_managed_threads_messages.py
+++ b/tests/test_pma_managed_threads_messages.py
@@ -45,9 +45,9 @@ def _enable_pma(
     if max_text_chars is not None:
         cfg["pma"]["max_text_chars"] = max_text_chars
     if managed_thread_terminal_followup_default is not None:
-        cfg["pma"]["managed_thread_terminal_followup_default"] = (
-            managed_thread_terminal_followup_default
-        )
+        cfg["pma"][
+            "managed_thread_terminal_followup_default"
+        ] = managed_thread_terminal_followup_default
     write_test_config(hub_root / CONFIG_FILENAME, cfg)
 
 
@@ -283,9 +283,7 @@ def test_send_message_persists_turns_and_reuses_backend_thread(hub_env) -> None:
 async def test_send_message_enqueues_assistant_output_to_bound_chat_outboxes(
     hub_env,
 ) -> None:
-    _enable_pma(
-        hub_env.hub_root, managed_thread_terminal_followup_default=False
-    )
+    _enable_pma(hub_env.hub_root, managed_thread_terminal_followup_default=False)
     app = create_hub_app(hub_env.hub_root)
 
     class FakeTurnHandle:

--- a/tests/test_pma_managed_threads_messages.py
+++ b/tests/test_pma_managed_threads_messages.py
@@ -33,6 +33,7 @@ def _enable_pma(
     model: str | None = None,
     reasoning: str | None = None,
     max_text_chars: int | None = None,
+    managed_thread_terminal_followup_default: bool | None = None,
 ) -> None:
     cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
     cfg.setdefault("pma", {})
@@ -43,6 +44,10 @@ def _enable_pma(
         cfg["pma"]["reasoning"] = reasoning
     if max_text_chars is not None:
         cfg["pma"]["max_text_chars"] = max_text_chars
+    if managed_thread_terminal_followup_default is not None:
+        cfg["pma"]["managed_thread_terminal_followup_default"] = (
+            managed_thread_terminal_followup_default
+        )
     write_test_config(hub_root / CONFIG_FILENAME, cfg)
 
 
@@ -278,7 +283,9 @@ def test_send_message_persists_turns_and_reuses_backend_thread(hub_env) -> None:
 async def test_send_message_enqueues_assistant_output_to_bound_chat_outboxes(
     hub_env,
 ) -> None:
-    _enable_pma(hub_env.hub_root)
+    _enable_pma(
+        hub_env.hub_root, managed_thread_terminal_followup_default=False
+    )
     app = create_hub_app(hub_env.hub_root)
 
     class FakeTurnHandle:
@@ -1139,9 +1146,17 @@ def test_send_message_notifies_automation_on_completion(hub_env) -> None:
     class FakeAutomationStore:
         def __init__(self) -> None:
             self.transitions: list[dict[str, object]] = []
+            self.subscriptions: list[dict[str, object]] = []
 
         def notify_transition(self, payload: dict[str, object]) -> None:
             self.transitions.append(dict(payload))
+
+        def create_subscription(self, payload: dict[str, object]) -> dict[str, object]:
+            subscription = dict(payload)
+            subscription.setdefault("subscription_id", "sub-1")
+            subscription.setdefault("thread_id", payload.get("thread_id"))
+            self.subscriptions.append(subscription)
+            return {"subscription": subscription}
 
     class FakeTurnHandle:
         turn_id = "backend-turn-1"
@@ -1883,6 +1898,83 @@ def test_send_message_notify_on_terminal_auto_subscribes_once(hub_env) -> None:
         subscription = notification.get("subscription") or {}
         assert subscription.get("thread_id") == managed_thread_id
         assert subscription.get("lane_id") == "pma:auto-lane"
+
+    automation_store = app.state.hub_supervisor.get_pma_automation_store()
+    active_subs = automation_store.list_subscriptions(thread_id=managed_thread_id)
+    assert active_subs == []
+    all_subs = automation_store.list_subscriptions(
+        include_inactive=True, thread_id=managed_thread_id
+    )
+    assert all_subs
+    assert all_subs[0].get("state") == "cancelled"
+    assert all_subs[0].get("match_count") == 1
+
+
+def test_send_message_defaults_to_terminal_followup_subscription(hub_env) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeTurnHandle:
+        turn_id = "backend-turn-1"
+
+        async def wait(self, timeout=None):
+            _ = timeout
+            return type(
+                "Result",
+                (),
+                {
+                    "agent_messages": ["assistant-output"],
+                    "raw_events": [],
+                    "errors": [],
+                },
+            )()
+
+    class FakeClient:
+        async def thread_start(self, root: str) -> dict:
+            _ = root
+            return {"id": "backend-thread-1"}
+
+        async def turn_start(
+            self,
+            thread_id: str,
+            prompt: str,
+            approval_policy: str,
+            sandbox_policy: str,
+            **turn_kwargs,
+        ):
+            _ = thread_id, prompt, approval_policy, sandbox_policy, turn_kwargs
+            return FakeTurnHandle()
+
+    class FakeSupervisor:
+        async def get_client(self, hub_root: Path):
+            _ = hub_root
+            return FakeClient()
+
+    app.state.app_server_supervisor = FakeSupervisor()
+    app.state.app_server_events = object()
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={"agent": "codex", **_repo_owner(hub_env)},
+        )
+        assert create_resp.status_code == 200
+        managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+        message_resp = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/messages",
+            json={
+                "message": "trigger completion",
+            },
+        )
+        assert message_resp.status_code == 200
+        payload = message_resp.json()
+        assert payload["status"] == "ok"
+        assert payload["send_state"] == "accepted"
+        notification = payload.get("notification") or {}
+        subscription = notification.get("subscription") or {}
+        assert notification.get("mode") == "terminal"
+        assert subscription.get("thread_id") == managed_thread_id
 
     automation_store = app.state.hub_supervisor.get_pma_automation_store()
     active_subs = automation_store.list_subscriptions(thread_id=managed_thread_id)


### PR DESCRIPTION
## Summary
- default managed thread sends to terminal wakeups instead of pushing PMA operators into `--watch` babysitting
- align the route-side PMA config lookup with the shared config normalizer so terminal followup defaults and future PMA settings do not drift
- update CLI/PMA guidance and tests to reflect async-by-default sends and explicit foreground `--watch`

## Testing
- `python3 -m pytest -q tests/test_pma_cli.py::test_pma_thread_send_request_and_response_helpers tests/test_pma_cli.py::test_pma_cli_thread_send_reads_message_from_file tests/test_pma_cli.py::test_pma_cli_thread_send_reads_message_from_stdin tests/test_pma_managed_threads_messages.py::test_send_message_notify_on_terminal_auto_subscribes_once tests/test_pma_managed_threads_messages.py::test_send_message_defaults_to_terminal_followup_subscription tests/test_pma_managed_threads_messages.py::test_send_message_notifies_automation_on_completion`
- Broader focused suite functionally passed its test bodies, but the repo currently has a separate session-level pytest temp-root cleanup teardown issue that still fails at the end of the run.