### PR TITLE
[codex] Fix Discord Hermes profile timeout recovery

### DIFF
--- a/src/codex_autorunner/agents/registry.py
+++ b/src/codex_autorunner/agents/registry.py
@@ -482,6 +482,37 @@ def _infer_backend_id_by_prefix(
     return None
 
 
+def _configured_profile_target(
+    config: Any,
+    agent_id: str,
+    base_agents: dict[str, AgentDescriptor],
+) -> Optional[tuple[str, str]]:
+    profile_getter = getattr(config, "agent_profiles", None)
+    if not callable(profile_getter):
+        return None
+    normalized_agent_id = str(agent_id or "").strip().lower()
+    if not normalized_agent_id:
+        return None
+    for backend_id, descriptor in base_agents.items():
+        runtime_kind = _agent_runtime_kind(backend_id, descriptor)
+        if runtime_kind != backend_id:
+            continue
+        derived_profile = _strip_runtime_kind_prefix(normalized_agent_id, runtime_kind)
+        if derived_profile == normalized_agent_id:
+            continue
+        try:
+            profiles = profile_getter(backend_id)
+        except (KeyError, AttributeError, TypeError, ValueError, RuntimeError):
+            continue
+        if not isinstance(profiles, dict):
+            continue
+        if derived_profile in {
+            str(profile_id or "").strip().lower() for profile_id in profiles
+        }:
+            return backend_id, derived_profile
+    return None
+
+
 def _build_config_alias_agents(context: Any) -> dict[str, AgentDescriptor]:
     config = _resolve_runtime_agent_config(context)
     if config is None:
@@ -498,8 +529,28 @@ def _build_config_alias_agents(context: Any) -> dict[str, AgentDescriptor]:
         if agent_id in base_agents:
             continue
         backend_id = agent_id
+        profile_target = _configured_profile_target(config, agent_id, base_agents)
         if callable(getattr(config, "agent_backend", None)):
-            backend_id = str(config.agent_backend(agent_id) or "").strip().lower()
+            try:
+                backend_id = str(config.agent_backend(agent_id) or "").strip().lower()
+            except (
+                ConfigError,
+                KeyError,
+                AttributeError,
+                TypeError,
+                ValueError,
+                RuntimeError,
+            ):
+                if profile_target is not None:
+                    resolved_backend_id, resolved_profile = profile_target
+                    _logger.debug(
+                        "Skipping config alias synthesis for %s; treated as %s profile %s",
+                        agent_id,
+                        resolved_backend_id,
+                        resolved_profile,
+                    )
+                    continue
+                raise
         if not backend_id:
             continue
         backend_descriptor = base_agents.get(backend_id)
@@ -514,6 +565,15 @@ def _build_config_alias_agents(context: Any) -> dict[str, AgentDescriptor]:
                 )
                 backend_id = inferred
                 backend_descriptor = base_agents.get(backend_id)
+        if backend_descriptor is None and profile_target is not None:
+            resolved_backend_id, resolved_profile = profile_target
+            _logger.debug(
+                "Skipping unresolved config alias %s; %s profile %s is configured canonically",
+                agent_id,
+                resolved_backend_id,
+                resolved_profile,
+            )
+            continue
         if backend_descriptor is None:
             _logger.warning(
                 "Configured agent %s references unknown backend %s",

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -1997,6 +1997,64 @@ def _build_managed_thread_input_items(
     )
 
 
+async def _evict_cached_runtime_supervisors(
+    service: Any,
+    *,
+    agent_id: str,
+    profile: Optional[str],
+    workspace_root: Path,
+) -> int:
+    cache = getattr(service, "_agent_runtime_supervisors", None)
+    if not isinstance(cache, dict) or not cache:
+        return 0
+    try:
+        resolution = resolve_agent_runtime(agent_id, profile, context=service)
+    except (KeyError, ValueError, TypeError, RuntimeError):
+        return 0
+    runtime_agent_id = str(getattr(resolution, "runtime_agent_id", "") or "").strip()
+    runtime_profile = (
+        str(getattr(resolution, "runtime_profile", "") or "").strip().lower()
+    )
+    if not runtime_agent_id:
+        return 0
+
+    matching_keys = [
+        key
+        for key in list(cache.keys())
+        if isinstance(key, tuple)
+        and len(key) == 3
+        and str(key[1] or "").strip() == runtime_agent_id
+        and str(key[2] or "").strip().lower() == runtime_profile
+    ]
+    if not matching_keys:
+        return 0
+
+    supervisors = [cache.pop(key, None) for key in matching_keys]
+    evicted = 0
+    for supervisor in supervisors:
+        if supervisor is None:
+            continue
+        evicted += 1
+        if getattr(service, "hermes_supervisor", None) is supervisor:
+            with contextlib.suppress(AttributeError):
+                service.hermes_supervisor = None
+        close_workspace = getattr(supervisor, "close_workspace", None)
+        close_all = getattr(supervisor, "close_all", None)
+        try:
+            if callable(close_workspace):
+                await close_workspace(workspace_root)
+            elif callable(close_all):
+                await close_all()
+        except (RuntimeError, ConnectionError, OSError, ValueError, TypeError):
+            _logger.debug(
+                "Runtime supervisor eviction cleanup failed for agent=%s profile=%s",
+                runtime_agent_id,
+                runtime_profile or None,
+                exc_info=True,
+            )
+    return evicted
+
+
 def build_discord_thread_orchestration_service(service: Any) -> Any:
     cached = getattr(service, "_discord_thread_orchestration_service", None)
     if cached is None:
@@ -2605,6 +2663,12 @@ async def _run_discord_orchestrated_turn_for_message(
 
     async def _on_submission_error(exc: BaseException) -> DiscordMessageTurnResult:
         if isinstance(exc, asyncio.TimeoutError):
+            evicted_supervisors = await _evict_cached_runtime_supervisors(
+                service,
+                agent_id=logical_agent,
+                profile=agent_profile,
+                workspace_root=workspace_root,
+            )
             log_event(
                 service._logger,
                 logging.ERROR,
@@ -2615,6 +2679,8 @@ async def _run_discord_orchestrated_turn_for_message(
                 pma_enabled=pma_enabled,
                 workspace_root=str(workspace_root),
                 agent=logical_agent,
+                agent_profile=agent_profile,
+                evicted_runtime_supervisors=evicted_supervisors,
             )
             tracker.set_label("failed")
             tracker.note_error("Turn failed to start in time. Please retry.")

--- a/tests/integrations/discord/test_timeout_recovery.py
+++ b/tests/integrations/discord/test_timeout_recovery.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import pytest
+from tests.discord_message_turns_support import _config, _FakeRest
+
+import codex_autorunner.integrations.discord.message_turns as discord_message_turns_module
+
+
+@pytest.mark.asyncio
+async def test_orchestrated_turn_submission_timeout_evicts_cached_runtime_supervisor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    rest = _FakeRest()
+    thread = SimpleNamespace(thread_target_id="thread-1")
+    submit_started = asyncio.Event()
+
+    class _FakeSupervisor:
+        def __init__(self) -> None:
+            self.closed_workspaces: list[Path] = []
+
+        async def close_workspace(self, workspace_root: Path) -> None:
+            self.closed_workspaces.append(workspace_root)
+
+    fake_supervisor = _FakeSupervisor()
+
+    class _Store:
+        async def get_binding(self, *, channel_id: str) -> dict[str, Any]:
+            assert channel_id == "channel-1"
+            return {}
+
+    class _Service:
+        def __init__(self) -> None:
+            self._config = _config(tmp_path)
+            self._store = _Store()
+            self._rest = rest
+            self._logger = logging.getLogger(__name__)
+            self._agent_runtime_supervisors = {
+                ("hermes", "hermes", "m4-pma"): fake_supervisor
+            }
+
+        async def _send_channel_message(
+            self, channel_id: str, payload: dict[str, Any]
+        ) -> dict[str, Any]:
+            return await rest.create_channel_message(
+                channel_id=channel_id,
+                payload=payload,
+            )
+
+        def _register_discord_turn_approval_context(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+        def _clear_discord_turn_approval_context(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+        def _resolve_agent_state(self, binding: Any) -> tuple[str, Optional[str]]:
+            _ = binding
+            return "hermes", "m4-pma"
+
+        def _runtime_agent_for_binding(self, binding: Any) -> str:
+            _ = binding
+            return "hermes"
+
+    async def _hanging_submit(self, *args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        submit_started.set()
+        await asyncio.Future()
+
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "resolve_discord_thread_target",
+        lambda *args, **kwargs: (SimpleNamespace(), thread),
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "resolve_agent_runtime",
+        lambda *args, **kwargs: SimpleNamespace(
+            runtime_agent_id="hermes",
+            runtime_profile="m4-pma",
+        ),
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "DISCORD_MANAGED_THREAD_SUBMISSION_TIMEOUT_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module.ManagedThreadTurnCoordinator,
+        "submit_execution",
+        _hanging_submit,
+    )
+
+    service = _Service()
+    with pytest.raises(
+        RuntimeError,
+        match="Turn failed to start in time. Please retry.",
+    ):
+        await discord_message_turns_module._run_discord_orchestrated_turn_for_message(
+            service,
+            workspace_root=tmp_path,
+            prompt_text="hi",
+            input_items=None,
+            source_message_id=None,
+            agent="hermes",
+            model_override=None,
+            reasoning_effort=None,
+            session_key="s1",
+            orchestrator_channel_key="channel-1",
+            managed_thread_surface_key=None,
+            mode="pma",
+            pma_enabled=True,
+            execution_prompt="<user_message>\nhi\n</user_message>\n",
+            public_execution_error="err",
+            timeout_error="timeout",
+            interrupted_error="interrupt",
+            approval_mode="never",
+            sandbox_policy="dangerFullAccess",
+            max_actions=12,
+            min_edit_interval_seconds=1.0,
+            heartbeat_interval_seconds=2.0,
+        )
+
+    assert submit_started.is_set()
+    assert fake_supervisor.closed_workspaces == [tmp_path]
+    assert service._agent_runtime_supervisors == {}

--- a/tests/test_agents_registry.py
+++ b/tests/test_agents_registry.py
@@ -18,6 +18,7 @@ from codex_autorunner.agents.registry import (
     wrap_requested_agent_context,
 )
 from codex_autorunner.core.config import AgentConfig, ResolvedAgentTarget
+from codex_autorunner.core.config_contract import ConfigError
 
 
 @pytest.fixture
@@ -551,6 +552,57 @@ class TestHermesHarness:
 
         assert validate_agent_id("hermes-m4-pma", Path("/tmp/repo")) == "hermes-m4-pma"
         assert calls == ["repo"]
+
+    def test_get_registered_agents_skips_warning_for_known_profile_style_id(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        class MockConfig:
+            agents = {
+                "hermes": AgentConfig(
+                    backend=None,
+                    binary="hermes",
+                    serve_command=None,
+                    base_url=None,
+                    subagent_models=None,
+                    profiles={"m4-pma": object()},
+                ),
+                "hermes-m4-pma": AgentConfig(
+                    backend=None,
+                    binary=None,
+                    serve_command=None,
+                    base_url=None,
+                    subagent_models=None,
+                ),
+            }
+
+            @staticmethod
+            def agent_binary(agent_id: str) -> str:
+                agent = MockConfig.agents[agent_id]
+                if not agent.binary:
+                    raise ConfigError(f"agents.{agent_id}.binary is required")
+                return agent.binary
+
+            @staticmethod
+            def agent_backend(agent_id: str) -> str:
+                if agent_id == "hermes-m4-pma":
+                    raise ConfigError(f"agents.{agent_id}.binary is required")
+                agent = MockConfig.agents[agent_id]
+                return str(agent.backend or agent_id)
+
+            @staticmethod
+            def agent_profiles(agent_id: str):
+                agent = MockConfig.agents.get(agent_id)
+                return dict(agent.profiles or {}) if agent is not None else {}
+
+        caplog.set_level("WARNING")
+
+        agents = get_registered_agents(MockConfig)
+
+        assert "hermes-m4-pma" not in agents
+        assert (
+            "Configured agent hermes-m4-pma references unknown backend"
+            not in caplog.text
+        )
 
     def test_wrap_requested_agent_context_preserves_profile(self):
         ctx = SimpleNamespace()


### PR DESCRIPTION
## What changed
- evict the cached runtime supervisor for the affected agent/profile/workspace when a Discord managed-thread turn times out during submission
- add logging fields around that recovery path so the timeout is easier to attribute in production
- stop treating profile-shaped ids like `hermes-m4-pma` as broken standalone aliases when they map to a canonically configured profile
- cover the recovery path and the alias/profile registry behavior with targeted tests

## Why
Profiled Hermes PMA sessions could answer the first Discord turn and then fail on later turns with `Turn failed to start in time. Please retry.` The live evidence pointed to the Discord worker reusing a poisoned cached profiled Hermes supervisor after the first turn. Separately, registry startup logs were emitting a misleading unknown-backend warning for profile-shaped ids, which made the Hermes profile path noisier to debug than it should be.

## Impact
- profiled Hermes PMA sessions recover on retry instead of repeatedly reusing a bad cached runtime supervisor
- Discord timeout logs include the profile and eviction count, which makes this class of incident easier to triage
- registry logs stop warning about known canonical profile ids that are not actually misconfigured aliases

## Root cause
- long-lived Discord workers cached a profiled Hermes runtime supervisor and kept reusing it even after a managed-thread submission timeout
- alias synthesis in the registry did not distinguish between true standalone aliases and ids that are just profile-shaped views of a canonical profile definition

## Validation
- `.venv/bin/pytest tests/test_hotspot_budgets.py tests/test_agents_registry.py tests/integrations/discord/test_message_turns.py tests/integrations/discord/test_timeout_recovery.py -k 'hotspot or hermes or submission_timeout'`
- pre-commit `scripts/check.sh` during `git commit` including strict mypy, frontend build/tests, and full pytest (`4805 passed`)

## Follow-up
- Refs #1360