### PR TITLE
[codex] Add Discord Hermes startup telemetry

### DIFF
--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -79,6 +79,7 @@ class HermesSupervisor:
         if not command:
             raise ValueError("Hermes command must not be empty")
         self._logger = logger or logging.getLogger(__name__)
+        self._command = tuple(str(part) for part in command)
         self._approval_handler = approval_handler
         self._default_approval_decision = _normalize_approval_decision(
             default_approval_decision,
@@ -100,8 +101,28 @@ class HermesSupervisor:
         self._session_turns: dict[tuple[str, str], str] = {}
         self._lock = asyncio.Lock()
 
+    @property
+    def launch_command(self) -> tuple[str, ...]:
+        return self._command
+
     async def ensure_ready(self, workspace_root: Path) -> None:
+        started_at = time.monotonic()
+        log_event(
+            self._logger,
+            logging.INFO,
+            "hermes.runtime.ensure_ready_requested",
+            workspace_root=_workspace_key(workspace_root),
+            launch_command=list(self._command),
+        )
         await self._acp.get_client(workspace_root)
+        log_event(
+            self._logger,
+            logging.INFO,
+            "hermes.runtime.ready",
+            workspace_root=_workspace_key(workspace_root),
+            launch_command=list(self._command),
+            elapsed_ms=_elapsed_ms(started_at),
+        )
 
     async def create_session(
         self,
@@ -111,6 +132,14 @@ class HermesSupervisor:
         metadata: Optional[dict[str, Any]] = None,
     ) -> HermesSessionHandle:
         started_at = time.monotonic()
+        log_event(
+            self._logger,
+            logging.INFO,
+            "hermes.session.create_requested",
+            workspace_root=_workspace_key(workspace_root),
+            title=title,
+            launch_command=list(self._command),
+        )
         session = await self._acp.create_session(
             workspace_root,
             title=title,
@@ -123,6 +152,7 @@ class HermesSupervisor:
             workspace_root=_workspace_key(workspace_root),
             session_id=session.session_id,
             title=title,
+            launch_command=list(self._command),
             elapsed_ms=_elapsed_ms(started_at),
         )
         return HermesSessionHandle(
@@ -137,6 +167,14 @@ class HermesSupervisor:
         session_id: str,
     ) -> HermesSessionHandle:
         started_at = time.monotonic()
+        log_event(
+            self._logger,
+            logging.INFO,
+            "hermes.session.resume_requested",
+            workspace_root=_workspace_key(workspace_root),
+            session_id=session_id,
+            launch_command=list(self._command),
+        )
         session = await self._acp.load_session(workspace_root, session_id)
         log_event(
             self._logger,
@@ -144,6 +182,7 @@ class HermesSupervisor:
             "hermes.session.resumed",
             workspace_root=_workspace_key(workspace_root),
             session_id=session.session_id,
+            launch_command=list(self._command),
             elapsed_ms=_elapsed_ms(started_at),
         )
         return HermesSessionHandle(
@@ -174,6 +213,16 @@ class HermesSupervisor:
     ) -> str:
         workspace = _workspace_key(workspace_root)
         started_at = time.monotonic()
+        log_event(
+            self._logger,
+            logging.INFO,
+            "hermes.turn.start_requested",
+            workspace_root=workspace,
+            session_id=session_id,
+            approval_mode=_normalize_optional_text(approval_mode),
+            model=_normalize_optional_text(model),
+            launch_command=list(self._command),
+        )
         handle = await self._acp.start_prompt(
             workspace_root,
             session_id,
@@ -217,6 +266,7 @@ class HermesSupervisor:
             turn_id=handle.turn_id,
             approval_mode=_normalize_optional_text(approval_mode),
             model=_normalize_optional_text(model),
+            launch_command=list(self._command),
             elapsed_ms=_elapsed_ms(started_at),
         )
         return handle.turn_id

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -2001,6 +2001,26 @@ def _build_managed_thread_input_items(
     )
 
 
+def _coerce_launch_command(value: Any) -> Optional[list[str]]:
+    if isinstance(value, (list, tuple)):
+        command = [str(part) for part in value if str(part).strip()]
+        return command or None
+    return None
+
+
+def _runtime_launch_command_from_harness(harness: Any) -> Optional[list[str]]:
+    supervisor = getattr(harness, "_supervisor", None)
+    if supervisor is None:
+        return None
+    launch_command = getattr(supervisor, "launch_command", None)
+    if callable(launch_command):
+        try:
+            return _coerce_launch_command(launch_command())
+        except (RuntimeError, ValueError, TypeError, AttributeError):
+            return None
+    return _coerce_launch_command(launch_command)
+
+
 async def _evict_cached_runtime_supervisors(
     service: Any,
     *,
@@ -2073,13 +2093,31 @@ def build_discord_thread_orchestration_service(service: Any) -> Any:
         descriptor = descriptors.get(resolution.runtime_agent_id)
         if descriptor is None:
             raise KeyError(f"Unknown agent definition '{resolution.runtime_agent_id}'")
-        return descriptor.make_harness(
+        harness = descriptor.make_harness(
             wrap_requested_agent_context(
                 service,
                 agent_id=resolution.runtime_agent_id,
                 profile=resolution.runtime_profile,
             )
         )
+        runtime_kind = str(
+            getattr(descriptor, "runtime_kind", resolution.runtime_agent_id) or ""
+        ).strip()
+        if runtime_kind == "hermes" or resolution.logical_agent_id == "hermes":
+            log_event(
+                service._logger,
+                logging.INFO,
+                "discord.hermes.runtime_resolution",
+                requested_agent_id=agent_id,
+                requested_profile=profile,
+                logical_agent_id=resolution.logical_agent_id,
+                logical_profile=resolution.logical_profile,
+                resolution_kind=resolution.resolution_kind,
+                runtime_agent_id=resolution.runtime_agent_id,
+                runtime_profile=resolution.runtime_profile,
+                launch_command=_runtime_launch_command_from_harness(harness),
+            )
+        return harness
 
     created = build_harness_backed_orchestration_service(
         descriptors=cast(Any, descriptors),

--- a/tests/integrations/discord/test_runtime_resolution_logging.py
+++ b/tests/integrations/discord/test_runtime_resolution_logging.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from tests.discord_message_turns_support import (
+    _config,
+    _FakeGateway,
+    _FakeOutboxManager,
+    _FakeRest,
+)
+
+import codex_autorunner.integrations.discord.message_turns as discord_message_turns_module
+from codex_autorunner.agents.registry import AgentDescriptor
+from codex_autorunner.integrations.discord.service import DiscordBotService
+from codex_autorunner.integrations.discord.state import DiscordStateStore
+
+
+def _build_service(tmp_path: Path) -> DiscordBotService:
+    store = DiscordStateStore(tmp_path / "state.sqlite3")
+    service = DiscordBotService(
+        _config(tmp_path, max_message_length=100),
+        logger=logging.getLogger("test"),
+        rest_client=_FakeRest(),
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    service._discord_thread_orchestration_service = None
+    service._discord_managed_thread_orchestration_service = None
+    return service
+
+
+def test_discord_harness_factory_logs_canonical_hermes_runtime_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_logs: list[dict[str, Any]] = []
+
+    def _fake_make_harness(_ctx: Any) -> SimpleNamespace:
+        return SimpleNamespace(
+            _supervisor=SimpleNamespace(
+                launch_command=("hermes", "-p", "m4-pma", "acp")
+            )
+        )
+
+    descriptor = AgentDescriptor(
+        id="hermes",
+        name="Hermes",
+        capabilities=("durable_threads",),
+        make_harness=_fake_make_harness,
+        healthcheck=lambda: True,
+        runtime_kind="hermes",
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "get_registered_agents",
+        lambda context=None: {"hermes": descriptor},
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "resolve_agent_runtime",
+        lambda *args, **kwargs: SimpleNamespace(
+            logical_agent_id="hermes",
+            logical_profile="m4-pma",
+            runtime_agent_id="hermes",
+            runtime_profile="m4-pma",
+            resolution_kind="canonical_profile",
+        ),
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "log_event",
+        lambda _logger, _level, event, **fields: captured_logs.append(
+            {"event": event, **fields}
+        ),
+    )
+
+    orch = discord_message_turns_module.build_discord_thread_orchestration_service(
+        _build_service(tmp_path)
+    )
+    orch._harness_for_agent("hermes", "m4-pma")
+
+    resolution_logs = [
+        record
+        for record in captured_logs
+        if record.get("event") == "discord.hermes.runtime_resolution"
+    ]
+    assert resolution_logs == [
+        {
+            "event": "discord.hermes.runtime_resolution",
+            "requested_agent_id": "hermes",
+            "requested_profile": "m4-pma",
+            "logical_agent_id": "hermes",
+            "logical_profile": "m4-pma",
+            "resolution_kind": "canonical_profile",
+            "runtime_agent_id": "hermes",
+            "runtime_profile": "m4-pma",
+            "launch_command": ["hermes", "-p", "m4-pma", "acp"],
+        }
+    ]
+
+
+def test_discord_harness_factory_logs_alias_hermes_runtime_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_logs: list[dict[str, Any]] = []
+
+    def _fake_make_harness(_ctx: Any) -> SimpleNamespace:
+        return SimpleNamespace(
+            _supervisor=SimpleNamespace(
+                launch_command=("hermes", "-p", "hermes-m4-pma", "acp")
+            )
+        )
+
+    descriptor = AgentDescriptor(
+        id="hermes-m4-pma",
+        name="Hermes Alias",
+        capabilities=("durable_threads",),
+        make_harness=_fake_make_harness,
+        healthcheck=lambda: True,
+        runtime_kind="hermes",
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "get_registered_agents",
+        lambda context=None: {"hermes-m4-pma": descriptor},
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "resolve_agent_runtime",
+        lambda *args, **kwargs: SimpleNamespace(
+            logical_agent_id="hermes",
+            logical_profile="m4-pma",
+            runtime_agent_id="hermes-m4-pma",
+            runtime_profile=None,
+            resolution_kind="alias_profile",
+        ),
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "log_event",
+        lambda _logger, _level, event, **fields: captured_logs.append(
+            {"event": event, **fields}
+        ),
+    )
+
+    orch = discord_message_turns_module.build_discord_thread_orchestration_service(
+        _build_service(tmp_path)
+    )
+    orch._harness_for_agent("hermes", "m4-pma")
+
+    resolution_logs = [
+        record
+        for record in captured_logs
+        if record.get("event") == "discord.hermes.runtime_resolution"
+    ]
+    assert resolution_logs == [
+        {
+            "event": "discord.hermes.runtime_resolution",
+            "requested_agent_id": "hermes",
+            "requested_profile": "m4-pma",
+            "logical_agent_id": "hermes",
+            "logical_profile": "m4-pma",
+            "resolution_kind": "alias_profile",
+            "runtime_agent_id": "hermes-m4-pma",
+            "runtime_profile": None,
+            "launch_command": ["hermes", "-p", "hermes-m4-pma", "acp"],
+        }
+    ]


### PR DESCRIPTION
## Summary
This adds Hermes startup telemetry for the Discord PMA path so issue #1360 can distinguish canonical profile resolution from legacy alias compatibility and show the exact launch command that was chosen.

## What Changed
- expose the Hermes supervisor launch command for structured logging
- log Discord Hermes runtime resolution with `resolution_kind`, `runtime_agent_id`, `runtime_profile`, and the chosen launch command when the harness is built
- add pre-call Hermes lifecycle trace points around `ensure_ready`, session creation/resume, and turn start so wedges can be localized to the last completed startup phase
- add focused Discord tests for both canonical-profile and alias-profile telemetry paths

## Why
Issue #1360 already has timeout recovery, but it still lacks the startup telemetry needed to tell whether a profiled Hermes PMA wedge happens before session resume, before prompt start, or after a specific runtime resolution path. This PR makes those signals explicit without adding broader recovery logic that could mask the underlying failure.

## Validation
- `.venv/bin/pytest tests/integrations/discord/test_runtime_resolution_logging.py tests/discord_message_turns_support.py -k 'discord_harness_factory_accepts_profile or runtime_resolution'`
- `.venv/bin/pytest tests/integrations/discord/test_timeout_recovery.py tests/agents/hermes/test_hermes_supervisor.py tests/test_hotspot_budgets.py -k 'test_hotspot_file_budgets or test_orchestrated_turn_submission_timeout_evicts_cached_runtime_supervisor or hermes_supervisor'`
- repository pre-commit hook suite during `git commit` including repo-wide mypy, frontend build/tests, and full pytest (`4816 passed`)

Closes #1360.
