### PR TITLE
[codex] Fix Discord stale progress lease reconciliation

### DIFF
--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -564,12 +564,12 @@ async def _retire_discord_progress_message(
     channel_id: str,
     message_id: str,
     note: str,
-) -> None:
+) -> bool:
     normalized_channel_id = str(channel_id or "").strip()
     normalized_message_id = str(message_id or "").strip()
     normalized_note = str(note or "").strip()
     if not normalized_channel_id or not normalized_message_id or not normalized_note:
-        return
+        return False
     content = normalized_note
     fetch_message = getattr(service._rest, "get_channel_message", None)
     if callable(fetch_message):
@@ -609,7 +609,8 @@ async def _retire_discord_progress_message(
             },
         )
     except (DiscordTransientError, RuntimeError, ConnectionError, OSError):
-        return
+        return False
+    return True
 
 
 def _orphaned_progress_note(*, startup: bool) -> str:
@@ -786,14 +787,15 @@ async def reconcile_discord_turn_progress_leases(
             lease_id=current_lease_id,
             state="retiring",
         )
-        await _retire_discord_progress_message(
+        retired = await _retire_discord_progress_message(
             service,
             channel_id=current_channel_id,
             message_id=current_message_id,
             note=note,
         )
-        await _delete_discord_progress_lease(service, lease_id=current_lease_id)
-        reconciled += 1
+        if retired:
+            await _delete_discord_progress_lease(service, lease_id=current_lease_id)
+            reconciled += 1
     return reconciled
 
 

--- a/tests/integrations/discord/test_message_turns_transient_progress.py
+++ b/tests/integrations/discord/test_message_turns_transient_progress.py
@@ -24,6 +24,83 @@ class _TransientEditProgressRest(support._FakeRest):
         raise DiscordTransientError("simulated transient progress edit failure")
 
 
+@pytest.mark.anyio
+async def test_reconcile_progress_lease_retries_when_retire_edit_fails(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = support.DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-1",
+        managed_thread_id="thread-1",
+        execution_id="exec-1",
+        channel_id="channel-1",
+        message_id="msg-1",
+        state="active",
+        progress_label="running",
+    )
+
+    fake_orchestration_service = SimpleNamespace(
+        get_thread_target=lambda _thread_id: SimpleNamespace(
+            thread_target_id="thread-1"
+        ),
+        get_latest_execution=lambda _thread_id: SimpleNamespace(
+            execution_id="exec-1",
+            status="ok",
+        ),
+        get_running_execution=lambda _thread_id: None,
+        get_execution=lambda _thread_id, _execution_id: SimpleNamespace(
+            execution_id="exec-1",
+            status="ok",
+        ),
+    )
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "build_discord_thread_orchestration_service",
+        lambda _service: fake_orchestration_service,
+    )
+
+    service = SimpleNamespace(
+        _store=store,
+        _rest=support._EditFailingProgressRest(),
+        _config=support._config(tmp_path),
+        _logger=logging.getLogger("test"),
+    )
+
+    try:
+        reconciled = await support.discord_message_turns_module.reconcile_discord_turn_progress_leases(
+            service,
+            lease_id="lease-1",
+        )
+        assert reconciled == 0
+
+        retained = await store.get_turn_progress_lease(lease_id="lease-1")
+        assert retained is not None
+        assert retained.state == "retiring"
+
+        service._rest = support._FakeRest()
+        reconciled = await support.discord_message_turns_module.reconcile_discord_turn_progress_leases(
+            service,
+            lease_id="lease-1",
+        )
+        assert reconciled == 1
+
+        retired = await store.get_turn_progress_lease(lease_id="lease-1")
+        assert retired is None
+        assert service._rest.edited_channel_messages == [
+            {
+                "channel_id": "channel-1",
+                "message_id": "msg-1",
+                "payload": {
+                    "content": "Status: this turn already completed.",
+                    "components": [],
+                },
+            }
+        ]
+    finally:
+        await store.close()
+
+
 @pytest.mark.asyncio
 async def test_orchestrated_turn_interrupt_send_falls_back_when_progress_ack_edit_is_transient(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## What changed
- make Discord progress-message retirement report success/failure instead of silently swallowing edit failures
- only delete a Discord turn progress lease after the stale progress message was actually retired
- add a regression test covering transient retire-edit failure followed by successful reconcile retry
- keep the regression in `tests/integrations/discord/test_message_turns_transient_progress.py` so the large support file stays under its hotspot budget

## Why
Discord can show a stale `working` PMA progress card even after the underlying turn has already completed. The concrete failure mode here was that reconciliation marked the lease as `retiring` and dropped it even when the Discord edit that should convert the stale card into a completed status note failed. After that, there was no lease left to retry cleanup.

## Impact
- completed PMA turns are less likely to remain visibly stuck in Discord after a transient progress-message edit failure
- startup/background reconciliation can retry retiring stale progress cards instead of orphaning them permanently on the first failed edit

## Root cause
The reconcile path treated progress-message retirement as best-effort, but it treated lease deletion as unconditional. That meant a transient Discord REST error during retirement could erase the only durable handle for later cleanup.

## Validation
- final subagent review: no findings
- `.venv/bin/python -m pytest tests/integrations/discord/test_message_turns_transient_progress.py -k "reconcile_progress_lease_retries_when_retire_edit_fails"`
- `.venv/bin/python -m pytest tests/chat_surface_integration/test_hermes_pma_surfaces.py -k "stale_preview_when_delivery_cleanup_fails"`
- `.venv/bin/python -m pytest tests/test_hotspot_budgets.py -k hotspot_file_budgets`
- full pre-commit hook suite via `git commit` including mypy, frontend build/tests, and repo-wide pytest (`4814 passed`)
