### PR TITLE
[codex] Speed up hub snapshot and hub listings

### DIFF
--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -795,6 +795,7 @@ class HubSupervisor:
             raise ValueError(detail)
         target.mkdir(parents=True, exist_ok=True)
         save_manifest(self.hub_config.manifest_path, manifest, self.hub_config.root)
+        self.list_repos(use_cache=False)
         return self._snapshot_for_agent_workspace(normalized_workspace_id)
 
     def remove_agent_workspace(
@@ -866,6 +867,7 @@ class HubSupervisor:
             workspace.display_name = normalized_display_name
 
         save_manifest(self.hub_config.manifest_path, manifest, self.hub_config.root)
+        self.list_repos(use_cache=False)
         return self._snapshot_for_agent_workspace(workspace_id)
 
     def set_agent_workspace_destination(
@@ -878,6 +880,7 @@ class HubSupervisor:
             raise ValueError(f"Agent workspace {workspace_id} not found in manifest")
         workspace.destination = normalize_manifest_destination(destination)
         save_manifest(self.hub_config.manifest_path, manifest, self.hub_config.root)
+        self.list_repos(use_cache=False)
         return self._snapshot_for_agent_workspace(workspace_id)
 
     def _reconcile_startup(self) -> None:

--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -454,13 +454,20 @@ def load_hub_state(state_path: Path, hub_root: Path) -> HubState:
     )
 
 
-def save_hub_state(state_path: Path, state: HubState, hub_root: Path) -> None:
+def save_hub_state(
+    state_path: Path,
+    state: HubState,
+    hub_root: Path,
+    *,
+    refresh_pma_threads_artifact: bool = True,
+) -> None:
     payload = state.to_dict(hub_root)
     atomic_write(state_path, json.dumps(payload, indent=2) + "\n")
-    try:
-        _save_pma_threads_artifact(hub_root)
-    except (OSError, ValueError, TypeError) as exc:
-        logger.warning("Failed to write PMA thread snapshot artifact: %s", exc)
+    if refresh_pma_threads_artifact:
+        try:
+            _save_pma_threads_artifact(hub_root)
+        except (OSError, ValueError, TypeError) as exc:
+            logger.warning("Failed to write PMA thread snapshot artifact: %s", exc)
 
 
 def _save_pma_threads_artifact(hub_root: Path) -> None:
@@ -682,7 +689,12 @@ class HubSupervisor:
                 agent_workspaces=agent_workspaces,
                 pinned_parent_repo_ids=pinned_parent_repo_ids,
             )
-            save_hub_state(self.state_path, self.state, self.hub_config.root)
+            save_hub_state(
+                self.state_path,
+                self.state,
+                self.hub_config.root,
+                refresh_pma_threads_artifact=False,
+            )
             self._list_cache = snapshots
             self._list_cache_at = time.monotonic()
             return snapshots
@@ -714,7 +726,12 @@ class HubSupervisor:
                 agent_workspaces=self.state.agent_workspaces,
                 pinned_parent_repo_ids=_normalize_pinned_parent_repo_ids(current),
             )
-            save_hub_state(self.state_path, self.state, self.hub_config.root)
+            save_hub_state(
+                self.state_path,
+                self.state,
+                self.hub_config.root,
+                refresh_pma_threads_artifact=False,
+            )
             return list(self.state.pinned_parent_repo_ids)
 
     def create_agent_workspace(
@@ -1546,9 +1563,7 @@ class HubSupervisor:
         workspace = manifest.get_agent_workspace(workspace_id)
         if not workspace:
             raise ValueError(f"Agent workspace {workspace_id} not found in manifest")
-        snapshot = self._snapshot_from_agent_workspace(workspace)
-        self.list_repos(use_cache=False)
-        return snapshot
+        return self._snapshot_from_agent_workspace(workspace)
 
     def _invalidate_list_cache(self) -> None:
         with self._list_lock:

--- a/src/codex_autorunner/core/pma_inbox.py
+++ b/src/codex_autorunner/core/pma_inbox.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any, Optional, cast
 
 from ..flows.ticket_flow.runtime_helpers import ticket_flow_inbox_preflight
-from .config import load_repo_config
 from .flows.failure_diagnostics import get_terminal_failure_reason_code
 from .flows.models import FlowRunStatus
 from .flows.store import FlowStore
@@ -556,8 +555,7 @@ def _gather_inbox(
         if not db_path.exists():
             continue
         try:
-            config = load_repo_config(repo_root)
-            with FlowStore(db_path, durable=config.durable_writes) as store:
+            with FlowStore.connect_readonly(db_path) as store:
                 ctx = _inbox_load_repo_flow_context(
                     snap, store, str(snap.last_run_id or "")
                 )

--- a/src/codex_autorunner/core/pma_thread_snapshot.py
+++ b/src/codex_autorunner/core/pma_thread_snapshot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sqlite3
 from pathlib import Path
 from typing import Any
 
@@ -32,9 +33,9 @@ def snapshot_pma_threads(
         return []
 
     try:
-        store = PmaThreadStore(hub_root)
+        store = PmaThreadStore.connect_readonly(hub_root)
         threads = store.list_threads(limit=limit)
-    except (OSError, RuntimeError, ValueError) as exc:
+    except (OSError, RuntimeError, ValueError, sqlite3.OperationalError) as exc:
         _logger.warning("Could not load PMA managed threads: %s", exc)
         return []
     try:

--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -333,10 +333,12 @@ class PmaThreadStore:
         *,
         durable: bool = False,
         stale_running_threshold_seconds: Optional[int] = None,
+        bootstrap_on_init: bool = True,
     ) -> None:
         self._hub_root = hub_root
         self._path = default_pma_threads_db_path(hub_root)
         self._durable = durable
+        self._bootstrap_on_init = bool(bootstrap_on_init)
         self._stale_running_threshold_seconds = (
             _resolve_stale_running_threshold_seconds(
                 hub_root, override=stale_running_threshold_seconds
@@ -357,6 +359,21 @@ class PmaThreadStore:
         )
         self._initialize()
 
+    @classmethod
+    def connect_readonly(
+        cls,
+        hub_root: Path,
+        *,
+        durable: bool = False,
+        stale_running_threshold_seconds: Optional[int] = None,
+    ) -> "PmaThreadStore":
+        return cls(
+            hub_root,
+            durable=durable,
+            stale_running_threshold_seconds=stale_running_threshold_seconds,
+            bootstrap_on_init=False,
+        )
+
     @property
     def path(self) -> Path:
         return self._path
@@ -366,6 +383,8 @@ class PmaThreadStore:
         return self._hub_root
 
     def _initialize(self) -> None:
+        if not self._bootstrap_on_init:
+            return
         self._bootstrap.initialize()
 
     @contextmanager

--- a/src/codex_autorunner/core/utils.py
+++ b/src/codex_autorunner/core/utils.py
@@ -8,6 +8,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import tempfile
 from functools import lru_cache
 from pathlib import Path
 from typing import (
@@ -157,8 +158,15 @@ def is_within(*, root: Path, target: Path) -> bool:
 
 def atomic_write(path: Path, content: str, durable: bool = False) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_suffix(path.suffix + ".tmp")
-    with tmp_path.open("w", encoding="utf-8") as f:
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f"{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as f:
+        tmp_path = Path(f.name)
         f.write(content)
         if durable:
             f.flush()

--- a/src/codex_autorunner/surfaces/cli/commands/hub.py
+++ b/src/codex_autorunner/surfaces/cli/commands/hub.py
@@ -181,6 +181,22 @@ def register_hub_commands(
     ) -> dict[str, Any]:
         manifest, workspace = _resolve_agent_workspace_entry(config, workspace_id)
         snapshot = supervisor.get_agent_workspace_snapshot(workspace_id)
+        return _agent_workspace_payload_from_workspace(
+            config,
+            supervisor,
+            manifest,
+            workspace,
+            snapshot=snapshot,
+        )
+
+    def _agent_workspace_payload_from_workspace(
+        config: HubConfig,
+        supervisor: HubSupervisor,
+        manifest: Manifest,
+        workspace: Any,
+        *,
+        snapshot: Any,
+    ) -> dict[str, Any]:
         resolution = resolve_effective_agent_workspace_destination(workspace)
         payload: dict[str, Any] = {
             **snapshot.to_dict(config.root),
@@ -192,7 +208,7 @@ def register_hub_commands(
                 *list(resolution.issues or ()),
             ],
         }
-        readiness = supervisor.get_agent_workspace_runtime_readiness(workspace_id)
+        readiness = supervisor.get_agent_workspace_runtime_readiness(workspace.id)
         if readiness is not None:
             payload["readiness"] = readiness
         return payload
@@ -556,11 +572,26 @@ def register_hub_commands(
         """List managed agent workspaces."""
         config = require_hub_config(path)
         supervisor = build_supervisor(config)
-        snapshots = supervisor.list_agent_workspaces(use_cache=False)
-        payload = [
-            _agent_workspace_payload(config, supervisor, snapshot.id)
-            for snapshot in snapshots
-        ]
+        manifest = load_manifest(config.manifest_path, config.root)
+        workspaces_by_id = {
+            workspace.id: workspace for workspace in manifest.agent_workspaces
+        }
+        payload = []
+        for snapshot in supervisor.list_agent_workspaces():
+            workspace = workspaces_by_id.get(snapshot.id)
+            if workspace is None:
+                raise_exit(
+                    f"Agent workspace id not found in hub manifest: {snapshot.id}"
+                )
+            payload.append(
+                _agent_workspace_payload_from_workspace(
+                    config,
+                    supervisor,
+                    manifest,
+                    workspace,
+                    snapshot=snapshot,
+                )
+            )
         if output_json:
             typer.echo(json.dumps({"agent_workspaces": payload}, indent=2))
             return

--- a/src/codex_autorunner/surfaces/cli/commands/worktree.py
+++ b/src/codex_autorunner/surfaces/cli/commands/worktree.py
@@ -117,7 +117,7 @@ def register_worktree_commands(
         supervisor = build_supervisor(config)
         snapshots = [
             snapshot
-            for snapshot in supervisor.list_repos(use_cache=False)
+            for snapshot in supervisor.list_repos()
             if snapshot.kind == "worktree"
         ]
         payload = [

--- a/src/codex_autorunner/surfaces/web/services/hub_gather.py
+++ b/src/codex_autorunner/surfaces/web/services/hub_gather.py
@@ -60,7 +60,8 @@ _hub_snapshot_cache: dict[tuple[int, str], _HubSnapshotCacheEntry] = {}
 
 @dataclass(frozen=True)
 class _HubSnapshotSettings:
-    include_action_queue: bool
+    include_inbox_queue_metadata: bool
+    include_full_action_queue_context: bool
     stale_threshold_seconds: int
     max_text_chars: int
     generated_at: str
@@ -274,7 +275,8 @@ def latest_dispatch(repo_root: Path, run_id: str, input_data: dict) -> Optional[
 def _build_snapshot_settings(
     context: HubAppContext, requested: set[str]
 ) -> _HubSnapshotSettings:
-    include_action_queue = bool(requested & {"inbox", "action_queue"})
+    include_inbox_queue_metadata = "inbox" in requested
+    include_full_action_queue_context = "action_queue" in requested
     pma_config = getattr(getattr(context, "config", None), "pma", None)
     stale_threshold_seconds = resolve_stale_threshold_seconds(
         getattr(pma_config, "freshness_stale_threshold_seconds", None)
@@ -285,7 +287,8 @@ def _build_snapshot_settings(
         else PMA_MAX_TEXT
     )
     return _HubSnapshotSettings(
-        include_action_queue=include_action_queue,
+        include_inbox_queue_metadata=include_inbox_queue_metadata,
+        include_full_action_queue_context=include_full_action_queue_context,
         stale_threshold_seconds=stale_threshold_seconds,
         max_text_chars=max_text_chars,
         generated_at=iso_now(),
@@ -607,7 +610,10 @@ def gather_hub_message_snapshot(
         ):
             return copy.deepcopy(cached.snapshot)
     inbox: list[dict[str, Any]] = []
-    if settings.include_action_queue:
+    if (
+        settings.include_inbox_queue_metadata
+        or settings.include_full_action_queue_context
+    ):
         inbox = _gather_inbox(
             context.supervisor,
             max_text_chars=settings.max_text_chars,
@@ -619,17 +625,20 @@ def gather_hub_message_snapshot(
     pma_threads: list[dict[str, Any]] = []
     automation = (
         _snapshot_pma_automation(context.supervisor)
-        if requested & {"automation"} or settings.include_action_queue
+        if requested & {"automation"} or settings.include_full_action_queue_context
         else {"items": [], "summary": {}}
     )
     if isinstance(hub_root, Path):
-        if requested & {"pma_files_detail"} or settings.include_action_queue:
+        if (
+            requested & {"pma_files_detail"}
+            or settings.include_full_action_queue_context
+        ):
             pma_files_detail = _collect_pma_files_detail(
                 hub_root,
                 generated_at=settings.generated_at,
                 stale_threshold_seconds=settings.stale_threshold_seconds,
             )
-        if requested & {"pma_threads"} or settings.include_action_queue:
+        if requested & {"pma_threads"} or settings.include_full_action_queue_context:
             pma_threads = _collect_pma_threads(
                 hub_root,
                 generated_at=settings.generated_at,
@@ -637,7 +646,10 @@ def gather_hub_message_snapshot(
             )
 
     action_queue: list[dict[str, Any]] = []
-    if settings.include_action_queue:
+    if (
+        settings.include_inbox_queue_metadata
+        or settings.include_full_action_queue_context
+    ):
         action_queue = build_pma_action_queue(
             inbox=inbox,
             pma_threads=pma_threads,

--- a/tests/test_cli_hub_agent_workspace.py
+++ b/tests/test_cli_hub_agent_workspace.py
@@ -6,6 +6,7 @@ from typer.testing import CliRunner
 
 from codex_autorunner.bootstrap import seed_hub_files
 from codex_autorunner.cli import app
+from codex_autorunner.core.hub import HubSupervisor
 
 runner = CliRunner()
 
@@ -126,6 +127,55 @@ def test_hub_agent_workspace_show_reports_runtime_readiness(
     payload = json.loads(show_result.output)
     assert payload["readiness"]["status"] == "incompatible"
     assert payload["readiness"]["version"] == "0.2.0"
+
+
+def test_hub_agent_workspace_list_uses_cached_listing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    seed_hub_files(hub_root, force=True)
+
+    runner.invoke(
+        app,
+        [
+            "hub",
+            "agent-workspace",
+            "create",
+            "zc-main",
+            "--runtime",
+            "zeroclaw",
+            "--disabled",
+            "--path",
+            str(hub_root),
+        ],
+        catch_exceptions=False,
+    )
+
+    calls: list[bool] = []
+    original = HubSupervisor.list_agent_workspaces
+
+    def _wrapped(self, *, use_cache: bool = True):  # type: ignore[no-untyped-def]
+        calls.append(use_cache)
+        return original(self, use_cache=use_cache)
+
+    monkeypatch.setattr(HubSupervisor, "list_agent_workspaces", _wrapped)
+
+    result = runner.invoke(
+        app,
+        [
+            "hub",
+            "agent-workspace",
+            "list",
+            "--json",
+            "--path",
+            str(hub_root),
+        ],
+    )
+    assert result.exit_code == 0
+    assert calls == [True]
+    payload = json.loads(result.output)
+    assert payload["agent_workspaces"][0]["id"] == "zc-main"
 
 
 def test_hub_agent_workspace_create_fails_on_incompatible_preflight(

--- a/tests/test_cli_hub_worktree.py
+++ b/tests/test_cli_hub_worktree.py
@@ -75,6 +75,33 @@ def test_cli_hub_worktree_list_filters_worktrees(tmp_path, monkeypatch) -> None:
     assert "cmd=car hub worktree archive base--feature" in result.output
 
 
+def test_cli_hub_worktree_list_uses_cached_repo_listing(tmp_path, monkeypatch) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    seed_hub_files(hub_root, force=True)
+
+    base = _snapshot(tmp_path, "base", kind="base")
+    worktree = _snapshot(
+        tmp_path, "base--feature", kind="worktree", worktree_of="base", branch="feature"
+    )
+    calls: list[bool] = []
+
+    def _fake_list(self, *, use_cache: bool = True):
+        calls.append(use_cache)
+        return [base, worktree]
+
+    monkeypatch.setattr(HubSupervisor, "list_repos", _fake_list)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["hub", "worktree", "list", "--path", str(hub_root), "--json"]
+    )
+    assert result.exit_code == 0
+    assert calls == [True]
+    payload = json.loads(result.output)
+    assert [item["id"] for item in payload["worktrees"]] == ["base--feature"]
+
+
 def test_cli_hub_worktree_scan_filters_worktrees_json(tmp_path, monkeypatch) -> None:
     hub_root = tmp_path / "hub"
     hub_root.mkdir()

--- a/tests/test_durable_writes.py
+++ b/tests/test_durable_writes.py
@@ -1,5 +1,7 @@
 """Tests for durable writes mode."""
 
+import concurrent.futures
+import threading
 from pathlib import Path
 
 from codex_autorunner.core.config import (
@@ -33,6 +35,26 @@ def test_atomic_write_with_durable(tmp_path: Path) -> None:
     atomic_write(file_path, content, durable=True)
     assert file_path.exists()
     assert file_path.read_text() == content
+
+
+def test_atomic_write_allows_concurrent_writers(tmp_path: Path) -> None:
+    file_path = tmp_path / "test.txt"
+    writer_count = 8
+    barrier = threading.Barrier(writer_count)
+
+    def _write(index: int) -> None:
+        barrier.wait(timeout=5)
+        atomic_write(file_path, f"content-{index}", durable=False)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=writer_count) as executor:
+        futures = [executor.submit(_write, index) for index in range(writer_count)]
+        for future in futures:
+            future.result(timeout=5)
+
+    assert file_path.exists()
+    assert file_path.read_text() in {
+        f"content-{index}" for index in range(writer_count)
+    }
 
 
 def test_connect_sqlite_without_durable(tmp_path: Path) -> None:

--- a/tests/test_hub_messages.py
+++ b/tests/test_hub_messages.py
@@ -25,6 +25,7 @@ from codex_autorunner.core.state import RunnerState, save_state
 from codex_autorunner.server import create_hub_app
 from codex_autorunner.surfaces.web import app as web_app_module
 from codex_autorunner.surfaces.web import app_state as web_app_state_module
+from codex_autorunner.surfaces.web.services import hub_gather as hub_gather_service
 
 
 def _seed_paused_run(repo_root: Path, run_id: str) -> None:
@@ -1226,3 +1227,27 @@ def test_hub_messages_action_queue_sections_honor_dismissals(
         after = client.get("/hub/messages?sections=action_queue")
         assert after.status_code == 200
         assert after.json()["action_queue"] == []
+
+
+def test_hub_messages_default_inbox_avoids_full_action_queue_collectors(
+    hub_env, monkeypatch
+) -> None:
+    run_id = "71717171-7171-7171-7171-717171717171"
+    _seed_paused_run(hub_env.repo_root, run_id)
+    _write_dispatch_history(hub_env.repo_root, run_id, seq=1)
+
+    def _unexpected(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("unexpected full action-queue collector call")
+
+    monkeypatch.setattr(hub_gather_service, "_collect_pma_threads", _unexpected)
+    monkeypatch.setattr(hub_gather_service, "_collect_pma_files_detail", _unexpected)
+    monkeypatch.setattr(hub_gather_service, "_snapshot_pma_automation", _unexpected)
+
+    app = _build_hub_messages_app(hub_env.hub_root, monkeypatch)
+    with TestClient(app) as client:
+        res = client.get("/hub/messages")
+
+    assert res.status_code == 200
+    payload = res.json()
+    assert payload["items"][0]["run_id"] == run_id
+    assert payload["items"][0]["queue_source"] == "ticket_flow_inbox"

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -481,6 +481,63 @@ def test_get_agent_workspace_snapshot_does_not_refresh_repo_listing(
     assert calls == []
 
 
+def test_agent_workspace_mutations_refresh_startup_cached_state(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+    repo_dir = hub_root / "demo"
+    (repo_dir / ".git").mkdir(parents=True, exist_ok=True)
+
+    initial_supervisor = HubSupervisor(load_hub_config(hub_root))
+    try:
+        initial_supervisor.scan()
+    finally:
+        initial_supervisor.shutdown()
+
+    supervisor = HubSupervisor(load_hub_config(hub_root))
+    try:
+        supervisor.create_agent_workspace(
+            workspace_id="zc-main",
+            runtime="zeroclaw",
+            display_name="ZeroClaw Main",
+            enabled=False,
+        )
+    finally:
+        supervisor.shutdown()
+
+    restarted = HubSupervisor(load_hub_config(hub_root))
+    try:
+        listed = restarted.list_agent_workspaces()
+        assert [item.id for item in listed] == ["zc-main"]
+        assert listed[0].display_name == "ZeroClaw Main"
+    finally:
+        restarted.shutdown()
+
+    supervisor = HubSupervisor(load_hub_config(hub_root))
+    try:
+        supervisor.update_agent_workspace("zc-main", display_name="Renamed Workspace")
+        supervisor.set_agent_workspace_destination(
+            "zc-main",
+            {"kind": "docker", "image": "ghcr.io/acme/zeroclaw:latest"},
+        )
+    finally:
+        supervisor.shutdown()
+
+    restarted = HubSupervisor(load_hub_config(hub_root))
+    try:
+        listed = restarted.list_agent_workspaces()
+        assert [item.id for item in listed] == ["zc-main"]
+        assert listed[0].display_name == "Renamed Workspace"
+        assert listed[0].effective_destination == {
+            "kind": "docker",
+            "image": "ghcr.io/acme/zeroclaw:latest",
+        }
+    finally:
+        restarted.shutdown()
+
+
 def test_hub_supervisor_rejects_unknown_agent_workspace_runtime(tmp_path: Path) -> None:
     hub_root = tmp_path / "hub"
     cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -309,6 +309,30 @@ def test_scan_writes_pma_threads_artifact(tmp_path: Path) -> None:
     assert payload["threads"][0]["name"] == "demo-thread"
 
 
+def test_list_repos_does_not_refresh_pma_threads_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+    repo_dir = hub_root / "demo"
+    (repo_dir / ".git").mkdir(parents=True, exist_ok=True)
+
+    supervisor = HubSupervisor(load_hub_config(hub_root))
+    calls: list[Path] = []
+
+    def _record_artifact_call(path: Path) -> None:
+        calls.append(path)
+
+    monkeypatch.setattr(hub_module, "_save_pma_threads_artifact", _record_artifact_call)
+    try:
+        supervisor.list_repos(use_cache=False)
+    finally:
+        supervisor.shutdown()
+
+    assert calls == []
+
+
 def test_hub_repos_sections_filter_excludes_unrequested_fields(tmp_path: Path) -> None:
     hub_root = tmp_path / "hub"
     cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
@@ -426,6 +450,35 @@ def test_hub_supervisor_can_create_list_and_remove_agent_workspaces(tmp_path: Pa
     supervisor.remove_agent_workspace("zc-main")
     assert workspace.path.exists() is False
     assert supervisor.list_agent_workspaces(use_cache=False) == []
+
+
+def test_get_agent_workspace_snapshot_does_not_refresh_repo_listing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    supervisor = HubSupervisor(load_hub_config(hub_root))
+    supervisor.create_agent_workspace(
+        workspace_id="zc-main",
+        runtime="zeroclaw",
+        display_name="ZeroClaw Main",
+        enabled=False,
+    )
+
+    calls: list[bool] = []
+    original = supervisor.list_repos
+
+    def _wrapped(*, use_cache: bool = True):  # type: ignore[no-untyped-def]
+        calls.append(use_cache)
+        return original(use_cache=use_cache)
+
+    monkeypatch.setattr(supervisor, "list_repos", _wrapped)
+
+    snapshot = supervisor.get_agent_workspace_snapshot("zc-main")
+    assert snapshot.id == "zc-main"
+    assert calls == []
 
 
 def test_hub_supervisor_rejects_unknown_agent_workspace_runtime(tmp_path: Path) -> None:

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -148,6 +148,34 @@ def test_backend_thread_binding_can_be_cleared_across_restart(tmp_path: Path) ->
     assert row["backend_thread_id"] is None
 
 
+def test_connect_readonly_skips_bootstrap_initialize(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    created = PmaThreadStore(hub_root).create_thread("codex", workspace_root)
+    initialize_calls: list[str] = []
+
+    def _record_initialize(self) -> None:  # type: ignore[no-untyped-def]
+        initialize_calls.append("called")
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.pma_thread_store.PmaThreadStoreBootstrap.initialize",
+        _record_initialize,
+    )
+
+    store = PmaThreadStore.connect_readonly(hub_root)
+    listed = store.list_threads(agent="codex")
+
+    assert initialize_calls == []
+    assert [thread["managed_thread_id"] for thread in listed] == [
+        created["managed_thread_id"]
+    ]
+
+
 def test_create_finish_turn_and_query(tmp_path: Path) -> None:
     store = PmaThreadStore(tmp_path / "hub")
     thread = store.create_thread("codex", tmp_path / "workspace")


### PR DESCRIPTION
## Summary

This PR speeds up the slow hub snapshot/listing paths behind issue #1367.

Key changes:
- stop inbox-only `/hub/messages` requests from building full PMA action-queue context
- avoid refreshing `pma_threads.json` on cached/listing paths that only need repo state
- reuse cached repo/agent-workspace snapshots in the CLI instead of rebuilding them repeatedly
- make PMA thread snapshot reads use a read-only store path that skips the legacy bootstrap lock
- make `atomic_write()` use unique temp files so concurrent hub writers do not race on `hub_state.json.tmp`

## Root Cause

The slow path was dominated by extra work paid for requests that did not need it:
- inbox-only `/hub/messages` still built PMA threads, PMA files, and automation context so it could construct a full action queue
- several fast listing flows called through code that rewrote hub state and synchronously regenerated the PMA thread artifact
- PMA thread snapshots paid the legacy bootstrap/mirror lock even for read-only inventory calls
- concurrent hub writers could race on the fixed `*.tmp` name used by `atomic_write()`, intermittently failing scans

## Impact

Measured on the local hub used during profiling:
- inbox-only hub messages: about `15.6s -> 1.16s` in-process
- `hub worktree list`: about `1.49s`
- `hub agent-workspace list`: about `1.52s`
- `hub agent-workspace show zc-pm`: about `1.50s`
- `hub scan`: about `2.53s`
- `hub worktree scan`: about `2.53s`

`hub snapshot --section pma_threads` still measured slower against the currently running hub service because that process has not been restarted onto this branch yet.

## Validation

Manual dogfooding:
- `python -m codex_autorunner.cli hub worktree list --path /Users/dazheng/car-workspace --json`
- `python -m codex_autorunner.cli hub agent-workspace list --path /Users/dazheng/car-workspace --json`
- `python -m codex_autorunner.cli hub agent-workspace show zc-pm --path /Users/dazheng/car-workspace --json`
- `python -m codex_autorunner.cli hub scan --path /Users/dazheng/car-workspace`
- `python -m codex_autorunner.cli hub worktree scan --path /Users/dazheng/car-workspace --json`
- `python -m codex_autorunner.cli hub snapshot --path /Users/dazheng/car-workspace --section pma_threads --json`

Focused tests:
- `tests/test_hub_messages.py`
- `tests/test_hub_supervisor.py`
- `tests/test_cli_hub_worktree.py`
- `tests/test_cli_hub_agent_workspace.py`
- `tests/test_pma_thread_store.py`
- `tests/pma_context_support.py`
- `tests/test_durable_writes.py`

Repo hooks during commit also passed, including the full pytest suite (`4821 passed`).

## Residual Risk

- cached worktree and agent-workspace list/show paths can now be briefly stale by design
- the read-only PMA snapshot path assumes the PMA DB has already been initialized and will fail closed on a partially seeded environment

Closes #1367