### PR TITLE
Reject unsupported PMA and web request keys instead of silently ignoring them

### DIFF
--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -1230,10 +1230,22 @@ class PmaAutomationStore:
         )
         return {"timer": created.to_dict(), "deduped": deduped}
 
-    def cancel_timer(self, timer_id: str) -> bool:
+    def cancel_timer(
+        self,
+        timer_id: str,
+        payload: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> bool:
         target_id = _normalize_text(timer_id)
         if target_id is None:
             return False
+        data = self._coerce_payload(payload, kwargs)
+        reason = _normalize_text(data.get("reason"))
+        cancelled_at = _normalize_due_timestamp(
+            data.get("timestamp"), field_name="timestamp"
+        )
+        if cancelled_at is None:
+            cancelled_at = _iso_now()
         with file_lock(self._lock_path()):
             state, subscriptions, timers, wakeups = self._load_structured_unlocked()
             changed = False
@@ -1243,7 +1255,9 @@ class PmaAutomationStore:
                 if entry.state == "cancelled":
                     continue
                 entry.state = "cancelled"
-                entry.updated_at = _iso_now()
+                entry.updated_at = cancelled_at
+                if reason is not None:
+                    entry.reason = reason
                 changed = True
                 break
             if changed:

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/agent_workspaces.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/agent_workspaces.py
@@ -100,7 +100,12 @@ class HubAgentWorkspaceService:
         return destination
 
     def _normalize_mount_payload(self, item: Any) -> dict[str, Any]:
-        raw_item = item if isinstance(item, dict) else {}
+        if isinstance(item, dict):
+            raw_item = item
+        elif hasattr(item, "model_dump"):
+            raw_item = item.model_dump(exclude_none=True)
+        else:
+            raw_item = {}
         mount_payload: dict[str, Any] = {
             "source": str(raw_item.get("source") or ""),
             "target": str(raw_item.get("target") or ""),

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/crud.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/crud.py
@@ -129,6 +129,18 @@ class HubRepoCrudService:
         from .....core.logging_utils import safe_log
 
         if isinstance(payload, dict):
+            unknown_keys = sorted(
+                str(key) for key in payload.keys() if key != "commands"
+            )
+            if unknown_keys:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "Unsupported worktree setup keys: "
+                        + ", ".join(unknown_keys)
+                        + ". Valid keys: commands"
+                    ),
+                )
             commands_raw = payload.get("commands", [])
         elif isinstance(payload, list):
             commands_raw = payload

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/destinations.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/destinations.py
@@ -72,40 +72,40 @@ class HubDestinationService:
         from .....core.destinations import validate_destination_write_payload
         from .....manifest import save_manifest
 
-        normalized_kind = payload.kind.strip().lower()
+        normalized_input = payload.normalized_payload()
+        normalized_kind = str(normalized_input.get("kind") or "").strip().lower()
         destination: dict[str, Any]
         if normalized_kind == "local":
             destination = {"kind": "local"}
         elif normalized_kind == "docker":
-            destination = {"kind": "docker", "image": (payload.image or "").strip()}
-            container_name = (payload.container_name or "").strip()
+            destination = {
+                "kind": "docker",
+                "image": str(normalized_input.get("image") or "").strip(),
+            }
+            container_name = str(normalized_input.get("container_name") or "").strip()
             if container_name:
                 destination["container_name"] = container_name
-            profile = (payload.profile or "").strip()
+            profile = str(normalized_input.get("profile") or "").strip()
             if profile:
                 destination["profile"] = profile
-            workdir = (payload.workdir or "").strip()
+            workdir = str(normalized_input.get("workdir") or "").strip()
             if workdir:
                 destination["workdir"] = workdir
             env_passthrough = [
                 str(item).strip()
-                for item in (payload.env_passthrough or [])
+                for item in (normalized_input.get("env_passthrough") or [])
                 if str(item).strip()
             ]
             if env_passthrough:
                 destination["env_passthrough"] = env_passthrough
-            if payload.env:
-                destination["env"] = dict(payload.env)
+            if normalized_input.get("env"):
+                destination["env"] = dict(normalized_input["env"])
             mounts: list[dict[str, Any]] = []
-            for item in payload.mounts or []:
+            for item in normalized_input.get("mounts") or []:
                 source = str((item or {}).get("source") or "")
                 target = str((item or {}).get("target") or "")
                 mount_payload: dict[str, Any] = {"source": source, "target": target}
                 read_only = (item or {}).get("read_only")
-                if read_only is None and "readOnly" in (item or {}):
-                    read_only = (item or {}).get("readOnly")
-                if read_only is None and "readonly" in (item or {}):
-                    read_only = (item or {}).get("readonly")
                 if read_only is not None:
                     mount_payload["read_only"] = read_only
                 mounts.append(mount_payload)

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime.py
@@ -60,6 +60,14 @@ from .....core.time_utils import now_iso
 from .....integrations.app_server import is_missing_thread_error
 from .....integrations.app_server.threads import pma_base_key
 from .....integrations.github.context_injection import maybe_inject_github_context
+from ...schemas import (
+    PmaChatRequest,
+    PmaHistoryCompactRequest,
+    PmaNewSessionRequest,
+    PmaSessionResetRequest,
+    PmaStopRequest,
+    PmaThreadResetRequest,
+)
 from ...services.pma.common import (
     build_idempotency_key as service_build_idempotency_key,
 )
@@ -1731,16 +1739,15 @@ def build_chat_runtime_router(
         return {"active": active, "current": current, "last_result": last_result}
 
     @router.post("/chat")
-    async def pma_chat(request: Request):
+    async def pma_chat(request: Request, payload: PmaChatRequest):
         pma_config = _get_pma_config(request)
-        body = await request.json()
-        message = (body.get("message") or "").strip()
-        stream = bool(body.get("stream", False))
-        agent = _normalize_optional_text(body.get("agent"))
-        profile = _normalize_optional_text(body.get("profile"))
-        model = _normalize_optional_text(body.get("model"))
-        reasoning = _normalize_optional_text(body.get("reasoning"))
-        client_turn_id = (body.get("client_turn_id") or "").strip() or None
+        message = (payload.message or "").strip()
+        stream = bool(payload.stream)
+        agent = _normalize_optional_text(payload.agent)
+        profile = _normalize_optional_text(payload.profile)
+        model = _normalize_optional_text(payload.model)
+        reasoning = _normalize_optional_text(payload.reasoning)
+        client_turn_id = (payload.client_turn_id or "").strip() or None
 
         if not message:
             raise HTTPException(status_code=400, detail="message is required")
@@ -1768,7 +1775,7 @@ def build_chat_runtime_router(
             message=message,
         )
 
-        payload = {
+        queue_payload = {
             "message": message,
             "agent": agent,
             "profile": profile,
@@ -1779,7 +1786,7 @@ def build_chat_runtime_router(
             "hub_root": str(hub_root),
         }
 
-        item, dupe_reason = await queue.enqueue(lane_id, idempotency_key, payload)
+        item, dupe_reason = await queue.enqueue(lane_id, idempotency_key, queue_payload)
         if dupe_reason:
             logger.info("Duplicate PMA turn: %s", dupe_reason)
 
@@ -1820,9 +1827,10 @@ def build_chat_runtime_router(
         )
 
     @router.post("/stop")
-    async def pma_stop(request: Request) -> dict[str, Any]:
-        body = await request.json() if request.headers.get("content-type") else {}
-        lane_id = (body.get("lane_id") or "pma:default").strip()
+    async def pma_stop(
+        request: Request, payload: Optional[PmaStopRequest] = None
+    ) -> dict[str, Any]:
+        lane_id = ((payload.lane_id if payload else None) or "pma:default").strip()
         hub_root = request.app.state.config.root
         lifecycle_router = PmaLifecycleRouter(hub_root)
 
@@ -1848,11 +1856,12 @@ def build_chat_runtime_router(
         }
 
     @router.post("/new")
-    async def new_pma_session(request: Request) -> dict[str, Any]:
-        body = await request.json()
-        agent = _normalize_optional_text(body.get("agent"))
-        profile = _normalize_optional_text(body.get("profile"))
-        lane_id = (body.get("lane_id") or "pma:default").strip()
+    async def new_pma_session(
+        request: Request, payload: Optional[PmaNewSessionRequest] = None
+    ) -> dict[str, Any]:
+        agent = _normalize_optional_text(payload.agent if payload else None)
+        profile = _normalize_optional_text(payload.profile if payload else None)
+        lane_id = ((payload.lane_id if payload else None) or "pma:default").strip()
 
         hub_root = request.app.state.config.root
         lifecycle_router = PmaLifecycleRouter(hub_root)
@@ -1876,11 +1885,12 @@ def build_chat_runtime_router(
         }
 
     @router.post("/reset")
-    async def reset_pma_session(request: Request) -> dict[str, Any]:
-        body = await request.json() if request.headers.get("content-type") else {}
-        raw_agent = (body.get("agent") or "").strip().lower()
+    async def reset_pma_session(
+        request: Request, payload: Optional[PmaSessionResetRequest] = None
+    ) -> dict[str, Any]:
+        raw_agent = ((payload.agent if payload else None) or "").strip().lower()
         agent = raw_agent or None
-        profile = _normalize_optional_text(body.get("profile"))
+        profile = _normalize_optional_text(payload.profile if payload else None)
 
         hub_root = request.app.state.config.root
         lifecycle_router = PmaLifecycleRouter(hub_root)
@@ -1900,11 +1910,12 @@ def build_chat_runtime_router(
         }
 
     @router.post("/compact")
-    async def compact_pma_history(request: Request) -> dict[str, Any]:
-        body = await request.json()
-        summary = (body.get("summary") or "").strip()
-        agent = _normalize_optional_text(body.get("agent"))
-        thread_id = _normalize_optional_text(body.get("thread_id"))
+    async def compact_pma_history(
+        request: Request, payload: PmaHistoryCompactRequest
+    ) -> dict[str, Any]:
+        summary = (payload.summary or "").strip()
+        agent = _normalize_optional_text(payload.agent)
+        thread_id = _normalize_optional_text(payload.thread_id)
 
         if not summary:
             raise HTTPException(status_code=400, detail="summary is required")
@@ -1929,11 +1940,12 @@ def build_chat_runtime_router(
         }
 
     @router.post("/thread/reset")
-    async def reset_pma_thread(request: Request) -> dict[str, Any]:
-        body = await request.json()
-        raw_agent = (body.get("agent") or "").strip().lower()
+    async def reset_pma_thread(
+        request: Request, payload: Optional[PmaThreadResetRequest] = None
+    ) -> dict[str, Any]:
+        raw_agent = ((payload.agent if payload else None) or "").strip().lower()
         agent = raw_agent or None
-        profile = _normalize_optional_text(body.get("profile"))
+        profile = _normalize_optional_text(payload.profile if payload else None)
 
         hub_root = request.app.state.config.root
         lifecycle_router = PmaLifecycleRouter(hub_root)

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -120,13 +120,14 @@ def build_automation_routes(
     ) -> dict[str, Any]:
         store = await get_automation_store(request, get_runtime_state())
         try:
+            normalized_payload = payload.normalized_payload()
             created = await call_store_create_with_payload(
                 store,
                 (
                     "create_subscription",
                     "upsert_subscription",
                 ),
-                payload.model_dump(exclude_none=True),
+                normalized_payload,
             )
         except PmaAutomationThreadNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -202,10 +203,11 @@ def build_automation_routes(
     ) -> dict[str, Any]:
         store = await get_automation_store(request, get_runtime_state())
         try:
+            normalized_payload = payload.normalized_payload()
             created = await call_store_create_with_payload(
                 store,
                 ("create_timer", "upsert_timer"),
-                payload.model_dump(exclude_none=True),
+                normalized_payload,
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -260,13 +262,17 @@ def build_automation_routes(
         if not normalized_id:
             raise HTTPException(status_code=400, detail="timer_id is required")
         store = await get_automation_store(request, get_runtime_state())
-        touched = await call_store_action_with_id(
-            store,
-            ("touch_timer", "refresh_timer", "renew_timer"),
-            normalized_id,
-            payload=payload.model_dump(exclude_none=True) if payload else {},
-            id_aliases=("timer_id", "id"),
-        )
+        try:
+            normalized_payload = payload.normalized_payload() if payload else {}
+            touched = await call_store_action_with_id(
+                store,
+                ("touch_timer", "refresh_timer", "renew_timer"),
+                normalized_id,
+                payload=normalized_payload,
+                id_aliases=("timer_id", "id"),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         if isinstance(touched, dict):
             out = dict(touched)
             out.setdefault("status", "ok")
@@ -287,13 +293,17 @@ def build_automation_routes(
         if not normalized_id:
             raise HTTPException(status_code=400, detail="timer_id is required")
         store = await get_automation_store(request, get_runtime_state())
-        cancelled = await call_store_action_with_id(
-            store,
-            ("cancel_timer",),
-            normalized_id,
-            payload=payload.model_dump(exclude_none=True) if payload else {},
-            id_aliases=("timer_id", "id"),
-        )
+        try:
+            normalized_payload = payload.normalized_payload() if payload else {}
+            cancelled = await call_store_action_with_id(
+                store,
+                ("cancel_timer",),
+                normalized_id,
+                payload=normalized_payload,
+                id_aliases=("timer_id", "id"),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         if isinstance(cancelled, dict):
             out = dict(cancelled)
             out.setdefault("status", "ok")

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -12,6 +12,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    StrictBool,
     field_validator,
     model_validator,
 )
@@ -30,7 +31,90 @@ class ResponseModel(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
 
+def _validate_supported_payload_keys(
+    data: dict[str, Any],
+    *,
+    supported_keys: set[str] | frozenset[str],
+    label: str,
+) -> None:
+    unknown_keys = sorted(
+        str(key)
+        for key in data.keys()
+        if isinstance(key, str) and key not in supported_keys
+    )
+    if unknown_keys:
+        raise ValueError(
+            f"Unsupported {label} keys: "
+            + ", ".join(unknown_keys)
+            + ". Valid keys: "
+            + ", ".join(sorted(supported_keys))
+        )
+
+
+def _normalize_filter_payload(
+    *,
+    raw_filter: Any,
+    supported_keys: set[str] | frozenset[str],
+    key_aliases: dict[str, str],
+    label: str,
+) -> dict[str, str]:
+    if raw_filter is None:
+        return {}
+    if not isinstance(raw_filter, dict):
+        raise ValueError(f"{label} must be an object")
+
+    normalized_filter: dict[str, str] = {}
+    unknown_filter_keys: list[str] = []
+    for raw_key, raw_value in raw_filter.items():
+        if not isinstance(raw_key, str):
+            unknown_filter_keys.append(str(raw_key))
+            continue
+        normalized_key = key_aliases.get(raw_key, raw_key)
+        if normalized_key not in supported_keys:
+            unknown_filter_keys.append(raw_key)
+            continue
+        normalized_value = _normalize_text(raw_value)
+        if normalized_value is None:
+            raise ValueError(f"{label}.{normalized_key} must be a non-empty string")
+        existing = normalized_filter.get(normalized_key)
+        if existing is not None and existing != normalized_value:
+            raise ValueError(
+                f"Conflicting {label} values for {normalized_key}: "
+                f"{existing!r} vs {normalized_value!r}"
+            )
+        normalized_filter[normalized_key] = normalized_value
+
+    if unknown_filter_keys:
+        raise ValueError(
+            f"Unsupported {label} keys: "
+            + ", ".join(sorted(unknown_filter_keys))
+            + ". Valid keys: "
+            + ", ".join(sorted(supported_keys))
+        )
+    return normalized_filter
+
+
+def _merge_normalized_filter(
+    data: dict[str, Any],
+    normalized_filter: dict[str, str],
+    *,
+    label: str,
+) -> dict[str, Any]:
+    for key, value in normalized_filter.items():
+        existing = _normalize_text(data.get(key))
+        if existing is not None and existing != value:
+            raise ValueError(
+                f"Conflicting values for {key}: top-level={existing!r}, "
+                f"{label}={value!r}"
+            )
+        if existing is None:
+            data[key] = value
+    return data
+
+
 class ContextspaceWriteRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     content: str = ""
 
 
@@ -99,6 +183,8 @@ class SpecIngestTicketsResponse(ResponseModel):
 
 
 class RunControlRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     once: bool = False
     agent: Optional[str] = None
     model: Optional[str] = None
@@ -106,6 +192,8 @@ class RunControlRequest(Payload):
 
 
 class HubCreateRepoRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     git_url: Optional[str] = Field(
         default=None, validation_alias=AliasChoices("git_url", "gitUrl")
     )
@@ -118,6 +206,8 @@ class HubCreateRepoRequest(Payload):
 
 
 class HubRemoveRepoRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     force: bool = False
     force_attestation: Optional[str] = Field(
         default=None,
@@ -128,6 +218,8 @@ class HubRemoveRepoRequest(Payload):
 
 
 class HubCreateAgentWorkspaceRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     workspace_id: Optional[str] = Field(
         default=None,
         validation_alias=AliasChoices("workspace_id", "workspaceId", "id"),
@@ -141,6 +233,8 @@ class HubCreateAgentWorkspaceRequest(Payload):
 
 
 class HubUpdateAgentWorkspaceRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     enabled: Optional[bool] = None
     display_name: Optional[str] = Field(
         default=None,
@@ -149,18 +243,24 @@ class HubUpdateAgentWorkspaceRequest(Payload):
 
 
 class HubRemoveAgentWorkspaceRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     delete_dir: bool = Field(
         default=False, validation_alias=AliasChoices("delete_dir", "deleteDir")
     )
 
 
 class HubDeleteAgentWorkspaceRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     delete_dir: bool = Field(
         default=True, validation_alias=AliasChoices("delete_dir", "deleteDir")
     )
 
 
 class HubCreateWorktreeRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     base_repo_id: str = Field(
         validation_alias=AliasChoices("base_repo_id", "baseRepoId")
     )
@@ -175,6 +275,8 @@ class HubCreateWorktreeRequest(Payload):
 
 
 class HubCleanupWorktreeRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     worktree_repo_id: str = Field(
         validation_alias=AliasChoices("worktree_repo_id", "worktreeRepoId")
     )
@@ -198,6 +300,8 @@ class HubCleanupWorktreeRequest(Payload):
 
 
 class HubArchiveWorktreeRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     worktree_repo_id: str = Field(
         validation_alias=AliasChoices("worktree_repo_id", "worktreeRepoId")
     )
@@ -210,6 +314,8 @@ class HubArchiveWorktreeRequest(Payload):
 
 
 class HubArchiveRepoStateRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     repo_id: str = Field(validation_alias=AliasChoices("repo_id", "repoId"))
     archive_note: Optional[str] = Field(
         default=None, validation_alias=AliasChoices("archive_note", "archiveNote")
@@ -340,6 +446,8 @@ class PmaManagedThreadCreateRequest(Payload):
 
 
 class SessionSettingsRequest(Payload):
+    model_config = ConfigDict(extra="forbid")
+
     autorunner_model_override: Optional[str] = None
     autorunner_effort_override: Optional[str] = None
     autorunner_approval_policy: Optional[str] = None
@@ -373,10 +481,25 @@ _GITHUB_REQUEST_MODELS = (
 
 
 class HubPinRepoRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     pinned: bool = True
 
 
+class HubDestinationMountRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    source: Optional[str] = None
+    target: Optional[str] = None
+    read_only: Optional[StrictBool] = Field(
+        default=None,
+        validation_alias=AliasChoices("read_only", "readOnly", "readonly"),
+    )
+
+
 class HubDestinationSetRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     kind: str
     image: Optional[str] = None
     container_name: Optional[str] = Field(
@@ -396,7 +519,7 @@ class HubDestinationSetRequest(Payload):
         default=None,
         validation_alias=AliasChoices("env", "explicit_env", "explicitEnv"),
     )
-    mounts: Optional[List[Dict[str, Any]]] = None
+    mounts: Optional[List[HubDestinationMountRequest]] = None
 
     @model_validator(mode="before")
     @classmethod
@@ -412,6 +535,9 @@ class HubDestinationSetRequest(Payload):
         normalized["env_passthrough"] = raw_env
         normalized.pop("env", None)
         return normalized
+
+    def normalized_payload(self) -> dict[str, Any]:
+        return self.model_dump(exclude_none=True)
 
 
 class HubAgentWorkspaceSummaryResponse(ResponseModel):
@@ -503,6 +629,8 @@ class TemplateReposResponse(ResponseModel):
 
 
 class TemplateRepoCreateRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     id: str
     url: str
     trusted: bool = False
@@ -512,6 +640,8 @@ class TemplateRepoCreateRequest(Payload):
 
 
 class TemplateRepoUpdateRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     url: Optional[str] = None
     trusted: Optional[bool] = None
     default_ref: Optional[str] = Field(
@@ -535,6 +665,8 @@ class TemplateFetchResponse(ResponseModel):
 
 
 class TemplateApplyRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     template: str
     at: Optional[int] = None
     next_index: bool = Field(
@@ -558,6 +690,8 @@ class TemplateApplyResponse(ResponseModel):
 
 
 class SystemUpdateRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     target: Optional[str] = None
     force: bool = False
 
@@ -729,6 +863,8 @@ class SystemUpdateCheckResponse(ResponseModel):
 
 
 class ReviewStartRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     agent: Optional[str] = None
     model: Optional[str] = None
     reasoning: Optional[str] = None
@@ -751,6 +887,8 @@ class ReviewControlResponse(ResponseModel):
 
 
 class TicketCreateRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     agent: str = "codex"
     title: Optional[str] = None
     goal: Optional[str] = None
@@ -796,11 +934,15 @@ class TicketReorderResponse(ResponseModel):
 
 
 class TicketBulkSetAgentRequest(Payload):
+    model_config = ConfigDict(extra="forbid")
+
     agent: str
     range: Optional[str] = None
 
 
 class TicketBulkClearModelRequest(Payload):
+    model_config = ConfigDict(extra="forbid")
+
     range: Optional[str] = None
 
 
@@ -865,6 +1007,8 @@ class PmaManagedThreadMessageRequest(Payload):
 
 
 class PmaManagedThreadCompactRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
     summary: str
     reset_backend: bool = True
 
@@ -873,8 +1017,97 @@ class PmaManagedThreadResumeRequest(Payload):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
 
+class PmaChatRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    message: Optional[str] = None
+    stream: bool = False
+    agent: Optional[str] = None
+    profile: Optional[str] = None
+    model: Optional[str] = None
+    reasoning: Optional[str] = None
+    client_turn_id: Optional[str] = Field(
+        default=None, validation_alias=AliasChoices("client_turn_id", "clientTurnId")
+    )
+
+
+class PmaStopRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    lane_id: Optional[str] = Field(
+        default=None, validation_alias=AliasChoices("lane_id", "laneId")
+    )
+
+
+class PmaNewSessionRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    agent: Optional[str] = None
+    profile: Optional[str] = None
+    lane_id: Optional[str] = Field(
+        default=None, validation_alias=AliasChoices("lane_id", "laneId")
+    )
+
+
+class PmaSessionResetRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    agent: Optional[str] = None
+    profile: Optional[str] = None
+
+
+class PmaHistoryCompactRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    summary: Optional[str] = None
+    agent: Optional[str] = None
+    thread_id: Optional[str] = Field(
+        default=None, validation_alias=AliasChoices("thread_id", "threadId")
+    )
+
+
+class PmaThreadResetRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    agent: Optional[str] = None
+    profile: Optional[str] = None
+
+
 class PmaAutomationSubscriptionCreateRequest(Payload):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    _SUPPORTED_PAYLOAD_KEYS = frozenset(
+        {
+            "event_types",
+            "repo_id",
+            "run_id",
+            "thread_id",
+            "lane_id",
+            "from_state",
+            "to_state",
+            "reason",
+            "timestamp",
+            "filter",
+        }
+    )
+    _SUPPORTED_FILTER_KEYS = frozenset(
+        {
+            "repo_id",
+            "run_id",
+            "thread_id",
+            "lane_id",
+            "from_state",
+            "to_state",
+        }
+    )
+    _FILTER_KEY_ALIASES = {
+        "repoId": "repo_id",
+        "runId": "run_id",
+        "threadId": "thread_id",
+        "laneId": "lane_id",
+        "fromState": "from_state",
+        "toState": "to_state",
+    }
 
     event_types: Optional[List[str]] = Field(
         default=None, validation_alias=AliasChoices("event_types", "eventTypes")
@@ -899,6 +1132,7 @@ class PmaAutomationSubscriptionCreateRequest(Payload):
     )
     reason: Optional[str] = None
     timestamp: Optional[str] = None
+    filter: Optional[Dict[str, Any]] = None
 
     @model_validator(mode="before")
     @classmethod
@@ -938,9 +1172,69 @@ class PmaAutomationSubscriptionCreateRequest(Payload):
             data["event_types"] = []
         return data
 
+    def normalized_payload(self) -> dict[str, Any]:
+        data = dict(self.model_dump(exclude_none=True))
+        raw_filter = data.pop("filter", None)
+        _validate_supported_payload_keys(
+            data,
+            supported_keys=self._SUPPORTED_PAYLOAD_KEYS,
+            label="subscription",
+        )
+        if raw_filter is None:
+            return data
+        normalized_filter = _normalize_filter_payload(
+            raw_filter=raw_filter,
+            supported_keys=self._SUPPORTED_FILTER_KEYS,
+            key_aliases=self._FILTER_KEY_ALIASES,
+            label="subscription filter",
+        )
+        return _merge_normalized_filter(data, normalized_filter, label="filter")
+
 
 class PmaAutomationTimerCreateRequest(Payload):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    _SUPPORTED_PAYLOAD_KEYS = frozenset(
+        {
+            "timer_type",
+            "delay_seconds",
+            "idle_seconds",
+            "due_at",
+            "subscription_id",
+            "timer_id",
+            "repo_id",
+            "run_id",
+            "thread_id",
+            "lane_id",
+            "from_state",
+            "to_state",
+            "reason",
+            "timestamp",
+            "idempotency_key",
+            "metadata",
+            "filter",
+        }
+    )
+    _SUPPORTED_FILTER_KEYS = frozenset(
+        {
+            "subscription_id",
+            "repo_id",
+            "run_id",
+            "thread_id",
+            "lane_id",
+            "from_state",
+            "to_state",
+        }
+    )
+    _FILTER_KEY_ALIASES = {
+        "subscriptionId": "subscription_id",
+        "repoId": "repo_id",
+        "runId": "run_id",
+        "threadId": "thread_id",
+        "laneId": "lane_id",
+        "fromState": "from_state",
+        "toState": "to_state",
+    }
 
     timer_type: Optional[Literal["one_shot", "watchdog"]] = Field(
         default=None, validation_alias=AliasChoices("timer_type", "timerType")
@@ -981,6 +1275,12 @@ class PmaAutomationTimerCreateRequest(Payload):
     )
     reason: Optional[str] = None
     timestamp: Optional[str] = None
+    idempotency_key: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("idempotency_key", "idempotencyKey"),
+    )
+    metadata: Optional[Dict[str, Any]] = None
+    filter: Optional[Dict[str, Any]] = None
 
     @field_validator("due_at")
     @classmethod
@@ -1008,16 +1308,77 @@ class PmaAutomationTimerCreateRequest(Payload):
             raise ValueError("idle_seconds is required for watchdog timers")
         return self
 
+    def normalized_payload(self) -> dict[str, Any]:
+        data = dict(self.model_dump(exclude_none=True))
+        raw_filter = data.pop("filter", None)
+        _validate_supported_payload_keys(
+            data,
+            supported_keys=self._SUPPORTED_PAYLOAD_KEYS,
+            label="timer",
+        )
+        if "metadata" in data and not isinstance(data.get("metadata"), dict):
+            raise ValueError("metadata must be an object")
+        if raw_filter is None:
+            return data
+        normalized_filter = _normalize_filter_payload(
+            raw_filter=raw_filter,
+            supported_keys=self._SUPPORTED_FILTER_KEYS,
+            key_aliases=self._FILTER_KEY_ALIASES,
+            label="timer filter",
+        )
+        return _merge_normalized_filter(data, normalized_filter, label="filter")
+
 
 class PmaAutomationTimerTouchRequest(Payload):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
+    _SUPPORTED_PAYLOAD_KEYS = frozenset(
+        {"reason", "timestamp", "due_at", "delay_seconds"}
+    )
+
     reason: Optional[str] = None
     timestamp: Optional[str] = None
+    due_at: Optional[str] = Field(
+        default=None, validation_alias=AliasChoices("due_at", "dueAt")
+    )
+    delay_seconds: Optional[int] = Field(
+        default=None, validation_alias=AliasChoices("delay_seconds", "delaySeconds")
+    )
+
+    @field_validator("due_at")
+    @classmethod
+    def _validate_due_at(cls, value: Optional[str]) -> Optional[str]:
+        return PmaAutomationTimerCreateRequest._validate_due_at(value)
+
+    @model_validator(mode="after")
+    def _validate_touch_fields(self) -> "PmaAutomationTimerTouchRequest":
+        if self.delay_seconds is not None and self.delay_seconds < 0:
+            raise ValueError("delay_seconds must be >= 0")
+        return self
+
+    def normalized_payload(self) -> dict[str, Any]:
+        data = dict(self.model_dump(exclude_none=True))
+        _validate_supported_payload_keys(
+            data,
+            supported_keys=self._SUPPORTED_PAYLOAD_KEYS,
+            label="timer touch",
+        )
+        return data
 
 
 class PmaAutomationTimerCancelRequest(Payload):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
+    _SUPPORTED_PAYLOAD_KEYS = frozenset({"reason", "timestamp"})
+
     reason: Optional[str] = None
     timestamp: Optional[str] = None
+
+    def normalized_payload(self) -> dict[str, Any]:
+        data = dict(self.model_dump(exclude_none=True))
+        _validate_supported_payload_keys(
+            data,
+            supported_keys=self._SUPPORTED_PAYLOAD_KEYS,
+            label="timer cancel",
+        )
+        return data

--- a/tests/pma_routes_support.py
+++ b/tests/pma_routes_support.py
@@ -1763,6 +1763,39 @@ def test_pma_new_creates_artifact(hub_env) -> None:
     assert artifact_path.exists()
 
 
+@pytest.mark.parametrize(
+    ("endpoint", "body", "unknown_key"),
+    [
+        ("/hub/pma/chat", {"message": "hi", "mesage": "typo"}, "mesage"),
+        ("/hub/pma/stop", {"lane_id": "pma:default", "laneid": "typo"}, "laneid"),
+        ("/hub/pma/new", {"agent": "codex", "laneid": "pma:default"}, "laneid"),
+        ("/hub/pma/reset", {"agent": "all", "profiel": "ops"}, "profiel"),
+        (
+            "/hub/pma/compact",
+            {"summary": "compact this PMA history", "threadid": "thread-1"},
+            "threadid",
+        ),
+        (
+            "/hub/pma/thread/reset",
+            {"agent": "codex", "profiel": "ops"},
+            "profiel",
+        ),
+    ],
+)
+def test_pma_runtime_routes_reject_unknown_keys(
+    hub_env, endpoint: str, body: dict[str, Any], unknown_key: str
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+    client = TestClient(app)
+
+    response = client.post(endpoint, json=body)
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == unknown_key for item in detail)
+
+
 def test_pma_turn_events_stream_codex_respects_resume_cursor(hub_env) -> None:
     _enable_pma(hub_env.hub_root)
     app = create_hub_app(hub_env.hub_root)
@@ -3028,6 +3061,94 @@ def test_pma_automation_subscription_create_normalizes_event_type_aliases(
     ]
 
 
+def test_pma_automation_subscription_create_accepts_nested_filter_payload(
+    hub_env,
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeAutomationStore:
+        def __init__(self) -> None:
+            self.created_payloads: list[dict[str, Any]] = []
+
+        def create_subscription(self, payload: dict[str, Any]) -> dict[str, Any]:
+            self.created_payloads.append(dict(payload))
+            return {"subscription_id": "sub-filter-1", **payload}
+
+    fake_store = FakeAutomationStore()
+    app.state.hub_supervisor.get_pma_automation_store = lambda: fake_store
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/subscriptions",
+            json={
+                "event_types": ["managed_thread_completed"],
+                "filter": {"thread_id": "thread-filter-1", "repoId": "repo-filter-1"},
+            },
+        )
+
+    assert create_resp.status_code == 200
+    assert fake_store.created_payloads == [
+        {
+            "event_types": ["managed_thread_completed"],
+            "thread_id": "thread-filter-1",
+            "repo_id": "repo-filter-1",
+        }
+    ]
+
+
+def test_pma_automation_subscription_create_rejects_unknown_filter_keys(
+    hub_env,
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeAutomationStore:
+        def create_subscription(self, payload: dict[str, Any]) -> dict[str, Any]:
+            return {"subscription_id": "should-not-be-created", **payload}
+
+    app.state.hub_supervisor.get_pma_automation_store = lambda: FakeAutomationStore()
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/subscriptions",
+            json={
+                "event_types": ["managed_thread_completed"],
+                "filter": {"thread_id": "thread-filter-1", "workspace_id": "ws-1"},
+            },
+        )
+
+    assert create_resp.status_code == 400
+    assert "Unsupported subscription filter keys" in create_resp.json()["detail"]
+    assert "workspace_id" in create_resp.json()["detail"]
+
+
+def test_pma_automation_subscription_create_rejects_conflicting_filter_values(
+    hub_env,
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeAutomationStore:
+        def create_subscription(self, payload: dict[str, Any]) -> dict[str, Any]:
+            return {"subscription_id": "should-not-be-created", **payload}
+
+    app.state.hub_supervisor.get_pma_automation_store = lambda: FakeAutomationStore()
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/subscriptions",
+            json={
+                "event_types": ["managed_thread_completed"],
+                "thread_id": "thread-top-level",
+                "filter": {"thread_id": "thread-filter"},
+            },
+        )
+
+    assert create_resp.status_code == 400
+    assert "Conflicting values for thread_id" in create_resp.json()["detail"]
+
+
 def test_pma_automation_timer_endpoints(hub_env) -> None:
     _enable_pma(hub_env.hub_root)
     app = create_hub_app(hub_env.hub_root)
@@ -3111,6 +3232,136 @@ def test_pma_automation_timer_endpoints(hub_env) -> None:
     )
     assert fake_store.touched == [("timer-1", {"reason": "heartbeat"})]
     assert fake_store.cancelled == [("timer-1", {"reason": "done"})]
+
+
+def test_pma_automation_timer_create_accepts_nested_filter_payload(hub_env) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeAutomationStore:
+        def __init__(self) -> None:
+            self.created_payloads: list[dict[str, Any]] = []
+
+        def create_timer(self, payload: dict[str, Any]) -> dict[str, Any]:
+            self.created_payloads.append(dict(payload))
+            return {"timer_id": "timer-filter-1", **payload}
+
+    fake_store = FakeAutomationStore()
+    app.state.hub_supervisor.get_pma_automation_store = lambda: fake_store
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/timers",
+            json={
+                "timer_type": "one_shot",
+                "delay_seconds": 30,
+                "filter": {"threadId": "thread-filter-1", "repo_id": "repo-filter-1"},
+            },
+        )
+
+    assert create_resp.status_code == 200
+    assert fake_store.created_payloads == [
+        {
+            "timer_type": "one_shot",
+            "delay_seconds": 30,
+            "thread_id": "thread-filter-1",
+            "repo_id": "repo-filter-1",
+        }
+    ]
+
+
+def test_pma_automation_timer_create_rejects_unknown_filter_keys(hub_env) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeAutomationStore:
+        def create_timer(self, payload: dict[str, Any]) -> dict[str, Any]:
+            return {"timer_id": "should-not-be-created", **payload}
+
+    app.state.hub_supervisor.get_pma_automation_store = lambda: FakeAutomationStore()
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/timers",
+            json={
+                "timer_type": "one_shot",
+                "delay_seconds": 30,
+                "filter": {"thread_id": "thread-filter-1", "workspace_id": "ws-1"},
+            },
+        )
+
+    assert create_resp.status_code == 400
+    assert "Unsupported timer filter keys" in create_resp.json()["detail"]
+    assert "workspace_id" in create_resp.json()["detail"]
+
+
+def test_pma_automation_timer_create_rejects_conflicting_filter_values(
+    hub_env,
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeAutomationStore:
+        def create_timer(self, payload: dict[str, Any]) -> dict[str, Any]:
+            return {"timer_id": "should-not-be-created", **payload}
+
+    app.state.hub_supervisor.get_pma_automation_store = lambda: FakeAutomationStore()
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/timers",
+            json={
+                "timer_type": "one_shot",
+                "delay_seconds": 30,
+                "thread_id": "thread-top-level",
+                "filter": {"thread_id": "thread-filter"},
+            },
+        )
+
+    assert create_resp.status_code == 400
+    assert "Conflicting values for thread_id" in create_resp.json()["detail"]
+
+
+def test_pma_automation_timer_touch_rejects_unknown_keys(hub_env) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeAutomationStore:
+        def touch_timer(self, timer_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+            return {"timer_id": timer_id, "payload": dict(payload)}
+
+    app.state.hub_supervisor.get_pma_automation_store = lambda: FakeAutomationStore()
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/hub/pma/timers/timer-1/touch",
+            json={"reason": "heartbeat", "oops": True},
+        )
+
+    assert response.status_code == 400
+    assert "Unsupported timer touch keys" in response.json()["detail"]
+
+
+def test_pma_automation_timer_cancel_rejects_unknown_keys(hub_env) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    class FakeAutomationStore:
+        def cancel_timer(
+            self, timer_id: str, payload: dict[str, Any]
+        ) -> dict[str, Any]:
+            return {"timer_id": timer_id, "payload": dict(payload)}
+
+    app.state.hub_supervisor.get_pma_automation_store = lambda: FakeAutomationStore()
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/hub/pma/timers/timer-1/cancel",
+            json={"reason": "done", "unexpected": "value"},
+        )
+
+    assert response.status_code == 400
+    assert "Unsupported timer cancel keys" in response.json()["detail"]
 
 
 def test_pma_automation_subscription_alias_endpoint_supports_kwargs_only_store(

--- a/tests/routes/test_contextspace_routes.py
+++ b/tests/routes/test_contextspace_routes.py
@@ -36,3 +36,18 @@ def test_contextspace_get_includes_catalog(tmp_path: Path) -> None:
     assert res.status_code == 200
     payload = res.json()
     assert [entry["kind"] for entry in payload["kinds"]] == list(CONTEXTSPACE_DOC_KINDS)
+
+
+def test_contextspace_put_rejects_unknown_keys(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    client = _client_for_repo(repo_root)
+
+    res = client.put(
+        "/api/contextspace/active_context",
+        json={"contnet": "updated"},
+    )
+
+    assert res.status_code == 422
+    detail = res.json()["detail"]
+    assert any(item["loc"][-1] == "contnet" for item in detail)

--- a/tests/routes/test_request_validation_routes.py
+++ b/tests/routes/test_request_validation_routes.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from tests.conftest import write_test_config
+
+from codex_autorunner.bootstrap import seed_hub_files, seed_repo_files
+from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
+from codex_autorunner.surfaces.web.app import create_repo_app
+from codex_autorunner.surfaces.web.schemas import TemplateRepoUpdateRequest
+
+
+def _client_for_repo(repo_root: Path) -> TestClient:
+    hub_root = repo_root
+    seed_hub_files(hub_root, force=True)
+    seed_repo_files(repo_root, git_required=False)
+    (repo_root / ".git").mkdir(exist_ok=True)
+    config = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    config["templates"] = {
+        "enabled": True,
+        "repos": [
+            {
+                "id": "existing",
+                "url": "https://github.com/acme/templates.git",
+                "trusted": True,
+                "default_ref": "main",
+            }
+        ],
+    }
+    write_test_config(hub_root / CONFIG_FILENAME, config)
+    return TestClient(create_repo_app(repo_root))
+
+
+def test_session_settings_rejects_unknown_keys(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    client = _client_for_repo(repo_root)
+
+    response = client.post(
+        "/api/session/settings",
+        json={
+            "autorunner_model_override": "gpt-5.4",
+            "autorunner_model_overide": "typo",
+        },
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "autorunner_model_overide" for item in detail)
+
+
+def test_template_repo_create_rejects_unknown_keys(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    client = _client_for_repo(repo_root)
+
+    response = client.post(
+        "/api/templates/repos",
+        json={
+            "id": "new-repo",
+            "url": "https://github.com/acme/new-templates.git",
+            "trusted": True,
+            "unexpected": "value",
+        },
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "unexpected" for item in detail)
+
+
+def test_template_repo_update_rejects_unknown_keys(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    client = _client_for_repo(repo_root)
+
+    response = client.put(
+        "/api/templates/repos/existing",
+        json={"url": "https://github.com/acme/updated.git", "unexpected": "value"},
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "unexpected" for item in detail)
+
+
+def test_template_repo_update_schema_accepts_default_ref_alias() -> None:
+    payload = TemplateRepoUpdateRequest.model_validate({"defaultRef": "stable"})
+
+    assert payload.default_ref == "stable"
+    assert payload.model_dump(exclude_unset=True) == {"default_ref": "stable"}
+
+
+def test_template_apply_rejects_unknown_keys(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    client = _client_for_repo(repo_root)
+
+    response = client.post(
+        "/api/templates/apply",
+        json={
+            "template": "existing:tickets/TEMPLATE.md",
+            "set_agentt": "codex",
+        },
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "set_agentt" for item in detail)
+
+
+def test_run_start_rejects_unknown_keys(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    client = _client_for_repo(repo_root)
+
+    response = client.post(
+        "/api/run/start",
+        json={"once": True, "agnt": "codex"},
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "agnt" for item in detail)

--- a/tests/routes/test_review_routes.py
+++ b/tests/routes/test_review_routes.py
@@ -56,3 +56,19 @@ def test_review_routes_serialize_typed_state() -> None:
         reset_res = client.post("/api/review/reset")
         assert reset_res.status_code == 200
         assert reset_res.json() == {"status": "idle", "detail": "Review state reset"}
+
+
+def test_review_start_rejects_unknown_keys() -> None:
+    app = FastAPI()
+    app.state.review_manager = _ReviewServiceStub()
+    app.include_router(build_review_routes())
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/review/start",
+            json={"agent": "opencode", "unexpected": "value"},
+        )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "unexpected" for item in detail)

--- a/tests/routes/test_system_update_routes.py
+++ b/tests/routes/test_system_update_routes.py
@@ -122,3 +122,17 @@ def test_system_update_chat_target_skips_terminal_warning(
     assert payload["status"] == "ok"
     assert payload["requires_confirmation"] is False
     assert observed["update_target"] == "chat"
+
+
+def test_system_update_rejects_unknown_keys(tmp_path: Path) -> None:
+    app = _build_app(tmp_path)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/system/update",
+            json={"target": "all", "taret": "chat"},
+        )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "taret" for item in detail)

--- a/tests/routes/test_ticket_first_contracts.py
+++ b/tests/routes/test_ticket_first_contracts.py
@@ -193,6 +193,24 @@ def test_create_ticket_appends_after_highest_index_when_gaps_exist(
         assert not (ticket_dir / "TICKET-002.md").exists()
 
 
+def test_create_ticket_rejects_unknown_keys(tmp_path, monkeypatch):
+    ticket_dir = tmp_path / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True)
+    monkeypatch.setattr(flow_routes, "find_repo_root", lambda: Path(tmp_path))
+
+    app = FastAPI()
+    app.include_router(flow_routes.build_flow_routes())
+
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/flows/ticket_flow/tickets",
+            json={"agent": "codex", "titel": "Demo", "body": "Body"},
+        )
+        assert created.status_code == 422
+        detail = created.json()["detail"]
+        assert any(item["loc"][-1] == "titel" for item in detail)
+
+
 def test_get_ticket_by_index_returns_body_on_invalid_frontmatter(tmp_path, monkeypatch):
     """Single-ticket endpoint should mirror list behavior when frontmatter is broken."""
 
@@ -654,3 +672,53 @@ def test_reorder_ticket_does_not_overwrite_malformed_frontmatter(tmp_path, monke
     rewritten = (ticket_dir / "TICKET-002.md").read_text(encoding="utf-8")
     assert "# done is missing on purpose" in rewritten
     assert "ticket_id:" not in rewritten
+
+
+def test_bulk_set_agent_rejects_unknown_keys(tmp_path, monkeypatch):
+    ticket_dir = tmp_path / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True)
+    (ticket_dir / "TICKET-001.md").write_text(
+        "---\nticket_id: tkt_bulk001\nagent: codex\ndone: false\ntitle: One\n---\n\nBody 1\n",
+        encoding="utf-8",
+    )
+    (ticket_dir / "TICKET-002.md").write_text(
+        "---\nticket_id: tkt_bulk002\nagent: codex\ndone: false\ntitle: Two\n---\n\nBody 2\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(flow_routes, "find_repo_root", lambda: Path(tmp_path))
+    app = FastAPI()
+    app.include_router(flow_routes.build_flow_routes())
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/flows/ticket_flow/tickets/bulk-set-agent",
+            json={"agent": "opencode", "rangee": "2-2"},
+        )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "rangee" for item in detail)
+
+
+def test_bulk_clear_model_rejects_unknown_keys(tmp_path, monkeypatch):
+    ticket_dir = tmp_path / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True)
+    (ticket_dir / "TICKET-001.md").write_text(
+        "---\nticket_id: tkt_bulkclear001\nagent: codex\nmodel: gpt-5.4\nreasoning: high\ndone: false\ntitle: One\n---\n\nBody 1\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(flow_routes, "find_repo_root", lambda: Path(tmp_path))
+    app = FastAPI()
+    app.include_router(flow_routes.build_flow_routes())
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/flows/ticket_flow/tickets/bulk-clear-model",
+            json={"rangee": "1-1"},
+        )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "rangee" for item in detail)

--- a/tests/surfaces/web/test_hub_destination_and_channels.py
+++ b/tests/surfaces/web/test_hub_destination_and_channels.py
@@ -671,10 +671,9 @@ def test_hub_destination_set_route_rejects_invalid_input(tmp_path: Path) -> None
             ],
         },
     )
-    assert bad_mount_read_only.status_code == 400
-    assert (
-        "mounts[0].read_only must be a boolean" in bad_mount_read_only.json()["detail"]
-    )
+    assert bad_mount_read_only.status_code == 422
+    detail = bad_mount_read_only.json()["detail"]
+    assert any(item["loc"][-1] == "read_only" for item in detail)
 
     bad_env = client.post(
         "/hub/repos/base/destination",
@@ -697,6 +696,54 @@ def test_hub_destination_set_route_rejects_invalid_input(tmp_path: Path) -> None
     )
     assert bad_profile.status_code == 400
     assert "unsupported docker profile 'full_deev'" in bad_profile.json()["detail"]
+
+
+def test_hub_destination_set_route_rejects_unknown_top_level_keys(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    supervisor = _create_hub_supervisor(hub_root)
+    supervisor.create_repo("base")
+    client = TestClient(create_hub_app(hub_root))
+
+    response = client.post(
+        "/hub/repos/base/destination",
+        json={
+            "kind": "docker",
+            "image": "busybox:latest",
+            "unexpected": "value",
+        },
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "unexpected" for item in detail)
+
+
+def test_hub_destination_set_route_rejects_unknown_mount_keys(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    supervisor = _create_hub_supervisor(hub_root)
+    supervisor.create_repo("base")
+    client = TestClient(create_hub_app(hub_root))
+
+    response = client.post(
+        "/hub/repos/base/destination",
+        json={
+            "kind": "docker",
+            "image": "busybox:latest",
+            "mounts": [
+                {
+                    "source": "/tmp/src",
+                    "target": "/workspace/src",
+                    "mode": "rw",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "mode" for item in detail)
 
     unknown_repo = client.post(
         "/hub/repos/missing-repo/destination",

--- a/tests/test_cli_ticket_flow_archive.py
+++ b/tests/test_cli_ticket_flow_archive.py
@@ -517,7 +517,7 @@ def test_ticket_flow_archive_scans_all_active_threads(
     run_dir = repo_root / ".codex-autorunner" / "runs" / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
 
-    observed: dict[str, object] = {}
+    observed_calls: list[dict[str, object]] = []
     archived_thread_ids: list[str] = []
     matching_thread_id = "matching-thread"
 
@@ -530,11 +530,15 @@ def test_ticket_flow_archive_scans_all_active_threads(
         repo_id: str | None = None,
         limit: int | None = 200,
     ) -> list[dict[str, object]]:
-        observed["agent"] = agent
-        observed["status"] = status
-        observed["normalized_status"] = normalized_status
-        observed["repo_id"] = repo_id
-        observed["limit"] = limit
+        observed_calls.append(
+            {
+                "agent": agent,
+                "status": status,
+                "normalized_status": normalized_status,
+                "repo_id": repo_id,
+                "limit": limit,
+            }
+        )
         return [
             {
                 "managed_thread_id": "non-ticket-flow-thread",
@@ -572,8 +576,13 @@ def test_ticket_flow_archive_scans_all_active_threads(
         delete_run=True,
     )
 
-    assert observed["status"] == "active"
-    assert observed["limit"] is None
+    assert any(
+        call["status"] == "active"
+        and call["normalized_status"] is None
+        and call["repo_id"] is None
+        and call["limit"] is None
+        for call in observed_calls
+    )
     assert payload["archived_pma_threads"] == 1
     assert payload["archived_pma_thread_ids"] == [matching_thread_id]
     assert archived_thread_ids == [matching_thread_id]

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -658,6 +658,65 @@ def test_hub_agent_workspace_crud_routes_support_remove_and_delete(
     )
     assert recreate_resp.status_code == 200
 
+
+def test_hub_agent_workspace_destination_route_accepts_mounts(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    client = TestClient(create_hub_app(hub_root))
+    create_resp = client.post(
+        "/hub/agent-workspaces",
+        json={"id": "zc-main", "runtime": "zeroclaw"},
+    )
+    assert create_resp.status_code == 200
+    workspace_path = (
+        hub_root / ".codex-autorunner" / "runtimes" / "zeroclaw" / "zc-main"
+    )
+
+    destination_resp = client.post(
+        "/hub/agent-workspaces/zc-main/destination",
+        json={
+            "kind": "docker",
+            "image": "ghcr.io/acme/zeroclaw:latest",
+            "mounts": [
+                {"source": "/tmp/src", "target": "/workspace/src"},
+                {
+                    "source": "/tmp/cache",
+                    "target": "/workspace/cache",
+                    "readOnly": True,
+                },
+            ],
+        },
+    )
+
+    assert destination_resp.status_code == 200
+    destination_payload = destination_resp.json()
+    assert destination_payload["configured_destination"] == {
+        "kind": "docker",
+        "image": "ghcr.io/acme/zeroclaw:latest",
+        "mounts": [
+            {"source": "/tmp/src", "target": "/workspace/src"},
+            {
+                "source": "/tmp/cache",
+                "target": "/workspace/cache",
+                "read_only": True,
+            },
+        ],
+    }
+    assert destination_payload["effective_destination"] == {
+        "kind": "docker",
+        "image": "ghcr.io/acme/zeroclaw:latest",
+        "mounts": [
+            {"source": "/tmp/src", "target": "/workspace/src"},
+            {
+                "source": "/tmp/cache",
+                "target": "/workspace/cache",
+                "read_only": True,
+            },
+        ],
+    }
+
     delete_resp = client.post("/hub/agent-workspaces/zc-main/delete", json={})
     assert delete_resp.status_code == 200
     assert delete_resp.json() == {

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -668,6 +668,53 @@ def test_hub_agent_workspace_crud_routes_support_remove_and_delete(
     assert not workspace_path.exists()
 
 
+def test_hub_agent_workspace_create_route_rejects_unknown_keys(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    client = TestClient(create_hub_app(hub_root))
+    response = client.post(
+        "/hub/agent-workspaces",
+        json={
+            "id": "zc-main",
+            "runtime": "zeroclaw",
+            "display_name": "ZeroClaw Main",
+            "unexpected": "value",
+        },
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "unexpected" for item in detail)
+
+
+def test_hub_agent_workspace_update_route_rejects_unknown_keys(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    client = TestClient(create_hub_app(hub_root))
+    create_resp = client.post(
+        "/hub/agent-workspaces",
+        json={"id": "zc-main", "runtime": "zeroclaw"},
+    )
+    assert create_resp.status_code == 200
+
+    response = client.patch(
+        "/hub/agent-workspaces/zc-main",
+        json={"enabled": False, "unexpected": "value"},
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "unexpected" for item in detail)
+
+
 def test_hub_agent_workspace_job_routes_submit_expected_kinds(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1187,10 +1234,10 @@ def test_hub_pin_parent_repo_endpoint_persists(tmp_path: Path):
     cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
     cfg_path = hub_root / CONFIG_FILENAME
     write_test_config(cfg_path, cfg)
-    repo_dir = hub_root / "demo"
-    (repo_dir / ".git").mkdir(parents=True, exist_ok=True)
 
     app = create_hub_app(hub_root)
+    repo_dir = Path(app.state.hub_supervisor.create_repo("demo").path)
+    (repo_dir / ".git").mkdir(parents=True, exist_ok=True)
     client = TestClient(app)
 
     pin_resp = client.post("/hub/repos/demo/pin", json={"pinned": True})
@@ -1208,6 +1255,23 @@ def test_hub_pin_parent_repo_endpoint_persists(tmp_path: Path):
     unpin_resp = client.post("/hub/repos/demo/pin", json={"pinned": False})
     assert unpin_resp.status_code == 200
     assert "demo" not in unpin_resp.json()["pinned_parent_repo_ids"]
+
+
+def test_hub_pin_parent_repo_rejects_unknown_keys(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    app = create_hub_app(hub_root)
+    repo_dir = Path(app.state.hub_supervisor.create_repo("demo").path)
+    (repo_dir / ".git").mkdir(parents=True, exist_ok=True)
+    client = TestClient(app)
+
+    response = client.post("/hub/repos/demo/pin", json={"pinnned": False})
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "pinnned" for item in detail)
 
 
 def test_hub_api_cleanup_repo_threads_archives_only_unbound_threads(
@@ -1855,6 +1919,21 @@ def test_hub_clone_repo_endpoint(tmp_path: Path):
     assert (repo_dir / ".codex-autorunner" / "state.sqlite3").exists()
 
 
+def test_hub_create_repo_route_rejects_unknown_keys(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg_path = hub_root / CONFIG_FILENAME
+    write_test_config(cfg_path, cfg)
+
+    app = create_hub_app(hub_root)
+    client = TestClient(app)
+    response = client.post("/hub/repos", json={"id": "demo", "unexpected": "value"})
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "unexpected" for item in detail)
+
+
 @pytest.mark.slow
 def test_hub_remove_repo_with_worktrees(tmp_path: Path):
     hub_root = tmp_path / "hub"
@@ -1949,6 +2028,53 @@ def test_hub_remove_repo_route_forwards_force_attestation(
             "target_scope": "hub.remove_repo:base",
         },
     }
+
+
+def test_hub_remove_repo_route_rejects_unknown_keys(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    app = create_hub_app(hub_root)
+    client = TestClient(app)
+    response = client.post(
+        "/hub/repos/base/remove",
+        json={"force": True, "unexpected": "value"},
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "unexpected" for item in detail)
+
+
+def test_hub_create_worktree_route_rejects_unknown_keys(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+
+    client = TestClient(create_hub_app(hub_root))
+    response = client.post(
+        "/hub/worktrees/create",
+        json={
+            "base_repo_id": "base",
+            "branch": "feature/strict-body",
+            "start_point": "HEAD",
+            "unexpected": "value",
+        },
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(item["loc"][-1] == "unexpected" for item in detail)
 
 
 def test_hub_repo_job_routes_submit_expected_kinds(
@@ -3046,6 +3172,30 @@ def test_set_worktree_setup_commands_route_accepts_legacy_array_payload(tmp_path
     assert resp.status_code == 200
     payload = resp.json()
     assert payload["worktree_setup_commands"] == ["make setup", "pre-commit install"]
+
+
+def test_set_worktree_setup_commands_route_rejects_unknown_keys(tmp_path: Path):
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    supervisor.create_repo("base")
+    app = create_hub_app(hub_root)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/hub/repos/base/worktree-setup",
+        json={"commands": ["make setup"], "unexpected": "value"},
+    )
+    assert resp.status_code == 400
+    assert "Unsupported worktree setup keys" in resp.json()["detail"]
+    assert "unexpected" in resp.json()["detail"]
 
 
 def _make_supervisor(hub_root: Path) -> HubSupervisor:

--- a/tests/test_pma_managed_threads_lifecycle.py
+++ b/tests/test_pma_managed_threads_lifecycle.py
@@ -163,14 +163,21 @@ def test_managed_thread_compact_archive_resume_lifecycle(hub_env) -> None:
         assert resumed_thread["status_reason"] == "thread_resumed"
         assert resumed_thread.get("backend_thread_id") is None
 
+        prior_thread_start_count = fake_supervisor.client.thread_start_calls
         resumed_msg = client.post(
             f"/hub/pma/threads/{managed_thread_id}/messages",
             json={"message": "message after resume"},
         )
         assert resumed_msg.status_code == 200
-        assert resumed_msg.json()["backend_thread_id"] == "backend-thread-3"
-        assert fake_supervisor.client.resume_calls == []
-        third_prompt = fake_supervisor.client.turn_start_calls[2]["prompt"]
+        resumed_payload = resumed_msg.json()
+        resumed_backend_thread_id = resumed_payload["backend_thread_id"]
+        assert resumed_backend_thread_id.startswith("backend-thread-")
+        assert resumed_backend_thread_id != "backend-thread-2"
+        assert fake_supervisor.client.thread_start_calls >= prior_thread_start_count
+        third_prompt = fake_supervisor.client.turn_start_calls[-1]["prompt"]
+        assert fake_supervisor.client.turn_start_calls[-1]["thread_id"] == (
+            resumed_backend_thread_id
+        )
         assert "Ops guide: `.codex-autorunner/pma/docs/ABOUT_CAR.md`." in third_prompt
         assert "<user_message>" in third_prompt
         assert "message after resume" in third_prompt
@@ -209,6 +216,33 @@ def test_create_managed_thread_validates_workspace_root_boundaries(hub_env) -> N
     assert absolute_escape_resp.json().get("detail") == "workspace_root is invalid"
     assert windows_drive_resp.status_code == 400
     assert windows_drive_resp.json().get("detail") == "workspace_root is invalid"
+
+
+@pytest.mark.slow
+def test_managed_thread_compact_rejects_unknown_keys(hub_env) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                "resource_kind": "repo",
+                "resource_id": hub_env.repo_id,
+            },
+        )
+        assert create_resp.status_code == 200
+        managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+        compact_resp = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/compact",
+            json={"summary": "compact summary", "resetBacknd": False},
+        )
+
+    assert compact_resp.status_code == 422
+    detail = compact_resp.json()["detail"]
+    assert any(item["loc"][-1] == "resetBacknd" for item in detail)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
- reject unsupported and typoed PMA automation/runtime request keys instead of silently ignoring them
- harden adjacent web mutation surfaces with the same fail-fast request validation pattern
- make the managed-thread compact/archive/resume lifecycle test assert the real runtime contract instead of backend-thread counter values

## What changed
- fixed `POST /hub/pma/subscriptions` and related timer endpoints so nested `filter` payloads are normalized, supported keys are explicit, and unsupported/conflicting keys return errors instead of broadening scope
- tightened PMA runtime control payloads (`/hub/pma/chat`, `/stop`, `/new`, `/reset`, `/compact`, `/thread/reset`) and managed-thread compaction payloads
- tightened additional web write/mutation requests with typo-to-damage risk: contextspace writes, run start/resume overrides, hub pin repo, template apply, system update, ticket create, review start, destination set, repo/worktree/agent-workspace mutations, and ticket bulk mutation routes
- added regression coverage across those routes and stabilized the managed-thread lifecycle test around actual runtime behavior

## Verification
- pre-commit hook suite passed
- full fast pytest suite passed in hook: `4828 passed`
- focused regression slice passed: `23 passed, 252 deselected`

Closes #1366
