### PR TITLE
[codex] Recover thread send timeouts from status

### DIFF
--- a/src/codex_autorunner/surfaces/cli/pma_cli.py
+++ b/src/codex_autorunner/surfaces/cli/pma_cli.py
@@ -41,6 +41,7 @@ from .commands.utils import format_hub_request_error
 
 logger = logging.getLogger(__name__)
 _MANAGED_THREAD_SEND_PREVIEW_LIMIT = 120
+_MANAGED_THREAD_SEND_TIMEOUT_STATUS_LIMIT = 50
 
 pma_app = typer.Typer(
     add_completion=False,
@@ -844,6 +845,8 @@ class _ManagedThreadSendTimeoutProbe:
     active_managed_turn_id: str
     active_turn_status: str
     queue_depth: int
+    queued_turn_ids: tuple[str, ...]
+    queued_prompt_previews: tuple[str, ...]
 
     @classmethod
     def from_status(cls, data: Any) -> "_ManagedThreadSendTimeoutProbe":
@@ -852,6 +855,18 @@ class _ManagedThreadSendTimeoutProbe:
         thread: dict[str, Any] = raw_thread if isinstance(raw_thread, dict) else {}
         raw_turn = payload.get("turn")
         turn: dict[str, Any] = raw_turn if isinstance(raw_turn, dict) else {}
+        raw_queued_turns = payload.get("queued_turns")
+        queued_turns = raw_queued_turns if isinstance(raw_queued_turns, list) else []
+        queued_turn_ids = tuple(
+            str(item.get("managed_turn_id") or "").strip()
+            for item in queued_turns
+            if isinstance(item, dict) and str(item.get("managed_turn_id") or "").strip()
+        )
+        queued_prompt_previews = tuple(
+            str(item.get("prompt_preview") or "").strip()
+            for item in queued_turns
+            if isinstance(item, dict) and str(item.get("prompt_preview") or "").strip()
+        )
         return cls(
             last_turn_id=str(
                 thread.get("last_turn_id")
@@ -863,6 +878,8 @@ class _ManagedThreadSendTimeoutProbe:
             active_managed_turn_id=str(turn.get("managed_turn_id") or "").strip(),
             active_turn_status=str(turn.get("status") or "").strip(),
             queue_depth=_coerce_optional_int(payload.get("queue_depth")) or 0,
+            queued_turn_ids=queued_turn_ids,
+            queued_prompt_previews=queued_prompt_previews,
         )
 
 
@@ -875,7 +892,7 @@ def _fetch_managed_thread_status_payload(
         "GET",
         _build_pma_url(config, f"/threads/{managed_thread_id}/status"),
         token_env=config.server_auth_token_env,
-        params={"limit": 1},
+        params={"limit": _MANAGED_THREAD_SEND_TIMEOUT_STATUS_LIMIT},
     )
 
 
@@ -919,31 +936,60 @@ def _recover_managed_thread_send_timeout(
     ).strip()
     if not expected_preview:
         return None
-    if current.last_turn_id == baseline.last_turn_id:
-        return None
-    if current.last_message_preview != expected_preview:
-        return None
+    recovered_turn_id = ""
+    queued = False
+    if current.last_turn_id != baseline.last_turn_id and current.last_turn_id:
+        recovered_turn_id = current.last_turn_id
+    else:
+        baseline_queued_ids = set(baseline.queued_turn_ids)
+        queued_match_id = next(
+            (
+                managed_turn_id
+                for managed_turn_id, prompt_preview in zip(
+                    current.queued_turn_ids, current.queued_prompt_previews
+                )
+                if prompt_preview == expected_preview
+                and managed_turn_id not in baseline_queued_ids
+            ),
+            "",
+        )
+        if (
+            not queued_match_id
+            and current.queue_depth > baseline.queue_depth
+            and expected_preview in current.queued_prompt_previews
+            and expected_preview not in baseline.queued_prompt_previews
+        ):
+            queued_match_id = next(
+                (
+                    managed_turn_id
+                    for managed_turn_id, prompt_preview in zip(
+                        current.queued_turn_ids, current.queued_prompt_previews
+                    )
+                    if prompt_preview == expected_preview
+                ),
+                "",
+            )
+        if not queued_match_id:
+            return None
+        recovered_turn_id = queued_match_id
+        queued = True
 
-    queued = (
-        current.active_managed_turn_id != ""
-        and current.last_turn_id != current.active_managed_turn_id
-    )
     payload: dict[str, Any] = {
         "status": "ok",
         "send_state": "queued" if queued else "accepted",
         "execution_state": (
             "queued" if queued else (current.active_turn_status or "running")
         ),
-        "managed_turn_id": current.last_turn_id,
+        "managed_turn_id": recovered_turn_id,
         "active_managed_turn_id": (
-            current.active_managed_turn_id if queued else current.last_turn_id
+            current.active_managed_turn_id if queued else recovered_turn_id
         ),
         "queue_depth": current.queue_depth,
         "delivered_message": message_body,
         "assistant_text": "",
         "detail": (
-            "Timed out waiting for send confirmation; recovered accepted delivery "
-            "from thread status."
+            "Timed out waiting for send confirmation; recovered delivery from "
+            "thread status."
         ),
         "error": "",
         "next_step": (

--- a/src/codex_autorunner/surfaces/cli/pma_cli.py
+++ b/src/codex_autorunner/surfaces/cli/pma_cli.py
@@ -36,9 +36,11 @@ from ...core.pma_hygiene import (
     build_pma_hygiene_report,
     render_pma_hygiene_report,
 )
+from ...core.text_utils import _truncate_text
 from .commands.utils import format_hub_request_error
 
 logger = logging.getLogger(__name__)
+_MANAGED_THREAD_SEND_PREVIEW_LIMIT = 120
 
 pma_app = typer.Typer(
     add_completion=False,
@@ -833,6 +835,125 @@ class _ManagedThreadSendResponse:
             f"managed_turn_id={self.managed_turn_id} "
             f"execution_state={self.execution_state or 'completed'}"
         ).strip()
+
+
+@dataclass(frozen=True)
+class _ManagedThreadSendTimeoutProbe:
+    last_turn_id: str
+    last_message_preview: str
+    active_managed_turn_id: str
+    active_turn_status: str
+    queue_depth: int
+
+    @classmethod
+    def from_status(cls, data: Any) -> "_ManagedThreadSendTimeoutProbe":
+        payload = data if isinstance(data, dict) else {}
+        raw_thread = payload.get("thread")
+        thread: dict[str, Any] = raw_thread if isinstance(raw_thread, dict) else {}
+        raw_turn = payload.get("turn")
+        turn: dict[str, Any] = raw_turn if isinstance(raw_turn, dict) else {}
+        return cls(
+            last_turn_id=str(
+                thread.get("last_turn_id")
+                or thread.get("latest_turn_id")
+                or payload.get("latest_turn_id")
+                or ""
+            ).strip(),
+            last_message_preview=str(thread.get("last_message_preview") or "").strip(),
+            active_managed_turn_id=str(turn.get("managed_turn_id") or "").strip(),
+            active_turn_status=str(turn.get("status") or "").strip(),
+            queue_depth=_coerce_optional_int(payload.get("queue_depth")) or 0,
+        )
+
+
+def _fetch_managed_thread_status_payload(
+    config,
+    *,
+    managed_thread_id: str,
+) -> dict[str, Any]:
+    return _request_json(
+        "GET",
+        _build_pma_url(config, f"/threads/{managed_thread_id}/status"),
+        token_env=config.server_auth_token_env,
+        params={"limit": 1},
+    )
+
+
+def _capture_managed_thread_send_timeout_probe(
+    config,
+    *,
+    managed_thread_id: str,
+) -> Optional[_ManagedThreadSendTimeoutProbe]:
+    try:
+        return _ManagedThreadSendTimeoutProbe.from_status(
+            _fetch_managed_thread_status_payload(
+                config,
+                managed_thread_id=managed_thread_id,
+            )
+        )
+    except (httpx.HTTPError, ValueError, OSError, TypeError):
+        return None
+
+
+def _recover_managed_thread_send_timeout(
+    config,
+    *,
+    managed_thread_id: str,
+    message_body: str,
+    baseline: Optional[_ManagedThreadSendTimeoutProbe],
+) -> Optional[_ManagedThreadSendResponse]:
+    if baseline is None:
+        return None
+    try:
+        current = _ManagedThreadSendTimeoutProbe.from_status(
+            _fetch_managed_thread_status_payload(
+                config,
+                managed_thread_id=managed_thread_id,
+            )
+        )
+    except (httpx.HTTPError, ValueError, OSError, TypeError):
+        return None
+
+    expected_preview = _truncate_text(
+        message_body, _MANAGED_THREAD_SEND_PREVIEW_LIMIT
+    ).strip()
+    if not expected_preview:
+        return None
+    if current.last_turn_id == baseline.last_turn_id:
+        return None
+    if current.last_message_preview != expected_preview:
+        return None
+
+    queued = (
+        current.active_managed_turn_id != ""
+        and current.last_turn_id != current.active_managed_turn_id
+    )
+    payload: dict[str, Any] = {
+        "status": "ok",
+        "send_state": "queued" if queued else "accepted",
+        "execution_state": (
+            "queued" if queued else (current.active_turn_status or "running")
+        ),
+        "managed_turn_id": current.last_turn_id,
+        "active_managed_turn_id": (
+            current.active_managed_turn_id if queued else current.last_turn_id
+        ),
+        "queue_depth": current.queue_depth,
+        "delivered_message": message_body,
+        "assistant_text": "",
+        "detail": (
+            "Timed out waiting for send confirmation; recovered accepted delivery "
+            "from thread status."
+        ),
+        "error": "",
+        "next_step": (
+            "Use `car pma thread status` or `car pma thread tail` if you want "
+            "to watch execution progress."
+        ),
+    }
+    return _ManagedThreadSendResponse.from_http(
+        200, payload, default_message=message_body
+    )
 
 
 def _render_active_turn_diagnostics(data: dict[str, Any]) -> None:
@@ -2063,8 +2184,15 @@ def pma_thread_send(
     if normalized_if_busy not in {"queue", "interrupt", "reject"}:
         raise typer.BadParameter("if-busy must be queue, interrupt, or reject")
     hub_root = _resolve_hub_path(path)
+    config = None
+    timeout_probe: Optional[_ManagedThreadSendTimeoutProbe] = None
+    response: Optional[_ManagedThreadSendResponse] = None
     try:
         config = load_hub_config(hub_root)
+        timeout_probe = _capture_managed_thread_send_timeout_probe(
+            config,
+            managed_thread_id=managed_thread_id,
+        )
         request_payload = _ManagedThreadSendRequest(
             message=message_body,
             busy_policy=normalized_if_busy,
@@ -2082,13 +2210,47 @@ def pma_thread_send(
             token_env=config.server_auth_token_env,
             timeout=15.0,
         )
+        response = _ManagedThreadSendResponse.from_http(
+            status_code, data, default_message=message_body
+        )
+    except httpx.TimeoutException as exc:
+        recovered_response = _recover_managed_thread_send_timeout(
+            config,
+            managed_thread_id=managed_thread_id,
+            message_body=message_body,
+            baseline=timeout_probe,
+        )
+        if recovered_response is not None:
+            response = recovered_response
+            data = {
+                "status": response.status,
+                "send_state": response.send_state,
+                "execution_state": response.execution_state,
+                "managed_turn_id": response.managed_turn_id,
+                "active_managed_turn_id": response.active_managed_turn_id,
+                "queue_depth": response.queue_depth,
+                "delivered_message": response.delivered_message,
+                "assistant_text": response.assistant_text,
+                "detail": response.detail,
+                "error": response.error,
+                "next_step": response.next_step,
+            }
+        else:
+            detail = (
+                "Timed out waiting for send confirmation. The message may still "
+                "have been delivered. Check `car pma thread status --id "
+                f"{managed_thread_id} --path {hub_root}` before retrying."
+            )
+            typer.echo(f"Error: {detail}", err=True)
+            raise typer.Exit(code=1) from exc
     except (httpx.HTTPError, ValueError, OSError, TypeError) as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from None
 
-    response = _ManagedThreadSendResponse.from_http(
-        status_code, data, default_message=message_body
-    )
+    if config is None:
+        raise typer.Exit(code=1) from None
+    if response is None:
+        raise typer.Exit(code=1) from None
     if not response.is_ok:
         if output_json:
             typer.echo(json.dumps(data, indent=2))
@@ -2124,6 +2286,8 @@ def pma_thread_send(
     ):
         typer.echo(response.accepted_line())
         _echo_delivered_message(response.delivered_message)
+        if response.detail:
+            typer.echo(f"note: {response.detail}")
         if watch:
             pma_thread_tail(
                 managed_thread_id=managed_thread_id,

--- a/tests/test_pma_cli.py
+++ b/tests/test_pma_cli.py
@@ -1260,6 +1260,172 @@ def test_pma_cli_thread_send_reads_message_from_stdin(
     )
 
 
+def test_pma_cli_thread_send_recovers_timeout_from_status_probe(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_cli,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json_with_status(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        timeout=None,
+    ):
+        _ = method, url, payload, token_env, timeout
+        raise httpx.TimeoutException("timed out")
+
+    status_payloads = iter(
+        [
+            {
+                "thread": {
+                    "last_turn_id": "turn-1",
+                    "latest_turn_id": "turn-1",
+                    "last_message_preview": "previous prompt",
+                },
+                "turn": {"managed_turn_id": "turn-1", "status": "running"},
+                "queue_depth": 0,
+            },
+            {
+                "thread": {
+                    "last_turn_id": "turn-2",
+                    "latest_turn_id": "turn-2",
+                    "last_message_preview": "follow up",
+                },
+                "turn": {"managed_turn_id": "turn-2", "status": "running"},
+                "queue_depth": 0,
+            },
+        ]
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = method, url, payload, token_env, params
+        return next(status_payloads)
+
+    monkeypatch.setattr(
+        pma_cli, "_request_json_with_status", _fake_request_json_with_status
+    )
+    monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pma_app,
+        [
+            "thread",
+            "send",
+            "--id",
+            "thread-1",
+            "--message",
+            "follow up",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "send_state=accepted managed_turn_id=turn-2" in result.stdout
+    assert "delivered message:\nfollow up\n" in result.stdout
+    assert "recovered accepted delivery from thread status" in result.stdout
+
+
+def test_pma_cli_thread_send_timeout_warns_before_retry_when_status_unclear(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_cli,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json_with_status(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        timeout=None,
+    ):
+        _ = method, url, payload, token_env, timeout
+        raise httpx.TimeoutException("timed out")
+
+    status_payloads = iter(
+        [
+            {
+                "thread": {
+                    "last_turn_id": "turn-1",
+                    "latest_turn_id": "turn-1",
+                    "last_message_preview": "previous prompt",
+                },
+                "turn": {"managed_turn_id": "turn-1", "status": "running"},
+                "queue_depth": 0,
+            },
+            {
+                "thread": {
+                    "last_turn_id": "turn-1",
+                    "latest_turn_id": "turn-1",
+                    "last_message_preview": "previous prompt",
+                },
+                "turn": {"managed_turn_id": "turn-1", "status": "running"},
+                "queue_depth": 0,
+            },
+        ]
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = method, url, payload, token_env, params
+        return next(status_payloads)
+
+    monkeypatch.setattr(
+        pma_cli, "_request_json_with_status", _fake_request_json_with_status
+    )
+    monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pma_app,
+        [
+            "thread",
+            "send",
+            "--id",
+            "thread-1",
+            "--message",
+            "follow up",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Timed out waiting for send confirmation." in result.output
+    assert "may still have been delivered" in result.output
+    assert "Check `car pma thread status --id thread-1" in result.output
+
+
 def test_pma_cli_thread_send_requires_exactly_one_message_source(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_pma_cli.py
+++ b/tests/test_pma_cli.py
@@ -1299,10 +1299,11 @@ def test_pma_cli_thread_send_recovers_timeout_from_status_probe(
                 "thread": {
                     "last_turn_id": "turn-2",
                     "latest_turn_id": "turn-2",
-                    "last_message_preview": "follow up",
+                    "last_message_preview": "previous prompt",
                 },
                 "turn": {"managed_turn_id": "turn-2", "status": "running"},
                 "queue_depth": 0,
+                "queued_turns": [],
             },
         ]
     )
@@ -1340,7 +1341,101 @@ def test_pma_cli_thread_send_recovers_timeout_from_status_probe(
     assert result.exit_code == 0
     assert "send_state=accepted managed_turn_id=turn-2" in result.stdout
     assert "delivered message:\nfollow up\n" in result.stdout
-    assert "recovered accepted delivery from thread status" in result.stdout
+    assert "recovered delivery from thread status" in result.stdout
+
+
+def test_pma_cli_thread_send_recovers_queued_timeout_from_status_probe(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_cli,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json_with_status(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        timeout=None,
+    ):
+        _ = method, url, payload, token_env, timeout
+        raise httpx.TimeoutException("timed out")
+
+    status_payloads = iter(
+        [
+            {
+                "thread": {
+                    "last_turn_id": "turn-1",
+                    "latest_turn_id": "turn-1",
+                    "last_message_preview": "previous prompt",
+                },
+                "turn": {"managed_turn_id": "turn-1", "status": "running"},
+                "queue_depth": 0,
+                "queued_turns": [],
+            },
+            {
+                "thread": {
+                    "last_turn_id": "turn-1",
+                    "latest_turn_id": "turn-1",
+                    "last_message_preview": "previous prompt",
+                },
+                "turn": {"managed_turn_id": "turn-1", "status": "running"},
+                "queue_depth": 1,
+                "queued_turns": [
+                    {
+                        "managed_turn_id": "turn-2",
+                        "prompt_preview": "follow up",
+                        "state": "queued",
+                    }
+                ],
+            },
+        ]
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = method, url, payload, token_env, params
+        return next(status_payloads)
+
+    monkeypatch.setattr(
+        pma_cli, "_request_json_with_status", _fake_request_json_with_status
+    )
+    monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pma_app,
+        [
+            "thread",
+            "send",
+            "--id",
+            "thread-1",
+            "--message",
+            "follow up",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert (
+        "send_state=queued managed_turn_id=turn-2 active_managed_turn_id=turn-1 "
+        "queue_depth=1" in result.stdout
+    )
+    assert "delivered message:\nfollow up\n" in result.stdout
+    assert "recovered delivery from thread status" in result.stdout
 
 
 def test_pma_cli_thread_send_timeout_warns_before_retry_when_status_unclear(


### PR DESCRIPTION
## Summary

This changes the PMA CLI send path to recover from false timeout failures when the server has already durably accepted the message but has not returned the HTTP acknowledgement yet.

## What Changed

- capture a minimal managed-thread status baseline before `car pma thread send` posts the new message
- if the POST times out, probe thread status once and recover success when the new turn and preview are visible there
- print the delivered message plus a note that confirmation was recovered from thread status
- if status cannot confirm delivery, fail with an explicit warning that the message may still have been delivered and should be checked before retrying
- add regression coverage for both the recovered-timeout and unresolved-timeout paths

## Root Cause

`defer_execution=True` in `car pma thread send` does not currently mean "return immediately after durable acceptance". The server still does runtime-startup work before it returns the success payload, so the CLI can hit its fixed HTTP timeout even though the message is already recorded and visible in thread status. That creates a false failure and makes duplicate retries likely.

This PR is the CLI-side mitigation. It removes the operator-facing false negative and retry hazard without changing the underlying server acknowledgement boundary.

## Validation

- `.venv/bin/pytest tests/test_pma_cli.py`
- repo pre-commit hooks during `git commit`, including strict `mypy`, frontend build/tests, and full `pytest` (`4818 passed`)
