### PR TITLE
Harden Discord interaction ACK path and bound handler concurrency

### DIFF
--- a/src/codex_autorunner/integrations/discord/command_runner.py
+++ b/src/codex_autorunner/integrations/discord/command_runner.py
@@ -107,6 +107,9 @@ class ScheduledInteraction:
 class RunnerConfig:
     timeout_seconds: Optional[float] = DEFAULT_HANDLER_TIMEOUT_SECONDS
     stalled_warning_seconds: Optional[float] = DEFAULT_STALLED_WARNING_SECONDS
+    # Keep a finite cap so a burst of interactions cannot fan out into
+    # unbounded handler concurrency and starve the event loop.
+    max_concurrent_interaction_handlers: int = 4
 
 
 class CommandRunner:
@@ -124,12 +127,17 @@ class CommandRunner:
         self._config = config
         self._logger = logger
         self._on_scheduler_conversation_idle = on_scheduler_conversation_idle
+        if config.max_concurrent_interaction_handlers < 1:
+            raise ValueError("max_concurrent_interaction_handlers must be at least 1")
         self._queue: asyncio.Queue[Any] = asyncio.Queue()
         self._drain_task: Optional[asyncio.Task[None]] = None
         self._interaction_tasks: Set[asyncio.Task[None]] = set()
         self._pending_interactions: Deque[ScheduledInteraction] = deque()
         self._active_resource_keys: set[str] = set()
         self._active_conversation_labels: dict[str, str] = {}
+        self._interaction_handler_slots = asyncio.Semaphore(
+            config.max_concurrent_interaction_handlers
+        )
         self._scheduler_lock = asyncio.Lock()
         self._started = False
 
@@ -375,11 +383,12 @@ class CommandRunner:
                     item,
                     scheduler_state="scheduled",
                 )
-            await self._run_with_lifecycle(
-                item.ctx,
-                item.payload,
-                replay_mode=item.replay_mode,
-            )
+            async with self._interaction_handler_slots:
+                await self._run_with_lifecycle(
+                    item.ctx,
+                    item.payload,
+                    replay_mode=item.replay_mode,
+                )
         except asyncio.CancelledError:
             return
         finally:

--- a/src/codex_autorunner/integrations/discord/command_runner.py
+++ b/src/codex_autorunner/integrations/discord/command_runner.py
@@ -344,6 +344,7 @@ class CommandRunner:
 
     async def _run_scheduled_interaction(self, item: ScheduledInteraction) -> None:
         acquired_schedule = False
+        queue_wait_ack_attempted = False
         notify_idle: set[str] = set()
         try:
             if item.schedule.resource_keys:
@@ -360,6 +361,7 @@ class CommandRunner:
                         scheduler_state="waiting_on_resources",
                     )
                     if item.queue_wait_ack_policy not in (None, "immediate"):
+                        queue_wait_ack_attempted = True
                         acknowledged = await self._service.acknowledge_runtime_envelope(
                             RuntimeInteractionEnvelope(
                                 context=item.ctx,
@@ -383,6 +385,24 @@ class CommandRunner:
                     item,
                     scheduler_state="scheduled",
                 )
+            if (
+                not queue_wait_ack_attempted
+                and item.queue_wait_ack_policy == "defer_ephemeral"
+            ):
+                # Queue-wait ACK must happen before waiting for a global handler
+                # slot; otherwise unrelated handler saturation can push ACK past
+                # Discord's callback window.
+                acknowledged = await self._service.acknowledge_runtime_envelope(
+                    RuntimeInteractionEnvelope(
+                        context=item.ctx,
+                        conversation_id=item.schedule.conversation_id,
+                        resource_keys=item.schedule.resource_keys,
+                        queue_wait_ack_policy=item.queue_wait_ack_policy,
+                    ),
+                    stage="queue_wait",
+                )
+                if not acknowledged:
+                    return
             async with self._interaction_handler_slots:
                 await self._run_with_lifecycle(
                     item.ctx,

--- a/src/codex_autorunner/integrations/discord/config.py
+++ b/src/codex_autorunner/integrations/discord/config.py
@@ -27,6 +27,8 @@ DEFAULT_SHELL_MAX_OUTPUT_CHARS = 3800
 DEFAULT_MEDIA_MAX_VOICE_BYTES = 10 * 1024 * 1024
 DEFAULT_DISPATCH_HANDLER_TIMEOUT_SECONDS: Optional[float] = None
 DEFAULT_DISPATCH_HANDLER_STALLED_WARNING_SECONDS: Optional[float] = 60.0
+DEFAULT_DISPATCH_ACK_BUDGET_MS = 2500
+DEFAULT_DISPATCH_MAX_CONCURRENT_INTERACTIONS = 4
 DEFAULT_INTENTS = (
     DISCORD_INTENT_GUILDS
     | DISCORD_INTENT_GUILD_MESSAGES
@@ -69,6 +71,8 @@ class DiscordBotDispatchConfig:
     handler_stalled_warning_seconds: Optional[float] = (
         DEFAULT_DISPATCH_HANDLER_STALLED_WARNING_SECONDS
     )
+    ack_budget_ms: int = DEFAULT_DISPATCH_ACK_BUDGET_MS
+    max_concurrent_interactions: int = DEFAULT_DISPATCH_MAX_CONCURRENT_INTERACTIONS
 
 
 @dataclass(frozen=True)
@@ -228,6 +232,16 @@ class DiscordBotConfig:
                 default=DEFAULT_DISPATCH_HANDLER_STALLED_WARNING_SECONDS,
                 key="discord_bot.dispatch.handler_stalled_warning_seconds",
             ),
+            ack_budget_ms=_parse_strict_positive_int_or_default(
+                dispatch_cfg.get("ack_budget_ms", _MISSING),
+                default=DEFAULT_DISPATCH_ACK_BUDGET_MS,
+                key="discord_bot.dispatch.ack_budget_ms",
+            ),
+            max_concurrent_interactions=_parse_strict_positive_int_or_default(
+                dispatch_cfg.get("max_concurrent_interactions", _MISSING),
+                default=DEFAULT_DISPATCH_MAX_CONCURRENT_INTERACTIONS,
+                key="discord_bot.dispatch.max_concurrent_interactions",
+            ),
         )
 
         if enabled:
@@ -306,6 +320,21 @@ def _parse_positive_int_or_default(value: Any, *, default: int, key: str) -> int
     if parsed <= 0:
         return default
     return parsed
+
+
+def _parse_strict_positive_int_or_default(
+    value: Any,
+    *,
+    default: int,
+    key: str,
+) -> int:
+    if value is _MISSING or value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise DiscordBotConfigError(f"{key} must be a positive integer or null")
+    if value <= 0:
+        raise DiscordBotConfigError(f"{key} must be a positive integer or null")
+    return int(value)
 
 
 def _parse_optional_positive_float(

--- a/src/codex_autorunner/integrations/discord/gateway.py
+++ b/src/codex_autorunner/integrations/discord/gateway.py
@@ -10,6 +10,7 @@ import random
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional
 
+from ...core.logging_utils import log_event
 from .constants import DISCORD_GATEWAY_URL
 from .errors import DiscordAPIError, DiscordPermanentError
 from .rest import DiscordRestClient
@@ -155,8 +156,22 @@ class DiscordGatewayClient:
             self._ready_in_connection = False
             try:
                 gateway_url = await self._resolve_gateway_url()
+                log_event(
+                    self._logger,
+                    logging.INFO,
+                    "discord.gateway.transport.connect.start",
+                    reconnect_attempt=reconnect_attempt,
+                    gateway_url=gateway_url,
+                )
                 async with websockets.connect(gateway_url) as websocket:
                     self._websocket = websocket
+                    log_event(
+                        self._logger,
+                        logging.INFO,
+                        "discord.gateway.transport.connect.success",
+                        reconnect_attempt=reconnect_attempt,
+                        gateway_url=gateway_url,
+                    )
                     established_session = await self._run_connection(
                         websocket, on_dispatch
                     )
@@ -165,6 +180,15 @@ class DiscordGatewayClient:
             except DiscordPermanentError as exc:
                 fatal_failure = True
                 fatal_reason = str(exc)
+                log_event(
+                    self._logger,
+                    logging.ERROR,
+                    "discord.gateway.reconnect.failure",
+                    reconnect_attempt=reconnect_attempt,
+                    fatal=True,
+                    cause="permanent_error",
+                    error=str(exc),
+                )
                 self._logger.error(
                     "Discord gateway encountered permanent failure; halting reconnect loop: %s",
                     exc,
@@ -174,6 +198,16 @@ class DiscordGatewayClient:
                 if close_code in FATAL_GATEWAY_CLOSE_CODES:
                     fatal_failure = True
                     fatal_reason = f"gateway_close_code={close_code}"
+                log_event(
+                    self._logger,
+                    logging.WARNING,
+                    "discord.gateway.reconnect.failure",
+                    reconnect_attempt=reconnect_attempt,
+                    fatal=bool(fatal_failure),
+                    cause="connection_closed",
+                    close_code=close_code,
+                )
+                if close_code in FATAL_GATEWAY_CLOSE_CODES:
                     self._logger.error(
                         "Discord gateway closed with fatal code=%s; halting reconnect loop",
                         close_code,
@@ -183,11 +217,29 @@ class DiscordGatewayClient:
             except (
                 Exception
             ) as exc:  # intentional: reconnect loop catches all transient failures
+                log_event(
+                    self._logger,
+                    logging.WARNING,
+                    "discord.gateway.reconnect.failure",
+                    reconnect_attempt=reconnect_attempt,
+                    fatal=False,
+                    cause="unexpected_error",
+                    error=str(exc),
+                )
                 self._logger.warning("Discord gateway error; reconnecting: %s", exc)
             finally:
                 self._websocket = None
                 await self._cancel_heartbeat()
                 await self._cancel_dispatch_worker()
+                log_event(
+                    self._logger,
+                    logging.INFO,
+                    "discord.gateway.transport.disconnect",
+                    reconnect_attempt=reconnect_attempt,
+                    established_session=established_session,
+                    ready_seen=self._ready_in_connection,
+                    fatal_failure=fatal_failure,
+                )
 
             if self._stop_event.is_set():
                 break
@@ -200,8 +252,24 @@ class DiscordGatewayClient:
                 await self._stop_event.wait()
                 break
             if established_session or self._ready_in_connection:
+                if reconnect_attempt > 0:
+                    log_event(
+                        self._logger,
+                        logging.INFO,
+                        "discord.gateway.reconnect.success",
+                        reconnect_attempt=reconnect_attempt,
+                        ready_seen=self._ready_in_connection,
+                        established_session=established_session,
+                    )
                 reconnect_attempt = 0
             backoff = calculate_reconnect_backoff(reconnect_attempt)
+            log_event(
+                self._logger,
+                logging.INFO,
+                "discord.gateway.reconnect.scheduled",
+                reconnect_attempt=reconnect_attempt,
+                backoff_seconds=backoff,
+            )
             reconnect_attempt += 1
             await asyncio.sleep(backoff)
 

--- a/src/codex_autorunner/integrations/discord/ingress.py
+++ b/src/codex_autorunner/integrations/discord/ingress.py
@@ -130,21 +130,30 @@ class InteractionIngress:
             ctx.interaction_token,
             kind=ctx.kind,
         )
-        register_interaction = getattr(
-            self._service, "_register_interaction_ingress", None
+        check_duplicate_interaction = getattr(
+            self._service, "_check_interaction_ingress_duplicate", None
         )
-        if callable(register_interaction):
-            is_duplicate = await register_interaction(ctx)
-            if is_duplicate:
-                self._logger.debug(
-                    "Skipping duplicate Discord interaction delivery: %s",
-                    ctx.interaction_id,
-                )
-                return IngressResult(
-                    accepted=False,
-                    context=ctx,
-                    rejection_reason="duplicate_interaction",
-                )
+        if callable(check_duplicate_interaction):
+            is_duplicate = await check_duplicate_interaction(ctx)
+        else:
+            register_interaction = getattr(
+                self._service, "_register_interaction_ingress", None
+            )
+            is_duplicate = (
+                await register_interaction(ctx)
+                if callable(register_interaction)
+                else False
+            )
+        if is_duplicate:
+            self._logger.debug(
+                "Skipping duplicate Discord interaction delivery: %s",
+                ctx.interaction_id,
+            )
+            return IngressResult(
+                accepted=False,
+                context=ctx,
+                rejection_reason="duplicate_interaction",
+            )
         ctx.timing = IngressTiming(
             interaction_created_at=ctx.timing.interaction_created_at,
             ingress_started_at=now,
@@ -157,6 +166,11 @@ class InteractionIngress:
             authz_finished_at=time.monotonic(),
         )
         if not authz_ok:
+            release_interaction = getattr(
+                self._service, "_release_interaction_ingress", None
+            )
+            if callable(release_interaction):
+                await release_interaction(ctx.interaction_id)
             return IngressResult(
                 accepted=False,
                 context=ctx,

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -311,7 +311,7 @@ from .rendering import (
     truncate_for_discord,
 )
 from .response_helpers import DiscordResponder
-from .rest import DiscordRestClient
+from .rest import DISCORD_INTERACTION_CALLBACK_TIMEOUT_SECONDS, DiscordRestClient
 from .service_normalization import (
     DiscordAttachmentAdapter,
     SavedDiscordAttachment,
@@ -680,11 +680,16 @@ class DiscordBotService:
             ),
         )
         self._ingress = InteractionIngress(self, logger=self._logger)
+        self._ingress_pre_ack_reservations: set[str] = set()
+        self._ingress_pre_ack_reservations_lock = asyncio.Lock()
         self._command_runner = _CommandRunner(
             self,
             config=_RunnerConfig(
                 timeout_seconds=config.dispatch.handler_timeout_seconds,
                 stalled_warning_seconds=config.dispatch.handler_stalled_warning_seconds,
+                max_concurrent_interaction_handlers=(
+                    config.dispatch.max_concurrent_interactions
+                ),
             ),
             logger=self._logger,
             on_scheduler_conversation_idle=self._wake_dispatcher_conversation,
@@ -765,19 +770,24 @@ class DiscordBotService:
             await self._shutdown()
 
     def _service_uptime_ms(self, *, now: Optional[float] = None) -> Optional[float]:
-        if self._service_started_at_monotonic is None:
+        started_at_raw = getattr(self, "_service_started_at_monotonic", None)
+        started_at = (
+            float(started_at_raw) if isinstance(started_at_raw, (int, float)) else None
+        )
+        if started_at is None:
             return None
         current = time.monotonic() if now is None else now
-        return round(max(0.0, (current - self._service_started_at_monotonic) * 1000), 1)
+        return round(max(0.0, (current - started_at) * 1000), 1)
 
     def _is_within_cold_start_window(self, *, now: Optional[float] = None) -> bool:
-        if self._service_started_at_monotonic is None:
+        started_at_raw = getattr(self, "_service_started_at_monotonic", None)
+        started_at = (
+            float(started_at_raw) if isinstance(started_at_raw, (int, float)) else None
+        )
+        if started_at is None:
             return False
         current = time.monotonic() if now is None else now
-        return (
-            current - self._service_started_at_monotonic
-            <= DISCORD_INTERACTION_COLD_START_WINDOW_SECONDS
-        )
+        return current - started_at <= DISCORD_INTERACTION_COLD_START_WINDOW_SECONDS
 
     def _interaction_telemetry_fields(
         self,
@@ -816,6 +826,27 @@ class DiscordBotService:
                 1,
             )
         return fields
+
+    def _initial_ack_budget_seconds(self) -> float:
+        dispatch_cfg = getattr(self._config, "dispatch", None)
+        budget_ms = getattr(dispatch_cfg, "ack_budget_ms", None)
+        if isinstance(budget_ms, int) and budget_ms > 0:
+            return float(
+                min(
+                    float(budget_ms) / 1000.0,
+                    DISCORD_INTERACTION_CALLBACK_TIMEOUT_SECONDS,
+                )
+            )
+        for attr_name in ("ack_budget_seconds", "ack_timeout_seconds"):
+            budget_seconds = getattr(dispatch_cfg, attr_name, None)
+            if isinstance(budget_seconds, (int, float)) and budget_seconds > 0:
+                return float(
+                    min(
+                        float(budget_seconds),
+                        DISCORD_INTERACTION_CALLBACK_TIMEOUT_SECONDS,
+                    )
+                )
+        return float(DISCORD_INTERACTION_CALLBACK_TIMEOUT_SECONDS)
 
     async def _run_dispatcher_loop(self) -> None:
         while True:
@@ -1167,11 +1198,14 @@ class DiscordBotService:
             ctx.interaction_token,
             kind=ctx.kind,
         )
+        budget_seconds = self._initial_ack_budget_seconds()
         durable_ack_mode = await self._load_interaction_ack_mode(ctx.interaction_id)
         if isinstance(durable_ack_mode, str) and durable_ack_mode.strip():
             session.restore_initial_response(durable_ack_mode)
         if session.has_initial_response():
             ctx.deferred = session.is_deferred()
+            finished_at = time.monotonic()
+            ctx.timing = replace(ctx.timing, ack_finished_at=finished_at)
             log_event(
                 self._logger,
                 logging.INFO,
@@ -1179,13 +1213,36 @@ class DiscordBotService:
                 stage=stage,
                 runtime_ack_policy=ack_policy,
                 durable_ack_mode=durable_ack_mode,
+                ack_latency_ms=round((finished_at - ack_started_at) * 1000, 1),
+                ack_budget_seconds=budget_seconds,
                 **self._interaction_telemetry_fields(
                     ctx,
-                    now=ack_started_at,
+                    now=finished_at,
                     envelope=envelope,
                 ),
             )
             return True
+        ingress_started_at = ctx.timing.ingress_started_at or ack_started_at
+        ack_deadline_at = ingress_started_at + budget_seconds
+        current_at = time.monotonic()
+        if current_at >= ack_deadline_at and ack_policy not in (None, "immediate"):
+            ctx.timing = replace(ctx.timing, ack_finished_at=current_at)
+            log_event(
+                self._logger,
+                logging.WARNING,
+                "discord.interaction.ack.expired_before_ack",
+                stage=stage,
+                runtime_ack_policy=ack_policy,
+                ack_budget_seconds=budget_seconds,
+                budget_overrun_ms=round((current_at - ack_deadline_at) * 1000, 1),
+                cause="deadline_exceeded_before_attempt",
+                **self._interaction_telemetry_fields(
+                    ctx,
+                    now=current_at,
+                    envelope=envelope,
+                ),
+            )
+            return False
         log_event(
             self._logger,
             logging.INFO,
@@ -1198,34 +1255,91 @@ class DiscordBotService:
                 envelope=envelope,
             ),
         )
-        await self._store.mark_interaction_scheduler_state(
-            ctx.interaction_id,
-            scheduler_state=(
-                "dispatch_ack_pending"
-                if stage == "dispatch"
-                else "queue_wait_ack_pending"
-            ),
-        )
-        if ack_policy == "defer_public":
-            acknowledged = await self._defer_public(
-                interaction_id=ctx.interaction_id,
-                interaction_token=ctx.interaction_token,
+        remaining_seconds = max(0.0, ack_deadline_at - time.monotonic())
+        try:
+            if ack_policy == "defer_public":
+                acknowledged = await asyncio.wait_for(
+                    self._defer_public(
+                        interaction_id=ctx.interaction_id,
+                        interaction_token=ctx.interaction_token,
+                    ),
+                    timeout=remaining_seconds,
+                )
+            elif ack_policy == "defer_component_update":
+                acknowledged = await asyncio.wait_for(
+                    self._defer_component_update(
+                        interaction_id=ctx.interaction_id,
+                        interaction_token=ctx.interaction_token,
+                    ),
+                    timeout=remaining_seconds,
+                )
+            else:
+                acknowledged = await asyncio.wait_for(
+                    self._defer_ephemeral(
+                        interaction_id=ctx.interaction_id,
+                        interaction_token=ctx.interaction_token,
+                    ),
+                    timeout=remaining_seconds,
+                )
+        except asyncio.TimeoutError:
+            acknowledged = False
+            current_at = time.monotonic()
+            ctx.timing = replace(ctx.timing, ack_finished_at=current_at)
+            log_event(
+                self._logger,
+                logging.WARNING,
+                "discord.interaction.ack.failed",
+                stage=stage,
+                runtime_ack_policy=ack_policy,
+                ack_latency_ms=round((current_at - ack_started_at) * 1000, 1),
+                ack_budget_seconds=budget_seconds,
+                budget_overrun_ms=round(
+                    max(0.0, current_at - ack_deadline_at) * 1000, 1
+                ),
+                expired_before_ack=True,
+                cause="deadline_exceeded_during_ack",
+                delivery_status=session.last_delivery_status,
+                delivery_error=session.last_delivery_error,
+                **self._interaction_telemetry_fields(
+                    ctx,
+                    now=current_at,
+                    envelope=envelope,
+                ),
             )
-        elif ack_policy == "defer_component_update":
-            acknowledged = await self._defer_component_update(
-                interaction_id=ctx.interaction_id,
-                interaction_token=ctx.interaction_token,
+            return False
+        except Exception as exc:
+            acknowledged = False
+            current_at = time.monotonic()
+            ctx.timing = replace(ctx.timing, ack_finished_at=current_at)
+            log_event(
+                self._logger,
+                logging.WARNING,
+                "discord.interaction.ack.failed",
+                stage=stage,
+                runtime_ack_policy=ack_policy,
+                ack_latency_ms=round((current_at - ack_started_at) * 1000, 1),
+                ack_budget_seconds=budget_seconds,
+                budget_overrun_ms=round(
+                    max(0.0, current_at - ack_deadline_at) * 1000, 1
+                ),
+                expired_before_ack=True,
+                cause="ack_error",
+                exc=exc,
+                delivery_status=session.last_delivery_status,
+                delivery_error=session.last_delivery_error,
+                **self._interaction_telemetry_fields(
+                    ctx,
+                    now=current_at,
+                    envelope=envelope,
+                ),
             )
-        else:
-            acknowledged = await self._defer_ephemeral(
-                interaction_id=ctx.interaction_id,
-                interaction_token=ctx.interaction_token,
-            )
+            return False
         if acknowledged:
+            finished_at = time.monotonic()
             ctx.deferred = True
             ctx.timing = replace(
                 ctx.timing,
-                ack_finished_at=time.monotonic(),
+                ack_finished_at=finished_at,
             )
             log_event(
                 self._logger,
@@ -1233,25 +1347,32 @@ class DiscordBotService:
                 "discord.interaction.ack.succeeded",
                 stage=stage,
                 runtime_ack_policy=ack_policy,
-                elapsed_ms=round((time.monotonic() - ack_started_at) * 1000, 1),
+                ack_latency_ms=round((finished_at - ack_started_at) * 1000, 1),
+                ack_budget_seconds=budget_seconds,
                 delivery_status=session.last_delivery_status,
                 **self._interaction_telemetry_fields(
                     ctx,
+                    now=finished_at,
                     envelope=envelope,
                 ),
             )
         else:
+            finished_at = time.monotonic()
+            ctx.timing = replace(ctx.timing, ack_finished_at=finished_at)
             log_event(
                 self._logger,
                 logging.WARNING,
                 "discord.interaction.ack.failed",
                 stage=stage,
                 runtime_ack_policy=ack_policy,
-                elapsed_ms=round((time.monotonic() - ack_started_at) * 1000, 1),
+                ack_latency_ms=round((finished_at - ack_started_at) * 1000, 1),
+                ack_budget_seconds=budget_seconds,
+                expired_before_ack=True,
                 delivery_status=session.last_delivery_status,
                 delivery_error=session.last_delivery_error,
                 **self._interaction_telemetry_fields(
                     ctx,
+                    now=finished_at,
                     envelope=envelope,
                 ),
             )
@@ -3859,92 +3980,95 @@ class DiscordBotService:
                         )
                 return
             if ingress_result.context is not None:
-                envelope = await self._build_runtime_interaction_envelope(
-                    ingress_result.context
-                )
-                log_event(
-                    self._logger,
-                    logging.INFO,
-                    "discord.interaction.admitted",
-                    **self._interaction_telemetry_fields(
-                        ingress_result.context,
-                        now=dispatch_started_at,
-                        envelope=envelope,
-                    ),
-                )
-                await self._persist_runtime_interaction(
-                    envelope,
-                    payload,
-                    scheduler_state="dispatch_ready",
-                )
-                acked = await self._acknowledge_runtime_envelope(
-                    envelope,
-                    stage="dispatch",
-                )
-                if not acked and envelope.dispatch_ack_policy not in (
-                    None,
-                    "immediate",
-                ):
-                    await self._store.mark_interaction_scheduler_state(
-                        ingress_result.context.interaction_id,
-                        scheduler_state="delivery_expired",
-                    )
+                ctx = ingress_result.context
+                try:
+                    envelope = await self._build_runtime_interaction_envelope(ctx)
                     log_event(
                         self._logger,
-                        logging.WARNING,
-                        "discord.interaction.delivery_expired_before_dispatch",
+                        logging.INFO,
+                        "discord.interaction.admitted",
                         **self._interaction_telemetry_fields(
-                            ingress_result.context,
+                            ctx,
+                            now=dispatch_started_at,
                             envelope=envelope,
                         ),
                     )
-                    await self._respond_ephemeral(
-                        ingress_result.context.interaction_id,
-                        ingress_result.context.interaction_token,
-                        "Discord interaction did not acknowledge. Please retry.",
+                    acked = await self._acknowledge_runtime_envelope(
+                        envelope,
+                        stage="dispatch",
                     )
-                    ingress_result.context.timing = replace(
-                        ingress_result.context.timing,
-                        ack_finished_at=time.monotonic(),
-                        ingress_finished_at=time.monotonic(),
+                    if not acked and envelope.dispatch_ack_policy not in (
+                        None,
+                        "immediate",
+                    ):
+                        log_event(
+                            self._logger,
+                            logging.WARNING,
+                            "discord.interaction.delivery_expired_before_dispatch",
+                            expired_before_ack=True,
+                            ack_budget_seconds=self._initial_ack_budget_seconds(),
+                            **self._interaction_telemetry_fields(
+                                ctx,
+                                envelope=envelope,
+                            ),
+                        )
+                        await self._respond_ephemeral(
+                            ctx.interaction_id,
+                            ctx.interaction_token,
+                            "Discord interaction did not acknowledge. Please retry.",
+                        )
+                        ctx.timing = replace(
+                            ctx.timing,
+                            ack_finished_at=time.monotonic(),
+                            ingress_finished_at=time.monotonic(),
+                        )
+                        return
+
+                    duplicate_after_ack = await self._register_interaction_ingress(ctx)
+                    if duplicate_after_ack:
+                        return
+                    await self._persist_runtime_interaction(
+                        envelope,
+                        payload,
+                        scheduler_state="acknowledged",
                     )
-                    return
-                self._ingress.finalize_success(ingress_result.context)
-                log_event(
-                    self._logger,
-                    logging.INFO,
-                    "discord.interaction.enqueued",
-                    ingress_elapsed_ms=(
-                        round(
-                            (
-                                ingress_result.context.timing.ingress_finished_at
-                                - ingress_result.context.timing.ingress_started_at
+                    self._ingress.finalize_success(ctx)
+                    log_event(
+                        self._logger,
+                        logging.INFO,
+                        "discord.interaction.enqueued",
+                        ingress_elapsed_ms=(
+                            round(
+                                (
+                                    ctx.timing.ingress_finished_at
+                                    - ctx.timing.ingress_started_at
+                                )
+                                * 1000,
+                                1,
                             )
-                            * 1000,
-                            1,
-                        )
-                        if (
-                            ingress_result.context.timing.ingress_started_at is not None
-                            and ingress_result.context.timing.ingress_finished_at
-                            is not None
-                        )
-                        else None
-                    ),
-                    **self._interaction_telemetry_fields(
-                        ingress_result.context,
-                        envelope=envelope,
-                    ),
-                )
-                self._command_runner.submit(
-                    envelope.context,
-                    payload,
-                    resource_keys=envelope.resource_keys,
-                    conversation_id=envelope.conversation_id,
-                    queue_wait_ack_policy=envelope.queue_wait_ack_policy,
-                )
-                # Let the admitted interaction task start before the next gateway
-                # interaction is processed so deferred command ordering stays stable.
-                await asyncio.sleep(0)
+                            if (
+                                ctx.timing.ingress_started_at is not None
+                                and ctx.timing.ingress_finished_at is not None
+                            )
+                            else None
+                        ),
+                        **self._interaction_telemetry_fields(
+                            ctx,
+                            envelope=envelope,
+                        ),
+                    )
+                    self._command_runner.submit(
+                        envelope.context,
+                        payload,
+                        resource_keys=envelope.resource_keys,
+                        conversation_id=envelope.conversation_id,
+                        queue_wait_ack_policy=envelope.queue_wait_ack_policy,
+                    )
+                    # Let the admitted interaction task start before the next gateway
+                    # interaction is processed so deferred command ordering stays stable.
+                    await asyncio.sleep(0)
+                finally:
+                    await self._release_interaction_ingress(ctx.interaction_id)
             return
         if event_type == "MESSAGE_CREATE":
             # Keep MESSAGE_CREATE handling off the gateway hot path. Channel/guild
@@ -5329,6 +5453,58 @@ class DiscordBotService:
             result=result,
         )
         return returned
+
+    async def _check_interaction_ingress_duplicate(self, ctx: IngressContext) -> bool:
+        reservations = getattr(self, "_ingress_pre_ack_reservations", None)
+        if not isinstance(reservations, set):
+            reservations = set()
+            self._ingress_pre_ack_reservations = reservations
+        reservation_lock = getattr(self, "_ingress_pre_ack_reservations_lock", None)
+        if reservation_lock is None:
+            reservation_lock = asyncio.Lock()
+            self._ingress_pre_ack_reservations_lock = reservation_lock
+        async with reservation_lock:
+            if ctx.interaction_id in reservations:
+                return True
+            reservations.add(ctx.interaction_id)
+        record = await self._store.get_interaction(ctx.interaction_id)
+        if record is None:
+            return False
+
+        has_pending_delivery = bool(
+            isinstance(record.delivery_cursor_json, dict)
+            and str(record.delivery_cursor_json.get("state") or "").strip()
+            in {"pending", "failed"}
+        )
+        if record.scheduler_state in {"completed", "delivery_expired", "abandoned"}:
+            await self._release_interaction_ingress(ctx.interaction_id)
+            return True
+        if (
+            record.execution_status in {"completed", "failed", "timeout", "cancelled"}
+            and not has_pending_delivery
+        ):
+            await self._release_interaction_ingress(ctx.interaction_id)
+            return True
+        log_event(
+            self._logger,
+            logging.INFO,
+            "discord.interaction.duplicate_resuming",
+            interaction_id=ctx.interaction_id,
+            scheduler_state=record.scheduler_state,
+            execution_status=record.execution_status,
+        )
+        return False
+
+    async def _release_interaction_ingress(self, interaction_id: str) -> None:
+        reservations = getattr(self, "_ingress_pre_ack_reservations", None)
+        if not isinstance(reservations, set):
+            return
+        reservation_lock = getattr(self, "_ingress_pre_ack_reservations_lock", None)
+        if reservation_lock is None:
+            reservation_lock = asyncio.Lock()
+            self._ingress_pre_ack_reservations_lock = reservation_lock
+        async with reservation_lock:
+            reservations.discard(interaction_id)
 
     async def _register_interaction_ingress(self, ctx: IngressContext) -> bool:
         registration = await self._store.register_interaction(

--- a/tests/integrations/discord/test_command_runner.py
+++ b/tests/integrations/discord/test_command_runner.py
@@ -534,7 +534,10 @@ async def test_multiple_submits_concurrent() -> None:
 
     runner = CommandRunner(
         service,
-        config=RunnerConfig(timeout_seconds=5.0),
+        config=RunnerConfig(
+            timeout_seconds=5.0,
+            max_concurrent_interaction_handlers=5,
+        ),
         logger=service._logger,
     )
 
@@ -553,6 +556,58 @@ async def test_multiple_submits_concurrent() -> None:
         evt.set()
     await asyncio.sleep(0.05)
     assert runner.active_task_count == 0
+
+
+@pytest.mark.anyio
+async def test_interaction_handler_concurrency_is_bounded() -> None:
+    service = _FakeService()
+    started_interactions: list[str] = []
+    first_two_started = asyncio.Event()
+    release_handlers = asyncio.Event()
+
+    async def blocking_handler(*args: Any, **kwargs: Any) -> None:
+        interaction_id = str(args[0]) if args else ""
+        started_interactions.append(interaction_id)
+        if len(started_interactions) == 2:
+            first_two_started.set()
+        await release_handlers.wait()
+
+    service._handle_car_command.side_effect = blocking_handler
+
+    runner = CommandRunner(
+        service,
+        config=RunnerConfig(
+            timeout_seconds=None,
+            stalled_warning_seconds=None,
+            max_concurrent_interaction_handlers=2,
+        ),
+        logger=service._logger,
+    )
+
+    for i in range(4):
+        ctx = _make_ctx(
+            interaction_id=f"inter-{i}",
+            interaction_token=f"token-{i}",
+        )
+        payload = {
+            **_slash_payload(),
+            "id": ctx.interaction_id,
+            "token": ctx.interaction_token,
+        }
+        runner.submit(ctx, payload)
+
+    for _ in range(100):
+        if first_two_started.is_set():
+            break
+        await asyncio.sleep(0.01)
+
+    assert first_two_started.is_set()
+    assert len(started_interactions) == 2
+    assert service._handle_car_command.await_count == 2
+
+    release_handlers.set()
+    await runner.shutdown(grace_seconds=5.0)
+    assert service._handle_car_command.await_count == 4
 
 
 @pytest.mark.anyio

--- a/tests/integrations/discord/test_command_runner.py
+++ b/tests/integrations/discord/test_command_runner.py
@@ -611,6 +611,84 @@ async def test_interaction_handler_concurrency_is_bounded() -> None:
 
 
 @pytest.mark.anyio
+async def test_queue_wait_ack_happens_before_waiting_for_handler_slot() -> None:
+    service = _FakeService()
+    slot_holder_started = asyncio.Event()
+    release_slot_holder = asyncio.Event()
+    queue_wait_acked = asyncio.Event()
+
+    async def blocking_handler(*args: Any, **_kwargs: Any) -> None:
+        interaction_id = str(args[0]) if args else ""
+        if interaction_id == "slot-holder":
+            slot_holder_started.set()
+            await release_slot_holder.wait()
+
+    async def _ack_envelope(envelope: Any, *, stage: str) -> bool:
+        if envelope.context.interaction_id == "waiter" and stage == "queue_wait":
+            queue_wait_acked.set()
+        return True
+
+    service._handle_car_command.side_effect = blocking_handler
+    service.acknowledge_runtime_envelope = AsyncMock(side_effect=_ack_envelope)
+
+    runner = CommandRunner(
+        service,
+        config=RunnerConfig(
+            timeout_seconds=None,
+            stalled_warning_seconds=None,
+            max_concurrent_interaction_handlers=1,
+        ),
+        logger=service._logger,
+    )
+
+    holder_ctx = _make_ctx(
+        interaction_id="slot-holder",
+        interaction_token="slot-token",
+        channel_id="chan-1",
+        guild_id="guild-1",
+    )
+    holder_payload = {
+        **_slash_payload(),
+        "id": "slot-holder",
+        "token": "slot-token",
+    }
+    runner.submit(
+        holder_ctx,
+        holder_payload,
+        resource_keys=("conversation:discord:chan-1:guild-1",),
+        conversation_id="discord:chan-1:guild-1",
+    )
+    await asyncio.wait_for(slot_holder_started.wait(), timeout=1.0)
+
+    waiter_ctx = _make_ctx(
+        interaction_id="waiter",
+        interaction_token="waiter-token",
+        channel_id="chan-2",
+        guild_id="guild-1",
+    )
+    waiter_payload = {
+        **_slash_payload(),
+        "id": "waiter",
+        "token": "waiter-token",
+    }
+    runner.submit(
+        waiter_ctx,
+        waiter_payload,
+        resource_keys=("conversation:discord:chan-2:guild-1",),
+        conversation_id="discord:chan-2:guild-1",
+        queue_wait_ack_policy="defer_ephemeral",
+    )
+
+    await asyncio.wait_for(queue_wait_acked.wait(), timeout=1.0)
+    # The waiter handler has not started yet because the global slot is still held.
+    assert service._handle_car_command.await_count == 1
+
+    release_slot_holder.set()
+    await runner.shutdown(grace_seconds=5.0)
+    assert service._handle_car_command.await_count == 2
+
+
+@pytest.mark.anyio
 async def test_submit_event_delegates_to_dispatch_chat_event() -> None:
     service = _FakeService()
     dispatch_event = AsyncMock()

--- a/tests/integrations/discord/test_config.py
+++ b/tests/integrations/discord/test_config.py
@@ -208,6 +208,8 @@ def test_discord_bot_config_dispatch_defaults(tmp_path) -> None:
     cfg = DiscordBotConfig.from_raw(root=tmp_path, raw={"enabled": False})
     assert cfg.dispatch.handler_timeout_seconds is None
     assert cfg.dispatch.handler_stalled_warning_seconds == 60.0
+    assert cfg.dispatch.ack_budget_ms == 2500
+    assert cfg.dispatch.max_concurrent_interactions == 4
 
 
 def test_discord_bot_config_dispatch_overrides(tmp_path) -> None:
@@ -218,11 +220,15 @@ def test_discord_bot_config_dispatch_overrides(tmp_path) -> None:
             "dispatch": {
                 "handler_timeout_seconds": 45,
                 "handler_stalled_warning_seconds": 15,
+                "ack_budget_ms": 1800,
+                "max_concurrent_interactions": 3,
             },
         },
     )
     assert cfg.dispatch.handler_timeout_seconds == 45.0
     assert cfg.dispatch.handler_stalled_warning_seconds == 15.0
+    assert cfg.dispatch.ack_budget_ms == 1800
+    assert cfg.dispatch.max_concurrent_interactions == 3
 
 
 def test_discord_bot_config_dispatch_explicit_null_disables_timeout_and_warning(
@@ -235,11 +241,43 @@ def test_discord_bot_config_dispatch_explicit_null_disables_timeout_and_warning(
             "dispatch": {
                 "handler_timeout_seconds": None,
                 "handler_stalled_warning_seconds": None,
+                "ack_budget_ms": None,
+                "max_concurrent_interactions": None,
             },
         },
     )
     assert cfg.dispatch.handler_timeout_seconds is None
     assert cfg.dispatch.handler_stalled_warning_seconds is None
+    assert cfg.dispatch.ack_budget_ms == 2500
+    assert cfg.dispatch.max_concurrent_interactions == 4
+
+
+@pytest.mark.parametrize(
+    ("dispatch_overrides", "expected_message"),
+    [
+        ({"ack_budget_ms": 0}, "discord_bot.dispatch.ack_budget_ms"),
+        ({"ack_budget_ms": "2500"}, "discord_bot.dispatch.ack_budget_ms"),
+        (
+            {"max_concurrent_interactions": 0},
+            "discord_bot.dispatch.max_concurrent_interactions",
+        ),
+        (
+            {"max_concurrent_interactions": False},
+            "discord_bot.dispatch.max_concurrent_interactions",
+        ),
+    ],
+)
+def test_discord_bot_config_dispatch_invalid_new_knobs_raise(
+    tmp_path, dispatch_overrides: dict[str, object], expected_message: str
+) -> None:
+    with pytest.raises(DiscordBotConfigError, match=expected_message):
+        DiscordBotConfig.from_raw(
+            root=tmp_path,
+            raw={
+                "enabled": False,
+                "dispatch": dispatch_overrides,
+            },
+        )
 
 
 def test_discord_bot_config_builds_shared_collaboration_policy(

--- a/tests/integrations/discord/test_reliability.py
+++ b/tests/integrations/discord/test_reliability.py
@@ -23,17 +23,21 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from codex_autorunner.integrations.chat.dispatcher import conversation_id_for
 from codex_autorunner.integrations.discord.command_runner import (
     CommandRunner,
     RunnerConfig,
 )
+from codex_autorunner.integrations.discord.gateway import DiscordGatewayClient
 from codex_autorunner.integrations.discord.ingress import (
     CommandSpec,
     IngressTiming,
     InteractionIngress,
     InteractionKind,
+    RuntimeInteractionEnvelope,
 )
 from codex_autorunner.integrations.discord.response_helpers import DiscordResponder
+from codex_autorunner.integrations.discord.service import DiscordBotService
 from codex_autorunner.integrations.discord.state import DiscordStateStore
 
 DISCORD_ACK_WINDOW_SECONDS = 3.0
@@ -1056,6 +1060,162 @@ async def test_ingress_leaves_ack_timing_to_runtime_admission() -> None:
 
 
 @pytest.mark.anyio
+async def test_ack_budget_expiry_stops_execution_and_logs_expired_before_ack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import time as _time
+
+    service = DiscordBotService.__new__(DiscordBotService)
+    service._logger = logging.getLogger("test.reliability.ack_budget")
+    service._config = SimpleNamespace(dispatch=SimpleNamespace(ack_budget_ms=10))
+    service._store = SimpleNamespace(
+        get_interaction=AsyncMock(return_value=None),
+        mark_interaction_scheduler_state=AsyncMock(),
+    )
+
+    class _Session:
+        last_delivery_status = None
+        last_delivery_error = None
+
+        def has_initial_response(self) -> bool:
+            return False
+
+        def is_deferred(self) -> bool:
+            return False
+
+        def restore_initial_response(self, _ack_mode: str) -> None:
+            return None
+
+    service._ensure_interaction_session = lambda *_args, **_kwargs: _Session()  # type: ignore[assignment]
+    service._load_interaction_ack_mode = AsyncMock(return_value=None)
+
+    async def _slow_defer(**_kwargs: Any) -> bool:
+        await asyncio.sleep(0.05)
+        return True
+
+    service._defer_ephemeral = _slow_defer  # type: ignore[assignment]
+    service._defer_public = _slow_defer  # type: ignore[assignment]
+    service._defer_component_update = _slow_defer  # type: ignore[assignment]
+
+    log_events: list[dict[str, Any]] = []
+    original_log = service._logger.log
+
+    def capture_log(level: int, msg: str, *args_log: Any, **kwargs_log: Any) -> None:
+        try:
+            parsed = json.loads(msg)
+            if parsed.get("event") == "discord.interaction.ack.failed":
+                log_events.append(parsed)
+        except (json.JSONDecodeError, TypeError):
+            pass
+        original_log(level, msg, *args_log, **kwargs_log)
+
+    service._logger.log = capture_log  # type: ignore[assignment]
+
+    ctx = _make_ctx(interaction_id="ack-budget-1", interaction_token="token-ack-1")
+    ctx.timing = IngressTiming(ingress_started_at=_time.monotonic())
+    envelope = RuntimeInteractionEnvelope(
+        context=ctx,
+        conversation_id="conversation:discord:chan-1",
+        resource_keys=("conversation:discord:chan-1",),
+        dispatch_ack_policy="defer_ephemeral",
+    )
+
+    acked = await service._acknowledge_runtime_envelope(
+        envelope,
+        stage="dispatch",
+    )
+
+    assert acked is False
+    assert service._store.mark_interaction_scheduler_state.await_count == 0
+    assert ctx.timing.ack_finished_at is not None
+    assert log_events
+    assert log_events[0]["expired_before_ack"] is True
+    assert log_events[0]["budget_overrun_ms"] is not None
+
+
+@pytest.mark.anyio
+async def test_gateway_emits_reconnect_lifecycle_logs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_autorunner.integrations.discord import gateway as gateway_module
+
+    client = DiscordGatewayClient(
+        bot_token="token",
+        intents=1,
+        logger=logging.getLogger("test.reliability.gateway"),
+        gateway_url="wss://example.invalid",
+    )
+
+    events: list[dict[str, Any]] = []
+    original_log = client._logger.log
+
+    def capture_log(level: int, msg: str, *args_log: Any, **kwargs_log: Any) -> None:
+        try:
+            parsed = json.loads(msg)
+            if str(parsed.get("event", "")).startswith("discord.gateway."):
+                events.append(parsed)
+        except (json.JSONDecodeError, TypeError):
+            pass
+        original_log(level, msg, *args_log, **kwargs_log)
+
+    client._logger.log = capture_log  # type: ignore[assignment]
+
+    class _DummyWebsocket:
+        async def close(self) -> None:
+            return None
+
+    class _DummyConnect:
+        async def __aenter__(self) -> _DummyWebsocket:
+            return _DummyWebsocket()
+
+        async def __aexit__(self, *_exc_info: object) -> None:
+            return None
+
+    monkeypatch.setattr(
+        gateway_module,
+        "websockets",
+        SimpleNamespace(connect=lambda *_args, **_kwargs: _DummyConnect()),
+    )
+
+    sleep_calls = 0
+
+    async def _sleep(_seconds: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls >= 2:
+            client._stop_event.set()
+
+    monkeypatch.setattr(gateway_module.asyncio, "sleep", _sleep)
+
+    calls = 0
+
+    async def _run_connection(_websocket: Any, _on_dispatch: Any) -> bool:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("temporary disconnect")
+        return True
+
+    async def _resolve_gateway_url() -> str:
+        return "wss://example.invalid"
+
+    monkeypatch.setattr(client, "_run_connection", _run_connection)
+    monkeypatch.setattr(client, "_resolve_gateway_url", _resolve_gateway_url)
+
+    await client.run(lambda *_args, **_kwargs: None)
+
+    assert any(
+        event["event"] == "discord.gateway.reconnect.failure" for event in events
+    )
+    assert any(
+        event["event"] == "discord.gateway.reconnect.success" for event in events
+    )
+    assert any(
+        event["event"] == "discord.gateway.transport.connect.start" for event in events
+    )
+
+
+@pytest.mark.anyio
 async def test_duplicate_interaction_id_does_not_attempt_second_ack(
     tmp_path: Path,
 ) -> None:
@@ -1122,6 +1282,106 @@ async def test_runner_skips_duplicate_execution_for_same_interaction_id(
         assert record.execution_status == "completed"
     finally:
         await store.close()
+
+
+@pytest.mark.anyio
+async def test_queue_wait_ack_happens_while_handler_slots_are_exhausted() -> None:
+    service = _FakeService()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    queue_wait_acked = asyncio.Event()
+    ack_calls: list[tuple[str, str]] = []
+
+    async def blocking_handler(*args: Any, **_kwargs: Any) -> None:
+        interaction_id = str(args[0]) if args else ""
+        if interaction_id == "slot-holder":
+            first_started.set()
+            await release_first.wait()
+
+    async def acknowledge_runtime_envelope(envelope: Any, *, stage: str) -> bool:
+        ack_calls.append((envelope.context.interaction_id, stage))
+        if envelope.context.interaction_id == "queue-wait-2" and stage == "queue_wait":
+            queue_wait_acked.set()
+        return True
+
+    service._handle_car_command.side_effect = blocking_handler
+    service.acknowledge_runtime_envelope = AsyncMock(
+        side_effect=acknowledge_runtime_envelope
+    )
+
+    runner = CommandRunner(
+        service,
+        config=RunnerConfig(
+            timeout_seconds=None,
+            stalled_warning_seconds=None,
+            max_concurrent_interaction_handlers=1,
+        ),
+        logger=service._logger,
+    )
+
+    blocker_ctx = _make_ctx(
+        interaction_id="slot-holder",
+        interaction_token="slot-token",
+    )
+    blocker_payload = {
+        **_slash_payload(),
+        "id": "slot-holder",
+        "token": "slot-token",
+    }
+    runner.submit(blocker_ctx, blocker_payload)
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+    conversation_id = conversation_id_for("discord", "chan-1", "guild-1")
+    resource_keys = (f"conversation:{conversation_id}",)
+
+    waiting_ctx = _make_ctx(
+        interaction_id="queue-wait-1",
+        interaction_token="queue-token-1",
+        channel_id="chan-1",
+        guild_id="guild-1",
+    )
+    waiting_payload = {
+        **_slash_payload(),
+        "id": "queue-wait-1",
+        "token": "queue-token-1",
+    }
+    runner.submit(
+        waiting_ctx,
+        waiting_payload,
+        resource_keys=resource_keys,
+        conversation_id=conversation_id,
+    )
+
+    for _ in range(100):
+        if runner.is_busy(conversation_id):
+            break
+        await asyncio.sleep(0.01)
+    assert runner.is_busy(conversation_id)
+
+    queued_ctx = _make_ctx(
+        interaction_id="queue-wait-2",
+        interaction_token="queue-token-2",
+        channel_id="chan-1",
+        guild_id="guild-1",
+    )
+    queued_payload = {
+        **_slash_payload(),
+        "id": "queue-wait-2",
+        "token": "queue-token-2",
+    }
+    runner.submit(
+        queued_ctx,
+        queued_payload,
+        resource_keys=resource_keys,
+        conversation_id=conversation_id,
+        queue_wait_ack_policy="defer_ephemeral",
+    )
+
+    await asyncio.wait_for(queue_wait_acked.wait(), timeout=1.0)
+    assert ack_calls == [("queue-wait-2", "queue_wait")]
+
+    release_first.set()
+    await runner.shutdown(grace_seconds=5.0)
 
 
 @pytest.mark.anyio

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -9,7 +9,7 @@ from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -7304,6 +7304,63 @@ async def test_car_newt_runs_hub_setup_commands_for_bound_workspace(
         assert len(rest.followup_messages) == 1
         content = rest.followup_messages[0]["payload"]["content"].lower()
         assert "ran 1 setup command" in content
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_dispatch_persists_runtime_state_only_after_ack(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway([_interaction(name="newt", options=[])])
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    call_order: list[tuple[str, Any]] = []
+
+    async def _tracked_ack(*_args: Any, **_kwargs: Any) -> bool:
+        call_order.append(("ack", _kwargs.get("stage")))
+        return True
+
+    async def _tracked_persist(*_args: Any, **kwargs: Any) -> None:
+        call_order.append(("persist", kwargs.get("scheduler_state")))
+
+    def _tracked_submit(*_args: Any, **_kwargs: Any) -> None:
+        call_order.append(("submit", None))
+
+    service._acknowledge_runtime_envelope = _tracked_ack  # type: ignore[assignment]
+    service._persist_runtime_interaction = _tracked_persist  # type: ignore[assignment]
+    service._command_runner = SimpleNamespace(
+        submit=_tracked_submit,
+        shutdown=AsyncMock(),
+    )
+
+    try:
+        await service.run_forever()
+        assert call_order[:3] == [
+            ("ack", "dispatch"),
+            ("persist", "acknowledged"),
+            ("submit", None),
+        ]
     finally:
         await store.close()
 


### PR DESCRIPTION
## Summary

This PR hardens Discord interaction reliability under transport instability and ingress pressure.

### 1) ACK path is now bounded and minimal before ACK
- Adds an internal ACK budget (`discord_bot.dispatch.ack_budget_ms`, default `2500`).
- Enforces the budget during `dispatch`/`queue_wait` defer ACK operations.
- Logs explicit expiry/timeout causes (`expired_before_ack`, `budget_overrun_ms`).
- Moves interaction ledger registration/persistence to post-ACK, so ingress no longer performs pre-ACK ledger writes.
- Adds pre-ACK duplicate protection via in-memory reservation + read-only ledger lookup, then releases reservation once dispatch admission completes.

### 2) Bounded interaction handler concurrency
- Adds configurable `discord_bot.dispatch.max_concurrent_interactions` (default `4`).
- Wires this into `CommandRunner` as `max_concurrent_interaction_handlers`.
- Uses a semaphore to cap concurrent interaction handler executions while preserving existing resource-key scheduling semantics.

### 3) Transport/reconnect observability
- Adds structured gateway lifecycle/reconnect events:
  - `discord.gateway.transport.connect.start|success|disconnect`
  - `discord.gateway.reconnect.failure|scheduled|success`

### 4) Tests
- Expanded/updated tests across config, runner, reliability, and service routing for:
  - ACK budget expiry behavior
  - post-ACK persistence ordering
  - bounded concurrency behavior
  - queue-wait ACK behavior under slot exhaustion
  - gateway reconnect lifecycle telemetry

## Validation

Local targeted runs:
- `.venv/bin/python -m pytest tests/integrations/discord/test_config.py`
- `.venv/bin/python -m pytest tests/integrations/discord/test_command_runner.py`
- `.venv/bin/python -m pytest tests/integrations/discord/test_ingress.py`
- `.venv/bin/python -m pytest tests/integrations/discord/test_reliability.py`
- `.venv/bin/python -m pytest tests/integrations/discord/test_service_routing.py`
- `.venv/bin/python -m pytest tests/integrations/discord/test_interaction_runtime_chaos.py -k 'duplicate_delivery_and_restart_keep_single_ack or callback_failure_before_defer_does_not_persist_ack or followup_failure_after_defer_recovers_after_restart or delayed_timeout_followup_and_late_business_error_never_reack'`

Pre-commit suite during commit:
- full repository pytest (`4825 passed`)
- black/ruff/mypy/eslint/static build/js tests/hooks all passed.
