### PR TITLE
Fix PMA managed-thread subscription dispatch for orchestration completions

### DIFF
--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -9,8 +9,10 @@ from typing import Any, Awaitable, Callable, Mapping, Optional, cast
 
 from ..car_context import CarContextProfile, normalize_car_context_profile
 from ..logging_utils import log_event
+from ..pma_automation_store import PmaAutomationStore
 from ..pma_thread_store import PmaThreadStore
 from ..text_utils import _truncate_text
+from ..time_utils import now_iso
 from .bindings import ActiveWorkSummary, OrchestrationBindingStore
 from .catalog import MappingAgentDefinitionCatalog, RuntimeAgentDescriptor
 from .events import OrchestrationEvent
@@ -359,6 +361,73 @@ class PmaThreadExecutionStore(ThreadExecutionStore):
     ) -> None:
         self._store.set_turn_backend_turn_id(execution_id, backend_turn_id)
 
+    def _notify_terminal_transition(
+        self,
+        *,
+        thread_target_id: str,
+        execution_id: str,
+        status: Optional[str],
+        error: Optional[str] = None,
+    ) -> None:
+        normalized_status = str(status or "").strip().lower()
+        if normalized_status == "ok":
+            to_state = "completed"
+            reason = "managed_turn_completed"
+        elif normalized_status == "interrupted":
+            to_state = "interrupted"
+            reason = "managed_turn_interrupted"
+        else:
+            to_state = "failed"
+            reason = str(error or "").strip() or "managed_turn_failed"
+
+        thread = self.get_thread_target(thread_target_id)
+        payload: dict[str, Any] = {
+            "thread_id": thread_target_id,
+            "from_state": "running",
+            "to_state": to_state,
+            "reason": reason,
+            "timestamp": now_iso(),
+            "event_type": f"managed_thread_{to_state}",
+            "transition_id": f"managed_turn:{execution_id}:{to_state}",
+            "idempotency_key": f"managed_turn:{execution_id}:{to_state}",
+            "managed_thread_id": thread_target_id,
+            "managed_turn_id": execution_id,
+        }
+        if thread is not None:
+            if thread.repo_id:
+                payload["repo_id"] = thread.repo_id
+            if thread.resource_kind:
+                payload["resource_kind"] = thread.resource_kind
+            if thread.resource_id:
+                payload["resource_id"] = thread.resource_id
+            payload["agent"] = thread.agent_id
+
+        try:
+            result = PmaAutomationStore(self._store.hub_root).notify_transition(payload)
+        except (OSError, RuntimeError, TypeError, ValueError):
+            logger.exception(
+                "Failed to notify PMA automation for terminal managed-thread transition "
+                "(thread_target_id=%s, execution_id=%s, to_state=%s)",
+                thread_target_id,
+                execution_id,
+                to_state,
+            )
+            return
+
+        try:
+            created = int(result.get("created") or 0)
+        except (TypeError, ValueError):
+            created = 0
+        if created > 0:
+            logger.info(
+                "Managed-thread PMA transition enqueued wakeups "
+                "(thread_target_id=%s, execution_id=%s, event_type=%s, created=%s)",
+                thread_target_id,
+                execution_id,
+                payload["event_type"],
+                created,
+            )
+
     def record_execution_result(
         self,
         thread_target_id: str,
@@ -385,6 +454,12 @@ class PmaThreadExecutionStore(ThreadExecutionStore):
             raise KeyError(
                 f"Execution '{execution_id}' is missing after result recording"
             )
+        self._notify_terminal_transition(
+            thread_target_id=thread_target_id,
+            execution_id=execution_id,
+            status=execution.status,
+            error=execution.error,
+        )
         return execution
 
     def record_execution_interrupted(
@@ -398,6 +473,12 @@ class PmaThreadExecutionStore(ThreadExecutionStore):
             raise KeyError(
                 f"Execution '{execution_id}' is missing after interrupt recording"
             )
+        self._notify_terminal_transition(
+            thread_target_id=thread_target_id,
+            execution_id=execution_id,
+            status=execution.status,
+            error=execution.error,
+        )
         return execution
 
     def cancel_queued_executions(self, thread_target_id: str) -> int:

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -35,6 +35,7 @@ from codex_autorunner.core.orchestration.service import (
 )
 from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.orchestration.transcript_mirror import TranscriptMirrorStore
+from codex_autorunner.core.pma_automation_store import PmaAutomationStore
 from codex_autorunner.core.pma_thread_store import PmaThreadStore
 
 FIXTURE_PATH = Path(__file__).resolve().parents[2] / "fixtures" / "fake_acp_server.py"
@@ -1083,6 +1084,122 @@ async def test_send_review_preserves_request_kind_through_queue_claim_and_result
         ).fetchone()
     assert row is not None
     assert row["request_kind"] == "review"
+
+
+@pytest.mark.parametrize(
+    ("result_status", "result_error", "expected_to_state", "expected_event_type"),
+    [
+        ("ok", None, "completed", "managed_thread_completed"),
+        ("error", "managed thread failed", "failed", "managed_thread_failed"),
+    ],
+)
+async def test_record_execution_result_notifies_managed_thread_subscriptions(
+    tmp_path: Path,
+    result_status: str,
+    result_error: Optional[str],
+    expected_to_state: str,
+    expected_event_type: str,
+) -> None:
+    harness = _FakeHarness()
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target(
+        "codex",
+        workspace_root,
+        repo_id="repo-automation",
+    )
+
+    automation_store = PmaAutomationStore(tmp_path / "hub")
+    automation_store.create_subscription(
+        {
+            "event_types": [expected_event_type],
+            "thread_id": thread.thread_target_id,
+            "from_state": "running",
+            "to_state": expected_to_state,
+            "lane_id": "pma:lane-next",
+            "idempotency_key": f"subscription:{expected_event_type}",
+        }
+    )
+
+    running = await service.send_message(
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="trigger transition",
+        )
+    )
+
+    finalized = service.record_execution_result(
+        thread.thread_target_id,
+        running.execution_id,
+        status=result_status,
+        assistant_text="" if result_status == "error" else "done",
+        error=result_error,
+    )
+    assert finalized.status == result_status
+
+    pending = automation_store.list_pending_wakeups(limit=10)
+    assert len(pending) == 1
+    wakeup = pending[0]
+    assert wakeup["source"] == "transition"
+    assert wakeup["thread_id"] == thread.thread_target_id
+    assert wakeup["repo_id"] == "repo-automation"
+    assert wakeup["from_state"] == "running"
+    assert wakeup["to_state"] == expected_to_state
+    assert wakeup["event_type"] == expected_event_type
+    assert wakeup["lane_id"] == "pma:lane-next"
+
+
+async def test_record_execution_interrupted_notifies_managed_thread_subscriptions(
+    tmp_path: Path,
+) -> None:
+    harness = _FakeHarness()
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target(
+        "codex",
+        workspace_root,
+        repo_id="repo-automation",
+    )
+
+    automation_store = PmaAutomationStore(tmp_path / "hub")
+    automation_store.create_subscription(
+        {
+            "event_types": ["managed_thread_interrupted"],
+            "thread_id": thread.thread_target_id,
+            "from_state": "running",
+            "to_state": "interrupted",
+            "lane_id": "pma:lane-next",
+            "idempotency_key": "subscription:managed_thread_interrupted",
+        }
+    )
+
+    running = await service.send_message(
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="trigger interruption",
+        )
+    )
+
+    finalized = service.record_execution_interrupted(
+        thread.thread_target_id,
+        running.execution_id,
+    )
+    assert finalized.status == "interrupted"
+
+    pending = automation_store.list_pending_wakeups(limit=10)
+    assert len(pending) == 1
+    wakeup = pending[0]
+    assert wakeup["source"] == "transition"
+    assert wakeup["thread_id"] == thread.thread_target_id
+    assert wakeup["repo_id"] == "repo-automation"
+    assert wakeup["from_state"] == "running"
+    assert wakeup["to_state"] == "interrupted"
+    assert wakeup["event_type"] == "managed_thread_interrupted"
+    assert wakeup["lane_id"] == "pma:lane-next"
 
 
 async def test_send_message_interrupts_busy_thread_when_requested(


### PR DESCRIPTION
## Summary
- add managed-thread terminal transition dispatch to `PmaThreadExecutionStore` so orchestration finalization paths emit `managed_thread_completed` / `managed_thread_failed` / `managed_thread_interrupted` events into PMA automation
- keep dispatch idempotent via `managed_turn:{execution_id}:{state}` transition keys and include thread/resource metadata when available
- add info logging when managed-thread terminal transition notifications create PMA wakeups
- add regression tests proving `record_execution_result` and `record_execution_interrupted` now trigger subscription wakeups outside web-route-only paths

## Testing
- `.venv/bin/python -m pytest -q tests/core/orchestration/test_service.py -k "notifies_managed_thread_subscriptions"`
- `.venv/bin/python -m pytest -q tests/test_pma_managed_threads_messages.py -k "managed_thread_completion_subscription_enqueues_wakeup"`
- full pre-commit suite passed during commit (includes full pytest)

Closes #1374
