### PR TITLE
[codex] Improve Discord interaction ingress concurrency

### DIFF
--- a/src/codex_autorunner/integrations/discord/command_runner.py
+++ b/src/codex_autorunner/integrations/discord/command_runner.py
@@ -40,6 +40,7 @@ DEFAULT_HANDLER_TIMEOUT_SECONDS: Optional[float] = None
 DEFAULT_STALLED_WARNING_SECONDS: Optional[float] = 60.0
 
 _DRAIN_SENTINEL: object = object()
+_SUBMISSION_SENTINEL: object = object()
 
 
 class DiscordRunnerService(Protocol):
@@ -85,6 +86,15 @@ class DiscordRunnerService(Protocol):
         text: str,
     ) -> None: ...
 
+    async def send_or_respond_public(
+        self,
+        *,
+        interaction_id: str,
+        interaction_token: str,
+        deferred: bool,
+        text: str,
+    ) -> None: ...
+
 
 @dataclass(frozen=True)
 class InteractionSchedule:
@@ -99,8 +109,17 @@ class ScheduledInteraction:
     schedule: InteractionSchedule
     replay_mode: str = "normal"
     queue_wait_ack_policy: Optional[DiscordAckPolicy] = None
+    submission_order: Optional[int] = None
     admitted: bool = False
     ready: Optional[asyncio.Future[None]] = None
+    queue_wait_notice: Optional["QueueWaitNotice"] = None
+
+
+@dataclass(frozen=True)
+class QueueWaitNotice:
+    scope: str
+    command_label: str
+    same_conversation: bool
 
 
 @dataclass(frozen=True)
@@ -125,10 +144,16 @@ class CommandRunner:
         self._logger = logger
         self._on_scheduler_conversation_idle = on_scheduler_conversation_idle
         self._queue: asyncio.Queue[Any] = asyncio.Queue()
+        self._submission_queue: asyncio.Queue[Any] = asyncio.Queue()
         self._drain_task: Optional[asyncio.Task[None]] = None
+        self._submission_task: Optional[asyncio.Task[None]] = None
         self._interaction_tasks: Set[asyncio.Task[None]] = set()
         self._pending_interactions: Deque[ScheduledInteraction] = deque()
+        self._pending_ordered_submissions: dict[int, ScheduledInteraction] = {}
+        self._skipped_submission_orders: set[int] = set()
+        self._next_submission_order = 1
         self._active_resource_keys: set[str] = set()
+        self._active_resource_owners: dict[str, ScheduledInteraction] = {}
         self._active_conversation_labels: dict[str, str] = {}
         self._scheduler_lock = asyncio.Lock()
         self._started = False
@@ -137,19 +162,21 @@ class CommandRunner:
         if self._started:
             return
         self._started = True
-        self._drain_task = asyncio.create_task(
-            self._drain_loop(), name="discord-runner-drain"
-        )
+        if self._drain_task is None or self._drain_task.done():
+            self._drain_task = asyncio.create_task(
+                self._drain_loop(), name="discord-runner-drain"
+            )
+        if self._submission_task is None or self._submission_task.done():
+            self._submission_task = asyncio.create_task(
+                self._submission_loop(), name="discord-runner-submissions"
+            )
 
     @property
     def active_task_count(self) -> int:
         self._interaction_tasks = {
             task for task in self._interaction_tasks if not task.done()
         }
-        count = len(self._interaction_tasks)
-        if self._drain_task is not None and not self._drain_task.done():
-            count += 1
-        return count
+        return len(self._interaction_tasks)
 
     def submit(
         self,
@@ -159,7 +186,9 @@ class CommandRunner:
         resource_keys: Sequence[str] = (),
         conversation_id: Optional[str] = None,
         queue_wait_ack_policy: Optional[DiscordAckPolicy] = None,
+        submission_order: Optional[int] = None,
     ) -> None:
+        self._ensure_submission_started()
         schedule = InteractionSchedule(
             resource_keys=tuple(dict.fromkeys(resource_keys)),
             conversation_id=conversation_id,
@@ -170,12 +199,9 @@ class CommandRunner:
             schedule=schedule,
             replay_mode="normal",
             queue_wait_ack_policy=queue_wait_ack_policy,
+            submission_order=submission_order,
         )
-        task = asyncio.create_task(
-            self._run_scheduled_interaction(item),
-            name=f"discord-runner-{ctx.interaction_id}",
-        )
-        self._track_interaction_task(task)
+        self._submission_queue.put_nowait(item)
 
     def submit_recovery(
         self,
@@ -186,6 +212,7 @@ class CommandRunner:
         conversation_id: Optional[str] = None,
         replay_mode: str,
     ) -> None:
+        self._ensure_submission_started()
         schedule = InteractionSchedule(
             resource_keys=tuple(dict.fromkeys(resource_keys)),
             conversation_id=conversation_id,
@@ -197,15 +224,23 @@ class CommandRunner:
             replay_mode=replay_mode,
             queue_wait_ack_policy=None,
         )
-        task = asyncio.create_task(
-            self._run_scheduled_interaction(item),
-            name=f"discord-runner-recovery-{ctx.interaction_id}",
-        )
-        self._track_interaction_task(task)
+        self._submission_queue.put_nowait(item)
 
     def submit_event(self, event: Any) -> None:
         self._ensure_started()
         self._queue.put_nowait(event)
+
+    def skip_submission_order(self, submission_order: Optional[int]) -> None:
+        if submission_order is None or submission_order < self._next_submission_order:
+            return
+        self._ensure_submission_started()
+        self._skipped_submission_orders.add(submission_order)
+        for scheduled in self._consume_ready_submission_items():
+            task = asyncio.create_task(
+                self._run_scheduled_interaction(scheduled),
+                name=f"discord-runner-{scheduled.ctx.interaction_id}",
+            )
+            self._track_interaction_task(task)
 
     def is_busy(self, conversation_id: str) -> bool:
         active = self._active_conversation_labels.get(conversation_id)
@@ -265,6 +300,20 @@ class CommandRunner:
             except asyncio.CancelledError:
                 pass
             self._drain_task = None
+        if self._submission_task is not None and not self._submission_task.done():
+            await self._submission_queue.put(_SUBMISSION_SENTINEL)
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(self._submission_task),
+                    timeout=max(0.0, deadline - time.monotonic()),
+                )
+            except asyncio.TimeoutError:
+                self._submission_task.cancel()
+                with contextlib_suppress(asyncio.CancelledError):
+                    await self._submission_task
+            except asyncio.CancelledError:
+                pass
+            self._submission_task = None
         if self._interaction_tasks:
             idle_conversations.update(self._active_conversation_labels)
             idle_conversations.update(
@@ -275,7 +324,11 @@ class CommandRunner:
             await self._drain_interaction_tasks(deadline=deadline)
         async with self._scheduler_lock:
             self._pending_interactions.clear()
+            self._pending_ordered_submissions.clear()
+            self._skipped_submission_orders.clear()
+            self._next_submission_order = 1
             self._active_resource_keys.clear()
+            self._active_resource_owners.clear()
             self._active_conversation_labels.clear()
         await self._notify_scheduler_conversations_idle(
             {
@@ -289,6 +342,12 @@ class CommandRunner:
     def _ensure_started(self) -> None:
         if not self._started:
             self.start()
+
+    def _ensure_submission_started(self) -> None:
+        if self._submission_task is None or self._submission_task.done():
+            self._submission_task = asyncio.create_task(
+                self._submission_loop(), name="discord-runner-submissions"
+            )
 
     @staticmethod
     def _format_command_label(ctx: IngressContext) -> str:
@@ -334,6 +393,51 @@ class CommandRunner:
         except asyncio.CancelledError:
             return
 
+    async def _submission_loop(self) -> None:
+        try:
+            while True:
+                item = await self._submission_queue.get()
+                if item is _SUBMISSION_SENTINEL:
+                    self._submission_queue.task_done()
+                    return
+                try:
+                    for scheduled in self._pop_ready_submission_items(item):
+                        task = asyncio.create_task(
+                            self._run_scheduled_interaction(scheduled),
+                            name=f"discord-runner-{scheduled.ctx.interaction_id}",
+                        )
+                        self._track_interaction_task(task)
+                finally:
+                    self._submission_queue.task_done()
+        except asyncio.CancelledError:
+            return
+
+    def _pop_ready_submission_items(
+        self, item: ScheduledInteraction
+    ) -> list[ScheduledInteraction]:
+        order = item.submission_order
+        if order is None:
+            return [item]
+        if order < self._next_submission_order:
+            return [item]
+        self._pending_ordered_submissions[order] = item
+        return self._consume_ready_submission_items()
+
+    def _consume_ready_submission_items(self) -> list[ScheduledInteraction]:
+        ready: list[ScheduledInteraction] = []
+        while True:
+            if self._next_submission_order in self._skipped_submission_orders:
+                self._skipped_submission_orders.remove(self._next_submission_order)
+                self._next_submission_order += 1
+                continue
+            if self._next_submission_order not in self._pending_ordered_submissions:
+                break
+            ready.append(
+                self._pending_ordered_submissions.pop(self._next_submission_order)
+            )
+            self._next_submission_order += 1
+        return ready
+
     async def _run_scheduled_interaction(self, item: ScheduledInteraction) -> None:
         acquired_schedule = False
         notify_idle: set[str] = set()
@@ -364,6 +468,7 @@ class CommandRunner:
                         if not acknowledged:
                             notify_idle = await self._remove_pending_schedule(item)
                             return
+                    await self._maybe_send_queue_wait_notice(item)
                     await self._wait_for_schedule(item)
                     await self._mark_scheduler_state(
                         item,
@@ -391,22 +496,105 @@ class CommandRunner:
     async def _admit_or_enqueue_schedule(self, item: ScheduledInteraction) -> bool:
         loop = asyncio.get_running_loop()
         async with self._scheduler_lock:
-            has_active_conflict = any(
-                key in self._active_resource_keys for key in item.schedule.resource_keys
-            )
-            has_pending_conflict = any(
-                any(
-                    key in pending.schedule.resource_keys
-                    for key in item.schedule.resource_keys
-                )
-                for pending in self._pending_interactions
-            )
-            if not has_active_conflict and not has_pending_conflict:
+            queue_wait_notice = self._find_queue_wait_notice_locked(item)
+            if queue_wait_notice is None:
                 self._admit_interaction_locked(item)
                 return True
             item.ready = loop.create_future()
+            item.queue_wait_notice = queue_wait_notice
             self._pending_interactions.append(item)
             return False
+
+    @staticmethod
+    def _resource_scope(resource_key: str) -> str:
+        if resource_key.startswith("conversation:"):
+            return "channel"
+        if resource_key.startswith("workspace:"):
+            return "workspace"
+        return "resource"
+
+    def _build_queue_wait_notice(
+        self,
+        *,
+        resource_key: str,
+        blocker: ScheduledInteraction,
+        item: ScheduledInteraction,
+    ) -> QueueWaitNotice:
+        return QueueWaitNotice(
+            scope=self._resource_scope(resource_key),
+            command_label=self._format_command_label(blocker.ctx),
+            same_conversation=(
+                blocker.schedule.conversation_id == item.schedule.conversation_id
+            ),
+        )
+
+    def _find_queue_wait_notice_locked(
+        self, item: ScheduledInteraction
+    ) -> Optional[QueueWaitNotice]:
+        for resource_key in item.schedule.resource_keys:
+            blocker = self._active_resource_owners.get(resource_key)
+            if blocker is not None:
+                return self._build_queue_wait_notice(
+                    resource_key=resource_key,
+                    blocker=blocker,
+                    item=item,
+                )
+        for pending in self._pending_interactions:
+            for resource_key in item.schedule.resource_keys:
+                if resource_key not in pending.schedule.resource_keys:
+                    continue
+                return self._build_queue_wait_notice(
+                    resource_key=resource_key,
+                    blocker=pending,
+                    item=item,
+                )
+        return None
+
+    @staticmethod
+    def _queue_wait_text(item: ScheduledInteraction) -> Optional[str]:
+        notice = item.queue_wait_notice
+        if notice is None:
+            return None
+        if notice.scope == "channel":
+            return (
+                f"Queued behind {notice.command_label} in this channel; "
+                "will run when it finishes."
+            )
+        if notice.scope == "workspace":
+            if notice.same_conversation:
+                return (
+                    f"Queued behind {notice.command_label} for this workspace; "
+                    "will run when it finishes."
+                )
+            return (
+                f"Queued behind {notice.command_label} in another channel bound "
+                "to the same workspace; will run when it finishes."
+            )
+        return f"Queued behind {notice.command_label}; will run when it finishes."
+
+    async def _maybe_send_queue_wait_notice(self, item: ScheduledInteraction) -> None:
+        if item.replay_mode != "normal":
+            return
+        if item.ctx.kind != item.ctx.kind.SLASH_COMMAND or not item.ctx.deferred:
+            return
+        text = self._queue_wait_text(item)
+        if not isinstance(text, str) or not text.strip():
+            return
+        ack_policy = item.ctx.command_spec.ack_policy if item.ctx.command_spec else None
+        if ack_policy == "defer_public":
+            await self._service.send_or_respond_public(
+                interaction_id=item.ctx.interaction_id,
+                interaction_token=item.ctx.interaction_token,
+                deferred=True,
+                text=text,
+            )
+            return
+        await self._service.send_or_respond_ephemeral(
+            interaction_id=item.ctx.interaction_id,
+            interaction_token=item.ctx.interaction_token,
+            deferred=True,
+            text=text,
+        )
 
     async def _wait_for_schedule(self, item: ScheduledInteraction) -> None:
         ready = item.ready
@@ -464,6 +652,8 @@ class CommandRunner:
 
     def _admit_interaction_locked(self, item: ScheduledInteraction) -> None:
         self._active_resource_keys.update(item.schedule.resource_keys)
+        for resource_key in item.schedule.resource_keys:
+            self._active_resource_owners[resource_key] = item
         item.admitted = True
         conversation_id = item.schedule.conversation_id
         if conversation_id:
@@ -478,6 +668,8 @@ class CommandRunner:
     def _release_schedule_locked(self, item: ScheduledInteraction) -> set[str]:
         for key in item.schedule.resource_keys:
             self._active_resource_keys.discard(key)
+            if self._active_resource_owners.get(key) is item:
+                self._active_resource_owners.pop(key, None)
         conversation_id = item.schedule.conversation_id
         if conversation_id:
             self._active_conversation_labels.pop(conversation_id, None)

--- a/src/codex_autorunner/integrations/discord/gateway.py
+++ b/src/codex_autorunner/integrations/discord/gateway.py
@@ -30,6 +30,7 @@ FATAL_GATEWAY_CLOSE_CODES = {4004, 4010, 4011, 4012, 4013, 4014}
 # Allow one queued dispatch in addition to the active worker item so later
 # frames can start flowing without letting backlog grow unbounded.
 DISCORD_DISPATCH_QUEUE_MAXSIZE = 1
+DISCORD_DISPATCH_CALLBACK_MAX_IN_FLIGHT = 8
 
 
 @dataclass(frozen=True)
@@ -129,6 +130,10 @@ class DiscordGatewayClient:
         self._heartbeat_task: Optional[asyncio.Task[None]] = None
         self._dispatch_queue: Optional[asyncio.Queue[tuple[str, dict[str, Any]]]] = None
         self._dispatch_worker_task: Optional[asyncio.Task[None]] = None
+        self._dispatch_callback_tasks: set[asyncio.Task[None]] = set()
+        self._dispatch_callback_semaphore: Optional[asyncio.Semaphore] = None
+        self._dispatch_failure_future: Optional[asyncio.Future[None]] = None
+        self._dispatch_order = 0
         self._websocket: Any = None
 
     async def stop(self) -> None:
@@ -246,6 +251,10 @@ class DiscordGatewayClient:
             maxsize=DISCORD_DISPATCH_QUEUE_MAXSIZE
         )
         self._dispatch_queue = dispatch_queue
+        self._dispatch_callback_semaphore = asyncio.Semaphore(
+            DISCORD_DISPATCH_CALLBACK_MAX_IN_FLIGHT
+        )
+        self._dispatch_failure_future = asyncio.get_running_loop().create_future()
         self._dispatch_worker_task = asyncio.create_task(
             self._dispatch_loop(dispatch_queue, on_dispatch)
         )
@@ -292,6 +301,8 @@ class DiscordGatewayClient:
                 await self._wait_for_dispatch_queue(dispatch_queue)
             finally:
                 self._dispatch_queue = None
+                self._dispatch_callback_semaphore = None
+                self._dispatch_failure_future = None
                 await self._cancel_dispatch_worker()
 
     async def _heartbeat_loop(self, websocket: Any, interval_seconds: float) -> None:
@@ -325,11 +336,21 @@ class DiscordGatewayClient:
         queue: asyncio.Queue[tuple[str, dict[str, Any]]],
         on_dispatch: Callable[[str, dict[str, Any]], Awaitable[None]],
     ) -> None:
+        if self._dispatch_callback_semaphore is None:
+            self._dispatch_callback_semaphore = asyncio.Semaphore(
+                DISCORD_DISPATCH_CALLBACK_MAX_IN_FLIGHT
+            )
+        if self._dispatch_failure_future is None:
+            self._dispatch_failure_future = asyncio.get_running_loop().create_future()
         try:
             while True:
                 event_type, payload = await queue.get()
                 try:
-                    await on_dispatch(event_type, payload)
+                    await self._start_dispatch_callback(
+                        event_type=event_type,
+                        payload=payload,
+                        on_dispatch=on_dispatch,
+                    )
                 finally:
                     queue.task_done()
         except asyncio.CancelledError:
@@ -346,15 +367,62 @@ class DiscordGatewayClient:
                     queue.task_done()
             raise
 
+    async def _start_dispatch_callback(
+        self,
+        *,
+        event_type: str,
+        payload: dict[str, Any],
+        on_dispatch: Callable[[str, dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        semaphore = self._dispatch_callback_semaphore
+        if semaphore is None:
+            raise RuntimeError("Discord dispatch callback semaphore is not running")
+        await semaphore.acquire()
+        dispatch_payload = dict(payload)
+        if event_type == "INTERACTION_CREATE":
+            self._dispatch_order += 1
+            dispatch_payload["__car_dispatch_order"] = self._dispatch_order
+
+        async def _run_dispatch_callback() -> None:
+            await on_dispatch(event_type, dispatch_payload)
+
+        task: asyncio.Task[None] = asyncio.create_task(_run_dispatch_callback())
+        self._dispatch_callback_tasks.add(task)
+        task.add_done_callback(self._dispatch_callback_done)
+
+    def _dispatch_callback_done(self, task: asyncio.Task[None]) -> None:
+        self._dispatch_callback_tasks.discard(task)
+        semaphore = self._dispatch_callback_semaphore
+        if semaphore is not None:
+            semaphore.release()
+        if task.cancelled():
+            return
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        if exc is None:
+            return
+        failure_future = self._dispatch_failure_future
+        if failure_future is not None and not failure_future.done():
+            failure_future.set_exception(exc)
+
     async def _recv_gateway_message(self, websocket_iter: Any) -> Any | None:
         dispatch_task = self._dispatch_worker_task
         if dispatch_task is None:
             raise RuntimeError("Discord dispatch worker is not running")
+        failure_future = self._dispatch_failure_future
 
         message_task = asyncio.create_task(websocket_iter.__anext__())
         try:
+            wait_targets: set[asyncio.Future[Any] | asyncio.Task[Any]] = {
+                message_task,
+                dispatch_task,
+            }
+            if failure_future is not None:
+                wait_targets.add(failure_future)
             done, _pending = await asyncio.wait(
-                {message_task, dispatch_task},
+                wait_targets,
                 return_when=asyncio.FIRST_COMPLETED,
             )
         except (
@@ -373,6 +441,11 @@ class DiscordGatewayClient:
                 return None
             self._raise_if_dispatch_worker_failed(dispatch_task)
             raise RuntimeError("Discord dispatch worker exited unexpectedly")
+        if failure_future is not None and failure_future in done:
+            message_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await message_task
+            failure_future.result()
 
         try:
             return message_task.result()
@@ -388,11 +461,18 @@ class DiscordGatewayClient:
         dispatch_task = self._dispatch_worker_task
         if dispatch_task is None:
             raise RuntimeError("Discord dispatch worker is not running")
+        failure_future = self._dispatch_failure_future
 
         queue_put_task = asyncio.create_task(queue.put((event_type, payload)))
         try:
+            wait_targets: set[asyncio.Future[Any] | asyncio.Task[Any]] = {
+                queue_put_task,
+                dispatch_task,
+            }
+            if failure_future is not None:
+                wait_targets.add(failure_future)
             done, _pending = await asyncio.wait(
-                {queue_put_task, dispatch_task},
+                wait_targets,
                 return_when=asyncio.FIRST_COMPLETED,
             )
         except (
@@ -411,6 +491,11 @@ class DiscordGatewayClient:
                 return False
             self._raise_if_dispatch_worker_failed(dispatch_task)
             raise RuntimeError("Discord dispatch worker exited unexpectedly")
+        if failure_future is not None and failure_future in done:
+            queue_put_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await queue_put_task
+            failure_future.result()
 
         await queue_put_task
         return True
@@ -422,11 +507,18 @@ class DiscordGatewayClient:
         dispatch_task = self._dispatch_worker_task
         if dispatch_task is None:
             return
+        failure_future = self._dispatch_failure_future
 
         join_task = asyncio.create_task(queue.join())
         try:
+            wait_targets: set[asyncio.Future[Any] | asyncio.Task[Any]] = {
+                join_task,
+                dispatch_task,
+            }
+            if failure_future is not None:
+                wait_targets.add(failure_future)
             done, _pending = await asyncio.wait(
-                {join_task, dispatch_task},
+                wait_targets,
                 return_when=asyncio.FIRST_COMPLETED,
             )
         except (
@@ -445,15 +537,30 @@ class DiscordGatewayClient:
                 return
             self._raise_if_dispatch_worker_failed(dispatch_task)
             raise RuntimeError("Discord dispatch worker exited unexpectedly")
+        if failure_future is not None and failure_future in done:
+            join_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await join_task
+            failure_future.result()
 
         await join_task
         self._raise_if_dispatch_worker_failed(dispatch_task)
+        await self._wait_for_dispatch_callbacks()
+
+    async def _wait_for_dispatch_callbacks(self) -> None:
+        if not self._dispatch_callback_tasks:
+            failure_future = self._dispatch_failure_future
+            if failure_future is not None and failure_future.done():
+                failure_future.result()
+            return
+        await asyncio.gather(*tuple(self._dispatch_callback_tasks))
 
     async def _cancel_dispatch_worker(self) -> None:
         queue = self._dispatch_queue
         if self._dispatch_worker_task is None:
             if queue is not None:
                 self._drain_dispatch_queue(queue)
+            await self._cancel_dispatch_callbacks()
             return
         task = self._dispatch_worker_task
         self._dispatch_worker_task = None
@@ -463,6 +570,17 @@ class DiscordGatewayClient:
             await task
         if queue is not None:
             self._drain_dispatch_queue(queue)
+        await self._cancel_dispatch_callbacks()
+
+    async def _cancel_dispatch_callbacks(self) -> None:
+        callbacks = tuple(self._dispatch_callback_tasks)
+        if not callbacks:
+            return
+        self._dispatch_callback_tasks.clear()
+        for task in callbacks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*callbacks, return_exceptions=True)
 
     @staticmethod
     def _drain_dispatch_queue(

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -3818,6 +3818,11 @@ class DiscordBotService:
     async def _on_dispatch(self, event_type: str, payload: dict[str, Any]) -> None:
         if event_type == "INTERACTION_CREATE":
             dispatch_started_at = time.monotonic()
+            submission_order = (
+                payload.get("__car_dispatch_order")
+                if isinstance(payload.get("__car_dispatch_order"), int)
+                else None
+            )
             ingress_result = await self._ingress.process_raw_payload(payload)
             if not ingress_result.accepted:
                 if ingress_result.context is not None:
@@ -3857,6 +3862,7 @@ class DiscordBotService:
                             ctx.interaction_token,
                             "This Discord command is not authorized for this channel/user/guild.",
                         )
+                self._command_runner.skip_submission_order(submission_order)
                 return
             if ingress_result.context is not None:
                 envelope = await self._build_runtime_interaction_envelope(
@@ -3908,6 +3914,7 @@ class DiscordBotService:
                         ack_finished_at=time.monotonic(),
                         ingress_finished_at=time.monotonic(),
                     )
+                    self._command_runner.skip_submission_order(submission_order)
                     return
                 self._ingress.finalize_success(ingress_result.context)
                 log_event(
@@ -3941,6 +3948,7 @@ class DiscordBotService:
                     resource_keys=envelope.resource_keys,
                     conversation_id=envelope.conversation_id,
                     queue_wait_ack_policy=envelope.queue_wait_ack_policy,
+                    submission_order=submission_order,
                 )
                 # Let the admitted interaction task start before the next gateway
                 # interaction is processed so deferred command ordering stays stable.

--- a/tests/integrations/discord/test_command_runner.py
+++ b/tests/integrations/discord/test_command_runner.py
@@ -28,6 +28,7 @@ def _make_ctx(
     kind: InteractionKind = InteractionKind.SLASH_COMMAND,
     deferred: bool = True,
     command_path: tuple[str, ...] = ("car", "status"),
+    ack_policy: str | None = "defer_ephemeral",
     guild_id: Optional[str] = None,
     user_id: Optional[str] = None,
     custom_id: Optional[str] = None,
@@ -41,7 +42,7 @@ def _make_ctx(
         CommandSpec(
             path=command_path,
             options={},
-            ack_policy="defer_ephemeral",
+            ack_policy=ack_policy,
             ack_timing="dispatch",
             requires_workspace=False,
         )
@@ -77,6 +78,7 @@ class _FakeService:
         self.respond_ephemeral = AsyncMock()
         self._respond_ephemeral = self.respond_ephemeral
         self._send_or_respond_ephemeral = AsyncMock()
+        self._send_or_respond_public = AsyncMock()
         self._dispatch_chat_event = AsyncMock()
 
     async def dispatch_chat_event(self, event: Any) -> None:
@@ -127,6 +129,21 @@ class _FakeService:
         text: str,
     ) -> None:
         await self._send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=text,
+        )
+
+    async def send_or_respond_public(
+        self,
+        *,
+        interaction_id: str,
+        interaction_token: str,
+        deferred: bool,
+        text: str,
+    ) -> None:
+        await self._send_or_respond_public(
             interaction_id=interaction_id,
             interaction_token=interaction_token,
             deferred=deferred,
@@ -215,6 +232,260 @@ async def test_slow_handler_does_not_block_new_interaction() -> None:
     slow_done.set()
     await asyncio.sleep(0.05)
     assert runner.active_task_count == 0
+
+
+@pytest.mark.anyio
+async def test_queued_workspace_slash_command_sends_public_queue_notice() -> None:
+    service = _FakeService()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def blocking_handler(*args: Any, **kwargs: Any) -> None:
+        interaction_id = str(args[0]) if args else ""
+        if interaction_id == "inter-1":
+            first_started.set()
+            await release_first.wait()
+
+    service._handle_car_command.side_effect = blocking_handler
+
+    runner = CommandRunner(
+        service,
+        config=RunnerConfig(timeout_seconds=None, stalled_warning_seconds=None),
+        logger=service._logger,
+    )
+
+    first_conversation_id = conversation_id_for("discord", "chan-1", "guild-1")
+    second_conversation_id = conversation_id_for("discord", "chan-2", "guild-1")
+    workspace_key = "workspace:/tmp/ws-a"
+
+    runner.submit(
+        _make_ctx(
+            interaction_id="inter-1",
+            interaction_token="token-1",
+            channel_id="chan-1",
+            guild_id="guild-1",
+            command_path=("car", "newt"),
+            ack_policy="defer_public",
+        ),
+        _slash_payload(command_name="car", subcommand_name="newt"),
+        resource_keys=(f"conversation:{first_conversation_id}", workspace_key),
+        conversation_id=first_conversation_id,
+    )
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+    runner.submit(
+        _make_ctx(
+            interaction_id="inter-2",
+            interaction_token="token-2",
+            channel_id="chan-2",
+            guild_id="guild-1",
+            command_path=("car", "newt"),
+            ack_policy="defer_public",
+        ),
+        {
+            **_slash_payload(command_name="car", subcommand_name="newt"),
+            "id": "inter-2",
+            "token": "token-2",
+            "channel_id": "chan-2",
+        },
+        resource_keys=(f"conversation:{second_conversation_id}", workspace_key),
+        conversation_id=second_conversation_id,
+    )
+
+    await asyncio.sleep(0.05)
+    service._send_or_respond_public.assert_awaited_once()
+    assert service._send_or_respond_public.await_args.kwargs["text"] == (
+        "Queued behind /car newt in another channel bound to the same workspace; "
+        "will run when it finishes."
+    )
+
+    release_first.set()
+    await asyncio.wait_for(runner.shutdown(grace_seconds=5.0), timeout=6.0)
+
+
+@pytest.mark.anyio
+async def test_queued_same_channel_slash_command_sends_channel_queue_notice() -> None:
+    service = _FakeService()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def blocking_handler(*args: Any, **kwargs: Any) -> None:
+        interaction_id = str(args[0]) if args else ""
+        if interaction_id == "inter-1":
+            first_started.set()
+            await release_first.wait()
+
+    service._handle_car_command.side_effect = blocking_handler
+
+    runner = CommandRunner(
+        service,
+        config=RunnerConfig(timeout_seconds=None, stalled_warning_seconds=None),
+        logger=service._logger,
+    )
+
+    conversation_id = conversation_id_for("discord", "chan-1", "guild-1")
+    conversation_key = f"conversation:{conversation_id}"
+
+    runner.submit(
+        _make_ctx(
+            interaction_id="inter-1",
+            interaction_token="token-1",
+            channel_id="chan-1",
+            guild_id="guild-1",
+            command_path=("car", "status"),
+        ),
+        _slash_payload(command_name="car", subcommand_name="status"),
+        resource_keys=(conversation_key,),
+        conversation_id=conversation_id,
+    )
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+    runner.submit(
+        _make_ctx(
+            interaction_id="inter-2",
+            interaction_token="token-2",
+            channel_id="chan-1",
+            guild_id="guild-1",
+            command_path=("car", "status"),
+        ),
+        {
+            **_slash_payload(command_name="car", subcommand_name="status"),
+            "id": "inter-2",
+            "token": "token-2",
+        },
+        resource_keys=(conversation_key,),
+        conversation_id=conversation_id,
+    )
+
+    await asyncio.sleep(0.05)
+    service._send_or_respond_ephemeral.assert_awaited()
+    assert service._send_or_respond_ephemeral.await_args.kwargs["text"] == (
+        "Queued behind /car status in this channel; will run when it finishes."
+    )
+
+    release_first.set()
+    await asyncio.wait_for(runner.shutdown(grace_seconds=5.0), timeout=6.0)
+
+
+@pytest.mark.anyio
+async def test_submit_preserves_explicit_submission_order_for_same_channel() -> None:
+    service = _FakeService()
+    release_first = asyncio.Event()
+    started_ids: list[str] = []
+
+    async def blocking_handler(*args: Any, **kwargs: Any) -> None:
+        interaction_id = str(args[0]) if args else ""
+        started_ids.append(interaction_id)
+        if interaction_id == "inter-1":
+            await release_first.wait()
+
+    service._handle_car_command.side_effect = blocking_handler
+
+    runner = CommandRunner(
+        service,
+        config=RunnerConfig(timeout_seconds=None, stalled_warning_seconds=None),
+        logger=service._logger,
+    )
+    conversation_id = conversation_id_for("discord", "chan-1", "guild-1")
+    conversation_key = f"conversation:{conversation_id}"
+
+    runner.submit(
+        _make_ctx(
+            interaction_id="inter-2",
+            interaction_token="token-2",
+            channel_id="chan-1",
+            guild_id="guild-1",
+        ),
+        {
+            **_slash_payload(command_name="car", subcommand_name="status"),
+            "id": "inter-2",
+            "token": "token-2",
+        },
+        resource_keys=(conversation_key,),
+        conversation_id=conversation_id,
+        submission_order=2,
+    )
+    runner.submit(
+        _make_ctx(
+            interaction_id="inter-1",
+            interaction_token="token-1",
+            channel_id="chan-1",
+            guild_id="guild-1",
+        ),
+        _slash_payload(command_name="car", subcommand_name="status"),
+        resource_keys=(conversation_key,),
+        conversation_id=conversation_id,
+        submission_order=1,
+    )
+
+    await asyncio.sleep(0.05)
+    assert started_ids == ["inter-1"]
+
+    release_first.set()
+    await asyncio.wait_for(runner.shutdown(grace_seconds=5.0), timeout=6.0)
+    assert started_ids == ["inter-1", "inter-2"]
+
+
+@pytest.mark.anyio
+async def test_skip_submission_order_releases_later_interaction() -> None:
+    service = _FakeService()
+    started = asyncio.Event()
+
+    async def handler(*args: Any, **kwargs: Any) -> None:
+        started.set()
+
+    service._handle_car_command.side_effect = handler
+
+    runner = CommandRunner(
+        service,
+        config=RunnerConfig(timeout_seconds=None, stalled_warning_seconds=None),
+        logger=service._logger,
+    )
+    conversation_id = conversation_id_for("discord", "chan-1", "guild-1")
+    conversation_key = f"conversation:{conversation_id}"
+
+    runner.submit(
+        _make_ctx(
+            interaction_id="inter-2",
+            interaction_token="token-2",
+            channel_id="chan-1",
+            guild_id="guild-1",
+        ),
+        {
+            **_slash_payload(command_name="car", subcommand_name="status"),
+            "id": "inter-2",
+            "token": "token-2",
+        },
+        resource_keys=(conversation_key,),
+        conversation_id=conversation_id,
+        submission_order=2,
+    )
+    await asyncio.sleep(0.05)
+    assert started.is_set() is False
+
+    runner.skip_submission_order(1)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    await asyncio.wait_for(runner.shutdown(grace_seconds=5.0), timeout=6.0)
+
+
+@pytest.mark.anyio
+async def test_submit_event_after_submit_reuses_existing_submission_loop() -> None:
+    service = _FakeService()
+    runner = CommandRunner(
+        service,
+        config=RunnerConfig(timeout_seconds=None, stalled_warning_seconds=None),
+        logger=service._logger,
+    )
+
+    runner.submit(_make_ctx(), _slash_payload())
+    await asyncio.sleep(0.05)
+    submission_task = runner._submission_task
+
+    runner.submit_event({"kind": "message"})
+    await asyncio.sleep(0.05)
+
+    assert runner._submission_task is submission_task
+    await asyncio.wait_for(runner.shutdown(grace_seconds=5.0), timeout=6.0)
 
 
 @pytest.mark.anyio

--- a/tests/integrations/discord/test_flow_handlers.py
+++ b/tests/integrations/discord/test_flow_handlers.py
@@ -374,15 +374,19 @@ async def test_flow_status_and_runs_render_expected_output(tmp_path: Path) -> No
         assert len(rest.interaction_responses) == 2
         assert rest.interaction_responses[0]["payload"]["type"] == 5
         assert rest.interaction_responses[1]["payload"]["type"] == 5
-        assert len(rest.followup_messages) == 2
+        assert len(rest.followup_messages) in (2, 3)
         status_payload = rest.followup_messages[0]["payload"]["content"]
-        runs_payload = rest.followup_messages[1]["payload"]["content"]
+        runs_payload = rest.followup_messages[-1]["payload"]["content"]
 
         assert f"Run: {paused_run_id}" in status_payload
         assert "Status: paused" in status_payload
         assert "Freshness:" in status_payload
         assert "Worker:" in status_payload
         assert "Current ticket:" in status_payload
+        if len(rest.followup_messages) == 3:
+            queue_wait_payload = rest.followup_messages[1]["payload"]["content"].lower()
+            assert "queued behind /car flow status" in queue_wait_payload
+            assert "in this channel" in queue_wait_payload
 
         assert "Recent ticket_flow runs (limit=2)" in runs_payload
         assert paused_run_id in runs_payload

--- a/tests/integrations/discord/test_gateway_helpers.py
+++ b/tests/integrations/discord/test_gateway_helpers.py
@@ -7,6 +7,7 @@ import pytest
 
 from codex_autorunner.integrations.discord.errors import DiscordPermanentError
 from codex_autorunner.integrations.discord.gateway import (
+    DISCORD_DISPATCH_CALLBACK_MAX_IN_FLIGHT,
     DiscordGatewayClient,
     build_identify_payload,
     calculate_reconnect_backoff,
@@ -425,7 +426,7 @@ async def test_run_connection_reads_later_frames_while_dispatch_worker_is_busy()
     await asyncio.wait_for(first_started.wait(), timeout=1.0)
     await asyncio.wait_for(websocket.second_frame_read.wait(), timeout=1.0)
 
-    assert second_started.is_set() is False
+    await asyncio.wait_for(second_started.wait(), timeout=1.0)
 
     release_first.set()
     await asyncio.wait_for(run_task, timeout=1.0)
@@ -443,16 +444,19 @@ async def test_run_connection_backpressures_when_dispatch_queue_is_full() -> Non
 
     class _FakeWebSocket:
         def __init__(self) -> None:
-            self.third_frame_read = asyncio.Event()
-            self.fourth_frame_read = asyncio.Event()
+            self.last_frame_read = asyncio.Event()
+            total = DISCORD_DISPATCH_CALLBACK_MAX_IN_FLIGHT + 3
             self._frames = iter(
                 [
-                    {"op": 0, "t": "INTERACTION_CREATE", "d": {"id": "first"}},
-                    {"op": 0, "t": "INTERACTION_CREATE", "d": {"id": "second"}},
-                    {"op": 0, "t": "INTERACTION_CREATE", "d": {"id": "third"}},
-                    {"op": 0, "t": "INTERACTION_CREATE", "d": {"id": "fourth"}},
+                    {
+                        "op": 0,
+                        "t": "INTERACTION_CREATE",
+                        "d": {"id": f"frame-{index}"},
+                    }
+                    for index in range(1, total + 1)
                 ]
             )
+            self._last_frame_id = f"frame-{total}"
 
         async def recv(self) -> dict[str, object]:
             return {"op": 10, "d": {"heartbeat_interval": 1000}}
@@ -466,34 +470,41 @@ async def test_run_connection_backpressures_when_dispatch_queue_is_full() -> Non
         async def __anext__(self) -> dict[str, object]:
             try:
                 frame = next(self._frames)
-                if frame["d"]["id"] == "third":
-                    self.third_frame_read.set()
-                if frame["d"]["id"] == "fourth":
-                    self.fourth_frame_read.set()
+                if frame["d"]["id"] == self._last_frame_id:
+                    self.last_frame_read.set()
                 return frame
             except StopIteration as exc:
                 raise StopAsyncIteration from exc
 
-    release_first = asyncio.Event()
-    first_started = asyncio.Event()
+    release_blocked = asyncio.Event()
+    blocked_started = asyncio.Event()
+    started_ids: list[str] = []
+    blocked_frame_ids = {
+        f"frame-{index}"
+        for index in range(1, DISCORD_DISPATCH_CALLBACK_MAX_IN_FLIGHT + 1)
+    }
 
     async def _dispatch(_event_type: str, payload: dict[str, object]) -> None:
-        if payload["id"] == "first":
-            first_started.set()
-            await release_first.wait()
+        frame_id = str(payload["id"])
+        started_ids.append(frame_id)
+        if frame_id in blocked_frame_ids:
+            if len([value for value in started_ids if value in blocked_frame_ids]) == (
+                DISCORD_DISPATCH_CALLBACK_MAX_IN_FLIGHT
+            ):
+                blocked_started.set()
+            await release_blocked.wait()
 
     websocket = _FakeWebSocket()
     run_task = asyncio.create_task(client._run_connection(websocket, _dispatch))
-    await asyncio.wait_for(first_started.wait(), timeout=1.0)
-    await asyncio.wait_for(websocket.third_frame_read.wait(), timeout=1.0)
+    await asyncio.wait_for(blocked_started.wait(), timeout=1.0)
     await asyncio.sleep(0)
 
-    assert websocket.fourth_frame_read.is_set() is False
+    assert websocket.last_frame_read.is_set() is False
 
-    release_first.set()
-    await asyncio.wait_for(run_task, timeout=1.0)
+    release_blocked.set()
+    await asyncio.wait_for(run_task, timeout=2.0)
 
-    assert websocket.fourth_frame_read.is_set()
+    assert websocket.last_frame_read.is_set()
 
 
 @pytest.mark.anyio

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -1853,6 +1853,38 @@ async def test_service_enforces_allowlist_and_denies_autocomplete_with_empty_cho
         await store.close()
 
 
+@pytest.mark.anyio
+async def test_rejected_interaction_skips_submission_order(tmp_path: Path) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    skip_submission_order = MagicMock()
+    service._command_runner.skip_submission_order = (  # type: ignore[method-assign]
+        skip_submission_order
+    )
+
+    try:
+        payload = _interaction(
+            name="bind",
+            options=[{"type": 3, "name": "workspace", "value": str(tmp_path)}],
+            user_id="unauthorized",
+        )
+        payload["__car_dispatch_order"] = 7
+        await service._on_dispatch("INTERACTION_CREATE", payload)
+        skip_submission_order.assert_called_once_with(7)
+    finally:
+        await service._shutdown()
+        await store.close()
+
+
 @pytest.mark.slow
 @pytest.mark.anyio
 async def test_service_bind_then_status_updates_and_reads_store(tmp_path: Path) -> None:

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -1927,10 +1927,12 @@ async def test_service_bind_then_status_updates_and_reads_store(tmp_path: Path) 
         bind_payload = rest.interaction_responses[0]["payload"]
         assert bind_payload["type"] == 5
         assert bind_payload["data"]["flags"] == 64
-        assert len(rest.followup_messages) == 2
+        assert len(rest.followup_messages) == 3
         bind_content = rest.followup_messages[0]["payload"]["content"].lower()
         assert "bound this channel" in bind_content
-        status_content = rest.followup_messages[1]["payload"]["content"].lower()
+        queue_wait_content = rest.followup_messages[1]["payload"]["content"].lower()
+        assert "queued behind /car bind in this channel" in queue_wait_content
+        status_content = rest.followup_messages[2]["payload"]["content"].lower()
         assert "channel is bound" in status_content
         assert "policy mode:" in status_content
     finally:
@@ -1995,8 +1997,10 @@ async def test_service_status_reports_effective_collaboration_policy(
         await service.run_forever()
         assert len(rest.interaction_responses) >= 1
         assert rest.interaction_responses[0]["payload"]["type"] == 5
-        assert len(rest.followup_messages) == 2
-        status_payload = rest.followup_messages[1]["payload"]["content"]
+        assert len(rest.followup_messages) == 3
+        queue_wait_content = rest.followup_messages[1]["payload"]["content"].lower()
+        assert "queued behind /car bind in this channel" in queue_wait_content
+        status_payload = rest.followup_messages[2]["payload"]["content"]
         lowered = status_payload.lower()
         assert "policy mode: active" in lowered
         assert "policy plain-text trigger: mentions" in lowered


### PR DESCRIPTION
## Summary
- remove the Discord gateway's global head-of-line blocking by dispatching gateway callbacks with bounded concurrency
- preserve same-channel interaction ordering with an ordered submission queue and explicit skip handling for rejected interactions
- improve queued slash-command UX with channel-vs-workspace queue-wait notices and update Discord tests for the new follow-up behavior

## Root cause
The command runner already serialized work by resource key, but the gateway still awaited each dispatch callback inline. That meant one in-flight slash command could stall ingestion for unrelated channels and even unrelated worktrees before requests ever reached the per-channel/per-workspace scheduler.

## What changed
- `DiscordGatewayClient` now runs dispatch callbacks with a bounded in-flight limit instead of a single callback at a time.
- Interaction dispatches carry an ingress order marker so same-channel ordering is preserved after gateway parallelism is introduced.
- `DiscordCommandRunner` now funnels interactions through an ordered submission loop and can skip order slots for rejected interactions.
- Deferred slash commands now get explicit queue-wait notices that explain whether they are blocked by the same channel or the workspace.
- Tests now cover bounded gateway concurrency, submission ordering, rejected-order skips, queue-wait notices, and the updated follow-up flows.

## Validation
- targeted pytest slices for Discord gateway, command runner, service routing, chaos coverage, and flow handlers
- repo commit hook suite: black, ruff, mypy, frontend build/tests, and full pytest (`4827 passed`)

## Review
A mini subagent review found two correctness issues during the first pass:
- rejected or filtered interactions could leave permanent gaps in ordered submission
- `submit_event()` could start a duplicate submission loop after interactions were already using one

Both issues were fixed in this branch before final validation.
