### PR TITLE
[codex] Offload PMA tail/status store reads from the event loop

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
@@ -491,6 +491,76 @@ def _managed_thread_harness(service: Any, agent_id: str) -> Any:
         return None
 
 
+def _load_managed_thread_tail_store_state(
+    *,
+    hub_root: Path,
+    service: Any,
+    managed_thread_id: str,
+) -> tuple[Any, Any, list[dict[str, Any]], Any]:
+    thread = service.get_thread_target(managed_thread_id)
+    if thread is None:
+        return None, None, [], None
+    turn = service.get_running_execution(
+        managed_thread_id
+    ) or service.get_latest_execution(managed_thread_id)
+    if turn is None:
+        return thread, None, [], None
+    managed_turn_id = str(turn.execution_id or "")
+    persisted_timeline_entries = list_turn_timeline(
+        hub_root,
+        execution_id=managed_turn_id,
+    )
+    turn_record = None
+    if managed_turn_id:
+        turn_record = PmaThreadStore(hub_root).get_turn(
+            managed_thread_id,
+            managed_turn_id,
+        )
+    return thread, turn, persisted_timeline_entries, turn_record
+
+
+def _load_managed_thread_status_state(
+    *,
+    hub_root: Path,
+    service: Any,
+    managed_thread_id: str,
+    limit: int,
+) -> tuple[Any, dict[str, Any] | None, list[dict[str, Any]], int]:
+    thread = service.get_thread_target(managed_thread_id)
+    if thread is None:
+        return None, None, [], 0
+    serialized_thread = _attach_latest_execution_fields(
+        _serialize_thread_target(thread),
+        service=service,
+        managed_thread_id=managed_thread_id,
+    )
+    queue_store = PmaThreadStore(hub_root)
+    queued_turns = queue_store.list_pending_turn_queue_items(
+        managed_thread_id,
+        limit=min(limit, 50),
+    )
+    queue_depth = service.get_queue_depth(managed_thread_id)
+    return thread, serialized_thread, queued_turns, queue_depth
+
+
+def _poll_managed_thread_execution_state(
+    *,
+    service: Any,
+    managed_thread_id: str,
+    managed_turn_id: str,
+) -> tuple[Any, str, Any]:
+    turn = service.get_execution(managed_thread_id, managed_turn_id)
+    status = str((turn.status if turn is not None else "") or "").strip().lower()
+    refreshed_thread = (
+        service.get_thread_target(managed_thread_id) if status == "running" else None
+    )
+    return turn, status, refreshed_thread
+
+
+async def _build_managed_thread_orchestration_service_async(request: Request) -> Any:
+    return await asyncio.to_thread(build_managed_thread_orchestration_service, request)
+
+
 def _runtime_raw_payload(raw_event: Any) -> dict[str, Any]:
     if isinstance(raw_event, dict):
         return dict(raw_event)
@@ -835,12 +905,14 @@ async def _build_managed_thread_tail_snapshot(
     since_ms: Optional[int],
     resume_after: Optional[int],
 ) -> dict[str, Any]:
-    thread = service.get_thread_target(managed_thread_id)
+    thread, turn, persisted_timeline_entries, turn_record = await asyncio.to_thread(
+        _load_managed_thread_tail_store_state,
+        hub_root=request.app.state.config.root,
+        service=service,
+        managed_thread_id=managed_thread_id,
+    )
     if thread is None:
         raise HTTPException(status_code=404, detail="Managed thread not found")
-    turn = service.get_running_execution(
-        managed_thread_id
-    ) or service.get_latest_execution(managed_thread_id)
     if turn is None:
         return {
             "managed_thread_id": managed_thread_id,
@@ -889,10 +961,6 @@ async def _build_managed_thread_tail_snapshot(
     )
     tail_events: list[dict[str, Any]] = []
     raw_last_activity_at: Optional[str] = None
-    persisted_timeline_entries = list_turn_timeline(
-        request.app.state.config.root,
-        execution_id=managed_turn_id,
-    )
     tail_events, raw_last_activity_at = _serialize_persisted_timeline_tail_events(
         persisted_timeline_entries,
         level=level,
@@ -989,8 +1057,6 @@ async def _build_managed_thread_tail_snapshot(
         events=tail_events,
         idle_seconds=idle_seconds,
     )
-    turn_store = PmaThreadStore(request.app.state.config.root)
-    turn_record = turn_store.get_turn(managed_thread_id, managed_turn_id)
     snapshot: dict[str, Any] = {
         "managed_thread_id": managed_thread_id,
         "managed_turn_id": managed_turn_id,
@@ -1039,7 +1105,7 @@ def build_managed_thread_tail_routes(
     ) -> dict[str, Any]:
         if limit <= 0:
             raise HTTPException(status_code=400, detail="limit must be greater than 0")
-        service = build_managed_thread_orchestration_service(request)
+        service = await _build_managed_thread_orchestration_service_async(request)
         snapshot = await _build_managed_thread_tail_snapshot(
             request=request,
             service=service,
@@ -1049,18 +1115,15 @@ def build_managed_thread_tail_routes(
             since_ms=since_ms_from_duration(since),
             resume_after=resolve_resume_after(request, since_event_id),
         )
-        thread = service.get_thread_target(managed_thread_id)
-        if thread is None:
-            raise HTTPException(status_code=404, detail="Managed thread not found")
-        serialized_thread = _attach_latest_execution_fields(
-            _serialize_thread_target(thread),
+        thread, serialized_thread, queued_turns, queue_depth = await asyncio.to_thread(
+            _load_managed_thread_status_state,
+            hub_root=request.app.state.config.root,
             service=service,
             managed_thread_id=managed_thread_id,
+            limit=limit,
         )
-        queue_store = PmaThreadStore(request.app.state.config.root)
-        queued_turns = queue_store.list_pending_turn_queue_items(
-            managed_thread_id, limit=min(limit, 50)
-        )
+        if thread is None or serialized_thread is None:
+            raise HTTPException(status_code=404, detail="Managed thread not found")
         turn_status = str(snapshot.get("turn_status") or "")
         return {
             "managed_thread_id": managed_thread_id,
@@ -1094,7 +1157,7 @@ def build_managed_thread_tail_routes(
                 "finished_at": snapshot.get("finished_at"),
                 "lifecycle_events": snapshot.get("lifecycle_events"),
             },
-            "queue_depth": service.get_queue_depth(managed_thread_id),
+            "queue_depth": queue_depth,
             "queued_turns": [
                 {
                     "managed_turn_id": item.get("managed_turn_id"),
@@ -1125,7 +1188,7 @@ def build_managed_thread_tail_routes(
     ) -> dict[str, Any]:
         if limit <= 0:
             raise HTTPException(status_code=400, detail="limit must be greater than 0")
-        service = build_managed_thread_orchestration_service(request)
+        service = await _build_managed_thread_orchestration_service_async(request)
         return await _build_managed_thread_tail_snapshot(
             request=request,
             service=service,
@@ -1149,8 +1212,11 @@ def build_managed_thread_tail_routes(
             raise HTTPException(status_code=400, detail="limit must be greater than 0")
         normalized_level = normalize_tail_level(level)
         since_ms = since_ms_from_duration(since)
-        service = build_managed_thread_orchestration_service(request)
-        thread_target = service.get_thread_target(managed_thread_id)
+        service = await _build_managed_thread_orchestration_service_async(request)
+        thread_target = await asyncio.to_thread(
+            service.get_thread_target,
+            managed_thread_id,
+        )
         harness = None
         if thread_target is not None:
             harness = _managed_thread_harness(
@@ -1189,14 +1255,11 @@ def build_managed_thread_tail_routes(
             if not snapshot.get("stream_available"):
                 while True:
                     await asyncio.sleep(5.0)
-                    turn = service.get_execution(
-                        managed_thread_id,
-                        str(snapshot.get("managed_turn_id") or ""),
-                    )
-                    status = (
-                        str((turn.status if turn is not None else "") or "")
-                        .strip()
-                        .lower()
+                    turn, status, refreshed_thread = await asyncio.to_thread(
+                        _poll_managed_thread_execution_state,
+                        service=service,
+                        managed_thread_id=managed_thread_id,
+                        managed_turn_id=str(snapshot.get("managed_turn_id") or ""),
                     )
                     if status != "running":
                         yield (
@@ -1205,7 +1268,6 @@ def build_managed_thread_tail_routes(
                         )
                         return
 
-                    refreshed_thread = service.get_thread_target(managed_thread_id)
                     refreshed_backend_thread_id = (
                         normalize_optional_text(
                             getattr(refreshed_thread, "backend_thread_id", None)

--- a/tests/test_pma_managed_threads_tail.py
+++ b/tests/test_pma_managed_threads_tail.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Optional
 
 import pytest
@@ -717,6 +719,87 @@ def test_managed_thread_tail_snapshot_stream_available_when_backend_binding_appe
     assert after["backend_turn_id"] == "opencode-turn-bind"
 
 
+def test_managed_thread_tail_snapshot_offloads_store_reads(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    event_loop_thread_id = threading.get_ident()
+    observed_thread_ids: list[tuple[str, int]] = []
+    thread = SimpleNamespace(
+        agent_id="codex",
+        backend_thread_id="backend-thread-1",
+    )
+    turn = SimpleNamespace(
+        execution_id="managed-turn-1",
+        status="running",
+        started_at="2026-04-06T10:00:00Z",
+        finished_at=None,
+        backend_id="backend-turn-1",
+    )
+
+    class _FakeService:
+        def get_thread_target(self, managed_thread_id: str):
+            _ = managed_thread_id
+            observed_thread_ids.append(("get_thread_target", threading.get_ident()))
+            return thread
+
+        def get_running_execution(self, managed_thread_id: str):
+            _ = managed_thread_id
+            observed_thread_ids.append(("get_running_execution", threading.get_ident()))
+            return turn
+
+        def get_latest_execution(self, managed_thread_id: str):
+            _ = managed_thread_id
+            observed_thread_ids.append(("get_latest_execution", threading.get_ident()))
+            return None
+
+    class _FakeTurnStore:
+        def __init__(self, hub_root: Path) -> None:
+            _ = hub_root
+            observed_thread_ids.append(("store_init", threading.get_ident()))
+
+        def get_turn(self, managed_thread_id: str, managed_turn_id: str):
+            _ = managed_thread_id, managed_turn_id
+            observed_thread_ids.append(("get_turn", threading.get_ident()))
+            return None
+
+    def _fake_list_turn_timeline(hub_root: Path, *, execution_id: str):
+        _ = hub_root, execution_id
+        observed_thread_ids.append(("list_turn_timeline", threading.get_ident()))
+        return []
+
+    monkeypatch.setattr(tail_stream, "PmaThreadStore", _FakeTurnStore)
+    monkeypatch.setattr(tail_stream, "list_turn_timeline", _fake_list_turn_timeline)
+
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                config=SimpleNamespace(root=tmp_path),
+            )
+        )
+    )
+
+    import asyncio
+
+    snapshot = asyncio.run(
+        tail_stream._build_managed_thread_tail_snapshot(
+            request=request,
+            service=_FakeService(),
+            managed_thread_id="managed-thread-1",
+            limit=20,
+            level="info",
+            since_ms=None,
+            resume_after=None,
+        )
+    )
+
+    assert snapshot["managed_thread_id"] == "managed-thread-1"
+    assert snapshot["managed_turn_id"] == "managed-turn-1"
+    assert observed_thread_ids
+    assert all(
+        thread_id != event_loop_thread_id for _label, thread_id in observed_thread_ids
+    )
+
+
 def test_managed_thread_status_aggregates_thread_turn_and_progress(hub_env) -> None:
     _enable_pma(hub_env.hub_root)
     app = create_hub_app(hub_env.hub_root)
@@ -790,6 +873,30 @@ def test_managed_thread_status_aggregates_thread_turn_and_progress(hub_env) -> N
             payload["thread"]["latest_assistant_text"] == "completed assistant output"
         )
         assert payload["thread"]["latest_turn_status"] == "ok"
+
+
+def test_managed_thread_status_route_offloads_blocking_reads(
+    hub_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+    managed_thread_id, _ = _seed_managed_thread_with_events(hub_env, app)
+    original_to_thread = tail_stream.asyncio.to_thread
+    offloaded_calls: list[str] = []
+
+    async def _recording_to_thread(func, /, *args, **kwargs):
+        offloaded_calls.append(getattr(func, "__name__", repr(func)))
+        return await original_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(tail_stream.asyncio, "to_thread", _recording_to_thread)
+
+    with TestClient(app) as client:
+        resp = client.get(f"/hub/pma/threads/{managed_thread_id}/status")
+
+    assert resp.status_code == 200
+    assert "build_managed_thread_orchestration_service" in offloaded_calls
+    assert "_load_managed_thread_tail_store_state" in offloaded_calls
+    assert "_load_managed_thread_status_state" in offloaded_calls
 
 
 def test_managed_thread_status_surfaces_attention_required_separately_from_failure(


### PR DESCRIPTION
## Summary
- move the managed-thread tail snapshot's blocking orchestration and PMA store reads behind `asyncio.to_thread`
- offload the status route's thread/latest-turn/queue lookups and the SSE fallback polling path off the hub event loop
- add regression coverage that verifies the snapshot helper runs store reads on a worker thread and the `/status` route uses the offload helpers

## Why
The hub runs all HTTP handlers and PMA background work on one asyncio event loop. The managed-thread tail and status paths were doing synchronous SQLite-backed reads directly from async handlers. Under SQLite contention, those reads could block the event loop long enough for the hub to accept TCP connections but return no HTTP bytes.

## Impact
This keeps the PMA tail, status, and fallback polling paths responsive even when orchestration or PMA SQLite reads are slow or contended, which reduces the chance of the hub appearing hung while one request is blocked on storage.

## Root Cause
The async PMA routes called `service.get_thread_target()`, execution lookups, `list_turn_timeline()`, `PmaThreadStore(...).get_turn()`, queue reads, and execution polling synchronously on the event loop.

## Validation
- `.venv/bin/python -m pytest tests/test_pma_managed_threads_tail.py`
- repo pre-commit pipeline during `git commit`:
  - black
  - ruff
  - strict mypy
  - frontend build/tests
  - full pytest suite

Closes #1375