### PR TITLE
[codex] Fix Discord PMA progress lease cleanup

### DIFF
--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -233,7 +233,7 @@ class HermesSupervisor:
         async with self._lock:
             previous_turn_id = self._session_turns.get((workspace, session_id))
             if previous_turn_id:
-                previous_state = self._turn_states.pop(
+                previous_state = self._turn_states.get(
                     (workspace, previous_turn_id),
                     None,
                 )
@@ -246,7 +246,7 @@ class HermesSupervisor:
             self._turn_states[(workspace, handle.turn_id)] = state
             self._session_turns[(workspace, session_id)] = handle.turn_id
         if previous_state is not None:
-            await self._retire_turn_state(previous_state)
+            await self._cancel_pending_approval_task(previous_state)
         for event in await self._acp.prompt_events_snapshot(
             workspace_root, handle.turn_id
         ):
@@ -505,6 +505,10 @@ class HermesSupervisor:
             existing_events.append(payload)
 
     async def _retire_turn_state(self, state: _HermesTurnState) -> None:
+        await self._cancel_pending_approval_task(state)
+        await state.event_buffer.close()
+
+    async def _cancel_pending_approval_task(self, state: _HermesTurnState) -> None:
         async with self._lock:
             pending_task = state.pending_approval_task
             state.pending_approval_task = None
@@ -520,7 +524,6 @@ class HermesSupervisor:
                     state.turn_id,
                     exc_info=True,
                 )
-        await state.event_buffer.close()
 
     async def _handle_acp_event(
         self,

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -897,7 +897,9 @@ def _spawn_discord_background_task(
     *,
     await_on_shutdown: bool = False,
 ) -> asyncio.Task[Any]:
-    spawn_task = service._spawn_task
+    spawn_task = getattr(service, "_spawn_task", None)
+    if not callable(spawn_task):
+        return cast(asyncio.Task[Any], asyncio.ensure_future(coro))
     if not await_on_shutdown:
         return cast(asyncio.Task[Any], spawn_task(coro))
     try:
@@ -909,6 +911,97 @@ def _spawn_discord_background_task(
         if "await_on_shutdown" not in str(exc):
             raise
         return cast(asyncio.Task[Any], spawn_task(coro))
+
+
+def _spawn_discord_progress_background_task(
+    service: Any,
+    coro: Awaitable[None],
+    *,
+    managed_thread_id: Optional[str] = None,
+    execution_id: Optional[str] = None,
+    lease_id: Optional[str] = None,
+    channel_id: Optional[str] = None,
+    message_id: Optional[str] = None,
+    failure_note: Optional[str] = None,
+    orphaned: bool = False,
+    await_on_shutdown: bool = False,
+) -> asyncio.Task[Any]:
+    task = _spawn_discord_background_task(
+        service,
+        coro,
+        await_on_shutdown=await_on_shutdown,
+    )
+    return bind_discord_progress_task_context(
+        task,
+        managed_thread_id=managed_thread_id,
+        execution_id=execution_id,
+        lease_id=lease_id,
+        channel_id=channel_id,
+        message_id=message_id,
+        failure_note=failure_note,
+        orphaned=orphaned,
+    )
+
+
+def _discord_progress_lease_is_not_newer_than_terminal_turn(
+    lease: Any,
+    *,
+    terminal_message_id: Optional[str],
+    terminal_created_at: Optional[str],
+) -> bool:
+    lease_message_id = _execution_field(lease, "message_id")
+    if (
+        isinstance(lease_message_id, str)
+        and lease_message_id.isdigit()
+        and isinstance(terminal_message_id, str)
+        and terminal_message_id.isdigit()
+    ):
+        return int(lease_message_id) <= int(terminal_message_id)
+    lease_created_at = _execution_field(lease, "created_at")
+    if lease_created_at and terminal_created_at:
+        return lease_created_at <= terminal_created_at
+    return False
+
+
+async def _reconcile_other_discord_turn_progress_leases(
+    service: Any,
+    *,
+    managed_thread_id: Optional[str],
+    keep_lease_id: Optional[str] = None,
+    keep_message_id: Optional[str] = None,
+    terminal_message_id: Optional[str] = None,
+    terminal_created_at: Optional[str] = None,
+) -> int:
+    normalized_thread_id = str(managed_thread_id or "").strip()
+    if not normalized_thread_id:
+        return 0
+    retained_lease_id = str(keep_lease_id or "").strip() or None
+    retained_message_id = str(keep_message_id or "").strip() or None
+    reconciled = 0
+    for lease in await _list_discord_progress_leases(
+        service,
+        managed_thread_id=normalized_thread_id,
+    ):
+        current_lease_id = _execution_field(lease, "lease_id")
+        current_message_id = _execution_field(lease, "message_id")
+        current_execution_id = _execution_field(lease, "execution_id")
+        if current_lease_id and current_lease_id == retained_lease_id:
+            continue
+        if current_message_id and current_message_id == retained_message_id:
+            continue
+        if current_execution_id is None and not (
+            _discord_progress_lease_is_not_newer_than_terminal_turn(
+                lease,
+                terminal_message_id=terminal_message_id,
+                terminal_created_at=terminal_created_at,
+            )
+        ):
+            continue
+        reconciled += await reconcile_discord_turn_progress_leases(
+            service,
+            lease_id=current_lease_id,
+        )
+    return reconciled
 
 
 async def _acknowledge_discord_progress_reuse(
@@ -1699,6 +1792,27 @@ async def _deliver_discord_turn_result(
         send_final_message = True
         preserve_progress_lease = False
 
+    managed_thread_id = None
+    current_lease_id = None
+    current_message_id = None
+    current_lease_created_at = None
+    if supervision is not None:
+        managed_thread_id = _execution_field(
+            supervision.task_context,
+            "managed_thread_id",
+        )
+        current_lease_id = _execution_field(supervision.task_context, "lease_id")
+        current_message_id = _execution_field(supervision.task_context, "message_id")
+        if current_lease_id:
+            current_lease = await _get_discord_progress_lease(
+                dispatch.service,
+                lease_id=current_lease_id,
+            )
+            current_lease_created_at = _execution_field(
+                current_lease,
+                "created_at",
+            )
+
     if supervision is not None:
         supervision.set_message_id(preview_message_id)
         supervision.set_execution_id(execution_id)
@@ -1759,14 +1873,24 @@ async def _deliver_discord_turn_result(
                 )
         if supervision is not None:
             supervision.set_lease_id(None)
-    if send_final_message:
-        await _send_discord_turn_section(
+    try:
+        if send_final_message:
+            await _send_discord_turn_section(
+                dispatch.service,
+                channel_id=dispatch.channel_id,
+                text=response_text or "(No response text returned.)",
+                record_prefix=f"turn:final:{dispatch.session_key}",
+                attachment_filename="final-response.md",
+                attachment_caption="Final response too long; attached as final-response.md.",
+            )
+    finally:
+        await _reconcile_other_discord_turn_progress_leases(
             dispatch.service,
-            channel_id=dispatch.channel_id,
-            text=response_text or "(No response text returned.)",
-            record_prefix=f"turn:final:{dispatch.session_key}",
-            attachment_filename="final-response.md",
-            attachment_caption="Final response too long; attached as final-response.md.",
+            managed_thread_id=managed_thread_id,
+            keep_lease_id=current_lease_id if preserve_progress_lease else None,
+            keep_message_id=current_message_id if preserve_progress_lease else None,
+            terminal_message_id=current_message_id,
+            terminal_created_at=current_lease_created_at,
         )
     try:
         if dispatch.pending_compact_seed is not None:
@@ -2620,12 +2744,14 @@ async def _run_discord_orchestrated_turn_for_message(
                 supervision.set_message_id(progress_message_id)
             await _register_progress_lease(state="pending")
             await _edit_progress(force=True)
-            progress_heartbeat_task = bind_discord_progress_task_context(
-                asyncio.create_task(_progress_heartbeat()),
+            progress_heartbeat_task = _spawn_discord_progress_background_task(
+                service,
+                _progress_heartbeat(),
                 managed_thread_id=managed_thread_id,
                 lease_id=progress_lease_id,
                 channel_id=channel_id,
                 message_id=progress_message_id,
+                await_on_shutdown=True,
             )
         else:
             initial_rendered = render_progress_text(
@@ -2658,12 +2784,14 @@ async def _run_discord_orchestrated_turn_for_message(
                 progress_rendered = initial_content
                 progress_last_updated = time.monotonic()
                 await _register_progress_lease(state="pending")
-                progress_heartbeat_task = bind_discord_progress_task_context(
-                    asyncio.create_task(_progress_heartbeat()),
+                progress_heartbeat_task = _spawn_discord_progress_background_task(
+                    service,
+                    _progress_heartbeat(),
                     managed_thread_id=managed_thread_id,
                     lease_id=progress_lease_id,
                     channel_id=channel_id,
                     message_id=progress_message_id,
+                    await_on_shutdown=True,
                 )
     except (DiscordTransientError, RuntimeError, ConnectionError, OSError):
         service._logger.warning(
@@ -2964,16 +3092,16 @@ async def _run_discord_orchestrated_turn_for_message(
             queue=ManagedSurfaceQueueConfig(
                 task_map=_get_discord_thread_queue_task_map(service),
                 managed_thread_id=managed_thread_id,
-                spawn_task=lambda coro: bind_discord_progress_task_context(
-                    _spawn_discord_background_task(
-                        service, coro, await_on_shutdown=True
-                    ),
+                spawn_task=lambda coro: _spawn_discord_progress_background_task(
+                    service,
+                    coro,
                     managed_thread_id=managed_thread_id,
                     failure_note=(
                         "Status: this progress message lost its queue worker and is "
                         "no longer live. Please retry if needed."
                     ),
                     orphaned=True,
+                    await_on_shutdown=True,
                 ),
                 begin_next_execution=cast(
                     ManagedThreadQueuedExecutionStarter,

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -957,9 +957,6 @@ def _discord_progress_lease_is_not_newer_than_terminal_turn(
         and terminal_message_id.isdigit()
     ):
         return int(lease_message_id) <= int(terminal_message_id)
-    lease_created_at = _execution_field(lease, "created_at")
-    if lease_created_at and terminal_created_at:
-        return lease_created_at <= terminal_created_at
     return False
 
 
@@ -987,6 +984,11 @@ async def _reconcile_other_discord_turn_progress_leases(
         if current_lease_id and current_lease_id == retained_lease_id:
             continue
         if current_message_id and current_message_id == retained_message_id:
+            continue
+        # A sibling lease on the same Discord message can only exist when a newer
+        # turn has reused that progress message and replaced the older lease row.
+        # Older-turn delivery must never retire that replacement lease.
+        if current_message_id and current_message_id == terminal_message_id:
             continue
         # Older-turn delivery should never retire a sibling lease that belongs to
         # a newer turn on the same managed thread, even if that newer turn has
@@ -1847,17 +1849,26 @@ async def _deliver_discord_turn_result(
             ),
         )
         if preview_message_deleted:
-            for lease in await _list_discord_progress_leases(
-                dispatch.service,
-                channel_id=dispatch.channel_id,
-                message_id=preview_message_id,
+            if current_lease_id:
+                await _delete_discord_progress_lease(
+                    dispatch.service,
+                    lease_id=current_lease_id,
+                )
+            elif (
+                isinstance(execution_id, str)
+                and execution_id
+                and not preserve_progress_lease
             ):
-                current_lease_id = _execution_field(lease, "lease_id")
-                if current_lease_id:
-                    await _delete_discord_progress_lease(
-                        dispatch.service,
-                        lease_id=current_lease_id,
-                    )
+                for lease in await _list_discord_progress_leases(
+                    dispatch.service,
+                    execution_id=execution_id,
+                ):
+                    orphaned_lease_id = _execution_field(lease, "lease_id")
+                    if orphaned_lease_id:
+                        await _delete_discord_progress_lease(
+                            dispatch.service,
+                            lease_id=orphaned_lease_id,
+                        )
             if supervision is not None:
                 supervision.clear_progress_tracking()
     elif isinstance(execution_id, str) and execution_id and not preserve_progress_lease:

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -984,17 +984,17 @@ async def _reconcile_other_discord_turn_progress_leases(
     ):
         current_lease_id = _execution_field(lease, "lease_id")
         current_message_id = _execution_field(lease, "message_id")
-        current_execution_id = _execution_field(lease, "execution_id")
         if current_lease_id and current_lease_id == retained_lease_id:
             continue
         if current_message_id and current_message_id == retained_message_id:
             continue
-        if current_execution_id is None and not (
-            _discord_progress_lease_is_not_newer_than_terminal_turn(
-                lease,
-                terminal_message_id=terminal_message_id,
-                terminal_created_at=terminal_created_at,
-            )
+        # Older-turn delivery should never retire a sibling lease that belongs to
+        # a newer turn on the same managed thread, even if that newer turn has
+        # already been assigned an execution id.
+        if not _discord_progress_lease_is_not_newer_than_terminal_turn(
+            lease,
+            terminal_message_id=terminal_message_id,
+            terminal_created_at=terminal_created_at,
         ):
             continue
         reconciled += await reconcile_discord_turn_progress_leases(

--- a/tests/agents/hermes/test_hermes_supervisor.py
+++ b/tests/agents/hermes/test_hermes_supervisor.py
@@ -601,12 +601,61 @@ async def test_hermes_supervisor_replacing_turn_cancels_previous_pending_approva
             session.session_id,
             second_turn_id,
         )
-
-        with pytest.raises(HermesSupervisorError, match="Unknown Hermes turn"):
-            await supervisor.wait_for_turn(tmp_path, session.session_id, first_turn_id)
+        first_result = await supervisor.wait_for_turn(
+            tmp_path,
+            session.session_id,
+            first_turn_id,
+        )
+        assert first_result.status == "cancelled"
         assert second_result.status == "completed"
     finally:
         approval_gate.set()
+        await supervisor.close_all()
+
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_hermes_supervisor_preserves_completed_turn_after_newer_turn_starts(
+    tmp_path: Path,
+) -> None:
+    supervisor = HermesSupervisor(fixture_command("official"))
+    try:
+        session = await supervisor.create_session(tmp_path)
+        first_turn_id = await supervisor.start_turn(
+            tmp_path,
+            session.session_id,
+            "hello from hermes",
+        )
+        await asyncio.sleep(0.2)
+
+        second_turn_id = await supervisor.start_turn(
+            tmp_path,
+            session.session_id,
+            "hello again",
+        )
+
+        first_result = await supervisor.wait_for_turn(
+            tmp_path,
+            session.session_id,
+            first_turn_id,
+        )
+        second_result = await supervisor.wait_for_turn(
+            tmp_path,
+            session.session_id,
+            second_turn_id,
+        )
+
+        assert first_result.status == "completed"
+        assert any(
+            event.get("method") == "prompt/completed"
+            for event in first_result.raw_events
+        )
+        assert second_result.status == "completed"
+        assert any(
+            event.get("method") == "prompt/completed"
+            for event in second_result.raw_events
+        )
+    finally:
         await supervisor.close_all()
 
 

--- a/tests/integrations/discord/test_message_turns_transient_progress.py
+++ b/tests/integrations/discord/test_message_turns_transient_progress.py
@@ -437,6 +437,102 @@ async def test_deliver_result_keeps_newer_pending_sibling_progress_lease(
 
 
 @pytest.mark.asyncio
+async def test_deliver_result_keeps_newer_queued_sibling_progress_lease_with_execution_id(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = support.DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-current",
+        managed_thread_id="thread-1",
+        execution_id="exec-2",
+        channel_id="channel-1",
+        message_id="200",
+        state="active",
+        progress_label="working",
+    )
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-newer",
+        managed_thread_id="thread-1",
+        execution_id="exec-3",
+        channel_id="channel-1",
+        message_id="300",
+        state="active",
+        progress_label="queued",
+    )
+
+    def _get_execution(_thread_id: str, execution_id: str) -> SimpleNamespace:
+        status = "queued" if execution_id == "exec-3" else "ok"
+        return SimpleNamespace(
+            execution_id=execution_id,
+            status=status,
+        )
+
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "build_discord_thread_orchestration_service",
+        lambda _service: SimpleNamespace(
+            get_thread_target=lambda _thread_id: SimpleNamespace(
+                thread_target_id="thread-1"
+            ),
+            get_latest_execution=lambda _thread_id: SimpleNamespace(
+                execution_id="exec-3",
+                status="queued",
+            ),
+            get_running_execution=lambda _thread_id: None,
+            get_execution=_get_execution,
+        ),
+    )
+
+    rest = support._FakeRest()
+    service = support.DiscordBotService(
+        support._config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=support._FakeGateway([]),
+        state_store=store,
+        outbox_manager=support._FakeOutboxManager(),
+    )
+    supervision = support.discord_message_turns_module._DiscordTurnExecutionSupervision(
+        service,
+        channel_id="channel-1",
+    )
+    supervision.set_managed_thread_id("thread-1")
+    supervision.set_lease_id("lease-current")
+    supervision.set_message_id("200")
+    supervision.set_execution_id("exec-2")
+    dispatch = SimpleNamespace(
+        service=service,
+        channel_id="channel-1",
+        session_key="session-1",
+        pending_compact_seed=None,
+        agent="codex",
+        model_override=None,
+    )
+
+    try:
+        await support.discord_message_turns_module._deliver_discord_turn_result(
+            dispatch,
+            workspace_root=workspace,
+            turn_result=support.DiscordMessageTurnResult(
+                final_message="done",
+                preview_message_id="200",
+                execution_id="exec-2",
+            ),
+            supervision=supervision,
+        )
+
+        remaining = await store.list_turn_progress_leases(managed_thread_id="thread-1")
+        assert [lease.lease_id for lease in remaining] == ["lease-newer"]
+        assert rest.edited_channel_messages == []
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
 async def test_orchestrated_turn_interrupt_send_falls_back_when_progress_ack_edit_is_transient(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,

--- a/tests/integrations/discord/test_message_turns_transient_progress.py
+++ b/tests/integrations/discord/test_message_turns_transient_progress.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import logging
 from types import SimpleNamespace
 from typing import Any, Optional
@@ -22,6 +23,52 @@ class _TransientEditProgressRest(support._FakeRest):
         _ = channel_id, message_id, payload
         self.edit_attempts += 1
         raise DiscordTransientError("simulated transient progress edit failure")
+
+
+@pytest.mark.asyncio
+async def test_spawn_discord_progress_background_task_uses_service_tracking() -> None:
+    class _Service:
+        def __init__(self) -> None:
+            self.spawn_kwargs: list[bool] = []
+
+        def _spawn_task(
+            self,
+            coro: Any,
+            *,
+            await_on_shutdown: bool = False,
+        ) -> asyncio.Task[Any]:
+            self.spawn_kwargs.append(await_on_shutdown)
+            return asyncio.create_task(coro)
+
+    async def _noop() -> None:
+        return None
+
+    service = _Service()
+    task = support.discord_message_turns_module._spawn_discord_progress_background_task(
+        service,
+        _noop(),
+        managed_thread_id="thread-1",
+        lease_id="lease-1",
+        channel_id="channel-1",
+        message_id="msg-1",
+        await_on_shutdown=True,
+    )
+
+    try:
+        await task
+    finally:
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    assert service.spawn_kwargs == [True]
+    assert getattr(task, "_discord_progress_task_context", None) == {
+        "managed_thread_id": "thread-1",
+        "lease_id": "lease-1",
+        "channel_id": "channel-1",
+        "message_id": "msg-1",
+    }
 
 
 @pytest.mark.anyio
@@ -97,6 +144,294 @@ async def test_reconcile_progress_lease_retries_when_retire_edit_fails(
                 },
             }
         ]
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_deliver_result_reconciles_stale_sibling_progress_leases(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = support.DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-stale",
+        managed_thread_id="thread-1",
+        execution_id=None,
+        channel_id="channel-1",
+        message_id="100",
+        state="pending",
+        progress_label="working",
+    )
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-current",
+        managed_thread_id="thread-1",
+        execution_id="exec-2",
+        channel_id="channel-1",
+        message_id="200",
+        state="active",
+        progress_label="working",
+    )
+
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "build_discord_thread_orchestration_service",
+        lambda _service: SimpleNamespace(
+            get_thread_target=lambda _thread_id: SimpleNamespace(
+                thread_target_id="thread-1"
+            ),
+            get_latest_execution=lambda _thread_id: SimpleNamespace(
+                execution_id="exec-2",
+                status="ok",
+            ),
+            get_running_execution=lambda _thread_id: None,
+            get_execution=lambda _thread_id, execution_id: SimpleNamespace(
+                execution_id=execution_id,
+                status="ok",
+            ),
+        ),
+    )
+
+    rest = support._FakeRest()
+    service = support.DiscordBotService(
+        support._config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=support._FakeGateway([]),
+        state_store=store,
+        outbox_manager=support._FakeOutboxManager(),
+    )
+    supervision = support.discord_message_turns_module._DiscordTurnExecutionSupervision(
+        service,
+        channel_id="channel-1",
+    )
+    supervision.set_managed_thread_id("thread-1")
+    supervision.set_lease_id("lease-current")
+    supervision.set_message_id("200")
+    supervision.set_execution_id("exec-2")
+    dispatch = SimpleNamespace(
+        service=service,
+        channel_id="channel-1",
+        session_key="session-1",
+        pending_compact_seed=None,
+        agent="codex",
+        model_override=None,
+    )
+
+    try:
+        await support.discord_message_turns_module._deliver_discord_turn_result(
+            dispatch,
+            workspace_root=workspace,
+            turn_result=support.DiscordMessageTurnResult(
+                final_message="done",
+                preview_message_id="200",
+                execution_id="exec-2",
+            ),
+            supervision=supervision,
+        )
+
+        assert await store.list_turn_progress_leases(managed_thread_id="thread-1") == []
+        assert any(
+            deleted["message_id"] == "200" for deleted in rest.deleted_channel_messages
+        )
+        assert any(
+            edited["message_id"] == "100"
+            and "failed before execution started"
+            in edited["payload"]["content"].lower()
+            for edited in rest.edited_channel_messages
+        )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_deliver_result_reconciles_stale_siblings_without_final_message(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = support.DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-stale",
+        managed_thread_id="thread-1",
+        execution_id=None,
+        channel_id="channel-1",
+        message_id="100",
+        state="pending",
+        progress_label="working",
+    )
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-current",
+        managed_thread_id="thread-1",
+        execution_id="exec-2",
+        channel_id="channel-1",
+        message_id="200",
+        state="active",
+        progress_label="working",
+    )
+
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "build_discord_thread_orchestration_service",
+        lambda _service: SimpleNamespace(
+            get_thread_target=lambda _thread_id: SimpleNamespace(
+                thread_target_id="thread-1"
+            ),
+            get_latest_execution=lambda _thread_id: SimpleNamespace(
+                execution_id="exec-2",
+                status="interrupted",
+            ),
+            get_running_execution=lambda _thread_id: None,
+            get_execution=lambda _thread_id, execution_id: SimpleNamespace(
+                execution_id=execution_id,
+                status="interrupted",
+            ),
+        ),
+    )
+
+    rest = support._FakeRest()
+    service = support.DiscordBotService(
+        support._config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=support._FakeGateway([]),
+        state_store=store,
+        outbox_manager=support._FakeOutboxManager(),
+    )
+    supervision = support.discord_message_turns_module._DiscordTurnExecutionSupervision(
+        service,
+        channel_id="channel-1",
+    )
+    supervision.set_managed_thread_id("thread-1")
+    supervision.set_lease_id("lease-current")
+    supervision.set_message_id("200")
+    supervision.set_execution_id("exec-2")
+    dispatch = SimpleNamespace(
+        service=service,
+        channel_id="channel-1",
+        session_key="session-1",
+        pending_compact_seed=None,
+        agent="codex",
+        model_override=None,
+    )
+
+    try:
+        await support.discord_message_turns_module._deliver_discord_turn_result(
+            dispatch,
+            workspace_root=workspace,
+            turn_result=support.DiscordMessageTurnResult(
+                final_message="Message received. Switching to it now...",
+                execution_id="exec-2",
+                send_final_message=False,
+            ),
+            supervision=supervision,
+        )
+
+        assert await store.list_turn_progress_leases(managed_thread_id="thread-1") == []
+        assert rest.channel_messages == []
+        assert any(
+            edited["message_id"] == "100"
+            and "failed before execution started"
+            in edited["payload"]["content"].lower()
+            for edited in rest.edited_channel_messages
+        )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_deliver_result_keeps_newer_pending_sibling_progress_lease(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = support.DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-current",
+        managed_thread_id="thread-1",
+        execution_id="exec-2",
+        channel_id="channel-1",
+        message_id="200",
+        state="active",
+        progress_label="working",
+    )
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-newer",
+        managed_thread_id="thread-1",
+        execution_id=None,
+        channel_id="channel-1",
+        message_id="300",
+        state="pending",
+        progress_label="working",
+    )
+
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "build_discord_thread_orchestration_service",
+        lambda _service: SimpleNamespace(
+            get_thread_target=lambda _thread_id: SimpleNamespace(
+                thread_target_id="thread-1"
+            ),
+            get_latest_execution=lambda _thread_id: SimpleNamespace(
+                execution_id="exec-2",
+                status="ok",
+            ),
+            get_running_execution=lambda _thread_id: None,
+            get_execution=lambda _thread_id, execution_id: SimpleNamespace(
+                execution_id=execution_id,
+                status="ok",
+            ),
+        ),
+    )
+
+    rest = support._FakeRest()
+    service = support.DiscordBotService(
+        support._config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=support._FakeGateway([]),
+        state_store=store,
+        outbox_manager=support._FakeOutboxManager(),
+    )
+    supervision = support.discord_message_turns_module._DiscordTurnExecutionSupervision(
+        service,
+        channel_id="channel-1",
+    )
+    supervision.set_managed_thread_id("thread-1")
+    supervision.set_lease_id("lease-current")
+    supervision.set_message_id("200")
+    supervision.set_execution_id("exec-2")
+    dispatch = SimpleNamespace(
+        service=service,
+        channel_id="channel-1",
+        session_key="session-1",
+        pending_compact_seed=None,
+        agent="codex",
+        model_override=None,
+    )
+
+    try:
+        await support.discord_message_turns_module._deliver_discord_turn_result(
+            dispatch,
+            workspace_root=workspace,
+            turn_result=support.DiscordMessageTurnResult(
+                final_message="done",
+                preview_message_id="200",
+                execution_id="exec-2",
+            ),
+            supervision=supervision,
+        )
+
+        remaining = await store.list_turn_progress_leases(managed_thread_id="thread-1")
+        assert [lease.lease_id for lease in remaining] == ["lease-newer"]
+        assert rest.edited_channel_messages == []
     finally:
         await store.close()
 

--- a/tests/integrations/discord/test_message_turns_transient_progress.py
+++ b/tests/integrations/discord/test_message_turns_transient_progress.py
@@ -533,6 +533,104 @@ async def test_deliver_result_keeps_newer_queued_sibling_progress_lease_with_exe
 
 
 @pytest.mark.asyncio
+async def test_deliver_result_keeps_newer_reused_progress_message_lease(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = support.DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-current",
+        managed_thread_id="thread-1",
+        execution_id="exec-2",
+        channel_id="channel-1",
+        message_id="200",
+        state="active",
+        progress_label="working",
+    )
+    # Reusing the same progress message for a newer queued execution replaces the
+    # stored lease row but must not be retired by the older turn's delivery.
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-newer",
+        managed_thread_id="thread-1",
+        execution_id="exec-3",
+        channel_id="channel-1",
+        message_id="200",
+        state="active",
+        progress_label="queued",
+    )
+
+    def _get_execution(_thread_id: str, execution_id: str) -> SimpleNamespace:
+        status = "queued" if execution_id == "exec-3" else "ok"
+        return SimpleNamespace(
+            execution_id=execution_id,
+            status=status,
+        )
+
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "build_discord_thread_orchestration_service",
+        lambda _service: SimpleNamespace(
+            get_thread_target=lambda _thread_id: SimpleNamespace(
+                thread_target_id="thread-1"
+            ),
+            get_latest_execution=lambda _thread_id: SimpleNamespace(
+                execution_id="exec-3",
+                status="queued",
+            ),
+            get_running_execution=lambda _thread_id: None,
+            get_execution=_get_execution,
+        ),
+    )
+
+    rest = support._FakeRest()
+    service = support.DiscordBotService(
+        support._config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=support._FakeGateway([]),
+        state_store=store,
+        outbox_manager=support._FakeOutboxManager(),
+    )
+    supervision = support.discord_message_turns_module._DiscordTurnExecutionSupervision(
+        service,
+        channel_id="channel-1",
+    )
+    supervision.set_managed_thread_id("thread-1")
+    supervision.set_lease_id("lease-current")
+    supervision.set_message_id("200")
+    supervision.set_execution_id("exec-2")
+    dispatch = SimpleNamespace(
+        service=service,
+        channel_id="channel-1",
+        session_key="session-1",
+        pending_compact_seed=None,
+        agent="codex",
+        model_override=None,
+    )
+
+    try:
+        await support.discord_message_turns_module._deliver_discord_turn_result(
+            dispatch,
+            workspace_root=workspace,
+            turn_result=support.DiscordMessageTurnResult(
+                final_message="done",
+                preview_message_id="200",
+                execution_id="exec-2",
+            ),
+            supervision=supervision,
+        )
+
+        remaining = await store.list_turn_progress_leases(managed_thread_id="thread-1")
+        assert [lease.lease_id for lease in remaining] == ["lease-newer"]
+        assert rest.edited_channel_messages == []
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
 async def test_orchestrated_turn_interrupt_send_falls_back_when_progress_ack_edit_is_transient(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,


### PR DESCRIPTION
## What changed
This PR fixes a cluster of Discord managed-thread PMA failures where Discord progress state drifted away from the underlying Hermes/orchestration state.

The branch now does four things:
- retires stale Discord sibling progress leases after terminal delivery instead of only cleaning up the just-finished preview/execution lease
- routes Discord progress heartbeat tasks through the service background-task tracker so cleanup and failure reconciliation use the normal service lifecycle
- preserves older Hermes turn state when a newer turn starts in the same Hermes session so late `wait_for_turn()` / finalization calls do not fail with `Unknown Hermes turn ...`
- protects newer Discord sibling leases when a queued turn reuses an existing progress message, including the cleanup path after preview-message deletion

## Why
The failing PMA threads showed two distinct disconnects:
- Hermes had already completed, but Discord still showed `working` because an older sibling progress lease survived
- Discord/orchestration was still finalizing against an older Hermes turn id after a newer turn had started in the same Hermes session, which produced `Unknown Hermes turn 'turn-3'`

The reused-progress-message path also had a second Discord-only edge case: if a newer queued turn inherited the same progress message, older-turn cleanup could delete or reconcile that replacement lease incorrectly.

## Root causes
- Discord progress cleanup was scoped too narrowly to the current preview/execution and missed sibling leases on the same managed thread.
- The reused-progress-message path treated `message_id` as if it implied turn ordering, even when a newer queued turn intentionally reused the same message.
- `HermesSupervisor.start_turn()` retired the previous turn state immediately on same-session supersession, so any later explicit wait/finalization against that older turn id failed even though the underlying Hermes turn had completed.

## Impact
After this change:
- stale Discord PMA placeholders are retired when a turn finishes, even when the terminal path does not send a fresh final message
- newer queued/reused placeholders are not swept just because an older turn finished first
- Hermes same-session supersession no longer breaks late delivery/finalization for the older explicit turn id
- Discord progress background failures and shutdown cleanup continue to flow through the tracked service task lifecycle

## Validation
- `pytest tests/agents/hermes/test_hermes_supervisor.py tests/integrations/discord/test_message_turns_transient_progress.py tests/test_discord_message_turn_background_failures.py tests/integrations/discord/test_service_routing.py`
- `python -m mypy src/codex_autorunner/agents/hermes/supervisor.py src/codex_autorunner/integrations/discord/message_turns.py`
- `ruff check src/codex_autorunner/agents/hermes/supervisor.py src/codex_autorunner/integrations/discord/message_turns.py tests/agents/hermes/test_hermes_supervisor.py tests/integrations/discord/test_message_turns_transient_progress.py`
- full pre-commit/commit hook suite, including repo-wide `mypy`, `pnpm run build`, frontend JS tests, and repo-wide `pytest` (`4974 passed`)
