### PR TITLE
[codex] Fix Discord stale interaction reconnect cascade

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -1502,6 +1502,32 @@ class DiscordBotService:
             )
         return acknowledged
 
+    def _dispatch_ack_failure_confirms_expiry(
+        self,
+        ctx: IngressContext,
+        envelope: RuntimeInteractionEnvelope,
+    ) -> bool:
+        ack_policy = envelope.dispatch_ack_policy
+        if ack_policy in (None, "immediate"):
+            return False
+
+        ack_finished_at = ctx.timing.ack_finished_at
+        ingress_started_at = ctx.timing.ingress_started_at
+        if ack_finished_at is not None and ingress_started_at is not None:
+            ack_deadline_at = ingress_started_at + self._initial_ack_budget_seconds()
+            if ack_finished_at >= ack_deadline_at:
+                return True
+
+        session = self._get_interaction_session(ctx.interaction_token)
+        if session is None:
+            return False
+
+        delivery_status = (session.last_delivery_status or "").strip()
+        delivery_error = (session.last_delivery_error or "").lower()
+        if delivery_status != "ack_failed":
+            return False
+        return "unknown interaction" in delivery_error or "10062" in delivery_error
+
     async def acknowledge_runtime_envelope(
         self,
         envelope: RuntimeInteractionEnvelope,
@@ -4146,9 +4172,9 @@ class DiscordBotService:
                         envelope,
                         stage="dispatch",
                     )
-                    if not acked and envelope.dispatch_ack_policy not in (
-                        None,
-                        "immediate",
+                    if not acked and self._dispatch_ack_failure_confirms_expiry(
+                        ctx,
+                        envelope,
                     ):
                         log_event(
                             self._logger,
@@ -4164,6 +4190,21 @@ class DiscordBotService:
                         # The interaction callback window is already gone. Trying to
                         # answer again only produces a second stale-callback failure
                         # that can bubble back into gateway reconnect handling.
+                        ctx.timing = replace(
+                            ctx.timing,
+                            ack_finished_at=time.monotonic(),
+                            ingress_finished_at=time.monotonic(),
+                        )
+                        return
+                    if not acked and envelope.dispatch_ack_policy not in (
+                        None,
+                        "immediate",
+                    ):
+                        await self._respond_ephemeral(
+                            ctx.interaction_id,
+                            ctx.interaction_token,
+                            "Discord interaction did not acknowledge. Please retry.",
+                        )
                         ctx.timing = replace(
                             ctx.timing,
                             ack_finished_at=time.monotonic(),

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -4161,11 +4161,9 @@ class DiscordBotService:
                                 envelope=envelope,
                             ),
                         )
-                        await self._respond_ephemeral(
-                            ctx.interaction_id,
-                            ctx.interaction_token,
-                            "Discord interaction did not acknowledge. Please retry.",
-                        )
+                        # The interaction callback window is already gone. Trying to
+                        # answer again only produces a second stale-callback failure
+                        # that can bubble back into gateway reconnect handling.
                         ctx.timing = replace(
                             ctx.timing,
                             ack_finished_at=time.monotonic(),

--- a/tests/integrations/discord/test_reliability.py
+++ b/tests/integrations/discord/test_reliability.py
@@ -19,7 +19,7 @@ import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Optional
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -1158,6 +1158,51 @@ async def test_ack_budget_expiry_stops_execution_and_logs_expired_before_ack(
     assert log_events
     assert log_events[0]["expired_before_ack"] is True
     assert log_events[0]["budget_overrun_ms"] is not None
+
+
+@pytest.mark.anyio
+async def test_on_dispatch_does_not_attempt_fallback_response_after_ack_expiry() -> (
+    None
+):
+    service = DiscordBotService.__new__(DiscordBotService)
+    service._logger = logging.getLogger("test.reliability.dispatch_ack_expiry")
+    service._ingress = SimpleNamespace()
+    service._command_runner = SimpleNamespace(skip_submission_order=Mock())
+    service._persist_runtime_interaction = AsyncMock()
+    service._register_interaction_ingress = AsyncMock(return_value=False)
+    service._release_interaction_ingress = AsyncMock()
+    service._interaction_telemetry_fields = lambda *args, **kwargs: {}  # type: ignore[assignment]
+    service._initial_ack_budget_seconds = lambda: 2.5  # type: ignore[assignment]
+    service._respond_ephemeral = AsyncMock(
+        side_effect=AssertionError("stale fallback should not be attempted")
+    )
+
+    ctx = _make_ctx(interaction_id="inter-expired", interaction_token="tok-expired")
+    envelope = RuntimeInteractionEnvelope(
+        context=ctx,
+        conversation_id="conversation:discord:chan-1",
+        resource_keys=("conversation:discord:chan-1",),
+        dispatch_ack_policy="defer_ephemeral",
+    )
+    service._build_runtime_interaction_envelope = AsyncMock(return_value=envelope)
+    service._acknowledge_runtime_envelope = AsyncMock(return_value=False)
+    service._ingress.process_raw_payload = AsyncMock(
+        return_value=SimpleNamespace(accepted=True, context=ctx)
+    )
+
+    payload = _slash_payload()
+    payload["id"] = "inter-expired"
+    payload["token"] = "tok-expired"
+
+    await service._on_dispatch("INTERACTION_CREATE", payload)
+
+    service._respond_ephemeral.assert_not_awaited()
+    service._persist_runtime_interaction.assert_not_awaited()
+    service._register_interaction_ingress.assert_not_awaited()
+    service._command_runner.skip_submission_order.assert_called_once_with(None)
+    service._release_interaction_ingress.assert_awaited_once_with("inter-expired")
+    assert ctx.timing.ack_finished_at is not None
+    assert ctx.timing.ingress_finished_at is not None
 
 
 @pytest.mark.anyio

--- a/tests/integrations/discord/test_reliability.py
+++ b/tests/integrations/discord/test_reliability.py
@@ -1161,7 +1161,7 @@ async def test_ack_budget_expiry_stops_execution_and_logs_expired_before_ack(
 
 
 @pytest.mark.anyio
-async def test_on_dispatch_does_not_attempt_fallback_response_after_ack_expiry() -> (
+async def test_on_dispatch_does_not_attempt_fallback_response_after_confirmed_ack_expiry() -> (
     None
 ):
     service = DiscordBotService.__new__(DiscordBotService)
@@ -1176,8 +1176,10 @@ async def test_on_dispatch_does_not_attempt_fallback_response_after_ack_expiry()
     service._respond_ephemeral = AsyncMock(
         side_effect=AssertionError("stale fallback should not be attempted")
     )
+    service._get_interaction_session = lambda _token: None  # type: ignore[assignment]
 
     ctx = _make_ctx(interaction_id="inter-expired", interaction_token="tok-expired")
+    ctx.timing = IngressTiming(ingress_started_at=10.0)
     envelope = RuntimeInteractionEnvelope(
         context=ctx,
         conversation_id="conversation:discord:chan-1",
@@ -1185,7 +1187,15 @@ async def test_on_dispatch_does_not_attempt_fallback_response_after_ack_expiry()
         dispatch_ack_policy="defer_ephemeral",
     )
     service._build_runtime_interaction_envelope = AsyncMock(return_value=envelope)
-    service._acknowledge_runtime_envelope = AsyncMock(return_value=False)
+
+    async def _fail_after_deadline(*_args: Any, **_kwargs: Any) -> bool:
+        ctx.timing = IngressTiming(
+            ingress_started_at=10.0,
+            ack_finished_at=12.6,
+        )
+        return False
+
+    service._acknowledge_runtime_envelope = AsyncMock(side_effect=_fail_after_deadline)
     service._ingress.process_raw_payload = AsyncMock(
         return_value=SimpleNamespace(accepted=True, context=ctx)
     )
@@ -1201,6 +1211,68 @@ async def test_on_dispatch_does_not_attempt_fallback_response_after_ack_expiry()
     service._register_interaction_ingress.assert_not_awaited()
     service._command_runner.skip_submission_order.assert_called_once_with(None)
     service._release_interaction_ingress.assert_awaited_once_with("inter-expired")
+    assert ctx.timing.ack_finished_at is not None
+    assert ctx.timing.ingress_finished_at is not None
+
+
+@pytest.mark.anyio
+async def test_on_dispatch_attempts_fallback_response_after_non_expired_ack_failure() -> (
+    None
+):
+    service = DiscordBotService.__new__(DiscordBotService)
+    service._logger = logging.getLogger(
+        "test.reliability.dispatch_ack_retryable_failure"
+    )
+    service._ingress = SimpleNamespace()
+    service._command_runner = SimpleNamespace(skip_submission_order=Mock())
+    service._persist_runtime_interaction = AsyncMock()
+    service._register_interaction_ingress = AsyncMock(return_value=False)
+    service._release_interaction_ingress = AsyncMock()
+    service._interaction_telemetry_fields = lambda *args, **kwargs: {}  # type: ignore[assignment]
+    service._initial_ack_budget_seconds = lambda: 2.5  # type: ignore[assignment]
+    service._respond_ephemeral = AsyncMock()
+    service._get_interaction_session = lambda _token: SimpleNamespace(  # type: ignore[assignment]
+        last_delivery_status="ack_failed",
+        last_delivery_error="Discord API network error for POST /interactions/123/callback: boom",
+    )
+
+    ctx = _make_ctx(interaction_id="inter-retry", interaction_token="tok-retry")
+    ctx.timing = IngressTiming(ingress_started_at=10.0)
+    envelope = RuntimeInteractionEnvelope(
+        context=ctx,
+        conversation_id="conversation:discord:chan-1",
+        resource_keys=("conversation:discord:chan-1",),
+        dispatch_ack_policy="defer_ephemeral",
+    )
+    service._build_runtime_interaction_envelope = AsyncMock(return_value=envelope)
+
+    async def _fail_before_deadline(*_args: Any, **_kwargs: Any) -> bool:
+        ctx.timing = IngressTiming(
+            ingress_started_at=10.0,
+            ack_finished_at=10.5,
+        )
+        return False
+
+    service._acknowledge_runtime_envelope = AsyncMock(side_effect=_fail_before_deadline)
+    service._ingress.process_raw_payload = AsyncMock(
+        return_value=SimpleNamespace(accepted=True, context=ctx)
+    )
+
+    payload = _slash_payload()
+    payload["id"] = "inter-retry"
+    payload["token"] = "tok-retry"
+
+    await service._on_dispatch("INTERACTION_CREATE", payload)
+
+    service._respond_ephemeral.assert_awaited_once_with(
+        "inter-retry",
+        "tok-retry",
+        "Discord interaction did not acknowledge. Please retry.",
+    )
+    service._persist_runtime_interaction.assert_not_awaited()
+    service._register_interaction_ingress.assert_not_awaited()
+    service._command_runner.skip_submission_order.assert_called_once_with(None)
+    service._release_interaction_ingress.assert_awaited_once_with("inter-retry")
     assert ctx.timing.ack_finished_at is not None
     assert ctx.timing.ingress_finished_at is not None
 

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -3931,7 +3931,7 @@ async def test_service_continues_when_sync_request_fails(tmp_path: Path) -> None
 
 
 @pytest.mark.anyio
-async def test_service_falls_back_to_followup_when_initial_response_fails(
+async def test_service_does_not_attempt_followup_when_initial_response_fails(
     tmp_path: Path,
 ) -> None:
     store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
@@ -3950,10 +3950,7 @@ async def test_service_falls_back_to_followup_when_initial_response_fails(
     try:
         await service.run_forever()
         assert rest.interaction_responses == []
-        assert len(rest.followup_messages) == 1
-        payload = rest.followup_messages[0]["payload"]
-        assert payload["flags"] == 64
-        assert "did not acknowledge" in payload["content"].lower()
+        assert rest.followup_messages == []
     finally:
         await store.close()
 
@@ -5935,12 +5932,7 @@ async def test_car_update_without_target_aborts_when_required_preflight_fails(
 
     try:
         await service.run_forever()
-        assert len(rest.interaction_responses) == 1
-        payload = rest.interaction_responses[0]["payload"]
-        assert payload["type"] == 4
-        data = payload.get("data") or {}
-        content = str(data.get("content", ""))
-        assert "did not acknowledge" in content.lower()
+        assert rest.interaction_responses == []
         assert rest.followup_messages == []
     finally:
         await store.close()

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -3931,7 +3931,7 @@ async def test_service_continues_when_sync_request_fails(tmp_path: Path) -> None
 
 
 @pytest.mark.anyio
-async def test_service_does_not_attempt_followup_when_initial_response_fails(
+async def test_service_attempts_fallback_reply_when_initial_response_fails(
     tmp_path: Path,
 ) -> None:
     store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
@@ -3950,7 +3950,11 @@ async def test_service_does_not_attempt_followup_when_initial_response_fails(
     try:
         await service.run_forever()
         assert rest.interaction_responses == []
-        assert rest.followup_messages == []
+        assert len(rest.followup_messages) == 1
+        assert (
+            rest.followup_messages[0]["payload"]["content"]
+            == "Discord interaction did not acknowledge. Please retry."
+        )
     finally:
         await store.close()
 
@@ -5909,7 +5913,7 @@ async def test_car_update_without_target_returns_picker(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
-async def test_car_update_without_target_aborts_when_required_preflight_fails(
+async def test_car_update_without_target_replies_when_dispatch_ack_fails_without_expiry(
     tmp_path: Path,
 ) -> None:
     store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
@@ -5932,7 +5936,14 @@ async def test_car_update_without_target_aborts_when_required_preflight_fails(
 
     try:
         await service.run_forever()
-        assert rest.interaction_responses == []
+        assert len(rest.interaction_responses) == 1
+        payload = rest.interaction_responses[0]["payload"]
+        assert payload["type"] == 4
+        assert (
+            payload["data"]["content"]
+            == "Discord interaction did not acknowledge. Please retry."
+        )
+        assert payload["data"]["flags"] == 64
         assert rest.followup_messages == []
     finally:
         await store.close()


### PR DESCRIPTION
## Summary
This stops Discord interaction ACK expiry from cascading into gateway reconnect loops.

When dispatch-time ACK misses Discord's callback window, CAR now logs `discord.interaction.delivery_expired_before_dispatch` and returns instead of attempting a second interaction response on the same stale token.

## Root Cause
The remaining bug was above the REST breaker/retry layer.

- Dispatch ACK failure in `DiscordBotService._on_dispatch()` still called `_respond_ephemeral(...)`.
- For expired interactions, that second response hit the same stale token and failed again.
- The failure was raised as a `DiscordEffectDeliveryError`, escaped `_on_dispatch()`, and was promoted by the gateway dispatch worker into `discord.gateway.reconnect.failure`.
- That turned an interaction-level `10062 Unknown interaction` into a transport-level reconnect loop.

## Changes
- Remove the stale fallback response attempt after dispatch ACK expiry in `src/codex_autorunner/integrations/discord/service.py`.
- Add a regression test proving `_on_dispatch()` does not attempt a fallback response after ACK expiry.
- Update routing tests that previously asserted the old stale-fallback behavior.

## Impact
- Expired Discord slash-command interactions no longer trigger self-reinforcing reconnect churn.
- CAR still surfaces the expiry through telemetry/logging, but it stops trying to answer an already-dead interaction.
- This should make Discord processes materially more stable and usable again under stale-interaction conditions.

## Validation
- `tests/integrations/discord/test_reliability.py`
- `tests/integrations/discord/test_execute_ingressed.py`
- Targeted routing regressions for stale initial-response failure and required-preflight failure

## Follow-up Note
During investigation I also saw a separate startup-latency issue in live logs: repeated `discord.turn.submission_timeout` / `discord.turn.startup_failed` events and `hub.scan_repos` jobs taking 24s to 46s. This PR does not address that path; it only fixes the reconnect cascade caused by stale interaction callbacks.