### PR TITLE
fix(tests): make pma_lane_worker test deterministic

### DIFF
--- a/tests/core/test_pma_lane_worker.py
+++ b/tests/core/test_pma_lane_worker.py
@@ -26,14 +26,17 @@ async def test_pma_lane_worker_processes_item(tmp_path: Path) -> None:
 
     await asyncio.wait_for(processed.wait(), timeout=2.0)
 
-    for _ in range(80):
-        items = await asyncio.to_thread(queue._read_items_from_sqlite, lane_id)
-        if items and items[0].state in (
-            QueueItemState.COMPLETED,
-            QueueItemState.FAILED,
-        ):
-            break
-        await asyncio.sleep(0.05)
+    async def _wait_terminal() -> None:
+        while True:
+            items = await asyncio.to_thread(queue._read_items_from_sqlite, lane_id)
+            if items and items[0].state in (
+                QueueItemState.COMPLETED,
+                QueueItemState.FAILED,
+            ):
+                return
+            await asyncio.sleep(0.05)
+
+    await asyncio.wait_for(_wait_terminal(), timeout=5.0)
 
     items = await asyncio.to_thread(queue._read_items_from_sqlite, lane_id)
     assert items, "queue item should be present"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the flaky `test_pma_lane_worker_processes_item` test.

## Root cause

The `processed` event fires inside the executor *before* it returns. After the executor returns, the worker still needs to call `complete_item()` to persist the terminal state. The old bounded polling loop (80×50ms = 4s max) could expire before the state write landed, leaving the item in `RUNNING`.

## Fix

Replace the bounded retry loop with `asyncio.wait_for()` wrapping an unbounded poll, using a 5s timeout. The poll still checks every 50ms, but it cannot silently expire — it either succeeds or raises `TimeoutError` with a clear signal.

## Verification

Ran the test 30 consecutive times with zero failures:

```
$ for i in $(seq 1 30); do .venv/bin/python -m pytest tests/core/test_pma_lane_worker.py::test_pma_lane_worker_processes_item -q 2>&1 | tail -1; done
1 passed in 0.47s
1 passed in 0.43s
... (30/30 passed)
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-323496b6-e8d7-45a7-b768-88832a68035b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-323496b6-e8d7-45a7-b768-88832a68035b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

