### PR TITLE
[codex] Fix staged mac update installs

### DIFF
--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -488,15 +488,16 @@ if [[ ! -f "${PLIST_PATH}" ]]; then
 fi
 
 HUB_ROOT="$(_plist_arg_value path)"
-PACKAGE_INSTALL_SPEC="${PACKAGE_SRC}[browser]"
+PACKAGE_EXTRAS="[browser]"
 if [[ -n "${HUB_ROOT}" ]]; then
   VOICE_PROVIDER="$(_voice_provider_for_hub_root "${HUB_ROOT}")"
   if [[ "${VOICE_PROVIDER}" == "local_whisper" ]]; then
-    PACKAGE_INSTALL_SPEC="${PACKAGE_SRC}[browser,voice-local]"
+    PACKAGE_EXTRAS="[browser,voice-local]"
   elif [[ "${VOICE_PROVIDER}" == "mlx_whisper" ]]; then
-    PACKAGE_INSTALL_SPEC="${PACKAGE_SRC}[browser,voice-mlx]"
+    PACKAGE_EXTRAS="[browser,voice-mlx]"
   fi
 fi
+PACKAGE_INSTALL_SPEC="${PACKAGE_SRC}${PACKAGE_EXTRAS}"
 
 _realpath() {
   "${HELPER_PYTHON}" - "$1" <<'PY'
@@ -541,6 +542,80 @@ subprocess.run([sys.executable, "-m", "playwright", "install", "chromium"], chec
 PY
 }
 
+_path_to_file_uri() {
+  "${HELPER_PYTHON}" - "$1" <<'PY'
+from pathlib import Path
+import sys
+
+print(Path(sys.argv[1]).resolve().as_uri())
+PY
+}
+
+_build_package_wheel() {
+  local python_bin wheel_dir wheel_path
+  python_bin="$1"
+  wheel_dir="$2"
+
+  rm -rf "${wheel_dir}"
+  mkdir -p "${wheel_dir}"
+
+  echo "Building codex-autorunner wheel from ${PACKAGE_SRC} into ${wheel_dir}..." >&2
+  "${python_bin}" -m pip -q wheel --no-deps --no-cache-dir --wheel-dir "${wheel_dir}" "${PACKAGE_SRC}" >&2
+
+  wheel_path="$("${HELPER_PYTHON}" - "${wheel_dir}" <<'PY'
+from pathlib import Path
+import sys
+
+wheel_dir = Path(sys.argv[1])
+wheels = sorted(wheel_dir.glob("codex_autorunner-*.whl"))
+if not wheels:
+    raise SystemExit(1)
+print(wheels[-1])
+PY
+)"
+  if [[ -z "${wheel_path}" || ! -f "${wheel_path}" ]]; then
+    fail "Unable to locate freshly built codex-autorunner wheel in ${wheel_dir}."
+  fi
+
+  "${HELPER_PYTHON}" - "${wheel_path}" <<'PY'
+from pathlib import PurePosixPath
+import sys
+import zipfile
+
+wheel_path = sys.argv[1]
+required_prefixes = {
+    "codex_autorunner/workspace/",
+    "codex_autorunner/tickets/",
+    "codex_autorunner/integrations/docker/",
+}
+with zipfile.ZipFile(wheel_path) as zf:
+    names = set(PurePosixPath(name).as_posix() for name in zf.namelist())
+missing = sorted(
+    prefix[:-1] if prefix.endswith("/") else prefix
+    for prefix in required_prefixes
+    if not any(name.startswith(prefix) for name in names)
+)
+if missing:
+    raise SystemExit(
+        "built wheel is missing required packages: " + ", ".join(missing)
+    )
+print("wheel package contents ok", file=sys.stderr)
+PY
+
+  printf '%s\n' "${wheel_path}"
+}
+
+_install_package_from_wheel() {
+  local python_bin wheel_path wheel_uri install_spec
+  python_bin="$1"
+  wheel_path="$2"
+  wheel_uri="$(_path_to_file_uri "${wheel_path}")"
+  install_spec="codex-autorunner${PACKAGE_EXTRAS} @ ${wheel_uri}"
+
+  echo "Installing codex-autorunner from staged wheel ${wheel_path} into staged venv..."
+  "${python_bin}" -m pip -q install --force-reinstall --no-cache-dir "${install_spec}"
+}
+
 if [[ ! -d "${PIPX_VENV}" ]]; then
   if [[ -L "${CURRENT_VENV_LINK}" ]]; then
     current_target="$(_realpath "${CURRENT_VENV_LINK}")"
@@ -573,17 +648,36 @@ fi
 
 ts="$(date +%Y%m%d-%H%M%S)"
 next_venv="${PIPX_ROOT}/venvs/codex-autorunner.next-${ts}"
+wheel_dir="${next_venv}.wheelhouse"
 
 echo "Creating staged venv at ${next_venv} (python: ${PIPX_PYTHON})..."
 "${PIPX_PYTHON}" -m venv "${next_venv}"
 "${next_venv}/bin/python" -m pip -q install --upgrade pip
 
-echo "Installing codex-autorunner from ${PACKAGE_INSTALL_SPEC} into staged venv..."
-"${next_venv}/bin/python" -m pip -q install --force-reinstall "${PACKAGE_INSTALL_SPEC}"
+echo "Preparing staged wheel for ${PACKAGE_INSTALL_SPEC}..."
+wheel_path="$(_build_package_wheel "${next_venv}/bin/python" "${wheel_dir}")"
+_install_package_from_wheel "${next_venv}/bin/python" "${wheel_path}"
 _ensure_playwright_chromium "${next_venv}/bin/python"
+rm -rf "${wheel_dir}"
 
 echo "Smoke-checking staged venv imports..."
-"${next_venv}/bin/python" -c "import codex_autorunner; from codex_autorunner.server import create_hub_app; print('ok')"
+"${next_venv}/bin/python" - <<'PY'
+import importlib.util
+
+required_modules = (
+    "codex_autorunner.workspace",
+    "codex_autorunner.tickets",
+    "codex_autorunner.integrations.docker",
+)
+for module_name in required_modules:
+    if importlib.util.find_spec(module_name) is None:
+        raise SystemExit(f"required staged module missing: {module_name}")
+
+import codex_autorunner
+from codex_autorunner.server import create_hub_app
+
+print("staged imports ok")
+PY
 echo "Smoke-checking hub startup lifecycle..."
 "${next_venv}/bin/python" - <<'PY'
 from pathlib import Path

--- a/src/codex_autorunner/core/update.py
+++ b/src/codex_autorunner/core/update.py
@@ -940,8 +940,8 @@ def _system_update_worker(
         if returncode != 0:
             if not existing or existing.get("status") not in ("rollback", "error"):
                 _write_update_status(
-                    "rollback",
-                    "Update failed; rollback attempted. Check hub logs for details.",
+                    "error",
+                    "Update failed; check hub logs for details.",
                     exit_code=returncode,
                 )
             return

--- a/tests/test_system_update_worker.py
+++ b/tests/test_system_update_worker.py
@@ -643,7 +643,7 @@ def test_system_update_worker_preserves_committed_ok_status_on_nonzero_exit(
     assert popen_calls == 1
 
 
-def test_system_update_worker_does_not_retry_non_packaging_refresh_failure(
+def test_system_update_worker_marks_non_packaging_refresh_failure_as_error(
     tmp_path: Path, monkeypatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -693,13 +693,14 @@ def test_system_update_worker_does_not_retry_non_packaging_refresh_failure(
     )
 
     payload = json.loads(system._update_status_path().read_text(encoding="utf-8"))
-    assert payload["status"] == "rollback"
+    assert payload["status"] == "error"
+    assert payload["message"] == "Update failed; check hub logs for details."
     assert payload["exit_code"] == 1
     assert popen_calls == 1
     assert run_cmd_calls.count(["git", "reset", "--hard", "FETCH_HEAD"]) == 1
 
 
-def test_system_update_worker_rolls_back_when_retryable_refresh_failure_persists(
+def test_system_update_worker_marks_persistent_packaging_failure_as_error(
     tmp_path: Path, monkeypatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -754,7 +755,8 @@ def test_system_update_worker_rolls_back_when_retryable_refresh_failure_persists
     )
 
     payload = json.loads(system._update_status_path().read_text(encoding="utf-8"))
-    assert payload["status"] == "rollback"
+    assert payload["status"] == "error"
+    assert payload["message"] == "Update failed; check hub logs for details."
     assert payload["exit_code"] == 1
     assert popen_calls == 2
     assert ["git", "reset", "--hard", "FETCH_HEAD"] in run_cmd_calls


### PR DESCRIPTION
## Summary
This fixes the macOS refresh path that was intermittently producing incomplete staged venvs during updates.

## What changed
- build a fresh wheel from the checked-out update source before installing into the staged venv
- install the staged venv from that wheel via a direct file URL requirement, with `--no-cache-dir`
- validate the built wheel contains the critical packages that were disappearing (`workspace`, `tickets`, `integrations/docker`)
- strengthen the staged import smoke check to verify those packages are present before cutover
- stop reporting a generic `rollback attempted` status when the refresh script exits nonzero without having reported an actual rollback

## Root cause
The update source tree was correct, but some staged update venvs were missing whole packages after `pip install --force-reinstall` from the mutable checkout. That meant the failure was in the updater's build/install path, not in the repository contents. Because the refresh script installed directly from the checkout, a bad artifact/install outcome could survive until the later import smoke checks.

## Impact
This makes staged mac updates deterministic and fails earlier with a concrete packaging error if the built artifact is incomplete. It also makes update status more accurate for pre-cutover failures.

## Validation
- `bash -n scripts/safe-refresh-local-mac-hub.sh`
- `python -m pytest -q tests/test_safe_refresh_local_mac_hub_script.py tests/test_system_update_worker.py`
- built a wheel locally, installed it via `codex-autorunner[browser] @ file:///...whl`, and verified the staged package contains `workspace`, `tickets`, and `integrations/docker`
