### PR TITLE
[codex] Fix collapsed ticket streaming preview

### DIFF
--- a/src/codex_autorunner/static/generated/tickets.js
+++ b/src/codex_autorunner/static/generated/tickets.js
@@ -454,6 +454,7 @@ function appendToLiveOutput(text) {
         liveOutputBuffer.shift();
     }
     scheduleLiveOutputTextUpdate();
+    scheduleLiveOutputRender();
 }
 function addLiveOutputEvent(parsed) {
     const { event, mergeStrategy } = parsed;
@@ -581,16 +582,50 @@ function renderLiveOutputCompact() {
     const compactEl = document.getElementById("ticket-live-output-compact");
     if (!compactEl)
         return;
-    const summary = summarizeEvents(liveOutputEvents, {
-        maxActions: 1, // Show only 1 action + thinking to fit in 3-line compact view
-        maxTextLength: COMPACT_MAX_TEXT_LENGTH,
-        startTime: flowStartedAt?.getTime(),
-    });
-    const text = liveOutputEvents.length ? renderCompactSummary(summary) : "";
+    const text = renderCompactLiveOutputText();
     const newText = text || "Waiting for agent output...";
     if (compactEl.textContent !== newText) {
         compactEl.textContent = newText;
     }
+}
+function renderCompactLiveOutputText() {
+    if (liveOutputEvents.length) {
+        const summary = summarizeEvents(liveOutputEvents, {
+            maxActions: 1, // Show only 1 action + thinking to fit in 3-line compact view
+            maxTextLength: COMPACT_MAX_TEXT_LENGTH,
+            startTime: flowStartedAt?.getTime(),
+        });
+        return renderCompactSummary(summary);
+    }
+    const fallbackText = compactLiveOutputBufferText();
+    if (!fallbackText)
+        return "";
+    const summary = summarizeEvents([
+        {
+            id: "ticket-live-output-fallback",
+            title: "Output",
+            summary: fallbackText,
+            detail: "",
+            kind: "output",
+            isSignificant: true,
+            time: flowStartedAt?.getTime() || Date.now(),
+            itemId: null,
+            method: "agent_stream_delta",
+        },
+    ], {
+        maxActions: 1,
+        maxTextLength: COMPACT_MAX_TEXT_LENGTH,
+        startTime: flowStartedAt?.getTime(),
+    });
+    return renderCompactSummary(summary);
+}
+function compactLiveOutputBufferText() {
+    const recentLines = liveOutputBuffer
+        .map((line) => line.trim())
+        .filter((line) => line && !/^--- Step: .* ---$/.test(line));
+    if (!recentLines.length)
+        return "";
+    return recentLines.slice(-3).join(" ").replace(/\s+/g, " ").trim();
 }
 function updateLiveOutputViewToggle() {
     const viewToggle = document.getElementById("ticket-live-output-view-toggle");
@@ -809,6 +844,20 @@ function initReasonModal() {
         });
     }
 }
+export const __ticketFlowTest = {
+    clearLiveOutput() {
+        clearLiveOutput();
+        liveOutputDetailExpanded = false;
+        flowStartedAt = null;
+        renderLiveOutputView();
+    },
+    handleFlowEvent,
+    initLiveOutputPanel,
+    renderLiveOutputView,
+    setFlowStartedAt(value) {
+        flowStartedAt = value == null ? null : new Date(value);
+    },
+};
 function els() {
     return {
         card: document.getElementById("ticket-card"),

--- a/src/codex_autorunner/static_src/tickets.ts
+++ b/src/codex_autorunner/static_src/tickets.ts
@@ -599,6 +599,7 @@ function appendToLiveOutput(text: string): void {
   }
 
   scheduleLiveOutputTextUpdate();
+  scheduleLiveOutputRender();
 }
 
 function addLiveOutputEvent(parsed: ParsedAgentEvent): void {
@@ -742,17 +743,56 @@ function renderLiveOutputEvents(): void {
 function renderLiveOutputCompact(): void {
   const compactEl = document.getElementById("ticket-live-output-compact");
   if (!compactEl) return;
-  const summary = summarizeEvents(liveOutputEvents, {
-    maxActions: 1, // Show only 1 action + thinking to fit in 3-line compact view
-    maxTextLength: COMPACT_MAX_TEXT_LENGTH,
-    startTime: flowStartedAt?.getTime(),
-  });
-  const text = liveOutputEvents.length ? renderCompactSummary(summary) : "";
+  const text = renderCompactLiveOutputText();
   const newText = text || "Waiting for agent output...";
   
   if (compactEl.textContent !== newText) {
     compactEl.textContent = newText;
   }
+}
+
+function renderCompactLiveOutputText(): string {
+  if (liveOutputEvents.length) {
+    const summary = summarizeEvents(liveOutputEvents, {
+      maxActions: 1, // Show only 1 action + thinking to fit in 3-line compact view
+      maxTextLength: COMPACT_MAX_TEXT_LENGTH,
+      startTime: flowStartedAt?.getTime(),
+    });
+    return renderCompactSummary(summary);
+  }
+
+  const fallbackText = compactLiveOutputBufferText();
+  if (!fallbackText) return "";
+
+  const summary = summarizeEvents(
+    [
+      {
+        id: "ticket-live-output-fallback",
+        title: "Output",
+        summary: fallbackText,
+        detail: "",
+        kind: "output",
+        isSignificant: true,
+        time: flowStartedAt?.getTime() || Date.now(),
+        itemId: null,
+        method: "agent_stream_delta",
+      },
+    ],
+    {
+      maxActions: 1,
+      maxTextLength: COMPACT_MAX_TEXT_LENGTH,
+      startTime: flowStartedAt?.getTime(),
+    }
+  );
+  return renderCompactSummary(summary);
+}
+
+function compactLiveOutputBufferText(): string {
+  const recentLines = liveOutputBuffer
+    .map((line) => line.trim())
+    .filter((line) => line && !/^--- Step: .* ---$/.test(line));
+  if (!recentLines.length) return "";
+  return recentLines.slice(-3).join(" ").replace(/\s+/g, " ").trim();
 }
 
 function updateLiveOutputViewToggle(): void {
@@ -986,6 +1026,21 @@ function initReasonModal(): void {
     });
   }
 }
+
+export const __ticketFlowTest = {
+  clearLiveOutput(): void {
+    clearLiveOutput();
+    liveOutputDetailExpanded = false;
+    flowStartedAt = null;
+    renderLiveOutputView();
+  },
+  handleFlowEvent,
+  initLiveOutputPanel,
+  renderLiveOutputView,
+  setFlowStartedAt(value: number | null): void {
+    flowStartedAt = value == null ? null : new Date(value);
+  },
+};
 
 function els(): {
   card: HTMLElement | null;

--- a/tests/test_ticket_flow_ui_integration.py
+++ b/tests/test_ticket_flow_ui_integration.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_ticket_flow_compact_live_output_falls_back_to_stream_deltas() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    tickets_js = (
+        repo_root / "src" / "codex_autorunner" / "static" / "generated" / "tickets.js"
+    )
+
+    script = textwrap.dedent(
+        f"""
+        import assert from "node:assert/strict";
+        import {{ pathToFileURL }} from "node:url";
+        import {{ JSDOM }} from "jsdom";
+
+        const dom = new JSDOM(
+          `<!doctype html><html><body>
+            <div id="ticket-live-output-status"></div>
+            <button id="ticket-live-output-view-toggle" type="button"></button>
+            <div id="ticket-live-output-compact"></div>
+            <div id="ticket-live-output-detail" class="hidden"></div>
+            <pre id="ticket-live-output-text"></pre>
+            <div id="ticket-live-output-events" class="hidden">
+              <span id="ticket-live-output-events-count"></span>
+              <div id="ticket-live-output-events-list"></div>
+            </div>
+          </body></html>`,
+          {{ url: "http://localhost/repos/test/" }}
+        );
+
+        globalThis.window = dom.window;
+        globalThis.document = dom.window.document;
+        globalThis.HTMLElement = dom.window.HTMLElement;
+        globalThis.HTMLButtonElement = dom.window.HTMLButtonElement;
+        globalThis.Node = dom.window.Node;
+        globalThis.Event = dom.window.Event;
+        globalThis.CustomEvent = dom.window.CustomEvent;
+        globalThis.DOMParser = dom.window.DOMParser;
+        globalThis.localStorage = dom.window.localStorage;
+        globalThis.sessionStorage = dom.window.sessionStorage;
+        globalThis.requestAnimationFrame = (cb) => setTimeout(() => cb(Date.now()), 0);
+        globalThis.cancelAnimationFrame = (id) => clearTimeout(id);
+        globalThis.fetch = async () => {{
+          throw new Error("unexpected fetch in ticket flow integration test");
+        }};
+
+        const moduleUrl = pathToFileURL("{tickets_js.as_posix()}").href;
+        const mod = await import(moduleUrl);
+        const helpers = mod.__ticketFlowTest;
+
+        helpers.clearLiveOutput();
+        helpers.initLiveOutputPanel();
+        helpers.setFlowStartedAt(Date.parse("2026-04-12T00:00:00Z"));
+
+        helpers.handleFlowEvent({{
+          event_type: "agent_stream_delta",
+          timestamp: "2026-04-12T00:00:01Z",
+          data: {{ delta: "This is live " }},
+        }});
+        helpers.handleFlowEvent({{
+          event_type: "agent_stream_delta",
+          timestamp: "2026-04-12T00:00:02Z",
+          data: {{ delta: "codex output" }},
+        }});
+
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        const compact = document.getElementById("ticket-live-output-compact")?.textContent || "";
+        const detail = document.getElementById("ticket-live-output-text")?.textContent || "";
+        const status = document.getElementById("ticket-live-output-status")?.textContent || "";
+
+        assert.match(detail, /This is live codex output/);
+        assert.match(compact, /This is live codex output/);
+        assert.doesNotMatch(compact, /Waiting for agent output/);
+        assert.equal(status, "Streaming");
+        """
+    )
+
+    subprocess.run(["node", "--input-type=module", "-e", script], check=True)


### PR DESCRIPTION
## Summary

Fix the ticket-flow web UI so collapsed live output previews update while Codex is streaming plain `agent_stream_delta` text.

## What changed

- update `tickets.ts` so raw streaming text deltas also trigger a compact live-output rerender
- add a compact fallback that summarizes the raw text buffer when no parsed rich `app_server_event` entries exist yet
- expose a narrow `__ticketFlowTest` hook for DOM-driven asset testing
- add an integration test that imports the generated tickets UI module through JSDOM and verifies collapsed mode no longer stays on `Waiting for agent output...` while expanded mode has real streamed output

## Root cause

The expanded view and collapsed view were reading from different state:

- expanded output used the raw `liveOutputBuffer` fed by `agent_stream_delta`
- collapsed output only summarized `liveOutputEvents`, which are populated by parsed `app_server_event` payloads

Codex can stream useful text before any rich parsed events arrive, so the collapsed panel kept rendering the placeholder even though the expanded panel already had real content.

## Impact

Collapsed ticket-flow streaming now reflects real agent output for Codex-style text streaming instead of appearing stuck. The integration test covers that regression path directly through the built browser asset.

## Validation

- `.venv/bin/pytest tests/test_ticket_flow_ui_integration.py -m integration -q`
- `node --test tests/js/*.test.js`
- repo commit hook validation, including full pytest (`4980 passed`)
