### PR TITLE
feat: make ticket_flow max_total_turns configurable via YAML

### DIFF
--- a/codex-autorunner.yml
+++ b/codex-autorunner.yml
@@ -71,6 +71,7 @@ repo_defaults:
     # When enabled, previous ticket content is truncated to 16KB and clearly labeled.
     # Prefer using contextspace docs (active_context.md, decisions.md, spec.md) for cross-ticket context.
     include_previous_ticket_context: false
+    max_total_turns: 150
 
   git:
     # Auto-commit after a run.

--- a/src/codex_autorunner/core/config.py
+++ b/src/codex_autorunner/core/config.py
@@ -1113,6 +1113,7 @@ class TicketFlowConfig:
     default_approval_decision: str
     include_previous_ticket_context: bool
     auto_resume: bool = False
+    max_total_turns: Optional[int] = None
 
 
 class SecurityConfigSection(TypedDict, total=False):
@@ -1587,11 +1588,18 @@ def _parse_ticket_flow_config(
     auto_resume = cfg.get("auto_resume", defaults.get("auto_resume", False))
     if not isinstance(auto_resume, bool):
         raise ConfigError("ticket_flow.auto_resume must be boolean")
+    max_total_turns = cfg.get("max_total_turns", defaults.get("max_total_turns"))
+    if max_total_turns is not None:
+        if isinstance(max_total_turns, bool) or not isinstance(max_total_turns, int) or max_total_turns < 1:
+            raise ConfigError(
+                "ticket_flow.max_total_turns must be a positive integer or null"
+            )
     return TicketFlowConfig(
         approval_mode=approval_mode,
         default_approval_decision=default_approval_decision,
         include_previous_ticket_context=include_previous_ticket_context,
         auto_resume=auto_resume,
+        max_total_turns=max_total_turns,
     )
 
 

--- a/src/codex_autorunner/core/config.py
+++ b/src/codex_autorunner/core/config.py
@@ -1590,7 +1590,11 @@ def _parse_ticket_flow_config(
         raise ConfigError("ticket_flow.auto_resume must be boolean")
     max_total_turns = cfg.get("max_total_turns", defaults.get("max_total_turns"))
     if max_total_turns is not None:
-        if isinstance(max_total_turns, bool) or not isinstance(max_total_turns, int) or max_total_turns < 1:
+        if (
+            isinstance(max_total_turns, bool)
+            or not isinstance(max_total_turns, int)
+            or max_total_turns < 1
+        ):
             raise ConfigError(
                 "ticket_flow.max_total_turns must be a positive integer or null"
             )

--- a/src/codex_autorunner/flows/ticket_flow/definition.py
+++ b/src/codex_autorunner/flows/ticket_flow/definition.py
@@ -20,6 +20,7 @@ def build_ticket_flow_definition(
     agent_pool: AgentPool,
     auto_commit_default: bool = False,
     include_previous_ticket_context_default: bool = False,
+    max_total_turns_default: int = DEFAULT_MAX_TOTAL_TURNS,
 ) -> FlowDefinition:
     """Build the single-step ticket runner flow.
 
@@ -54,7 +55,7 @@ def build_ticket_flow_definition(
 
         ticket_dir = (workspace_root / ".codex-autorunner" / "tickets").resolve()
         max_total_turns = int(
-            input_data.get("max_total_turns") or DEFAULT_MAX_TOTAL_TURNS
+            input_data.get("max_total_turns") or max_total_turns_default
         )
 
         repo_id = _resolve_ticket_flow_repo_id(workspace_root)

--- a/src/codex_autorunner/flows/ticket_flow/runtime_helpers.py
+++ b/src/codex_autorunner/flows/ticket_flow/runtime_helpers.py
@@ -27,6 +27,7 @@ from ...core.flows.workspace_root import (
 from ...core.runtime import RuntimeContext
 from ...integrations.agents import build_backend_orchestrator
 from ...integrations.agents.build_agent_pool import build_agent_pool
+from ...tickets import DEFAULT_MAX_TOTAL_TURNS
 from ...tickets.files import list_ticket_paths, safe_relpath
 from .definition import build_ticket_flow_definition
 
@@ -64,6 +65,11 @@ def build_ticket_flow_runtime_resources(repo_root: Path) -> TicketFlowRuntimeRes
         auto_commit_default=config.git_auto_commit,
         include_previous_ticket_context_default=(
             config.ticket_flow.include_previous_ticket_context
+        ),
+        max_total_turns_default=(
+            config.ticket_flow.max_total_turns
+            if config.ticket_flow.max_total_turns is not None
+            else DEFAULT_MAX_TOTAL_TURNS
         ),
     )
     definition.validate()

--- a/src/codex_autorunner/surfaces/cli/commands/flow.py
+++ b/src/codex_autorunner/surfaces/cli/commands/flow.py
@@ -44,7 +44,7 @@ from ....core.orchestration import build_ticket_flow_orchestration_service
 from ....core.orchestration.models import FlowRunTarget
 from ....core.runtime import RuntimeContext
 from ....core.utils import resolve_executable
-from ....tickets import AgentPool
+from ....tickets import DEFAULT_MAX_TOTAL_TURNS, AgentPool
 from ....tickets.files import list_ticket_paths, read_ticket, ticket_is_done
 from ....tickets.frontmatter import generate_ticket_id
 
@@ -539,6 +539,11 @@ def register_flow_commands(
             include_previous_ticket_context_default=(
                 engine.config.ticket_flow.include_previous_ticket_context
             ),
+            max_total_turns_default=(
+                engine.config.ticket_flow.max_total_turns
+                if engine.config.ticket_flow.max_total_turns is not None
+                else DEFAULT_MAX_TOTAL_TURNS
+            ),
         )
         definition.validate()
         controller = FlowController(
@@ -668,6 +673,10 @@ def register_flow_commands(
                         auto_commit_default=engine.config.git_auto_commit,
                         include_previous_ticket_context_default=(
                             engine.config.ticket_flow.include_previous_ticket_context
+                        ),
+                        max_total_turns_default=(
+                            engine.config.ticket_flow.max_total_turns
+                            or DEFAULT_MAX_TOTAL_TURNS
                         ),
                     )
                 raise_exit(f"Unknown flow type for run {worker_run_id}: {flow_type}")

--- a/src/codex_autorunner/surfaces/web/routes/flow_routes/definitions.py
+++ b/src/codex_autorunner/surfaces/web/routes/flow_routes/definitions.py
@@ -50,6 +50,7 @@ def build_flow_definition(
     from ....core.runtime import RuntimeContext
     from ....flows.ticket_flow import build_ticket_flow_definition
     from ....integrations.agents.build_agent_pool import build_agent_pool
+    from ....tickets import DEFAULT_MAX_TOTAL_TURNS
 
     if flow_type == "ticket_flow":
         config = load_repo_config(repo_root)
@@ -63,6 +64,11 @@ def build_flow_definition(
             auto_commit_default=engine.config.git_auto_commit,
             include_previous_ticket_context_default=(
                 engine.config.ticket_flow.include_previous_ticket_context
+            ),
+            max_total_turns_default=(
+                engine.config.ticket_flow.max_total_turns
+                if engine.config.ticket_flow.max_total_turns is not None
+                else DEFAULT_MAX_TOTAL_TURNS
             ),
         )
     else:

--- a/src/codex_autorunner/surfaces/web/routes/flows.py
+++ b/src/codex_autorunner/surfaces/web/routes/flows.py
@@ -58,6 +58,7 @@ from ....flows.ticket_flow import build_ticket_flow_definition
 from ....flows.ticket_flow.runtime_helpers import normalize_ticket_flow_input_data
 from ....integrations.agents.build_agent_pool import build_agent_pool
 from ....integrations.github.service import GitHubError, GitHubService
+from ....tickets import DEFAULT_MAX_TOTAL_TURNS
 from ....tickets.bulk import (
     bulk_canonicalize_hermes_agents,
     bulk_clear_model_pin,
@@ -329,6 +330,11 @@ def _build_flow_definition(
             auto_commit_default=engine.config.git_auto_commit,
             include_previous_ticket_context_default=(
                 engine.config.ticket_flow.include_previous_ticket_context
+            ),
+            max_total_turns_default=(
+                engine.config.ticket_flow.max_total_turns
+                if engine.config.ticket_flow.max_total_turns is not None
+                else DEFAULT_MAX_TOTAL_TURNS
             ),
         )
     else:

--- a/tests/test_flow_worker_graceful_shutdown.py
+++ b/tests/test_flow_worker_graceful_shutdown.py
@@ -56,7 +56,9 @@ body
         durable_writes = False
         app_server = SimpleNamespace(command=["python"])
         git_auto_commit = False
-        ticket_flow = SimpleNamespace(include_previous_ticket_context=False)
+        ticket_flow = SimpleNamespace(
+            include_previous_ticket_context=False, max_total_turns=None
+        )
 
         def agent_serve_command(self, _agent: str) -> Optional[list[str]]:
             return None


### PR DESCRIPTION
## Summary

Adds `max_total_turns` to `TicketFlowConfig`, allowing a repo-level default override in `codex-autorunner.yml` under the `ticket_flow:` section. Per-dispatch override via `--max-total-turns` or `input_data` still takes highest priority.

### Precedence
1. `input_data["max_total_turns"]` (per-dispatch override, highest priority)
2. `config.ticket_flow.max_total_turns` (repo-level YAML config)
3. `DEFAULT_MAX_TOTAL_TURNS` (50, hardcoded fallback)

### Changes
- `TicketFlowConfig` dataclass: added `max_total_turns: Optional[int] = None`
- `_parse_ticket_flow_config`: validates the field type
- `build_ticket_flow_definition`: accepts `max_total_turns_default` parameter
- `runtime_helpers.py`, `flow.py`, and web routes pass the config value through
- `codex-autorunner.yml`: sets `max_total_turns: 150` under `ticket_flow:`