### PR TITLE
[codex] Clarify PMA managed-thread defaults

### DIFF
--- a/src/codex_autorunner/bootstrap.py
+++ b/src/codex_autorunner/bootstrap.py
@@ -327,8 +327,10 @@ You are an **abstraction layer, not an executor**. Coordinate tickets and flows 
 
 ## Managed Threads vs Ticket Flows
 
-- Use managed threads for exploratory/review/quick-fix/interactive debugging work in one repo.
-- Use ticket flows for structured, multi-step deliverables with acceptance criteria or cross-repo changes.
+- Managed threads are the default for straightforward work in one repo: exploratory work, reviews, bug fixes, focused refactors, and single-feature PRs that fit in one clear prompt.
+- Reuse an existing relevant managed thread before spawning a new one.
+- Do not write ticket files as scaffolding for managed-thread work.
+- Use ticket flows for larger structured work: cross-repo changes, 3+ planned tickets, explicit acceptance criteria tracking, or work that benefits from pause/resume/review handoffs.
 - Managed thread state is visible in `hub_snapshot.pma_threads`.
 - For hub-scoped PMA CLI commands, include `--path <hub_root>` so they resolve the
   intended hub config instead of relying on the current working directory.
@@ -613,6 +615,7 @@ This document is jointly maintained by the user and PMA.
 
 ## Defaults (examples)
 
+- Default to managed threads for straightforward single-session work; promote to ticket flow only when the work needs ordered multi-step structure.
 - After implementation work, add a final review ticket, then a ticket to open a PR.
 """
 

--- a/src/codex_autorunner/bootstrap.py
+++ b/src/codex_autorunner/bootstrap.py
@@ -329,6 +329,7 @@ You are an **abstraction layer, not an executor**. Coordinate tickets and flows 
 
 - Managed threads are the default for straightforward work in one repo: exploratory work, reviews, bug fixes, focused refactors, and single-feature PRs that fit in one clear prompt.
 - Reuse an existing relevant managed thread before spawning a new one.
+- Do not launch runtime CLIs directly (`codex`, `opencode`, `zeroclaw`, etc.) for PMA-managed work when a managed thread fits; use `car pma thread spawn` and `car pma thread send` so CAR can track lifecycle and progress.
 - Do not write ticket files as scaffolding for managed-thread work.
 - Use ticket flows for larger structured work: cross-repo changes, 3+ planned tickets, explicit acceptance criteria tracking, or work that benefits from pause/resume/review handoffs.
 - Managed thread state is visible in `hub_snapshot.pma_threads`.

--- a/src/codex_autorunner/core/pma_prompt_builder.py
+++ b/src/codex_autorunner/core/pma_prompt_builder.py
@@ -45,7 +45,7 @@ First-turn routine:
       - diagnose_or_restart: Run failed or stopped - suggest diagnose or restart.
     - Always include the item.open_url so the user can jump to the repo Inbox tab.
 3) BRANCH B - Managed threads vs ticket flows:
-    - If request is exploratory/review/debug/quick-fix work in one managed resource, prefer managed threads.
+    - Managed threads are the default for straightforward work in one managed resource: exploratory work, reviews, bug fixes, focused refactors, and single-feature PRs that fit in one clear prompt.
     - If `hub_snapshot.pma_threads` has a relevant active thread, resume it instead of spawning a new one.
     - Treat `chat_bound=true` managed threads as continuity artifacts protected from cleanup by default. Broad requests like "clean up workspace" do not authorize archiving or removing them; only explicit user direction does.
     - For hub-scoped PMA CLI commands, include `--path <hub_root>` so they resolve the intended hub config instead of relying on the current working directory.
@@ -58,7 +58,8 @@ First-turn routine:
       - `car pma thread status --id <managed_thread_id> --path <hub_root>`
       - `car pma thread compact --id <id> --summary "..." --path <hub_root>`
       - `car pma thread archive --id <id> --path <hub_root>`
-    - If request is a multi-step deliverable or cross-repo change, prefer tickets/ticket_flow.
+    - Do not write ticket files as scaffolding for managed-thread work. If the task fits in one clear prompt, stay in a managed thread.
+    - Use tickets/ticket_flow when the work needs ordered multi-step structure: cross-repo changes, 3+ planned tickets, explicit acceptance-criteria tracking, or pause/resume/review handoffs.
 4) BRANCH C - PMA File Inbox (fresh uploads vs stale leftovers):
     - If PMA File Inbox shows next_action="process_uploaded_file" and hub_snapshot.inbox is empty:
       - Inspect files in `.codex-autorunner/filebox/inbox/` (read their contents).
@@ -94,7 +95,7 @@ First-turn routine:
     - Identify the target managed resource(s): repo(s) and/or agent workspace(s).
     - Prefer hub-owned worktrees for changes.
     - Prefer one-shot setup/repair commands: `car hub tickets setup-pack`, `car hub tickets fmt`, `car hub tickets doctor --fix`.
-    - Create/adjust repo tickets under each repo's `.codex-autorunner/tickets/` when the target resource is repo-backed.
+    - Only create/adjust repo tickets under each repo's `.codex-autorunner/tickets/` when you have already decided the work should run as ticket_flow.
 
 Web UI map (user perspective):
 - Hub root: `/` (repos list + global notifications).

--- a/src/codex_autorunner/core/pma_prompt_builder.py
+++ b/src/codex_autorunner/core/pma_prompt_builder.py
@@ -49,6 +49,7 @@ First-turn routine:
     - If `hub_snapshot.pma_threads` has a relevant active thread, resume it instead of spawning a new one.
     - Treat `chat_bound=true` managed threads as continuity artifacts protected from cleanup by default. Broad requests like "clean up workspace" do not authorize archiving or removing them; only explicit user direction does.
     - For hub-scoped PMA CLI commands, include `--path <hub_root>` so they resolve the intended hub config instead of relying on the current working directory.
+    - Do not launch runtime CLIs directly (`codex`, `opencode`, `zeroclaw`, etc.) for PMA-managed work when a managed thread fits. Use CAR managed threads so lifecycle, progress, subscriptions, and wake-ups stay visible to PMA.
     - If no suitable thread exists, spawn one, run work, and keep it compact:
       - `car pma thread spawn --agent codex --repo <repo_id> --name <label> --path <hub_root>`
       - `car pma thread spawn --resource-kind agent_workspace --resource-id <workspace_id> --name <label> --path <hub_root>`

--- a/tests/pma_context_support.py
+++ b/tests/pma_context_support.py
@@ -484,6 +484,12 @@ def test_format_pma_prompt_includes_hub_snapshot_and_message(tmp_path: Path) -> 
     assert "Run Dispatches (paused runs needing attention):" in result
     assert "Ticket planning constraints (state machine):" in result
     assert "Managed threads vs ticket flows:" in result
+    assert (
+        "Managed threads are the default for straightforward work in one managed resource"
+        in result
+    )
+    assert "Do not write ticket files as scaffolding for managed-thread work" in result
+    assert "3+ planned tickets" in result
     assert "car pma thread spawn" in result
     assert "Automation continuity (subscriptions + timers):" in result
     assert "/hub/pma/subscriptions" in result

--- a/tests/pma_context_support.py
+++ b/tests/pma_context_support.py
@@ -488,6 +488,8 @@ def test_format_pma_prompt_includes_hub_snapshot_and_message(tmp_path: Path) -> 
         "Managed threads are the default for straightforward work in one managed resource"
         in result
     )
+    assert "Do not launch runtime CLIs directly" in result
+    assert "`codex`, `opencode`, `zeroclaw`" in result
     assert "Do not write ticket files as scaffolding for managed-thread work" in result
     assert "3+ planned tickets" in result
     assert "car pma thread spawn" in result

--- a/tests/test_pma_bootstrap.py
+++ b/tests/test_pma_bootstrap.py
@@ -34,6 +34,15 @@ def test_pma_files_created_on_hub_init(tmp_path: Path) -> None:
     assert "decisions.md" in prompt_content
     assert "spec.md" in prompt_content
     assert "car pma thread" in prompt_content
+    assert (
+        "Managed threads are the default for straightforward work in one repo"
+        in prompt_content
+    )
+    assert (
+        "Do not write ticket files as scaffolding for managed-thread work"
+        in prompt_content
+    )
+    assert "3+ planned tickets" in prompt_content
     assert "Automation primitives (event-driven continuity)" in prompt_content
     assert "/hub/pma/subscriptions" in prompt_content
     assert "/hub/pma/timers" in prompt_content
@@ -57,6 +66,14 @@ def test_pma_files_created_on_hub_init(tmp_path: Path) -> None:
     assert "flow_completed" in about_content
     assert "managed_thread_failed" in about_content
     assert ".codex-autorunner/pma/automation_store.json" in about_content
+
+    agents_path = docs_dir / "AGENTS.md"
+    assert agents_path.exists()
+    agents_content = agents_path.read_text(encoding="utf-8")
+    assert (
+        "Default to managed threads for straightforward single-session work"
+        in agents_content
+    )
 
 
 def test_pma_config_defaults(tmp_path: Path) -> None:

--- a/tests/test_pma_bootstrap.py
+++ b/tests/test_pma_bootstrap.py
@@ -38,6 +38,8 @@ def test_pma_files_created_on_hub_init(tmp_path: Path) -> None:
         "Managed threads are the default for straightforward work in one repo"
         in prompt_content
     )
+    assert "Do not launch runtime CLIs directly" in prompt_content
+    assert "`codex`, `opencode`, `zeroclaw`" in prompt_content
     assert (
         "Do not write ticket files as scaffolding for managed-thread work"
         in prompt_content


### PR DESCRIPTION
## Summary

Clarifies PMA’s default dispatch policy so straightforward coding tasks stay on managed threads instead of being inflated into ticket flow.

## What Changed

- tightened the shared PMA fastpath guidance to make managed threads the default for straightforward one-resource work
- added explicit guardrails against writing ticket files as scaffolding for managed-thread work
- limited ticket creation guidance to cases where PMA has already decided to use `ticket_flow`
- updated seeded PMA docs so new hubs inherit the same heuristic
- added tests covering both seeded PMA docs and assembled PMA prompt content

## Why

Issue #1398 describes a recurring behavior where PMA sometimes creates tickets and dispatches work directly even for small or medium coding tasks. That adds ceremony, weakens progress visibility, and bypasses managed-thread lifecycle integrations. This change moves the default policy toward managed threads for work that fits in one clear prompt, while preserving ticket flow for larger structured efforts.

## Validation

- `.venv/bin/python -m pytest tests/test_pma_bootstrap.py tests/pma_context_support.py`
- repo commit hooks completed black, ruff, mypy, frontend build/tests, and the full pytest suite during commit before the commit was recorded
