### PR TITLE
Recover from closed-loop backend bindings

### DIFF
--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -58,6 +58,7 @@ _MISSING_THREAD_MARKERS = (
     "unknown hermes turn",
     "no active hermes turn tracked",
 )
+_RECOVERABLE_BACKEND_MARKERS = _MISSING_THREAD_MARKERS + ("event loop is closed",)
 _REHYDRATION_TRANSCRIPT_LIMIT = 3
 _REHYDRATION_TEXT_LIMIT = 4_000
 logger = logging.getLogger(__name__)
@@ -123,6 +124,10 @@ def _normalize_request_kind(value: Any) -> MessageRequestKind:
 
 def _is_missing_thread_error(exc: Exception) -> bool:
     return any(marker in str(exc).lower() for marker in _MISSING_THREAD_MARKERS)
+
+
+def _is_recoverable_backend_error(exc: Exception) -> bool:
+    return any(marker in str(exc).lower() for marker in _RECOVERABLE_BACKEND_MARKERS)
 
 
 async def _resolve_harness_runtime_instance_id(
@@ -847,12 +852,12 @@ class _ThreadExecutionLifecycle:
                             AttributeError,
                             ConnectionError,
                         ) as exc:
-                            if not _is_missing_thread_error(exc):
+                            if not _is_recoverable_backend_error(exc):
                                 raise
                             log_event(
                                 logger,
                                 logging.INFO,
-                                "orchestration.thread.resume_missing_backend",
+                                "orchestration.thread.resume_recoverable_backend_error",
                                 exc=exc,
                                 thread_target_id=thread.thread_target_id,
                                 backend_thread_id=conversation_id,
@@ -964,6 +969,41 @@ class _ThreadExecutionLifecycle:
                         backend_thread_id=conversation_id,
                         operation=exc.operation,
                         status_code=exc.status_code,
+                        reason=str(exc),
+                    )
+                    self.thread_store.set_thread_backend_id(
+                        thread.thread_target_id,
+                        None,
+                        backend_runtime_instance_id=None,
+                    )
+                    conversation_id = None
+                    continue
+                except (
+                    RuntimeError,
+                    OSError,
+                    ValueError,
+                    TypeError,
+                    AttributeError,
+                    ConnectionError,
+                ) as exc:
+                    if (
+                        not used_existing_conversation
+                        or fresh_conversation_retry_attempted
+                        or not _is_recoverable_backend_error(exc)
+                    ):
+                        raise
+                    fresh_conversation_retry_attempted = True
+                    log_event(
+                        logger,
+                        logging.INFO,
+                        "orchestration.thread.refreshing_backend_binding",
+                        thread_target_id=thread.thread_target_id,
+                        execution_id=execution.execution_id,
+                        backend_thread_id=conversation_id,
+                        operation=(
+                            "start_review" if request.kind == "review" else "start_turn"
+                        ),
+                        status_code=None,
                         reason=str(exc),
                     )
                     self.thread_store.set_thread_backend_id(
@@ -1385,23 +1425,29 @@ class _ThreadRecoveryHelper:
         try:
             interrupted = await self.interrupt_thread(thread_target_id)
         except Exception as exc:
-            if not _is_missing_thread_error(exc):
+            if not _is_recoverable_backend_error(exc):
                 raise
+            reason = (
+                "interrupt_thread_not_found"
+                if _is_missing_thread_error(exc)
+                else "interrupt_thread_runtime_unavailable"
+            )
             log_event(
                 logger,
                 logging.INFO,
-                "orchestration.thread.interrupt_missing_backend",
+                "orchestration.thread.interrupt_recoverable_backend_error",
                 thread_target_id=thread_target_id,
                 execution_id=execution.execution_id,
                 backend_thread_id=backend_thread_id,
                 backend_turn_id=execution.backend_id,
+                reason=reason,
                 exc=exc,
             )
             interrupted = self.interrupt_lost_backend_execution(
                 thread_target_id=thread_target_id,
                 execution=execution,
                 backend_thread_id=backend_thread_id,
-                reason="interrupt_thread_not_found",
+                reason=reason,
             )
             return ThreadStopOutcome(
                 thread_target_id=thread_target_id,

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -680,6 +680,102 @@ async def test_send_message_retries_with_fresh_conversation_when_existing_bindin
     )
 
 
+async def test_send_message_retries_with_fresh_conversation_when_resume_hits_closed_loop(
+    tmp_path: Path,
+) -> None:
+    harness = _FakeHarness(
+        next_conversation_id="backend-fresh-2",
+        resume_conversation_error=RuntimeError("Event loop is closed"),
+    )
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target(
+        "codex",
+        workspace_root,
+        backend_thread_id="backend-existing-1",
+    )
+
+    execution = await service.send_message(
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="hello again",
+        )
+    )
+
+    refreshed_thread = service.get_thread_target(thread.thread_target_id)
+
+    assert execution.status == "running"
+    assert harness.resume_conversation_calls == [(workspace_root, "backend-existing-1")]
+    assert harness.new_conversation_calls == [(workspace_root, None)]
+    assert [call["conversation_id"] for call in harness.start_turn_calls] == [
+        "backend-fresh-2"
+    ]
+    assert refreshed_thread is not None
+    binding = _thread_runtime_binding(service, thread.thread_target_id)
+    assert binding is not None
+    assert binding.backend_thread_id == "backend-fresh-2"
+
+
+async def test_send_message_retries_with_fresh_conversation_when_start_turn_hits_closed_loop(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    harness = _FakeHarness(
+        next_conversation_id="backend-fresh-2",
+        start_turn_errors={"backend-existing-1": RuntimeError("Event loop is closed")},
+    )
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target(
+        "codex",
+        workspace_root,
+        backend_thread_id="backend-existing-1",
+    )
+
+    with caplog.at_level(
+        logging.INFO,
+        logger="codex_autorunner.core.orchestration.service",
+    ):
+        execution = await service.send_message(
+            MessageRequest(
+                target_id=thread.thread_target_id,
+                target_kind="thread",
+                message_text="hello again",
+            )
+        )
+
+    refreshed_thread = service.get_thread_target(thread.thread_target_id)
+    payloads = [
+        json.loads(record.message)
+        for record in caplog.records
+        if record.name == "codex_autorunner.core.orchestration.service"
+    ]
+
+    assert execution.status == "running"
+    assert harness.resume_conversation_calls == [(workspace_root, "backend-existing-1")]
+    assert [call["conversation_id"] for call in harness.start_turn_calls] == [
+        "backend-existing-1",
+        "backend-fresh-2",
+    ]
+    assert harness.new_conversation_calls == [(workspace_root, None)]
+    assert refreshed_thread is not None
+    binding = _thread_runtime_binding(service, thread.thread_target_id)
+    assert binding is not None
+    assert binding.backend_thread_id == "backend-fresh-2"
+    assert any(
+        payload.get("event") == "orchestration.thread.refreshing_backend_binding"
+        and payload.get("thread_target_id") == thread.thread_target_id
+        and payload.get("execution_id") == execution.execution_id
+        and payload.get("backend_thread_id") == "backend-existing-1"
+        and payload.get("operation") == "start_turn"
+        and payload.get("reason") == "Event loop is closed"
+        for payload in payloads
+    )
+
+
 async def test_send_review_retries_with_fresh_conversation_when_existing_binding_is_invalid(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -1513,6 +1609,34 @@ async def test_stop_thread_recovers_unknown_hermes_turn_interrupt_error(
     )
 
     harness.interrupt_error = RuntimeError("Unknown Hermes turn 'turn-10'")
+
+    outcome = await service.stop_thread(thread.thread_target_id)
+
+    assert len(harness.interrupt_calls) == 1
+    assert outcome.interrupted_active is True
+    assert outcome.recovered_lost_backend is True
+    assert outcome.execution is not None
+    assert outcome.execution.execution_id == execution.execution_id
+    assert outcome.execution.status == "interrupted"
+
+
+async def test_stop_thread_recovers_closed_loop_interrupt_error(
+    tmp_path: Path,
+) -> None:
+    harness = _FakeHarness()
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target("codex", workspace_root)
+    execution = await service.send_message(
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="Need an answer",
+        )
+    )
+
+    harness.interrupt_error = RuntimeError("Event loop is closed")
 
     outcome = await service.stop_thread(thread.thread_target_id)
 


### PR DESCRIPTION
## Summary
- recover managed-thread orchestration when a stale backend binding fails with `Event loop is closed`
- treat that condition like other lost-backend cases during both resume/start and stop/reset flows
- add regression coverage for fresh-conversation fallback and reset recovery

## Root cause
Recent refactoring left the surface reset paths depending on the old managed thread being interrupted cleanly before a fresh session could be created. When the underlying backend/client had already torn down, orchestration surfaced `RuntimeError: Event loop is closed` as a fatal error instead of recognizing that the backend binding was already dead.

That broke both:
- Discord fresh-session flows, which surfaced `Failed to start a fresh session.` / `Branch reset succeeded, but starting a fresh session failed.`
- Telegram PMA reset flows, which surfaced `Failed to reset PMA session; check logs for details.`

## What changed
- extend orchestration's recoverable lost-backend detection to include `Event loop is closed`
- clear stale backend bindings and retry with a fresh conversation when resume/start hits that condition on an existing binding
- treat interrupt failures with that condition as lost-backend recovery during `stop_thread`, so reset/archive can continue
- add tests covering:
  - resume on closed loop
  - start-turn on closed loop
  - stop-thread interrupt on closed loop

## Verification
- `pytest -q tests/core/orchestration/test_service.py`
- `pytest -q tests/integrations/discord/test_service_routing.py -k "reset_discord_thread_binding or handle_car_new or newt"`
- `pytest -q tests/test_telegram_pma_workspace_commands.py`
- `pytest -q tests/test_app_server_client.py tests/test_app_server_registry.py`

## Notes
I also checked the local runtime artifacts. The preserved DB/log evidence pointed to stale thread/session state and app-server disconnect cleanup, but the literal user-facing strings were not retained in the current log set.