### PR TITLE
Isolate hub control-plane clients per background loop

### DIFF
--- a/src/codex_autorunner/core/hub_control_plane/http_client.py
+++ b/src/codex_autorunner/core/hub_control_plane/http_client.py
@@ -89,15 +89,25 @@ class HttpHubControlPlaneClient(HubControlPlaneClient):
         http_client: Optional[httpx.AsyncClient] = None,
     ) -> None:
         self._base_url = _normalize_base_url(base_url)
+        self._timeout = timeout
+        self._headers = dict(headers or {})
         self._owns_client = http_client is None
         if http_client is None:
             self._http_client = httpx.AsyncClient(
                 base_url=self._base_url,
                 timeout=timeout,
-                headers=dict(headers or {}),
+                headers=dict(self._headers),
             )
         else:
             self._http_client = http_client
+
+    def clone_for_background_loop(self) -> "HttpHubControlPlaneClient":
+        """Return a client copy with its own AsyncClient for a separate event loop."""
+        return HttpHubControlPlaneClient(
+            base_url=self._base_url,
+            timeout=self._timeout,
+            headers=self._headers,
+        )
 
     async def __aenter__(self) -> "HttpHubControlPlaneClient":
         return self

--- a/src/codex_autorunner/core/hub_control_plane/remote_binding_store.py
+++ b/src/codex_autorunner/core/hub_control_plane/remote_binding_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, Callable, Coroutine, Optional, TypeVar
@@ -55,10 +56,27 @@ class RemoteSurfaceBindingStore:
         self,
         *,
         operation: str,
-        action: Callable[[], Coroutine[Any, Any, ResultT]],
+        action: Callable[[HubControlPlaneClient], Coroutine[Any, Any, ResultT]],
     ) -> ResultT:
         def _invoke() -> ResultT:
-            return asyncio.run(action())
+            background_client = self._client
+            clone = getattr(type(self._client), "clone_for_background_loop", None)
+            if callable(clone) and not inspect.iscoroutinefunction(clone):
+                cloned_client = clone(self._client)
+                if cloned_client is not None and not inspect.isawaitable(cloned_client):
+                    background_client = cloned_client
+
+            async def _run_action() -> ResultT:
+                try:
+                    return await action(background_client)
+                finally:
+                    close = getattr(background_client, "aclose", None)
+                    if callable(close) and background_client is not self._client:
+                        result = close()
+                        if inspect.isawaitable(result):
+                            await result
+
+            return asyncio.run(_run_action())
 
         try:
             with ThreadPoolExecutor(max_workers=1) as pool:
@@ -118,7 +136,7 @@ class RemoteSurfaceBindingStore:
     ) -> Any:
         response = self._run(
             operation="upsert_surface_binding",
-            action=lambda: self._client.upsert_surface_binding(
+            action=lambda client: client.upsert_surface_binding(
                 SurfaceBindingUpsertRequest(
                     surface_kind=surface_kind,
                     surface_key=surface_key,
@@ -150,7 +168,7 @@ class RemoteSurfaceBindingStore:
     ) -> Any:
         response = self._run(
             operation="get_surface_binding",
-            action=lambda: self._client.get_surface_binding(
+            action=lambda client: client.get_surface_binding(
                 SurfaceBindingLookupRequest(
                     surface_kind=surface_kind,
                     surface_key=surface_key,
@@ -260,7 +278,7 @@ class RemoteSurfaceBindingStore:
         try:
             response = self._run(
                 operation="list_surface_bindings",
-                action=lambda: self._client.list_surface_bindings(
+                action=lambda client: client.list_surface_bindings(
                     SurfaceBindingListRequest(
                         thread_target_id=thread_target_id,
                         repo_id=repo_id,

--- a/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
+++ b/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from pathlib import Path
@@ -76,10 +77,27 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
         self,
         *,
         operation: str,
-        action: Callable[[], Coroutine[Any, Any, ResultT]],
+        action: Callable[[HubControlPlaneClient], Coroutine[Any, Any, ResultT]],
     ) -> ResultT:
         def _invoke() -> ResultT:
-            return asyncio.run(action())
+            background_client = self._client
+            clone = getattr(type(self._client), "clone_for_background_loop", None)
+            if callable(clone) and not inspect.iscoroutinefunction(clone):
+                cloned_client = clone(self._client)
+                if cloned_client is not None and not inspect.isawaitable(cloned_client):
+                    background_client = cloned_client
+
+            async def _run_action() -> ResultT:
+                try:
+                    return await action(background_client)
+                finally:
+                    close = getattr(background_client, "aclose", None)
+                    if callable(close) and background_client is not self._client:
+                        result = close()
+                        if inspect.isawaitable(result):
+                            await result
+
+            return asyncio.run(_run_action())
 
         try:
             with ThreadPoolExecutor(max_workers=1) as pool:
@@ -154,7 +172,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
             metadata_payload["context_profile"] = normalized_context_profile
         response = self._run(
             operation="create_thread_target",
-            action=lambda: self._client.create_thread_target(
+            action=lambda client: client.create_thread_target(
                 ThreadTargetCreateRequest(
                     agent_id=agent_id,
                     workspace_root=str(workspace_root),
@@ -175,7 +193,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     def get_thread_target(self, thread_target_id: str) -> Optional[ThreadTarget]:
         response = self._run(
             operation="get_thread_target",
-            action=lambda: self._client.get_thread_target(
+            action=lambda client: client.get_thread_target(
                 ThreadTargetLookupRequest(thread_target_id=thread_target_id)
             ),
         )
@@ -211,7 +229,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     ) -> list[ThreadTarget]:
         response = self._run(
             operation="list_thread_targets",
-            action=lambda: self._client.list_thread_targets(
+            action=lambda client: client.list_thread_targets(
                 ThreadTargetListRequest(
                     agent_id=agent_id,
                     lifecycle_status=lifecycle_status,
@@ -234,7 +252,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     ) -> Optional[ThreadTarget]:
         response = self._run(
             operation="resume_thread_target",
-            action=lambda: self._client.resume_thread_target(
+            action=lambda client: client.resume_thread_target(
                 ThreadTargetResumeRequest(
                     thread_target_id=thread_target_id,
                     backend_thread_id=backend_thread_id,
@@ -247,7 +265,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     def archive_thread_target(self, thread_target_id: str) -> Optional[ThreadTarget]:
         response = self._run(
             operation="archive_thread_target",
-            action=lambda: self._client.archive_thread_target(
+            action=lambda client: client.archive_thread_target(
                 ThreadTargetArchiveRequest(thread_target_id=thread_target_id)
             ),
         )
@@ -262,7 +280,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     ) -> None:
         self._run(
             operation="set_thread_backend_id",
-            action=lambda: self._client.set_thread_backend_id(
+            action=lambda client: client.set_thread_backend_id(
                 ThreadBackendIdUpdateRequest(
                     thread_target_id=thread_target_id,
                     backend_thread_id=backend_thread_id,
@@ -285,7 +303,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     ) -> ExecutionRecord:
         response = self._run(
             operation="create_execution",
-            action=lambda: self._client.create_execution(
+            action=lambda client: client.create_execution(
                 ExecutionCreateRequest(
                     thread_target_id=thread_target_id,
                     prompt=prompt,
@@ -308,7 +326,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     ) -> Optional[ExecutionRecord]:
         response = self._run(
             operation="get_execution",
-            action=lambda: self._client.get_execution(
+            action=lambda client: client.get_execution(
                 ExecutionLookupRequest(
                     thread_target_id=thread_target_id,
                     execution_id=execution_id,
@@ -320,7 +338,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     def get_running_execution(self, thread_target_id: str) -> Optional[ExecutionRecord]:
         response = self._run(
             operation="get_running_execution",
-            action=lambda: self._client.get_running_execution(
+            action=lambda client: client.get_running_execution(
                 RunningExecutionLookupRequest(thread_target_id=thread_target_id)
             ),
         )
@@ -329,7 +347,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     def get_latest_execution(self, thread_target_id: str) -> Optional[ExecutionRecord]:
         response = self._run(
             operation="get_latest_execution",
-            action=lambda: self._client.get_latest_execution(
+            action=lambda client: client.get_latest_execution(
                 LatestExecutionLookupRequest(thread_target_id=thread_target_id)
             ),
         )
@@ -340,7 +358,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     ) -> list[ExecutionRecord]:
         response = self._run(
             operation="list_queued_executions",
-            action=lambda: self._client.list_queued_executions(
+            action=lambda client: client.list_queued_executions(
                 QueuedExecutionListRequest(
                     thread_target_id=thread_target_id,
                     limit=limit,
@@ -352,7 +370,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     def get_queue_depth(self, thread_target_id: str) -> int:
         response = self._run(
             operation="get_queue_depth",
-            action=lambda: self._client.get_queue_depth(
+            action=lambda client: client.get_queue_depth(
                 QueueDepthRequest(thread_target_id=thread_target_id)
             ),
         )
@@ -361,7 +379,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     def cancel_queued_execution(self, thread_target_id: str, execution_id: str) -> bool:
         response = self._run(
             operation="cancel_queued_execution",
-            action=lambda: self._client.cancel_queued_execution(
+            action=lambda client: client.cancel_queued_execution(
                 ExecutionCancelRequest(
                     thread_target_id=thread_target_id,
                     execution_id=execution_id,
@@ -375,7 +393,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     ) -> bool:
         response = self._run(
             operation="promote_queued_execution",
-            action=lambda: self._client.promote_queued_execution(
+            action=lambda client: client.promote_queued_execution(
                 ExecutionPromoteRequest(
                     thread_target_id=thread_target_id,
                     execution_id=execution_id,
@@ -389,7 +407,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     ) -> Optional[tuple[ExecutionRecord, dict[str, Any]]]:
         response = self._run(
             operation="claim_next_queued_execution",
-            action=lambda: self._client.claim_next_queued_execution(
+            action=lambda client: client.claim_next_queued_execution(
                 ExecutionClaimNextRequest(thread_target_id=thread_target_id)
             ),
         )
@@ -402,7 +420,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     ) -> None:
         self._run(
             operation="set_execution_backend_id",
-            action=lambda: self._client.set_execution_backend_id(
+            action=lambda client: client.set_execution_backend_id(
                 ExecutionBackendIdUpdateRequest(
                     execution_id=execution_id,
                     backend_turn_id=backend_turn_id,
@@ -423,7 +441,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     ) -> ExecutionRecord:
         response = self._run(
             operation="record_execution_result",
-            action=lambda: self._client.record_execution_result(
+            action=lambda client: client.record_execution_result(
                 ExecutionResultRecordRequest(
                     thread_target_id=thread_target_id,
                     execution_id=execution_id,
@@ -445,7 +463,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     ) -> ExecutionRecord:
         response = self._run(
             operation="record_execution_interrupted",
-            action=lambda: self._client.record_execution_interrupted(
+            action=lambda client: client.record_execution_interrupted(
                 ExecutionInterruptRecordRequest(
                     thread_target_id=thread_target_id,
                     execution_id=execution_id,
@@ -460,7 +478,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     def cancel_queued_executions(self, thread_target_id: str) -> int:
         response = self._run(
             operation="cancel_queued_executions",
-            action=lambda: self._client.cancel_queued_executions(
+            action=lambda client: client.cancel_queued_executions(
                 ExecutionCancelAllRequest(thread_target_id=thread_target_id)
             ),
         )
@@ -475,7 +493,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     ) -> None:
         self._run(
             operation="record_thread_activity",
-            action=lambda: self._client.record_thread_activity(
+            action=lambda client: client.record_thread_activity(
                 ThreadActivityRecordRequest(
                     thread_target_id=thread_target_id,
                     execution_id=execution_id,

--- a/tests/core/test_remote_binding_store.py
+++ b/tests/core/test_remote_binding_store.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 from codex_autorunner.core.hub_control_plane import (
@@ -42,6 +44,20 @@ class _ListingClient:
 class _UnavailableListingClient:
     async def list_surface_bindings(self, request):
         raise HubControlPlaneError("hub_unavailable", "hub offline")
+
+
+class _LoopBoundListingClient(_ListingClient):
+    def __init__(self, bindings: list[Binding]) -> None:
+        super().__init__(bindings)
+        self._owner_thread_id = threading.get_ident()
+
+    def clone_for_background_loop(self):
+        return _ListingClient(list(self.bindings))
+
+    async def list_surface_bindings(self, request):
+        if threading.get_ident() != self._owner_thread_id:
+            raise RuntimeError("Event loop is closed")
+        return await super().list_surface_bindings(request)
 
 
 def test_remote_surface_binding_store_lists_bindings_from_hub_authoritatively() -> None:
@@ -145,3 +161,15 @@ def test_remote_surface_binding_store_preserves_non_transport_hub_errors() -> No
 
     assert exc_info.value.code == "hub_rejected"
     assert str(exc_info.value) == "invalid filter payload"
+
+
+def test_remote_surface_binding_store_clones_loop_bound_client_for_background_calls() -> (
+    None
+):
+    store = RemoteSurfaceBindingStore(
+        _LoopBoundListingClient([_binding_from_mapping(binding_id="binding-hub")])
+    )
+
+    listed = store.list_bindings(limit=5)
+
+    assert [binding.binding_id for binding in listed] == ["binding-hub"]

--- a/tests/core/test_remote_execution_store.py
+++ b/tests/core/test_remote_execution_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -417,6 +418,20 @@ class _ConnectionErrorClient(_FakeHubClient):
         raise OSError("hub socket missing")
 
 
+class _LoopBoundThreadClient(_FakeHubClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self._owner_thread_id = threading.get_ident()
+
+    def clone_for_background_loop(self):
+        return _FakeHubClient()
+
+    async def get_thread_target(self, request):
+        if threading.get_ident() != self._owner_thread_id:
+            raise RuntimeError("Event loop is closed")
+        return await super().get_thread_target(request)
+
+
 def test_remote_execution_store_translates_transport_failures_to_hub_unavailable() -> (
     None
 ):
@@ -452,3 +467,12 @@ def test_remote_execution_store_translates_connection_errors_to_hub_unavailable(
     assert exc_info.value.code == "hub_unavailable"
     assert exc_info.value.details["operation"] == "get_thread_target"
     assert exc_info.value.details["cause_type"] == "OSError"
+
+
+def test_remote_execution_store_clones_loop_bound_client_for_background_calls() -> None:
+    store = RemoteThreadExecutionStore(_LoopBoundThreadClient())
+
+    thread = store.get_thread_target("thread-1")
+
+    assert thread is not None
+    assert thread.thread_target_id == "thread-1"


### PR DESCRIPTION
## Summary
- isolate hub control-plane HTTP clients per background worker loop instead of reusing one async client across thread-hopped `asyncio.run(...)` calls
- add regression tests that reproduce `RuntimeError("Event loop is closed")` on clean `origin/main` for both remote thread execution and remote surface binding stores
- keep the fix scoped to the shared reset/new-session dependency used by Discord and Telegram managed-thread resets

## Root cause
The previous merged fix (`cba99b42`) handled recoverable closed-loop errors downstream during managed-thread execution startup, but the user-reported failures happen earlier during fresh-session/reset flows.

Both Discord fresh-session/newt and Telegram PMA reset/new go through hub-backed orchestration stores:
- `RemoteThreadExecutionStore`
- `RemoteSurfaceBindingStore`

On `origin/main`, both stores call hub methods by:
1. entering a worker thread via `ThreadPoolExecutor`
2. creating a new event loop with `asyncio.run(...)`
3. reusing the same shared async hub client created on the surface service

That is a cross-loop client reuse bug. With a loop-bound async transport, the first reset-path control-plane call fails with `RuntimeError("Event loop is closed")` before the later recovery logic in `core/orchestration/service.py` ever runs.

## Reproduction
On clean `origin/main`, I added focused regression tests that simulate a loop-bound hub client. Before this patch they fail with `RuntimeError: Event loop is closed` from:
- `tests/core/test_remote_execution_store.py::test_remote_execution_store_clones_loop_bound_client_for_background_calls`
- `tests/core/test_remote_binding_store.py::test_remote_surface_binding_store_clones_loop_bound_client_for_background_calls`

## Validation
- added the two loop-bound regression tests above
- `/Users/dazheng/car-workspace/codex-autorunner/.venv/bin/pytest -q tests/core/test_remote_execution_store.py tests/core/test_remote_binding_store.py`
- `/Users/dazheng/car-workspace/codex-autorunner/.venv/bin/pytest -q tests/integrations/discord/test_service_routing.py -k "reset_discord_thread_binding or handle_car_new or newt"`
- `/Users/dazheng/car-workspace/codex-autorunner/.venv/bin/pytest -q tests/test_telegram_pma_workspace_commands.py -k "pma_new or pma_reset or reset_telegram_thread_binding or sync_telegram_thread_binding"`
- `/Users/dazheng/car-workspace/codex-autorunner/.venv/bin/pytest -q tests/core/test_hub_control_plane_contract.py`
- `/Users/dazheng/car-workspace/codex-autorunner/.venv/bin/pytest -q tests/core/test_remote_execution_store.py tests/core/test_remote_binding_store.py tests/core/test_hub_control_plane_contract.py tests/test_telegram_pma_workspace_commands.py -k "not slow"`
- full pre-commit/commit hook suite, including repo-wide pytest: `5111 passed`

## Notes
Repo-local logs from the redeploy window do not retain the exact surface error strings, but the local state is consistent with reset/startup failing before fresh bindings are re-established:
- current app-server process is new
- `app_server_threads.json` still points at an old `autorunner.opencode` session
- `sessions` / `repo_to_session` in `state.sqlite3` are empty
