### PR TITLE
Fix hub loop reuse and thread agent round-trips

### DIFF
--- a/src/codex_autorunner/core/hub_control_plane/http_client.py
+++ b/src/codex_autorunner/core/hub_control_plane/http_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from types import TracebackType
 from typing import Any, Mapping, Optional
 
@@ -92,14 +94,45 @@ class HttpHubControlPlaneClient(HubControlPlaneClient):
         self._timeout = timeout
         self._headers = dict(headers or {})
         self._owns_client = http_client is None
-        if http_client is None:
-            self._http_client = httpx.AsyncClient(
-                base_url=self._base_url,
-                timeout=timeout,
-                headers=dict(self._headers),
-            )
-        else:
-            self._http_client = http_client
+        self._client_loop: asyncio.AbstractEventLoop | None = None
+        self._http_client: Optional[httpx.AsyncClient] = (
+            self._build_http_client() if http_client is None else http_client
+        )
+        with contextlib.suppress(RuntimeError):
+            self._client_loop = asyncio.get_running_loop()
+
+    def _build_http_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=self._timeout,
+            headers=dict(self._headers),
+        )
+
+    async def _get_http_client(self) -> httpx.AsyncClient:
+        current_loop = asyncio.get_running_loop()
+        client = self._http_client
+        if client is None or (
+            self._owns_client and getattr(client, "is_closed", False)
+        ):
+            client = self._build_http_client()
+            self._http_client = client
+            self._client_loop = current_loop
+            return client
+        if (
+            self._owns_client
+            and self._client_loop is not None
+            and self._client_loop is not current_loop
+        ):
+            stale_client = client
+            client = self._build_http_client()
+            self._http_client = client
+            self._client_loop = current_loop
+            with contextlib.suppress(RuntimeError, OSError):
+                await stale_client.aclose()
+            return client
+        if self._owns_client and self._client_loop is None:
+            self._client_loop = current_loop
+        return client
 
     def clone_for_background_loop(self) -> "HttpHubControlPlaneClient":
         """Return a client copy with its own AsyncClient for a separate event loop."""
@@ -121,8 +154,14 @@ class HttpHubControlPlaneClient(HubControlPlaneClient):
         await self.aclose()
 
     async def aclose(self) -> None:
-        if self._owns_client:
-            await self._http_client.aclose()
+        if not self._owns_client:
+            return
+        client = self._http_client
+        self._client_loop = None
+        if client is None:
+            return
+        with contextlib.suppress(RuntimeError, OSError):
+            await client.aclose()
 
     async def _request(
         self,
@@ -133,7 +172,7 @@ class HttpHubControlPlaneClient(HubControlPlaneClient):
         params: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         try:
-            response = await self._http_client.request(
+            response = await (await self._get_http_client()).request(
                 method,
                 path,
                 json=dict(json_payload) if json_payload is not None else None,
@@ -183,7 +222,7 @@ class HttpHubControlPlaneClient(HubControlPlaneClient):
         params: Mapping[str, Any] | None = None,
     ) -> None:
         try:
-            response = await self._http_client.request(
+            response = await (await self._get_http_client()).request(
                 method,
                 path,
                 json=dict(json_payload) if json_payload is not None else None,

--- a/src/codex_autorunner/core/orchestration/models.py
+++ b/src/codex_autorunner/core/orchestration/models.py
@@ -162,7 +162,15 @@ class ThreadTarget:
         )
         if thread_target_id is None:
             raise ValueError("ThreadTarget requires an orchestration-owned thread id")
-        agent = _normalize_optional_text(data.get("agent")) or "unknown"
+        agent = (
+            _normalize_optional_text(
+                data.get("agent_id")
+                or data.get("agent")
+                or metadata.get("agent_id")
+                or metadata.get("agent")
+            )
+            or "unknown"
+        )
         resource_kind, resource_id, repo_id = normalize_resource_owner_fields(
             resource_kind=data.get("resource_kind"),
             resource_id=data.get("resource_id"),

--- a/tests/core/orchestration/test_orchestration_models.py
+++ b/tests/core/orchestration/test_orchestration_models.py
@@ -57,6 +57,20 @@ def test_thread_target_normalizes_managed_thread_mapping() -> None:
     assert "backend_thread_id" not in target.to_dict()
 
 
+def test_thread_target_normalizes_agent_id_round_trip_field() -> None:
+    target = ThreadTarget.from_mapping(
+        {
+            "thread_target_id": "mt-2",
+            "agent_id": "hermes",
+            "workspace_root": "/tmp/repo",
+            "metadata": {"agent_profile": "m4-pma"},
+        }
+    )
+
+    assert target.agent_id == AgentId("hermes")
+    assert target.agent_profile == "m4-pma"
+
+
 def test_binding_normalizes_surface_mapping() -> None:
     binding = Binding.from_mapping(
         {

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from codex_autorunner.core.filebox import (
@@ -20,6 +21,7 @@ from codex_autorunner.core.filebox import (
     outbox_sent_dir,
 )
 from codex_autorunner.core.flows import FlowRunStatus
+from codex_autorunner.core.hub_control_plane import WorkspaceSetupCommandRequest
 from codex_autorunner.core.update import UpdateInProgressError
 from codex_autorunner.integrations.app_server.client import CodexAppServerResponseError
 from codex_autorunner.integrations.chat.collaboration_policy import (
@@ -37,6 +39,9 @@ from codex_autorunner.integrations.chat.models import (
 )
 from codex_autorunner.integrations.discord import message_turns as discord_message_turns
 from codex_autorunner.integrations.discord import service as discord_service_module
+from codex_autorunner.integrations.discord import (
+    workspace_commands as discord_workspace_commands_module,
+)
 from codex_autorunner.integrations.discord.car_autocomplete import (
     repo_autocomplete_value,
     workspace_autocomplete_value,
@@ -7430,6 +7435,131 @@ async def test_car_newt_runs_hub_setup_commands_for_bound_workspace(
         assert len(rest.followup_messages) == 1
         content = rest.followup_messages[0]["payload"]["content"].lower()
         assert "ran 1 setup command" in content
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_hub_client_setup_commands_survive_loop_switch_after_workspace_lookup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway([_interaction(name="newt", options=[])])
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    class _LoopStickyAsyncClient:
+        instances: list["_LoopStickyAsyncClient"] = []
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            _ = args
+            self.base_url = str(kwargs.get("base_url") or "")
+            self.bound_loop: asyncio.AbstractEventLoop | None = None
+            self.calls: list[str] = []
+            type(self).instances.append(self)
+
+        async def request(
+            self,
+            method: str,
+            path: str,
+            *,
+            json: dict[str, Any] | None = None,
+            params: dict[str, Any] | None = None,
+        ) -> httpx.Response:
+            _ = method, params
+            current_loop = asyncio.get_running_loop()
+            if self.bound_loop is None:
+                self.bound_loop = current_loop
+            elif self.bound_loop is not current_loop:
+                raise RuntimeError("Event loop is closed")
+            self.calls.append(path)
+            if path == "/hub/api/control-plane/agent-workspaces":
+                return httpx.Response(
+                    200,
+                    json={
+                        "workspaces": [
+                            {
+                                "workspace_id": "wksp-1",
+                                "runtime_kind": "hermes",
+                                "workspace_root": str(workspace.resolve()),
+                                "display_name": "Workspace One",
+                                "enabled": True,
+                                "exists_on_disk": True,
+                                "resource_kind": "agent_workspace",
+                            }
+                        ]
+                    },
+                )
+            if path == "/hub/api/control-plane/handshake":
+                return httpx.Response(
+                    200,
+                    json={
+                        "api_version": "1.0.0",
+                        "minimum_client_api_version": "1.0.0",
+                        "schema_generation": discord_service_module.ORCHESTRATION_SCHEMA_VERSION,
+                        "capabilities": [],
+                    },
+                )
+            if path == "/hub/api/control-plane/workspace-setup-commands":
+                return httpx.Response(
+                    200,
+                    json={
+                        "workspace_root": json["workspace_root"] if json else "",
+                        "repo_id_hint": json.get("repo_id_hint") if json else None,
+                        "setup_command_count": 1,
+                    },
+                )
+            raise AssertionError(f"Unexpected control-plane request path: {path}")
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.hub_control_plane.http_client.httpx.AsyncClient",
+        _LoopStickyAsyncClient,
+    )
+    service._hub_client = discord_service_module.HttpHubControlPlaneClient(
+        base_url="http://testserver"
+    )
+
+    try:
+        workspaces = discord_workspace_commands_module._list_agent_workspaces(service)
+        assert workspaces == [("wksp-1", str(workspace.resolve()), "Workspace One")]
+
+        setup_result = await service._hub_client.run_workspace_setup_commands(
+            WorkspaceSetupCommandRequest(
+                workspace_root=str(workspace.resolve()),
+                repo_id_hint="repo-1",
+            )
+        )
+
+        assert setup_result.setup_command_count == 1
+        assert any(
+            "/hub/api/control-plane/agent-workspaces" in instance.calls
+            for instance in _LoopStickyAsyncClient.instances
+        )
+        assert any(
+            "/hub/api/control-plane/workspace-setup-commands" in instance.calls
+            for instance in _LoopStickyAsyncClient.instances
+        )
     finally:
         await store.close()
 

--- a/tests/surfaces/web/routes/test_hub_control_plane_routes.py
+++ b/tests/surfaces/web/routes/test_hub_control_plane_routes.py
@@ -25,6 +25,8 @@ from codex_autorunner.core.hub_control_plane import (
     QueuedExecutionListRequest,
     SurfaceBindingListRequest,
     SurfaceBindingUpsertRequest,
+    ThreadTargetListRequest,
+    ThreadTargetLookupRequest,
     TranscriptWriteRequest,
     WorkspaceSetupCommandRequest,
     serialize_run_event,
@@ -238,6 +240,21 @@ async def test_hub_control_plane_http_client_round_trip(tmp_path: Path) -> None:
                 }
             )
         )
+        fetched_thread = await client.get_thread_target(
+            ThreadTargetLookupRequest.from_mapping(
+                {"thread_target_id": thread_target_id}
+            )
+        )
+        listed_threads = await client.list_thread_targets(
+            ThreadTargetListRequest.from_mapping(
+                {
+                    "agent_id": "codex",
+                    "resource_kind": "agent_workspace",
+                    "resource_id": "wksp-1",
+                    "limit": 10,
+                }
+            )
+        )
         listed_bindings = await client.list_surface_bindings(
             SurfaceBindingListRequest.from_mapping(
                 {
@@ -393,6 +410,10 @@ async def test_hub_control_plane_http_client_round_trip(tmp_path: Path) -> None:
     assert second_delivery.record is not None
     assert first_delivery.record.delivered_message_id == "88"
     assert second_delivery.record.delivered_message_id == "88"
+    assert fetched_thread.thread is not None
+    assert fetched_thread.thread.agent_id == "codex"
+    assert listed_threads.threads
+    assert listed_threads.threads[0].agent_id == "codex"
     assert discord_binding.binding is not None
     assert [binding.binding_id for binding in listed_bindings.bindings] == [
         discord_binding.binding.binding_id


### PR DESCRIPTION
## Summary
- make the owned hub control-plane HTTP client safe to reuse after event-loop changes
- preserve `agent_id` when thread targets round-trip through the hub control plane
- add local regressions for the loop-switch setup-command path and the thread-target control-plane round-trip

## Root causes
1. `Event loop is closed`
   - `HttpHubControlPlaneClient` kept a single owned `httpx.AsyncClient` and reused it across loop boundaries.
   - That is enough to break direct control-plane calls like workspace setup commands after a prior background-loop workspace lookup.

2. `Unknown agent definition 'unknown'`
   - `ThreadTarget.to_dict()` serializes `agent_id`, but `ThreadTarget.from_mapping()` only read `agent`.
   - Hub control-plane thread responses therefore turned valid threads like `agent_id=hermes` into `agent_id=unknown` on deserialize.

## What changed
- `HttpHubControlPlaneClient` now tracks the loop for its owned client and rebuilds the owned `httpx.AsyncClient` when a request arrives from a different loop.
- `ThreadTarget.from_mapping()` now accepts both `agent_id` and `agent` (including metadata fallbacks) so control-plane round-trips preserve the runtime agent.
- Added regressions for:
  - Discord-side workspace lookup followed by `run_workspace_setup_commands(...)` on the same hub client
  - hub control-plane thread get/list round-trips preserving `agent_id`
  - `ThreadTarget.from_mapping()` with `agent_id`

## Validation
- `.venv/bin/python -m pytest tests/core/test_hub_control_plane_contract.py -q -k "http_client_aclose_closes_owned_httpx_client or http_client_context_manager_closes"`
- `.venv/bin/python -m pytest tests/core/orchestration/test_orchestration_models.py tests/surfaces/web/routes/test_hub_control_plane_routes.py tests/core/test_remote_execution_store.py tests/core/test_remote_binding_store.py tests/integrations/discord/test_service_routing.py tests/telegram_pma_routing_support.py tests/discord_message_turns_support.py -q -k "thread_target_normalizes_agent_id_round_trip_field or hub_control_plane_http_client_round_trip or hub_client_setup_commands_survive_loop_switch_after_workspace_lookup or car_newt_runs_hub_setup_commands_for_bound_workspace or newt_runs_hub_setup_commands_for_workspace or resolve_discord_thread_target_stores_agent_profile_in_metadata or resolve_discord_thread_target_reuses_legacy_hermes_runtime_alias_thread or test_remote_execution_store or test_remote_surface_binding_store"`
