### PR TITLE
[codex] Fix loop-bound hub clients and stale PMA backends

### DIFF
--- a/src/codex_autorunner/core/orchestration/models.py
+++ b/src/codex_autorunner/core/orchestration/models.py
@@ -191,7 +191,9 @@ class ThreadTarget:
             resource_kind=resource_kind,
             resource_id=resource_id,
             workspace_root=_normalize_optional_text(data.get("workspace_root")),
-            display_name=_normalize_optional_text(data.get("name")),
+            display_name=_normalize_optional_text(
+                data.get("name") or data.get("display_name")
+            ),
             status=_normalize_optional_text(
                 data.get("normalized_status") or data.get("status")
             ),
@@ -227,10 +229,37 @@ class ThreadTarget:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        payload = asdict(self)
-        payload.pop("backend_thread_id", None)
-        payload.pop("backend_runtime_instance_id", None)
-        return payload
+        return {
+            "thread_target_id": self.thread_target_id,
+            "agent": self.agent_id,
+            "agent_id": self.agent_id,
+            "agent_profile": self.agent_profile,
+            "backend_thread_id": self.backend_thread_id,
+            "backend_runtime_instance_id": self.backend_runtime_instance_id,
+            "repo_id": self.repo_id,
+            "resource_kind": self.resource_kind,
+            "resource_id": self.resource_id,
+            "workspace_root": self.workspace_root,
+            "name": self.display_name,
+            "display_name": self.display_name,
+            "status": self.status,
+            "lifecycle_status": self.lifecycle_status,
+            "status_reason": self.status_reason,
+            "status_reason_code": self.status_reason,
+            "status_changed_at": self.status_changed_at,
+            "status_updated_at": self.status_changed_at,
+            "status_terminal": self.status_terminal,
+            "status_turn_id": self.status_turn_id,
+            "last_execution_id": self.last_execution_id,
+            "last_turn_id": self.last_execution_id,
+            "last_message_preview": self.last_message_preview,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "compact_seed": self.compact_seed,
+            "thread_kind": self.thread_kind,
+            "context_profile": self.context_profile,
+            "approval_mode": self.approval_mode,
+        }
 
 
 @dataclass(frozen=True)

--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -565,7 +565,7 @@ class PmaThreadStore:
                     (
                         managed_thread_id,
                         agent,
-                        None,
+                        normalized_backend_thread_id,
                         normalized_repo_id,
                         normalized_resource_kind,
                         normalized_resource_id,
@@ -707,12 +707,13 @@ class PmaThreadStore:
                 conn.execute(
                     """
                     UPDATE orch_thread_targets
-                       SET backend_thread_id = NULL,
+                       SET backend_thread_id = ?,
                            metadata_json = ?,
                            updated_at = ?
                      WHERE thread_target_id = ?
                     """,
                     (
+                        backend_thread_id,
                         _json_dumps(metadata),
                         now_iso(),
                         managed_thread_id,

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -392,7 +392,22 @@ def _resume_managed_thread_target(
     desired_runtime_instance_id: Optional[str],
 ) -> Any:
     resume_kwargs: dict[str, Any] = {}
-    if desired_backend_thread_id is not None or current_backend_thread_id is not None:
+    if desired_backend_thread_id is None and current_backend_thread_id is not None:
+        clear_backend_thread_id = getattr(
+            orchestration_service, "set_thread_backend_id", None
+        )
+        if not callable(clear_backend_thread_id):
+            thread_store = getattr(orchestration_service, "thread_store", None)
+            clear_backend_thread_id = getattr(
+                thread_store, "set_thread_backend_id", None
+            )
+        if callable(clear_backend_thread_id):
+            clear_backend_thread_id(
+                thread.thread_target_id,
+                None,
+                backend_runtime_instance_id=desired_runtime_instance_id,
+            )
+    elif desired_backend_thread_id is not None or current_backend_thread_id is not None:
         resume_kwargs["backend_thread_id"] = desired_backend_thread_id
     resume_kwargs["backend_runtime_instance_id"] = desired_runtime_instance_id
     return orchestration_service.resume_thread_target(

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -387,27 +387,28 @@ def _resume_managed_thread_target(
     orchestration_service: Any,
     thread: Any,
     *,
+    clear_backend_thread_id: bool,
     desired_backend_thread_id: Optional[str],
     current_backend_thread_id: Optional[str],
     desired_runtime_instance_id: Optional[str],
 ) -> Any:
     resume_kwargs: dict[str, Any] = {}
-    if desired_backend_thread_id is None and current_backend_thread_id is not None:
-        clear_backend_thread_id = getattr(
+    if clear_backend_thread_id and current_backend_thread_id is not None:
+        clear_backend_thread_id_fn = getattr(
             orchestration_service, "set_thread_backend_id", None
         )
-        if not callable(clear_backend_thread_id):
+        if not callable(clear_backend_thread_id_fn):
             thread_store = getattr(orchestration_service, "thread_store", None)
-            clear_backend_thread_id = getattr(
+            clear_backend_thread_id_fn = getattr(
                 thread_store, "set_thread_backend_id", None
             )
-        if callable(clear_backend_thread_id):
-            clear_backend_thread_id(
+        if callable(clear_backend_thread_id_fn):
+            clear_backend_thread_id_fn(
                 thread.thread_target_id,
                 None,
                 backend_runtime_instance_id=desired_runtime_instance_id,
             )
-    elif desired_backend_thread_id is not None or current_backend_thread_id is not None:
+    elif desired_backend_thread_id is not None:
         resume_kwargs["backend_thread_id"] = desired_backend_thread_id
     resume_kwargs["backend_runtime_instance_id"] = desired_runtime_instance_id
     return orchestration_service.resume_thread_target(
@@ -617,6 +618,9 @@ def resolve_managed_thread_target(
         thread = _resume_managed_thread_target(
             orchestration_service,
             thread,
+            clear_backend_thread_id=(
+                request.mode == "pma" and desired_backend_thread_id is None
+            ),
             desired_backend_thread_id=desired_backend_thread_id,
             current_backend_thread_id=current_backend_thread_id,
             desired_runtime_instance_id=desired_runtime_instance_id,

--- a/tests/core/orchestration/test_orchestration_models.py
+++ b/tests/core/orchestration/test_orchestration_models.py
@@ -54,7 +54,8 @@ def test_thread_target_normalizes_managed_thread_mapping() -> None:
     assert target.resource_id == "repo-1"
     assert target.status == "running"
     assert target.thread_kind == "ticket_flow"
-    assert "backend_thread_id" not in target.to_dict()
+    assert target.to_dict()["backend_thread_id"] is None
+    assert target.to_dict()["agent"] == "codex"
 
 
 def test_thread_target_normalizes_agent_id_round_trip_field() -> None:

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -9,12 +9,18 @@ from typing import Any, Optional
 
 from codex_autorunner.agents.registry import AgentDescriptor
 from codex_autorunner.agents.types import TerminalTurnResult
+from codex_autorunner.core.hub_control_plane import (
+    ExecutionResponse,
+    RemoteThreadExecutionStore,
+    ThreadTargetResponse,
+)
 from codex_autorunner.core.orchestration import (
     HarnessBackedOrchestrationService,
     MappingAgentDefinitionCatalog,
     MessageRequest,
     PmaThreadExecutionStore,
 )
+from codex_autorunner.core.orchestration.models import ExecutionRecord, ThreadTarget
 from codex_autorunner.core.orchestration.runtime_threads import (
     RUNTIME_THREAD_MISSING_BACKEND_IDS_ERROR,
     await_runtime_thread_outcome,
@@ -300,6 +306,90 @@ def _build_service(
     )
 
 
+class _SerializedHubClient:
+    def __init__(self, store: PmaThreadExecutionStore) -> None:
+        self._store = store
+
+    @staticmethod
+    def _serialize_thread(thread: ThreadTarget | None) -> ThreadTargetResponse:
+        return ThreadTargetResponse.from_mapping(
+            ThreadTargetResponse(thread=thread).to_dict()
+        )
+
+    @staticmethod
+    def _serialize_execution(execution: ExecutionRecord | None) -> ExecutionResponse:
+        payload = (
+            None
+            if execution is None
+            else ExecutionResponse(execution=execution).to_dict()["execution"]
+        )
+        return ExecutionResponse.from_mapping({"execution": payload})
+
+    async def create_thread_target(self, request: Any) -> ThreadTargetResponse:
+        return self._serialize_thread(
+            self._store.create_thread_target(
+                request.agent_id,
+                Path(request.workspace_root),
+                repo_id=request.repo_id,
+                resource_kind=request.resource_kind,
+                resource_id=request.resource_id,
+                display_name=request.display_name,
+                backend_thread_id=request.backend_thread_id,
+                context_profile=request.metadata.get("context_profile"),
+                metadata=request.metadata,
+            )
+        )
+
+    async def get_thread_target(self, request: Any) -> ThreadTargetResponse:
+        return self._serialize_thread(
+            self._store.get_thread_target(request.thread_target_id)
+        )
+
+    async def create_execution(self, request: Any) -> ExecutionResponse:
+        return self._serialize_execution(
+            self._store.create_execution(
+                request.thread_target_id,
+                prompt=request.prompt,
+                request_kind=request.request_kind,
+                busy_policy=request.busy_policy,
+                model=request.model,
+                reasoning=request.reasoning,
+                client_request_id=request.client_request_id,
+                queue_payload=request.queue_payload,
+            )
+        )
+
+    async def get_execution(self, request: Any) -> ExecutionResponse:
+        return self._serialize_execution(
+            self._store.get_execution(request.thread_target_id, request.execution_id)
+        )
+
+    async def get_running_execution(self, request: Any) -> ExecutionResponse:
+        return self._serialize_execution(
+            self._store.get_running_execution(request.thread_target_id)
+        )
+
+    async def set_thread_backend_id(self, request: Any) -> None:
+        self._store.set_thread_backend_id(
+            request.thread_target_id,
+            request.backend_thread_id,
+            backend_runtime_instance_id=request.backend_runtime_instance_id,
+        )
+
+    async def set_execution_backend_id(self, request: Any) -> None:
+        self._store.set_execution_backend_id(
+            request.execution_id,
+            request.backend_turn_id,
+        )
+
+    async def record_thread_activity(self, request: Any) -> None:
+        self._store.record_thread_activity(
+            request.thread_target_id,
+            execution_id=request.execution_id,
+            message_preview=request.message_preview,
+        )
+
+
 async def test_runtime_threads_begin_and_wait_with_agent_harness(
     tmp_path: Path,
 ) -> None:
@@ -362,6 +452,46 @@ async def test_runtime_threads_use_wait_for_turn_contract_for_session_runtimes(
     assert outcome.status == "ok"
     assert harness.wait_calls == [(workspace_root, "session-1", "stream-turn-1")]
     assert outcome.assistant_text == "hello world"
+
+
+async def test_runtime_threads_begin_and_wait_via_serialized_remote_store(
+    tmp_path: Path,
+) -> None:
+    harness = _HarnessWithWait()
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    local_store = PmaThreadExecutionStore(PmaThreadStore(tmp_path / "hub"))
+    remote_store = RemoteThreadExecutionStore(_SerializedHubClient(local_store))
+    descriptors = {"codex": _make_descriptor("codex")}
+    service = HarnessBackedOrchestrationService(
+        definition_catalog=MappingAgentDefinitionCatalog(descriptors),
+        thread_store=remote_store,
+        harness_factory=lambda resolved_agent_id: harness,
+    )
+    thread = service.create_thread_target("codex", workspace_root)
+
+    started = await begin_runtime_thread_execution(
+        service,
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="user-visible prompt",
+        ),
+    )
+    outcome = await await_runtime_thread_outcome(
+        started,
+        interrupt_event=asyncio.Event(),
+        timeout_seconds=5,
+        execution_error_message="Managed thread execution failed",
+    )
+
+    assert started.thread.agent_id == "codex"
+    assert started.thread.backend_thread_id == "backend-thread-1"
+    assert started.execution.backend_id == "backend-turn-1"
+    assert harness.wait_calls == [
+        (workspace_root, "backend-thread-1", "backend-turn-1")
+    ]
+    assert outcome.status == "ok"
 
 
 async def test_runtime_threads_allow_missing_interrupt_event(

--- a/tests/core/test_hub_control_plane_contract.py
+++ b/tests/core/test_hub_control_plane_contract.py
@@ -244,6 +244,32 @@ def test_thread_target_response_uses_existing_generic_thread_model() -> None:
     assert response.to_dict()["thread"]["thread_target_id"] == "thread-1"
 
 
+def test_thread_target_response_round_trips_agent_and_backend_ids() -> None:
+    response = ThreadTargetResponse.from_mapping(
+        {
+            "thread": {
+                "thread_target_id": "thread-1",
+                "agent": "codex",
+                "workspace_root": "/tmp/repo",
+                "backend_thread_id": "backend-thread-1",
+                "backend_runtime_instance_id": "runtime-1",
+                "name": "Main thread",
+            }
+        }
+    )
+
+    payload = response.to_dict()
+    round_tripped = ThreadTargetResponse.from_mapping(payload)
+
+    assert payload["thread"]["agent"] == "codex"
+    assert payload["thread"]["backend_thread_id"] == "backend-thread-1"
+    assert payload["thread"]["backend_runtime_instance_id"] == "runtime-1"
+    assert round_tripped.thread is not None
+    assert round_tripped.thread.agent_id == "codex"
+    assert round_tripped.thread.backend_thread_id == "backend-thread-1"
+    assert round_tripped.thread.backend_runtime_instance_id == "runtime-1"
+
+
 def test_execution_models_round_trip_with_existing_execution_record() -> None:
     create_request = ExecutionCreateRequest.from_mapping(
         {

--- a/tests/integrations/chat/test_managed_thread_turns.py
+++ b/tests/integrations/chat/test_managed_thread_turns.py
@@ -607,6 +607,96 @@ def test_resolve_managed_thread_target_resumes_matching_binding(tmp_path: Path) 
     ]
 
 
+def test_resolve_managed_thread_target_clears_stale_backend_for_fresh_pma_session(
+    tmp_path: Path,
+) -> None:
+    canonical_workspace = str(tmp_path.resolve())
+    thread = SimpleNamespace(
+        thread_target_id="thread-1",
+        agent_id="codex",
+        agent_profile=None,
+        workspace_root=canonical_workspace,
+        lifecycle_status="paused",
+        backend_thread_id="stale-session",
+        backend_runtime_instance_id="runtime-old",
+    )
+    binding = SimpleNamespace(thread_target_id="thread-1", mode="pma")
+    clear_calls: list[dict[str, Any]] = []
+    resume_calls: list[dict[str, Any]] = []
+
+    class _Service:
+        def get_binding(self, *, surface_kind: str, surface_key: str) -> Any:
+            _ = surface_kind, surface_key
+            return binding
+
+        def get_thread_target(self, thread_target_id: str) -> Any:
+            assert thread_target_id == "thread-1"
+            return thread
+
+        def set_thread_backend_id(
+            self,
+            thread_target_id: str,
+            backend_thread_id: Optional[str],
+            *,
+            backend_runtime_instance_id: Optional[str] = None,
+        ) -> None:
+            assert thread_target_id == "thread-1"
+            clear_calls.append(
+                {
+                    "backend_thread_id": backend_thread_id,
+                    "backend_runtime_instance_id": backend_runtime_instance_id,
+                }
+            )
+            thread.backend_thread_id = backend_thread_id
+            thread.backend_runtime_instance_id = backend_runtime_instance_id
+
+        def resume_thread_target(self, thread_target_id: str, **kwargs: Any) -> Any:
+            assert thread_target_id == "thread-1"
+            resume_calls.append(kwargs)
+            return SimpleNamespace(
+                thread_target_id="thread-1",
+                agent_id="codex",
+                agent_profile=None,
+                workspace_root=canonical_workspace,
+                lifecycle_status="active",
+                backend_thread_id=thread.backend_thread_id,
+                backend_runtime_instance_id=thread.backend_runtime_instance_id,
+            )
+
+        def create_thread_target(self, *args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("create_thread_target should not be called")
+
+        def upsert_binding(self, **kwargs: Any) -> None:
+            pass
+
+    _, resolved_thread = managed_thread_turns_module.resolve_managed_thread_target(
+        _Service(),
+        request=managed_thread_turns_module.ManagedThreadTargetRequest(
+            surface_kind="telegram",
+            surface_key="telegram:-1001:101",
+            mode="pma",
+            agent="codex",
+            workspace_root=tmp_path,
+            display_name="telegram:surface",
+            binding_metadata={"topic_key": "telegram:-1001:101"},
+        ),
+    )
+
+    assert resolved_thread is not None
+    assert clear_calls == [
+        {
+            "backend_thread_id": None,
+            "backend_runtime_instance_id": None,
+        }
+    ]
+    assert resume_calls == [
+        {
+            "backend_runtime_instance_id": None,
+        }
+    ]
+    assert resolved_thread.backend_thread_id is None
+
+
 def test_resolve_managed_thread_target_reuses_backend_matched_thread(
     tmp_path: Path,
 ) -> None:

--- a/tests/integrations/chat/test_managed_thread_turns.py
+++ b/tests/integrations/chat/test_managed_thread_turns.py
@@ -697,6 +697,85 @@ def test_resolve_managed_thread_target_clears_stale_backend_for_fresh_pma_sessio
     assert resolved_thread.backend_thread_id is None
 
 
+def test_resolve_managed_thread_target_keeps_backend_for_repo_resume_without_rebind(
+    tmp_path: Path,
+) -> None:
+    canonical_workspace = str(tmp_path.resolve())
+    thread = SimpleNamespace(
+        thread_target_id="thread-1",
+        agent_id="codex",
+        agent_profile=None,
+        workspace_root=canonical_workspace,
+        lifecycle_status="archived",
+        backend_thread_id="backend-existing",
+        backend_runtime_instance_id=None,
+    )
+    binding = SimpleNamespace(thread_target_id="thread-1", mode="repo")
+    clear_calls: list[dict[str, Any]] = []
+    resume_calls: list[dict[str, Any]] = []
+
+    class _Service:
+        def get_binding(self, *, surface_kind: str, surface_key: str) -> Any:
+            _ = surface_kind, surface_key
+            return binding
+
+        def get_thread_target(self, thread_target_id: str) -> Any:
+            assert thread_target_id == "thread-1"
+            return thread
+
+        def set_thread_backend_id(
+            self,
+            thread_target_id: str,
+            backend_thread_id: Optional[str],
+            *,
+            backend_runtime_instance_id: Optional[str] = None,
+        ) -> None:
+            assert thread_target_id == "thread-1"
+            clear_calls.append(
+                {
+                    "backend_thread_id": backend_thread_id,
+                    "backend_runtime_instance_id": backend_runtime_instance_id,
+                }
+            )
+
+        def resume_thread_target(self, thread_target_id: str, **kwargs: Any) -> Any:
+            assert thread_target_id == "thread-1"
+            resume_calls.append(kwargs)
+            return SimpleNamespace(
+                thread_target_id="thread-1",
+                agent_id="codex",
+                agent_profile=None,
+                workspace_root=canonical_workspace,
+                lifecycle_status="active",
+                backend_thread_id=thread.backend_thread_id,
+                backend_runtime_instance_id=thread.backend_runtime_instance_id,
+            )
+
+        def create_thread_target(self, *args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("create_thread_target should not be called")
+
+        def upsert_binding(self, **kwargs: Any) -> None:
+            pass
+
+    _, resolved_thread = managed_thread_turns_module.resolve_managed_thread_target(
+        _Service(),
+        request=managed_thread_turns_module.ManagedThreadTargetRequest(
+            surface_kind="discord",
+            surface_key="discord:channel-1",
+            mode="repo",
+            agent="codex",
+            workspace_root=tmp_path,
+            display_name="discord:surface",
+            binding_metadata={"channel_id": "channel-1"},
+        ),
+    )
+
+    assert resolved_thread is not None
+    assert clear_calls == []
+    assert resume_calls == [{"backend_runtime_instance_id": None}]
+    assert resolved_thread.backend_thread_id == "backend-existing"
+
+
 def test_resolve_managed_thread_target_reuses_backend_matched_thread(
     tmp_path: Path,
 ) -> None:

--- a/tests/surfaces/web/routes/test_hub_control_plane_routes.py
+++ b/tests/surfaces/web/routes/test_hub_control_plane_routes.py
@@ -25,6 +25,7 @@ from codex_autorunner.core.hub_control_plane import (
     QueuedExecutionListRequest,
     SurfaceBindingListRequest,
     SurfaceBindingUpsertRequest,
+    ThreadBackendIdUpdateRequest,
     ThreadTargetListRequest,
     ThreadTargetLookupRequest,
     TranscriptWriteRequest,
@@ -436,6 +437,39 @@ async def test_hub_control_plane_http_client_round_trip(tmp_path: Path) -> None:
     assert claimed.execution.execution_id == queued_execution.execution.execution_id
     assert claimed.queue_payload == {"source": "test"}
     assert setup_result.setup_command_count == 3
+
+
+@pytest.mark.anyio
+async def test_hub_control_plane_http_client_preserves_thread_backend_ids(
+    tmp_path: Path,
+) -> None:
+    app, thread_target_id = _build_test_app(tmp_path)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as http_client:
+        client = HttpHubControlPlaneClient(
+            base_url="http://testserver",
+            http_client=http_client,
+        )
+        await client.set_thread_backend_id(
+            ThreadBackendIdUpdateRequest.from_mapping(
+                {
+                    "thread_target_id": thread_target_id,
+                    "backend_thread_id": "conversation-1",
+                    "backend_runtime_instance_id": "runtime-1",
+                }
+            )
+        )
+        fetched = await client.get_thread_target(
+            ThreadTargetLookupRequest(thread_target_id=thread_target_id)
+        )
+
+    assert fetched.thread is not None
+    assert fetched.thread.agent_id == "codex"
+    assert fetched.thread.backend_thread_id == "conversation-1"
+    assert fetched.thread.backend_runtime_instance_id == "runtime-1"
 
 
 @pytest.mark.anyio

--- a/tests/telegram_pma_routing_support.py
+++ b/tests/telegram_pma_routing_support.py
@@ -2959,7 +2959,6 @@ async def test_resolve_telegram_managed_thread_ignores_backend_thread_id_binding
         (
             "thread-1",
             {
-                "backend_thread_id": None,
                 "backend_runtime_instance_id": None,
             },
         )

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -11,6 +11,7 @@ from codex_autorunner.core.orchestration.execution_history import ExecutionCheck
 from codex_autorunner.core.orchestration.runtime_bindings import (
     clear_runtime_thread_binding,
 )
+from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.pma_thread_store import (
     ManagedThreadAlreadyHasRunningTurnError,
     ManagedThreadNotActiveError,
@@ -63,6 +64,34 @@ def test_create_list_get_thread(tmp_path: Path) -> None:
     )
     assert len(normalized_listed) == 1
     assert normalized_listed[0]["managed_thread_id"] == created["managed_thread_id"]
+
+
+def test_create_thread_mirrors_backend_thread_id_into_orchestration_row(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    store = PmaThreadStore(hub_root)
+    created = store.create_thread(
+        "codex",
+        workspace_root,
+        backend_thread_id="backend-1",
+    )
+
+    with open_orchestration_sqlite(hub_root, durable=False) as conn:
+        row = conn.execute(
+            """
+            SELECT backend_thread_id
+              FROM orch_thread_targets
+             WHERE thread_target_id = ?
+            """,
+            (created["managed_thread_id"],),
+        ).fetchone()
+
+    assert row is not None
+    assert row["backend_thread_id"] == "backend-1"
 
 
 def test_create_thread_enriches_head_branch_metadata(
@@ -273,6 +302,17 @@ def test_set_thread_backend_id_preserves_runtime_tag_when_omitted(
     assert binding.backend_runtime_instance_id == "runtime-1"
     assert "backend_thread_id" not in updated
     assert "backend_runtime_instance_id" not in updated
+    with open_orchestration_sqlite(tmp_path / "hub", durable=False) as conn:
+        row = conn.execute(
+            """
+            SELECT backend_thread_id
+              FROM orch_thread_targets
+             WHERE thread_target_id = ?
+            """,
+            (thread["managed_thread_id"],),
+        ).fetchone()
+    assert row is not None
+    assert row["backend_thread_id"] == "backend-2"
 
 
 def test_create_turn_rejects_when_running_turn_exists(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- make hub control-plane clients safe to use from remote stores that execute requests on background event loops by cloning loop-bound HTTP clients before dispatch
- clear stale PMA backend bindings before resuming a fresh PMA-managed thread so `/new`-style flows do not carry forward dead backend session ids
- add regression coverage for remote binding/execution stores, managed-thread resolution, and Telegram PMA routing

## Root Cause

- `RemoteThreadExecutionStore` and `RemoteSurfaceBindingStore` call async hub clients from a background `asyncio.run(...)` loop. Reusing a loop-bound `HttpHubControlPlaneClient` across those loops can surface `Event loop is closed` even when the hub is healthy.
- PMA resume paths could reuse an archived thread while leaving its old `backend_thread_id` attached when the caller intentionally wanted a fresh session. That made fresh-session resets inconsistent across surfaces.

## Validation

- `rtk .venv/bin/pytest tests/core/test_remote_binding_store.py tests/core/test_remote_execution_store.py tests/integrations/chat/test_managed_thread_turns.py tests/test_telegram_pma_managed_threads.py tests/core/orchestration/test_orchestration_models.py -q`
- `rtk .venv/bin/pytest tests/core/test_hub_control_plane_contract.py tests/surfaces/web/routes/test_hub_control_plane_routes.py tests/core/orchestration/test_runtime_threads.py tests/test_pma_thread_store.py tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py -q`
