### PR TITLE
Documentation: contextspace alignment, links, and clarity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This repo dogfoods codex-autorunner to build itself. Read this before running th
 
 ## Layout and key files
 - Core package: `src/codex_autorunner/` (engine, CLI, server/API, UI assets).
-- Frontend JS is generated from TypeScript: edit `static_src/*.ts`, not `static/*.js` (run `pnpm run build` after).
+- Frontend JS is generated from TypeScript: edit `src/codex_autorunner/static_src/*.ts`, not `src/codex_autorunner/static/*.js` (run `pnpm run build` after).
 - Runtime/config/state live under `.codex-autorunner/` (not at repo root):
   - Primary work surface: `.codex-autorunner/tickets/TICKET-###.md` (required).
   - Optional contextspace docs (auto-created on write; missing is OK):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thanks for helping improve codex-autorunner.
 ## Development
 - Bootstrap dev env (venv, dev deps, npm deps, hooks): `make setup`
 - Install dev deps: `pip install -e .[dev]`
-- Run tests: `python -m pytest` (or `make test`)
+- Run tests: `.venv/bin/python -m pytest` after `make setup` (or `make test`)
 - JS lint (UI): `npm run lint:js`
 - Format: `python -m black src tests`
 - Build static assets: `pnpm run build` (source is `src/codex_autorunner/static_src/`, output is `src/codex_autorunner/static/`)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -26,7 +26,7 @@ Hub root:
 Per-repo (under hub or standalone for development):
   .codex-autorunner/
     tickets/ (TICKET-###.md files)
-    workspace/ (active_context.md, decisions.md, spec.md)
+    contextspace/ (active_context.md, decisions.md, spec.md)
     config.yml (generated)
     state.sqlite3, codex-autorunner.log, codex-server.log, lock
     prompt.txt (optional template)
@@ -37,8 +37,10 @@ Precedence: built-ins < codex-autorunner.yml < override < .codex-autorunner/conf
 ## Core loop
 - Parse TODO checkboxes and preserve ordering.
 - Build prompt from docs plus bounded prior run output.
-- Run Codex app-server with streaming logs via OpenCode runtime.
+- Run the configured execution backend (for example Codex app-server with OpenCode runtime, or an ACP-backed runtime such as Hermes).
 - Update state and stop on empty TODOs, non-zero exit, stop_after_runs, wallclock limit, or external stop flag.
+
+If `.codex-autorunner/workspace/` still exists with content from older installs, migrate to `contextspace/` using `docs/migrations/workspace-to-contextspace.md`.
 
 ## API surface (repo)
 - Docs: /api/docs, /api/docs/{kind}, doc chat endpoints, /api/ingest-spec, /api/docs/clear.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The shim will try `PYTHONPATH=src` first and, if dependencies are missing, will 
 ## Supported agents
 CAR currently supports:
 - Codex
-- Opencode
+- OpenCode
 - Hermes (ACP-backed runtime with durable threads)
 
 CAR is built to easily integrate any reasonable agent built for Agent Client Protocol (ACP). If you would like to see your agent supported, please reach out or open a PR.
@@ -101,15 +101,15 @@ Tickets are just markdown files that both you and the agent can edit.
 You don't have to babysit the agents, they inbox you or ping you on Telegram.
 ![CAR Inbox Screenshot](docs/screenshots/inbox.png)
 
-You can collaborate with the agents in a shared workspace, independent of the codebase. Drop context there, extract artifacts, it's like a shared scratchpad.
-![CAR Workspace Screenshot](docs/screenshots/workspace.png)
+You can collaborate with the agents in the shared **contextspace** (context documents under `.codex-autorunner/contextspace/`), independent of the codebase. Drop context there, extract artifacts, it's like a shared scratchpad.
+![CAR contextspace screenshot](docs/screenshots/workspace.png)
 
-All core workspace documents are also just markdown files, so you and the agent can easily edit them.
-![CAR Workspace New MD Screenshot](docs/screenshots/workspace-new-md.png)
+All core contextspace documents are also just markdown files, so you and the agent can easily edit them.
+![CAR contextspace new markdown screenshot](docs/screenshots/workspace-new-md.png)
 
 If you need to do something more custom or granular, you can use your favorite agent TUIs in the built-in terminal.
 ![CAR Terminal Codex Screenshot](docs/screenshots/terminal-codex.png)
-![CAR Terminal Opencode Screenshot](docs/screenshots/terminal-opencode.png)
+![CAR Terminal OpenCode screenshot](docs/screenshots/terminal-opencode.png)
 
 On the go or want to use your favorite chat apps? CAR supports Telegram and Discord.
 ![CAR Discord Media Image Screenshot](docs/screenshots/discord-media-image.png)

--- a/docs/STATE_ROOTS.md
+++ b/docs/STATE_ROOTS.md
@@ -26,7 +26,7 @@ All durable artifacts must live under one of these roots:
 - `pma/` - PMA state and queue
 - `archive/` - Worktree snapshots
 - `bin/` - Generated helper scripts
-- `workspace/` - Workspace directory
+- `workspace/` - Legacy directory name only; CAR reads durable context from `contextspace/` (see [workspace → contextspace migration](migrations/workspace-to-contextspace.md)). If this directory still exists, `car doctor` may warn until you migrate or remove it.
 - `app_server_workspaces/` - App-server supervisor/workspace state when the effective destination is `docker`
 - `filebox/` - Shared inbox/outbox attachment root (`filebox/inbox`, `filebox/outbox`)
 

--- a/docs/car_constitution/10_CODEBASE_CONSTITUTION.md
+++ b/docs/car_constitution/10_CODEBASE_CONSTITUTION.md
@@ -3,7 +3,7 @@
 This document defines the identity and long-lived invariants of the CAR codebase. It is intentionally aspirational and time-decay resistant.
 
 ## Identity
-CAR is a local-first, filesystem-backed agent orchestration system with multiple user surfaces (e.g., Telegram, Web) and multiple execution backends (e.g., Codex, OpenCode). It optimizes for leverage, speed, and evolvability.
+CAR is a local-first, filesystem-backed agent orchestration system with multiple user surfaces (e.g., Telegram, Web) and multiple execution backends (e.g., Codex, OpenCode, Hermes and other ACP-backed runtimes). It optimizes for leverage, speed, and evolvability.
 
 ## Non-negotiable invariants
 

--- a/docs/car_constitution/20_ARCHITECTURE_MAP.md
+++ b/docs/car_constitution/20_ARCHITECTURE_MAP.md
@@ -51,7 +51,7 @@ Non-responsibilities:
 Mapping the conceptual layers to the codebase:
 
 - **Engine**: `src/codex_autorunner/core/`. Handles the core loop, state, and locking.
-- **Control Plane**: `.codex-autorunner/` (files), `tickets/` (python).
+- **Control Plane**: `.codex-autorunner/` (files, including the ticket queue under `tickets/`). Ticket queue behavior is implemented under `src/codex_autorunner/tickets/`.
 - **Adapters**: `src/codex_autorunner/integrations/` (GitHub, Telegram, App Server).
   - **Discord interaction runtime**: ingress (`ingress.py`) -> command runner (`command_runner.py`) -> interaction dispatch (`interaction_dispatch.py`).  Two-phase lifecycle: ingress acknowledges on the gateway hot path, then the runner executes the handler in the background with timeout enforcement.
 - **Surfaces**:
@@ -84,7 +84,7 @@ Mapping the conceptual layers to the codebase:
 ## Execution Loop
 1. **Select Ticket**: Active ticket target under `.codex-autorunner/tickets/`.
 2. **Build Prompt**: From ticket content, contextspace docs, and bounded prior run output.
-3. **Run**: Execute Codex app-server with streaming logs via OpenCode runtime.
+3. **Run**: Execute the configured backend (for example Codex app-server with OpenCode runtime, or Hermes and other ACP-backed runtimes; see `docs/ops/hermes-acp.md`).
 4. **Update State**: Handle stop rules (exit code, stop_after_runs, limits).
 
 ## Dispatch Model (Agent-Human Communication)

--- a/docs/car_constitution/90_PROTOCOLS_REFERENCES.md
+++ b/docs/car_constitution/90_PROTOCOLS_REFERENCES.md
@@ -2,7 +2,7 @@
 
 This folder contains stable external protocol references used by CAR integrations. Only consult these when implementing or debugging low-level protocol behavior (streaming, events, RPC, etc.).
 
-- Codex app-server developer guide: `../references/Codex app-server developer guide.md`
-- OpenCode server API reference: `../references/OpenCode Server API.md`
-- CAR plugin API (entry points): `../references/plugin-api.md`
-- Telegram integration spec (outbox, triggers, dispatch, allowlist): `../references/telegram-integration.md`
+- Codex app-server developer guide: `../codex/Codex app-server developer guide.md`
+- OpenCode server API reference: `../opencode/OpenCode Server API.md`
+- CAR plugin API (entry points): `../plugin-api.md`
+- Telegram integration spec (outbox, triggers, dispatch, allowlist): `../telegram/telegram-integration.md`

--- a/docs/car_constitution/95_GLOSSARY.md
+++ b/docs/car_constitution/95_GLOSSARY.md
@@ -4,12 +4,14 @@
 
 - **Engine**: protocol-agnostic runtime semantics (runs, scheduling, state transitions).
 - **Control plane**: filesystem-backed intent + artifacts; canonical state under `.codex-autorunner/`.
-- **Adapter**: protocol translation layer (Telegram/Web/Codex/OpenCode) into engine commands.
+- **Adapter**: protocol translation layer (Telegram/Web/Codex/OpenCode/Hermes) into engine commands.
 - **Surface**: user-facing UX (Telegram chat, web UI, terminal views).
 - **Run**: a single execution with a unique identity and durable artifacts.
 - **Run event**: structured record of a significant state transition/decision.
 - **Artifact**: any durable file that explains intent, action, or output.
-- **Workspace**: isolated filesystem scope for a task/run (often disposable).
+- **Ticket**: a numbered markdown work item under `.codex-autorunner/tickets/` (for example `TICKET-001.md`); the primary human–agent execution surface.
+- **Contextspace**: durable agent context docs under `.codex-autorunner/contextspace/` (`active_context.md`, `decisions.md`, `spec.md`). Not the same as a disposable process working directory.
+- **Workspace**: isolated filesystem scope for a task or runtime (often disposable), or the deprecated `.codex-autorunner/workspace/` directory replaced by contextspace (see migration doc).
 - **YOLO mode**: default permissive execution posture; safety is opt-in.
 
 ## Agent-Human Communication
@@ -23,6 +25,8 @@
 - **Notification**: External alert sent to Discord/Telegram when system events occur (run finished, tui idle, etc.). Distinct from dispatches—notifications are delivery infrastructure, not agent communication.
 
 ## Filesystem Paths
+
+Per run, under the repo-local runs tree (for example `runs/<run_id>/`):
 
 - `dispatch/` → dispatch staging directory (attachments before archival)
 - `dispatch_history/` → dispatch archive directory

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,0 +1,4 @@
+# Configuration
+
+- [Path resolution](path-resolution.md) — how CAR resolves repo, hub, and global paths.
+- [Destination runtimes](destinations.md) — Docker and local execution profiles for agents.

--- a/docs/migrations/workspace-to-contextspace.md
+++ b/docs/migrations/workspace-to-contextspace.md
@@ -85,10 +85,11 @@ docs:
 
 ## Rollback
 
-If you need to rollback (e.g., to test the old workspace behavior):
+If you need to rollback (e.g., to test the old workspace directory name):
+
+Run these from the **repository root**. `.codex-autorunner/contextspace` must exist. `.codex-autorunner/workspace` must not already exist (remove or rename it first), or `mv` will fail or nest directories incorrectly. This only restores the **on-disk folder name**; current CAR releases read context from `contextspace/`, so rollback is for manual experiments, not supported runtime behavior.
 
 ```bash
-# Ensure contextspace exists
 mv .codex-autorunner/contextspace .codex-autorunner/workspace
 ```
 

--- a/docs/ops/running-in-a-vm.md
+++ b/docs/ops/running-in-a-vm.md
@@ -10,7 +10,7 @@ Notes for running codex-autorunner inside containerized or cloud-provisioned VMs
 | Web Hub (FastAPI/Uvicorn) | `make serve-dev` (port 4173) | Set `CAR_DEV_INCLUDE_ROOT_REPO=1` to include the repo itself in the hub |
 | Python tests | `make test` or `.venv/bin/python -m pytest -m "not integration"` | Uses pytest with xdist for parallel runs |
 | Linting | `make check` (full suite) or individually: `black --check`, `ruff check`, `mypy`, `pnpm lint` | See `scripts/check.sh` for the full pre-commit check sequence |
-| TS build | `pnpm run build` or `make build` | Compiles `static_src/*.ts` → `static/*.js`; always rebuild after TS changes |
+| TS build | `pnpm run build` or `make build` | Compiles `src/codex_autorunner/static_src/*.ts` → `src/codex_autorunner/static/*.js`; always rebuild after TS changes |
 
 ## Startup caveats
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documentation-only changes driven by a consistency pass (with explore subagents) across constitution, ops, README, and design notes.

## Changes

- **DESIGN.md**: Per-repo layout now documents `contextspace/` instead of deprecated `workspace/` for shared docs; core loop mentions configurable backends (Codex/OpenCode/Hermes) and points to the workspace→contextspace migration when an old directory remains.
- **AGENTS.md** and **docs/ops/running-in-a-vm.md**: TypeScript sources are under `src/codex_autorunner/static_src/`, outputs under `static/`.
- **CONTRIBUTING.md**: Prefer `.venv/bin/python -m pytest` after `make setup` for parity with the agent guide.
- **docs/car_constitution/90_PROTOCOLS_REFERENCES.md**: Fixed broken `../references/` links to real paths under `docs/`.
- **docs/car_constitution/20_ARCHITECTURE_MAP.md**: Control plane line no longer reads like a second filesystem root; execution step generalized beyond Codex+OpenCode only.
- **docs/car_constitution/10_CODEBASE_CONSTITUTION.md** and **95_GLOSSARY.md**: Hermes/ACP in identity and adapters; glossary entries for ticket and contextspace; dispatch paths scoped under `runs/<run_id>/`.
- **docs/STATE_ROOTS.md**: Clarified that repo-local `workspace/` is legacy relative to contextspace migration.
- **docs/migrations/workspace-to-contextspace.md**: Rollback section states cwd, prerequisites, and that rollback is not supported runtime behavior.
- **README.md**: User-facing “shared workspace” copy uses contextspace terminology; “OpenCode” spelling normalized in supported agents and alt text.
- **docs/configuration/index.md**: New stub index so the migration doc’s Configuration link resolves.

## Notes

README screenshots still reference `docs/screenshots/*.png`; those assets were not added in this PR (only copy and internal links were fixed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec4398bd-175e-48d6-b7b7-0225992144d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec4398bd-175e-48d6-b7b7-0225992144d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

