### PR TITLE
[codex] Reuse queued Discord notice for live progress

### DIFF
--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -2688,6 +2688,22 @@ async def _run_discord_orchestrated_turn_for_message(
         thread_target_id=managed_thread_id,
         source_message_id=source_message_id,
     )
+    if reusable_progress_message_id is None and source_message_id:
+        claim_queued_notice_message = getattr(
+            service,
+            "_claim_queued_notice_progress_message",
+            None,
+        )
+        if callable(claim_queued_notice_message):
+            claimed_notice_message_id = claim_queued_notice_message(
+                channel_id=channel_id,
+                source_message_id=source_message_id,
+            )
+            if (
+                isinstance(claimed_notice_message_id, str)
+                and claimed_notice_message_id.strip()
+            ):
+                reusable_progress_message_id = claimed_notice_message_id.strip()
 
     async def _load_progress_lease() -> Any:
         return await _get_discord_progress_lease(service, lease_id=progress_lease_id)

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -795,6 +795,9 @@ class DiscordBotService:
         )
         self._effect_sink = DiscordEffectSink(self)
         self._queued_notice_messages: dict[tuple[str, str], str] = {}
+        self._queued_notice_messages_by_source: dict[
+            tuple[str, str], tuple[str, str]
+        ] = {}
         self._discord_turn_progress_reuse_requests: dict[str, Any] = {}
         self._discord_reusable_progress_messages: dict[str, Any] = {}
         self._background_tasks: set[asyncio.Task[Any]] = set()
@@ -1087,13 +1090,15 @@ class DiscordBotService:
         async def _handle_dispatched_event(
             queued_event: ChatEvent, context: DispatchContext
         ) -> None:
-            if isinstance(queued_event, ChatMessageEvent):
-                await self._clear_queued_notice(
-                    conversation_id=context.conversation_id,
-                    source_message_id=queued_event.message.message_id,
-                    channel_id=context.chat_id,
-                )
-            await self._handle_chat_event(queued_event, context)
+            try:
+                await self._handle_chat_event(queued_event, context)
+            finally:
+                if isinstance(queued_event, ChatMessageEvent):
+                    await self._clear_queued_notice(
+                        conversation_id=context.conversation_id,
+                        source_message_id=queued_event.message.message_id,
+                        channel_id=context.chat_id,
+                    )
 
         dispatch_result = await self._dispatcher.dispatch(
             event, _handle_dispatched_event
@@ -1775,6 +1780,11 @@ class DiscordBotService:
     ) -> None:
         key = (conversation_id, source_message_id)
         notice_message_id = self._queued_notice_messages.pop(key, None)
+        source_key = (channel_id, source_message_id)
+        source_entry = self._queued_notice_messages_by_source.pop(source_key, None)
+        if not notice_message_id and isinstance(source_entry, tuple):
+            _, source_notice_message_id = source_entry
+            notice_message_id = source_notice_message_id
         if not notice_message_id:
             return
         await self._delete_channel_message_safe(
@@ -1782,6 +1792,22 @@ class DiscordBotService:
             notice_message_id,
             record_id=f"queue-notice-delete:{channel_id}:{source_message_id}",
         )
+
+    def _claim_queued_notice_progress_message(
+        self,
+        *,
+        channel_id: str,
+        source_message_id: str,
+    ) -> Optional[str]:
+        source_key = (channel_id, source_message_id)
+        source_entry = self._queued_notice_messages_by_source.pop(source_key, None)
+        if not isinstance(source_entry, tuple):
+            return None
+        conversation_id, notice_message_id = source_entry
+        if conversation_id:
+            self._queued_notice_messages.pop((conversation_id, source_message_id), None)
+        normalized_notice_message_id = str(notice_message_id or "").strip()
+        return normalized_notice_message_id or None
 
     async def _queued_notice_config_for_conversation(
         self, conversation_id: str
@@ -1830,9 +1856,13 @@ class DiscordBotService:
             )
             notice_message_id = response.get("id")
             if isinstance(notice_message_id, str) and notice_message_id:
-                self._queued_notice_messages[
-                    (dispatch_result.context.conversation_id, source_message_id)
-                ] = notice_message_id
+                conversation_id = dispatch_result.context.conversation_id
+                self._queued_notice_messages[(conversation_id, source_message_id)] = (
+                    notice_message_id
+                )
+                self._queued_notice_messages_by_source[
+                    (channel_id, source_message_id)
+                ] = (conversation_id, notice_message_id)
         except (DiscordAPIError, OSError, TypeError, ValueError):
             await self._send_channel_message_safe(
                 channel_id,

--- a/tests/discord_message_turns_queue_notice_support.py
+++ b/tests/discord_message_turns_queue_notice_support.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import pytest
+
+import codex_autorunner.integrations.discord.message_turns as discord_message_turns_module
+from tests.discord_message_turns_support import _config, _FakeRest
+
+
+@pytest.mark.asyncio
+async def test_orchestrated_turn_queued_reuses_claimed_queue_notice(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    rest = _FakeRest()
+    thread = SimpleNamespace(thread_target_id="thread-1")
+    started_execution = SimpleNamespace(
+        execution=SimpleNamespace(status="queued", execution_id="turn-2"),
+        thread=thread,
+    )
+
+    async def _fake_begin(*args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        return started_execution
+
+    class _Store:
+        async def get_binding(self, *, channel_id: str) -> dict[str, Any]:
+            assert channel_id == "channel-1"
+            return {}
+
+    class _Service:
+        def __init__(self) -> None:
+            self._config = _config(tmp_path)
+            self._store = _Store()
+            self._rest = rest
+            self._logger = logging.getLogger(__name__)
+            self._spawn_task = asyncio.create_task
+            self.claim_calls: list[tuple[str, str]] = []
+
+        async def _send_channel_message(
+            self, channel_id: str, payload: dict[str, Any]
+        ) -> dict[str, Any]:
+            return await rest.create_channel_message(
+                channel_id=channel_id,
+                payload=payload,
+            )
+
+        async def _delete_channel_message_safe(
+            self,
+            channel_id: str,
+            message_id: str,
+            *,
+            record_id: Optional[str] = None,
+        ) -> None:
+            _ = record_id
+            await rest.delete_channel_message(
+                channel_id=channel_id,
+                message_id=message_id,
+            )
+
+        def _claim_queued_notice_progress_message(
+            self,
+            *,
+            channel_id: str,
+            source_message_id: str,
+        ) -> Optional[str]:
+            self.claim_calls.append((channel_id, source_message_id))
+            return "notice-1"
+
+        def _register_discord_turn_approval_context(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+        def _clear_discord_turn_approval_context(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+        def _resolve_agent_state(self, binding: Any) -> tuple[str, Optional[str]]:
+            _ = binding
+            return "codex", None
+
+        def _runtime_agent_for_binding(self, binding: Any) -> str:
+            _ = binding
+            return "codex"
+
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "resolve_discord_thread_target",
+        lambda *args, **kwargs: (SimpleNamespace(), thread),
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "begin_runtime_thread_execution",
+        _fake_begin,
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module.ManagedThreadTurnCoordinator,
+        "ensure_queue_worker",
+        lambda *args, **kwargs: None,
+    )
+
+    service = _Service()
+    result = (
+        await discord_message_turns_module._run_discord_orchestrated_turn_for_message(
+            service,
+            workspace_root=tmp_path,
+            prompt_text="hi",
+            input_items=None,
+            source_message_id="m-2",
+            agent="codex",
+            model_override=None,
+            reasoning_effort=None,
+            session_key="s1",
+            orchestrator_channel_key="channel-1",
+            managed_thread_surface_key=None,
+            mode="pma",
+            pma_enabled=True,
+            execution_prompt="<user_message>\nhi\n</user_message>\n",
+            public_execution_error="err",
+            timeout_error="timeout",
+            interrupted_error="interrupt",
+            approval_mode="never",
+            sandbox_policy="dangerFullAccess",
+            max_actions=12,
+            min_edit_interval_seconds=1.0,
+            heartbeat_interval_seconds=2.0,
+        )
+    )
+
+    assert result.send_final_message is False
+    assert "Queued" in (result.final_message or "")
+    assert service.claim_calls == [("channel-1", "m-2")]
+    assert rest.channel_messages == []
+    assert rest.edited_channel_messages
+    assert rest.edited_channel_messages[0]["message_id"] == "notice-1"
+    assert "working" in rest.edited_channel_messages[0]["payload"]["content"].lower()
+    assert "queued" in rest.edited_channel_messages[-1]["payload"]["content"].lower()

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -1,6 +1,9 @@
 # ruff: noqa: F401
 
 import pytest
+from tests.discord_message_turns_queue_notice_support import (
+    test_orchestrated_turn_queued_reuses_claimed_queue_notice,
+)
 from tests.discord_message_turns_support import (
     test_build_attachment_filename_does_not_infer_audio_suffix_for_video,
     test_build_attachment_filename_uses_source_url_audio_suffix,


### PR DESCRIPTION
## Summary
- reuse Discord queued notices as the live progress surface when the queued turn actually starts
- keep queued notices claimable until the handler starts, then fall back to deleting them after handling if they were not reused
- add a regression test covering the queued-notice reuse path without growing the existing oversized support module

## Root Cause
Discord treated the queued notice and the live progress message as two separate lifecycles. When a queued message started running, the dispatcher cleared the queued notice independently and the managed-turn runner created a fresh progress placeholder. If the delete path lagged or missed, the thread showed both the old queued notice and a second edited working message.

## Impact
Queued Discord messages now transition in place from `Queued behind ...` to the live `working` progress update, so users only see a single status message for that queued turn.

## Validation
- `.venv/bin/python -m pytest tests/discord_message_turns_queue_notice_support.py tests/discord_message_turns_support.py -k 'queued_updates_placeholder or queued_reuses_claimed_queue_notice or message_create_sends_queued_notice_when_dispatch_queue_is_busy'`
- `.venv/bin/python -m pytest tests/test_hotspot_budgets.py -k hotspot_file_budgets`
- `.venv/bin/python -m pytest tests/integrations/discord/test_service_routing.py -k 'queued_notice or queue_cancel or queued_behind or test_car_model_rejects_invalid_opencode_model_name'`
- full `git commit` hook suite, including repo-wide pytest (`5119 passed`)
