### PR TITLE
[codex] Fix Discord interrupt button acknowledgements

### DIFF
--- a/src/codex_autorunner/integrations/discord/interaction_registry.py
+++ b/src/codex_autorunner/integrations/discord/interaction_registry.py
@@ -1888,6 +1888,22 @@ async def _handle_continue_turn_component(service: Any, ctx: Any) -> None:
     )
 
 
+def _interrupt_component_route(
+    *,
+    id: str,
+    handler: ComponentHandler,
+    exact_custom_id: Optional[str] = None,
+    custom_id_prefix: Optional[str] = None,
+) -> ComponentRoute:
+    return ComponentRoute(
+        id=id,
+        exact_custom_id=exact_custom_id,
+        custom_id_prefix=custom_id_prefix,
+        handler=handler,
+        scheduler_ack_strategy="scheduler_ephemeral",
+    )
+
+
 _COMPONENT_ROUTES: tuple[ComponentRoute, ...] = (
     ComponentRoute(
         id="tickets.filter",
@@ -2010,22 +2026,22 @@ _COMPONENT_ROUTES: tuple[ComponentRoute, ...] = (
         custom_id_prefix="qcancel:",
         handler=_handle_cancel_queued_turn_component,
     ),
-    ComponentRoute(
+    _interrupt_component_route(
         id="queue.interrupt_send",
         custom_id_prefix="queue_interrupt_send:",
         handler=_handle_queue_interrupt_send_component,
     ),
-    ComponentRoute(
+    _interrupt_component_route(
         id="queued_turn.interrupt_send",
         custom_id_prefix="qis:",
         handler=_handle_queued_turn_interrupt_send_component,
     ),
-    ComponentRoute(
+    _interrupt_component_route(
         id="turn.cancel",
         exact_custom_id="cancel_turn",
         handler=_handle_cancel_turn_component,
     ),
-    ComponentRoute(
+    _interrupt_component_route(
         id="turn.cancel_scoped",
         custom_id_prefix="cancel_turn:",
         handler=_handle_cancel_turn_component,

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -8966,7 +8966,7 @@ class DiscordBotService:
     ) -> None:
         source_message_id = custom_id.split(":", 1)[1].strip()
         if not source_message_id:
-            await self._send_interrupt_component_response(
+            await self._respond_ephemeral(
                 interaction_id,
                 interaction_token,
                 "Queued request is unavailable.",
@@ -9013,7 +9013,7 @@ class DiscordBotService:
     ) -> None:
         source_message_id = custom_id.split(":", 1)[1].strip()
         if not source_message_id:
-            await self._respond_ephemeral(
+            await self._send_interrupt_component_response(
                 interaction_id,
                 interaction_token,
                 "Queued request is unavailable.",

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -285,6 +285,7 @@ from .interaction_registry import (
     slash_command_route_for_path,
     slash_command_workspace_lock_policy,
 )
+from .interaction_runtime import ensure_ephemeral_response_deferred
 from .interaction_session import (
     DiscordInteractionSession,
     InteractionSessionKind,
@@ -8764,6 +8765,24 @@ class DiscordBotService:
             source_user_id=source_user_id,
         )
 
+    async def _send_interrupt_component_response(
+        self,
+        interaction_id: str,
+        interaction_token: str,
+        text: str,
+    ) -> None:
+        deferred = await ensure_ephemeral_response_deferred(
+            self,
+            interaction_id,
+            interaction_token,
+        )
+        await self.send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=text,
+        )
+
     async def _handle_cancel_turn_button(
         self,
         interaction_id: str,
@@ -8876,7 +8895,7 @@ class DiscordBotService:
             custom_id
         )
         if not execution_id or not source_message_id:
-            await self._respond_ephemeral(
+            await self._send_interrupt_component_response(
                 interaction_id,
                 interaction_token,
                 "Queued request is unavailable.",
@@ -8889,7 +8908,7 @@ class DiscordBotService:
             self._get_discord_thread_binding(channel_id=channel_id, mode=mode)
         )
         if current_thread is None:
-            await self._respond_ephemeral(
+            await self._send_interrupt_component_response(
                 interaction_id,
                 interaction_token,
                 "Queued request is unavailable.",
@@ -8900,7 +8919,7 @@ class DiscordBotService:
             execution_id,
         )
         if not promoted:
-            await self._respond_ephemeral(
+            await self._send_interrupt_component_response(
                 interaction_id,
                 interaction_token,
                 "Queued request is no longer pending.",
@@ -8914,7 +8933,7 @@ class DiscordBotService:
         if callable(get_running_execution):
             running_execution = get_running_execution(current_thread.thread_target_id)
             if running_execution is None:
-                await self._respond_ephemeral(
+                await self._send_interrupt_component_response(
                     interaction_id,
                     interaction_token,
                     "Queued request moved to the front.",
@@ -8947,7 +8966,7 @@ class DiscordBotService:
     ) -> None:
         source_message_id = custom_id.split(":", 1)[1].strip()
         if not source_message_id:
-            await self._respond_ephemeral(
+            await self._send_interrupt_component_response(
                 interaction_id,
                 interaction_token,
                 "Queued request is unavailable.",
@@ -9009,7 +9028,7 @@ class DiscordBotService:
             source_message_id,
         )
         if not promoted:
-            await self._respond_ephemeral(
+            await self._send_interrupt_component_response(
                 interaction_id,
                 interaction_token,
                 "Queued request is no longer pending.",
@@ -9022,7 +9041,7 @@ class DiscordBotService:
             self._get_discord_thread_binding(channel_id=channel_id, mode=mode)
         )
         if current_thread is None:
-            await self._respond_ephemeral(
+            await self._send_interrupt_component_response(
                 interaction_id,
                 interaction_token,
                 "Queued request moved to the front.",

--- a/tests/integrations/discord/test_command_registry.py
+++ b/tests/integrations/discord/test_command_registry.py
@@ -13,6 +13,7 @@ from codex_autorunner.integrations.discord.commands import (
 from codex_autorunner.integrations.discord.interaction_registry import (
     autocomplete_route_for,
     component_route_for_custom_id,
+    component_scheduler_ack_strategy,
     modal_route_for_custom_id,
     normalize_discord_command_path,
     slash_command_route_for_path,
@@ -132,6 +133,22 @@ def test_registry_matches_high_risk_component_and_modal_patterns() -> None:
     assert component_route_for_custom_id("tickets_select") is not None
     assert component_route_for_custom_id("tickets_filter_select") is not None
     assert modal_route_for_custom_id("tickets_modal:abc123") is not None
+
+
+def test_interrupt_components_share_ephemeral_scheduler_ack_strategy() -> None:
+    assert component_scheduler_ack_strategy("cancel_turn") == "scheduler_ephemeral"
+    assert (
+        component_scheduler_ack_strategy("cancel_turn:thread-1:turn-1")
+        == "scheduler_ephemeral"
+    )
+    assert (
+        component_scheduler_ack_strategy("queue_interrupt_send:message-1")
+        == "scheduler_ephemeral"
+    )
+    assert (
+        component_scheduler_ack_strategy("qis:turn-1:message-1")
+        == "scheduler_ephemeral"
+    )
 
 
 def test_registry_matches_autocomplete_routes_for_registered_paths() -> None:

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -3638,8 +3638,71 @@ async def test_component_interaction_queued_turn_interrupt_send_acknowledges_whe
         )
 
         assert interrupt_called is False
+        assert rest.followup_messages[-1]["payload"]["content"] == (
+            "Queued request moved to the front."
+        )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_queued_turn_interrupt_send_uses_followup_after_predefer(
+    tmp_path: Path,
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    class _FakeThreadService:
+        def promote_queued_execution(
+            self, thread_target_id: str, execution_id: str
+        ) -> bool:
+            assert thread_target_id == "thread-1"
+            assert execution_id == "turn-2"
+            return True
+
+        def get_running_execution(self, thread_target_id: str) -> Any:
+            assert thread_target_id == "thread-1"
+            return None
+
+    try:
+        await store.upsert_binding(
+            channel_id="channel-1",
+            guild_id="guild-1",
+            workspace_path=str(tmp_path),
+            repo_id="repo-1",
+        )
+
+        service._get_discord_thread_binding = lambda **_kwargs: (  # type: ignore[method-assign]
+            _FakeThreadService(),
+            None,
+            SimpleNamespace(thread_target_id="thread-1"),
+        )
+
+        await service.defer_ephemeral(
+            interaction_id="interaction-1",
+            interaction_token="token-1",
+        )
+        await service._handle_queued_turn_interrupt_send_button(
+            "interaction-1",
+            "token-1",
+            channel_id="channel-1",
+            custom_id="qis:turn-2:m-2",
+            user_id="user-1",
+            message_id="progress-2",
+        )
+
+        assert len(rest.followup_messages) == 1
         assert (
-            rest.interaction_responses[-1]["payload"]["data"]["content"]
+            rest.followup_messages[0]["payload"]["content"]
             == "Queued request moved to the front."
         )
     finally:


### PR DESCRIPTION
## Summary
Fix Discord interrupt-related component interactions so button presses acknowledge reliably even when the handler later exits early or has to interrupt an active turn.

## Root Cause
The interrupt button family (`Cancel`, scoped `Cancel`, queue `Interrupt and Send`, queued-turn `Interrupt and Send`) was inheriting the generic component scheduler ack strategy instead of sharing an explicit interrupt-specific contract.

That meant these buttons could take different acknowledgement paths from the rest of the interrupt flow. In practice, the follow-up interrupt logic often still completed, but Discord had already decided the component interaction was not acknowledged cleanly, which surfaced as `This interaction failed` on repeated button presses.

## What Changed
- Added a shared interrupt-component route helper in the Discord interaction registry.
- Moved all interrupt-related component routes onto the same ephemeral scheduler ack strategy.
- Added a shared service helper for interrupt component replies so early-return cases use a defer-safe followup path.
- Added regression tests covering the shared route contract and the pre-deferred queued-turn `Interrupt and Send` path.

## Validation
- Focused pytest:
  - `tests/integrations/discord/test_command_registry.py`
  - `tests/integrations/discord/test_command_runner.py`
  - `tests/integrations/discord/test_service_routing.py -k 'interrupt or queue_wait_ack or scheduler_ack_strategy'`
- Repo hooks during commit:
  - `black --check`
  - `ruff`
  - command-contract checks
  - `mypy src/codex_autorunner`
  - `pnpm run build`
  - `pnpm test:markdown`
  - full `pytest` (`5121 passed`)
