### PR TITLE
fix(chat): log turn_finalized after orchestration ok, before thread activity

### DIFF
--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -1793,23 +1793,9 @@ async def finalize_managed_thread_execution(
                 backend_thread_id=resolved_backend_thread_id,
                 token_usage=event_state.token_usage,
             )
-        try:
-            if resolved_hub_client is None:
-                raise RuntimeError("Hub control-plane client unavailable")
-            await _record_thread_activity_via_hub(
-                resolved_hub_client,
-                thread_target_id=managed_thread_id,
-                execution_id=managed_turn_id,
-                message_preview=turn_preview,
-            )
-        except (HubControlPlaneError, RuntimeError, OSError):
-            logger.warning(
-                "%s Failed to persist thread activity via hub control plane (thread=%s turn=%s)",
-                surface.log_label,
-                managed_thread_id,
-                managed_turn_id,
-                exc_info=True,
-            )
+        # Log turn_finalized immediately after orchestration acknowledges ok so log-plane
+        # correlates with orch_thread_executions even if optional hub calls below fail or
+        # raise an exception type we do not catch.
         log_event(
             logger,
             logging.INFO,
@@ -1828,6 +1814,23 @@ async def finalize_managed_thread_execution(
             token_usage=event_state.token_usage,
             **_managed_thread_runtime_trace_fields(event_state),
         )
+        try:
+            if resolved_hub_client is None:
+                raise RuntimeError("Hub control-plane client unavailable")
+            await _record_thread_activity_via_hub(
+                resolved_hub_client,
+                thread_target_id=managed_thread_id,
+                execution_id=managed_turn_id,
+                message_preview=turn_preview,
+            )
+        except (HubControlPlaneError, RuntimeError, OSError):
+            logger.warning(
+                "%s Failed to persist thread activity via hub control plane (thread=%s turn=%s)",
+                surface.log_label,
+                managed_thread_id,
+                managed_turn_id,
+                exc_info=True,
+            )
         return _build_finalization_result(
             status="ok",
             assistant_text=resolved_assistant_text,


### PR DESCRIPTION
## Summary

Emit `chat.managed_thread.turn_finalized` on the success path **immediately after** orchestration reports `finalized_status == "ok"` from `record_execution_result`, and **before** the optional `_record_thread_activity_via_hub` call.

## Problem

When `_record_thread_activity_via_hub` (or an uncaught exception after `record_execution_result`) failed, logs could omit `turn_finalized` even though `orch_thread_executions` already showed `ok` with assistant text. That broke correlation between hub JSON logs and the orchestration database during PMA/Discord/hub stress.

## Semantics

`turn_finalized` with `status: ok` now means **orchestration has recorded the turn as ok**. Thread activity persistence remains best-effort and runs afterward, with failures still logged as warnings.

## Code review (subagent)

**Verdict:** Approved for the stated goal. `turn_finalized` now aligns with orchestration’s acknowledged terminal state.

**Risks / semantics:** Consumers should treat `turn_finalized` (ok) as “orchestration recorded ok,” not “every hub follow-up succeeded.” Thread activity remains best-effort afterward.

**Follow-up:** Consider broadening `_record_thread_activity_via_hub` exception handling (for example `TimeoutError` / `ConnectionError`) so activity failures are less likely to bubble after this log.
