### PR TITLE
[codex] Cache repo capability hints in hub inbox

### DIFF
--- a/src/codex_autorunner/surfaces/web/services/hub_gather.py
+++ b/src/codex_autorunner/surfaces/web/services/hub_gather.py
@@ -489,7 +489,7 @@ def _cached_repo_capability_hints(
             and cached.expires_at > now
             and cached.fingerprint == fingerprint
         ):
-            return list(cached.items)
+            return [dict(item) for item in cached.items]
     try:
         hint_items = build_repo_capability_hints(
             hub_config=context.config,

--- a/src/codex_autorunner/surfaces/web/services/hub_gather.py
+++ b/src/codex_autorunner/surfaces/web/services/hub_gather.py
@@ -11,6 +11,12 @@ from ....core.capability_hints import (
     build_hub_capability_hints,
     build_repo_capability_hints,
 )
+from ....core.config import (
+    CONFIG_FILENAME,
+    REPO_OVERRIDE_FILENAME,
+    ROOT_CONFIG_FILENAME,
+    ROOT_OVERRIDE_FILENAME,
+)
 from ....core.filebox import BOXES, empty_listing
 from ....core.flows.workspace_root import resolve_ticket_flow_workspace_root
 from ....core.freshness import (
@@ -46,6 +52,8 @@ from ..schemas import (
 
 _HUB_SNAPSHOT_CACHE_TTL_SECONDS = 2.0
 _hub_snapshot_cache_lock = threading.Lock()
+_REPO_CAPABILITY_HINT_CACHE_TTL_SECONDS = 30.0
+_repo_capability_hint_cache_lock = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -56,6 +64,18 @@ class _HubSnapshotCacheEntry:
 
 
 _hub_snapshot_cache: dict[tuple[int, str], _HubSnapshotCacheEntry] = {}
+
+
+@dataclass(frozen=True)
+class _RepoCapabilityHintCacheEntry:
+    fingerprint: tuple[Any, ...]
+    expires_at: float
+    items: list[dict[str, Any]]
+
+
+_repo_capability_hint_cache: dict[
+    tuple[str, str, str, str], _RepoCapabilityHintCacheEntry
+] = {}
 
 
 @dataclass(frozen=True)
@@ -406,6 +426,89 @@ def _serialize_resolvable_item(item: dict[str, Any], item_type: str) -> dict[str
     }
 
 
+def _repo_capability_hint_fingerprint(
+    *,
+    hub_root: Optional[Path],
+    repo_id: str,
+    repo_root: Path,
+    repo_display_name: str,
+) -> tuple[Any, ...]:
+    hub_config_root = hub_root if isinstance(hub_root, Path) else None
+    return (
+        repo_id,
+        repo_display_name,
+        str(repo_root),
+        str(hub_config_root) if hub_config_root is not None else "",
+        _path_stat_fingerprint(repo_root / REPO_OVERRIDE_FILENAME),
+        _path_stat_fingerprint(repo_root / ".env"),
+        _path_stat_fingerprint(repo_root / ".codex-autorunner" / ".env"),
+        _path_stat_fingerprint(repo_root / CONFIG_FILENAME),
+        _path_stat_fingerprint(
+            hub_config_root / ROOT_CONFIG_FILENAME
+            if hub_config_root is not None
+            else Path(ROOT_CONFIG_FILENAME)
+        ),
+        _path_stat_fingerprint(
+            hub_config_root / ROOT_OVERRIDE_FILENAME
+            if hub_config_root is not None
+            else Path(ROOT_OVERRIDE_FILENAME)
+        ),
+        _path_stat_fingerprint(
+            hub_config_root / CONFIG_FILENAME
+            if hub_config_root is not None
+            else Path(CONFIG_FILENAME)
+        ),
+    )
+
+
+def _cached_repo_capability_hints(
+    context: HubAppContext,
+    *,
+    repo_id: str,
+    repo_root: Path,
+    repo_display_name: str,
+) -> list[dict[str, Any]]:
+    hub_root = getattr(getattr(context, "config", None), "root", None)
+    cache_key = (
+        str(hub_root) if isinstance(hub_root, Path) else "",
+        str(repo_root),
+        repo_id,
+        repo_display_name,
+    )
+    fingerprint = _repo_capability_hint_fingerprint(
+        hub_root=hub_root,
+        repo_id=repo_id,
+        repo_root=repo_root,
+        repo_display_name=repo_display_name,
+    )
+    now = time.monotonic()
+    with _repo_capability_hint_cache_lock:
+        cached = _repo_capability_hint_cache.get(cache_key)
+        if (
+            cached is not None
+            and cached.expires_at > now
+            and cached.fingerprint == fingerprint
+        ):
+            return list(cached.items)
+    try:
+        hint_items = build_repo_capability_hints(
+            hub_config=context.config,
+            repo_id=repo_id,
+            repo_root=repo_root,
+            repo_display_name=repo_display_name,
+        )
+    except (AttributeError, OSError, ValueError, RuntimeError):
+        hint_items = []
+    stored_items = [dict(item) for item in hint_items]
+    with _repo_capability_hint_cache_lock:
+        _repo_capability_hint_cache[cache_key] = _RepoCapabilityHintCacheEntry(
+            fingerprint=fingerprint,
+            expires_at=now + _REPO_CAPABILITY_HINT_CACHE_TTL_SECONDS,
+            items=stored_items,
+        )
+    return [dict(item) for item in stored_items]
+
+
 def _filter_action_queue_items(
     action_queue: list[dict[str, Any]],
     *,
@@ -517,18 +620,16 @@ def _collect_inbox_messages(
         repo_root = getattr(snap, "path", None)
         if not repo_id or not isinstance(repo_root, Path):
             continue
-        try:
-            hint_items = build_repo_capability_hints(
-                hub_config=context.config,
-                repo_id=repo_id,
-                repo_root=repo_root,
-                repo_display_name=str(
-                    getattr(snap, "display_name", None) or getattr(snap, "id", "")
-                ).strip()
-                or repo_id,
-            )
-        except (AttributeError, OSError, ValueError, RuntimeError):
-            hint_items = []
+        repo_display_name = (
+            str(getattr(snap, "display_name", None) or getattr(snap, "id", "")).strip()
+            or repo_id
+        )
+        hint_items = _cached_repo_capability_hints(
+            context,
+            repo_id=repo_id,
+            repo_root=repo_root,
+            repo_display_name=repo_display_name,
+        )
         dismissals = _repo_dismissals(repo_context, repo_id, repo_root)
         for item in hint_items:
             item_type = str(item.get("item_type") or "")

--- a/tests/surfaces/web/routes/test_hub_performance_caches.py
+++ b/tests/surfaces/web/routes/test_hub_performance_caches.py
@@ -837,3 +837,94 @@ def test_gather_hub_message_snapshot_reuses_short_ttl_cache(
     assert first["items"] == []
     assert second["items"] == []
     assert calls["list_repos"] == 1
+
+
+def test_gather_hub_message_snapshot_reuses_repo_hint_cache_across_snapshot_misses(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "demo"
+    repo_root.mkdir(parents=True, exist_ok=True)
+    snapshot = _repo_snapshot(repo_root)
+    state = SimpleNamespace(last_scan_at="2026-04-05T00:00:00Z")
+    context = SimpleNamespace(
+        supervisor=SimpleNamespace(list_repos=lambda: [snapshot], state=state),
+        config=SimpleNamespace(root=hub_root),
+    )
+    calls = {"repo_hints": 0}
+
+    def fake_repo_hints(**_kwargs) -> list[dict[str, object]]:
+        calls["repo_hints"] += 1
+        return []
+
+    monkeypatch.setattr(
+        hub_gather_service, "_gather_inbox", lambda *_args, **_kwargs: []
+    )
+    monkeypatch.setattr(
+        hub_gather_service, "build_hub_capability_hints", lambda **_kwargs: []
+    )
+    monkeypatch.setattr(
+        hub_gather_service, "build_repo_capability_hints", fake_repo_hints
+    )
+    monkeypatch.setattr(
+        hub_gather_service, "load_hub_inbox_dismissals", lambda _root: {}
+    )
+
+    first = hub_gather_service.gather_hub_message_snapshot(context, sections={"inbox"})
+    state.last_scan_at = "2026-04-05T00:00:01Z"
+    second = hub_gather_service.gather_hub_message_snapshot(
+        context,
+        sections={"inbox"},
+    )
+
+    assert first["items"] == []
+    assert second["items"] == []
+    assert calls["repo_hints"] == 1
+
+
+def test_gather_hub_message_snapshot_refreshes_repo_hint_cache_when_repo_inputs_change(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "demo"
+    repo_root.mkdir(parents=True, exist_ok=True)
+    snapshot = _repo_snapshot(repo_root)
+    state = SimpleNamespace(last_scan_at="2026-04-05T00:00:00Z")
+    context = SimpleNamespace(
+        supervisor=SimpleNamespace(list_repos=lambda: [snapshot], state=state),
+        config=SimpleNamespace(root=hub_root),
+    )
+    calls = {"repo_hints": 0}
+
+    def fake_repo_hints(**_kwargs) -> list[dict[str, object]]:
+        calls["repo_hints"] += 1
+        return []
+
+    monkeypatch.setattr(
+        hub_gather_service, "_gather_inbox", lambda *_args, **_kwargs: []
+    )
+    monkeypatch.setattr(
+        hub_gather_service, "build_hub_capability_hints", lambda **_kwargs: []
+    )
+    monkeypatch.setattr(
+        hub_gather_service, "build_repo_capability_hints", fake_repo_hints
+    )
+    monkeypatch.setattr(
+        hub_gather_service, "load_hub_inbox_dismissals", lambda _root: {}
+    )
+
+    first = hub_gather_service.gather_hub_message_snapshot(context, sections={"inbox"})
+    repo_override = repo_root / ".codex-autorunner" / "repo.override.yml"
+    repo_override.parent.mkdir(parents=True, exist_ok=True)
+    repo_override.write_text("voice:\n  enabled: false\n", encoding="utf-8")
+    state.last_scan_at = "2026-04-05T00:00:01Z"
+    second = hub_gather_service.gather_hub_message_snapshot(
+        context,
+        sections={"inbox"},
+    )
+
+    assert first["items"] == []
+    assert second["items"] == []
+    assert calls["repo_hints"] == 2


### PR DESCRIPTION
## Summary

This fixes the new hub CPU-spin regression by caching repo capability hints during hub inbox snapshot assembly.

## Root Cause

Profiling the live hub process showed the hot path had moved into the hub inbox snapshot rebuild rather than the earlier orchestration-history path.

Evidence from the live hub root (`/Users/dazheng/car-workspace`):

- `gather_hub_message_snapshot(..., sections={"inbox"})` took about `1.25s` on a cache miss.
- `_collect_inbox_messages(...)` accounted for about `1.165s` of that work.
- Repo dismissal loading was effectively free.
- `build_repo_capability_hints(...)` across 46 repos/worktrees took about `1.179s`, which matched the inbox rebuild cost almost exactly.

The hub snapshot cache was still being invalidated by unrelated PMA/activity changes, so the hub kept re-running repo capability hint generation for every repo on each snapshot miss. On an actively changing hub, that was enough to peg a core.

## What Changed

- Added a repo capability hint cache in `hub_gather.py`.
- Keyed the cache to the repo plus the specific hub/repo config and env files that affect capability hint generation.
- Reused cached repo hints across hub snapshot misses when repo inputs are unchanged.
- Refreshed cached repo hints immediately when repo inputs change.

## Validation

Measured against the live hub root after the patch:

- Forced inbox snapshot misses dropped from about `1.261s` to about `0.093s` after the initial fill.
- `_collect_inbox_messages(...)` dropped from about `1.164s` to about `0.001s` on subsequent forced misses.

Tests:

- `rtk .venv/bin/pytest tests/surfaces/web/test_hub_gather_service.py tests/surfaces/web/routes/test_hub_performance_caches.py tests/test_hub_messages.py`
- Pre-commit/check hooks passed, including repo-wide pytest from `.githooks/pre-commit`.

## Regression Coverage

Added tests that verify:

- repo capability hints are reused across hub snapshot cache misses when repo inputs are stable
- repo capability hint cache refreshes when repo override inputs change
