### PR TITLE
[codex] Fix flow telemetry export batching

### DIFF
--- a/src/codex_autorunner/core/flows/store.py
+++ b/src/codex_autorunner/core/flows/store.py
@@ -30,6 +30,7 @@ UNSET = object()
 _REQUIRED_SCHEMA_TABLES = frozenset(
     {"schema_info", "flow_runs", "flow_events", "flow_artifacts"}
 )
+_DELETE_SEQ_BATCH_SIZE = 900
 _SQLITE_PRAGMAS_READONLY = (
     "PRAGMA foreign_keys=ON;",
     f"PRAGMA busy_timeout={DEFAULT_SQLITE_BUSY_TIMEOUT_MS};",
@@ -924,16 +925,28 @@ class FlowStore:
         cursor = conn.execute("DELETE FROM flow_telemetry WHERE run_id = ?", (run_id,))
         return cursor.rowcount
 
-    def delete_telemetry_by_seqs(self, seqs: List[int]) -> int:
+    def _delete_rows_by_seqs(self, table_name: str, seqs: List[int]) -> int:
         if not seqs:
             return 0
+        if table_name not in {"flow_events", "flow_telemetry"}:
+            raise ValueError(f"Unsupported flow table for seq deletion: {table_name}")
         conn = self._get_conn()
-        placeholders = ",".join("?" for _ in seqs)
-        cursor = conn.execute(
-            f"DELETE FROM flow_telemetry WHERE seq IN ({placeholders})",
-            list(seqs),
-        )
-        return cursor.rowcount
+        deleted = 0
+        for start in range(0, len(seqs), _DELETE_SEQ_BATCH_SIZE):
+            batch = seqs[start : start + _DELETE_SEQ_BATCH_SIZE]
+            placeholders = ",".join("?" for _ in batch)
+            cursor = conn.execute(
+                f"DELETE FROM {table_name} WHERE seq IN ({placeholders})",
+                list(batch),
+            )
+            deleted += cursor.rowcount
+        return deleted
+
+    def delete_events_by_seqs(self, seqs: List[int]) -> int:
+        return self._delete_rows_by_seqs("flow_events", seqs)
+
+    def delete_telemetry_by_seqs(self, seqs: List[int]) -> int:
+        return self._delete_rows_by_seqs("flow_telemetry", seqs)
 
     def _row_to_flow_run(self, row: sqlite3.Row) -> FlowRunRecord:
         return FlowRunRecord(

--- a/src/codex_autorunner/core/flows/telemetry_export.py
+++ b/src/codex_autorunner/core/flows/telemetry_export.py
@@ -202,15 +202,7 @@ def _write_jsonl_gz(events: Sequence[dict], path: Path) -> int:
 
 
 def _prune_events(store: FlowStore, seqs: Sequence[int]) -> int:
-    if not seqs:
-        return 0
-    conn = store._get_conn()
-    placeholders = ",".join("?" for _ in seqs)
-    cursor = conn.execute(
-        f"DELETE FROM flow_events WHERE seq IN ({placeholders})",
-        list(seqs),
-    )
-    return cursor.rowcount
+    return store.delete_events_by_seqs(list(seqs))
 
 
 def _prune_telemetry(store: FlowStore, seqs: Sequence[int]) -> int:

--- a/tests/flows/test_telemetry_export.py
+++ b/tests/flows/test_telemetry_export.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+import codex_autorunner.core.flows.store as flow_store_module
 from codex_autorunner.core.flows.models import FlowEventType, FlowRunStatus
 from codex_autorunner.core.flows.store import FlowStore
 from codex_autorunner.core.flows.telemetry_export import (
@@ -614,3 +615,58 @@ def test_export_run_handles_both_tables(temp_dir):
     assert len(remaining_events) == 0
     remaining_telemetry = store.get_telemetry(run_id)
     assert len(remaining_telemetry) == 0
+
+
+def test_export_run_prunes_large_seq_sets_in_batches(temp_dir, monkeypatch):
+    monkeypatch.setattr(flow_store_module, "_DELETE_SEQ_BATCH_SIZE", 2)
+
+    store = _make_store(temp_dir)
+    run_id = _create_terminal_run(store)
+
+    for idx in range(5):
+        _add_event(
+            store,
+            run_id,
+            FlowEventType.APP_SERVER_EVENT,
+            {
+                "message": {
+                    "method": "message.part.updated",
+                    "params": {"index": idx},
+                },
+                "turn_id": f"t-app-{idx}",
+            },
+            event_id=f"evt-app-{idx}",
+        )
+
+    for idx in range(4):
+        _add_event(
+            store,
+            run_id,
+            FlowEventType.AGENT_STREAM_DELTA,
+            {"delta": f"chunk-{idx}", "turn_id": f"t-delta-{idx}"},
+            event_id=f"evt-delta-{idx}",
+        )
+
+    for idx in range(3):
+        _add_telemetry(
+            store,
+            run_id,
+            FlowEventType.APP_SERVER_EVENT,
+            {
+                "message": {
+                    "method": "message.part.updated",
+                    "params": {"index": idx},
+                },
+                "turn_id": f"t-tel-{idx}",
+            },
+            telemetry_id=f"tel-app-{idx}",
+        )
+
+    record = store.get_flow_run(run_id)
+    assert record is not None
+
+    result = export_run(temp_dir, store, record, dry_run=False)
+    assert result.prunable_app_server_events == 8
+    assert result.prunable_stream_deltas == 4
+    assert store.get_events(run_id) == []
+    assert store.get_telemetry(run_id) == []


### PR DESCRIPTION
## What changed
This PR batches flow telemetry pruning by `seq` instead of deleting an entire run's prunable rows in one `IN (...)` clause.

It adds:
- chunked `seq` deletion helpers in `FlowStore` for both `flow_events` and `flow_telemetry`
- `telemetry_export` pruning wired through the new batched delete path
- a regression test that forces multi-batch pruning and verifies both tables are fully cleaned up

## Root cause
The hub was repeatedly trying to export a very large historical run (`aed60737-de32-45c0-873d-1e432a83b79e`) while the Discord `/car newt` failures were happening.

On this machine:
- the run had `899,766` `app_server_event` rows and `211,912` `agent_stream_delta` rows in `flow_events`
- SQLite was compiled with `MAX_VARIABLE_NUMBER=500000`
- the exporter issued a single `DELETE FROM flow_events WHERE seq IN (?, ?, ...)` for all `app_server_event` rows

That exceeded SQLite's bound-variable limit and raised `OperationalError: too many SQL variables`. The hub log was showing repeated `Failed to export run ...: too many SQL variables` entries during the same window that the hub control plane started timing out (`get_running_execution`, `get_surface_binding`, and then `discord.newt.setup.failed`).

## Impact
Large terminal runs can now be exported and pruned without tripping SQLite's variable cap, which prevents the repeated exporter failure loop that was contributing to hub instability.

## Validation
Automated:
- `.venv/bin/pytest tests/flows/test_telemetry_export.py -q`

Local repro before fix on a temp copy of the real failing DB:
- `export_run(...)` for `aed60737-de32-45c0-873d-1e432a83b79e` failed with `OperationalError: too many SQL variables`

Local repro after fix on a fresh temp copy of the same DB:
- `exported_events=1111678`
- `prunable_app_server_events=899766`
- `prunable_stream_deltas=211912`
- archive written successfully
- only non-prunable flow events remained (`remaining_events=172`)
