### PR TITLE
[codex] Stabilize hub thread binding cache updates

### DIFF
--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -690,14 +690,44 @@ class PmaThreadStore:
         *,
         backend_runtime_instance_id: Optional[str] = None,
     ) -> None:
+        normalized_backend_thread_id = _coerce_text(backend_thread_id)
         current_binding = get_runtime_thread_binding(self._hub_root, managed_thread_id)
-        resolved_runtime_instance_id = backend_runtime_instance_id
-        if backend_thread_id is not None and resolved_runtime_instance_id is None:
+        resolved_runtime_instance_id = _coerce_text(backend_runtime_instance_id)
+        if (
+            normalized_backend_thread_id is not None
+            and resolved_runtime_instance_id is None
+        ):
             resolved_runtime_instance_id = (
                 current_binding.backend_runtime_instance_id
                 if current_binding is not None
                 else None
             )
+        with self._read_conn() as conn:
+            row = conn.execute(
+                """
+                SELECT backend_thread_id
+                  FROM orch_thread_targets
+                 WHERE thread_target_id = ?
+                """,
+                (managed_thread_id,),
+            ).fetchone()
+        current_backend_thread_id = (
+            _coerce_text(row["backend_thread_id"]) if row is not None else None
+        )
+        binding_matches = (
+            normalized_backend_thread_id is None and current_binding is None
+        ) or (
+            current_binding is not None
+            and current_binding.backend_thread_id == normalized_backend_thread_id
+            and current_binding.backend_runtime_instance_id
+            == resolved_runtime_instance_id
+        )
+        if (
+            row is not None
+            and current_backend_thread_id == normalized_backend_thread_id
+            and binding_matches
+        ):
+            return
         with self._write_conn() as conn:
             thread = self._fetch_thread(conn, managed_thread_id)
             metadata = _sanitize_thread_metadata(
@@ -713,7 +743,7 @@ class PmaThreadStore:
                      WHERE thread_target_id = ?
                     """,
                     (
-                        backend_thread_id,
+                        normalized_backend_thread_id,
                         _json_dumps(metadata),
                         now_iso(),
                         managed_thread_id,
@@ -722,7 +752,7 @@ class PmaThreadStore:
         set_runtime_thread_binding(
             self._hub_root,
             managed_thread_id,
-            backend_thread_id=backend_thread_id,
+            backend_thread_id=normalized_backend_thread_id,
             backend_runtime_instance_id=resolved_runtime_instance_id,
         )
 

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/repo_listing.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/repo_listing.py
@@ -199,16 +199,36 @@ class HubRepoListingService:
         snapshots: list[Any],
         chat_binding_counts: dict[str, int],
         chat_binding_counts_by_source: dict[str, dict[str, int]],
+        unbound_thread_counts: Optional[dict[str, int]] = None,
     ) -> list[dict[str, Any]]:
-        tasks = [
-            asyncio.to_thread(
-                self._enricher.enrich_repo,
-                snap,
-                chat_binding_counts,
-                chat_binding_counts_by_source,
+        supports_unbound_counts = unbound_thread_counts is not None and callable(
+            getattr(
+                self._enricher,
+                "unbound_repo_thread_counts_snapshot",
+                None,
             )
-            for snap in snapshots
-        ]
+        )
+        if supports_unbound_counts:
+            tasks = [
+                asyncio.to_thread(
+                    self._enricher.enrich_repo,
+                    snap,
+                    chat_binding_counts,
+                    chat_binding_counts_by_source,
+                    unbound_thread_counts,
+                )
+                for snap in snapshots
+            ]
+        else:
+            tasks = [
+                asyncio.to_thread(
+                    self._enricher.enrich_repo,
+                    snap,
+                    chat_binding_counts,
+                    chat_binding_counts_by_source,
+                )
+                for snap in snapshots
+            ]
         return cast(list[dict[str, Any]], await asyncio.gather(*tasks))
 
     def _active_chat_binding_counts_by_source(self) -> dict[str, dict[str, int]]:
@@ -227,6 +247,16 @@ class HubRepoListingService:
                 exc=exc,
             )
             return {}
+
+    async def _unbound_thread_counts_snapshot(self) -> Optional[dict[str, int]]:
+        snapshot_fn = getattr(
+            self._enricher,
+            "unbound_repo_thread_counts_snapshot",
+            None,
+        )
+        if not callable(snapshot_fn):
+            return None
+        return cast(dict[str, int], await asyncio.to_thread(snapshot_fn))
 
     def _store_response_cache(
         self,
@@ -406,11 +436,13 @@ class HubRepoListingService:
                 repo_id: sum(source_counts.values())
                 for repo_id, source_counts in chat_binding_counts_by_source.items()
             }
+            unbound_thread_counts = await self._unbound_thread_counts_snapshot()
             await self._mount_manager.refresh_mounts(snapshots)
             repos = await self._enrich_repos(
                 snapshots,
                 chat_binding_counts,
                 chat_binding_counts_by_source,
+                unbound_thread_counts,
             )
             if needs_agent_workspaces:
                 agent_workspaces = [
@@ -592,11 +624,13 @@ class HubRepoListingService:
             repo_id: sum(source_counts.values())
             for repo_id, source_counts in chat_binding_counts_by_source.items()
         }
+        unbound_thread_counts = await self._unbound_thread_counts_snapshot()
         await self._mount_manager.refresh_mounts(snapshots)
         repos = await self._enrich_repos(
             snapshots,
             chat_binding_counts,
             chat_binding_counts_by_source,
+            unbound_thread_counts,
         )
         agent_workspaces = [
             workspace.to_dict(self._context.config.root)

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/services.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/services.py
@@ -76,6 +76,9 @@ class HubRepoEnricher:
             self._unbound_thread_counts_cached_at = now
             return dict(counts)
 
+    def unbound_repo_thread_counts_snapshot(self) -> dict[str, int]:
+        return self._unbound_repo_thread_counts()
+
     def _path_stat_fingerprint(
         self, path: Path
     ) -> tuple[bool, Optional[int], Optional[int]]:
@@ -278,6 +281,7 @@ class HubRepoEnricher:
         snapshot,
         chat_binding_counts: Optional[dict[str, int]] = None,
         chat_binding_counts_by_source: Optional[dict[str, dict[str, int]]] = None,
+        unbound_thread_counts: Optional[dict[str, int]] = None,
     ) -> dict:
         from .....core.freshness import resolve_stale_threshold_seconds
 
@@ -305,9 +309,12 @@ class HubRepoEnricher:
         repo_dict["cleanup_blocked_by_chat_binding"] = non_pma_binding_count > 0
         unbound_thread_count = 0
         if snapshot.kind == "base":
-            unbound_thread_count = int(
-                self._unbound_repo_thread_counts().get(snapshot.id, 0)
+            counts = (
+                dict(unbound_thread_counts)
+                if unbound_thread_counts is not None
+                else self._unbound_repo_thread_counts()
             )
+            unbound_thread_count = int(counts.get(snapshot.id, 0))
         repo_dict["unbound_managed_thread_count"] = max(0, unbound_thread_count)
         repo_dict.update(
             self._repo_state_payload(

--- a/tests/surfaces/web/routes/test_hub_performance_caches.py
+++ b/tests/surfaces/web/routes/test_hub_performance_caches.py
@@ -498,6 +498,73 @@ def test_hub_repo_listing_service_enriches_repos_in_parallel(tmp_path: Path) -> 
     assert [repo["repo_id"] for repo in payload["repos"]] == ["repo-1", "repo-2"]
 
 
+def test_hub_repo_listing_service_reuses_unbound_thread_counts_per_listing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    class _AsyncMountManager:
+        async def refresh_mounts(self, _snapshots) -> None:
+            return None
+
+        def add_mount_info(self, repo_dict: dict) -> dict:
+            return repo_dict
+
+    snapshots = [
+        _repo_snapshot(tmp_path / "repo-1", repo_id="repo-1"),
+        _repo_snapshot(tmp_path / "repo-2", repo_id="repo-2"),
+    ]
+    calls = {"unbound": 0}
+
+    def fake_unbound_repo_thread_counts() -> dict[str, int]:
+        calls["unbound"] += 1
+        return {"repo-1": 1, "repo-2": 2}
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.archive.has_car_state",
+        lambda _path: True,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.ticket_flow_summary.build_ticket_flow_summary",
+        lambda _path, *, include_failure, store=None: None,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.pma_context.get_latest_ticket_flow_run_state_with_record",
+        lambda _repo_root, _repo_id, *, store=None: ({}, None),
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.ticket_flow_projection.build_canonical_state_v1",
+        lambda **_kwargs: {},
+    )
+
+    context = SimpleNamespace(
+        config=SimpleNamespace(
+            root=tmp_path,
+            raw={},
+            pma=SimpleNamespace(freshness_stale_threshold_seconds=None),
+        ),
+        supervisor=SimpleNamespace(
+            list_repos=lambda: snapshots,
+            state=SimpleNamespace(last_scan_at=None, pinned_parent_repo_ids=[]),
+            unbound_repo_thread_counts=fake_unbound_repo_thread_counts,
+        ),
+        logger=logging.getLogger(__name__),
+    )
+    enricher = HubRepoEnricher(context, _AsyncMountManager())  # type: ignore[arg-type]
+    listing_service = HubRepoListingService(
+        context,
+        _AsyncMountManager(),  # type: ignore[arg-type]
+        enricher,
+    )
+    listing_service._active_chat_binding_counts_by_source = lambda: {}
+
+    payload = asyncio.run(listing_service.list_repos(sections={"repos"}))
+
+    repos_by_id = {repo["id"]: repo for repo in payload["repos"]}
+    assert repos_by_id["repo-1"]["unbound_managed_thread_count"] == 1
+    assert repos_by_id["repo-2"]["unbound_managed_thread_count"] == 2
+    assert calls["unbound"] == 1
+
+
 def test_hub_repo_listing_service_reuses_stale_response_while_refreshing(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -315,6 +315,60 @@ def test_set_thread_backend_id_preserves_runtime_tag_when_omitted(
     assert row["backend_thread_id"] == "backend-2"
 
 
+def test_set_thread_backend_id_skips_noop_write_when_binding_matches(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = PmaThreadStore(tmp_path / "hub")
+    thread = store.create_thread(
+        "codex",
+        tmp_path / "workspace",
+        backend_thread_id="backend-1",
+        metadata={"backend_runtime_instance_id": "runtime-1"},
+    )
+
+    def _fail_write_conn():  # type: ignore[no-untyped-def]
+        raise AssertionError("no-op backend binding update should not write")
+
+    monkeypatch.setattr(store, "_write_conn", _fail_write_conn)
+
+    store.set_thread_backend_id(
+        thread["managed_thread_id"],
+        "backend-1",
+        backend_runtime_instance_id="runtime-1",
+    )
+
+    binding = store.get_thread_runtime_binding(thread["managed_thread_id"])
+    assert binding is not None
+    assert binding.backend_thread_id == "backend-1"
+    assert binding.backend_runtime_instance_id == "runtime-1"
+
+
+def test_set_thread_backend_id_skips_noop_write_when_runtime_tag_is_omitted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = PmaThreadStore(tmp_path / "hub")
+    thread = store.create_thread(
+        "codex",
+        tmp_path / "workspace",
+        backend_thread_id="backend-1",
+        metadata={"backend_runtime_instance_id": "runtime-1"},
+    )
+
+    def _fail_write_conn():  # type: ignore[no-untyped-def]
+        raise AssertionError("no-op backend binding update should not write")
+
+    monkeypatch.setattr(store, "_write_conn", _fail_write_conn)
+
+    store.set_thread_backend_id(thread["managed_thread_id"], "backend-1")
+
+    binding = store.get_thread_runtime_binding(thread["managed_thread_id"])
+    assert binding is not None
+    assert binding.backend_thread_id == "backend-1"
+    assert binding.backend_runtime_instance_id == "runtime-1"
+
+
 def test_create_turn_rejects_when_running_turn_exists(tmp_path: Path) -> None:
     store = PmaThreadStore(tmp_path / "hub")
     thread = store.create_thread("codex", tmp_path / "workspace")


### PR DESCRIPTION
## What changed
This tightens two hub code paths that were doing avoidable work during repo listing and managed-thread binding updates.

- `PmaThreadStore.set_thread_backend_id(...)` now short-circuits when the requested backend thread/runtime binding already matches the current stored state.
- `HubRepoListingService` now snapshots unbound managed-thread counts once per listing refresh and passes that snapshot into repo enrichment instead of recomputing counts per repo.
- Added regression tests for both behaviors.

## Why
The previous behavior could still write thread-target state even when nothing had actually changed, and hub repo enrichment could repeatedly recompute unbound thread counts during a single listing pass. Both patterns add unnecessary churn on the hub path and increase the odds of instability under load.

## Impact
- Reduces no-op writes for managed-thread backend bindings.
- Reduces repeated supervisor/cache work while building hub repo listings.
- Keeps the hub listing path deterministic within a single refresh by using one unbound-count snapshot.

## Root cause
Two separate no-op paths were missing guards:

1. backend thread binding updates did not exit early when the persisted target row and runtime binding already matched the requested values.
2. repo enrichment read unbound managed-thread counts lazily inside per-repo enrichment instead of capturing one listing-scoped snapshot.

## Validation
Local validation completed successfully:

- `.venv/bin/python -m pytest tests/test_pma_thread_store.py tests/surfaces/web/routes/test_hub_performance_caches.py`
- `.venv/bin/python -m pytest tests/surfaces/web/routes`
- pre-commit hook chain on `git commit`, including:
  - `black`
  - `ruff`
  - repo-wide `mypy`
  - `pnpm run build`
  - frontend JS tests
  - full `pytest` suite: `5134 passed`

## Deployment note
This has not been live-verified against the real launchd hub in this worktree. The evidence here is strong local validation; the remaining risk is deployment-only behavior.