### PR TITLE
[codex] Harden Discord hub control-plane timeout handling

### DIFF
--- a/src/codex_autorunner/core/hub_control_plane/http_client.py
+++ b/src/codex_autorunner/core/hub_control_plane/http_client.py
@@ -71,6 +71,8 @@ from .models import (
     WorkspaceSetupCommandResult,
 )
 
+_USE_CLIENT_DEFAULT_TIMEOUT = object()
+
 
 def _normalize_base_url(base_url: str) -> str:
     normalized = str(base_url or "").strip().rstrip("/")
@@ -170,13 +172,19 @@ class HttpHubControlPlaneClient(HubControlPlaneClient):
         path: str,
         json_payload: Mapping[str, Any] | None = None,
         params: Mapping[str, Any] | None = None,
+        timeout: object = _USE_CLIENT_DEFAULT_TIMEOUT,
     ) -> dict[str, Any]:
+        request_kwargs: dict[str, Any] = {
+            "json": dict(json_payload) if json_payload is not None else None,
+            "params": dict(params) if params is not None else None,
+        }
+        if timeout is not _USE_CLIENT_DEFAULT_TIMEOUT:
+            request_kwargs["timeout"] = timeout
         try:
             response = await (await self._get_http_client()).request(
                 method,
                 path,
-                json=dict(json_payload) if json_payload is not None else None,
-                params=dict(params) if params is not None else None,
+                **request_kwargs,
             )
         except httpx.RequestError as exc:
             raise HubControlPlaneError(
@@ -220,13 +228,19 @@ class HttpHubControlPlaneClient(HubControlPlaneClient):
         path: str,
         json_payload: Mapping[str, Any] | None = None,
         params: Mapping[str, Any] | None = None,
+        timeout: object = _USE_CLIENT_DEFAULT_TIMEOUT,
     ) -> None:
+        request_kwargs: dict[str, Any] = {
+            "json": dict(json_payload) if json_payload is not None else None,
+            "params": dict(params) if params is not None else None,
+        }
+        if timeout is not _USE_CLIENT_DEFAULT_TIMEOUT:
+            request_kwargs["timeout"] = timeout
         try:
             response = await (await self._get_http_client()).request(
                 method,
                 path,
-                json=dict(json_payload) if json_payload is not None else None,
-                params=dict(params) if params is not None else None,
+                **request_kwargs,
             )
         except httpx.RequestError as exc:
             raise HubControlPlaneError(
@@ -641,6 +655,8 @@ class HttpHubControlPlaneClient(HubControlPlaneClient):
             method="POST",
             path="/hub/api/control-plane/workspace-setup-commands",
             json_payload=request.to_dict(),
+            # Setup commands may run for an unbounded sequence of user-defined steps.
+            timeout=None,
         )
         return WorkspaceSetupCommandResult.from_mapping(payload)
 

--- a/src/codex_autorunner/core/hub_control_plane/remote_binding_store.py
+++ b/src/codex_autorunner/core/hub_control_plane/remote_binding_store.py
@@ -82,12 +82,11 @@ class RemoteSurfaceBindingStore:
 
             return asyncio.run(_run_action())
 
-        pool = ThreadPoolExecutor(max_workers=1)
-        future = pool.submit(_invoke)
         try:
-            return future.result(timeout=self._timeout_seconds)
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(_invoke)
+                return future.result(timeout=self._timeout_seconds)
         except FuturesTimeoutError as exc:
-            future.cancel()
             raise self._hub_unavailable(
                 operation=operation,
                 message=f"request timed out after {self._timeout_seconds:g}s",
@@ -110,12 +109,15 @@ class RemoteSurfaceBindingStore:
                 message=str(exc) or exc.__class__.__name__,
                 details={"cause_type": exc.__class__.__name__},
             ) from exc
-        finally:
-            pool.shutdown(wait=False, cancel_futures=True)
 
     @staticmethod
     def _normalize_key(surface_kind: str, surface_key: str) -> tuple[str, str]:
         return (str(surface_kind or "").strip(), str(surface_key or "").strip())
+
+    def _forget_binding(self, *, surface_kind: str, surface_key: str) -> None:
+        key = self._normalize_key(surface_kind, surface_key)
+        self._bindings_by_key.pop(key, None)
+        self._binding_cached_at_by_key.pop(key, None)
 
     def _remember(self, binding: Any) -> Any:
         if binding is None:
@@ -222,6 +224,9 @@ class RemoteSurfaceBindingStore:
             if cached is None:
                 raise
             return cached
+        if response.binding is None:
+            self._forget_binding(surface_kind=surface_kind, surface_key=surface_key)
+            return None
         return self._remember(response.binding)
 
     @staticmethod

--- a/src/codex_autorunner/core/hub_control_plane/remote_binding_store.py
+++ b/src/codex_autorunner/core/hub_control_plane/remote_binding_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import time
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, Callable, Coroutine, Optional, TypeVar
@@ -29,11 +30,14 @@ class RemoteSurfaceBindingStore:
         self,
         client: HubControlPlaneClient,
         *,
-        timeout_seconds: float = 10.0,
+        timeout_seconds: float = 30.0,
+        cache_fallback_ttl_seconds: float = 300.0,
     ) -> None:
         self._client = client
         self._timeout_seconds = timeout_seconds
+        self._cache_fallback_ttl_seconds = max(0.0, float(cache_fallback_ttl_seconds))
         self._bindings_by_key: dict[tuple[str, str], Any] = {}
+        self._binding_cached_at_by_key: dict[tuple[str, str], float] = {}
 
     def _hub_unavailable(
         self,
@@ -78,11 +82,12 @@ class RemoteSurfaceBindingStore:
 
             return asyncio.run(_run_action())
 
+        pool = ThreadPoolExecutor(max_workers=1)
+        future = pool.submit(_invoke)
         try:
-            with ThreadPoolExecutor(max_workers=1) as pool:
-                future = pool.submit(_invoke)
-                return future.result(timeout=self._timeout_seconds)
+            return future.result(timeout=self._timeout_seconds)
         except FuturesTimeoutError as exc:
+            future.cancel()
             raise self._hub_unavailable(
                 operation=operation,
                 message=f"request timed out after {self._timeout_seconds:g}s",
@@ -105,6 +110,8 @@ class RemoteSurfaceBindingStore:
                 message=str(exc) or exc.__class__.__name__,
                 details={"cause_type": exc.__class__.__name__},
             ) from exc
+        finally:
+            pool.shutdown(wait=False, cancel_futures=True)
 
     @staticmethod
     def _normalize_key(surface_kind: str, surface_key: str) -> tuple[str, str]:
@@ -119,7 +126,34 @@ class RemoteSurfaceBindingStore:
         )
         if all(key):
             self._bindings_by_key[key] = binding
+            self._binding_cached_at_by_key[key] = time.monotonic()
         return binding
+
+    def _get_cached_binding(
+        self,
+        *,
+        surface_kind: str,
+        surface_key: str,
+        include_disabled: bool = False,
+    ) -> Any:
+        key = self._normalize_key(surface_kind, surface_key)
+        cached = self._bindings_by_key.get(key)
+        if cached is None:
+            return None
+        cached_at = self._binding_cached_at_by_key.get(key)
+        if cached_at is None:
+            return None
+        if (
+            self._cache_fallback_ttl_seconds > 0.0
+            and time.monotonic() - cached_at > self._cache_fallback_ttl_seconds
+        ):
+            return None
+        if (
+            not include_disabled
+            and str(getattr(cached, "disabled_at", "") or "").strip()
+        ):
+            return None
+        return cached
 
     def upsert_binding(
         self,
@@ -166,16 +200,28 @@ class RemoteSurfaceBindingStore:
         surface_key: str,
         include_disabled: bool = False,
     ) -> Any:
-        response = self._run(
-            operation="get_surface_binding",
-            action=lambda client: client.get_surface_binding(
-                SurfaceBindingLookupRequest(
-                    surface_kind=surface_kind,
-                    surface_key=surface_key,
-                    include_disabled=include_disabled,
-                )
-            ),
-        )
+        try:
+            response = self._run(
+                operation="get_surface_binding",
+                action=lambda client: client.get_surface_binding(
+                    SurfaceBindingLookupRequest(
+                        surface_kind=surface_kind,
+                        surface_key=surface_key,
+                        include_disabled=include_disabled,
+                    )
+                ),
+            )
+        except HubControlPlaneError as exc:
+            if exc.code != "hub_unavailable":
+                raise
+            cached = self._get_cached_binding(
+                surface_kind=surface_kind,
+                surface_key=surface_key,
+                include_disabled=include_disabled,
+            )
+            if cached is None:
+                raise
+            return cached
         return self._remember(response.binding)
 
     @staticmethod

--- a/tests/core/test_hub_control_plane_contract.py
+++ b/tests/core/test_hub_control_plane_contract.py
@@ -391,3 +391,71 @@ async def test_http_client_context_manager_closes() -> None:
     async with client:
         assert not client._http_client.is_closed
     assert client._http_client.is_closed
+
+
+async def test_http_client_uses_extended_timeout_for_workspace_setup_commands() -> None:
+    from codex_autorunner.core.hub_control_plane.http_client import (
+        HttpHubControlPlaneClient,
+    )
+    from codex_autorunner.core.hub_control_plane.models import (
+        WorkspaceSetupCommandRequest,
+    )
+
+    class _FakeAsyncClient:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        async def request(
+            self,
+            method: str,
+            path: str,
+            *,
+            json: dict[str, object] | None = None,
+            params: dict[str, object] | None = None,
+            timeout: float | None = None,
+        ) -> httpx.Response:
+            self.calls.append(
+                {
+                    "method": method,
+                    "path": path,
+                    "json": json,
+                    "params": params,
+                    "timeout": timeout,
+                }
+            )
+            return httpx.Response(
+                200,
+                json={
+                    "workspace_root": (json or {}).get("workspace_root", ""),
+                    "repo_id_hint": (json or {}).get("repo_id_hint"),
+                    "setup_command_count": 1,
+                },
+            )
+
+    fake_client = _FakeAsyncClient()
+    client = HttpHubControlPlaneClient(
+        base_url="http://localhost:9999",
+        timeout=10.0,
+        http_client=fake_client,  # type: ignore[arg-type]
+    )
+
+    result = await client.run_workspace_setup_commands(
+        WorkspaceSetupCommandRequest(
+            workspace_root="/tmp/workspace",
+            repo_id_hint="repo-1",
+        )
+    )
+
+    assert result.setup_command_count == 1
+    assert fake_client.calls == [
+        {
+            "method": "POST",
+            "path": "/hub/api/control-plane/workspace-setup-commands",
+            "json": {
+                "workspace_root": "/tmp/workspace",
+                "repo_id_hint": "repo-1",
+            },
+            "params": None,
+            "timeout": None,
+        }
+    ]

--- a/tests/core/test_remote_binding_store.py
+++ b/tests/core/test_remote_binding_store.py
@@ -51,6 +51,29 @@ class _UnavailableLookupClient:
         raise HubControlPlaneError("hub_unavailable", "hub offline")
 
 
+class _LookupClient:
+    def __init__(self, binding: Binding | None) -> None:
+        self.binding = binding
+
+    async def get_surface_binding(self, request):
+        from codex_autorunner.core.hub_control_plane import SurfaceBindingResponse
+
+        return SurfaceBindingResponse(binding=self.binding)
+
+
+class _MissThenUnavailableLookupClient:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def get_surface_binding(self, request):
+        from codex_autorunner.core.hub_control_plane import SurfaceBindingResponse
+
+        self.calls += 1
+        if self.calls == 1:
+            return SurfaceBindingResponse(binding=None)
+        raise HubControlPlaneError("hub_unavailable", "hub offline")
+
+
 class _LoopBoundListingClient(_ListingClient):
     def __init__(self, bindings: list[Binding]) -> None:
         super().__init__(bindings)
@@ -176,6 +199,24 @@ def test_remote_surface_binding_store_get_binding_requires_fresh_cache_for_fallb
     cached = _binding_from_mapping(binding_id="binding-cache")
     store._remember(cached)
     store._binding_cached_at_by_key[("discord", "channel:1")] -= 61.0
+
+    with pytest.raises(HubControlPlaneError) as exc_info:
+        store.get_binding(surface_kind="discord", surface_key="channel:1")
+
+    assert exc_info.value.code == "hub_unavailable"
+
+
+def test_remote_surface_binding_store_get_binding_evicts_cache_on_successful_miss() -> (
+    None
+):
+    store = RemoteSurfaceBindingStore(_MissThenUnavailableLookupClient())
+    cached = _binding_from_mapping(binding_id="binding-cache")
+    store._remember(cached)
+
+    first = store.get_binding(surface_kind="discord", surface_key="channel:1")
+
+    assert first is None
+    assert ("discord", "channel:1") not in store._bindings_by_key
 
     with pytest.raises(HubControlPlaneError) as exc_info:
         store.get_binding(surface_kind="discord", surface_key="channel:1")

--- a/tests/core/test_remote_binding_store.py
+++ b/tests/core/test_remote_binding_store.py
@@ -46,6 +46,11 @@ class _UnavailableListingClient:
         raise HubControlPlaneError("hub_unavailable", "hub offline")
 
 
+class _UnavailableLookupClient:
+    async def get_surface_binding(self, request):
+        raise HubControlPlaneError("hub_unavailable", "hub offline")
+
+
 class _LoopBoundListingClient(_ListingClient):
     def __init__(self, bindings: list[Binding]) -> None:
         super().__init__(bindings)
@@ -147,6 +152,35 @@ def test_remote_surface_binding_store_falls_back_to_cache_when_hub_unavailable()
         "binding-enabled",
         "binding-disabled",
     ]
+
+
+def test_remote_surface_binding_store_get_binding_falls_back_to_cache_when_hub_unavailable() -> (
+    None
+):
+    store = RemoteSurfaceBindingStore(_UnavailableLookupClient())
+    cached = _binding_from_mapping(binding_id="binding-cache")
+    store._remember(cached)
+
+    binding = store.get_binding(surface_kind="discord", surface_key="channel:1")
+
+    assert binding is cached
+
+
+def test_remote_surface_binding_store_get_binding_requires_fresh_cache_for_fallback() -> (
+    None
+):
+    store = RemoteSurfaceBindingStore(
+        _UnavailableLookupClient(),
+        cache_fallback_ttl_seconds=60.0,
+    )
+    cached = _binding_from_mapping(binding_id="binding-cache")
+    store._remember(cached)
+    store._binding_cached_at_by_key[("discord", "channel:1")] -= 61.0
+
+    with pytest.raises(HubControlPlaneError) as exc_info:
+        store.get_binding(surface_kind="discord", surface_key="channel:1")
+
+    assert exc_info.value.code == "hub_unavailable"
 
 
 def test_remote_surface_binding_store_preserves_non_transport_hub_errors() -> None:

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -7546,6 +7546,7 @@ async def test_hub_client_setup_commands_survive_loop_switch_after_workspace_loo
             *,
             json: dict[str, Any] | None = None,
             params: dict[str, Any] | None = None,
+            timeout: float | None = None,
         ) -> httpx.Response:
             _ = method, params
             current_loop = asyncio.get_running_loop()
@@ -7553,7 +7554,7 @@ async def test_hub_client_setup_commands_survive_loop_switch_after_workspace_loo
                 self.bound_loop = current_loop
             elif self.bound_loop is not current_loop:
                 raise RuntimeError("Event loop is closed")
-            self.calls.append(path)
+            self.calls.append(f"{path}|timeout={timeout}")
             if path == "/hub/api/control-plane/agent-workspaces":
                 return httpx.Response(
                     200,
@@ -7616,11 +7617,17 @@ async def test_hub_client_setup_commands_survive_loop_switch_after_workspace_loo
 
         assert setup_result.setup_command_count == 1
         assert any(
-            "/hub/api/control-plane/agent-workspaces" in instance.calls
+            any(
+                call.startswith("/hub/api/control-plane/agent-workspaces")
+                for call in instance.calls
+            )
             for instance in _LoopStickyAsyncClient.instances
         )
         assert any(
-            "/hub/api/control-plane/workspace-setup-commands" in instance.calls
+            any(
+                call == "/hub/api/control-plane/workspace-setup-commands|timeout=None"
+                for call in instance.calls
+            )
             for instance in _LoopStickyAsyncClient.instances
         )
     finally:


### PR DESCRIPTION
## What changed
This hardens the Discord hub control-plane path for repo-bound chats and `/car newt` setup flows.

The change does three things:
- disables the client-side timeout specifically for `/workspace-setup-commands`, so Discord does not fail after 10 seconds while valid setup commands are still running
- raises the remote surface-binding read timeout budget from 10 seconds to 30 seconds to align better with orchestration contention
- adds degraded fallback for `get_surface_binding`, but only when there is a fresh cached binding available

## Why it changed
Discord was surfacing two related failure modes:
- `Hub control-plane unavailable during get_surface_binding: request timed out after 10s`
- `Reset branch ... but setup commands failed: Hub control-plane transport request failed ...`

The root cause was a timeout mismatch. The Discord control-plane client used a 10 second request timeout for every endpoint, while workspace setup commands can legitimately run much longer and hub-backed binding reads can be delayed by orchestration contention. That made transient hub slowness look like a hard Discord failure.

## User impact
Repo-bound Discord chats should now be more stable under temporary hub slowness.

More specifically:
- fresh-session setup no longer fails just because setup commands exceed the old 10 second HTTP timeout
- repo-bound channel routing can continue through short hub outages when a recent binding is already known locally
- stale bindings are not reused indefinitely; the degraded fallback is limited to fresh cached entries only

## Validation
I ran:
- `python -m pytest tests/core/test_remote_binding_store.py -q`
- `python -m pytest tests/core/test_hub_control_plane_contract.py -q`
- `python -m pytest tests/core/test_remote_execution_store.py -q`
- `python -m pytest tests/integrations/discord/test_service_routing.py -q -k "sticky or setup"`

I also did a mini subagent review before publishing and addressed the issues it found.

## Notes
This intentionally leaves two explicit tradeoffs:
- the degraded binding fallback only applies to fresh cached bindings during hub-unavailable reads
- `/workspace-setup-commands` now relies on hub-side command time limits instead of a short client-side timeout, which avoids false failures but means a genuinely hung setup can keep the Discord flow open longer