### PR TITLE
[codex] Add GitHub review login filters for SCM reactions

### DIFF
--- a/src/codex_autorunner/core/config.py
+++ b/src/codex_autorunner/core/config.py
@@ -395,6 +395,8 @@ def _default_github_automation_section() -> Dict[str, Any]:
             "merged": True,
             "duplicate_escalation_threshold": 3,
             "delivery_failure_escalation_threshold": 3,
+            "github_login_whitelist": [],
+            "github_login_blacklist": [],
         },
         "polling": {
             "enabled": False,

--- a/src/codex_autorunner/core/config_validation.py
+++ b/src/codex_autorunner/core/config_validation.py
@@ -747,6 +747,28 @@ def _validate_repo_config(cfg: Dict[str, Any], *, root: Path) -> None:
                         raise ConfigError(
                             "github.automation.reactions.profile must be 'all' or 'minimal_noise'"
                         )
+                for key in (
+                    "github_login_whitelist",
+                    "github_login_blacklist",
+                    "github_login_allowlist",
+                    "github_login_denylist",
+                    "whitelist",
+                    "blacklist",
+                    "allowlist",
+                    "denylist",
+                ):
+                    raw_logins = reactions.get(key)
+                    if raw_logins is None:
+                        continue
+                    if not isinstance(raw_logins, list):
+                        raise ConfigError(
+                            f"github.automation.reactions.{key} must be a list of strings"
+                        )
+                    for login in raw_logins:
+                        if not isinstance(login, str):
+                            raise ConfigError(
+                                f"github.automation.reactions.{key} must be a list of strings"
+                            )
             policy = automation.get("policy")
             if policy is not None and not isinstance(policy, dict):
                 raise ConfigError(

--- a/src/codex_autorunner/core/scm_reaction_router.py
+++ b/src/codex_autorunner/core/scm_reaction_router.py
@@ -21,6 +21,9 @@ _FAILED_CHECK_CONCLUSIONS = frozenset(
     {"action_required", "cancelled", "failure", "startup_failure", "stale", "timed_out"}
 )
 _REVIEW_COMMENT_ID_IN_URL = re.compile(r"(?:#discussion_r|/pulls/comments/)(\d+)")
+_GITHUB_REVIEW_REACTION_KINDS = frozenset(
+    {"changes_requested", "review_comment", "approved_and_green"}
+)
 
 
 def _normalize_lower_text(value: Any) -> Optional[str]:
@@ -181,6 +184,13 @@ def _resolve_review_comment_id(payload: Mapping[str, Any]) -> Optional[str]:
     return None
 
 
+def _github_review_author_login(event: ScmEvent) -> Optional[str]:
+    payload = _event_payload(event)
+    return _normalize_lower_text(payload.get("author_login")) or _normalize_lower_text(
+        payload.get("sender_login")
+    )
+
+
 def _match_reaction_kind(
     event: ScmEvent,
     *,
@@ -254,6 +264,12 @@ def route_scm_reactions(
     resolved_config = ScmReactionConfig.from_mapping(config)
     reaction_kind = _match_reaction_kind(event, binding=binding)
     if reaction_kind is None or not resolved_config.is_enabled(reaction_kind):
+        return []
+    if (
+        event.provider == "github"
+        and reaction_kind in _GITHUB_REVIEW_REACTION_KINDS
+        and not resolved_config.github_login_allowed(_github_review_author_login(event))
+    ):
         return []
 
     intents: list[ReactionIntent] = []

--- a/src/codex_autorunner/core/scm_reaction_types.py
+++ b/src/codex_autorunner/core/scm_reaction_types.py
@@ -55,6 +55,34 @@ def _int_from_mapping(
     return max(normalized, minimum)
 
 
+def _normalize_login(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _login_list_from_mapping(mapping: Mapping[str, Any], *keys: str) -> tuple[str, ...]:
+    seen: set[str] = set()
+    logins: list[str] = []
+    for key in keys:
+        raw_value = mapping.get(key)
+        candidates: list[Any]
+        if isinstance(raw_value, str):
+            candidates = [raw_value]
+        elif isinstance(raw_value, (list, tuple, set)):
+            candidates = list(raw_value)
+        else:
+            continue
+        for candidate in candidates:
+            normalized = _normalize_login(candidate)
+            if normalized is None or normalized in seen:
+                continue
+            seen.add(normalized)
+            logins.append(normalized)
+    return tuple(logins)
+
+
 @dataclass(frozen=True)
 class ScmReactionConfig:
     ci_failed: bool = True
@@ -64,6 +92,8 @@ class ScmReactionConfig:
     merged: bool = True
     duplicate_escalation_threshold: int = 3
     delivery_failure_escalation_threshold: int = 3
+    github_login_whitelist: tuple[str, ...] = ()
+    github_login_blacklist: tuple[str, ...] = ()
 
     @classmethod
     def from_mapping(
@@ -134,6 +164,20 @@ class ScmReactionConfig:
                 "delivery_failure_escalation_threshold",
                 default=3,
             ),
+            github_login_whitelist=_login_list_from_mapping(
+                mapping,
+                "github_login_whitelist",
+                "github_login_allowlist",
+                "whitelist",
+                "allowlist",
+            ),
+            github_login_blacklist=_login_list_from_mapping(
+                mapping,
+                "github_login_blacklist",
+                "github_login_denylist",
+                "blacklist",
+                "denylist",
+            ),
         )
 
     @staticmethod
@@ -166,6 +210,15 @@ class ScmReactionConfig:
 
     def is_enabled(self, reaction_kind: ReactionKind) -> bool:
         return bool(getattr(self, reaction_kind))
+
+    def github_login_allowed(self, login: Any) -> bool:
+        normalized = _normalize_login(login)
+        if self.github_login_whitelist:
+            if normalized is None or normalized not in self.github_login_whitelist:
+                return False
+        if normalized is not None and normalized in self.github_login_blacklist:
+            return False
+        return True
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/tests/core/test_scm_reaction_router.py
+++ b/tests/core/test_scm_reaction_router.py
@@ -484,6 +484,50 @@ def test_route_scm_reactions_still_reacts_to_review_comment_without_chat_target(
     assert intents[0].payload["repo_slug"] == "acme/widgets"
 
 
+def test_route_scm_reactions_blocks_non_whitelisted_review_authors() -> None:
+    event = _event(
+        "pull_request_review",
+        event_id="github:event-whitelist-blocked",
+        payload={
+            "action": "submitted",
+            "review_state": "changes_requested",
+            "author_login": "reviewer",
+            "body": "Please split this helper.",
+        },
+    )
+
+    intents = route_scm_reactions(
+        event,
+        binding=_binding(),
+        config=ScmReactionConfig(github_login_whitelist=("trusted-reviewer",)),
+    )
+
+    assert intents == []
+
+
+def test_route_scm_reactions_blocks_blacklisted_review_authors() -> None:
+    event = _event(
+        "pull_request_review_comment",
+        event_id="github:event-blacklist-blocked",
+        payload={
+            "action": "created",
+            "comment_id": "999",
+            "author_login": "reviewer",
+            "author_type": "User",
+            "issue_author_login": "pr-author",
+            "body": "Please cover the blacklist path.",
+        },
+    )
+
+    intents = route_scm_reactions(
+        event,
+        binding=_binding(thread_target_id="thread-inline"),
+        config=ScmReactionConfig(github_login_blacklist=("reviewer",)),
+    )
+
+    assert intents == []
+
+
 def test_route_scm_reactions_returns_no_intents_for_irrelevant_events() -> None:
     opened = _event(
         "pull_request",

--- a/tests/core/test_scm_reaction_types.py
+++ b/tests/core/test_scm_reaction_types.py
@@ -26,3 +26,47 @@ def test_scm_reaction_config_profile_allows_explicit_overrides() -> None:
     assert config.approved_and_green is True
     assert config.review_comment is True
     assert config.merged is False
+
+
+def test_scm_reaction_config_normalizes_and_deduplicates_login_lists() -> None:
+    config = ScmReactionConfig.from_mapping(
+        {
+            "reactions": {
+                "github_login_whitelist": [" Reviewer ", "reviewer", "", "Approver"],
+                "github_login_blacklist": ["bot[bot]", " BOT[bot] "],
+                "github_login_allowlist": ["trusted-reviewer"],
+                "github_login_denylist": ["noisy-reviewer"],
+            }
+        }
+    )
+
+    assert config.github_login_whitelist == (
+        "reviewer",
+        "approver",
+        "trusted-reviewer",
+    )
+    assert config.github_login_blacklist == ("bot[bot]", "noisy-reviewer")
+
+
+def test_scm_reaction_config_github_login_allowed_respects_allow_and_deny_lists() -> (
+    None
+):
+    allow_and_deny = ScmReactionConfig.from_mapping(
+        {
+            "reactions": {
+                "github_login_whitelist": ["reviewer", "trusted-user"],
+                "github_login_blacklist": ["trusted-user"],
+            }
+        }
+    )
+    deny_only = ScmReactionConfig.from_mapping(
+        {"reactions": {"github_login_blacklist": ["blocked-user"]}}
+    )
+
+    assert allow_and_deny.github_login_allowed("reviewer") is True
+    assert allow_and_deny.github_login_allowed("trusted-user") is False
+    assert allow_and_deny.github_login_allowed("someone-else") is False
+    assert allow_and_deny.github_login_allowed(None) is False
+
+    assert deny_only.github_login_allowed("ok-user") is True
+    assert deny_only.github_login_allowed("blocked-user") is False

--- a/tests/fixtures/default_hub_config.v2.json
+++ b/tests/fixtures/default_hub_config.v2.json
@@ -304,6 +304,8 @@
           "delivery_failure_escalation_threshold": 3,
           "duplicate_escalation_threshold": 3,
           "enabled": true,
+          "github_login_blacklist": [],
+          "github_login_whitelist": [],
           "merged": true,
           "review_comment": true
         },

--- a/tests/fixtures/default_repo_config.v2.json
+++ b/tests/fixtures/default_repo_config.v2.json
@@ -151,6 +151,8 @@
         "delivery_failure_escalation_threshold": 3,
         "duplicate_escalation_threshold": 3,
         "enabled": true,
+        "github_login_blacklist": [],
+        "github_login_whitelist": [],
         "merged": true,
         "review_comment": true
       },


### PR DESCRIPTION
## Summary
- add GitHub review author login filters to `ScmReactionConfig` (whitelist + blacklist, with allow/denylist aliases)
- apply those filters in `route_scm_reactions` for GitHub review reactions so polling and webhook paths share the same behavior
- extend config defaults/validation and update default config snapshots
- add unit coverage for config normalization and router allow/deny behavior

## Validation
- .venv/bin/python -m pytest tests/core/test_scm_reaction_types.py tests/core/test_scm_reaction_router.py tests/test_config_default_snapshots.py
- .venv/bin/python -m pytest tests/integrations/github/test_polling.py -k "arm_watch_captures_baseline_and_minimal_noise_profile or process_due_watches_emits_new_pr_comment_and_inline_review_comment"

Closes #1414
