### PR TITLE
Fix delayed archive feedback in flow callbacks

### DIFF
--- a/src/codex_autorunner/integrations/discord/flow_commands.py
+++ b/src/codex_autorunner/integrations/discord/flow_commands.py
@@ -2211,13 +2211,13 @@ async def handle_flow_button(
                 if isinstance(exc, (RuntimeError, ConfigError))
                 else "Unable to query flow database. Please try again later."
             )
-            action = (
+            failed_action = (
                 "open flow database"
                 if event.endswith("store_open_failed")
                 else "query flow run"
             )
             raise DiscordTransientError(
-                f"Failed to {action}: {exc}",
+                f"Failed to {failed_action}: {exc}",
                 user_message=user_message,
             ) from None
 

--- a/src/codex_autorunner/integrations/discord/flow_commands.py
+++ b/src/codex_autorunner/integrations/discord/flow_commands.py
@@ -2176,36 +2176,50 @@ async def handle_flow_button(
             )
             return
 
-        try:
+        def _resolve_archive_target() -> Optional[FlowRunRecord]:
             store = service._open_flow_store(workspace_root)
-        except (sqlite3.Error, OSError, RuntimeError, ConfigError) as exc:
-            log_event(
-                service._logger,
-                logging.ERROR,
-                "discord.flow.store_open_failed",
-                workspace_root=str(workspace_root),
-                exc=exc,
-            )
-            raise DiscordTransientError(
-                f"Failed to open flow database: {exc}",
-                user_message="Unable to access flow database. Please try again later.",
-            ) from None
+            try:
+                return cast(
+                    Optional[FlowRunRecord],
+                    service._resolve_flow_run_by_id(store, run_id=run_id),
+                )
+            finally:
+                store.close()
+
         try:
-            target = service._resolve_flow_run_by_id(store, run_id=run_id)
-        except (sqlite3.Error, OSError) as exc:
+            target = await asyncio.to_thread(_resolve_archive_target)
+        except (sqlite3.Error, OSError, RuntimeError, ConfigError) as exc:
+            event = (
+                "discord.flow.store_open_failed"
+                if isinstance(exc, (RuntimeError, ConfigError))
+                else "discord.flow.query_failed"
+            )
+            payload: dict[str, Any] = {
+                "exc": exc,
+                "workspace_root": str(workspace_root),
+            }
+            if isinstance(exc, (sqlite3.Error, OSError)):
+                payload = {"exc": exc, "run_id": run_id}
             log_event(
                 service._logger,
                 logging.ERROR,
-                "discord.flow.query_failed",
-                exc=exc,
-                run_id=run_id,
+                event,
+                **payload,
+            )
+            user_message = (
+                "Unable to access flow database. Please try again later."
+                if isinstance(exc, (RuntimeError, ConfigError))
+                else "Unable to query flow database. Please try again later."
+            )
+            action = (
+                "open flow database"
+                if event.endswith("store_open_failed")
+                else "query flow run"
             )
             raise DiscordTransientError(
-                f"Failed to query flow run: {exc}",
-                user_message="Unable to query flow database. Please try again later.",
+                f"Failed to {action}: {exc}",
+                user_message=user_message,
             ) from None
-        finally:
-            store.close()
 
         if target is None:
             stale_text = (

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import uuid
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional, TypeVar
 
 from .....core.config import ConfigError, load_repo_config
 from .....core.flows import (
@@ -65,6 +65,7 @@ from .shared import TelegramCommandSupportMixin
 
 _logger = logging.getLogger(__name__)
 _FLOW_REPO_CONTEXT_CACHE_MAX = 512
+_T = TypeVar("_T")
 
 
 def _flow_paths(repo_root: Path) -> tuple[Path, Path]:
@@ -128,6 +129,11 @@ def _worktree_suffix(repo_id: str) -> Optional[str]:
 
 
 class FlowCommands(TelegramCommandSupportMixin):
+    async def _run_blocking_flow_call(
+        self, func: Callable[..., _T], /, *args: Any, **kwargs: Any
+    ) -> _T:
+        return await asyncio.to_thread(func, *args, **kwargs)
+
     def _flow_run_mirror(self, repo_root: Path) -> ChatRunMirror:
         return ChatRunMirror(repo_root, logger_=_logger)
 
@@ -617,6 +623,21 @@ class FlowCommands(TelegramCommandSupportMixin):
         *,
         repo_id: Optional[str] = None,
     ) -> None:
+        text, keyboard = await self._run_blocking_flow_call(
+            self._build_flow_status_callback_payload,
+            repo_root,
+            run_id_raw,
+            repo_id=repo_id,
+        )
+        await self._edit_callback_message(callback, text, reply_markup=keyboard)
+
+    def _build_flow_status_callback_payload(
+        self,
+        repo_root: Path,
+        run_id_raw: Optional[str],
+        *,
+        repo_id: Optional[str] = None,
+    ) -> tuple[str, dict[str, Any]]:
         store = _load_flow_store(repo_root)
         try:
             store.initialize()
@@ -625,31 +646,21 @@ class FlowCommands(TelegramCommandSupportMixin):
                 if not run_id_raw:
                     summary_text = self._build_flow_status_summary_fallback(repo_root)
                     if summary_text:
-                        await self._edit_callback_message(
-                            callback,
-                            summary_text,
-                            reply_markup={"inline_keyboard": []},
-                        )
-                        return
-                await self._edit_callback_message(
-                    callback, error, reply_markup={"inline_keyboard": []}
-                )
-                return
+                        return summary_text, {"inline_keyboard": []}
+                return error, {"inline_keyboard": []}
             if record is not None:
                 record, _updated, locked = reconcile_flow_run(repo_root, record, store)
                 if locked:
-                    await self._edit_callback_message(
-                        callback,
+                    return (
                         f"Run {_code(record.id)} is locked for reconcile; try again.",
-                        reply_markup={"inline_keyboard": []},
+                        {"inline_keyboard": []},
                     )
-                    return
             text, keyboard = self._build_flow_status_card(
                 repo_root, record, store, repo_id=repo_id
             )
         finally:
             store.close()
-        await self._edit_callback_message(callback, text, reply_markup=keyboard)
+        return text, keyboard
 
     async def _handle_flow_callback(
         self, callback: TelegramCallbackQuery, parsed: FlowCallback
@@ -757,7 +768,10 @@ class FlowCommands(TelegramCommandSupportMixin):
                     error = "No active ticket flow run found."
                 if error is None:
                     await _answer_once("Working...")
-                    record, updated, locked = flow_service.reconcile_flow_run(record.id)
+                    record, updated, locked = await self._run_blocking_flow_call(
+                        flow_service.reconcile_flow_run,
+                        record.id,
+                    )
                     if locked:
                         error = (
                             f"Run {record.run_id} is locked for reconcile; try again."
@@ -825,7 +839,8 @@ class FlowCommands(TelegramCommandSupportMixin):
                             self._flow_archive_in_progress_text(record.id),
                             reply_markup={"inline_keyboard": []},
                         )
-                        summary = flow_service.archive_flow_run(
+                        summary = await self._run_blocking_flow_call(
+                            flow_service.archive_flow_run,
                             record.id,
                             force=ticket_flow_archive_requires_force(record),
                             delete_run=True,
@@ -1942,9 +1957,10 @@ You are the first ticket in a new ticket_flow run.
                     reply_to=message.message_id,
                 )
                 return
-            record, updated, locked = self._ticket_flow_orchestration_service(
-                repo_root
-            ).reconcile_flow_run(record.id)
+            record, updated, locked = await self._run_blocking_flow_call(
+                self._ticket_flow_orchestration_service(repo_root).reconcile_flow_run,
+                record.id,
+            )
             if locked:
                 await self._send_message(
                     message.chat_id,
@@ -2060,7 +2076,8 @@ You are the first ticket in a new ticket_flow run.
             )
             return
 
-        summary = self._ticket_flow_orchestration_service(repo_root).archive_flow_run(
+        summary = await self._run_blocking_flow_call(
+            self._ticket_flow_orchestration_service(repo_root).archive_flow_run,
             record.id,
             force=ticket_flow_archive_requires_force(record),
             delete_run=True,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import logging
@@ -2457,7 +2458,8 @@ Compact canceled.""",
 Applying summary...""",
             reply_markup=None,
         )
-        status = self._write_compact_status(
+        status = await asyncio.to_thread(
+            self._write_compact_status,
             "running",
             "Applying summary...",
             chat_id=callback.chat_id,
@@ -2481,7 +2483,8 @@ Applying summary...""",
             message, record, state.summary_text
         )
         if not success:
-            status = self._write_compact_status(
+            status = await asyncio.to_thread(
+                self._write_compact_status,
                 "error",
                 failure_message or "Failed to start new thread with summary.",
                 chat_id=callback.chat_id,
@@ -2507,7 +2510,8 @@ Failed to start new thread with summary.""",
                     callback.chat_id, failure_message, thread_id=callback.thread_id
                 )
             return
-        status = self._write_compact_status(
+        status = await asyncio.to_thread(
+            self._write_compact_status,
             "ok",
             "Summary applied.",
             chat_id=callback.chat_id,
@@ -2689,7 +2693,8 @@ Summary applied.""",
             await self._answer_callback(callback, "Starting update...")
             callback_answered = True
         try:
-            _spawn_update_process(
+            await asyncio.to_thread(
+                _spawn_update_process,
                 repo_url=repo_url,
                 repo_ref=repo_ref,
                 update_dir=update_dir,
@@ -3037,7 +3042,8 @@ Summary applied.""",
         message = status.message
         if state == "running":
             message = "Compact apply interrupted by restart. Please retry."
-            status = self._write_compact_status(
+            status = await asyncio.to_thread(
+                self._write_compact_status,
                 "interrupted",
                 message,
                 chat_id=chat_id,


### PR DESCRIPTION
## Summary
- Fix delayed progress feedback for `/flow status` Archive in Telegram by moving blocking flow operations off the event loop.
- Apply the same anti-blocking pattern to adjacent flow callback/command paths and related callback status writes.
- Improve Discord flow archive button responsiveness by resolving archive targets in a worker thread.

## Root Cause
The Archive callback edited the message to `Archiving run ...` and then immediately executed synchronous archival work in the same async handler. That blocked the event loop, delaying visible UI updates until the blocking call completed.

## Changes
- Telegram flow callbacks (`flows.py`):
  - Added a shared `_run_blocking_flow_call(...)` helper using `asyncio.to_thread`.
  - Offloaded `archive_flow_run` and `reconcile_flow_run` calls.
  - Offloaded flow status callback payload building (`FlowStore` + reconcile + card build) into a blocking helper run via `to_thread`.
- Telegram runtime callbacks (`commands_runtime.py`):
  - Offloaded compact status file writes to `to_thread` in apply/interrupted paths.
  - Offloaded `_spawn_update_process(...)` to `to_thread` for update callbacks.
- Discord flow buttons (`flow_commands.py`):
  - Offloaded archive target store open/query (`_open_flow_store` + `_resolve_flow_run_by_id`) to `to_thread` before action handling.

## Inventory (mini subagents)
Other buttons with similar risk were inventoried across Telegram/Discord surfaces. This PR patches the high-signal flow/status/update paths directly tied to callback responsiveness and the reported issue.

## Validation
- Local pre-commit pipeline passed (includes strict mypy, frontend build/tests, and full pytest): `5134 passed`.
- Additional focused runs during development:
  - `tests/test_telegram_flow_callback_actions.py`
  - `tests/integrations/discord/test_flow_archive.py`
  - `tests/test_telegram_flow_status.py -k callback`
  - `tests/test_telegram_handlers_callbacks.py tests/test_telegram_typed_states.py tests/test_telegram_bot_integration.py -k "compact or update_confirm or start_update"`
- Mini-subagent code review reported no defects in the final diff.
