### PR TITLE
Add bounded process monitor summaries

### DIFF
--- a/src/codex_autorunner/core/diagnostics/__init__.py
+++ b/src/codex_autorunner/core/diagnostics/__init__.py
@@ -1,3 +1,11 @@
+from .process_monitor import (
+    DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS,
+    DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS,
+    ProcessMonitorStore,
+    build_process_monitor_summary,
+    capture_process_monitor_sample,
+    format_process_monitor_compact,
+)
 from .process_snapshot import (
     ProcessCategory,
     ProcessOwnership,
@@ -7,9 +15,15 @@ from .process_snapshot import (
 )
 
 __all__ = [
+    "DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS",
+    "DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS",
     "ProcessCategory",
+    "ProcessMonitorStore",
     "ProcessOwnership",
     "ProcessSnapshot",
+    "build_process_monitor_summary",
+    "capture_process_monitor_sample",
     "collect_processes",
     "enrich_with_ownership",
+    "format_process_monitor_compact",
 ]

--- a/src/codex_autorunner/core/diagnostics/__init__.py
+++ b/src/codex_autorunner/core/diagnostics/__init__.py
@@ -4,7 +4,6 @@ from .process_monitor import (
     ProcessMonitorStore,
     build_process_monitor_summary,
     capture_process_monitor_sample,
-    format_process_monitor_compact,
 )
 from .process_snapshot import (
     ProcessCategory,
@@ -25,5 +24,4 @@ __all__ = [
     "capture_process_monitor_sample",
     "collect_processes",
     "enrich_with_ownership",
-    "format_process_monitor_compact",
 ]

--- a/src/codex_autorunner/core/diagnostics/process_monitor.py
+++ b/src/codex_autorunner/core/diagnostics/process_monitor.py
@@ -10,7 +10,7 @@ from typing import Any, Optional
 
 from ..locks import file_lock
 from ..runtime import summarize_opencode_lifecycle
-from ..text_utils import _parse_iso_timestamp, _truncate_text, lock_path_for
+from ..text_utils import _parse_iso_timestamp, lock_path_for
 from ..utils import atomic_write
 from .process_snapshot import ProcessOwnership, collect_processes, enrich_with_ownership
 
@@ -428,43 +428,6 @@ def build_process_monitor_summary(
     }
 
 
-def format_process_metric_compact(
-    label: str,
-    payload: dict[str, Any],
-    *,
-    include_history: bool,
-) -> str:
-    current = _coerce_int(payload.get("current"))
-    if not include_history:
-        return f"{label}: {current}"
-    average = float(payload.get("average") or 0.0)
-    p95 = _coerce_int(payload.get("p95"))
-    peak = _coerce_int(payload.get("peak"))
-    return f"{label}: {current} (avg {average:.1f}, tp95 {p95}, peak {peak})"
-
-
-def format_process_monitor_compact(
-    summary: dict[str, Any], *, max_chars: int = 240
-) -> str:
-    metrics = summary.get("metrics") or {}
-    include_history = bool(summary.get("status") != "ok")
-    parts = [
-        f"status={summary.get('status') or 'unknown'}",
-        format_process_metric_compact(
-            "opencode",
-            dict(metrics.get("opencode") or {}),
-            include_history=include_history,
-        ),
-        format_process_metric_compact(
-            "app-server",
-            dict(metrics.get("app_server") or {}),
-            include_history=include_history,
-        ),
-    ]
-    text = " | ".join(parts)
-    return _truncate_text(text, max_chars)
-
-
 __all__ = [
     "DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS",
     "DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS",
@@ -473,5 +436,4 @@ __all__ = [
     "ProcessMonitorStore",
     "build_process_monitor_summary",
     "capture_process_monitor_sample",
-    "format_process_monitor_compact",
 ]

--- a/src/codex_autorunner/core/diagnostics/process_monitor.py
+++ b/src/codex_autorunner/core/diagnostics/process_monitor.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+import json
+import logging
+import math
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from ..locks import file_lock
+from ..runtime import summarize_opencode_lifecycle
+from ..text_utils import _parse_iso_timestamp, _truncate_text, lock_path_for
+from ..utils import atomic_write
+from .process_snapshot import ProcessOwnership, collect_processes, enrich_with_ownership
+
+logger = logging.getLogger(__name__)
+
+PROCESS_MONITOR_VERSION = 1
+DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS = 120
+DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS = 3 * 60 * 60
+_DEFAULT_PROCESS_MONITOR_SAMPLE_LIMIT = 120
+_PROCESS_MONITOR_FILENAME = "process-monitor.json"
+
+_ABSOLUTE_ALERT_FLOORS = {
+    "opencode": 12,
+    "app_server": 12,
+    "total": 18,
+}
+_RELATIVE_ALERT_MINIMUMS = {
+    "opencode": 6,
+    "app_server": 6,
+    "total": 10,
+}
+_DELTA_ALERT_FLOORS = {
+    "opencode": 3,
+    "app_server": 3,
+    "total": 4,
+}
+_MIN_BASELINE_SAMPLES = 5
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _utc_iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _monitor_path(root: Path) -> Path:
+    return root / ".codex-autorunner" / "diagnostics" / _PROCESS_MONITOR_FILENAME
+
+
+def _coerce_int(value: Any, *, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return default
+        try:
+            return int(text)
+        except ValueError:
+            return default
+    return default
+
+
+def _percentile(values: list[int], percentile: float) -> int:
+    if not values:
+        return 0
+    if len(values) == 1:
+        return int(values[0])
+    bounded = min(max(percentile, 0.0), 100.0)
+    rank = max(0, math.ceil((bounded / 100.0) * len(values)) - 1)
+    ordered = sorted(int(value) for value in values)
+    return ordered[min(rank, len(ordered) - 1)]
+
+
+def _ownership_counts(snapshot_items: list[Any]) -> dict[str, int]:
+    counts = {
+        ownership.value: 0
+        for ownership in (
+            ProcessOwnership.MANAGED,
+            ProcessOwnership.STALE_RECORD,
+            ProcessOwnership.UNTRACKED_LIVE_PROCESS,
+            ProcessOwnership.OWNER_MISSING,
+        )
+    }
+    for item in snapshot_items:
+        ownership = getattr(item, "ownership", None)
+        if ownership is None:
+            continue
+        counts[ownership.value] = counts.get(ownership.value, 0) + 1
+    return counts
+
+
+def capture_process_monitor_sample(root: Path) -> dict[str, Any]:
+    resolved_root = Path(root).resolve()
+    snapshot = collect_processes()
+    snapshot = enrich_with_ownership(snapshot, resolved_root)
+
+    opencode_ownership = _ownership_counts(snapshot.opencode_processes)
+    app_server_ownership = _ownership_counts(snapshot.app_server_processes)
+
+    sample: dict[str, Any] = {
+        "captured_at": _utc_iso(_utc_now()),
+        "opencode_count": int(snapshot.opencode_count),
+        "app_server_count": int(snapshot.app_server_count),
+        "total_count": int(snapshot.opencode_count + snapshot.app_server_count),
+        "ownership": {
+            "opencode": opencode_ownership,
+            "app_server": app_server_ownership,
+        },
+    }
+
+    try:
+        lifecycle = summarize_opencode_lifecycle(resolved_root)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        lifecycle = {}
+    if lifecycle:
+        sample["opencode_lifecycle"] = {
+            "server_scope": lifecycle.get("server_scope"),
+            "counts": dict(lifecycle.get("counts") or {}),
+        }
+
+    return sample
+
+
+@dataclass(frozen=True)
+class ProcessMetricSummary:
+    current: int
+    average: float
+    p95: int
+    peak: int
+    abnormal: bool
+    reason: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "current": self.current,
+            "average": self.average,
+            "p95": self.p95,
+            "peak": self.peak,
+            "abnormal": self.abnormal,
+            "reason": self.reason,
+        }
+
+
+class ProcessMonitorStore:
+    def __init__(self, root: Path) -> None:
+        self._root = Path(root).resolve()
+        self._path = _monitor_path(self._root)
+        self._lock_path = lock_path_for(self._path)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def load(self) -> dict[str, Any]:
+        if not self._path.exists():
+            return self._default_payload()
+        try:
+            with self._path.open("r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except (OSError, ValueError, json.JSONDecodeError):
+            logger.warning("Failed to read process monitor store %s", self._path)
+            return self._default_payload()
+        if not isinstance(payload, dict):
+            return self._default_payload()
+        samples = payload.get("samples")
+        if not isinstance(samples, list):
+            samples = []
+        cadence_seconds = max(
+            1,
+            _coerce_int(
+                payload.get("cadence_seconds"),
+                default=DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS,
+            ),
+        )
+        window_seconds = max(
+            cadence_seconds,
+            _coerce_int(
+                payload.get("window_seconds"),
+                default=DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS,
+            ),
+        )
+        sample_limit = max(
+            1,
+            _coerce_int(
+                payload.get("sample_limit"),
+                default=_DEFAULT_PROCESS_MONITOR_SAMPLE_LIMIT,
+            ),
+        )
+        return {
+            "version": PROCESS_MONITOR_VERSION,
+            "cadence_seconds": cadence_seconds,
+            "window_seconds": window_seconds,
+            "sample_limit": sample_limit,
+            "samples": [entry for entry in samples if isinstance(entry, dict)],
+        }
+
+    def record_sample(
+        self,
+        sample: dict[str, Any],
+        *,
+        cadence_seconds: int = DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS,
+        window_seconds: int = DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS,
+    ) -> dict[str, Any]:
+        resolved_cadence = max(1, int(cadence_seconds))
+        resolved_window = max(resolved_cadence, int(window_seconds))
+        sample_limit = max(
+            _DEFAULT_PROCESS_MONITOR_SAMPLE_LIMIT,
+            int(math.ceil(resolved_window / resolved_cadence)) + 4,
+        )
+        normalized_sample = dict(sample)
+        captured_at = _parse_iso_timestamp(normalized_sample.get("captured_at"))
+        if captured_at is None:
+            captured_at = _utc_now()
+            normalized_sample["captured_at"] = _utc_iso(captured_at)
+        cutoff = captured_at - timedelta(seconds=resolved_window)
+
+        with file_lock(self._lock_path):
+            payload = self.load()
+            samples = [
+                entry
+                for entry in payload.get("samples") or []
+                if isinstance(entry, dict)
+                and (_parse_iso_timestamp(entry.get("captured_at")) or cutoff) >= cutoff
+            ]
+            samples.append(normalized_sample)
+            samples = samples[-sample_limit:]
+            payload = {
+                "version": PROCESS_MONITOR_VERSION,
+                "cadence_seconds": resolved_cadence,
+                "window_seconds": resolved_window,
+                "sample_limit": sample_limit,
+                "samples": samples,
+            }
+            atomic_write(
+                self._path,
+                json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            )
+        return payload
+
+    def recent_samples(
+        self,
+        *,
+        window_seconds: Optional[int] = None,
+    ) -> list[dict[str, Any]]:
+        payload = self.load()
+        samples = [
+            entry for entry in payload.get("samples") or [] if isinstance(entry, dict)
+        ]
+        resolved_window = max(
+            1,
+            int(
+                window_seconds
+                or payload.get("window_seconds")
+                or DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS
+            ),
+        )
+        cutoff = _utc_now() - timedelta(seconds=resolved_window)
+        return [
+            entry
+            for entry in samples
+            if (_parse_iso_timestamp(entry.get("captured_at")) or cutoff) >= cutoff
+        ]
+
+    def latest_sample(self) -> Optional[dict[str, Any]]:
+        samples = self.recent_samples()
+        if not samples:
+            return None
+        return samples[-1]
+
+    @staticmethod
+    def _default_payload() -> dict[str, Any]:
+        return {
+            "version": PROCESS_MONITOR_VERSION,
+            "cadence_seconds": DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS,
+            "window_seconds": DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS,
+            "sample_limit": _DEFAULT_PROCESS_MONITOR_SAMPLE_LIMIT,
+            "samples": [],
+        }
+
+
+def _summarize_metric(
+    metric: str,
+    latest_value: int,
+    values: list[int],
+) -> ProcessMetricSummary:
+    if not values:
+        values = [latest_value]
+    average = sum(values) / len(values)
+    p95 = _percentile(values, 95.0)
+    peak = max(values) if values else latest_value
+    baseline = values[:-1]
+    absolute_floor = _ABSOLUTE_ALERT_FLOORS.get(metric, 12)
+    relative_minimum = _RELATIVE_ALERT_MINIMUMS.get(metric, 6)
+    delta_floor = _DELTA_ALERT_FLOORS.get(metric, 3)
+    abnormal = False
+    reason: Optional[str] = None
+    if baseline and len(baseline) >= _MIN_BASELINE_SAMPLES:
+        baseline_avg = sum(baseline) / len(baseline)
+        baseline_p95 = _percentile(baseline, 95.0)
+        if latest_value >= absolute_floor:
+            abnormal = True
+            reason = (
+                f"current={latest_value} exceeds the absolute alert floor "
+                f"of {absolute_floor}"
+            )
+        elif (
+            latest_value >= relative_minimum
+            and latest_value >= baseline_avg + delta_floor
+            and latest_value >= baseline_p95 + 1
+        ):
+            abnormal = True
+            reason = (
+                f"current={latest_value} is above the trailing baseline "
+                f"(avg={baseline_avg:.1f}, p95={baseline_p95})"
+            )
+    elif latest_value >= absolute_floor:
+        abnormal = True
+        reason = (
+            f"current={latest_value} exceeds the bootstrap alert floor "
+            f"of {absolute_floor}"
+        )
+    return ProcessMetricSummary(
+        current=int(latest_value),
+        average=float(round(average, 2)),
+        p95=int(p95),
+        peak=int(peak),
+        abnormal=abnormal,
+        reason=reason,
+    )
+
+
+def build_process_monitor_summary(
+    root: Path,
+    *,
+    cadence_seconds: int = DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS,
+    window_seconds: int = DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS,
+    capture_if_stale: bool = True,
+) -> dict[str, Any]:
+    resolved_root = Path(root).resolve()
+    store = ProcessMonitorStore(resolved_root)
+    samples = store.recent_samples(window_seconds=window_seconds)
+    latest = samples[-1] if samples else None
+    latest_at = (
+        _parse_iso_timestamp(latest.get("captured_at"))
+        if isinstance(latest, dict)
+        else None
+    )
+    if capture_if_stale and (
+        latest_at is None
+        or (_utc_now() - latest_at).total_seconds() >= max(1, cadence_seconds)
+    ):
+        payload = store.record_sample(
+            capture_process_monitor_sample(resolved_root),
+            cadence_seconds=cadence_seconds,
+            window_seconds=window_seconds,
+        )
+        samples = [
+            entry for entry in payload.get("samples") or [] if isinstance(entry, dict)
+        ]
+        latest = samples[-1] if samples else None
+        latest_at = (
+            _parse_iso_timestamp(latest.get("captured_at"))
+            if isinstance(latest, dict)
+            else None
+        )
+
+    opencode_values = [_coerce_int(entry.get("opencode_count")) for entry in samples]
+    app_server_values = [
+        _coerce_int(entry.get("app_server_count")) for entry in samples
+    ]
+    total_values = [_coerce_int(entry.get("total_count")) for entry in samples]
+    latest_sample = latest if isinstance(latest, dict) else {}
+    latest_opencode = _coerce_int(latest_sample.get("opencode_count"))
+    latest_app_server = _coerce_int(latest_sample.get("app_server_count"))
+    latest_total = _coerce_int(latest_sample.get("total_count"))
+
+    metrics = {
+        "opencode": _summarize_metric("opencode", latest_opencode, opencode_values),
+        "app_server": _summarize_metric(
+            "app_server",
+            latest_app_server,
+            app_server_values,
+        ),
+        "total": _summarize_metric("total", latest_total, total_values),
+    }
+    lifecycle_counts = dict(
+        ((latest_sample.get("opencode_lifecycle") or {}).get("counts") or {})
+    )
+    stale_records = _coerce_int(lifecycle_counts.get("stale"))
+    status = "warning" if any(metric.abnormal for metric in metrics.values()) else "ok"
+    if stale_records > 0:
+        status = "warning"
+    reasons = [
+        metric.reason
+        for metric in metrics.values()
+        if metric.abnormal and metric.reason
+    ]
+    if stale_records > 0:
+        reasons.append(f"OpenCode lifecycle reports stale={stale_records}")
+
+    return {
+        "status": status,
+        "root": str(resolved_root),
+        "path": str(store.path),
+        "cadence_seconds": max(1, int(cadence_seconds)),
+        "window_seconds": max(1, int(window_seconds)),
+        "sample_count": len(samples),
+        "latest_at": _utc_iso(latest_at) if latest_at is not None else None,
+        "metrics": {name: metric.to_dict() for name, metric in metrics.items()},
+        "latest": {
+            "opencode_count": latest_opencode,
+            "app_server_count": latest_app_server,
+            "total_count": latest_total,
+            "ownership": dict(latest_sample.get("ownership") or {}),
+            "opencode_lifecycle": dict(latest_sample.get("opencode_lifecycle") or {}),
+        },
+        "reasons": reasons,
+    }
+
+
+def format_process_metric_compact(
+    label: str,
+    payload: dict[str, Any],
+    *,
+    include_history: bool,
+) -> str:
+    current = _coerce_int(payload.get("current"))
+    if not include_history:
+        return f"{label}: {current}"
+    average = float(payload.get("average") or 0.0)
+    p95 = _coerce_int(payload.get("p95"))
+    peak = _coerce_int(payload.get("peak"))
+    return f"{label}: {current} (avg {average:.1f}, tp95 {p95}, peak {peak})"
+
+
+def format_process_monitor_compact(
+    summary: dict[str, Any], *, max_chars: int = 240
+) -> str:
+    metrics = summary.get("metrics") or {}
+    include_history = bool(summary.get("status") != "ok")
+    parts = [
+        f"status={summary.get('status') or 'unknown'}",
+        format_process_metric_compact(
+            "opencode",
+            dict(metrics.get("opencode") or {}),
+            include_history=include_history,
+        ),
+        format_process_metric_compact(
+            "app-server",
+            dict(metrics.get("app_server") or {}),
+            include_history=include_history,
+        ),
+    ]
+    text = " | ".join(parts)
+    return _truncate_text(text, max_chars)
+
+
+__all__ = [
+    "DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS",
+    "DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS",
+    "PROCESS_MONITOR_VERSION",
+    "ProcessMetricSummary",
+    "ProcessMonitorStore",
+    "build_process_monitor_summary",
+    "capture_process_monitor_sample",
+    "format_process_monitor_compact",
+]

--- a/src/codex_autorunner/core/diagnostics/process_monitor.py
+++ b/src/codex_autorunner/core/diagnostics/process_monitor.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from ..config_contract import ConfigError
 from ..locks import file_lock
 from ..runtime import summarize_opencode_lifecycle
 from ..text_utils import _parse_iso_timestamp, lock_path_for
@@ -120,7 +121,7 @@ def capture_process_monitor_sample(root: Path) -> dict[str, Any]:
 
     try:
         lifecycle = summarize_opencode_lifecycle(resolved_root)
-    except (OSError, RuntimeError, TypeError, ValueError):
+    except (ConfigError, OSError, RuntimeError, TypeError, ValueError):
         lifecycle = {}
     if lifecycle:
         sample["opencode_lifecycle"] = {

--- a/src/codex_autorunner/core/pma_rendering.py
+++ b/src/codex_autorunner/core/pma_rendering.py
@@ -174,6 +174,68 @@ def _render_availability_section(
     lines.append("")
 
 
+def _render_process_monitor_section(
+    snapshot: dict[str, Any],
+    lines: list[str],
+    *,
+    max_field_chars: int,
+) -> None:
+    payload = snapshot.get("process_monitor")
+    if not isinstance(payload, Mapping):
+        return
+    status = _field(payload, "status", max_field_chars) or "unknown"
+    if status == "ok":
+        return
+    metrics = payload.get("metrics") or {}
+    if not isinstance(metrics, Mapping):
+        return
+    cadence_seconds = _field(payload, "cadence_seconds", max_field_chars)
+    window_seconds = payload.get("window_seconds")
+    sample_count = _field(payload, "sample_count", max_field_chars)
+    latest_at = _field(payload, "latest_at", max_field_chars)
+    lines.append("Process Monitor:")
+    header = f"- status={status}"
+    if cadence_seconds:
+        header += f" cadence_seconds={cadence_seconds}"
+    if isinstance(window_seconds, (int, float)) and int(window_seconds) > 0:
+        header += f" window_hours={int(window_seconds) // 3600}"
+    if sample_count:
+        header += f" samples={sample_count}"
+    if latest_at:
+        header += f" latest_at={latest_at}"
+    lines.append(header)
+    for label, key in (
+        ("opencode", "opencode"),
+        ("app_server", "app_server"),
+        ("total", "total"),
+    ):
+        metric = metrics.get(key)
+        if not isinstance(metric, Mapping):
+            continue
+        current = _field(metric, "current", max_field_chars)
+        average = metric.get("average")
+        tp95 = _field(metric, "p95", max_field_chars)
+        peak = _field(metric, "peak", max_field_chars)
+        abnormal = bool(metric.get("abnormal"))
+        line = f"- {label}={current or '0'}"
+        if average is not None:
+            line += f" avg={float(average):.1f}"
+        if tp95:
+            line += f" tp95={tp95}"
+        if peak:
+            line += f" peak={peak}"
+        if abnormal:
+            line += " HIGH"
+        lines.append(line)
+    reasons = payload.get("reasons")
+    if isinstance(reasons, Sequence):
+        for reason in reasons:
+            text = _truncate(str(reason or ""), max_field_chars * 4)
+            if text:
+                lines.append(f"- reason: {text}")
+    lines.append("")
+
+
 def _render_action_queue_item(
     item: Mapping[str, Any],
     lines: list[str],
@@ -824,6 +886,7 @@ def _render_hub_snapshot(
         max_text_chars=max_text_chars,
     )
     _render_freshness_section(snapshot, lines, fc)
+    _render_process_monitor_section(snapshot, lines, max_field_chars=fc)
     _render_action_queue_section(
         snapshot,
         lines,

--- a/src/codex_autorunner/core/pma_snapshot_builder.py
+++ b/src/codex_autorunner/core/pma_snapshot_builder.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional
 
+from .diagnostics import build_process_monitor_summary
 from .filebox import BOXES, empty_listing, list_filebox
 from .flows.models import flow_run_duration_seconds
 from .freshness import (
@@ -400,6 +401,15 @@ async def build_hub_snapshot_payload(
     *,
     gather_inbox: Callable[..., list[dict[str, Any]]],
 ) -> dict[str, Any]:
+    async def _build_process_monitor_payload() -> Optional[dict[str, Any]]:
+        if hub_root is None:
+            return None
+        return await asyncio.to_thread(
+            build_process_monitor_summary,
+            hub_root,
+            capture_if_stale=False,
+        )
+
     generated_at = iso_now()
     stale_threshold_seconds = _resolve_pma_freshness_threshold_seconds(supervisor)
     if supervisor is None:
@@ -414,6 +424,7 @@ async def build_hub_snapshot_payload(
             "lifecycle_events": [],
             "pma_files_detail": empty_files,
             "pma_threads": [],
+            "process_monitor": None,
             "automation": {
                 "subscriptions": {"active_count": 0, "sample": []},
                 "timers": {"pending_count": 0, "sample": []},
@@ -436,26 +447,29 @@ async def build_hub_snapshot_payload(
         }
 
     limits = PmaSnapshotLimits.from_supervisor(supervisor)
-    repos, agent_workspaces, inbox, lifecycle_events = await asyncio.gather(
-        asyncio.to_thread(
-            _build_repo_summaries,
-            supervisor,
-            stale_threshold_seconds=stale_threshold_seconds,
-            limits=limits,
-        ),
-        asyncio.to_thread(
-            _build_agent_workspace_summaries,
-            supervisor,
-            hub_root=hub_root,
-            limits=limits,
-        ),
-        asyncio.to_thread(
-            gather_inbox,
-            supervisor,
-            max_text_chars=limits.max_text_chars,
-            stale_threshold_seconds=stale_threshold_seconds,
-        ),
-        asyncio.to_thread(_gather_lifecycle_events, supervisor, limit=20),
+    repos, agent_workspaces, inbox, lifecycle_events, process_monitor = (
+        await asyncio.gather(
+            asyncio.to_thread(
+                _build_repo_summaries,
+                supervisor,
+                stale_threshold_seconds=stale_threshold_seconds,
+                limits=limits,
+            ),
+            asyncio.to_thread(
+                _build_agent_workspace_summaries,
+                supervisor,
+                hub_root=hub_root,
+                limits=limits,
+            ),
+            asyncio.to_thread(
+                gather_inbox,
+                supervisor,
+                max_text_chars=limits.max_text_chars,
+                stale_threshold_seconds=stale_threshold_seconds,
+            ),
+            asyncio.to_thread(_gather_lifecycle_events, supervisor, limit=20),
+            _build_process_monitor_payload(),
+        )
     )
     inbox = inbox[: limits.max_messages]
 
@@ -496,6 +510,7 @@ async def build_hub_snapshot_payload(
         "pma_files": pma_files,
         "pma_files_detail": pma_files_detail,
         "pma_threads": pma_threads,
+        "process_monitor": process_monitor,
         "automation": automation,
         "lifecycle_events": lifecycle_events,
         "freshness": freshness,

--- a/src/codex_autorunner/integrations/chat/command_contract.py
+++ b/src/codex_autorunner/integrations/chat/command_contract.py
@@ -85,6 +85,16 @@ _COMMAND_CONTRACT_BASE: tuple[CommandContractEntry, ...] = (
         discord_exposure="public",
     ),
     CommandContractEntry(
+        id="car.processes",
+        path=("car", "processes"),
+        requires_bound_workspace=False,
+        status="stable",
+        telegram_commands=("processes",),
+        discord_paths=(("car", "processes"),),
+        discord_ack_policy="defer_ephemeral",
+        discord_exposure="public",
+    ),
+    CommandContractEntry(
         id="car.new",
         path=("car", "new"),
         requires_bound_workspace=True,
@@ -643,6 +653,11 @@ _TELEGRAM_COMMAND_METADATA: dict[str, TelegramCommandMetadata] = {
         allow_during_turn=True,
     ),
     "status": TelegramCommandMetadata(
+        exposure="public",
+        response_policy="typing",
+        allow_during_turn=True,
+    ),
+    "processes": TelegramCommandMetadata(
         exposure="public",
         response_policy="typing",
         allow_during_turn=True,

--- a/src/codex_autorunner/integrations/chat/status_diagnostics.py
+++ b/src/codex_autorunner/integrations/chat/status_diagnostics.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Optional
 
+from ...core.diagnostics import build_process_monitor_summary
 from ...core.text_utils import _parse_iso_timestamp
 
 
@@ -254,3 +255,138 @@ def build_status_block_lines(context: StatusBlockContext) -> list[str]:
     _append_status_line(lines, "Active turn", context.turn_id)
     lines.extend(line for line in context.extra_lines if _clean_line(line))
     return lines
+
+
+def format_process_monitor_lines(
+    summary: Optional[dict[str, Any]],
+    *,
+    include_history: bool = False,
+    include_header: bool = True,
+) -> list[str]:
+    if not isinstance(summary, dict):
+        return []
+    metrics = summary.get("metrics")
+    if not isinstance(metrics, dict):
+        return []
+    lines: list[str] = []
+    status = _clean_line(summary.get("status")) or "unknown"
+    sample_count = _coerce_number(summary.get("sample_count"))
+    cadence_seconds = _coerce_number(summary.get("cadence_seconds"))
+    window_seconds = _coerce_number(summary.get("window_seconds"))
+    header_bits = [f"Process monitor: {status}"]
+    if include_header:
+        detail_bits: list[str] = []
+        if isinstance(window_seconds, float) and window_seconds > 0:
+            detail_bits.append(f"window={int(round(window_seconds / 3600))}h")
+        if isinstance(sample_count, float) and sample_count > 0:
+            detail_bits.append(f"samples={int(sample_count)}")
+        if isinstance(cadence_seconds, float) and cadence_seconds > 0:
+            detail_bits.append(f"cadence={int(cadence_seconds)}s")
+        if detail_bits:
+            header_bits.append(f"({' '.join(detail_bits)})")
+    lines.append(" ".join(header_bits))
+
+    def _metric_line(label: str, payload: Any) -> Optional[str]:
+        if not isinstance(payload, dict):
+            return None
+        current = _coerce_number(payload.get("current"))
+        if current is None:
+            return None
+        line = f"{label}: {int(current) if current.is_integer() else current}"
+        if include_history:
+            average = _coerce_number(payload.get("average"))
+            p95 = _coerce_number(payload.get("p95"))
+            peak = _coerce_number(payload.get("peak"))
+            history_bits: list[str] = []
+            if average is not None:
+                history_bits.append(f"avg {average:.1f}")
+            if p95 is not None:
+                history_bits.append(
+                    f"tp95 {int(p95) if p95.is_integer() else f'{p95:.1f}'}"
+                )
+            if peak is not None:
+                history_bits.append(
+                    f"peak {int(peak) if peak.is_integer() else f'{peak:.1f}'}"
+                )
+            if history_bits:
+                line += f" ({', '.join(history_bits)})"
+        reason = _clean_line(payload.get("reason"))
+        if reason and payload.get("abnormal") is True:
+            line += " high"
+        return line
+
+    for label, key in (
+        ("OpenCode", "opencode"),
+        ("App server", "app_server"),
+        ("Total", "total"),
+    ):
+        rendered = _metric_line(label, metrics.get(key))
+        if rendered:
+            lines.append(rendered)
+
+    latest = summary.get("latest")
+    if isinstance(latest, dict):
+        lifecycle = latest.get("opencode_lifecycle")
+        counts = lifecycle.get("counts") if isinstance(lifecycle, dict) else None
+        if isinstance(counts, dict) and counts:
+            active = int(counts.get("active") or 0)
+            stale = int(counts.get("stale") or 0)
+            spawned = int(counts.get("spawned_local") or 0)
+            reuse = int(counts.get("registry_reuse") or 0)
+            lines.append(
+                "OpenCode lifecycle: "
+                f"active={active} stale={stale} spawned_local={spawned} "
+                f"registry_reuse={reuse}"
+            )
+        ownership = latest.get("ownership")
+        if isinstance(ownership, dict):
+            opencode = ownership.get("opencode")
+            app_server = ownership.get("app_server")
+            ownership_parts: list[str] = []
+            if isinstance(opencode, dict):
+                ownership_parts.append(
+                    "opencode "
+                    + ", ".join(
+                        f"{key}={int(value)}"
+                        for key, value in sorted(opencode.items())
+                        if _coerce_number(value)
+                    )
+                )
+            if isinstance(app_server, dict):
+                ownership_parts.append(
+                    "app-server "
+                    + ", ".join(
+                        f"{key}={int(value)}"
+                        for key, value in sorted(app_server.items())
+                        if _coerce_number(value)
+                    )
+                )
+            ownership_parts = [
+                part for part in ownership_parts if not part.endswith(" ")
+            ]
+            if ownership_parts:
+                lines.append("Ownership: " + " | ".join(ownership_parts))
+    return lines
+
+
+def build_process_monitor_lines_for_root(
+    root: Any,
+    *,
+    include_history: bool,
+    capture_if_stale: bool = True,
+) -> list[str]:
+    if root is None:
+        return []
+    try:
+        summary = build_process_monitor_summary(
+            root,
+            capture_if_stale=capture_if_stale,
+        )
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return []
+    if not include_history and summary.get("status") == "ok":
+        return []
+    return format_process_monitor_lines(
+        summary,
+        include_history=include_history,
+    )

--- a/src/codex_autorunner/integrations/discord/interaction_registry.py
+++ b/src/codex_autorunner/integrations/discord/interaction_registry.py
@@ -686,6 +686,20 @@ _SLASH_ROUTES: tuple[SlashCommandRoute, ...] = (
         exposure="public",
     ),
     SlashCommandRoute(
+        id="car.processes",
+        canonical_path=("car", "processes"),
+        registered_path=("car", "processes"),
+        description="Show process monitor summary",
+        handler=lambda *args, **kwargs: _dispatch_service_method(
+            *args,
+            **kwargs,
+            method_name="_handle_processes",
+            include_channel_id=True,
+        ),
+        ack_policy="defer_ephemeral",
+        exposure="public",
+    ),
+    SlashCommandRoute(
         id="car.new",
         canonical_path=("car", "new"),
         registered_path=("car", "new"),

--- a/src/codex_autorunner/integrations/discord/pma_commands.py
+++ b/src/codex_autorunner/integrations/discord/pma_commands.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Optional
+
+from ..chat.status_diagnostics import build_process_monitor_lines_for_root
 
 
 def _previous_binding_fields(
@@ -132,6 +135,14 @@ async def handle_pma_status(
         text = "PMA mode: disabled\nCurrent workspace: unbound"
     elif binding.get("pma_enabled", False):
         text = "PMA mode: enabled"
+        root = getattr(getattr(service, "_config", None), "root", None)
+        if root is not None:
+            process_lines = build_process_monitor_lines_for_root(
+                Path(root),
+                include_history=False,
+            )
+            if process_lines:
+                text = "\n".join([text, *process_lines])
     else:
         workspace = binding.get("workspace_path", "unknown")
         text = f"PMA mode: disabled\nCurrent workspace: {workspace}"

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -346,6 +346,7 @@ from .workspace_commands import (
     handle_debug,
     handle_help,
     handle_ids,
+    handle_processes,
     handle_status,
 )
 
@@ -6025,6 +6026,21 @@ class DiscordBotService:
             channel_id=channel_id,
             guild_id=guild_id,
             user_id=user_id,
+        )
+
+    async def _handle_processes(
+        self,
+        interaction_id: str,
+        interaction_token: str,
+        *,
+        channel_id: str,
+    ) -> None:
+        await DiscordBotService._run_effectful_handler(
+            self,
+            handle_processes,
+            interaction_id,
+            interaction_token,
+            channel_id=channel_id,
         )
 
     async def _get_active_flow_info(

--- a/src/codex_autorunner/integrations/discord/workspace_commands.py
+++ b/src/codex_autorunner/integrations/discord/workspace_commands.py
@@ -11,6 +11,9 @@ from ...integrations.chat.command_diagnostics import (
     build_status_text,
 )
 from ...integrations.chat.help_catalog import build_discord_help_lines
+from ...integrations.chat.status_diagnostics import (
+    build_process_monitor_lines_for_root,
+)
 from ...manifest import ManifestError, load_manifest
 from ..chat.approval_modes import (
     normalize_approval_mode,
@@ -44,6 +47,30 @@ from .interaction_runtime import (
 from .rendering import format_discord_message
 
 _logger = logging.getLogger(__name__)
+
+
+def _resolve_process_monitor_root(
+    service: Any,
+    binding: Optional[Mapping[str, Any]],
+    *,
+    allow_fallback: bool = False,
+) -> Optional[Path]:
+    if binding is not None and binding.get("pma_enabled", False):
+        config_root = getattr(getattr(service, "_config", None), "root", None)
+        if config_root is not None:
+            return Path(config_root)
+    workspace_path = (
+        str(binding.get("workspace_path")).strip()
+        if binding is not None and binding.get("workspace_path")
+        else ""
+    )
+    if workspace_path:
+        return Path(workspace_path)
+    if allow_fallback:
+        config_root = getattr(getattr(service, "_config", None), "root", None)
+        if config_root is not None:
+            return Path(config_root)
+    return None
 
 
 def _list_manifest_repos(
@@ -771,7 +798,43 @@ async def handle_status(
         extra_lines=tuple(extra_lines),
     )
     lines.extend(build_status_block_lines(status_block))
+    lines.extend(
+        build_process_monitor_lines_for_root(
+            _resolve_process_monitor_root(service, binding),
+            include_history=False,
+        )
+    )
     lines.append("Use /flow status for ticket flow details.")
+    await send_runtime_ephemeral(
+        service,
+        interaction_id,
+        interaction_token,
+        "\n".join(lines),
+    )
+
+
+async def handle_processes(
+    service: Any,
+    interaction_id: str,
+    interaction_token: str,
+    *,
+    channel_id: str,
+) -> None:
+    binding = await service._store.get_binding(channel_id=channel_id)
+    root = _resolve_process_monitor_root(service, binding, allow_fallback=True)
+    if root is None:
+        await send_runtime_ephemeral(
+            service,
+            interaction_id,
+            interaction_token,
+            "Process monitor unavailable; no workspace or hub root is available.",
+        )
+        return
+    lines = [f"Process monitor root: {root}"]
+    lines.extend(
+        build_process_monitor_lines_for_root(root, include_history=True)
+        or ["Process monitor unavailable."]
+    )
     await send_runtime_ephemeral(
         service,
         interaction_id,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -43,6 +43,7 @@ from ....chat.session_messages import (
 )
 from ....chat.status_diagnostics import (
     StatusBlockContext,
+    build_process_monitor_lines_for_root,
     build_status_block_lines,
 )
 from ....chat.thread_summaries import _format_resume_timestamp
@@ -171,6 +172,24 @@ def _telegram_status_base_lines(
 
 
 class WorkspaceCommands(TelegramCommandSupportMixin):
+    def _process_monitor_root(
+        self,
+        record: Optional["TelegramTopicRecord"],
+        *,
+        allow_fallback: bool = False,
+    ) -> Optional[Path]:
+        if record is not None and getattr(record, "pma_enabled", False):
+            hub_root = getattr(self, "_hub_root", None)
+            if hub_root is not None:
+                return Path(hub_root)
+        if record is not None and record.workspace_path:
+            return Path(record.workspace_path)
+        if allow_fallback:
+            config_root = getattr(getattr(self, "_config", None), "root", None)
+            if config_root is not None:
+                return Path(config_root)
+        return None
+
     def _resolve_workspace_path(
         self,
         record: Optional["TelegramTopicRecord"],
@@ -3615,6 +3634,12 @@ class WorkspaceCommands(TelegramCommandSupportMixin):
                 self._logger.debug(
                     "status: hub repo status aggregation failed", exc_info=True
                 )
+        lines.extend(
+            build_process_monitor_lines_for_root(
+                self._process_monitor_root(record),
+                include_history=False,
+            )
+        )
 
         if not record.workspace_path and not is_pma:
             lines.append("Use /bind <repo_id> or /bind <path>.")
@@ -3642,6 +3667,32 @@ class WorkspaceCommands(TelegramCommandSupportMixin):
                 finally:
                     store.close()
 
+        await self._send_message(
+            message.chat_id,
+            "\n".join(lines),
+            thread_id=message.thread_id,
+            reply_to=message.message_id,
+        )
+
+    async def _handle_processes(
+        self, message: TelegramMessage, _args: str = "", _runtime: Optional[Any] = None
+    ) -> None:
+        key = await self._resolve_topic_key(message.chat_id, message.thread_id)
+        record = await self._router.get_topic(key)
+        root = self._process_monitor_root(record, allow_fallback=True)
+        if root is None:
+            await self._send_message(
+                message.chat_id,
+                "Process monitor unavailable; no workspace or hub root is bound.",
+                thread_id=message.thread_id,
+                reply_to=message.message_id,
+            )
+            return
+        lines = [f"Process monitor root: {root}"]
+        lines.extend(
+            build_process_monitor_lines_for_root(root, include_history=True)
+            or ["Process monitor unavailable."]
+        )
         await self._send_message(
             message.chat_id,
             "\n".join(lines),

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -39,6 +39,7 @@ from ...chat.session_messages import (
     format_update_started_message,
     format_update_status_message,
 )
+from ...chat.status_diagnostics import build_process_monitor_lines_for_root
 from ...chat.turn_metrics import compose_turn_response_with_footer
 from ...chat.update_notifier import mark_update_status_notified
 from ..adapter import (
@@ -1434,9 +1435,17 @@ class TelegramCommandHandlers(
         elif action in ("off", "disable", "false"):
             enabled = False
         elif action in ("status", "show", ""):
+            text = status_text(record)
+            if record is not None and record.pma_enabled and self._hub_root is not None:
+                process_lines = build_process_monitor_lines_for_root(
+                    self._hub_root,
+                    include_history=False,
+                )
+                if process_lines:
+                    text = "\n".join([text, *process_lines])
             await self._send_message(
                 message.chat_id,
-                status_text(record),
+                text,
                 thread_id=message.thread_id,
                 reply_to=message.message_id,
             )

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_spec.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_spec.py
@@ -118,6 +118,11 @@ def build_command_specs(handlers: Any) -> dict[str, CommandSpec]:
             "show current binding, thread, and collaboration status",
             handlers._handle_status,
         ),
+        "processes": _spec(
+            "processes",
+            "show process monitor summary",
+            handlers._handle_processes,
+        ),
         "files": _spec(
             "files",
             "list or manage Telegram file inbox/outbox",

--- a/src/codex_autorunner/surfaces/web/app.py
+++ b/src/codex_autorunner/surfaces/web/app.py
@@ -13,6 +13,12 @@ from starlette.middleware.gzip import GZipMiddleware
 from starlette.types import ASGIApp
 
 from ...core.config import parse_flow_retention_config
+from ...core.diagnostics import (
+    DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS,
+    DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS,
+    ProcessMonitorStore,
+    capture_process_monitor_sample,
+)
 from ...core.filebox_retention import (
     prune_filebox_root,
     resolve_filebox_retention_policy,
@@ -118,6 +124,15 @@ async def _run_prune_loop(
                 safe_log(logger, logging.WARNING, failure_message, exc)
     except asyncio.CancelledError:
         return
+
+
+def _record_process_monitor_sample(root: Path) -> None:
+    store = ProcessMonitorStore(root)
+    store.record_sample(
+        capture_process_monitor_sample(root),
+        cadence_seconds=DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS,
+        window_seconds=DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS,
+    )
 
 
 def create_hub_app(
@@ -560,6 +575,30 @@ def create_hub_app(
                             "PMA lane worker registration failed",
                             exc,
                         )
+
+                async def _process_monitor_loop() -> None:
+                    while True:
+                        try:
+                            await asyncio.to_thread(
+                                _record_process_monitor_sample,
+                                app.state.config.root,
+                            )
+                        except (
+                            RuntimeError,
+                            OSError,
+                            ConnectionError,
+                            ValueError,
+                            TypeError,
+                        ) as exc:  # intentional: background loop must not crash
+                            safe_log(
+                                app.state.logger,
+                                logging.WARNING,
+                                "Hub process monitor sampling failed",
+                                exc,
+                            )
+                        await asyncio.sleep(DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS)
+
+                tasks.append(asyncio.create_task(_process_monitor_loop()))
             # Default lane worker starts in _deferred_hub_startup so /health is not blocked.
             # Eager repo lifespans run there too; until then, /repos/* still activates via
             # _LazyRepoApp._ensure_ready when hub_started is True.

--- a/src/codex_autorunner/surfaces/web/app.py
+++ b/src/codex_autorunner/surfaces/web/app.py
@@ -576,29 +576,29 @@ def create_hub_app(
                             exc,
                         )
 
-                async def _process_monitor_loop() -> None:
-                    while True:
-                        try:
-                            await asyncio.to_thread(
-                                _record_process_monitor_sample,
-                                app.state.config.root,
-                            )
-                        except (
-                            RuntimeError,
-                            OSError,
-                            ConnectionError,
-                            ValueError,
-                            TypeError,
-                        ) as exc:  # intentional: background loop must not crash
-                            safe_log(
-                                app.state.logger,
-                                logging.WARNING,
-                                "Hub process monitor sampling failed",
-                                exc,
-                            )
-                        await asyncio.sleep(DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS)
+            async def _process_monitor_loop() -> None:
+                while True:
+                    try:
+                        await asyncio.to_thread(
+                            _record_process_monitor_sample,
+                            app.state.config.root,
+                        )
+                    except (
+                        RuntimeError,
+                        OSError,
+                        ConnectionError,
+                        ValueError,
+                        TypeError,
+                    ) as exc:  # intentional: background loop must not crash
+                        safe_log(
+                            app.state.logger,
+                            logging.WARNING,
+                            "Hub process monitor sampling failed",
+                            exc,
+                        )
+                    await asyncio.sleep(DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS)
 
-                tasks.append(asyncio.create_task(_process_monitor_loop()))
+            tasks.append(asyncio.create_task(_process_monitor_loop()))
             # Default lane worker starts in _deferred_hub_startup so /health is not blocked.
             # Eager repo lifespans run there too; until then, /repos/* still activates via
             # _LazyRepoApp._ensure_ready when hub_started is True.

--- a/tests/core/test_process_monitor.py
+++ b/tests/core/test_process_monitor.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
+
+from codex_autorunner.core.config_contract import ConfigError
 from codex_autorunner.core.diagnostics.process_monitor import (
     ProcessMonitorStore,
     build_process_monitor_summary,
@@ -92,3 +96,40 @@ def test_build_process_monitor_summary_flags_high_outlier(tmp_path: Path) -> Non
     assert opencode["average"] > 3.0
     assert opencode["p95"] == 15
     assert "absolute alert floor" in (opencode["reason"] or "")
+
+
+def test_build_process_monitor_summary_skips_lifecycle_when_repo_config_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+
+    def _fake_collect_processes() -> SimpleNamespace:
+        return SimpleNamespace(
+            opencode_processes=[],
+            app_server_processes=[],
+            opencode_count=0,
+            app_server_count=0,
+        )
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.diagnostics.process_monitor.collect_processes",
+        _fake_collect_processes,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.diagnostics.process_monitor.enrich_with_ownership",
+        lambda snapshot, _root: snapshot,
+    )
+
+    def _raise_missing_config(_root: Path) -> None:
+        raise ConfigError("missing hub config")
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.diagnostics.process_monitor.summarize_opencode_lifecycle",
+        _raise_missing_config,
+    )
+
+    summary = build_process_monitor_summary(root)
+
+    assert summary["status"] == "ok"
+    assert summary["latest"]["opencode_lifecycle"] == {}

--- a/tests/core/test_process_monitor.py
+++ b/tests/core/test_process_monitor.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from codex_autorunner.core.diagnostics.process_monitor import (
+    ProcessMonitorStore,
+    build_process_monitor_summary,
+)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_process_monitor_store_keeps_recent_tail(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    store = ProcessMonitorStore(root)
+    now = datetime.now(timezone.utc)
+
+    for offset in range(8, 0, -1):
+        captured_at = now - timedelta(minutes=offset * 10)
+        store.record_sample(
+            {
+                "captured_at": _iso(captured_at),
+                "opencode_count": offset,
+                "app_server_count": 0,
+                "total_count": offset,
+            },
+            cadence_seconds=120,
+            window_seconds=3 * 60 * 60,
+        )
+
+    samples = store.recent_samples(window_seconds=3 * 60 * 60)
+
+    assert len(samples) == 8
+
+    store.record_sample(
+        {
+            "captured_at": _iso(now + timedelta(minutes=1)),
+            "opencode_count": 99,
+            "app_server_count": 0,
+            "total_count": 99,
+        },
+        cadence_seconds=120,
+        window_seconds=30 * 60,
+    )
+
+    trimmed = store.recent_samples(window_seconds=30 * 60)
+
+    assert len(trimmed) == 3
+    assert [entry["opencode_count"] for entry in trimmed] == [2, 1, 99]
+
+
+def test_build_process_monitor_summary_flags_high_outlier(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    store = ProcessMonitorStore(root)
+    now = datetime.now(timezone.utc) - timedelta(minutes=12)
+
+    for step in range(6):
+        captured_at = now + timedelta(minutes=step * 2)
+        store.record_sample(
+            {
+                "captured_at": _iso(captured_at),
+                "opencode_count": 2,
+                "app_server_count": 1,
+                "total_count": 3,
+            },
+            cadence_seconds=120,
+            window_seconds=3 * 60 * 60,
+        )
+
+    store.record_sample(
+        {
+            "captured_at": _iso(now + timedelta(minutes=12)),
+            "opencode_count": 15,
+            "app_server_count": 1,
+            "total_count": 16,
+        },
+        cadence_seconds=120,
+        window_seconds=3 * 60 * 60,
+    )
+
+    summary = build_process_monitor_summary(root, capture_if_stale=False)
+
+    assert summary["status"] == "warning"
+    opencode = summary["metrics"]["opencode"]
+    assert opencode["abnormal"] is True
+    assert opencode["current"] == 15
+    assert opencode["average"] > 3.0
+    assert opencode["p95"] == 15
+    assert "absolute alert floor" in (opencode["reason"] or "")

--- a/tests/integrations/chat/test_status_diagnostics.py
+++ b/tests/integrations/chat/test_status_diagnostics.py
@@ -2,6 +2,7 @@ from codex_autorunner.integrations.chat.status_diagnostics import (
     StatusBlockContext,
     build_status_block_lines,
     extract_rate_limits,
+    format_process_monitor_lines,
 )
 
 
@@ -75,3 +76,50 @@ class TestExtractRateLimits:
         payload = {"primary": {"used_percent": 5}, "secondary": {"used_percent": 8}}
 
         assert extract_rate_limits(payload) == payload
+
+
+class TestFormatProcessMonitorLines:
+    def test_renders_history_with_tp95_when_requested(self) -> None:
+        lines = format_process_monitor_lines(
+            {
+                "status": "warning",
+                "sample_count": 42,
+                "cadence_seconds": 120,
+                "window_seconds": 3 * 60 * 60,
+                "metrics": {
+                    "opencode": {
+                        "current": 18,
+                        "average": 7.25,
+                        "p95": 14,
+                        "peak": 18,
+                        "abnormal": True,
+                        "reason": "high",
+                    },
+                    "app_server": {
+                        "current": 4,
+                        "average": 2.0,
+                        "p95": 3,
+                        "peak": 4,
+                        "abnormal": False,
+                        "reason": None,
+                    },
+                    "total": {
+                        "current": 22,
+                        "average": 9.25,
+                        "p95": 17,
+                        "peak": 22,
+                        "abnormal": True,
+                        "reason": "high",
+                    },
+                },
+                "latest": {},
+            },
+            include_history=True,
+        )
+
+        assert (
+            lines[0] == "Process monitor: warning (window=3h samples=42 cadence=120s)"
+        )
+        assert "OpenCode: 18 (avg 7.2, tp95 14, peak 18) high" in lines
+        assert "App server: 4 (avg 2.0, tp95 3, peak 4)" in lines
+        assert "Total: 22 (avg 9.2, tp95 17, peak 22) high" in lines

--- a/tests/integrations/discord/test_commands_payload.py
+++ b/tests/integrations/discord/test_commands_payload.py
@@ -35,6 +35,7 @@ def test_build_application_commands_structure_is_stable() -> None:
     expected_subcommands = [
         "bind",
         "status",
+        "processes",
         "new",
         "newt",
         "agent",

--- a/tests/integrations/discord/test_pma_commands.py
+++ b/tests/integrations/discord/test_pma_commands.py
@@ -18,6 +18,7 @@ from codex_autorunner.integrations.discord.state import DiscordStateStore
 class _FakeRest:
     def __init__(self) -> None:
         self.interaction_responses: list[dict[str, Any]] = []
+        self.followup_messages: list[dict[str, Any]] = []
         self.command_sync_calls: list[dict[str, Any]] = []
 
     async def create_interaction_response(
@@ -39,6 +40,23 @@ class _FakeRest:
         self, *, channel_id: str, payload: dict[str, Any]
     ) -> dict[str, Any]:
         return {"id": "msg-1", "channel_id": channel_id, "payload": payload}
+
+    async def create_followup_message(
+        self,
+        *,
+        application_id: str | None = None,
+        interaction_token: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        self.followup_messages.append(
+            {
+                "application_id": application_id,
+                "interaction_token": interaction_token,
+                "payload": payload,
+            }
+        )
+        return {"id": "followup-1", "payload": payload}
 
     async def bulk_overwrite_application_commands(
         self,
@@ -140,6 +158,20 @@ def _bind_interaction(*, path: str, user_id: str = "user-1") -> dict[str, Any]:
                     "options": [{"type": 3, "name": "workspace", "value": path}],
                 }
             ],
+        },
+    }
+
+
+def _car_processes_interaction(*, user_id: str = "user-1") -> dict[str, Any]:
+    return {
+        "id": "inter-processes",
+        "token": "token-processes",
+        "channel_id": "channel-1",
+        "guild_id": "guild-1",
+        "member": {"user": {"id": user_id}},
+        "data": {
+            "name": "car",
+            "options": [{"type": 1, "name": "processes", "options": []}],
         },
     }
 
@@ -369,6 +401,57 @@ async def test_pma_status_unbound_channel_reports_disabled(tmp_path: Path) -> No
 
 
 @pytest.mark.anyio
+async def test_pma_status_includes_process_summary_when_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+    await store.update_pma_state(
+        channel_id="channel-1",
+        pma_enabled=True,
+        pma_prev_workspace_path=str(workspace),
+        pma_prev_repo_id="repo-1",
+    )
+
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.discord.pma_commands.build_process_monitor_lines_for_root",
+        lambda *_args, **_kwargs: [
+            "Process monitor: warning (window=3h samples=6 cadence=120s)",
+            "OpenCode: 18 (avg 7.0, tp95 14, peak 18) high",
+        ],
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway([_pma_interaction(subcommand="status")])
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await service.run_forever()
+        content = rest.interaction_responses[0]["payload"]["data"]["content"]
+        assert "PMA mode: enabled" in content
+        assert "Process monitor: warning" in content
+        assert "tp95 14" in content
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_pma_off_unbound_channel_is_idempotent(tmp_path: Path) -> None:
     store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
     await store.initialize()
@@ -491,5 +574,42 @@ async def test_pma_target_group_returns_unknown_subcommand(tmp_path: Path) -> No
         assert len(rest.interaction_responses) == 1
         content = rest.interaction_responses[0]["payload"]["data"]["content"]
         assert content == "Unknown PMA subcommand. Use on, off, or status."
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_car_processes_returns_process_summary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.discord.workspace_commands.build_process_monitor_lines_for_root",
+        lambda *_args, **_kwargs: [
+            "Process monitor: warning (window=3h samples=8 cadence=120s)",
+            "OpenCode: 12 (avg 5.0, tp95 9, peak 12) high",
+            "Total: 16 (avg 7.0, tp95 13, peak 16) high",
+        ],
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway([_car_processes_interaction()])
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await service.run_forever()
+        content = rest.followup_messages[0]["payload"]["content"]
+        assert "Process monitor root:" in content
+        assert "Process monitor: warning" in content
+        assert "tp95 9" in content
     finally:
         await store.close()

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -191,7 +191,8 @@ def test_connect_readonly_skips_bootstrap_initialize(
     initialize_calls: list[str] = []
 
     def _record_initialize(self) -> None:  # type: ignore[no-untyped-def]
-        initialize_calls.append("called")
+        if Path(self.hub_root) == hub_root.resolve():
+            initialize_calls.append("called")
 
     monkeypatch.setattr(
         "codex_autorunner.core.pma_thread_store.PmaThreadStoreBootstrap.initialize",


### PR DESCRIPTION
## Summary
- add a bounded process monitor with a 120s default cadence and a 3h trailing window for abnormal process detection
- surface abnormal process monitor summaries in PMA/hub status and add /processes plus /car processes user-facing commands
- run the hub-side background sampler and include process alerts in the PMA hub snapshot

## Testing
- .venv/bin/python -m pytest tests/core/test_process_monitor.py tests/integrations/chat/test_status_diagnostics.py tests/integrations/chat/test_command_contract.py tests/integrations/discord/test_pma_commands.py tests/test_telegram_status_rate_limits.py tests/telegram_pma_routing_support.py tests/integrations/discord/test_status.py tests/test_telegram_bot_integration.py -k "status or process or pma or command_contract"
- repo pre-commit hook suite during git commit, including strict mypy, frontend build/tests, and full pytest (5139 passed)
