### PR TITLE
Fix Discord flow archive store-open error classification

### DIFF
--- a/src/codex_autorunner/integrations/discord/flow_commands.py
+++ b/src/codex_autorunner/integrations/discord/flow_commands.py
@@ -2176,36 +2176,50 @@ async def handle_flow_button(
             )
             return
 
-        try:
+        def _resolve_archive_target() -> Optional[FlowRunRecord]:
             store = service._open_flow_store(workspace_root)
-        except (sqlite3.Error, OSError, RuntimeError, ConfigError) as exc:
-            log_event(
-                service._logger,
-                logging.ERROR,
-                "discord.flow.store_open_failed",
-                workspace_root=str(workspace_root),
-                exc=exc,
-            )
-            raise DiscordTransientError(
-                f"Failed to open flow database: {exc}",
-                user_message="Unable to access flow database. Please try again later.",
-            ) from None
+            try:
+                return cast(
+                    Optional[FlowRunRecord],
+                    service._resolve_flow_run_by_id(store, run_id=run_id),
+                )
+            finally:
+                store.close()
+
         try:
-            target = service._resolve_flow_run_by_id(store, run_id=run_id)
-        except (sqlite3.Error, OSError) as exc:
+            target = await asyncio.to_thread(_resolve_archive_target)
+        except (sqlite3.Error, OSError, RuntimeError, ConfigError) as exc:
+            event = (
+                "discord.flow.store_open_failed"
+                if isinstance(exc, (RuntimeError, ConfigError))
+                else "discord.flow.query_failed"
+            )
+            payload: dict[str, Any] = {
+                "exc": exc,
+                "workspace_root": str(workspace_root),
+            }
+            if isinstance(exc, (sqlite3.Error, OSError)):
+                payload = {"exc": exc, "run_id": run_id}
             log_event(
                 service._logger,
                 logging.ERROR,
-                "discord.flow.query_failed",
-                exc=exc,
-                run_id=run_id,
+                event,
+                **payload,
+            )
+            user_message = (
+                "Unable to access flow database. Please try again later."
+                if isinstance(exc, (RuntimeError, ConfigError))
+                else "Unable to query flow database. Please try again later."
+            )
+            action = (
+                "open flow database"
+                if event.endswith("store_open_failed")
+                else "query flow run"
             )
             raise DiscordTransientError(
-                f"Failed to query flow run: {exc}",
-                user_message="Unable to query flow database. Please try again later.",
+                f"Failed to {action}: {exc}",
+                user_message=user_message,
             ) from None
-        finally:
-            store.close()
 
         if target is None:
             stale_text = (

--- a/src/codex_autorunner/integrations/discord/flow_commands.py
+++ b/src/codex_autorunner/integrations/discord/flow_commands.py
@@ -2177,49 +2177,47 @@ async def handle_flow_button(
             return
 
         def _resolve_archive_target() -> Optional[FlowRunRecord]:
-            store = service._open_flow_store(workspace_root)
             try:
-                return cast(
-                    Optional[FlowRunRecord],
-                    service._resolve_flow_run_by_id(store, run_id=run_id),
+                store = service._open_flow_store(workspace_root)
+            except (sqlite3.Error, OSError, RuntimeError, ConfigError) as exc:
+                log_event(
+                    service._logger,
+                    logging.ERROR,
+                    "discord.flow.store_open_failed",
+                    workspace_root=str(workspace_root),
+                    exc=exc,
                 )
+                raise DiscordTransientError(
+                    f"Failed to open flow database: {exc}",
+                    user_message="Unable to access flow database. Please try again later.",
+                ) from None
+            try:
+                try:
+                    return cast(
+                        Optional[FlowRunRecord],
+                        service._resolve_flow_run_by_id(store, run_id=run_id),
+                    )
+                except (sqlite3.Error, OSError) as exc:
+                    log_event(
+                        service._logger,
+                        logging.ERROR,
+                        "discord.flow.query_failed",
+                        exc=exc,
+                        run_id=run_id,
+                    )
+                    raise DiscordTransientError(
+                        f"Failed to query flow run: {exc}",
+                        user_message=(
+                            "Unable to query flow database. Please try again later."
+                        ),
+                    ) from None
             finally:
                 store.close()
 
         try:
             target = await asyncio.to_thread(_resolve_archive_target)
-        except (sqlite3.Error, OSError, RuntimeError, ConfigError) as exc:
-            event = (
-                "discord.flow.store_open_failed"
-                if isinstance(exc, (RuntimeError, ConfigError))
-                else "discord.flow.query_failed"
-            )
-            payload: dict[str, Any] = {
-                "exc": exc,
-                "workspace_root": str(workspace_root),
-            }
-            if isinstance(exc, (sqlite3.Error, OSError)):
-                payload = {"exc": exc, "run_id": run_id}
-            log_event(
-                service._logger,
-                logging.ERROR,
-                event,
-                **payload,
-            )
-            user_message = (
-                "Unable to access flow database. Please try again later."
-                if isinstance(exc, (RuntimeError, ConfigError))
-                else "Unable to query flow database. Please try again later."
-            )
-            action = (
-                "open flow database"
-                if event.endswith("store_open_failed")
-                else "query flow run"
-            )
-            raise DiscordTransientError(
-                f"Failed to {action}: {exc}",
-                user_message=user_message,
-            ) from None
+        except DiscordTransientError:
+            raise
 
         if target is None:
             stale_text = (

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/flows.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import uuid
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional, TypeVar
 
 from .....core.config import ConfigError, load_repo_config
 from .....core.flows import (
@@ -65,6 +65,7 @@ from .shared import TelegramCommandSupportMixin
 
 _logger = logging.getLogger(__name__)
 _FLOW_REPO_CONTEXT_CACHE_MAX = 512
+_T = TypeVar("_T")
 
 
 def _flow_paths(repo_root: Path) -> tuple[Path, Path]:
@@ -128,6 +129,11 @@ def _worktree_suffix(repo_id: str) -> Optional[str]:
 
 
 class FlowCommands(TelegramCommandSupportMixin):
+    async def _run_blocking_flow_call(
+        self, func: Callable[..., _T], /, *args: Any, **kwargs: Any
+    ) -> _T:
+        return await asyncio.to_thread(func, *args, **kwargs)
+
     def _flow_run_mirror(self, repo_root: Path) -> ChatRunMirror:
         return ChatRunMirror(repo_root, logger_=_logger)
 
@@ -617,6 +623,21 @@ class FlowCommands(TelegramCommandSupportMixin):
         *,
         repo_id: Optional[str] = None,
     ) -> None:
+        text, keyboard = await self._run_blocking_flow_call(
+            self._build_flow_status_callback_payload,
+            repo_root,
+            run_id_raw,
+            repo_id=repo_id,
+        )
+        await self._edit_callback_message(callback, text, reply_markup=keyboard)
+
+    def _build_flow_status_callback_payload(
+        self,
+        repo_root: Path,
+        run_id_raw: Optional[str],
+        *,
+        repo_id: Optional[str] = None,
+    ) -> tuple[str, dict[str, Any]]:
         store = _load_flow_store(repo_root)
         try:
             store.initialize()
@@ -625,31 +646,21 @@ class FlowCommands(TelegramCommandSupportMixin):
                 if not run_id_raw:
                     summary_text = self._build_flow_status_summary_fallback(repo_root)
                     if summary_text:
-                        await self._edit_callback_message(
-                            callback,
-                            summary_text,
-                            reply_markup={"inline_keyboard": []},
-                        )
-                        return
-                await self._edit_callback_message(
-                    callback, error, reply_markup={"inline_keyboard": []}
-                )
-                return
+                        return summary_text, {"inline_keyboard": []}
+                return error, {"inline_keyboard": []}
             if record is not None:
                 record, _updated, locked = reconcile_flow_run(repo_root, record, store)
                 if locked:
-                    await self._edit_callback_message(
-                        callback,
+                    return (
                         f"Run {_code(record.id)} is locked for reconcile; try again.",
-                        reply_markup={"inline_keyboard": []},
+                        {"inline_keyboard": []},
                     )
-                    return
             text, keyboard = self._build_flow_status_card(
                 repo_root, record, store, repo_id=repo_id
             )
         finally:
             store.close()
-        await self._edit_callback_message(callback, text, reply_markup=keyboard)
+        return text, keyboard
 
     async def _handle_flow_callback(
         self, callback: TelegramCallbackQuery, parsed: FlowCallback
@@ -757,7 +768,10 @@ class FlowCommands(TelegramCommandSupportMixin):
                     error = "No active ticket flow run found."
                 if error is None:
                     await _answer_once("Working...")
-                    record, updated, locked = flow_service.reconcile_flow_run(record.id)
+                    record, updated, locked = await self._run_blocking_flow_call(
+                        flow_service.reconcile_flow_run,
+                        record.id,
+                    )
                     if locked:
                         error = (
                             f"Run {record.run_id} is locked for reconcile; try again."
@@ -825,7 +839,8 @@ class FlowCommands(TelegramCommandSupportMixin):
                             self._flow_archive_in_progress_text(record.id),
                             reply_markup={"inline_keyboard": []},
                         )
-                        summary = flow_service.archive_flow_run(
+                        summary = await self._run_blocking_flow_call(
+                            flow_service.archive_flow_run,
                             record.id,
                             force=ticket_flow_archive_requires_force(record),
                             delete_run=True,
@@ -1942,9 +1957,10 @@ You are the first ticket in a new ticket_flow run.
                     reply_to=message.message_id,
                 )
                 return
-            record, updated, locked = self._ticket_flow_orchestration_service(
-                repo_root
-            ).reconcile_flow_run(record.id)
+            record, updated, locked = await self._run_blocking_flow_call(
+                self._ticket_flow_orchestration_service(repo_root).reconcile_flow_run,
+                record.id,
+            )
             if locked:
                 await self._send_message(
                     message.chat_id,
@@ -2060,7 +2076,8 @@ You are the first ticket in a new ticket_flow run.
             )
             return
 
-        summary = self._ticket_flow_orchestration_service(repo_root).archive_flow_run(
+        summary = await self._run_blocking_flow_call(
+            self._ticket_flow_orchestration_service(repo_root).archive_flow_run,
             record.id,
             force=ticket_flow_archive_requires_force(record),
             delete_run=True,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import logging
@@ -2457,7 +2458,8 @@ Compact canceled.""",
 Applying summary...""",
             reply_markup=None,
         )
-        status = self._write_compact_status(
+        status = await asyncio.to_thread(
+            self._write_compact_status,
             "running",
             "Applying summary...",
             chat_id=callback.chat_id,
@@ -2481,7 +2483,8 @@ Applying summary...""",
             message, record, state.summary_text
         )
         if not success:
-            status = self._write_compact_status(
+            status = await asyncio.to_thread(
+                self._write_compact_status,
                 "error",
                 failure_message or "Failed to start new thread with summary.",
                 chat_id=callback.chat_id,
@@ -2507,7 +2510,8 @@ Failed to start new thread with summary.""",
                     callback.chat_id, failure_message, thread_id=callback.thread_id
                 )
             return
-        status = self._write_compact_status(
+        status = await asyncio.to_thread(
+            self._write_compact_status,
             "ok",
             "Summary applied.",
             chat_id=callback.chat_id,
@@ -2689,7 +2693,8 @@ Summary applied.""",
             await self._answer_callback(callback, "Starting update...")
             callback_answered = True
         try:
-            _spawn_update_process(
+            await asyncio.to_thread(
+                _spawn_update_process,
                 repo_url=repo_url,
                 repo_ref=repo_ref,
                 update_dir=update_dir,
@@ -3037,7 +3042,8 @@ Summary applied.""",
         message = status.message
         if state == "running":
             message = "Compact apply interrupted by restart. Please retry."
-            status = self._write_compact_status(
+            status = await asyncio.to_thread(
+                self._write_compact_status,
                 "interrupted",
                 message,
                 chat_id=chat_id,

--- a/tests/integrations/discord/test_flow_archive.py
+++ b/tests/integrations/discord/test_flow_archive.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sqlite3
 import uuid
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,7 @@ from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
     DiscordCommandRegistration,
 )
+from codex_autorunner.integrations.discord.errors import DiscordTransientError
 from codex_autorunner.integrations.discord.service import DiscordBotService
 from codex_autorunner.integrations.discord.state import DiscordStateStore
 
@@ -458,6 +460,50 @@ async def test_flow_archive_button_real_archive_renders_archived_state(
     assert "Status: archived" in edited["content"]
     assert f"Archive path: .codex-autorunner/archive/runs/{run_id}" in edited["content"]
     assert edited["components"] == []
+
+
+@pytest.mark.anyio
+async def test_flow_archive_button_classifies_open_sqlite_errors_as_store_open_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _workspace(tmp_path)
+    run_id = str(uuid.uuid4())
+
+    rest = _FakeRest()
+    service = _service(tmp_path, rest)
+    logged_events: list[str] = []
+    logged_payloads: list[dict[str, Any]] = []
+
+    def _fake_log_event(_logger: Any, _level: int, event: str, **kwargs: Any) -> None:
+        logged_events.append(event)
+        logged_payloads.append(kwargs)
+
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.discord.flow_commands.log_event",
+        _fake_log_event,
+    )
+
+    def _raise_open_store(_workspace_root: Path) -> FlowStore:
+        raise sqlite3.OperationalError("open failed")
+
+    service._open_flow_store = _raise_open_store  # type: ignore[assignment]
+
+    try:
+        with pytest.raises(DiscordTransientError, match="Failed to open flow database"):
+            await service._handle_flow_button(
+                "interaction-archive-db-open-fail",
+                "token-archive-db-open-fail",
+                workspace_root=workspace,
+                custom_id=f"flow:{run_id}:archive",
+                channel_id="channel-1",
+                guild_id="guild-1",
+            )
+    finally:
+        await service._store.close()
+
+    assert logged_events == ["discord.flow.store_open_failed"]
+    assert logged_payloads[0]["workspace_root"] == str(workspace)
+    assert isinstance(logged_payloads[0]["exc"], sqlite3.OperationalError)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Correct error classification in Discord `/flow` archive button handling when `FlowStore` fails to open with a SQLite-layer error.
- Keep transient error mapping and user messaging deterministic: store-open failures now consistently log `discord.flow.store_open_failed` and return "Unable to access flow database...".
- Add regression coverage for SQLite open failures raised by `_open_flow_store`.

## Root Cause
The archive callback previously classified exceptions by broad type *after* `to_thread(...)` returned. When `_open_flow_store(...)` raised `sqlite3.OperationalError`, it was treated as a query failure (`discord.flow.query_failed`) because the type matched `sqlite3.Error`, even though the failure happened before query execution.

## Fix
- Move open/query classification into `_resolve_archive_target()` itself:
  - `_open_flow_store(...)` errors -> `discord.flow.store_open_failed` + store-access user message.
  - `_resolve_flow_run_by_id(...)` errors -> `discord.flow.query_failed` + query user message.
- Re-raise only `DiscordTransientError` from the threaded call path.

## Validation
- Focused: `.venv/bin/pytest tests/integrations/discord/test_flow_archive.py -q`
- Repo gate via commit hooks (passed): formatting, ruff, mypy, frontend build/tests, full pytest (`5135 passed`).
