### PR TITLE
Fix Discord flow archive store-open error classification

### DIFF
--- a/src/codex_autorunner/integrations/discord/flow_commands.py
+++ b/src/codex_autorunner/integrations/discord/flow_commands.py
@@ -2214,10 +2214,7 @@ async def handle_flow_button(
             finally:
                 store.close()
 
-        try:
-            target = await asyncio.to_thread(_resolve_archive_target)
-        except DiscordTransientError:
-            raise
+        target = await asyncio.to_thread(_resolve_archive_target)
 
         if target is None:
             stale_text = (

--- a/src/codex_autorunner/integrations/discord/flow_commands.py
+++ b/src/codex_autorunner/integrations/discord/flow_commands.py
@@ -2177,49 +2177,47 @@ async def handle_flow_button(
             return
 
         def _resolve_archive_target() -> Optional[FlowRunRecord]:
-            store = service._open_flow_store(workspace_root)
             try:
-                return cast(
-                    Optional[FlowRunRecord],
-                    service._resolve_flow_run_by_id(store, run_id=run_id),
+                store = service._open_flow_store(workspace_root)
+            except (sqlite3.Error, OSError, RuntimeError, ConfigError) as exc:
+                log_event(
+                    service._logger,
+                    logging.ERROR,
+                    "discord.flow.store_open_failed",
+                    workspace_root=str(workspace_root),
+                    exc=exc,
                 )
+                raise DiscordTransientError(
+                    f"Failed to open flow database: {exc}",
+                    user_message="Unable to access flow database. Please try again later.",
+                ) from None
+            try:
+                try:
+                    return cast(
+                        Optional[FlowRunRecord],
+                        service._resolve_flow_run_by_id(store, run_id=run_id),
+                    )
+                except (sqlite3.Error, OSError) as exc:
+                    log_event(
+                        service._logger,
+                        logging.ERROR,
+                        "discord.flow.query_failed",
+                        exc=exc,
+                        run_id=run_id,
+                    )
+                    raise DiscordTransientError(
+                        f"Failed to query flow run: {exc}",
+                        user_message=(
+                            "Unable to query flow database. Please try again later."
+                        ),
+                    ) from None
             finally:
                 store.close()
 
         try:
             target = await asyncio.to_thread(_resolve_archive_target)
-        except (sqlite3.Error, OSError, RuntimeError, ConfigError) as exc:
-            event = (
-                "discord.flow.store_open_failed"
-                if isinstance(exc, (RuntimeError, ConfigError))
-                else "discord.flow.query_failed"
-            )
-            payload: dict[str, Any] = {
-                "exc": exc,
-                "workspace_root": str(workspace_root),
-            }
-            if isinstance(exc, (sqlite3.Error, OSError)):
-                payload = {"exc": exc, "run_id": run_id}
-            log_event(
-                service._logger,
-                logging.ERROR,
-                event,
-                **payload,
-            )
-            user_message = (
-                "Unable to access flow database. Please try again later."
-                if isinstance(exc, (RuntimeError, ConfigError))
-                else "Unable to query flow database. Please try again later."
-            )
-            failed_action = (
-                "open flow database"
-                if event.endswith("store_open_failed")
-                else "query flow run"
-            )
-            raise DiscordTransientError(
-                f"Failed to {failed_action}: {exc}",
-                user_message=user_message,
-            ) from None
+        except DiscordTransientError:
+            raise
 
         if target is None:
             stale_text = (

--- a/tests/integrations/discord/test_flow_archive.py
+++ b/tests/integrations/discord/test_flow_archive.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sqlite3
 import uuid
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,7 @@ from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
     DiscordCommandRegistration,
 )
+from codex_autorunner.integrations.discord.errors import DiscordTransientError
 from codex_autorunner.integrations.discord.service import DiscordBotService
 from codex_autorunner.integrations.discord.state import DiscordStateStore
 
@@ -458,6 +460,50 @@ async def test_flow_archive_button_real_archive_renders_archived_state(
     assert "Status: archived" in edited["content"]
     assert f"Archive path: .codex-autorunner/archive/runs/{run_id}" in edited["content"]
     assert edited["components"] == []
+
+
+@pytest.mark.anyio
+async def test_flow_archive_button_classifies_open_sqlite_errors_as_store_open_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _workspace(tmp_path)
+    run_id = str(uuid.uuid4())
+
+    rest = _FakeRest()
+    service = _service(tmp_path, rest)
+    logged_events: list[str] = []
+    logged_payloads: list[dict[str, Any]] = []
+
+    def _fake_log_event(_logger: Any, _level: int, event: str, **kwargs: Any) -> None:
+        logged_events.append(event)
+        logged_payloads.append(kwargs)
+
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.discord.flow_commands.log_event",
+        _fake_log_event,
+    )
+
+    def _raise_open_store(_workspace_root: Path) -> FlowStore:
+        raise sqlite3.OperationalError("open failed")
+
+    service._open_flow_store = _raise_open_store  # type: ignore[assignment]
+
+    try:
+        with pytest.raises(DiscordTransientError, match="Failed to open flow database"):
+            await service._handle_flow_button(
+                "interaction-archive-db-open-fail",
+                "token-archive-db-open-fail",
+                workspace_root=workspace,
+                custom_id=f"flow:{run_id}:archive",
+                channel_id="channel-1",
+                guild_id="guild-1",
+            )
+    finally:
+        await service._store.close()
+
+    assert logged_events == ["discord.flow.store_open_failed"]
+    assert logged_payloads[0]["workspace_root"] == str(workspace)
+    assert isinstance(logged_payloads[0]["exc"], sqlite3.OperationalError)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Correct error classification in Discord `/flow` archive button handling when `FlowStore` fails to open with a SQLite-layer error.
- Keep transient error mapping and user messaging deterministic: store-open failures now consistently log `discord.flow.store_open_failed` and return "Unable to access flow database...".
- Add regression coverage for SQLite open failures raised by `_open_flow_store`.

## Root Cause
The archive callback previously classified exceptions by broad type *after* `to_thread(...)` returned. When `_open_flow_store(...)` raised `sqlite3.OperationalError`, it was treated as a query failure (`discord.flow.query_failed`) because the type matched `sqlite3.Error`, even though the failure happened before query execution.

## Fix
- Move open/query classification into `_resolve_archive_target()` itself:
  - `_open_flow_store(...)` errors -> `discord.flow.store_open_failed` + store-access user message.
  - `_resolve_flow_run_by_id(...)` errors -> `discord.flow.query_failed` + query user message.
- Re-raise only `DiscordTransientError` from the threaded call path.

## Validation
- Focused: `.venv/bin/pytest tests/integrations/discord/test_flow_archive.py -q`
- Repo gate via commit hooks (passed): formatting, ruff, mypy, frontend build/tests, full pytest (`5152 passed` in this branch snapshot).