### PR TITLE
[codex] Fix managed thread backend rebinding

### DIFF
--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -61,6 +61,13 @@ _MISSING_THREAD_MARKERS = (
 _RECOVERABLE_BACKEND_MARKERS = _MISSING_THREAD_MARKERS + ("event loop is closed",)
 _REHYDRATION_TRANSCRIPT_LIMIT = 3
 _REHYDRATION_TEXT_LIMIT = 4_000
+_FRESH_BACKEND_SESSION_NOTICE = (
+    "Notice: the previous live session was unavailable, so I started a new " "session."
+)
+_FRESH_BACKEND_SESSION_REHYDRATED_NOTICE = (
+    "Notice: the previous live session was unavailable, so I started a new "
+    "session and recovered context from durable history."
+)
 logger = logging.getLogger(__name__)
 
 HarnessFactory = Callable[..., RuntimeThreadHarness]
@@ -784,6 +791,21 @@ class _ThreadExecutionLifecycle:
             return runtime_prompt
         return f"{prefix}\n\n{runtime_prompt}"
 
+    @staticmethod
+    def mark_fresh_backend_session(
+        request: MessageRequest,
+        *,
+        reason: str,
+        rehydrated: bool,
+    ) -> None:
+        request.metadata["fresh_backend_session_started"] = True
+        request.metadata["fresh_backend_session_reason"] = reason
+        request.metadata["fresh_backend_session_notice"] = (
+            _FRESH_BACKEND_SESSION_REHYDRATED_NOTICE
+            if rehydrated
+            else _FRESH_BACKEND_SESSION_NOTICE
+        )
+
     async def start_execution(
         self,
         thread: ThreadTarget,
@@ -797,6 +819,8 @@ class _ThreadExecutionLifecycle:
         runtime_prompt = self.resolve_runtime_prompt(request)
         fresh_conversation_retry_attempted = False
         rehydrated_runtime_prompt = False
+        fresh_backend_session_reason: Optional[str] = None
+        previous_backend_thread_id: Optional[str] = None
         runtime_instance_id: Optional[str] = None
         conversation_id: Optional[str] = None
         used_existing_conversation = False
@@ -830,6 +854,8 @@ class _ThreadExecutionLifecycle:
                     current_runtime_instance_id=runtime_instance_id,
                     action="start_new_conversation",
                 )
+                fresh_backend_session_reason = "stale_runtime_instance"
+                previous_backend_thread_id = conversation_id
                 self.thread_store.set_thread_backend_id(
                     thread.thread_target_id,
                     None,
@@ -863,6 +889,8 @@ class _ThreadExecutionLifecycle:
                                 backend_thread_id=conversation_id,
                                 action="start_new_conversation",
                             )
+                            fresh_backend_session_reason = "resume_recoverable_error"
+                            previous_backend_thread_id = conversation_id
                             self.thread_store.set_thread_backend_id(
                                 thread.thread_target_id,
                                 None,
@@ -895,9 +923,45 @@ class _ThreadExecutionLifecycle:
                             )
                     else:
                         if not rehydrated_runtime_prompt:
-                            runtime_prompt = self.rehydrated_runtime_prompt(
-                                thread, runtime_prompt
+                            prefix = self.build_rehydration_prefix(
+                                thread,
+                                include_compact_seed="Context summary (from compaction):"
+                                not in runtime_prompt,
                             )
+                            should_mark_fresh_backend_session = bool(
+                                previous_backend_thread_id
+                                or str(
+                                    getattr(thread, "last_execution_id", "") or ""
+                                ).strip()
+                                or str(
+                                    getattr(thread, "compact_seed", "") or ""
+                                ).strip()
+                            )
+                            if should_mark_fresh_backend_session:
+                                fresh_backend_session_reason = (
+                                    fresh_backend_session_reason
+                                    or "missing_backend_binding"
+                                )
+                                self.mark_fresh_backend_session(
+                                    request,
+                                    reason=fresh_backend_session_reason,
+                                    rehydrated=bool(prefix),
+                                )
+                                log_event(
+                                    logger,
+                                    logging.INFO,
+                                    "orchestration.thread.fresh_backend_session_started",
+                                    thread_target_id=thread.thread_target_id,
+                                    execution_id=execution.execution_id,
+                                    previous_backend_thread_id=(
+                                        previous_backend_thread_id
+                                    ),
+                                    request_kind=request.kind,
+                                    reason=fresh_backend_session_reason,
+                                    rehydrated=bool(prefix),
+                                )
+                            if prefix:
+                                runtime_prompt = f"{prefix}\n\n{runtime_prompt}"
                             rehydrated_runtime_prompt = True
                         conversation = await harness.new_conversation(
                             workspace_root,
@@ -971,6 +1035,8 @@ class _ThreadExecutionLifecycle:
                         status_code=exc.status_code,
                         reason=str(exc),
                     )
+                    fresh_backend_session_reason = "fresh_conversation_required"
+                    previous_backend_thread_id = conversation_id
                     self.thread_store.set_thread_backend_id(
                         thread.thread_target_id,
                         None,
@@ -1006,6 +1072,8 @@ class _ThreadExecutionLifecycle:
                         status_code=None,
                         reason=str(exc),
                     )
+                    fresh_backend_session_reason = "start_turn_recoverable_error"
+                    previous_backend_thread_id = conversation_id
                     self.thread_store.set_thread_backend_id(
                         thread.thread_target_id,
                         None,

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -428,6 +428,8 @@ def _resume_managed_thread_target(
         resume_kwargs["backend_thread_id"] = None
     elif desired_backend_thread_id is not None:
         resume_kwargs["backend_thread_id"] = desired_backend_thread_id
+    elif current_backend_thread_id is not None:
+        resume_kwargs["backend_thread_id"] = current_backend_thread_id
     resume_kwargs["backend_runtime_instance_id"] = desired_runtime_instance_id
     resumed_thread = orchestration_service.resume_thread_target(
         thread.thread_target_id,
@@ -641,9 +643,18 @@ def resolve_managed_thread_target(
                 reusable_agent_ids=reusable_agent_ids,
                 canonical_workspace=canonical_workspace,
             )
+    clear_backend_thread_id = (
+        request.mode == "pma"
+        and desired_backend_thread_id is None
+        and current_backend_thread_id is not None
+    )
     should_resume_reusable = reusable_thread and (
         str(getattr(thread, "lifecycle_status", "") or "").strip().lower() != "active"
-        or current_backend_thread_id != desired_backend_thread_id
+        or clear_backend_thread_id
+        or (
+            desired_backend_thread_id is not None
+            and current_backend_thread_id != desired_backend_thread_id
+        )
         or (
             desired_runtime_instance_id is not None
             and current_runtime_instance_id != desired_runtime_instance_id
@@ -654,9 +665,7 @@ def resolve_managed_thread_target(
         thread = _resume_managed_thread_target(
             orchestration_service,
             thread,
-            clear_backend_thread_id=(
-                request.mode == "pma" and desired_backend_thread_id is None
-            ),
+            clear_backend_thread_id=clear_backend_thread_id,
             desired_backend_thread_id=desired_backend_thread_id,
             current_backend_thread_id=current_backend_thread_id,
             desired_runtime_instance_id=desired_runtime_instance_id,

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -88,6 +88,8 @@ class ManagedThreadFinalizationResult:
     managed_turn_id: str
     backend_thread_id: Optional[str]
     token_usage: Optional[dict[str, Any]] = None
+    session_notice: Optional[str] = None
+    fresh_backend_session_reason: Optional[str] = None
 
 
 FinalizeQueuedExecution = Callable[
@@ -539,6 +541,8 @@ def _build_finalization_result(
     managed_turn_id: str,
     backend_thread_id: Optional[str],
     token_usage: Optional[dict[str, Any]],
+    session_notice: Optional[str] = None,
+    fresh_backend_session_reason: Optional[str] = None,
 ) -> ManagedThreadFinalizationResult:
     return ManagedThreadFinalizationResult(
         status=status,
@@ -548,6 +552,8 @@ def _build_finalization_result(
         managed_turn_id=managed_turn_id,
         backend_thread_id=backend_thread_id,
         token_usage=token_usage,
+        session_notice=session_notice,
+        fresh_backend_session_reason=fresh_backend_session_reason,
     )
 
 
@@ -583,7 +589,57 @@ def coerce_managed_thread_finalization_result(
             str(finalized.get("backend_thread_id") or "").strip() or None
         ),
         token_usage=normalized_token_usage,
+        session_notice=(str(finalized.get("session_notice") or "").strip() or None),
+        fresh_backend_session_reason=(
+            str(finalized.get("fresh_backend_session_reason") or "").strip() or None
+        ),
     )
+
+
+def _normalized_session_metadata_text(
+    metadata: Mapping[str, Any], key: str
+) -> Optional[str]:
+    return str(metadata.get(key) or "").strip() or None
+
+
+def managed_thread_session_metadata(
+    request: MessageRequest,
+) -> tuple[Optional[str], Optional[str], bool]:
+    metadata = getattr(request, "metadata", {})
+    if not isinstance(metadata, Mapping):
+        return None, None, False
+    session_notice = _normalized_session_metadata_text(
+        metadata, "fresh_backend_session_notice"
+    )
+    fresh_backend_session_reason = _normalized_session_metadata_text(
+        metadata, "fresh_backend_session_reason"
+    )
+    fresh_backend_session_started = bool(
+        metadata.get("fresh_backend_session_started")
+        or session_notice
+        or fresh_backend_session_reason
+    )
+    return (
+        session_notice,
+        fresh_backend_session_reason,
+        fresh_backend_session_started,
+    )
+
+
+def render_managed_thread_response_text(
+    finalized: ManagedThreadFinalizationResult,
+    *,
+    no_response_fallback: str = "(No response text returned.)",
+) -> str:
+    assistant_text = str(finalized.assistant_text or "").strip()
+    session_notice = str(finalized.session_notice or "").strip()
+    if session_notice and assistant_text:
+        return f"{session_notice}\n\n{assistant_text}"
+    if session_notice:
+        return session_notice
+    if assistant_text:
+        return assistant_text
+    return no_response_fallback
 
 
 def resolve_managed_thread_target(
@@ -1218,6 +1274,9 @@ def _surface_metadata(
     backend_turn_id: Optional[str],
     status: str,
 ) -> dict[str, Any]:
+    _, fresh_backend_session_reason, fresh_backend_session_started = (
+        managed_thread_session_metadata(started.request)
+    )
     metadata = {
         "agent": getattr(started.thread, "agent_id", None),
         "execution_id": started.execution.execution_id,
@@ -1231,6 +1290,10 @@ def _surface_metadata(
         "surface_kind": surface.surface_kind,
         "surface_key": surface.surface_key,
     }
+    if fresh_backend_session_started:
+        metadata["fresh_backend_session_started"] = True
+    if fresh_backend_session_reason:
+        metadata["fresh_backend_session_reason"] = fresh_backend_session_reason
     metadata.update(dict(surface.metadata))
     return metadata
 
@@ -1730,6 +1793,11 @@ async def finalize_managed_thread_execution(
         orchestration_service,
         managed_thread_id,
     )
+    (
+        session_notice,
+        fresh_backend_session_reason,
+        fresh_backend_session_started,
+    ) = managed_thread_session_metadata(started.request)
     resolved_backend_thread_id = (
         str(
             getattr(finalized_runtime_binding, "backend_thread_id", None)
@@ -1763,6 +1831,12 @@ async def finalize_managed_thread_execution(
             "surface_kind": surface.surface_kind,
             "surface_key": surface.surface_key,
         }
+        if fresh_backend_session_started:
+            transcript_metadata["fresh_backend_session_started"] = True
+        if fresh_backend_session_reason:
+            transcript_metadata["fresh_backend_session_reason"] = (
+                fresh_backend_session_reason
+            )
         transcript_metadata.update(dict(surface.metadata))
         try:
             if resolved_hub_client is None:
@@ -1827,6 +1901,8 @@ async def finalize_managed_thread_execution(
                 finalized_status=finalized_status or None,
                 detail=detail,
                 event_error=event_state.last_error_message,
+                fresh_backend_session_started=fresh_backend_session_started,
+                fresh_backend_session_reason=fresh_backend_session_reason,
                 **_managed_thread_runtime_trace_fields(event_state),
             )
             return _build_finalization_result(
@@ -1837,6 +1913,8 @@ async def finalize_managed_thread_execution(
                 managed_turn_id=managed_turn_id,
                 backend_thread_id=resolved_backend_thread_id,
                 token_usage=event_state.token_usage,
+                session_notice=session_notice,
+                fresh_backend_session_reason=fresh_backend_session_reason,
             )
         # Log turn_finalized immediately after orchestration acknowledges ok so log-plane
         # correlates with orch_thread_executions even if optional hub calls below fail or
@@ -1857,6 +1935,8 @@ async def finalize_managed_thread_execution(
             assistant_chars=len(resolved_assistant_text),
             event_error=event_state.last_error_message,
             token_usage=event_state.token_usage,
+            fresh_backend_session_started=fresh_backend_session_started,
+            fresh_backend_session_reason=fresh_backend_session_reason,
             **_managed_thread_runtime_trace_fields(event_state),
         )
         try:
@@ -1884,6 +1964,8 @@ async def finalize_managed_thread_execution(
             managed_turn_id=managed_turn_id,
             backend_thread_id=resolved_backend_thread_id,
             token_usage=event_state.token_usage,
+            session_notice=session_notice,
+            fresh_backend_session_reason=fresh_backend_session_reason,
         )
 
     if outcome.status == "interrupted":
@@ -1910,6 +1992,8 @@ async def finalize_managed_thread_execution(
             detail=errors.interrupted_error,
             event_error=event_state.last_error_message,
             token_usage=event_state.token_usage,
+            fresh_backend_session_started=fresh_backend_session_started,
+            fresh_backend_session_reason=fresh_backend_session_reason,
             **_managed_thread_runtime_trace_fields(event_state),
         )
         return _build_finalization_result(
@@ -1920,6 +2004,8 @@ async def finalize_managed_thread_execution(
             managed_turn_id=managed_turn_id,
             backend_thread_id=resolved_backend_thread_id,
             token_usage=event_state.token_usage,
+            session_notice=session_notice,
+            fresh_backend_session_reason=fresh_backend_session_reason,
         )
 
     detail = resolve_runtime_thread_error_detail(
@@ -1958,6 +2044,8 @@ async def finalize_managed_thread_execution(
         outcome_error=outcome.error,
         event_error=event_state.last_error_message,
         token_usage=event_state.token_usage,
+        fresh_backend_session_started=fresh_backend_session_started,
+        fresh_backend_session_reason=fresh_backend_session_reason,
         **_managed_thread_runtime_trace_fields(event_state),
     )
     return _build_finalization_result(
@@ -1968,4 +2056,6 @@ async def finalize_managed_thread_execution(
         managed_turn_id=managed_turn_id,
         backend_thread_id=resolved_backend_thread_id,
         token_usage=event_state.token_usage,
+        session_notice=session_notice,
+        fresh_backend_session_reason=fresh_backend_session_reason,
     )

--- a/src/codex_autorunner/integrations/chat/runtime.py
+++ b/src/codex_autorunner/integrations/chat/runtime.py
@@ -89,11 +89,38 @@ async def resolve_chat_thread_runtime_binding(
     normalized_requested_backend_thread_id = _normalized_optional_text(
         requested_backend_thread_id
     )
+    existing_backend_thread_id = _normalized_optional_text(
+        getattr(existing_thread, "backend_thread_id", None)
+    )
+    existing_thread_matches_runtime_owner = (
+        existing_backend_thread_id is not None
+        and _thread_matches_runtime_owner(
+            existing_thread,
+            workspace_root=workspace_root,
+            agent_id=agent_id,
+            agent_profile=agent_profile,
+        )
+    )
     if normalized_requested_backend_thread_id is None:
+        if not existing_thread_matches_runtime_owner:
+            return ChatThreadRuntimeBinding(
+                backend_thread_id=None,
+                backend_runtime_instance_id=None,
+                runtime_available=False,
+                used_requested_backend_thread_id=False,
+            )
+        runtime = await acquire_chat_workspace_runtime(
+            orchestration_service,
+            agent_id=agent_id,
+            workspace_root=workspace_root,
+        )
+        runtime_instance_id = _normalized_optional_text(
+            runtime.backend_runtime_instance_id
+        )
         return ChatThreadRuntimeBinding(
-            backend_thread_id=None,
-            backend_runtime_instance_id=None,
-            runtime_available=False,
+            backend_thread_id=existing_backend_thread_id,
+            backend_runtime_instance_id=runtime_instance_id,
+            runtime_available=runtime_instance_id is not None,
             used_requested_backend_thread_id=False,
         )
     runtime = await acquire_chat_workspace_runtime(
@@ -109,18 +136,9 @@ async def resolve_chat_thread_runtime_binding(
             runtime_available=True,
             used_requested_backend_thread_id=True,
         )
-    existing_backend_thread_id = _normalized_optional_text(
-        getattr(existing_thread, "backend_thread_id", None)
-    )
     if (
-        existing_backend_thread_id is not None
+        existing_thread_matches_runtime_owner
         and existing_backend_thread_id != normalized_requested_backend_thread_id
-        and _thread_matches_runtime_owner(
-            existing_thread,
-            workspace_root=workspace_root,
-            agent_id=agent_id,
-            agent_profile=agent_profile,
-        )
     ):
         return ChatThreadRuntimeBinding(
             backend_thread_id=existing_backend_thread_id,

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -2402,13 +2402,6 @@ def resolve_discord_thread_target(
             RuntimeError, ValueError, TypeError, KeyError, AttributeError
         ):
             existing_thread = get_thread_target(existing_thread_target_id)
-    current_backend_thread_id = (
-        str(getattr(existing_thread, "backend_thread_id", "") or "").strip() or None
-    )
-    current_runtime_instance_id = (
-        str(getattr(existing_thread, "backend_runtime_instance_id", "") or "").strip()
-        or None
-    )
     runtime_agent = resolve_chat_runtime_agent(
         agent,
         agent_profile,
@@ -2420,6 +2413,28 @@ def resolve_discord_thread_target(
         repo_id=repo_id,
         resource_kind=resource_kind,
         resource_id=resource_id,
+    )
+    canonical_workspace = str(workspace_root.resolve())
+    reusable_agent_ids = tuple(dict.fromkeys((agent, runtime_agent)))
+    existing_thread_reusable = (
+        existing_thread is not None
+        and str(getattr(existing_thread, "agent_id", "") or "").strip()
+        in reusable_agent_ids
+        and (getattr(existing_thread, "agent_profile", None) or None)
+        == (agent_profile or None)
+        and str(getattr(existing_thread, "workspace_root", "") or "").strip()
+        == canonical_workspace
+    )
+    current_backend_thread_id = (
+        str(getattr(existing_thread, "backend_thread_id", "") or "").strip() or None
+        if existing_thread_reusable
+        else None
+    )
+    current_runtime_instance_id = (
+        str(getattr(existing_thread, "backend_runtime_instance_id", "") or "").strip()
+        or None
+        if existing_thread_reusable
+        else None
     )
     return _shared_resolve_managed_thread_target(
         orchestration_service,

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -2377,6 +2377,37 @@ def resolve_discord_thread_target(
             "Discord orchestration service unavailable: hub control-plane client not connected"
         )
     surface_key = managed_thread_surface_key or channel_id
+    existing_binding = None
+    existing_thread = None
+    get_binding = getattr(orchestration_service, "get_binding", None)
+    get_thread_target = getattr(orchestration_service, "get_thread_target", None)
+    if callable(get_binding):
+        with contextlib.suppress(
+            RuntimeError, ValueError, TypeError, KeyError, AttributeError
+        ):
+            existing_binding = get_binding(
+                surface_kind="discord",
+                surface_key=surface_key,
+            )
+    normalized_mode = str(mode or "").strip().lower()
+    existing_thread_target_id = (
+        str(getattr(existing_binding, "thread_target_id", "") or "").strip()
+        if str(getattr(existing_binding, "mode", "") or "").strip().lower()
+        == normalized_mode
+        else ""
+    )
+    if callable(get_thread_target) and existing_thread_target_id:
+        with contextlib.suppress(
+            RuntimeError, ValueError, TypeError, KeyError, AttributeError
+        ):
+            existing_thread = get_thread_target(existing_thread_target_id)
+    current_backend_thread_id = (
+        str(getattr(existing_thread, "backend_thread_id", "") or "").strip() or None
+    )
+    current_runtime_instance_id = (
+        str(getattr(existing_thread, "backend_runtime_instance_id", "") or "").strip()
+        or None
+    )
     runtime_agent = resolve_chat_runtime_agent(
         agent,
         agent_profile,
@@ -2404,6 +2435,10 @@ def resolve_discord_thread_target(
             resource_id=owner_id,
             binding_metadata={"channel_id": channel_id, "pma_enabled": pma_enabled},
             reusable_agent_ids=(runtime_agent,),
+            backend_thread_id=current_backend_thread_id,
+            backend_runtime_instance_id=current_runtime_instance_id,
+            existing_binding=existing_binding,
+            existing_thread=existing_thread,
         ),
     )
 

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -80,6 +80,7 @@ from ..chat.managed_thread_turns import (
     ManagedThreadTargetRequest,
     ManagedThreadTurnCoordinator,
     complete_managed_thread_execution,
+    render_managed_thread_response_text,
 )
 from ..chat.managed_thread_turns import (
     build_managed_thread_input_items as _shared_build_managed_thread_input_items,
@@ -2567,7 +2568,7 @@ def _build_discord_runner_hooks(
 
     async def _deliver_result(finalized: ManagedThreadFinalizationResult) -> None:
         if finalized.status == "ok":
-            assistant_text = finalized.assistant_text.strip()
+            assistant_text = render_managed_thread_response_text(finalized)
             formatted = (
                 format_discord_message(assistant_text)
                 if assistant_text
@@ -3215,7 +3216,7 @@ async def _run_discord_orchestrated_turn_for_message(
                 render_mode="final",
             )
         return DiscordMessageTurnResult(
-            final_message=finalized.assistant_text,
+            final_message=render_managed_thread_response_text(finalized),
             preview_message_id=progress_message_id,
             execution_id=progress_execution_id,
             intermediate_message=intermediate_message,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -85,6 +85,7 @@ from .....integrations.chat.managed_thread_turns import (
     ManagedThreadTargetRequest,
     ManagedThreadTurnCoordinator,
     complete_managed_thread_execution,
+    render_managed_thread_response_text,
 )
 from .....integrations.chat.managed_thread_turns import (
     build_managed_thread_input_items as _shared_build_managed_thread_input_items,
@@ -879,9 +880,7 @@ async def _run_telegram_managed_thread_turn(
         finalized: ManagedThreadFinalizationResult,
     ) -> None:
         if finalized.status == "ok":
-            message_text = finalized.assistant_text.strip()
-            if not message_text:
-                message_text = "(No response text returned.)"
+            message_text = render_managed_thread_response_text(finalized)
             await handlers._send_message(
                 message.chat_id,
                 message_text,
@@ -1164,7 +1163,7 @@ async def _run_telegram_managed_thread_turn(
             record=record,
             thread_id=resolved_backend_thread_id,
             turn_id=backend_turn_id or None,
-            response=finalized.assistant_text,
+            response=render_managed_thread_response_text(finalized),
             placeholder_id=prepared_placeholder_id,
             elapsed_seconds=None,
             token_usage=finalized.token_usage,

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -929,13 +929,12 @@ async def test_send_message_rehydrates_from_transcripts_after_runtime_binding_re
     harness.start_turn_calls.clear()
 
     restarted_service = _build_service(tmp_path, harness)
-    next_execution = await restarted_service.send_message(
-        MessageRequest(
-            target_id=thread.thread_target_id,
-            target_kind="thread",
-            message_text="second question",
-        )
+    request = MessageRequest(
+        target_id=thread.thread_target_id,
+        target_kind="thread",
+        message_text="second question",
     )
+    next_execution = await restarted_service.send_message(request)
 
     prompt = harness.start_turn_calls[0]["prompt"]
     assert next_execution.status == "running"
@@ -945,6 +944,13 @@ async def test_send_message_rehydrates_from_transcripts_after_runtime_binding_re
     assert "first question" in prompt
     assert "first answer" in prompt
     assert "second question" in prompt
+    assert request.metadata["fresh_backend_session_started"] is True
+    assert request.metadata["fresh_backend_session_reason"] == "missing_backend_binding"
+    assert (
+        request.metadata["fresh_backend_session_notice"]
+        == "Notice: the previous live session was unavailable, so I started a new "
+        "session and recovered context from durable history."
+    )
 
 
 async def test_start_next_queued_execution_starts_fresh_after_runtime_binding_restart(

--- a/tests/discord_message_turns_support.py
+++ b/tests/discord_message_turns_support.py
@@ -9613,7 +9613,6 @@ async def test_resolve_discord_thread_target_stores_agent_profile_in_metadata(
         await store.close()
 
 
-@pytest.mark.anyio
 async def test_resolve_discord_thread_target_reuses_legacy_hermes_runtime_alias_thread(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integrations/chat/test_chat_runtime_helpers.py
+++ b/tests/integrations/chat/test_chat_runtime_helpers.py
@@ -73,6 +73,32 @@ async def test_resolve_chat_thread_runtime_binding_reuses_existing_binding_when_
 
 
 @pytest.mark.anyio
+async def test_resolve_chat_thread_runtime_binding_reuses_existing_binding_without_requested_backend_id(
+    tmp_path: Path,
+) -> None:
+    service = _RuntimeService("runtime-1")
+    existing_thread = SimpleNamespace(
+        agent_id="opencode",
+        agent_profile=None,
+        workspace_root=str(tmp_path.resolve()),
+        backend_thread_id="backend-old",
+    )
+
+    binding = await resolve_chat_thread_runtime_binding(
+        service,
+        agent_id="opencode",
+        workspace_root=tmp_path,
+        requested_backend_thread_id=None,
+        existing_thread=existing_thread,
+    )
+
+    assert binding.backend_thread_id == "backend-old"
+    assert binding.backend_runtime_instance_id == "runtime-1"
+    assert binding.runtime_available is True
+    assert binding.used_requested_backend_thread_id is False
+
+
+@pytest.mark.anyio
 async def test_resolve_chat_thread_runtime_binding_keeps_requested_binding_for_nonmatching_thread(
     tmp_path: Path,
 ) -> None:

--- a/tests/integrations/chat/test_managed_thread_turns.py
+++ b/tests/integrations/chat/test_managed_thread_turns.py
@@ -74,6 +74,22 @@ def _replace_started_execution(
     )
 
 
+def test_render_managed_thread_response_text_prepends_session_notice() -> None:
+    rendered = managed_thread_turns_module.render_managed_thread_response_text(
+        managed_thread_turns_module.ManagedThreadFinalizationResult(
+            status="ok",
+            assistant_text="Recovered answer",
+            error=None,
+            managed_thread_id="thread-1",
+            managed_turn_id="turn-1",
+            backend_thread_id="backend-1",
+            session_notice="Notice: a new session was started.",
+        )
+    )
+
+    assert rendered == "Notice: a new session was started.\n\nRecovered answer"
+
+
 @pytest.mark.anyio
 async def test_managed_thread_turn_coordinator_runs_lifecycle_hooks(
     tmp_path: Path,
@@ -1111,6 +1127,100 @@ async def test_finalize_managed_thread_execution_logs_timeout_source(
     assert fake_hub_client.trace_requests[0].backend_turn_id == "turn-1"
     assert fake_hub_client.transcript_requests == []
     assert fake_hub_client.activity_requests == []
+
+
+@pytest.mark.anyio
+async def test_finalize_managed_thread_execution_propagates_session_recovery_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = _started_execution_with_backend_ids(tmp_path)
+    started.request.metadata["fresh_backend_session_started"] = True
+    started.request.metadata["fresh_backend_session_reason"] = "missing_backend_binding"
+    started.request.metadata["fresh_backend_session_notice"] = (
+        "Notice: the previous live session was unavailable, so I started a new "
+        "session and recovered context from durable history."
+    )
+    fake_hub_client = _FakeHubPersistenceClient()
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "harness_supports_progress_event_stream",
+        lambda _harness: False,
+    )
+
+    async def _successful_outcome(*args: Any, **kwargs: Any) -> RuntimeThreadOutcome:
+        return RuntimeThreadOutcome(
+            status="ok",
+            assistant_text="fixture reply",
+            error=None,
+            backend_thread_id="session-2",
+            backend_turn_id="turn-2",
+        )
+
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "await_runtime_thread_outcome",
+        _successful_outcome,
+    )
+
+    orchestration_service = SimpleNamespace(
+        get_thread_target=lambda managed_thread_id: SimpleNamespace(
+            backend_thread_id="session-2"
+        ),
+        get_thread_runtime_binding=lambda managed_thread_id: SimpleNamespace(
+            backend_thread_id="session-2"
+        ),
+        record_execution_result=lambda *args, **kwargs: SimpleNamespace(
+            status="ok",
+            error=None,
+        ),
+    )
+
+    result = await managed_thread_turns_module.finalize_managed_thread_execution(
+        orchestration_service=orchestration_service,
+        started=started,
+        state_root=tmp_path,
+        hub_client=fake_hub_client,
+        surface=managed_thread_turns_module.ManagedThreadSurfaceInfo(
+            log_label="Telegram",
+            surface_kind="telegram",
+            surface_key="telegram:-1001:101",
+        ),
+        errors=managed_thread_turns_module.ManagedThreadErrorMessages(
+            public_execution_error="Telegram PMA execution failed",
+            timeout_error="Telegram PMA turn timed out",
+            interrupted_error="Telegram PMA turn interrupted",
+            timeout_seconds=5,
+        ),
+        logger=logging.getLogger("test.managed_thread.session_recovery"),
+        turn_preview="preview",
+    )
+
+    assert result.status == "ok"
+    assert (
+        result.session_notice
+        == "Notice: the previous live session was unavailable, so I started a new "
+        "session and recovered context from durable history."
+    )
+    assert result.fresh_backend_session_reason == "missing_backend_binding"
+    assert len(fake_hub_client.timeline_requests) == 1
+    assert (
+        fake_hub_client.timeline_requests[0].metadata["fresh_backend_session_started"]
+        is True
+    )
+    assert (
+        fake_hub_client.timeline_requests[0].metadata["fresh_backend_session_reason"]
+        == "missing_backend_binding"
+    )
+    assert len(fake_hub_client.transcript_requests) == 1
+    assert (
+        fake_hub_client.transcript_requests[0].metadata["fresh_backend_session_started"]
+        is True
+    )
+    assert (
+        fake_hub_client.transcript_requests[0].metadata["fresh_backend_session_reason"]
+        == "missing_backend_binding"
+    )
 
 
 @pytest.mark.anyio

--- a/tests/integrations/chat/test_managed_thread_turns.py
+++ b/tests/integrations/chat/test_managed_thread_turns.py
@@ -778,8 +778,66 @@ def test_resolve_managed_thread_target_keeps_backend_for_repo_resume_without_reb
 
     assert resolved_thread is not None
     assert clear_calls == []
-    assert resume_calls == [{"backend_runtime_instance_id": None}]
+    assert resume_calls == [
+        {
+            "backend_thread_id": "backend-existing",
+            "backend_runtime_instance_id": None,
+        }
+    ]
     assert resolved_thread.backend_thread_id == "backend-existing"
+
+
+def test_resolve_managed_thread_target_keeps_active_repo_binding_without_resume(
+    tmp_path: Path,
+) -> None:
+    canonical_workspace = str(tmp_path.resolve())
+    thread = SimpleNamespace(
+        thread_target_id="thread-1",
+        agent_id="codex",
+        agent_profile=None,
+        workspace_root=canonical_workspace,
+        lifecycle_status="active",
+        backend_thread_id="backend-existing",
+        backend_runtime_instance_id="runtime-1",
+    )
+    binding = SimpleNamespace(thread_target_id="thread-1", mode="repo")
+    resume_calls: list[dict[str, Any]] = []
+
+    class _Service:
+        def get_binding(self, *, surface_kind: str, surface_key: str) -> Any:
+            _ = surface_kind, surface_key
+            return binding
+
+        def get_thread_target(self, thread_target_id: str) -> Any:
+            assert thread_target_id == "thread-1"
+            return thread
+
+        def resume_thread_target(self, thread_target_id: str, **kwargs: Any) -> Any:
+            _ = thread_target_id
+            resume_calls.append(kwargs)
+            raise AssertionError("resume_thread_target should not be called")
+
+        def create_thread_target(self, *args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("create_thread_target should not be called")
+
+        def upsert_binding(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+    _, resolved_thread = managed_thread_turns_module.resolve_managed_thread_target(
+        _Service(),
+        request=managed_thread_turns_module.ManagedThreadTargetRequest(
+            surface_kind="discord",
+            surface_key="discord:channel-1",
+            mode="repo",
+            agent="codex",
+            workspace_root=tmp_path,
+            display_name="discord:surface",
+            binding_metadata={"channel_id": "channel-1"},
+        ),
+    )
+
+    assert resolved_thread is thread
+    assert resume_calls == []
 
 
 def test_resolve_managed_thread_target_reuses_backend_matched_thread(

--- a/tests/integrations/discord/test_message_turns_backend_binding.py
+++ b/tests/integrations/discord/test_message_turns_backend_binding.py
@@ -109,3 +109,104 @@ async def test_resolve_discord_thread_target_keeps_existing_backend_binding_for_
         ]
     finally:
         await store.close()
+
+
+@pytest.mark.anyio
+async def test_resolve_discord_thread_target_does_not_carry_stale_backend_binding_into_replacement_thread(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+    service = DiscordBotService(
+        _config(tmp_path, max_message_length=120),
+        logger=logging.getLogger("test"),
+        rest_client=_FakeRest(),
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    binding = SimpleNamespace(thread_target_id="thread-1", mode="pma")
+    thread = SimpleNamespace(
+        thread_target_id="thread-1",
+        agent_id="hermes",
+        agent_profile="other-profile",
+        workspace_root=str(workspace.resolve()),
+        lifecycle_status="active",
+        backend_thread_id="backend-stale",
+        backend_runtime_instance_id="runtime-stale",
+    )
+    create_calls: list[dict[str, Any]] = []
+    upserts: list[dict[str, Any]] = []
+
+    class _FakeThreadService:
+        def get_binding(self, *, surface_kind: str, surface_key: str) -> Any:
+            assert surface_kind == "discord"
+            assert surface_key == "channel-1"
+            return binding
+
+        def get_thread_target(self, thread_target_id: str) -> Any:
+            assert thread_target_id == "thread-1"
+            return thread
+
+        def resume_thread_target(self, thread_target_id: str, **kwargs: Any) -> Any:
+            raise AssertionError("resume_thread_target should not be called")
+
+        def create_thread_target(self, *args: Any, **kwargs: Any) -> Any:
+            create_calls.append(dict(kwargs))
+            return SimpleNamespace(
+                thread_target_id="thread-2",
+                agent_id="hermes",
+                agent_profile="m4-pma",
+                workspace_root=str(workspace.resolve()),
+                lifecycle_status="active",
+                backend_thread_id=kwargs.get("backend_thread_id"),
+                backend_runtime_instance_id=None,
+            )
+
+        def upsert_binding(self, **kwargs: Any) -> None:
+            upserts.append(kwargs)
+
+    service._discord_managed_thread_orchestration_service = _FakeThreadService()
+
+    try:
+        _orch, resolved = discord_message_turns_module.resolve_discord_thread_target(
+            service,
+            channel_id="channel-1",
+            workspace_root=workspace.resolve(),
+            agent="hermes",
+            agent_profile="m4-pma",
+            repo_id="repo-1",
+            resource_kind="repo",
+            resource_id="repo-1",
+            mode="pma",
+            pma_enabled=True,
+        )
+
+        assert resolved.thread_target_id == "thread-2"
+        assert len(create_calls) == 1
+        assert create_calls[0]["backend_thread_id"] is None
+        assert upserts == [
+            {
+                "surface_kind": "discord",
+                "surface_key": "channel-1",
+                "thread_target_id": "thread-2",
+                "agent_id": "hermes",
+                "repo_id": "repo-1",
+                "resource_kind": "repo",
+                "resource_id": "repo-1",
+                "mode": "pma",
+                "metadata": {"channel_id": "channel-1", "pma_enabled": True},
+            }
+        ]
+    finally:
+        await store.close()

--- a/tests/integrations/discord/test_message_turns_backend_binding.py
+++ b/tests/integrations/discord/test_message_turns_backend_binding.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from tests.discord_message_turns_support import (
+    _config,
+    _FakeGateway,
+    _FakeOutboxManager,
+    _FakeRest,
+)
+
+import codex_autorunner.integrations.discord.message_turns as discord_message_turns_module
+from codex_autorunner.integrations.discord.service import DiscordBotService
+from codex_autorunner.integrations.discord.state import DiscordStateStore
+
+
+@pytest.mark.anyio
+async def test_resolve_discord_thread_target_keeps_existing_backend_binding_for_pma_followup(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+    service = DiscordBotService(
+        _config(tmp_path, max_message_length=120),
+        logger=logging.getLogger("test"),
+        rest_client=_FakeRest(),
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    binding = SimpleNamespace(thread_target_id="thread-1", mode="pma")
+    thread = SimpleNamespace(
+        thread_target_id="thread-1",
+        agent_id="hermes",
+        agent_profile="m4-pma",
+        workspace_root=str(workspace.resolve()),
+        lifecycle_status="active",
+        backend_thread_id="backend-existing",
+        backend_runtime_instance_id="runtime-1",
+    )
+    resume_calls: list[dict[str, Any]] = []
+    upserts: list[dict[str, Any]] = []
+
+    class _FakeThreadService:
+        def get_binding(self, *, surface_kind: str, surface_key: str) -> Any:
+            assert surface_kind == "discord"
+            assert surface_key == "channel-1"
+            return binding
+
+        def get_thread_target(self, thread_target_id: str) -> Any:
+            assert thread_target_id == "thread-1"
+            return thread
+
+        def resume_thread_target(self, thread_target_id: str, **kwargs: Any) -> Any:
+            _ = thread_target_id
+            resume_calls.append(dict(kwargs))
+            raise AssertionError("resume_thread_target should not be called")
+
+        def create_thread_target(self, *args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("create_thread_target should not be called")
+
+        def upsert_binding(self, **kwargs: Any) -> None:
+            upserts.append(kwargs)
+
+    service._discord_managed_thread_orchestration_service = _FakeThreadService()
+
+    try:
+        _orch, resolved = discord_message_turns_module.resolve_discord_thread_target(
+            service,
+            channel_id="channel-1",
+            workspace_root=workspace.resolve(),
+            agent="hermes",
+            agent_profile="m4-pma",
+            repo_id="repo-1",
+            resource_kind="repo",
+            resource_id="repo-1",
+            mode="pma",
+            pma_enabled=True,
+        )
+
+        assert resolved is thread
+        assert resume_calls == []
+        assert upserts == [
+            {
+                "surface_kind": "discord",
+                "surface_key": "channel-1",
+                "thread_target_id": "thread-1",
+                "agent_id": "hermes",
+                "repo_id": "repo-1",
+                "resource_kind": "repo",
+                "resource_id": "repo-1",
+                "mode": "pma",
+                "metadata": {"channel_id": "channel-1", "pma_enabled": True},
+            }
+        ]
+    finally:
+        await store.close()

--- a/tests/telegram_pma_routing_support.py
+++ b/tests/telegram_pma_routing_support.py
@@ -2882,7 +2882,6 @@ async def test_resolve_telegram_managed_thread_reuses_archived_thread(
         pma_enabled=True,
         allow_new_thread=False,
     )
-
     assert resolved is not None
     assert resolved.thread_target_id == current_thread.thread_target_id
     assert resolved.lifecycle_status == "active"
@@ -2900,9 +2899,8 @@ async def test_resolve_telegram_managed_thread_ignores_backend_thread_id_binding
         async def resolve_backend_runtime_instance_id(
             self, agent_id: str, workspace_root: Path
         ) -> Optional[str]:
-            raise AssertionError(
-                "runtime instance lookup should be skipped in PMA mode"
-            )
+            _ = agent_id, workspace_root
+            return "runtime-test-1"
 
         def resume_thread_target(self, thread_target_id: str, **kwargs: Any) -> Any:
             calls.append((thread_target_id, dict(kwargs)))
@@ -2938,19 +2936,18 @@ async def test_resolve_telegram_managed_thread_ignores_backend_thread_id_binding
         ),
     )
 
-    (
-        _service,
-        resolved,
-    ) = await execution_commands_module._resolve_telegram_managed_thread(
-        SimpleNamespace(_logger=logging.getLogger("test")),
-        surface_key="telegram:-1001:101",
-        workspace_root=workspace.resolve(),
-        agent="codex",
-        repo_id="repo-1",
-        mode="pma",
-        pma_enabled=True,
-        backend_thread_id="stale-backend",
-        allow_new_thread=False,
+    _service, resolved = (
+        await execution_commands_module._resolve_telegram_managed_thread(
+            SimpleNamespace(_logger=logging.getLogger("test")),
+            surface_key="telegram:-1001:101",
+            workspace_root=workspace.resolve(),
+            agent="codex",
+            repo_id="repo-1",
+            mode="pma",
+            pma_enabled=True,
+            backend_thread_id="stale-backend",
+            allow_new_thread=False,
+        )
     )
 
     assert resolved is not None
@@ -2959,8 +2956,8 @@ async def test_resolve_telegram_managed_thread_ignores_backend_thread_id_binding
         (
             "thread-1",
             {
-                "backend_thread_id": None,
-                "backend_runtime_instance_id": None,
+                "backend_thread_id": "legacy-backend",
+                "backend_runtime_instance_id": "runtime-test-1",
             },
         )
     ]
@@ -3292,16 +3289,20 @@ async def test_pma_interrupt_uses_managed_thread_orchestration_for_text_turns(
         )
         with anyio.fail_after(2):
             while (
-                "Recovered stale PMA session after backend thread was lost. Cancelled 1 queued PMA turn(s)."
+                "Interrupted active PMA turn. Cancelled 1 queued PMA turn(s)."
                 not in handler._sent
             ):
                 await anyio.sleep(0.05)
         release_first.set()
         await first_task
 
-        assert harness.interrupt_calls == []
+        assert len(harness.interrupt_calls) == 1
+        assert harness.interrupt_calls[0][1:] == (
+            "telegram-backend-thread-1",
+            "telegram-backend-turn-1",
+        )
         assert (
-            "Recovered stale PMA session after backend thread was lost. Cancelled 1 queued PMA turn(s)."
+            "Interrupted active PMA turn. Cancelled 1 queued PMA turn(s)."
             in handler._sent
         )
         assert "unexpected queued reply" not in handler._sent

--- a/tests/telegram_pma_routing_support.py
+++ b/tests/telegram_pma_routing_support.py
@@ -4010,7 +4010,7 @@ async def test_repo_interrupt_uses_orchestration_binding_for_text_turns(
         )
         with anyio.fail_after(2):
             while (
-                "Recovered stale session after backend thread was lost. Cancelled 1 queued turn(s)."
+                "Interrupted active turn. Cancelled 1 queued turn(s)."
                 not in handler._sent
             ):
                 await anyio.sleep(0.05)
@@ -4018,11 +4018,12 @@ async def test_repo_interrupt_uses_orchestration_binding_for_text_turns(
         await first_task
 
         assert handler._client.thread_start_calls == []
-        assert harness.interrupt_calls == []
-        assert (
-            "Recovered stale session after backend thread was lost. Cancelled 1 queued turn(s)."
-            in handler._sent
+        assert len(harness.interrupt_calls) == 1
+        assert harness.interrupt_calls[0][1:] == (
+            "repo-backend-thread-1",
+            "repo-backend-turn-1",
         )
+        assert "Interrupted active turn. Cancelled 1 queued turn(s)." in handler._sent
         assert "unexpected queued repo reply" not in handler._sent
     finally:
         release_first.set()
@@ -4618,7 +4619,7 @@ async def test_repo_interrupt_uses_orchestration_binding_for_hermes_text_turns(
         )
         with anyio.fail_after(2):
             while (
-                "Recovered stale session after backend thread was lost. Cancelled 1 queued turn(s)."
+                "Interrupted active turn. Cancelled 1 queued turn(s)."
                 not in handler._sent
             ):
                 await anyio.sleep(0.05)
@@ -4626,11 +4627,9 @@ async def test_repo_interrupt_uses_orchestration_binding_for_hermes_text_turns(
         await first_task
 
         assert handler._client.thread_start_calls == []
-        assert harness.interrupt_calls == []
-        assert (
-            "Recovered stale session after backend thread was lost. Cancelled 1 queued turn(s)."
-            in handler._sent
-        )
+        assert len(harness.interrupt_calls) == 1
+        assert harness.interrupt_calls[0][1:] == ("hermes-fresh-1", "hermes-turn-1")
+        assert "Interrupted active turn. Cancelled 1 queued turn(s)." in handler._sent
         assert "unexpected hermes queued reply" not in handler._sent
     finally:
         release_first.set()

--- a/tests/test_telegram_session_recovery_notice.py
+++ b/tests/test_telegram_session_recovery_notice.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import pytest
+
+from codex_autorunner.core.orchestration.runtime_bindings import (
+    clear_runtime_thread_binding,
+)
+from tests import telegram_pma_routing_support as support
+
+_SESSION_NOTICE = (
+    "Notice: the previous live session was unavailable, so I started a new " "session."
+)
+
+
+@pytest.mark.anyio
+async def test_repo_turn_notifies_user_when_runtime_binding_restarts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    record = support.TelegramTopicRecord(
+        pma_enabled=False,
+        workspace_path=str(tmp_path),
+        repo_id="repo-1",
+        agent="codex",
+    )
+    handler = support._ManagedThreadPMAHandler(record, tmp_path)
+
+    class _FakeHarness:
+        display_name = "Fake"
+        capabilities = frozenset(
+            {
+                "durable_threads",
+                "message_turns",
+                "interrupt",
+                "event_streaming",
+            }
+        )
+
+        def __init__(self) -> None:
+            self.start_calls: list[tuple[str, str]] = []
+            self._conversation_count = 0
+
+        async def ensure_ready(self, workspace_root: Path) -> None:
+            assert workspace_root == tmp_path
+
+        async def backend_runtime_instance_id(
+            self, workspace_root: Path
+        ) -> Optional[str]:
+            assert workspace_root == tmp_path
+            return "runtime-test-1"
+
+        def supports(self, capability: str) -> bool:
+            return capability in self.capabilities
+
+        async def new_conversation(
+            self, workspace_root: Path, title: Optional[str] = None
+        ) -> SimpleNamespace:
+            _ = workspace_root, title
+            self._conversation_count += 1
+            return SimpleNamespace(id=f"repo-backend-thread-{self._conversation_count}")
+
+        async def resume_conversation(
+            self, workspace_root: Path, conversation_id: str
+        ) -> SimpleNamespace:
+            _ = workspace_root
+            return SimpleNamespace(id=conversation_id)
+
+        async def start_turn(
+            self,
+            workspace_root: Path,
+            conversation_id: str,
+            prompt: str,
+            model: Optional[str],
+            reasoning: Optional[str],
+            *,
+            approval_mode: Optional[str],
+            sandbox_policy: Optional[Any],
+            input_items: Optional[list[dict[str, Any]]] = None,
+        ) -> SimpleNamespace:
+            _ = model, reasoning, approval_mode, sandbox_policy, input_items
+            assert workspace_root == tmp_path
+            self.start_calls.append((conversation_id, prompt))
+            turn_id = f"{conversation_id}:turn-{len(self.start_calls)}"
+            return SimpleNamespace(conversation_id=conversation_id, turn_id=turn_id)
+
+        async def start_review(self, *args: Any, **kwargs: Any) -> SimpleNamespace:
+            raise AssertionError("review mode should not be used in this test")
+
+        async def wait_for_turn(
+            self,
+            workspace_root: Path,
+            conversation_id: str,
+            turn_id: Optional[str],
+            *,
+            timeout: Optional[float] = None,
+        ) -> SimpleNamespace:
+            _ = workspace_root, timeout
+            assert isinstance(turn_id, str)
+            return SimpleNamespace(
+                status="ok",
+                assistant_text=f"reply for {conversation_id}/{turn_id}",
+                errors=[],
+            )
+
+        async def interrupt(
+            self, workspace_root: Path, conversation_id: str, turn_id: Optional[str]
+        ) -> None:
+            _ = workspace_root, conversation_id, turn_id
+
+        async def stream_events(
+            self, workspace_root: Path, conversation_id: str, turn_id: str
+        ):
+            _ = workspace_root, conversation_id, turn_id
+            if False:
+                yield ""
+
+    harness = _FakeHarness()
+    monkeypatch.setattr(
+        support.execution_commands_module,
+        "get_registered_agents",
+        lambda context=None: {
+            "codex": support.AgentDescriptor(
+                id="codex",
+                name="Codex",
+                capabilities=harness.capabilities,
+                make_harness=lambda _ctx: harness,
+            )
+        },
+    )
+
+    first_message = support.TelegramMessage(
+        update_id=1,
+        message_id=10,
+        chat_id=-1001,
+        thread_id=101,
+        from_user_id=42,
+        text="first repo orchestration prompt",
+        date=None,
+        is_topic_message=True,
+    )
+    second_message = support.TelegramMessage(
+        update_id=2,
+        message_id=11,
+        chat_id=-1001,
+        thread_id=101,
+        from_user_id=42,
+        text="second repo orchestration prompt",
+        date=None,
+        is_topic_message=True,
+    )
+
+    await handler._handle_normal_message(first_message, runtime=support._RuntimeStub())
+
+    orchestration_service = (
+        support.execution_commands_module._build_telegram_thread_orchestration_service(
+            handler
+        )
+    )
+    binding = orchestration_service.get_binding(
+        surface_kind="telegram",
+        surface_key="-1001:101",
+    )
+    assert binding is not None
+    clear_runtime_thread_binding(tmp_path, binding.thread_target_id)
+
+    await handler._handle_normal_message(second_message, runtime=support._RuntimeStub())
+
+    assert harness.start_calls[0] == (
+        "repo-backend-thread-1",
+        "first repo orchestration prompt",
+    )
+    assert harness.start_calls[1][0] == "repo-backend-thread-2"
+    assert harness.start_calls[1][1] == "second repo orchestration prompt"
+    assert handler._sent[-1].startswith(_SESSION_NOTICE)
+    assert "reply for repo-backend-thread-2/" in handler._sent[-1]
+    assert record.active_thread_id == "repo-backend-thread-2"


### PR DESCRIPTION
## Summary
Fix managed-thread follow-up rebinding so existing backend conversations are preserved instead of being silently cleared.

## Root Cause
The shared managed-thread resolver resumed reusable threads even when no backend rebind had been requested. In the control-plane store, resuming a thread with `backend_thread_id=None` clears the stored backend binding. That made repo chats vulnerable to context loss whenever a reusable managed thread was resumed without an explicit backend id.

Discord PMA had an additional surface-specific regression: it reused the same managed thread target but did not pass the existing backend conversation id back into the shared resolver, so normal PMA follow-ups were treated like fresh PMA sessions and the backend binding was cleared before the next turn.

## What Changed
- Hardened the shared managed-thread resolver so repo-thread resumes preserve the current backend binding when no rebind is requested.
- Stopped needlessly resuming active reusable repo threads when there is no requested backend change.
- Updated the Discord managed-thread target resolver to carry forward the existing backend thread id and runtime instance id, so PMA follow-ups keep the live backend conversation.
- Added regression coverage for the shared resolver behavior and the Discord PMA follow-up path.
- Updated the Telegram repo interrupt characterization to assert the corrected behavior: with the binding preserved, interrupts now hit the live backend turn instead of falling back to lost-backend recovery.

## Validation
- `pytest tests/integrations/chat/test_managed_thread_turns.py`
- `pytest tests/integrations/discord/test_message_turns_backend_binding.py`
- `pytest tests/test_telegram_pma_managed_threads.py -k "repo_text_turns_use_orchestration_binding_and_preserve_thread_continuity or repo_interrupt_uses_orchestration_binding_for_text_turns or repo_interrupt_uses_orchestration_binding_for_hermes_text_turns"`
- `pytest tests/test_hotspot_budgets.py -k hotspot_file_budgets`
- Full pre-commit hook via `git commit`
