### PR TITLE
[codex] Recover from corrupted update cache fetch failures

### DIFF
--- a/src/codex_autorunner/core/update.py
+++ b/src/codex_autorunner/core/update.py
@@ -9,7 +9,7 @@ import sys
 import time
 from collections import deque
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Union
 from urllib.parse import unquote, urlparse
 
 from .git_utils import GitError, run_git
@@ -31,6 +31,15 @@ _UPDATE_LOCK_STARTUP_GRACE_SECONDS = 10.0
 _UPDATE_LOCK_CMD_HINTS = ("codex_autorunner.core.update_runner",)
 _UPDATE_BUILD_ARTIFACT_DIRS = ("build", "dist", ".eggs")
 _UPDATE_BUILD_ARTIFACT_GLOBS = ("*.egg-info", "src/*.egg-info")
+_UPDATE_CACHE_RECOVERY_HINTS = (
+    "unresolved deltas left after unpacking",
+    "unpack-objects failed",
+    "pack has bad object",
+    "bad object",
+    "index file corrupt",
+    "object file is empty",
+    "unable to read sha1 file",
+)
 _UPDATE_CMD_TIMEOUT_SECONDS = 300
 _SERVICE_STATUS_CHECK_TIMEOUT_SECONDS = 2
 _GIT_FETCH_UPDATE_TIMEOUT_SECONDS = 60
@@ -126,6 +135,13 @@ def _reset_update_cache_for_retry(
         )
         return False
     return True
+
+
+def _update_cache_refresh_failure_is_retryable(
+    error: Union[BaseException, str],
+) -> bool:
+    message = str(error).lower()
+    return any(hint in message for hint in _UPDATE_CACHE_RECOVERY_HINTS)
 
 
 def _run_refresh_script(
@@ -842,18 +858,28 @@ def _system_update_worker(
                     repo_ref,
                 )
                 try:
-                    _run_cmd(
-                        ["git", "remote", "set-url", "origin", repo_url],
-                        cwd=update_dir,
+                    try:
+                        _run_cmd(
+                            ["git", "remote", "set-url", "origin", repo_url],
+                            cwd=update_dir,
+                        )
+                    except (RuntimeError, OSError):
+                        _run_cmd(
+                            ["git", "remote", "add", "origin", repo_url],
+                            cwd=update_dir,
+                        )
+                    _run_cmd(["git", "fetch", "origin", repo_ref], cwd=update_dir)
+                    _run_cmd(["git", "reset", "--hard", "FETCH_HEAD"], cwd=update_dir)
+                    updated = True
+                except (RuntimeError, OSError) as exc:
+                    if not _update_cache_refresh_failure_is_retryable(exc):
+                        raise
+                    logger.warning(
+                        "Update cache refresh failed with recoverable git corruption; removing %s and recloning. %s",
+                        update_dir,
+                        exc,
                     )
-                except (RuntimeError, OSError):
-                    _run_cmd(
-                        ["git", "remote", "add", "origin", repo_url],
-                        cwd=update_dir,
-                    )
-                _run_cmd(["git", "fetch", "origin", repo_ref], cwd=update_dir)
-                _run_cmd(["git", "reset", "--hard", "FETCH_HEAD"], cwd=update_dir)
-                updated = True
+                    shutil.rmtree(update_dir)
         if not updated:
             if update_dir.exists():
                 shutil.rmtree(update_dir)

--- a/tests/test_system_update_worker.py
+++ b/tests/test_system_update_worker.py
@@ -316,6 +316,15 @@ def test_refresh_failure_is_retryable_only_for_packaging_style_errors() -> None:
     )
 
 
+def test_update_cache_refresh_failure_is_retryable_detects_git_corruption() -> None:
+    assert system.update_core._update_cache_refresh_failure_is_retryable(
+        "fatal: unresolved deltas left after unpacking\nfatal: unpack-objects failed"
+    )
+    assert not system.update_core._update_cache_refresh_failure_is_retryable(
+        "fatal: unable to access 'https://example.com/repo.git/': Could not resolve host"
+    )
+
+
 def test_spawn_update_process_writes_status(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
     calls: dict[str, object] = {}
@@ -502,6 +511,72 @@ def test_system_update_worker_sets_helper_python_for_refresh_script(
 
     assert captured_env["HELPER_PYTHON"] == "/opt/car/bin/python3"
     assert captured_env["UPDATE_DISCORD_SERVICE_NAME"] == "car-discord"
+
+
+def test_system_update_worker_reclones_when_cached_repo_fetch_is_corrupt(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    update_dir = tmp_path / "update"
+    (update_dir / ".git").mkdir(parents=True)
+    (update_dir / "stale.txt").write_text("stale", encoding="utf-8")
+    refresh_script = tmp_path / "safe-refresh-local-linux-hub.sh"
+    refresh_script.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+
+    monkeypatch.setattr(system.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(system.update_core, "_is_valid_git_repo", lambda _path: True)
+    monkeypatch.setattr(
+        system.update_core,
+        "_refresh_script",
+        lambda *_args, **_kwargs: refresh_script,
+    )
+    monkeypatch.setattr(
+        system.update_core,
+        "_run_refresh_script",
+        lambda **_kwargs: (0, ["Health check OK; update successful."]),
+    )
+
+    run_cmd_calls: list[tuple[list[str], Path]] = []
+    failed_fetch = False
+
+    def fake_run_cmd(cmd: list[str], cwd: Path) -> None:
+        nonlocal failed_fetch
+        run_cmd_calls.append((list(cmd), cwd))
+        if (
+            cmd == ["git", "fetch", "origin", "main"]
+            and cwd == update_dir
+            and not failed_fetch
+        ):
+            failed_fetch = True
+            raise RuntimeError(
+                "Command failed: git fetch origin main\n"
+                "Stdout: \n"
+                "Stderr: fatal: unresolved deltas left after unpacking\n"
+                "fatal: unpack-objects failed\n"
+            )
+
+    monkeypatch.setattr(system.update_core, "_run_cmd", fake_run_cmd)
+    logger = logging.getLogger("test")
+
+    system._system_update_worker(
+        repo_url="https://example.com/repo.git",
+        repo_ref="main",
+        update_dir=update_dir,
+        logger=logger,
+        update_target="web",
+        update_backend="systemd-user",
+        skip_checks=True,
+    )
+
+    payload = json.loads(system._update_status_path().read_text(encoding="utf-8"))
+    assert payload["status"] == "ok"
+    assert failed_fetch is True
+    assert not update_dir.exists()
+    assert (
+        ["git", "clone", "https://example.com/repo.git", str(update_dir)],
+        update_dir.parent,
+    ) in run_cmd_calls
 
 
 def test_system_update_worker_retries_refresh_after_packaging_failure(


### PR DESCRIPTION
## What changed
- recover from corrupted cached update repos during `git fetch`/`git reset` by removing the broken cache and recloning
- add focused tests for corruption detection and worker recovery

## Why
The updater crashed before the refresh script ran when the global update cache at `~/.codex-autorunner/update_cache` became corrupt. The concrete failure in `update-standalone.log` was:

```text
fatal: unresolved deltas left after unpacking
fatal: unpack-objects failed
```

That left update status at `error` with `Update crashed; see hub logs for details.` even though the hub state itself was not stuck.

## Impact
- updates now self-heal from this class of cached git corruption instead of hard-failing
- the next update can proceed after a fresh clone

## Validation
- `./.venv/bin/python -m pytest tests/test_system_update_worker.py -q`

## Runtime repair applied
- moved the corrupted global cache aside to `~/.codex-autorunner/update_cache.corrupt-20260414T124136Z` so the next `/update` starts from a clean clone
