### PR TITLE
[codex] Fix Discord long-running component responsiveness

### DIFF
--- a/src/codex_autorunner/integrations/discord/car_handlers/session_commands.py
+++ b/src/codex_autorunner/integrations/discord/car_handlers/session_commands.py
@@ -27,6 +27,7 @@ from ..components import (
 )
 from ..interaction_registry import NEWT_CANCEL_CUSTOM_ID, NEWT_HARD_RESET_CUSTOM_ID
 from ..interaction_runtime import (
+    defer_and_update_runtime_component_message,
     ensure_component_response_deferred,
     ensure_ephemeral_response_deferred,
     ensure_public_response_deferred,
@@ -97,6 +98,12 @@ def _format_newt_reject_message(reasons: list[str]) -> str:
         "Choose **Hard reset** to discard local changes and continue, or **Cancel** to keep them.",
     ]
     return format_discord_message("\n".join(lines))
+
+
+def _format_newt_hard_reset_progress_message() -> str:
+    return format_discord_message(
+        "Discarding local changes and starting a fresh `/car newt`..."
+    )
 
 
 async def _send_newt_response(
@@ -625,6 +632,13 @@ async def handle_car_newt_hard_reset(
         )
         return
 
+    deferred = await defer_and_update_runtime_component_message(
+        service,
+        interaction_id,
+        interaction_token,
+        _format_newt_hard_reset_progress_message(),
+        components=[],
+    )
     branch_name = _newt_branch_name(channel_id, workspace_root)
     try:
         await asyncio.to_thread(reset_worktree_to_head, workspace_root)

--- a/src/codex_autorunner/integrations/discord/flow_commands.py
+++ b/src/codex_autorunner/integrations/discord/flow_commands.py
@@ -46,6 +46,7 @@ from .components import (
 from .errors import DiscordTransientError
 from .interaction_registry import FLOW_ACTION_SELECT_PREFIX
 from .interaction_runtime import (
+    defer_and_update_runtime_component_message,
     ensure_component_response_deferred,
     ensure_public_response_deferred,
     interaction_response_deferred,
@@ -82,6 +83,94 @@ def flow_archive_prompt_text(record: FlowRunRecord) -> str:
 
 def flow_archive_in_progress_text(run_id: str) -> str:
     return f"Archiving run {run_id}... This can take a few seconds."
+
+
+def flow_restart_in_progress_text(run_id: str) -> str:
+    return f"Restarting run {run_id}..."
+
+
+def flow_resume_in_progress_text(run_id: str) -> str:
+    return f"Resuming run {run_id}..."
+
+
+def flow_stop_in_progress_text(run_id: str) -> str:
+    return f"Stopping run {run_id}..."
+
+
+def flow_refresh_in_progress_text(run_id: str) -> str:
+    return f"Refreshing run {run_id}..."
+
+
+async def _send_flow_public_response(
+    service: Any,
+    interaction_id: str,
+    interaction_token: str,
+    *,
+    deferred: bool,
+    text: str,
+    component_response: bool = False,
+    components: Optional[list[dict[str, Any]]] = None,
+) -> None:
+    if component_response:
+        await service.send_or_update_component_message(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=text,
+            components=components,
+        )
+        return
+    if components is not None:
+        await service.send_or_respond_public_with_components(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=text,
+            components=components,
+        )
+        return
+    await service.send_or_respond_public(
+        interaction_id=interaction_id,
+        interaction_token=interaction_token,
+        deferred=deferred,
+        text=text,
+    )
+
+
+async def _send_flow_ephemeral_response(
+    service: Any,
+    interaction_id: str,
+    interaction_token: str,
+    *,
+    deferred: bool,
+    text: str,
+    component_response: bool = False,
+    components: Optional[list[dict[str, Any]]] = None,
+) -> None:
+    if component_response:
+        await service.send_or_update_component_message(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=text,
+            components=components,
+        )
+        return
+    if components is not None:
+        await service.send_or_respond_ephemeral_with_components(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=text,
+            components=components,
+        )
+        return
+    await service.send_or_respond_ephemeral(
+        interaction_id=interaction_id,
+        interaction_token=interaction_token,
+        deferred=deferred,
+        text=text,
+    )
 
 
 def _normalize_run_id(value: str) -> Optional[str]:
@@ -978,6 +1067,7 @@ async def handle_flow_start(
     workspace_root: Path,
     options: dict[str, Any],
     deferred_public: Optional[bool] = None,
+    component_response: bool = False,
 ) -> None:
     force_new = bool(options.get("force_new"))
     restart_from = options.get("restart_from")
@@ -1068,10 +1158,12 @@ async def handle_flow_start(
                         user_message="Unable to query flow database. Please try again later.",
                     ) from None
                 if record is None:
-                    await service.send_or_respond_public(
-                        interaction_id=interaction_id,
-                        interaction_token=interaction_token,
+                    await _send_flow_public_response(
+                        service,
+                        interaction_id,
+                        interaction_token,
                         deferred=deferred_public,
+                        component_response=component_response,
                         text=(
                             "Reusing ticket_flow run "
                             f"{active_or_paused.id} ({active_or_paused.status.value})."
@@ -1083,10 +1175,12 @@ async def handle_flow_start(
                         workspace_root, record, store
                     )
                     if locked:
-                        await service.send_or_respond_ephemeral(
-                            interaction_id=interaction_id,
-                            interaction_token=interaction_token,
+                        await _send_flow_ephemeral_response(
+                            service,
+                            interaction_id,
+                            interaction_token,
                             deferred=deferred_public,
+                            component_response=component_response,
                             text=f"Run {record.id} is locked for reconcile; try again.",
                         )
                         return
@@ -1126,21 +1220,15 @@ async def handle_flow_start(
                     f"Reusing ticket_flow run {record.id} ({record.status.value})."
                 ),
             )
-            if status_buttons:
-                await service.send_or_respond_public_with_components(
-                    interaction_id=interaction_id,
-                    interaction_token=interaction_token,
-                    deferred=deferred_public,
-                    text=response_text,
-                    components=status_buttons,
-                )
-            else:
-                await service.send_or_respond_public(
-                    interaction_id=interaction_id,
-                    interaction_token=interaction_token,
-                    deferred=deferred_public,
-                    text=response_text,
-                )
+            await _send_flow_public_response(
+                service,
+                interaction_id,
+                interaction_token,
+                deferred=deferred_public,
+                component_response=component_response,
+                text=response_text,
+                components=status_buttons or [],
+            )
             return
 
     metadata: dict[str, Any] = {"origin": "discord", "force_new": force_new}
@@ -1154,10 +1242,12 @@ async def handle_flow_start(
             metadata=metadata,
         )
     except ValueError as exc:
-        await service.send_or_respond_ephemeral(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
+        await _send_flow_ephemeral_response(
+            service,
+            interaction_id,
+            interaction_token,
             deferred=deferred_public,
+            component_response=component_response,
             text=str(exc),
         )
         return
@@ -1194,20 +1284,24 @@ async def handle_flow_start(
             ) from None
         if record is None:
             prefix = "Started new" if force_new else "Started"
-            await service.send_or_respond_public(
-                interaction_id=interaction_id,
-                interaction_token=interaction_token,
+            await _send_flow_public_response(
+                service,
+                interaction_id,
+                interaction_token,
                 deferred=deferred_public,
+                component_response=component_response,
                 text=f"{prefix} ticket_flow run {started.run_id}.",
             )
             return
         try:
             record, _updated, locked = reconcile_flow_run(workspace_root, record, store)
             if locked:
-                await service.send_or_respond_ephemeral(
-                    interaction_id=interaction_id,
-                    interaction_token=interaction_token,
+                await _send_flow_ephemeral_response(
+                    service,
+                    interaction_id,
+                    interaction_token,
                     deferred=deferred_public,
+                    component_response=component_response,
                     text=f"Run {record.id} is locked for reconcile; try again.",
                 )
                 return
@@ -1247,21 +1341,15 @@ async def handle_flow_start(
         snapshot=snapshot,
         prefix=f"{prefix} ticket_flow run {record.id}.",
     )
-    if status_buttons:
-        await service.send_or_respond_public_with_components(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
-            deferred=deferred_public,
-            text=response_text,
-            components=status_buttons,
-        )
-    else:
-        await service.send_or_respond_public(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
-            deferred=deferred_public,
-            text=response_text,
-        )
+    await _send_flow_public_response(
+        service,
+        interaction_id,
+        interaction_token,
+        deferred=deferred_public,
+        component_response=component_response,
+        text=response_text,
+        components=status_buttons or [],
+    )
 
 
 async def handle_flow_restart(
@@ -1272,6 +1360,7 @@ async def handle_flow_restart(
     workspace_root: Path,
     options: dict[str, Any],
     deferred_public: Optional[bool] = None,
+    component_response: bool = False,
 ) -> None:
     if deferred_public is None:
         deferred_public = await ensure_public_response_deferred(
@@ -1343,10 +1432,12 @@ async def handle_flow_restart(
         store.close()
 
     if isinstance(run_id_opt, str) and run_id_opt.strip() and target is None:
-        await service.send_or_respond_ephemeral(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
+        await _send_flow_ephemeral_response(
+            service,
+            interaction_id,
+            interaction_token,
             deferred=deferred_public,
+            component_response=component_response,
             text=f"No ticket_flow run found for run_id {run_id_opt.strip()}.",
         )
         return
@@ -1356,10 +1447,12 @@ async def handle_flow_restart(
         try:
             await flow_service.stop_flow_run(target.id)
         except ValueError as exc:
-            await service.send_or_respond_ephemeral(
-                interaction_id=interaction_id,
-                interaction_token=interaction_token,
+            await _send_flow_ephemeral_response(
+                service,
+                interaction_id,
+                interaction_token,
                 deferred=deferred_public,
+                component_response=component_response,
                 text=str(exc),
             )
             return
@@ -1370,10 +1463,12 @@ async def handle_flow_restart(
             "failed",
         }:
             status_value = latest.status if latest is not None else "unknown"
-            await service.send_or_respond_public(
-                interaction_id=interaction_id,
-                interaction_token=interaction_token,
+            await _send_flow_public_response(
+                service,
+                interaction_id,
+                interaction_token,
                 deferred=deferred_public,
+                component_response=component_response,
                 text=(
                     f"Run {target.id} is still active ({status_value}); "
                     "restart aborted to avoid concurrent workers. Try again after it stops."
@@ -1391,6 +1486,7 @@ async def handle_flow_restart(
             "restart_from": target.id if target is not None else None,
         },
         deferred_public=deferred_public,
+        component_response=component_response,
     )
 
 
@@ -1507,6 +1603,7 @@ async def handle_flow_resume(
     options: dict[str, Any],
     channel_id: Optional[str] = None,
     guild_id: Optional[str] = None,
+    component_response: bool = False,
 ) -> None:
     deferred = await ensure_public_response_deferred(
         service,
@@ -1576,10 +1673,12 @@ async def handle_flow_resume(
         store.close()
 
     if target is None:
-        await service.send_or_respond_ephemeral(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
+        await _send_flow_ephemeral_response(
+            service,
+            interaction_id,
+            interaction_token,
             deferred=deferred,
+            component_response=component_response,
             text="No paused ticket_flow run found to resume.",
         )
         return
@@ -1600,21 +1699,36 @@ async def handle_flow_resume(
     try:
         updated = await flow_service.resume_flow_run(target.id)
     except ValueError as exc:
-        await service.send_or_respond_ephemeral(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
+        await _send_flow_ephemeral_response(
+            service,
+            interaction_id,
+            interaction_token,
             deferred=deferred,
+            component_response=component_response,
             text=str(exc),
         )
         return
 
     outbound_text = f"Resumed run {updated.run_id}."
-    await service.send_or_respond_ephemeral(
-        interaction_id=interaction_id,
-        interaction_token=interaction_token,
-        deferred=deferred,
-        text=outbound_text,
-    )
+    if component_response:
+        await handle_flow_status(
+            service,
+            interaction_id,
+            interaction_token,
+            workspace_root=workspace_root,
+            options={"run_id": updated.run_id},
+            channel_id=channel_id,
+            guild_id=guild_id,
+            update_message=True,
+            prefix=outbound_text,
+        )
+    else:
+        await service.send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=outbound_text,
+        )
     run_mirror.mirror_outbound(
         run_id=updated.run_id,
         platform="discord",
@@ -1636,6 +1750,7 @@ async def handle_flow_stop(
     options: dict[str, Any],
     channel_id: Optional[str] = None,
     guild_id: Optional[str] = None,
+    component_response: bool = False,
 ) -> None:
     deferred = await ensure_public_response_deferred(
         service,
@@ -1705,10 +1820,12 @@ async def handle_flow_stop(
         store.close()
 
     if target is None:
-        await service.send_or_respond_ephemeral(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
+        await _send_flow_ephemeral_response(
+            service,
+            interaction_id,
+            interaction_token,
             deferred=deferred,
+            component_response=component_response,
             text="No active ticket_flow run found to stop.",
         )
         return
@@ -1729,21 +1846,36 @@ async def handle_flow_stop(
     try:
         updated = await flow_service.stop_flow_run(target.id)
     except ValueError as exc:
-        await service.send_or_respond_ephemeral(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
+        await _send_flow_ephemeral_response(
+            service,
+            interaction_id,
+            interaction_token,
             deferred=deferred,
+            component_response=component_response,
             text=str(exc),
         )
         return
 
     outbound_text = f"Stop requested for run {updated.run_id} ({updated.status})."
-    await service.send_or_respond_ephemeral(
-        interaction_id=interaction_id,
-        interaction_token=interaction_token,
-        deferred=deferred,
-        text=outbound_text,
-    )
+    if component_response:
+        await handle_flow_status(
+            service,
+            interaction_id,
+            interaction_token,
+            workspace_root=workspace_root,
+            options={"run_id": updated.run_id},
+            channel_id=channel_id,
+            guild_id=guild_id,
+            update_message=True,
+            prefix=outbound_text,
+        )
+    else:
+        await service.send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=outbound_text,
+        )
     run_mirror.mirror_outbound(
         run_id=updated.run_id,
         platform="discord",
@@ -1927,6 +2059,7 @@ async def handle_flow_reply(
     channel_id: Optional[str] = None,
     guild_id: Optional[str] = None,
     user_id: Optional[str] = None,
+    component_response: bool = False,
 ) -> None:
     text = options.get("text")
     if not isinstance(text, str) or not text.strip():
@@ -2027,10 +2160,12 @@ async def handle_flow_reply(
         store.close()
 
     if target is None:
-        await service.send_or_respond_ephemeral(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
+        await _send_flow_ephemeral_response(
+            service,
+            interaction_id,
+            interaction_token,
             deferred=deferred,
+            component_response=component_response,
             text="No paused ticket_flow run found for reply.",
         )
         return
@@ -2053,10 +2188,12 @@ async def handle_flow_reply(
     try:
         updated = await flow_service.resume_flow_run(target.id)
     except ValueError as exc:
-        await service.send_or_respond_ephemeral(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
+        await _send_flow_ephemeral_response(
+            service,
+            interaction_id,
+            interaction_token,
             deferred=deferred,
+            component_response=component_response,
             text=str(exc),
         )
         return
@@ -2064,10 +2201,12 @@ async def handle_flow_reply(
     outbound_text = (
         f"Reply saved to {reply_path.name} and resumed run {updated.run_id}."
     )
-    await service.send_or_respond_ephemeral(
-        interaction_id=interaction_id,
-        interaction_token=interaction_token,
+    await _send_flow_ephemeral_response(
+        service,
+        interaction_id,
+        interaction_token,
         deferred=deferred,
+        component_response=component_response,
         text=outbound_text,
     )
     run_mirror.mirror_outbound(
@@ -2104,43 +2243,41 @@ async def handle_flow_button(
 
     run_id = parts[1]
     action = parts[2]
-    flow_service = service._ticket_flow_orchestration_service(workspace_root)
-
     if action == "resume":
-        try:
-            updated = await flow_service.resume_flow_run(run_id)
-        except (KeyError, ValueError) as exc:
-            await send_runtime_ephemeral(
-                service,
-                interaction_id,
-                interaction_token,
-                str(exc),
-            )
-            return
-
-        await send_runtime_ephemeral(
+        await defer_and_update_runtime_component_message(
             service,
             interaction_id,
             interaction_token,
-            f"Resumed run {updated.run_id}.",
+            flow_resume_in_progress_text(run_id),
+            components=[],
+        )
+        await handle_flow_resume(
+            service,
+            interaction_id,
+            interaction_token,
+            workspace_root=workspace_root,
+            options={"run_id": run_id},
+            channel_id=channel_id,
+            guild_id=guild_id,
+            component_response=True,
         )
     elif action == "stop":
-        try:
-            updated = await flow_service.stop_flow_run(run_id)
-        except (KeyError, ValueError) as exc:
-            await send_runtime_ephemeral(
-                service,
-                interaction_id,
-                interaction_token,
-                str(exc),
-            )
-            return
-
-        await send_runtime_ephemeral(
+        await defer_and_update_runtime_component_message(
             service,
             interaction_id,
             interaction_token,
-            f"Stop requested for run {updated.run_id} ({updated.status}).",
+            flow_stop_in_progress_text(run_id),
+            components=[],
+        )
+        await handle_flow_stop(
+            service,
+            interaction_id,
+            interaction_token,
+            workspace_root=workspace_root,
+            options={"run_id": run_id},
+            channel_id=channel_id,
+            guild_id=guild_id,
+            component_response=True,
         )
     elif action in {
         "archive",
@@ -2149,6 +2286,7 @@ async def handle_flow_button(
         "archive_confirm_prompt",
         "archive_cancel_prompt",
     }:
+        flow_service = service._ticket_flow_orchestration_service(workspace_root)
         deferred = await ensure_component_response_deferred(
             service,
             interaction_id,
@@ -2314,6 +2452,13 @@ async def handle_flow_button(
         )
         return
     elif action == "restart":
+        await defer_and_update_runtime_component_message(
+            service,
+            interaction_id,
+            interaction_token,
+            flow_restart_in_progress_text(run_id),
+            components=[],
+        )
         await handle_flow_restart(
             service,
             interaction_id,
@@ -2325,8 +2470,16 @@ async def handle_flow_button(
                 interaction_id,
                 interaction_token,
             ),
+            component_response=True,
         )
     elif action == "refresh":
+        await defer_and_update_runtime_component_message(
+            service,
+            interaction_id,
+            interaction_token,
+            flow_refresh_in_progress_text(run_id),
+            components=[],
+        )
         await handle_flow_status(
             service,
             interaction_id,

--- a/src/codex_autorunner/integrations/discord/flow_commands.py
+++ b/src/codex_autorunner/integrations/discord/flow_commands.py
@@ -1698,7 +1698,7 @@ async def handle_flow_resume(
     flow_service = service._ticket_flow_orchestration_service(workspace_root)
     try:
         updated = await flow_service.resume_flow_run(target.id)
-    except ValueError as exc:
+    except (KeyError, ValueError) as exc:
         await _send_flow_ephemeral_response(
             service,
             interaction_id,
@@ -1845,7 +1845,7 @@ async def handle_flow_stop(
     flow_service = service._ticket_flow_orchestration_service(workspace_root)
     try:
         updated = await flow_service.stop_flow_run(target.id)
-    except ValueError as exc:
+    except (KeyError, ValueError) as exc:
         await _send_flow_ephemeral_response(
             service,
             interaction_id,

--- a/src/codex_autorunner/integrations/discord/interaction_registry.py
+++ b/src/codex_autorunner/integrations/discord/interaction_registry.py
@@ -24,6 +24,7 @@ from ..chat.model_selection import (
     reasoning_effort_description,
 )
 from .interaction_runtime import (
+    defer_and_update_runtime_component_message,
     ensure_ephemeral_response_deferred,
 )
 
@@ -1791,8 +1792,16 @@ async def _handle_flow_action_select_component(service: Any, ctx: Any) -> None:
                 text="Reply selection expired. Re-run `/flow reply text:<...>`.",
             )
             return
+        await defer_and_update_runtime_component_message(
+            service,
+            ctx.interaction_id,
+            ctx.interaction_token,
+            f"Saving reply and resuming run {run_id}...",
+            components=[],
+        )
         kwargs["options"] = {"run_id": run_id, "text": pending_text}
         kwargs["user_id"] = ctx.user_id
+        kwargs["component_response"] = True
     await getattr(service, handler_name)(
         ctx.interaction_id,
         ctx.interaction_token,

--- a/src/codex_autorunner/integrations/discord/interaction_runtime.py
+++ b/src/codex_autorunner/integrations/discord/interaction_runtime.py
@@ -281,3 +281,26 @@ async def update_runtime_component_message(
         text=text,
         components=components or [],
     )
+
+
+async def defer_and_update_runtime_component_message(
+    runtime: DiscordInteractionRuntime,
+    interaction_id: str,
+    interaction_token: str,
+    text: str,
+    *,
+    components: Optional[list[dict[str, Any]]] = None,
+) -> bool:
+    deferred = await ensure_component_response_deferred(
+        runtime,
+        interaction_id,
+        interaction_token,
+    )
+    await runtime.send_or_update_component_message(
+        interaction_id=interaction_id,
+        interaction_token=interaction_token,
+        deferred=deferred,
+        text=text,
+        components=components,
+    )
+    return deferred

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -285,7 +285,10 @@ from .interaction_registry import (
     slash_command_route_for_path,
     slash_command_workspace_lock_policy,
 )
-from .interaction_runtime import ensure_ephemeral_response_deferred
+from .interaction_runtime import (
+    defer_and_update_runtime_component_message,
+    ensure_ephemeral_response_deferred,
+)
 from .interaction_session import (
     DiscordInteractionSession,
     InteractionSessionKind,
@@ -7556,6 +7559,7 @@ class DiscordBotService:
         channel_id: Optional[str] = None,
         guild_id: Optional[str] = None,
         user_id: Optional[str] = None,
+        component_response: bool = False,
     ) -> None:
         await self._run_effectful_handler(
             handle_flow_reply,
@@ -7566,6 +7570,7 @@ class DiscordBotService:
             channel_id=channel_id,
             guild_id=guild_id,
             user_id=user_id,
+            component_response=component_response,
         )
 
     def _write_user_reply(
@@ -8826,6 +8831,13 @@ class DiscordBotService:
         from .components import parse_cancel_turn_custom_id
 
         thread_target_id, execution_id = parse_cancel_turn_custom_id(custom_id)
+        await defer_and_update_runtime_component_message(
+            self,
+            interaction_id,
+            interaction_token,
+            "Stopping current turn...",
+            components=[],
+        )
         await self._handle_car_interrupt(
             interaction_id,
             interaction_token,
@@ -8882,6 +8894,13 @@ class DiscordBotService:
                 "Queued request is no longer pending.",
             )
             return
+        await defer_and_update_runtime_component_message(
+            self,
+            interaction_id,
+            interaction_token,
+            "Cancelling queued request...",
+            components=[],
+        )
         await clear_discord_turn_progress_leases(
             self,
             managed_thread_id=current_thread.thread_target_id,
@@ -8969,6 +8988,13 @@ class DiscordBotService:
                     "Queued request moved to the front.",
                 )
                 return
+        await defer_and_update_runtime_component_message(
+            self,
+            interaction_id,
+            interaction_token,
+            "Message received. Switching to it now...",
+            components=[],
+        )
         await self._handle_car_interrupt(
             interaction_id,
             interaction_token,
@@ -9017,6 +9043,13 @@ class DiscordBotService:
                 "Queued request is no longer pending.",
             )
             return
+        await defer_and_update_runtime_component_message(
+            self,
+            interaction_id,
+            interaction_token,
+            "Cancelling queued request...",
+            components=[],
+        )
         await self._clear_queued_notice(
             conversation_id=conversation_id,
             source_message_id=source_message_id,
@@ -9077,6 +9110,13 @@ class DiscordBotService:
                 "Queued request moved to the front.",
             )
             return
+        await defer_and_update_runtime_component_message(
+            self,
+            interaction_id,
+            interaction_token,
+            "Message received. Switching to it now...",
+            components=[],
+        )
         await self._handle_car_interrupt(
             interaction_id,
             interaction_token,

--- a/tests/integrations/discord/test_flow_handlers.py
+++ b/tests/integrations/discord/test_flow_handlers.py
@@ -1399,6 +1399,64 @@ async def test_flow_resume_button_updates_existing_status_message(
 
 
 @pytest.mark.anyio
+async def test_flow_resume_button_reports_stale_run_after_progress_update(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _workspace(tmp_path)
+    paused_run_id = str(uuid.uuid4())
+    _create_run(workspace, paused_run_id, status=FlowRunStatus.PAUSED)
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+
+    flow_service = _FlowServiceStub()
+
+    async def _resume_flow_run(run_id: str, *, force: bool = False) -> SimpleNamespace:
+        _ = force
+        flow_service.resume_calls.append(run_id)
+        raise KeyError(f"Unknown flow run '{run_id}'")
+
+    flow_service.resume_flow_run = _resume_flow_run  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.discord.service.build_ticket_flow_orchestration_service",
+        lambda *, workspace_root: flow_service,
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [_flow_component_interaction(f"flow:{paused_run_id}:resume")]
+    )
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await service.run_forever()
+        assert flow_service.resume_calls == [paused_run_id]
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
+        assert len(rest.edited_original_interaction_responses) == 2
+        progress_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert progress_payload["content"] == f"Resuming run {paused_run_id}..."
+        assert progress_payload["components"] == []
+        final_payload = rest.edited_original_interaction_responses[-1]["payload"]
+        assert final_payload["content"] == f"\"Unknown flow run '{paused_run_id}'\""
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_flow_stop_button_updates_existing_status_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1456,6 +1514,61 @@ async def test_flow_stop_button_updates_existing_status_message(
             in final_payload["content"]
         )
         assert "Status: stopped" in final_payload["content"]
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_flow_stop_button_reports_stale_run_after_progress_update(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _workspace(tmp_path)
+    running_run_id = str(uuid.uuid4())
+    _create_run(workspace, running_run_id, status=FlowRunStatus.RUNNING)
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+
+    flow_service = _FlowServiceStub()
+
+    async def _stop_flow_run(run_id: str) -> SimpleNamespace:
+        flow_service.stop_calls.append(run_id)
+        raise KeyError(f"Unknown flow run '{run_id}'")
+
+    flow_service.stop_flow_run = _stop_flow_run  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.discord.service.build_ticket_flow_orchestration_service",
+        lambda *, workspace_root: flow_service,
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway([_flow_component_interaction(f"flow:{running_run_id}:stop")])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await service.run_forever()
+        assert flow_service.stop_calls == [running_run_id]
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
+        assert len(rest.edited_original_interaction_responses) == 2
+        progress_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert progress_payload["content"] == f"Stopping run {running_run_id}..."
+        assert progress_payload["components"] == []
+        final_payload = rest.edited_original_interaction_responses[-1]["payload"]
+        assert final_payload["content"] == f"\"Unknown flow run '{running_run_id}'\""
     finally:
         await store.close()
 

--- a/tests/integrations/discord/test_flow_handlers.py
+++ b/tests/integrations/discord/test_flow_handlers.py
@@ -913,10 +913,13 @@ async def test_flow_refresh_button_updates_existing_status_message(
         assert "Status: running" in initial_payload["content"]
 
         assert refresh_payload["type"] == 6
-        assert len(rest.edited_original_interaction_responses) == 1
+        assert len(rest.edited_original_interaction_responses) == 2
+        progress_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert progress_payload["content"] == f"Refreshing run {run_id}..."
+        assert progress_payload["components"] == []
         assert (
             "Status: completed"
-            in rest.edited_original_interaction_responses[0]["payload"]["content"]
+            in rest.edited_original_interaction_responses[-1]["payload"]["content"]
         )
     finally:
         await store.close()
@@ -1320,11 +1323,139 @@ async def test_flow_restart_button_uses_component_safe_response_path(
         assert len(rest.interaction_responses) == 1
         payload = rest.interaction_responses[0]["payload"]
         assert payload["type"] == 6
-        assert len(rest.followup_messages) == 1
+        assert rest.followup_messages == []
+        assert len(rest.edited_original_interaction_responses) == 2
+        progress_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert progress_payload["content"] == f"Restarting run {failed_run_id}..."
+        assert progress_payload["components"] == []
         assert (
             f"Started new ticket_flow run {new_run_id}."
-            in rest.followup_messages[0]["payload"]["content"]
+            in rest.edited_original_interaction_responses[-1]["payload"]["content"]
         )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_flow_resume_button_updates_existing_status_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _workspace(tmp_path)
+    paused_run_id = str(uuid.uuid4())
+    _create_run(workspace, paused_run_id, status=FlowRunStatus.PAUSED)
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+
+    flow_service = _FlowServiceStub()
+
+    async def _resume_flow_run(run_id: str, *, force: bool = False) -> SimpleNamespace:
+        _ = force
+        flow_service.resume_calls.append(run_id)
+        with FlowStore(workspace / ".codex-autorunner" / "flows.db") as db:
+            db.update_flow_run_status(run_id, FlowRunStatus.RUNNING)
+        return SimpleNamespace(run_id=run_id, status="running")
+
+    flow_service.resume_flow_run = _resume_flow_run  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.discord.service.build_ticket_flow_orchestration_service",
+        lambda *, workspace_root: flow_service,
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway(
+        [_flow_component_interaction(f"flow:{paused_run_id}:resume")]
+    )
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await service.run_forever()
+        assert flow_service.resume_calls == [paused_run_id]
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
+        assert rest.followup_messages == []
+        assert len(rest.edited_original_interaction_responses) == 2
+        progress_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert progress_payload["content"] == f"Resuming run {paused_run_id}..."
+        assert progress_payload["components"] == []
+        final_payload = rest.edited_original_interaction_responses[-1]["payload"]
+        assert f"Resumed run {paused_run_id}." in final_payload["content"]
+        assert "Status:" in final_payload["content"]
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_flow_stop_button_updates_existing_status_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _workspace(tmp_path)
+    running_run_id = str(uuid.uuid4())
+    _create_run(workspace, running_run_id, status=FlowRunStatus.RUNNING)
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+
+    flow_service = _FlowServiceStub()
+
+    async def _stop_flow_run(run_id: str) -> SimpleNamespace:
+        flow_service.stop_calls.append(run_id)
+        with FlowStore(workspace / ".codex-autorunner" / "flows.db") as db:
+            db.update_flow_run_status(run_id, FlowRunStatus.STOPPED)
+        return SimpleNamespace(run_id=run_id, status="stopped")
+
+    flow_service.stop_flow_run = _stop_flow_run  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.discord.service.build_ticket_flow_orchestration_service",
+        lambda *, workspace_root: flow_service,
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway([_flow_component_interaction(f"flow:{running_run_id}:stop")])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await service.run_forever()
+        assert flow_service.stop_calls == [running_run_id]
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
+        assert rest.followup_messages == []
+        assert len(rest.edited_original_interaction_responses) == 2
+        progress_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert progress_payload["content"] == f"Stopping run {running_run_id}..."
+        assert progress_payload["components"] == []
+        final_payload = rest.edited_original_interaction_responses[-1]["payload"]
+        assert (
+            f"Stop requested for run {running_run_id} (stopped)."
+            in final_payload["content"]
+        )
+        assert "Status: stopped" in final_payload["content"]
     finally:
         await store.close()
 

--- a/tests/integrations/discord/test_interaction_runtime_contracts.py
+++ b/tests/integrations/discord/test_interaction_runtime_contracts.py
@@ -115,6 +115,32 @@ def _module_function_names(relative_path: str) -> set[str]:
     }
 
 
+def _function_node(relative_path: str, function_name: str) -> ast.AST:
+    repo_root = DISCORD_DIR.parents[3]
+    path = repo_root / relative_path
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == function_name:
+                return node
+    raise AssertionError(f"Function {function_name!r} not found in {relative_path}")
+
+
+def _function_has_call(
+    relative_path: str, function_name: str, callee_name: str
+) -> bool:
+    node = _function_node(relative_path, function_name)
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        func = child.func
+        if isinstance(func, ast.Name) and func.id == callee_name:
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == callee_name:
+            return True
+    return False
+
+
 def test_contract_only_boundary_modules_touch_raw_discord_response_primitives() -> None:
     users = _raw_response_users()
 
@@ -188,3 +214,37 @@ def test_contract_legacy_normalized_interaction_path_is_removed() -> None:
     assert "_handle_normalized_interaction" not in _module_function_names(
         "src/codex_autorunner/integrations/discord/service.py"
     )
+
+
+def test_contract_long_running_component_handlers_show_immediate_progress() -> None:
+    required_helper = "defer_and_update_runtime_component_message"
+    targets = {
+        "src/codex_autorunner/integrations/discord/car_handlers/session_commands.py": (
+            "handle_car_newt_hard_reset",
+        ),
+        "src/codex_autorunner/integrations/discord/flow_commands.py": (
+            "handle_flow_button",
+        ),
+        "src/codex_autorunner/integrations/discord/interaction_registry.py": (
+            "_handle_flow_action_select_component",
+        ),
+        "src/codex_autorunner/integrations/discord/service.py": (
+            "_handle_cancel_turn_button",
+            "_handle_cancel_queued_turn_button",
+            "_handle_queued_turn_interrupt_send_button",
+            "_handle_queue_cancel_button",
+            "_handle_queue_interrupt_send_button",
+        ),
+    }
+
+    missing = {
+        relative_path: [
+            function_name
+            for function_name in function_names
+            if not _function_has_call(relative_path, function_name, required_helper)
+        ]
+        for relative_path, function_names in targets.items()
+    }
+    missing = {path: names for path, names in missing.items() if names}
+
+    assert missing == {}

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -3365,8 +3365,7 @@ async def test_component_interaction_queue_cancel_cancels_selected_pending_messa
             == "Queued request cancelled."
         )
         assert (
-            rest.edited_original_interaction_responses[-1]["payload"]["content"]
-            == "Queued request cancelled."
+            rest.edited_original_interaction_responses[-1]["payload"]["components"] == []
         )
     finally:
         await store.close()

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -3350,8 +3350,22 @@ async def test_component_interaction_queue_cancel_cancels_selected_pending_messa
         assert rest.deleted_channel_messages == [
             {"channel_id": "channel-1", "message_id": "notice-1"}
         ]
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
+        assert len(rest.edited_original_interaction_responses) == 2
         assert (
-            rest.interaction_responses[-1]["payload"]["data"]["content"]
+            rest.edited_original_interaction_responses[0]["payload"]["content"]
+            == "Cancelling queued request..."
+        )
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["components"] == []
+        )
+        assert (
+            rest.edited_original_interaction_responses[-1]["payload"]["content"]
+            == "Queued request cancelled."
+        )
+        assert (
+            rest.edited_original_interaction_responses[-1]["payload"]["content"]
             == "Queued request cancelled."
         )
     finally:
@@ -3425,6 +3439,14 @@ async def test_component_interaction_queue_interrupt_send_promotes_and_interrupt
                 "m-2",
             )
         ]
+        assert len(rest.edited_original_interaction_responses) == 1
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["content"]
+            == "Message received. Switching to it now..."
+        )
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["components"] == []
+        )
     finally:
         await store.close()
 
@@ -3489,12 +3511,26 @@ async def test_component_interaction_cancel_queued_turn_cancels_selected_executi
         finally:
             discord_message_turns.clear_discord_turn_progress_leases = original_clear  # type: ignore[assignment]
 
+        assert len(rest.edited_original_interaction_responses) == 2
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["content"]
+            == "Cancelling queued request..."
+        )
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["components"] == []
+        )
+        assert (
+            rest.edited_original_interaction_responses[-1]["payload"]["content"]
+            == "Queued request cancelled."
+        )
         assert rest.edited_channel_messages[-1]["message_id"] == "progress-2"
         assert rest.edited_channel_messages[-1]["payload"]["content"] == (
             "Queued request cancelled."
         )
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
         assert (
-            rest.interaction_responses[-1]["payload"]["data"]["content"]
+            rest.edited_original_interaction_responses[-1]["payload"]["content"]
             == "Queued request cancelled."
         )
     finally:
@@ -3573,6 +3609,14 @@ async def test_component_interaction_queued_turn_interrupt_send_promotes_and_int
                 False,
             )
         ]
+        assert len(rest.edited_original_interaction_responses) == 1
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["content"]
+            == "Message received. Switching to it now..."
+        )
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["components"] == []
+        )
     finally:
         await store.close()
 
@@ -5510,6 +5554,7 @@ async def test_component_interaction_flow_action_reply_uses_pending_text(
         channel_id: str | None = None,
         guild_id: str | None = None,
         user_id: str | None = None,
+        component_response: bool = False,
     ) -> None:
         _ = (
             interaction_id,
@@ -5520,6 +5565,7 @@ async def test_component_interaction_flow_action_reply_uses_pending_text(
             user_id,
         )
         captured["options"] = options
+        captured["component_response"] = component_response
 
     service._handle_flow_reply = _fake_handle_flow_reply  # type: ignore[assignment]
 
@@ -5527,6 +5573,17 @@ async def test_component_interaction_flow_action_reply_uses_pending_text(
         await service.run_forever()
         assert captured["options"]["run_id"] == "run-1"
         assert captured["options"]["text"] == "reply from pending"
+        assert captured["component_response"] is True
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
+        assert len(rest.edited_original_interaction_responses) == 1
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["content"]
+            == "Saving reply and resuming run run-1..."
+        )
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["components"] == []
+        )
         assert service._pending_flow_reply_text["channel-1:user-2"] == "other pending"
     finally:
         await store.close()
@@ -7890,8 +7947,11 @@ async def test_car_newt_hard_reset_button_discards_changes_and_retries(
             6,
         ]
         assert len(rest.followup_messages) == 1
-        assert len(rest.edited_original_interaction_responses) == 1
-        edited_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert len(rest.edited_original_interaction_responses) == 2
+        progress_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert "discarding local changes" in progress_payload["content"].lower()
+        assert progress_payload["components"] == []
+        edited_payload = rest.edited_original_interaction_responses[-1]["payload"]
         assert "reset branch" in edited_payload["content"].lower()
         assert "origin/master" in edited_payload["content"].lower()
         assert edited_payload["components"] == []
@@ -8042,8 +8102,11 @@ async def test_car_newt_hard_reset_reports_discard_when_retry_reset_fails(
         assert len(rest.interaction_responses) == 2
         assert rest.interaction_responses[1]["payload"]["type"] == 6
         assert hard_reset_calls == [workspace.resolve()]
-        assert len(rest.edited_original_interaction_responses) == 1
-        edited_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert len(rest.edited_original_interaction_responses) == 2
+        progress_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert "discarding local changes" in progress_payload["content"].lower()
+        assert progress_payload["components"] == []
+        edited_payload = rest.edited_original_interaction_responses[-1]["payload"]
         content = edited_payload["content"].lower()
         assert "local changes were discarded" in content
         assert "retry `/car newt`" in content
@@ -8116,8 +8179,11 @@ async def test_car_newt_hard_reset_reports_when_tracked_discard_step_fails(
         await service.run_forever()
         assert len(rest.interaction_responses) == 2
         assert rest.interaction_responses[1]["payload"]["type"] == 6
-        assert len(rest.edited_original_interaction_responses) == 1
-        edited_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert len(rest.edited_original_interaction_responses) == 2
+        progress_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert "discarding local changes" in progress_payload["content"].lower()
+        assert progress_payload["components"] == []
+        edited_payload = rest.edited_original_interaction_responses[-1]["payload"]
         content = edited_payload["content"].lower()
         assert "did not complete cleanly" in content
         assert "simulated failure" in content
@@ -8195,8 +8261,11 @@ async def test_car_newt_hard_reset_reports_when_untracked_cleanup_fails(
         await service.run_forever()
         assert len(rest.interaction_responses) == 2
         assert rest.interaction_responses[1]["payload"]["type"] == 6
-        assert len(rest.edited_original_interaction_responses) == 1
-        edited_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert len(rest.edited_original_interaction_responses) == 2
+        progress_payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert "discarding local changes" in progress_payload["content"].lower()
+        assert progress_payload["components"] == []
+        edited_payload = rest.edited_original_interaction_responses[-1]["payload"]
         content = edited_payload["content"].lower()
         assert "tracked changes were discarded" in content
         assert "some untracked paths could not be removed" in content
@@ -8891,8 +8960,16 @@ async def test_cancel_turn_button_stale_execution_does_not_interrupt_newer_turn(
         )
 
         assert stop_calls == []
+        assert len(rest.edited_original_interaction_responses) == 1
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["content"]
+            == "Stopping current turn..."
+        )
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["components"] == []
+        )
         assert len(rest.interaction_responses) == 1
-        assert rest.interaction_responses[0]["payload"]["type"] == 5
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
         assert len(rest.followup_messages) == 1
         assert "older turn" in rest.followup_messages[0]["payload"]["content"].lower()
         assert len(rest.edited_channel_messages) == 1

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -3365,7 +3365,8 @@ async def test_component_interaction_queue_cancel_cancels_selected_pending_messa
             == "Queued request cancelled."
         )
         assert (
-            rest.edited_original_interaction_responses[-1]["payload"]["components"] == []
+            rest.edited_original_interaction_responses[-1]["payload"]["components"]
+            == []
         )
     finally:
         await store.close()


### PR DESCRIPTION
## Summary

This PR makes long-running Discord component interactions visibly responsive instead of waiting until the expensive work finishes before anything changes on screen.

## What Changed

- added a shared `defer_and_update_runtime_component_message(...)` helper in the Discord interaction runtime
- kept the existing `/car newt` hard-reset fix and extended the same pattern to the remaining Discord flow buttons
  - `restart`
  - `resume`
  - `stop`
  - `refresh`
  - flow-reply picker selection
- updated turn-control component handlers in the Discord service so interrupt/cancel actions immediately replace the source message with in-progress state before the heavier work runs
- added a narrow AST contract test that asserts the specific long-running component entrypoints continue to use the progress-update helper

## Why

The root issue was structural: several component handlers deferred the interaction but only produced a visible message change after the actual operation completed. On Discord that reads as a dead button press.

This change standardizes the fix where it is cheap and low-noise: show an immediate component-message update first, then let the final status or completion update replace that same message.

## Validation

Targeted verification:

- `pytest -q tests/integrations/discord/test_flow_handlers.py::test_flow_refresh_button_updates_existing_status_message tests/integrations/discord/test_flow_handlers.py::test_flow_restart_button_uses_component_safe_response_path tests/integrations/discord/test_flow_handlers.py::test_flow_resume_button_updates_existing_status_message tests/integrations/discord/test_flow_handlers.py::test_flow_stop_button_updates_existing_status_message tests/integrations/discord/test_service_routing.py::test_component_interaction_flow_action_reply_uses_pending_text tests/integrations/discord/test_service_routing.py::test_component_interaction_queue_cancel_cancels_selected_pending_message tests/integrations/discord/test_service_routing.py::test_component_interaction_queue_interrupt_send_promotes_and_interrupts tests/integrations/discord/test_service_routing.py::test_component_interaction_cancel_queued_turn_cancels_selected_execution tests/integrations/discord/test_service_routing.py::test_component_interaction_queued_turn_interrupt_send_promotes_and_interrupts tests/integrations/discord/test_service_routing.py::test_cancel_turn_button_stale_execution_does_not_interrupt_newer_turn tests/integrations/discord/test_interaction_runtime_contracts.py::test_contract_long_running_component_handlers_show_immediate_progress`
- `pytest -q tests/integrations/discord/test_interaction_runtime_contracts.py tests/integrations/discord/test_service_routing.py::test_component_flow_reply_pending_state_is_user_scoped`
- `ruff check` on touched Discord/runtime/test files

Repo hook verification during commit:

- repo-wide `mypy`
- frontend build and JS tests
- full repo `pytest` sweep via hook (`5148 passed`)
