### PR TITLE
[codex] Fix CAR process monitor grouping

### DIFF
--- a/src/codex_autorunner/core/diagnostics/process_monitor.py
+++ b/src/codex_autorunner/core/diagnostics/process_monitor.py
@@ -17,25 +17,31 @@ from .process_snapshot import ProcessOwnership, collect_processes, enrich_with_o
 
 logger = logging.getLogger(__name__)
 
-PROCESS_MONITOR_VERSION = 1
+PROCESS_MONITOR_VERSION = 2
 DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS = 120
 DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS = 3 * 60 * 60
 _DEFAULT_PROCESS_MONITOR_SAMPLE_LIMIT = 120
 _PROCESS_MONITOR_FILENAME = "process-monitor.json"
 
 _ABSOLUTE_ALERT_FLOORS = {
+    "car_services": 12,
+    "managed_runtimes": 12,
     "opencode": 12,
-    "app_server": 12,
+    "codex_app_server": 12,
     "total": 18,
 }
 _RELATIVE_ALERT_MINIMUMS = {
+    "car_services": 6,
+    "managed_runtimes": 6,
     "opencode": 6,
-    "app_server": 6,
+    "codex_app_server": 6,
     "total": 10,
 }
 _DELTA_ALERT_FLOORS = {
+    "car_services": 3,
+    "managed_runtimes": 3,
     "opencode": 3,
-    "app_server": 3,
+    "codex_app_server": 3,
     "total": 4,
 }
 _MIN_BASELINE_SAMPLES = 5
@@ -100,22 +106,52 @@ def _ownership_counts(snapshot_items: list[Any]) -> dict[str, int]:
     return counts
 
 
+def _merge_ownership_counts(*groups: dict[str, int]) -> dict[str, int]:
+    merged: dict[str, int] = {}
+    for group in groups:
+        for key, value in group.items():
+            merged[key] = merged.get(key, 0) + int(value or 0)
+    return merged
+
+
+def _sample_count(
+    sample: dict[str, Any],
+    key: str,
+    *,
+    legacy_keys: tuple[str, ...] = (),
+    default: int = 0,
+) -> int:
+    for candidate in (key, *legacy_keys):
+        if candidate in sample and sample.get(candidate) is not None:
+            return _coerce_int(sample.get(candidate), default=default)
+    return default
+
+
 def capture_process_monitor_sample(root: Path) -> dict[str, Any]:
     resolved_root = Path(root).resolve()
     snapshot = collect_processes()
     snapshot = enrich_with_ownership(snapshot, resolved_root)
 
     opencode_ownership = _ownership_counts(snapshot.opencode_processes)
-    app_server_ownership = _ownership_counts(snapshot.app_server_processes)
+    codex_app_server_ownership = _ownership_counts(snapshot.app_server_processes)
+    managed_runtime_ownership = _merge_ownership_counts(
+        opencode_ownership,
+        codex_app_server_ownership,
+    )
 
     sample: dict[str, Any] = {
         "captured_at": _utc_iso(_utc_now()),
+        "car_service_count": int(snapshot.car_service_count),
+        "managed_runtime_count": int(snapshot.managed_runtime_count),
         "opencode_count": int(snapshot.opencode_count),
-        "app_server_count": int(snapshot.app_server_count),
-        "total_count": int(snapshot.opencode_count + snapshot.app_server_count),
+        "app_server_count": int(snapshot.codex_app_server_count),
+        "codex_app_server_count": int(snapshot.codex_app_server_count),
+        "total_count": int(snapshot.total_count),
         "ownership": {
+            "managed_runtimes": managed_runtime_ownership,
             "opencode": opencode_ownership,
-            "app_server": app_server_ownership,
+            "app_server": codex_app_server_ownership,
+            "codex_app_server": codex_app_server_ownership,
         },
     }
 
@@ -172,6 +208,8 @@ class ProcessMonitorStore:
             logger.warning("Failed to read process monitor store %s", self._path)
             return self._default_payload()
         if not isinstance(payload, dict):
+            return self._default_payload()
+        if _coerce_int(payload.get("version")) != PROCESS_MONITOR_VERSION:
             return self._default_payload()
         samples = payload.get("samples")
         if not isinstance(samples, list):
@@ -376,38 +414,90 @@ def build_process_monitor_summary(
         )
 
     opencode_values = [_coerce_int(entry.get("opencode_count")) for entry in samples]
-    app_server_values = [
-        _coerce_int(entry.get("app_server_count")) for entry in samples
+    car_service_values = [
+        _sample_count(entry, "car_service_count") for entry in samples
     ]
-    total_values = [_coerce_int(entry.get("total_count")) for entry in samples]
+    managed_runtime_values = [
+        _sample_count(
+            entry,
+            "managed_runtime_count",
+            legacy_keys=("total_count",),
+        )
+        for entry in samples
+    ]
+    codex_app_server_values = [
+        _sample_count(
+            entry,
+            "codex_app_server_count",
+            legacy_keys=("app_server_count",),
+        )
+        for entry in samples
+    ]
+    total_values = [
+        _sample_count(
+            entry,
+            "total_count",
+            default=(
+                _sample_count(entry, "car_service_count")
+                + _sample_count(
+                    entry,
+                    "managed_runtime_count",
+                    legacy_keys=("total_count",),
+                )
+            ),
+        )
+        for entry in samples
+    ]
     latest_sample = latest if isinstance(latest, dict) else {}
+    latest_car_services = _sample_count(latest_sample, "car_service_count")
+    latest_managed_runtimes = _sample_count(
+        latest_sample,
+        "managed_runtime_count",
+        legacy_keys=("total_count",),
+    )
     latest_opencode = _coerce_int(latest_sample.get("opencode_count"))
-    latest_app_server = _coerce_int(latest_sample.get("app_server_count"))
-    latest_total = _coerce_int(latest_sample.get("total_count"))
+    latest_codex_app_server = _sample_count(
+        latest_sample,
+        "codex_app_server_count",
+        legacy_keys=("app_server_count",),
+    )
+    latest_total = _sample_count(
+        latest_sample,
+        "total_count",
+        default=(latest_car_services + latest_managed_runtimes),
+    )
 
     metrics = {
+        "car_services": _summarize_metric(
+            "car_services", latest_car_services, car_service_values
+        ),
+        "managed_runtimes": _summarize_metric(
+            "managed_runtimes",
+            latest_managed_runtimes,
+            managed_runtime_values,
+        ),
         "opencode": _summarize_metric("opencode", latest_opencode, opencode_values),
-        "app_server": _summarize_metric(
-            "app_server",
-            latest_app_server,
-            app_server_values,
+        "codex_app_server": _summarize_metric(
+            "codex_app_server",
+            latest_codex_app_server,
+            codex_app_server_values,
         ),
         "total": _summarize_metric("total", latest_total, total_values),
     }
+    primary_metrics = tuple(metrics.values())
     lifecycle_counts = dict(
         ((latest_sample.get("opencode_lifecycle") or {}).get("counts") or {})
     )
     stale_records = _coerce_int(lifecycle_counts.get("stale"))
-    status = "warning" if any(metric.abnormal for metric in metrics.values()) else "ok"
+    status = "warning" if any(metric.abnormal for metric in primary_metrics) else "ok"
     if stale_records > 0:
         status = "warning"
     reasons = [
-        metric.reason
-        for metric in metrics.values()
-        if metric.abnormal and metric.reason
+        metric.reason for metric in primary_metrics if metric.abnormal and metric.reason
     ]
     if stale_records > 0:
         reasons.append(f"OpenCode lifecycle reports stale={stale_records}")
+    metrics["app_server"] = metrics["codex_app_server"]
 
     return {
         "status": status,
@@ -419,10 +509,23 @@ def build_process_monitor_summary(
         "latest_at": _utc_iso(latest_at) if latest_at is not None else None,
         "metrics": {name: metric.to_dict() for name, metric in metrics.items()},
         "latest": {
+            "car_service_count": latest_car_services,
+            "managed_runtime_count": latest_managed_runtimes,
             "opencode_count": latest_opencode,
-            "app_server_count": latest_app_server,
+            "app_server_count": latest_codex_app_server,
+            "codex_app_server_count": latest_codex_app_server,
             "total_count": latest_total,
-            "ownership": dict(latest_sample.get("ownership") or {}),
+            "ownership": {
+                **dict(latest_sample.get("ownership") or {}),
+                "app_server": dict(
+                    (
+                        dict(latest_sample.get("ownership") or {}).get(
+                            "codex_app_server"
+                        )
+                        or {}
+                    )
+                ),
+            },
             "opencode_lifecycle": dict(latest_sample.get("opencode_lifecycle") or {}),
         },
         "reasons": reasons,

--- a/src/codex_autorunner/core/diagnostics/process_snapshot.py
+++ b/src/codex_autorunner/core/diagnostics/process_snapshot.py
@@ -12,6 +12,7 @@ from ...core.managed_processes import ProcessRecord, list_process_records
 
 
 class ProcessCategory(Enum):
+    CAR_SERVICE = "car_service"
     OPENCODE = "opencode"
     APP_SERVER = "app_server"
     OTHER = "other"
@@ -39,6 +40,7 @@ class ProcessInfo:
 
 @dataclass
 class ProcessSnapshot:
+    car_service_processes: list[ProcessInfo] = field(default_factory=list)
     opencode_processes: list[ProcessInfo] = field(default_factory=list)
     app_server_processes: list[ProcessInfo] = field(default_factory=list)
     other_processes: list[ProcessInfo] = field(default_factory=list)
@@ -73,10 +75,28 @@ class ProcessSnapshot:
 
         return {
             "collected_at": self.collected_at,
+            "counts": {
+                "car_services": self.car_service_count,
+                "managed_runtimes": self.managed_runtime_count,
+                "opencode": self.opencode_count,
+                "codex_app_server": self.codex_app_server_count,
+                "app_server": self.codex_app_server_count,
+                "total": self.total_count,
+            },
+            "car_services": [
+                _process_info_to_dict(p) for p in self.car_service_processes
+            ],
             "opencode": [_process_info_to_dict(p) for p in self.opencode_processes],
+            "codex_app_server": [
+                _process_info_to_dict(p) for p in self.app_server_processes
+            ],
             "app_server": [_process_info_to_dict(p) for p in self.app_server_processes],
             "other": [_process_info_to_dict(p) for p in self.other_processes],
         }
+
+    @property
+    def car_service_count(self) -> int:
+        return len(self.car_service_processes)
 
     @property
     def opencode_count(self) -> int:
@@ -86,11 +106,29 @@ class ProcessSnapshot:
     def app_server_count(self) -> int:
         return len(self.app_server_processes)
 
+    @property
+    def codex_app_server_count(self) -> int:
+        return len(self.app_server_processes)
 
-OPENCODE_MARKERS = (
-    "opencode",
+    @property
+    def managed_runtime_count(self) -> int:
+        return self.opencode_count + self.codex_app_server_count
+
+    @property
+    def total_count(self) -> int:
+        return self.car_service_count + self.managed_runtime_count
+
+
+CAR_SERVICE_MARKERS = (
     "codex_autorunner",
+    "codex-autorunner hub ",
+    "codex-autorunner discord ",
+    "codex-autorunner telegram ",
+    "codex-autorunner flow ",
+    "codex-autorunner serve ",
 )
+
+OPENCODE_MARKERS = ("opencode",)
 
 APP_SERVER_MARKERS = (
     "codex app-server",
@@ -102,6 +140,8 @@ APP_SERVER_MARKERS = (
 
 def _classify_process(command: str) -> ProcessCategory:
     command_lc = command.lower()
+    if any(marker in command_lc for marker in CAR_SERVICE_MARKERS):
+        return ProcessCategory.CAR_SERVICE
     if any(marker in command_lc for marker in APP_SERVER_MARKERS):
         return ProcessCategory.APP_SERVER
     if any(marker in command_lc for marker in OPENCODE_MARKERS):
@@ -145,7 +185,9 @@ def parse_ps_output(
             rss_kb=rss_kb,
             elapsed=elapsed or None,
         )
-        if category == ProcessCategory.OPENCODE:
+        if category == ProcessCategory.CAR_SERVICE:
+            snapshot.car_service_processes.append(info)
+        elif category == ProcessCategory.OPENCODE:
             snapshot.opencode_processes.append(info)
         elif category == ProcessCategory.APP_SERVER:
             snapshot.app_server_processes.append(info)

--- a/src/codex_autorunner/core/diagnostics/process_snapshot.py
+++ b/src/codex_autorunner/core/diagnostics/process_snapshot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -119,8 +120,13 @@ class ProcessSnapshot:
         return self.car_service_count + self.managed_runtime_count
 
 
+# Match underscore-named binary only as the argv0 segment (not a parent dir like
+# .../codex_autorunner/.venv/bin/codex), which would misclassify app-server/opencode.
+_CODEX_AUTORUNNER_UNDERSCORE_EXE_RE = re.compile(
+    r"(?:^|[/\\])codex_autorunner(?=\s|$)",
+)
+
 CAR_SERVICE_MARKERS = (
-    "codex_autorunner",
     "codex-autorunner hub ",
     "codex-autorunner discord ",
     "codex-autorunner telegram ",
@@ -140,6 +146,8 @@ APP_SERVER_MARKERS = (
 
 def _classify_process(command: str) -> ProcessCategory:
     command_lc = command.lower()
+    if _CODEX_AUTORUNNER_UNDERSCORE_EXE_RE.search(command_lc):
+        return ProcessCategory.CAR_SERVICE
     if any(marker in command_lc for marker in CAR_SERVICE_MARKERS):
         return ProcessCategory.CAR_SERVICE
     if any(marker in command_lc for marker in APP_SERVER_MARKERS):

--- a/src/codex_autorunner/core/pma_rendering.py
+++ b/src/codex_autorunner/core/pma_rendering.py
@@ -205,8 +205,10 @@ def _render_process_monitor_section(
         header += f" latest_at={latest_at}"
     lines.append(header)
     for label, key in (
+        ("car_services", "car_services"),
+        ("managed_runtimes", "managed_runtimes"),
         ("opencode", "opencode"),
-        ("app_server", "app_server"),
+        ("codex_app_server", "codex_app_server"),
         ("total", "total"),
     ):
         metric = metrics.get(key)

--- a/src/codex_autorunner/integrations/chat/status_diagnostics.py
+++ b/src/codex_autorunner/integrations/chat/status_diagnostics.py
@@ -316,8 +316,10 @@ def format_process_monitor_lines(
         return line
 
     for label, key in (
+        ("CAR services", "car_services"),
+        ("Managed runtimes", "managed_runtimes"),
         ("OpenCode", "opencode"),
-        ("App server", "app_server"),
+        ("Codex app-server", "codex_app_server"),
         ("Total", "total"),
     ):
         rendered = _metric_line(label, metrics.get(key))
@@ -340,9 +342,19 @@ def format_process_monitor_lines(
             )
         ownership = latest.get("ownership")
         if isinstance(ownership, dict):
+            managed_runtimes = ownership.get("managed_runtimes")
             opencode = ownership.get("opencode")
-            app_server = ownership.get("app_server")
+            codex_app_server = ownership.get("codex_app_server")
             ownership_parts: list[str] = []
+            if isinstance(managed_runtimes, dict):
+                ownership_parts.append(
+                    "managed-runtimes "
+                    + ", ".join(
+                        f"{key}={int(value)}"
+                        for key, value in sorted(managed_runtimes.items())
+                        if _coerce_number(value)
+                    )
+                )
             if isinstance(opencode, dict):
                 ownership_parts.append(
                     "opencode "
@@ -352,12 +364,12 @@ def format_process_monitor_lines(
                         if _coerce_number(value)
                     )
                 )
-            if isinstance(app_server, dict):
+            if isinstance(codex_app_server, dict):
                 ownership_parts.append(
-                    "app-server "
+                    "codex-app-server "
                     + ", ".join(
                         f"{key}={int(value)}"
-                        for key, value in sorted(app_server.items())
+                        for key, value in sorted(codex_app_server.items())
                         if _coerce_number(value)
                     )
                 )

--- a/src/codex_autorunner/surfaces/cli/commands/doctor.py
+++ b/src/codex_autorunner/surfaces/cli/commands/doctor.py
@@ -408,7 +408,7 @@ def register_doctor_commands(
         ),
     ):
         """
-        Capture a snapshot of CAR-related processes (opencode, codex app-server).
+        Capture a snapshot of CAR-related processes.
 
         Useful for diagnosing process leaks. Repro steps:
         1. Start a ticket_flow worker
@@ -416,8 +416,9 @@ def register_doctor_commands(
         3. Run this command before and after to compare process counts
 
         This command shows counts and top N cmdlines for:
-        - opencode processes
-        - codex app-server processes
+        - CAR service processes
+        - OpenCode runtime processes
+        - Codex app-server processes
         """
         try:
             start_path = repo or Path.cwd()
@@ -459,6 +460,13 @@ def register_doctor_commands(
             return
 
         typer.echo(f"snapshot collected={snapshot.collected_at}")
+        typer.echo(f"car_services({snapshot.car_service_count}):")
+        for proc in snapshot.car_service_processes[:top_n]:
+            mem = f" rss={proc.rss_kb}KB" if proc.rss_kb else ""
+            own = f" [{proc.ownership.value}]" if proc.ownership else ""
+            typer.echo(
+                f"  pid={proc.pid} ppid={proc.ppid} pgid={proc.pgid}{mem}{own}: {proc.command[:80]}"
+            )
         typer.echo(f"opencode({snapshot.opencode_count}):")
         for proc in snapshot.opencode_processes[:top_n]:
             mem = f" rss={proc.rss_kb}KB" if proc.rss_kb else ""
@@ -466,13 +474,17 @@ def register_doctor_commands(
             typer.echo(
                 f"  pid={proc.pid} ppid={proc.ppid} pgid={proc.pgid}{mem}{own}: {proc.command[:80]}"
             )
-        typer.echo(f"app_server({snapshot.app_server_count}):")
+        typer.echo(f"codex_app_server({snapshot.codex_app_server_count}):")
         for proc in snapshot.app_server_processes[:top_n]:
             mem = f" rss={proc.rss_kb}KB" if proc.rss_kb else ""
             own = f" [{proc.ownership.value}]" if proc.ownership else ""
             typer.echo(
                 f"  pid={proc.pid} ppid={proc.ppid} pgid={proc.pgid}{mem}{own}: {proc.command[:80]}"
             )
+        typer.echo(
+            "summary: "
+            f"managed_runtimes={snapshot.managed_runtime_count} total={snapshot.total_count}"
+        )
         if not registry_counts:
             typer.echo("registry: none")
         else:

--- a/tests/core/test_process_monitor.py
+++ b/tests/core/test_process_monitor.py
@@ -28,8 +28,10 @@ def test_process_monitor_store_keeps_recent_tail(tmp_path: Path) -> None:
         store.record_sample(
             {
                 "captured_at": _iso(captured_at),
+                "car_service_count": 0,
+                "managed_runtime_count": offset,
                 "opencode_count": offset,
-                "app_server_count": 0,
+                "codex_app_server_count": 0,
                 "total_count": offset,
             },
             cadence_seconds=120,
@@ -43,9 +45,11 @@ def test_process_monitor_store_keeps_recent_tail(tmp_path: Path) -> None:
     store.record_sample(
         {
             "captured_at": _iso(now + timedelta(minutes=1)),
+            "car_service_count": 1,
+            "managed_runtime_count": 99,
             "opencode_count": 99,
-            "app_server_count": 0,
-            "total_count": 99,
+            "codex_app_server_count": 0,
+            "total_count": 100,
         },
         cadence_seconds=120,
         window_seconds=30 * 60,
@@ -68,9 +72,11 @@ def test_build_process_monitor_summary_flags_high_outlier(tmp_path: Path) -> Non
         store.record_sample(
             {
                 "captured_at": _iso(captured_at),
+                "car_service_count": 3,
+                "managed_runtime_count": 3,
                 "opencode_count": 2,
-                "app_server_count": 1,
-                "total_count": 3,
+                "codex_app_server_count": 1,
+                "total_count": 6,
             },
             cadence_seconds=120,
             window_seconds=3 * 60 * 60,
@@ -79,9 +85,11 @@ def test_build_process_monitor_summary_flags_high_outlier(tmp_path: Path) -> Non
     store.record_sample(
         {
             "captured_at": _iso(now + timedelta(minutes=12)),
+            "car_service_count": 3,
+            "managed_runtime_count": 16,
             "opencode_count": 15,
-            "app_server_count": 1,
-            "total_count": 16,
+            "codex_app_server_count": 1,
+            "total_count": 19,
         },
         cadence_seconds=120,
         window_seconds=3 * 60 * 60,
@@ -90,6 +98,10 @@ def test_build_process_monitor_summary_flags_high_outlier(tmp_path: Path) -> Non
     summary = build_process_monitor_summary(root, capture_if_stale=False)
 
     assert summary["status"] == "warning"
+    assert summary["metrics"]["car_services"]["current"] == 3
+    managed = summary["metrics"]["managed_runtimes"]
+    assert managed["abnormal"] is True
+    assert managed["current"] == 16
     opencode = summary["metrics"]["opencode"]
     assert opencode["abnormal"] is True
     assert opencode["current"] == 15
@@ -106,10 +118,15 @@ def test_build_process_monitor_summary_skips_lifecycle_when_repo_config_missing(
 
     def _fake_collect_processes() -> SimpleNamespace:
         return SimpleNamespace(
+            car_service_processes=[],
             opencode_processes=[],
             app_server_processes=[],
+            car_service_count=0,
+            managed_runtime_count=0,
             opencode_count=0,
             app_server_count=0,
+            codex_app_server_count=0,
+            total_count=0,
         )
 
     monkeypatch.setattr(
@@ -133,3 +150,21 @@ def test_build_process_monitor_summary_skips_lifecycle_when_repo_config_missing(
 
     assert summary["status"] == "ok"
     assert summary["latest"]["opencode_lifecycle"] == {}
+
+
+def test_process_monitor_store_discards_prior_schema_version(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    diagnostics = root / ".codex-autorunner" / "diagnostics"
+    diagnostics.mkdir(parents=True)
+    (diagnostics / "process-monitor.json").write_text(
+        '{"version": 1, "samples": [{"captured_at": "2026-01-01T00:00:00Z", "total_count": 5}]}',
+        encoding="utf-8",
+    )
+
+    store = ProcessMonitorStore(root)
+
+    payload = store.load()
+
+    assert payload["version"] == 2
+    assert payload["samples"] == []

--- a/tests/core/test_process_snapshot.py
+++ b/tests/core/test_process_snapshot.py
@@ -7,24 +7,32 @@ from codex_autorunner.core.diagnostics.process_snapshot import (
 SAMPLE_PS_OUTPUT = """\
 1234 1000 1000  1024  00:05:30 /usr/bin/opencode serve --port 8080
 1235 1000 1000  2048  00:10:15 /usr/bin/codex_autorunner run
-1236 1100 1100  5120  01:30:00 /usr/bin/codex app-server --port 9000
+1236 1000 1000  2048  00:10:15 /usr/local/bin/codex-autorunner hub serve
+1243 1100 1100  5120  01:30:00 /usr/bin/codex app-server --port 9000
 1237 1100 1100   256  00:02:45 /usr/bin/some-other-process --arg
 1238 1200 1200  1536  00:08:20 /Users/user/.local/bin/opencode
 1239 1200 1200  4096  00:45:00 /opt/codex/bin/codex app-server --workspace /tmp/ws
 1240 1300 1300   512  00:12:00 /bin/bash -c /usr/bin/opencode
 1241 1300 1300   128  00:01:30 /usr/bin/other-tool
+1242 1300 1300   768  00:06:00 /bin/sh -lc PATH=/foo; /Users/user/.local/bin/codex-autorunner discord start
 """
 
 
 class TestClassifyProcess:
-    def test_opencode_in_command(self):
-        assert _classify_process("/usr/bin/opencode serve") == ProcessCategory.OPENCODE
-
     def test_codex_autorunner_in_command(self):
         assert (
             _classify_process("/usr/bin/codex_autorunner run")
-            == ProcessCategory.OPENCODE
+            == ProcessCategory.CAR_SERVICE
         )
+
+    def test_codex_autorunner_hyphenated_binary_in_command(self):
+        assert (
+            _classify_process("/usr/local/bin/codex-autorunner hub serve")
+            == ProcessCategory.CAR_SERVICE
+        )
+
+    def test_opencode_in_command(self):
+        assert _classify_process("/usr/bin/opencode serve") == ProcessCategory.OPENCODE
 
     def test_app_server_classic_format(self):
         assert (
@@ -53,19 +61,25 @@ class TestClassifyProcess:
 class TestParsePsOutput:
     def test_parse_sample_output(self):
         snapshot = parse_ps_output(SAMPLE_PS_OUTPUT)
-        assert snapshot.opencode_count == 4
+        assert snapshot.car_service_count == 3
+        assert snapshot.opencode_count == 3
         assert snapshot.app_server_count == 2
         assert len(snapshot.other_processes) == 2
+
+    def test_car_service_processes_correct(self):
+        snapshot = parse_ps_output(SAMPLE_PS_OUTPUT)
+        pids = {p.pid for p in snapshot.car_service_processes}
+        assert pids == {1235, 1236, 1242}
 
     def test_opencode_processes_correct(self):
         snapshot = parse_ps_output(SAMPLE_PS_OUTPUT)
         pids = {p.pid for p in snapshot.opencode_processes}
-        assert pids == {1234, 1235, 1238, 1240}
+        assert pids == {1234, 1238, 1240}
 
     def test_app_server_processes_correct(self):
         snapshot = parse_ps_output(SAMPLE_PS_OUTPUT)
         pids = {p.pid for p in snapshot.app_server_processes}
-        assert pids == {1236, 1239}
+        assert pids == {1239, 1243}
 
     def test_other_processes_correct(self):
         snapshot = parse_ps_output(SAMPLE_PS_OUTPUT)
@@ -74,6 +88,7 @@ class TestParsePsOutput:
 
     def test_empty_output(self):
         snapshot = parse_ps_output("")
+        assert snapshot.car_service_count == 0
         assert snapshot.opencode_count == 0
         assert snapshot.app_server_count == 0
         assert len(snapshot.other_processes) == 0
@@ -85,24 +100,35 @@ not_a_pid 1000 1000  100 00:01:00 bad line
 1235 1000 1000  100 00:01:00 another good command
 """
         snapshot = parse_ps_output(malformed)
-        assert len(snapshot.opencode_processes) + len(snapshot.other_processes) == 2
+        assert (
+            len(snapshot.car_service_processes)
+            + len(snapshot.opencode_processes)
+            + len(snapshot.other_processes)
+            == 2
+        )
 
     def test_to_dict(self):
         snapshot = parse_ps_output(SAMPLE_PS_OUTPUT)
         d = snapshot.to_dict()
         assert "collected_at" in d
+        assert "counts" in d
+        assert "car_services" in d
         assert "opencode" in d
-        assert "app_server" in d
+        assert "codex_app_server" in d
         assert "other" in d
-        assert len(d["opencode"]) == 4
-        assert len(d["app_server"]) == 2
+        assert len(d["car_services"]) == 3
+        assert len(d["opencode"]) == 3
+        assert len(d["codex_app_server"]) == 2
 
 
 class TestProcessSnapshot:
     def test_counts(self):
         snapshot = parse_ps_output(SAMPLE_PS_OUTPUT)
-        assert snapshot.opencode_count == 4
+        assert snapshot.car_service_count == 3
+        assert snapshot.opencode_count == 3
         assert snapshot.app_server_count == 2
+        assert snapshot.managed_runtime_count == 5
+        assert snapshot.total_count == 8
 
 
 class TestProcessInfoFields:
@@ -127,7 +153,9 @@ class TestProcessInfoFields:
     def test_to_dict_includes_category(self):
         snapshot = parse_ps_output(SAMPLE_PS_OUTPUT)
         d = snapshot.to_dict()
+        car_services = d["car_services"]
         opencode = d["opencode"]
+        assert all(p["category"] == "car_service" for p in car_services)
         assert all(p["category"] == "opencode" for p in opencode)
 
     def test_missing_rss_handled(self):

--- a/tests/core/test_process_snapshot.py
+++ b/tests/core/test_process_snapshot.py
@@ -53,6 +53,20 @@ class TestClassifyProcess:
             == ProcessCategory.APP_SERVER
         )
 
+    def test_app_server_not_misclassified_when_path_contains_codex_autorunner_dir(self):
+        assert (
+            _classify_process(
+                "/opt/codex_autorunner/.venv/bin/codex app-server --port 9000"
+            )
+            == ProcessCategory.APP_SERVER
+        )
+
+    def test_opencode_not_misclassified_when_path_contains_codex_autorunner_dir(self):
+        assert (
+            _classify_process("/home/user/codex_autorunner/bin/opencode serve")
+            == ProcessCategory.OPENCODE
+        )
+
     def test_other_process(self):
         assert _classify_process("/usr/bin/some-other-process") == ProcessCategory.OTHER
         assert _classify_process("bash -c echo hello") == ProcessCategory.OTHER

--- a/tests/integrations/chat/test_status_diagnostics.py
+++ b/tests/integrations/chat/test_status_diagnostics.py
@@ -87,6 +87,22 @@ class TestFormatProcessMonitorLines:
                 "cadence_seconds": 120,
                 "window_seconds": 3 * 60 * 60,
                 "metrics": {
+                    "car_services": {
+                        "current": 6,
+                        "average": 4.0,
+                        "p95": 5,
+                        "peak": 6,
+                        "abnormal": False,
+                        "reason": None,
+                    },
+                    "managed_runtimes": {
+                        "current": 16,
+                        "average": 5.25,
+                        "p95": 12,
+                        "peak": 16,
+                        "abnormal": True,
+                        "reason": "high",
+                    },
                     "opencode": {
                         "current": 18,
                         "average": 7.25,
@@ -95,7 +111,7 @@ class TestFormatProcessMonitorLines:
                         "abnormal": True,
                         "reason": "high",
                     },
-                    "app_server": {
+                    "codex_app_server": {
                         "current": 4,
                         "average": 2.0,
                         "p95": 3,
@@ -120,6 +136,8 @@ class TestFormatProcessMonitorLines:
         assert (
             lines[0] == "Process monitor: warning (window=3h samples=42 cadence=120s)"
         )
+        assert "CAR services: 6 (avg 4.0, tp95 5, peak 6)" in lines
+        assert "Managed runtimes: 16 (avg 5.2, tp95 12, peak 16) high" in lines
         assert "OpenCode: 18 (avg 7.2, tp95 14, peak 18) high" in lines
-        assert "App server: 4 (avg 2.0, tp95 3, peak 4)" in lines
+        assert "Codex app-server: 4 (avg 2.0, tp95 3, peak 4)" in lines
         assert "Total: 22 (avg 9.2, tp95 17, peak 22) high" in lines

--- a/tests/test_cli_process_diagnostics.py
+++ b/tests/test_cli_process_diagnostics.py
@@ -40,6 +40,15 @@ def test_doctor_processes_json_includes_snapshot_and_registry(
     from codex_autorunner.surfaces.cli.commands import doctor as doctor_cmd
 
     snapshot = ProcessSnapshot(
+        car_service_processes=[
+            ProcessInfo(
+                pid=1200,
+                ppid=1,
+                pgid=1200,
+                command="codex-autorunner hub serve",
+                category=ProcessCategory.CAR_SERVICE,
+            )
+        ],
         opencode_processes=[
             ProcessInfo(
                 pid=1234,
@@ -84,7 +93,9 @@ def test_doctor_processes_json_includes_snapshot_and_registry(
 
     payload = json.loads(result.output)
     assert "snapshot" in payload
+    assert payload["snapshot"]["car_services"][0]["pid"] == 1200
     assert payload["snapshot"]["opencode"][0]["pid"] == 1234
+    assert payload["snapshot"]["counts"]["managed_runtimes"] == 1
     assert "registry" in payload
     assert payload["registry"]["counts_by_kind"]["opencode"] == 1
     assert payload["registry"]["records"][0]["record_key"] == "ws"
@@ -304,7 +315,10 @@ def test_doctor_processes_skips_opencode_lifecycle_when_repo_config_missing(
     from codex_autorunner.surfaces.cli.commands import doctor as doctor_cmd
 
     snapshot = ProcessSnapshot(
-        opencode_processes=[], app_server_processes=[], other_processes=[]
+        car_service_processes=[],
+        opencode_processes=[],
+        app_server_processes=[],
+        other_processes=[],
     )
 
     monkeypatch.setattr(doctor_cmd, "collect_processes", lambda: snapshot)


### PR DESCRIPTION
## What changed
Reworked CAR process diagnostics so `/processes`, `car doctor processes`, and the persisted process monitor distinguish CAR services from managed runtimes instead of collapsing CAR-owned wrappers into the OpenCode bucket.

The change adds an explicit `CAR services` category, keeps runtime breakdowns for `OpenCode` and `Codex app-server`, and promotes `Managed runtimes` plus `Total` as the top-level monitor groups. It also updates the monitor schema and drops old samples when the schema version changes so stale, misclassified history does not pollute the new alert baselines.

## Why it changed
The existing classifier treated any command containing `codex_autorunner` as `OpenCode`, while the monitor formatter only exposed `OpenCode`, `App server`, and `Total`. In practice that meant hub, Discord, Telegram, and flow-worker processes were reported as OpenCode-related processes, which made the `/processes` command misleading and made process-count telemetry partly conflate CAR services with managed runtimes.

## User and developer impact
Operators now get a process view that matches the real runtime model:
- `CAR services`
- `Managed runtimes`
- runtime breakdown for `OpenCode` and `Codex app-server`
- `Total`

`car doctor processes --json` also exposes clearer counts while preserving compatibility aliases for existing `app_server` readers.

## Root cause
The old process snapshot heuristics encoded product semantics directly into a two-bucket classifier and used the same buckets for live snapshots, persisted monitor samples, warnings, and chat formatting. That made the classification gap systemic rather than cosmetic.

## Validation
- Focused pytest:
  - `.venv/bin/pytest tests/core/test_process_snapshot.py tests/core/test_process_monitor.py tests/integrations/chat/test_status_diagnostics.py tests/test_cli_process_diagnostics.py`
- Full commit-hook validation:
  - repo hooks ran formatting, ruff, mypy, frontend build/tests, and full pytest
  - final full pytest run passed: `5164 passed`
- Live local-process validation on this machine after the change:
  - `CAR services: 11`
  - `Managed runtimes: 36`
  - `OpenCode: 6`
  - `Codex app-server: 30`
  - `Total: 47`
  - verified hub/discord/telegram/flow-worker wrappers no longer land in the app-server bucket
