### PR TITLE
Fix #1400: show time taken on tickets and turns

### DIFF
--- a/src/codex_autorunner/static/generated/tickets.js
+++ b/src/codex_autorunner/static/generated/tickets.js
@@ -1309,12 +1309,12 @@ function renderDispatchHistory(runId, data) {
             statsEl.title = `${ins} insertions, ${del} deletions${diffStats.files_changed ? `, ${diffStats.files_changed} files` : ""}`;
             head.appendChild(statsEl);
         }
-        // Turn duration: time from this dispatch to the next (chronologically later) one
+        // Turn duration until chronologically next dispatch (newer neighbor: index - 1; newest-first list).
         const thisTime = entry.created_at ? new Date(entry.created_at).getTime() : 0;
-        const nextEntry = entries[index + 1];
-        const nextTime = nextEntry?.created_at ? new Date(nextEntry.created_at).getTime() : 0;
-        if (thisTime && nextTime && nextTime > thisTime) {
-            const durSecs = Math.max(0, Math.round((nextTime - thisTime) / 1000));
+        const prevEntry = entries[index - 1];
+        const prevTime = prevEntry?.created_at ? new Date(prevEntry.created_at).getTime() : 0;
+        if (thisTime && prevTime && prevTime > thisTime) {
+            const durSecs = Math.max(0, Math.round((prevTime - thisTime) / 1000));
             const durEl = document.createElement("span");
             durEl.className = "dispatch-duration";
             durEl.textContent = formatElapsedSeconds(durSecs);

--- a/src/codex_autorunner/static/generated/tickets.js
+++ b/src/codex_autorunner/static/generated/tickets.js
@@ -1169,6 +1169,13 @@ function renderTickets(data) {
             statsEl.title = `${ins} insertions, ${del} deletions${diffStats.files_changed ? `, ${diffStats.files_changed} files` : ""}`;
             head.appendChild(statsEl);
         }
+        if (typeof ticket.duration_seconds === "number" && ticket.duration_seconds > 0) {
+            const durEl = document.createElement("span");
+            durEl.className = "ticket-duration";
+            durEl.textContent = formatElapsedSeconds(ticket.duration_seconds);
+            durEl.title = `Time taken: ${formatElapsedSeconds(ticket.duration_seconds)}`;
+            head.appendChild(durEl);
+        }
         head.appendChild(badges);
         item.appendChild(head);
         if (ticket.errors && ticket.errors.length) {
@@ -1301,6 +1308,18 @@ function renderDispatchHistory(runId, data) {
             statsEl.innerHTML = `<span class="diff-add">+${formatNumber(ins)}</span><span class="diff-del">-${formatNumber(del)}</span>`;
             statsEl.title = `${ins} insertions, ${del} deletions${diffStats.files_changed ? `, ${diffStats.files_changed} files` : ""}`;
             head.appendChild(statsEl);
+        }
+        // Turn duration: time from this dispatch to the next (chronologically later) one
+        const thisTime = entry.created_at ? new Date(entry.created_at).getTime() : 0;
+        const nextEntry = entries[index + 1];
+        const nextTime = nextEntry?.created_at ? new Date(nextEntry.created_at).getTime() : 0;
+        if (thisTime && nextTime && nextTime > thisTime) {
+            const durSecs = Math.max(0, Math.round((nextTime - thisTime) / 1000));
+            const durEl = document.createElement("span");
+            durEl.className = "dispatch-duration";
+            durEl.textContent = formatElapsedSeconds(durSecs);
+            durEl.title = `Turn duration: ${formatElapsedSeconds(durSecs)}`;
+            head.appendChild(durEl);
         }
         // Add ticket reference if present
         const ticketId = dispatch?.extra?.ticket_id;

--- a/src/codex_autorunner/static/styles.css
+++ b/src/codex_autorunner/static/styles.css
@@ -3292,6 +3292,14 @@ button.icon-btn {
   color: #f85149;
 }
 
+.dispatch-duration {
+  font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+  font-size: 11px;
+  color: var(--muted, #8b949e);
+  white-space: nowrap;
+  margin-left: 6px;
+}
+
 /* Diff stats on ticket items (cumulative per ticket) */
 .ticket-diff-stats {
   display: inline-flex;
@@ -3308,6 +3316,14 @@ button.icon-btn {
 
 .ticket-diff-stats .diff-del {
   color: #f85149;
+}
+
+.ticket-duration {
+  font-family: 'JetBrains Mono', 'SF Mono', Monaco, monospace;
+  font-size: 11px;
+  color: var(--muted, #8b949e);
+  white-space: nowrap;
+  margin-left: 6px;
 }
 
 /* Diff stats in analytics metrics */

--- a/src/codex_autorunner/static_src/tickets.ts
+++ b/src/codex_autorunner/static_src/tickets.ts
@@ -1580,12 +1580,12 @@ function renderDispatchHistory(
       head.appendChild(statsEl);
     }
 
-    // Turn duration: time from this dispatch to the next (chronologically later) one
+    // Turn duration until chronologically next dispatch (newer neighbor: index - 1; newest-first list).
     const thisTime = entry.created_at ? new Date(entry.created_at).getTime() : 0;
-    const nextEntry = entries[index + 1];
-    const nextTime = nextEntry?.created_at ? new Date(nextEntry.created_at).getTime() : 0;
-    if (thisTime && nextTime && nextTime > thisTime) {
-      const durSecs = Math.max(0, Math.round((nextTime - thisTime) / 1000));
+    const prevEntry = entries[index - 1];
+    const prevTime = prevEntry?.created_at ? new Date(prevEntry.created_at).getTime() : 0;
+    if (thisTime && prevTime && prevTime > thisTime) {
+      const durSecs = Math.max(0, Math.round((prevTime - thisTime) / 1000));
       const durEl = document.createElement("span");
       durEl.className = "dispatch-duration";
       durEl.textContent = formatElapsedSeconds(durSecs);

--- a/src/codex_autorunner/static_src/tickets.ts
+++ b/src/codex_autorunner/static_src/tickets.ts
@@ -72,6 +72,7 @@ type TicketFile = {
     deletions: number;
     files_changed: number;
   } | null;
+  duration_seconds?: number | null;
 };
 
 type DispatchAttachment = {
@@ -1417,6 +1418,14 @@ function renderTickets(data: { tickets?: TicketFile[]; lint_errors?: string[] } 
       head.appendChild(statsEl);
     }
 
+    if (typeof ticket.duration_seconds === "number" && ticket.duration_seconds > 0) {
+      const durEl = document.createElement("span");
+      durEl.className = "ticket-duration";
+      durEl.textContent = formatElapsedSeconds(ticket.duration_seconds);
+      durEl.title = `Time taken: ${formatElapsedSeconds(ticket.duration_seconds)}`;
+      head.appendChild(durEl);
+    }
+
     head.appendChild(badges);
     item.appendChild(head);
 
@@ -1569,6 +1578,19 @@ function renderDispatchHistory(
       statsEl.innerHTML = `<span class="diff-add">+${formatNumber(ins)}</span><span class="diff-del">-${formatNumber(del)}</span>`;
       statsEl.title = `${ins} insertions, ${del} deletions${diffStats.files_changed ? `, ${diffStats.files_changed} files` : ""}`;
       head.appendChild(statsEl);
+    }
+
+    // Turn duration: time from this dispatch to the next (chronologically later) one
+    const thisTime = entry.created_at ? new Date(entry.created_at).getTime() : 0;
+    const nextEntry = entries[index + 1];
+    const nextTime = nextEntry?.created_at ? new Date(nextEntry.created_at).getTime() : 0;
+    if (thisTime && nextTime && nextTime > thisTime) {
+      const durSecs = Math.max(0, Math.round((nextTime - thisTime) / 1000));
+      const durEl = document.createElement("span");
+      durEl.className = "dispatch-duration";
+      durEl.textContent = formatElapsedSeconds(durSecs);
+      durEl.title = `Turn duration: ${formatElapsedSeconds(durSecs)}`;
+      head.appendChild(durEl);
     }
     
     // Add ticket reference if present

--- a/src/codex_autorunner/surfaces/cli/commands/flow.py
+++ b/src/codex_autorunner/surfaces/cli/commands/flow.py
@@ -24,7 +24,13 @@ from ....core.flows.flow_housekeeping import (
     gather_stats,
     parse_flow_retention_config,
 )
-from ....core.flows.models import FlowEventType, FlowRunRecord, FlowRunStatus
+from ....core.flows.models import (
+    FlowEventType,
+    FlowRunRecord,
+    FlowRunStatus,
+    flow_run_duration_seconds,
+    format_flow_duration,
+)
 from ....core.flows.start_policy import evaluate_ticket_start_policy
 from ....core.flows.telemetry_export import export_all_runs
 from ....core.flows.ux_helpers import build_flow_status_snapshot, ensure_worker
@@ -418,6 +424,7 @@ def register_flow_commands(
             "created_at": record.created_at,
             "started_at": record.started_at,
             "finished_at": record.finished_at,
+            "duration_seconds": flow_run_duration_seconds(record),
             "last_event_seq": snapshot.get("last_event_seq"),
             "last_event_at": snapshot.get("last_event_at"),
             "current_ticket": effective_ticket,
@@ -455,6 +462,9 @@ def register_flow_commands(
             f"created={payload.get('created_at')} started={payload.get('started_at')} "
             f"finished={payload.get('finished_at')}"
         )
+        duration_str = format_flow_duration(payload.get("duration_seconds"))
+        if duration_str:
+            typer.echo(f"duration={duration_str}")
         typer.echo(
             f"last_event={payload.get('last_event_at')} seq={payload.get('last_event_seq')}"
         )

--- a/src/codex_autorunner/surfaces/web/routes/flow_routes/status_history_routes.py
+++ b/src/codex_autorunner/surfaces/web/routes/flow_routes/status_history_routes.py
@@ -5,6 +5,7 @@ import logging
 import re
 import subprocess
 from dataclasses import asdict
+from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, Optional, cast
 from urllib.parse import quote
@@ -223,6 +224,15 @@ def build_status_history_routes(
                             "url": f"api/flows/{normalized}/dispatch_history/{entry.name}/{quote(rel)}",
                         }
                     )
+                created_at: Optional[str] = None
+                for _cand in (dispatch_path, entry):
+                    try:
+                        created_at = datetime.fromtimestamp(
+                            _cand.stat().st_mtime, tz=timezone.utc
+                        ).isoformat()
+                        break
+                    except OSError:
+                        continue
                 history_entries.append(
                     {
                         "seq": entry.name,
@@ -230,6 +240,7 @@ def build_status_history_routes(
                         "errors": errors,
                         "attachments": attachments,
                         "path": safe_relpath(entry, repo_root),
+                        "created_at": created_at,
                     }
                 )
 

--- a/src/codex_autorunner/surfaces/web/routes/flows.py
+++ b/src/codex_autorunner/surfaces/web/routes/flows.py
@@ -29,6 +29,7 @@ from ....core.flows import (
     FlowStore,
     archive_flow_run_artifacts,
     flow_run_duration_seconds,
+    parse_flow_timestamp,
 )
 from ....core.flows.reconciler import reconcile_flow_run
 from ....core.flows.start_policy import (
@@ -1142,10 +1143,13 @@ You are the first ticket in a new ticket_flow run.
             repo_root, flow_type="ticket_flow", recover_stuck=True
         )
         diff_by_ref: dict[str, dict[str, int]] = {}
+        duration_by_ref: dict[str, Optional[float]] = {}
         if runs:
             store = _require_flow_store(repo_root)
             if store is not None:
                 try:
+                    first_ts_by_ref: dict[str, datetime] = {}
+                    last_ts_by_ref: dict[str, datetime] = {}
                     for run in runs:
                         try:
                             events = store.get_events_by_type(
@@ -1171,6 +1175,24 @@ You are the first ticket in a new ticket_flow run.
                             stats["files_changed"] += int(
                                 data.get("files_changed") or 0
                             )
+                            ev_dt = parse_flow_timestamp(ev.timestamp)
+                            if ev_dt is not None:
+                                if (
+                                    ref not in first_ts_by_ref
+                                    or ev_dt < first_ts_by_ref[ref]
+                                ):
+                                    first_ts_by_ref[ref] = ev_dt
+                                if (
+                                    ref not in last_ts_by_ref
+                                    or ev_dt > last_ts_by_ref[ref]
+                                ):
+                                    last_ts_by_ref[ref] = ev_dt
+                    for ref, first_dt in first_ts_by_ref.items():
+                        last_dt = last_ts_by_ref.get(ref)
+                        if last_dt is not None:
+                            duration_by_ref[ref] = max(
+                                0.0, (last_dt - first_dt).total_seconds()
+                            )
                 finally:
                     try:
                         store.close()
@@ -1195,6 +1217,11 @@ You are the first ticket in a new ticket_flow run.
             rel_path = safe_relpath(path, repo_root)
             stable_ticket_id = ticket_stable_id(path)
             diff_refs = [stable_ticket_id] if stable_ticket_id else []
+            ticket_duration: Optional[float] = None
+            for _dref in diff_refs:
+                if _dref in duration_by_ref:
+                    ticket_duration = duration_by_ref[_dref]
+                    break
             tickets.append(
                 {
                     "path": rel_path,
@@ -1204,6 +1231,7 @@ You are the first ticket in a new ticket_flow run.
                     "body": doc.body if doc else parsed_body,
                     "errors": errors,
                     "diff_stats": _merge_ticket_diff_stats(diff_refs, diff_by_ref),
+                    "duration_seconds": ticket_duration,
                 }
             )
         return {"tickets": tickets}


### PR DESCRIPTION
Fixes #1400 — Display elapsed time for ticket flow tickets and individual turns.

**What changed:**
- **Web UI tickets panel:** Each ticket row now shows a duration badge (e.g. "12m 34s") computed from the first/last event timestamps in the flow store, giving a per-ticket time-taken indicator.
- **Web UI dispatch history:** Each dispatch entry shows the turn duration (time between consecutive dispatches), so operators can see how long each agent turn took.
- **CLI `car ticket-flow status`:** Added `duration=` field showing the formatted run duration.
- **CSS:** Added `.ticket-duration` and `.dispatch-duration` styles for consistent muted monospace display.

**Files changed:**
- `static_src/tickets.ts` + `static/generated/tickets.js` — ticket duration + turn duration rendering
- `static/styles.css` — duration badge styles
- `surfaces/cli/commands/flow.py` — CLI duration output
- `surfaces/web/routes/flows.py` — ticket duration calculation from event timestamps
- `surfaces/web/routes/flow_routes/status_history_routes.py` — dispatch `created_at` for turn duration calculation