### PR TITLE
Fix #1365: retry thread-send timeout recovery with polling

### DIFF
--- a/src/codex_autorunner/surfaces/cli/pma_cli.py
+++ b/src/codex_autorunner/surfaces/cli/pma_cli.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import sys
+import time
 from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -42,6 +43,8 @@ from .commands.utils import format_hub_request_error
 logger = logging.getLogger(__name__)
 _MANAGED_THREAD_SEND_PREVIEW_LIMIT = 120
 _MANAGED_THREAD_SEND_TIMEOUT_STATUS_LIMIT = 50
+_MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_WINDOW_SECONDS = 3.0
+_MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_POLL_SECONDS = 0.25
 
 pma_app = typer.Typer(
     add_completion=False,
@@ -921,44 +924,31 @@ def _recover_managed_thread_send_timeout(
 ) -> Optional[_ManagedThreadSendResponse]:
     if baseline is None:
         return None
-    try:
-        current = _ManagedThreadSendTimeoutProbe.from_status(
-            _fetch_managed_thread_status_payload(
-                config,
-                managed_thread_id=managed_thread_id,
-            )
-        )
-    except (httpx.HTTPError, ValueError, OSError, TypeError):
-        return None
 
     expected_preview = _truncate_text(
         message_body, _MANAGED_THREAD_SEND_PREVIEW_LIMIT
     ).strip()
     if not expected_preview:
         return None
-    recovered_turn_id = ""
-    queued = False
-    if current.last_turn_id != baseline.last_turn_id and current.last_turn_id:
-        recovered_turn_id = current.last_turn_id
-    else:
-        baseline_queued_ids = set(baseline.queued_turn_ids)
-        queued_match_id = next(
-            (
-                managed_turn_id
-                for managed_turn_id, prompt_preview in zip(
-                    current.queued_turn_ids, current.queued_prompt_previews
+
+    deadline = time.monotonic() + _MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_WINDOW_SECONDS
+    baseline_queued_ids = set(baseline.queued_turn_ids)
+    while True:
+        try:
+            current = _ManagedThreadSendTimeoutProbe.from_status(
+                _fetch_managed_thread_status_payload(
+                    config,
+                    managed_thread_id=managed_thread_id,
                 )
-                if prompt_preview == expected_preview
-                and managed_turn_id not in baseline_queued_ids
-            ),
-            "",
-        )
-        if (
-            not queued_match_id
-            and current.queue_depth > baseline.queue_depth
-            and expected_preview in current.queued_prompt_previews
-            and expected_preview not in baseline.queued_prompt_previews
-        ):
+            )
+        except (httpx.HTTPError, ValueError, OSError, TypeError):
+            return None
+
+        recovered_turn_id = ""
+        queued = False
+        if current.last_turn_id != baseline.last_turn_id and current.last_turn_id:
+            recovered_turn_id = current.last_turn_id
+        else:
             queued_match_id = next(
                 (
                     managed_turn_id
@@ -966,40 +956,61 @@ def _recover_managed_thread_send_timeout(
                         current.queued_turn_ids, current.queued_prompt_previews
                     )
                     if prompt_preview == expected_preview
+                    and managed_turn_id not in baseline_queued_ids
                 ),
                 "",
             )
-        if not queued_match_id:
-            return None
-        recovered_turn_id = queued_match_id
-        queued = True
+            if (
+                not queued_match_id
+                and current.queue_depth > baseline.queue_depth
+                and expected_preview in current.queued_prompt_previews
+                and expected_preview not in baseline.queued_prompt_previews
+            ):
+                queued_match_id = next(
+                    (
+                        managed_turn_id
+                        for managed_turn_id, prompt_preview in zip(
+                            current.queued_turn_ids, current.queued_prompt_previews
+                        )
+                        if prompt_preview == expected_preview
+                    ),
+                    "",
+                )
+            if queued_match_id:
+                recovered_turn_id = queued_match_id
+                queued = True
 
-    payload: dict[str, Any] = {
-        "status": "ok",
-        "send_state": "queued" if queued else "accepted",
-        "execution_state": (
-            "queued" if queued else (current.active_turn_status or "running")
-        ),
-        "managed_turn_id": recovered_turn_id,
-        "active_managed_turn_id": (
-            current.active_managed_turn_id if queued else recovered_turn_id
-        ),
-        "queue_depth": current.queue_depth,
-        "delivered_message": message_body,
-        "assistant_text": "",
-        "detail": (
-            "Timed out waiting for send confirmation; recovered delivery from "
-            "thread status."
-        ),
-        "error": "",
-        "next_step": (
-            "Use `car pma thread status` or `car pma thread tail` if you want "
-            "to watch execution progress."
-        ),
-    }
-    return _ManagedThreadSendResponse.from_http(
-        200, payload, default_message=message_body
-    )
+        if recovered_turn_id:
+            payload: dict[str, Any] = {
+                "status": "ok",
+                "send_state": "queued" if queued else "accepted",
+                "execution_state": (
+                    "queued" if queued else (current.active_turn_status or "running")
+                ),
+                "managed_turn_id": recovered_turn_id,
+                "active_managed_turn_id": (
+                    current.active_managed_turn_id if queued else recovered_turn_id
+                ),
+                "queue_depth": current.queue_depth,
+                "delivered_message": message_body,
+                "assistant_text": "",
+                "detail": (
+                    "Timed out waiting for send confirmation; recovered delivery "
+                    "from thread status."
+                ),
+                "error": "",
+                "next_step": (
+                    "Use `car pma thread status` or `car pma thread tail` if you "
+                    "want to watch execution progress."
+                ),
+            }
+            return _ManagedThreadSendResponse.from_http(
+                200, payload, default_message=message_body
+            )
+
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(_MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_POLL_SECONDS)
 
 
 def _render_active_turn_diagnostics(data: dict[str, Any]) -> None:

--- a/src/codex_autorunner/surfaces/cli/pma_cli.py
+++ b/src/codex_autorunner/surfaces/cli/pma_cli.py
@@ -942,7 +942,10 @@ def _recover_managed_thread_send_timeout(
                 )
             )
         except (httpx.HTTPError, ValueError, OSError, TypeError):
-            return None
+            if time.monotonic() >= deadline:
+                return None
+            time.sleep(_MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_POLL_SECONDS)
+            continue
 
         recovered_turn_id = ""
         queued = False

--- a/tests/test_pma_cli.py
+++ b/tests/test_pma_cli.py
@@ -1332,6 +1332,11 @@ def test_pma_cli_thread_send_recovers_timeout_from_status_probe(
         pma_cli, "_request_json_with_status", _fake_request_json_with_status
     )
     monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
+    monotonic_values = iter([100.0, 103.0])
+    monkeypatch.setattr(
+        pma_cli.time, "monotonic", lambda: next(monotonic_values, 103.0)
+    )
+    monkeypatch.setattr(pma_cli.time, "sleep", lambda seconds: None)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -1423,6 +1428,11 @@ def test_pma_cli_thread_send_recovers_queued_timeout_from_status_probe(
         pma_cli, "_request_json_with_status", _fake_request_json_with_status
     )
     monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
+    monotonic_values = iter([100.0, 103.0])
+    monkeypatch.setattr(
+        pma_cli.time, "monotonic", lambda: next(monotonic_values, 103.0)
+    )
+    monkeypatch.setattr(pma_cli.time, "sleep", lambda seconds: None)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -1446,6 +1456,113 @@ def test_pma_cli_thread_send_recovers_queued_timeout_from_status_probe(
     )
     assert "delivered message:\nfollow up\n" in result.stdout
     assert "recovered delivery from thread status" in result.stdout
+
+
+def test_pma_cli_thread_send_retries_timeout_recovery_until_status_catches_up(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_cli,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json_with_status(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        timeout=None,
+    ):
+        _ = method, url, payload, token_env, timeout
+        raise httpx.TimeoutException("timed out")
+
+    status_payloads = iter(
+        [
+            {
+                "thread": {
+                    "last_turn_id": "turn-1",
+                    "latest_turn_id": "turn-1",
+                    "last_message_preview": "previous prompt",
+                },
+                "turn": {"managed_turn_id": "turn-1", "status": "running"},
+                "queue_depth": 0,
+                "queued_turns": [],
+            },
+            {
+                "thread": {
+                    "last_turn_id": "turn-1",
+                    "latest_turn_id": "turn-1",
+                    "last_message_preview": "previous prompt",
+                },
+                "turn": {"managed_turn_id": "turn-1", "status": "running"},
+                "queue_depth": 0,
+                "queued_turns": [],
+            },
+            {
+                "thread": {
+                    "last_turn_id": "turn-2",
+                    "latest_turn_id": "turn-2",
+                    "last_message_preview": "follow up",
+                },
+                "turn": {"managed_turn_id": "turn-2", "status": "running"},
+                "queue_depth": 0,
+                "queued_turns": [],
+            },
+        ]
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = method, url, payload, token_env, params
+        return next(status_payloads)
+
+    monotonic_values = iter([100.0, 100.0, 100.1])
+    sleep_calls: list[float] = []
+
+    monkeypatch.setattr(
+        pma_cli, "_request_json_with_status", _fake_request_json_with_status
+    )
+    monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
+    monkeypatch.setattr(
+        pma_cli.time, "monotonic", lambda: next(monotonic_values, 101.0)
+    )
+    monkeypatch.setattr(
+        pma_cli.time, "sleep", lambda seconds: sleep_calls.append(seconds)
+    )
+
+    message_path = tmp_path / "prompt.md"
+    message_path.write_text("follow up\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pma_app,
+        [
+            "thread",
+            "send",
+            "--id",
+            "thread-1",
+            "--message-file",
+            str(message_path),
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "send_state=accepted managed_turn_id=turn-2" in result.stdout
+    assert "recovered delivery from thread status" in result.stdout
+    assert sleep_calls == [pma_cli._MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_POLL_SECONDS]
 
 
 def test_pma_cli_thread_send_timeout_warns_before_retry_when_status_unclear(
@@ -1509,6 +1626,11 @@ def test_pma_cli_thread_send_timeout_warns_before_retry_when_status_unclear(
         pma_cli, "_request_json_with_status", _fake_request_json_with_status
     )
     monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
+    monotonic_values = iter([100.0, 103.0])
+    monkeypatch.setattr(
+        pma_cli.time, "monotonic", lambda: next(monotonic_values, 103.0)
+    )
+    monkeypatch.setattr(pma_cli.time, "sleep", lambda seconds: None)
 
     runner = CliRunner()
     result = runner.invoke(


### PR DESCRIPTION
Fixes #1365 — `car pma thread send` false timeout on slow sends.

**Problem:** The timeout recovery path did a single status probe after the HTTP timeout. If the hub hadn't yet processed the send, recovery returned `None` and the CLI reported failure — even though the message was delivered moments later.

**Fix:** Replace the single probe with a polling loop (3-second window, 250ms interval). The recovery path now retries status checks until either the new turn appears or the window expires, eliminating the race condition between send confirmation and timeout.

**Changes:**
- `pma_cli.py`: Loop with `time.monotonic()` deadline in `_recover_managed_thread_send_timeout()`
- `test_pma_cli.py`: Existing recovery tests updated to mock `time.monotonic`/`time.sleep`; new test `test_pma_cli_thread_send_retries_timeout_recovery_until_status_catches_up` verifying multi-poll retry
