### PR TITLE
[codex] Fix Discord typing cleanup on cancelled begin

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -1993,7 +1993,6 @@ class DiscordBotService:
         began = False
         try:
             await self._begin_typing_indicator(channel_id)
-            began = True
         except (RuntimeError, TypeError) as exc:
             log_event(
                 self._logger,
@@ -2002,6 +2001,16 @@ class DiscordBotService:
                 channel_id=channel_id,
                 exc=exc,
             )
+        except BaseException:
+            with contextlib.suppress(
+                RuntimeError,
+                TypeError,
+                asyncio.CancelledError,
+            ):
+                await asyncio.shield(self._end_typing_indicator(channel_id))
+            raise
+        else:
+            began = True
         try:
             await work()
         finally:

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -5,6 +5,7 @@ import contextlib
 import hashlib
 import json
 import logging
+import time
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -186,6 +187,22 @@ class _FakeRest:
             }
         )
         return commands
+
+
+class _TypingExpiryFakeRest(_FakeRest):
+    def __init__(self, *, ttl_seconds: float) -> None:
+        super().__init__()
+        self._ttl_seconds = ttl_seconds
+        self._visible_until_by_channel: dict[str, float] = {}
+
+    async def trigger_typing(self, *, channel_id: str) -> None:
+        await super().trigger_typing(channel_id=channel_id)
+        self._visible_until_by_channel[channel_id] = (
+            time.monotonic() + self._ttl_seconds
+        )
+
+    def typing_visible(self, channel_id: str) -> bool:
+        return time.monotonic() < self._visible_until_by_channel.get(channel_id, 0.0)
 
 
 class _FakeGateway:
@@ -10363,6 +10380,80 @@ async def test_typing_indicator_reference_count_waits_for_last_end(
         assert await service._typing_session_active("channel-1")
         await service._end_typing_indicator("channel-1")
         assert not await service._typing_session_active("channel-1")
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_typing_indicator_can_remain_visible_briefly_after_local_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _TypingExpiryFakeRest(ttl_seconds=0.1)
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    monkeypatch.setattr(
+        discord_service_module,
+        "DISCORD_TYPING_HEARTBEAT_INTERVAL_SECONDS",
+        0.02,
+    )
+
+    async def _work() -> None:
+        deadline = time.monotonic() + 1.0
+        while len(rest.typing_calls) < 2:
+            assert time.monotonic() < deadline
+            await asyncio.sleep(0.005)
+
+    try:
+        await service._run_with_typing_indicator(channel_id="channel-1", work=_work)
+        assert rest.typing_calls[:2] == ["channel-1", "channel-1"]
+        assert not await service._typing_session_active("channel-1")
+        assert rest.typing_visible("channel-1")
+        await asyncio.sleep(0.15)
+        assert not rest.typing_visible("channel-1")
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_typing_indicator_cleans_up_if_begin_is_cancelled_after_start(
+    tmp_path: Path,
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    original_begin = service._begin_typing_indicator
+
+    async def _cancel_after_start(channel_id: str) -> None:
+        await original_begin(channel_id)
+        raise asyncio.CancelledError()
+
+    service._begin_typing_indicator = _cancel_after_start  # type: ignore[method-assign]
+
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await service._run_with_typing_indicator(
+                channel_id="channel-1",
+                work=lambda: asyncio.sleep(0),
+            )
+        assert not await service._typing_session_active("channel-1")
+        assert service._typing_sessions == {}
+        assert service._typing_tasks == {}
     finally:
         await store.close()
 


### PR DESCRIPTION
## What changed
This PR tightens Discord typing-indicator cleanup and adds regression coverage around the investigation into lingering typing indicators after PMA/Hermes turns.

Changes:
- fix `DiscordBotService._run_with_typing_indicator(...)` so cancellation during `_begin_typing_indicator(...)` still unwinds the local typing session before re-raising
- add a regression test that reproduces the cancellation-after-start case and verifies `typing_sessions` / `typing_tasks` are cleaned up
- add a focused test that models Discord's server-side typing expiry to document and reproduce the benign case where typing can still be visible briefly after local completion
- slightly loosen the fake expiry timing in the linger test to reduce CI flake risk

## Why it changed
The investigation turned up two different explanations for the user-visible symptom:

1. Discord platform behavior:
   The Discord typing endpoint is a heartbeat that expires server-side after a short TTL. There is no explicit remote "stop typing" call, so the last heartbeat can remain visible briefly even after our local turn is complete.

2. Real local cleanup hole:
   In the old code, if cancellation landed after `_begin_typing_indicator(...)` had already incremented local state but before `_run_with_typing_indicator(...)` had set `began = True`, the matching `_end_typing_indicator(...)` call could be skipped. That leaked the local typing session/task and could extend the symptom beyond the normal Discord expiry window.

This PR fixes the second issue and adds tests for both behaviors so the distinction is explicit.

## Impact
- prevents leaked Discord typing sessions/tasks during cancellation races
- preserves existing behavior for ordinary begin failures (`RuntimeError` / `TypeError`)
- documents that brief post-completion typing visibility can still be expected from Discord's own expiry semantics

## Validation
Manual investigation:
- reviewed Discord typing lifecycle, PMA managed-thread flow, hub logs, and orchestration/Discord sqlite state
- reproduced the cancellation leak with a targeted Python harness before the fix

Automated checks:
- `./.venv/bin/pytest tests/integrations/discord/test_service_routing.py -k "typing_indicator"`
- pre-commit hook suite during `git commit`, including repo checks and full pytest
- hook result: `5173 passed`

## Root cause
Root cause for the actual bug fixed here: `_run_with_typing_indicator(...)` only marked `began = True` after `_begin_typing_indicator(...)` returned. A cancellation in that narrow window could increment local typing state without running the matching end path.

Root cause for the remaining brief symptom: Discord typing visibility is heartbeat/TTL based, so local completion cannot instantly retract the last successfully posted typing indicator.