### PR TITLE
[codex] Restore contextspace tree compatibility

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/contextspace.py
+++ b/src/codex_autorunner/surfaces/web/routes/contextspace.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from pathlib import Path
+
 from fastapi import APIRouter, HTTPException, Request
 
 from ....contextspace.paths import (
     CONTEXTSPACE_DOC_KINDS,
+    contextspace_dir,
     read_contextspace_docs,
     serialize_contextspace_doc_catalog,
     write_contextspace_doc,
@@ -31,10 +35,68 @@ def build_contextspace_routes() -> APIRouter:
             "kinds": serialize_contextspace_doc_catalog(),
         }
 
+    def _contextspace_tree_payload(repo_root):
+        base = contextspace_dir(repo_root)
+        base.mkdir(parents=True, exist_ok=True)
+        pinned_paths = {entry["path"] for entry in serialize_contextspace_doc_catalog()}
+
+        def _serialize_node(path: Path) -> dict[str, object]:
+            rel_path = path.relative_to(base).as_posix()
+            stat = path.stat()
+            modified_at = datetime.fromtimestamp(
+                stat.st_mtime, tz=timezone.utc
+            ).isoformat()
+            if path.is_dir():
+                children = [
+                    _serialize_node(child)
+                    for child in sorted(
+                        path.iterdir(),
+                        key=lambda child: (
+                            child.is_file(),
+                            child.name.lower(),
+                        ),
+                    )
+                ]
+                return {
+                    "name": path.name,
+                    "path": rel_path,
+                    "type": "folder",
+                    "modified_at": modified_at,
+                    "size": None,
+                    "is_pinned": False,
+                    "children": children,
+                }
+            return {
+                "name": path.name,
+                "path": rel_path,
+                "type": "file",
+                "modified_at": modified_at,
+                "size": stat.st_size,
+                "is_pinned": rel_path in pinned_paths,
+            }
+
+        tree = [
+            _serialize_node(child)
+            for child in sorted(
+                base.iterdir(),
+                key=lambda child: (
+                    child.is_file(),
+                    0 if child.name in pinned_paths else 1,
+                    child.name.lower(),
+                ),
+            )
+        ]
+        return {"tree": tree, "defaultPath": "active_context.md"}
+
     @router.get("/contextspace", response_model=ContextspaceResponse)
     def get_contextspace(request: Request):
         repo_root = request.app.state.engine.repo_root
         return _contextspace_payload(repo_root)
+
+    @router.get("/contextspace/tree")
+    def get_contextspace_tree(request: Request):
+        repo_root = request.app.state.engine.repo_root
+        return _contextspace_tree_payload(repo_root)
 
     @router.put("/contextspace/{kind}", response_model=ContextspaceResponse)
     def put_contextspace(

--- a/tests/routes/test_contextspace_routes.py
+++ b/tests/routes/test_contextspace_routes.py
@@ -38,6 +38,23 @@ def test_contextspace_get_includes_catalog(tmp_path: Path) -> None:
     assert [entry["kind"] for entry in payload["kinds"]] == list(CONTEXTSPACE_DOC_KINDS)
 
 
+def test_contextspace_tree_lists_seeded_docs(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    client = _client_for_repo(repo_root)
+
+    res = client.get("/api/contextspace/tree")
+
+    assert res.status_code == 200
+    payload = res.json()
+    assert payload["defaultPath"] == "active_context.md"
+    nodes = {entry["path"]: entry for entry in payload["tree"]}
+    assert set(nodes) >= {"active_context.md", "decisions.md", "spec.md"}
+    assert nodes["active_context.md"]["type"] == "file"
+    assert nodes["active_context.md"]["is_pinned"] is True
+    assert isinstance(nodes["active_context.md"]["size"], int)
+
+
 def test_contextspace_put_rejects_unknown_keys(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     repo_root.mkdir()


### PR DESCRIPTION
## Summary
- restore `GET /api/contextspace/tree` as a compatibility route for older folder-aware Contextspace clients
- return the seeded pinned docs as tree nodes with metadata and `defaultPath=active_context.md`
- add a route regression test that locks the compatibility contract in place

## Root cause
The mounted repo UI in the failing screenshot was still calling `GET /api/contextspace/tree`.
That route had been removed when Contextspace was simplified to the catalog-based `/api/contextspace` API, but `PUT /api/contextspace/{kind}` still existed.
As a result, `GET /api/contextspace/tree` matched the same path shape and FastAPI returned `405 Method Not Allowed`, which prevented the Contextspace tree from loading and left the tab blank.

## Validation
- `./.venv/bin/pytest tests/routes/test_contextspace_routes.py -q`
- `curl http://127.0.0.1:8765/api/contextspace/tree`
- `./car render screenshot --url 'http://127.0.0.1:8766/car/repos/codex-autorunner--discord-1/?tab=contextspace' ...`
