### PR TITLE
Make running execution lookups read-only

### DIFF
--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -1214,14 +1214,9 @@ class PmaThreadStore:
         return self.get_running_turn(managed_thread_id) is not None
 
     def get_running_turn(self, managed_thread_id: str) -> Optional[dict[str, Any]]:
-        with self._write_conn() as conn:
-            # Status checks can be polled frequently; avoid age-based interruption of
-            # the currently-tracked status turn during passive reads.
-            self._recover_stale_running_turns(
-                conn,
-                managed_thread_id,
-                include_status_turn_age_recovery=False,
-            )
+        # Passive status checks must stay read-only so hub control-plane probes do
+        # not contend on the PMA write lock or trigger the legacy mirror path.
+        with self._read_conn() as conn:
             row = conn.execute(
                 """
                 SELECT *

--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -1216,21 +1216,33 @@ class PmaThreadStore:
     def get_running_turn(self, managed_thread_id: str) -> Optional[dict[str, Any]]:
         # Passive status checks must stay read-only so hub control-plane probes do
         # not contend on the PMA write lock or trigger the legacy mirror path.
+        # Still filter out rows that are already logically stale because thread
+        # state no longer points at them; mutation paths perform the actual
+        # recovery when they acquire the write lock.
         with self._read_conn() as conn:
-            row = conn.execute(
+            stale_execution_ids = set(
+                self._lifecycle.find_stale_running_turn_ids(
+                    conn,
+                    managed_thread_id,
+                    include_status_turn_age_recovery=False,
+                )
+            )
+            rows = conn.execute(
                 """
                 SELECT *
                   FROM orch_thread_executions
                  WHERE thread_target_id = ?
                    AND status = 'running'
                  ORDER BY started_at DESC, execution_id DESC
-                 LIMIT 1
                 """,
                 (managed_thread_id,),
-            ).fetchone()
-        if row is None:
-            return None
-        return _execution_row_to_record(row)
+            ).fetchall()
+        for row in rows:
+            execution_id = str(row["execution_id"] or "").strip()
+            if execution_id and execution_id in stale_execution_ids:
+                continue
+            return _execution_row_to_record(row)
+        return None
 
     def get_turn(
         self, managed_thread_id: str, managed_turn_id: str

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -724,6 +724,44 @@ def test_get_running_turn_uses_read_only_status_path(
     assert fetched["status"] == "running"
 
 
+def test_get_running_turn_hides_logically_stale_running_rows_without_writing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = PmaThreadStore(tmp_path / "hub")
+    thread = store.create_thread("codex", tmp_path / "workspace")
+    running_turn = store.create_turn(thread["managed_thread_id"], prompt="first")
+
+    with store._write_conn() as conn:
+        with conn:
+            conn.execute(
+                """
+                UPDATE orch_thread_targets
+                   SET status_turn_id = ?,
+                       updated_at = ?
+                 WHERE thread_target_id = ?
+                """,
+                (
+                    "different-execution",
+                    running_turn["started_at"],
+                    thread["managed_thread_id"],
+                ),
+            )
+
+    def _fail_write_conn():  # type: ignore[no-untyped-def]
+        raise AssertionError("passive running-turn lookup should not write")
+
+    monkeypatch.setattr(store, "_write_conn", _fail_write_conn)
+
+    assert store.get_running_turn(thread["managed_thread_id"]) is None
+
+    stale_row = store.get_turn(
+        thread["managed_thread_id"], running_turn["managed_turn_id"]
+    )
+    assert stale_row is not None
+    assert stale_row["status"] == "running"
+
+
 def test_claim_next_queued_turn_recovers_old_running_execution_when_status_turn_matches(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -704,6 +704,26 @@ def test_create_turn_recovers_old_running_execution_when_status_turn_matches(
     assert stale_after["finished_at"]
 
 
+def test_get_running_turn_uses_read_only_status_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = PmaThreadStore(tmp_path / "hub")
+    thread = store.create_thread("codex", tmp_path / "workspace")
+    running_turn = store.create_turn(thread["managed_thread_id"], prompt="first")
+
+    def _fail_write_conn():  # type: ignore[no-untyped-def]
+        raise AssertionError("passive running-turn lookup should not write")
+
+    monkeypatch.setattr(store, "_write_conn", _fail_write_conn)
+
+    fetched = store.get_running_turn(thread["managed_thread_id"])
+
+    assert fetched is not None
+    assert fetched["managed_turn_id"] == running_turn["managed_turn_id"]
+    assert fetched["status"] == "running"
+
+
 def test_claim_next_queued_turn_recovers_old_running_execution_when_status_turn_matches(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- make passive PMA running-execution lookups use the read-only path instead of the write/mirror path
- keep stale-running recovery on mutation paths and add a regression test that fails if `get_running_turn()` re-enters `_write_conn()`
- avoid hub control-plane status probes contending on the PMA write lock or triggering the legacy mirror for simple `get_running_execution` checks

## Root cause
`RemoteThreadExecutionStore.get_running_execution()` has a hard 10 second timeout. The hub-side implementation for `get_running_execution` eventually called `PmaThreadStore.get_running_turn()`, which used `_write_conn()`. That path takes the PMA lock and runs the legacy mirror on exit, so a passive status probe could block long enough to trip the control-plane timeout.

## Testing
- `.venv/bin/python -m pytest tests/test_pma_thread_store.py -q`
- `.venv/bin/python -m pytest tests/core/test_hub_control_plane_service.py -q`
- `git commit` pre-commit suite: `5572 passed, 9 xfailed`
