### PR TITLE
[codex] Fix compact live output when stream only has step updates

### DIFF
--- a/src/codex_autorunner/static/generated/tickets.js
+++ b/src/codex_autorunner/static/generated/tickets.js
@@ -622,10 +622,12 @@ function renderCompactLiveOutputText() {
 function compactLiveOutputBufferText() {
     const recentLines = liveOutputBuffer
         .map((line) => line.trim())
-        .filter((line) => line && !/^--- Step: .* ---$/.test(line));
+        .filter((line) => line);
     if (!recentLines.length)
         return "";
-    return recentLines.slice(-3).join(" ").replace(/\s+/g, " ").trim();
+    const nonStepLines = recentLines.filter((line) => !/^--- Step: .* ---$/.test(line));
+    const compactLines = nonStepLines.length ? nonStepLines : recentLines;
+    return compactLines.slice(-3).join(" ").replace(/\s+/g, " ").trim();
 }
 function updateLiveOutputViewToggle() {
     const viewToggle = document.getElementById("ticket-live-output-view-toggle");

--- a/src/codex_autorunner/static_src/tickets.ts
+++ b/src/codex_autorunner/static_src/tickets.ts
@@ -791,9 +791,12 @@ function renderCompactLiveOutputText(): string {
 function compactLiveOutputBufferText(): string {
   const recentLines = liveOutputBuffer
     .map((line) => line.trim())
-    .filter((line) => line && !/^--- Step: .* ---$/.test(line));
+    .filter((line) => line);
   if (!recentLines.length) return "";
-  return recentLines.slice(-3).join(" ").replace(/\s+/g, " ").trim();
+
+  const nonStepLines = recentLines.filter((line) => !/^--- Step: .* ---$/.test(line));
+  const compactLines = nonStepLines.length ? nonStepLines : recentLines;
+  return compactLines.slice(-3).join(" ").replace(/\s+/g, " ").trim();
 }
 
 function updateLiveOutputViewToggle(): void {

--- a/tests/test_ticket_flow_ui_integration.py
+++ b/tests/test_ticket_flow_ui_integration.py
@@ -85,3 +85,76 @@ def test_ticket_flow_compact_live_output_falls_back_to_stream_deltas() -> None:
     )
 
     subprocess.run(["node", "--input-type=module", "-e", script], check=True)
+
+
+def test_ticket_flow_compact_live_output_shows_step_progress_when_no_agent_text() -> (
+    None
+):
+    repo_root = Path(__file__).resolve().parents[1]
+    tickets_js = (
+        repo_root / "src" / "codex_autorunner" / "static" / "generated" / "tickets.js"
+    )
+
+    script = textwrap.dedent(
+        f"""
+        import assert from "node:assert/strict";
+        import {{ pathToFileURL }} from "node:url";
+        import {{ JSDOM }} from "jsdom";
+
+        const dom = new JSDOM(
+          `<!doctype html><html><body>
+            <div id="ticket-live-output-status"></div>
+            <button id="ticket-live-output-view-toggle" type="button"></button>
+            <div id="ticket-live-output-compact"></div>
+            <div id="ticket-live-output-detail" class="hidden"></div>
+            <pre id="ticket-live-output-text"></pre>
+            <div id="ticket-live-output-events" class="hidden">
+              <span id="ticket-live-output-events-count"></span>
+              <div id="ticket-live-output-events-list"></div>
+            </div>
+          </body></html>`,
+          {{ url: "http://localhost/repos/test/" }}
+        );
+
+        globalThis.window = dom.window;
+        globalThis.document = dom.window.document;
+        globalThis.HTMLElement = dom.window.HTMLElement;
+        globalThis.HTMLButtonElement = dom.window.HTMLButtonElement;
+        globalThis.Node = dom.window.Node;
+        globalThis.Event = dom.window.Event;
+        globalThis.CustomEvent = dom.window.CustomEvent;
+        globalThis.DOMParser = dom.window.DOMParser;
+        globalThis.localStorage = dom.window.localStorage;
+        globalThis.sessionStorage = dom.window.sessionStorage;
+        globalThis.requestAnimationFrame = (cb) => setTimeout(() => cb(Date.now()), 0);
+        globalThis.cancelAnimationFrame = (id) => clearTimeout(id);
+        globalThis.fetch = async () => {{
+          throw new Error("unexpected fetch in ticket flow integration test");
+        }};
+
+        const moduleUrl = pathToFileURL("{tickets_js.as_posix()}").href;
+        const mod = await import(moduleUrl);
+        const helpers = mod.__ticketFlowTest;
+
+        helpers.clearLiveOutput();
+        helpers.initLiveOutputPanel();
+        helpers.setFlowStartedAt(Date.parse("2026-04-12T00:00:00Z"));
+
+        helpers.handleFlowEvent({{
+          event_type: "step_started",
+          timestamp: "2026-04-12T00:00:01Z",
+          data: {{ step_name: "ticket_turn" }},
+        }});
+
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        const compact = document.getElementById("ticket-live-output-compact")?.textContent || "";
+        const detail = document.getElementById("ticket-live-output-text")?.textContent || "";
+
+        assert.match(detail, /--- Step: ticket_turn ---/);
+        assert.match(compact, /--- Step: ticket_turn ---/);
+        assert.doesNotMatch(compact, /Waiting for agent output/);
+        """
+    )
+
+    subprocess.run(["node", "--input-type=module", "-e", script], check=True)


### PR DESCRIPTION
## Summary
- fix compact ticket-flow live output so it no longer falls back to "Waiting for agent output..." when the stream currently contains only step progress lines
- keep the previous preference for non-step lines, but fall back to step lines when those are the only available stream content
- add an integration regression test for the step-only stream case

## Root Cause
The compact renderer filtered out `--- Step: ... ---` lines unconditionally. During windows where the stream had step progress but no assistant text yet, the compact buffer became empty and the UI incorrectly showed "Waiting for agent output..." while expanded view still displayed the step output.

## Validation
- `pytest -q tests/test_ticket_flow_ui_integration.py`
- full pre-commit aggregate lane executed during commit (ruff, mypy, pytest suite, frontend build/tests, contract checks)
