### PR TITLE
[codex] Fix Discord archive button fallback

### DIFF
--- a/src/codex_autorunner/integrations/discord/flow_commands.py
+++ b/src/codex_autorunner/integrations/discord/flow_commands.py
@@ -302,6 +302,81 @@ def _format_archived_flow_status_text(
     return "\n".join(lines)
 
 
+def _archived_flow_status_summary_from_archive_result(
+    workspace_root: Path,
+    summary: dict[str, Any],
+) -> Optional[dict[str, Any]]:
+    run_id_value = summary.get("run_id")
+    if not isinstance(run_id_value, str) or not run_id_value.strip():
+        return None
+    normalized_run_id = _normalize_run_id(run_id_value)
+    if normalized_run_id is None:
+        return None
+
+    archive_dir_value = summary.get("archive_dir")
+    if isinstance(archive_dir_value, str) and archive_dir_value.strip():
+        archive_root = Path(archive_dir_value)
+    else:
+        archive_root = flow_run_archive_root(workspace_root, normalized_run_id)
+
+    has_tickets = bool(summary.get("archived_tickets"))
+    has_runs = bool(summary.get("archived_runs"))
+    has_contextspace = bool(summary.get("archived_contextspace"))
+    has_flow_state = bool(summary.get("archived_flow_state"))
+
+    artifact_children: list[Path] = []
+    if archive_root.exists() and archive_root.is_dir():
+        artifact_children = [
+            child
+            for child in archive_root.iterdir()
+            if child.is_dir()
+            and (
+                child.name == "archived_tickets"
+                or child.name == "contextspace"
+                or child.name.startswith("archived_runs")
+                or child.name.startswith("flow_state")
+            )
+        ]
+        has_tickets = has_tickets or any(
+            child.name == "archived_tickets" for child in artifact_children
+        )
+        has_runs = has_runs or any(
+            child.name.startswith("archived_runs") for child in artifact_children
+        )
+        has_contextspace = has_contextspace or any(
+            child.name == "contextspace" for child in artifact_children
+        )
+        has_flow_state = has_flow_state or any(
+            child.name.startswith("flow_state") for child in artifact_children
+        )
+
+    mtime_candidates = []
+    for child in artifact_children:
+        try:
+            mtime_candidates.append(child.stat().st_mtime)
+        except OSError:
+            continue
+    archived_at = None
+    if mtime_candidates:
+        archived_at = datetime.fromtimestamp(
+            max(mtime_candidates), tz=timezone.utc
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    try:
+        archive_path = archive_root.relative_to(workspace_root).as_posix()
+    except ValueError:
+        archive_path = str(archive_root)
+    return {
+        "run_id": normalized_run_id,
+        "archive_path": archive_path,
+        "archived_at": archived_at,
+        "has_tickets": has_tickets,
+        "has_runs": has_runs,
+        "has_contextspace": has_contextspace,
+        "has_flow_state": has_flow_state,
+    }
+
+
 def _format_flow_archive_completion_text(summary: dict[str, Any]) -> str:
     return (
         f"Archived run {summary['run_id']} "
@@ -2434,17 +2509,45 @@ async def handle_flow_button(
             )
             return
 
-        await handle_flow_status(
-            service,
-            interaction_id,
-            interaction_token,
-            workspace_root=workspace_root,
-            options={"run_id": summary["run_id"]},
-            channel_id=channel_id,
-            guild_id=guild_id,
-            update_message=True,
-            prefix=_format_flow_archive_completion_text(summary),
-        )
+        archive_prefix = _format_flow_archive_completion_text(summary)
+        try:
+            await handle_flow_status(
+                service,
+                interaction_id,
+                interaction_token,
+                workspace_root=workspace_root,
+                options={"run_id": summary["run_id"]},
+                channel_id=channel_id,
+                guild_id=guild_id,
+                update_message=True,
+                prefix=archive_prefix,
+            )
+        except DiscordTransientError as exc:
+            archived_summary = _archived_flow_status_summary_from_archive_result(
+                workspace_root,
+                summary,
+            )
+            if archived_summary is None:
+                raise
+            log_event(
+                service._logger,
+                logging.WARNING,
+                "discord.flow.archive.status_refresh_failed",
+                run_id=summary["run_id"],
+                workspace_root=str(workspace_root),
+                exc=exc,
+            )
+            await update_runtime_component_message(
+                service,
+                interaction_id,
+                interaction_token,
+                _format_archived_flow_status_text(
+                    summary["run_id"],
+                    archived_summary,
+                    prefix=archive_prefix,
+                ),
+                components=[],
+            )
         return
     elif action == "restart":
         await defer_and_update_runtime_component_message(

--- a/tests/integrations/discord/test_flow_archive.py
+++ b/tests/integrations/discord/test_flow_archive.py
@@ -463,6 +463,80 @@ async def test_flow_archive_button_real_archive_renders_archived_state(
 
 
 @pytest.mark.anyio
+async def test_flow_archive_button_falls_back_when_status_refresh_is_transient(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = _workspace(tmp_path)
+    run_id = str(uuid.uuid4())
+    _create_run(workspace, run_id, FlowRunStatus.COMPLETED)
+
+    tickets_dir = workspace / ".codex-autorunner" / "tickets"
+    tickets_dir.mkdir(parents=True, exist_ok=True)
+    (tickets_dir / "TICKET-001.md").write_text("ticket", encoding="utf-8")
+
+    context_dir = workspace / ".codex-autorunner" / "contextspace"
+    context_dir.mkdir(parents=True, exist_ok=True)
+    (context_dir / "active_context.md").write_text("Active context\n", encoding="utf-8")
+
+    run_dir = workspace / ".codex-autorunner" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "DISPATCH.md").write_text("dispatch", encoding="utf-8")
+    live_flow_dir = workspace / ".codex-autorunner" / "flows" / run_id / "chat"
+    live_flow_dir.mkdir(parents=True, exist_ok=True)
+    (live_flow_dir / "outbound.jsonl").write_text("{}", encoding="utf-8")
+
+    rest = _FakeRest()
+    service = _service(tmp_path, rest)
+    real_open_flow_store = service._open_flow_store
+    open_calls = 0
+    logged_events: list[str] = []
+
+    def _fake_log_event(_logger: Any, _level: int, event: str, **kwargs: Any) -> None:
+        _ = kwargs
+        logged_events.append(event)
+
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.discord.flow_commands.log_event",
+        _fake_log_event,
+    )
+
+    def _flaky_open_flow_store(workspace_root: Path) -> FlowStore:
+        nonlocal open_calls
+        open_calls += 1
+        if open_calls == 1:
+            return real_open_flow_store(workspace_root)
+        raise sqlite3.OperationalError("database is locked")
+
+    service._open_flow_store = _flaky_open_flow_store  # type: ignore[assignment]
+
+    try:
+        await service._handle_flow_button(
+            "interaction-2-transient",
+            "token-2-transient",
+            workspace_root=workspace,
+            custom_id=f"flow:{run_id}:archive",
+            channel_id="channel-1",
+            guild_id="guild-1",
+        )
+    finally:
+        await service._store.close()
+
+    assert rest.interaction_responses[0]["payload"]["type"] == 6
+    assert len(rest.followup_messages) == 1
+    assert "Archiving run" in rest.followup_messages[0]["payload"]["content"]
+    edited = rest.edited_original_interaction_responses[0]["payload"]
+    assert "Archived run" in edited["content"]
+    assert "Status: archived" in edited["content"]
+    assert f"Archive path: .codex-autorunner/archive/runs/{run_id}" in edited["content"]
+    assert "Flow state archived: yes" in edited["content"]
+    assert edited["components"] == []
+    assert logged_events == [
+        "discord.flow.store_open_failed",
+        "discord.flow.archive.status_refresh_failed",
+    ]
+
+
+@pytest.mark.anyio
 async def test_flow_archive_button_classifies_open_sqlite_errors_as_store_open_failed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
Fix the Discord `/flow status` archive button path so a successful archive still updates the status card even when the immediate post-archive status refresh hits a transient `flows.db` error.

## Root cause
The archive button and `/flow archive` slash command both call the same archive backend, but the button path does extra Discord-side work afterward: it re-renders the original status card via `handle_flow_status(..., update_message=True)`.

If the archive succeeds and that follow-up status refresh encounters a transient SQLite lock, the interaction looks like a failed archive even though the run has already been archived. This matches the observed behavior in the Discord logs: the run was already archive-ready, `/flow archive` succeeded, and the noisy failures were on the status-card path.

## Changes
- add a helper that derives archived-run status details directly from the archive result and archive artifacts
- catch transient post-archive status refresh failures in the Discord flow button handler
- fall back to rendering an archived status card from archive artifacts instead of surfacing the transient refresh failure as the visible result
- add a regression test that simulates `sqlite3.OperationalError("database is locked")` during the post-archive status refresh

## Validation
- `python -m pytest tests/integrations/discord/test_flow_archive.py`
- full pre-commit suite completed on retry, including repo-wide pytest (`5701 passed, 9 xfailed`)

## Notes
I initially saw unrelated flaky failures during the hook-driven repo-wide pytest run. Rerunning those failing tests directly passed, and the second full hook run cleared successfully. The local `git commit` path then hung in a post-test budget-report step, so I published this branch from a clean commit built on `origin/main` after the substantive checks had already passed.