### PR TITLE
[codex] prune stale telegram prewarm workspaces

### DIFF
--- a/src/codex_autorunner/integrations/telegram/service.py
+++ b/src/codex_autorunner/integrations/telegram/service.py
@@ -521,19 +521,12 @@ class TelegramBotService(
             )
 
     async def _housekeeping_roots(self) -> list[Path]:
-        roots: set[Path] = set()
-        try:
-            state = await self._store.load()
-            for record in state.topics.values():
-                if isinstance(record.workspace_path, str) and record.workspace_path:
-                    roots.add(Path(record.workspace_path).expanduser().resolve())
-        except (OSError, ValueError) as exc:
-            log_event(
-                self._logger,
-                logging.WARNING,
-                "telegram.housekeeping.state_failed",
-                exc=exc,
+        roots = set(
+            await self._workspace_roots_from_state(
+                state_failed_event="telegram.housekeeping.state_failed",
+                prune_reason="housekeeping",
             )
+        )
         if self._hub_root and self._manifest_path and self._manifest_path.exists():
             try:
                 manifest = load_manifest(self._manifest_path, self._hub_root)
@@ -551,20 +544,83 @@ class TelegramBotService(
         return sorted(roots)
 
     async def _gather_workspace_roots(self) -> list[Path]:
+        return await self._workspace_roots_from_state(
+            state_failed_event="telegram.prewarm.state_failed",
+            prune_reason="prewarm",
+        )
+
+    async def _workspace_roots_from_state(
+        self,
+        *,
+        state_failed_event: str,
+        prune_reason: str,
+    ) -> list[Path]:
         roots: set[Path] = set()
+        stale_topics: list[tuple[str, Path]] = []
         try:
             state = await self._store.load()
-            for record in state.topics.values():
-                if isinstance(record.workspace_path, str) and record.workspace_path:
-                    roots.add(Path(record.workspace_path).expanduser().resolve())
+            for key, record in state.topics.items():
+                workspace_root = self._canonical_workspace_root(record.workspace_path)
+                if workspace_root is None:
+                    continue
+                if workspace_root.is_dir():
+                    roots.add(workspace_root)
+                    continue
+                stale_topics.append((key, workspace_root))
         except (OSError, ValueError) as exc:
             log_event(
                 self._logger,
                 logging.WARNING,
-                "telegram.prewarm.state_failed",
+                state_failed_event,
                 exc=exc,
             )
+            return []
+        if stale_topics:
+            await self._clear_stale_workspace_topics(
+                stale_topics,
+                reason=prune_reason,
+            )
         return sorted(roots)
+
+    async def _clear_stale_workspace_topics(
+        self,
+        topics: Sequence[tuple[str, Path]],
+        *,
+        reason: str,
+    ) -> None:
+        pruned_keys: list[str] = []
+        pruned_workspaces: list[str] = []
+        for key, workspace_root in topics:
+
+            def clear_stale_workspace(record: TelegramTopicRecord) -> None:
+                record.workspace_path = None
+                record.workspace_id = None
+
+            try:
+                await self._store.update_topic(key, clear_stale_workspace)
+            except (OSError, ValueError) as exc:
+                log_event(
+                    self._logger,
+                    logging.WARNING,
+                    "telegram.workspace_binding.prune_failed",
+                    reason=reason,
+                    topic_key=key,
+                    workspace_root=str(workspace_root),
+                    exc=exc,
+                )
+                continue
+            pruned_keys.append(key)
+            pruned_workspaces.append(str(workspace_root))
+        if pruned_keys:
+            log_event(
+                self._logger,
+                logging.INFO,
+                "telegram.workspace_binding.pruned",
+                reason=reason,
+                pruned_count=len(pruned_keys),
+                topic_keys=pruned_keys,
+                workspaces=pruned_workspaces,
+            )
 
     async def _prewarm_workspace_clients(self) -> None:
         workspace_roots = await self._gather_workspace_roots()
@@ -588,10 +644,21 @@ class TelegramBotService(
         sem = asyncio.Semaphore(3)
         prewarmed_count = 0
         failed_count = 0
+        skipped_missing_count = 0
 
         async def prewarm_one(workspace_root: Path) -> None:
-            nonlocal prewarmed_count, failed_count
+            nonlocal prewarmed_count, failed_count, skipped_missing_count
             async with sem:
+                if not workspace_root.is_dir():
+                    skipped_missing_count += 1
+                    log_event(
+                        self._logger,
+                        logging.INFO,
+                        "telegram.prewarm.client_skipped",
+                        workspace_root=str(workspace_root),
+                        reason="missing_workspace",
+                    )
+                    return
                 try:
                     await self._app_server_supervisor.get_client(workspace_root)
                     prewarmed_count += 1
@@ -623,6 +690,7 @@ class TelegramBotService(
             workspace_count=len(workspace_roots),
             prewarmed_count=prewarmed_count,
             failed_count=failed_count,
+            skipped_missing_count=skipped_missing_count,
         )
 
     async def _housekeeping_loop(self) -> None:

--- a/tests/test_telegram_filebox_housekeeping.py
+++ b/tests/test_telegram_filebox_housekeeping.py
@@ -8,6 +8,7 @@ import pytest
 from codex_autorunner.integrations.telegram import service as telegram_service_module
 from codex_autorunner.integrations.telegram.config import TelegramBotConfig
 from codex_autorunner.integrations.telegram.service import TelegramBotService
+from codex_autorunner.integrations.telegram.state import topic_key
 
 
 def _config(root: Path) -> TelegramBotConfig:
@@ -112,3 +113,88 @@ async def test_housekeeping_cycle_prunes_fileboxes_using_per_root_repo_config(
     assert housekeeping_calls == [[repo_root, workspace_root]]
     assert app_server_pruned == 1
     assert opencode_pruned == 1
+
+
+@pytest.mark.anyio
+async def test_gather_workspace_roots_prunes_missing_workspace_bindings(
+    tmp_path: Path,
+) -> None:
+    service = TelegramBotService(_config(tmp_path), hub_root=tmp_path)
+    live_workspace = tmp_path / "live-workspace"
+    live_workspace.mkdir()
+    missing_workspace = tmp_path / "missing-workspace"
+    live_key = topic_key(123, 10)
+    missing_key = topic_key(123, 11)
+
+    try:
+        await service._store.bind_topic(live_key, str(live_workspace))
+        await service._store.bind_topic(missing_key, str(missing_workspace))
+
+        roots = await service._gather_workspace_roots()
+        stale_record = await service._store.get_topic(missing_key)
+        live_record = await service._store.get_topic(live_key)
+    finally:
+        await service._bot.close()
+        await service._store.close()
+
+    assert roots == [live_workspace.resolve()]
+    assert live_record is not None
+    assert live_record.workspace_path == str(live_workspace)
+    assert stale_record is not None
+    assert stale_record.workspace_path is None
+    assert stale_record.workspace_id is None
+
+
+@pytest.mark.anyio
+async def test_housekeeping_roots_prune_missing_workspace_bindings(
+    tmp_path: Path,
+) -> None:
+    service = TelegramBotService(_config(tmp_path), hub_root=tmp_path)
+    live_workspace = tmp_path / "housekeeping-live"
+    live_workspace.mkdir()
+    missing_workspace = tmp_path / "housekeeping-missing"
+    missing_key = topic_key(123, 12)
+
+    try:
+        await service._store.bind_topic(topic_key(123, 13), str(live_workspace))
+        await service._store.bind_topic(missing_key, str(missing_workspace))
+
+        roots = await service._housekeeping_roots()
+        stale_record = await service._store.get_topic(missing_key)
+    finally:
+        await service._bot.close()
+        await service._store.close()
+
+    assert roots == sorted([tmp_path.resolve(), live_workspace.resolve()])
+    assert stale_record is not None
+    assert stale_record.workspace_path is None
+    assert stale_record.workspace_id is None
+
+
+@pytest.mark.anyio
+async def test_prewarm_skips_missing_workspaces_without_spawning(
+    tmp_path: Path,
+) -> None:
+    service = TelegramBotService(_config(tmp_path), hub_root=tmp_path)
+    live_workspace = tmp_path / "prewarm-live"
+    live_workspace.mkdir()
+    missing_workspace = tmp_path / "prewarm-missing"
+
+    await service._store.bind_topic(topic_key(123, 20), str(live_workspace))
+    await service._store.bind_topic(topic_key(123, 21), str(missing_workspace))
+
+    started_roots: list[Path] = []
+
+    async def _fake_get_client(workspace_root: Path) -> object:
+        started_roots.append(workspace_root)
+        return object()
+
+    service._app_server_supervisor = SimpleNamespace(get_client=_fake_get_client)
+
+    try:
+        await service._prewarm_workspace_clients()
+    finally:
+        await service._bot.close()
+        await service._store.close()
+
+    assert started_roots == [live_workspace.resolve()]


### PR DESCRIPTION
## Summary
- prune missing Telegram workspace bindings before prewarm and housekeeping reuse them
- skip app-server prewarm when a workspace disappears between root gathering and spawn
- add regression coverage for stale binding cleanup and prewarm skipping

## Root Cause
Telegram startup prewarm was reading persisted workspace paths from topic state without validating they still existed on disk. Removed worktrees stayed in state indefinitely, so every hub restart could spawn or attempt to spawn app-servers for dead paths.

## Validation
- .venv/bin/python -m pytest tests/test_telegram_filebox_housekeeping.py
- pre-commit lane via git hook: black, ruff, mypy, pytest (5737 passed, 9 xfailed)

Closes #1448
