### PR TITLE
[codex] Fix Discord interrupt UX and interrupted turn messaging

### DIFF
--- a/src/codex_autorunner/integrations/discord/car_handlers/session_commands.py
+++ b/src/codex_autorunner/integrations/discord/car_handlers/session_commands.py
@@ -1341,7 +1341,7 @@ async def handle_car_interrupt(
     interaction_token: str,
     *,
     channel_id: str,
-    active_turn_text: str = "Stopping current turn...",
+    active_turn_text: str = "Interrupt succeeded.",
     cancel_queued: bool = True,
     allow_promoted_no_active_success: bool = False,
     thread_target_id: Optional[str] = None,
@@ -1460,11 +1460,37 @@ async def handle_car_interrupt(
         text = format_discord_message("No active turn to interrupt.")
         await service.respond_ephemeral(interaction_id, interaction_token, text)
         return
-    deferred = await ensure_ephemeral_response_deferred(
-        service,
-        interaction_id,
-        interaction_token,
-    )
+    respond_via_component_update = source == "component"
+    if respond_via_component_update:
+        deferred = await ensure_component_response_deferred(
+            service,
+            interaction_id,
+            interaction_token,
+        )
+    else:
+        deferred = await ensure_ephemeral_response_deferred(
+            service,
+            interaction_id,
+            interaction_token,
+        )
+
+    async def _send_interrupt_response(text: str) -> None:
+        if respond_via_component_update:
+            await service.send_or_update_component_message(
+                interaction_id=interaction_id,
+                interaction_token=interaction_token,
+                deferred=deferred,
+                text=text,
+                components=[],
+            )
+            return
+        await service.send_or_respond_ephemeral(
+            interaction_id=interaction_id,
+            interaction_token=interaction_token,
+            deferred=deferred,
+            text=text,
+        )
+
     get_running_execution = getattr(
         orchestration_service, "get_running_execution", None
     )
@@ -1501,12 +1527,7 @@ async def handle_car_interrupt(
             note=note,
         )
         text = format_discord_message("This progress message belongs to an older turn.")
-        await service.send_or_respond_ephemeral(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
-            deferred=deferred,
-            text=text,
-        )
+        await _send_interrupt_response(text)
         return
     try:
         operation_store = None
@@ -1549,21 +1570,11 @@ async def handle_car_interrupt(
                     thread_target_id=current_thread.thread_target_id,
                 )
             text = format_discord_message("Interrupt failed. Please try again.")
-            await service.send_or_respond_ephemeral(
-                interaction_id=interaction_id,
-                interaction_token=interaction_token,
-                deferred=deferred,
-                text=text,
-            )
+            await _send_interrupt_response(text)
             return
         if interrupt_outcome.state == SharedInterruptState.STILL_STOPPING:
             text = format_discord_message("Still stopping current turn...")
-            await service.send_or_respond_ephemeral(
-                interaction_id=interaction_id,
-                interaction_token=interaction_token,
-                deferred=deferred,
-                text=text,
-            )
+            await _send_interrupt_response(text)
             return
         if (
             not interrupted_active
@@ -1572,12 +1583,7 @@ async def handle_car_interrupt(
         ):
             if allow_promoted_no_active_success:
                 text = format_discord_message("Queued request moved to the front.")
-                await service.send_or_respond_ephemeral(
-                    interaction_id=interaction_id,
-                    interaction_token=interaction_token,
-                    deferred=deferred,
-                    text=text,
-                )
+                await _send_interrupt_response(text)
                 return
             get_execution = getattr(orchestration_service, "get_execution", None)
             get_latest_execution = getattr(
@@ -1616,15 +1622,10 @@ async def handle_car_interrupt(
                 note=note,
             )
             text = format_discord_message("No active turn to interrupt.")
-            await service.send_or_respond_ephemeral(
-                interaction_id=interaction_id,
-                interaction_token=interaction_token,
-                deferred=deferred,
-                text=(
-                    format_discord_message("Current turn already finished.")
-                    if interrupt_outcome.state == SharedInterruptState.ALREADY_FINISHED
-                    else text
-                ),
+            await _send_interrupt_response(
+                format_discord_message("Current turn already finished.")
+                if interrupt_outcome.state == SharedInterruptState.ALREADY_FINISHED
+                else text
             )
             return
         if interrupted_active:
@@ -1664,12 +1665,7 @@ async def handle_car_interrupt(
                 queued_text_template="Cancelled {count} queued turn(s).",
             )
         )
-        await service.send_or_respond_ephemeral(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
-            deferred=deferred,
-            text=text,
-        )
+        await _send_interrupt_response(text)
 
     except (RuntimeError, ConnectionError, OSError, ValueError) as exc:
         if progress_reuse_source_message_id or progress_reuse_acknowledgement:
@@ -1693,12 +1689,7 @@ async def handle_car_interrupt(
             exc=exc,
         )
         text = format_discord_message("Interrupt failed. Please try again.")
-        await service.send_or_respond_ephemeral(
-            interaction_id=interaction_id,
-            interaction_token=interaction_token,
-            deferred=deferred,
-            text=text,
-        )
+        await _send_interrupt_response(text)
 
 
 # Keep explicit module-level references so dead-code heuristics treat the

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -1319,6 +1319,7 @@ async def _submit_discord_thread_message(
             timeout_error=timeout_error,
             interrupted_error=interrupted_error,
         )
+        interrupted_turn = failure_message == interrupted_error
         dispatch.log_event_fn(
             dispatch.service._logger,
             logging.WARNING,
@@ -1342,7 +1343,11 @@ async def _submit_discord_thread_message(
             "Status: this turn finished, but Discord failed before the final "
             "reply was delivered. Please retry if needed."
             if during_delivery
-            else f"Turn failed: {failure_message}"
+            else (
+                "Status: this turn was interrupted."
+                if interrupted_turn
+                else f"Turn failed: {failure_message}"
+            )
         )
         reconciled = await supervision.reconcile_failure(
             failure_note=reconciliation_note,
@@ -1364,7 +1369,11 @@ async def _submit_discord_thread_message(
             fallback_text = (
                 "Turn finished, but final reply delivery failed. Please retry."
                 if during_delivery
-                else f"Turn failed: {failure_message}"
+                else (
+                    "Turn interrupted."
+                    if interrupted_turn
+                    else f"Turn failed: {failure_message}"
+                )
             )
             await dispatch.service._send_channel_message_safe(
                 dispatch.channel_id,
@@ -2672,6 +2681,8 @@ def _build_discord_runner_hooks(
                     record_id=record_id,
                 )
             return
+        if finalized.status == "interrupted":
+            return
         await service._send_channel_message_safe(
             channel_id,
             {"content": (f"Turn failed: {finalized.error or public_execution_error}")},
@@ -3285,6 +3296,12 @@ async def _run_discord_orchestrated_turn_for_message(
                         execution_id=progress_execution_id,
                         send_final_message=not acknowledgement_delivered,
                     )
+                return DiscordMessageTurnResult(
+                    final_message="",
+                    preview_message_id=progress_message_id,
+                    execution_id=progress_execution_id,
+                    send_final_message=False,
+                )
             raise RuntimeError(str(finalized.error or public_execution_error))
         summary_snapshot = ""
         if (

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -9241,7 +9241,7 @@ class DiscordBotService:
         interaction_token: str,
         *,
         channel_id: str,
-        active_turn_text: str = "Stopping current turn...",
+        active_turn_text: str = "Interrupt succeeded.",
         cancel_queued: bool = True,
         allow_promoted_no_active_success: bool = False,
         thread_target_id: Optional[str] = None,

--- a/tests/chat_surface_integration/test_hermes_pma_ux_regressions.py
+++ b/tests/chat_surface_integration/test_hermes_pma_ux_regressions.py
@@ -194,9 +194,17 @@ async def test_surfaces_acknowledge_interrupt_controls_before_final_confirmation
         assert discord.rest is not None
         assert discord.rest.interaction_responses[0]["payload"]["type"] == 6
         assert (
-            discord.rest.edited_original_interaction_responses[-1]["payload"]["content"]
+            discord.rest.edited_original_interaction_responses[0]["payload"]["content"]
             == "Stopping current turn..."
         )
+        discord_final_interrupt_content = (
+            discord.rest.edited_original_interaction_responses[-1]["payload"]["content"]
+        )
+        assert discord_final_interrupt_content != "Stopping current turn..."
+        assert discord_final_interrupt_content in {
+            "Interrupt succeeded.",
+            "Recovered stale session after backend thread was lost.",
+        }
         discord_ack = await discord.wait_for_log_event(
             "discord.turn.cancel_acknowledged"
         )

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -8799,7 +8799,7 @@ async def test_car_interrupt_uses_orchestration_thread_state(tmp_path: Path) -> 
         assert rest.interaction_responses[0]["payload"]["type"] == 5
         assert len(rest.followup_messages) == 1
         content = rest.followup_messages[0]["payload"]["content"].lower()
-        assert "stopping current turn" in content
+        assert "interrupt succeeded" in content
         assert "cancelled 2 queued turn" in content
     finally:
         await store.close()
@@ -9129,6 +9129,84 @@ async def test_car_interrupt_reports_already_finished_when_turn_is_no_longer_act
 
 
 @pytest.mark.anyio
+async def test_cancel_turn_button_updates_component_to_interrupt_success_on_confirmation(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+    )
+
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    class _FakeThreadService:
+        def get_thread_target(self, thread_target_id: str) -> Any:
+            assert thread_target_id == "thread-1"
+            return SimpleNamespace(thread_target_id="thread-1")
+
+        def get_running_execution(self, thread_target_id: str) -> Any:
+            assert thread_target_id == "thread-1"
+            return SimpleNamespace(execution_id="turn-1", status="running")
+
+        async def stop_thread(self, thread_target_id: str) -> Any:
+            assert thread_target_id == "thread-1"
+            return SimpleNamespace(
+                interrupted_active=True,
+                recovered_lost_backend=False,
+                cancelled_queued=0,
+                execution=SimpleNamespace(execution_id="turn-1"),
+            )
+
+    service._discord_thread_service = lambda: _FakeThreadService()  # type: ignore[assignment]
+
+    try:
+        await service._handle_cancel_turn_button(
+            "interaction-1",
+            "token-1",
+            channel_id="channel-1",
+            user_id="user-1",
+            message_id="preview-1",
+            custom_id="cancel_turn:thread-1:turn-1",
+        )
+
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
+        assert rest.followup_messages == []
+        assert len(rest.edited_original_interaction_responses) == 2
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["content"]
+            == "Stopping current turn..."
+        )
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["components"] == []
+        )
+        assert (
+            rest.edited_original_interaction_responses[1]["payload"]["content"]
+            == "Interrupt succeeded."
+        )
+        assert (
+            rest.edited_original_interaction_responses[1]["payload"]["components"] == []
+        )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_cancel_turn_button_stale_execution_does_not_interrupt_newer_turn(
     tmp_path: Path,
 ) -> None:
@@ -9186,7 +9264,6 @@ async def test_cancel_turn_button_stale_execution_does_not_interrupt_newer_turn(
         )
 
         assert stop_calls == []
-        assert len(rest.edited_original_interaction_responses) == 1
         assert (
             rest.edited_original_interaction_responses[0]["payload"]["content"]
             == "Stopping current turn..."
@@ -9194,10 +9271,16 @@ async def test_cancel_turn_button_stale_execution_does_not_interrupt_newer_turn(
         assert (
             rest.edited_original_interaction_responses[0]["payload"]["components"] == []
         )
+        assert len(rest.edited_original_interaction_responses) == 2
+        assert "older turn" in (
+            rest.edited_original_interaction_responses[1]["payload"]["content"].lower()
+        )
+        assert (
+            rest.edited_original_interaction_responses[1]["payload"]["components"] == []
+        )
         assert len(rest.interaction_responses) == 1
         assert rest.interaction_responses[0]["payload"]["type"] == 6
-        assert len(rest.followup_messages) == 1
-        assert "older turn" in rest.followup_messages[0]["payload"]["content"].lower()
+        assert rest.followup_messages == []
         assert len(rest.edited_channel_messages) == 1
         assert rest.edited_channel_messages[0]["payload"]["components"] == []
         assert "newer turn is active" in (
@@ -9276,8 +9359,11 @@ async def test_cancel_turn_button_stale_execution_ignores_message_fetch_failures
             custom_id="cancel_turn:thread-1:turn-1",
         )
 
-        assert len(rest.followup_messages) == 1
-        assert "older turn" in rest.followup_messages[0]["payload"]["content"].lower()
+        assert rest.followup_messages == []
+        assert len(rest.edited_original_interaction_responses) == 2
+        assert "older turn" in (
+            rest.edited_original_interaction_responses[1]["payload"]["content"].lower()
+        )
         assert (
             await store.list_turn_progress_leases(
                 managed_thread_id="thread-1",


### PR DESCRIPTION
## Summary
This PR fixes Discord interrupt UX regressions where interrupt actions were surfaced as failures and where stop status messaging was duplicated/confusing.

## What Changed
- Updated Discord interrupt confirmation copy to use explicit success language (`Interrupt succeeded.`) when the active turn is actually interrupted.
- Changed component-origin interrupt responses to update the same component message instead of emitting a second ephemeral follow-up. This removes the duplicated `Stopping current turn...` notice.
- Kept `Still stopping current turn...` and genuine error paths unchanged.
- Treated managed-turn `interrupted` finalization as a successful interrupt path in Discord turn delivery:
  - no `Turn failed: ... interrupted` channel message,
  - interrupted queued deliveries are no longer posted as failures,
  - background reconcile fallback uses interrupted wording instead of failure wording for interrupted outcomes.

## Root Cause
- The interrupt handler rendered `Stopping current turn...` for confirmed interrupts, so users saw the same stop text twice.
- Component callbacks acknowledged with a component update and then also sent an ephemeral follow-up, producing duplicate status notices.
- Interrupted managed-turn outcomes were raised as runtime failures and then surfaced with `Turn failed: ...`, even when interruption succeeded.

## User Impact
- Discord users now get clearer interrupt outcomes.
- Successful interrupts are no longer mislabeled as failed turns.
- Component interrupt flows no longer duplicate stop notices.

## Validation
- `.venv/bin/pytest -q tests/discord_message_turns_support.py -k "orchestrated_turn_interrupt_send"`
- `.venv/bin/pytest -q tests/integrations/discord/test_service_routing.py -k "car_interrupt or cancel_turn_button"`
- `.venv/bin/pytest -q tests/chat_surface_integration/test_hermes_pma_ux_regressions.py -k "acknowledge_interrupt_controls_before_final_confirmation"`
- Commit hook suite: `5739 passed, 9 xfailed`
