### PR TITLE
[codex] Batch SCM review comment follow-ups

### DIFF
--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -9,6 +9,7 @@ import logging
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional, Protocol
 
@@ -260,6 +261,25 @@ def _publish_notice_payload(
     }
 
 
+def _parse_iso_datetime(value: object) -> Optional[datetime]:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _isoformat_z(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def _auxiliary_correlation_id(*, correlation_id: str, operation_key: str) -> str:
     digest = hashlib.sha256(operation_key.encode("utf-8")).hexdigest()[:12]
     return f"{correlation_id}:aux:{digest}"
@@ -299,46 +319,21 @@ def _trimmed_summary(value: Any, *, limit: int = 120) -> Optional[str]:
     return f"{text[: limit - 3].rstrip()}..."
 
 
-def _review_comment_location(payload: Mapping[str, Any]) -> Optional[str]:
-    path = _collapse_whitespace(payload.get("path"))
-    line = payload.get("line")
-    if path is None:
-        return None
-    if isinstance(line, int):
-        return f"{path}:{line}"
-    return path
-
-
-def _review_comment_url(payload: Mapping[str, Any]) -> Optional[str]:
-    url = _collapse_whitespace(payload.get("html_url"))
-    if url is None or not url.startswith(("http://", "https://")):
-        return None
-    return url
-
-
-def _review_comment_wakeup_message(
+def _review_comment_notice_message(
+    tracking: Mapping[str, Any],
     *,
-    event: ScmEvent,
-    binding: PrBinding,
+    enqueue_status: str,
 ) -> str:
-    payload = _event_payload(event)
-    subject = f"{binding.repo_slug}#{binding.pr_number}"
-    commenter_login = _collapse_whitespace(payload.get("author_login"))
-    location = _review_comment_location(payload)
-    comment_summary = _trimmed_summary(payload.get("body"))
-    review_url = _review_comment_url(payload)
-
-    lines = [f"PR review feedback on {subject}"]
-    if commenter_login is not None:
-        lines.append(f"From: {commenter_login}")
-    if location is not None:
-        lines.append(f"Location: {location}")
-    if comment_summary is not None:
-        lines.append(f"Summary: {comment_summary}")
-    if review_url is not None:
-        lines.append(f"Link: <{review_url}>")
-    lines.append("The bound agent thread is taking a look.")
-    return "\n".join(lines)
+    subject = _reaction_subject(tracking)
+    if enqueue_status == "queued":
+        return (
+            f"Queued the latest PR review batch for {subject}.\n"
+            "The bound agent thread has the work item and will pick it up next."
+        )
+    return (
+        f"Started the latest PR review batch for {subject}.\n"
+        "The bound agent thread is working on the latest review feedback now."
+    )
 
 
 def _reaction_subject(tracking: Mapping[str, Any]) -> str:
@@ -515,17 +510,43 @@ class ScmAutomationService:
             raise LookupError(f"SCM event '{event_id}' was not found")
         return event
 
-    def _review_comment_notice_key(
+    def _review_comment_enqueue_batch_key(
         self,
         *,
         event: ScmEvent,
         binding: PrBinding,
     ) -> str:
+        batch_window_seconds = self._reaction_config.review_comment_batch_window_seconds
+        if batch_window_seconds <= 0:
+            return stable_reaction_operation_key(
+                provider=event.provider,
+                event_id=event.event_id,
+                reaction_kind="review_comment",
+                operation_kind="enqueue_managed_turn",
+                repo_slug=binding.repo_slug,
+                repo_id=binding.repo_id or event.repo_id,
+                pr_number=binding.pr_number,
+                binding_id=binding.binding_id,
+                thread_target_id=binding.thread_target_id,
+            )
+        event_time = (
+            _parse_iso_datetime(event.received_at)
+            or _parse_iso_datetime(event.occurred_at)
+            or _parse_iso_datetime(event.created_at)
+            or datetime.now(timezone.utc)
+        )
+        bucket_start_seconds = (
+            int(event_time.timestamp()) // batch_window_seconds
+        ) * batch_window_seconds
+        batch_end = datetime.fromtimestamp(
+            bucket_start_seconds + batch_window_seconds,
+            tz=timezone.utc,
+        )
         return stable_reaction_operation_key(
             provider=event.provider,
-            event_id=event.event_id,
+            event_id=f"review-batch:{_isoformat_z(batch_end)}",
             reaction_kind="review_comment",
-            operation_kind="notify_chat",
+            operation_kind="enqueue_managed_turn",
             repo_slug=binding.repo_slug,
             repo_id=binding.repo_id or event.repo_id,
             pr_number=binding.pr_number,
@@ -533,22 +554,65 @@ class ScmAutomationService:
             thread_target_id=binding.thread_target_id,
         )
 
-    def _create_review_comment_notice_operation(
+    def _review_comment_enqueue_next_attempt_at(
         self,
         *,
         event: ScmEvent,
-        binding: PrBinding,
-        correlation_id: str,
+    ) -> Optional[str]:
+        batch_window_seconds = self._reaction_config.review_comment_batch_window_seconds
+        if batch_window_seconds <= 0:
+            return None
+        event_time = (
+            _parse_iso_datetime(event.received_at)
+            or _parse_iso_datetime(event.occurred_at)
+            or _parse_iso_datetime(event.created_at)
+        )
+        if event_time is None:
+            return None
+        bucket_start_seconds = (
+            int(event_time.timestamp()) // batch_window_seconds
+        ) * batch_window_seconds
+        return _isoformat_z(
+            datetime.fromtimestamp(
+                bucket_start_seconds + batch_window_seconds,
+                tz=timezone.utc,
+            )
+        )
+
+    def _review_comment_notice_key(
+        self,
+        *,
+        enqueue_operation_key: str,
+    ) -> str:
+        return stable_reaction_operation_key(
+            provider="scm",
+            event_id=enqueue_operation_key,
+            reaction_kind="review_comment",
+            operation_kind="notify_chat",
+        )
+
+    def _create_review_comment_notice_operation(
+        self,
+        *,
+        tracking: Mapping[str, Any],
+        enqueue_operation: PublishOperation,
         seen_operation_keys: set[str],
-        publish_operations: list[PublishOperation],
-    ) -> None:
-        thread_target_id = _normalize_text(binding.thread_target_id)
-        if thread_target_id is None:
-            return
-        operation_key = self._review_comment_notice_key(event=event, binding=binding)
+    ) -> Optional[PublishOperation]:
+        thread_target_id = _normalize_text(tracking.get("thread_target_id"))
+        enqueue_status = _normalize_text(enqueue_operation.response.get("status"))
+        if thread_target_id is None or enqueue_status not in {"queued", "running"}:
+            return None
+        operation_key = self._review_comment_notice_key(
+            enqueue_operation_key=enqueue_operation.operation_key
+        )
         if operation_key in seen_operation_keys:
-            return
+            return None
         seen_operation_keys.add(operation_key)
+        correlation_id = correlation_id_for_operation(
+            enqueue_operation
+        ) or _normalize_text(tracking.get("correlation_id"))
+        if correlation_id is None:
+            correlation_id = f"scm:{enqueue_operation.operation_id}"
         notice_correlation_id = _auxiliary_correlation_id(
             correlation_id=correlation_id,
             operation_key=operation_key,
@@ -556,9 +620,9 @@ class ScmAutomationService:
         payload = with_correlation_id(
             _publish_notice_payload(
                 thread_target_id=thread_target_id,
-                message=_review_comment_wakeup_message(
-                    event=event,
-                    binding=binding,
+                message=_review_comment_notice_message(
+                    tracking,
+                    enqueue_status=enqueue_status,
                 ),
             ),
             correlation_id=notice_correlation_id,
@@ -571,16 +635,16 @@ class ScmAutomationService:
         self._audit_recorder.record(
             action_type=SCM_AUDIT_PUBLISH_CREATED,
             correlation_id=correlation_id,
-            event=event,
-            binding=binding,
             operation=operation,
             payload={
                 "deduped": deduped,
                 "auxiliary": True,
-                "wake_notice": True,
+                "enqueue_notice": True,
+                "source_operation_key": enqueue_operation.operation_key,
+                "enqueue_status": enqueue_status,
             },
         )
-        publish_operations.append(operation)
+        return operation
 
     def ingest_event(
         self,
@@ -707,9 +771,23 @@ class ScmAutomationService:
                             metadata=tracking,
                         )
                     continue
-            if intent.operation_key in seen_operation_keys:
+            operation_key = intent.operation_key
+            next_attempt_at: Optional[str] = None
+            if (
+                binding is not None
+                and intent.reaction_kind == "review_comment"
+                and intent.operation_kind == "enqueue_managed_turn"
+            ):
+                operation_key = self._review_comment_enqueue_batch_key(
+                    event=event,
+                    binding=binding,
+                )
+                next_attempt_at = self._review_comment_enqueue_next_attempt_at(
+                    event=event
+                )
+            if operation_key in seen_operation_keys:
                 continue
-            seen_operation_keys.add(intent.operation_key)
+            seen_operation_keys.add(operation_key)
             payload = with_correlation_id(
                 copy.deepcopy(intent.payload),
                 correlation_id=correlation_id,
@@ -717,9 +795,10 @@ class ScmAutomationService:
             if tracking:
                 payload["scm_reaction"] = tracking
             operation, deduped = self._journal.create_operation(
-                operation_key=intent.operation_key,
+                operation_key=operation_key,
                 operation_kind=intent.operation_kind,
                 payload=payload,
+                next_attempt_at=next_attempt_at,
             )
             self._audit_recorder.record(
                 action_type=SCM_AUDIT_PUBLISH_CREATED,
@@ -740,22 +819,10 @@ class ScmAutomationService:
                     reaction_kind=reaction_state_kind,
                     fingerprint=fingerprint,
                     event_id=intent.event_id or event.event_id,
-                    operation_key=intent.operation_key,
+                    operation_key=operation_key,
                     metadata=tracking,
                 )
             publish_operations.append(operation)
-            if (
-                binding is not None
-                and intent.reaction_kind == "review_comment"
-                and intent.operation_kind == "enqueue_managed_turn"
-            ):
-                self._create_review_comment_notice_operation(
-                    event=event,
-                    binding=binding,
-                    correlation_id=correlation_id,
-                    seen_operation_keys=seen_operation_keys,
-                    publish_operations=publish_operations,
-                )
 
         return ScmAutomationIngestResult(
             event=event,
@@ -864,6 +931,18 @@ class ScmAutomationService:
             event_id = _normalize_text(tracking.get("event_id"))
             try:
                 if operation.state == "succeeded":
+                    if (
+                        operation.operation_kind == "enqueue_managed_turn"
+                        and _normalize_text(tracking.get("reaction_kind"))
+                        == "review_comment"
+                    ):
+                        notice_operation = self._create_review_comment_notice_operation(
+                            tracking=tracking,
+                            enqueue_operation=operation,
+                            seen_operation_keys=seen_operation_keys,
+                        )
+                        if notice_operation is not None:
+                            escalations.append(notice_operation)
                     self._reaction_state_store.mark_reaction_delivery_succeeded(
                         binding_id=binding_id,
                         reaction_kind=reaction_state_kind,

--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -510,7 +510,9 @@ class ScmAutomationService:
                 self._deferred_drain_timer.cancel()
                 self._deferred_drain_timer = None
 
-    def _schedule_deferred_publish_drain_at(self, next_attempt_at_iso: Optional[str]) -> None:
+    def _schedule_deferred_publish_drain_at(
+        self, next_attempt_at_iso: Optional[str]
+    ) -> None:
         if not self._schedule_deferred_publish_drain:
             return
         if not next_attempt_at_iso:
@@ -518,9 +520,7 @@ class ScmAutomationService:
         parsed = _parse_iso_datetime(next_attempt_at_iso)
         if parsed is None:
             return
-        delay = max(
-            0.0, (parsed - datetime.now(timezone.utc)).total_seconds()
-        )
+        delay = max(0.0, (parsed - datetime.now(timezone.utc)).total_seconds())
         with self._deferred_drain_lock:
             if self._deferred_drain_timer is not None:
                 self._deferred_drain_timer.cancel()

--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -7,6 +7,7 @@ import importlib
 import json
 import logging
 import re
+import threading
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -473,6 +474,7 @@ class ScmAutomationService:
         reaction_state_store: Optional[ScmReactionStateTracker] = None,
         journal: Optional[PublishJournalWriter] = None,
         publish_processor: Optional[PublishOperationDrainer] = None,
+        schedule_deferred_publish_drain: bool = False,
     ) -> None:
         self._hub_root = Path(hub_root)
         self._event_store = event_store or ScmEventStore(self._hub_root)
@@ -498,6 +500,82 @@ class ScmAutomationService:
             raise TypeError(
                 "publish_processor is required when journal is not a PublishJournalStore"
             )
+        self._schedule_deferred_publish_drain = schedule_deferred_publish_drain
+        self._deferred_drain_timer: Optional[threading.Timer] = None
+        self._deferred_drain_lock = threading.Lock()
+
+    def _cancel_deferred_publish_drain(self) -> None:
+        with self._deferred_drain_lock:
+            if self._deferred_drain_timer is not None:
+                self._deferred_drain_timer.cancel()
+                self._deferred_drain_timer = None
+
+    def _schedule_deferred_publish_drain_at(self, next_attempt_at_iso: Optional[str]) -> None:
+        if not self._schedule_deferred_publish_drain:
+            return
+        if not next_attempt_at_iso:
+            return
+        parsed = _parse_iso_datetime(next_attempt_at_iso)
+        if parsed is None:
+            return
+        delay = max(
+            0.0, (parsed - datetime.now(timezone.utc)).total_seconds()
+        )
+        with self._deferred_drain_lock:
+            if self._deferred_drain_timer is not None:
+                self._deferred_drain_timer.cancel()
+                self._deferred_drain_timer = None
+            timer = threading.Timer(delay, self._run_deferred_publish_drain)
+            timer.daemon = True
+            self._deferred_drain_timer = timer
+            timer.start()
+
+    def _reschedule_deferred_publish_drain_if_needed(self) -> None:
+        if not self._schedule_deferred_publish_drain:
+            return
+        if not isinstance(self._journal, PublishJournalStore):
+            return
+        now = datetime.now(timezone.utc)
+        pending = self._journal.list_operations(
+            state="pending",
+            operation_kind="enqueue_managed_turn",
+            limit=500,
+        )
+        earliest_future: Optional[datetime] = None
+        for op in pending:
+            if not op.next_attempt_at:
+                continue
+            parsed = _parse_iso_datetime(op.next_attempt_at)
+            if parsed is None:
+                continue
+            if parsed <= now:
+                continue
+            if earliest_future is None or parsed < earliest_future:
+                earliest_future = parsed
+        if earliest_future is None:
+            self._cancel_deferred_publish_drain()
+            return
+        self._schedule_deferred_publish_drain_at(_isoformat_z(earliest_future))
+
+    def _run_deferred_publish_drain(self) -> None:
+        with self._deferred_drain_lock:
+            self._deferred_drain_timer = None
+        try:
+            processed = self._publish_processor.process_now(limit=10)
+            self._record_publish_finished_audit_entries(processed)
+            escalations = self._handle_processed_operations(processed)
+            if escalations:
+                escalation_results = self._publish_processor.process_now(
+                    limit=len(escalations)
+                )
+                self._record_publish_finished_audit_entries(escalation_results)
+        except Exception:
+            _LOGGER.warning(
+                "Deferred publish drain after review-comment batch window failed",
+                exc_info=True,
+            )
+        finally:
+            self._reschedule_deferred_publish_drain_if_needed()
 
     def _resolve_event(self, event_or_id: ScmEvent | str) -> ScmEvent:
         if isinstance(event_or_id, ScmEvent):
@@ -799,6 +877,14 @@ class ScmAutomationService:
                 payload=payload,
                 next_attempt_at=next_attempt_at,
             )
+            if (
+                next_attempt_at is not None
+                and intent.reaction_kind == "review_comment"
+                and intent.operation_kind == "enqueue_managed_turn"
+            ):
+                drain_at = operation.next_attempt_at
+                if drain_at is not None:
+                    self._schedule_deferred_publish_drain_at(drain_at)
             self._audit_recorder.record(
                 action_type=SCM_AUDIT_PUBLISH_CREATED,
                 correlation_id=correlation_id,
@@ -840,6 +926,7 @@ class ScmAutomationService:
             )
             self._record_publish_finished_audit_entries(escalation_results)
             processed.extend(escalation_results)
+        self._reschedule_deferred_publish_drain_if_needed()
         return processed
 
     def _create_escalation_operation(

--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -566,9 +566,8 @@ class ScmAutomationService:
             _parse_iso_datetime(event.received_at)
             or _parse_iso_datetime(event.occurred_at)
             or _parse_iso_datetime(event.created_at)
+            or datetime.now(timezone.utc)
         )
-        if event_time is None:
-            return None
         bucket_start_seconds = (
             int(event_time.timestamp()) // batch_window_seconds
         ) * batch_window_seconds

--- a/src/codex_autorunner/core/scm_reaction_types.py
+++ b/src/codex_autorunner/core/scm_reaction_types.py
@@ -88,6 +88,7 @@ class ScmReactionConfig:
     ci_failed: bool = True
     changes_requested: bool = True
     review_comment: bool = True
+    review_comment_batch_window_seconds: int = 15
     approved_and_green: bool = True
     merged: bool = True
     duplicate_escalation_threshold: int = 3
@@ -137,6 +138,11 @@ class ScmReactionConfig:
                     if default_enabled is None
                     else default_value
                 ),
+            ),
+            review_comment_batch_window_seconds=_int_from_mapping(
+                mapping,
+                "review_comment_batch_window_seconds",
+                default=15,
             ),
             approved_and_green=_bool_from_mapping(
                 mapping,

--- a/src/codex_autorunner/integrations/github/polling.py
+++ b/src/codex_autorunner/integrations/github/polling.py
@@ -1978,6 +1978,7 @@ class GitHubScmPollingService:
         return ScmAutomationService(
             self._hub_root,
             reaction_config=reaction_config or self._raw_config,
+            schedule_deferred_publish_drain=True,
         )
 
     def _claim_discovery_cycle(self, *, polling_config: GitHubPollingConfig) -> bool:

--- a/src/codex_autorunner/integrations/github/reaction_prompts.py
+++ b/src/codex_autorunner/integrations/github/reaction_prompts.py
@@ -155,6 +155,11 @@ def build_review_comment_message(
 ) -> str:
     payload = _event_payload(event)
     subject = _reaction_subject(event, binding)
+    if operation_kind == "enqueue_managed_turn":
+        return _join_message(
+            f"New PR review feedback arrived on {subject}",
+            "Inspect the latest review comments on the PR, address the feedback, and reply on the PR after updating the branch",
+        )
     commenter_login = _reviewer_login(payload)
     comment_summary = _trimmed_summary(payload.get("body"))
     location = _comment_location(payload)
@@ -166,12 +171,6 @@ def build_review_comment_message(
         summary = f"{summary} at {location}"
     if comment_summary is not None:
         summary = f"{summary}: {comment_summary}"
-
-    if operation_kind == "enqueue_managed_turn":
-        return _join_message(
-            summary,
-            "Address the feedback and reply on the PR after updating the branch",
-        )
     return _ensure_sentence(summary)
 
 

--- a/src/codex_autorunner/surfaces/web/routes/scm_webhooks.py
+++ b/src/codex_autorunner/surfaces/web/routes/scm_webhooks.py
@@ -178,6 +178,7 @@ def _default_drain_callback_factory(
     service = ScmAutomationService(
         hub_root,
         reaction_config=_github_automation_config(raw_config),
+        schedule_deferred_publish_drain=True,
     )
 
     def callback(_request: Request, event: ScmEvent) -> None:

--- a/tests/core/test_scm_automation_service.py
+++ b/tests/core/test_scm_automation_service.py
@@ -144,6 +144,7 @@ class _JournalFake:
     def __init__(self) -> None:
         self.operations_by_key: dict[str, PublishOperation] = {}
         self.create_calls: list[tuple[str, str]] = []
+        self.next_attempts_by_key: dict[str, Optional[str]] = {}
 
     def create_operation(
         self,
@@ -153,8 +154,8 @@ class _JournalFake:
         payload: Optional[dict] = None,
         next_attempt_at: Optional[str] = None,
     ) -> tuple[PublishOperation, bool]:
-        _ = next_attempt_at
         self.create_calls.append((operation_key, operation_kind))
+        self.next_attempts_by_key[operation_key] = next_attempt_at
         existing = self.operations_by_key.get(operation_key)
         if existing is not None:
             return existing, True
@@ -164,7 +165,11 @@ class _JournalFake:
             operation_kind=operation_kind,
         )
         created = PublishOperation(
-            **{**created.to_dict(), "payload": dict(payload or {})}
+            **{
+                **created.to_dict(),
+                "payload": dict(payload or {}),
+                "next_attempt_at": next_attempt_at or created.next_attempt_at,
+            }
         )
         self.operations_by_key[operation_key] = created
         return created, False
@@ -799,7 +804,6 @@ def test_ingest_event_tracks_review_comment_operations_in_separate_state_namespa
     assert [operation.operation_kind for operation in result.publish_operations] == [
         "react_pr_review_comment",
         "enqueue_managed_turn",
-        "notify_chat",
     ]
     assert state_store.should_calls == [
         (
@@ -828,7 +832,7 @@ def test_ingest_event_tracks_review_comment_operations_in_separate_state_namespa
     ]
 
 
-def test_ingest_event_formats_review_comment_notice_with_link_and_clean_summary(
+def test_ingest_event_batches_review_comment_enqueue_for_15_seconds(
     tmp_path: Path,
 ) -> None:
     event = ScmEvent(
@@ -836,7 +840,7 @@ def test_ingest_event_formats_review_comment_notice_with_link_and_clean_summary(
         provider="github",
         event_type="pull_request_review_comment",
         occurred_at="2026-03-26T00:00:00Z",
-        received_at="2026-03-26T00:00:01Z",
+        received_at="2026-03-26T00:00:14Z",
         created_at="2026-03-26T00:00:02Z",
         repo_slug="acme/widgets",
         repo_id="repo-1",
@@ -856,37 +860,34 @@ def test_ingest_event_formats_review_comment_notice_with_link_and_clean_summary(
         raw_payload=None,
     )
     binding = _binding()
+    journal = _JournalFake()
     service = ScmAutomationService(
         tmp_path,
         event_store=_EventStoreFake(event),
         binding_resolver=_BindingResolverFake(binding),
         reaction_router=route_scm_reactions,
         reaction_state_store=_PermissiveReactionStateFake(),
-        journal=_JournalFake(),
+        journal=journal,
         publish_processor=_ProcessorFake(processed=[]),
     )
 
     result = service.ingest_event(event.event_id)
 
-    notify_op = next(
+    enqueue_op = next(
         operation
         for operation in result.publish_operations
-        if operation.operation_kind == "notify_chat"
+        if operation.operation_kind == "enqueue_managed_turn"
     )
-    assert notify_op.payload["message"] == (
-        "PR review feedback on acme/widgets#42\n"
-        "From: reviewer\n"
-        "Location: src/codex_autorunner/integrations/discord/message_turns.py:942\n"
-        "Summary: P1 Surface startup timeouts as fallback regressions.\n"
-        "Link: <https://github.com/acme/widgets/pull/42#discussion_r2844>\n"
-        "The bound agent thread is taking a look."
+    assert enqueue_op.next_attempt_at == "2026-03-26T00:00:15Z"
+    assert journal.next_attempts_by_key[enqueue_op.operation_key] == (
+        "2026-03-26T00:00:15Z"
     )
 
 
-def test_ingest_event_preserves_angle_bracket_content_in_review_summary(
+def test_ingest_event_dedupes_review_comment_enqueue_within_same_batch_window(
     tmp_path: Path,
 ) -> None:
-    event = ScmEvent(
+    first = ScmEvent(
         event_id="github:event-inline-comment-generics",
         provider="github",
         event_type="pull_request_review_comment",
@@ -909,27 +910,109 @@ def test_ingest_event_preserves_angle_bracket_content_in_review_summary(
         },
         raw_payload=None,
     )
+    second = ScmEvent(
+        **{
+            **first.to_dict(),
+            "event_id": "github:event-inline-comment-generics-2",
+            "received_at": "2026-03-26T00:00:13Z",
+            "payload": {
+                **first.payload,
+                "comment_id": "2846",
+                "body": "Also keep batching stable within the first 15 seconds.",
+            },
+        }
+    )
     binding = _binding()
+    journal = _JournalFake()
     service = ScmAutomationService(
         tmp_path,
-        event_store=_EventStoreFake(event),
+        event_store=_EventStoreFake(first, second),
         binding_resolver=_BindingResolverFake(binding),
         reaction_router=route_scm_reactions,
         reaction_state_store=_PermissiveReactionStateFake(),
-        journal=_JournalFake(),
+        journal=journal,
         publish_processor=_ProcessorFake(processed=[]),
     )
 
-    result = service.ingest_event(event.event_id)
+    first_result = service.ingest_event(first.event_id)
+    second_result = service.ingest_event(second.event_id)
 
-    notify_op = next(
+    first_enqueue = next(
         operation
-        for operation in result.publish_operations
-        if operation.operation_kind == "notify_chat"
+        for operation in first_result.publish_operations
+        if operation.operation_kind == "enqueue_managed_turn"
     )
-    assert "Response<T>" in notify_op.payload["message"]
-    assert "<foo>" in notify_op.payload["message"]
-    assert "<sub>" not in notify_op.payload["message"]
+    second_enqueue = next(
+        operation
+        for operation in second_result.publish_operations
+        if operation.operation_kind == "enqueue_managed_turn"
+    )
+    assert first_enqueue.operation_key == second_enqueue.operation_key
+    assert (
+        journal.create_calls.count(
+            (first_enqueue.operation_key, "enqueue_managed_turn")
+        )
+        == 2
+    )
+
+
+def test_handle_processed_operations_creates_truthful_review_comment_notice_on_success(
+    tmp_path: Path,
+) -> None:
+    state_store = ScmReactionStateStore(tmp_path)
+    state_store.mark_reaction_emitted(
+        binding_id="binding-1",
+        reaction_kind="review_comment:enqueue_managed_turn",
+        fingerprint="fp-inline",
+        event_id="github:event-inline-comment",
+        operation_key="scm:key-inline",
+    )
+    journal = _JournalFake()
+    service = ScmAutomationService(
+        tmp_path,
+        event_store=_EventStoreFake(),
+        binding_resolver=_BindingResolverFake(None),
+        reaction_router=_ReactionRouterFake([]),
+        reaction_state_store=state_store,
+        journal=journal,
+        publish_processor=_ProcessorFake(processed=[]),
+    )
+    succeeded = PublishOperation(
+        **{
+            **_operation(
+                operation_id="op-inline",
+                operation_key="scm:key-inline",
+                operation_kind="enqueue_managed_turn",
+                state="succeeded",
+            ).to_dict(),
+            "payload": {
+                "scm_reaction": {
+                    "binding_id": "binding-1",
+                    "reaction_kind": "review_comment",
+                    "reaction_state_kind": "review_comment:enqueue_managed_turn",
+                    "fingerprint": "fp-inline",
+                    "event_id": "github:event-inline-comment",
+                    "operation_kind": "enqueue_managed_turn",
+                    "repo_slug": "acme/widgets",
+                    "pr_number": 42,
+                    "thread_target_id": "thread-1",
+                }
+            },
+            "response": {
+                "status": "queued",
+            },
+        }
+    )
+
+    follow_ups = service._handle_processed_operations([succeeded])
+
+    assert len(follow_ups) == 1
+    assert follow_ups[0].operation_kind == "notify_chat"
+    assert follow_ups[0].payload["thread_target_id"] == "thread-1"
+    assert (
+        "Queued the latest PR review batch for acme/widgets#42."
+        in follow_ups[0].payload["message"]
+    )
 
 
 def test_handle_processed_operations_uses_reaction_state_kind_tracking_key(

--- a/tests/core/test_scm_reaction_router.py
+++ b/tests/core/test_scm_reaction_router.py
@@ -187,9 +187,9 @@ def test_route_scm_reactions_routes_commented_review_as_review_comment() -> None
     assert intents[0].reaction_kind == "review_comment"
     assert intents[0].operation_kind == "enqueue_managed_turn"
     assert intents[0].payload["request"]["message_text"] == (
-        "New PR comment on acme/widgets#42 from chatgpt-codex-connector[bot]: "
-        "Please extract the webhook normalization helper. "
-        "Address the feedback and reply on the PR after updating the branch."
+        "New PR review feedback arrived on acme/widgets#42. "
+        "Inspect the latest review comments on the PR, address the feedback, "
+        "and reply on the PR after updating the branch."
     )
 
 
@@ -273,10 +273,9 @@ def test_route_scm_reactions_routes_pr_comment_to_managed_thread() -> None:
     assert intents[0].reaction_kind == "review_comment"
     assert intents[0].operation_kind == "enqueue_managed_turn"
     assert intents[0].payload["request"]["message_text"] == (
-        "New PR comment on acme/widgets#42 from reviewer at "
-        "src/codex_autorunner/core/scm_reaction_router.py:164: "
-        "Please guard the wake-up path with a PR-comment filter. "
-        "Address the feedback and reply on the PR after updating the branch."
+        "New PR review feedback arrived on acme/widgets#42. "
+        "Inspect the latest review comments on the PR, address the feedback, "
+        "and reply on the PR after updating the branch."
     )
 
 

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -1435,6 +1435,9 @@ def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
         )
 
     automation_config = _polling_config()
+    automation_config["github"]["automation"]["reactions"][
+        "review_comment_batch_window_seconds"
+    ] = 0
     automation_config["github"]["automation"]["policy"] = {
         "react_pr_review_comment": "allow"
     }
@@ -1479,7 +1482,7 @@ def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
     processed_operations = []
     automation = ScmAutomationService(
         hub_root,
-        reaction_config=automation_config,
+        reaction_config=automation_config["github"]["automation"],
         publish_processor=processor,
     )
 
@@ -1538,10 +1541,10 @@ def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
     outbox = asyncio.run(_load_outbox())
     assert any(
         record.channel_id == "repo-discord"
-        and "taking a look" in str(record.payload_json.get("content", "")).lower()
-        and "inline review wakeup path"
+        and "started the latest pr review batch"
         in str(record.payload_json.get("content", "")).lower()
-        and "discussion_r2844" in str(record.payload_json.get("content", ""))
+        and "working on the latest review feedback now"
+        in str(record.payload_json.get("content", "")).lower()
         for record in outbox
     )
 
@@ -1655,6 +1658,9 @@ def test_process_due_watches_keeps_distinct_bound_notices_for_multiple_review_co
         )
 
     automation_config = _polling_config()
+    automation_config["github"]["automation"]["reactions"][
+        "review_comment_batch_window_seconds"
+    ] = 0
     automation_config["github"]["automation"]["policy"] = {
         "react_pr_review_comment": "allow"
     }
@@ -1697,7 +1703,7 @@ def test_process_due_watches_keeps_distinct_bound_notices_for_multiple_review_co
     processed_operations = []
     automation = ScmAutomationService(
         hub_root,
-        reaction_config=automation_config,
+        reaction_config=automation_config["github"]["automation"],
         publish_processor=processor,
     )
 
@@ -1755,12 +1761,12 @@ def test_process_due_watches_keeps_distinct_bound_notices_for_multiple_review_co
     ]
     assert len(contents) == 2
     normalized_contents = [content.lower() for content in contents]
+    assert all("latest pr review batch" in content for content in normalized_contents)
     assert any(
-        "inline review wakeup path" in content for content in normalized_contents
+        "working on the latest review feedback now" in content
+        for content in normalized_contents
     )
-    assert any("discussion_r2844" in content for content in contents)
-    assert any("discussion_r2845" in content for content in contents)
-    assert any("does not dedupe away later comments" in content for content in contents)
+    assert any("will pick it up next" in content for content in normalized_contents)
 
 
 def test_process_due_watches_does_not_reemit_when_thread_is_reopened_without_new_comments(

--- a/tests/routes/test_scm_webhooks.py
+++ b/tests/routes/test_scm_webhooks.py
@@ -650,7 +650,8 @@ def test_scm_webhook_inline_drain_delegates_to_scm_automation_service(
     calls: list[tuple[str, object]] = []
 
     class _ServiceStub:
-        def __init__(self, hub_root: Path, *, reaction_config=None) -> None:
+        def __init__(self, hub_root: Path, *, reaction_config=None, **kwargs) -> None:
+            _ = kwargs
             calls.append(("init", hub_root))
             calls.append(
                 (


### PR DESCRIPTION
## Summary
This changes the SCM review-comment follow-up path so review comments are batched for 15 seconds and the bound-chat notice is only emitted after the enqueue operation has actually succeeded.

## What Changed
- batch `review_comment` `enqueue_managed_turn` operations onto a 15-second window
- switch review-comment enqueue prompts to a batch-safe message that tells the agent to inspect the latest PR feedback
- stop creating the bound-chat wakeup notice during ingest
- create the bound-chat notice only after a successful enqueue result, with status-aware wording for `running` vs `queued`
- add coverage for batched enqueue keys, truthful follow-up notices, and the updated router prompt expectations

## Why
Issue #1460 showed that the old flow could tell the bound chat "the thread is taking a look" before there was a trustworthy enqueue outcome. This PR makes the notice contingent on the actual enqueue result and gives review comments a short batch window so closely spaced review feedback turns into one coordinated follow-up.

Closes #1460.

## Validation
- pre-commit aggregate lane
- repo-wide `mypy`
- repo-wide `pytest` (`5743 passed, 9 xfailed`)
- targeted `ruff check` on touched files
- targeted pytest slices for SCM automation and GitHub polling
