### PR TITLE
Batch live timeline writes to protect hub fairness

### DIFF
--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -113,6 +113,11 @@ _DIRECT_RUN_EVENT_TYPES = (
     Started,
 )
 
+# Bound live timeline write pressure so one busy thread cannot starve hub requests
+# from other threads.
+_LIVE_TIMELINE_BATCH_MAX_EVENTS = 25
+_LIVE_TIMELINE_BATCH_MAX_DELAY_SECONDS = 5.0
+
 
 def _runtime_raw_event_message(raw_event: Any) -> dict[str, Any]:
     if not isinstance(raw_event, dict):
@@ -1402,6 +1407,8 @@ async def finalize_managed_thread_execution(
     timeline_events: list[Any] = []
     live_timeline_count = 0
     live_timeline_error_logged = False
+    live_timeline_pending_events: list[Any] = []
+    live_timeline_pending_started_at: float | None = None
     final_trace_manifest_id: Optional[str] = None
 
     log_event(
@@ -1424,6 +1431,8 @@ async def finalize_managed_thread_execution(
         nonlocal live_timeline_count
         nonlocal live_timeline_error_logged
         if not events:
+            return
+        if live_timeline_error_logged:
             return
         if resolved_hub_client is None:
             if not live_timeline_error_logged:
@@ -1483,6 +1492,43 @@ async def finalize_managed_thread_execution(
                 )
         else:
             live_timeline_count += len(events)
+
+    def _live_timeline_flush_due(now: float) -> bool:
+        if not live_timeline_pending_events:
+            return False
+        if len(live_timeline_pending_events) >= _LIVE_TIMELINE_BATCH_MAX_EVENTS:
+            return True
+        if live_timeline_pending_started_at is None:
+            return False
+        return (
+            now - live_timeline_pending_started_at
+            >= _LIVE_TIMELINE_BATCH_MAX_DELAY_SECONDS
+        )
+
+    async def _flush_live_timeline_buffer(*, force: bool = False) -> None:
+        nonlocal live_timeline_pending_events
+        nonlocal live_timeline_pending_started_at
+        if not live_timeline_pending_events:
+            return
+        if not force:
+            loop_now = asyncio.get_running_loop().time()
+            if not _live_timeline_flush_due(loop_now):
+                return
+        pending = live_timeline_pending_events
+        live_timeline_pending_events = []
+        live_timeline_pending_started_at = None
+        await _persist_live_timeline_events(pending)
+
+    async def _enqueue_live_timeline_events(events: list[Any]) -> None:
+        nonlocal live_timeline_pending_started_at
+        if not events:
+            return
+        if live_timeline_error_logged:
+            return
+        live_timeline_pending_events.extend(events)
+        if live_timeline_pending_started_at is None:
+            live_timeline_pending_started_at = asyncio.get_running_loop().time()
+        await _flush_live_timeline_buffer(force=False)
 
     async def _persist_final_timeline_with_cold_trace(
         *,
@@ -1654,7 +1700,7 @@ async def finalize_managed_thread_execution(
                                 content_summary=content_summary,
                             )
                     timeline_events.extend(run_events)
-                    await _persist_live_timeline_events(run_events)
+                    await _enqueue_live_timeline_events(run_events)
                     if on_progress_event is None:
                         continue
                     for run_event in run_events:
@@ -1785,6 +1831,8 @@ async def finalize_managed_thread_execution(
                     )
                 else:
                     raise exc
+
+    await _flush_live_timeline_buffer(force=True)
 
     recovered_outcome = recover_post_completion_outcome(outcome, event_state)
     recovered_after_completion = recovered_outcome is not outcome

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -1409,6 +1409,8 @@ async def finalize_managed_thread_execution(
     live_timeline_error_logged = False
     live_timeline_pending_events: list[Any] = []
     live_timeline_pending_started_at: float | None = None
+    live_timeline_flush_task: asyncio.Task[None] | None = None
+    live_timeline_flush_epoch = 0
     final_trace_manifest_id: Optional[str] = None
 
     log_event(
@@ -1435,14 +1437,13 @@ async def finalize_managed_thread_execution(
         if live_timeline_error_logged:
             return
         if resolved_hub_client is None:
-            if not live_timeline_error_logged:
-                live_timeline_error_logged = True
-                logger.error(
-                    "%s Skipping live timeline persistence without a hub control-plane client (thread=%s turn=%s)",
-                    surface.log_label,
-                    managed_thread_id,
-                    managed_turn_id,
-                )
+            live_timeline_error_logged = True
+            logger.error(
+                "%s Skipping live timeline persistence without a hub control-plane client (thread=%s turn=%s)",
+                surface.log_label,
+                managed_thread_id,
+                managed_turn_id,
+            )
             return
         try:
             await _persist_execution_timeline_via_hub(
@@ -1472,26 +1473,60 @@ async def finalize_managed_thread_execution(
                 start_index=live_timeline_count + 1,
             )
         except asyncio.CancelledError:
-            if not live_timeline_error_logged:
-                live_timeline_error_logged = True
-                logger.warning(
-                    "Live %s thread timeline persistence cancelled; continuing without live persistence (thread=%s turn=%s)",
-                    surface.log_label,
-                    managed_thread_id,
-                    managed_turn_id,
-                    exc_info=True,
-                )
+            live_timeline_error_logged = True
+            logger.warning(
+                "Live %s thread timeline persistence cancelled; continuing without live persistence (thread=%s turn=%s)",
+                surface.log_label,
+                managed_thread_id,
+                managed_turn_id,
+                exc_info=True,
+            )
         except Exception:
-            if not live_timeline_error_logged:
-                live_timeline_error_logged = True
-                logger.exception(
-                    "Failed to persist live %s thread timeline via hub control plane (thread=%s turn=%s)",
-                    surface.log_label,
-                    managed_thread_id,
-                    managed_turn_id,
-                )
+            live_timeline_error_logged = True
+            logger.exception(
+                "Failed to persist live %s thread timeline via hub control plane (thread=%s turn=%s)",
+                surface.log_label,
+                managed_thread_id,
+                managed_turn_id,
+            )
         else:
             live_timeline_count += len(events)
+
+    async def _delayed_live_timeline_flush(captured_epoch: int) -> None:
+        try:
+            loop = asyncio.get_running_loop()
+            if live_timeline_pending_started_at is None:
+                return
+            deadline = (
+                live_timeline_pending_started_at
+                + _LIVE_TIMELINE_BATCH_MAX_DELAY_SECONDS
+            )
+            await asyncio.sleep(max(0.0, deadline - loop.time()))
+            if captured_epoch != live_timeline_flush_epoch:
+                return
+            await _flush_live_timeline_buffer(force=False)
+        except asyncio.CancelledError:
+            raise
+
+    def _schedule_live_timeline_delayed_flush_if_needed() -> None:
+        nonlocal live_timeline_flush_task
+        if live_timeline_error_logged:
+            return
+        if not live_timeline_pending_events:
+            return
+        if len(live_timeline_pending_events) >= _LIVE_TIMELINE_BATCH_MAX_EVENTS:
+            return
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        if live_timeline_pending_started_at is None:
+            return
+        if _live_timeline_flush_due(now):
+            return
+        if live_timeline_flush_task is not None and not live_timeline_flush_task.done():
+            return
+        live_timeline_flush_task = loop.create_task(
+            _delayed_live_timeline_flush(live_timeline_flush_epoch)
+        )
 
     def _live_timeline_flush_due(now: float) -> bool:
         if not live_timeline_pending_events:
@@ -1508,12 +1543,25 @@ async def finalize_managed_thread_execution(
     async def _flush_live_timeline_buffer(*, force: bool = False) -> None:
         nonlocal live_timeline_pending_events
         nonlocal live_timeline_pending_started_at
+        nonlocal live_timeline_flush_task
+        nonlocal live_timeline_flush_epoch
+        if force:
+            live_timeline_flush_epoch += 1
+            t = live_timeline_flush_task
+            live_timeline_flush_task = None
+            if t is not None and not t.done():
+                t.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await t
         if not live_timeline_pending_events:
             return
         if not force:
             loop_now = asyncio.get_running_loop().time()
             if not _live_timeline_flush_due(loop_now):
                 return
+        live_timeline_flush_epoch += 1
+        if live_timeline_flush_task is asyncio.current_task():
+            live_timeline_flush_task = None
         pending = live_timeline_pending_events
         live_timeline_pending_events = []
         live_timeline_pending_started_at = None
@@ -1529,6 +1577,7 @@ async def finalize_managed_thread_execution(
         if live_timeline_pending_started_at is None:
             live_timeline_pending_started_at = asyncio.get_running_loop().time()
         await _flush_live_timeline_buffer(force=False)
+        _schedule_live_timeline_delayed_flush_if_needed()
 
     async def _persist_final_timeline_with_cold_trace(
         *,

--- a/tests/integrations/chat/test_managed_thread_turns.py
+++ b/tests/integrations/chat/test_managed_thread_turns.py
@@ -1667,6 +1667,115 @@ async def test_finalize_managed_thread_execution_batches_live_timeline_persisten
 
 
 @pytest.mark.anyio
+async def test_finalize_managed_thread_execution_flushes_live_timeline_on_delay_without_more_progress(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Buffered events must flush when the delay cap elapses, not only on the next chunk."""
+    started = _started_execution_with_backend_ids(tmp_path)
+    fake_hub_client = _FakeHubPersistenceClient()
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "harness_supports_progress_event_stream",
+        lambda _harness: True,
+    )
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "_LIVE_TIMELINE_BATCH_MAX_EVENTS",
+        100,
+    )
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "_LIVE_TIMELINE_BATCH_MAX_DELAY_SECONDS",
+        0.05,
+    )
+
+    async def _progress_stream(*args: Any, **kwargs: Any):
+        _ = args, kwargs
+        yield {"index": 0, "message": {"method": "session/update"}}
+        await asyncio.sleep(0.15)
+        yield {"index": 1, "message": {"method": "session/update"}}
+
+    async def _normalize(raw_event: Any, _state: Any) -> list[Any]:
+        index = int(raw_event["index"])
+        return [
+            managed_thread_turns_module.RunNotice(
+                timestamp=f"2026-04-15T00:00:{index:02d}Z",
+                kind="progress",
+                message=f"partial-{index}",
+            )
+        ]
+
+    async def _successful_outcome(*args: Any, **kwargs: Any) -> RuntimeThreadOutcome:
+        _ = args, kwargs
+        return RuntimeThreadOutcome(
+            status="ok",
+            assistant_text="fixture reply",
+            error=None,
+            backend_thread_id="session-1",
+            backend_turn_id="turn-1",
+        )
+
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "harness_progress_event_stream",
+        _progress_stream,
+    )
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "_normalize_runtime_progress_event",
+        _normalize,
+    )
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "await_runtime_thread_outcome",
+        _successful_outcome,
+    )
+
+    orchestration_service = SimpleNamespace(
+        get_thread_target=lambda managed_thread_id: SimpleNamespace(
+            backend_thread_id="session-1"
+        ),
+        get_thread_runtime_binding=lambda managed_thread_id: SimpleNamespace(
+            backend_thread_id="session-1"
+        ),
+        record_execution_result=lambda *args, **kwargs: SimpleNamespace(
+            status="ok",
+            error=None,
+        ),
+    )
+
+    result = await managed_thread_turns_module.finalize_managed_thread_execution(
+        orchestration_service=orchestration_service,
+        started=started,
+        state_root=tmp_path,
+        hub_client=fake_hub_client,
+        surface=managed_thread_turns_module.ManagedThreadSurfaceInfo(
+            log_label="Discord",
+            surface_kind="discord",
+            surface_key="discord:chan-1:msg-1",
+        ),
+        errors=managed_thread_turns_module.ManagedThreadErrorMessages(
+            public_execution_error="Discord PMA execution failed",
+            timeout_error="Discord PMA turn timed out",
+            interrupted_error="Discord PMA turn interrupted",
+            timeout_seconds=5,
+        ),
+        logger=logging.getLogger("test.managed_thread.timeline_delay_flush"),
+        turn_preview="preview",
+    )
+
+    assert result.status == "ok"
+    running = [
+        r
+        for r in fake_hub_client.timeline_requests
+        if r.metadata["status"] == "running"
+    ]
+    assert len(running) >= 2
+    assert [len(r.events) for r in running] == [1, 1]
+
+
+@pytest.mark.anyio
 async def test_finalize_managed_thread_execution_continues_when_progress_pump_is_cancelled(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integrations/chat/test_managed_thread_turns.py
+++ b/tests/integrations/chat/test_managed_thread_turns.py
@@ -1543,6 +1543,130 @@ async def test_finalize_managed_thread_execution_continues_when_timeline_persist
 
 
 @pytest.mark.anyio
+async def test_finalize_managed_thread_execution_batches_live_timeline_persistence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = _started_execution_with_backend_ids(tmp_path)
+    fake_hub_client = _FakeHubPersistenceClient()
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "harness_supports_progress_event_stream",
+        lambda _harness: True,
+    )
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "_LIVE_TIMELINE_BATCH_MAX_EVENTS",
+        3,
+    )
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "_LIVE_TIMELINE_BATCH_MAX_DELAY_SECONDS",
+        60.0,
+    )
+
+    async def _progress_stream(*args: Any, **kwargs: Any):
+        _ = args, kwargs
+        for index in range(9):
+            yield {
+                "index": index,
+                "message": {"method": "session/update"},
+            }
+
+    async def _normalize(raw_event: Any, _state: Any) -> list[Any]:
+        index = int(raw_event["index"])
+        return [
+            managed_thread_turns_module.RunNotice(
+                timestamp=f"2026-04-15T00:00:{index:02d}Z",
+                kind="progress",
+                message=f"partial-{index}",
+            )
+        ]
+
+    async def _successful_outcome(*args: Any, **kwargs: Any) -> RuntimeThreadOutcome:
+        _ = args, kwargs
+        return RuntimeThreadOutcome(
+            status="ok",
+            assistant_text="fixture reply",
+            error=None,
+            backend_thread_id="session-1",
+            backend_turn_id="turn-1",
+        )
+
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "harness_progress_event_stream",
+        _progress_stream,
+    )
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "_normalize_runtime_progress_event",
+        _normalize,
+    )
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "await_runtime_thread_outcome",
+        _successful_outcome,
+    )
+
+    orchestration_service = SimpleNamespace(
+        get_thread_target=lambda managed_thread_id: SimpleNamespace(
+            backend_thread_id="session-1"
+        ),
+        get_thread_runtime_binding=lambda managed_thread_id: SimpleNamespace(
+            backend_thread_id="session-1"
+        ),
+        record_execution_result=lambda *args, **kwargs: SimpleNamespace(
+            status="ok",
+            error=None,
+        ),
+    )
+
+    result = await managed_thread_turns_module.finalize_managed_thread_execution(
+        orchestration_service=orchestration_service,
+        started=started,
+        state_root=tmp_path,
+        hub_client=fake_hub_client,
+        surface=managed_thread_turns_module.ManagedThreadSurfaceInfo(
+            log_label="Discord",
+            surface_kind="discord",
+            surface_key="discord:chan-1:msg-1",
+        ),
+        errors=managed_thread_turns_module.ManagedThreadErrorMessages(
+            public_execution_error="Discord PMA execution failed",
+            timeout_error="Discord PMA turn timed out",
+            interrupted_error="Discord PMA turn interrupted",
+            timeout_seconds=5,
+        ),
+        logger=logging.getLogger("test.managed_thread.timeline_batching"),
+        turn_preview="preview",
+    )
+
+    assert result.status == "ok"
+    assert len(fake_hub_client.timeline_requests) == 4
+    assert [request.start_index for request in fake_hub_client.timeline_requests] == [
+        1,
+        4,
+        7,
+        10,
+    ]
+    assert [len(request.events) for request in fake_hub_client.timeline_requests] == [
+        3,
+        3,
+        3,
+        1,
+    ]
+    assert [
+        request.metadata["status"] for request in fake_hub_client.timeline_requests
+    ] == [
+        "running",
+        "running",
+        "running",
+        "ok",
+    ]
+
+
+@pytest.mark.anyio
 async def test_finalize_managed_thread_execution_continues_when_progress_pump_is_cancelled(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- batch live managed-thread timeline persistence before sending hub control-plane writes (25 events or 5 seconds)
- stop repeated live timeline retries after the first live persistence failure for a turn; remaining events still persist in finalization
- flush any buffered live events before terminal finalization so start indexes and persisted slices stay consistent
- add a regression test that simulates bursty progress events and verifies timeline writes are batched

## Validation
- .venv/bin/python -m pytest tests/integrations/chat/test_managed_thread_turns.py
- pre-commit validation lane during commit (includes mypy + repo pytest suite)

Closes #1463