### PR TITLE
fix: extend bot author filter to pull_request_review_comment events (#1444)

### DIFF
--- a/src/codex_autorunner/core/scm_reaction_router.py
+++ b/src/codex_autorunner/core/scm_reaction_router.py
@@ -232,9 +232,8 @@ def _match_reaction_kind(
             and author_login == issue_author_login
         ):
             return None
-        if event.event_type == "issue_comment" and (
-            author_type == "bot"
-            or (author_login is not None and author_login.endswith("[bot]"))
+        if author_type == "bot" or (
+            author_login is not None and author_login.endswith("[bot]")
         ):
             return None
         return "review_comment"

--- a/tests/core/test_scm_reaction_router.py
+++ b/tests/core/test_scm_reaction_router.py
@@ -451,11 +451,7 @@ def test_route_scm_reactions_routes_bot_pull_request_review_comment() -> None:
         event, binding=_binding(thread_target_id="thread-inline-bot")
     )
 
-    assert len(intents) == 2
-    assert intents[0].reaction_kind == "review_comment"
-    assert intents[0].operation_kind == "enqueue_managed_turn"
-    assert intents[1].reaction_kind == "review_comment"
-    assert intents[1].operation_kind == "react_pr_review_comment"
+    assert len(intents) == 0
 
 
 def test_route_scm_reactions_still_reacts_to_review_comment_without_chat_target() -> (


### PR DESCRIPTION
Closes #1444.

Bot accounts such as `cursor[bot]` are now filtered from `pull_request_review_comment` reaction routing the same way they were already filtered from `issue_comment` reactions.
