### PR TITLE
fix(telegram): construct TelegramMessage from callback fields in update confirm flow

### DIFF
--- a/src/codex_autorunner/integrations/telegram/handlers/selections.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/selections.py
@@ -430,8 +430,7 @@ class TelegramSelectionHandlers(ChatSelectionHandlers):
         if self._has_active_turns() and _update_target_restarts_surface(
             update_target, surface="telegram"
         ):
-            message = getattr(callback, "message", None)
-            if message is None:
+            if callback.chat_id is None or callback.message_id is None:
                 await self._answer_callback(callback, "Active session detected")
                 await self._finalize_selection(
                     key,
@@ -439,6 +438,16 @@ class TelegramSelectionHandlers(ChatSelectionHandlers):
                     "Update confirmation expired. Run /update again.",
                 )
                 return
+            message = TelegramMessage(
+                update_id=callback.update_id,
+                message_id=callback.message_id,
+                chat_id=callback.chat_id,
+                thread_id=callback.thread_id,
+                from_user_id=callback.from_user_id,
+                text=None,
+                date=None,
+                is_topic_message=bool(callback.thread_id),
+            )
             await self._answer_callback(callback, "Confirm update")
             await self._prompt_update_confirmation(
                 message,


### PR DESCRIPTION
## Summary

- `TelegramCallbackQuery` is a flat dataclass with `chat_id`/`message_id`/`thread_id` as direct fields — it has **no** `message` attribute
- `getattr(callback, "message", None)` at `selections.py:433` always returned `None`, so the update confirmation prompt was never shown and users always saw "Update confirmation expired. Run /update again." when active sessions existed
- Constructs a proper `TelegramMessage` from the callback fields, matching the pattern already used in the same file for review-commit callbacks (line 508)

## Test plan
- [x] All 5745 tests pass (including `test_telegram_typed_states`, `test_telegram_flow_callback_actions`, `test_telegram_bot_integration` update tests)
- [x] mypy strict passes
- [ ] Manual: `/update` with an active session should now show the confirmation prompt with Yes/Cancel buttons