### PR TITLE
[codex] Fix hub orchestration history housekeeping

### DIFF
--- a/src/codex_autorunner/core/orchestration/execution_history_maintenance.py
+++ b/src/codex_autorunner/core/orchestration/execution_history_maintenance.py
@@ -27,6 +27,8 @@ _COMPACTION_SUMMARY_SUFFIX = ":compaction-summary"
 _DEFAULT_COMPACTION_MAX_HOT_ROWS = 16
 _DEFAULT_HOT_RETENTION_DAYS = 30
 _DEFAULT_COLD_TRACE_RETENTION_DAYS = 90
+_DEFAULT_DB_SIZE_WARNING_BYTES = 1 * 1024 * 1024 * 1024
+_DEFAULT_DB_SIZE_ERROR_BYTES = 3 * 1024 * 1024 * 1024
 _TERMINAL_EXECUTION_STATUSES = frozenset(
     {
         "completed",
@@ -139,6 +141,42 @@ class ExecutionHistoryVacuumSummary:
 
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass(frozen=True)
+class ExecutionHistoryDatabaseHealth:
+    database_path: str
+    size_bytes: int
+    status: str
+    warning_threshold_bytes: int
+    error_threshold_bytes: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass(frozen=True)
+class ExecutionHistoryHousekeepingSummary:
+    started_at: str
+    finished_at: str
+    policy: ExecutionHistoryMaintenancePolicy
+    database_size_before_bytes: int
+    database_size_after_bytes: int
+    compaction: ExecutionHistoryCompactionSummary
+    retention: ExecutionHistoryRetentionSummary
+    vacuum: Optional[ExecutionHistoryVacuumSummary] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "policy": self.policy.to_dict(),
+            "database_size_before_bytes": self.database_size_before_bytes,
+            "database_size_after_bytes": self.database_size_after_bytes,
+            "compaction": self.compaction.to_dict(),
+            "retention": self.retention.to_dict(),
+            "vacuum": self.vacuum.to_dict() if self.vacuum is not None else None,
+        }
 
 
 def resolve_execution_history_maintenance_policy(
@@ -825,6 +863,74 @@ def vacuum_execution_history(hub_root: Path) -> ExecutionHistoryVacuumSummary:
     )
 
 
+def execution_history_database_size_bytes(hub_root: Path) -> int:
+    db_path = resolve_orchestration_sqlite_path(hub_root)
+    try:
+        return int(db_path.stat().st_size)
+    except OSError:
+        return 0
+
+
+def collect_execution_history_database_health(
+    hub_root: Path,
+    *,
+    warning_threshold_bytes: int = _DEFAULT_DB_SIZE_WARNING_BYTES,
+    error_threshold_bytes: int = _DEFAULT_DB_SIZE_ERROR_BYTES,
+) -> ExecutionHistoryDatabaseHealth:
+    warning_threshold = max(0, int(warning_threshold_bytes))
+    error_threshold = max(warning_threshold, int(error_threshold_bytes))
+    size_bytes = execution_history_database_size_bytes(hub_root)
+    if size_bytes >= error_threshold:
+        status = "error"
+    elif size_bytes >= warning_threshold:
+        status = "warning"
+    else:
+        status = "ok"
+    return ExecutionHistoryDatabaseHealth(
+        database_path=str(resolve_orchestration_sqlite_path(hub_root)),
+        size_bytes=size_bytes,
+        status=status,
+        warning_threshold_bytes=warning_threshold,
+        error_threshold_bytes=error_threshold,
+    )
+
+
+def run_execution_history_housekeeping_once(
+    hub_root: Path,
+    *,
+    policy: ExecutionHistoryMaintenancePolicy | None = None,
+) -> ExecutionHistoryHousekeepingSummary:
+    resolved_policy = policy or ExecutionHistoryMaintenancePolicy()
+    started_at = now_iso()
+    db_size_before = execution_history_database_size_bytes(hub_root)
+    compaction = compact_completed_execution_history(
+        hub_root,
+        policy=resolved_policy,
+    )
+    retention = prune_execution_history_retention(
+        hub_root,
+        policy=resolved_policy,
+    )
+    vacuum_summary: Optional[ExecutionHistoryVacuumSummary] = None
+    if compaction.rows_deleted > 0 or retention.hot_rows_deleted > 0:
+        vacuum_summary = vacuum_execution_history(hub_root)
+    db_size_after = (
+        vacuum_summary.size_after
+        if vacuum_summary is not None
+        else execution_history_database_size_bytes(hub_root)
+    )
+    return ExecutionHistoryHousekeepingSummary(
+        started_at=started_at,
+        finished_at=now_iso(),
+        policy=resolved_policy,
+        database_size_before_bytes=db_size_before,
+        database_size_after_bytes=db_size_after,
+        compaction=compaction,
+        retention=retention,
+        vacuum=vacuum_summary,
+    )
+
+
 def _normalized_execution_ids(
     execution_ids: Optional[Sequence[str]],
 ) -> Optional[tuple[str, ...]]:
@@ -1488,16 +1594,21 @@ def _iso_cutoff(retention_days: int) -> Optional[str]:
 __all__ = [
     "ExecutionHistoryAuditSummary",
     "ExecutionHistoryCompactionSummary",
+    "ExecutionHistoryDatabaseHealth",
     "ExecutionHistoryExportSummary",
+    "ExecutionHistoryHousekeepingSummary",
     "ExecutionHistoryMaintenancePolicy",
     "ExecutionHistoryMigrationSummary",
     "ExecutionHistoryRetentionSummary",
     "ExecutionHistoryVacuumSummary",
     "audit_execution_history",
     "backfill_legacy_execution_history",
+    "collect_execution_history_database_health",
     "compact_completed_execution_history",
+    "execution_history_database_size_bytes",
     "export_execution_history_bundle",
     "prune_execution_history_retention",
     "resolve_execution_history_maintenance_policy",
+    "run_execution_history_housekeeping_once",
     "vacuum_execution_history",
 ]

--- a/src/codex_autorunner/core/orchestration/verification.py
+++ b/src/codex_autorunner/core/orchestration/verification.py
@@ -655,7 +655,11 @@ def verify_event_parity(hub_root: Path, conn: Any) -> list[ParityCheckResult]:
     results = []
     if _table_exists(conn, "orch_event_projections"):
         new_count_row = conn.execute(
-            "SELECT COUNT(*) as cnt FROM orch_event_projections"
+            """
+            SELECT COUNT(*) as cnt
+              FROM orch_event_projections
+             WHERE event_family = 'pma.lifecycle'
+            """
         ).fetchone()
         new_count = int(new_count_row["cnt"]) if new_count_row else 0
     else:

--- a/src/codex_autorunner/surfaces/web/app.py
+++ b/src/codex_autorunner/surfaces/web/app.py
@@ -30,6 +30,10 @@ from ...core.hub_diagnostics import (
 )
 from ...core.logging_utils import safe_log
 from ...core.managed_processes import reap_managed_processes
+from ...core.orchestration.execution_history_maintenance import (
+    resolve_execution_history_maintenance_policy,
+    run_execution_history_housekeeping_once,
+)
 from ...housekeeping import reap_managed_docker_containers, run_housekeeping_once
 from .app_builders import create_app, create_repo_app
 from .app_factory import CacheStaticFiles, resolve_allowed_hosts, resolve_auth_token
@@ -149,6 +153,7 @@ def create_hub_app(
     app.state.static_files = static_files
     app.state.static_assets_lock = threading.Lock()
     app.state.hub_static_assets = None
+    app.state.orchestration_housekeeping = None
     app.mount("/static", static_files, name="static")
     raw_config = getattr(context.config, "raw", {})
     pma_config = raw_config.get("pma", {}) if isinstance(raw_config, dict) else {}
@@ -414,6 +419,28 @@ def create_hub_app(
                                 app.state.config.root,
                                 logger=app.state.logger,
                             )
+                            try:
+                                summary = await asyncio.to_thread(
+                                    run_execution_history_housekeeping_once,
+                                    app.state.config.root,
+                                    policy=resolve_execution_history_maintenance_policy(
+                                        app.state.config.pma
+                                    ),
+                                )
+                                app.state.orchestration_housekeeping = summary.to_dict()
+                            except (
+                                OSError,
+                                RuntimeError,
+                                ConnectionError,
+                                ValueError,
+                                TypeError,
+                            ) as exc:
+                                safe_log(
+                                    app.state.logger,
+                                    logging.WARNING,
+                                    "Orchestration execution-history housekeeping failed",
+                                    exc,
+                                )
                         except (
                             RuntimeError,
                             OSError,

--- a/src/codex_autorunner/surfaces/web/app.py
+++ b/src/codex_autorunner/surfaces/web/app.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import sqlite3
 import threading
 import time
 from contextlib import asynccontextmanager
@@ -434,6 +435,7 @@ def create_hub_app(
                                 ConnectionError,
                                 ValueError,
                                 TypeError,
+                                sqlite3.Error,
                             ) as exc:
                                 safe_log(
                                     app.state.logger,
@@ -447,6 +449,7 @@ def create_hub_app(
                             ConnectionError,
                             ValueError,
                             TypeError,
+                            sqlite3.Error,
                         ) as exc:  # intentional: background loop must not crash
                             safe_log(
                                 app.state.logger,

--- a/src/codex_autorunner/surfaces/web/routes/system.py
+++ b/src/codex_autorunner/surfaces/web/routes/system.py
@@ -9,6 +9,9 @@ from fastapi.responses import JSONResponse
 from ....core import update as update_core
 from ....core.config import HubConfig
 from ....core.constants import DEFAULT_UPDATE_REPO_REF, DEFAULT_UPDATE_REPO_URL
+from ....core.orchestration.execution_history_maintenance import (
+    collect_execution_history_database_health,
+)
 from ....core.self_describe import collect_describe_data
 from ....core.text_utils import _pid_is_running
 from ....core.update import (
@@ -79,6 +82,28 @@ def build_system_routes() -> APIRouter:
         mode = "hub" if isinstance(config, HubConfig) else "repo"
         base_path = getattr(request.app.state, "base_path", "")
         asset_version = getattr(request.app.state, "asset_version", None)
+        orchestration_health = None
+        if isinstance(config, HubConfig):
+            database_health = await asyncio.to_thread(
+                collect_execution_history_database_health,
+                config.root,
+            )
+            orchestration_health = {
+                "database_path": database_health.database_path,
+                "database_size_bytes": database_health.size_bytes,
+                "database_size_status": database_health.status,
+                "database_size_warning_bytes": (
+                    database_health.warning_threshold_bytes
+                ),
+                "database_size_error_bytes": database_health.error_threshold_bytes,
+            }
+            last_housekeeping = getattr(
+                getattr(request.app, "state", None),
+                "orchestration_housekeeping",
+                None,
+            )
+            if isinstance(last_housekeeping, dict):
+                orchestration_health["last_housekeeping"] = last_housekeeping
         static_dir = getattr(getattr(request.app, "state", None), "static_dir", None)
         if not isinstance(static_dir, Path):
             return JSONResponse(
@@ -87,6 +112,7 @@ def build_system_routes() -> APIRouter:
                     "detail": "Static UI assets missing; reinstall package",
                     "mode": mode,
                     "base_path": base_path,
+                    "orchestration": orchestration_health,
                 },
                 status_code=500,
             )
@@ -106,6 +132,7 @@ def build_system_routes() -> APIRouter:
                     "mode": mode,
                     "base_path": base_path,
                     "asset_version": asset_version,
+                    "orchestration": orchestration_health,
                 }
             return JSONResponse(
                 {
@@ -114,6 +141,7 @@ def build_system_routes() -> APIRouter:
                     "missing": missing,
                     "mode": mode,
                     "base_path": base_path,
+                    "orchestration": orchestration_health,
                 },
                 status_code=500,
             )
@@ -122,6 +150,7 @@ def build_system_routes() -> APIRouter:
             "mode": mode,
             "base_path": base_path,
             "asset_version": asset_version,
+            "orchestration": orchestration_health,
         }
 
     @router.get("/system/update/check", response_model=SystemUpdateCheckResponse)

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -840,6 +840,7 @@ class SystemHealthResponse(ResponseModel):
     mode: str
     base_path: str
     asset_version: Optional[str] = None
+    orchestration: Optional[Dict[str, Any]] = None
 
 
 class SystemUpdateResponse(ResponseModel):

--- a/tests/core/orchestration/test_execution_history_maintenance.py
+++ b/tests/core/orchestration/test_execution_history_maintenance.py
@@ -14,9 +14,12 @@ from codex_autorunner.core.orchestration.execution_history_maintenance import (
     ExecutionHistoryMaintenancePolicy,
     audit_execution_history,
     backfill_legacy_execution_history,
+    collect_execution_history_database_health,
     compact_completed_execution_history,
+    execution_history_database_size_bytes,
     export_execution_history_bundle,
     prune_execution_history_retention,
+    run_execution_history_housekeeping_once,
 )
 from codex_autorunner.core.orchestration.sqlite import (
     initialize_orchestration_sqlite,
@@ -619,6 +622,57 @@ def test_prune_execution_history_retention_clears_checkpoint_trace_manifest_json
     checkpoint = store.load_checkpoint("exec-old-json")
     assert checkpoint is not None
     assert checkpoint.trace_manifest_id is None
+
+
+def test_run_execution_history_housekeeping_once_runs_compaction_and_vacuum(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    _seed_execution(hub_root, execution_id="exec-housekeep", output_chunks=20)
+
+    summary = run_execution_history_housekeeping_once(
+        hub_root,
+        policy=ExecutionHistoryMaintenancePolicy(
+            max_hot_rows_per_completed_execution=8,
+            hot_history_retention_days=30,
+            cold_trace_retention_days=90,
+        ),
+    )
+
+    assert summary.compaction.compacted_executions == 1
+    assert summary.compaction.rows_deleted > 0
+    assert summary.vacuum is not None
+    assert summary.database_size_before_bytes >= 0
+    assert summary.database_size_after_bytes >= 0
+
+    with open_orchestration_sqlite(hub_root, durable=False) as conn:
+        row = conn.execute(
+            """
+            SELECT COUNT(*) AS cnt
+              FROM orch_event_projections
+             WHERE event_family = 'turn.timeline'
+               AND execution_id = 'exec-housekeep'
+            """
+        ).fetchone()
+    assert int(row["cnt"] or 0) <= 8
+
+
+def test_collect_execution_history_database_health_reports_threshold_status(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    _seed_execution(hub_root, execution_id="exec-db-health", output_chunks=3)
+
+    size_bytes = execution_history_database_size_bytes(hub_root)
+    health = collect_execution_history_database_health(
+        hub_root,
+        warning_threshold_bytes=max(0, size_bytes - 1),
+        error_threshold_bytes=size_bytes + 1,
+    )
+    assert health.size_bytes == size_bytes
+    assert health.status == "warning"
 
 
 def test_compaction_never_keeps_more_than_policy_limit(

--- a/tests/core/orchestration/test_migration_verification.py
+++ b/tests/core/orchestration/test_migration_verification.py
@@ -126,6 +126,63 @@ def test_verify_event_parity_empty_legacy(tmp_path: Path) -> None:
     assert results[0].check_name == "event_projections_count"
 
 
+def test_verify_event_parity_ignores_non_lifecycle_projection_rows(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    lifecycle_log = hub_root / ".codex-autorunner" / "pma" / "lifecycle_events.jsonl"
+    lifecycle_log.parent.mkdir(parents=True, exist_ok=True)
+    lifecycle_log.write_text(
+        '{"event_id": "event-1", "event_type": "test", "timestamp": "2026-03-13T00:00:00Z"}\n',
+        encoding="utf-8",
+    )
+
+    with open_orchestration_sqlite(hub_root, durable=False) as conn:
+        backfill_legacy_pma_lifecycle_events(hub_root, conn)
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO orch_event_projections (
+                    event_id,
+                    event_family,
+                    event_type,
+                    target_kind,
+                    target_id,
+                    execution_id,
+                    repo_id,
+                    resource_kind,
+                    resource_id,
+                    run_id,
+                    timestamp,
+                    status,
+                    payload_json,
+                    processed
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "timeline-1",
+                    "turn.timeline",
+                    "turn_started",
+                    "thread_target",
+                    "thread-1",
+                    "exec-1",
+                    "repo-1",
+                    "repo",
+                    "repo-1",
+                    None,
+                    "2026-03-13T00:00:01Z",
+                    "recorded",
+                    "{}",
+                    1,
+                ),
+            )
+        results = verify_event_parity(hub_root, conn)
+
+    assert results[0].status == "passed"
+    assert results[0].legacy_count == 1
+    assert results[0].new_count == 1
+
+
 def test_verify_audit_parity_empty_legacy(tmp_path: Path) -> None:
     hub_root = tmp_path / "hub"
     with open_orchestration_sqlite(hub_root, durable=False) as conn:

--- a/tests/test_hub_issue_1266.py
+++ b/tests/test_hub_issue_1266.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import sqlite3
 import sys
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
@@ -332,3 +334,67 @@ def test_hub_health_includes_last_orchestration_housekeeping(
         payload["orchestration"]["last_housekeeping"]["compaction"]["rows_deleted"]
         == 12
     )
+
+
+def test_hub_housekeeping_loop_survives_sqlite_errors(
+    hub_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codex_autorunner.core.config import CONFIG_FILENAME
+
+    _stub_opencode_supervisor(monkeypatch)
+    first_call = threading.Event()
+    second_call = threading.Event()
+
+    class _Summary:
+        def to_dict(self) -> dict[str, object]:
+            return {"status": "ok"}
+
+    def _fake_prune_filebox_root(*args: object, **kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            inbox_pruned=(),
+            outbox_pruned=(),
+            bytes_before=0,
+            bytes_after=0,
+        )
+
+    def _fake_execution_history_housekeeping(
+        *args: object, **kwargs: object
+    ) -> _Summary:
+        if not first_call.is_set():
+            first_call.set()
+            raise sqlite3.OperationalError("database is locked")
+        second_call.set()
+        return _Summary()
+
+    monkeypatch.setattr(
+        web_app_module,
+        "prune_filebox_root",
+        _fake_prune_filebox_root,
+    )
+    monkeypatch.setattr(
+        web_app_module,
+        "run_housekeeping_once",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        web_app_module,
+        "run_execution_history_housekeeping_once",
+        _fake_execution_history_housekeeping,
+    )
+    write_test_config(
+        Path(hub_env.hub_root) / CONFIG_FILENAME,
+        {
+            "mode": "hub",
+            "housekeeping": {"interval_seconds": 1},
+        },
+    )
+
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        assert first_call.wait(timeout=5.0)
+        assert second_call.wait(timeout=5.0)
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"

--- a/tests/test_hub_issue_1266.py
+++ b/tests/test_hub_issue_1266.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 from codex_autorunner.core.orchestration import (
     legacy_backfill_gate as legacy_backfill_gate_module,
 )
+from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.server import create_hub_app
 from codex_autorunner.surfaces.web import app as web_app_module
 from tests.conftest import write_test_config
@@ -290,3 +291,44 @@ def test_pma_automation_load_does_not_retrigger_backfill_after_explicit_prepare(
     PmaAutomationStore(hub_root).load()
 
     assert calls == [], "routine loads must not retrigger legacy backfill after prepare"
+
+
+def test_hub_health_reports_orchestration_database_size(hub_env, monkeypatch) -> None:
+    _stub_opencode_supervisor(monkeypatch)
+    with open_orchestration_sqlite(hub_env.hub_root, durable=False):
+        pass
+
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["orchestration"]["database_path"].endswith("orchestration.sqlite3")
+    assert payload["orchestration"]["database_size_bytes"] >= 0
+    assert payload["orchestration"]["database_size_status"] == "ok"
+
+
+def test_hub_health_includes_last_orchestration_housekeeping(
+    hub_env, monkeypatch
+) -> None:
+    _stub_opencode_supervisor(monkeypatch)
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        app.state.orchestration_housekeeping = {
+            "started_at": "2026-04-16T00:00:00Z",
+            "finished_at": "2026-04-16T00:00:01Z",
+            "compaction": {"rows_deleted": 12},
+            "retention": {"hot_rows_deleted": 4},
+        }
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert (
+        payload["orchestration"]["last_housekeeping"]["compaction"]["rows_deleted"]
+        == 12
+    )


### PR DESCRIPTION
## Summary
- wire execution-history compaction, retention, and vacuum into the hub housekeeping loop and persist the last run summary on app state
- expose orchestration DB size and last housekeeping details on `/health`
- scope migration event parity verification to `pma.lifecycle` rows so it no longer scans unrelated hot timeline projections

## Root Cause
The hub was not automatically enforcing execution-history retention, so `orch_event_projections` could grow without bound. Large hot timelines then made unbounded projection scans expensive enough to starve startup and control-plane responsiveness.

## Validation
- `.venv/bin/python -m pytest tests/core/orchestration/test_execution_history_maintenance.py tests/core/orchestration/test_migration_verification.py tests/test_hub_issue_1266.py`
- repo hook checks reached full mypy and repo-wide pytest multiple times; the only failures were unrelated flaky Discord integration timing tests outside this change

Closes #1470