### PR TITLE
[codex] stabilize discord fast hook checks

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -181,26 +181,36 @@ if [[ "$RUN_CORE" == true ]]; then
   echo "Running tests (pytest)..."
   if [ -z "${CI:-}" ]; then
     FAST_TEST_JUNIT="$(mktemp)"
-    FAST_TEST_SELECTED="$(mktemp)"
     cleanup_fast_test_artifacts() {
-      rm -f "$FAST_TEST_JUNIT" "$FAST_TEST_SELECTED"
+      rm -f "$FAST_TEST_JUNIT" "${FAST_TEST_SELECTED:-}"
     }
     trap cleanup_fast_test_artifacts EXIT
-    "$PYTHON_BIN" -m pytest -m "not integration and not slow" --collect-only -q > "$FAST_TEST_SELECTED"
     "$PYTHON_BIN" -m pytest -m "not integration and not slow" -n auto -o junit_duration_report=call --junitxml "$FAST_TEST_JUNIT"
-    "$PYTHON_BIN" scripts/report_fast_test_budget.py \
-      "$FAST_TEST_JUNIT" \
-      --selected-nodeids "$FAST_TEST_SELECTED" \
-      --repo-root "$REPO_ROOT" \
-      --verify-nodeids \
-      --max-duration "${CODEX_FAST_TEST_MAX_DURATION_SECONDS:-1.0}" \
+    FAST_TEST_REPORT_ARGS=(
+      "$FAST_TEST_JUNIT"
+      --repo-root "$REPO_ROOT"
+      --max-duration "${CODEX_FAST_TEST_MAX_DURATION_SECONDS:-1.0}"
       --max-report "${CODEX_FAST_TEST_REPORT_LIMIT:-20}"
+    )
+    if [[ "${CODEX_FAST_TEST_VERIFY_NODEIDS:-0}" == "1" ]]; then
+      FAST_TEST_SELECTED="$(mktemp)"
+      "$PYTHON_BIN" -m pytest -m "not integration and not slow" --collect-only -q > "$FAST_TEST_SELECTED"
+      FAST_TEST_REPORT_ARGS+=(
+        --selected-nodeids "$FAST_TEST_SELECTED"
+        --verify-nodeids
+      )
+    fi
+    "$PYTHON_BIN" scripts/report_fast_test_budget.py "${FAST_TEST_REPORT_ARGS[@]}"
   else
     "$PYTHON_BIN" -m pytest -m "not integration and not slow" -n auto
   fi
 
-  echo "Dead-code check (heuristic)..."
-  "$PYTHON_BIN" "$REPO_ROOT/scripts/deadcode.py" --check
+  if [ -n "${CI:-}" ] || [[ "${CODEX_LOCAL_CHECK_INCLUDE_DEADCODE:-0}" == "1" ]]; then
+    echo "Dead-code check (heuristic)..."
+    "$PYTHON_BIN" "$REPO_ROOT/scripts/deadcode.py" --check
+  else
+    echo "Skipping dead-code check locally; set CODEX_LOCAL_CHECK_INCLUDE_DEADCODE=1 to enable."
+  fi
 fi
 
 # --- Web-UI lane checks ------------------------------------------------------

--- a/scripts/report_fast_test_budget.py
+++ b/scripts/report_fast_test_budget.py
@@ -275,12 +275,16 @@ def verify_fast_test_budget_offenders(
     threshold_seconds: float,
     repo_root: Path,
     duration_collector: DurationCollector = _collect_call_durations_from_pytest,
+    max_nodeids: Optional[int] = None,
 ) -> list[FastTestBudgetOffender]:
     if not offenders:
         return []
 
+    verification_candidates = (
+        offenders[:max_nodeids] if max_nodeids is not None else offenders
+    )
     verified_durations = duration_collector(
-        [offender.nodeid for offender in offenders],
+        [offender.nodeid for offender in verification_candidates],
         repo_root.resolve(),
     )
     verified: list[FastTestBudgetOffender] = []
@@ -325,10 +329,12 @@ def main(argv: list[str] | None = None) -> int:
         repo_root=args.repo_root,
     )
     if args.verify_nodeids and offenders:
+        verification_limit = None if args.fail_on_violation else report_limit
         offenders = verify_fast_test_budget_offenders(
             offenders,
             threshold_seconds=threshold_seconds,
             repo_root=args.repo_root,
+            max_nodeids=verification_limit,
         )
     all_durations: list[float] = []
     tree = ET.parse(args.report_path)

--- a/tests/chat_surface_harness/discord.py
+++ b/tests/chat_surface_harness/discord.py
@@ -156,6 +156,11 @@ class DiscordPmaEnvironment:
         await self.store.close()
 
 
+async def drain_spawned_tasks(service: DiscordBotService) -> None:
+    while service._background_tasks:
+        await asyncio.gather(*list(service._background_tasks), return_exceptions=True)
+
+
 async def build_discord_pma_environment(
     root: Path,
     *,

--- a/tests/core/test_pma_safety.py
+++ b/tests/core/test_pma_safety.py
@@ -204,7 +204,7 @@ class TestDuplicateDetection:
     def test_duplicate_detection_window_expiry(
         self, hub_root: Path, config: PmaSafetyConfig
     ) -> None:
-        config.dedup_window_seconds = 0.5
+        config.dedup_window_seconds = 10
         config.enable_rate_limit = False
         config.enable_circuit_breaker = False
         config.max_duplicate_actions = 2
@@ -227,7 +227,7 @@ class TestDuplicateDetection:
 
         expired_checker = PmaSafetyChecker(hub_root / "expired", config=config)
         expired_timestamp = (
-            datetime.now(timezone.utc) - timedelta(seconds=1)
+            datetime.now(timezone.utc) - timedelta(seconds=11)
         ).isoformat()
 
         for _i in range(config.max_duplicate_actions):

--- a/tests/discord_message_turns_support.py
+++ b/tests/discord_message_turns_support.py
@@ -57,6 +57,7 @@ from codex_autorunner.integrations.chat.compaction import build_compact_seed_pro
 from codex_autorunner.integrations.chat.dispatcher import build_dispatch_context
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
+    DiscordBotDispatchConfig,
     DiscordBotMediaConfig,
     DiscordBotShellConfig,
     DiscordCommandRegistration,
@@ -1728,6 +1729,7 @@ def _config(
     media_voice: bool = True,
     media_max_voice_bytes: int = 10 * 1024 * 1024,
     collaboration_policy: CollaborationPolicy | None = None,
+    ack_budget_ms: int = 10_000,
 ) -> DiscordBotConfig:
     return DiscordBotConfig(
         root=root,
@@ -1749,6 +1751,7 @@ def _config(
         max_message_length=max_message_length,
         message_overflow=message_overflow,
         pma_enabled=pma_enabled,
+        dispatch=DiscordBotDispatchConfig(ack_budget_ms=ack_budget_ms),
         shell=DiscordBotShellConfig(
             enabled=shell_enabled,
             timeout_ms=shell_timeout_ms,

--- a/tests/integrations/chat/test_hermes_official_completion.py
+++ b/tests/integrations/chat/test_hermes_official_completion.py
@@ -4,7 +4,10 @@ import asyncio
 
 import anyio
 import pytest
-from tests.chat_surface_harness.discord import build_discord_pma_environment
+from tests.chat_surface_harness.discord import (
+    build_discord_pma_environment,
+    discord_message_create,
+)
 from tests.chat_surface_harness.hermes import patch_hermes_registry
 from tests.chat_surface_harness.telegram import (
     build_telegram_pma_environment,
@@ -13,6 +16,7 @@ from tests.chat_surface_harness.telegram import (
 )
 
 import codex_autorunner.integrations.discord.message_turns as discord_message_turns_module
+from codex_autorunner.integrations.chat.dispatcher import build_dispatch_context
 from codex_autorunner.integrations.telegram.handlers.commands import (
     execution as telegram_execution_module,
 )
@@ -36,7 +40,14 @@ async def test_discord_pma_turn_completes_for_official_hermes_prompt(
         message_content="echo hello world",
     )
     try:
-        await asyncio.wait_for(env.service.run_forever(), timeout=3)
+        event = env.service._chat_adapter.parse_message_event(
+            discord_message_create("echo hello world")
+        )
+        assert event is not None
+        await asyncio.wait_for(
+            env.service._handle_message_event(event, build_dispatch_context(event)),
+            timeout=3,
+        )
         with anyio.fail_after(2):
             while not any(
                 "fixture reply" in message["payload"].get("content", "")

--- a/tests/integrations/discord/test_channel_directory_ingest.py
+++ b/tests/integrations/discord/test_channel_directory_ingest.py
@@ -13,6 +13,7 @@ from codex_autorunner.integrations.chat.channel_directory import (
 )
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
+    DiscordBotDispatchConfig,
     DiscordCommandRegistration,
 )
 from codex_autorunner.integrations.discord.service import DiscordBotService
@@ -57,7 +58,7 @@ class _FakeGateway:
         return None
 
 
-def _config(root: Path) -> DiscordBotConfig:
+def _config(root: Path, *, ack_budget_ms: int = 10_000) -> DiscordBotConfig:
     return DiscordBotConfig(
         root=root,
         enabled=True,
@@ -78,6 +79,7 @@ def _config(root: Path) -> DiscordBotConfig:
         max_message_length=2000,
         message_overflow="split",
         pma_enabled=True,
+        dispatch=DiscordBotDispatchConfig(ack_budget_ms=ack_budget_ms),
     )
 
 

--- a/tests/integrations/discord/test_filebox_housekeeping.py
+++ b/tests/integrations/discord/test_filebox_housekeeping.py
@@ -9,6 +9,7 @@ import pytest
 from codex_autorunner.integrations.discord import service as discord_service_module
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
+    DiscordBotDispatchConfig,
     DiscordCommandRegistration,
 )
 from codex_autorunner.integrations.discord.service import DiscordBotService
@@ -39,7 +40,7 @@ class _FakeOutboxManager:
         return None
 
 
-def _config(root: Path) -> DiscordBotConfig:
+def _config(root: Path, *, ack_budget_ms: int = 10_000) -> DiscordBotConfig:
     return DiscordBotConfig(
         root=root,
         enabled=True,
@@ -60,6 +61,7 @@ def _config(root: Path) -> DiscordBotConfig:
         max_message_length=2000,
         message_overflow="split",
         pma_enabled=False,
+        dispatch=DiscordBotDispatchConfig(ack_budget_ms=ack_budget_ms),
     )
 
 

--- a/tests/integrations/discord/test_flow_archive.py
+++ b/tests/integrations/discord/test_flow_archive.py
@@ -15,6 +15,7 @@ from codex_autorunner.core.flows.models import FlowRunStatus
 from codex_autorunner.integrations.discord import service as discord_service_module
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
+    DiscordBotDispatchConfig,
     DiscordCommandRegistration,
 )
 from codex_autorunner.integrations.discord.errors import DiscordTransientError
@@ -138,7 +139,7 @@ class _FlowServiceValueErrorStub:
         raise ValueError("Can only archive completed/stopped/failed flows")
 
 
-def _config(root: Path) -> DiscordBotConfig:
+def _config(root: Path, *, ack_budget_ms: int = 10_000) -> DiscordBotConfig:
     return DiscordBotConfig(
         root=root,
         enabled=True,
@@ -159,6 +160,7 @@ def _config(root: Path) -> DiscordBotConfig:
         max_message_length=2000,
         message_overflow="split",
         pma_enabled=True,
+        dispatch=DiscordBotDispatchConfig(ack_budget_ms=ack_budget_ms),
     )
 
 

--- a/tests/integrations/discord/test_flow_handlers.py
+++ b/tests/integrations/discord/test_flow_handlers.py
@@ -16,6 +16,7 @@ from codex_autorunner.core.flows import hub_overview as hub_overview_module
 from codex_autorunner.core.flows.models import FlowRunStatus
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
+    DiscordBotDispatchConfig,
     DiscordCommandRegistration,
 )
 from codex_autorunner.integrations.discord.service import DiscordBotService
@@ -138,6 +139,27 @@ def _latest_public_response_payload(rest: _FakeRest) -> dict[str, Any]:
     raise AssertionError("expected a Discord public response payload")
 
 
+async def _invoke_flow_status(
+    service: DiscordBotService,
+    *,
+    workspace_root: Path,
+    options: dict[str, Any] | None = None,
+    channel_id: str = "channel-1",
+    guild_id: str = "guild-1",
+    update_message: bool = False,
+) -> None:
+    interaction_id = str(uuid.uuid4())
+    await service._handle_flow_status(
+        interaction_id,
+        f"token-{interaction_id}",
+        workspace_root=workspace_root,
+        options=options or {},
+        channel_id=channel_id,
+        guild_id=guild_id,
+        update_message=update_message,
+    )
+
+
 class _FlowServiceStub:
     def __init__(self) -> None:
         self.start_calls: list[dict[str, Any]] = []
@@ -186,7 +208,7 @@ class _FlowServiceStub:
         return SimpleNamespace(run_id=run_id, status="running"), True, False
 
 
-def _config(root: Path) -> DiscordBotConfig:
+def _config(root: Path, *, ack_budget_ms: int = 10_000) -> DiscordBotConfig:
     return DiscordBotConfig(
         root=root,
         enabled=True,
@@ -207,6 +229,9 @@ def _config(root: Path) -> DiscordBotConfig:
         max_message_length=2000,
         message_overflow="split",
         pma_enabled=True,
+        # These tests focus on flow handler behavior; reliability tests own the
+        # production Discord callback budget edge cases.
+        dispatch=DiscordBotDispatchConfig(ack_budget_ms=ack_budget_ms),
     )
 
 
@@ -458,7 +483,7 @@ async def test_flow_status_without_run_id_uses_authoritative_run_and_includes_pi
     )
 
     try:
-        await service.run_forever()
+        await _invoke_flow_status(service, workspace_root=workspace)
         assert len(rest.interaction_responses) == 1
         assert rest.interaction_responses[0]["payload"]["type"] == 5
         payload = _latest_status_message(rest)
@@ -515,7 +540,7 @@ async def test_flow_status_without_run_id_shows_no_current_run_for_history_only(
     )
 
     try:
-        await service.run_forever()
+        await _invoke_flow_status(service, workspace_root=workspace)
         assert len(rest.interaction_responses) == 1
         assert rest.interaction_responses[0]["payload"]["type"] == 5
         payload = _latest_status_message(rest)
@@ -571,7 +596,7 @@ async def test_flow_status_without_run_uses_ticket_summary_fallback(
     )
 
     try:
-        await service.run_forever()
+        await _invoke_flow_status(service, workspace_root=workspace)
         assert len(rest.interaction_responses) == 1
         assert rest.interaction_responses[0]["payload"]["type"] == 5
         payload = _latest_status_message(rest)
@@ -658,7 +683,11 @@ async def test_flow_status_shows_elapsed_for_completed_run(tmp_path: Path) -> No
     )
 
     try:
-        await service.run_forever()
+        await _invoke_flow_status(
+            service,
+            workspace_root=workspace,
+            options={"run_id": completed_run_id},
+        )
         assert rest.interaction_responses[0]["payload"]["type"] == 5
         content = _latest_status_message(rest)["content"]
         assert "Status: completed" in content
@@ -704,7 +733,11 @@ async def test_flow_status_with_missing_explicit_run_id_reports_not_found(
     )
 
     try:
-        await service.run_forever()
+        await _invoke_flow_status(
+            service,
+            workspace_root=workspace,
+            options={"run_id": missing_run_id},
+        )
         assert len(rest.interaction_responses) == 1
         assert rest.interaction_responses[0]["payload"]["type"] == 5
         content = rest.followup_messages[0]["payload"]["content"]
@@ -755,7 +788,11 @@ async def test_flow_status_with_archived_explicit_run_id_renders_archived_state(
     )
 
     try:
-        await service.run_forever()
+        await _invoke_flow_status(
+            service,
+            workspace_root=workspace,
+            options={"run_id": run_id},
+        )
         assert len(rest.interaction_responses) == 1
         assert rest.interaction_responses[0]["payload"]["type"] == 5
         content = _latest_status_message(rest)["content"]
@@ -804,7 +841,11 @@ async def test_flow_status_with_stray_archive_dir_still_reports_not_found(
     )
 
     try:
-        await service.run_forever()
+        await _invoke_flow_status(
+            service,
+            workspace_root=workspace,
+            options={"run_id": run_id},
+        )
         assert len(rest.interaction_responses) == 1
         assert rest.interaction_responses[0]["payload"]["type"] == 5
         content = rest.followup_messages[0]["payload"]["content"]
@@ -848,7 +889,11 @@ async def test_flow_status_with_path_traversal_run_id_does_not_render_archived_s
     )
 
     try:
-        await service.run_forever()
+        await _invoke_flow_status(
+            service,
+            workspace_root=workspace,
+            options={"run_id": malicious_run_id},
+        )
         assert len(rest.interaction_responses) == 1
         assert rest.interaction_responses[0]["payload"]["type"] == 5
         content = rest.followup_messages[0]["payload"]["content"]

--- a/tests/integrations/discord/test_opencode_lifecycle.py
+++ b/tests/integrations/discord/test_opencode_lifecycle.py
@@ -14,6 +14,7 @@ from codex_autorunner.agents.opencode.supervisor_protocol import (
 from codex_autorunner.integrations.discord import service as discord_service_module
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
+    DiscordBotDispatchConfig,
     DiscordCommandRegistration,
 )
 from codex_autorunner.integrations.discord.service import DiscordBotService
@@ -92,7 +93,7 @@ class _StubOpenCodeSupervisor:
         self.close_all_calls += 1
 
 
-def _config(root: Path) -> DiscordBotConfig:
+def _config(root: Path, *, ack_budget_ms: int = 10_000) -> DiscordBotConfig:
     return DiscordBotConfig(
         root=root,
         enabled=True,
@@ -113,6 +114,7 @@ def _config(root: Path) -> DiscordBotConfig:
         max_message_length=2000,
         message_overflow="split",
         pma_enabled=False,
+        dispatch=DiscordBotDispatchConfig(ack_budget_ms=ack_budget_ms),
     )
 
 

--- a/tests/integrations/discord/test_pause_bridge.py
+++ b/tests/integrations/discord/test_pause_bridge.py
@@ -15,6 +15,7 @@ from codex_autorunner.core.flows import FlowStore
 from codex_autorunner.core.flows.models import FlowRunStatus
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
+    DiscordBotDispatchConfig,
     DiscordCommandRegistration,
 )
 from codex_autorunner.integrations.discord.service import DiscordBotService
@@ -72,7 +73,7 @@ class _FakeOutboxManager:
         await asyncio.Event().wait()
 
 
-def _config(root: Path) -> DiscordBotConfig:
+def _config(root: Path, *, ack_budget_ms: int = 10_000) -> DiscordBotConfig:
     return DiscordBotConfig(
         root=root,
         enabled=True,
@@ -93,6 +94,7 @@ def _config(root: Path) -> DiscordBotConfig:
         max_message_length=2000,
         message_overflow="split",
         pma_enabled=True,
+        dispatch=DiscordBotDispatchConfig(ack_budget_ms=ack_budget_ms),
     )
 
 

--- a/tests/integrations/discord/test_pma_commands.py
+++ b/tests/integrations/discord/test_pma_commands.py
@@ -9,6 +9,7 @@ import pytest
 
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
+    DiscordBotDispatchConfig,
     DiscordCommandRegistration,
 )
 from codex_autorunner.integrations.discord.service import DiscordBotService
@@ -97,7 +98,11 @@ class _FakeOutboxManager:
 
 
 def _config(
-    root: Path, *, allow_user_ids: frozenset[str], pma_enabled: bool = True
+    root: Path,
+    *,
+    allow_user_ids: frozenset[str],
+    pma_enabled: bool = True,
+    ack_budget_ms: int = 10_000,
 ) -> DiscordBotConfig:
     return DiscordBotConfig(
         root=root,
@@ -119,6 +124,7 @@ def _config(
         max_message_length=2000,
         message_overflow="split",
         pma_enabled=pma_enabled,
+        dispatch=DiscordBotDispatchConfig(ack_budget_ms=ack_budget_ms),
     )
 
 

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -55,6 +55,7 @@ from codex_autorunner.integrations.discord.car_handlers import (
 )
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
+    DiscordBotDispatchConfig,
     DiscordCommandRegistration,
 )
 from codex_autorunner.integrations.discord.errors import (
@@ -1236,6 +1237,7 @@ def _config(
     command_scope: str = "guild",
     command_guild_ids: tuple[str, ...] = ("guild-1",),
     collaboration_policy: CollaborationPolicy | None = None,
+    ack_budget_ms: int = 10_000,
 ) -> DiscordBotConfig:
     return DiscordBotConfig(
         root=root,
@@ -1257,6 +1259,9 @@ def _config(
         max_message_length=2000,
         message_overflow="split",
         pma_enabled=True,
+        # These tests primarily validate routing/business behavior; dedicated
+        # reliability coverage owns the real Discord ack-budget deadline paths.
+        dispatch=DiscordBotDispatchConfig(ack_budget_ms=ack_budget_ms),
         collaboration_policy=collaboration_policy,
     )
 
@@ -4820,36 +4825,33 @@ async def test_car_model_rejects_invalid_opencode_model_name(tmp_path: Path) -> 
     )
     await store.update_agent_state(channel_id="channel-1", agent="opencode")
     rest = _FakeRest()
-    gateway = _FakeGateway(
-        [
-            _interaction(
-                name="model",
-                options=[{"name": "name", "value": "gpt-5.3-codex-unknown"}],
-            )
-        ]
-    )
     service = DiscordBotService(
         _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
         logger=logging.getLogger("test"),
         rest_client=rest,
-        gateway_client=gateway,
+        gateway_client=_FakeGateway([]),
         state_store=store,
         outbox_manager=_FakeOutboxManager(),
     )
 
     try:
-        await service.run_forever()
+        await service._handle_car_model(
+            interaction_id="inter-1",
+            interaction_token="token-1",
+            channel_id="channel-1",
+            user_id="user-1",
+            options={"name": "gpt-5.3-codex-unknown"},
+        )
         binding = await store.get_binding(channel_id="channel-1")
         assert binding is not None
         assert binding.get("model_override") is None
         assert len(rest.interaction_responses) == 1
-        assert rest.interaction_responses[0]["payload"]["type"] == 5
-        delivery_payloads = [
-            item["payload"] for item in rest.edited_original_interaction_responses
-        ] + [item["payload"] for item in rest.followup_messages]
-        assert len(delivery_payloads) == 1
-        content = str(delivery_payloads[0]["content"]).lower()
+        payload = rest.interaction_responses[0]["payload"]
+        assert payload["type"] == 4
+        content = str(payload["data"]["content"]).lower()
         assert "provider/model" in content
+        assert rest.followup_messages == []
+        assert rest.edited_original_interaction_responses == []
     finally:
         await store.close()
 

--- a/tests/integrations/discord/test_service_startup.py
+++ b/tests/integrations/discord/test_service_startup.py
@@ -11,6 +11,7 @@ from codex_autorunner.integrations.app_server.event_buffer import AppServerEvent
 from codex_autorunner.integrations.discord import service as discord_service_module
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
+    DiscordBotDispatchConfig,
     DiscordCommandRegistration,
 )
 from codex_autorunner.integrations.discord.service import DiscordBotService
@@ -44,7 +45,7 @@ class _FakeOutboxManager:
         return None
 
 
-def _config(root: Path) -> DiscordBotConfig:
+def _config(root: Path, *, ack_budget_ms: int = 10_000) -> DiscordBotConfig:
     return DiscordBotConfig(
         root=root,
         enabled=True,
@@ -65,6 +66,7 @@ def _config(root: Path) -> DiscordBotConfig:
         max_message_length=2000,
         message_overflow="split",
         pma_enabled=False,
+        dispatch=DiscordBotDispatchConfig(ack_budget_ms=ack_budget_ms),
     )
 
 

--- a/tests/surfaces/web/routes/test_hub_performance_caches.py
+++ b/tests/surfaces/web/routes/test_hub_performance_caches.py
@@ -628,11 +628,9 @@ def test_hub_repo_listing_service_reuses_stale_response_while_refreshing(
         stale = await listing_service.list_repos(sections={"repos"})
         assert stale["repos"][0]["call"] == 1
 
-        for _ in range(50):
-            if calls["enrich_repo"] >= 2:
-                break
-            await asyncio.sleep(0.01)
-
+        refresh_task = listing_service._response_refresh_tasks.get(("repos",))
+        assert refresh_task is not None
+        await refresh_task
         assert calls["enrich_repo"] == 2
         refreshed = await listing_service.list_repos(sections={"repos"})
         assert refreshed["repos"][0]["call"] == 2

--- a/tests/test_discord_hub_handshake.py
+++ b/tests/test_discord_hub_handshake.py
@@ -12,6 +12,7 @@ from codex_autorunner.bootstrap import seed_hub_files
 from codex_autorunner.core.orchestration import ORCHESTRATION_SCHEMA_VERSION
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
+    DiscordBotDispatchConfig,
     DiscordBotShellConfig,
     DiscordCommandRegistration,
 )
@@ -99,6 +100,7 @@ def _config(
     shell_max_output_chars: int = 3800,
     max_message_length: int = 2000,
     message_overflow: str = "split",
+    ack_budget_ms: int = 10_000,
 ) -> DiscordBotConfig:
     return DiscordBotConfig(
         root=root,
@@ -120,6 +122,7 @@ def _config(
         max_message_length=max_message_length,
         message_overflow=message_overflow,
         pma_enabled=pma_enabled,
+        dispatch=DiscordBotDispatchConfig(ack_budget_ms=ack_budget_ms),
         shell=DiscordBotShellConfig(
             enabled=shell_enabled,
             timeout_ms=shell_timeout_ms,

--- a/tests/test_discord_message_turn_startup_pending.py
+++ b/tests/test_discord_message_turn_startup_pending.py
@@ -7,14 +7,15 @@ from types import SimpleNamespace
 
 import pytest
 
+from codex_autorunner.integrations.chat.dispatcher import build_dispatch_context
 from codex_autorunner.integrations.discord import (
     message_turns as discord_message_turns_module,
 )
 from codex_autorunner.integrations.discord.service import DiscordBotService
 from codex_autorunner.integrations.discord.state import DiscordStateStore
+from tests.chat_surface_harness.discord import drain_spawned_tasks
 from tests.discord_message_turns_support import (
     _config,
-    _FakeGateway,
     _FakeOutboxManager,
     _FakeRest,
     _message_create,
@@ -37,12 +38,10 @@ async def test_message_create_startup_failure_keeps_generic_error_without_raw_de
         repo_id="repo-1",
     )
     rest = _FakeRest()
-    gateway = _FakeGateway([("MESSAGE_CREATE", _message_create("please continue"))])
     service = DiscordBotService(
         _config(tmp_path),
         logger=logging.getLogger("test"),
         rest_client=rest,
-        gateway_client=gateway,
         state_store=store,
         outbox_manager=_FakeOutboxManager(),
     )
@@ -74,7 +73,16 @@ async def test_message_create_startup_failure_keeps_generic_error_without_raw_de
     )
 
     try:
-        await asyncio.wait_for(service.run_forever(), timeout=5)
+        event = service._chat_adapter.parse_message_event(
+            _message_create("please continue")
+        )
+        assert event is not None
+        await asyncio.wait_for(
+            service._handle_message_event(event, build_dispatch_context(event)),
+            timeout=3,
+        )
+        await asyncio.wait_for(submit_started.wait(), timeout=1)
+        await asyncio.wait_for(drain_spawned_tasks(service), timeout=1)
         assert submit_started.is_set()
         assert rest.edited_channel_messages
         assert any(

--- a/tests/test_report_fast_test_budget.py
+++ b/tests/test_report_fast_test_budget.py
@@ -128,3 +128,34 @@ def test_verify_fast_test_budget_offenders_filters_by_verified_call_duration() -
         FastTestBudgetOffender("c::test_fallback", 1.25, "passed"),
         FastTestBudgetOffender("b::test_still_slow", 1.1, "failed"),
     ]
+
+
+def test_verify_fast_test_budget_offenders_limits_verified_nodeids() -> None:
+    offenders = [
+        FastTestBudgetOffender("a::test_slowest", 4.0, "passed"),
+        FastTestBudgetOffender("b::test_second", 3.0, "passed"),
+        FastTestBudgetOffender("c::test_third", 2.0, "passed"),
+    ]
+    seen_nodeids: list[str] = []
+
+    def _collector(nodeids: list[str], repo_root: Path) -> dict[str, float]:
+        _ = repo_root
+        seen_nodeids.extend(nodeids)
+        return {
+            "a::test_slowest": 0.5,
+            "b::test_second": 2.5,
+        }
+
+    verified = verify_fast_test_budget_offenders(
+        offenders,
+        threshold_seconds=1.0,
+        repo_root=Path.cwd(),
+        duration_collector=_collector,
+        max_nodeids=2,
+    )
+
+    assert seen_nodeids == ["a::test_slowest", "b::test_second"]
+    assert verified == [
+        FastTestBudgetOffender("b::test_second", 2.5, "passed"),
+        FastTestBudgetOffender("c::test_third", 2.0, "passed"),
+    ]


### PR DESCRIPTION
## Summary
This PR stabilizes the fast pre-commit / aggregate hook path by removing a few remaining wall-clock-sensitive tests and trimming avoidable local hook overhead.

## What Changed
- Avoid local `check.sh` overhead that made commits feel hung:
  - only run `pytest --collect-only` / nodeid verification when `CODEX_FAST_TEST_VERIFY_NODEIDS=1`
  - cap non-failing fast-budget offender verification to the reported top offenders
  - skip the dead-code pass locally unless `CODEX_LOCAL_CHECK_INCLUDE_DEADCODE=1`
- Stabilize Discord fast tests that were exercising the full gateway/ack path even when the assertion was only about handler output:
  - move pure `flow status` rendering tests to direct `_handle_flow_status(...)` invocation
  - route the invalid model-name test through the direct command handler instead of `run_forever()`
  - give the shared Discord test configs in pure business-behavior suites a larger synthetic ack budget so reliability tests remain the place that owns the real deadline edge cases
- Replace remaining timing-sensitive fast tests with deterministic boundaries:
  - Discord Hermes PMA test now waits for the observable reply path instead of draining every background task
  - Discord startup-pending test now drives the message handler directly and waits on the explicit startup signal
  - PMA safety duplicate-window test now uses a comfortable window rather than a sub-second real-time cutoff
  - hub repo cache test now awaits the actual background refresh task instead of polling for a side effect that happened before the cache write completed

## Root Cause
The pre-commit flake was not primarily slow/integration tests leaking into the fast lane. The main issue was a set of fast tests that still depended on real wall-clock timing around:
- Discord ack/runtime scheduling under xdist load
- sub-second freshness windows around real I/O
- detached async refresh tasks where the test observed "refresh started" instead of "refresh finished"

That meant the same commit could pass once and fail on the next run even though the underlying product behavior was fine.

## Validation
- Repeated targeted reruns of the recently flaky bundle: passed 5 consecutive times
- `./scripts/check.sh --lane core`: passed twice after the fixes
- `git commit` hook (`aggregate` lane): passed end-to-end on the final staged snapshot

## Impact
Local commits should no longer appear flaky because of these tests, and the fast hook path is materially leaner for normal local development while keeping the stricter optional verification path available behind env flags.