### PR TITLE
[codex] Reduce CAR idle service overhead and add idle CPU optimization harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ PIPX_ROOT ?= $(HOME)/.local/pipx
 PIPX_VENV ?= $(PIPX_ROOT)/venvs/codex-autorunner
 PIPX_PYTHON ?= $(PIPX_VENV)/bin/python
 
-.PHONY: install dev hooks build test test-chat-platform-contract test-managed-thread-cutover check check-full check-extended preflight-hub-startup format serve serve-dev launchd-hub deadcode-baseline venv venv-dev setup npm-install car-artifacts lint-html dom-check frontend-check _inject-static-banners agent-compatibility-check agent-compatibility-refresh protocol-schemas-check protocol-schemas-refresh typecheck-strict
+.PHONY: install dev hooks build test test-chat-platform-contract test-managed-thread-cutover check check-full check-extended preflight-hub-startup format serve serve-dev launchd-hub deadcode-baseline venv venv-dev setup npm-install car-artifacts lint-html dom-check frontend-check _inject-static-banners agent-compatibility-check agent-compatibility-refresh protocol-schemas-check protocol-schemas-refresh typecheck-strict perf-idle-cpu
 
 _inject-static-banners:
 	pnpm run postbuild
@@ -188,3 +188,8 @@ refresh-launchd:
 
 car-artifacts:
 	scripts/car-artifact-sizes.sh
+
+PROFILE ?= hub_only
+
+perf-idle-cpu:
+	$(PYTHON) scripts/idle_cpu_soak.py --profile $(PROFILE)

--- a/docs/ops/idle-cpu-soak.md
+++ b/docs/ops/idle-cpu-soak.md
@@ -7,13 +7,14 @@ resource consumption and sign off against committed budgets.
 
 ```bash
 # From repo root with the project venv active:
-.venv/bin/python scripts/idle_cpu_benchmark.py \
-  --profile hub_only \
-  --output .codex-autorunner/diagnostics/idle-cpu/
-```
+make perf-idle-cpu
 
-*(The harness script does not exist yet; this runbook describes the contract
-the future harness must satisfy.)*
+# Or run with a specific profile:
+make perf-idle-cpu PROFILE=hub_only
+
+# Or invoke the harness directly:
+.venv/bin/python scripts/idle_cpu_soak.py --profile hub_only --verbose
+```
 
 ## Profile definitions
 
@@ -162,3 +163,67 @@ The first optimization campaign succeeds when:
 This metric is the **only** success criterion for the first campaign and is now
 committed in this document and the profile definitions rather than living only
 in chat history.
+
+## First campaign results (2026-04-17)
+
+### Environment
+
+| Field | Value |
+|---|---|
+| Platform | macOS-26.4-arm64 (Apple Silicon) |
+| Python | 3.9.6 |
+| CPU cores | 10 |
+| Git ref | cd2b43a3-dirty |
+
+### hub_only baseline
+
+| Metric | Value |
+|---|---|
+| CPU mean | **0.010%** |
+| CPU p95 | 0.000% |
+| CPU max | 0.600% |
+| RSS mean | 99.3 MB |
+| RSS max | 99.3 MB |
+| Samples | 59 |
+| Health probes | 59/59 passed |
+| **Signoff** | **PASS** (0.010% < 5.0% hard budget) |
+
+The `hub_only` profile comfortably passes the hard budget gate at **500x under**
+the 5% threshold.
+
+### Remaining hotspots
+
+None. The idle hub consumes effectively zero CPU during steady state. The
+optimizations from tickets 420-440 (adaptive idle backoff, mtime guards,
+loop attribution) reduced idle polling to negligible levels.
+
+### Host caveats
+
+- The harness isolates measurement to the service process tree using session/PID
+  filtering. Other CAR instances on the same host are excluded from measurement.
+- Results may vary on heavily loaded machines. Run on a quiet host for
+  reproducible numbers.
+
+## Guardrails decisions
+
+### What belongs in CI
+
+- **Harness correctness tests** (artifact schema, profile validation, signoff
+  logic) run in normal CI via `tests/unit/test_idle_cpu_soak.py`,
+  `tests/unit/test_cpu_sampler.py`, `tests/unit/test_idle_cpu_profiles.py`.
+
+### What does NOT belong in CI
+
+- **Absolute CPU budget checks** should NOT run in normal CI. They require:
+  - A quiet, dedicated host
+  - A 5+ minute soak window
+  - No competing processes
+  These are suitable for **manual operator runs** (`make perf-idle-cpu`) or
+  **nightly/scheduled workflows** on dedicated hardware only.
+
+### Recommended cadence
+
+- Run `make perf-idle-cpu` after significant changes to the hub event loop,
+  polling intervals, or reconciliation logic.
+- Record artifacts in `.codex-autorunner/diagnostics/idle-cpu/history/` for
+  regression tracking across releases.

--- a/docs/ops/idle-cpu-soak.md
+++ b/docs/ops/idle-cpu-soak.md
@@ -1,0 +1,164 @@
+# Idle CPU Soak Benchmark
+
+Run a reproducible idle-CPU soak against a CAR hub to measure steady-state
+resource consumption and sign off against committed budgets.
+
+## Quick start
+
+```bash
+# From repo root with the project venv active:
+.venv/bin/python scripts/idle_cpu_benchmark.py \
+  --profile hub_only \
+  --output .codex-autorunner/diagnostics/idle-cpu/
+```
+
+*(The harness script does not exist yet; this runbook describes the contract
+the future harness must satisfy.)*
+
+## Profile definitions
+
+All profiles live in the committed file **`scripts/idle_cpu_profiles.yml`**.
+Each profile specifies:
+
+| Field | Description |
+|---|---|
+| `services` | Service commands the harness must launch |
+| `warmup_seconds` | Seconds to wait before sampling begins |
+| `duration_seconds` | Total measurement window |
+| `sample_interval_seconds` | Cadence between CPU/memory snapshots |
+| `health_probe` | HTTP health check target during the soak |
+| `expected_owned_process_categories` | `ProcessCategory` values the harness attributes to CAR |
+
+### Available profiles
+
+| Profile | Topology | Budget type | Target |
+|---|---|---|---|
+| `hub_only` | Hub API/UI only | **Hard gate** | <5% aggregate CAR CPU |
+| `hub_plus_discord` | Hub + Discord bot idle | Comparison | <8% aggregate CAR CPU |
+| `hub_plus_telegram` | Hub + Telegram bot idle | Comparison | <8% aggregate CAR CPU |
+| `hub_with_idle_runtime` | Hub + idle OpenCode server | Comparison | <10% aggregate CAR CPU |
+
+### Hard gate vs comparison profiles
+
+- **Hard gate** (`hub_only`): the benchmark **must pass** for the campaign to
+  succeed.  Failure blocks downstream optimization work.
+- **Comparison**: the profile is measured and recorded but does not block the
+  campaign.  Data feeds regression tracking across releases.
+
+Only `hub_only` is a hard gate in the first campaign.  Other profiles may be
+promoted to hard gates in later campaigns as baselines stabilize.
+
+## Host requirements
+
+- **Quiet local or dedicated machine.** No competing CPU-heavy processes during
+  the soak.  Close IDEs, builds, and other CAR instances before running.
+- **macOS or Linux.** The harness uses `ps` / `pidstat` (Linux) or `ps` alone
+  (macOS) to sample per-process CPU.
+- **Python 3.10+** with the project venv active.
+- **Network access** to the hub health endpoint (loopback by default).
+
+## Artifact directory
+
+All artifacts are written to:
+
+```
+.codex-autorunner/diagnostics/idle-cpu/
+```
+
+Each run produces one JSON file named:
+
+```
+{profile}_{timestamp}.json
+```
+
+Example: `hub_only_2026-04-17T12-00-00Z.json`.
+
+## JSON artifact contract
+
+Every artifact JSON file must conform to this structure (see also the
+`artifact_contract` section of `scripts/idle_cpu_profiles.yml`):
+
+```json
+{
+  "version": 1,
+  "profile": "hub_only",
+  "started_at": "2026-04-17T12:00:00Z",
+  "finished_at": "2026-04-17T12:05:00Z",
+  "environment": {
+    "hostname": "macbook.local",
+    "platform": "darwin",
+    "python_version": "3.12.3",
+    "car_version": "0.1.0",
+    "car_git_ref": "abc1234",
+    "cpu_count": 10,
+    "total_memory_gb": 32.0
+  },
+  "aggregate_metrics": {
+    "car_owned_cpu_mean_percent": 2.1,
+    "car_owned_cpu_max_percent": 4.8,
+    "car_owned_cpu_p95_percent": 3.9,
+    "car_owned_cpu_samples": 60,
+    "car_owned_memory_mean_mb": 85.3,
+    "car_owned_memory_max_mb": 92.1
+  },
+  "per_process_metrics": [
+    {
+      "alias": "hub",
+      "command": "car hub serve",
+      "category": "car_service",
+      "cpu_mean_percent": 2.1,
+      "cpu_max_percent": 4.8,
+      "memory_mean_mb": 85.3,
+      "memory_max_mb": 92.1
+    }
+  ],
+  "health_probe_summary": {
+    "total_probes": 60,
+    "successful_probes": 60,
+    "failed_probes": 0,
+    "last_probe_status": 200
+  },
+  "signoff": {
+    "passed": true,
+    "budget_type": "hard",
+    "budget_threshold_percent": 5.0,
+    "actual_aggregate_cpu_percent": 2.1,
+    "message": "hub_only hard budget passed: 2.1% < 5.0%"
+  }
+}
+```
+
+### Required fields
+
+| Section | Fields |
+|---|---|
+| Top-level | `version`, `profile`, `started_at`, `finished_at` |
+| `environment` | `hostname`, `platform`, `python_version`, `car_version`, `cpu_count`, `total_memory_gb` |
+| `aggregate_metrics` | `car_owned_cpu_mean_percent`, `car_owned_cpu_max_percent`, `car_owned_cpu_p95_percent`, `car_owned_cpu_samples`, `car_owned_memory_mean_mb`, `car_owned_memory_max_mb` |
+| `per_process_metrics` | Array of objects with `alias`, `command`, `category`, `cpu_mean_percent`, `cpu_max_percent`, `memory_mean_mb`, `memory_max_mb` |
+| `health_probe_summary` | `total_probes`, `successful_probes`, `failed_probes`, `last_probe_status` |
+| `signoff` | `passed`, `budget_type`, `budget_threshold_percent`, `actual_aggregate_cpu_percent`, `message` |
+
+## Separation from existing diagnostics
+
+- The idle soak contract is **separate** from the live `process-monitor.json`
+  time-series that the hub writes during normal operation.
+- The idle soak contract is **separate** from `check.sh` validation.  It is a
+  campaign-specific measurement, not a CI gate.
+- The harness must not depend on `process-monitor.json` internals.
+
+## First campaign success metric
+
+The first optimization campaign succeeds when:
+
+1. A `hub_only` soak produces a passing `signoff` with
+   `car_owned_cpu_mean_percent < 5.0` on a quiet local or dedicated host.
+2. The artifact is checked into `.codex-autorunner/diagnostics/idle-cpu/` for
+   regression tracking.
+3. Comparison profiles (`hub_plus_discord`, `hub_plus_telegram`,
+   `hub_with_idle_runtime`) are measured and recorded but do not need to pass
+   a hard gate.
+
+This metric is the **only** success criterion for the first campaign and is now
+committed in this document and the profile definitions rather than living only
+in chat history.

--- a/scripts/idle_cpu_profiles.yml
+++ b/scripts/idle_cpu_profiles.yml
@@ -1,0 +1,134 @@
+# Idle CPU benchmark profiles for the first CAR optimization campaign.
+#
+# Each profile specifies the service topology, measurement parameters, and
+# budget expectations for a reproducible idle-CPU soak.  A later harness
+# script consumes these profiles directly; no ad hoc CLI flags required.
+#
+# Artifact directory contract: .codex-autorunner/diagnostics/idle-cpu/
+
+version: 1
+
+defaults:
+  warmup_seconds: 30
+  duration_seconds: 300
+  sample_interval_seconds: 5
+  health_probe:
+    method: http_get
+    path: /health
+    timeout_seconds: 5
+    retries: 3
+  owned_process_categories:
+    - car_service
+    - opencode
+    - app_server
+
+profiles:
+  hub_only:
+    description: >-
+      CAR hub serving the local UI/API only.  No chat-surface integrations
+      are active.  This is the hard-budget gate for the first campaign.
+    services:
+      - command: car hub serve
+        alias: hub
+    hard_budget:
+      enabled: true
+      max_aggregate_cpu_percent: 5.0
+    comparison_budget: null
+    expected_owned_process_categories:
+      - car_service
+
+  hub_plus_discord:
+    description: >-
+      CAR hub with the Discord bot connected and idle (no active dispatches
+      or user interactions).  Measured for comparison; not a hard gate.
+    services:
+      - command: car hub serve
+        alias: hub
+      - command: car discord serve
+        alias: discord
+    hard_budget:
+      enabled: false
+    comparison_budget:
+      max_aggregate_cpu_percent: 8.0
+    expected_owned_process_categories:
+      - car_service
+
+  hub_plus_telegram:
+    description: >-
+      CAR hub with the Telegram bot polling and idle (no active dispatches
+      or user interactions).  Measured for comparison; not a hard gate.
+    services:
+      - command: car hub serve
+        alias: hub
+      - command: car telegram serve
+        alias: telegram
+    hard_budget:
+      enabled: false
+    comparison_budget:
+      max_aggregate_cpu_percent: 8.0
+    expected_owned_process_categories:
+      - car_service
+
+  hub_with_idle_runtime:
+    description: >-
+      CAR hub with at least one managed OpenCode server spawned and sitting
+      idle (no active sessions or agent turns).  Measures the steady-state
+      cost of an idle managed runtime.  Not a hard gate.
+    services:
+      - command: car hub serve
+        alias: hub
+    preconditions:
+      - type: spawn_idle_opencode
+        description: >-
+          Spawn one managed OpenCode server via the hub API and wait for it
+          to reach idle state before starting measurement.
+    hard_budget:
+      enabled: false
+    comparison_budget:
+      max_aggregate_cpu_percent: 10.0
+    expected_owned_process_categories:
+      - car_service
+      - opencode
+
+artifact_contract:
+  directory: .codex-autorunner/diagnostics/idle-cpu/
+  filename_pattern: "{profile}_{timestamp}.json"
+  schema:
+    version: 1
+    profile: str
+    started_at: "ISO-8601 UTC"
+    finished_at: "ISO-8601 UTC"
+    environment:
+      hostname: str
+      platform: str
+      python_version: str
+      car_version: str
+      car_git_ref: "str or null"
+      cpu_count: int
+      total_memory_gb: float
+    aggregate_metrics:
+      car_owned_cpu_mean_percent: float
+      car_owned_cpu_max_percent: float
+      car_owned_cpu_p95_percent: float
+      car_owned_cpu_samples: int
+      car_owned_memory_mean_mb: float
+      car_owned_memory_max_mb: float
+    per_process_metrics:
+      - alias: str
+        command: str
+        category: str
+        cpu_mean_percent: float
+        cpu_max_percent: float
+        memory_mean_mb: float
+        memory_max_mb: float
+    health_probe_summary:
+      total_probes: int
+      successful_probes: int
+      failed_probes: int
+      last_probe_status: "int or null"
+    signoff:
+      passed: bool
+      budget_type: "hard|comparison|none"
+      budget_threshold_percent: "float or null"
+      actual_aggregate_cpu_percent: float
+      message: str

--- a/scripts/idle_cpu_soak.py
+++ b/scripts/idle_cpu_soak.py
@@ -51,14 +51,8 @@ from codex_autorunner.core.diagnostics.process_snapshot import ProcessCategory
 from codex_autorunner.core.utils import atomic_write
 
 
-def _car_bin() -> str:
-    candidate = Path(sys.executable).with_name("car")
-    if candidate.exists():
-        return str(candidate)
-    resolved = shutil.which("car")
-    if resolved:
-        return resolved
-    return sys.executable
+def _car_bin() -> list[str]:
+    return [sys.executable, "-m", "codex_autorunner.cli"]
 
 
 def _find_free_port() -> int:
@@ -180,20 +174,79 @@ def _wait_for_health(
 
 def _parse_services(profile: dict[str, Any], port: int) -> list[dict[str, Any]]:
     services = []
+    car_bin = _car_bin()
     for svc in profile.get("services", []):
         cmd_str = svc["command"]
         alias = svc.get("alias", "service")
         parts = cmd_str.split()
         if parts[0:2] == ["car", "hub"] and "serve" in parts:
-            cmd = [_car_bin(), "hub", "serve", "--port", str(port)]
+            cmd = car_bin + ["hub", "serve", "--port", str(port)]
         elif parts[0:2] == ["car", "discord"] and "serve" in parts:
-            cmd = [_car_bin(), "discord", "serve"]
+            cmd = car_bin + ["discord", "serve"]
         elif parts[0:2] == ["car", "telegram"] and "serve" in parts:
-            cmd = [_car_bin(), "telegram", "serve"]
+            cmd = car_bin + ["telegram", "serve"]
         else:
-            cmd = [_car_bin()] + parts[1:]
+            cmd = car_bin + parts[1:]
         services.append({"alias": alias, "command": cmd, "original": cmd_str})
     return services
+
+
+def _collect_service_pids(
+    procs: list[subprocess.Popen], logger: logging.Logger
+) -> list[int]:
+    pids: list[int] = []
+    for proc in procs:
+        try:
+            sid = os.getsid(proc.pid)
+            result = subprocess.run(
+                ["ps", "-A", "-o", "pid=", "-o", "sid="],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode == 0:
+                for line in result.stdout.splitlines():
+                    parts = line.strip().split()
+                    if len(parts) == 2 and parts[1].isdigit():
+                        if int(parts[1]) == sid and parts[0].isdigit():
+                            pids.append(int(parts[0]))
+            if not pids:
+                logger.warning(
+                    "no session peers found for pid=%d sid=%d; "
+                    "falling back to descendant scan",
+                    proc.pid,
+                    sid,
+                )
+                result = subprocess.run(
+                    ["ps", "-o", "pid=", "-o", "ppid="],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if result.returncode == 0:
+                    pp_to_pid: dict[int, list[int]] = {}
+                    for line in result.stdout.splitlines():
+                        parts = line.strip().split()
+                        if (
+                            len(parts) == 2
+                            and parts[0].isdigit()
+                            and parts[1].isdigit()
+                        ):
+                            pp_to_pid.setdefault(int(parts[1]), []).append(
+                                int(parts[0])
+                            )
+                    queue = [proc.pid]
+                    visited = set()
+                    while queue:
+                        p = queue.pop(0)
+                        if p in visited:
+                            continue
+                        visited.add(p)
+                        pids.append(p)
+                        queue.extend(pp_to_pid.get(p, []))
+        except ProcessLookupError:
+            pids.append(proc.pid)
+    return list(set(pids))
 
 
 def _start_service(
@@ -201,7 +254,9 @@ def _start_service(
     hub_root: Path,
     logger: logging.Logger,
 ) -> subprocess.Popen:
-    cmd = svc["command"]
+    cmd = list(svc["command"])
+    if "hub" in cmd and "serve" in cmd:
+        cmd.extend(["--path", str(hub_root)])
     env = os.environ.copy()
     env["CAR_HUB_ROOT"] = str(hub_root)
     env["CAR_DEV_INCLUDE_ROOT_REPO"] = "1"
@@ -391,7 +446,7 @@ def run_soak(
                 svc["pid"] = proc.pid
 
             health_ok = _wait_for_health(
-                base_url, probe_config, timeout=30.0, logger=logger
+                base_url, probe_config, timeout=60.0, logger=logger
             )
             if not health_ok:
                 for proc in procs:
@@ -403,6 +458,9 @@ def run_soak(
             logger.info("warming up for %ds ...", warmup)
             time.sleep(warmup)
 
+            service_pids = _collect_service_pids(procs, logger)
+            logger.info("restricting measurement to PIDs: %s", service_pids)
+
             logger.info("sampling for %ds (interval=%ds) ...", duration, interval)
             samples: list[CpuSample] = []
             health_probes: list[dict[str, Any]] = []
@@ -412,6 +470,7 @@ def run_soak(
                 sample = collect_cpu_sample(
                     repo_root=repo_root,
                     owned_categories=cat_enums,
+                    restrict_pids=service_pids,
                 )
                 samples.append(sample)
                 probe_result = _health_probe(base_url, probe_config, logger)

--- a/scripts/idle_cpu_soak.py
+++ b/scripts/idle_cpu_soak.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+"""Idle CPU soak harness for CAR service commands.
+
+Reads profiles from scripts/idle_cpu_profiles.yml, starts the target
+service(s) against a disposable root, samples CPU/RSS during the
+observation window, and writes durable JSON artifacts under
+.codex-autorunner/diagnostics/idle-cpu/.
+
+Usage:
+    python scripts/idle_cpu_soak.py --profile hub_only
+    python scripts/idle_cpu_soak.py --profile hub_only --output /tmp/result.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import platform
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+import urllib.error
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPT_DIR.parent
+_PROFILES_PATH = _SCRIPT_DIR / "idle_cpu_profiles.yml"
+
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from codex_autorunner.bootstrap import seed_hub_files
+from codex_autorunner.core.config import REPO_OVERRIDE_FILENAME
+from codex_autorunner.core.diagnostics.cpu_sampler import (
+    CpuSample,
+    aggregate_samples,
+    collect_cpu_sample,
+    compute_per_process_aggregates,
+    evaluate_signoff,
+)
+from codex_autorunner.core.diagnostics.process_snapshot import ProcessCategory
+from codex_autorunner.core.utils import atomic_write
+
+
+def _car_bin() -> str:
+    candidate = Path(sys.executable).with_name("car")
+    if candidate.exists():
+        return str(candidate)
+    resolved = shutil.which("car")
+    if resolved:
+        return resolved
+    return sys.executable
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _load_profile(name: str) -> dict[str, Any]:
+    if not _PROFILES_PATH.is_file():
+        raise FileNotFoundError(f"Profiles file not found: {_PROFILES_PATH}")
+    data = yaml.safe_load(_PROFILES_PATH.read_text(encoding="utf-8"))
+    profiles = data.get("profiles", {})
+    if name not in profiles:
+        available = ", ".join(sorted(profiles.keys()))
+        raise ValueError(f"Unknown profile {name!r}. Available: {available}")
+    defaults = data.get("defaults", {})
+    profile = profiles[name]
+    profile.setdefault("warmup_seconds", defaults.get("warmup_seconds", 30))
+    profile.setdefault("duration_seconds", defaults.get("duration_seconds", 300))
+    profile.setdefault(
+        "sample_interval_seconds",
+        defaults.get("sample_interval_seconds", 5),
+    )
+    profile.setdefault("health_probe", defaults.get("health_probe", {}))
+    profile.setdefault(
+        "owned_process_categories",
+        defaults.get("owned_process_categories", ["car_service"]),
+    )
+    return profile
+
+
+def _write_repo_override(repo_root: Path) -> None:
+    override_path = repo_root / REPO_OVERRIDE_FILENAME
+    override_path.parent.mkdir(parents=True, exist_ok=True)
+    override_path.write_text(
+        yaml.safe_dump(
+            {
+                "server": {"port": 0},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _seed_disposable_root(tmpdir: str) -> Path:
+    hub_root = Path(tmpdir) / "hub"
+    hub_root.mkdir(parents=True, exist_ok=True)
+    seed_hub_files(hub_root, force=True)
+    repo_root = hub_root / "repo"
+    repo_root.mkdir(parents=True, exist_ok=True)
+    (repo_root / ".git").mkdir()
+    _write_repo_override(repo_root)
+    return hub_root
+
+
+def _health_probe(
+    base_url: str,
+    probe_config: dict[str, Any],
+    logger: logging.Logger,
+) -> dict[str, Any]:
+    path = probe_config.get("path", "/health")
+    timeout = probe_config.get("timeout_seconds", 5)
+    retries = probe_config.get("retries", 3)
+    url = f"{base_url}{path}"
+    total = 0
+    successful = 0
+    failed = 0
+    last_status: Optional[int] = None
+    for attempt in range(retries):
+        total += 1
+        try:
+            req = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                last_status = resp.status
+                successful += 1
+                logger.debug("health probe ok: %s (attempt %d)", url, attempt + 1)
+                break
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
+            failed += 1
+            last_status = getattr(getattr(exc, "code", None), "__int__", lambda: None)()
+            if isinstance(exc, urllib.error.HTTPError):
+                last_status = exc.code
+            logger.debug(
+                "health probe failed: %s (attempt %d): %s", url, attempt + 1, exc
+            )
+    return {
+        "total_probes": total,
+        "successful_probes": successful,
+        "failed_probes": failed,
+        "last_probe_status": last_status,
+    }
+
+
+def _wait_for_health(
+    base_url: str,
+    probe_config: dict[str, Any],
+    timeout: float,
+    logger: logging.Logger,
+) -> bool:
+    path = probe_config.get("path", "/health")
+    url = f"{base_url}{path}"
+    probe_timeout = probe_config.get("timeout_seconds", 5)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            req = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(req, timeout=probe_timeout) as resp:
+                if resp.status == 200:
+                    logger.info("health check passed: %s", url)
+                    return True
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError):
+            pass
+        time.sleep(0.5)
+    logger.error("health check timed out after %.1fs: %s", timeout, url)
+    return False
+
+
+def _parse_services(profile: dict[str, Any], port: int) -> list[dict[str, Any]]:
+    services = []
+    for svc in profile.get("services", []):
+        cmd_str = svc["command"]
+        alias = svc.get("alias", "service")
+        parts = cmd_str.split()
+        if parts[0:2] == ["car", "hub"] and "serve" in parts:
+            cmd = [_car_bin(), "hub", "serve", "--port", str(port)]
+        elif parts[0:2] == ["car", "discord"] and "serve" in parts:
+            cmd = [_car_bin(), "discord", "serve"]
+        elif parts[0:2] == ["car", "telegram"] and "serve" in parts:
+            cmd = [_car_bin(), "telegram", "serve"]
+        else:
+            cmd = [_car_bin()] + parts[1:]
+        services.append({"alias": alias, "command": cmd, "original": cmd_str})
+    return services
+
+
+def _start_service(
+    svc: dict[str, Any],
+    hub_root: Path,
+    logger: logging.Logger,
+) -> subprocess.Popen:
+    cmd = svc["command"]
+    env = os.environ.copy()
+    env["CAR_HUB_ROOT"] = str(hub_root)
+    env["CAR_DEV_INCLUDE_ROOT_REPO"] = "1"
+    logger.info("starting service: %s (%s)", svc["alias"], " ".join(cmd))
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        preexec_fn=os.setsid,
+    )
+    return proc
+
+
+def _stop_service(proc: subprocess.Popen, logger: logging.Logger) -> None:
+    if proc.poll() is not None:
+        return
+    logger.info("stopping service pid=%d", proc.pid)
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+def _collect_environment() -> dict[str, Any]:
+    git_sha: Optional[str] = None
+    git_dirty = False
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=str(_REPO_ROOT),
+        )
+        if result.returncode == 0:
+            git_sha = result.stdout.strip()
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=str(_REPO_ROOT),
+        )
+        if status.returncode == 0 and status.stdout.strip():
+            git_dirty = True
+    except OSError:
+        pass
+
+    total_memory_gb = 0.0
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "hw.memsize"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip().isdigit():
+            total_memory_gb = int(result.stdout.strip()) / (1024**3)
+    except OSError:
+        pass
+
+    return {
+        "hostname": socket.gethostname(),
+        "platform": platform.platform(),
+        "python_version": platform.python_version(),
+        "car_version": "dev",
+        "car_git_ref": f"{git_sha}{'-dirty' if git_dirty else ''}" if git_sha else None,
+        "cpu_count": os.cpu_count() or 0,
+        "total_memory_gb": round(total_memory_gb, 2),
+    }
+
+
+def _category_names_to_enums(
+    names: list[str],
+) -> list[ProcessCategory]:
+    mapping = {
+        "car_service": ProcessCategory.CAR_SERVICE,
+        "opencode": ProcessCategory.OPENCODE,
+        "app_server": ProcessCategory.APP_SERVER,
+    }
+    return [mapping[n] for n in names if n in mapping]
+
+
+def _write_artifacts(
+    artifact: dict[str, Any],
+    profile_name: str,
+    output_root: Optional[Path],
+    logger: logging.Logger,
+) -> Path:
+    if output_root is None:
+        output_root = _REPO_ROOT / ".codex-autorunner" / "diagnostics" / "idle-cpu"
+
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    latest_path = output_root / "latest.json"
+    atomic_write(latest_path, json.dumps(artifact, indent=2, sort_keys=True) + "\n")
+    logger.info("wrote %s", latest_path)
+
+    history_dir = output_root / "history"
+    history_dir.mkdir(parents=True, exist_ok=True)
+    ts = (
+        artifact.get("started_at", "")
+        .replace(":", "")
+        .replace("-", "")
+        .replace("T", "-")
+    )
+    ts = ts.replace("Z", "")
+    history_path = history_dir / f"{ts}-{profile_name}.json"
+    atomic_write(history_path, json.dumps(artifact, indent=2, sort_keys=True) + "\n")
+    logger.info("wrote %s", history_path)
+
+    return latest_path
+
+
+def _print_summary(artifact: dict[str, Any]) -> None:
+    agg = artifact.get("aggregate_metrics", {})
+    signoff = artifact.get("signoff", {})
+    env = artifact.get("environment", {})
+    print("=" * 60)
+    print("IDLE CPU SOAK SUMMARY")
+    print("=" * 60)
+    print(f"  Profile:    {artifact.get('profile', '?')}")
+    print(f"  Git ref:    {env.get('car_git_ref', 'unknown')}")
+    print(f"  Platform:   {env.get('platform', 'unknown')}")
+    print(f"  Python:     {env.get('python_version', 'unknown')}")
+    print(f"  Samples:    {agg.get('car_owned_cpu_samples', 0)}")
+    print(f"  CPU mean:   {agg.get('car_owned_cpu_mean_percent', 0):.3f}%")
+    print(f"  CPU p95:    {agg.get('car_owned_cpu_p95_percent', 0):.3f}%")
+    print(f"  CPU max:    {agg.get('car_owned_cpu_max_percent', 0):.3f}%")
+    print(f"  RSS mean:   {agg.get('car_owned_memory_mean_mb', 0):.1f} MB")
+    print(f"  RSS max:    {agg.get('car_owned_memory_max_mb', 0):.1f} MB")
+    print("-" * 60)
+    signoff_passed = signoff.get("passed", False)
+    print(
+        f"  SIGNOFF:    {'PASS' if signoff_passed else 'FAIL'} "
+        f"({signoff.get('budget_type', 'none')}: "
+        f"{signoff.get('message', '')})"
+    )
+    print("=" * 60)
+
+
+def run_soak(
+    profile_name: str,
+    output: Optional[Path] = None,
+    artifact_dir: Optional[Path] = None,
+    logger: Optional[logging.Logger] = None,
+) -> dict[str, Any]:
+    if logger is None:
+        logger = logging.getLogger("idle_cpu_soak")
+
+    profile = _load_profile(profile_name)
+    warmup = profile.get("warmup_seconds", 30)
+    duration = profile.get("duration_seconds", 300)
+    interval = profile.get("sample_interval_seconds", 5)
+    probe_config = profile.get("health_probe", {})
+    owned_cats = profile.get("owned_process_categories", ["car_service"])
+    cat_enums = _category_names_to_enums(owned_cats)
+
+    port = _find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    with tempfile.TemporaryDirectory(prefix="idle-cpu-soak-") as tmpdir:
+        hub_root = _seed_disposable_root(tmpdir)
+        repo_root = hub_root / "repo"
+
+        services = _parse_services(profile, port)
+        procs: list[subprocess.Popen] = []
+
+        try:
+            for svc in services:
+                proc = _start_service(svc, hub_root, logger)
+                procs.append(proc)
+                svc["pid"] = proc.pid
+
+            health_ok = _wait_for_health(
+                base_url, probe_config, timeout=30.0, logger=logger
+            )
+            if not health_ok:
+                for proc in procs:
+                    _stop_service(proc, logger)
+                raise RuntimeError(
+                    f"Service(s) failed to become healthy at {base_url}/health"
+                )
+
+            logger.info("warming up for %ds ...", warmup)
+            time.sleep(warmup)
+
+            logger.info("sampling for %ds (interval=%ds) ...", duration, interval)
+            samples: list[CpuSample] = []
+            health_probes: list[dict[str, Any]] = []
+            deadline = time.monotonic() + duration
+
+            while time.monotonic() < deadline:
+                sample = collect_cpu_sample(
+                    repo_root=repo_root,
+                    owned_categories=cat_enums,
+                )
+                samples.append(sample)
+                probe_result = _health_probe(base_url, probe_config, logger)
+                health_probes.append(probe_result)
+                remaining = deadline - time.monotonic()
+                if remaining > interval:
+                    time.sleep(interval)
+                elif remaining > 0:
+                    time.sleep(remaining)
+
+        finally:
+            for proc in procs:
+                _stop_service(proc, logger)
+
+        finished_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    agg = aggregate_samples(samples)
+    per_process = compute_per_process_aggregates(samples)
+
+    for svc in services:
+        for pp in per_process:
+            if svc.get("alias") and not pp.get("alias"):
+                pp["alias"] = svc["alias"]
+
+    last_probe = (
+        health_probes[-1]
+        if health_probes
+        else {
+            "total_probes": 0,
+            "successful_probes": 0,
+            "failed_probes": 0,
+            "last_probe_status": None,
+        }
+    )
+
+    signoff = evaluate_signoff(
+        agg,
+        hard_budget=profile.get("hard_budget"),
+        comparison_budget=profile.get("comparison_budget"),
+    )
+
+    artifact: dict[str, Any] = {
+        "version": 1,
+        "profile": profile_name,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "environment": _collect_environment(),
+        "services": [
+            {
+                "alias": s.get("alias", ""),
+                "command": s.get("original", ""),
+                "pid": s.get("pid"),
+            }
+            for s in services
+        ],
+        "config": {
+            "warmup_seconds": warmup,
+            "duration_seconds": duration,
+            "sample_interval_seconds": interval,
+        },
+        "aggregate_metrics": agg,
+        "per_process_metrics": per_process,
+        "health_probe_summary": {
+            "total_probes": sum(p["total_probes"] for p in health_probes),
+            "successful_probes": sum(p["successful_probes"] for p in health_probes),
+            "failed_probes": sum(p["failed_probes"] for p in health_probes),
+            "last_probe_status": last_probe.get("last_probe_status"),
+        },
+        "signoff": signoff,
+    }
+
+    _write_artifacts(artifact, profile_name, artifact_dir, logger)
+
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+    _print_summary(artifact)
+    return artifact
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run an idle CPU soak against a CAR service profile and "
+            "write a JSON artifact set."
+        )
+    )
+    parser.add_argument(
+        "--profile",
+        required=True,
+        help="Profile name from scripts/idle_cpu_profiles.yml",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to write the JSON artifact",
+    )
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        default=None,
+        help="Override artifact directory (default: .codex-autorunner/diagnostics/idle-cpu/)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    args = parser.parse_args()
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    logger = logging.getLogger("idle_cpu_soak")
+
+    try:
+        artifact = run_soak(
+            profile_name=args.profile,
+            output=args.output,
+            artifact_dir=args.artifact_dir,
+            logger=logger,
+        )
+    except Exception as exc:
+        logger.error("soak failed: %s", exc, exc_info=True)
+        return 1
+
+    return 0 if artifact.get("signoff", {}).get("passed", False) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/idle_cpu_soak.py
+++ b/scripts/idle_cpu_soak.py
@@ -196,6 +196,7 @@ def _collect_service_pids(
 ) -> list[int]:
     pids: list[int] = []
     for proc in procs:
+        service_pids: list[int] = []
         try:
             sid = os.getsid(proc.pid)
             result = subprocess.run(
@@ -209,8 +210,8 @@ def _collect_service_pids(
                     parts = line.strip().split()
                     if len(parts) == 2 and parts[1].isdigit():
                         if int(parts[1]) == sid and parts[0].isdigit():
-                            pids.append(int(parts[0]))
-            if not pids:
+                            service_pids.append(int(parts[0]))
+            if not service_pids:
                 logger.warning(
                     "no session peers found for pid=%d sid=%d; "
                     "falling back to descendant scan",
@@ -242,10 +243,11 @@ def _collect_service_pids(
                         if p in visited:
                             continue
                         visited.add(p)
-                        pids.append(p)
+                        service_pids.append(p)
                         queue.extend(pp_to_pid.get(p, []))
         except ProcessLookupError:
-            pids.append(proc.pid)
+            service_pids.append(proc.pid)
+        pids.extend(service_pids)
     return list(set(pids))
 
 

--- a/src/codex_autorunner/core/diagnostics/__init__.py
+++ b/src/codex_autorunner/core/diagnostics/__init__.py
@@ -6,6 +6,14 @@ from .cpu_sampler import (
     evaluate_signoff,
     sample_cpu_for_pids,
 )
+from .loop_attribution import (
+    LoopWakeupCounters,
+    WakeupScope,
+    get_loop_names,
+    reset_loop_attribution,
+    snapshot_loop_attribution,
+    track_loop,
+)
 from .process_monitor import (
     DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS,
     DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS,
@@ -25,10 +33,12 @@ __all__ = [
     "CpuSample",
     "DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS",
     "DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS",
+    "LoopWakeupCounters",
     "ProcessCategory",
     "ProcessMonitorStore",
     "ProcessOwnership",
     "ProcessSnapshot",
+    "WakeupScope",
     "aggregate_samples",
     "build_process_monitor_summary",
     "capture_process_monitor_sample",
@@ -37,5 +47,9 @@ __all__ = [
     "compute_per_process_aggregates",
     "enrich_with_ownership",
     "evaluate_signoff",
+    "get_loop_names",
+    "reset_loop_attribution",
     "sample_cpu_for_pids",
+    "snapshot_loop_attribution",
+    "track_loop",
 ]

--- a/src/codex_autorunner/core/diagnostics/__init__.py
+++ b/src/codex_autorunner/core/diagnostics/__init__.py
@@ -1,3 +1,11 @@
+from .cpu_sampler import (
+    CpuSample,
+    aggregate_samples,
+    collect_cpu_sample,
+    compute_per_process_aggregates,
+    evaluate_signoff,
+    sample_cpu_for_pids,
+)
 from .process_monitor import (
     DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS,
     DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS,
@@ -14,14 +22,20 @@ from .process_snapshot import (
 )
 
 __all__ = [
+    "CpuSample",
     "DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS",
     "DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS",
     "ProcessCategory",
     "ProcessMonitorStore",
     "ProcessOwnership",
     "ProcessSnapshot",
+    "aggregate_samples",
     "build_process_monitor_summary",
     "capture_process_monitor_sample",
+    "collect_cpu_sample",
     "collect_processes",
+    "compute_per_process_aggregates",
     "enrich_with_ownership",
+    "evaluate_signoff",
+    "sample_cpu_for_pids",
 ]

--- a/src/codex_autorunner/core/diagnostics/cpu_sampler.py
+++ b/src/codex_autorunner/core/diagnostics/cpu_sampler.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import math
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from .process_snapshot import (
+    ProcessCategory,
+    collect_processes,
+    enrich_with_ownership,
+)
+
+
+@dataclass
+class CpuSample:
+    car_service_cpu_percent: float = 0.0
+    car_service_rss_mb: float = 0.0
+    opencode_cpu_percent: float = 0.0
+    opencode_rss_mb: float = 0.0
+    app_server_cpu_percent: float = 0.0
+    app_server_rss_mb: float = 0.0
+    aggregate_cpu_percent: float = 0.0
+    aggregate_rss_mb: float = 0.0
+    per_process: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    bounded = min(max(pct, 0.0), 100.0)
+    rank = max(0, math.ceil((bounded / 100.0) * len(values)) - 1)
+    ordered = sorted(values)
+    return ordered[min(rank, len(ordered) - 1)]
+
+
+def sample_cpu_for_pids(
+    pids: list[int],
+) -> dict[int, tuple[float, float]]:
+    if not pids:
+        return {}
+    pid_strs = ",".join(str(p) for p in pids)
+    try:
+        proc = subprocess.run(
+            ["ps", "-p", pid_strs, "-o", "pid=", "-o", "%cpu=", "-o", "rss="],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return {}
+    if proc.returncode != 0:
+        return {}
+    result: dict[int, tuple[float, float]] = {}
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            cpu_pct = float(parts[1])
+            rss_kb = float(parts[2])
+        except (ValueError, IndexError):
+            continue
+        result[pid] = (cpu_pct, rss_kb / 1024.0)
+    return result
+
+
+def collect_cpu_sample(
+    *,
+    repo_root: Optional[Path] = None,
+    owned_categories: Optional[list[ProcessCategory]] = None,
+    ps_output_getter: Optional[Callable[[], str]] = None,
+    pid_cpu_getter: Optional[
+        Callable[[list[int]], dict[int, tuple[float, float]]]
+    ] = None,
+) -> CpuSample:
+    if owned_categories is None:
+        owned_categories = [
+            ProcessCategory.CAR_SERVICE,
+            ProcessCategory.OPENCODE,
+            ProcessCategory.APP_SERVER,
+        ]
+
+    snapshot = collect_processes(ps_output_getter=ps_output_getter)
+    if repo_root is not None:
+        snapshot = enrich_with_ownership(snapshot, repo_root)
+
+    _sample_cpu = pid_cpu_getter or sample_cpu_for_pids
+
+    category_procs: dict[ProcessCategory, list] = {
+        ProcessCategory.CAR_SERVICE: snapshot.car_service_processes,
+        ProcessCategory.OPENCODE: snapshot.opencode_processes,
+        ProcessCategory.APP_SERVER: snapshot.app_server_processes,
+    }
+
+    all_owned_pids: list[int] = []
+    per_category_pids: dict[ProcessCategory, list[int]] = {}
+    for cat in owned_categories:
+        procs = category_procs.get(cat, [])
+        pids = [p.pid for p in procs]
+        per_category_pids[cat] = pids
+        all_owned_pids.extend(pids)
+
+    cpu_by_pid = _sample_cpu(all_owned_pids) if all_owned_pids else {}
+
+    def _cat_metrics(cat: ProcessCategory) -> tuple[float, float]:
+        cpu_total = 0.0
+        rss_total = 0.0
+        for pid in per_category_pids.get(cat, []):
+            if pid in cpu_by_pid:
+                cpu_total += cpu_by_pid[pid][0]
+                rss_total += cpu_by_pid[pid][1]
+        return cpu_total, rss_total
+
+    car_cpu, car_rss = _cat_metrics(ProcessCategory.CAR_SERVICE)
+    opencode_cpu, opencode_rss = _cat_metrics(ProcessCategory.OPENCODE)
+    app_server_cpu, app_server_rss = _cat_metrics(ProcessCategory.APP_SERVER)
+
+    per_process: list[dict[str, Any]] = []
+    for cat in owned_categories:
+        for proc in category_procs.get(cat, []):
+            cpu, rss = cpu_by_pid.get(proc.pid, (0.0, 0.0))
+            per_process.append(
+                {
+                    "pid": proc.pid,
+                    "command": proc.command,
+                    "category": cat.value,
+                    "cpu_percent": round(cpu, 3),
+                    "rss_mb": round(rss, 3),
+                }
+            )
+
+    return CpuSample(
+        car_service_cpu_percent=round(car_cpu, 3),
+        car_service_rss_mb=round(car_rss, 3),
+        opencode_cpu_percent=round(opencode_cpu, 3),
+        opencode_rss_mb=round(opencode_rss, 3),
+        app_server_cpu_percent=round(app_server_cpu, 3),
+        app_server_rss_mb=round(app_server_rss, 3),
+        aggregate_cpu_percent=round(car_cpu + opencode_cpu + app_server_cpu, 3),
+        aggregate_rss_mb=round(car_rss + opencode_rss + app_server_rss, 3),
+        per_process=per_process,
+    )
+
+
+def aggregate_samples(
+    samples: list[CpuSample],
+) -> dict[str, Any]:
+    if not samples:
+        return {
+            "car_owned_cpu_mean_percent": 0.0,
+            "car_owned_cpu_max_percent": 0.0,
+            "car_owned_cpu_p95_percent": 0.0,
+            "car_owned_cpu_samples": 0,
+            "car_owned_memory_mean_mb": 0.0,
+            "car_owned_memory_max_mb": 0.0,
+        }
+
+    cpu_values = [s.aggregate_cpu_percent for s in samples]
+    rss_values = [s.aggregate_rss_mb for s in samples]
+
+    return {
+        "car_owned_cpu_mean_percent": round(sum(cpu_values) / len(cpu_values), 3),
+        "car_owned_cpu_max_percent": round(max(cpu_values), 3),
+        "car_owned_cpu_p95_percent": round(_percentile(cpu_values, 95.0), 3),
+        "car_owned_cpu_samples": len(samples),
+        "car_owned_memory_mean_mb": round(sum(rss_values) / len(rss_values), 3),
+        "car_owned_memory_max_mb": round(max(rss_values), 3),
+    }
+
+
+def compute_per_process_aggregates(
+    samples: list[CpuSample],
+) -> list[dict[str, Any]]:
+    if not samples:
+        return []
+
+    by_key: dict[tuple[int, str], list[dict[str, Any]]] = {}
+    for sample in samples:
+        for proc in sample.per_process:
+            key = (proc["pid"], proc["category"])
+            by_key.setdefault(key, []).append(proc)
+
+    results: list[dict[str, Any]] = []
+    for (_pid, category), proc_samples in by_key.items():
+        cpu_values = [p["cpu_percent"] for p in proc_samples]
+        rss_values = [p["rss_mb"] for p in proc_samples]
+        command = proc_samples[0]["command"]
+        results.append(
+            {
+                "alias": "",
+                "command": command,
+                "category": category,
+                "cpu_mean_percent": round(sum(cpu_values) / len(cpu_values), 3),
+                "cpu_max_percent": round(max(cpu_values), 3),
+                "memory_mean_mb": round(sum(rss_values) / len(rss_values), 3),
+                "memory_max_mb": round(max(rss_values), 3),
+            }
+        )
+    return results
+
+
+def evaluate_signoff(
+    aggregate: dict[str, Any],
+    *,
+    hard_budget: Optional[dict[str, Any]] = None,
+    comparison_budget: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    actual_cpu = aggregate.get("car_owned_cpu_mean_percent", 0.0)
+
+    if hard_budget and hard_budget.get("enabled"):
+        threshold = hard_budget.get("max_aggregate_cpu_percent")
+        if threshold is not None:
+            passed = actual_cpu <= threshold
+            return {
+                "passed": passed,
+                "budget_type": "hard",
+                "budget_threshold_percent": threshold,
+                "actual_aggregate_cpu_percent": actual_cpu,
+                "message": (
+                    f"{'PASS' if passed else 'FAIL'}: aggregate CPU "
+                    f"{actual_cpu:.3f}% vs hard budget {threshold}%"
+                ),
+            }
+
+    if (
+        comparison_budget
+        and comparison_budget.get("max_aggregate_cpu_percent") is not None
+    ):
+        threshold = comparison_budget["max_aggregate_cpu_percent"]
+        passed = actual_cpu <= threshold
+        return {
+            "passed": passed,
+            "budget_type": "comparison",
+            "budget_threshold_percent": threshold,
+            "actual_aggregate_cpu_percent": actual_cpu,
+            "message": (
+                f"{'PASS' if passed else 'FAIL'}: aggregate CPU "
+                f"{actual_cpu:.3f}% vs comparison budget {threshold}%"
+            ),
+        }
+
+    return {
+        "passed": True,
+        "budget_type": "none",
+        "budget_threshold_percent": None,
+        "actual_aggregate_cpu_percent": actual_cpu,
+        "message": f"No budget gate; aggregate CPU {actual_cpu:.3f}%",
+    }
+
+
+__all__ = [
+    "CpuSample",
+    "aggregate_samples",
+    "collect_cpu_sample",
+    "compute_per_process_aggregates",
+    "evaluate_signoff",
+    "sample_cpu_for_pids",
+]

--- a/src/codex_autorunner/core/diagnostics/cpu_sampler.py
+++ b/src/codex_autorunner/core/diagnostics/cpu_sampler.py
@@ -76,6 +76,7 @@ def collect_cpu_sample(
     *,
     repo_root: Optional[Path] = None,
     owned_categories: Optional[list[ProcessCategory]] = None,
+    restrict_pids: Optional[list[int]] = None,
     ps_output_getter: Optional[Callable[[], str]] = None,
     pid_cpu_getter: Optional[
         Callable[[list[int]], dict[int, tuple[float, float]]]
@@ -91,14 +92,21 @@ def collect_cpu_sample(
     snapshot = collect_processes(ps_output_getter=ps_output_getter)
     if repo_root is not None:
         snapshot = enrich_with_ownership(snapshot, repo_root)
+    if restrict_pids is not None:
+        pid_set = set(restrict_pids)
+        snapshot = snapshot.filter_by_pids(pid_set)
 
     _sample_cpu = pid_cpu_getter or sample_cpu_for_pids
 
     category_procs: dict[ProcessCategory, list] = {
-        ProcessCategory.CAR_SERVICE: snapshot.car_service_processes,
-        ProcessCategory.OPENCODE: snapshot.opencode_processes,
-        ProcessCategory.APP_SERVER: snapshot.app_server_processes,
+        ProcessCategory.CAR_SERVICE: list(snapshot.car_service_processes),
+        ProcessCategory.OPENCODE: list(snapshot.opencode_processes),
+        ProcessCategory.APP_SERVER: list(snapshot.app_server_processes),
     }
+
+    if restrict_pids is not None:
+        for proc in snapshot.other_processes:
+            category_procs.setdefault(ProcessCategory.CAR_SERVICE, []).append(proc)
 
     all_owned_pids: list[int] = []
     per_category_pids: dict[ProcessCategory, list[int]] = {}

--- a/src/codex_autorunner/core/diagnostics/loop_attribution.py
+++ b/src/codex_autorunner/core/diagnostics/loop_attribution.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class LoopWakeupCounters:
+    wakeups: int = 0
+    productive_wakeups: int = 0
+    idle_wakeups: int = 0
+    disk_reads: int = 0
+    db_reads: int = 0
+    total_wakeup_duration_seconds: float = 0.0
+
+
+_REGISTRY_LOCK = threading.Lock()
+_REGISTRY: dict[str, LoopWakeupCounters] = {}
+
+
+def _ensure_counters(loop_name: str) -> LoopWakeupCounters:
+    with _REGISTRY_LOCK:
+        counters = _REGISTRY.get(loop_name)
+        if counters is None:
+            counters = LoopWakeupCounters()
+            _REGISTRY[loop_name] = counters
+        return counters
+
+
+class WakeupScope:
+    __slots__ = ("_counters", "_productive", "_disk_reads", "_db_reads", "_start")
+
+    def __init__(self, counters: LoopWakeupCounters) -> None:
+        self._counters = counters
+        self._productive = False
+        self._disk_reads = 0
+        self._db_reads = 0
+        self._start = 0.0
+
+    def mark_productive(self) -> None:
+        self._productive = True
+
+    def record_disk_read(self, count: int = 1) -> None:
+        self._disk_reads += count
+
+    def record_db_read(self, count: int = 1) -> None:
+        self._db_reads += count
+
+    def __enter__(self) -> WakeupScope:
+        self._start = time.monotonic()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        elapsed = time.monotonic() - self._start
+        c = self._counters
+        c.wakeups += 1
+        c.total_wakeup_duration_seconds += elapsed
+        if self._productive:
+            c.productive_wakeups += 1
+        else:
+            c.idle_wakeups += 1
+        c.disk_reads += self._disk_reads
+        c.db_reads += self._db_reads
+
+
+def track_loop(loop_name: str) -> WakeupScope:
+    return WakeupScope(_ensure_counters(loop_name))
+
+
+def snapshot_loop_attribution() -> dict[str, Any]:
+    with _REGISTRY_LOCK:
+        items: dict[str, dict[str, Any]] = {}
+        for name, counters in sorted(_REGISTRY.items()):
+            items[name] = {
+                "wakeups": counters.wakeups,
+                "productive_wakeups": counters.productive_wakeups,
+                "idle_wakeups": counters.idle_wakeups,
+                "disk_reads": counters.disk_reads,
+                "db_reads": counters.db_reads,
+                "total_wakeup_duration_seconds": round(
+                    counters.total_wakeup_duration_seconds, 6
+                ),
+                "avg_wakeup_duration_seconds": (
+                    round(counters.total_wakeup_duration_seconds / counters.wakeups, 6)
+                    if counters.wakeups > 0
+                    else 0.0
+                ),
+            }
+    return {"loops": items, "snapshot_at": time.time()}
+
+
+def reset_loop_attribution() -> None:
+    with _REGISTRY_LOCK:
+        _REGISTRY.clear()
+
+
+def get_loop_names() -> list[str]:
+    with _REGISTRY_LOCK:
+        return sorted(_REGISTRY.keys())
+
+
+__all__ = [
+    "LoopWakeupCounters",
+    "WakeupScope",
+    "get_loop_names",
+    "reset_loop_attribution",
+    "snapshot_loop_attribution",
+    "track_loop",
+]

--- a/src/codex_autorunner/core/diagnostics/process_snapshot.py
+++ b/src/codex_autorunner/core/diagnostics/process_snapshot.py
@@ -119,6 +119,19 @@ class ProcessSnapshot:
     def total_count(self) -> int:
         return self.car_service_count + self.managed_runtime_count
 
+    def filter_by_pids(self, pids: set[int]) -> ProcessSnapshot:
+        return ProcessSnapshot(
+            car_service_processes=[
+                p for p in self.car_service_processes if p.pid in pids
+            ],
+            opencode_processes=[p for p in self.opencode_processes if p.pid in pids],
+            app_server_processes=[
+                p for p in self.app_server_processes if p.pid in pids
+            ],
+            other_processes=[p for p in self.other_processes if p.pid in pids],
+            collected_at=self.collected_at,
+        )
+
 
 # Match underscore-named binary only as the argv0 segment (not a parent dir like
 # .../codex_autorunner/.venv/bin/codex), which would misclassify app-server/opencode.

--- a/src/codex_autorunner/core/flows/reconciler.py
+++ b/src/codex_autorunner/core/flows/reconciler.py
@@ -31,6 +31,30 @@ _ACTIVE_STATUSES = (
     FlowRunStatus.PAUSED,
 )
 
+_mtime_cache: dict[Path, tuple[float, int]] = {}
+
+
+def _db_mtime_key(db_path: Path) -> tuple[float, int]:
+    try:
+        st = db_path.stat()
+        return (st.st_mtime, st.st_size)
+    except OSError:
+        return (0.0, 0)
+
+
+def _should_skip_reconcile(db_path: Path) -> bool:
+    current = _db_mtime_key(db_path)
+    cached = _mtime_cache.get(db_path)
+    if cached is None:
+        return False
+    if current != cached:
+        return False
+    return True
+
+
+def _record_reconcile_mtime(db_path: Path) -> None:
+    _mtime_cache[db_path] = _db_mtime_key(db_path)
+
 
 @dataclass
 class FlowReconcileSummary:
@@ -470,6 +494,12 @@ def reconcile_flow_runs(
     records: list[FlowRunRecord] = []
     try:
         store.initialize()
+        if _should_skip_reconcile(db_path):
+            active_count = store.count_active_flow_runs(flow_type=flow_type)
+            if active_count == 0:
+                return FlowReconcileResult(
+                    records=records, summary=FlowReconcileSummary()
+                )
         for record in store.list_flow_runs(flow_type=flow_type):
             if record.status in _ACTIVE_STATUSES:
                 summary.active += 1
@@ -482,6 +512,7 @@ def reconcile_flow_runs(
                 if locked:
                     summary.locked += 1
             records.append(record)
+        _record_reconcile_mtime(db_path)
     except (
         sqlite3.Error,
         RuntimeError,

--- a/src/codex_autorunner/core/flows/reconciler.py
+++ b/src/codex_autorunner/core/flows/reconciler.py
@@ -31,7 +31,7 @@ _ACTIVE_STATUSES = (
     FlowRunStatus.PAUSED,
 )
 
-_mtime_cache: dict[Path, tuple[float, int]] = {}
+_mtime_cache: dict[Path, tuple[float, int, int, int]] = {}
 
 
 def _db_mtime_key(db_path: Path) -> tuple[float, int]:
@@ -42,8 +42,17 @@ def _db_mtime_key(db_path: Path) -> tuple[float, int]:
         return (0.0, 0)
 
 
-def _should_skip_reconcile(db_path: Path) -> bool:
-    current = _db_mtime_key(db_path)
+def _reconcile_skip_signature(store: FlowStore) -> tuple[float, int, int, int]:
+    mtime, size = _db_mtime_key(store.db_path)
+    return (
+        mtime,
+        size,
+        store.count_flow_runs_total(),
+        store.count_flow_events_total(),
+    )
+
+
+def _should_skip_reconcile(db_path: Path, current: tuple[float, int, int, int]) -> bool:
     cached = _mtime_cache.get(db_path)
     if cached is None:
         return False
@@ -52,8 +61,10 @@ def _should_skip_reconcile(db_path: Path) -> bool:
     return True
 
 
-def _record_reconcile_mtime(db_path: Path) -> None:
-    _mtime_cache[db_path] = _db_mtime_key(db_path)
+def _record_reconcile_mtime(
+    db_path: Path, signature: tuple[float, int, int, int]
+) -> None:
+    _mtime_cache[db_path] = signature
 
 
 @dataclass
@@ -494,7 +505,8 @@ def reconcile_flow_runs(
     records: list[FlowRunRecord] = []
     try:
         store.initialize()
-        if _should_skip_reconcile(db_path):
+        skip_sig = _reconcile_skip_signature(store)
+        if _should_skip_reconcile(db_path, skip_sig):
             active_count = store.count_active_flow_runs(flow_type=flow_type)
             if active_count == 0:
                 return FlowReconcileResult(
@@ -512,7 +524,7 @@ def reconcile_flow_runs(
                 if locked:
                     summary.locked += 1
             records.append(record)
-        _record_reconcile_mtime(db_path)
+        _record_reconcile_mtime(db_path, _reconcile_skip_signature(store))
     except (
         sqlite3.Error,
         RuntimeError,

--- a/src/codex_autorunner/core/flows/store.py
+++ b/src/codex_autorunner/core/flows/store.py
@@ -462,6 +462,16 @@ class FlowStore:
         row = conn.execute(query, params).fetchone()
         return int(row[0]) if row is not None else 0
 
+    def count_flow_runs_total(self) -> int:
+        conn = self._get_conn()
+        row = conn.execute("SELECT COUNT(*) FROM flow_runs").fetchone()
+        return int(row[0]) if row is not None else 0
+
+    def count_flow_events_total(self) -> int:
+        conn = self._get_conn()
+        row = conn.execute("SELECT COUNT(*) FROM flow_events").fetchone()
+        return int(row[0]) if row is not None else 0
+
     def get_latest_flow_run(
         self, flow_type: Optional[str] = None, status: Optional[FlowRunStatus] = None
     ) -> Optional[FlowRunRecord]:

--- a/src/codex_autorunner/core/flows/store.py
+++ b/src/codex_autorunner/core/flows/store.py
@@ -448,6 +448,20 @@ class FlowStore:
         rows = conn.execute(query, params).fetchall()
         return [self._row_to_flow_run(row) for row in rows]
 
+    def count_active_flow_runs(self, flow_type: Optional[str] = None) -> int:
+        conn = self._get_conn()
+        query = "SELECT COUNT(*) FROM flow_runs WHERE status IN (?, ?, ?)"
+        params: List[Any] = [
+            FlowRunStatus.RUNNING.value,
+            FlowRunStatus.STOPPING.value,
+            FlowRunStatus.PAUSED.value,
+        ]
+        if flow_type is not None:
+            query += " AND flow_type = ?"
+            params.append(flow_type)
+        row = conn.execute(query, params).fetchone()
+        return int(row[0]) if row is not None else 0
+
     def get_latest_flow_run(
         self, flow_type: Optional[str] = None, status: Optional[FlowRunStatus] = None
     ) -> Optional[FlowRunRecord]:

--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -1391,7 +1391,8 @@ class HubSupervisor:
 
     def _process_lifecycle_event_cycle(self) -> bool:
         productive = False
-        self.process_lifecycle_events()
+        if self.process_lifecycle_events() > 0:
+            productive = True
         scm_counts = self.process_scm_automation_polls()
         if scm_counts.get("polled", 0) > 0 or scm_counts.get("events_emitted", 0) > 0:
             productive = True
@@ -1403,12 +1404,13 @@ class HubSupervisor:
             productive = True
         return productive
 
-    def process_lifecycle_events(self) -> None:
-        self._lifecycle_event_processor.process_events(limit=100)
+    def process_lifecycle_events(self) -> int:
+        processed = self._lifecycle_event_processor.process_events(limit=100)
         try:
             self.drain_pma_automation_wakeups()
         except Exception:
             logger.exception("Failed draining PMA automation wake-ups")
+        return processed
 
     def process_scm_automation_polls(self, *, limit: int = 20) -> dict[str, int]:
         processor = self._scm_poll_processor

--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -1389,11 +1389,19 @@ class HubSupervisor:
     def trigger_pma_from_lifecycle_event(self, event: LifecycleEvent) -> None:
         self._process_lifecycle_event(event)
 
-    def _process_lifecycle_event_cycle(self) -> None:
+    def _process_lifecycle_event_cycle(self) -> bool:
+        productive = False
         self.process_lifecycle_events()
-        self.process_scm_automation_polls()
-        self.process_pma_automation_timers()
-        self.drain_pma_automation_wakeups()
+        scm_counts = self.process_scm_automation_polls()
+        if scm_counts.get("polled", 0) > 0 or scm_counts.get("events_emitted", 0) > 0:
+            productive = True
+        timer_count = self.process_pma_automation_timers()
+        if timer_count > 0:
+            productive = True
+        wakeup_count = self.drain_pma_automation_wakeups()
+        if wakeup_count > 0:
+            productive = True
+        return productive
 
     def process_lifecycle_events(self) -> None:
         self._lifecycle_event_processor.process_events(limit=100)
@@ -1469,6 +1477,7 @@ class HubSupervisor:
                 self._lifecycle_emitter.emit_dispatch_created(
                     repo_id, run_id, data=data, origin=origin
                 )
+                self._lifecycle_worker.wake()
 
         set_lifecycle_emitter(_emit_outbox_event)
 

--- a/src/codex_autorunner/core/hub_lifecycle.py
+++ b/src/codex_autorunner/core/hub_lifecycle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Optional, Protocol
@@ -240,6 +241,7 @@ class HubLifecycleWorker:
         self._thread_name = thread_name
         self._logger = logger or logging.getLogger("codex_autorunner.hub")
         self._stop_event = threading.Event()
+        self._wake_event = threading.Event()
         self._thread_lock = threading.Lock()
         self._thread: Optional[threading.Thread] = None
         self._idle_streak = 0
@@ -260,8 +262,7 @@ class HubLifecycleWorker:
 
     def wake(self) -> None:
         self._idle_streak = 0
-        self._stop_event.set()
-        self._stop_event.clear()
+        self._wake_event.set()
 
     def start(self) -> None:
         with self._thread_lock:
@@ -269,11 +270,25 @@ class HubLifecycleWorker:
             if thread is not None and thread.is_alive():
                 return
             self._stop_event.clear()
+            self._wake_event.clear()
             self._idle_streak = 0
 
             def _process_loop() -> None:
                 current_interval = self._base_poll_interval_seconds
-                while not self._stop_event.wait(current_interval):
+                while not self._stop_event.is_set():
+                    deadline = time.monotonic() + current_interval
+                    while True:
+                        if self._stop_event.is_set():
+                            return
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            break
+                        chunk = min(remaining, 0.5)
+                        if self._wake_event.wait(timeout=chunk):
+                            self._wake_event.clear()
+                            break
+                    if self._stop_event.is_set():
+                        return
                     try:
                         result = self._process_once()
                         if result:

--- a/src/codex_autorunner/core/hub_lifecycle.py
+++ b/src/codex_autorunner/core/hub_lifecycle.py
@@ -208,25 +208,37 @@ class LifecycleEventProcessor:
 
 
 class HubLifecycleWorker:
-    """Threaded poller for lifecycle event processing."""
+    """Threaded poller for lifecycle event processing with adaptive backoff."""
+
+    _BACKOFF_GROW_FACTOR = 1.5
 
     def __init__(
         self,
         *,
-        process_once: Callable[[], None],
+        process_once: Callable[[], Optional[bool]],
         poll_interval_seconds: float = 5.0,
+        max_poll_interval_seconds: Optional[float] = None,
         join_timeout_seconds: float = 2.0,
         thread_name: str = "lifecycle-event-processor",
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self._process_once = process_once
-        self._poll_interval_seconds = poll_interval_seconds
+        self._base_poll_interval_seconds = max(0.1, float(poll_interval_seconds))
+        self._max_poll_interval_seconds = max(
+            self._base_poll_interval_seconds,
+            float(
+                max_poll_interval_seconds
+                if max_poll_interval_seconds is not None
+                else self._base_poll_interval_seconds * 6
+            ),
+        )
         self._join_timeout_seconds = join_timeout_seconds
         self._thread_name = thread_name
         self._logger = logger or logging.getLogger("codex_autorunner.hub")
         self._stop_event = threading.Event()
         self._thread_lock = threading.Lock()
         self._thread: Optional[threading.Thread] = None
+        self._idle_streak = 0
 
     @property
     def running(self) -> bool:
@@ -234,17 +246,38 @@ class HubLifecycleWorker:
             thread = self._thread
         return thread is not None and thread.is_alive()
 
+    def _current_interval(self) -> float:
+        if self._idle_streak <= 0:
+            return self._base_poll_interval_seconds
+        grown = self._base_poll_interval_seconds * (
+            self._BACKOFF_GROW_FACTOR**self._idle_streak
+        )
+        return min(grown, self._max_poll_interval_seconds)
+
+    def wake(self) -> None:
+        self._idle_streak = 0
+        self._stop_event.set()
+        self._stop_event.clear()
+
     def start(self) -> None:
         with self._thread_lock:
             thread = self._thread
             if thread is not None and thread.is_alive():
                 return
             self._stop_event.clear()
+            self._idle_streak = 0
 
             def _process_loop() -> None:
-                while not self._stop_event.wait(self._poll_interval_seconds):
+                current_interval = self._base_poll_interval_seconds
+                while not self._stop_event.wait(current_interval):
                     try:
-                        self._process_once()
+                        result = self._process_once()
+                        if result:
+                            self._idle_streak = 0
+                            current_interval = self._base_poll_interval_seconds
+                        else:
+                            self._idle_streak += 1
+                            current_interval = self._current_interval()
                     except (
                         Exception
                     ) as exc:  # intentional: process_once is a user-provided callback

--- a/src/codex_autorunner/core/hub_lifecycle.py
+++ b/src/codex_autorunner/core/hub_lifecycle.py
@@ -192,19 +192,23 @@ class LifecycleEventProcessor:
             exc,
         )
 
-    def process_events(self, *, limit: int = 100) -> None:
+    def process_events(self, *, limit: int = 100) -> int:
         events = self._store.get_unprocessed(limit=limit)
         if not events:
-            return
+            return 0
+        processed = 0
         for event in events:
             if not self._should_attempt_now(event, now=self._now_fn()):
                 continue
             try:
                 self._process_event(event)
+                processed += 1
             except (
                 Exception
             ) as exc:  # intentional: process_event is a user-provided callback
                 self._record_failure(event, exc)
+                processed += 1
+        return processed
 
 
 class HubLifecycleWorker:

--- a/src/codex_autorunner/core/pma_lane_worker.py
+++ b/src/codex_autorunner/core/pma_lane_worker.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from typing import Any, Awaitable, Callable, Optional
 
+from .diagnostics.loop_attribution import track_loop
 from .pma_queue import PmaQueue, PmaQueueItem
 
 logger = logging.getLogger(__name__)
@@ -66,62 +67,69 @@ class PmaLaneWorker:
     async def _run(self) -> None:
         await self._queue.replay_pending(self.lane_id)
         while not self._cancel_event.is_set():
-            item = await self._queue.dequeue(self.lane_id)
-            if item is None:
-                await self._queue.wait_for_lane_item(
-                    self.lane_id,
-                    self._cancel_event,
-                    poll_interval_seconds=self._poll_interval_seconds,
-                )
-                continue
+            with track_loop(f"pma.lane_worker.{self.lane_id}") as scope:
+                scope.record_db_read(1)
+                item = await self._queue.dequeue(self.lane_id)
+                if item is None:
+                    await self._queue.wait_for_lane_item(
+                        self.lane_id,
+                        self._cancel_event,
+                        poll_interval_seconds=self._poll_interval_seconds,
+                    )
+                    continue
 
-            if self._cancel_event.is_set():
-                await self._queue.fail_item(item, "cancelled by lane stop")
-                await self._notify(item, {"status": "error", "detail": "lane stopped"})
-                continue
+                if self._cancel_event.is_set():
+                    await self._queue.fail_item(item, "cancelled by lane stop")
+                    await self._notify(
+                        item, {"status": "error", "detail": "lane stopped"}
+                    )
+                    continue
 
-            self._log.info(
-                "PMA lane item started (lane_id=%s item_id=%s)",
-                self.lane_id,
-                item.item_id,
-            )
-            item_terminalized = False
-            try:
-                result = await self._executor(item)
-                await self._queue.complete_item(item, result)
-                item_terminalized = True
+                scope.mark_productive()
                 self._log.info(
-                    "PMA lane item completed (lane_id=%s item_id=%s status=%s)",
+                    "PMA lane item started (lane_id=%s item_id=%s)",
                     self.lane_id,
                     item.item_id,
-                    result.get("status") if isinstance(result, dict) else None,
                 )
-                await self._notify(item, result)
-            except (
-                BaseException
-            ) as exc:  # intentional: executor is a user-provided callback
-                self._log.exception("Failed to process PMA queue item %s", item.item_id)
-                detail = str(exc).strip() or "PMA lane item terminated unexpectedly"
-                error_result = {"status": "error", "detail": detail}
-                if not item_terminalized:
-                    try:
-                        await self._queue.fail_item(item, detail)
-                        item_terminalized = True
-                    except Exception:
-                        self._log.exception(
-                            "Failed to persist PMA queue failure (lane_id=%s item_id=%s)",
-                            self.lane_id,
-                            item.item_id,
-                        )
-                self._log.info(
-                    "PMA lane item failed (lane_id=%s item_id=%s error=%s)",
-                    self.lane_id,
-                    item.item_id,
-                    detail,
-                )
-                await self._notify(item, error_result)
-                if isinstance(exc, asyncio.CancelledError):
-                    raise
+                item_terminalized = False
+                try:
+                    result = await self._executor(item)
+                    await self._queue.complete_item(item, result)
+                    item_terminalized = True
+                    self._log.info(
+                        "PMA lane item completed (lane_id=%s item_id=%s status=%s)",
+                        self.lane_id,
+                        item.item_id,
+                        result.get("status") if isinstance(result, dict) else None,
+                    )
+                    await self._notify(item, result)
+                except (
+                    BaseException
+                ) as exc:  # intentional: executor is a user-provided callback
+                    self._log.exception(
+                        "Failed to process PMA queue item %s", item.item_id
+                    )
+                    detail = str(exc).strip() or "PMA lane item terminated unexpectedly"
+                    error_result = {"status": "error", "detail": detail}
+                    if not item_terminalized:
+                        try:
+                            await self._queue.fail_item(item, detail)
+                            item_terminalized = True
+                        except Exception:
+                            self._log.exception(
+                                "Failed to persist PMA queue failure (lane_id=%s item_id=%s)",
+                                self.lane_id,
+                                item.item_id,
+                            )
+                    self._log.info(
+                        "PMA lane item failed (lane_id=%s item_id=%s error=%s)",
+                        self.lane_id,
+                        item.item_id,
+                        detail,
+                    )
+                    await self._notify(item, error_result)
+                    if isinstance(exc, asyncio.CancelledError):
+                        raise
 
     async def _notify(self, item: PmaQueueItem, result: dict[str, Any]) -> None:
         if self._on_result is None:

--- a/src/codex_autorunner/core/pma_lane_worker.py
+++ b/src/codex_autorunner/core/pma_lane_worker.py
@@ -68,7 +68,6 @@ class PmaLaneWorker:
         await self._queue.replay_pending(self.lane_id)
         while not self._cancel_event.is_set():
             with track_loop(f"pma.lane_worker.{self.lane_id}") as scope:
-                scope.record_db_read(1)
                 item = await self._queue.dequeue(self.lane_id)
                 if item is None:
                     await self._queue.wait_for_lane_item(
@@ -78,6 +77,9 @@ class PmaLaneWorker:
                     )
                     continue
 
+                scope.record_db_read(1)
+                scope.mark_productive()
+
                 if self._cancel_event.is_set():
                     await self._queue.fail_item(item, "cancelled by lane stop")
                     await self._notify(
@@ -85,7 +87,6 @@ class PmaLaneWorker:
                     )
                     continue
 
-                scope.mark_productive()
                 self._log.info(
                     "PMA lane item started (lane_id=%s item_id=%s)",
                     self.lane_id,

--- a/src/codex_autorunner/core/pma_lane_worker.py
+++ b/src/codex_autorunner/core/pma_lane_worker.py
@@ -67,16 +67,16 @@ class PmaLaneWorker:
     async def _run(self) -> None:
         await self._queue.replay_pending(self.lane_id)
         while not self._cancel_event.is_set():
-            with track_loop(f"pma.lane_worker.{self.lane_id}") as scope:
-                item = await self._queue.dequeue(self.lane_id)
-                if item is None:
-                    await self._queue.wait_for_lane_item(
-                        self.lane_id,
-                        self._cancel_event,
-                        poll_interval_seconds=self._poll_interval_seconds,
-                    )
-                    continue
+            item = await self._queue.dequeue(self.lane_id)
+            if item is None:
+                await self._queue.wait_for_lane_item(
+                    self.lane_id,
+                    self._cancel_event,
+                    poll_interval_seconds=self._poll_interval_seconds,
+                )
+                continue
 
+            with track_loop(f"pma.lane_worker.{self.lane_id}") as scope:
                 scope.record_db_read(1)
                 scope.mark_productive()
 

--- a/src/codex_autorunner/core/pma_queue.py
+++ b/src/codex_autorunner/core/pma_queue.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import uuid
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -21,9 +20,6 @@ PMA_QUEUE_DIR = ".codex-autorunner/pma/queue"
 QUEUE_FILE_SUFFIX = ".jsonl"
 DEFAULT_COMPACTION_KEEP_LAST = 200
 COMPACTION_MIN_SIZE_BYTES = 256 * 1024
-WAIT_IDLE_BACKOFF_MAX_SECONDS = 30.0
-WAIT_IDLE_BACKOFF_GROW_FACTOR = 1.5
-
 logger = logging.getLogger(__name__)
 
 
@@ -105,7 +101,6 @@ class PmaQueue:
         self._lock: Optional[asyncio.Lock] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._lane_mirror_mtimes: dict[str, float] = {}
-        self._lane_idle_streaks: dict[str, int] = {}
         self._initialize_canonical_state()
 
     def _initialize_canonical_state(self) -> None:
@@ -189,7 +184,6 @@ class PmaQueue:
             await queue.put(item)
             self._ensure_lane_known_ids(lane_id).add(item.item_id)
             self._ensure_lane_event(lane_id).set()
-            self._lane_idle_streaks.pop(lane_id, None)
             return item, None
 
     def enqueue_sync(
@@ -313,15 +307,9 @@ class PmaQueue:
         event = self._ensure_lane_event(lane_id)
         if event.is_set():
             event.clear()
-            self._lane_idle_streaks.pop(lane_id, None)
             return True
 
-        base_interval = max(0.1, poll_interval_seconds)
-        streak = self._lane_idle_streaks.get(lane_id, 0)
-        poll_interval = min(
-            base_interval * (WAIT_IDLE_BACKOFF_GROW_FACTOR**streak),
-            WAIT_IDLE_BACKOFF_MAX_SECONDS,
-        )
+        poll_interval = max(0.1, poll_interval_seconds)
 
         while True:
             wait_tasks = [asyncio.create_task(event.wait())]
@@ -344,36 +332,23 @@ class PmaQueue:
 
             if event.is_set():
                 event.clear()
-                self._lane_idle_streaks.pop(lane_id, None)
                 return True
 
-            streak = self._lane_idle_streaks.get(lane_id, 0)
             mirror_path = self._lane_queue_path(lane_id)
             try:
-                current_mtime = os.stat(mirror_path).st_mtime
+                current_mtime = mirror_path.stat().st_mtime
             except OSError:
                 current_mtime = 0.0
             prev_mtime = self._lane_mirror_mtimes.get(lane_id, 0.0)
 
-            if current_mtime == prev_mtime and streak > 0:
-                self._lane_idle_streaks[lane_id] = streak + 1
-                poll_interval = min(
-                    base_interval * (WAIT_IDLE_BACKOFF_GROW_FACTOR ** (streak + 1)),
-                    WAIT_IDLE_BACKOFF_MAX_SECONDS,
-                )
+            if current_mtime == prev_mtime:
                 continue
 
             added = await self._refresh_lane_from_disk(lane_id)
             if added:
-                self._lane_idle_streaks.pop(lane_id, None)
                 return True
 
             self._lane_mirror_mtimes[lane_id] = current_mtime
-            self._lane_idle_streaks[lane_id] = streak + 1
-            poll_interval = min(
-                base_interval * (WAIT_IDLE_BACKOFF_GROW_FACTOR ** (streak + 1)),
-                WAIT_IDLE_BACKOFF_MAX_SECONDS,
-            )
 
     async def list_items(self, lane_id: str) -> list[PmaQueueItem]:
         async with self._ensure_lane_lock(lane_id):
@@ -588,12 +563,9 @@ class PmaQueue:
         if loop is None or loop.is_closed() or queue is None or event is None:
             return
 
-        lane_id = item.lane_id
-
         def _enqueue() -> None:
             queue.put_nowait(item)
             event.set()
-            self._lane_idle_streaks.pop(lane_id, None)
 
         try:
             loop.call_soon_threadsafe(_enqueue)

--- a/src/codex_autorunner/core/pma_queue.py
+++ b/src/codex_autorunner/core/pma_queue.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import uuid
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -20,6 +21,8 @@ PMA_QUEUE_DIR = ".codex-autorunner/pma/queue"
 QUEUE_FILE_SUFFIX = ".jsonl"
 DEFAULT_COMPACTION_KEEP_LAST = 200
 COMPACTION_MIN_SIZE_BYTES = 256 * 1024
+WAIT_IDLE_BACKOFF_MAX_SECONDS = 30.0
+WAIT_IDLE_BACKOFF_GROW_FACTOR = 1.5
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +104,8 @@ class PmaQueue:
         self._replayed_lanes: set[str] = set()
         self._lock: Optional[asyncio.Lock] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._lane_mirror_mtimes: dict[str, float] = {}
+        self._lane_idle_streaks: dict[str, int] = {}
         self._initialize_canonical_state()
 
     def _initialize_canonical_state(self) -> None:
@@ -184,6 +189,7 @@ class PmaQueue:
             await queue.put(item)
             self._ensure_lane_known_ids(lane_id).add(item.item_id)
             self._ensure_lane_event(lane_id).set()
+            self._lane_idle_streaks.pop(lane_id, None)
             return item, None
 
     def enqueue_sync(
@@ -307,9 +313,16 @@ class PmaQueue:
         event = self._ensure_lane_event(lane_id)
         if event.is_set():
             event.clear()
+            self._lane_idle_streaks.pop(lane_id, None)
             return True
 
-        poll_interval = max(0.1, poll_interval_seconds)
+        base_interval = max(0.1, poll_interval_seconds)
+        streak = self._lane_idle_streaks.get(lane_id, 0)
+        poll_interval = min(
+            base_interval * (WAIT_IDLE_BACKOFF_GROW_FACTOR**streak),
+            WAIT_IDLE_BACKOFF_MAX_SECONDS,
+        )
+
         while True:
             wait_tasks = [asyncio.create_task(event.wait())]
             if cancel_event is not None:
@@ -331,11 +344,36 @@ class PmaQueue:
 
             if event.is_set():
                 event.clear()
+                self._lane_idle_streaks.pop(lane_id, None)
                 return True
+
+            streak = self._lane_idle_streaks.get(lane_id, 0)
+            mirror_path = self._lane_queue_path(lane_id)
+            try:
+                current_mtime = os.stat(mirror_path).st_mtime
+            except OSError:
+                current_mtime = 0.0
+            prev_mtime = self._lane_mirror_mtimes.get(lane_id, 0.0)
+
+            if current_mtime == prev_mtime and streak > 0:
+                self._lane_idle_streaks[lane_id] = streak + 1
+                poll_interval = min(
+                    base_interval * (WAIT_IDLE_BACKOFF_GROW_FACTOR ** (streak + 1)),
+                    WAIT_IDLE_BACKOFF_MAX_SECONDS,
+                )
+                continue
 
             added = await self._refresh_lane_from_disk(lane_id)
             if added:
+                self._lane_idle_streaks.pop(lane_id, None)
                 return True
+
+            self._lane_mirror_mtimes[lane_id] = current_mtime
+            self._lane_idle_streaks[lane_id] = streak + 1
+            poll_interval = min(
+                base_interval * (WAIT_IDLE_BACKOFF_GROW_FACTOR ** (streak + 1)),
+                WAIT_IDLE_BACKOFF_MAX_SECONDS,
+            )
 
     async def list_items(self, lane_id: str) -> list[PmaQueueItem]:
         async with self._ensure_lane_lock(lane_id):
@@ -550,9 +588,12 @@ class PmaQueue:
         if loop is None or loop.is_closed() or queue is None or event is None:
             return
 
+        lane_id = item.lane_id
+
         def _enqueue() -> None:
             queue.put_nowait(item)
             event.set()
+            self._lane_idle_streaks.pop(lane_id, None)
 
         try:
             loop.call_soon_threadsafe(_enqueue)

--- a/src/codex_autorunner/integrations/chat/queue_control.py
+++ b/src/codex_autorunner/integrations/chat/queue_control.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any, Optional
 
@@ -96,12 +97,32 @@ class ChatQueueControlStore:
         self._write_payload(self._commands_path, payload)
         return request
 
+    def has_reset_requests(self, *, platform: Optional[str] = None) -> bool:
+        try:
+            stat_result = os.stat(self._commands_path)
+        except OSError:
+            return False
+        if stat_result.st_size < 3:
+            return False
+        payload = self._read_commands_payload()
+        requests = payload.get("reset_requests")
+        if not isinstance(requests, dict) or not requests:
+            return False
+        normalized_platform = str(platform or "").strip().lower() or None
+        if normalized_platform is None:
+            return True
+        return any(
+            str(v.get("platform") or "").strip().lower() == normalized_platform
+            for v in requests.values()
+            if isinstance(v, dict)
+        )
+
     def take_reset_requests(
         self, *, platform: Optional[str] = None
     ) -> list[dict[str, Any]]:
         payload = self._read_commands_payload()
         requests = payload.get("reset_requests")
-        if not isinstance(requests, dict):
+        if not isinstance(requests, dict) or not requests:
             return []
 
         normalized_platform = str(platform or "").strip().lower() or None
@@ -119,6 +140,9 @@ class ChatQueueControlStore:
                 request.get("conversation_id") or conversation_id
             ).strip()
             taken.append(request)
+
+        if not taken:
+            return []
 
         payload["reset_requests"] = remaining
         self._write_payload(self._commands_path, payload)

--- a/src/codex_autorunner/integrations/discord/flow_watchers.py
+++ b/src/codex_autorunner/integrations/discord/flow_watchers.py
@@ -10,6 +10,7 @@ from ...core.chat_bindings import (
     preferred_non_pma_chat_notification_sources_by_workspace,
 )
 from ...core.config import ConfigError, load_hub_config, load_repo_config
+from ...core.diagnostics.loop_attribution import track_loop
 from ...core.flows import (
     FlowRunRecord,
     FlowRunStatus,
@@ -374,27 +375,35 @@ async def _scan_and_enqueue_terminal_notifications(service: Any) -> None:
 
 async def watch_ticket_flow_pauses(service: Any) -> None:
     while True:
-        try:
-            await _scan_and_enqueue_pause_notifications(service)
-        except Exception as exc:  # intentional: supervisor loop must never die
-            log_event(
-                service._logger,
-                logging.WARNING,
-                "discord.pause_watch.scan_failed",
-                exc=exc,
-            )
+        with track_loop("discord.flow_watchers.pause_scan") as scope:
+            scope.record_db_read(1)
+            try:
+                await _scan_and_enqueue_pause_notifications(service)
+                if await service._store.list_bindings():
+                    scope.mark_productive()
+            except Exception as exc:  # intentional: supervisor loop must never die
+                log_event(
+                    service._logger,
+                    logging.WARNING,
+                    "discord.pause_watch.scan_failed",
+                    exc=exc,
+                )
         await asyncio.sleep(PAUSE_SCAN_INTERVAL_SECONDS)
 
 
 async def watch_ticket_flow_terminals(service: Any) -> None:
     while True:
-        try:
-            await _scan_and_enqueue_terminal_notifications(service)
-        except Exception as exc:  # intentional: supervisor loop must never die
-            log_event(
-                service._logger,
-                logging.WARNING,
-                "discord.terminal_watch.scan_failed",
-                exc=exc,
-            )
+        with track_loop("discord.flow_watchers.terminal_scan") as scope:
+            scope.record_db_read(1)
+            try:
+                await _scan_and_enqueue_terminal_notifications(service)
+                if await service._store.list_bindings():
+                    scope.mark_productive()
+            except Exception as exc:  # intentional: supervisor loop must never die
+                log_event(
+                    service._logger,
+                    logging.WARNING,
+                    "discord.terminal_watch.scan_failed",
+                    exc=exc,
+                )
         await asyncio.sleep(TERMINAL_SCAN_INTERVAL_SECONDS)

--- a/src/codex_autorunner/integrations/discord/flow_watchers.py
+++ b/src/codex_autorunner/integrations/discord/flow_watchers.py
@@ -179,7 +179,8 @@ def _preferred_bound_sources_by_workspace(service: Any) -> dict[str, str]:
         return {}
 
 
-async def _scan_and_enqueue_pause_notifications(service: Any) -> None:
+async def _scan_and_enqueue_pause_notifications(service: Any) -> int:
+    notified = 0
     bindings = await service._store.list_bindings()
     preferred_sources = _preferred_bound_sources_by_workspace(service)
     for binding in bindings:
@@ -303,9 +304,12 @@ async def _scan_and_enqueue_pause_notifications(service: Any) -> None:
                 mode=snapshot.mode,
                 chunk_count=len(chunks),
             )
+            notified += 1
+    return notified
 
 
-async def _scan_and_enqueue_terminal_notifications(service: Any) -> None:
+async def _scan_and_enqueue_terminal_notifications(service: Any) -> int:
+    notified = 0
     bindings = await service._store.list_bindings()
     for binding in bindings:
         channel_id = binding.get("channel_id")
@@ -373,6 +377,8 @@ async def _scan_and_enqueue_terminal_notifications(service: Any) -> None:
             run_id=run_id,
             status=status,
         )
+        notified += 1
+    return notified
 
 
 def _next_idle_interval(
@@ -392,9 +398,8 @@ async def watch_ticket_flow_pauses(service: Any) -> None:
         with track_loop("discord.flow_watchers.pause_scan") as scope:
             scope.record_db_read(1)
             try:
-                await _scan_and_enqueue_pause_notifications(service)
-                bindings = await service._store.list_bindings()
-                if bindings:
+                notified = await _scan_and_enqueue_pause_notifications(service) or 0
+                if notified > 0:
                     found_work = True
                     scope.mark_productive()
             except Exception as exc:  # intentional: supervisor loop must never die
@@ -420,9 +425,8 @@ async def watch_ticket_flow_terminals(service: Any) -> None:
         with track_loop("discord.flow_watchers.terminal_scan") as scope:
             scope.record_db_read(1)
             try:
-                await _scan_and_enqueue_terminal_notifications(service)
-                bindings = await service._store.list_bindings()
-                if bindings:
+                notified = await _scan_and_enqueue_terminal_notifications(service) or 0
+                if notified > 0:
                     found_work = True
                     scope.mark_productive()
             except Exception as exc:  # intentional: supervisor loop must never die

--- a/src/codex_autorunner/integrations/discord/flow_watchers.py
+++ b/src/codex_autorunner/integrations/discord/flow_watchers.py
@@ -28,6 +28,8 @@ from .state import OutboxRecord
 
 PAUSE_SCAN_INTERVAL_SECONDS = 5.0
 TERMINAL_SCAN_INTERVAL_SECONDS = 5.0
+_IDLE_BACKOFF_MAX_SECONDS = 30.0
+_IDLE_BACKOFF_STEP_SECONDS = 5.0
 
 
 def _truncate_error(error_message: Optional[str], limit: int = 200) -> str:
@@ -373,13 +375,27 @@ async def _scan_and_enqueue_terminal_notifications(service: Any) -> None:
         )
 
 
+def _next_idle_interval(
+    base: float,
+    consecutive_idle: int,
+    *,
+    step: float = _IDLE_BACKOFF_STEP_SECONDS,
+    maximum: float = _IDLE_BACKOFF_MAX_SECONDS,
+) -> float:
+    return min(base + consecutive_idle * step, maximum)
+
+
 async def watch_ticket_flow_pauses(service: Any) -> None:
+    consecutive_idle = 0
     while True:
+        found_work = False
         with track_loop("discord.flow_watchers.pause_scan") as scope:
             scope.record_db_read(1)
             try:
                 await _scan_and_enqueue_pause_notifications(service)
-                if await service._store.list_bindings():
+                bindings = await service._store.list_bindings()
+                if bindings:
+                    found_work = True
                     scope.mark_productive()
             except Exception as exc:  # intentional: supervisor loop must never die
                 log_event(
@@ -388,16 +404,26 @@ async def watch_ticket_flow_pauses(service: Any) -> None:
                     "discord.pause_watch.scan_failed",
                     exc=exc,
                 )
-        await asyncio.sleep(PAUSE_SCAN_INTERVAL_SECONDS)
+        if found_work:
+            consecutive_idle = 0
+        else:
+            consecutive_idle += 1
+        await asyncio.sleep(
+            _next_idle_interval(PAUSE_SCAN_INTERVAL_SECONDS, consecutive_idle)
+        )
 
 
 async def watch_ticket_flow_terminals(service: Any) -> None:
+    consecutive_idle = 0
     while True:
+        found_work = False
         with track_loop("discord.flow_watchers.terminal_scan") as scope:
             scope.record_db_read(1)
             try:
                 await _scan_and_enqueue_terminal_notifications(service)
-                if await service._store.list_bindings():
+                bindings = await service._store.list_bindings()
+                if bindings:
+                    found_work = True
                     scope.mark_productive()
             except Exception as exc:  # intentional: supervisor loop must never die
                 log_event(
@@ -406,4 +432,10 @@ async def watch_ticket_flow_terminals(service: Any) -> None:
                     "discord.terminal_watch.scan_failed",
                     exc=exc,
                 )
-        await asyncio.sleep(TERMINAL_SCAN_INTERVAL_SECONDS)
+        if found_work:
+            consecutive_idle = 0
+        else:
+            consecutive_idle += 1
+        await asyncio.sleep(
+            _next_idle_interval(TERMINAL_SCAN_INTERVAL_SECONDS, consecutive_idle)
+        )

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -485,6 +485,8 @@ def _plan_delivery_recovery_cursor(
 
 DISCORD_EPHEMERAL_FLAG = 64
 CHAT_QUEUE_RESET_POLL_INTERVAL_SECONDS = 2.0
+CHAT_QUEUE_RESET_POLL_MAX_INTERVAL_SECONDS = 30.0
+CHAT_QUEUE_RESET_POLL_BACKOFF_GROW_FACTOR = 1.5
 DISCORD_TURN_PROGRESS_MIN_EDIT_INTERVAL_SECONDS = 1.0
 DISCORD_TURN_PROGRESS_HEARTBEAT_INTERVAL_SECONDS = 2.0
 DISCORD_TURN_PROGRESS_MAX_ACTIONS = 12
@@ -4035,34 +4037,48 @@ class DiscordBotService:
         await _scan_and_enqueue_pause_notifications_impl(self)
 
     async def _run_chat_queue_reset_loop(self) -> None:
+        idle_streak = 0
+        poll_interval = CHAT_QUEUE_RESET_POLL_INTERVAL_SECONDS
         while True:
             with track_loop("discord.chat_queue_reset_poll") as scope:
-                scope.record_disk_read(1)
                 try:
-                    requests = self._chat_queue_control_store.take_reset_requests(
+                    if not self._chat_queue_control_store.has_reset_requests(
                         platform="discord"
-                    )
-                    if requests:
-                        scope.mark_productive()
-                    for request in requests:
-                        conversation_id = str(
-                            request.get("conversation_id") or ""
-                        ).strip()
-                        if not conversation_id:
-                            continue
-                        result = await self._dispatcher.force_reset(conversation_id)
-                        log_event(
-                            self._logger,
-                            logging.WARNING,
-                            "discord.chat_queue.reset_applied",
-                            conversation_id=conversation_id,
-                            chat_id=request.get("chat_id"),
-                            thread_id=request.get("thread_id"),
-                            requested_at=request.get("requested_at"),
-                            requested_by=request.get("requested_by"),
-                            cancelled_pending=result.get("cancelled_pending"),
-                            cancelled_active=result.get("cancelled_active"),
+                    ):
+                        idle_streak += 1
+                        poll_interval = min(
+                            CHAT_QUEUE_RESET_POLL_INTERVAL_SECONDS
+                            * (CHAT_QUEUE_RESET_POLL_BACKOFF_GROW_FACTOR**idle_streak),
+                            CHAT_QUEUE_RESET_POLL_MAX_INTERVAL_SECONDS,
                         )
+                    else:
+                        scope.record_disk_read(1)
+                        requests = self._chat_queue_control_store.take_reset_requests(
+                            platform="discord"
+                        )
+                        if requests:
+                            scope.mark_productive()
+                            idle_streak = 0
+                            poll_interval = CHAT_QUEUE_RESET_POLL_INTERVAL_SECONDS
+                        for request in requests:
+                            conversation_id = str(
+                                request.get("conversation_id") or ""
+                            ).strip()
+                            if not conversation_id:
+                                continue
+                            result = await self._dispatcher.force_reset(conversation_id)
+                            log_event(
+                                self._logger,
+                                logging.WARNING,
+                                "discord.chat_queue.reset_applied",
+                                conversation_id=conversation_id,
+                                chat_id=request.get("chat_id"),
+                                thread_id=request.get("thread_id"),
+                                requested_at=request.get("requested_at"),
+                                requested_by=request.get("requested_by"),
+                                cancelled_pending=result.get("cancelled_pending"),
+                                cancelled_active=result.get("cancelled_active"),
+                            )
                 except (
                     Exception
                 ) as exc:  # intentional: long-running loop must not crash
@@ -4072,7 +4088,7 @@ class DiscordBotService:
                         "discord.chat_queue.reset_scan_failed",
                         exc=exc,
                     )
-            await asyncio.sleep(CHAT_QUEUE_RESET_POLL_INTERVAL_SECONDS)
+            await asyncio.sleep(poll_interval)
 
     async def _watch_ticket_flow_terminals(self) -> None:
         await watch_ticket_flow_terminals(self)

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -500,6 +500,7 @@ THREAD_LIST_PAGE_LIMIT = 100
 APP_SERVER_START_BACKOFF_INITIAL_SECONDS = 1.0
 APP_SERVER_START_BACKOFF_MAX_SECONDS = 30.0
 DISCORD_OPENCODE_PRUNE_FALLBACK_INTERVAL_SECONDS = 300.0
+DISCORD_OPENCODE_PRUNE_EMPTY_INTERVAL_SECONDS = 600.0
 # Kept for test compatibility; queued notice payloads are shaped in
 # service_normalization.py.
 DISCORD_QUEUED_PLACEHOLDER_TEXT = "Queued (waiting for available worker...)"
@@ -3253,8 +3254,11 @@ class DiscordBotService:
                 for entry in self._opencode_supervisors.values()
                 if entry.prune_interval_seconds is not None
             ]
+            has_supervisors = bool(self._opencode_supervisors)
         if intervals:
             return min(intervals)
+        if not has_supervisors:
+            return DISCORD_OPENCODE_PRUNE_EMPTY_INTERVAL_SECONDS
         return DISCORD_OPENCODE_PRUNE_FALLBACK_INTERVAL_SECONDS
 
     async def _run_opencode_prune_loop(self) -> None:

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -41,6 +41,7 @@ from ...core.config import (
     load_repo_config,
     resolve_env_for_root,
 )
+from ...core.diagnostics.loop_attribution import track_loop
 from ...core.filebox import (
     delete_regular_files,
     inbox_dir,
@@ -4035,38 +4036,43 @@ class DiscordBotService:
 
     async def _run_chat_queue_reset_loop(self) -> None:
         while True:
-            try:
-                await self._apply_pending_chat_queue_resets()
-            except Exception as exc:  # intentional: long-running loop must not crash
-                log_event(
-                    self._logger,
-                    logging.WARNING,
-                    "discord.chat_queue.reset_scan_failed",
-                    exc=exc,
-                )
+            with track_loop("discord.chat_queue_reset_poll") as scope:
+                scope.record_disk_read(1)
+                try:
+                    requests = self._chat_queue_control_store.take_reset_requests(
+                        platform="discord"
+                    )
+                    if requests:
+                        scope.mark_productive()
+                    for request in requests:
+                        conversation_id = str(
+                            request.get("conversation_id") or ""
+                        ).strip()
+                        if not conversation_id:
+                            continue
+                        result = await self._dispatcher.force_reset(conversation_id)
+                        log_event(
+                            self._logger,
+                            logging.WARNING,
+                            "discord.chat_queue.reset_applied",
+                            conversation_id=conversation_id,
+                            chat_id=request.get("chat_id"),
+                            thread_id=request.get("thread_id"),
+                            requested_at=request.get("requested_at"),
+                            requested_by=request.get("requested_by"),
+                            cancelled_pending=result.get("cancelled_pending"),
+                            cancelled_active=result.get("cancelled_active"),
+                        )
+                except (
+                    Exception
+                ) as exc:  # intentional: long-running loop must not crash
+                    log_event(
+                        self._logger,
+                        logging.WARNING,
+                        "discord.chat_queue.reset_scan_failed",
+                        exc=exc,
+                    )
             await asyncio.sleep(CHAT_QUEUE_RESET_POLL_INTERVAL_SECONDS)
-
-    async def _apply_pending_chat_queue_resets(self) -> None:
-        requests = self._chat_queue_control_store.take_reset_requests(
-            platform="discord"
-        )
-        for request in requests:
-            conversation_id = str(request.get("conversation_id") or "").strip()
-            if not conversation_id:
-                continue
-            result = await self._dispatcher.force_reset(conversation_id)
-            log_event(
-                self._logger,
-                logging.WARNING,
-                "discord.chat_queue.reset_applied",
-                conversation_id=conversation_id,
-                chat_id=request.get("chat_id"),
-                thread_id=request.get("thread_id"),
-                requested_at=request.get("requested_at"),
-                requested_by=request.get("requested_by"),
-                cancelled_pending=result.get("cancelled_pending"),
-                cancelled_active=result.get("cancelled_active"),
-            )
 
     async def _watch_ticket_flow_terminals(self) -> None:
         await watch_ticket_flow_terminals(self)

--- a/src/codex_autorunner/integrations/telegram/service.py
+++ b/src/codex_autorunner/integrations/telegram/service.py
@@ -697,10 +697,21 @@ class TelegramBotService(
         config = self._housekeeping_config
         if config is None or not config.enabled:
             return
-        interval = max(config.interval_seconds, 1)
+        base_interval = max(config.interval_seconds, 1)
+        idle_streak = 0
         while True:
             try:
-                await self._run_housekeeping_cycle(config)
+                roots = await self._housekeeping_roots()
+                if not roots:
+                    idle_streak += 1
+                    extended = min(
+                        base_interval * (1.5 ** min(idle_streak, 8)),
+                        base_interval * 4,
+                    )
+                    await asyncio.sleep(extended)
+                    continue
+                idle_streak = 0
+                await self._run_housekeeping_cycle_with_roots(config, roots)
             except Exception as exc:  # intentional: top-level error handler
                 log_event(
                     self._logger,
@@ -708,10 +719,15 @@ class TelegramBotService(
                     "telegram.housekeeping.failed",
                     exc=exc,
                 )
-            await asyncio.sleep(interval)
+            await asyncio.sleep(base_interval)
 
     async def _run_housekeeping_cycle(self, config: HousekeepingConfig) -> None:
         roots = await self._housekeeping_roots()
+        await self._run_housekeeping_cycle_with_roots(config, roots)
+
+    async def _run_housekeeping_cycle_with_roots(
+        self, config: HousekeepingConfig, roots: list[Path]
+    ) -> None:
         if roots:
             for root in roots:
                 try:
@@ -1205,9 +1221,19 @@ class TelegramBotService(
             elif cache_name == "pending_questions":
                 self._pending_questions.pop(key, None)
 
+    def _has_any_cache_entries(self) -> bool:
+        return bool(self._cache_timestamps)
+
     async def _cache_cleanup_loop(self) -> None:
         interval = max(self._config.cache.cleanup_interval_seconds, 1.0)
+        empty_streak = 0
         while True:
+            if not self._has_any_cache_entries():
+                empty_streak += 1
+                extended = min(interval * (1.5 ** min(empty_streak, 10)), interval * 4)
+                await asyncio.sleep(extended)
+                continue
+            empty_streak = 0
             await asyncio.sleep(interval)
             self._evict_expired_cache_entries(
                 "reasoning_buffers", self._config.cache.reasoning_buffer_ttl_seconds

--- a/src/codex_autorunner/surfaces/web/app_builders.py
+++ b/src/codex_autorunner/surfaces/web/app_builders.py
@@ -11,6 +11,7 @@ from starlette.middleware.gzip import GZipMiddleware
 from starlette.types import ASGIApp
 
 from ...core.config import HubConfig
+from ...core.diagnostics.loop_attribution import track_loop
 from ...core.filebox_retention import (
     prune_filebox_root,
     resolve_filebox_retention_policy,
@@ -137,11 +138,15 @@ def _app_lifespan(context: AppContext):
             idle_interval = 5.0
             try:
                 while True:
-                    result = await asyncio.to_thread(
-                        reconcile_flow_runs,
-                        app.state.engine.repo_root,
-                        logger=app.state.logger,
-                    )
+                    with track_loop("web.flow_reconcile") as scope:
+                        scope.record_db_read(1)
+                        result = await asyncio.to_thread(
+                            reconcile_flow_runs,
+                            app.state.engine.repo_root,
+                            logger=app.state.logger,
+                        )
+                        if result.summary.active > 0:
+                            scope.mark_productive()
                     interval = (
                         active_interval if result.summary.active > 0 else idle_interval
                     )

--- a/src/codex_autorunner/surfaces/web/app_builders.py
+++ b/src/codex_autorunner/surfaces/web/app_builders.py
@@ -135,7 +135,10 @@ def _app_lifespan(context: AppContext):
 
         async def _flow_reconcile_loop():
             active_interval = 2.0
-            idle_interval = 5.0
+            idle_base = 5.0
+            idle_step = 5.0
+            idle_max = 30.0
+            consecutive_idle = 0
             try:
                 while True:
                     with track_loop("web.flow_reconcile") as scope:
@@ -147,8 +150,13 @@ def _app_lifespan(context: AppContext):
                         )
                         if result.summary.active > 0:
                             scope.mark_productive()
+                            consecutive_idle = 0
+                        else:
+                            consecutive_idle += 1
                     interval = (
-                        active_interval if result.summary.active > 0 else idle_interval
+                        active_interval
+                        if result.summary.active > 0
+                        else min(idle_base + consecutive_idle * idle_step, idle_max)
                     )
                     await asyncio.sleep(interval)
             except asyncio.CancelledError:

--- a/tests/core/flows/test_reconciler_idle.py
+++ b/tests/core/flows/test_reconciler_idle.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from codex_autorunner.core.flows.models import FlowRunStatus
+from codex_autorunner.core.flows.reconciler import (
+    _mtime_cache,
+    _record_reconcile_mtime,
+    _should_skip_reconcile,
+    reconcile_flow_runs,
+)
+from codex_autorunner.core.flows.store import FlowStore
+
+
+def test_count_active_flow_runs_returns_zero_for_empty_db(tmp_path: Path) -> None:
+    db_path = tmp_path / ".codex-autorunner" / "flows.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    store = FlowStore(db_path)
+    store.initialize()
+    assert store.count_active_flow_runs() == 0
+    store.close()
+
+
+def test_count_active_flow_runs_counts_running_and_paused(tmp_path: Path) -> None:
+    db_path = tmp_path / ".codex-autorunner" / "flows.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    store = FlowStore(db_path)
+    store.initialize()
+    store.create_flow_run("r1", "ticket_flow", {})
+    store.update_flow_run_status("r1", FlowRunStatus.RUNNING)
+    store.create_flow_run("r2", "ticket_flow", {})
+    store.update_flow_run_status("r2", FlowRunStatus.PAUSED)
+    store.create_flow_run("r3", "ticket_flow", {})
+    store.update_flow_run_status("r3", FlowRunStatus.COMPLETED)
+    assert store.count_active_flow_runs() == 2
+    assert store.count_active_flow_runs(flow_type="ticket_flow") == 2
+    store.close()
+
+
+def test_count_active_flow_runs_filters_by_type(tmp_path: Path) -> None:
+    db_path = tmp_path / ".codex-autorunner" / "flows.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    store = FlowStore(db_path)
+    store.initialize()
+    store.create_flow_run("r1", "ticket_flow", {})
+    store.update_flow_run_status("r1", FlowRunStatus.RUNNING)
+    store.create_flow_run("r2", "other_flow", {})
+    store.update_flow_run_status("r2", FlowRunStatus.RUNNING)
+    assert store.count_active_flow_runs() == 2
+    assert store.count_active_flow_runs(flow_type="ticket_flow") == 1
+    assert store.count_active_flow_runs(flow_type="other_flow") == 1
+    store.close()
+
+
+def test_mtime_skip_returns_false_when_no_cache(tmp_path: Path) -> None:
+    db_path = tmp_path / ".codex-autorunner" / "flows.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_path.write_text("test")
+    _mtime_cache.clear()
+    assert _should_skip_reconcile(db_path) is False
+
+
+def test_mtime_skip_returns_false_when_mtime_changes(tmp_path: Path) -> None:
+    db_path = tmp_path / ".codex-autorunner" / "flows.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_path.write_text("v1")
+    _record_reconcile_mtime(db_path)
+    time.sleep(0.05)
+    db_path.write_text("v2")
+    assert _should_skip_reconcile(db_path) is False
+
+
+def test_mtime_skip_returns_true_when_unchanged(tmp_path: Path) -> None:
+    db_path = tmp_path / ".codex-autorunner" / "flows.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_path.write_text("v1")
+    _record_reconcile_mtime(db_path)
+    assert _should_skip_reconcile(db_path) is True
+
+
+def test_reconcile_skips_when_db_unchanged_and_no_active(tmp_path: Path) -> None:
+    _mtime_cache.clear()
+    repo_root = tmp_path
+    codex_dir = repo_root / ".codex-autorunner"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    db_path = codex_dir / "flows.db"
+    store = FlowStore(db_path)
+    store.initialize()
+    store.create_flow_run("r1", "ticket_flow", {})
+    store.update_flow_run_status("r1", FlowRunStatus.COMPLETED)
+    store.close()
+
+    result = reconcile_flow_runs(repo_root)
+    assert result.summary.active == 0
+    assert len(result.records) > 0
+
+    result2 = reconcile_flow_runs(repo_root)
+    assert result2.summary.active == 0
+    assert len(result2.records) == 0
+
+
+def test_reconcile_does_not_skip_when_active_runs_exist(tmp_path: Path) -> None:
+    _mtime_cache.clear()
+    repo_root = tmp_path
+    codex_dir = repo_root / ".codex-autorunner"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    db_path = codex_dir / "flows.db"
+    store = FlowStore(db_path)
+    store.initialize()
+    store.create_flow_run("r1", "ticket_flow", {})
+    store.update_flow_run_status("r1", FlowRunStatus.RUNNING)
+    store.close()
+
+    result = reconcile_flow_runs(repo_root)
+    assert result.summary.active >= 1
+    assert len(result.records) >= 1
+
+    _record_reconcile_mtime(db_path)
+    result2 = reconcile_flow_runs(repo_root)
+    assert result2.summary.active >= 1
+    assert len(result2.records) >= 1

--- a/tests/core/flows/test_reconciler_idle.py
+++ b/tests/core/flows/test_reconciler_idle.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
 
 from codex_autorunner.core.flows.models import FlowRunStatus
 from codex_autorunner.core.flows.reconciler import (
     _mtime_cache,
+    _reconcile_skip_signature,
     _record_reconcile_mtime,
     _should_skip_reconcile,
     reconcile_flow_runs,
@@ -56,27 +58,39 @@ def test_count_active_flow_runs_filters_by_type(tmp_path: Path) -> None:
 def test_mtime_skip_returns_false_when_no_cache(tmp_path: Path) -> None:
     db_path = tmp_path / ".codex-autorunner" / "flows.db"
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    db_path.write_text("test")
+    store = FlowStore(db_path)
+    store.initialize()
+    sig = _reconcile_skip_signature(store)
+    store.close()
     _mtime_cache.clear()
-    assert _should_skip_reconcile(db_path) is False
+    assert _should_skip_reconcile(db_path, sig) is False
 
 
 def test_mtime_skip_returns_false_when_mtime_changes(tmp_path: Path) -> None:
     db_path = tmp_path / ".codex-autorunner" / "flows.db"
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    db_path.write_text("v1")
-    _record_reconcile_mtime(db_path)
+    store = FlowStore(db_path)
+    store.initialize()
+    _record_reconcile_mtime(db_path, _reconcile_skip_signature(store))
+    store.close()
     time.sleep(0.05)
-    db_path.write_text("v2")
-    assert _should_skip_reconcile(db_path) is False
+    os.utime(db_path, None)
+    store2 = FlowStore(db_path)
+    store2.initialize()
+    sig2 = _reconcile_skip_signature(store2)
+    store2.close()
+    assert _should_skip_reconcile(db_path, sig2) is False
 
 
 def test_mtime_skip_returns_true_when_unchanged(tmp_path: Path) -> None:
     db_path = tmp_path / ".codex-autorunner" / "flows.db"
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    db_path.write_text("v1")
-    _record_reconcile_mtime(db_path)
-    assert _should_skip_reconcile(db_path) is True
+    store = FlowStore(db_path)
+    store.initialize()
+    sig = _reconcile_skip_signature(store)
+    _record_reconcile_mtime(db_path, sig)
+    assert _should_skip_reconcile(db_path, _reconcile_skip_signature(store)) is True
+    store.close()
 
 
 def test_reconcile_skips_when_db_unchanged_and_no_active(tmp_path: Path) -> None:
@@ -116,7 +130,10 @@ def test_reconcile_does_not_skip_when_active_runs_exist(tmp_path: Path) -> None:
     assert result.summary.active >= 1
     assert len(result.records) >= 1
 
-    _record_reconcile_mtime(db_path)
+    store3 = FlowStore(db_path)
+    store3.initialize()
+    _record_reconcile_mtime(db_path, _reconcile_skip_signature(store3))
+    store3.close()
     result2 = reconcile_flow_runs(repo_root)
     assert result2.summary.active >= 1
     assert len(result2.records) >= 1

--- a/tests/core/test_hub_lifecycle.py
+++ b/tests/core/test_hub_lifecycle.py
@@ -265,3 +265,120 @@ def test_hub_lifecycle_worker_stop_clears_dead_thread_after_self_termination() -
 
     assert worker._thread is None
     assert worker.running is False
+
+
+def test_hub_lifecycle_worker_adaptive_backoff_on_idle() -> None:
+    call_count = 0
+    completed = threading.Event()
+    logger = logging.getLogger("test.hub_lifecycle.worker.backoff")
+
+    def _process_once():
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 3:
+            completed.set()
+        return False
+
+    worker = HubLifecycleWorker(
+        process_once=_process_once,
+        poll_interval_seconds=0.01,
+        max_poll_interval_seconds=10.0,
+        join_timeout_seconds=0.5,
+        logger=logger,
+    )
+
+    worker.start()
+    try:
+        wait_for_thread_event(
+            completed,
+            timeout_seconds=5.0,
+            description="lifecycle worker idle backoff cycles",
+        )
+    finally:
+        worker.stop()
+
+    assert call_count >= 3
+    assert worker._idle_streak > 0
+    assert worker._current_interval() > worker._base_poll_interval_seconds
+
+
+def test_hub_lifecycle_worker_resets_backoff_on_productive() -> None:
+    call_count = 0
+    completed = threading.Event()
+    logger = logging.getLogger("test.hub_lifecycle.worker.reset")
+
+    def _process_once():
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 4:
+            completed.set()
+        return call_count == 3
+
+    worker = HubLifecycleWorker(
+        process_once=_process_once,
+        poll_interval_seconds=0.01,
+        max_poll_interval_seconds=0.5,
+        join_timeout_seconds=0.5,
+        logger=logger,
+    )
+
+    worker.start()
+    try:
+        wait_for_thread_event(
+            completed,
+            timeout_seconds=5.0,
+            description="lifecycle worker backoff reset cycle",
+        )
+    finally:
+        worker.stop()
+
+    assert call_count >= 4
+
+
+def test_hub_lifecycle_worker_wake_resets_idle_streak() -> None:
+    call_count = 0
+    first_call = threading.Event()
+    wake_done = threading.Event()
+    second_call = threading.Event()
+    streak_after_wake = None
+    logger = logging.getLogger("test.hub_lifecycle.worker.wake")
+
+    def _process_once():
+        nonlocal call_count, streak_after_wake
+        call_count += 1
+        if call_count == 1:
+            first_call.set()
+            wake_done.wait(timeout=2.0)
+            streak_after_wake = worker._idle_streak
+        elif call_count == 2:
+            second_call.set()
+        return False
+
+    worker = HubLifecycleWorker(
+        process_once=_process_once,
+        poll_interval_seconds=0.01,
+        max_poll_interval_seconds=5.0,
+        join_timeout_seconds=0.5,
+        logger=logger,
+    )
+
+    worker.start()
+    try:
+        wait_for_thread_event(
+            first_call,
+            timeout_seconds=1.0,
+            description="lifecycle worker first call",
+        )
+        worker._idle_streak = 5
+        worker.wake()
+        wake_done.set()
+        wait_for_thread_event(
+            second_call,
+            timeout_seconds=1.0,
+            description="lifecycle worker second call after wake",
+        )
+    finally:
+        worker.stop()
+
+    assert call_count >= 2
+    assert streak_after_wake == 0

--- a/tests/core/test_hub_lifecycle.py
+++ b/tests/core/test_hub_lifecycle.py
@@ -335,6 +335,29 @@ def test_hub_lifecycle_worker_resets_backoff_on_productive() -> None:
     assert call_count >= 4
 
 
+def test_lifecycle_event_processor_reports_processed_count() -> None:
+    first = LifecycleEvent(
+        event_type=LifecycleEventType.FLOW_FAILED,
+        repo_id="repo-1",
+        run_id="run-1",
+    )
+    second = LifecycleEvent(
+        event_type=LifecycleEventType.FLOW_FAILED,
+        repo_id="repo-2",
+        run_id="run-2",
+    )
+    store = _StoreStub([first, second])
+    processed_ids: list[str] = []
+
+    processor = LifecycleEventProcessor(
+        store=store,
+        process_event=lambda event: processed_ids.append(event.event_id),
+    )
+
+    assert processor.process_events(limit=50) == 2
+    assert processed_ids == [first.event_id, second.event_id]
+
+
 def test_hub_lifecycle_worker_wake_resets_idle_streak() -> None:
     call_count = 0
     first_call = threading.Event()

--- a/tests/core/test_idle_polling_reduction.py
+++ b/tests/core/test_idle_polling_reduction.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from codex_autorunner.core.diagnostics.loop_attribution import (
+    reset_loop_attribution,
+    snapshot_loop_attribution,
+)
+from codex_autorunner.core.pma_lane_worker import PmaLaneWorker
+from codex_autorunner.core.pma_queue import PmaQueue, QueueItemState
+from tests.support.waits import wait_for_async_event, wait_for_async_predicate
+
+
+@pytest.fixture(autouse=True)
+def _reset_loop_attribution():
+    reset_loop_attribution()
+    yield
+    reset_loop_attribution()
+
+
+@pytest.mark.anyio
+async def test_pma_idle_wait_skips_disk_read_when_mirror_unchanged(
+    tmp_path: Path,
+) -> None:
+    lane_id = "pma:default"
+    queue = PmaQueue(tmp_path)
+    cancel = asyncio.Event()
+    wait_task = asyncio.create_task(
+        queue.wait_for_lane_item(
+            lane_id,
+            cancel,
+            poll_interval_seconds=0.05,
+        )
+    )
+    await asyncio.sleep(0.3)
+    cancel.set()
+    result = await wait_task
+    assert result is False
+
+    snap = snapshot_loop_attribution()
+    assert "loops" not in snap or lane_id not in snap.get("loops", {})
+
+
+@pytest.mark.anyio
+async def test_pma_idle_wait_grows_backoff_on_consecutive_timeouts(
+    tmp_path: Path,
+) -> None:
+    lane_id = "pma:backoff-test"
+    queue = PmaQueue(tmp_path)
+    cancel = asyncio.Event()
+
+    poll_interval = 0.05
+    wait_task = asyncio.create_task(
+        queue.wait_for_lane_item(
+            lane_id,
+            cancel,
+            poll_interval_seconds=poll_interval,
+        )
+    )
+
+    await asyncio.sleep(0.15)
+    assert not wait_task.done(), "should still be waiting"
+
+    cancel.set()
+    result = await wait_task
+    assert result is False
+
+
+@pytest.mark.anyio
+async def test_pma_idle_wait_resets_backoff_on_enqueue(tmp_path: Path) -> None:
+    lane_id = "pma:streak-reset"
+    queue = PmaQueue(tmp_path)
+    processed = asyncio.Event()
+
+    async def executor(_item):
+        processed.set()
+        return {"status": "ok"}
+
+    worker = PmaLaneWorker(
+        lane_id,
+        queue,
+        executor,
+        poll_interval_seconds=0.05,
+    )
+    await worker.start()
+
+    _, _ = await queue.enqueue(lane_id, "key-a", {"msg": "first"})
+    await wait_for_async_event(
+        processed,
+        timeout_seconds=2.0,
+        description="first item processed",
+    )
+
+    terminal_item_state = None
+
+    async def _item_terminal():
+        nonlocal terminal_item_state
+        items = await queue.list_items(lane_id)
+        target = next((i for i in items if i.idempotency_key == "key-a"), None)
+        if target is None:
+            return False
+        if target.state in (QueueItemState.COMPLETED, QueueItemState.FAILED):
+            terminal_item_state = target.state
+            return True
+        return False
+
+    await wait_for_async_predicate(
+        _item_terminal,
+        timeout_seconds=2.0,
+        description="first item terminal",
+    )
+
+    assert queue._lane_idle_streaks.get(lane_id, 0) == 0
+
+    processed.clear()
+    _, _ = await queue.enqueue(lane_id, "key-b", {"msg": "second"})
+    await wait_for_async_event(
+        processed,
+        timeout_seconds=2.0,
+        description="second item processed",
+    )
+
+    await worker.stop()
+
+
+@pytest.mark.anyio
+async def test_pma_idle_wait_does_not_hit_disk_when_event_set(tmp_path: Path) -> None:
+    lane_id = "pma:event-fast"
+    queue = PmaQueue(tmp_path)
+    _, _ = await queue.enqueue(lane_id, "pre-key", {"msg": "pre"})
+
+    _ = await queue.dequeue(lane_id)
+
+    event = queue._ensure_lane_event(lane_id)
+    event.clear()
+
+    _, _ = await queue.enqueue(lane_id, "trigger-key", {"msg": "trigger"})
+
+    result = await asyncio.wait_for(
+        queue.wait_for_lane_item(lane_id, poll_interval_seconds=10.0),
+        timeout=0.5,
+    )
+    assert result is True
+
+
+@pytest.mark.anyio
+async def test_pma_lane_worker_idle_does_not_count_db_reads(
+    tmp_path: Path,
+) -> None:
+    lane_id = "pma:worker-idle"
+    queue = PmaQueue(tmp_path)
+    cancel = asyncio.Event()
+    processed = asyncio.Event()
+
+    async def executor(_item):
+        processed.set()
+        return {"status": "ok"}
+
+    worker = PmaLaneWorker(
+        lane_id,
+        queue,
+        executor,
+        poll_interval_seconds=0.05,
+    )
+    await worker.start()
+
+    await asyncio.sleep(0.3)
+
+    snap = snapshot_loop_attribution()
+    loop_key = f"pma.lane_worker.{lane_id}"
+    loop_stats = snap.get("loops", {}).get(loop_key, {})
+    assert (
+        loop_stats.get("db_reads", 0) == 0
+    ), f"idle worker should not accumulate db_reads, got {loop_stats.get('db_reads')}"
+
+    cancel.set()
+    await worker.stop()

--- a/tests/core/test_idle_polling_reduction.py
+++ b/tests/core/test_idle_polling_reduction.py
@@ -45,31 +45,6 @@ async def test_pma_idle_wait_skips_disk_read_when_mirror_unchanged(
 
 
 @pytest.mark.anyio
-async def test_pma_idle_wait_grows_backoff_on_consecutive_timeouts(
-    tmp_path: Path,
-) -> None:
-    lane_id = "pma:backoff-test"
-    queue = PmaQueue(tmp_path)
-    cancel = asyncio.Event()
-
-    poll_interval = 0.05
-    wait_task = asyncio.create_task(
-        queue.wait_for_lane_item(
-            lane_id,
-            cancel,
-            poll_interval_seconds=poll_interval,
-        )
-    )
-
-    await asyncio.sleep(0.15)
-    assert not wait_task.done(), "should still be waiting"
-
-    cancel.set()
-    result = await wait_task
-    assert result is False
-
-
-@pytest.mark.anyio
 async def test_pma_idle_wait_resets_backoff_on_enqueue(tmp_path: Path) -> None:
     lane_id = "pma:streak-reset"
     queue = PmaQueue(tmp_path)
@@ -112,8 +87,6 @@ async def test_pma_idle_wait_resets_backoff_on_enqueue(tmp_path: Path) -> None:
         timeout_seconds=2.0,
         description="first item terminal",
     )
-
-    assert queue._lane_idle_streaks.get(lane_id, 0) == 0
 
     processed.clear()
     _, _ = await queue.enqueue(lane_id, "key-b", {"msg": "second"})

--- a/tests/core/test_loop_attribution.py
+++ b/tests/core/test_loop_attribution.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import time
+
+from codex_autorunner.core.diagnostics.loop_attribution import (
+    get_loop_names,
+    reset_loop_attribution,
+    snapshot_loop_attribution,
+    track_loop,
+)
+
+
+def test_track_loop_records_idle_wakeup():
+    reset_loop_attribution()
+
+    with track_loop("test.loop_a"):
+        pass
+
+    snap = snapshot_loop_attribution()
+    assert "test.loop_a" in snap["loops"]
+    entry = snap["loops"]["test.loop_a"]
+    assert entry["wakeups"] == 1
+    assert entry["idle_wakeups"] == 1
+    assert entry["productive_wakeups"] == 0
+    assert entry["disk_reads"] == 0
+    assert entry["db_reads"] == 0
+
+
+def test_track_loop_records_productive_wakeup():
+    reset_loop_attribution()
+
+    with track_loop("test.loop_b") as scope:
+        scope.mark_productive()
+        scope.record_disk_read(2)
+        scope.record_db_read(1)
+
+    snap = snapshot_loop_attribution()
+    entry = snap["loops"]["test.loop_b"]
+    assert entry["wakeups"] == 1
+    assert entry["productive_wakeups"] == 1
+    assert entry["idle_wakeups"] == 0
+    assert entry["disk_reads"] == 2
+    assert entry["db_reads"] == 1
+
+
+def test_track_loop_accumulates_across_iterations():
+    reset_loop_attribution()
+
+    for i in range(5):
+        with track_loop("test.loop_c") as scope:
+            if i % 2 == 0:
+                scope.mark_productive()
+
+    snap = snapshot_loop_attribution()
+    entry = snap["loops"]["test.loop_c"]
+    assert entry["wakeups"] == 5
+    assert entry["productive_wakeups"] == 3
+    assert entry["idle_wakeups"] == 2
+
+
+def test_snapshot_includes_timestamp():
+    reset_loop_attribution()
+
+    before = time.time()
+    snap = snapshot_loop_attribution()
+    after = time.time()
+
+    assert "snapshot_at" in snap
+    assert before <= snap["snapshot_at"] <= after
+
+
+def test_snapshot_empty_when_no_loops_registered():
+    reset_loop_attribution()
+
+    snap = snapshot_loop_attribution()
+    assert snap["loops"] == {}
+
+
+def test_reset_clears_all_counters():
+    reset_loop_attribution()
+
+    with track_loop("test.loop_d"):
+        pass
+
+    reset_loop_attribution()
+    snap = snapshot_loop_attribution()
+    assert snap["loops"] == {}
+
+
+def test_get_loop_names():
+    reset_loop_attribution()
+
+    with track_loop("test.alpha"):
+        pass
+    with track_loop("test.beta"):
+        pass
+
+    names = get_loop_names()
+    assert names == ["test.alpha", "test.beta"]
+
+
+def test_avg_wakeup_duration():
+    reset_loop_attribution()
+
+    with track_loop("test.duration"):
+        time.sleep(0.01)
+
+    snap = snapshot_loop_attribution()
+    entry = snap["loops"]["test.duration"]
+    assert entry["avg_wakeup_duration_seconds"] > 0
+
+
+def test_wakeup_scope_tracks_multiple_reads():
+    reset_loop_attribution()
+
+    with track_loop("test.multi_read") as scope:
+        scope.record_disk_read(3)
+        scope.record_db_read(2)
+        scope.record_disk_read(1)
+
+    snap = snapshot_loop_attribution()
+    entry = snap["loops"]["test.multi_read"]
+    assert entry["disk_reads"] == 4
+    assert entry["db_reads"] == 2
+
+
+def test_snapshot_durable_across_runs():
+    reset_loop_attribution()
+
+    with track_loop("test.run1"):
+        pass
+
+    snap1 = snapshot_loop_attribution()
+
+    with track_loop("test.run1") as scope:
+        scope.mark_productive()
+
+    snap2 = snapshot_loop_attribution()
+
+    assert snap1["loops"]["test.run1"]["wakeups"] == 1
+    assert snap1["loops"]["test.run1"]["idle_wakeups"] == 1
+    assert snap2["loops"]["test.run1"]["wakeups"] == 2
+    assert snap2["loops"]["test.run1"]["productive_wakeups"] == 1
+
+
+def test_smoke_soak_artifact_includes_attribution():
+    reset_loop_attribution()
+
+    with track_loop("smoke.loop_a") as scope:
+        scope.mark_productive()
+        scope.record_db_read(1)
+
+    with track_loop("smoke.loop_b"):
+        pass
+
+    with track_loop("smoke.loop_b"):
+        pass
+
+    artifact = snapshot_loop_attribution()
+
+    assert "loops" in artifact
+    assert "snapshot_at" in artifact
+    assert len(artifact["loops"]) == 2
+
+    a = artifact["loops"]["smoke.loop_a"]
+    assert a["wakeups"] == 1
+    assert a["productive_wakeups"] == 1
+    assert a["db_reads"] == 1
+
+    b = artifact["loops"]["smoke.loop_b"]
+    assert b["wakeups"] == 2
+    assert b["idle_wakeups"] == 2
+
+    serialized = json.dumps(artifact)
+    assert "smoke.loop_a" in serialized
+    assert "smoke.loop_b" in serialized

--- a/tests/integrations/chat/test_queue_control.py
+++ b/tests/integrations/chat/test_queue_control.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_autorunner.integrations.chat.queue_control import ChatQueueControlStore
+
+
+@pytest.mark.anyio
+async def test_take_reset_requests_no_write_when_empty(tmp_path: Path) -> None:
+    store = ChatQueueControlStore(tmp_path)
+    commands_path = store._commands_path
+
+    taken = store.take_reset_requests(platform="discord")
+    assert taken == []
+    assert (
+        not commands_path.exists()
+    ), "take_reset_requests should not create the file when there are no requests"
+
+
+@pytest.mark.anyio
+async def test_has_reset_requests_returns_false_when_no_file(tmp_path: Path) -> None:
+    store = ChatQueueControlStore(tmp_path)
+    assert store.has_reset_requests(platform="discord") is False
+
+
+@pytest.mark.anyio
+async def test_has_reset_requests_returns_true_when_pending(
+    tmp_path: Path,
+) -> None:
+    store = ChatQueueControlStore(tmp_path)
+    store.request_reset(
+        conversation_id="discord:123:-",
+        platform="discord",
+        chat_id="123",
+        thread_id=None,
+        reason="stuck",
+    )
+    assert store.has_reset_requests(platform="discord") is True
+
+
+@pytest.mark.anyio
+async def test_has_reset_requests_filters_by_platform(tmp_path: Path) -> None:
+    store = ChatQueueControlStore(tmp_path)
+    store.request_reset(
+        conversation_id="telegram:456:-",
+        platform="telegram",
+        chat_id="456",
+        thread_id=None,
+    )
+    assert store.has_reset_requests(platform="discord") is False
+    assert store.has_reset_requests(platform="telegram") is True
+
+
+@pytest.mark.anyio
+async def test_take_reset_requests_observes_promptly(tmp_path: Path) -> None:
+    store = ChatQueueControlStore(tmp_path)
+    store.request_reset(
+        conversation_id="discord:789:-",
+        platform="discord",
+        chat_id="789",
+        thread_id=None,
+        requested_by="test",
+    )
+
+    taken = store.take_reset_requests(platform="discord")
+    assert len(taken) == 1
+    assert taken[0]["conversation_id"] == "discord:789:-"
+    assert taken[0]["requested_by"] == "test"
+
+    second = store.take_reset_requests(platform="discord")
+    assert second == []
+
+
+@pytest.mark.anyio
+async def test_take_reset_requests_preserves_other_platform(
+    tmp_path: Path,
+) -> None:
+    store = ChatQueueControlStore(tmp_path)
+    store.request_reset(
+        conversation_id="discord:100:-",
+        platform="discord",
+        chat_id="100",
+        thread_id=None,
+    )
+    store.request_reset(
+        conversation_id="telegram:200:-",
+        platform="telegram",
+        chat_id="200",
+        thread_id=None,
+    )
+
+    taken = store.take_reset_requests(platform="discord")
+    assert len(taken) == 1
+    assert taken[0]["conversation_id"] == "discord:100:-"
+
+    assert store.has_reset_requests(platform="telegram") is True
+    remaining = store.take_reset_requests(platform="telegram")
+    assert len(remaining) == 1
+    assert remaining[0]["conversation_id"] == "telegram:200:-"
+
+    final = store.take_reset_requests()
+    assert final == []

--- a/tests/integrations/discord/test_flow_watchers_idle.py
+++ b/tests/integrations/discord/test_flow_watchers_idle.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from codex_autorunner.integrations.discord.flow_watchers import (
+    _IDLE_BACKOFF_MAX_SECONDS,
+    _IDLE_BACKOFF_STEP_SECONDS,
+    PAUSE_SCAN_INTERVAL_SECONDS,
+    TERMINAL_SCAN_INTERVAL_SECONDS,
+    _next_idle_interval,
+)
+
+
+def test_next_idle_interval_returns_base_for_zero_idle():
+    assert _next_idle_interval(5.0, 0) == 5.0
+
+
+def test_next_idle_interval_increases_with_consecutive_idle():
+    base = 5.0
+    assert _next_idle_interval(base, 1) == base + _IDLE_BACKOFF_STEP_SECONDS
+    assert _next_idle_interval(base, 2) == base + 2 * _IDLE_BACKOFF_STEP_SECONDS
+    assert _next_idle_interval(base, 3) == base + 3 * _IDLE_BACKOFF_STEP_SECONDS
+
+
+def test_next_idle_interval_caps_at_maximum():
+    result = _next_idle_interval(5.0, 100)
+    assert result == _IDLE_BACKOFF_MAX_SECONDS
+
+
+def test_next_idle_interval_with_custom_step_and_max():
+    result = _next_idle_interval(2.0, 5, step=3.0, maximum=20.0)
+    assert result == min(2.0 + 5 * 3.0, 20.0)
+    assert result == 17.0
+
+
+def test_next_idle_interval_does_not_exceed_max():
+    result = _next_idle_interval(5.0, 50)
+    assert result == _IDLE_BACKOFF_MAX_SECONDS
+    assert result <= 30.0
+
+
+def test_next_idle_interval_monotonically_increases():
+    base = 5.0
+    prev = base
+    for i in range(20):
+        current = _next_idle_interval(base, i)
+        assert current >= prev
+        prev = current
+    assert prev == _IDLE_BACKOFF_MAX_SECONDS
+
+
+@pytest.mark.anyio
+async def test_pause_watcher_adaptive_backoff_intervals():
+    from codex_autorunner.integrations.discord.flow_watchers import (
+        watch_ticket_flow_pauses,
+    )
+
+    sleep_intervals: list[float] = []
+    max_iterations = 5
+    iteration = 0
+
+    service = MagicMock()
+    service._logger = logging.getLogger("test")
+    service._store = MagicMock()
+    service._store.list_bindings = AsyncMock(return_value=[])
+    service._hub_raw_config_cache = {}
+
+    async def fake_scan(svc: Any) -> None:
+        pass
+
+    async def capturing_sleep(interval: float) -> None:
+        nonlocal iteration
+        sleep_intervals.append(interval)
+        iteration += 1
+        if iteration >= max_iterations:
+            raise asyncio.CancelledError()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "codex_autorunner.integrations.discord.flow_watchers._scan_and_enqueue_pause_notifications",
+            fake_scan,
+        )
+        mp.setattr(
+            "codex_autorunner.integrations.discord.flow_watchers.asyncio.sleep",
+            capturing_sleep,
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await watch_ticket_flow_pauses(service)
+
+    assert len(sleep_intervals) == max_iterations
+    assert (
+        sleep_intervals[0] == PAUSE_SCAN_INTERVAL_SECONDS + _IDLE_BACKOFF_STEP_SECONDS
+    )
+    assert (
+        sleep_intervals[1]
+        == PAUSE_SCAN_INTERVAL_SECONDS + 2 * _IDLE_BACKOFF_STEP_SECONDS
+    )
+    assert (
+        sleep_intervals[2]
+        == PAUSE_SCAN_INTERVAL_SECONDS + 3 * _IDLE_BACKOFF_STEP_SECONDS
+    )
+
+
+@pytest.mark.anyio
+async def test_terminal_watcher_adaptive_backoff_intervals():
+    from codex_autorunner.integrations.discord.flow_watchers import (
+        watch_ticket_flow_terminals,
+    )
+
+    sleep_intervals: list[float] = []
+    max_iterations = 4
+    iteration = 0
+
+    service = MagicMock()
+    service._logger = logging.getLogger("test")
+    service._store = MagicMock()
+    service._store.list_bindings = AsyncMock(return_value=[])
+    service._hub_raw_config_cache = {}
+
+    async def fake_scan(svc: Any) -> None:
+        pass
+
+    async def capturing_sleep(interval: float) -> None:
+        nonlocal iteration
+        sleep_intervals.append(interval)
+        iteration += 1
+        if iteration >= max_iterations:
+            raise asyncio.CancelledError()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "codex_autorunner.integrations.discord.flow_watchers._scan_and_enqueue_terminal_notifications",
+            fake_scan,
+        )
+        mp.setattr(
+            "codex_autorunner.integrations.discord.flow_watchers.asyncio.sleep",
+            capturing_sleep,
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await watch_ticket_flow_terminals(service)
+
+    assert len(sleep_intervals) == max_iterations
+    assert (
+        sleep_intervals[0]
+        == TERMINAL_SCAN_INTERVAL_SECONDS + _IDLE_BACKOFF_STEP_SECONDS
+    )
+    assert (
+        sleep_intervals[1]
+        == TERMINAL_SCAN_INTERVAL_SECONDS + 2 * _IDLE_BACKOFF_STEP_SECONDS
+    )
+
+
+@pytest.mark.anyio
+async def test_pause_watcher_resets_backoff_on_productive_scan():
+    from codex_autorunner.integrations.discord.flow_watchers import (
+        watch_ticket_flow_pauses,
+    )
+
+    sleep_intervals: list[float] = []
+    iteration = 0
+
+    service = MagicMock()
+    service._logger = logging.getLogger("test")
+    service._hub_raw_config_cache = {}
+
+    async def productive_after_two() -> list[dict[str, Any]]:
+        nonlocal iteration
+        iteration += 1
+        if iteration <= 2:
+            return []
+        return [{"channel_id": "ch-1", "workspace_path": "/tmp/ws"}]
+
+    service._store = MagicMock()
+    service._store.list_bindings = productive_after_two
+
+    async def fake_scan(svc: Any) -> None:
+        pass
+
+    max_sleeps = 6
+    sleep_count = 0
+
+    async def capturing_sleep(interval: float) -> None:
+        nonlocal sleep_count
+        sleep_intervals.append(interval)
+        sleep_count += 1
+        if sleep_count >= max_sleeps:
+            raise asyncio.CancelledError()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "codex_autorunner.integrations.discord.flow_watchers._scan_and_enqueue_pause_notifications",
+            fake_scan,
+        )
+        mp.setattr(
+            "codex_autorunner.integrations.discord.flow_watchers.asyncio.sleep",
+            capturing_sleep,
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await watch_ticket_flow_pauses(service)
+
+    assert len(sleep_intervals) == max_sleeps
+    assert (
+        sleep_intervals[0] == PAUSE_SCAN_INTERVAL_SECONDS + _IDLE_BACKOFF_STEP_SECONDS
+    )
+    assert (
+        sleep_intervals[1]
+        == PAUSE_SCAN_INTERVAL_SECONDS + 2 * _IDLE_BACKOFF_STEP_SECONDS
+    )
+    assert sleep_intervals[2] == PAUSE_SCAN_INTERVAL_SECONDS
+    assert sleep_intervals[3] == PAUSE_SCAN_INTERVAL_SECONDS

--- a/tests/integrations/discord/test_flow_watchers_idle.py
+++ b/tests/integrations/discord/test_flow_watchers_idle.py
@@ -168,18 +168,10 @@ async def test_pause_watcher_resets_backoff_on_productive_scan():
     service._logger = logging.getLogger("test")
     service._hub_raw_config_cache = {}
 
-    async def productive_after_two() -> list[dict[str, Any]]:
+    async def fake_scan(svc: Any) -> int:
         nonlocal iteration
         iteration += 1
-        if iteration <= 2:
-            return []
-        return [{"channel_id": "ch-1", "workspace_path": "/tmp/ws"}]
-
-    service._store = MagicMock()
-    service._store.list_bindings = productive_after_two
-
-    async def fake_scan(svc: Any) -> None:
-        pass
+        return 1 if iteration >= 3 else 0
 
     max_sleeps = 6
     sleep_count = 0

--- a/tests/integrations/discord/test_opencode_lifecycle.py
+++ b/tests/integrations/discord/test_opencode_lifecycle.py
@@ -571,3 +571,32 @@ async def test_discord_orchestrator_shares_workspace_opencode_supervisor(
         )
     finally:
         await store.close()
+
+
+@pytest.mark.anyio
+async def test_opencode_prune_interval_uses_longer_fallback_when_no_supervisors(
+    tmp_path: Path,
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test.discord.opencode.empty"),
+        rest_client=_FakeRest(),
+        gateway_client=_FakeGateway(),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        interval = await service._next_opencode_prune_interval_seconds()
+        assert (
+            interval
+            == discord_service_module.DISCORD_OPENCODE_PRUNE_EMPTY_INTERVAL_SECONDS
+        )
+        assert (
+            interval
+            > discord_service_module.DISCORD_OPENCODE_PRUNE_FALLBACK_INTERVAL_SECONDS
+        )
+    finally:
+        await store.close()

--- a/tests/test_pma_cli.py
+++ b/tests/test_pma_cli.py
@@ -1,5 +1,6 @@
 """Tests for PMA CLI commands."""
 
+import itertools
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -1589,7 +1590,11 @@ def test_pma_cli_thread_send_timeout_warns_before_retry_when_status_unclear(
         _ = method, url, payload, token_env, timeout
         raise httpx.TimeoutException("timed out")
 
-    status_payloads = iter(
+    # Cycle status payloads: recovery polls until the deadline; Typer/Click may
+    # call time.monotonic() extra times on some Python versions, so a fixed
+    # two-value iterator for monotonic can shift the deadline and exhaust a
+    # finite status iterator (StopIteration).
+    status_payloads = itertools.cycle(
         [
             {
                 "thread": {
@@ -1626,10 +1631,8 @@ def test_pma_cli_thread_send_timeout_warns_before_retry_when_status_unclear(
         pma_cli, "_request_json_with_status", _fake_request_json_with_status
     )
     monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
-    monotonic_values = iter([100.0, 103.0])
-    monkeypatch.setattr(
-        pma_cli.time, "monotonic", lambda: next(monotonic_values, 103.0)
-    )
+    monotonic_seq = itertools.count(100.0, 0.01)
+    monkeypatch.setattr(pma_cli.time, "monotonic", lambda: next(monotonic_seq))
     monkeypatch.setattr(pma_cli.time, "sleep", lambda seconds: None)
 
     runner = CliRunner()

--- a/tests/test_telegram_cache_cleanup.py
+++ b/tests/test_telegram_cache_cleanup.py
@@ -53,5 +53,11 @@ async def test_cache_cleanup_eviction(tmp_path: Path) -> None:
             "flow_run_options", SELECTION_STATE_TTL_SECONDS
         )
         assert "topic-2" not in service._flow_run_options
+
+        service._cache_timestamps.clear()
+        assert service._has_any_cache_entries() is False
+
+        service._cache_timestamps["test"] = {"key": time.monotonic()}
+        assert service._has_any_cache_entries() is True
     finally:
         await service._bot.close()

--- a/tests/unit/test_cpu_sampler.py
+++ b/tests/unit/test_cpu_sampler.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from codex_autorunner.core.diagnostics.cpu_sampler import (
+    CpuSample,
+    aggregate_samples,
+    collect_cpu_sample,
+    compute_per_process_aggregates,
+    evaluate_signoff,
+    sample_cpu_for_pids,
+)
+from codex_autorunner.core.diagnostics.process_snapshot import ProcessCategory
+
+
+class TestSampleCpuForPids:
+    def test_empty_pids_returns_empty(self):
+        assert sample_cpu_for_pids([]) == {}
+
+    def test_parses_valid_ps_output(self):
+        def _mock_run(*args, **kwargs):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = "  123  1.5  10240\n  456  0.3  5120\n"
+            return proc
+
+        import subprocess
+
+        original = subprocess.run
+        subprocess.run = _mock_run
+        try:
+            result = sample_cpu_for_pids([123, 456])
+        finally:
+            subprocess.run = original
+
+        assert 123 in result
+        assert 456 in result
+        assert result[123] == (1.5, 10.0)
+        assert result[456] == (0.3, 5.0)
+
+    def test_malformed_ps_line_skipped(self):
+        def _mock_run(*args, **kwargs):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = "  bad  xyz  abc\n  456  0.3  5120\n"
+            return proc
+
+        import subprocess
+
+        original = subprocess.run
+        subprocess.run = _mock_run
+        try:
+            result = sample_cpu_for_pids([456])
+        finally:
+            subprocess.run = original
+
+        assert 456 in result
+        assert 123 not in result
+
+    def test_ps_failure_returns_empty(self):
+        def _mock_run(*args, **kwargs):
+            proc = MagicMock()
+            proc.returncode = 1
+            proc.stdout = ""
+            return proc
+
+        import subprocess
+
+        original = subprocess.run
+        subprocess.run = _mock_run
+        try:
+            result = sample_cpu_for_pids([123])
+        finally:
+            subprocess.run = original
+
+        assert result == {}
+
+    def test_oserror_returns_empty(self):
+        import subprocess
+
+        original = subprocess.run
+
+        def _raise(*args, **kwargs):
+            raise OSError("no ps")
+
+        subprocess.run = _raise
+        try:
+            result = sample_cpu_for_pids([123])
+        finally:
+            subprocess.run = original
+
+        assert result == {}
+
+    def test_incomplete_line_skipped(self):
+        def _mock_run(*args, **kwargs):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = "  123  1.5\n"
+            return proc
+
+        import subprocess
+
+        original = subprocess.run
+        subprocess.run = _mock_run
+        try:
+            result = sample_cpu_for_pids([123])
+        finally:
+            subprocess.run = original
+
+        assert result == {}
+
+    def test_empty_output_returns_empty(self):
+        def _mock_run(*args, **kwargs):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = "\n\n"
+            return proc
+
+        import subprocess
+
+        original = subprocess.run
+        subprocess.run = _mock_run
+        try:
+            result = sample_cpu_for_pids([123])
+        finally:
+            subprocess.run = original
+
+        assert result == {}
+
+
+class TestCollectCpuSample:
+    def test_no_car_processes(self):
+        def _mock_ps():
+            return ""
+
+        def _mock_cpu(pids):
+            return {}
+
+        sample = collect_cpu_sample(
+            ps_output_getter=_mock_ps,
+            pid_cpu_getter=_mock_cpu,
+        )
+        assert sample.aggregate_cpu_percent == 0.0
+        assert sample.per_process == []
+
+    def test_with_car_service_processes(self):
+        ps_output = (
+            "  100  1  1  50000  00:01:00  codex-autorunner hub serve\n"
+            "  200  1  1  10000  00:00:30  something else\n"
+        )
+
+        def _mock_ps():
+            return ps_output
+
+        def _mock_cpu(pids):
+            result = {}
+            if 100 in pids:
+                result[100] = (2.5, 48.828)
+            return result
+
+        sample = collect_cpu_sample(
+            ps_output_getter=_mock_ps,
+            pid_cpu_getter=_mock_cpu,
+        )
+        assert sample.car_service_cpu_percent == 2.5
+        assert sample.aggregate_cpu_percent == 2.5
+        assert len(sample.per_process) == 1
+        assert sample.per_process[0]["pid"] == 100
+        assert sample.per_process[0]["category"] == "car_service"
+
+    def test_multiple_categories(self):
+        ps_output = (
+            "  100  1  1  50000  00:01:00  codex-autorunner hub serve\n"
+            "  200  1  1  20000  00:00:30  opencode serve\n"
+            "  300  1  1  15000  00:00:15  codex app-server\n"
+        )
+
+        def _mock_ps():
+            return ps_output
+
+        def _mock_cpu(pids):
+            return {
+                100: (1.0, 48.828),
+                200: (0.5, 19.531),
+                300: (0.3, 14.648),
+            }
+
+        sample = collect_cpu_sample(
+            ps_output_getter=_mock_ps,
+            pid_cpu_getter=_mock_cpu,
+        )
+        assert sample.car_service_cpu_percent == 1.0
+        assert sample.opencode_cpu_percent == 0.5
+        assert sample.app_server_cpu_percent == 0.3
+        assert sample.aggregate_cpu_percent == pytest.approx(1.8, abs=0.01)
+        assert len(sample.per_process) == 3
+
+    def test_filtered_categories(self):
+        ps_output = (
+            "  100  1  1  50000  00:01:00  codex-autorunner hub serve\n"
+            "  200  1  1  20000  00:00:30  opencode serve\n"
+        )
+
+        def _mock_ps():
+            return ps_output
+
+        def _mock_cpu(pids):
+            return {100: (1.0, 48.828)}
+
+        sample = collect_cpu_sample(
+            owned_categories=[ProcessCategory.CAR_SERVICE],
+            ps_output_getter=_mock_ps,
+            pid_cpu_getter=_mock_cpu,
+        )
+        assert sample.car_service_cpu_percent == 1.0
+        assert sample.opencode_cpu_percent == 0.0
+        assert sample.aggregate_cpu_percent == 1.0
+        assert len(sample.per_process) == 1
+
+
+class TestAggregateSamples:
+    def test_empty_samples(self):
+        result = aggregate_samples([])
+        assert result["car_owned_cpu_mean_percent"] == 0.0
+        assert result["car_owned_cpu_max_percent"] == 0.0
+        assert result["car_owned_cpu_p95_percent"] == 0.0
+        assert result["car_owned_cpu_samples"] == 0
+
+    def test_single_sample(self):
+        samples = [CpuSample(aggregate_cpu_percent=3.5, aggregate_rss_mb=50.0)]
+        result = aggregate_samples(samples)
+        assert result["car_owned_cpu_mean_percent"] == 3.5
+        assert result["car_owned_cpu_max_percent"] == 3.5
+        assert result["car_owned_cpu_p95_percent"] == 3.5
+        assert result["car_owned_cpu_samples"] == 1
+        assert result["car_owned_memory_mean_mb"] == 50.0
+
+    def test_multiple_samples(self):
+        samples = [
+            CpuSample(aggregate_cpu_percent=1.0, aggregate_rss_mb=40.0),
+            CpuSample(aggregate_cpu_percent=2.0, aggregate_rss_mb=50.0),
+            CpuSample(aggregate_cpu_percent=3.0, aggregate_rss_mb=60.0),
+            CpuSample(aggregate_cpu_percent=4.0, aggregate_rss_mb=70.0),
+            CpuSample(aggregate_cpu_percent=5.0, aggregate_rss_mb=80.0),
+        ]
+        result = aggregate_samples(samples)
+        assert result["car_owned_cpu_mean_percent"] == 3.0
+        assert result["car_owned_cpu_max_percent"] == 5.0
+        assert result["car_owned_cpu_samples"] == 5
+        assert result["car_owned_memory_mean_mb"] == 60.0
+        assert result["car_owned_memory_max_mb"] == 80.0
+
+    def test_p95_computation(self):
+        samples = [CpuSample(aggregate_cpu_percent=float(i)) for i in range(1, 21)]
+        result = aggregate_samples(samples)
+        assert result["car_owned_cpu_mean_percent"] == 10.5
+        assert result["car_owned_cpu_max_percent"] == 20.0
+        assert result["car_owned_cpu_p95_percent"] == 19.0
+
+
+class TestComputePerProcessAggregates:
+    def test_empty_samples(self):
+        assert compute_per_process_aggregates([]) == []
+
+    def test_single_process_multiple_samples(self):
+        samples = [
+            CpuSample(
+                per_process=[
+                    {
+                        "pid": 100,
+                        "command": "car hub",
+                        "category": "car_service",
+                        "cpu_percent": 1.0,
+                        "rss_mb": 50.0,
+                    }
+                ]
+            ),
+            CpuSample(
+                per_process=[
+                    {
+                        "pid": 100,
+                        "command": "car hub",
+                        "category": "car_service",
+                        "cpu_percent": 3.0,
+                        "rss_mb": 60.0,
+                    }
+                ]
+            ),
+        ]
+        result = compute_per_process_aggregates(samples)
+        assert len(result) == 1
+        assert result[0]["cpu_mean_percent"] == 2.0
+        assert result[0]["cpu_max_percent"] == 3.0
+        assert result[0]["memory_mean_mb"] == 55.0
+        assert result[0]["memory_max_mb"] == 60.0
+
+    def test_multiple_processes(self):
+        samples = [
+            CpuSample(
+                per_process=[
+                    {
+                        "pid": 100,
+                        "command": "car hub",
+                        "category": "car_service",
+                        "cpu_percent": 1.0,
+                        "rss_mb": 50.0,
+                    },
+                    {
+                        "pid": 200,
+                        "command": "opencode",
+                        "category": "opencode",
+                        "cpu_percent": 0.5,
+                        "rss_mb": 30.0,
+                    },
+                ]
+            ),
+        ]
+        result = compute_per_process_aggregates(samples)
+        assert len(result) == 2
+
+
+class TestEvaluateSignoff:
+    def test_hard_budget_pass(self):
+        agg = {"car_owned_cpu_mean_percent": 3.0}
+        result = evaluate_signoff(
+            agg,
+            hard_budget={"enabled": True, "max_aggregate_cpu_percent": 5.0},
+        )
+        assert result["passed"] is True
+        assert result["budget_type"] == "hard"
+        assert result["budget_threshold_percent"] == 5.0
+        assert "PASS" in result["message"]
+
+    def test_hard_budget_fail(self):
+        agg = {"car_owned_cpu_mean_percent": 7.5}
+        result = evaluate_signoff(
+            agg,
+            hard_budget={"enabled": True, "max_aggregate_cpu_percent": 5.0},
+        )
+        assert result["passed"] is False
+        assert result["budget_type"] == "hard"
+        assert "FAIL" in result["message"]
+
+    def test_comparison_budget_pass(self):
+        agg = {"car_owned_cpu_mean_percent": 5.0}
+        result = evaluate_signoff(
+            agg,
+            comparison_budget={"max_aggregate_cpu_percent": 8.0},
+        )
+        assert result["passed"] is True
+        assert result["budget_type"] == "comparison"
+
+    def test_comparison_budget_fail(self):
+        agg = {"car_owned_cpu_mean_percent": 10.0}
+        result = evaluate_signoff(
+            agg,
+            comparison_budget={"max_aggregate_cpu_percent": 8.0},
+        )
+        assert result["passed"] is False
+        assert result["budget_type"] == "comparison"
+
+    def test_no_budget(self):
+        agg = {"car_owned_cpu_mean_percent": 42.0}
+        result = evaluate_signoff(agg)
+        assert result["passed"] is True
+        assert result["budget_type"] == "none"
+        assert result["budget_threshold_percent"] is None
+
+    def test_hard_budget_disabled(self):
+        agg = {"car_owned_cpu_mean_percent": 99.0}
+        result = evaluate_signoff(
+            agg,
+            hard_budget={"enabled": False},
+        )
+        assert result["passed"] is True
+        assert result["budget_type"] == "none"
+
+    def test_missing_cpu_key_defaults_zero(self):
+        agg: dict[str, Any] = {}
+        result = evaluate_signoff(
+            agg,
+            hard_budget={"enabled": True, "max_aggregate_cpu_percent": 5.0},
+        )
+        assert result["passed"] is True
+        assert result["actual_aggregate_cpu_percent"] == 0.0
+
+
+class TestCpuSample:
+    def test_defaults(self):
+        s = CpuSample()
+        assert s.aggregate_cpu_percent == 0.0
+        assert s.aggregate_rss_mb == 0.0
+        assert s.per_process == []
+
+    def test_values(self):
+        s = CpuSample(
+            car_service_cpu_percent=1.5,
+            car_service_rss_mb=40.0,
+            aggregate_cpu_percent=1.5,
+            aggregate_rss_mb=40.0,
+        )
+        assert s.car_service_cpu_percent == 1.5
+        assert s.aggregate_rss_mb == 40.0
+
+
+class TestMalformedPsOutput:
+    def test_garbage_lines_skipped(self):
+        ps_output = "not a real line\n  also bad\n"
+
+        def _mock_ps():
+            return ps_output
+
+        def _mock_cpu(pids):
+            return {}
+
+        sample = collect_cpu_sample(
+            ps_output_getter=_mock_ps,
+            pid_cpu_getter=_mock_cpu,
+        )
+        assert sample.aggregate_cpu_percent == 0.0
+
+    def test_partial_columns_skipped(self):
+        ps_output = "  100  1\n"
+
+        def _mock_ps():
+            return ps_output
+
+        def _mock_cpu(pids):
+            return {}
+
+        sample = collect_cpu_sample(
+            ps_output_getter=_mock_ps,
+            pid_cpu_getter=_mock_cpu,
+        )
+        assert sample.aggregate_cpu_percent == 0.0
+
+    def test_non_numeric_pid_skipped(self):
+        ps_output = "  abc  1  1  50000  00:01:00  codex-autorunner hub serve\n"
+
+        def _mock_ps():
+            return ps_output
+
+        def _mock_cpu(pids):
+            return {}
+
+        sample = collect_cpu_sample(
+            ps_output_getter=_mock_ps,
+            pid_cpu_getter=_mock_cpu,
+        )
+        assert sample.aggregate_cpu_percent == 0.0
+
+    def test_negative_rss_handled(self):
+        ps_output = "  100  1  1  -500  00:01:00  codex-autorunner hub serve\n"
+
+        def _mock_ps():
+            return ps_output
+
+        def _mock_cpu(pids):
+            return {100: (1.0, 0.0)}
+
+        sample = collect_cpu_sample(
+            ps_output_getter=_mock_ps,
+            pid_cpu_getter=_mock_cpu,
+        )
+        assert len(sample.per_process) == 1
+
+    def test_very_long_command_truncated_by_split(self):
+        ps_output = (
+            "  100  1  1  50000  00:01:00  codex-autorunner hub serve "
+            + "x" * 500
+            + "\n"
+        )
+
+        def _mock_ps():
+            return ps_output
+
+        def _mock_cpu(pids):
+            return {100: (1.0, 48.828)}
+
+        sample = collect_cpu_sample(
+            ps_output_getter=_mock_ps,
+            pid_cpu_getter=_mock_cpu,
+        )
+        assert sample.aggregate_cpu_percent == 1.0

--- a/tests/unit/test_idle_cpu_profiles.py
+++ b/tests/unit/test_idle_cpu_profiles.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_PROFILES_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "idle_cpu_profiles.yml"
+)
+
+_REQUIRED_TOP_KEYS = {"version", "defaults", "profiles", "artifact_contract"}
+
+_REQUIRED_PROFILE_KEYS = {
+    "description",
+    "services",
+    "hard_budget",
+    "expected_owned_process_categories",
+}
+
+_REQUIRED_SERVICE_KEYS = {"command", "alias"}
+
+_REQUIRED_HEALTH_PROBE_KEYS = {"method", "path", "timeout_seconds", "retries"}
+
+_REQUIRED_ARTIFACT_CONTRACT_KEYS = {"directory", "filename_pattern", "schema"}
+
+_FIRST_CAMPAIGN_PROFILES_SET = {
+    "hub_only",
+    "hub_plus_discord",
+    "hub_plus_telegram",
+    "hub_with_idle_runtime",
+}
+
+_FIRST_CAMPAIGN_PROFILES = tuple(sorted(_FIRST_CAMPAIGN_PROFILES_SET))
+
+_HARD_BUDGET_KEYS = {"enabled"}
+
+_COMPARISON_BUDGET_KEYS = {"max_aggregate_cpu_percent"}
+
+
+def _load_profiles() -> dict:
+    return yaml.safe_load(_PROFILES_PATH.read_text(encoding="utf-8"))
+
+
+class TestIdleCpuProfilesFormat:
+    def test_file_exists(self):
+        assert _PROFILES_PATH.is_file(), f"Missing profile file: {_PROFILES_PATH}"
+
+    def test_valid_yaml(self):
+        data = _load_profiles()
+        assert isinstance(data, dict)
+
+    def test_top_level_keys(self):
+        data = _load_profiles()
+        missing = _REQUIRED_TOP_KEYS - set(data.keys())
+        assert not missing, f"Missing top-level keys: {missing}"
+
+    def test_version_is_integer(self):
+        data = _load_profiles()
+        assert isinstance(data["version"], int)
+
+    def test_defaults_has_required_keys(self):
+        data = _load_profiles()
+        defaults = data.get("defaults", {})
+        for key in ("warmup_seconds", "duration_seconds", "sample_interval_seconds"):
+            assert key in defaults, f"defaults missing key: {key}"
+            assert isinstance(
+                defaults[key], (int, float)
+            ), f"defaults.{key} must be numeric"
+
+    def test_defaults_health_probe(self):
+        data = _load_profiles()
+        probe = data.get("defaults", {}).get("health_probe", {})
+        missing = _REQUIRED_HEALTH_PROBE_KEYS - set(probe.keys())
+        assert not missing, f"health_probe missing keys: {missing}"
+
+    def test_defaults_owned_process_categories(self):
+        data = _load_profiles()
+        cats = data.get("defaults", {}).get("owned_process_categories", [])
+        assert isinstance(cats, list) and len(cats) > 0
+        for cat in cats:
+            assert isinstance(cat, str)
+
+
+class TestIdleCpuProfileDefinitions:
+    def test_all_first_campaign_profiles_present(self):
+        data = _load_profiles()
+        profiles = set(data.get("profiles", {}).keys())
+        missing = _FIRST_CAMPAIGN_PROFILES_SET - profiles
+        assert not missing, f"Missing profiles: {missing}"
+
+    @pytest.mark.parametrize("profile_name", _FIRST_CAMPAIGN_PROFILES)
+    def test_profile_has_required_keys(self, profile_name: str):
+        data = _load_profiles()
+        profile = data["profiles"][profile_name]
+        missing = _REQUIRED_PROFILE_KEYS - set(profile.keys())
+        assert not missing, f"{profile_name} missing keys: {missing}"
+
+    @pytest.mark.parametrize("profile_name", _FIRST_CAMPAIGN_PROFILES)
+    def test_profile_services_structure(self, profile_name: str):
+        data = _load_profiles()
+        services = data["profiles"][profile_name]["services"]
+        assert isinstance(services, list) and len(services) > 0
+        for svc in services:
+            missing = _REQUIRED_SERVICE_KEYS - set(svc.keys())
+            assert not missing, f"{profile_name} service missing keys: {missing}"
+
+    @pytest.mark.parametrize("profile_name", _FIRST_CAMPAIGN_PROFILES)
+    def test_profile_expected_categories_are_strings(self, profile_name: str):
+        data = _load_profiles()
+        cats = data["profiles"][profile_name]["expected_owned_process_categories"]
+        assert isinstance(cats, list)
+        for cat in cats:
+            assert isinstance(cat, str)
+
+    def test_hub_only_is_hard_budget(self):
+        data = _load_profiles()
+        hb = data["profiles"]["hub_only"]["hard_budget"]
+        assert hb["enabled"] is True
+        assert isinstance(hb["max_aggregate_cpu_percent"], (int, float))
+        assert hb["max_aggregate_cpu_percent"] <= 5.0
+
+    def test_comparison_profiles_are_not_hard_budget(self):
+        data = _load_profiles()
+        comparison_profiles = _FIRST_CAMPAIGN_PROFILES_SET - {"hub_only"}
+        for name in comparison_profiles:
+            hb = data["profiles"][name]["hard_budget"]
+            assert hb["enabled"] is False, f"{name} should not be a hard budget"
+
+
+class TestArtifactContract:
+    def test_artifact_directory_is_diagnostics_idle_cpu(self):
+        data = _load_profiles()
+        directory = data["artifact_contract"]["directory"]
+        assert directory == ".codex-autorunner/diagnostics/idle-cpu/"
+
+    def test_artifact_contract_has_required_keys(self):
+        data = _load_profiles()
+        contract = data["artifact_contract"]
+        missing = _REQUIRED_ARTIFACT_CONTRACT_KEYS - set(contract.keys())
+        assert not missing, f"artifact_contract missing keys: {missing}"
+
+    def test_artifact_schema_has_signoff(self):
+        data = _load_profiles()
+        schema = data["artifact_contract"]["schema"]
+        assert "signoff" in schema, "artifact schema must include signoff"
+        signoff = schema["signoff"]
+        for key in ("passed", "budget_type", "actual_aggregate_cpu_percent", "message"):
+            assert key in signoff, f"signoff missing key: {key}"
+
+    def test_artifact_schema_has_aggregate_metrics(self):
+        data = _load_profiles()
+        schema = data["artifact_contract"]["schema"]
+        assert "aggregate_metrics" in schema
+        metrics = schema["aggregate_metrics"]
+        for key in (
+            "car_owned_cpu_mean_percent",
+            "car_owned_cpu_max_percent",
+            "car_owned_cpu_p95_percent",
+            "car_owned_cpu_samples",
+        ):
+            assert key in metrics, f"aggregate_metrics missing key: {key}"
+
+    def test_artifact_schema_has_per_process_metrics(self):
+        data = _load_profiles()
+        schema = data["artifact_contract"]["schema"]
+        assert "per_process_metrics" in schema
+
+    def test_artifact_schema_has_health_probe_summary(self):
+        data = _load_profiles()
+        schema = data["artifact_contract"]["schema"]
+        assert "health_probe_summary" in schema
+
+    def test_artifact_schema_has_environment(self):
+        data = _load_profiles()
+        schema = data["artifact_contract"]["schema"]
+        assert "environment" in schema
+
+
+class TestMalformedProfileRejection:
+    def test_missing_profile_key_rejected(self, tmp_path: Path):
+        malformed = {
+            "version": 1,
+            "defaults": {},
+            "profiles": {
+                "bad_profile": {
+                    "services": [{"command": "car hub serve", "alias": "hub"}],
+                },
+            },
+            "artifact_contract": {},
+        }
+        path = tmp_path / "bad.yml"
+        path.write_text(yaml.safe_dump(malformed), encoding="utf-8")
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        profile = data["profiles"]["bad_profile"]
+        missing = _REQUIRED_PROFILE_KEYS - set(profile.keys())
+        assert missing, "Malformed profile should be missing required keys"
+
+    def test_empty_profiles_rejected(self):
+        data = _load_profiles()
+        profiles = data.get("profiles", {})
+        assert len(profiles) >= len(_FIRST_CAMPAIGN_PROFILES_SET)
+
+    def test_service_without_command_rejected(self, tmp_path: Path):
+        malformed = {
+            "version": 1,
+            "defaults": {},
+            "profiles": {
+                "no_cmd": {
+                    "description": "test",
+                    "services": [{"alias": "hub"}],
+                    "hard_budget": {"enabled": True},
+                    "expected_owned_process_categories": ["car_service"],
+                },
+            },
+            "artifact_contract": {},
+        }
+        path = tmp_path / "no_cmd.yml"
+        path.write_text(yaml.safe_dump(malformed), encoding="utf-8")
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for svc in data["profiles"]["no_cmd"]["services"]:
+            missing = _REQUIRED_SERVICE_KEYS - set(svc.keys())
+            assert missing, "Service without command should be rejected"

--- a/tests/unit/test_idle_cpu_soak.py
+++ b/tests/unit/test_idle_cpu_soak.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SOAK_SCRIPT = _REPO_ROOT / "scripts" / "idle_cpu_soak.py"
+
+
+class TestIdleCpuSoakArtifactSchema:
+    def test_artifact_has_required_keys(self):
+        from codex_autorunner.core.diagnostics.cpu_sampler import (
+            CpuSample,
+            aggregate_samples,
+            evaluate_signoff,
+        )
+
+        samples = [
+            CpuSample(
+                aggregate_cpu_percent=1.0,
+                aggregate_rss_mb=30.0,
+                per_process=[
+                    {
+                        "pid": 100,
+                        "command": "car hub serve",
+                        "category": "car_service",
+                        "cpu_percent": 1.0,
+                        "rss_mb": 30.0,
+                    }
+                ],
+            )
+        ]
+        agg = aggregate_samples(samples)
+        signoff = evaluate_signoff(
+            agg,
+            hard_budget={"enabled": True, "max_aggregate_cpu_percent": 5.0},
+        )
+
+        artifact: dict[str, Any] = {
+            "version": 1,
+            "profile": "hub_only",
+            "started_at": "2026-01-01T00:00:00Z",
+            "finished_at": "2026-01-01T00:05:00Z",
+            "environment": {
+                "hostname": "test",
+                "platform": "test",
+                "python_version": "3.11",
+                "car_version": "dev",
+                "car_git_ref": None,
+                "cpu_count": 8,
+                "total_memory_gb": 16.0,
+            },
+            "aggregate_metrics": agg,
+            "per_process_metrics": [],
+            "health_probe_summary": {
+                "total_probes": 10,
+                "successful_probes": 10,
+                "failed_probes": 0,
+                "last_probe_status": 200,
+            },
+            "signoff": signoff,
+        }
+
+        for key in (
+            "version",
+            "profile",
+            "started_at",
+            "finished_at",
+            "environment",
+            "aggregate_metrics",
+            "per_process_metrics",
+            "health_probe_summary",
+            "signoff",
+        ):
+            assert key in artifact, f"artifact missing key: {key}"
+
+        for key in (
+            "car_owned_cpu_mean_percent",
+            "car_owned_cpu_max_percent",
+            "car_owned_cpu_p95_percent",
+            "car_owned_cpu_samples",
+            "car_owned_memory_mean_mb",
+            "car_owned_memory_max_mb",
+        ):
+            assert (
+                key in artifact["aggregate_metrics"]
+            ), f"aggregate_metrics missing key: {key}"
+
+        for key in (
+            "passed",
+            "budget_type",
+            "actual_aggregate_cpu_percent",
+            "message",
+        ):
+            assert key in artifact["signoff"], f"signoff missing key: {key}"
+
+    def test_artifact_is_valid_json(self, tmp_path: Path):
+        from codex_autorunner.core.diagnostics.cpu_sampler import (
+            CpuSample,
+            aggregate_samples,
+            evaluate_signoff,
+        )
+
+        samples = [CpuSample(aggregate_cpu_percent=2.0, aggregate_rss_mb=40.0)]
+        agg = aggregate_samples(samples)
+        signoff = evaluate_signoff(agg)
+        artifact = {
+            "version": 1,
+            "profile": "test",
+            "aggregate_metrics": agg,
+            "signoff": signoff,
+        }
+        text = json.dumps(artifact, indent=2, sort_keys=True)
+        parsed = json.loads(text)
+        assert parsed["profile"] == "test"
+
+
+class TestIdleCpuSoakWriteArtifacts:
+    def test_writes_latest_and_history(self, tmp_path: Path):
+        artifact = {
+            "version": 1,
+            "profile": "hub_only",
+            "started_at": "20260101T000000Z",
+            "aggregate_metrics": {"car_owned_cpu_mean_percent": 1.0},
+            "signoff": {"passed": True},
+        }
+        artifact_dir = tmp_path / "diag" / "idle-cpu"
+
+        from codex_autorunner.core.utils import atomic_write
+
+        output_root = artifact_dir
+        output_root.mkdir(parents=True, exist_ok=True)
+        latest_path = output_root / "latest.json"
+        atomic_write(latest_path, json.dumps(artifact, indent=2, sort_keys=True) + "\n")
+
+        history_dir = output_root / "history"
+        history_dir.mkdir(parents=True, exist_ok=True)
+        history_path = history_dir / "20260101T000000Z-hub_only.json"
+        atomic_write(
+            history_path, json.dumps(artifact, indent=2, sort_keys=True) + "\n"
+        )
+
+        assert latest_path.exists()
+        assert history_path.exists()
+        loaded = json.loads(latest_path.read_text(encoding="utf-8"))
+        assert loaded["profile"] == "hub_only"
+        loaded_hist = json.loads(history_path.read_text(encoding="utf-8"))
+        assert loaded_hist["profile"] == "hub_only"
+
+
+class TestIdleCpuSoakProfileParsing:
+    def test_loads_hub_only_profile(self):
+        sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+        profiles_path = _REPO_ROOT / "scripts" / "idle_cpu_profiles.yml"
+        data = yaml.safe_load(profiles_path.read_text(encoding="utf-8"))
+        profile = data["profiles"]["hub_only"]
+        assert profile["hard_budget"]["enabled"] is True
+        assert "car hub serve" in profile["services"][0]["command"]
+
+    def test_loads_all_profiles(self):
+        profiles_path = _REPO_ROOT / "scripts" / "idle_cpu_profiles.yml"
+        data = yaml.safe_load(profiles_path.read_text(encoding="utf-8"))
+        profiles = data["profiles"]
+        for name in (
+            "hub_only",
+            "hub_plus_discord",
+            "hub_plus_telegram",
+            "hub_with_idle_runtime",
+        ):
+            assert name in profiles
+            assert "services" in profiles[name]
+            assert "hard_budget" in profiles[name]
+
+
+class TestIdleCpuSoakSignoffLogic:
+    def test_hard_budget_pass_at_threshold(self):
+        from codex_autorunner.core.diagnostics.cpu_sampler import evaluate_signoff
+
+        agg = {"car_owned_cpu_mean_percent": 5.0}
+        result = evaluate_signoff(
+            agg,
+            hard_budget={"enabled": True, "max_aggregate_cpu_percent": 5.0},
+        )
+        assert result["passed"] is True
+
+    def test_hard_budget_fail_above_threshold(self):
+        from codex_autorunner.core.diagnostics.cpu_sampler import evaluate_signoff
+
+        agg = {"car_owned_cpu_mean_percent": 5.001}
+        result = evaluate_signoff(
+            agg,
+            hard_budget={"enabled": True, "max_aggregate_cpu_percent": 5.0},
+        )
+        assert result["passed"] is False
+
+    def test_comparison_budget_is_not_hard_gate(self):
+        from codex_autorunner.core.diagnostics.cpu_sampler import evaluate_signoff
+
+        agg = {"car_owned_cpu_mean_percent": 99.0}
+        result = evaluate_signoff(
+            agg,
+            hard_budget={"enabled": False},
+            comparison_budget={"max_aggregate_cpu_percent": 8.0},
+        )
+        assert result["budget_type"] == "comparison"
+        assert result["passed"] is False
+
+
+class TestIdleCpuSoakIntegration:
+    @pytest.mark.integration
+    def test_smoke_soak_against_disposable_root(self, tmp_path: Path):
+        if not _SOAK_SCRIPT.exists():
+            pytest.skip("soak script not found")
+
+        artifact_dir = tmp_path / "artifacts"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_SOAK_SCRIPT),
+                "--profile",
+                "hub_only",
+                "--artifact-dir",
+                str(artifact_dir),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=600,
+            cwd=str(_REPO_ROOT),
+        )
+
+        latest = artifact_dir / "latest.json"
+        assert (
+            latest.exists()
+        ), f"latest.json not found. stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+        artifact = json.loads(latest.read_text(encoding="utf-8"))
+        assert artifact["profile"] == "hub_only"
+        assert "aggregate_metrics" in artifact
+        assert "signoff" in artifact
+        assert artifact["version"] == 1
+
+        agg = artifact["aggregate_metrics"]
+        assert agg["car_owned_cpu_samples"] > 0
+        assert agg["car_owned_cpu_mean_percent"] >= 0.0
+
+        history_dir = artifact_dir / "history"
+        assert history_dir.exists()
+        history_files = list(history_dir.glob("*.json"))
+        assert len(history_files) >= 1


### PR DESCRIPTION
## Summary

This optimization branch dogfoods CAR against itself to reduce baseline always-on service overhead and add the tooling needed to keep tuning it.

The branch adds:

- an idle CPU soak harness, benchmark profiles, and validation docs
- reusable CPU sampling and loop wakeup attribution utilities
- polling and cadence reductions across PMA, Discord watchers, web reconciliation, hub lifecycle, Telegram cleanup, and related background services
- coverage for the new diagnostics and idle-path behavior

## Review fixes

During review I found and fixed three regressions in the optimization work:

- Discord flow watcher backoff was treating bound workspaces as productive even when no notifications were emitted, which prevented the idle backoff from engaging
- PMA queue idle backoff could delay cross-process work pickup too long, so the queue now keeps a constant low-latency poll interval while still skipping unnecessary refresh work when the mirror file mtime is unchanged
- hub lifecycle processing did not treat lifecycle-event backlog as productive work, which could let the worker back off while there was still a queue to drain

## Validation

- `./.venv/bin/python -m pytest tests/core/test_hub_lifecycle.py tests/core/test_idle_polling_reduction.py tests/integrations/discord/test_flow_watchers_idle.py -q`
- `./.venv/bin/python -m pytest tests/integrations/chat/test_queue_control.py tests/test_telegram_cache_cleanup.py tests/core/flows/test_reconciler_idle.py -q`
- full pre-commit / repo validation lane via `git commit`
  - `5867 passed, 9 xfailed in 113.96s`

## Notes

- One Discord routing test failed once during the first aggregate hook attempt, passed immediately in isolation, and the full validation lane passed on retry. I did not identify a deterministic failure in the optimization changes from that flake.
- Diff against `main`: 30 files changed, 3688 insertions, 132 deletions.
