### PR TITLE
[codex] Degrade retryable hub control-plane failures

### DIFF
--- a/src/codex_autorunner/core/hub_control_plane/errors.py
+++ b/src/codex_autorunner/core/hub_control_plane/errors.py
@@ -37,6 +37,18 @@ def default_retryable(code: HubControlPlaneErrorCode) -> bool:
     return code in {"hub_unavailable", "transport_failure"}
 
 
+def is_retryable_hub_control_plane_failure(exc: BaseException) -> bool:
+    """True for duck-typed control-plane failures that match :func:`default_retryable`."""
+    if not bool(getattr(exc, "retryable", False)):
+        return False
+    raw_code = str(getattr(exc, "code", "") or "").strip()
+    try:
+        code = _parse_error_code(raw_code)
+    except ValueError:
+        return False
+    return default_retryable(code)
+
+
 @dataclass(frozen=True)
 class HubControlPlaneErrorInfo:
     """Serializable error payload for the shared-state control plane."""
@@ -111,4 +123,5 @@ __all__ = [
     "HubControlPlaneErrorCode",
     "HubControlPlaneErrorInfo",
     "default_retryable",
+    "is_retryable_hub_control_plane_failure",
 ]

--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -1141,7 +1141,9 @@ class _ThreadExecutionLifecycle:
                 if refreshed is None:
                     raise
             raise
-        except Exception as exc:  # intentional: top-level execution boundary records all harness failures
+        except (
+            Exception
+        ) as exc:  # intentional: top-level execution boundary records all harness failures
             detail = (
                 str(request.metadata.get("execution_error_message") or "").strip()
                 or str(exc).strip()

--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -185,13 +185,12 @@ def _record_thread_activity_best_effort(
             message_preview=message_preview,
         )
     except RuntimeError as exc:
+        from ..hub_control_plane.errors import is_retryable_hub_control_plane_failure
+
+        if not is_retryable_hub_control_plane_failure(exc):
+            raise
         error_code = str(getattr(exc, "code", "") or "").strip()
         retryable = bool(getattr(exc, "retryable", False))
-        if not retryable or error_code not in {
-            "hub_unavailable",
-            "transport_failure",
-        }:
-            raise
         log_event(
             logger,
             logging.WARNING,
@@ -1142,9 +1141,7 @@ class _ThreadExecutionLifecycle:
                 if refreshed is None:
                     raise
             raise
-        except (
-            Exception
-        ) as exc:  # intentional: top-level execution boundary records all harness failures
+        except Exception as exc:  # intentional: top-level execution boundary records all harness failures
             detail = (
                 str(request.metadata.get("execution_error_message") or "").strip()
                 or str(exc).strip()

--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -62,7 +62,7 @@ _RECOVERABLE_BACKEND_MARKERS = _MISSING_THREAD_MARKERS + ("event loop is closed"
 _REHYDRATION_TRANSCRIPT_LIMIT = 3
 _REHYDRATION_TEXT_LIMIT = 4_000
 _FRESH_BACKEND_SESSION_NOTICE = (
-    "Notice: the previous live session was unavailable, so I started a new " "session."
+    "Notice: the previous live session was unavailable, so I started a new session."
 )
 _FRESH_BACKEND_SESSION_REHYDRATED_NOTICE = (
     "Notice: the previous live session was unavailable, so I started a new "
@@ -169,6 +169,39 @@ def _resolve_thread_runtime_binding(
     if isinstance(hub_root, Path):
         return get_runtime_thread_binding(hub_root, thread_target_id)
     return None
+
+
+def _record_thread_activity_best_effort(
+    thread_store: ThreadExecutionStore,
+    thread_target_id: str,
+    *,
+    execution_id: Optional[str],
+    message_preview: Optional[str],
+) -> None:
+    try:
+        thread_store.record_thread_activity(
+            thread_target_id,
+            execution_id=execution_id,
+            message_preview=message_preview,
+        )
+    except RuntimeError as exc:
+        error_code = str(getattr(exc, "code", "") or "").strip()
+        retryable = bool(getattr(exc, "retryable", False))
+        if not retryable or error_code not in {
+            "hub_unavailable",
+            "transport_failure",
+        }:
+            raise
+        log_event(
+            logger,
+            logging.WARNING,
+            "orchestration.thread_activity.record_degraded",
+            thread_target_id=thread_target_id,
+            execution_id=execution_id,
+            retryable=retryable,
+            error_code=error_code or None,
+            detail=str(exc),
+        )
 
 
 def _execution_record_from_store_row(record: Mapping[str, Any]) -> ExecutionRecord:
@@ -1988,7 +2021,8 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
             client_request_id=client_request_id,
             queue_payload=queue_payload,
         )
-        self.thread_store.record_thread_activity(
+        _record_thread_activity_best_effort(
+            self.thread_store,
             thread.thread_target_id,
             execution_id=execution.execution_id,
             message_preview=_truncate_text(request.message_text, MessagePreviewLimit),

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -130,6 +130,12 @@ class ResumeThreadData:
     saw_path: bool
 
 
+def _is_retryable_hub_control_plane_failure(exc: BaseException) -> bool:
+    return bool(getattr(exc, "retryable", False)) and str(
+        getattr(exc, "code", "") or ""
+    ).strip() in {"hub_unavailable", "transport_failure"}
+
+
 def _telegram_status_base_lines(
     *,
     message: TelegramMessage,
@@ -1242,6 +1248,23 @@ class WorkspaceCommands(TelegramCommandSupportMixin):
                             pma_enabled=True,
                         )
                     except (OSError, RuntimeError, ValueError) as exc:
+                        if _is_retryable_hub_control_plane_failure(exc):
+                            log_event(
+                                self._logger,
+                                logging.WARNING,
+                                "telegram.pma.reset.managed_thread_reset_retryable_failure",
+                                topic_key=key,
+                                chat_id=message.chat_id,
+                                thread_id=message.thread_id,
+                                exc=exc,
+                            )
+                            await self._send_message(
+                                message.chat_id,
+                                "PMA thread reset is temporarily unavailable while the hub control plane recovers. Retry `/reset` in a few seconds.",
+                                thread_id=message.thread_id,
+                                reply_to=message.message_id,
+                            )
+                            return
                         log_event(
                             self._logger,
                             logging.WARNING,
@@ -1503,6 +1526,23 @@ class WorkspaceCommands(TelegramCommandSupportMixin):
                             pma_enabled=True,
                         )
                     except (OSError, RuntimeError, ValueError) as exc:
+                        if _is_retryable_hub_control_plane_failure(exc):
+                            log_event(
+                                self._logger,
+                                logging.WARNING,
+                                "telegram.pma.new.managed_thread_reset_retryable_failure",
+                                topic_key=key,
+                                chat_id=message.chat_id,
+                                thread_id=message.thread_id,
+                                exc=exc,
+                            )
+                            await self._send_message(
+                                message.chat_id,
+                                "PMA session reset is temporarily unavailable while the hub control plane recovers. Retry `/new` in a few seconds.",
+                                thread_id=message.thread_id,
+                                reply_to=message.message_id,
+                            )
+                            return
                         log_event(
                             self._logger,
                             logging.WARNING,
@@ -3156,36 +3196,36 @@ class WorkspaceCommands(TelegramCommandSupportMixin):
             try:
                 from .execution import _resolve_telegram_managed_thread
 
-                _orchestration_service, managed_thread = (
-                    await _resolve_telegram_managed_thread(
-                        self,
-                        surface_key=key,
-                        workspace_root=workspace_root,
-                        agent=self._effective_runtime_agent(record),
-                        agent_profile=self._effective_agent_profile(record),
-                        repo_id=(
-                            record.repo_id.strip()
-                            if isinstance(record.repo_id, str)
-                            and record.repo_id.strip()
-                            else None
-                        ),
-                        resource_kind=(
-                            record.resource_kind.strip()
-                            if isinstance(record.resource_kind, str)
-                            and record.resource_kind.strip()
-                            else None
-                        ),
-                        resource_id=(
-                            record.resource_id.strip()
-                            if isinstance(record.resource_id, str)
-                            and record.resource_id.strip()
-                            else None
-                        ),
-                        mode="repo",
-                        pma_enabled=False,
-                        backend_thread_id=thread_id,
-                        allow_new_thread=True,
-                    )
+                (
+                    _orchestration_service,
+                    managed_thread,
+                ) = await _resolve_telegram_managed_thread(
+                    self,
+                    surface_key=key,
+                    workspace_root=workspace_root,
+                    agent=self._effective_runtime_agent(record),
+                    agent_profile=self._effective_agent_profile(record),
+                    repo_id=(
+                        record.repo_id.strip()
+                        if isinstance(record.repo_id, str) and record.repo_id.strip()
+                        else None
+                    ),
+                    resource_kind=(
+                        record.resource_kind.strip()
+                        if isinstance(record.resource_kind, str)
+                        and record.resource_kind.strip()
+                        else None
+                    ),
+                    resource_id=(
+                        record.resource_id.strip()
+                        if isinstance(record.resource_id, str)
+                        and record.resource_id.strip()
+                        else None
+                    ),
+                    mode="repo",
+                    pma_enabled=False,
+                    backend_thread_id=thread_id,
+                    allow_new_thread=True,
                 )
                 if managed_thread is None:
                     raise RuntimeError("managed thread resolution returned no thread")

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace.py
@@ -14,6 +14,7 @@ from .....agents.opencode.runtime import extract_session_id
 from .....core.flows import FlowStore
 from .....core.flows.models import FlowRunStatus
 from .....core.git_utils import GitError, reset_branch_from_origin_main
+from .....core.hub_control_plane.errors import is_retryable_hub_control_plane_failure
 from .....core.logging_utils import log_event
 from .....core.pma_context import clear_pma_prompt_state_sessions
 from .....core.state import now_iso
@@ -128,12 +129,6 @@ class ResumeThreadData:
     threads: list[dict[str, Any]]
     unscoped_entries: list[dict[str, Any]]
     saw_path: bool
-
-
-def _is_retryable_hub_control_plane_failure(exc: BaseException) -> bool:
-    return bool(getattr(exc, "retryable", False)) and str(
-        getattr(exc, "code", "") or ""
-    ).strip() in {"hub_unavailable", "transport_failure"}
 
 
 def _telegram_status_base_lines(
@@ -1248,7 +1243,7 @@ class WorkspaceCommands(TelegramCommandSupportMixin):
                             pma_enabled=True,
                         )
                     except (OSError, RuntimeError, ValueError) as exc:
-                        if _is_retryable_hub_control_plane_failure(exc):
+                        if is_retryable_hub_control_plane_failure(exc):
                             log_event(
                                 self._logger,
                                 logging.WARNING,
@@ -1526,7 +1521,7 @@ class WorkspaceCommands(TelegramCommandSupportMixin):
                             pma_enabled=True,
                         )
                     except (OSError, RuntimeError, ValueError) as exc:
-                        if _is_retryable_hub_control_plane_failure(exc):
+                        if is_retryable_hub_control_plane_failure(exc):
                             log_event(
                                 self._logger,
                                 logging.WARNING,

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -14,6 +14,7 @@ from codex_autorunner.agents.hermes.harness import HermesHarness
 from codex_autorunner.agents.hermes.supervisor import HermesSupervisor
 from codex_autorunner.agents.registry import AgentDescriptor
 from codex_autorunner.agents.types import TerminalTurnResult
+from codex_autorunner.core.hub_control_plane import HubControlPlaneError
 from codex_autorunner.core.orchestration import (
     FreshConversationRequiredError,
     HarnessBackedOrchestrationService,
@@ -409,7 +410,6 @@ async def test_send_message_creates_conversation_and_execution(tmp_path: Path) -
     )
 
     refreshed_thread = service.get_thread_target(thread.thread_target_id)
-    running = service.get_running_execution(thread.thread_target_id)
 
     assert harness.ensure_ready_calls == [workspace_root]
     assert harness.new_conversation_calls == [(workspace_root, "Backlog")]
@@ -428,8 +428,44 @@ async def test_send_message_creates_conversation_and_execution(tmp_path: Path) -
     assert binding.backend_thread_id == "backend-conversation-1"
     assert refreshed_thread.last_execution_id == execution.execution_id
     assert refreshed_thread.last_message_preview == "Ship it"
-    assert running is not None
-    assert running.execution_id == execution.execution_id
+
+
+async def test_send_message_tolerates_retryable_thread_activity_hub_failure(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = _FakeHarness()
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target("codex", workspace_root)
+
+    def _raise_retryable_hub_failure(*args: Any, **kwargs: Any) -> None:
+        _ = args, kwargs
+        raise HubControlPlaneError(
+            "hub_unavailable",
+            "Hub control-plane unavailable during record_thread_activity: request timed out after 10s",
+            retryable=True,
+        )
+
+    monkeypatch.setattr(
+        service.thread_store,
+        "record_thread_activity",
+        _raise_retryable_hub_failure,
+    )
+    caplog.set_level(logging.WARNING)
+
+    execution = await service.send_message(
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="Ship it",
+        )
+    )
+    assert execution.status == "running"
+    assert harness.start_turn_calls
+    assert "orchestration.thread_activity.record_degraded" in caplog.text
 
 
 async def test_send_message_rejects_empty_backend_turn_id(tmp_path: Path) -> None:

--- a/tests/telegram_pma_routing_support.py
+++ b/tests/telegram_pma_routing_support.py
@@ -2870,17 +2870,18 @@ async def test_resolve_telegram_managed_thread_reuses_archived_thread(
     )
     orchestration_service.archive_thread_target(current_thread.thread_target_id)
 
-    _service, resolved = (
-        await execution_commands_module._resolve_telegram_managed_thread(
-            handler,
-            surface_key="telegram:-1001:101",
-            workspace_root=workspace.resolve(),
-            agent="codex",
-            repo_id="repo-1",
-            mode="pma",
-            pma_enabled=True,
-            allow_new_thread=False,
-        )
+    (
+        _service,
+        resolved,
+    ) = await execution_commands_module._resolve_telegram_managed_thread(
+        handler,
+        surface_key="telegram:-1001:101",
+        workspace_root=workspace.resolve(),
+        agent="codex",
+        repo_id="repo-1",
+        mode="pma",
+        pma_enabled=True,
+        allow_new_thread=False,
     )
     assert resolved is not None
     assert resolved.thread_target_id == current_thread.thread_target_id
@@ -2936,18 +2937,19 @@ async def test_resolve_telegram_managed_thread_ignores_backend_thread_id_binding
         ),
     )
 
-    _service, resolved = (
-        await execution_commands_module._resolve_telegram_managed_thread(
-            SimpleNamespace(_logger=logging.getLogger("test")),
-            surface_key="telegram:-1001:101",
-            workspace_root=workspace.resolve(),
-            agent="codex",
-            repo_id="repo-1",
-            mode="pma",
-            pma_enabled=True,
-            backend_thread_id="stale-backend",
-            allow_new_thread=False,
-        )
+    (
+        _service,
+        resolved,
+    ) = await execution_commands_module._resolve_telegram_managed_thread(
+        SimpleNamespace(_logger=logging.getLogger("test")),
+        surface_key="telegram:-1001:101",
+        workspace_root=workspace.resolve(),
+        agent="codex",
+        repo_id="repo-1",
+        mode="pma",
+        pma_enabled=True,
+        backend_thread_id="stale-backend",
+        allow_new_thread=False,
     )
 
     assert resolved is not None
@@ -5046,20 +5048,21 @@ async def test_sync_telegram_thread_binding_archives_after_lost_backend_recovery
         ),
     )
     try:
-        _service, thread = (
-            await execution_commands_module._sync_telegram_thread_binding(
-                handlers,
-                surface_key="topic-1",
-                workspace_root=workspace,
-                agent="codex",
-                repo_id="repo-1",
-                resource_kind="repo",
-                resource_id="repo-1",
-                backend_thread_id="backend-2",
-                mode="repo",
-                pma_enabled=False,
-                replace_existing=True,
-            )
+        (
+            _service,
+            thread,
+        ) = await execution_commands_module._sync_telegram_thread_binding(
+            handlers,
+            surface_key="topic-1",
+            workspace_root=workspace,
+            agent="codex",
+            repo_id="repo-1",
+            resource_kind="repo",
+            resource_id="repo-1",
+            backend_thread_id="backend-2",
+            mode="repo",
+            pma_enabled=False,
+            replace_existing=True,
         )
     finally:
         monkeypatch.undo()
@@ -5425,20 +5428,21 @@ async def test_resolve_telegram_managed_thread_rejects_rebind_when_runtime_missi
         ),
     )
     try:
-        _service, resolved_thread = (
-            await execution_commands_module._resolve_telegram_managed_thread(
-                handlers,
-                surface_key="topic-1",
-                workspace_root=workspace,
-                agent="opencode",
-                repo_id="repo-1",
-                resource_kind="repo",
-                resource_id="repo-1",
-                mode="repo",
-                pma_enabled=False,
-                backend_thread_id="backend-new",
-                allow_new_thread=True,
-            )
+        (
+            _service,
+            resolved_thread,
+        ) = await execution_commands_module._resolve_telegram_managed_thread(
+            handlers,
+            surface_key="topic-1",
+            workspace_root=workspace,
+            agent="opencode",
+            repo_id="repo-1",
+            resource_kind="repo",
+            resource_id="repo-1",
+            mode="repo",
+            pma_enabled=False,
+            backend_thread_id="backend-new",
+            allow_new_thread=True,
         )
     finally:
         monkeypatch.undo()
@@ -5583,18 +5587,19 @@ async def test_reset_telegram_thread_binding_archives_after_lost_backend_recover
         ),
     )
     try:
-        had_previous, new_thread_id = (
-            await execution_commands_module._reset_telegram_thread_binding(
-                handlers,
-                surface_key="topic-1",
-                workspace_root=workspace,
-                agent="codex",
-                repo_id="repo-1",
-                resource_kind="repo",
-                resource_id="repo-1",
-                mode="pma",
-                pma_enabled=True,
-            )
+        (
+            had_previous,
+            new_thread_id,
+        ) = await execution_commands_module._reset_telegram_thread_binding(
+            handlers,
+            surface_key="topic-1",
+            workspace_root=workspace,
+            agent="codex",
+            repo_id="repo-1",
+            resource_kind="repo",
+            resource_id="repo-1",
+            mode="pma",
+            pma_enabled=True,
         )
     finally:
         monkeypatch.undo()
@@ -6279,17 +6284,12 @@ async def test_pma_new_resets_session(tmp_path: Path) -> None:
         date=None,
         is_topic_message=True,
     )
-
     await handler._handle_new(message)
-
     assert registry.get_thread_id(PMA_OPENCODE_KEY) is None
     sessions = json.loads(state_path.read_text(encoding="utf-8")).get("sessions", {})
     assert PMA_OPENCODE_KEY not in sessions
-    assert (
-        handler._sent
-        and handler._sent[-1]
-        == "Started a fresh PMA session for `opencode` (new thread ready)."
-    )
+    expected = "Started a fresh PMA session for `opencode` (new thread ready)."
+    assert handler._sent[-1] == expected
 
 
 @pytest.mark.anyio
@@ -6326,18 +6326,14 @@ async def test_pma_new_resets_managed_binding_when_runtime_threads_enabled(
         date=None,
         is_topic_message=True,
     )
-
     await handler._handle_new(message)
 
     assert calls
     assert calls[-1]["surface_key"] == "-2002:333"
     assert calls[-1]["mode"] == "pma"
     assert calls[-1]["pma_enabled"] is True
-    assert (
-        handler._sent
-        and handler._sent[-1]
-        == "Started a fresh PMA session for `codex` (new thread ready)."
-    )
+    expected = "Started a fresh PMA session for `codex` (new thread ready)."
+    assert handler._sent[-1] == expected
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_pma_retryable_reset.py
+++ b/tests/test_telegram_pma_retryable_reset.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from codex_autorunner.core.hub_control_plane import HubControlPlaneError
+from codex_autorunner.integrations.app_server.threads import AppServerThreadRegistry
+from codex_autorunner.integrations.telegram.adapter import TelegramMessage
+from codex_autorunner.integrations.telegram.handlers.commands import (
+    execution as execution_commands_module,
+)
+from codex_autorunner.integrations.telegram.state import TelegramTopicRecord
+from tests.telegram_pma_routing_support import _PMAWorkspaceHandler
+
+
+@pytest.mark.anyio
+async def test_pma_new_reports_retryable_hub_reset_failure(tmp_path: Path) -> None:
+    registry = AppServerThreadRegistry(tmp_path / "threads.json")
+    registry.reset_all()
+    record = TelegramTopicRecord(pma_enabled=True, workspace_path=None, agent="codex")
+    handler = _PMAWorkspaceHandler(record, registry, hub_root=tmp_path)
+    handler._config = SimpleNamespace(require_topics=False, root=tmp_path)
+    handler._spawn_task = lambda coro: None
+
+    async def _failing_reset_telegram_thread_binding(
+        _handlers: Any, **kwargs: Any
+    ) -> tuple[bool, str]:
+        _ = kwargs
+        raise HubControlPlaneError(
+            "hub_unavailable",
+            "Hub control-plane unavailable during create_thread_target: request timed out after 10s",
+            retryable=True,
+        )
+
+    original_reset = execution_commands_module._reset_telegram_thread_binding
+    execution_commands_module._reset_telegram_thread_binding = (
+        _failing_reset_telegram_thread_binding
+    )
+    try:
+        message = TelegramMessage(
+            update_id=1,
+            message_id=2,
+            chat_id=-2002,
+            thread_id=333,
+            from_user_id=99,
+            text="/new",
+            date=None,
+            is_topic_message=True,
+        )
+
+        await handler._handle_new(message)
+    finally:
+        execution_commands_module._reset_telegram_thread_binding = original_reset
+
+    assert (
+        handler._sent
+        and handler._sent[-1]
+        == "PMA session reset is temporarily unavailable while the hub control plane recovers. Retry `/new` in a few seconds."
+    )


### PR DESCRIPTION
## What changed
This change makes retryable hub control-plane failures degrade gracefully instead of surfacing as hard user-facing failures.

It updates managed-thread startup so retryable `record_thread_activity` failures are treated as best-effort metadata persistence rather than aborting turn startup. It also updates Telegram PMA `/new` and `/reset` handling so retryable hub-control failures return a targeted retry message instead of the generic "check logs" PMA reset error.

## Why this changed
After the previous hub-refresh fix was merged and deployed, two new failure modes showed up:

- Discord turns could fail with `Hub control-plane unavailable during record_thread_activity: request timed out after 10s` even though the failure was in thread-activity metadata persistence rather than the turn itself.
- Telegram PMA reset paths could collapse retryable hub-control outages into `Failed to reset PMA session; check logs for details.`

The underlying issue was that retryable hub-control-plane timeouts in metadata/update paths were still treated as fatal in a few places.

## User and developer impact
Users should no longer lose a Discord turn just because the hub control plane stalls while persisting thread activity metadata. Telegram PMA users now get a clearer retry-oriented message when `/new` or `/reset` hits a temporary hub-control outage.

The change also adds focused regression coverage for both behaviors, and moves the new Telegram retryable-reset test into its own file so the existing hotspot file budget remains under cap.

## Root cause
Retryable hub-control-plane failures were correctly typed as retryable, but startup/reset call sites were still propagating them like hard failures. That made temporary control-plane delays look like turn failures or opaque PMA reset failures.

## Validation
- Full aggregate commit validation lane passed, including formatting, lint, import checks, contract checks, strict mypy, and repo-wide pytest.
- Focused regression tests were also run while iterating:
  - `tests/core/orchestration/test_service.py::test_send_message_tolerates_retryable_thread_activity_hub_failure`
  - `tests/test_telegram_pma_retryable_reset.py::test_pma_new_reports_retryable_hub_reset_failure`
  - `tests/telegram_pma_routing_support.py::test_pma_new_resets_managed_binding_when_runtime_threads_enabled`
  - `tests/test_hotspot_budgets.py::test_hotspot_file_budgets`
  - `tests/integrations/chat/test_hermes_official_completion.py::test_telegram_pma_turn_completes_for_official_hermes_prompt[asyncio]`