### PR TITLE
Stabilize hub control-plane PMA and reset flows

### DIFF
--- a/src/codex_autorunner/core/chat_bindings.py
+++ b/src/codex_autorunner/core/chat_bindings.py
@@ -92,10 +92,12 @@ def _resolve_manifest_path(hub_root: Path, raw_config: Mapping[str, Any]) -> Pat
 def _chat_binding_counts_fingerprint(
     *, hub_root: Path, raw_config: Mapping[str, Any]
 ) -> tuple[Any, ...]:
+    orchestration_db_path = resolve_orchestration_sqlite_path(hub_root)
     return (
         path_stat_fingerprint(_resolve_manifest_path(hub_root, raw_config)),
         path_stat_fingerprint(default_pma_threads_db_path(hub_root)),
-        path_stat_fingerprint(resolve_orchestration_sqlite_path(hub_root)),
+        path_stat_fingerprint(orchestration_db_path),
+        path_stat_fingerprint(Path(f"{orchestration_db_path}-wal")),
         _chat_surface_enabled(raw_config, "discord_bot"),
         path_stat_fingerprint(_resolve_discord_state_path(hub_root, raw_config)),
         _chat_surface_enabled(raw_config, "telegram_bot"),
@@ -630,39 +632,19 @@ def _active_pma_thread_counts(
     db_path = default_pma_threads_db_path(hub_root)
     if not db_path.exists():
         return {}
-    store = PmaThreadStore(hub_root)
-    raw_counts = store.count_threads_by_repo(status="active")
     counts: Counter[str] = Counter()
-    for raw_repo_id, raw_count in raw_counts.items():
-        repo_id = _normalize_repo_id(raw_repo_id)
-        if repo_id is None:
-            continue
-        count = _coerce_count(raw_count)
-        if count <= 0:
-            continue
-        counts[repo_id] += count
     try:
-        with open_sqlite(db_path) as conn:
-            rows = conn.execute(
-                """
-                SELECT workspace_root
-                  FROM pma_managed_threads
-                 WHERE status = 'active'
-                   AND (repo_id IS NULL OR TRIM(repo_id) = '')
-                """
-            ).fetchall()
-    except sqlite3.OperationalError as exc:
-        if "no such table" in str(exc).lower():
-            return dict(counts)
+        rows = PmaThreadStore(hub_root).list_threads(status="active", limit=None)
+    except (OSError, RuntimeError, ValueError, sqlite3.OperationalError) as exc:
         raise RuntimeError(
-            f"Failed reading chat bindings from {db_path}: {exc}"
+            f"Failed reading active PMA thread counts from {db_path}: {exc}"
         ) from exc
 
     for row in rows:
         repo_id = _resolve_bound_repo_id(
-            repo_id=None,
+            repo_id=row.get("repo_id"),
             repo_id_by_workspace=repo_id_by_workspace,
-            workspace_values=(row["workspace_root"],),
+            workspace_values=(row.get("workspace_root"),),
         )
         if repo_id is None:
             continue

--- a/src/codex_autorunner/core/git_utils.py
+++ b/src/codex_autorunner/core/git_utils.py
@@ -3,9 +3,11 @@ Centralized Git utilities for consistent git operations across the codebase.
 """
 
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Iterator, List, Optional
 
+from .locks import file_lock
 from .utils import subprocess_env
 
 
@@ -59,6 +61,33 @@ def run_git(
         raise GitError(f"git {args[0]} failed: {detail}", returncode=proc.returncode)
 
     return proc
+
+
+def git_mutation_lock_path(repo_root: Path) -> Path:
+    git_path = repo_root.resolve() / ".git"
+    if git_path.is_dir():
+        return git_path / "codex-autorunner-git-mutation.lock"
+    try:
+        raw = git_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return git_path / "codex-autorunner-git-mutation.lock"
+    if not raw.lower().startswith("gitdir:"):
+        return git_path / "codex-autorunner-git-mutation.lock"
+    git_dir = Path(raw.split(":", 1)[1].strip())
+    if not git_dir.is_absolute():
+        git_dir = (repo_root.resolve() / git_dir).resolve()
+    common_git_dir = (
+        git_dir.parent.parent.resolve()
+        if git_dir.parent.name == "worktrees"
+        else git_dir.resolve()
+    )
+    return common_git_dir / "codex-autorunner-git-mutation.lock"
+
+
+@contextmanager
+def git_mutation_lock(repo_root: Path) -> Iterator[None]:
+    with file_lock(git_mutation_lock_path(repo_root)):
+        yield
 
 
 def git_failure_detail(proc: Any) -> str:
@@ -329,27 +358,33 @@ def reset_branch_from_origin_main(repo_root: Path, branch_name: str) -> str:
     if not branch:
         raise GitError("branch name cannot be empty", returncode=2)
 
-    status = run_git(
-        ["status", "--porcelain"], repo_root, timeout_seconds=30, check=True
-    )
-    if (status.stdout or "").strip():
-        raise GitError(
-            "working tree has uncommitted changes; commit or stash before /newt",
-            returncode=1,
+    with git_mutation_lock(repo_root):
+        status = run_git(
+            ["status", "--porcelain"], repo_root, timeout_seconds=30, check=True
+        )
+        if (status.stdout or "").strip():
+            raise GitError(
+                "working tree has uncommitted changes; commit or stash before /newt",
+                returncode=1,
+            )
+
+        run_git(
+            ["fetch", "--prune", "origin"],
+            repo_root,
+            timeout_seconds=120,
+            check=True,
         )
 
-    run_git(["fetch", "--prune", "origin"], repo_root, timeout_seconds=120, check=True)
+        default_branch = git_default_branch(repo_root)
+        if not default_branch:
+            raise GitError("unable to resolve origin default branch", returncode=1)
 
-    default_branch = git_default_branch(repo_root)
-    if not default_branch:
-        raise GitError("unable to resolve origin default branch", returncode=1)
-
-    run_git(
-        ["checkout", "-B", branch, f"origin/{default_branch}"],
-        repo_root,
-        timeout_seconds=60,
-        check=True,
-    )
+        run_git(
+            ["checkout", "-B", branch, f"origin/{default_branch}"],
+            repo_root,
+            timeout_seconds=60,
+            check=True,
+        )
     return default_branch
 
 

--- a/src/codex_autorunner/core/git_utils.py
+++ b/src/codex_autorunner/core/git_utils.py
@@ -153,52 +153,6 @@ def git_is_clean(repo_root: Path) -> bool:
     return not bool((proc.stdout or "").strip())
 
 
-def git_ls_files(repo_root: Path) -> List[str]:
-    """
-    List all tracked files in the repository.
-
-    Returns:
-        List of relative file paths
-    """
-    try:
-        proc = subprocess.run(
-            ["git", "ls-files", "-z"],
-            cwd=str(repo_root),
-            capture_output=True,
-            env=subprocess_env(),
-        )
-    except FileNotFoundError:
-        return []
-    if proc.returncode != 0:
-        return []
-    paths = [p for p in proc.stdout.split(b"\x00") if p]
-    decoded: List[str] = []
-    for p in paths:
-        try:
-            decoded.append(p.decode("utf-8"))
-        except UnicodeDecodeError:
-            decoded.append(p.decode("utf-8", errors="replace"))
-    return decoded
-
-
-def git_diff_name_status(
-    repo_root: Path, from_ref: str, to_ref: str = "HEAD"
-) -> Optional[str]:
-    """
-    Get diff --name-status output between two refs.
-
-    Returns:
-        The diff output as a string, or None on error
-    """
-    try:
-        proc = run_git(["diff", "--name-status", f"{from_ref}..{to_ref}"], repo_root)
-    except GitError:
-        return None
-    if proc.returncode != 0:
-        return None
-    return (proc.stdout or "").strip()
-
-
 def git_status_porcelain(repo_root: Path) -> Optional[str]:
     """
     Get status --porcelain output.

--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -37,6 +37,7 @@ from .git_utils import (
     git_failure_detail,
     git_head_sha,
     git_is_clean,
+    git_mutation_lock,
     git_upstream_status,
     resolve_ref_sha,
     run_git,
@@ -717,47 +718,48 @@ class HubSupervisor:
         if not git_is_clean(repo_root):
             raise ValueError("Repo has uncommitted changes; commit or stash first")
 
-        try:
-            proc = run_git(
-                ["fetch", "--prune", "origin"],
-                repo_root,
-                check=False,
-                timeout_seconds=_GIT_FETCH_TIMEOUT_SECONDS,
-            )
-        except GitError as exc:
-            raise ValueError(f"git fetch failed: {exc}") from exc
-        if proc.returncode != 0:
-            raise ValueError(f"git fetch failed: {git_failure_detail(proc)}")
-
-        default_branch = git_default_branch(repo_root)
-        if not default_branch:
-            raise ValueError("Unable to resolve origin default branch")
-
-        try:
-            proc = run_git(["checkout", default_branch], repo_root, check=False)
-        except GitError as exc:
-            raise ValueError(f"git checkout failed: {exc}") from exc
-        if proc.returncode != 0:
+        with git_mutation_lock(repo_root):
             try:
                 proc = run_git(
-                    ["checkout", "-B", default_branch, f"origin/{default_branch}"],
+                    ["fetch", "--prune", "origin"],
                     repo_root,
                     check=False,
+                    timeout_seconds=_GIT_FETCH_TIMEOUT_SECONDS,
                 )
+            except GitError as exc:
+                raise ValueError(f"git fetch failed: {exc}") from exc
+            if proc.returncode != 0:
+                raise ValueError(f"git fetch failed: {git_failure_detail(proc)}")
+
+            default_branch = git_default_branch(repo_root)
+            if not default_branch:
+                raise ValueError("Unable to resolve origin default branch")
+
+            try:
+                proc = run_git(["checkout", default_branch], repo_root, check=False)
             except GitError as exc:
                 raise ValueError(f"git checkout failed: {exc}") from exc
             if proc.returncode != 0:
-                raise ValueError(f"git checkout failed: {git_failure_detail(proc)}")
+                try:
+                    proc = run_git(
+                        ["checkout", "-B", default_branch, f"origin/{default_branch}"],
+                        repo_root,
+                        check=False,
+                    )
+                except GitError as exc:
+                    raise ValueError(f"git checkout failed: {exc}") from exc
+                if proc.returncode != 0:
+                    raise ValueError(f"git checkout failed: {git_failure_detail(proc)}")
 
-        try:
-            proc = run_git(
-                ["pull", "--ff-only", "origin", default_branch],
-                repo_root,
-                check=False,
-                timeout_seconds=_GIT_PULL_TIMEOUT_SECONDS,
-            )
-        except GitError as exc:
-            raise ValueError(f"git pull failed: {exc}") from exc
+            try:
+                proc = run_git(
+                    ["pull", "--ff-only", "origin", default_branch],
+                    repo_root,
+                    check=False,
+                    timeout_seconds=_GIT_PULL_TIMEOUT_SECONDS,
+                )
+            except GitError as exc:
+                raise ValueError(f"git pull failed: {exc}") from exc
         if proc.returncode != 0:
             raise ValueError(f"git pull failed: {git_failure_detail(proc)}")
         local_sha = git_head_sha(repo_root)

--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -760,19 +760,19 @@ class HubSupervisor:
                 )
             except GitError as exc:
                 raise ValueError(f"git pull failed: {exc}") from exc
-        if proc.returncode != 0:
-            raise ValueError(f"git pull failed: {git_failure_detail(proc)}")
-        local_sha = git_head_sha(repo_root)
-        if not local_sha:
-            raise ValueError("Unable to resolve local HEAD after sync")
-        origin_ref = f"refs/remotes/origin/{default_branch}"
-        origin_sha = resolve_ref_sha(repo_root, origin_ref)
-        if local_sha != origin_sha:
-            raise ValueError(
-                "Sync main did not land on origin/%s: local=%s origin=%s. "
-                "Local branch may contain extra commits; resolve divergence first."
-                % (default_branch, local_sha[:12], origin_sha[:12])
-            )
+            if proc.returncode != 0:
+                raise ValueError(f"git pull failed: {git_failure_detail(proc)}")
+            local_sha = git_head_sha(repo_root)
+            if not local_sha:
+                raise ValueError("Unable to resolve local HEAD after sync")
+            origin_ref = f"refs/remotes/origin/{default_branch}"
+            origin_sha = resolve_ref_sha(repo_root, origin_ref)
+            if local_sha != origin_sha:
+                raise ValueError(
+                    "Sync main did not land on origin/%s: local=%s origin=%s. "
+                    "Local branch may contain extra commits; resolve divergence first."
+                    % (default_branch, local_sha[:12], origin_sha[:12])
+                )
         return self._snapshot_for_repo(repo_id)
 
     def create_repo(

--- a/src/codex_autorunner/core/hub_control_plane/background_runner.py
+++ b/src/codex_autorunner/core/hub_control_plane/background_runner.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Callable, TypeVar
+
+WorkResultT = TypeVar("WorkResultT")
+
+
+class BackgroundRunnerSaturated(RuntimeError):
+    def __init__(self, *, max_workers: int, acquire_timeout_seconds: float) -> None:
+        super().__init__("background runner saturated")
+        self.max_workers = max_workers
+        self.acquire_timeout_seconds = acquire_timeout_seconds
+
+
+class BoundedBackgroundRunner:
+    """Bound concurrent background work so timeouts do not leak unbounded threads."""
+
+    def __init__(
+        self,
+        *,
+        max_workers: int,
+        saturation_wait_seconds: float = 0.05,
+        thread_name_prefix: str,
+    ) -> None:
+        self._max_workers = max(1, int(max_workers))
+        self._saturation_wait_seconds = max(0.0, float(saturation_wait_seconds))
+        self._slots = threading.BoundedSemaphore(self._max_workers)
+        self._executor = ThreadPoolExecutor(
+            max_workers=self._max_workers,
+            thread_name_prefix=thread_name_prefix,
+        )
+
+    @property
+    def max_workers(self) -> int:
+        return self._max_workers
+
+    @property
+    def saturation_wait_seconds(self) -> float:
+        return self._saturation_wait_seconds
+
+    def submit(
+        self,
+        work: Callable[[], WorkResultT],
+        *,
+        timeout_seconds: float,
+    ) -> Future[WorkResultT]:
+        acquire_timeout = min(
+            max(0.0, float(timeout_seconds)),
+            self._saturation_wait_seconds,
+        )
+        if not self._slots.acquire(timeout=acquire_timeout):
+            raise BackgroundRunnerSaturated(
+                max_workers=self._max_workers,
+                acquire_timeout_seconds=acquire_timeout,
+            )
+
+        released = False
+        release_lock = threading.Lock()
+
+        def _release_slot(_future: Future[WorkResultT]) -> None:
+            nonlocal released
+            with release_lock:
+                if released:
+                    return
+                released = True
+            self._slots.release()
+
+        try:
+            future = self._executor.submit(work)
+        except BaseException:
+            _release_slot(Future())
+            raise
+        future.add_done_callback(_release_slot)
+        return future
+
+    def close(self, *, wait: bool = True) -> None:
+        self._executor.shutdown(wait=wait, cancel_futures=not wait)
+
+
+__all__ = [
+    "BackgroundRunnerSaturated",
+    "BoundedBackgroundRunner",
+]

--- a/src/codex_autorunner/core/hub_control_plane/http_client.py
+++ b/src/codex_autorunner/core/hub_control_plane/http_client.py
@@ -72,6 +72,9 @@ from .models import (
 )
 
 _USE_CLIENT_DEFAULT_TIMEOUT = object()
+_SURFACE_BINDING_TIMEOUT_SECONDS = 30.0
+_THREAD_TARGET_CREATE_TIMEOUT_SECONDS = 30.0
+_EXECUTION_RESULT_TIMEOUT_SECONDS = 30.0
 
 
 def _normalize_base_url(base_url: str) -> str:
@@ -333,6 +336,7 @@ class HttpHubControlPlaneClient(HubControlPlaneClient):
             method="GET",
             path="/hub/api/control-plane/surface-bindings",
             params=request.to_dict(),
+            timeout=_SURFACE_BINDING_TIMEOUT_SECONDS,
         )
         return SurfaceBindingResponse.from_mapping(payload)
 
@@ -343,6 +347,7 @@ class HttpHubControlPlaneClient(HubControlPlaneClient):
             method="PUT",
             path="/hub/api/control-plane/surface-bindings",
             json_payload=request.to_dict(),
+            timeout=_SURFACE_BINDING_TIMEOUT_SECONDS,
         )
         return SurfaceBindingResponse.from_mapping(payload)
 
@@ -430,6 +435,7 @@ class HttpHubControlPlaneClient(HubControlPlaneClient):
             method="POST",
             path="/hub/api/control-plane/thread-targets",
             json_payload=request.to_dict(),
+            timeout=_THREAD_TARGET_CREATE_TIMEOUT_SECONDS,
         )
         return ThreadTargetResponse.from_mapping(payload)
 
@@ -534,6 +540,7 @@ class HttpHubControlPlaneClient(HubControlPlaneClient):
                 f"{request.thread_target_id}/executions/{request.execution_id}/result"
             ),
             json_payload=request.to_dict(),
+            timeout=_EXECUTION_RESULT_TIMEOUT_SECONDS,
         )
         return ExecutionResponse.from_mapping(payload)
 

--- a/src/codex_autorunner/core/hub_control_plane/remote_binding_store.py
+++ b/src/codex_autorunner/core/hub_control_plane/remote_binding_store.py
@@ -82,11 +82,14 @@ class RemoteSurfaceBindingStore:
 
             return asyncio.run(_run_action())
 
+        pool = ThreadPoolExecutor(max_workers=1)
+        future = pool.submit(_invoke)
+        timed_out = False
         try:
-            with ThreadPoolExecutor(max_workers=1) as pool:
-                future = pool.submit(_invoke)
-                return future.result(timeout=self._timeout_seconds)
+            return future.result(timeout=self._timeout_seconds)
         except FuturesTimeoutError as exc:
+            timed_out = True
+            future.cancel()
             raise self._hub_unavailable(
                 operation=operation,
                 message=f"request timed out after {self._timeout_seconds:g}s",
@@ -109,6 +112,8 @@ class RemoteSurfaceBindingStore:
                 message=str(exc) or exc.__class__.__name__,
                 details={"cause_type": exc.__class__.__name__},
             ) from exc
+        finally:
+            pool.shutdown(wait=not timed_out, cancel_futures=timed_out)
 
     @staticmethod
     def _normalize_key(surface_kind: str, surface_key: str) -> tuple[str, str]:

--- a/src/codex_autorunner/core/hub_control_plane/remote_binding_store.py
+++ b/src/codex_autorunner/core/hub_control_plane/remote_binding_store.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import asyncio
 import inspect
 import time
-from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, Callable, Coroutine, Optional, TypeVar
 
+from .background_runner import BackgroundRunnerSaturated, BoundedBackgroundRunner
 from .client import HubControlPlaneClient
 from .errors import HubControlPlaneError
 from .models import (
@@ -16,6 +16,11 @@ from .models import (
 )
 
 ResultT = TypeVar("ResultT")
+_BACKGROUND_RUNNER = BoundedBackgroundRunner(
+    max_workers=8,
+    saturation_wait_seconds=0.05,
+    thread_name_prefix="hub-binding",
+)
 
 
 class RemoteSurfaceBindingStore:
@@ -32,12 +37,14 @@ class RemoteSurfaceBindingStore:
         *,
         timeout_seconds: float = 30.0,
         cache_fallback_ttl_seconds: float = 300.0,
+        background_runner: Optional[BoundedBackgroundRunner] = None,
     ) -> None:
         self._client = client
         self._timeout_seconds = timeout_seconds
         self._cache_fallback_ttl_seconds = max(0.0, float(cache_fallback_ttl_seconds))
         self._bindings_by_key: dict[tuple[str, str], Any] = {}
         self._binding_cached_at_by_key: dict[tuple[str, str], float] = {}
+        self._background_runner = background_runner or _BACKGROUND_RUNNER
 
     def _hub_unavailable(
         self,
@@ -82,13 +89,23 @@ class RemoteSurfaceBindingStore:
 
             return asyncio.run(_run_action())
 
-        pool = ThreadPoolExecutor(max_workers=1)
-        future = pool.submit(_invoke)
-        timed_out = False
+        try:
+            future = self._background_runner.submit(
+                _invoke,
+                timeout_seconds=self._timeout_seconds,
+            )
+        except BackgroundRunnerSaturated as exc:
+            raise self._hub_unavailable(
+                operation=operation,
+                message="background worker pool saturated",
+                details={
+                    "max_workers": exc.max_workers,
+                    "acquire_timeout_seconds": exc.acquire_timeout_seconds,
+                },
+            ) from exc
         try:
             return future.result(timeout=self._timeout_seconds)
         except FuturesTimeoutError as exc:
-            timed_out = True
             future.cancel()
             raise self._hub_unavailable(
                 operation=operation,
@@ -112,8 +129,6 @@ class RemoteSurfaceBindingStore:
                 message=str(exc) or exc.__class__.__name__,
                 details={"cause_type": exc.__class__.__name__},
             ) from exc
-        finally:
-            pool.shutdown(wait=not timed_out, cancel_futures=timed_out)
 
     @staticmethod
     def _normalize_key(surface_kind: str, surface_key: str) -> tuple[str, str]:

--- a/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
+++ b/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
@@ -42,6 +42,8 @@ from .models import (
 )
 
 ResultT = TypeVar("ResultT")
+_THREAD_TARGET_CREATE_TIMEOUT_SECONDS = 30.0
+_EXECUTION_RESULT_TIMEOUT_SECONDS = 30.0
 
 
 class RemoteThreadExecutionStore(ThreadExecutionStore):
@@ -78,6 +80,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
         *,
         operation: str,
         action: Callable[[HubControlPlaneClient], Coroutine[Any, Any, ResultT]],
+        timeout_seconds: Optional[float] = None,
     ) -> ResultT:
         def _invoke() -> ResultT:
             background_client = self._client
@@ -99,15 +102,24 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
 
             return asyncio.run(_run_action())
 
+        effective_timeout_seconds = (
+            self._timeout_seconds
+            if timeout_seconds is None
+            else max(0.0, float(timeout_seconds))
+        )
+
+        pool = ThreadPoolExecutor(max_workers=1)
+        future = pool.submit(_invoke)
+        timed_out = False
         try:
-            with ThreadPoolExecutor(max_workers=1) as pool:
-                future = pool.submit(_invoke)
-                return future.result(timeout=self._timeout_seconds)
+            return future.result(timeout=effective_timeout_seconds)
         except FuturesTimeoutError as exc:
+            timed_out = True
+            future.cancel()
             raise self._hub_unavailable(
                 operation=operation,
-                message=f"request timed out after {self._timeout_seconds:g}s",
-                details={"timeout_seconds": self._timeout_seconds},
+                message=f"request timed out after {effective_timeout_seconds:g}s",
+                details={"timeout_seconds": effective_timeout_seconds},
             ) from exc
         except HubControlPlaneError as exc:
             if exc.code in {"hub_unavailable", "transport_failure"}:
@@ -126,6 +138,8 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
                 message=str(exc) or exc.__class__.__name__,
                 details={"cause_type": exc.__class__.__name__},
             ) from exc
+        finally:
+            pool.shutdown(wait=not timed_out, cancel_futures=timed_out)
 
     @staticmethod
     def _require_thread(
@@ -172,6 +186,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
             metadata_payload["context_profile"] = normalized_context_profile
         response = self._run(
             operation="create_thread_target",
+            timeout_seconds=_THREAD_TARGET_CREATE_TIMEOUT_SECONDS,
             action=lambda client: client.create_thread_target(
                 ThreadTargetCreateRequest(
                     agent_id=agent_id,
@@ -441,6 +456,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     ) -> ExecutionRecord:
         response = self._run(
             operation="record_execution_result",
+            timeout_seconds=_EXECUTION_RESULT_TIMEOUT_SECONDS,
             action=lambda client: client.record_execution_result(
                 ExecutionResultRecordRequest(
                     thread_target_id=thread_target_id,

--- a/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
+++ b/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from pathlib import Path
 from typing import Any, Callable, Coroutine, Optional, TypeVar
@@ -16,6 +15,7 @@ from ..orchestration.models import (
     ThreadTarget,
 )
 from ..orchestration.runtime_bindings import RuntimeThreadBinding
+from .background_runner import BackgroundRunnerSaturated, BoundedBackgroundRunner
 from .client import HubControlPlaneClient
 from .errors import HubControlPlaneError
 from .models import (
@@ -44,6 +44,11 @@ from .models import (
 ResultT = TypeVar("ResultT")
 _THREAD_TARGET_CREATE_TIMEOUT_SECONDS = 30.0
 _EXECUTION_RESULT_TIMEOUT_SECONDS = 30.0
+_BACKGROUND_RUNNER = BoundedBackgroundRunner(
+    max_workers=8,
+    saturation_wait_seconds=0.05,
+    thread_name_prefix="hub-execution",
+)
 
 
 class RemoteThreadExecutionStore(ThreadExecutionStore):
@@ -54,9 +59,11 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
         client: HubControlPlaneClient,
         *,
         timeout_seconds: float = 10.0,
+        background_runner: Optional[BoundedBackgroundRunner] = None,
     ) -> None:
         self._client = client
         self._timeout_seconds = timeout_seconds
+        self._background_runner = background_runner or _BACKGROUND_RUNNER
 
     def _hub_unavailable(
         self,
@@ -108,13 +115,23 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
             else max(0.0, float(timeout_seconds))
         )
 
-        pool = ThreadPoolExecutor(max_workers=1)
-        future = pool.submit(_invoke)
-        timed_out = False
+        try:
+            future = self._background_runner.submit(
+                _invoke,
+                timeout_seconds=effective_timeout_seconds,
+            )
+        except BackgroundRunnerSaturated as exc:
+            raise self._hub_unavailable(
+                operation=operation,
+                message="background worker pool saturated",
+                details={
+                    "max_workers": exc.max_workers,
+                    "acquire_timeout_seconds": exc.acquire_timeout_seconds,
+                },
+            ) from exc
         try:
             return future.result(timeout=effective_timeout_seconds)
         except FuturesTimeoutError as exc:
-            timed_out = True
             future.cancel()
             raise self._hub_unavailable(
                 operation=operation,
@@ -138,8 +155,6 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
                 message=str(exc) or exc.__class__.__name__,
                 details={"cause_type": exc.__class__.__name__},
             ) from exc
-        finally:
-            pool.shutdown(wait=not timed_out, cancel_futures=timed_out)
 
     @staticmethod
     def _require_thread(

--- a/src/codex_autorunner/core/hub_worktree_manager.py
+++ b/src/codex_autorunner/core/hub_worktree_manager.py
@@ -47,6 +47,7 @@ from .git_utils import (
     git_failure_detail,
     git_head_sha,
     git_is_clean,
+    git_mutation_lock,
     resolve_ref_sha,
     run_git,
 )
@@ -123,77 +124,78 @@ class WorktreeManager:
         )
         effective_start_ref = explicit_start_ref
 
-        if explicit_start_ref is None or explicit_start_ref.startswith("origin/"):
+        with git_mutation_lock(base_path):
+            if explicit_start_ref is None or explicit_start_ref.startswith("origin/"):
+                try:
+                    fetch_proc = run_git(
+                        ["fetch", "--prune", "origin"],
+                        base_path,
+                        check=False,
+                        timeout_seconds=_GIT_FETCH_TIMEOUT_SECONDS,
+                    )
+                except GitError as exc:
+                    raise ValueError(
+                        "Unable to refresh origin before creating worktree: %s" % exc
+                    ) from exc
+                if fetch_proc.returncode != 0:
+                    raise ValueError(
+                        "Unable to refresh origin before creating worktree: %s"
+                        % git_failure_detail(fetch_proc)
+                    )
+
+            if effective_start_ref is None:
+                default_branch = git_default_branch(base_path)
+                if not default_branch:
+                    raise ValueError("Unable to resolve origin default branch")
+                effective_start_ref = f"origin/{default_branch}"
+
+            assert effective_start_ref is not None
+            start_sha = resolve_ref_sha(base_path, effective_start_ref)
             try:
-                fetch_proc = run_git(
-                    ["fetch", "--prune", "origin"],
+                exists = run_git(
+                    ["show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
                     base_path,
                     check=False,
-                    timeout_seconds=_GIT_FETCH_TIMEOUT_SECONDS,
                 )
             except GitError as exc:
-                raise ValueError(
-                    "Unable to refresh origin before creating worktree: %s" % exc
-                ) from exc
-            if fetch_proc.returncode != 0:
-                raise ValueError(
-                    "Unable to refresh origin before creating worktree: %s"
-                    % git_failure_detail(fetch_proc)
-                )
-
-        if effective_start_ref is None:
-            default_branch = git_default_branch(base_path)
-            if not default_branch:
-                raise ValueError("Unable to resolve origin default branch")
-            effective_start_ref = f"origin/{default_branch}"
-
-        assert effective_start_ref is not None
-        start_sha = resolve_ref_sha(base_path, effective_start_ref)
-        try:
-            exists = run_git(
-                ["show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
-                base_path,
-                check=False,
-            )
-        except GitError as exc:
-            raise ValueError(f"git worktree add failed: {exc}") from exc
-        try:
-            if exists.returncode == 0:
-                branch_sha = resolve_ref_sha(base_path, f"refs/heads/{branch}")
-                if branch_sha != start_sha:
-                    raise ValueError(
-                        "Branch %r already exists and points to %s, but %s resolves to %s. "
-                        "Use a different branch name or realign the existing branch first."
-                        % (
-                            branch,
-                            branch_sha[:12],
-                            effective_start_ref,
-                            start_sha[:12],
+                raise ValueError(f"git worktree add failed: {exc}") from exc
+            try:
+                if exists.returncode == 0:
+                    branch_sha = resolve_ref_sha(base_path, f"refs/heads/{branch}")
+                    if branch_sha != start_sha:
+                        raise ValueError(
+                            "Branch %r already exists and points to %s, but %s resolves to %s. "
+                            "Use a different branch name or realign the existing branch first."
+                            % (
+                                branch,
+                                branch_sha[:12],
+                                effective_start_ref,
+                                start_sha[:12],
+                            )
                         )
+                    proc = run_git(
+                        ["worktree", "add", str(worktree_path), branch],
+                        base_path,
+                        check=False,
+                        timeout_seconds=_GIT_WORKTREE_TIMEOUT_SECONDS,
                     )
-                proc = run_git(
-                    ["worktree", "add", str(worktree_path), branch],
-                    base_path,
-                    check=False,
-                    timeout_seconds=_GIT_WORKTREE_TIMEOUT_SECONDS,
-                )
-            else:
-                cmd = [
-                    "worktree",
-                    "add",
-                    "-b",
-                    branch,
-                    str(worktree_path),
-                    effective_start_ref,
-                ]
-                proc = run_git(
-                    cmd,
-                    base_path,
-                    check=False,
-                    timeout_seconds=_GIT_WORKTREE_TIMEOUT_SECONDS,
-                )
-        except GitError as exc:
-            raise ValueError(f"git worktree add failed: {exc}") from exc
+                else:
+                    cmd = [
+                        "worktree",
+                        "add",
+                        "-b",
+                        branch,
+                        str(worktree_path),
+                        effective_start_ref,
+                    ]
+                    proc = run_git(
+                        cmd,
+                        base_path,
+                        check=False,
+                        timeout_seconds=_GIT_WORKTREE_TIMEOUT_SECONDS,
+                    )
+            except GitError as exc:
+                raise ValueError(f"git worktree add failed: {exc}") from exc
         if proc.returncode != 0:
             raise ValueError(f"git worktree add failed: {git_failure_detail(proc)}")
 

--- a/src/codex_autorunner/core/hub_worktree_manager.py
+++ b/src/codex_autorunner/core/hub_worktree_manager.py
@@ -196,8 +196,8 @@ class WorktreeManager:
                     )
             except GitError as exc:
                 raise ValueError(f"git worktree add failed: {exc}") from exc
-        if proc.returncode != 0:
-            raise ValueError(f"git worktree add failed: {git_failure_detail(proc)}")
+            if proc.returncode != 0:
+                raise ValueError(f"git worktree add failed: {git_failure_detail(proc)}")
 
         seed_repo_files(worktree_path, force=force, git_required=False)
         manifest.ensure_repo(

--- a/src/codex_autorunner/core/orchestration/verification.py
+++ b/src/codex_autorunner/core/orchestration/verification.py
@@ -19,6 +19,8 @@ from .migrate_legacy_state import (
     _table_exists,
 )
 
+_LIVE_THREAD_PARITY_SUPPORTED = False
+
 
 @dataclass(frozen=True)
 class ParityCheckResult:
@@ -184,7 +186,6 @@ def _get_thread_ids(hub_root: Path, limit: int = 10) -> list[str]:
 
 
 def verify_thread_parity(hub_root: Path, conn: Any) -> list[ParityCheckResult]:
-    legacy_counts = _count_legacy_threads(hub_root)
     results = []
     if _table_exists(conn, "orch_thread_targets"):
         new_threads = conn.execute(
@@ -194,18 +195,30 @@ def verify_thread_parity(hub_root: Path, conn: Any) -> list[ParityCheckResult]:
     else:
         new_thread_count = 0
 
-    status = (
-        "passed" if legacy_counts.get("threads", 0) == new_thread_count else "failed"
-    )
+    if _LIVE_THREAD_PARITY_SUPPORTED:
+        legacy_counts = _count_legacy_threads(hub_root)
+        legacy_thread_count = legacy_counts.get("threads", 0)
+    else:
+        legacy_counts = {"threads": new_thread_count, "turns": 0, "actions": 0}
+        legacy_thread_count = new_thread_count
     results.append(
         ParityCheckResult(
             check_name="thread_targets_count",
-            status=status,
-            legacy_count=legacy_counts.get("threads", 0),
+            status="passed",
+            legacy_count=legacy_thread_count,
             new_count=new_thread_count,
             message=(
-                f"Thread targets: {legacy_counts.get('threads', 0)} legacy, "
-                f"{new_thread_count} migrated"
+                f"Thread targets: {legacy_thread_count} canonical"
+                if not _LIVE_THREAD_PARITY_SUPPORTED
+                else (
+                    f"Thread targets: {legacy_thread_count} legacy, "
+                    f"{new_thread_count} migrated"
+                )
+            ),
+            details=(
+                {"legacy_thread_mirror_runtime_sync": False}
+                if not _LIVE_THREAD_PARITY_SUPPORTED
+                else {}
             ),
         )
     )
@@ -217,16 +230,29 @@ def verify_thread_parity(hub_root: Path, conn: Any) -> list[ParityCheckResult]:
         new_turn_count = int(new_turns["cnt"]) if new_turns else 0
     else:
         new_turn_count = 0
-    status = "passed" if legacy_counts.get("turns", 0) == new_turn_count else "failed"
+    legacy_turn_count = (
+        legacy_counts.get("turns", 0)
+        if _LIVE_THREAD_PARITY_SUPPORTED
+        else new_turn_count
+    )
     results.append(
         ParityCheckResult(
             check_name="thread_executions_count",
-            status=status,
-            legacy_count=legacy_counts.get("turns", 0),
+            status="passed",
+            legacy_count=legacy_turn_count,
             new_count=new_turn_count,
             message=(
-                f"Thread executions: {legacy_counts.get('turns', 0)} legacy, "
-                f"{new_turn_count} migrated"
+                f"Thread executions: {legacy_turn_count} canonical"
+                if not _LIVE_THREAD_PARITY_SUPPORTED
+                else (
+                    f"Thread executions: {legacy_turn_count} legacy, "
+                    f"{new_turn_count} migrated"
+                )
+            ),
+            details=(
+                {"legacy_thread_mirror_runtime_sync": False}
+                if not _LIVE_THREAD_PARITY_SUPPORTED
+                else {}
             ),
         )
     )
@@ -238,21 +264,35 @@ def verify_thread_parity(hub_root: Path, conn: Any) -> list[ParityCheckResult]:
         new_action_count = int(new_actions["cnt"]) if new_actions else 0
     else:
         new_action_count = 0
-    status = (
-        "passed" if legacy_counts.get("actions", 0) == new_action_count else "failed"
+    legacy_action_count = (
+        legacy_counts.get("actions", 0)
+        if _LIVE_THREAD_PARITY_SUPPORTED
+        else new_action_count
     )
     results.append(
         ParityCheckResult(
             check_name="thread_actions_count",
-            status=status,
-            legacy_count=legacy_counts.get("actions", 0),
+            status="passed",
+            legacy_count=legacy_action_count,
             new_count=new_action_count,
             message=(
-                f"Thread actions: {legacy_counts.get('actions', 0)} legacy, "
-                f"{new_action_count} migrated"
+                f"Thread actions: {legacy_action_count} canonical"
+                if not _LIVE_THREAD_PARITY_SUPPORTED
+                else (
+                    f"Thread actions: {legacy_action_count} legacy, "
+                    f"{new_action_count} migrated"
+                )
+            ),
+            details=(
+                {"legacy_thread_mirror_runtime_sync": False}
+                if not _LIVE_THREAD_PARITY_SUPPORTED
+                else {}
             ),
         )
     )
+
+    if not _LIVE_THREAD_PARITY_SUPPORTED:
+        return results
 
     legacy_ids = _get_thread_ids(hub_root)
     if legacy_ids and _table_exists(conn, "orch_thread_targets"):

--- a/src/codex_autorunner/core/pma_thread_store_bootstrap.py
+++ b/src/codex_autorunner/core/pma_thread_store_bootstrap.py
@@ -99,7 +99,8 @@ class PmaThreadStoreBootstrap:
                 migrate=False,
             ) as conn:
                 if self._prepare_marker_present(conn):
-                    self._run_legacy_mirror(conn)
+                    if not self._db_path.exists():
+                        self._run_legacy_mirror(conn)
                     return
                 self._run_legacy_mirror(conn)
                 self._mark_prepared(conn)
@@ -125,7 +126,6 @@ class PmaThreadStoreBootstrap:
                 migrate=False,
             ) as conn:
                 yield conn
-                self._run_legacy_mirror(conn)
 
 
 __all__ = [

--- a/src/codex_autorunner/surfaces/web/app.py
+++ b/src/codex_autorunner/surfaces/web/app.py
@@ -327,25 +327,10 @@ def create_hub_app(
                                 "hub.deferred_startup.phase done=pma_lane_worker elapsed_ms=%.2f",
                                 (time.monotonic() - t_phase) * 1000,
                             )
-                t_phase = time.monotonic()
-                try:
-                    await mount_manager.start_repo_lifespans()
-                except (
-                    OSError,
-                    RuntimeError,
-                    AttributeError,
-                ) as exc:  # intentional: best-effort startup
-                    safe_log(
-                        log,
-                        logging.WARNING,
-                        "Hub repo lifespans failed during deferred startup",
-                        exc,
-                    )
-                else:
-                    log.info(
-                        "hub.deferred_startup.phase done=start_repo_lifespans elapsed_ms=%.2f",
-                        (time.monotonic() - t_phase) * 1000,
-                    )
+                log.info(
+                    "hub.deferred_startup.phase skipped=start_repo_lifespans "
+                    "detail=repo_apps_stay_lazy_until_first_request"
+                )
                 log.info(
                     "hub.deferred_startup.complete total_elapsed_ms=%.2f",
                     (time.monotonic() - t0) * 1000,
@@ -354,10 +339,11 @@ def create_hub_app(
             tasks.append(asyncio.create_task(_deferred_hub_startup()))
             if app.state.config.housekeeping.enabled:
                 interval = max(app.state.config.housekeeping.interval_seconds, 1)
-                initial_delay = min(interval, 60)
+                housekeeping_initial_delay = min(interval, 60)
+                docker_reaper_initial_delay = 60
 
                 async def _managed_docker_reaper_loop():
-                    await asyncio.sleep(initial_delay)
+                    await asyncio.sleep(docker_reaper_initial_delay)
                     while True:
                         try:
                             await asyncio.to_thread(
@@ -380,6 +366,7 @@ def create_hub_app(
                         await asyncio.sleep(interval)
 
                 async def _housekeeping_loop():
+                    await asyncio.sleep(housekeeping_initial_delay)
                     while True:
                         try:
                             try:
@@ -465,9 +452,10 @@ def create_hub_app(
                     app.state.config.repo_defaults,
                     app.state.logger,
                 )
+                flow_sweep_initial_delay = min(flow_sweep_interval, 60)
 
                 async def _flow_telemetry_sweep_loop():
-                    await asyncio.sleep(initial_delay)
+                    await asyncio.sleep(flow_sweep_initial_delay)
                     while True:
                         try:
                             from ...core.flows.flow_telemetry_hooks import (
@@ -630,8 +618,8 @@ def create_hub_app(
 
             tasks.append(asyncio.create_task(_process_monitor_loop()))
             # Default lane worker starts in _deferred_hub_startup so /health is not blocked.
-            # Eager repo lifespans run there too; until then, /repos/* still activates via
-            # _LazyRepoApp._ensure_ready when hub_started is True.
+            # Repo apps stay lazy and still activate via _LazyRepoApp._ensure_ready once
+            # hub_started is True.
             startup_completed = True
             try:
                 yield

--- a/src/codex_autorunner/surfaces/web/services/hub_gather.py
+++ b/src/codex_autorunner/surfaces/web/services/hub_gather.py
@@ -30,6 +30,7 @@ from ....core.hub_inbox_resolution import (
     message_resolution_state,
     message_resolvable_actions,
 )
+from ....core.orchestration.sqlite import resolve_orchestration_sqlite_path
 from ....core.pma_context import (
     PMA_MAX_TEXT,
     _gather_inbox,
@@ -162,12 +163,15 @@ def _hub_snapshot_fingerprint(
         getattr(supervisor_state, "last_scan_at", None),
     ]
     if root_path is not None:
+        orchestration_db_path = resolve_orchestration_sqlite_path(root_path)
         fingerprint.extend(
             [
                 str(root_path),
                 _path_stat_fingerprint(root_path / ".codex-autorunner"),
                 _path_stat_fingerprint(root_path / ".codex-autorunner" / "filebox"),
                 _path_stat_fingerprint(default_pma_threads_db_path(root_path)),
+                _path_stat_fingerprint(orchestration_db_path),
+                _path_stat_fingerprint(Path(f"{orchestration_db_path}-wal")),
             ]
         )
     return tuple(fingerprint)

--- a/tests/core/orchestration/test_legacy_backfill_gate.py
+++ b/tests/core/orchestration/test_legacy_backfill_gate.py
@@ -8,7 +8,10 @@ from codex_autorunner.core.orchestration.legacy_backfill_gate import (
     ensure_legacy_orchestration_backfill,
 )
 from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
-from codex_autorunner.core.pma_thread_store import prepare_pma_thread_store
+from codex_autorunner.core.pma_thread_store import (
+    default_pma_threads_db_path,
+    prepare_pma_thread_store,
+)
 
 
 def test_ensure_legacy_orchestration_backfill_skips_work_when_marker_present(
@@ -48,3 +51,24 @@ def test_prepare_pma_thread_store_runs_thread_backfill_once_without_marker(
         prepare_pma_thread_store(hub_root, durable=False)
         prepare_pma_thread_store(hub_root, durable=False)
         assert mock_threads.call_count == 1
+
+
+def test_prepare_pma_thread_store_only_bootstraps_legacy_mirror_once(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+
+    def _touch_legacy_mirror(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        _ = args, kwargs
+        legacy_path = default_pma_threads_db_path(hub_root)
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.touch()
+
+    with patch(
+        "codex_autorunner.core.pma_thread_store_bootstrap.sync_legacy_mirror",
+        side_effect=_touch_legacy_mirror,
+    ) as mock_mirror:
+        prepare_pma_thread_store(hub_root, durable=False)
+        prepare_pma_thread_store(hub_root, durable=False)
+        assert mock_mirror.call_count == 1

--- a/tests/core/orchestration/test_legacy_state_backfill.py
+++ b/tests/core/orchestration/test_legacy_state_backfill.py
@@ -10,7 +10,14 @@ from codex_autorunner.core.orchestration.migrate_legacy_state import (
 from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.pma_automation_persistence import PmaAutomationPersistence
 from codex_autorunner.core.pma_automation_types import default_pma_automation_state
-from codex_autorunner.core.pma_thread_store import PmaThreadStore
+from codex_autorunner.core.pma_thread_mirror import sync_legacy_mirror
+from codex_autorunner.core.pma_thread_store import (
+    PmaThreadStore,
+    _ensure_schema,
+    _execution_row_to_record,
+    _thread_row_to_record,
+    default_pma_threads_db_path,
+)
 
 
 def test_backfill_legacy_thread_state_imports_threads_turns_and_actions(
@@ -49,6 +56,15 @@ def test_backfill_legacy_thread_state_imports_threads_turns_and_actions(
     )
 
     with open_orchestration_sqlite(hub_root, durable=False) as conn:
+        sync_legacy_mirror(
+            hub_root=hub_root,
+            legacy_db_path=default_pma_threads_db_path(hub_root),
+            durable=False,
+            orchestration_conn=conn,
+            thread_row_to_record=_thread_row_to_record,
+            execution_row_to_record=_execution_row_to_record,
+            ensure_legacy_schema=_ensure_schema,
+        )
         with conn:
             conn.execute("DELETE FROM orch_thread_actions")
             conn.execute("DELETE FROM orch_thread_executions")

--- a/tests/core/test_git_utils.py
+++ b/tests/core/test_git_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from pathlib import Path
 from subprocess import CompletedProcess
 
@@ -97,6 +98,58 @@ def test_reset_branch_from_origin_main_raises_when_worktree_dirty(
         match="working tree has uncommitted changes; commit or stash before /newt",
     ):
         git_utils.reset_branch_from_origin_main(Path("/tmp/repo"), "thread-123")
+
+
+def test_reset_branch_from_origin_main_serializes_git_mutations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entered: list[Path] = []
+
+    @contextmanager
+    def _fake_git_mutation_lock(repo_root: Path):
+        entered.append(repo_root)
+        yield
+
+    def _fake_run_git(
+        args: list[str],
+        _cwd: Path,
+        *,
+        timeout_seconds: int = 30,
+        check: bool = False,
+    ) -> CompletedProcess[str]:
+        _ = timeout_seconds, check
+        if args == ["status", "--porcelain"]:
+            return _ok_proc(stdout="")
+        if args == ["fetch", "--prune", "origin"]:
+            return _ok_proc()
+        if args == ["checkout", "-B", "thread-123", "origin/main"]:
+            return _ok_proc()
+        raise AssertionError(f"unexpected git args: {args}")
+
+    monkeypatch.setattr(git_utils, "git_mutation_lock", _fake_git_mutation_lock)
+    monkeypatch.setattr(git_utils, "git_default_branch", lambda _repo_root: "main")
+    monkeypatch.setattr(git_utils, "run_git", _fake_run_git)
+
+    repo_root = Path("/tmp/repo")
+    assert git_utils.reset_branch_from_origin_main(repo_root, "thread-123") == "main"
+    assert entered == [repo_root]
+
+
+def test_git_mutation_lock_path_uses_common_git_dir_for_worktrees(
+    tmp_path: Path,
+) -> None:
+    common_git_dir = tmp_path / "main-repo" / ".git"
+    common_git_dir.mkdir(parents=True)
+    worktree_root = tmp_path / "worktree"
+    worktree_root.mkdir()
+    (worktree_root / ".git").write_text(
+        f"gitdir: {common_git_dir / 'worktrees' / 'topic'}\n",
+        encoding="utf-8",
+    )
+
+    assert git_utils.git_mutation_lock_path(worktree_root) == (
+        common_git_dir / "codex-autorunner-git-mutation.lock"
+    )
 
 
 def test_describe_newt_reject_reasons_summarizes_git_status(

--- a/tests/core/test_pma_persistence_invariants.py
+++ b/tests/core/test_pma_persistence_invariants.py
@@ -13,7 +13,6 @@ These tests are behavior-preserving guards for the block-030 refactoring.
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import pytest
@@ -667,82 +666,52 @@ class TestReactiveCanonicalInvariants:
 
 
 class TestLegacyThreadMirrorInvariant:
-    def test_legacy_mirror_written_when_enabled(self, tmp_path: Path) -> None:
+    def test_legacy_mirror_is_bootstrap_only_after_live_writes(
+        self, tmp_path: Path
+    ) -> None:
         hub_root = tmp_path / "hub"
-        os.environ["CAR_LEGACY_MIRROR_ENABLED"] = "true"
-        try:
-            store = PmaThreadStore(hub_root)
-            thread = store.create_thread("codex", hub_root)
-            thread_id = str(thread["managed_thread_id"])
-            store.create_turn(thread_id, prompt="hello")
+        store = PmaThreadStore(hub_root)
+        thread = store.create_thread("codex", hub_root)
+        thread_id = str(thread["managed_thread_id"])
+        store.create_turn(thread_id, prompt="hello")
 
-            legacy_path = _legacy_thread_db_path(hub_root)
-            assert legacy_path.exists()
+        legacy_path = _legacy_thread_db_path(hub_root)
+        assert legacy_path.exists()
 
-            from codex_autorunner.core.sqlite_utils import open_sqlite
+        from codex_autorunner.core.sqlite_utils import open_sqlite
 
-            with open_sqlite(legacy_path, durable=False) as conn:
-                threads = conn.execute(
-                    "SELECT managed_thread_id FROM pma_managed_threads"
-                ).fetchall()
-                turns = conn.execute(
-                    "SELECT managed_turn_id FROM pma_managed_turns"
-                ).fetchall()
-            assert len(threads) == 1
-            assert len(turns) == 1
-        finally:
-            os.environ.pop("CAR_LEGACY_MIRROR_ENABLED", None)
-
-    @pytest.mark.xfail(
-        reason="CAR_LEGACY_MIRROR_ENABLED env var not yet wired into PmaThreadStore",
-        strict=True,
-    )
-    def test_legacy_mirror_not_written_when_disabled(self, tmp_path: Path) -> None:
-        hub_root = tmp_path / "hub"
-        os.environ["CAR_LEGACY_MIRROR_ENABLED"] = "false"
-        try:
-            store = PmaThreadStore(hub_root)
-            thread = store.create_thread("codex", hub_root)
-            thread_id = str(thread["managed_thread_id"])
-            store.create_turn(thread_id, prompt="hello")
-
-            legacy_path = _legacy_thread_db_path(hub_root)
-            assert not legacy_path.exists()
-
-            with open_orchestration_sqlite(hub_root, durable=False) as conn:
-                row = conn.execute(
-                    "SELECT thread_target_id FROM orch_thread_targets"
-                ).fetchone()
-            assert row is not None
-        finally:
-            os.environ.pop("CAR_LEGACY_MIRROR_ENABLED", None)
+        with open_sqlite(legacy_path, durable=False) as conn:
+            threads = conn.execute(
+                "SELECT managed_thread_id FROM pma_managed_threads"
+            ).fetchall()
+            turns = conn.execute(
+                "SELECT managed_turn_id FROM pma_managed_turns"
+            ).fetchall()
+        assert threads == []
+        assert turns == []
 
     def test_canonical_state_intact_when_legacy_mirror_disabled(
         self, tmp_path: Path
     ) -> None:
         hub_root = tmp_path / "hub"
-        os.environ["CAR_LEGACY_MIRROR_ENABLED"] = "false"
-        try:
-            store = PmaThreadStore(hub_root)
-            thread = store.create_thread("codex", hub_root)
-            thread_id = str(thread["managed_thread_id"])
-            store.create_turn(thread_id, prompt="hello")
-            turn_id = str(store.list_turns(thread_id)[0]["managed_turn_id"])
-            store.mark_turn_finished(turn_id, status="ok")
+        store = PmaThreadStore(hub_root)
+        thread = store.create_thread("codex", hub_root)
+        thread_id = str(thread["managed_thread_id"])
+        store.create_turn(thread_id, prompt="hello")
+        turn_id = str(store.list_turns(thread_id)[0]["managed_turn_id"])
+        store.mark_turn_finished(turn_id, status="ok")
 
-            with open_orchestration_sqlite(hub_root, durable=False) as conn:
-                t_row = conn.execute(
-                    "SELECT lifecycle_status FROM orch_thread_targets WHERE thread_target_id = ?",
-                    (thread_id,),
-                ).fetchone()
-                e_row = conn.execute(
-                    "SELECT status FROM orch_thread_executions WHERE execution_id = ?",
-                    (turn_id,),
-                ).fetchone()
-            assert t_row["lifecycle_status"] is not None
-            assert e_row["status"] == "ok"
-        finally:
-            os.environ.pop("CAR_LEGACY_MIRROR_ENABLED", None)
+        with open_orchestration_sqlite(hub_root, durable=False) as conn:
+            t_row = conn.execute(
+                "SELECT lifecycle_status FROM orch_thread_targets WHERE thread_target_id = ?",
+                (thread_id,),
+            ).fetchone()
+            e_row = conn.execute(
+                "SELECT status FROM orch_thread_executions WHERE execution_id = ?",
+                (turn_id,),
+            ).fetchone()
+        assert t_row["lifecycle_status"] is not None
+        assert e_row["status"] == "ok"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_remote_binding_store.py
+++ b/tests/core/test_remote_binding_store.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import threading
+import time
 
 import pytest
 
@@ -86,6 +88,17 @@ class _LoopBoundListingClient(_ListingClient):
         if threading.get_ident() != self._owner_thread_id:
             raise RuntimeError("Event loop is closed")
         return await super().list_surface_bindings(request)
+
+
+class _SlowLookupClient:
+    def __init__(self) -> None:
+        self.finished = threading.Event()
+
+    async def get_surface_binding(self, request):
+        try:
+            await asyncio.sleep(0.2)
+        finally:
+            self.finished.set()
 
 
 def test_remote_surface_binding_store_lists_bindings_from_hub_authoritatively() -> None:
@@ -248,3 +261,21 @@ def test_remote_surface_binding_store_clones_loop_bound_client_for_background_ca
     listed = store.list_bindings(limit=5)
 
     assert [binding.binding_id for binding in listed] == ["binding-hub"]
+
+
+def test_remote_surface_binding_store_timeout_does_not_wait_for_background_shutdown() -> (
+    None
+):
+    client = _SlowLookupClient()
+    store = RemoteSurfaceBindingStore(client, timeout_seconds=0.01)
+
+    started = time.monotonic()
+    with pytest.raises(HubControlPlaneError) as exc_info:
+        store.get_binding(surface_kind="discord", surface_key="channel:1")
+    elapsed = time.monotonic() - started
+
+    assert exc_info.value.code == "hub_unavailable"
+    assert exc_info.value.details["operation"] == "get_surface_binding"
+    assert exc_info.value.details["timeout_seconds"] == 0.01
+    assert elapsed < 0.1
+    assert client.finished.wait(timeout=1.0)

--- a/tests/core/test_remote_binding_store.py
+++ b/tests/core/test_remote_binding_store.py
@@ -12,6 +12,9 @@ from codex_autorunner.core.hub_control_plane import (
     RemoteSurfaceBindingStore,
     SurfaceBindingListResponse,
 )
+from codex_autorunner.core.hub_control_plane.background_runner import (
+    BoundedBackgroundRunner,
+)
 
 
 def _binding_from_mapping(**overrides: object) -> Binding:
@@ -99,6 +102,19 @@ class _SlowLookupClient:
             await asyncio.sleep(0.2)
         finally:
             self.finished.set()
+
+
+class _BlockingLookupClient:
+    def __init__(self) -> None:
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    async def get_surface_binding(self, request):
+        self.started.set()
+        await asyncio.to_thread(self.release.wait)
+        from codex_autorunner.core.hub_control_plane import SurfaceBindingResponse
+
+        return SurfaceBindingResponse(binding=None)
 
 
 def test_remote_surface_binding_store_lists_bindings_from_hub_authoritatively() -> None:
@@ -279,3 +295,41 @@ def test_remote_surface_binding_store_timeout_does_not_wait_for_background_shutd
     assert exc_info.value.details["timeout_seconds"] == 0.01
     assert elapsed < 0.1
     assert client.finished.wait(timeout=1.0)
+
+
+def test_remote_surface_binding_store_bounds_background_timeout_fallout() -> None:
+    runner = BoundedBackgroundRunner(
+        max_workers=1,
+        saturation_wait_seconds=0.0,
+        thread_name_prefix="test-hub-binding",
+    )
+    client = _BlockingLookupClient()
+    store = RemoteSurfaceBindingStore(
+        client,
+        timeout_seconds=0.5,
+        background_runner=runner,
+    )
+
+    errors: list[BaseException] = []
+
+    def _first_call() -> None:
+        try:
+            store.get_binding(surface_kind="discord", surface_key="channel:1")
+        except BaseException as exc:  # pragma: no cover - test assertion below
+            errors.append(exc)
+
+    worker = threading.Thread(target=_first_call)
+    worker.start()
+    assert client.started.wait(timeout=1.0)
+
+    with pytest.raises(HubControlPlaneError) as exc_info:
+        store.get_binding(surface_kind="discord", surface_key="channel:2")
+
+    client.release.set()
+    worker.join(timeout=1.0)
+    runner.close()
+
+    assert not errors
+    assert exc_info.value.code == "hub_unavailable"
+    assert exc_info.value.details["operation"] == "get_surface_binding"
+    assert exc_info.value.details["max_workers"] == 1

--- a/tests/core/test_remote_execution_store.py
+++ b/tests/core/test_remote_execution_store.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import threading
+import time
 from pathlib import Path
 from typing import Any
 
@@ -432,6 +434,20 @@ class _LoopBoundThreadClient(_FakeHubClient):
         return await super().get_thread_target(request)
 
 
+class _SlowGetThreadTargetClient(_FakeHubClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.finished = threading.Event()
+
+    async def get_thread_target(self, request):
+        self.calls.append(("get_thread_target", request))
+        try:
+            await asyncio.sleep(0.2)
+        finally:
+            self.finished.set()
+        return self.thread_response
+
+
 def test_remote_execution_store_translates_transport_failures_to_hub_unavailable() -> (
     None
 ):
@@ -476,3 +492,19 @@ def test_remote_execution_store_clones_loop_bound_client_for_background_calls() 
 
     assert thread is not None
     assert thread.thread_target_id == "thread-1"
+
+
+def test_remote_execution_store_timeout_does_not_wait_for_background_shutdown() -> None:
+    client = _SlowGetThreadTargetClient()
+    store = RemoteThreadExecutionStore(client, timeout_seconds=0.01)
+
+    started = time.monotonic()
+    with pytest.raises(HubControlPlaneError) as exc_info:
+        store.get_thread_target("thread-1")
+    elapsed = time.monotonic() - started
+
+    assert exc_info.value.code == "hub_unavailable"
+    assert exc_info.value.details["operation"] == "get_thread_target"
+    assert exc_info.value.details["timeout_seconds"] == 0.01
+    assert elapsed < 0.1
+    assert client.finished.wait(timeout=1.0)

--- a/tests/core/test_remote_execution_store.py
+++ b/tests/core/test_remote_execution_store.py
@@ -21,6 +21,9 @@ from codex_autorunner.core.hub_control_plane import (
     ThreadTargetListResponse,
     ThreadTargetResponse,
 )
+from codex_autorunner.core.hub_control_plane.background_runner import (
+    BoundedBackgroundRunner,
+)
 from codex_autorunner.core.orchestration.interfaces import ThreadExecutionStore
 from codex_autorunner.core.orchestration.models import ExecutionRecord, ThreadTarget
 
@@ -448,6 +451,19 @@ class _SlowGetThreadTargetClient(_FakeHubClient):
         return self.thread_response
 
 
+class _BlockingGetThreadTargetClient(_FakeHubClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    async def get_thread_target(self, request):
+        self.calls.append(("get_thread_target", request))
+        self.started.set()
+        await asyncio.to_thread(self.release.wait)
+        return self.thread_response
+
+
 def test_remote_execution_store_translates_transport_failures_to_hub_unavailable() -> (
     None
 ):
@@ -508,3 +524,41 @@ def test_remote_execution_store_timeout_does_not_wait_for_background_shutdown() 
     assert exc_info.value.details["timeout_seconds"] == 0.01
     assert elapsed < 0.1
     assert client.finished.wait(timeout=1.0)
+
+
+def test_remote_execution_store_bounds_background_timeout_fallout() -> None:
+    runner = BoundedBackgroundRunner(
+        max_workers=1,
+        saturation_wait_seconds=0.0,
+        thread_name_prefix="test-hub-execution",
+    )
+    client = _BlockingGetThreadTargetClient()
+    store = RemoteThreadExecutionStore(
+        client,
+        timeout_seconds=0.5,
+        background_runner=runner,
+    )
+
+    errors: list[BaseException] = []
+
+    def _first_call() -> None:
+        try:
+            store.get_thread_target("thread-1")
+        except BaseException as exc:  # pragma: no cover - test assertion below
+            errors.append(exc)
+
+    worker = threading.Thread(target=_first_call)
+    worker.start()
+    assert client.started.wait(timeout=1.0)
+
+    with pytest.raises(HubControlPlaneError) as exc_info:
+        store.get_thread_target("thread-2")
+
+    client.release.set()
+    worker.join(timeout=1.0)
+    runner.close()
+
+    assert not errors
+    assert exc_info.value.code == "hub_unavailable"
+    assert exc_info.value.details["operation"] == "get_thread_target"
+    assert exc_info.value.details["max_workers"] == 1

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -20,7 +20,6 @@ from codex_autorunner.core.pma_thread_store import (
     pma_threads_db_lock_path,
 )
 from codex_autorunner.core.pma_thread_store_rows import PmaThreadRecord
-from codex_autorunner.core.sqlite_utils import open_sqlite
 
 
 def test_create_list_get_thread(tmp_path: Path) -> None:
@@ -165,18 +164,6 @@ def test_backend_thread_binding_can_be_cleared_across_restart(tmp_path: Path) ->
     assert listed[0]["managed_thread_id"] == managed_thread_id
     assert "backend_thread_id" not in listed[0]
     assert "backend_runtime_instance_id" not in listed[0]
-
-    with open_sqlite(restarted.path) as conn:
-        row = conn.execute(
-            """
-            SELECT backend_thread_id
-              FROM pma_managed_threads
-             WHERE managed_thread_id = ?
-            """,
-            (managed_thread_id,),
-        ).fetchone()
-    assert row is not None
-    assert row["backend_thread_id"] is None
 
 
 def test_connect_readonly_skips_bootstrap_initialize(


### PR DESCRIPTION
## Summary
- remove live PMA legacy mirror sync from the hot path and move remaining runtime readers off the live `threads.sqlite3` mirror
- align hub control-plane transport budgets with the intended 30s operations budget and make timeout wrappers return immediately instead of blocking on executor shutdown
- serialize repo/worktree git mutations during fetch/reset, keep repo apps lazy on hub startup, and update migration/verification coverage for the new bootstrap-only mirror behavior

## Root cause
Telegram and Discord were both hitting the same underlying hub control-plane instability, with restart only acting as an amplifier.

1. PMA writes were still doing full legacy mirror work on the request path.
   Every PMA write could trigger `sync_legacy_mirror`, which rescanned orchestration tables and rewrote `threads.sqlite3`. That cost scaled with total PMA history, so `get_surface_binding`, `record_execution_result`, and related operations were exposed to long stalls under load.

2. The effective timeout budget was still 10 seconds for several remote control-plane calls.
   Some higher-level code assumed a 30s budget, but the HTTP client still defaulted to 10s for key operations. That is why errors like `Hub control-plane transport request failed: ReadTimeout` continued even well after restart.

3. Branch reset/fetch paths were mutating shared git state without a shared repo/worktree lock.
   That left a race window around `git fetch --prune origin` and related reset flows, which matches the `incorrect old value provided` fetch failure you were seeing.

4. Startup made the degraded period worse by eagerly starting repo lifespans.
   That inflated control-plane pressure right when the hub was cold, but it was not the only bug.

## Why this should stabilize things
- PMA request-path writes no longer pay the full legacy mirror tax.
- Runtime cache invalidation now keys off orchestration DB/WAL activity instead of assuming the legacy mirror changes on every write.
- Control-plane timeout wrappers now honor the configured budget and fail fast when the background call is stuck, instead of waiting for executor shutdown.
- Git resets and worktree creation now serialize mutations through a shared common-dir lock.
- Legacy thread parity checks no longer treat a stale bootstrap mirror as a live source of truth.

## Validation
- aggregate validation lane from `git commit` passed, including repo-wide mypy and pytest
- focused suites also passed during development, including PMA persistence, hub control-plane routes/services, remote binding/execution stores, legacy backfill, and hub destination/channel coverage
