### PR TITLE
[codex] Reduce hub list_repos churn and avoid async loop blocking

### DIFF
--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -91,6 +91,7 @@ logger = logging.getLogger("codex_autorunner.hub")
 
 _GIT_FETCH_TIMEOUT_SECONDS = 120
 _GIT_PULL_TIMEOUT_SECONDS = 120
+_LIST_REPOS_CACHE_TTL_SECONDS = 30.0
 
 BackendFactoryBuilder = Callable[[Path, RepoConfig], BackendFactory]
 AppServerSupervisorFactoryBuilder = Callable[[RepoConfig], AppServerSupervisorFactory]
@@ -420,7 +421,10 @@ class HubSupervisor:
     def list_repos(self, *, use_cache: bool = True) -> List[RepoSnapshot]:
         with self._list_lock:
             if use_cache and self._list_cache and self._list_cache_at is not None:
-                if time.monotonic() - self._list_cache_at < 2.0:
+                if (
+                    time.monotonic() - self._list_cache_at
+                    < _LIST_REPOS_CACHE_TTL_SECONDS
+                ):
                     return self._list_cache
             if use_cache and self._startup_repo_state_pending and self.state.repos:
                 self._startup_repo_state_pending = False

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/repo_listing.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/repo_listing.py
@@ -206,20 +206,24 @@ class HubRepoListingService:
                 payload=copy.deepcopy(payload),
             )
 
-    def _current_topology_snapshots(
+    async def _current_topology_snapshots(
         self, *, needs_repos: bool, needs_agent_workspaces: bool
     ) -> tuple[list[Any], list[Any]]:
         supervisor_state = getattr(self._context.supervisor, "state", None)
         snapshots = list(getattr(supervisor_state, "repos", []) or [])
         agent_workspaces = list(getattr(supervisor_state, "agent_workspaces", []) or [])
         if needs_repos and not snapshots:
-            snapshots = list(self._context.supervisor.list_repos())
+            snapshots = list(
+                await asyncio.to_thread(self._context.supervisor.list_repos)
+            )
             supervisor_state = getattr(self._context.supervisor, "state", None)
             agent_workspaces = list(
                 getattr(supervisor_state, "agent_workspaces", []) or agent_workspaces
             )
         if needs_agent_workspaces and not agent_workspaces:
-            agent_workspaces = list(self._context.supervisor.list_agent_workspaces())
+            agent_workspaces = list(
+                await asyncio.to_thread(self._context.supervisor.list_agent_workspaces)
+            )
         return snapshots, agent_workspaces
 
     def _force_list_repos(self) -> list[Any]:
@@ -258,7 +262,7 @@ class HubRepoListingService:
                     self._force_list_agent_workspaces
                 )
                 return [], list(agent_workspaces)
-        return self._current_topology_snapshots(
+        return await self._current_topology_snapshots(
             needs_repos=needs_repos,
             needs_agent_workspaces=needs_agent_workspaces,
         )
@@ -359,7 +363,7 @@ class HubRepoListingService:
 
         if needs_repos:
             if not snapshots or (needs_agent_workspaces and not agent_workspaces):
-                snapshots, agent_workspaces = self._current_topology_snapshots(
+                snapshots, agent_workspaces = await self._current_topology_snapshots(
                     needs_repos=True,
                     needs_agent_workspaces=needs_agent_workspaces,
                 )
@@ -385,7 +389,7 @@ class HubRepoListingService:
                 ]
         elif needs_agent_workspaces:
             if not agent_workspaces:
-                _, agent_workspace_snaps = self._current_topology_snapshots(
+                _, agent_workspace_snaps = await self._current_topology_snapshots(
                     needs_repos=False,
                     needs_agent_workspaces=True,
                 )

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -274,7 +274,7 @@ def test_list_repos_refreshes_after_startup_state_cache_ttl(
     assert first[0].display_name == "persisted-demo"
 
     assert supervisor._list_cache_at is not None
-    supervisor._list_cache_at -= 3.0
+    supervisor._list_cache_at -= hub_module._LIST_REPOS_CACHE_TTL_SECONDS + 1.0
 
     second = supervisor.list_repos()
     assert manifest_call_count == 1


### PR DESCRIPTION
## Summary
- increased `HubSupervisor.list_repos` in-memory cache TTL from 2 seconds to 30 seconds via a named constant
- moved fallback topology loading in hub repo listing service onto `asyncio.to_thread(...)` so async request handlers do not execute `supervisor.list_repos()` on the event loop
- updated the cache-expiry test to key off the shared TTL constant

## Root Cause
`list_repos()` cache churn was too aggressive for large hub topologies, which caused frequent expensive refreshes. In async listing paths, fallback topology loads could also run synchronously on the event loop when warm state was missing.

## Impact
- lower repo-listing recomputation frequency under load
- reduced event-loop blocking risk in `/hub/repos` async paths
- no behavioral change to PMA artifact writes (`list_repos` still keeps `refresh_pma_threads_artifact=False`)

## Validation
- `.venv/bin/pytest tests/test_hub_supervisor.py -k "list_repos_refreshes_after_startup_state_cache_ttl or list_repos_does_not_refresh_pma_threads_artifact"`
- `.venv/bin/pytest tests/surfaces/web/routes/test_hub_performance_caches.py -k "hub_repo_listing_service"`
- pre-commit aggregate lane during commit:
  - black, ruff, import-boundary checks, contract checks, mypy strict (`src/`), full pytest suite, frontend build/tests

Closes #1479
