### PR TITLE
[codex] Cap live flow wire rows per run

### DIFF
--- a/src/codex_autorunner/core/flows/store.py
+++ b/src/codex_autorunner/core/flows/store.py
@@ -31,6 +31,16 @@ _REQUIRED_SCHEMA_TABLES = frozenset(
     {"schema_info", "flow_runs", "flow_events", "flow_artifacts"}
 )
 _DELETE_SEQ_BATCH_SIZE = 900
+_MAX_RUN_AGENT_STREAM_DELTA_ROWS = 10_000
+_MAX_RUN_APP_SERVER_EVENT_ROWS = 10_000
+_MAX_RUN_APP_SERVER_TELEMETRY_ROWS = 10_000
+_FLOW_EVENT_TYPE_LIVE_CAPS: dict[str, int] = {
+    FlowEventType.AGENT_STREAM_DELTA.value: _MAX_RUN_AGENT_STREAM_DELTA_ROWS,
+    FlowEventType.APP_SERVER_EVENT.value: _MAX_RUN_APP_SERVER_EVENT_ROWS,
+}
+_FLOW_TELEMETRY_TYPE_LIVE_CAPS: dict[str, int] = {
+    FlowEventType.APP_SERVER_EVENT.value: _MAX_RUN_APP_SERVER_TELEMETRY_ROWS,
+}
 _SQLITE_PRAGMAS_READONLY = (
     "PRAGMA foreign_keys=ON;",
     f"PRAGMA busy_timeout={DEFAULT_SQLITE_BUSY_TIMEOUT_MS};",
@@ -219,6 +229,9 @@ class FlowStore:
             "CREATE INDEX IF NOT EXISTS idx_flow_events_run_id ON flow_events(run_id, seq)"
         )
         conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_flow_events_run_type ON flow_events(run_id, event_type, seq)"
+        )
+        conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_flow_artifacts_run_id ON flow_artifacts(run_id)"
         )
         conn.execute(
@@ -278,6 +291,9 @@ class FlowStore:
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_flow_events_run_id ON flow_events(run_id, seq)"
             )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_flow_events_run_type ON flow_events(run_id, event_type, seq)"
+            )
         elif version == 3:
             conn.execute(
                 """
@@ -298,6 +314,79 @@ class FlowStore:
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_flow_telemetry_run_type ON flow_telemetry(run_id, event_type, seq)"
             )
+
+    def _prune_rows_for_run_event_type(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        table_name: str,
+        run_id: str,
+        event_type: str,
+        max_rows: int,
+    ) -> int:
+        if table_name not in {"flow_events", "flow_telemetry"}:
+            raise ValueError(
+                f"Unsupported flow table for overflow pruning: {table_name}"
+            )
+        if max_rows <= 0:
+            return 0
+        cutoff_row = conn.execute(
+            f"""
+            SELECT seq
+            FROM {table_name}
+            WHERE run_id = ? AND event_type = ?
+            ORDER BY seq DESC
+            LIMIT 1 OFFSET ?
+            """,
+            (run_id, event_type, max_rows - 1),
+        ).fetchone()
+        if cutoff_row is None:
+            return 0
+        cutoff_seq = int(cutoff_row["seq"])
+        cursor = conn.execute(
+            f"""
+            DELETE FROM {table_name}
+            WHERE run_id = ? AND event_type = ? AND seq < ?
+            """,
+            (run_id, event_type, cutoff_seq),
+        )
+        return int(cursor.rowcount or 0)
+
+    def _enforce_live_event_cap(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        run_id: str,
+        event_type: FlowEventType,
+    ) -> int:
+        max_rows = _FLOW_EVENT_TYPE_LIVE_CAPS.get(event_type.value)
+        if max_rows is None:
+            return 0
+        return self._prune_rows_for_run_event_type(
+            conn,
+            table_name="flow_events",
+            run_id=run_id,
+            event_type=event_type.value,
+            max_rows=max_rows,
+        )
+
+    def _enforce_live_telemetry_cap(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        run_id: str,
+        event_type: FlowEventType,
+    ) -> int:
+        max_rows = _FLOW_TELEMETRY_TYPE_LIVE_CAPS.get(event_type.value)
+        if max_rows is None:
+            return 0
+        return self._prune_rows_for_run_event_type(
+            conn,
+            table_name="flow_telemetry",
+            run_id=run_id,
+            event_type=event_type.value,
+            max_rows=max_rows,
+        )
 
     def create_flow_run(
         self,
@@ -577,6 +666,7 @@ class FlowStore:
                     step_id,
                 ),
             )
+            self._enforce_live_event_cap(conn, run_id=run_id, event_type=event_type)
             row = conn.execute(
                 "SELECT * FROM flow_events WHERE id = ?", (event_id,)
             ).fetchone()
@@ -816,6 +906,7 @@ class FlowStore:
                     json.dumps(normalized_data),
                 ),
             )
+            self._enforce_live_telemetry_cap(conn, run_id=run_id, event_type=event_type)
             row = conn.execute(
                 "SELECT * FROM flow_telemetry WHERE id = ?", (telemetry_id,)
             ).fetchone()

--- a/tests/flows/test_flow_store_live_caps.py
+++ b/tests/flows/test_flow_store_live_caps.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import codex_autorunner.core.flows.store as flow_store_module
+from codex_autorunner.core.flows.models import FlowEventType
+from codex_autorunner.core.flows.store import FlowStore
+
+
+def _create_run(store: FlowStore, run_id: str) -> str:
+    record = store.create_flow_run(
+        run_id=run_id, flow_type="ticket_flow", input_data={}
+    )
+    return record.id
+
+
+def test_live_cap_keeps_latest_agent_stream_deltas(tmp_path, monkeypatch) -> None:
+    monkeypatch.setitem(
+        flow_store_module._FLOW_EVENT_TYPE_LIVE_CAPS,
+        FlowEventType.AGENT_STREAM_DELTA.value,
+        3,
+    )
+    store = FlowStore(tmp_path / "flows.db")
+    store.initialize()
+    run_id = _create_run(store, "run-deltas")
+
+    for idx in range(6):
+        store.create_event(
+            event_id=f"evt-delta-{idx}",
+            run_id=run_id,
+            event_type=FlowEventType.AGENT_STREAM_DELTA,
+            data={"delta": f"chunk-{idx}", "turn_id": "turn-1"},
+        )
+
+    kept = store.get_events_by_type(run_id, FlowEventType.AGENT_STREAM_DELTA)
+    assert [event.id for event in kept] == ["evt-delta-3", "evt-delta-4", "evt-delta-5"]
+
+
+def test_live_cap_keeps_latest_app_server_telemetry_per_run(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setitem(
+        flow_store_module._FLOW_TELEMETRY_TYPE_LIVE_CAPS,
+        FlowEventType.APP_SERVER_EVENT.value,
+        2,
+    )
+    store = FlowStore(tmp_path / "flows.db")
+    store.initialize()
+    run_a = _create_run(store, "run-telemetry-a")
+    run_b = _create_run(store, "run-telemetry-b")
+
+    for idx in range(4):
+        for run_id in (run_a, run_b):
+            store.create_telemetry(
+                telemetry_id=f"tel-{run_id}-{idx}",
+                run_id=run_id,
+                event_type=FlowEventType.APP_SERVER_EVENT,
+                data={
+                    "message": {
+                        "method": "message.part.updated",
+                        "params": {"idx": idx},
+                    },
+                    "turn_id": f"turn-{idx}",
+                },
+            )
+
+    kept_a = store.get_telemetry_by_type(run_a, FlowEventType.APP_SERVER_EVENT)
+    kept_b = store.get_telemetry_by_type(run_b, FlowEventType.APP_SERVER_EVENT)
+    assert [event.id for event in kept_a] == [
+        "tel-run-telemetry-a-2",
+        "tel-run-telemetry-a-3",
+    ]
+    assert [event.id for event in kept_b] == [
+        "tel-run-telemetry-b-2",
+        "tel-run-telemetry-b-3",
+    ]
+
+
+def test_live_caps_do_not_prune_non_wire_event_types(tmp_path, monkeypatch) -> None:
+    monkeypatch.setitem(
+        flow_store_module._FLOW_EVENT_TYPE_LIVE_CAPS,
+        FlowEventType.AGENT_STREAM_DELTA.value,
+        1,
+    )
+    store = FlowStore(tmp_path / "flows.db")
+    store.initialize()
+    run_id = _create_run(store, "run-progress")
+
+    for idx in range(5):
+        store.create_event(
+            event_id=f"evt-progress-{idx}",
+            run_id=run_id,
+            event_type=FlowEventType.STEP_PROGRESS,
+            data={"progress": idx},
+        )
+
+    kept = store.get_events_by_type(run_id, FlowEventType.STEP_PROGRESS)
+    assert len(kept) == 5


### PR DESCRIPTION
## Summary
- cap high-volume live wire rows per run inside `FlowStore` to prevent active thread worktrees from growing `flows.db` without bound
- enforce newest-N retention for `agent_stream_delta` and legacy `app_server_event` rows in `flow_events`, plus `app_server_event` rows in `flow_telemetry`
- add `flow_events(run_id, event_type, seq)` index to keep cap enforcement efficient on large active runs
- add regression tests proving newest-N retention, per-run isolation, and no pruning for non-wire event types

## Root Cause
Flow housekeeping/export only pruned wire telemetry after runs became terminal. Long-lived active/paused runs never hit that path, so `flow_events` and `flow_telemetry` could accumulate millions of rows.

## Validation
- `.venv/bin/python -m pytest tests/flows/test_flow_store_live_caps.py tests/flows/test_telemetry_export.py tests/flows/test_flow_housekeeping.py tests/flows/test_flow_telemetry_hooks.py`
- Full pre-commit lane on commit (`mypy` + full `pytest` suite)

Closes #1478
