### PR TITLE
[codex] Keep Discord bind ack path local

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -1318,17 +1318,43 @@ class DiscordBotService:
         if not isinstance(token, str) or not token.strip():
             return None
         normalized = token.strip()
-        resolved = self._resolve_workspace_from_token(
-            normalized,
-            self._list_bind_workspace_candidates(),
-        )
-        if resolved is not None:
-            candidate = canonicalize_path(Path(resolved[2]))
-            return candidate if candidate.exists() and candidate.is_dir() else None
         candidate = Path(normalized)
-        if not candidate.is_absolute():
-            candidate = self._config.root / candidate
-        workspace_root = canonicalize_path(candidate)
+        # Keep bind-target resolution pre-ack strictly local and cheap. The full
+        # bind handler can do slower candidate enumeration after Discord has been
+        # acknowledged, but scheduler lock resolution must not spend the ack budget
+        # on live hub calls.
+        if candidate.is_absolute() or "/" in normalized or "\\" in normalized:
+            if not candidate.is_absolute():
+                candidate = self._config.root / candidate
+            workspace_root = canonicalize_path(candidate)
+            return (
+                workspace_root
+                if workspace_root.exists() and workspace_root.is_dir()
+                else None
+            )
+
+        cheap_candidates: list[tuple[Optional[str], Optional[str], str]] = [
+            ("repo", repo_id, str(canonicalize_path(Path(path))))
+            for repo_id, path in self._list_manifest_repos()
+        ]
+        cheap_candidates.extend(
+            (
+                "agent_workspace",
+                workspace_id,
+                workspace_path,
+            )
+            for workspace_id, workspace_path, _display_name in self._list_agent_workspaces_from_cache()
+        )
+        resolved = self._resolve_workspace_from_token(normalized, cheap_candidates)
+        if resolved is not None:
+            resolved_root = canonicalize_path(Path(resolved[2]))
+            return (
+                resolved_root
+                if resolved_root.exists() and resolved_root.is_dir()
+                else None
+            )
+
+        workspace_root = canonicalize_path(self._config.root / candidate)
         return (
             workspace_root
             if workspace_root.exists() and workspace_root.is_dir()
@@ -4705,6 +4731,11 @@ class DiscordBotService:
 
     def _list_agent_workspaces(self) -> list[tuple[str, str, str]]:
         from .workspace_commands import _list_agent_workspaces as _impl
+
+        return _impl(self)
+
+    def _list_agent_workspaces_from_cache(self) -> list[tuple[str, str, str]]:
+        from .workspace_commands import _list_agent_workspaces_from_cache as _impl
 
         return _impl(self)
 

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -1337,6 +1337,7 @@ class DiscordBotService:
             ("repo", repo_id, str(canonicalize_path(Path(path))))
             for repo_id, path in self._list_manifest_repos()
         ]
+        seen_paths = {workspace_path for _kind, _id, workspace_path in cheap_candidates}
         cheap_candidates.extend(
             (
                 "agent_workspace",
@@ -1345,6 +1346,28 @@ class DiscordBotService:
             )
             for workspace_id, workspace_path, _display_name in self._list_agent_workspaces_from_cache()
         )
+        seen_paths.update(
+            workspace_path for _kind, _id, workspace_path in cheap_candidates
+        )
+        try:
+            for child in sorted(
+                self._config.root.iterdir(),
+                key=lambda entry: entry.name.lower(),
+            ):
+                if not child.is_dir():
+                    continue
+                if child.name.startswith("."):
+                    continue
+                normalized_path = str(canonicalize_path(child))
+                if normalized_path in seen_paths:
+                    continue
+                seen_paths.add(normalized_path)
+                cheap_candidates.append((None, None, normalized_path))
+        except OSError:
+            self._logger.debug(
+                "failed to scan root directory for scheduler bind candidates",
+                exc_info=True,
+            )
         resolved = self._resolve_workspace_from_token(normalized, cheap_candidates)
         if resolved is not None:
             resolved_root = canonicalize_path(Path(resolved[2]))

--- a/tests/integrations/discord/test_reliability.py
+++ b/tests/integrations/discord/test_reliability.py
@@ -1226,6 +1226,53 @@ async def test_ack_succeeds_within_budget_and_records_latency() -> None:
 
 
 @pytest.mark.anyio
+async def test_scheduler_bind_target_workspace_root_uses_direct_path_fast_path(
+    tmp_path: Path,
+) -> None:
+    service = DiscordBotService.__new__(DiscordBotService)
+    workspace_root = tmp_path / "bound-workspace"
+    workspace_root.mkdir()
+    service._config = SimpleNamespace(root=tmp_path)
+    service._list_manifest_repos = Mock(  # type: ignore[assignment]
+        side_effect=AssertionError("direct path should not scan manifest repos")
+    )
+    service._list_agent_workspaces_from_cache = Mock(  # type: ignore[assignment]
+        side_effect=AssertionError("direct path should not scan cached workspaces")
+    )
+
+    resolved = await service._scheduler_bind_target_workspace_root(str(workspace_root))
+
+    assert resolved == workspace_root
+
+
+@pytest.mark.anyio
+async def test_scheduler_bind_target_workspace_root_uses_local_manifest_repo_only(
+    tmp_path: Path,
+) -> None:
+    service = DiscordBotService.__new__(DiscordBotService)
+    repo_root = tmp_path / "repo-one"
+    repo_root.mkdir()
+    service._config = SimpleNamespace(root=tmp_path)
+    service._list_manifest_repos = Mock(  # type: ignore[assignment]
+        return_value=[("repo_1", str(repo_root))]
+    )
+    service._list_agent_workspaces_from_cache = Mock(  # type: ignore[assignment]
+        return_value=[]
+    )
+    service._list_agent_workspaces = Mock(  # type: ignore[assignment]
+        side_effect=AssertionError(
+            "scheduler resolution must not live-fetch agent workspaces"
+        )
+    )
+
+    resolved = await service._scheduler_bind_target_workspace_root("repo_1")
+
+    assert resolved == repo_root
+    service._list_manifest_repos.assert_called_once()
+    service._list_agent_workspaces_from_cache.assert_called_once()
+
+
+@pytest.mark.anyio
 async def test_on_dispatch_does_not_attempt_fallback_response_after_confirmed_ack_expiry() -> (
     None
 ):

--- a/tests/integrations/discord/test_reliability.py
+++ b/tests/integrations/discord/test_reliability.py
@@ -24,6 +24,9 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from codex_autorunner.integrations.chat.dispatcher import conversation_id_for
+from codex_autorunner.integrations.discord.car_autocomplete import (
+    workspace_autocomplete_value,
+)
 from codex_autorunner.integrations.discord.command_runner import (
     CommandRunner,
     RunnerConfig,
@@ -1268,6 +1271,31 @@ async def test_scheduler_bind_target_workspace_root_uses_local_manifest_repo_onl
     resolved = await service._scheduler_bind_target_workspace_root("repo_1")
 
     assert resolved == repo_root
+    service._list_manifest_repos.assert_called_once()
+    service._list_agent_workspaces_from_cache.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_scheduler_bind_target_workspace_root_resolves_tokenized_local_path(
+    tmp_path: Path,
+) -> None:
+    service = DiscordBotService.__new__(DiscordBotService)
+    workspace_root = tmp_path / ("workspace-" + ("x" * 120))
+    workspace_root.mkdir()
+    service._config = SimpleNamespace(root=tmp_path)
+    service._list_manifest_repos = Mock(return_value=[])  # type: ignore[assignment]
+    service._list_agent_workspaces_from_cache = Mock(return_value=[])  # type: ignore[assignment]
+    service._list_agent_workspaces = Mock(  # type: ignore[assignment]
+        side_effect=AssertionError(
+            "scheduler resolution must not live-fetch agent workspaces"
+        )
+    )
+
+    resolved = await service._scheduler_bind_target_workspace_root(
+        workspace_autocomplete_value(str(workspace_root))
+    )
+
+    assert resolved == workspace_root
     service._list_manifest_repos.assert_called_once()
     service._list_agent_workspaces_from_cache.assert_called_once()
 

--- a/tests/test_hub_issue_1266.py
+++ b/tests/test_hub_issue_1266.py
@@ -373,6 +373,11 @@ def test_hub_housekeeping_loop_survives_sqlite_errors(
     )
     monkeypatch.setattr(
         web_app_module,
+        "reap_managed_docker_containers",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        web_app_module,
         "run_housekeeping_once",
         lambda *args, **kwargs: None,
     )


### PR DESCRIPTION
## Summary
- keep Discord `/car bind` scheduler lock resolution on the pre-ack path strictly local and cheap
- resolve manifest repos and cached agent workspaces without triggering live workspace enumeration before the Discord ack is sent
- add regression coverage for direct-path and manifest-repo bind target resolution
- stub the managed Docker reaper in `test_hub_housekeeping_loop_survives_sqlite_errors` so the repo's aggregate validation lane no longer hangs during TestClient shutdown on this machine

## Root Cause
`/car bind` uses `bind_target_workspace` locking, and the runtime computes that scheduler key before sending the initial Discord defer/ack. The existing resolver called `_list_bind_workspace_candidates()`, which can perform live hub-backed agent workspace enumeration. That work can consume the Discord ack budget before the interaction is acknowledged, which surfaces in Discord as `The application did not respond`.

Sibling log evidence was directionally consistent with ack-expiry failures in this area:
- `discord-1/.codex-autorunner/tmp/flake-audit/fast-suite/run-2.log` recorded `discord.interaction.ack.failed` with `expired_before_ack: true`
- the same log immediately recorded `discord.interaction.delivery_expired_before_dispatch`

## Validation
- `.venv/bin/python -m pytest tests/integrations/discord/test_reliability.py -k 'scheduler_bind_target_workspace_root or ack_budget'`
- `.venv/bin/python -m pytest tests/integrations/discord/test_service_routing.py -k 'bind_picker_component_interaction or invalid_workspace'`
- `.venv/bin/python -m pytest tests/test_hub_issue_1266.py -k 'hub_housekeeping_loop_survives_sqlite_errors'`
- repo commit hook / aggregate lane
  - `mypy` clean
  - `pytest`: `5873 passed, 9 xfailed`
  - `pnpm run build`
  - `pnpm test:markdown`
