### PR TITLE
[codex] Fix CAR temp-root cleanup discovery

### DIFF
--- a/src/codex_autorunner/core/pytest_temp_cleanup.py
+++ b/src/codex_autorunner/core/pytest_temp_cleanup.py
@@ -187,8 +187,29 @@ def cleanup_repo_temp_paths(
     *,
     dry_run: bool = False,
     temp_base: Path | None = None,
+    min_age_seconds: float = 0.0,
 ) -> TempCleanupSummary:
     paths = discover_repo_temp_paths(repo_root, temp_base=temp_base)
+    if not paths:
+        return TempCleanupSummary(
+            scanned=0,
+            deleted=0,
+            active=0,
+            failed=0,
+            bytes_before=0,
+            bytes_after=0,
+        )
+    if min_age_seconds > 0.0:
+        cutoff = time.time() - max(0.0, float(min_age_seconds))
+        filtered: list[Path] = []
+        for path in paths:
+            try:
+                if path.stat().st_mtime >= cutoff:
+                    continue
+            except OSError:
+                continue
+            filtered.append(path)
+        paths = tuple(filtered)
     if not paths:
         return TempCleanupSummary(
             scanned=0,
@@ -222,6 +243,7 @@ def cleanup_repo_managed_temp_paths(
                 repo_root,
                 dry_run=dry_run,
                 temp_base=temp_base,
+                min_age_seconds=min_age_seconds,
             ),
         )
     )

--- a/src/codex_autorunner/core/pytest_temp_cleanup.py
+++ b/src/codex_autorunner/core/pytest_temp_cleanup.py
@@ -9,17 +9,24 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Iterable
+from typing import Callable, Hashable, Iterable, TypeVar
 
 _PYTEST_RUNTIME_TEMP_SUBDIR = "t"
 _DEFAULT_LSOF_TIMEOUT_SECONDS = 10.0
 _TEMP_ENV_KEYS = ("TMPDIR", "TMP", "TEMP")
+_CAR_TEMP_DIR_PREFIXES = (
+    "car-cached-",
+    "car-hub-profile-",
+    "car-nocache-",
+    "car-patch-",
+)
 _RMTREE_RETRY_ERRNOS = {
     errno.ENOTEMPTY,
     errno.EBUSY,
 }
 _RMTREE_RETRY_ATTEMPTS = 8
 _RMTREE_RETRY_SLEEP_SECONDS = 0.1
+_T = TypeVar("_T", bound=Hashable)
 
 
 @dataclass(frozen=True)
@@ -71,6 +78,36 @@ def repo_pytest_temp_root(repo_root: Path, *, temp_base: Path | None = None) -> 
     )
 
 
+def candidate_system_temp_roots() -> tuple[Path, ...]:
+    roots: dict[Path, Path] = {}
+    for candidate in (system_temp_root(),):
+        normalized = Path(candidate).expanduser().resolve(strict=False)
+        roots.setdefault(normalized, normalized)
+        for alias in _system_temp_root_aliases(normalized):
+            resolved_alias = alias.expanduser().resolve(strict=False)
+            roots.setdefault(resolved_alias, resolved_alias)
+    return tuple(sorted(roots.values(), key=lambda path: str(path)))
+
+
+def existing_repo_pytest_runtime_roots(
+    repo_root: Path,
+    *,
+    temp_base: Path | None = None,
+) -> tuple[Path, ...]:
+    runtime_root = repo_pytest_runtime_root(repo_root, temp_base=temp_base)
+    if temp_base is not None:
+        return (runtime_root,) if runtime_root.exists() else ()
+
+    roots: dict[Path, Path] = {}
+    for base_root in candidate_system_temp_roots():
+        candidate = repo_pytest_runtime_root(repo_root, temp_base=base_root)
+        if not candidate.exists():
+            continue
+        normalized = candidate.resolve(strict=False)
+        roots.setdefault(normalized, candidate)
+    return tuple(sorted(roots.values(), key=lambda path: str(path)))
+
+
 def cleanup_repo_pytest_temp_runs(
     repo_root: Path,
     *,
@@ -79,9 +116,11 @@ def cleanup_repo_pytest_temp_runs(
     temp_base: Path | None = None,
     min_age_seconds: float = 0.0,
 ) -> TempCleanupSummary:
-    temp_root = repo_pytest_temp_root(repo_root, temp_base=temp_base)
-    keep = {token for token in (keep_run_tokens or set()) if token}
-    if not temp_root.exists():
+    runtime_roots = existing_repo_pytest_runtime_roots(repo_root, temp_base=temp_base)
+    if temp_base is not None and not runtime_roots:
+        temp_root = repo_pytest_temp_root(repo_root, temp_base=temp_base)
+        runtime_roots = (temp_root.parent,) if temp_root.exists() else ()
+    if not runtime_roots:
         return TempCleanupSummary(
             scanned=0,
             deleted=0,
@@ -90,25 +129,102 @@ def cleanup_repo_pytest_temp_runs(
             bytes_before=0,
             bytes_after=0,
         )
+    keep = {token for token in (keep_run_tokens or set()) if token}
     cutoff = time.time() - max(0.0, float(min_age_seconds))
-    paths = []
-    for path in sorted(temp_root.iterdir()):
-        if path.name in keep or not path.is_dir():
+    summaries: list[TempCleanupSummary] = []
+    for runtime_root in runtime_roots:
+        temp_root = runtime_root / _PYTEST_RUNTIME_TEMP_SUBDIR
+        if not temp_root.exists():
             continue
-        if min_age_seconds > 0.0:
-            try:
-                if path.stat().st_mtime >= cutoff:
-                    continue
-            except OSError:
+        paths = []
+        for path in sorted(temp_root.iterdir()):
+            if path.name in keep or not path.is_dir():
                 continue
-        paths.append(path)
-    summary = cleanup_temp_paths(paths, dry_run=dry_run)
-    if not dry_run:
-        _remove_empty_parent_dirs(
-            temp_root,
-            stop_before=repo_pytest_runtime_root(repo_root, temp_base=temp_base).parent,
+            if min_age_seconds > 0.0:
+                try:
+                    if path.stat().st_mtime >= cutoff:
+                        continue
+                except OSError:
+                    continue
+            paths.append(path)
+        summary = cleanup_temp_paths(paths, dry_run=dry_run)
+        summaries.append(summary)
+        if not dry_run:
+            _remove_empty_parent_dirs(temp_root, stop_before=runtime_root.parent)
+    return _combine_cleanup_summaries(summaries)
+
+
+def discover_repo_temp_paths(
+    repo_root: Path,
+    *,
+    temp_base: Path | None = None,
+) -> tuple[Path, ...]:
+    candidate_roots: tuple[Path, ...]
+    if temp_base is not None:
+        candidate_roots = (Path(temp_base),)
+    else:
+        candidate_roots = candidate_system_temp_roots()
+    discovered: dict[Path, Path] = {}
+    for base_root in candidate_roots:
+        root = Path(base_root).expanduser().resolve(strict=False)
+        if not root.exists() or not root.is_dir():
+            continue
+        try:
+            children = sorted(root.iterdir(), key=lambda path: path.name)
+        except OSError:
+            continue
+        for child in children:
+            if not child.is_dir():
+                continue
+            if _is_repo_owned_temp_path(child):
+                normalized = child.resolve(strict=False)
+                discovered.setdefault(normalized, child)
+    return tuple(sorted(discovered.values(), key=lambda path: str(path)))
+
+
+def cleanup_repo_temp_paths(
+    repo_root: Path,
+    *,
+    dry_run: bool = False,
+    temp_base: Path | None = None,
+) -> TempCleanupSummary:
+    paths = discover_repo_temp_paths(repo_root, temp_base=temp_base)
+    if not paths:
+        return TempCleanupSummary(
+            scanned=0,
+            deleted=0,
+            active=0,
+            failed=0,
+            bytes_before=0,
+            bytes_after=0,
         )
-    return summary
+    return cleanup_temp_paths(paths, dry_run=dry_run)
+
+
+def cleanup_repo_managed_temp_paths(
+    repo_root: Path,
+    *,
+    keep_run_tokens: set[str] | None = None,
+    dry_run: bool = False,
+    temp_base: Path | None = None,
+    min_age_seconds: float = 0.0,
+) -> TempCleanupSummary:
+    return _combine_cleanup_summaries(
+        (
+            cleanup_repo_pytest_temp_runs(
+                repo_root,
+                keep_run_tokens=keep_run_tokens,
+                dry_run=dry_run,
+                temp_base=temp_base,
+                min_age_seconds=min_age_seconds,
+            ),
+            cleanup_repo_temp_paths(
+                repo_root,
+                dry_run=dry_run,
+                temp_base=temp_base,
+            ),
+        )
+    )
 
 
 def cleanup_temp_paths(
@@ -280,6 +396,81 @@ def system_temp_root() -> Path:
                 os.environ[key] = value
 
 
+def _system_temp_root_aliases(root: Path) -> tuple[Path, ...]:
+    aliases: dict[Path, Path] = {}
+    text = str(root)
+    if text == "/tmp":
+        aliases[Path("/private/tmp")] = Path("/private/tmp")
+    elif text == "/private/tmp":
+        aliases[Path("/tmp")] = Path("/tmp")
+    if text.startswith("/var/"):
+        aliases[Path("/private").joinpath(text.lstrip("/"))] = Path(
+            "/private"
+        ).joinpath(text.lstrip("/"))
+    elif text.startswith("/private/var/"):
+        aliases[Path("/" + text.removeprefix("/private/"))] = Path(
+            "/" + text.removeprefix("/private/")
+        )
+    return tuple(sorted(aliases.values(), key=lambda path: str(path)))
+
+
+def _combine_cleanup_summaries(
+    summaries: Iterable[TempCleanupSummary],
+) -> TempCleanupSummary:
+    collected = list(summaries)
+    deleted_paths = _dedupe_ordered(
+        path for summary in collected for path in summary.deleted_paths
+    )
+    active_paths = _dedupe_ordered(
+        path for summary in collected for path in summary.active_paths
+    )
+    failed_paths = _dedupe_ordered(
+        detail for summary in collected for detail in summary.failed_paths
+    )
+    active_processes = _dedupe_processes(
+        process for summary in collected for process in summary.active_processes
+    )
+    return TempCleanupSummary(
+        scanned=sum(summary.scanned for summary in collected),
+        deleted=sum(summary.deleted for summary in collected),
+        active=sum(summary.active for summary in collected),
+        failed=sum(summary.failed for summary in collected),
+        bytes_before=sum(summary.bytes_before for summary in collected),
+        bytes_after=sum(summary.bytes_after for summary in collected),
+        deleted_paths=tuple(deleted_paths),
+        active_paths=tuple(active_paths),
+        failed_paths=tuple(failed_paths),
+        active_processes=tuple(active_processes),
+    )
+
+
+def _is_repo_owned_temp_path(path: Path) -> bool:
+    name = path.name
+    if any(name.startswith(prefix) for prefix in _CAR_TEMP_DIR_PREFIXES):
+        return True
+    if not name.startswith("tmp."):
+        return False
+    return _looks_like_repo_temp_workspace(path)
+
+
+def _looks_like_repo_temp_workspace(path: Path) -> bool:
+    try:
+        names = {child.name for child in path.iterdir()}
+    except OSError:
+        return False
+    has_flows_db = any(
+        name in names for name in ("flows.db", "flows.db-wal", "flows.db-shm")
+    )
+    has_repo_state = ".codex-autorunner" in names
+    repo_dir = path / "repo"
+    has_repo_checkout = repo_dir.is_dir() and (
+        (repo_dir / ".git").exists() or (repo_dir / ".codex-autorunner").exists()
+    )
+    return (has_repo_checkout and has_flows_db) or (
+        has_repo_checkout and has_repo_state
+    )
+
+
 def _tree_size_bytes(root: Path) -> int:
     try:
         if not root.exists():
@@ -336,4 +527,15 @@ def _dedupe_processes(
             continue
         seen.add(key)
         deduped.append(process)
+    return deduped
+
+
+def _dedupe_ordered(items: Iterable[_T]) -> list[_T]:
+    seen: set[_T] = set()
+    deduped: list[_T] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        deduped.append(item)
     return deduped

--- a/src/codex_autorunner/surfaces/cli/commands/cleanup.py
+++ b/src/codex_autorunner/surfaces/cli/commands/cleanup.py
@@ -26,7 +26,10 @@ from ....core.force_attestation import FORCE_ATTESTATION_REQUIRED_PHRASE
 from ....core.locks import process_alive, process_command_matches
 from ....core.managed_processes import reap_managed_processes
 from ....core.managed_processes.registry import list_process_records
-from ....core.pytest_temp_cleanup import cleanup_repo_pytest_temp_runs
+from ....core.pytest_temp_cleanup import (
+    cleanup_repo_managed_temp_paths,
+    cleanup_repo_pytest_temp_runs,
+)
 from ....core.report_retention import (
     DEFAULT_REPORT_MAX_HISTORY_FILES,
     DEFAULT_REPORT_MAX_TOTAL_BYTES,
@@ -242,6 +245,39 @@ def register_cleanup_commands(
         typer.echo(
             prefix
             + "pytest tmp cleanup: "
+            + " ".join(
+                [
+                    f"scanned={summary.scanned}",
+                    f"deleted={summary.deleted}",
+                    f"active={summary.active}",
+                    f"failed={summary.failed}",
+                    f"bytes_before={summary.bytes_before}",
+                    f"bytes_after={summary.bytes_after}",
+                ]
+            )
+        )
+        for path in summary.active_paths:
+            typer.echo(f"ACTIVE {path}")
+        for detail in summary.failed_paths:
+            typer.echo(f"FAILED {detail}")
+
+    @cleanup_app.command("temp-roots")
+    def cleanup_temp_roots(
+        repo: Optional[Path] = typer.Option(None, "--repo", help="Repo path"),
+        hub: Optional[Path] = hub_root_path_option(),
+        dry_run: bool = typer.Option(
+            False,
+            "--dry-run",
+            help="Preview CAR temp-root cleanup without deleting inactive roots.",
+        ),
+    ) -> None:
+        """Prune stale CAR-managed temp roots outside repo-local state."""
+        engine = require_repo_config(repo, hub)
+        summary = cleanup_repo_managed_temp_paths(engine.repo_root, dry_run=dry_run)
+        prefix = "Dry run: " if dry_run else ""
+        typer.echo(
+            prefix
+            + "temp root cleanup: "
             + " ".join(
                 [
                     f"scanned={summary.scanned}",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ def _format_temp_processes(processes: tuple[object, ...]) -> str:
 
 _HERMETIC_ROOTS.prepare_process_environment()
 _HERMETIC_ROOTS.prune_inactive_pytest_temp_runs(min_age_seconds=300.0)
+_HERMETIC_ROOTS.prune_inactive_repo_temp_roots(min_age_seconds=300.0)
 _HERMETIC_ROOTS.prune_old_opencode_state_runs(max_age_seconds=86400)
 
 

--- a/tests/core/test_hermetic_roots.py
+++ b/tests/core/test_hermetic_roots.py
@@ -116,3 +116,33 @@ def test_prune_inactive_pytest_temp_runs_routes_through_cleanup_module(
     roots.prune_inactive_pytest_temp_runs(min_age_seconds=123.0)
 
     assert calls == [(roots.repo_root, {"run-z"}, 123.0)]
+
+
+def test_prune_inactive_repo_temp_roots_routes_through_cleanup_module(
+    tmp_path: Path, monkeypatch
+) -> None:
+    system_tmp = tmp_path / "system-tmp"
+    monkeypatch.setattr(roots_module, "_system_temp_root", lambda _repo: system_tmp)
+    calls: list[tuple[Path, set[str], float]] = []
+
+    def _cleanup_repo_managed_temp_paths(
+        repo_root: Path, *, keep_run_tokens: set[str], min_age_seconds: float
+    ) -> None:
+        calls.append((repo_root, keep_run_tokens, min_age_seconds))
+
+    monkeypatch.setattr(
+        roots_module,
+        "_load_pytest_temp_cleanup_module",
+        lambda _repo: SimpleNamespace(
+            cleanup_repo_managed_temp_paths=_cleanup_repo_managed_temp_paths
+        ),
+    )
+
+    roots = roots_module.HermeticTestRoots.from_repo_root(
+        tmp_path / "repo",
+        environ={"CAR_PYTEST_RUN_TOKEN": "run-q", "PYTEST_XDIST_WORKER": "gw3"},
+    )
+
+    roots.prune_inactive_repo_temp_roots(min_age_seconds=321.0)
+
+    assert calls == [(roots.repo_root, {"run-q"}, 321.0)]

--- a/tests/core/test_pytest_temp_cleanup.py
+++ b/tests/core/test_pytest_temp_cleanup.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import errno
+import os
+import time
 from pathlib import Path
 
 from codex_autorunner.core import pytest_temp_cleanup as cleanup_module
@@ -127,6 +129,36 @@ def test_cleanup_repo_managed_temp_paths_combines_pytest_and_generic_temp_roots(
     assert summary.deleted == 2
     assert stale_run.exists() is False
     assert generic_root.exists() is False
+
+
+def test_cleanup_repo_managed_temp_paths_skips_recent_generic_car_dirs(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    temp_base = tmp_path / "tmp"
+    stale_run = repo_pytest_temp_root(repo_root, temp_base=temp_base) / "stale"
+    recent_generic = temp_base / "car-hub-profile-20260414"
+    (stale_run / "payload").mkdir(parents=True)
+    (recent_generic / "Profile").mkdir(parents=True)
+    (stale_run / "payload" / "artifact.bin").write_bytes(b"1234")
+    (recent_generic / "Profile" / "prefs.json").write_text(
+        "{}",
+        encoding="utf-8",
+    )
+    old = time.time() - 400.0
+    os.utime(stale_run, (old, old))
+
+    summary = cleanup_repo_managed_temp_paths(
+        repo_root,
+        temp_base=temp_base,
+        min_age_seconds=300.0,
+    )
+
+    assert summary.scanned == 1
+    assert summary.deleted == 1
+    assert stale_run.exists() is False
+    assert recent_generic.exists() is True
 
 
 def test_cleanup_temp_paths_skips_active_roots(tmp_path: Path) -> None:

--- a/tests/core/test_pytest_temp_cleanup.py
+++ b/tests/core/test_pytest_temp_cleanup.py
@@ -7,8 +7,10 @@ from codex_autorunner.core import pytest_temp_cleanup as cleanup_module
 from codex_autorunner.core.pytest_temp_cleanup import (
     TempPathScanResult,
     TempRootProcess,
+    cleanup_repo_managed_temp_paths,
     cleanup_repo_pytest_temp_runs,
     cleanup_temp_paths,
+    discover_repo_temp_paths,
     repo_pytest_temp_root,
 )
 
@@ -57,6 +59,74 @@ def test_cleanup_repo_pytest_temp_runs_skips_recent_run_dirs(
     assert summary.scanned == 0
     assert summary.deleted == 0
     assert recent_run.exists() is True
+
+
+def test_cleanup_repo_pytest_temp_runs_scans_multiple_temp_roots(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    temp_a = tmp_path / "tmp-a"
+    temp_b = tmp_path / "tmp-b"
+    stale_a = repo_pytest_temp_root(repo_root, temp_base=temp_a) / "stale-a"
+    stale_b = repo_pytest_temp_root(repo_root, temp_base=temp_b) / "stale-b"
+    (stale_a / "data").mkdir(parents=True)
+    (stale_b / "data").mkdir(parents=True)
+    (stale_a / "data" / "artifact.bin").write_bytes(b"1234")
+    (stale_b / "data" / "artifact.bin").write_bytes(b"5678")
+    monkeypatch.setattr(
+        cleanup_module,
+        "candidate_system_temp_roots",
+        lambda: (temp_a, temp_b),
+    )
+
+    summary = cleanup_repo_pytest_temp_runs(repo_root)
+
+    assert summary.scanned == 2
+    assert summary.deleted == 2
+    assert stale_a.exists() is False
+    assert stale_b.exists() is False
+
+
+def test_discover_repo_temp_paths_finds_car_dirs_and_repo_workspaces(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    temp_base = tmp_path / "tmp"
+    car_profile = temp_base / "car-hub-profile-20260414"
+    workspace = temp_base / "tmp.NmYoDUn4Sd"
+    (car_profile / "Profile").mkdir(parents=True)
+    (workspace / "repo" / ".git").mkdir(parents=True)
+    (workspace / "flows.db").write_text("sqlite", encoding="utf-8")
+
+    paths = discover_repo_temp_paths(repo_root, temp_base=temp_base)
+
+    assert paths == (car_profile, workspace)
+
+
+def test_cleanup_repo_managed_temp_paths_combines_pytest_and_generic_temp_roots(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    temp_base = tmp_path / "tmp"
+    stale_run = repo_pytest_temp_root(repo_root, temp_base=temp_base) / "stale"
+    generic_root = temp_base / "car-hub-profile-20260414"
+    (stale_run / "payload").mkdir(parents=True)
+    (generic_root / "Profile").mkdir(parents=True)
+    (stale_run / "payload" / "artifact.bin").write_bytes(b"1234")
+    (generic_root / "Profile" / "prefs.json").write_text(
+        "{}",
+        encoding="utf-8",
+    )
+
+    summary = cleanup_repo_managed_temp_paths(repo_root, temp_base=temp_base)
+
+    assert summary.scanned == 2
+    assert summary.deleted == 2
+    assert stale_run.exists() is False
+    assert generic_root.exists() is False
 
 
 def test_cleanup_temp_paths_skips_active_roots(tmp_path: Path) -> None:

--- a/tests/support/hermetic_roots.py
+++ b/tests/support/hermetic_roots.py
@@ -143,6 +143,14 @@ class HermeticTestRoots:
             min_age_seconds=min_age_seconds,
         )
 
+    def prune_inactive_repo_temp_roots(self, *, min_age_seconds: float = 300.0) -> None:
+        cleanup_module = self.load_pytest_temp_cleanup_module()
+        cleanup_module.cleanup_repo_managed_temp_paths(
+            self.repo_root,
+            keep_run_tokens={self.run_token},
+            min_age_seconds=min_age_seconds,
+        )
+
     def prune_old_opencode_state_runs(self, *, max_age_seconds: int = 86400) -> None:
         if not self.pytest_opencode_state_root.exists():
             return

--- a/tests/test_cli_cleanup_pytest_tmp.py
+++ b/tests/test_cli_cleanup_pytest_tmp.py
@@ -47,3 +47,40 @@ def test_cleanup_pytest_tmp_reports_summary(monkeypatch, tmp_path: Path) -> None
     assert "deleted=2" in result.output
     assert "active=1" in result.output
     assert f"ACTIVE {tmp_path / 'active-run'}" in result.output
+
+
+def test_cleanup_temp_roots_reports_summary(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        cleanup_cmd,
+        "cleanup_repo_managed_temp_paths",
+        lambda repo_root, dry_run=False: TempCleanupSummary(
+            scanned=4,
+            deleted=3,
+            active=1,
+            failed=0,
+            bytes_before=400,
+            bytes_after=100,
+            deleted_paths=(),
+            active_paths=(tmp_path / "car-hub-profile-20260414",),
+            failed_paths=(),
+            active_processes=(),
+        ),
+    )
+
+    cleanup_app = typer.Typer()
+    cleanup_cmd.register_cleanup_commands(
+        cleanup_app,
+        require_repo_config=lambda _repo, _hub: types.SimpleNamespace(  # type: ignore[arg-type]
+            repo_root=tmp_path,
+            config=types.SimpleNamespace(pma=types.SimpleNamespace()),
+        ),
+    )
+
+    result = runner.invoke(cleanup_app, ["temp-roots", "--repo", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "temp root cleanup:" in result.output
+    assert "scanned=4" in result.output
+    assert "deleted=3" in result.output
+    assert "active=1" in result.output
+    assert f"ACTIVE {tmp_path / 'car-hub-profile-20260414'}" in result.output


### PR DESCRIPTION
## Summary
- broaden repo temp-root discovery so cleanup can find stale `cp-*` roots across macOS temp aliases instead of only one computed base
- add `car cleanup temp-roots` for stale CAR-managed temp directories such as `car-hub-profile-*` and repo workspace temp trees that include copied repos plus `flows.db`
- run the broader managed-temp cleanup during pytest session startup so stale external temp roots get pruned before the suite grows again

## Root Cause
The existing cleanup path only walked a single repo-scoped pytest temp root under the current system temp base. On macOS, CAR-owned temp trees can accumulate under alternate aliases and sibling temp directories, so stale `cp-*`, `car-*`, and repo workspace temp trees were left outside repo-local state with no operator cleanup path.

## Validation
- `.venv/bin/python -m pytest tests/core/test_pytest_temp_cleanup.py tests/core/test_hermetic_roots.py tests/test_cli_cleanup_pytest_tmp.py`
- pre-commit aggregate lane during `git commit`, including strict repo-wide mypy, full pytest (`5889 passed, 8 xfailed`), frontend build, and JS tests

Closes #1476