### PR TITLE
[codex] Repair SCM follow-up when PR thread is archived

### DIFF
--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -1290,6 +1290,40 @@ class PmaThreadStore:
             return None
         return _execution_row_to_record(row)
 
+    def get_turn_by_client_turn_id_any_thread(
+        self, client_turn_id: str
+    ) -> Optional[dict[str, Any]]:
+        """Return the best matching execution for this client id across all threads.
+
+        Publish dedupe keys do not vary when a PR binding is repointed to a new
+        managed thread; without a global lookup, a retried enqueue could miss a
+        turn created on the replacement thread and enqueue a duplicate.
+        """
+        normalized_client_turn_id = _coerce_text(client_turn_id)
+        if normalized_client_turn_id is None:
+            return None
+        with self._read_conn() as conn:
+            row = conn.execute(
+                """
+                SELECT *
+                  FROM orch_thread_executions
+                 WHERE client_request_id = ?
+                 ORDER BY
+                       CASE status
+                           WHEN 'running' THEN 0
+                           WHEN 'queued' THEN 1
+                           ELSE 2
+                       END,
+                       COALESCE(started_at, created_at) DESC,
+                       execution_id DESC
+                 LIMIT 1
+                """,
+                (normalized_client_turn_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return _execution_row_to_record(row)
+
     def list_queued_turns(
         self, managed_thread_id: str, *, limit: int = 200
     ) -> list[dict[str, Any]]:

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -510,10 +510,10 @@ def build_enqueue_managed_turn_executor(*, hub_root: Path) -> PublishActionExecu
         if thread_target_id is None:
             thread_target_id = requested_thread_target_id
         client_request_id = _operation_digest(operation, prefix="publish-turn")
-        existing = store.get_turn_by_client_turn_id(thread_target_id, client_request_id)
+        existing = store.get_turn_by_client_turn_id_any_thread(client_request_id)
         if existing is not None:
             return _managed_turn_result(
-                thread_target_id=thread_target_id,
+                thread_target_id=existing["managed_thread_id"],
                 client_request_id=client_request_id,
                 turn=existing,
                 existed=True,

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -3,18 +3,23 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import threading
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Callable, Coroutine, Optional
 
+from ..manifest import ManifestError, load_manifest
+from .config import load_hub_config
 from .orchestration.models import MessageRequest, MessageRequestKind
 from .pma_chat_delivery import (
     deliver_pma_notification,
     notify_preferred_bound_chat_for_workspace,
     notify_primary_pma_chat_for_repo,
 )
-from .pma_thread_store import PmaThreadStore
+from .pma_thread_store import ManagedThreadNotActiveError, PmaThreadStore
+from .pr_bindings import PrBinding, PrBindingStore
 from .publish_executor import PublishActionExecutor, TerminalPublishError
 from .publish_journal import PublishOperation
+from .scm_events import ScmEvent, ScmEventStore
 from .scm_observability import correlation_id_for_operation, correlation_id_from_payload
 from .text_utils import _coerce_int, _normalize_optional_text
 
@@ -28,6 +33,10 @@ def _require_text(value: Any, *, field_name: str) -> str:
 
 def _normalize_mapping(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, dict) else {}
+
+
+def _normalize_scm_tracking(payload: dict[str, Any]) -> dict[str, Any]:
+    return _normalize_mapping(payload.get("scm_reaction"))
 
 
 def _normalize_request_kind(value: Any) -> MessageRequestKind:
@@ -131,16 +140,375 @@ def _managed_turn_result(
     return result
 
 
+def _resolve_scm_binding(
+    hub_root: Path,
+    *,
+    tracking: Mapping[str, Any],
+) -> Optional[PrBinding]:
+    provider = _normalize_optional_text(tracking.get("provider"))
+    repo_slug = _normalize_optional_text(tracking.get("repo_slug"))
+    pr_number = _coerce_int(tracking.get("pr_number"))
+    if provider is None or repo_slug is None or pr_number is None or pr_number <= 0:
+        return None
+    return PrBindingStore(hub_root).get_binding_by_pr(
+        provider=provider,
+        repo_slug=repo_slug,
+        pr_number=pr_number,
+    )
+
+
+def _resolve_scm_event(
+    hub_root: Path,
+    *,
+    tracking: Mapping[str, Any],
+) -> Optional[ScmEvent]:
+    event_id = _normalize_optional_text(tracking.get("event_id"))
+    if event_id is None:
+        return None
+    return ScmEventStore(hub_root).get_event(event_id)
+
+
+def _active_thread_record(
+    store: PmaThreadStore,
+    thread_target_id: Optional[str],
+) -> tuple[Optional[str], Optional[dict[str, Any]]]:
+    normalized_thread_target_id = _normalize_optional_text(thread_target_id)
+    if normalized_thread_target_id is None:
+        return None, None
+    thread = store.get_thread(normalized_thread_target_id)
+    if thread is None:
+        return None, None
+    lifecycle_status = _normalize_optional_text(
+        thread.get("lifecycle_status") or thread.get("status")
+    )
+    if lifecycle_status != "active":
+        return None, thread
+    return normalized_thread_target_id, thread
+
+
+def _resolve_manifest_workspace(
+    hub_root: Path,
+    *,
+    repo_id: Optional[str],
+) -> Optional[Path]:
+    normalized_repo_id = _normalize_optional_text(repo_id)
+    if normalized_repo_id is None:
+        return None
+    try:
+        manifest = load_manifest(load_hub_config(hub_root).manifest_path, hub_root)
+    except (ManifestError, OSError, ValueError):
+        return None
+    entry = manifest.get(normalized_repo_id)
+    if entry is None:
+        return None
+    workspace_root = (hub_root / entry.path).resolve()
+    return workspace_root if workspace_root.exists() else None
+
+
+def _resolve_scm_workspace_root(
+    hub_root: Path,
+    *,
+    tracking: Mapping[str, Any],
+    source_thread: Optional[Mapping[str, Any]],
+) -> Optional[Path]:
+    if source_thread is not None:
+        workspace_text = _normalize_optional_text(source_thread.get("workspace_root"))
+        if workspace_text is not None:
+            workspace_root = Path(workspace_text)
+            if workspace_root.exists():
+                return workspace_root
+    return _resolve_manifest_workspace(
+        hub_root,
+        repo_id=_normalize_optional_text(tracking.get("repo_id")),
+    )
+
+
+def _scm_pr_url(*, repo_slug: Optional[str], pr_number: Optional[int]) -> Optional[str]:
+    if repo_slug is None or pr_number is None or pr_number <= 0:
+        return None
+    return f"https://github.com/{repo_slug}/pull/{pr_number}"
+
+
+def _trimmed_summary(value: Any, *, limit: int = 140) -> Optional[str]:
+    text = _normalize_optional_text(value)
+    if text is None:
+        return None
+    collapsed = " ".join(text.split())
+    if len(collapsed) <= limit:
+        return collapsed
+    return f"{collapsed[: limit - 3].rstrip()}..."
+
+
+def _scm_trigger_summary(
+    *,
+    event: Optional[ScmEvent],
+    tracking: Mapping[str, Any],
+) -> Optional[str]:
+    reaction_kind = _normalize_optional_text(tracking.get("reaction_kind"))
+    if event is None:
+        if reaction_kind is None:
+            return None
+        return reaction_kind.replace("_", " ")
+    payload = _normalize_mapping(event.payload)
+    if event.event_type == "check_run":
+        name = _normalize_optional_text(payload.get("name"))
+        conclusion = _normalize_optional_text(payload.get("conclusion"))
+        if name and conclusion:
+            return f"CI failed: {name} ({conclusion})"
+        if name:
+            return f"CI failed: {name}"
+    if event.event_type == "pull_request_review":
+        reviewer = _normalize_optional_text(payload.get("author_login"))
+        state = _normalize_optional_text(payload.get("review_state"))
+        if reviewer and state:
+            return f"Review {state} from {reviewer}"
+        if state:
+            return f"Review {state}"
+    if event.event_type in {"issue_comment", "pull_request_review_comment"}:
+        reviewer = _normalize_optional_text(payload.get("author_login"))
+        comment_id = _normalize_optional_text(payload.get("comment_id"))
+        if reviewer and comment_id:
+            return f"New review comment {comment_id} from {reviewer}"
+        if reviewer:
+            return f"New review comment from {reviewer}"
+    if reaction_kind is None:
+        return event.event_type
+    return reaction_kind.replace("_", " ")
+
+
+def _scm_review_focus_lines(
+    *,
+    event: Optional[ScmEvent],
+) -> list[str]:
+    if event is None:
+        return []
+    payload = _normalize_mapping(event.payload)
+    body = _trimmed_summary(payload.get("body"))
+    path = _normalize_optional_text(payload.get("path"))
+    line = _coerce_int(payload.get("line"))
+    location = path
+    if location is not None and line is not None and line > 0:
+        location = f"{location}:{line}"
+    comment_id = _normalize_optional_text(payload.get("comment_id"))
+    lines: list[str] = []
+    if event.event_type in {"issue_comment", "pull_request_review_comment"}:
+        detail = "Start with the latest review comment"
+        if comment_id is not None:
+            detail = f"{detail} {comment_id}"
+        if location is not None:
+            detail = f"{detail} at {location}"
+        if body is not None:
+            detail = f"{detail}: {body}"
+        lines.append(detail)
+    elif event.event_type == "pull_request_review" and body is not None:
+        reviewer = _normalize_optional_text(payload.get("author_login"))
+        if reviewer is not None:
+            lines.append(f"Review summary from {reviewer}: {body}")
+        else:
+            lines.append(f"Review summary: {body}")
+    return lines
+
+
+def _build_scm_rebootstrap_message(
+    *,
+    binding: PrBinding,
+    event: Optional[ScmEvent],
+    tracking: Mapping[str, Any],
+    previous_thread_target_id: str,
+) -> str:
+    subject = f"{binding.repo_slug}#{binding.pr_number}"
+    pr_url = _scm_pr_url(repo_slug=binding.repo_slug, pr_number=binding.pr_number)
+    lines = [
+        "Bootstrap a fresh SCM PR follow-up session because the previous bound managed thread is archived or unavailable.",
+        f"Target PR: {subject}",
+    ]
+    if pr_url is not None:
+        lines.append(f"PR URL: {pr_url}")
+    if binding.head_branch is not None:
+        lines.append(f"Branch: {binding.head_branch}")
+    trigger = _scm_trigger_summary(event=event, tracking=tracking)
+    if trigger is not None:
+        lines.append(f"Trigger: {trigger}")
+    lines.append(f"Previous thread: {previous_thread_target_id}")
+    focus_lines = _scm_review_focus_lines(event=event)
+    if focus_lines:
+        lines.append("Review focus:")
+        lines.extend(f"- {line}" for line in focus_lines)
+    lines.extend(
+        [
+            "Useful commands:",
+            f"- gh pr view {binding.pr_number} --repo {binding.repo_slug} --comments",
+            f"- gh pr checks {binding.pr_number} --repo {binding.repo_slug}",
+            "Task:",
+            "- Inspect the latest review comments and current PR status.",
+            "- Address any unresolved feedback and any failing checks relevant to this PR.",
+            "- If you make changes, push them to the PR branch.",
+            "- Reply on the PR summarizing what you addressed.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _build_scm_rebootstrap_request(
+    request: MessageRequest,
+    *,
+    replacement_thread_target_id: str,
+    previous_thread_target_id: str,
+    binding: PrBinding,
+    event: Optional[ScmEvent],
+    tracking: Mapping[str, Any],
+) -> MessageRequest:
+    metadata = dict(request.metadata)
+    scm_metadata = _normalize_mapping(metadata.get("scm"))
+    scm_metadata["binding_id"] = binding.binding_id
+    scm_metadata["previous_thread_target_id"] = previous_thread_target_id
+    scm_metadata["thread_target_id"] = replacement_thread_target_id
+    metadata["scm"] = scm_metadata
+    return MessageRequest(
+        target_id=replacement_thread_target_id,
+        target_kind=request.target_kind,
+        message_text=_build_scm_rebootstrap_message(
+            binding=binding,
+            event=event,
+            tracking=tracking,
+            previous_thread_target_id=previous_thread_target_id,
+        ),
+        kind=request.kind,
+        busy_policy=request.busy_policy,
+        agent_profile=request.agent_profile,
+        model=request.model,
+        reasoning=request.reasoning,
+        approval_mode=request.approval_mode,
+        input_items=request.input_items,
+        context_profile=request.context_profile,
+        metadata=metadata,
+    )
+
+
+def _repair_scm_thread_binding(
+    hub_root: Path,
+    store: PmaThreadStore,
+    *,
+    current_thread_target_id: str,
+    request: MessageRequest,
+    tracking: Mapping[str, Any],
+) -> tuple[str, MessageRequest]:
+    binding = _resolve_scm_binding(hub_root, tracking=tracking)
+    if binding is None:
+        raise ManagedThreadNotActiveError(current_thread_target_id, None)
+    source_thread = store.get_thread(current_thread_target_id)
+    workspace_root = _resolve_scm_workspace_root(
+        hub_root,
+        tracking=tracking,
+        source_thread=source_thread,
+    )
+    if workspace_root is None:
+        raise ManagedThreadNotActiveError(current_thread_target_id, None)
+    try:
+        default_agent = load_hub_config(hub_root).pma.default_agent
+    except (OSError, ValueError):
+        default_agent = "codex"
+    source_metadata = (
+        _normalize_mapping(source_thread.get("metadata"))
+        if isinstance(source_thread, Mapping)
+        else {}
+    )
+    metadata = dict(source_metadata)
+    scm_metadata = _normalize_mapping(metadata.get("scm"))
+    scm_metadata.update(
+        {
+            "provider": binding.provider,
+            "repo_slug": binding.repo_slug,
+            "repo_id": binding.repo_id,
+            "pr_number": binding.pr_number,
+            "pr_url": _scm_pr_url(
+                repo_slug=binding.repo_slug,
+                pr_number=binding.pr_number,
+            ),
+        }
+    )
+    if binding.head_branch is not None:
+        scm_metadata["head_branch"] = binding.head_branch
+        metadata["head_branch"] = binding.head_branch
+    if binding.base_branch is not None:
+        scm_metadata["base_branch"] = binding.base_branch
+    metadata["scm"] = scm_metadata
+    metadata["pr_number"] = binding.pr_number
+    if scm_metadata.get("pr_url") is not None:
+        metadata["pr_url"] = scm_metadata["pr_url"]
+    replacement = store.create_thread(
+        _normalize_optional_text(
+            source_thread.get("agent_id")
+            if isinstance(source_thread, Mapping)
+            else None
+        )
+        or default_agent
+        or "codex",
+        workspace_root,
+        repo_id=binding.repo_id,
+        resource_kind=_normalize_optional_text(
+            source_thread.get("resource_kind")
+            if isinstance(source_thread, Mapping)
+            else None
+        ),
+        resource_id=_normalize_optional_text(
+            source_thread.get("resource_id")
+            if isinstance(source_thread, Mapping)
+            else None
+        ),
+        name=_normalize_optional_text(
+            source_thread.get("display_name")
+            if isinstance(source_thread, Mapping)
+            else None
+        )
+        or f"PR #{binding.pr_number} follow-up",
+        metadata=metadata,
+    )
+    replacement_thread_target_id = _normalize_optional_text(
+        replacement.get("managed_thread_id")
+    )
+    if replacement_thread_target_id is None:
+        raise TerminalPublishError("Failed to create replacement managed thread")
+    rebound = PrBindingStore(hub_root).attach_thread_target(
+        provider=binding.provider,
+        repo_slug=binding.repo_slug,
+        pr_number=binding.pr_number,
+        thread_target_id=replacement_thread_target_id,
+    )
+    effective_binding = rebound or binding
+    event = _resolve_scm_event(hub_root, tracking=tracking)
+    return replacement_thread_target_id, _build_scm_rebootstrap_request(
+        request,
+        replacement_thread_target_id=replacement_thread_target_id,
+        previous_thread_target_id=current_thread_target_id,
+        binding=effective_binding,
+        event=event,
+        tracking=tracking,
+    )
+
+
 def build_enqueue_managed_turn_executor(*, hub_root: Path) -> PublishActionExecutor:
     store = PmaThreadStore(hub_root)
 
     def executor(operation: PublishOperation) -> dict[str, Any]:
         payload = _normalize_mapping(operation.payload)
         correlation_id = correlation_id_for_operation(operation)
-        thread_target_id = _require_text(
+        requested_thread_target_id = _require_text(
             payload.get("thread_target_id"),
             field_name="thread_target_id",
         )
+        tracking = _normalize_scm_tracking(payload)
+        binding = _resolve_scm_binding(hub_root, tracking=tracking)
+        thread_target_id, _active_thread = _active_thread_record(
+            store,
+            (
+                binding.thread_target_id
+                if binding is not None and binding.thread_target_id is not None
+                else requested_thread_target_id
+            ),
+        )
+        if thread_target_id is None:
+            thread_target_id = requested_thread_target_id
         client_request_id = _operation_digest(operation, prefix="publish-turn")
         existing = store.get_turn_by_client_turn_id(thread_target_id, client_request_id)
         if existing is not None:
@@ -158,23 +526,67 @@ def build_enqueue_managed_turn_executor(*, hub_root: Path) -> PublishActionExecu
             "client_request_id": client_request_id,
             "sandbox_policy": sandbox_policy,
         }
-        created = store.create_turn(
-            thread_target_id,
-            prompt=request.message_text,
-            request_kind=request.kind,
-            busy_policy="queue",
-            model=request.model,
-            reasoning=request.reasoning,
-            client_turn_id=client_request_id,
-            queue_payload=queue_payload,
-        )
-        return _managed_turn_result(
+        rebound_from_thread_target_id: Optional[str] = None
+        try:
+            created = store.create_turn(
+                thread_target_id,
+                prompt=request.message_text,
+                request_kind=request.kind,
+                busy_policy="queue",
+                model=request.model,
+                reasoning=request.reasoning,
+                client_turn_id=client_request_id,
+                queue_payload=queue_payload,
+            )
+        except ManagedThreadNotActiveError:
+            if not tracking:
+                raise
+            rebound_from_thread_target_id = thread_target_id
+            thread_target_id, request = _repair_scm_thread_binding(
+                hub_root,
+                store,
+                current_thread_target_id=thread_target_id,
+                request=request,
+                tracking=tracking,
+            )
+            existing = store.get_turn_by_client_turn_id(
+                thread_target_id, client_request_id
+            )
+            if existing is not None:
+                result = _managed_turn_result(
+                    thread_target_id=thread_target_id,
+                    client_request_id=client_request_id,
+                    turn=existing,
+                    existed=True,
+                    correlation_id=correlation_id,
+                )
+                result["rebound_from_thread_target_id"] = rebound_from_thread_target_id
+                return result
+            queue_payload = {
+                "request": request.to_dict(),
+                "client_request_id": client_request_id,
+                "sandbox_policy": sandbox_policy,
+            }
+            created = store.create_turn(
+                thread_target_id,
+                prompt=request.message_text,
+                request_kind=request.kind,
+                busy_policy="queue",
+                model=request.model,
+                reasoning=request.reasoning,
+                client_turn_id=client_request_id,
+                queue_payload=queue_payload,
+            )
+        result = _managed_turn_result(
             thread_target_id=thread_target_id,
             client_request_id=client_request_id,
             turn=created,
             existed=False,
             correlation_id=correlation_id,
         )
+        if rebound_from_thread_target_id is not None:
+            result["rebound_from_thread_target_id"] = rebound_from_thread_target_id
+        return result
 
     return executor
 

--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -675,7 +675,9 @@ class ScmAutomationService:
         enqueue_operation: PublishOperation,
         seen_operation_keys: set[str],
     ) -> Optional[PublishOperation]:
-        thread_target_id = _normalize_text(tracking.get("thread_target_id"))
+        thread_target_id = _normalize_text(
+            enqueue_operation.response.get("thread_target_id")
+        ) or _normalize_text(tracking.get("thread_target_id"))
         enqueue_status = _normalize_text(enqueue_operation.response.get("status"))
         if thread_target_id is None or enqueue_status not in {"queued", "running"}:
             return None
@@ -789,6 +791,8 @@ class ScmAutomationService:
                         "reaction_state_kind": reaction_state_kind,
                         "repo_id": binding.repo_id or event.repo_id,
                         "repo_slug": binding.repo_slug or event.repo_slug,
+                        "head_branch": binding.head_branch,
+                        "base_branch": binding.base_branch,
                         "thread_target_id": binding.thread_target_id,
                     }
                 )

--- a/tests/core/test_publish_executor.py
+++ b/tests/core/test_publish_executor.py
@@ -699,6 +699,96 @@ def test_enqueue_managed_turn_executor_rebinds_archived_scm_thread_with_bootstra
     assert replacement_thread["metadata"]["head_branch"] == "feature/scm-rebind"
 
 
+def test_enqueue_managed_turn_executor_dedupes_retry_after_scm_rebind_to_new_thread(
+    tmp_path: Path,
+) -> None:
+    """If the PR binding moves to a replacement thread, retries must still dedupe."""
+    hub_root, workspace_root, repo_id = _publish_hub(tmp_path)
+    thread_store = PmaThreadStore(hub_root)
+    archived_thread = thread_store.create_thread(
+        "codex",
+        workspace_root,
+        repo_id=repo_id,
+        name="Original PR thread",
+    )
+    thread_store.archive_thread(archived_thread["managed_thread_id"])
+
+    binding = PrBindingStore(hub_root).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        repo_id=repo_id,
+        pr_number=42,
+        pr_state="open",
+        head_branch="feature/scm-rebind",
+        base_branch="main",
+        thread_target_id=archived_thread["managed_thread_id"],
+    )
+    event = ScmEventStore(hub_root).record_event(
+        provider="github",
+        event_type="pull_request_review_comment",
+        event_id="github:event-rebind-dedupe",
+        occurred_at="2026-03-25T00:00:00Z",
+        received_at="2026-03-25T00:00:01Z",
+        repo_slug="acme/widgets",
+        repo_id=repo_id,
+        pr_number=42,
+        payload={
+            "action": "created",
+            "comment_id": "314",
+            "author_login": "reviewer",
+            "body": "Dedupe after rebind.",
+            "path": "src/example.py",
+            "line": 1,
+        },
+    )
+    journal = PublishJournalStore(hub_root)
+    operation, _ = journal.create_operation(
+        operation_key="enqueue:scm:archived-thread-retry-dedupe",
+        operation_kind="enqueue_managed_turn",
+        payload={
+            "thread_target_id": archived_thread["managed_thread_id"],
+            "request": {
+                "kind": "message",
+                "message_text": "First attempt message.",
+                "metadata": {
+                    "scm": {
+                        "binding_id": binding.binding_id,
+                        "event_id": event.event_id,
+                        "provider": "github",
+                        "repo_slug": "acme/widgets",
+                        "repo_id": repo_id,
+                        "pr_number": 42,
+                    }
+                },
+            },
+            "scm_reaction": {
+                "binding_id": binding.binding_id,
+                "event_id": event.event_id,
+                "provider": "github",
+                "reaction_kind": "review_comment",
+                "repo_slug": "acme/widgets",
+                "repo_id": repo_id,
+                "pr_number": 42,
+                "thread_target_id": archived_thread["managed_thread_id"],
+            },
+        },
+    )
+
+    executor = build_enqueue_managed_turn_executor(hub_root=hub_root)
+    first = executor(operation)
+    second = executor(operation)
+
+    assert first["deduped"] is False
+    assert second["deduped"] is True
+    assert first["managed_turn_id"] == second["managed_turn_id"]
+    assert first["thread_target_id"] == second["thread_target_id"]
+
+    rebound_id = first["thread_target_id"]
+    assert rebound_id != archived_thread["managed_thread_id"]
+    turns = thread_store.list_turns(rebound_id)
+    assert len(turns) == 1
+
+
 def test_process_now_runs_first_publish_operation_types(
     tmp_path: Path,
 ) -> None:

--- a/tests/core/test_publish_executor.py
+++ b/tests/core/test_publish_executor.py
@@ -12,6 +12,7 @@ from codex_autorunner.bootstrap import seed_hub_files
 from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
 from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.pma_thread_store import PmaThreadStore
+from codex_autorunner.core.pr_bindings import PrBindingStore
 from codex_autorunner.core.publish_executor import (
     PublishExecutorRegistry,
     PublishOperationProcessor,
@@ -23,6 +24,7 @@ from codex_autorunner.core.publish_operation_executors import (
     build_enqueue_managed_turn_executor,
     build_notify_chat_executor,
 )
+from codex_autorunner.core.scm_events import ScmEventStore
 from codex_autorunner.integrations.discord.state import DiscordStateStore
 from codex_autorunner.integrations.github.publisher import (
     build_post_pr_comment_executor,
@@ -585,6 +587,116 @@ def test_enqueue_managed_turn_executor_reuses_existing_execution_for_same_operat
     assert len(turns) == 1
     assert turns[0]["request_kind"] == "review"
     assert turns[0]["client_turn_id"] == first["client_request_id"]
+
+
+def test_enqueue_managed_turn_executor_rebinds_archived_scm_thread_with_bootstrap_prompt(
+    tmp_path: Path,
+) -> None:
+    hub_root, workspace_root, repo_id = _publish_hub(tmp_path)
+    thread_store = PmaThreadStore(hub_root)
+    archived_thread = thread_store.create_thread(
+        "codex",
+        workspace_root,
+        repo_id=repo_id,
+        name="Original PR thread",
+        metadata={"head_branch": "feature/scm-rebind"},
+    )
+    thread_store.archive_thread(archived_thread["managed_thread_id"])
+
+    binding = PrBindingStore(hub_root).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        repo_id=repo_id,
+        pr_number=42,
+        pr_state="open",
+        head_branch="feature/scm-rebind",
+        base_branch="main",
+        thread_target_id=archived_thread["managed_thread_id"],
+    )
+    event = ScmEventStore(hub_root).record_event(
+        provider="github",
+        event_type="pull_request_review_comment",
+        event_id="github:event-rebind",
+        occurred_at="2026-03-25T00:00:00Z",
+        received_at="2026-03-25T00:00:01Z",
+        repo_slug="acme/widgets",
+        repo_id=repo_id,
+        pr_number=42,
+        payload={
+            "action": "created",
+            "comment_id": "314",
+            "author_login": "reviewer",
+            "body": "Please cover the archived-thread fallback.",
+            "path": "src/codex_autorunner/core/scm_automation_service.py",
+            "line": 371,
+        },
+    )
+    journal = PublishJournalStore(hub_root)
+    operation, _ = journal.create_operation(
+        operation_key="enqueue:scm:archived-thread",
+        operation_kind="enqueue_managed_turn",
+        payload={
+            "thread_target_id": archived_thread["managed_thread_id"],
+            "request": {
+                "kind": "message",
+                "message_text": "New PR review feedback arrived on acme/widgets#42.",
+                "metadata": {
+                    "scm": {
+                        "binding_id": binding.binding_id,
+                        "event_id": event.event_id,
+                        "provider": "github",
+                        "repo_slug": "acme/widgets",
+                        "repo_id": repo_id,
+                        "pr_number": 42,
+                    }
+                },
+            },
+            "scm_reaction": {
+                "binding_id": binding.binding_id,
+                "event_id": event.event_id,
+                "provider": "github",
+                "reaction_kind": "review_comment",
+                "repo_slug": "acme/widgets",
+                "repo_id": repo_id,
+                "pr_number": 42,
+                "head_branch": "feature/scm-rebind",
+                "base_branch": "main",
+                "thread_target_id": archived_thread["managed_thread_id"],
+            },
+        },
+    )
+
+    result = build_enqueue_managed_turn_executor(hub_root=hub_root)(operation)
+
+    assert result["thread_target_id"] != archived_thread["managed_thread_id"]
+    assert (
+        result["rebound_from_thread_target_id"] == archived_thread["managed_thread_id"]
+    )
+
+    rebound_binding = PrBindingStore(hub_root).get_binding_by_pr(
+        provider="github",
+        repo_slug="acme/widgets",
+        pr_number=42,
+    )
+    assert rebound_binding is not None
+    assert rebound_binding.thread_target_id == result["thread_target_id"]
+
+    turns = thread_store.list_turns(result["thread_target_id"])
+    assert len(turns) == 1
+    queued = turns[0]
+    assert "Bootstrap a fresh SCM PR follow-up session" in queued["prompt"]
+    assert "Target PR: acme/widgets#42" in queued["prompt"]
+    assert "Start with the latest review comment 314" in queued["prompt"]
+    assert "gh pr view 42 --repo acme/widgets --comments" in queued["prompt"]
+    assert "push them to the PR branch" in queued["prompt"]
+
+    replacement_thread = thread_store.get_thread(result["thread_target_id"])
+    assert replacement_thread is not None
+    assert replacement_thread["metadata"]["pr_number"] == 42
+    assert replacement_thread["metadata"]["pr_url"] == (
+        "https://github.com/acme/widgets/pull/42"
+    )
+    assert replacement_thread["metadata"]["head_branch"] == "feature/scm-rebind"
 
 
 def test_process_now_runs_first_publish_operation_types(

--- a/tests/core/test_scm_automation_service.py
+++ b/tests/core/test_scm_automation_service.py
@@ -1000,6 +1000,7 @@ def test_handle_processed_operations_creates_truthful_review_comment_notice_on_s
             },
             "response": {
                 "status": "queued",
+                "thread_target_id": "thread-2",
             },
         }
     )
@@ -1008,7 +1009,7 @@ def test_handle_processed_operations_creates_truthful_review_comment_notice_on_s
 
     assert len(follow_ups) == 1
     assert follow_ups[0].operation_kind == "notify_chat"
-    assert follow_ups[0].payload["thread_target_id"] == "thread-1"
+    assert follow_ups[0].payload["thread_target_id"] == "thread-2"
     assert (
         "Queued the latest PR review batch for acme/widgets#42."
         in follow_ups[0].payload["message"]


### PR DESCRIPTION
## Summary
This repairs SCM follow-up delivery when a PR binding still points at an archived or missing managed thread.

## Root Cause
SCM automation kept the original `thread_target_id` from the PR binding even after that managed thread had been archived. `enqueue_managed_turn` then retried delivery against the same inactive thread, which raised `ManagedThreadNotActiveError` on every attempt. After the retry budget was exhausted, the automation layer escalated with the delivery failure message instead of recovering the PR follow-up flow.

## What Changed
- detect stale SCM-bound managed threads during `enqueue_managed_turn` execution
- create a replacement managed thread in the PR workspace and rebind the PR to it
- enqueue a bootstrap prompt for the fresh session with the PR, branch, trigger, review-comment focus, and `gh pr` commands to inspect/update the PR
- prefer the executor response thread id when sending the review-batch notice after a successful enqueue
- keep head/base branch details in SCM tracking metadata so the replacement session has the right PR context
- add regression coverage for archived-thread rebinding and the notice target selection

## Impact
PR review feedback and CI follow-ups now recover by starting a fresh managed session instead of failing three times against an archived thread and escalating.

## Validation
- `.venv/bin/pytest tests/core/test_publish_executor.py tests/core/test_scm_automation_service.py`
- repo pre-commit validation lane (`black`, `ruff`, strict `mypy`, fast-test budget verification, dead-code check)
- full non-integration pytest lane via pre-commit: `5746 passed, 9 xfailed`
