### PR TITLE
[codex] Relax backend-id control-plane timeout

### DIFF
--- a/src/codex_autorunner/core/hub_control_plane/http_client.py
+++ b/src/codex_autorunner/core/hub_control_plane/http_client.py
@@ -74,6 +74,7 @@ from .models import (
 _USE_CLIENT_DEFAULT_TIMEOUT = object()
 _SURFACE_BINDING_TIMEOUT_SECONDS = 30.0
 _THREAD_TARGET_CREATE_TIMEOUT_SECONDS = 30.0
+_EXECUTION_BACKEND_ID_TIMEOUT_SECONDS = 30.0
 _EXECUTION_RESULT_TIMEOUT_SECONDS = 30.0
 
 
@@ -578,6 +579,7 @@ class HttpHubControlPlaneClient(HubControlPlaneClient):
                 f"{request.execution_id}/backend-id"
             ),
             json_payload=request.to_dict(),
+            timeout=_EXECUTION_BACKEND_ID_TIMEOUT_SECONDS,
         )
 
     async def claim_next_queued_execution(

--- a/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
+++ b/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
@@ -43,6 +43,7 @@ from .models import (
 
 ResultT = TypeVar("ResultT")
 _THREAD_TARGET_CREATE_TIMEOUT_SECONDS = 30.0
+_EXECUTION_BACKEND_ID_TIMEOUT_SECONDS = 30.0
 _EXECUTION_RESULT_TIMEOUT_SECONDS = 30.0
 _BACKGROUND_RUNNER = BoundedBackgroundRunner(
     max_workers=8,
@@ -450,6 +451,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
     ) -> None:
         self._run(
             operation="set_execution_backend_id",
+            timeout_seconds=_EXECUTION_BACKEND_ID_TIMEOUT_SECONDS,
             action=lambda client: client.set_execution_backend_id(
                 ExecutionBackendIdUpdateRequest(
                     execution_id=execution_id,

--- a/tests/core/test_hub_control_plane_contract.py
+++ b/tests/core/test_hub_control_plane_contract.py
@@ -462,6 +462,66 @@ async def test_http_client_uses_extended_timeout_for_workspace_setup_commands() 
     ]
 
 
+async def test_http_client_uses_extended_timeout_for_backend_id_updates() -> None:
+    from codex_autorunner.core.hub_control_plane.http_client import (
+        HttpHubControlPlaneClient,
+    )
+    from codex_autorunner.core.hub_control_plane.models import (
+        ExecutionBackendIdUpdateRequest,
+    )
+
+    class _FakeAsyncClient:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        async def request(
+            self,
+            method: str,
+            path: str,
+            *,
+            json: dict[str, object] | None = None,
+            params: dict[str, object] | None = None,
+            timeout: float | None = None,
+        ) -> httpx.Response:
+            self.calls.append(
+                {
+                    "method": method,
+                    "path": path,
+                    "json": json,
+                    "params": params,
+                    "timeout": timeout,
+                }
+            )
+            return httpx.Response(204)
+
+    fake_client = _FakeAsyncClient()
+    client = HttpHubControlPlaneClient(
+        base_url="http://localhost:9999",
+        timeout=10.0,
+        http_client=fake_client,  # type: ignore[arg-type]
+    )
+
+    await client.set_execution_backend_id(
+        ExecutionBackendIdUpdateRequest(
+            execution_id="exec-1",
+            backend_turn_id="turn-2",
+        )
+    )
+
+    assert fake_client.calls == [
+        {
+            "method": "PUT",
+            "path": "/hub/api/control-plane/thread-executions/exec-1/backend-id",
+            "json": {
+                "execution_id": "exec-1",
+                "backend_turn_id": "turn-2",
+            },
+            "params": None,
+            "timeout": 30.0,
+        }
+    ]
+
+
 async def test_http_client_includes_exception_class_for_blank_transport_errors() -> (
     None
 ):

--- a/tests/core/test_remote_execution_store.py
+++ b/tests/core/test_remote_execution_store.py
@@ -464,6 +464,13 @@ class _BlockingGetThreadTargetClient(_FakeHubClient):
         return self.thread_response
 
 
+class _SlowSetExecutionBackendIdClient(_FakeHubClient):
+    async def set_execution_backend_id(self, request):
+        self.calls.append(("set_execution_backend_id", request))
+        await asyncio.sleep(0.02)
+        return None
+
+
 def test_remote_execution_store_translates_transport_failures_to_hub_unavailable() -> (
     None
 ):
@@ -562,3 +569,19 @@ def test_remote_execution_store_bounds_background_timeout_fallout() -> None:
     assert exc_info.value.code == "hub_unavailable"
     assert exc_info.value.details["operation"] == "get_thread_target"
     assert exc_info.value.details["max_workers"] == 1
+
+
+def test_remote_execution_store_uses_extended_timeout_for_backend_id_updates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "codex_autorunner.core.hub_control_plane.remote_execution_store."
+        "_EXECUTION_BACKEND_ID_TIMEOUT_SECONDS",
+        0.05,
+    )
+    store = RemoteThreadExecutionStore(
+        _SlowSetExecutionBackendIdClient(),
+        timeout_seconds=0.01,
+    )
+
+    store.set_execution_backend_id("exec-1", "turn-2")


### PR DESCRIPTION
## Summary
This narrows the control-plane timeout policy for `set_execution_backend_id`.

The failure path was:
- orchestration starts a managed execution
- it records a provisional backend turn id through the hub control plane
- the remote execution store waits only 10 seconds for that request
- the hub-side write path can block longer under PMA thread-store lock / SQLite contention
- the client reports `Hub control-plane unavailable during set_execution_backend_id: request timed out after 10s`

## What Changed
- add a dedicated 30 second timeout for `set_execution_backend_id` in `RemoteThreadExecutionStore`
- add the same dedicated 30 second timeout in `HttpHubControlPlaneClient`
- add regression coverage proving this operation uses its extended timeout instead of the generic 10 second default

## Why This Fix
`set_execution_backend_id` is an idempotent state update. Extending only this operation is the safest immediate mitigation for the observed failure without masking unrelated hub stalls by raising the global default timeout.

## Validation
- `.venv/bin/pytest tests/core/test_remote_execution_store.py tests/core/test_hub_control_plane_contract.py -q`
- `git commit` hook validation lane:
  - formatting/lint/import boundary checks
  - mypy on `src/codex_autorunner`
  - repo test suite: `5886 passed, 8 xfailed`
