### PR TITLE
Prevent Discord ingress stalls from sync chat-operation ledger calls

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -5538,6 +5538,15 @@ class DiscordBotService:
             return store
         return None
 
+    async def _chat_operation_get(
+        self, operation_id: str
+    ) -> Optional[ChatOperationSnapshot]:
+        store = self._chat_operation_store_or_none()
+        if store is None:
+            return None
+        # Keep Discord ingress callbacks non-blocking on SQLite lock contention.
+        return await asyncio.to_thread(store.get_operation, operation_id)
+
     def _chat_operation_terminal_duplicate(
         self, snapshot: ChatOperationSnapshot
     ) -> bool:
@@ -5588,25 +5597,34 @@ class DiscordBotService:
         store = self._chat_operation_store_or_none()
         if store is None:
             return None
-        registration = store.register_operation(
-            operation_id=ctx.interaction_id,
-            surface_kind="discord",
-            surface_operation_key=ctx.interaction_id,
-            state=ChatOperationState.RECEIVED,
-            conversation_id=conversation_id,
-            metadata=self._interaction_ledger_metadata(ctx),
-        )
-        store.patch_operation(
-            registration.snapshot.operation_id,
-            ack_requested_at=now_iso(),
-        )
-        if registration.inserted:
-            return registration.snapshot
-        return store.patch_operation(
-            ctx.interaction_id,
-            conversation_id=conversation_id or registration.snapshot.conversation_id,
-            metadata_updates=self._interaction_ledger_metadata(ctx),
-        )
+
+        interaction_id = ctx.interaction_id
+        metadata = self._interaction_ledger_metadata(ctx)
+
+        def _register_sync() -> Optional[ChatOperationSnapshot]:
+            registration = store.register_operation(
+                operation_id=interaction_id,
+                surface_kind="discord",
+                surface_operation_key=interaction_id,
+                state=ChatOperationState.RECEIVED,
+                conversation_id=conversation_id,
+                metadata=metadata,
+            )
+            store.patch_operation(
+                registration.snapshot.operation_id,
+                ack_requested_at=now_iso(),
+            )
+            if registration.inserted:
+                return registration.snapshot
+            return store.patch_operation(
+                interaction_id,
+                conversation_id=(
+                    conversation_id or registration.snapshot.conversation_id
+                ),
+                metadata_updates=metadata,
+            )
+
+        return await asyncio.to_thread(_register_sync)
 
     async def _patch_chat_operation(
         self,
@@ -5621,79 +5639,90 @@ class DiscordBotService:
         if store is None:
             return None
         patch_state = state if state is not None else _PATCH_STATE_UNSET
-        try:
-            return store.patch_operation(
-                interaction_id,
-                state=patch_state,
-                validate_transition=validate_transition,
-                metadata_updates=metadata_updates,
-                **changes,
-            )
-        except ValueError:
-            current = store.get_operation(interaction_id)
-            if current is None:
-                return None
-            if current.first_visible_feedback_at is not None:
-                changes["first_visible_feedback_at"] = current.first_visible_feedback_at
-            fallback_state = state or current.state
-            merged_metadata = dict(current.metadata)
-            if metadata_updates:
-                merged_metadata.update(dict(metadata_updates))
-            return store.upsert_operation(
-                replace(
-                    current,
-                    state=fallback_state,
-                    execution_id=changes.get("execution_id", current.execution_id),
-                    backend_turn_id=changes.get(
-                        "backend_turn_id", current.backend_turn_id
-                    ),
-                    status_message=changes.get(
-                        "status_message", current.status_message
-                    ),
-                    blocking_reason=changes.get(
-                        "blocking_reason", current.blocking_reason
-                    ),
-                    conversation_id=changes.get(
-                        "conversation_id", current.conversation_id
-                    ),
-                    ack_requested_at=changes.get(
-                        "ack_requested_at", current.ack_requested_at
-                    ),
-                    ack_completed_at=changes.get(
-                        "ack_completed_at", current.ack_completed_at
-                    ),
-                    first_visible_feedback_at=changes.get(
-                        "first_visible_feedback_at",
-                        current.first_visible_feedback_at,
-                    ),
-                    anchor_ref=changes.get("anchor_ref", current.anchor_ref),
-                    interrupt_ref=changes.get("interrupt_ref", current.interrupt_ref),
-                    delivery_state=changes.get(
-                        "delivery_state", current.delivery_state
-                    ),
-                    delivery_cursor=changes.get(
-                        "delivery_cursor", current.delivery_cursor
-                    ),
-                    delivery_attempt_count=int(
-                        changes.get(
-                            "delivery_attempt_count",
-                            current.delivery_attempt_count,
-                        )
-                        or 0
-                    ),
-                    delivery_claimed_at=changes.get(
-                        "delivery_claimed_at", current.delivery_claimed_at
-                    ),
-                    terminal_outcome=changes.get(
-                        "terminal_outcome", current.terminal_outcome
-                    ),
-                    terminal_detail=changes.get(
-                        "terminal_detail", current.terminal_detail
-                    ),
-                    updated_at=changes.get("updated_at", now_iso()),
-                    metadata=merged_metadata,
+
+        def _patch_sync() -> Optional[ChatOperationSnapshot]:
+            changes_local = dict(changes)
+            try:
+                return store.patch_operation(
+                    interaction_id,
+                    state=patch_state,
+                    validate_transition=validate_transition,
+                    metadata_updates=metadata_updates,
+                    **changes_local,
                 )
-            )
+            except ValueError:
+                current = store.get_operation(interaction_id)
+                if current is None:
+                    return None
+                if current.first_visible_feedback_at is not None:
+                    changes_local["first_visible_feedback_at"] = (
+                        current.first_visible_feedback_at
+                    )
+                fallback_state = state or current.state
+                merged_metadata = dict(current.metadata)
+                if metadata_updates:
+                    merged_metadata.update(dict(metadata_updates))
+                return store.upsert_operation(
+                    replace(
+                        current,
+                        state=fallback_state,
+                        execution_id=changes_local.get(
+                            "execution_id", current.execution_id
+                        ),
+                        backend_turn_id=changes_local.get(
+                            "backend_turn_id", current.backend_turn_id
+                        ),
+                        status_message=changes_local.get(
+                            "status_message", current.status_message
+                        ),
+                        blocking_reason=changes_local.get(
+                            "blocking_reason", current.blocking_reason
+                        ),
+                        conversation_id=changes_local.get(
+                            "conversation_id", current.conversation_id
+                        ),
+                        ack_requested_at=changes_local.get(
+                            "ack_requested_at", current.ack_requested_at
+                        ),
+                        ack_completed_at=changes_local.get(
+                            "ack_completed_at", current.ack_completed_at
+                        ),
+                        first_visible_feedback_at=changes_local.get(
+                            "first_visible_feedback_at",
+                            current.first_visible_feedback_at,
+                        ),
+                        anchor_ref=changes_local.get("anchor_ref", current.anchor_ref),
+                        interrupt_ref=changes_local.get(
+                            "interrupt_ref", current.interrupt_ref
+                        ),
+                        delivery_state=changes_local.get(
+                            "delivery_state", current.delivery_state
+                        ),
+                        delivery_cursor=changes_local.get(
+                            "delivery_cursor", current.delivery_cursor
+                        ),
+                        delivery_attempt_count=int(
+                            changes_local.get(
+                                "delivery_attempt_count",
+                                current.delivery_attempt_count,
+                            )
+                            or 0
+                        ),
+                        delivery_claimed_at=changes_local.get(
+                            "delivery_claimed_at", current.delivery_claimed_at
+                        ),
+                        terminal_outcome=changes_local.get(
+                            "terminal_outcome", current.terminal_outcome
+                        ),
+                        terminal_detail=changes_local.get(
+                            "terminal_detail", current.terminal_detail
+                        ),
+                        updated_at=changes_local.get("updated_at", now_iso()),
+                        metadata=merged_metadata,
+                    )
+                )
+
+        return await asyncio.to_thread(_patch_sync)
 
     async def _record_interaction_ack(
         self,
@@ -6309,10 +6338,7 @@ class DiscordBotService:
             if ctx.interaction_id in reservations:
                 return True
             reservations.add(ctx.interaction_id)
-        snapshot = None
-        store = self._chat_operation_store_or_none()
-        if store is not None:
-            snapshot = store.get_operation(ctx.interaction_id)
+        snapshot = await self._chat_operation_get(ctx.interaction_id)
         record = await self._store.get_interaction(ctx.interaction_id)
         if snapshot is None and record is None:
             return False
@@ -6376,10 +6402,7 @@ class DiscordBotService:
         if registration.inserted:
             return False
         record = registration.record
-        snapshot = None
-        store = self._chat_operation_store_or_none()
-        if store is not None:
-            snapshot = store.get_operation(ctx.interaction_id)
+        snapshot = await self._chat_operation_get(ctx.interaction_id)
         has_pending_delivery = bool(
             isinstance(record.delivery_cursor_json, dict)
             and str(record.delivery_cursor_json.get("state") or "").strip()

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -841,6 +841,8 @@ class DiscordBotService:
         self._ingress = InteractionIngress(self, logger=self._logger)
         self._ingress_pre_ack_reservations: set[str] = set()
         self._ingress_pre_ack_reservations_lock = asyncio.Lock()
+        self._chat_operation_write_lock_guard = asyncio.Lock()
+        self._chat_operation_write_locks: dict[str, asyncio.Lock] = {}
         self._command_runner = _CommandRunner(
             self,
             config=_RunnerConfig(
@@ -5538,6 +5540,22 @@ class DiscordBotService:
             return store
         return None
 
+    @contextlib.asynccontextmanager
+    async def _chat_operation_write_guard(self, operation_id: str):
+        """Serialize ledger read/write for one interaction across asyncio tasks.
+
+        ``SQLiteChatOperationLedger.patch_operation`` is read-modify-write; concurrent
+        ``asyncio.to_thread`` calls could otherwise apply stale snapshots after offloading.
+        """
+        normalized = str(operation_id or "").strip()
+        async with self._chat_operation_write_lock_guard:
+            lock = self._chat_operation_write_locks.get(normalized)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._chat_operation_write_locks[normalized] = lock
+        async with lock:
+            yield
+
     async def _chat_operation_get(
         self, operation_id: str
     ) -> Optional[ChatOperationSnapshot]:
@@ -5545,7 +5563,8 @@ class DiscordBotService:
         if store is None:
             return None
         # Keep Discord ingress callbacks non-blocking on SQLite lock contention.
-        return await asyncio.to_thread(store.get_operation, operation_id)
+        async with self._chat_operation_write_guard(operation_id):
+            return await asyncio.to_thread(store.get_operation, operation_id)
 
     def _chat_operation_terminal_duplicate(
         self, snapshot: ChatOperationSnapshot
@@ -5624,7 +5643,8 @@ class DiscordBotService:
                 metadata_updates=metadata,
             )
 
-        return await asyncio.to_thread(_register_sync)
+        async with self._chat_operation_write_guard(interaction_id):
+            return await asyncio.to_thread(_register_sync)
 
     async def _patch_chat_operation(
         self,
@@ -5722,7 +5742,8 @@ class DiscordBotService:
                     )
                 )
 
-        return await asyncio.to_thread(_patch_sync)
+        async with self._chat_operation_write_guard(interaction_id):
+            return await asyncio.to_thread(_patch_sync)
 
     async def _record_interaction_ack(
         self,

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -5540,6 +5540,13 @@ class DiscordBotService:
             return store
         return None
 
+    def _ensure_chat_operation_write_lock_state(self) -> None:
+        """Tests may construct partial ``DiscordBotService`` fixtures without ``__init__``."""
+        if getattr(self, "_chat_operation_write_lock_guard", None) is None:
+            self._chat_operation_write_lock_guard = asyncio.Lock()
+        if getattr(self, "_chat_operation_write_locks", None) is None:
+            self._chat_operation_write_locks = {}
+
     @contextlib.asynccontextmanager
     async def _chat_operation_write_guard(self, operation_id: str):
         """Serialize ledger read/write for one interaction across asyncio tasks.
@@ -5547,6 +5554,7 @@ class DiscordBotService:
         ``SQLiteChatOperationLedger.patch_operation`` is read-modify-write; concurrent
         ``asyncio.to_thread`` calls could otherwise apply stale snapshots after offloading.
         """
+        self._ensure_chat_operation_write_lock_state()
         normalized = str(operation_id or "").strip()
         async with self._chat_operation_write_lock_guard:
             lock = self._chat_operation_write_locks.get(normalized)


### PR DESCRIPTION
## Summary
This change removes synchronous chat-operation ledger SQLite access from the Discord interaction ingress hot path.

In parent-hub logs, `/car new` and `/car newt` timeouts were repeatedly paired with `discord.interaction.delivery_expired_before_dispatch` and high `gateway_age_ms` (for example ~4.8s, ~5.2s, ~9.7s, and one ~17.9s sample).

The shared chat-operation ledger is SQLite-backed and was being read/written synchronously on the event loop during ingress/duplicate checks. Under lock contention or slow disk behavior this can block the loop long enough for interactions to become stale before ack.

## Root Cause Signal
- `2026-04-18 00:40:32` `/car newt` admitted with `gateway_age_ms=4123.1`, then `Unknown interaction` + `delivery_expired_before_dispatch` at `gateway_age_ms=4843.9`.
- `2026-04-18 00:09:20-00:09:21` `/car new` showed the same pattern, including `gateway_age_ms=5189.3`.
- `2026-04-17 22:50:47-22:50:48` `/car newt` hit `gateway_age_ms=17963.5` before dispatch expiry.

## What Changed
- Added `DiscordBotService._chat_operation_get()` that runs `SQLiteChatOperationLedger.get_operation()` in `asyncio.to_thread`.
- Updated `_check_interaction_ingress_duplicate()` and `_register_interaction_ingress()` to use the non-blocking helper.
- Moved `_register_chat_operation_received()` ledger registration/patch logic into `asyncio.to_thread`.
- Moved `_patch_chat_operation()` ledger patch/upsert fallback logic into `asyncio.to_thread`.

## Validation
Local lane checks passed during commit hook:
- `black` check
- `ruff`
- import boundary and contract checks
- `mypy` (strict)
- pytest suite: `5890 passed, 8 xfailed`

Plus focused manual run before commit:
- `tests/integrations/discord/test_reliability.py::test_on_dispatch_does_not_attempt_fallback_response_after_confirmed_ack_expiry`
- `tests/integrations/discord/test_reliability.py::test_on_dispatch_attempts_fallback_response_after_non_expired_ack_failure`
- `tests/integrations/discord/test_reliability.py::test_duplicate_interaction_id_does_not_attempt_second_ack`
- `tests/integrations/discord/test_service_routing.py::test_on_dispatch_routes_interactions_through_scheduler`
- `tests/integrations/discord/test_service_routing.py::test_car_interrupt_reports_still_stopping_from_shared_ledger`

