### PR TITLE
[codex] Fix validation lane routing and live output panel UX

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -84,11 +84,21 @@ need_cmd make
 if [[ -z "$LANE" ]]; then
   STAGED_FILES="$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)"
   if [[ -n "$STAGED_FILES" ]]; then
-    LANE="$(echo "$STAGED_FILES" | "$PYTHON_BIN" scripts/select_validation_lane.py --format json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["lane"])')"
+    SELECTION_TEXT="$(printf '%s\n' "$STAGED_FILES" | "$PYTHON_BIN" scripts/select_validation_lane.py)"
+    LANE="$(
+      printf '%s\n' "$STAGED_FILES" \
+        | "$PYTHON_BIN" scripts/select_validation_lane.py --format json \
+        | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["lane"])'
+    )"
   else
     LANE="aggregate"
   fi
-  echo "Detected validation lane: $LANE"
+  if [[ -n "${SELECTION_TEXT:-}" ]]; then
+    echo "Detected validation lane:"
+    echo "$SELECTION_TEXT"
+  else
+    echo "Detected validation lane: $LANE"
+  fi
 fi
 
 echo "Validation lane: $LANE"

--- a/src/codex_autorunner/core/validation_lanes.py
+++ b/src/codex_autorunner/core/validation_lanes.py
@@ -66,8 +66,11 @@ _LANE_GLOBS: dict[ScopedValidationLane, tuple[str, ...]] = {
         "tests/test_app_server*.py",
         "tests/test_auth_middleware.py",
         "tests/test_base_path*.py",
+        "tests/test_browser_docs.py",
         "tests/test_hub_ui*.py",
         "tests/test_static*.py",
+        "tests/test_ticket_flow_ui*.py",
+        "tests/test_voice_ui.py",
     ),
     "chat-apps": (
         "tests/test_chat*.py",
@@ -85,6 +88,7 @@ class ValidationLaneSelection:
     reason: str
     normalized_paths: tuple[str, ...]
     lanes_touched: tuple[ScopedValidationLane, ...]
+    lane_paths: tuple[tuple[ScopedValidationLane, tuple[str, ...]], ...]
     shared_risk_paths: tuple[str, ...]
     unknown_paths: tuple[str, ...]
 
@@ -110,6 +114,7 @@ def classify_changed_files(paths: Iterable[str]) -> ValidationLaneSelection:
             reason="empty-change-set",
             normalized_paths=(),
             lanes_touched=(),
+            lane_paths=(),
             shared_risk_paths=(),
             unknown_paths=(),
         )
@@ -117,17 +122,31 @@ def classify_changed_files(paths: Iterable[str]) -> ValidationLaneSelection:
     shared_risk_paths: list[str] = []
     unknown_paths: list[str] = []
     touched_lanes: set[ScopedValidationLane] = set()
+    lane_paths: dict[ScopedValidationLane, list[str]] = {
+        lane: [] for lane in _SCOPED_LANES
+    }
 
     for path in normalized_paths:
         if _is_shared_risk_path(path):
             shared_risk_paths.append(path)
             continue
 
-        scoped_lane = _classify_scoped_lane(path)
-        if scoped_lane is None:
+        scoped_lanes = _matching_scoped_lanes(path)
+        if len(scoped_lanes) == 1:
+            scoped_lane = scoped_lanes[0]
+            touched_lanes.add(scoped_lane)
+            lane_paths[scoped_lane].append(path)
+            continue
+
+        if not scoped_lanes and fnmatch(path, "tests/test_*.py"):
+            touched_lanes.add("core")
+            lane_paths["core"].append(path)
+            continue
+
+        if not scoped_lanes:
             unknown_paths.append(path)
             continue
-        touched_lanes.add(scoped_lane)
+        unknown_paths.append(path)
 
     lanes_touched = tuple(lane for lane in _SCOPED_LANES if lane in touched_lanes)
     if shared_risk_paths:
@@ -151,6 +170,11 @@ def classify_changed_files(paths: Iterable[str]) -> ValidationLaneSelection:
         reason=reason,
         normalized_paths=normalized_paths,
         lanes_touched=lanes_touched,
+        lane_paths=tuple(
+            (lane, tuple(paths))
+            for lane, paths in ((lane, lane_paths[lane]) for lane in _SCOPED_LANES)
+            if paths
+        ),
         shared_risk_paths=tuple(shared_risk_paths),
         unknown_paths=tuple(unknown_paths),
     )
@@ -162,6 +186,7 @@ def lane_selection_to_payload(selection: ValidationLaneSelection) -> dict[str, o
         "reason": selection.reason,
         "paths": list(selection.normalized_paths),
         "lanes_touched": list(selection.lanes_touched),
+        "lane_paths": {lane: list(paths) for lane, paths in selection.lane_paths},
         "shared_risk_paths": list(selection.shared_risk_paths),
         "unknown_paths": list(selection.unknown_paths),
     }
@@ -175,6 +200,8 @@ def render_lane_selection(selection: ValidationLaneSelection) -> str:
     ]
     if selection.lanes_touched:
         lines.append(f"lanes_touched: {', '.join(selection.lanes_touched)}")
+    for lane, paths in selection.lane_paths:
+        lines.append(f"{lane}_paths: {', '.join(paths)}")
     if selection.shared_risk_paths:
         lines.append(f"shared_risk_paths: {', '.join(selection.shared_risk_paths)}")
     if selection.unknown_paths:
@@ -189,6 +216,15 @@ def _is_shared_risk_path(path: str) -> bool:
 
 
 def _classify_scoped_lane(path: str) -> ScopedValidationLane | None:
+    matches = _matching_scoped_lanes(path)
+    if len(matches) == 1:
+        return matches[0]
+    if not matches and fnmatch(path, "tests/test_*.py"):
+        return "core"
+    return None
+
+
+def _matching_scoped_lanes(path: str) -> tuple[ScopedValidationLane, ...]:
     matches: list[ScopedValidationLane] = []
     for lane in _SCOPED_LANES:
         prefixes = _LANE_PREFIXES.get(lane, ())
@@ -197,11 +233,7 @@ def _classify_scoped_lane(path: str) -> ScopedValidationLane | None:
             fnmatch(path, pattern) for pattern in globs
         ):
             matches.append(lane)
-    if len(matches) == 1:
-        return matches[0]
-    if not matches and fnmatch(path, "tests/test_*.py"):
-        return "core"
-    return None
+    return tuple(matches)
 
 
 def _matches_prefix(path: str, prefix: str) -> bool:

--- a/src/codex_autorunner/core/validation_lanes.py
+++ b/src/codex_autorunner/core/validation_lanes.py
@@ -215,15 +215,6 @@ def _is_shared_risk_path(path: str) -> bool:
     return any(_matches_prefix(path, prefix) for prefix in _SHARED_RISK_PREFIXES)
 
 
-def _classify_scoped_lane(path: str) -> ScopedValidationLane | None:
-    matches = _matching_scoped_lanes(path)
-    if len(matches) == 1:
-        return matches[0]
-    if not matches and fnmatch(path, "tests/test_*.py"):
-        return "core"
-    return None
-
-
 def _matching_scoped_lanes(path: str) -> tuple[ScopedValidationLane, ...]:
     matches: list[ScopedValidationLane] = []
     for lane in _SCOPED_LANES:

--- a/src/codex_autorunner/static/generated/ticketFlowStream.js
+++ b/src/codex_autorunner/static/generated/ticketFlowStream.js
@@ -4,7 +4,6 @@ import { openModal } from "./utils.js";
 import { summarizeEvents, renderCompactSummary, COMPACT_MAX_TEXT_LENGTH } from "./eventSummarizer.js";
 import { MAX_OUTPUT_LINES, LIVE_EVENT_MAX, MAX_REASON_LENGTH, formatElapsed, formatTimeAgo, } from "./ticketFlowState.js";
 let liveOutputPanelExpanded = false;
-let liveOutputDetailExpanded = false;
 let liveOutputBuffer = [];
 let liveOutputEvents = [];
 let liveOutputEventIndex = {};
@@ -61,7 +60,7 @@ function scheduleLiveOutputTextUpdate() {
                 outputEl.textContent = newText;
             }
             const detailEl = document.getElementById("ticket-live-output-detail");
-            if (detailEl && liveOutputDetailExpanded) {
+            if (detailEl && liveOutputPanelExpanded) {
                 detailEl.scrollTop = detailEl.scrollHeight;
             }
         }
@@ -186,7 +185,7 @@ function renderLiveOutputEvents() {
     if (count.textContent !== String(liveOutputEvents.length)) {
         count.textContent = String(liveOutputEvents.length);
     }
-    const shouldHide = !hasEvents || !liveOutputDetailExpanded;
+    const shouldHide = !hasEvents || !liveOutputPanelExpanded;
     if (container.classList.contains("hidden") !== shouldHide) {
         container.classList.toggle("hidden", shouldHide);
     }
@@ -266,7 +265,7 @@ function renderLiveOutputCompact() {
     if (!compactEl)
         return;
     const text = renderCompactLiveOutputText();
-    const newText = text || "Waiting for agent output...";
+    const newText = text || "";
     if (compactEl.textContent !== newText) {
         compactEl.textContent = newText;
     }
@@ -326,44 +325,18 @@ function updateLiveOutputPanelToggle() {
         chevron.textContent = liveOutputPanelExpanded ? "▴" : "▾";
     }
 }
-function updateLiveOutputDetailToggle() {
-    const detailToggle = document.getElementById("ticket-live-output-detail-toggle");
-    if (!detailToggle)
-        return;
-    if (liveOutputDetailExpanded) {
-        if (!detailToggle.classList.contains("active"))
-            detailToggle.classList.add("active");
-        if (detailToggle.textContent !== "≡")
-            detailToggle.textContent = "≡";
-        if (detailToggle.title !== "Show summary")
-            detailToggle.title = "Show summary";
-    }
-    else {
-        if (detailToggle.classList.contains("active"))
-            detailToggle.classList.remove("active");
-        if (detailToggle.textContent !== "⋯")
-            detailToggle.textContent = "⋯";
-        if (detailToggle.title !== "Show full output")
-            detailToggle.title = "Show full output";
-    }
-}
 export function renderLiveOutputView() {
     const compactEl = document.getElementById("ticket-live-output-compact");
     const detailEl = document.getElementById("ticket-live-output-detail");
-    const eventsEl = document.getElementById("ticket-live-output-events");
     if (compactEl) {
-        compactEl.classList.toggle("hidden", liveOutputDetailExpanded || !liveOutputPanelExpanded);
+        compactEl.classList.add("hidden");
     }
     if (detailEl) {
-        detailEl.classList.toggle("hidden", !liveOutputDetailExpanded || !liveOutputPanelExpanded);
-    }
-    if (eventsEl) {
-        eventsEl.classList.toggle("hidden", !liveOutputDetailExpanded || !liveOutputPanelExpanded);
+        detailEl.classList.toggle("hidden", !liveOutputPanelExpanded);
     }
     renderLiveOutputCompact();
     renderLiveOutputEvents();
     updateLiveOutputPanelToggle();
-    updateLiveOutputDetailToggle();
 }
 export function clearLiveOutput() {
     liveOutputBuffer = [];
@@ -396,37 +369,21 @@ export function setLiveOutputStatus(status) {
 }
 export function initLiveOutputPanel() {
     const panelToggleBtn = document.getElementById("ticket-live-output-panel-toggle");
-    const detailToggleBtn = document.getElementById("ticket-live-output-detail-toggle");
     const panel = document.getElementById("ticket-live-output-panel");
     if (panel) {
         liveOutputPanelExpanded = !panel.classList.contains("collapsed");
-    }
-    const detailEl = document.getElementById("ticket-live-output-detail");
-    if (detailEl) {
-        liveOutputDetailExpanded = !detailEl.classList.contains("hidden");
     }
     const togglePanel = () => {
         liveOutputPanelExpanded = !liveOutputPanelExpanded;
         renderLiveOutputView();
     };
-    const toggleDetail = () => {
-        liveOutputDetailExpanded = !liveOutputDetailExpanded;
-        renderLiveOutputView();
-    };
     if (panelToggleBtn) {
         panelToggleBtn.addEventListener("click", togglePanel);
-    }
-    if (detailToggleBtn) {
-        detailToggleBtn.addEventListener("click", (e) => {
-            e.stopPropagation();
-            toggleDetail();
-        });
     }
     renderLiveOutputView();
 }
 export function resetAllStreamState() {
     liveOutputPanelExpanded = false;
-    liveOutputDetailExpanded = false;
     flowStartedAt = null;
     lastActivityTime = null;
     lastKnownEventAt = null;

--- a/src/codex_autorunner/static/generated/ticketFlowStream.js
+++ b/src/codex_autorunner/static/generated/ticketFlowStream.js
@@ -1,7 +1,6 @@
 // GENERATED FILE - do not edit directly. Source: static_src/
 import { parseAppServerEvent, resetOpenCodeEventState } from "./agentEvents.js";
 import { openModal } from "./utils.js";
-import { summarizeEvents, renderCompactSummary, COMPACT_MAX_TEXT_LENGTH } from "./eventSummarizer.js";
 import { MAX_OUTPUT_LINES, LIVE_EVENT_MAX, MAX_REASON_LENGTH, formatElapsed, formatTimeAgo, } from "./ticketFlowState.js";
 let liveOutputPanelExpanded = false;
 let liveOutputBuffer = [];
@@ -260,57 +259,6 @@ function renderLiveOutputEvents() {
     });
     list.scrollTop = list.scrollHeight;
 }
-function renderLiveOutputCompact() {
-    const compactEl = document.getElementById("ticket-live-output-compact");
-    if (!compactEl)
-        return;
-    const text = renderCompactLiveOutputText();
-    const newText = text || "";
-    if (compactEl.textContent !== newText) {
-        compactEl.textContent = newText;
-    }
-}
-function renderCompactLiveOutputText() {
-    if (liveOutputEvents.length) {
-        const summary = summarizeEvents(liveOutputEvents, {
-            maxActions: 1,
-            maxTextLength: COMPACT_MAX_TEXT_LENGTH,
-            startTime: flowStartedAt?.getTime(),
-        });
-        return renderCompactSummary(summary);
-    }
-    const fallbackText = compactLiveOutputBufferText();
-    if (!fallbackText)
-        return "";
-    const summary = summarizeEvents([
-        {
-            id: "ticket-live-output-fallback",
-            title: "Output",
-            summary: fallbackText,
-            detail: "",
-            kind: "output",
-            isSignificant: true,
-            time: flowStartedAt?.getTime() || Date.now(),
-            itemId: null,
-            method: "agent_stream_delta",
-        },
-    ], {
-        maxActions: 1,
-        maxTextLength: COMPACT_MAX_TEXT_LENGTH,
-        startTime: flowStartedAt?.getTime(),
-    });
-    return renderCompactSummary(summary);
-}
-function compactLiveOutputBufferText() {
-    const recentLines = liveOutputBuffer
-        .map((line) => line.trim())
-        .filter((line) => line);
-    if (!recentLines.length)
-        return "";
-    const nonStepLines = recentLines.filter((line) => !/^--- Step: .* ---$/.test(line));
-    const compactLines = nonStepLines.length ? nonStepLines : recentLines;
-    return compactLines.slice(-3).join(" ").replace(/\s+/g, " ").trim();
-}
 function updateLiveOutputPanelToggle() {
     const panelToggle = document.getElementById("ticket-live-output-panel-toggle");
     const panel = document.getElementById("ticket-live-output-panel");
@@ -334,7 +282,6 @@ export function renderLiveOutputView() {
     if (detailEl) {
         detailEl.classList.toggle("hidden", !liveOutputPanelExpanded);
     }
-    renderLiveOutputCompact();
     renderLiveOutputEvents();
     updateLiveOutputPanelToggle();
 }

--- a/src/codex_autorunner/static/index.html
+++ b/src/codex_autorunner/static/index.html
@@ -702,8 +702,6 @@
                 <span class="ticket-live-output-spacer"></span>
                 <span class="ticket-live-output-chevron" id="ticket-live-output-chevron" aria-hidden="true">▾</span>
               </button>
-              <button class="ticket-live-output-detail-toggle" id="ticket-live-output-detail-toggle" type="button"
-                title="Show full output">⋯</button>
             </div>
             <pre class="ticket-live-output-compact" id="ticket-live-output-compact"></pre>
             <div class="ticket-live-output-detail hidden" id="ticket-live-output-detail">

--- a/src/codex_autorunner/static/styles.css
+++ b/src/codex_autorunner/static/styles.css
@@ -3944,7 +3944,7 @@ button.icon-btn {
 }
 
 .ticket-live-output-panel-toggle:hover {
-  background: rgba(255, 255, 255, 0.02);
+  background: rgba(108, 245, 216, 0.06);
 }
 
 .ticket-live-output-panel-toggle:focus-visible {
@@ -3983,35 +3983,9 @@ button.icon-btn {
 }
 
 .ticket-live-output-status.streaming {
-  background: rgba(108, 245, 216, 0.15);
+  background: rgba(108, 245, 216, 0.12);
   color: var(--accent);
-  animation: pulse-running 1.5s ease-in-out infinite;
-}
-
-/* Summary vs full output toggle (⋯ / ≡) */
-.ticket-live-output-detail-toggle {
-  background: none;
-  border: 1px solid rgba(108, 245, 216, 0.25);
-  border-radius: 4px;
-  padding: 2px 8px;
-  font-size: 11px;
-  color: var(--accent);
-  cursor: pointer;
-  transition: all 0.12s ease;
-  flex-shrink: 0;
-  line-height: 1.2;
-  text-transform: none;
-  letter-spacing: normal;
-}
-
-.ticket-live-output-detail-toggle:hover {
-  background: rgba(108, 245, 216, 0.1);
-  border-color: rgba(108, 245, 216, 0.4);
-}
-
-.ticket-live-output-detail-toggle.active {
-  background: rgba(108, 245, 216, 0.15);
-  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px rgba(108, 245, 216, 0.22);
 }
 
 .ticket-live-output-chevron {
@@ -4034,6 +4008,10 @@ button.icon-btn {
   -webkit-box-orient: vertical;
   max-height: calc(3 * 1.4em + 12px);
   /* 3 lines + padding */
+}
+
+.ticket-live-output-panel.collapsed .ticket-live-output-compact {
+  display: none;
 }
 
 .ticket-live-output-compact:empty::before {

--- a/src/codex_autorunner/static_src/ticketFlowStream.ts
+++ b/src/codex_autorunner/static_src/ticketFlowStream.ts
@@ -1,6 +1,5 @@
 import { parseAppServerEvent, resetOpenCodeEventState, type AgentEvent, type ParsedAgentEvent } from "./agentEvents.js";
 import { openModal } from "./utils.js";
-import { summarizeEvents, renderCompactSummary, COMPACT_MAX_TEXT_LENGTH } from "./eventSummarizer.js";
 import {
   type FlowEvent,
   type FlowRun,
@@ -307,64 +306,6 @@ function renderLiveOutputEvents(): void {
   list.scrollTop = list.scrollHeight;
 }
 
-function renderLiveOutputCompact(): void {
-  const compactEl = document.getElementById("ticket-live-output-compact");
-  if (!compactEl) return;
-  const text = renderCompactLiveOutputText();
-  const newText = text || "";
-
-  if (compactEl.textContent !== newText) {
-    compactEl.textContent = newText;
-  }
-}
-
-function renderCompactLiveOutputText(): string {
-  if (liveOutputEvents.length) {
-    const summary = summarizeEvents(liveOutputEvents, {
-      maxActions: 1,
-      maxTextLength: COMPACT_MAX_TEXT_LENGTH,
-      startTime: flowStartedAt?.getTime(),
-    });
-    return renderCompactSummary(summary);
-  }
-
-  const fallbackText = compactLiveOutputBufferText();
-  if (!fallbackText) return "";
-
-  const summary = summarizeEvents(
-    [
-      {
-        id: "ticket-live-output-fallback",
-        title: "Output",
-        summary: fallbackText,
-        detail: "",
-        kind: "output",
-        isSignificant: true,
-        time: flowStartedAt?.getTime() || Date.now(),
-        itemId: null,
-        method: "agent_stream_delta",
-      },
-    ],
-    {
-      maxActions: 1,
-      maxTextLength: COMPACT_MAX_TEXT_LENGTH,
-      startTime: flowStartedAt?.getTime(),
-    }
-  );
-  return renderCompactSummary(summary);
-}
-
-function compactLiveOutputBufferText(): string {
-  const recentLines = liveOutputBuffer
-    .map((line) => line.trim())
-    .filter((line) => line);
-  if (!recentLines.length) return "";
-
-  const nonStepLines = recentLines.filter((line) => !/^--- Step: .* ---$/.test(line));
-  const compactLines = nonStepLines.length ? nonStepLines : recentLines;
-  return compactLines.slice(-3).join(" ").replace(/\s+/g, " ").trim();
-}
-
 function updateLiveOutputPanelToggle(): void {
   const panelToggle = document.getElementById("ticket-live-output-panel-toggle");
   const panel = document.getElementById("ticket-live-output-panel");
@@ -394,7 +335,6 @@ export function renderLiveOutputView(): void {
     detailEl.classList.toggle("hidden", !liveOutputPanelExpanded);
   }
 
-  renderLiveOutputCompact();
   renderLiveOutputEvents();
   updateLiveOutputPanelToggle();
 }

--- a/src/codex_autorunner/static_src/ticketFlowStream.ts
+++ b/src/codex_autorunner/static_src/ticketFlowStream.ts
@@ -12,7 +12,6 @@ import {
 } from "./ticketFlowState.js";
 
 let liveOutputPanelExpanded = false;
-let liveOutputDetailExpanded = false;
 let liveOutputBuffer: string[] = [];
 let liveOutputEvents: AgentEvent[] = [];
 let liveOutputEventIndex: Record<string, number> = {};
@@ -80,7 +79,7 @@ function scheduleLiveOutputTextUpdate(): void {
         outputEl.textContent = newText;
       }
       const detailEl = document.getElementById("ticket-live-output-detail");
-      if (detailEl && liveOutputDetailExpanded) {
+      if (detailEl && liveOutputPanelExpanded) {
         detailEl.scrollTop = detailEl.scrollHeight;
       }
     }
@@ -217,7 +216,7 @@ function renderLiveOutputEvents(): void {
     count.textContent = String(liveOutputEvents.length);
   }
 
-  const shouldHide = !hasEvents || !liveOutputDetailExpanded;
+  const shouldHide = !hasEvents || !liveOutputPanelExpanded;
   if (container.classList.contains("hidden") !== shouldHide) {
     container.classList.toggle("hidden", shouldHide);
   }
@@ -312,7 +311,7 @@ function renderLiveOutputCompact(): void {
   const compactEl = document.getElementById("ticket-live-output-compact");
   if (!compactEl) return;
   const text = renderCompactLiveOutputText();
-  const newText = text || "Waiting for agent output...";
+  const newText = text || "";
 
   if (compactEl.textContent !== newText) {
     compactEl.textContent = newText;
@@ -384,40 +383,20 @@ function updateLiveOutputPanelToggle(): void {
   }
 }
 
-function updateLiveOutputDetailToggle(): void {
-  const detailToggle = document.getElementById("ticket-live-output-detail-toggle");
-  if (!detailToggle) return;
-
-  if (liveOutputDetailExpanded) {
-    if (!detailToggle.classList.contains("active")) detailToggle.classList.add("active");
-    if (detailToggle.textContent !== "≡") detailToggle.textContent = "≡";
-    if (detailToggle.title !== "Show summary") detailToggle.title = "Show summary";
-  } else {
-    if (detailToggle.classList.contains("active")) detailToggle.classList.remove("active");
-    if (detailToggle.textContent !== "⋯") detailToggle.textContent = "⋯";
-    if (detailToggle.title !== "Show full output") detailToggle.title = "Show full output";
-  }
-}
-
 export function renderLiveOutputView(): void {
   const compactEl = document.getElementById("ticket-live-output-compact");
   const detailEl = document.getElementById("ticket-live-output-detail");
-  const eventsEl = document.getElementById("ticket-live-output-events");
 
   if (compactEl) {
-    compactEl.classList.toggle("hidden", liveOutputDetailExpanded || !liveOutputPanelExpanded);
+    compactEl.classList.add("hidden");
   }
   if (detailEl) {
-    detailEl.classList.toggle("hidden", !liveOutputDetailExpanded || !liveOutputPanelExpanded);
-  }
-  if (eventsEl) {
-    eventsEl.classList.toggle("hidden", !liveOutputDetailExpanded || !liveOutputPanelExpanded);
+    detailEl.classList.toggle("hidden", !liveOutputPanelExpanded);
   }
 
   renderLiveOutputCompact();
   renderLiveOutputEvents();
   updateLiveOutputPanelToggle();
-  updateLiveOutputDetailToggle();
 }
 
 export function clearLiveOutput(): void {
@@ -452,15 +431,10 @@ export function setLiveOutputStatus(status: "disconnected" | "connected" | "stre
 
 export function initLiveOutputPanel(): void {
   const panelToggleBtn = document.getElementById("ticket-live-output-panel-toggle");
-  const detailToggleBtn = document.getElementById("ticket-live-output-detail-toggle");
 
   const panel = document.getElementById("ticket-live-output-panel");
   if (panel) {
     liveOutputPanelExpanded = !panel.classList.contains("collapsed");
-  }
-  const detailEl = document.getElementById("ticket-live-output-detail");
-  if (detailEl) {
-    liveOutputDetailExpanded = !detailEl.classList.contains("hidden");
   }
 
   const togglePanel = () => {
@@ -468,19 +442,8 @@ export function initLiveOutputPanel(): void {
     renderLiveOutputView();
   };
 
-  const toggleDetail = () => {
-    liveOutputDetailExpanded = !liveOutputDetailExpanded;
-    renderLiveOutputView();
-  };
-
   if (panelToggleBtn) {
     panelToggleBtn.addEventListener("click", togglePanel);
-  }
-  if (detailToggleBtn) {
-    detailToggleBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      toggleDetail();
-    });
   }
 
   renderLiveOutputView();
@@ -488,7 +451,6 @@ export function initLiveOutputPanel(): void {
 
 export function resetAllStreamState(): void {
   liveOutputPanelExpanded = false;
-  liveOutputDetailExpanded = false;
   flowStartedAt = null;
   lastActivityTime = null;
   lastKnownEventAt = null;

--- a/tests/core/test_validation_lanes.py
+++ b/tests/core/test_validation_lanes.py
@@ -47,6 +47,27 @@ def test_classify_web_ui_lane_for_root_level_web_test() -> None:
     assert selection.lane == "web-ui"
     assert selection.reason == "single-lane-diff"
     assert selection.lanes_touched == ("web-ui",)
+    assert selection.lane_paths == (("web-ui", ("tests/test_app_server_events.py",)),)
+
+
+def test_classify_web_ui_lane_for_ticket_flow_ui_integration_test() -> None:
+    selection = classify_changed_files(["tests/test_ticket_flow_ui_integration.py"])
+
+    assert selection.lane == "web-ui"
+    assert selection.reason == "single-lane-diff"
+    assert selection.lanes_touched == ("web-ui",)
+    assert selection.lane_paths == (
+        ("web-ui", ("tests/test_ticket_flow_ui_integration.py",)),
+    )
+
+
+def test_classify_web_ui_lane_for_root_level_voice_ui_test() -> None:
+    selection = classify_changed_files(["tests/test_voice_ui.py"])
+
+    assert selection.lane == "web-ui"
+    assert selection.reason == "single-lane-diff"
+    assert selection.lanes_touched == ("web-ui",)
+    assert selection.lane_paths == (("web-ui", ("tests/test_voice_ui.py",)),)
 
 
 def test_shared_risk_paths_force_aggregate() -> None:
@@ -92,6 +113,10 @@ def test_multi_lane_diff_forces_aggregate() -> None:
     assert selection.lane == "aggregate"
     assert selection.reason == "multi-lane-diff"
     assert selection.lanes_touched == ("core", "web-ui")
+    assert selection.lane_paths == (
+        ("core", ("src/codex_autorunner/core/update_targets.py",)),
+        ("web-ui", ("src/codex_autorunner/static_src/updateTargets.ts",)),
+    )
 
 
 def test_classification_is_deterministic_for_same_input_set() -> None:
@@ -142,6 +167,7 @@ def test_payload_and_human_rendering_are_stable() -> None:
             "src/codex_autorunner/core/update_targets.py",
         ],
         "lanes_touched": ["core"],
+        "lane_paths": {"core": ["src/codex_autorunner/core/update_targets.py"]},
         "shared_risk_paths": ["scripts/check.sh"],
         "unknown_paths": [],
     }
@@ -151,6 +177,7 @@ def test_payload_and_human_rendering_are_stable() -> None:
             "reason: shared-risk-path",
             "changed_files: 2",
             "lanes_touched: core",
+            "core_paths: src/codex_autorunner/core/update_targets.py",
             "shared_risk_paths: scripts/check.sh",
         ]
     )

--- a/tests/js/ticket_flow_ui.test.js
+++ b/tests/js/ticket_flow_ui.test.js
@@ -9,7 +9,6 @@ const dom = new JSDOM(
       <div id="ticket-live-output-compact" class="hidden"></div>
       <div id="ticket-live-output-detail" class="hidden"></div>
       <div id="ticket-live-output-events" class="hidden"></div>
-      <button id="ticket-live-output-detail-toggle" type="button"></button>
     </div>
     <div id="ticket-live-output-text"></div>
     <div id="ticket-last-activity"></div>

--- a/tests/test_pma_cli.py
+++ b/tests/test_pma_cli.py
@@ -1431,9 +1431,9 @@ def test_pma_cli_thread_send_recovers_queued_timeout_from_status_probe(
     )
     monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
     monkeypatch.setattr(pma_control_plane, "request_json", _fake_request_json)
-    monotonic_values = iter([100.0, 103.0])
+    monotonic_seq = itertools.count(100.0, 1.0)
     monkeypatch.setattr(
-        pma_control_plane.time, "monotonic", lambda: next(monotonic_values, 103.0)
+        pma_control_plane.time, "monotonic", lambda: next(monotonic_seq)
     )
     monkeypatch.setattr(pma_control_plane.time, "sleep", lambda seconds: None)
 
@@ -1536,9 +1536,9 @@ def test_pma_cli_thread_send_timeout_recovery_keeps_queued_turn_rows_aligned(
     )
     monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
     monkeypatch.setattr(pma_control_plane, "request_json", _fake_request_json)
-    monotonic_values = iter([100.0, 103.0])
+    monotonic_seq = itertools.count(100.0, 1.0)
     monkeypatch.setattr(
-        pma_control_plane.time, "monotonic", lambda: next(monotonic_values, 103.0)
+        pma_control_plane.time, "monotonic", lambda: next(monotonic_seq)
     )
     monkeypatch.setattr(pma_control_plane.time, "sleep", lambda seconds: None)
 
@@ -1634,7 +1634,7 @@ def test_pma_cli_thread_send_retries_timeout_recovery_until_status_catches_up(
         _ = method, url, payload, token_env, params
         return next(status_payloads)
 
-    monotonic_values = iter([100.0, 100.0, 100.1])
+    monotonic_seq = itertools.count(100.0, 1.0)
     sleep_calls: list[float] = []
 
     monkeypatch.setattr(
@@ -1643,7 +1643,7 @@ def test_pma_cli_thread_send_retries_timeout_recovery_until_status_catches_up(
     monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
     monkeypatch.setattr(pma_control_plane, "request_json", _fake_request_json)
     monkeypatch.setattr(
-        pma_control_plane.time, "monotonic", lambda: next(monotonic_values, 101.0)
+        pma_control_plane.time, "monotonic", lambda: next(monotonic_seq)
     )
     monkeypatch.setattr(
         pma_control_plane.time, "sleep", lambda seconds: sleep_calls.append(seconds)
@@ -1699,10 +1699,10 @@ def test_pma_cli_thread_send_timeout_warns_before_retry_when_status_unclear(
         _ = method, url, payload, token_env, timeout
         raise httpx.TimeoutException("timed out")
 
-    # Cycle status payloads: recovery polls until the deadline; Typer/Click may
-    # call time.monotonic() extra times on some Python versions, so a fixed
-    # two-value iterator for monotonic can shift the deadline and exhaust a
-    # finite status iterator (StopIteration).
+    # Cycle status payloads: recovery polls until the deadline. Typer/Click may
+    # call time.monotonic() before recovery runs; a short finite iterator can
+    # leave recovery stuck never reaching the deadline (infinite loop → CI
+    # timeout). Use an inexhaustible sequence with a fixed step.
     status_payloads = itertools.cycle(
         [
             {
@@ -1741,9 +1741,9 @@ def test_pma_cli_thread_send_timeout_warns_before_retry_when_status_unclear(
     )
     monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
     monkeypatch.setattr(pma_control_plane, "request_json", _fake_request_json)
-    monotonic_values = iter([100.0, 103.0])
+    monotonic_seq = itertools.count(100.0, 1.0)
     monkeypatch.setattr(
-        pma_control_plane.time, "monotonic", lambda: next(monotonic_values, 103.0)
+        pma_control_plane.time, "monotonic", lambda: next(monotonic_seq)
     )
     monkeypatch.setattr(pma_control_plane.time, "sleep", lambda seconds: None)
 

--- a/tests/test_select_ci_validation_jobs_script.py
+++ b/tests/test_select_ci_validation_jobs_script.py
@@ -33,6 +33,7 @@ def test_select_ci_validation_jobs_script_json_output() -> None:
         "reason": "single-lane-diff",
         "paths": ["src/codex_autorunner/core/update_targets.py"],
         "lanes_touched": ["core"],
+        "lane_paths": {"core": ["src/codex_autorunner/core/update_targets.py"]},
         "shared_risk_paths": [],
         "unknown_paths": [],
         "run_core": True,

--- a/tests/test_select_validation_lane_script.py
+++ b/tests/test_select_validation_lane_script.py
@@ -31,6 +31,7 @@ def test_select_validation_lane_script_json_output() -> None:
         "reason": "single-lane-diff",
         "paths": ["src/codex_autorunner/core/update_targets.py"],
         "lanes_touched": ["core"],
+        "lane_paths": {"core": ["src/codex_autorunner/core/update_targets.py"]},
         "shared_risk_paths": [],
         "unknown_paths": [],
     }

--- a/tests/test_ticket_flow_ui_integration.py
+++ b/tests/test_ticket_flow_ui_integration.py
@@ -26,7 +26,6 @@ def test_ticket_flow_compact_live_output_falls_back_to_stream_deltas() -> None:
             <div id="ticket-live-output-panel" class="ticket-live-output-panel"></div>
             <div id="ticket-live-output-status"></div>
             <button id="ticket-live-output-panel-toggle" type="button"></button>
-            <button id="ticket-live-output-detail-toggle" type="button"></button>
             <pre id="ticket-live-output-compact"></pre>
             <div id="ticket-live-output-detail" class="hidden"></div>
             <pre id="ticket-live-output-text"></pre>
@@ -106,7 +105,6 @@ def test_ticket_flow_live_output_expands_from_collapsed_bar() -> None:
             <div id="ticket-live-output-panel" class="ticket-live-output-panel collapsed"></div>
             <div id="ticket-live-output-status"></div>
             <button id="ticket-live-output-panel-toggle" type="button" aria-expanded="false"></button>
-            <button id="ticket-live-output-detail-toggle" type="button"></button>
             <span id="ticket-live-output-chevron"></span>
             <pre id="ticket-live-output-compact"></pre>
             <div id="ticket-live-output-detail" class="hidden"></div>
@@ -157,23 +155,21 @@ def test_ticket_flow_live_output_expands_from_collapsed_bar() -> None:
         await new Promise((resolve) => setTimeout(resolve, 20));
 
         const detailWrapper = document.getElementById("ticket-live-output-detail");
+        const compactWrapper = document.getElementById("ticket-live-output-compact");
         const detail = document.getElementById("ticket-live-output-text")?.textContent || "";
         const status = document.getElementById("ticket-live-output-status")?.textContent || "";
         const panelToggle = document.getElementById("ticket-live-output-panel-toggle");
-        const detailToggle = document.getElementById("ticket-live-output-detail-toggle");
 
         assert.equal(detailWrapper?.classList.contains("hidden"), true);
+        assert.equal(compactWrapper?.classList.contains("hidden"), true);
         assert.match(detail, /This is live codex output/);
         assert.equal(status, "Streaming");
 
         panelToggle?.dispatchEvent(new dom.window.MouseEvent("click", {{ bubbles: true }}));
 
         assert.equal(panelToggle?.getAttribute("aria-expanded"), "true");
-        assert.equal(detailWrapper?.classList.contains("hidden"), true);
-
-        detailToggle?.dispatchEvent(new dom.window.MouseEvent("click", {{ bubbles: true }}));
-
         assert.equal(detailWrapper?.classList.contains("hidden"), false);
+        assert.equal(compactWrapper?.classList.contains("hidden"), true);
         """
     )
 
@@ -199,7 +195,6 @@ def test_ticket_flow_compact_live_output_shows_step_progress_when_no_agent_text(
             <div id="ticket-live-output-panel" class="ticket-live-output-panel"></div>
             <div id="ticket-live-output-status"></div>
             <button id="ticket-live-output-panel-toggle" type="button"></button>
-            <button id="ticket-live-output-detail-toggle" type="button"></button>
             <pre id="ticket-live-output-compact"></pre>
             <div id="ticket-live-output-detail" class="hidden"></div>
             <pre id="ticket-live-output-text"></pre>

--- a/tests/test_ticket_flow_ui_integration.py
+++ b/tests/test_ticket_flow_ui_integration.py
@@ -74,13 +74,10 @@ def test_ticket_flow_compact_live_output_falls_back_to_stream_deltas() -> None:
 
         await new Promise((resolve) => setTimeout(resolve, 20));
 
-        const compact = document.getElementById("ticket-live-output-compact")?.textContent || "";
         const detail = document.getElementById("ticket-live-output-text")?.textContent || "";
         const status = document.getElementById("ticket-live-output-status")?.textContent || "";
 
         assert.match(detail, /This is live codex output/);
-        assert.match(compact, /This is live codex output/);
-        assert.doesNotMatch(compact, /Waiting for agent output/);
         assert.equal(status, "Streaming");
         """
     )
@@ -238,12 +235,9 @@ def test_ticket_flow_compact_live_output_shows_step_progress_when_no_agent_text(
 
         await new Promise((resolve) => setTimeout(resolve, 20));
 
-        const compact = document.getElementById("ticket-live-output-compact")?.textContent || "";
         const detail = document.getElementById("ticket-live-output-text")?.textContent || "";
 
         assert.match(detail, /--- Step: ticket_turn ---/);
-        assert.match(compact, /--- Step: ticket_turn ---/);
-        assert.doesNotMatch(compact, /Waiting for agent output/);
         """
     )
 


### PR DESCRIPTION
## Summary
- keep ticket-flow UI integration and other clearly frontend root tests in the `web-ui` validation lane
- include lane-path reporting so aggregate escalation explains exactly which files triggered it
- simplify the repo agent live-output panel to a single header-toggle interaction with a quieter streaming highlight
- related live-output modularization follow-up tracked in `#1466`

## Validation
- `pnpm run build`
- `pnpm test:markdown`
- `.venv/bin/python -m pytest tests/core/test_validation_lanes.py tests/test_select_validation_lane_script.py tests/test_select_ci_validation_jobs_script.py tests/test_ticket_flow_ui_integration.py`
- aggregate pre-commit hook (`scripts/check.sh`) during `git commit`

Closes #1465
Related: #1466
