### PR TITLE
[codex] Port Hermes commentary UX into chat progress

### DIFF
--- a/src/codex_autorunner/core/acp_lifecycle.py
+++ b/src/codex_autorunner/core/acp_lifecycle.py
@@ -77,6 +77,26 @@ def extract_session_update_kind(update: Mapping[str, Any]) -> Optional[str]:
     return _normalize_optional_text(value)
 
 
+def extract_message_phase(payload: Mapping[str, Any]) -> Optional[str]:
+    phase = _normalize_optional_text(payload.get("phase"))
+    if phase:
+        return phase.lower()
+    content = payload.get("content")
+    if isinstance(content, Mapping):
+        nested = _normalize_optional_text(content.get("phase"))
+        if nested:
+            return nested.lower()
+    return None
+
+
+def extract_already_streamed(payload: Mapping[str, Any]) -> bool:
+    for key in ("alreadyStreamed", "already_streamed"):
+        value = payload.get(key)
+        if isinstance(value, bool):
+            return value
+    return False
+
+
 def extract_usage(payload: Mapping[str, Any]) -> dict[str, Any]:
     usage = payload.get("usage")
     if isinstance(usage, Mapping):
@@ -359,6 +379,8 @@ class ACPLifecycleSnapshot:
     usage: dict[str, Any] = field(default_factory=dict)
     permission_request_id: str = ""
     permission_description: str = ""
+    message_phase: Optional[str] = None
+    already_streamed: bool = False
     uses_turn_id_fallback: bool = False
     closes_turn_buffer: bool = False
 
@@ -406,6 +428,8 @@ def analyze_acp_lifecycle_message(message: Mapping[str, Any]) -> ACPLifecycleSna
     error_message: Optional[str] = None
     permission_request_id = ""
     permission_description = ""
+    message_phase: Optional[str] = None
+    already_streamed = False
 
     if method in {"session/created", "session/loaded"}:
         normalized_kind = "session"
@@ -422,6 +446,8 @@ def analyze_acp_lifecycle_message(message: Mapping[str, Any]) -> ACPLifecycleSna
         normalized_kind = "unknown"
         if update_kind == "agent_message_chunk":
             normalized_kind = "output_delta"
+            message_phase = extract_message_phase(update)
+            already_streamed = extract_already_streamed(update)
             output_delta = extract_text_content(update.get("content")) or ""
             if not output_delta:
                 output_delta = extract_output_delta(update)
@@ -455,6 +481,7 @@ def analyze_acp_lifecycle_message(message: Mapping[str, Any]) -> ACPLifecycleSna
     elif method in {"prompt/message", "turn/message"}:
         normalized_kind = "message"
         assistant_text = extract_message_text(payload)
+        message_phase = extract_message_phase(payload)
     elif method in {"permission/requested", "session/request_permission"}:
         normalized_kind = "permission_requested"
         permission_request_id = (
@@ -486,6 +513,8 @@ def analyze_acp_lifecycle_message(message: Mapping[str, Any]) -> ACPLifecycleSna
         usage=usage,
         permission_request_id=permission_request_id,
         permission_description=permission_description,
+        message_phase=message_phase,
+        already_streamed=already_streamed,
         uses_turn_id_fallback=should_map_missing_turn_id(method, payload),
         closes_turn_buffer=should_close_turn_buffer(method, payload),
     )

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -432,6 +432,20 @@ def normalize_runtime_thread_message(
         update = _extract_session_update(params)
         update_kind = acp_lifecycle.session_update_kind or ""
         if update_kind == "agent_message_chunk":
+            if acp_lifecycle.message_phase == "commentary":
+                commentary_text = acp_lifecycle.output_delta or _extract_output_delta(
+                    _extract_session_update_message_params(update)
+                )
+                if not commentary_text:
+                    return []
+                return [
+                    RunNotice(
+                        timestamp=event_timestamp,
+                        kind="commentary",
+                        message=commentary_text,
+                        data={"already_streamed": acp_lifecycle.already_streamed},
+                    )
+                ]
             return _assistant_stream_events(
                 _extract_session_update_message_params(update),
                 state,
@@ -465,6 +479,15 @@ def normalize_runtime_thread_message(
         content = acp_lifecycle.assistant_text
         if not content:
             return []
+        if acp_lifecycle.message_phase == "commentary":
+            return [
+                RunNotice(
+                    timestamp=event_timestamp,
+                    kind="commentary",
+                    message=content,
+                    data={"already_streamed": acp_lifecycle.already_streamed},
+                )
+            ]
         state.note_message_text(content)
         return [
             OutputDelta(
@@ -563,7 +586,17 @@ def normalize_runtime_thread_message(
             return []
         if item_type == "agentMessage":
             if _is_commentary_agent_message(item):
-                return []
+                content = _extract_agent_message_text(item)
+                if not content:
+                    return []
+                return [
+                    RunNotice(
+                        timestamp=event_timestamp,
+                        kind="commentary",
+                        message=content,
+                        data={"already_streamed": _extract_already_streamed_flag(item)},
+                    )
+                ]
             content = _extract_agent_message_text(item)
             if not content:
                 return []
@@ -687,7 +720,17 @@ def normalize_runtime_thread_message(
             timestamp=event_timestamp,
         )
         if _extract_message_phase(params) == "commentary":
-            return role_events
+            content = _extract_message_text(params)
+            if not content:
+                return role_events
+            return role_events + [
+                RunNotice(
+                    timestamp=event_timestamp,
+                    kind="commentary",
+                    message=content,
+                    data={"already_streamed": _extract_already_streamed_flag(params)},
+                )
+            ]
         content = _extract_message_text(params)
         if not content:
             return role_events
@@ -787,7 +830,17 @@ def _assistant_stream_events(
 ) -> list[RunEvent]:
     phase = str(params.get("phase") or "").strip().lower()
     if phase == "commentary":
-        return []
+        content = _extract_output_delta(params)
+        if not content:
+            return []
+        return [
+            RunNotice(
+                timestamp=timestamp or now_iso(),
+                kind="commentary",
+                message=content,
+                data={"already_streamed": _extract_already_streamed_flag(params)},
+            )
+        ]
     content = _extract_output_delta(params)
     if not content:
         return []
@@ -1105,6 +1158,19 @@ def _extract_message_phase(params: dict[str, Any]) -> Optional[str]:
     if isinstance(nested_phase, str) and nested_phase.strip():
         return nested_phase.strip().lower()
     return None
+
+
+def _extract_already_streamed_flag(payload: dict[str, Any]) -> bool:
+    for key in ("already_streamed", "alreadyStreamed"):
+        value = payload.get(key)
+        if isinstance(value, bool):
+            return value
+    info = _extract_message_info(payload)
+    for key in ("already_streamed", "alreadyStreamed"):
+        value = info.get(key)
+        if isinstance(value, bool):
+            return value
+    return False
 
 
 def _extract_usage(params: dict[str, Any]) -> Optional[dict[str, Any]]:

--- a/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
+++ b/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
@@ -6,6 +6,7 @@ from typing import Any, Literal, Optional
 
 from ..acp_lifecycle import (
     analyze_acp_lifecycle_message,
+    extract_message_phase,
 )
 from ..acp_lifecycle import (
     extract_error_message as _extract_error_message,
@@ -506,7 +507,7 @@ def _inspect_raw_event(
             }
             or "outputdelta" in method_lower
         )
-        and lifecycle.message_phase != "commentary"
+        and extract_message_phase(params) != "commentary"
     ):
         assistant_stream_text = _extract_output_delta(params)
     if assistant_stream_text is None and method == "session/update":

--- a/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
+++ b/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
@@ -455,10 +455,14 @@ def _inspect_raw_event(
 
     if method in {"message.completed", "message.updated"}:
         role = _extract_message_role(params)
-        if role != "user":
+        if (
+            role != "user"
+            and str(params.get("phase") or "").strip().lower() != "commentary"
+        ):
             assistant_message_text = _extract_message_text(params)
     elif method in {"prompt/message", "turn/message"}:
-        assistant_message_text = lifecycle.assistant_text
+        if lifecycle.message_phase != "commentary":
+            assistant_message_text = lifecycle.assistant_text
     elif lifecycle.runtime_terminal_status is not None:
         assistant_message_text = lifecycle.assistant_text or None
         terminal_signal = RuntimeThreadTerminalSignal(
@@ -487,25 +491,32 @@ def _inspect_raw_event(
         ):
             assistant_message_text = _shared_extract_agent_message_text(item) or None
 
-    if assistant_message_text is None and (
-        method
-        in {
-            "prompt/output",
-            "prompt/delta",
-            "prompt/progress",
-            "turn/progress",
-            "item/agentMessage/delta",
-            "message.delta",
-            "turn/streamDelta",
-        }
-        or "outputdelta" in method_lower
+    if (
+        assistant_message_text is None
+        and (
+            method
+            in {
+                "prompt/output",
+                "prompt/delta",
+                "prompt/progress",
+                "turn/progress",
+                "item/agentMessage/delta",
+                "message.delta",
+                "turn/streamDelta",
+            }
+            or "outputdelta" in method_lower
+        )
+        and lifecycle.message_phase != "commentary"
     ):
         assistant_stream_text = _extract_output_delta(params)
     if assistant_stream_text is None and method == "session/update":
         update = params.get("update")
         if isinstance(update, dict):
             update_kind = str(lifecycle.session_update_kind or "").strip()
-            if update_kind == "agent_message_chunk":
+            if (
+                update_kind == "agent_message_chunk"
+                and lifecycle.message_phase != "commentary"
+            ):
                 assistant_stream_text = _extract_output_delta(update)
 
     return _RawEventInspection(

--- a/src/codex_autorunner/integrations/chat/managed_thread_progress.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_progress.py
@@ -94,6 +94,7 @@ def apply_run_event_to_progress_tracker(
 
     if isinstance(run_event, ToolCall):
         tool_name = run_event.tool_name.strip() if run_event.tool_name else ""
+        tracker.end_output_segment()
         tracker.note_tool(tool_name or "Tool call")
         return ProgressTrackerEventOutcome(changed=True, force=True)
 
@@ -113,6 +114,18 @@ def apply_run_event_to_progress_tracker(
                 changed=True,
                 force=prior_transient is None or prior_transient.label != "thinking",
             )
+        if run_event.kind == "commentary":
+            already_streamed = bool(
+                run_event.data.get("already_streamed")
+                or run_event.data.get("alreadyStreamed")
+            )
+            tracker.end_output_segment()
+            if already_streamed:
+                return ProgressTrackerEventOutcome(changed=False)
+            if not notice:
+                return ProgressTrackerEventOutcome(changed=False)
+            tracker.note_commentary(notice)
+            return ProgressTrackerEventOutcome(changed=True, force=True)
         if run_event.kind == "interrupted":
             if tracker.label == "done" and runtime_state.final_message:
                 return ProgressTrackerEventOutcome(changed=False)

--- a/src/codex_autorunner/integrations/chat/progress_primitives.py
+++ b/src/codex_autorunner/integrations/chat/progress_primitives.py
@@ -282,6 +282,17 @@ class TurnProgressTracker:
         )
         self.update_action_raw(self.last_output_index, self.output_buffer, "update")
 
+    def note_commentary(self, text: str) -> None:
+        commentary_text = _normalize_output_text(text)
+        if not commentary_text.strip():
+            return
+        self.add_action(
+            "commentary",
+            commentary_text,
+            "update",
+            normalize_text=False,
+        )
+
     def note_command(self, text: str) -> None:
         normalized = _normalize_inline_text(text)
         if not normalized:
@@ -345,7 +356,7 @@ def render_progress_text(
         actions = [
             action
             for action in tracker.actions
-            if action.label not in {"thinking", "tool", "command"}
+            if action.label not in {"thinking", "tool", "command", "commentary"}
         ]
         if tracker.max_actions > 0:
             actions = actions[-tracker.max_actions :]
@@ -399,7 +410,7 @@ def render_progress_text(
             block = [f"🧠 {action.text}"]
             if blocks:
                 block.insert(0, "")
-        elif action.label == "output":
+        elif action.label in {"output", "commentary"}:
             output_lines = action.text.split("\n")
             if not output_lines:
                 block = [action.text]

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -43,9 +43,18 @@ async def test_normalize_runtime_thread_raw_event_shared_lifecycle_corpus() -> N
                 assert events[0].error_message == expected["error_message"]
                 assert state.last_error_message == expected["error_message"]
         elif expected["normalized_kind"] == "output_delta":
-            assert isinstance(events[0], OutputDelta)
-            assert events[0].content == expected["output_delta"]
-            assert state.best_assistant_text() == expected["output_delta"]
+            if expected.get("message_phase") == "commentary":
+                assert isinstance(events[0], RunNotice)
+                assert events[0].kind == "commentary"
+                assert events[0].message == expected["output_delta"]
+                assert events[0].data.get("already_streamed") is expected.get(
+                    "already_streamed", False
+                )
+                assert state.best_assistant_text() == ""
+            else:
+                assert isinstance(events[0], OutputDelta)
+                assert events[0].content == expected["output_delta"]
+                assert state.best_assistant_text() == expected["output_delta"]
         elif expected["normalized_kind"] == "progress":
             if (
                 raw["method"] in {"session.status", "session/status"}
@@ -584,6 +593,41 @@ async def test_normalize_runtime_thread_raw_event_handles_official_session_updat
     assert len(output) == 1
     assert isinstance(output[0], OutputDelta)
     assert output[0].content == "hello world"
+
+
+async def test_normalize_runtime_thread_raw_event_maps_official_commentary_update_to_notice() -> (
+    None
+):
+    state = RuntimeThreadRunEventState()
+
+    events = await normalize_runtime_thread_raw_event(
+        {
+            "message": {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "session-1",
+                    "turnId": "turn-1",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "phase": "commentary",
+                        "alreadyStreamed": True,
+                        "content": [
+                            {"type": "text", "text": "draft"},
+                            {"type": "output_text", "text": " plan"},
+                        ],
+                    },
+                },
+            }
+        },
+        state,
+    )
+
+    assert len(events) == 1
+    assert isinstance(events[0], RunNotice)
+    assert events[0].kind == "commentary"
+    assert events[0].message == "draft plan"
+    assert events[0].data == {"already_streamed": True}
+    assert state.best_assistant_text() == ""
 
 
 async def test_recover_post_completion_outcome_uses_streamed_output_after_completion() -> (
@@ -1738,7 +1782,7 @@ class TestCrossBackendToolParity:
 class TestCrossBackendCommentaryFiltering:
     """Commentary/reasoning must not leak into final assistant answer."""
 
-    async def test_codex_commentary_agent_message_filtered(self) -> None:
+    async def test_codex_commentary_agent_message_becomes_notice(self) -> None:
         state = RuntimeThreadRunEventState()
 
         events = await normalize_runtime_thread_raw_event(
@@ -1755,7 +1799,10 @@ class TestCrossBackendCommentaryFiltering:
             state,
         )
 
-        assert events == []
+        assert len(events) == 1
+        assert isinstance(events[0], RunNotice)
+        assert events[0].kind == "commentary"
+        assert events[0].message == "thinking about approach"
         assert state.best_assistant_text() == ""
 
     async def test_codex_non_commentary_agent_message_kept(self) -> None:
@@ -1774,7 +1821,7 @@ class TestCrossBackendCommentaryFiltering:
         assert events[0].content == "final answer"
         assert state.best_assistant_text() == "final answer"
 
-    async def test_opencode_commentary_message_completed_filtered(self) -> None:
+    async def test_opencode_commentary_message_completed_becomes_notice(self) -> None:
         state = RuntimeThreadRunEventState()
 
         events = await normalize_runtime_thread_raw_event(
@@ -1791,7 +1838,10 @@ class TestCrossBackendCommentaryFiltering:
             state,
         )
 
-        assert events == []
+        assert len(events) == 1
+        assert isinstance(events[0], RunNotice)
+        assert events[0].kind == "commentary"
+        assert events[0].message == "internal commentary"
         assert state.best_assistant_text() == ""
 
     async def test_opencode_reasoning_part_never_leaks_to_stream(self) -> None:
@@ -1840,7 +1890,9 @@ class TestCrossBackendCommentaryFiltering:
         assert state.best_assistant_text() == "the actual answer"
         assert state.assistant_stream_text == "the actual answer"
 
-    async def test_opencode_assistant_stream_phase_commentary_filtered(self) -> None:
+    async def test_opencode_assistant_stream_phase_commentary_becomes_notice(
+        self,
+    ) -> None:
         state = RuntimeThreadRunEventState()
 
         events = await normalize_runtime_thread_raw_event(
@@ -1851,10 +1903,13 @@ class TestCrossBackendCommentaryFiltering:
             state,
         )
 
-        assert events == []
+        assert len(events) == 1
+        assert isinstance(events[0], RunNotice)
+        assert events[0].kind == "commentary"
+        assert events[0].message == "commentary text"
         assert state.assistant_stream_text == ""
 
-    async def test_prompt_message_commentary_ignored(self) -> None:
+    async def test_prompt_message_commentary_becomes_notice(self) -> None:
         state = RuntimeThreadRunEventState()
 
         events = await normalize_runtime_thread_raw_event(
@@ -1869,8 +1924,10 @@ class TestCrossBackendCommentaryFiltering:
         )
 
         assert len(events) == 1
-        assert isinstance(events[0], OutputDelta)
-        assert events[0].content == "reasoning about the problem"
+        assert isinstance(events[0], RunNotice)
+        assert events[0].kind == "commentary"
+        assert events[0].message == "reasoning about the problem"
+        assert state.best_assistant_text() == ""
 
 
 class TestCrossBackendApprovalParity:

--- a/tests/core/orchestration/test_runtime_turn_terminal_state.py
+++ b/tests/core/orchestration/test_runtime_turn_terminal_state.py
@@ -22,8 +22,10 @@ def test_runtime_turn_terminal_state_machine_shared_lifecycle_corpus() -> None:
 
         if expected["assistant_text"]:
             assert state.last_assistant_text == expected["assistant_text"]
-        if expected["output_delta"]:
+        if expected["output_delta"] and expected.get("message_phase") != "commentary":
             assert state.last_assistant_text == expected["output_delta"]
+        if expected.get("message_phase") == "commentary":
+            assert state.last_assistant_text == ""
         if expected["error_message"]:
             assert state.failure_cause == expected["error_message"]
         if expected["runtime_terminal_status"] is None:
@@ -124,3 +126,27 @@ def test_runtime_turn_terminal_state_machine_builds_compact_checkpoint() -> None
     assert checkpoint.raw_event_count == 2
     assert checkpoint.projection_event_cursor == 4
     assert checkpoint.terminal_signals[0].status == "ok"
+
+
+def test_runtime_turn_terminal_state_machine_ignores_commentary_stream_for_fallback() -> (
+    None
+):
+    state = RuntimeTurnTerminalStateMachine(
+        backend_thread_id="thread-1",
+        backend_turn_id="turn-1",
+    )
+
+    state.note_raw_event(
+        {
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "phase": "commentary",
+                    "content": [{"type": "text", "text": "draft plan"}],
+                }
+            },
+        }
+    )
+
+    assert state.last_assistant_text == ""

--- a/tests/core/orchestration/test_runtime_turn_terminal_state.py
+++ b/tests/core/orchestration/test_runtime_turn_terminal_state.py
@@ -150,3 +150,24 @@ def test_runtime_turn_terminal_state_machine_ignores_commentary_stream_for_fallb
     )
 
     assert state.last_assistant_text == ""
+
+
+def test_runtime_turn_terminal_state_machine_ignores_prompt_output_commentary_for_fallback() -> (
+    None
+):
+    state = RuntimeTurnTerminalStateMachine(
+        backend_thread_id="thread-1",
+        backend_turn_id="turn-1",
+    )
+
+    state.note_raw_event(
+        {
+            "method": "prompt/output",
+            "params": {
+                "phase": "commentary",
+                "delta": "draft plan",
+            },
+        }
+    )
+
+    assert state.last_assistant_text == ""

--- a/tests/core/test_acp_lifecycle_invariants.py
+++ b/tests/core/test_acp_lifecycle_invariants.py
@@ -511,6 +511,26 @@ def test_analyze_acp_lifecycle_session_update_agent_message_chunk() -> None:
     assert snap.output_delta == "streamed text"
 
 
+def test_analyze_acp_lifecycle_session_update_commentary_metadata() -> None:
+    snap = analyze_acp_lifecycle_message(
+        {
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": "draft plan",
+                    "phase": "commentary",
+                    "alreadyStreamed": True,
+                }
+            },
+        }
+    )
+    assert snap.normalized_kind == "output_delta"
+    assert snap.output_delta == "draft plan"
+    assert snap.message_phase == "commentary"
+    assert snap.already_streamed is True
+
+
 def test_analyze_acp_lifecycle_session_update_agent_thought_chunk() -> None:
     snap = analyze_acp_lifecycle_message(
         {

--- a/tests/fixtures/acp_lifecycle_corpus.json
+++ b/tests/fixtures/acp_lifecycle_corpus.json
@@ -207,6 +207,45 @@
     }
   },
   {
+    "name": "session_update_commentary_message_chunk_missing_turn_id",
+    "raw": {
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "sessionUpdate": "agent_message_chunk",
+          "phase": "commentary",
+          "alreadyStreamed": true,
+          "content": [
+            {
+              "type": "text",
+              "text": "draft"
+            },
+            {
+              "type": "output_text",
+              "text": " plan"
+            }
+          ]
+        }
+      }
+    },
+    "expected": {
+      "normalized_kind": "output_delta",
+      "terminal_status": null,
+      "runtime_terminal_status": null,
+      "uses_turn_id_fallback": true,
+      "closes_turn_buffer": false,
+      "assistant_text": "",
+      "output_delta": "draft plan",
+      "progress_message": "",
+      "error_message": null,
+      "session_status": null,
+      "session_update_kind": "agent_message_chunk",
+      "message_phase": "commentary",
+      "already_streamed": true
+    }
+  },
+  {
     "name": "session_update_thought_chunk_missing_turn_id",
     "raw": {
       "method": "session/update",

--- a/tests/test_managed_thread_progress.py
+++ b/tests/test_managed_thread_progress.py
@@ -221,6 +221,129 @@ def test_apply_run_event_to_progress_tracker_preserves_boundary_between_snapshot
     ]
 
 
+def test_apply_run_event_to_progress_tracker_renders_commentary_live_only() -> None:
+    tracker = _tracker()
+    runtime_state = ProgressRuntimeState()
+
+    outcome = apply_run_event_to_progress_tracker(
+        tracker,
+        RunNotice(
+            timestamp="2026-03-15T00:00:00Z",
+            kind="commentary",
+            message="Checking the ACP event path",
+        ),
+        runtime_state=runtime_state,
+    )
+
+    assert outcome.changed is True
+    assert outcome.force is True
+    assert [action.label for action in tracker.actions] == ["commentary"]
+
+    live = render_progress_text(tracker, max_length=2000, now=1.0)
+    final = render_progress_text(tracker, max_length=2000, now=1.0, render_mode="final")
+
+    assert "Checking the ACP event path" in live
+    assert "Checking the ACP event path" not in final
+
+
+def test_apply_run_event_to_progress_tracker_commentary_preserves_segments() -> None:
+    tracker = _tracker()
+    runtime_state = ProgressRuntimeState()
+
+    apply_run_event_to_progress_tracker(
+        tracker,
+        RunNotice(timestamp="t0", kind="commentary", message="First interim note"),
+        runtime_state=runtime_state,
+    )
+    apply_run_event_to_progress_tracker(
+        tracker,
+        RunNotice(timestamp="t1", kind="commentary", message="Second interim note"),
+        runtime_state=runtime_state,
+    )
+
+    commentary_actions = [
+        action.text for action in tracker.actions if action.label == "commentary"
+    ]
+    assert commentary_actions == ["First interim note", "Second interim note"]
+
+
+def test_apply_run_event_to_progress_tracker_already_streamed_commentary_only_ends_segment() -> (
+    None
+):
+    tracker = _tracker()
+    runtime_state = ProgressRuntimeState()
+
+    apply_run_event_to_progress_tracker(
+        tracker,
+        OutputDelta(
+            timestamp="t0",
+            content="streamed answer",
+            delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
+        ),
+        runtime_state=runtime_state,
+    )
+
+    outcome = apply_run_event_to_progress_tracker(
+        tracker,
+        RunNotice(
+            timestamp="t1",
+            kind="commentary",
+            message="streamed answer",
+            data={"already_streamed": True},
+        ),
+        runtime_state=runtime_state,
+    )
+
+    assert outcome.changed is False
+    assert [action.label for action in tracker.actions] == ["output"]
+    assert tracker.last_output_index is None
+
+
+def test_tool_call_ends_output_segment_before_later_commentary_and_snapshot() -> None:
+    tracker = _tracker()
+    runtime_state = ProgressRuntimeState()
+
+    apply_run_event_to_progress_tracker(
+        tracker,
+        OutputDelta(
+            timestamp="t0",
+            content="initial output",
+            delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
+        ),
+        runtime_state=runtime_state,
+    )
+    apply_run_event_to_progress_tracker(
+        tracker,
+        ToolCall(timestamp="t1", tool_name="exec", tool_input={}),
+        runtime_state=runtime_state,
+    )
+    apply_run_event_to_progress_tracker(
+        tracker,
+        RunNotice(
+            timestamp="t2",
+            kind="commentary",
+            message="post-tool commentary",
+        ),
+        runtime_state=runtime_state,
+    )
+    apply_run_event_to_progress_tracker(
+        tracker,
+        OutputDelta(
+            timestamp="t3",
+            content="post-tool snapshot",
+            delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
+        ),
+        runtime_state=runtime_state,
+    )
+
+    actions = [(action.label, action.text) for action in tracker.actions]
+    assert actions == [
+        ("output", "initial output"),
+        ("commentary", "post-tool commentary"),
+        ("output", "post-tool snapshot"),
+    ]
+
+
 def test_progress_notice_shows_when_no_transient_action() -> None:
     tracker = _tracker()
 

--- a/tests/test_telegram_progress_stream.py
+++ b/tests/test_telegram_progress_stream.py
@@ -306,6 +306,27 @@ def test_final_mode_keeps_output_even_when_compact_window_excludes_it() -> None:
     assert "files:" not in rendered
 
 
+def test_render_progress_text_keeps_commentary_live_only() -> None:
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="codex",
+        model="mock-model",
+        label="working",
+        max_actions=10,
+        max_output_chars=500,
+    )
+    tracker.note_output("streamed output")
+    tracker.note_commentary("interim commentary block")
+
+    live = render_progress_text(tracker, max_length=2000, now=1.0)
+    final = render_progress_text(tracker, max_length=2000, now=1.0, render_mode="final")
+
+    assert "streamed output" in live
+    assert "interim commentary block" in live
+    assert "streamed output" in final
+    assert "interim commentary block" not in final
+
+
 def test_final_mode_uses_consolidated_output_after_interleaved_actions() -> None:
     tracker = TurnProgressTracker(
         started_at=0.0,


### PR DESCRIPTION
## Summary
Port the Hermes interim commentary UX into CAR's shared chat progress pipeline.

## What changed
- preserve ACP commentary metadata on `session/update` message chunks
- normalize commentary-phase runtime updates into `RunNotice(kind="commentary")` instead of assistant output
- render commentary as durable live-only blocks in the shared managed-thread progress tracker
- end output segments on commentary and tool boundaries so later snapshots do not smear into earlier text
- ignore commentary when recovering terminal fallback assistant text
- add focused lifecycle, runtime, terminal-state, and progress rendering coverage

## Why
Hermes can emit richer interim assistant commentary, but CAR was treating ACP `agent_message_chunk` updates as normal assistant output or dropping commentary entirely. That prevented the Discord/Telegram working anchor from showing useful in-progress commentary without risking duplicate final output.

## Impact
Discord and Telegram managed-thread progress can now show interim commentary inside the existing working message without sending extra visible chat bubbles, while the final delivered answer remains unchanged.

## Validation
- full commit hook validation passed
- `.venv/bin/python -m pytest -q tests/core/test_acp_lifecycle_invariants.py tests/core/orchestration/test_runtime_thread_events.py tests/core/orchestration/test_runtime_turn_terminal_state.py tests/test_managed_thread_progress.py tests/test_telegram_progress_stream.py`
- repo-wide pytest from the commit hook: `7262 passed, 8 xfailed`
- strict mypy on `src/codex_autorunner`
- frontend asset build and `pnpm test:markdown`
