### PR TITLE
[codex] Fix PMA wake-up delivery routing

### DIFF
--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -1690,6 +1690,12 @@ class HubSupervisor:
                 "subscription_id": wakeup.get("subscription_id"),
                 "timer_id": wakeup.get("timer_id"),
             }
+            metadata = wakeup.get("metadata")
+            if isinstance(metadata, dict):
+                wake_payload["metadata"] = dict(metadata)
+                delivery_target = metadata.get("delivery_target")
+                if isinstance(delivery_target, dict):
+                    wake_payload["delivery_target"] = dict(delivery_target)
             payload = {
                 "message": self._build_pma_wakeup_message(wake_payload),
                 "agent": None,

--- a/src/codex_autorunner/core/hub_lifecycle_routing.py
+++ b/src/codex_autorunner/core/hub_lifecycle_routing.py
@@ -295,6 +295,13 @@ class LifecycleEventRouter:
                 f"lifecycle:{event.event_id}:subscription:"
                 f"{subscription_id or 'unknown'}"
             )
+            subscription_metadata = subscription.get("metadata")
+            metadata = (
+                dict(subscription_metadata)
+                if isinstance(subscription_metadata, dict)
+                else {}
+            )
+            metadata["origin"] = event.origin
             reason = (
                 str(subscription.get("reason")).strip()
                 if isinstance(subscription.get("reason"), str)
@@ -321,7 +328,7 @@ class LifecycleEventRouter:
                 event_id=event.event_id,
                 event_type=event.event_type.value,
                 event_data=event.data if isinstance(event.data, dict) else {},
-                metadata={"origin": event.origin},
+                metadata=metadata,
             )
             if not deduped:
                 created += 1

--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -34,7 +34,7 @@ from .pma_automation_types import (
     default_pma_automation_state,
 )
 from .pma_thread_store import PmaThreadStore
-from .text_utils import lock_path_for
+from .text_utils import _normalize_pma_delivery_target, lock_path_for
 
 logger = logging.getLogger(__name__)
 
@@ -46,12 +46,10 @@ class PmaAutomationThreadNotFoundError(ValueError):
 
 
 def _normalize_delivery_target(value: Any) -> Optional[dict[str, str]]:
-    if not isinstance(value, dict):
+    normalized = _normalize_pma_delivery_target(value)
+    if normalized is None:
         return None
-    surface_kind = _normalize_text(value.get("surface_kind"))
-    surface_key = _normalize_text(value.get("surface_key"))
-    if surface_kind not in {"discord", "telegram"} or surface_key is None:
-        return None
+    surface_kind, surface_key = normalized
     return {
         "surface_kind": surface_kind,
         "surface_key": surface_key,

--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -45,6 +45,19 @@ class PmaAutomationThreadNotFoundError(ValueError):
         self.thread_id = thread_id
 
 
+def _normalize_delivery_target(value: Any) -> Optional[dict[str, str]]:
+    if not isinstance(value, dict):
+        return None
+    surface_kind = _normalize_text(value.get("surface_kind"))
+    surface_key = _normalize_text(value.get("surface_key"))
+    if surface_kind not in {"discord", "telegram"} or surface_key is None:
+        return None
+    return {
+        "surface_kind": surface_kind,
+        "surface_key": surface_key,
+    }
+
+
 @dataclass
 class PmaLifecycleSubscription:
     subscription_id: str
@@ -1076,6 +1089,26 @@ class PmaAutomationStore:
             return binding_kind
         return DEFAULT_PMA_LANE_ID
 
+    def _resolve_thread_delivery_target(
+        self, *, thread_id: str
+    ) -> Optional[dict[str, str]]:
+        thread_store = PmaThreadStore(self._hub_root)
+        thread = thread_store.get_thread(thread_id)
+        if thread is None:
+            raise PmaAutomationThreadNotFoundError(thread_id)
+
+        binding_metadata = active_chat_binding_metadata_by_thread(
+            hub_root=self._hub_root
+        ).get(thread_id)
+        if not isinstance(binding_metadata, dict):
+            return None
+        return _normalize_delivery_target(
+            {
+                "surface_kind": binding_metadata.get("binding_kind"),
+                "surface_key": binding_metadata.get("binding_id"),
+            }
+        )
+
     def _resolve_subscription_lane_id(
         self,
         *,
@@ -1089,6 +1122,30 @@ class PmaAutomationStore:
 
         resolved_lane_id = self._resolve_thread_lane_id(thread_id=normalized_thread_id)
         return resolved_lane_id
+
+    def _resolve_subscription_metadata(
+        self,
+        *,
+        thread_id: Optional[str],
+        metadata: Optional[dict[str, Any]],
+    ) -> dict[str, Any]:
+        resolved_metadata = dict(metadata or {})
+        delivery_target = _normalize_delivery_target(
+            resolved_metadata.get("delivery_target")
+        )
+        normalized_thread_id = _normalize_text(thread_id)
+        if delivery_target is None and normalized_thread_id is not None:
+            try:
+                delivery_target = self._resolve_thread_delivery_target(
+                    thread_id=normalized_thread_id
+                )
+            except PmaAutomationThreadNotFoundError:
+                delivery_target = None
+        if delivery_target is not None:
+            resolved_metadata["delivery_target"] = delivery_target
+        else:
+            resolved_metadata.pop("delivery_target", None)
+        return resolved_metadata
 
     def upsert_subscription(
         self,
@@ -1113,6 +1170,10 @@ class PmaAutomationStore:
             thread_id=normalized_thread_id,
             lane_id=lane_id,
         )
+        resolved_metadata = self._resolve_subscription_metadata(
+            thread_id=normalized_thread_id,
+            metadata=metadata,
+        )
         if not normalized_event_types:
             logger.warning(
                 "Creating PMA subscription with empty event_types; subscription will match all events"
@@ -1136,7 +1197,7 @@ class PmaAutomationStore:
                         idempotency_key=key,
                         notify_once=notify_once,
                         max_matches=max_matches,
-                        metadata=metadata,
+                        metadata=resolved_metadata,
                     )
                     self._insert_subscription_row(conn, created)
             self._rewrite_json_mirror_unlocked()
@@ -1864,6 +1925,8 @@ class PmaAutomationStore:
                 if deduped:
                     continue
 
+                wakeup_metadata = dict(entry.metadata or {})
+                wakeup_metadata.update(metadata_payload)
                 wakeups.append(
                     PmaAutomationWakeup.create(
                         source="transition",
@@ -1878,7 +1941,7 @@ class PmaAutomationStore:
                         idempotency_key=wakeup_key,
                         subscription_id=subscription_id,
                         event_type=event_type_norm,
-                        metadata=dict(metadata_payload),
+                        metadata=wakeup_metadata,
                     )
                 )
                 created += 1

--- a/src/codex_autorunner/core/pma_chat_delivery.py
+++ b/src/codex_autorunner/core/pma_chat_delivery.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from .chat_bindings import (
+    active_chat_binding_metadata_by_thread,
     normalize_workspace_path,
     preferred_non_pma_chat_notification_source_for_workspace,
     resolve_bound_repo_id,
@@ -31,6 +32,16 @@ logger = logging.getLogger(__name__)
 _DISCORD_MESSAGE_MAX_LEN = 1900
 
 
+def _normalize_delivery_target(value: Any) -> Optional[tuple[str, str]]:
+    if not isinstance(value, dict):
+        return None
+    surface_kind = _normalize_optional_text(value.get("surface_kind"))
+    surface_key = _normalize_optional_text(value.get("surface_key"))
+    if surface_kind not in {"discord", "telegram"} or surface_key is None:
+        return None
+    return surface_kind, surface_key
+
+
 def _notification_context_payload(
     *,
     message: str,
@@ -43,6 +54,27 @@ def _notification_context_payload(
     payload.setdefault("correlation_id", correlation_id)
     payload.setdefault("source_kind", source_kind)
     return payload
+
+
+def _delivery_target_matches_active_thread_binding(
+    *,
+    hub_root: Path,
+    managed_thread_id: Optional[str],
+    surface_kind: str,
+    surface_key: str,
+) -> bool:
+    normalized_thread_id = _normalize_optional_text(managed_thread_id)
+    if normalized_thread_id is None:
+        return True
+    binding_metadata = active_chat_binding_metadata_by_thread(hub_root=hub_root).get(
+        normalized_thread_id
+    )
+    if not isinstance(binding_metadata, dict):
+        return False
+    return (
+        _normalize_optional_text(binding_metadata.get("binding_kind")) == surface_kind
+        and _normalize_optional_text(binding_metadata.get("binding_id")) == surface_key
+    )
 
 
 def _build_discord_record_id(
@@ -296,6 +328,157 @@ async def _deliver_bound_telegram(
     return {"route": "bound", "targets": targets, "published": published}
 
 
+async def _deliver_direct_discord(
+    *,
+    hub_root: Path,
+    raw_config: dict[str, Any],
+    channel_id: str,
+    message: str,
+    correlation_id: str,
+    source_kind: str,
+    repo_id: Optional[str],
+    run_id: Optional[str],
+    managed_thread_id: Optional[str],
+    context_payload: Optional[dict[str, Any]],
+    notification_store: PmaNotificationStore,
+) -> dict[str, Any]:
+    from ..integrations.discord.rendering import (
+        chunk_discord_message,
+        format_discord_message,
+    )
+    from ..integrations.discord.state import DiscordStateStore
+    from ..integrations.discord.state import OutboxRecord as DiscordOutboxRecord
+
+    created_at = now_iso()
+    store = DiscordStateStore(resolve_discord_state_path(hub_root, raw_config))
+    try:
+        bindings = await store.list_bindings()
+        if not any(
+            _normalize_optional_text(binding.get("channel_id")) == channel_id
+            for binding in bindings
+        ):
+            return {"route": "explicit", "targets": 0, "published": 0}
+        chunks = chunk_discord_message(
+            format_discord_message(message),
+            max_len=_DISCORD_MESSAGE_MAX_LEN,
+            with_numbering=False,
+        )
+        if not chunks:
+            chunks = [format_discord_message(message)]
+        published = 0
+        for index, chunk in enumerate(chunks, start=1):
+            record_id = _build_discord_record_id(
+                correlation_id=correlation_id,
+                delivery_mode="bound",
+                channel_id=channel_id,
+                index=index,
+            )
+            _record_notification_delivery(
+                notification_store,
+                correlation_id=correlation_id,
+                source_kind=source_kind,
+                delivery_mode="bound",
+                surface_kind="discord",
+                surface_key=channel_id,
+                delivery_record_id=record_id,
+                repo_id=repo_id,
+                workspace_root=None,
+                run_id=run_id,
+                managed_thread_id=managed_thread_id,
+                context_payload=context_payload,
+            )
+            if await store.get_outbox(record_id) is not None:
+                continue
+            await store.enqueue_outbox(
+                DiscordOutboxRecord(
+                    record_id=record_id,
+                    channel_id=channel_id,
+                    message_id=None,
+                    operation="send",
+                    payload_json={"content": chunk},
+                    created_at=created_at,
+                )
+            )
+            published += 1
+        return {"route": "explicit", "targets": 1, "published": published}
+    finally:
+        await store.close()
+
+
+async def _deliver_direct_telegram(
+    *,
+    hub_root: Path,
+    raw_config: dict[str, Any],
+    topic_surface_key: str,
+    message: str,
+    correlation_id: str,
+    source_kind: str,
+    repo_id: Optional[str],
+    run_id: Optional[str],
+    managed_thread_id: Optional[str],
+    context_payload: Optional[dict[str, Any]],
+    notification_store: PmaNotificationStore,
+) -> dict[str, Any]:
+    from ..integrations.telegram.state import (
+        OutboxRecord as TelegramOutboxRecord,
+    )
+    from ..integrations.telegram.state import TelegramStateStore, parse_topic_key
+
+    created_at = now_iso()
+    store = TelegramStateStore(resolve_telegram_state_path(hub_root, raw_config))
+    try:
+        topics = await store.list_topics()
+        topic = topics.get(topic_surface_key)
+        if topic is None:
+            return {"route": "explicit", "targets": 0, "published": 0}
+        try:
+            chat_id, thread_id, scope = parse_topic_key(topic_surface_key)
+        except ValueError:
+            return {"route": "explicit", "targets": 0, "published": 0}
+        base_key = f"{chat_id}:{thread_id or 'root'}"
+        if scope != await store.get_topic_scope(base_key):
+            return {"route": "explicit", "targets": 0, "published": 0}
+        record_id = _build_telegram_record_id(
+            correlation_id=correlation_id,
+            delivery_mode="bound",
+            chat_id=chat_id,
+            thread_id=thread_id,
+        )
+        _record_notification_delivery(
+            notification_store,
+            correlation_id=correlation_id,
+            source_kind=source_kind,
+            delivery_mode="bound",
+            surface_kind="telegram",
+            surface_key=topic_surface_key,
+            delivery_record_id=record_id,
+            repo_id=repo_id,
+            workspace_root=None,
+            run_id=run_id,
+            managed_thread_id=managed_thread_id,
+            context_payload=context_payload,
+        )
+        if await store.get_outbox(record_id) is not None:
+            return {"route": "explicit", "targets": 1, "published": 0}
+        await store.enqueue_outbox(
+            TelegramOutboxRecord(
+                record_id=record_id,
+                chat_id=chat_id,
+                thread_id=thread_id,
+                reply_to_message_id=None,
+                placeholder_message_id=None,
+                text=message,
+                created_at=created_at,
+                operation="send",
+                message_id=None,
+                outbox_key=f"pma-notice:{correlation_id}:{topic_surface_key}:send",
+            )
+        )
+        return {"route": "explicit", "targets": 1, "published": 1}
+    finally:
+        await store.close()
+
+
 async def _deliver_primary_pma_discord(
     *,
     hub_root: Path,
@@ -507,6 +690,7 @@ async def deliver_pma_notification(
     workspace_root: Optional[Path] = None,
     run_id: Optional[str] = None,
     managed_thread_id: Optional[str] = None,
+    delivery_target: Optional[dict[str, Any]] = None,
     context_payload: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     text = str(message or "").strip()
@@ -528,6 +712,45 @@ async def deliver_pma_notification(
     )
     if normalized_delivery == "none":
         return {"route": "none", "targets": 0, "published": 0}
+    normalized_target = _normalize_delivery_target(delivery_target)
+    if normalized_target is not None:
+        surface_kind, surface_key = normalized_target
+        if _delivery_target_matches_active_thread_binding(
+            hub_root=hub_root,
+            managed_thread_id=managed_thread_id,
+            surface_kind=surface_kind,
+            surface_key=surface_key,
+        ):
+            if surface_kind == "discord":
+                direct_outcome = await _deliver_direct_discord(
+                    hub_root=hub_root,
+                    raw_config=raw_config,
+                    channel_id=surface_key,
+                    message=text,
+                    correlation_id=correlation_id,
+                    source_kind=normalized_source_kind,
+                    repo_id=normalized_repo_id,
+                    run_id=run_id,
+                    managed_thread_id=managed_thread_id,
+                    context_payload=payload,
+                    notification_store=notification_store,
+                )
+            else:
+                direct_outcome = await _deliver_direct_telegram(
+                    hub_root=hub_root,
+                    raw_config=raw_config,
+                    topic_surface_key=surface_key,
+                    message=text,
+                    correlation_id=correlation_id,
+                    source_kind=normalized_source_kind,
+                    repo_id=normalized_repo_id,
+                    run_id=run_id,
+                    managed_thread_id=managed_thread_id,
+                    context_payload=payload,
+                    notification_store=notification_store,
+                )
+            if direct_outcome.get("targets", 0) > 0:
+                return direct_outcome
     if normalized_delivery in {"auto", "primary_pma"} and normalized_repo_id:
         pma_discord = await _deliver_primary_pma_discord(
             hub_root=hub_root,

--- a/src/codex_autorunner/core/pma_chat_delivery.py
+++ b/src/codex_autorunner/core/pma_chat_delivery.py
@@ -24,22 +24,12 @@ from .chat_bindings import (
 )
 from .config import load_hub_config
 from .pma_notification_store import PmaNotificationStore
-from .text_utils import _normalize_optional_text
+from .text_utils import _normalize_optional_text, _normalize_pma_delivery_target
 from .time_utils import now_iso
 
 logger = logging.getLogger(__name__)
 
 _DISCORD_MESSAGE_MAX_LEN = 1900
-
-
-def _normalize_delivery_target(value: Any) -> Optional[tuple[str, str]]:
-    if not isinstance(value, dict):
-        return None
-    surface_kind = _normalize_optional_text(value.get("surface_kind"))
-    surface_key = _normalize_optional_text(value.get("surface_key"))
-    if surface_kind not in {"discord", "telegram"} or surface_key is None:
-        return None
-    return surface_kind, surface_key
 
 
 def _notification_context_payload(
@@ -712,7 +702,7 @@ async def deliver_pma_notification(
     )
     if normalized_delivery == "none":
         return {"route": "none", "targets": 0, "published": 0}
-    normalized_target = _normalize_delivery_target(delivery_target)
+    normalized_target = _normalize_pma_delivery_target(delivery_target)
     if normalized_target is not None:
         surface_kind, surface_key = normalized_target
         if _delivery_target_matches_active_thread_binding(

--- a/src/codex_autorunner/core/text_utils.py
+++ b/src/codex_autorunner/core/text_utils.py
@@ -25,6 +25,21 @@ def _normalize_optional_text(value: Any) -> Optional[str]:
     return text or None
 
 
+def _normalize_pma_delivery_target(value: Any) -> Optional[tuple[str, str]]:
+    """Validate ``surface_kind`` / ``surface_key`` for PMA chat delivery targets.
+
+    Uses strict string normalization for both fields so persistence and runtime
+    delivery agree on which payloads are valid.
+    """
+    if not isinstance(value, dict):
+        return None
+    surface_kind = _normalize_text(value.get("surface_kind"))
+    surface_key = _normalize_text(value.get("surface_key"))
+    if surface_kind not in {"discord", "telegram"} or surface_key is None:
+        return None
+    return surface_kind, surface_key
+
+
 def _json_dumps(obj: Any) -> str:
     return json.dumps(obj, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
 

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/publish.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/publish.py
@@ -78,6 +78,43 @@ def resolve_publish_repo_id(
     return normalize_optional_text(thread.get("repo_id"))
 
 
+def resolve_publish_workspace_root(
+    *,
+    request: Request,
+    lifecycle_event: Optional[dict[str, Any]],
+    wake_up: Optional[dict[str, Any]],
+) -> Optional[Path]:
+    from .....core.pma_thread_store import PmaThreadStore
+
+    if isinstance(wake_up, dict):
+        raw_workspace = normalize_optional_text(wake_up.get("workspace_root"))
+        if raw_workspace:
+            return Path(raw_workspace)
+    if isinstance(lifecycle_event, dict):
+        raw_workspace = normalize_optional_text(lifecycle_event.get("workspace_root"))
+        if raw_workspace:
+            return Path(raw_workspace)
+    thread_id = (
+        normalize_optional_text(wake_up.get("thread_id"))
+        if isinstance(wake_up, dict)
+        else None
+    )
+    if not thread_id:
+        return None
+    try:
+        thread = PmaThreadStore(request.app.state.config.root).get_thread(thread_id)
+    except (OSError, ValueError, RuntimeError):
+        logger.exception(
+            "Failed resolving managed thread workspace for publish thread_id=%s",
+            thread_id,
+        )
+        return None
+    if not isinstance(thread, dict):
+        return None
+    raw_workspace = normalize_optional_text(thread.get("workspace_root"))
+    return Path(raw_workspace) if raw_workspace else None
+
+
 def build_publish_correlation_id(
     *,
     result: dict[str, Any],
@@ -204,19 +241,22 @@ async def publish_automation_result(
         wake_up=wake_up_dict,
         correlation_id=correlation_id,
     )
-    workspace_root: Optional[Path] = None
-    if isinstance(wake_up_dict, dict):
-        workspace_root = (
-            Path(wake_up_dict["workspace_root"])
-            if normalize_optional_text(wake_up_dict.get("workspace_root"))
-            else None
-        )
-    if workspace_root is None and isinstance(lifecycle_event_dict, dict):
-        raw_workspace = normalize_optional_text(
-            lifecycle_event_dict.get("workspace_root")
-        )
-        if raw_workspace:
-            workspace_root = Path(raw_workspace)
+    workspace_root = resolve_publish_workspace_root(
+        request=request,
+        lifecycle_event=lifecycle_event_dict,
+        wake_up=wake_up_dict,
+    )
+    wake_up_payload = wake_up_dict or {}
+    wake_up_metadata = (
+        wake_up_payload.get("metadata")
+        if isinstance(wake_up_payload.get("metadata"), dict)
+        else None
+    )
+    wake_up_delivery_target = (
+        wake_up_payload.get("delivery_target")
+        if isinstance(wake_up_payload.get("delivery_target"), dict)
+        else None
+    )
     outcome: dict[str, Any] = {"route": "auto", "targets": 0, "published": 0}
 
     async def _deliver() -> None:
@@ -248,6 +288,15 @@ async def publish_automation_result(
             ),
             managed_thread_id=normalize_optional_text(
                 (wake_up_dict or {}).get("thread_id")
+            ),
+            delivery_target=(
+                wake_up_delivery_target
+                or (
+                    wake_up_metadata.get("delivery_target")
+                    if wake_up_metadata is not None
+                    and isinstance(wake_up_metadata.get("delivery_target"), dict)
+                    else None
+                )
             ),
             context_payload={
                 "result": dict(result or {}),

--- a/tests/core/test_lifecycle_event_processing.py
+++ b/tests/core/test_lifecycle_event_processing.py
@@ -517,6 +517,50 @@ def test_flow_completion_subscription_can_trigger_next_lane(tmp_path: Path) -> N
         supervisor.shutdown()
 
 
+def test_drain_automation_wakeup_copies_delivery_target_from_subscription(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _write_hub_config(
+        hub_root,
+        dispatch_interception=False,
+        extra_lines=["  reactive_enabled: false"],
+    )
+    supervisor = HubSupervisor(load_hub_config(hub_root))
+    supervisor._stop_lifecycle_event_processor()
+
+    try:
+        store = supervisor.get_pma_automation_store()
+        created = store.create_subscription(
+            {
+                "event_types": ["flow_completed"],
+                "repo_id": "repo-1",
+                "run_id": "run-1",
+                "metadata": {
+                    "delivery_target": {
+                        "surface_kind": "discord",
+                        "surface_key": "discord:channel-1",
+                    }
+                },
+                "idempotency_key": "sub-delivery-target",
+            }
+        )
+        assert created.get("deduped") is False
+
+        supervisor.lifecycle_emitter.emit_flow_completed("repo-1", "run-1")
+        supervisor.process_lifecycle_events()
+
+        items = _read_queue_items(hub_root, "pma:default")
+        assert len(items) == 1
+        wake_up = (items[0].get("payload") or {}).get("wake_up") or {}
+        assert wake_up.get("delivery_target") == {
+            "surface_kind": "discord",
+            "surface_key": "discord:channel-1",
+        }
+    finally:
+        supervisor.shutdown()
+
+
 def test_drain_automation_wakeups_requests_lane_worker_start(tmp_path: Path) -> None:
     hub_root = tmp_path / "hub"
     _write_hub_config(

--- a/tests/core/test_pma_automation_store.py
+++ b/tests/core/test_pma_automation_store.py
@@ -360,6 +360,44 @@ def test_create_subscription_auto_resolves_lane_from_thread_binding(tmp_path) ->
 
     assert subscription["thread_id"] == thread_id
     assert subscription["lane_id"] == "discord"
+    assert subscription["metadata"]["delivery_target"] == {
+        "surface_kind": "discord",
+        "surface_key": "discord:binding-1",
+    }
+
+
+def test_notify_transition_copies_subscription_delivery_target_into_wakeup(
+    tmp_path,
+) -> None:
+    store = PmaAutomationStore(tmp_path)
+    thread_id = _create_managed_thread(tmp_path, surface_kind="telegram")
+
+    subscription = store.create_subscription(
+        {
+            "event_type": "managed_thread_completed",
+            "thread_id": thread_id,
+        }
+    )["subscription"]
+
+    result = store.notify_transition(
+        {
+            "event_type": "managed_thread_completed",
+            "thread_id": thread_id,
+            "from_state": "running",
+            "to_state": "completed",
+            "transition_id": f"{thread_id}:completed",
+        }
+    )
+
+    assert result["matched"] == 1
+    assert result["created"] == 1
+    pending = store.list_pending_wakeups(limit=10)
+    assert len(pending) == 1
+    assert pending[0]["subscription_id"] == subscription["subscription_id"]
+    assert pending[0]["metadata"]["delivery_target"] == {
+        "surface_kind": "telegram",
+        "surface_key": "telegram:binding-1",
+    }
 
 
 def test_create_subscription_with_unknown_thread_requires_resolvable_lane(

--- a/tests/core/test_pma_chat_delivery.py
+++ b/tests/core/test_pma_chat_delivery.py
@@ -8,6 +8,7 @@ import pytest
 
 from codex_autorunner.bootstrap import seed_hub_files
 from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
+from codex_autorunner.core.orchestration import OrchestrationBindingStore
 from codex_autorunner.core.pma_chat_delivery import (
     deliver_pma_notification,
     notify_preferred_bound_chat_for_workspace,
@@ -17,6 +18,7 @@ from codex_autorunner.core.pma_notification_store import (
     PmaNotificationStore,
     build_notification_context_block,
 )
+from codex_autorunner.core.pma_thread_store import PmaThreadStore
 from codex_autorunner.integrations.discord.state import DiscordStateStore
 from codex_autorunner.integrations.telegram.state import TelegramStateStore, topic_key
 from tests.conftest import write_test_config
@@ -51,6 +53,19 @@ def _write_manifest(hub_root: Path, repo_id: str, workspace: Path) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def _create_bound_thread(
+    hub_root: Path, workspace: Path, *, surface_kind: str, surface_key: str
+) -> str:
+    thread = PmaThreadStore(hub_root).create_thread("codex", workspace)
+    thread_id = str(thread["managed_thread_id"])
+    OrchestrationBindingStore(hub_root).upsert_binding(
+        surface_kind=surface_kind,
+        surface_key=surface_key,
+        thread_target_id=thread_id,
+    )
+    return thread_id
 
 
 def _set_discord_binding_updated_at(
@@ -252,6 +267,126 @@ async def test_deliver_pma_notification_persists_replyable_context_for_bound_del
         assert "<notification_context>" in context_block
         assert '"notification_id"' in context_block
         assert '"dispatch_paused"' in context_block
+    finally:
+        await discord_store.close()
+
+
+@pytest.mark.anyio
+async def test_deliver_pma_notification_uses_explicit_delivery_target_for_bound_thread(
+    tmp_path: Path,
+) -> None:
+    hub_root = _hub(tmp_path)
+    workspace = (hub_root / "worktrees" / "repo-g").resolve()
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_manifest(hub_root, "repo-g", workspace)
+
+    discord_store = DiscordStateStore(
+        hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+    )
+    try:
+        await discord_store.upsert_binding(
+            channel_id="repo-g-discord",
+            guild_id="guild-1",
+            workspace_path=str(workspace),
+            repo_id="repo-g",
+        )
+        thread_id = _create_bound_thread(
+            hub_root,
+            workspace,
+            surface_kind="discord",
+            surface_key="repo-g-discord",
+        )
+
+        outcome = await deliver_pma_notification(
+            hub_root=hub_root,
+            repo_id="repo-g",
+            message="Terminal follow-up",
+            correlation_id="corr-explicit-1",
+            delivery="auto",
+            source_kind="managed_thread_completed",
+            managed_thread_id=thread_id,
+            delivery_target={
+                "surface_kind": "discord",
+                "surface_key": "repo-g-discord",
+            },
+        )
+
+        assert outcome == {"route": "explicit", "targets": 1, "published": 1}
+        outbox = await discord_store.list_outbox()
+        assert any(
+            record.channel_id == "repo-g-discord"
+            and record.payload_json.get("content") == "Terminal follow-up"
+            for record in outbox
+        )
+    finally:
+        await discord_store.close()
+
+
+@pytest.mark.anyio
+async def test_deliver_pma_notification_falls_back_when_explicit_target_binding_changes(
+    tmp_path: Path,
+) -> None:
+    hub_root = _hub(tmp_path)
+    workspace = (hub_root / "worktrees" / "repo-h").resolve()
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_manifest(hub_root, "repo-h", workspace)
+
+    discord_store = DiscordStateStore(
+        hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+    )
+    try:
+        await discord_store.upsert_binding(
+            channel_id="repo-h-origin",
+            guild_id="guild-1",
+            workspace_path=str(workspace),
+            repo_id="repo-h",
+        )
+        await discord_store.upsert_binding(
+            channel_id="repo-h-default",
+            guild_id="guild-1",
+            workspace_path=str(workspace),
+            repo_id="repo-h",
+        )
+        await discord_store.update_pma_state(
+            channel_id="repo-h-default",
+            pma_enabled=True,
+            pma_prev_workspace_path=str(workspace),
+            pma_prev_repo_id="repo-h",
+        )
+        thread_id = _create_bound_thread(
+            hub_root,
+            workspace,
+            surface_kind="discord",
+            surface_key="repo-h-origin",
+        )
+        OrchestrationBindingStore(hub_root).upsert_binding(
+            surface_kind="telegram",
+            surface_key=topic_key(7101, 8102),
+            thread_target_id=thread_id,
+        )
+
+        outcome = await deliver_pma_notification(
+            hub_root=hub_root,
+            repo_id="repo-h",
+            message="Fallback delivery",
+            correlation_id="corr-explicit-2",
+            delivery="auto",
+            source_kind="managed_thread_completed",
+            managed_thread_id=thread_id,
+            delivery_target={
+                "surface_kind": "discord",
+                "surface_key": "repo-h-origin",
+            },
+        )
+
+        assert outcome == {"route": "primary_pma", "targets": 1, "published": 1}
+        outbox = await discord_store.list_outbox()
+        assert any(
+            record.channel_id == "repo-h-default"
+            and record.payload_json.get("content") == "Fallback delivery"
+            for record in outbox
+        )
+        assert not any(record.channel_id == "repo-h-origin" for record in outbox)
     finally:
         await discord_store.close()
 

--- a/tests/surfaces/web/routes/pma_routes/test_publish_helpers.py
+++ b/tests/surfaces/web/routes/pma_routes/test_publish_helpers.py
@@ -7,12 +7,15 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from codex_autorunner.core.pma_thread_store import PmaThreadStore
 from codex_autorunner.surfaces.web.routes.pma_routes.publish import (
     build_publish_correlation_id,
     build_publish_message,
     enqueue_with_retry,
     normalize_optional_text,
+    publish_automation_result,
     resolve_chat_state_path,
+    resolve_publish_workspace_root,
 )
 
 
@@ -174,3 +177,80 @@ class TestEnqueueWithRetry:
         with pytest.raises(RuntimeError, match="permanent"):
             await enqueue_with_retry(call)
         assert call.call_count == 3
+
+
+class TestResolvePublishWorkspaceRoot:
+    def test_falls_back_to_managed_thread_workspace(self, tmp_path: Path) -> None:
+        hub_root = (tmp_path / "hub").resolve()
+        hub_root.mkdir(parents=True, exist_ok=True)
+        workspace = (hub_root / "worktrees" / "repo-1").resolve()
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        thread = PmaThreadStore(hub_root).create_thread("codex", workspace)
+        thread_id = str(thread["managed_thread_id"])
+        request = SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(config=SimpleNamespace(root=hub_root, raw={}))
+            )
+        )
+
+        result = resolve_publish_workspace_root(
+            request=request,
+            lifecycle_event=None,
+            wake_up={"thread_id": thread_id},
+        )
+
+        assert result == workspace
+
+
+class TestPublishAutomationResult:
+    @pytest.mark.anyio
+    async def test_forwards_delivery_target_and_thread_context(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        hub_root = (tmp_path / "hub").resolve()
+        hub_root.mkdir(parents=True, exist_ok=True)
+        request = SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(config=SimpleNamespace(root=hub_root, raw={}))
+            )
+        )
+        captured: dict[str, Any] = {}
+
+        async def _fake_deliver_pma_notification(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"route": "explicit", "targets": 1, "published": 1}
+
+        monkeypatch.setattr(
+            "codex_autorunner.surfaces.web.routes.pma_routes.publish.deliver_pma_notification",
+            _fake_deliver_pma_notification,
+        )
+
+        result = await publish_automation_result(
+            request=request,
+            result={"status": "ok", "message": "done"},
+            client_turn_id="client-1",
+            lifecycle_event=None,
+            wake_up={
+                "wakeup_id": "wake-1",
+                "thread_id": "thread-123",
+                "delivery_target": {
+                    "surface_kind": "discord",
+                    "surface_key": "discord:preferred",
+                },
+                "metadata": {
+                    "delivery_target": {
+                        "surface_kind": "discord",
+                        "surface_key": "discord:stale",
+                    }
+                },
+            },
+        )
+
+        assert captured["managed_thread_id"] == "thread-123"
+        assert captured["delivery_target"] == {
+            "surface_kind": "discord",
+            "surface_key": "discord:preferred",
+        }
+        assert result["delivery_status"] == "success"
+        assert result["delivery_outcome"]["route"] == "explicit"


### PR DESCRIPTION
## Summary
- persist an explicit PMA subscription `delivery_target` as `surface_kind + surface_key` and carry it into wake-ups
- deliver automation results back to that explicit target when it still matches the thread's active binding, with fallback to existing default routing when it does not
- resolve publish `workspace_root` from the managed thread when wake-up payloads do not already carry it, and add regression coverage for store, lifecycle, delivery, and publish forwarding behavior

## Root cause
PMA subscription wake-ups were only carrying enough information to run on a PMA lane, not enough information to reliably route the final response back to the originating chat surface. On the lifecycle subscription path, wake-up metadata also dropped subscription-level delivery context, which left publish routing to infer a destination from repo/workspace heuristics and often produce `targets: 0`.

## Impact
Thread-bound PMA subscriptions now reply back to the originating Discord channel or Telegram topic when that binding is still active. If the binding changes or the direct target is stale, delivery falls back to the configured/default PMA routing instead of silently skipping delivery.

## Validation
- `python -m pytest -q tests/core/test_pma_automation_store.py tests/core/test_lifecycle_event_processing.py tests/core/test_pma_chat_delivery.py tests/surfaces/web/routes/pma_routes/test_publish_helpers.py`
- aggregate commit hook validation
- repo-wide `mypy src/codex_autorunner`
- repo-wide `pytest` via the aggregate validation lane
- frontend build and `pnpm test:markdown` via the aggregate validation lane

## Notes
- This keeps the delivery address in metadata as a normalized `delivery_target` object instead of overloading orchestration binding row ids.
- This PR addresses #1499.
