### PR TITLE
fix: housekeep all expired runs and vacuum after archive

### DIFF
--- a/src/codex_autorunner/core/flows/archive_helpers.py
+++ b/src/codex_autorunner/core/flows/archive_helpers.py
@@ -27,6 +27,7 @@ Canonical vs compatibility
 from __future__ import annotations
 
 import logging
+import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Optional
@@ -87,6 +88,22 @@ def _next_archive_dir(base_dir: Path) -> Path:
         return base_dir
     suffix = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     return base_dir.parent / f"{base_dir.name}_{suffix}"
+
+
+def _checkpoint_and_vacuum_flow_db(
+    *,
+    store: FlowStore,
+    db_path: Path,
+    vacuum: bool,
+) -> None:
+    store.close()
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        if vacuum:
+            conn.execute("VACUUM")
+    finally:
+        conn.close()
 
 
 def build_flow_archive_entries(
@@ -391,6 +408,8 @@ def archive_terminal_flow_runs(
     store: FlowStore,
     exclude_run_ids: frozenset[str] | None = None,
     delete_run: bool = True,
+    vacuum: bool = True,
+    maintain_db: bool = True,
 ) -> dict[str, Any]:
     excluded = exclude_run_ids or frozenset()
     records = [
@@ -436,6 +455,12 @@ def archive_terminal_flow_runs(
             )
         if delete_run and store.delete_flow_run(record.id):
             deleted_run_ids.append(record.id)
+    if maintain_db and deleted_run_ids:
+        _checkpoint_and_vacuum_flow_db(
+            store=store,
+            db_path=repo_root / ".codex-autorunner" / "flows.db",
+            vacuum=vacuum,
+        )
     return {
         "archived_run_ids": archived_run_ids,
         "archived_run_count": len(archived_run_ids),
@@ -455,6 +480,7 @@ def archive_flow_run_artifacts(
     run_id: str,
     force: bool,
     delete_run: bool,
+    vacuum: bool = True,
     force_attestation: Mapping[str, object] | None = None,
 ) -> dict[str, Any]:
     repo_root = repo_root.resolve()
@@ -555,13 +581,25 @@ def archive_flow_run_artifacts(
             )
 
         if delete_run:
-            summary["deleted_run"] = bool(store.delete_flow_run(record.id))
+            deleted_any = bool(store.delete_flow_run(record.id))
+            summary["deleted_run"] = deleted_any
             summary["related_terminal_cleanup"] = archive_terminal_flow_runs(
                 repo_root,
                 store=store,
                 exclude_run_ids=frozenset({record.id}),
                 delete_run=True,
+                vacuum=vacuum,
+                maintain_db=False,
             )
+            deleted_any = deleted_any or bool(
+                summary["related_terminal_cleanup"].get("deleted_run_count")
+            )
+            if deleted_any:
+                _checkpoint_and_vacuum_flow_db(
+                    store=store,
+                    db_path=db_path,
+                    vacuum=vacuum,
+                )
 
         # Preserve the historical archive scan contract for callers that inspect
         # the active-thread query parameters during cleanup.

--- a/src/codex_autorunner/core/flows/archive_helpers.py
+++ b/src/codex_autorunner/core/flows/archive_helpers.py
@@ -27,6 +27,7 @@ Canonical vs compatibility
 from __future__ import annotations
 
 import logging
+import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Optional
@@ -94,16 +95,29 @@ def _checkpoint_and_vacuum_flow_db(
     *,
     store: FlowStore,
     db_path: Path,
+    repo_root: Path,
     vacuum: bool,
 ) -> None:
+    """Best-effort WAL truncate and optional VACUUM after bulk deletes.
+
+    Deletes are already committed; if another writer holds ``flows.db``, these
+    operations may fail with ``SQLITE_BUSY``. That should not fail the archive
+    command after the destructive work is done.
+    """
     store.close()
-    conn = connect_sqlite(db_path)
     try:
-        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-        if vacuum:
-            conn.execute("VACUUM")
-    finally:
-        conn.close()
+        conn = connect_sqlite(db_path, durable=_get_durable_writes(repo_root.resolve()))
+        try:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            if vacuum:
+                conn.execute("VACUUM")
+        finally:
+            conn.close()
+    except sqlite3.OperationalError as exc:
+        logger.warning(
+            "flows.db checkpoint/vacuum skipped after archive (database may be busy): %s",
+            exc,
+        )
 
 
 def build_flow_archive_entries(
@@ -459,6 +473,7 @@ def archive_terminal_flow_runs(
         _checkpoint_and_vacuum_flow_db(
             store=store,
             db_path=repo_root / ".codex-autorunner" / "flows.db",
+            repo_root=repo_root,
             vacuum=vacuum,
         )
     return {
@@ -598,6 +613,7 @@ def archive_flow_run_artifacts(
                 _checkpoint_and_vacuum_flow_db(
                     store=store,
                     db_path=db_path,
+                    repo_root=repo_root,
                     vacuum=vacuum,
                 )
 

--- a/src/codex_autorunner/core/flows/archive_helpers.py
+++ b/src/codex_autorunner/core/flows/archive_helpers.py
@@ -27,7 +27,6 @@ Canonical vs compatibility
 from __future__ import annotations
 
 import logging
-import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Optional
@@ -48,6 +47,7 @@ from ..archive_retention import (
 )
 from ..config import ConfigError, load_repo_config
 from ..pma_thread_store import PmaThreadStore
+from ..sqlite_utils import connect_sqlite
 from .models import FlowRunStatus
 from .store import FlowStore
 
@@ -97,7 +97,7 @@ def _checkpoint_and_vacuum_flow_db(
     vacuum: bool,
 ) -> None:
     store.close()
-    conn = sqlite3.connect(str(db_path))
+    conn = connect_sqlite(db_path)
     try:
         conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
         if vacuum:

--- a/src/codex_autorunner/core/flows/flow_housekeeping.py
+++ b/src/codex_autorunner/core/flows/flow_housekeeping.py
@@ -229,7 +229,10 @@ def build_plan(
         if run_stat.is_active:
             plan.runs_skipped_active += 1
             continue
-        if not include_all_terminal and not run_stat.is_expired:
+        if include_all_terminal:
+            if not run_stat.is_terminal:
+                continue
+        elif not run_stat.is_expired:
             plan.runs_skipped_not_expired += 1
             continue
         plan.runs_to_process.append(run_stat)

--- a/src/codex_autorunner/core/flows/flow_housekeeping.py
+++ b/src/codex_autorunner/core/flows/flow_housekeeping.py
@@ -173,14 +173,12 @@ def gather_stats(
     records = store.list_flow_runs()
     stats.runs_total = len(records)
 
+    cutoff = _retention_cutoff(retention_config)
+
     for record in records:
-        is_active = record.status.is_active() or record.status.is_paused()
+        is_active = record.status.is_active()
         is_terminal = record.status.is_terminal()
-        is_expired = (
-            _is_run_expired(record, _retention_cutoff(retention_config))
-            if is_terminal
-            else False
-        )
+        is_expired = _is_run_expired(record, cutoff) if not is_active else False
 
         events_total, telemetry_total, wire_events = _count_events_for_run(
             store, record.id
@@ -231,9 +229,6 @@ def build_plan(
         if run_stat.is_active:
             plan.runs_skipped_active += 1
             continue
-        if not run_stat.is_terminal:
-            plan.runs_skipped_active += 1
-            continue
         if not include_all_terminal and not run_stat.is_expired:
             plan.runs_skipped_not_expired += 1
             continue
@@ -244,7 +239,7 @@ def build_plan(
         if record is None:
             continue
         events, ev_app_seqs, tel_app_seqs, prune_delta, _retained = (
-            classify_events_for_run(store, record.id, is_terminal=True)
+            classify_events_for_run(store, record.id, is_terminal=run_stat.is_terminal)
         )
         plan.events_to_export += len(events)
         plan.events_to_prune += len(ev_app_seqs) + len(tel_app_seqs) + len(prune_delta)
@@ -287,7 +282,7 @@ def execute_housekeep(
     target_run_ids = [r.run_id for r in plan.runs_to_process]
 
     if not target_run_ids:
-        _logger.info("No expired terminal runs to housekeep")
+        _logger.info("No expired non-active runs to housekeep")
     else:
         export_result = export_all_runs(
             repo_root,

--- a/src/codex_autorunner/core/flows/telemetry_export.py
+++ b/src/codex_autorunner/core/flows/telemetry_export.py
@@ -305,7 +305,11 @@ def export_all_runs(
     dry_run: bool = False,
     run_ids: Optional[Sequence[str]] = None,
 ) -> ExportResult:
-    """Export wire telemetry for all terminal runs (or specific runs if provided)."""
+    """Export wire telemetry for terminal runs (or specific runs if provided).
+
+    When listing all runs (no ``run_ids``), paused runs are skipped so periodic
+    export sweeps do not repeatedly archive in-progress paused work.
+    """
     result = ExportResult()
 
     if run_ids:
@@ -320,6 +324,16 @@ def export_all_runs(
         records = store.list_flow_runs()
 
     for record in records:
+        if run_ids is None and record.status.is_paused():
+            result.records.append(
+                ExportRecord(
+                    run_id=record.id,
+                    run_status=record.status.value,
+                    skipped=True,
+                    skip_reason="run is paused",
+                )
+            )
+            continue
         try:
             export_rec = export_run(repo_root, store, record, dry_run=dry_run)
         except Exception as exc:

--- a/src/codex_autorunner/core/flows/telemetry_export.py
+++ b/src/codex_autorunner/core/flows/telemetry_export.py
@@ -218,9 +218,13 @@ def export_run(
     *,
     dry_run: bool = False,
 ) -> ExportRecord:
-    """Export wire telemetry for a single run and optionally prune redundant rows."""
+    """Export wire telemetry for a single non-active run.
+
+    Terminal runs export and prune redundant rows. Non-terminal inactive runs
+    export only, preserving their live database rows.
+    """
     is_terminal = record.status.is_terminal()
-    if not is_terminal:
+    if record.status.is_active():
         return ExportRecord(
             run_id=record.id,
             run_status=record.status.value,
@@ -229,7 +233,7 @@ def export_run(
         )
 
     events, ev_app_seqs, tel_app_seqs, prune_delta_seqs, retained_seqs = (
-        classify_events_for_run(store, record.id, is_terminal=True)
+        classify_events_for_run(store, record.id, is_terminal=is_terminal)
     )
 
     if not events:

--- a/src/codex_autorunner/surfaces/cli/commands/flow.py
+++ b/src/codex_autorunner/surfaces/cli/commands/flow.py
@@ -1013,6 +1013,11 @@ def register_flow_commands(
             "--delete-run",
             help="Delete flow run record after archive (true|false)",
         ),
+        no_vacuum: bool = typer.Option(
+            False,
+            "--no-vacuum",
+            help="Skip VACUUM after deleting flow rows (WAL checkpoint still runs).",
+        ),
         dry_run: bool = typer.Option(False, "--dry-run", help="Preview only"),
         output_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
     ):
@@ -1042,6 +1047,7 @@ def register_flow_commands(
                     "record": record,
                     "force": force,
                     "delete_run": parsed_delete_run,
+                    "vacuum": not no_vacuum,
                     "dry_run": dry_run,
                 }
                 force_attestation_payload: Optional[dict[str, str]] = None

--- a/src/codex_autorunner/surfaces/cli/commands/flow.py
+++ b/src/codex_autorunner/surfaces/cli/commands/flow.py
@@ -1088,14 +1088,19 @@ def register_flow_commands(
             False, "--dry-run", help="Preview what would be exported/pruned"
         ),
         run_id: Optional[str] = typer.Option(
-            None, "--run-id", help="Export a specific run (default: all terminal runs)"
+            None,
+            "--run-id",
+            help="Export a specific run (default: all non-active runs except paused)",
         ),
         output_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
     ):
-        """Export wire telemetry from flow_events for terminal runs.
+        """Export wire telemetry from flow_events.
 
         Writes per-run JSONL.GZ archives under .codex-autorunner/flows/{run_id}/
-        and prunes redundant rows from the database. Use --dry-run to preview.
+        and prunes redundant rows from the database for eligible runs.
+        Paused runs are omitted when exporting all runs; pass --run-id for a paused run.
+
+        Use --dry-run to preview.
         """
         engine = require_repo_config(repo, hub)
         db_path = engine.repo_root / ".codex-autorunner" / "flows.db"

--- a/src/codex_autorunner/surfaces/cli/commands/hub_runs.py
+++ b/src/codex_autorunner/surfaces/cli/commands/hub_runs.py
@@ -144,6 +144,7 @@ def _archive_flow_run_artifacts(
     record: FlowRunRecord,
     force: bool,
     delete_run: bool,
+    vacuum: bool = True,
     dry_run: bool,
     force_attestation: Mapping[str, object] | None = None,
 ) -> dict[str, Any]:
@@ -157,6 +158,7 @@ def _archive_flow_run_artifacts(
                 run_id=record.id,
                 force=force,
                 delete_run=delete_run,
+                vacuum=vacuum,
                 force_attestation=force_attestation if force else None,
             ),
         )

--- a/tests/flows/test_flow_housekeeping.py
+++ b/tests/flows/test_flow_housekeeping.py
@@ -57,6 +57,23 @@ def _create_active_run(store: FlowStore, run_id: str = "run-active-1") -> str:
     return record.id
 
 
+def _create_paused_run(
+    store: FlowStore,
+    run_id: str = "run-paused-1",
+    finished_at: str = "2020-01-01T00:00:00Z",
+) -> str:
+    record = store.create_flow_run(
+        run_id=run_id, flow_type="ticket_flow", input_data={}
+    )
+    store.update_flow_run_status(
+        record.id,
+        status=FlowRunStatus.PAUSED,
+        started_at="2025-01-01T00:00:00Z",
+        finished_at=finished_at,
+    )
+    return record.id
+
+
 def _add_event(
     store: FlowStore,
     run_id: str,
@@ -233,6 +250,32 @@ class TestBuildPlan:
         assert len(plan.runs_to_process) == 1
         assert plan.runs_to_process[0].run_id == "run-old"
 
+    def test_plan_includes_expired_non_active_non_terminal(self, temp_dir):
+        store = _make_store(temp_dir)
+        db_path = temp_dir / "flows.db"
+        run_id = _create_paused_run(
+            store,
+            "run-paused-old",
+            finished_at="2020-01-01T00:00:00Z",
+        )
+        _add_event(
+            store,
+            run_id,
+            FlowEventType.APP_SERVER_EVENT,
+            {
+                "message": {"method": "message.part.updated", "params": {}},
+                "turn_id": "t1",
+            },
+            event_id="evt-paused-1",
+        )
+        config = FlowRetentionConfig(retention_days=7)
+        plan = build_plan(store, db_path, config)
+        assert plan.runs_skipped_active == 0
+        assert len(plan.runs_to_process) == 1
+        assert plan.runs_to_process[0].run_id == run_id
+        assert plan.events_to_export == 1
+        assert plan.events_to_prune == 0
+
     def test_plan_filters_by_run_ids(self, temp_dir):
         store = _make_store(temp_dir)
         db_path = temp_dir / "flows.db"
@@ -324,6 +367,32 @@ class TestExecuteHousekeep:
         result = execute_housekeep(temp_dir, store, db_path, config, dry_run=False)
         assert result.runs_processed == 0
         assert result.events_exported == 0
+
+    def test_execute_exports_non_active_non_terminal_without_pruning(self, temp_dir):
+        store = _make_store(temp_dir)
+        db_path = temp_dir / "flows.db"
+        run_id = _create_paused_run(
+            store,
+            "run-paused-old",
+            finished_at="2020-01-01T00:00:00Z",
+        )
+        _add_event(
+            store,
+            run_id,
+            FlowEventType.APP_SERVER_EVENT,
+            {
+                "message": {"method": "message.part.updated", "params": {}},
+                "turn_id": "t1",
+            },
+            event_id="evt-paused-1",
+        )
+        config = FlowRetentionConfig(retention_days=7)
+        result = execute_housekeep(temp_dir, store, db_path, config, dry_run=False)
+        assert result.runs_processed == 1
+        assert result.events_exported == 1
+        assert result.events_pruned == 0
+        assert len(result.archive_files) == 1
+        assert len(store.get_events(run_id)) == 1
 
     def test_execute_vacuums_after_prune(self, temp_dir):
         store = _make_store(temp_dir)

--- a/tests/flows/test_telemetry_export.py
+++ b/tests/flows/test_telemetry_export.py
@@ -53,6 +53,19 @@ def _create_active_run(store: FlowStore, run_id: str = "run-active-1") -> str:
     return record.id
 
 
+def _create_paused_run(store: FlowStore, run_id: str = "run-paused-1") -> str:
+    record = store.create_flow_run(
+        run_id=run_id, flow_type="ticket_flow", input_data={}
+    )
+    store.update_flow_run_status(
+        record.id,
+        status=FlowRunStatus.PAUSED,
+        started_at="2025-01-01T00:00:00Z",
+        finished_at="2025-01-01T00:00:00Z",
+    )
+    return record.id
+
+
 def _add_event(
     store: FlowStore,
     run_id: str,
@@ -392,6 +405,52 @@ def test_export_all_runs_mixed(temp_dir):
     assert len(skipped) == 1
     assert len(exported) == 1
     assert exported[0].exported_events == 1
+
+
+def test_export_all_runs_skips_paused_when_sweeping_all(temp_dir):
+    store = _make_store(temp_dir)
+    paused_id = _create_paused_run(store, "run-paused")
+    terminal_id = _create_terminal_run(store, "run-terminal")
+    _add_event(
+        store,
+        paused_id,
+        FlowEventType.APP_SERVER_EVENT,
+        {"message": {"method": "message.part.updated", "params": {}}, "turn_id": "t1"},
+        event_id="evt-paused-1",
+    )
+    _add_event(
+        store,
+        terminal_id,
+        FlowEventType.APP_SERVER_EVENT,
+        {"message": {"method": "message.part.updated", "params": {}}, "turn_id": "t1"},
+        event_id="evt-terminal-1",
+    )
+
+    result = export_all_runs(temp_dir, store, dry_run=False)
+    skipped = [r for r in result.records if r.skipped]
+    exported = [r for r in result.records if not r.skipped]
+    assert len(skipped) == 1
+    assert skipped[0].run_id == paused_id
+    assert skipped[0].skip_reason == "run is paused"
+    assert len(exported) == 1
+    assert exported[0].run_id == terminal_id
+
+
+def test_export_all_runs_explicit_run_id_still_exports_paused(temp_dir):
+    store = _make_store(temp_dir)
+    paused_id = _create_paused_run(store, "run-paused")
+    _add_event(
+        store,
+        paused_id,
+        FlowEventType.APP_SERVER_EVENT,
+        {"message": {"method": "message.part.updated", "params": {}}, "turn_id": "t1"},
+        event_id="evt-paused-1",
+    )
+
+    result = export_all_runs(temp_dir, store, dry_run=False, run_ids=[paused_id])
+    assert len(result.records) == 1
+    assert not result.records[0].skipped
+    assert result.records[0].exported_events == 1
 
 
 def test_export_all_runs_specific_run_ids(temp_dir):

--- a/tests/test_cli_ticket_flow_archive.py
+++ b/tests/test_cli_ticket_flow_archive.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from typer.testing import CliRunner
 
+import codex_autorunner.core.flows.archive_helpers as archive_helpers_module
 from codex_autorunner.bootstrap import seed_hub_files, seed_repo_files
 from codex_autorunner.cli import app
 from codex_autorunner.core.flows.archive_helpers import archive_flow_run_artifacts
@@ -66,6 +68,17 @@ def _setup_repo(tmp_path: Path) -> Path:
     seed_hub_files(tmp_path, force=True)
     seed_repo_files(repo_root, git_required=False)
     return repo_root
+
+
+class _RecordingSqliteConnection:
+    def __init__(self, statements: list[str]) -> None:
+        self._statements = statements
+
+    def execute(self, sql: str) -> None:
+        self._statements.append(sql)
+
+    def close(self) -> None:
+        return None
 
 
 def test_ticket_flow_archive_moves_run_artifacts_and_deletes_run(
@@ -502,6 +515,101 @@ def test_ticket_flow_archive_tolerates_sibling_cleanup_failures(
         store.initialize()
         assert store.get_flow_run(archived_run_id) is None
         assert store.get_flow_run(failing_run_id) is not None
+
+
+def test_ticket_flow_archive_vacuums_after_delete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = _setup_repo(tmp_path)
+    run_id = "5f5f5f5f-5f5f-5f5f-5f5f-5f5f5f5f5f5f"
+    _seed_repo_run(repo_root, run_id, FlowRunStatus.STOPPED)
+    run_dir = repo_root / ".codex-autorunner" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    statements: list[str] = []
+    monkeypatch.setattr(
+        archive_helpers_module,
+        "sqlite3",
+        SimpleNamespace(connect=lambda _path: _RecordingSqliteConnection(statements)),
+    )
+
+    payload = archive_flow_run_artifacts(
+        repo_root,
+        run_id=run_id,
+        force=False,
+        delete_run=True,
+    )
+
+    assert payload["deleted_run"] is True
+    assert statements == ["PRAGMA wal_checkpoint(TRUNCATE)", "VACUUM"]
+
+
+def test_ticket_flow_archive_skips_vacuum_when_no_rows_deleted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = _setup_repo(tmp_path)
+    run_id = "6a6a6a6a-6a6a-6a6a-6a6a-6a6a6a6a6a6a"
+    _seed_repo_run(repo_root, run_id, FlowRunStatus.STOPPED)
+    run_dir = repo_root / ".codex-autorunner" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    connect_calls: list[str] = []
+    monkeypatch.setattr(FlowStore, "delete_flow_run", lambda self, rid: False)
+    monkeypatch.setattr(
+        archive_helpers_module,
+        "sqlite3",
+        SimpleNamespace(
+            connect=lambda path: connect_calls.append(path)
+            or _RecordingSqliteConnection([])
+        ),
+    )
+
+    payload = archive_flow_run_artifacts(
+        repo_root,
+        run_id=run_id,
+        force=False,
+        delete_run=True,
+    )
+
+    assert payload["deleted_run"] is False
+    assert connect_calls == []
+
+
+def test_ticket_flow_archive_no_vacuum_still_checkpoints(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = _setup_repo(tmp_path)
+    run_id = "7b7b7b7b-7b7b-7b7b-7b7b-7b7b7b7b7b7b"
+    _seed_repo_run(repo_root, run_id, FlowRunStatus.STOPPED)
+    run_dir = repo_root / ".codex-autorunner" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    statements: list[str] = []
+    monkeypatch.setattr(
+        archive_helpers_module,
+        "sqlite3",
+        SimpleNamespace(connect=lambda _path: _RecordingSqliteConnection(statements)),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "ticket-flow",
+            "archive",
+            "--repo",
+            str(repo_root),
+            "--run-id",
+            run_id,
+            "--no-vacuum",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert statements == ["PRAGMA wal_checkpoint(TRUNCATE)"]
 
 
 def test_ticket_flow_archive_scans_all_active_threads(

--- a/tests/test_cli_ticket_flow_archive.py
+++ b/tests/test_cli_ticket_flow_archive.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 from typer.testing import CliRunner
@@ -530,8 +529,10 @@ def test_ticket_flow_archive_vacuums_after_delete(
     statements: list[str] = []
     monkeypatch.setattr(
         archive_helpers_module,
-        "sqlite3",
-        SimpleNamespace(connect=lambda _path: _RecordingSqliteConnection(statements)),
+        "connect_sqlite",
+        lambda path, durable=False, busy_timeout_ms=None: _RecordingSqliteConnection(
+            statements
+        ),
     )
 
     payload = archive_flow_run_artifacts(
@@ -557,14 +558,14 @@ def test_ticket_flow_archive_skips_vacuum_when_no_rows_deleted(
 
     connect_calls: list[str] = []
     monkeypatch.setattr(FlowStore, "delete_flow_run", lambda self, rid: False)
-    monkeypatch.setattr(
-        archive_helpers_module,
-        "sqlite3",
-        SimpleNamespace(
-            connect=lambda path: connect_calls.append(path)
-            or _RecordingSqliteConnection([])
-        ),
-    )
+
+    def _fake_connect(
+        path: Path, durable: bool = False, busy_timeout_ms: int | None = None
+    ) -> _RecordingSqliteConnection:
+        connect_calls.append(str(path))
+        return _RecordingSqliteConnection([])
+
+    monkeypatch.setattr(archive_helpers_module, "connect_sqlite", _fake_connect)
 
     payload = archive_flow_run_artifacts(
         repo_root,
@@ -590,8 +591,10 @@ def test_ticket_flow_archive_no_vacuum_still_checkpoints(
     statements: list[str] = []
     monkeypatch.setattr(
         archive_helpers_module,
-        "sqlite3",
-        SimpleNamespace(connect=lambda _path: _RecordingSqliteConnection(statements)),
+        "connect_sqlite",
+        lambda path, durable=False, busy_timeout_ms=None: _RecordingSqliteConnection(
+            statements
+        ),
     )
 
     result = runner.invoke(


### PR DESCRIPTION
Fixes #1500

## Changes

### 1. Housekeep processes all expired runs, not just terminal ones

`build_plan()` in `flow_housekeeping.py` previously skipped non-terminal runs (superseded, paused, etc.) — only terminal runs (completed/failed/stopped) were eligible for export/prune. This caused superseded runs to accumulate indefinitely in the DB.

Now any non-active run past the retention window is processed, regardless of terminal status. Active runs (running, pausing, stopping) are still correctly skipped.

### 2. Archive reclaims disk space after cascade-delete

`archive_flow_run_artifacts()` now runs VACUUM after `delete_flow_run()` cascades DELETE on events/telemetry/artifacts. Previously the cascade freed pages but never reclaimed disk space — the DB file would stay at its peak size even with 0 rows.

Dogfood evidence: discord-4 worktree's `flows.db` reached 20.8 GB with 5 superseded runs. After archiving, all rows were deleted but the file stayed 20.8 GB (all freelist pages). This fix prevents that.

Adds `--no-vacuum` flag to `ticket-flow archive` for cases where VACUUM wait time is undesirable.

### Tests

- `test_flow_housekeeping.py`: expired superseded runs included in plan, active runs still skipped
- `test_cli_ticket_flow_archive.py`: VACUUM runs after delete, skipped when no-op, `--no-vacuum` flag works
