### PR TITLE
[codex] Fix PMA auto-subscription overlaps

### DIFF
--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -38,6 +38,11 @@ from .text_utils import _normalize_pma_delivery_target, lock_path_for
 
 logger = logging.getLogger(__name__)
 
+MANAGED_THREAD_AUTO_SUBSCRIPTION_PREFIXES = (
+    "managed-thread-notify:",
+    "managed-thread-send-notify:",
+)
+
 
 class PmaAutomationThreadNotFoundError(ValueError):
     def __init__(self, thread_id: str) -> None:
@@ -1121,6 +1126,86 @@ class PmaAutomationStore:
         resolved_lane_id = self._resolve_thread_lane_id(thread_id=normalized_thread_id)
         return resolved_lane_id
 
+    @staticmethod
+    def _is_auto_subscription_key(idempotency_key: Optional[str]) -> bool:
+        normalized_key = _normalize_text(idempotency_key)
+        if normalized_key is None:
+            return False
+        return normalized_key.startswith(MANAGED_THREAD_AUTO_SUBSCRIPTION_PREFIXES)
+
+    @staticmethod
+    def _scope_value_is_covered(
+        *, requested: Optional[str], existing: Optional[str]
+    ) -> bool:
+        if existing is None:
+            return True
+        if requested is None:
+            return False
+        return existing == requested
+
+    @staticmethod
+    def _event_types_are_covered(
+        *,
+        requested: list[str],
+        existing: list[str],
+    ) -> bool:
+        if not existing:
+            return True
+        if not requested:
+            return False
+        existing_set = set(existing)
+        return all(event_type in existing_set for event_type in requested)
+
+    def _find_covering_auto_subscription(
+        self,
+        *,
+        event_types: list[str],
+        repo_id: Optional[str],
+        run_id: Optional[str],
+        thread_id: Optional[str],
+        from_state: Optional[str],
+        to_state: Optional[str],
+    ) -> Optional[PmaLifecycleSubscription]:
+        state = self.load()
+        subscriptions = self._normalize_subscriptions(state.get("subscriptions"))
+        for entry in subscriptions:
+            if entry.state != "active":
+                continue
+            if not self._is_auto_subscription_key(entry.idempotency_key):
+                continue
+            if not self._event_types_are_covered(
+                requested=event_types,
+                existing=entry.event_types,
+            ):
+                continue
+            if not self._scope_value_is_covered(
+                requested=repo_id,
+                existing=entry.repo_id,
+            ):
+                continue
+            if not self._scope_value_is_covered(
+                requested=run_id,
+                existing=entry.run_id,
+            ):
+                continue
+            if not self._scope_value_is_covered(
+                requested=thread_id,
+                existing=entry.thread_id,
+            ):
+                continue
+            if not self._scope_value_is_covered(
+                requested=from_state,
+                existing=entry.from_state,
+            ):
+                continue
+            if not self._scope_value_is_covered(
+                requested=to_state,
+                existing=entry.to_state,
+            ):
+                continue
+            return entry
+        return None
+
     def _resolve_subscription_metadata(
         self,
         *,
@@ -1205,20 +1290,61 @@ class PmaAutomationStore:
         self, payload: Optional[dict[str, Any]] = None, **kwargs: Any
     ) -> dict[str, Any]:
         data = self._coerce_payload(payload, kwargs)
-        created, deduped = self.upsert_subscription(
-            event_types=self._normalize_subscription_event_types(
-                data.get("event_types"),
-                singular=data.get("event_type"),
+        normalized_event_types = self._normalize_subscription_event_types(
+            data.get("event_types"),
+            singular=data.get("event_type"),
+        )
+        normalized_repo_id = _normalize_text(data.get("repo_id"))
+        normalized_run_id = _normalize_text(data.get("run_id"))
+        normalized_thread_id = _normalize_text(data.get("thread_id"))
+        normalized_from_state = _normalize_text(data.get("from_state"))
+        normalized_to_state = _normalize_text(data.get("to_state"))
+        normalized_idempotency_key = _normalize_text(data.get("idempotency_key"))
+        confirm_duplicate = _normalize_bool(data.get("confirm"), fallback=False)
+        if not confirm_duplicate and not self._is_auto_subscription_key(
+            normalized_idempotency_key
+        ):
+            existing_auto = self._find_covering_auto_subscription(
+                event_types=normalized_event_types,
+                repo_id=normalized_repo_id,
+                run_id=normalized_run_id,
+                thread_id=normalized_thread_id,
+                from_state=normalized_from_state,
+                to_state=normalized_to_state,
             )
-            or None,
-            repo_id=_normalize_text(data.get("repo_id")),
-            run_id=_normalize_text(data.get("run_id")),
-            thread_id=_normalize_text(data.get("thread_id")),
+            if existing_auto is not None:
+                scope_label = "this scope"
+                if normalized_thread_id is not None:
+                    scope_label = "this thread"
+                elif normalized_run_id is not None:
+                    scope_label = "this run"
+                elif normalized_repo_id is not None:
+                    scope_label = "this repo"
+                event_label = (
+                    normalized_event_types[0]
+                    if len(normalized_event_types) == 1
+                    else "the requested event scope"
+                )
+                return {
+                    "subscription": existing_auto.to_dict(),
+                    "deduped": True,
+                    "warning": (
+                        "An active auto-subscription "
+                        f"({existing_auto.idempotency_key or existing_auto.subscription_id}) "
+                        f"already covers {event_label} for {scope_label}. "
+                        "Pass confirm=true to create a duplicate subscription."
+                    ),
+                }
+        created, deduped = self.upsert_subscription(
+            event_types=normalized_event_types or None,
+            repo_id=normalized_repo_id,
+            run_id=normalized_run_id,
+            thread_id=normalized_thread_id,
             lane_id=_normalize_text(data.get("lane_id")),
-            from_state=_normalize_text(data.get("from_state")),
-            to_state=_normalize_text(data.get("to_state")),
+            from_state=normalized_from_state,
+            to_state=normalized_to_state,
             reason=_normalize_text(data.get("reason")),
-            idempotency_key=_normalize_text(data.get("idempotency_key")),
+            idempotency_key=normalized_idempotency_key,
             notify_once=_normalize_bool(data.get("notify_once"), fallback=None),
             max_matches=_normalize_positive_int(data.get("max_matches"), fallback=None),
             metadata=(

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
@@ -448,7 +448,6 @@ def resolve_managed_thread_create_resolution(
     payload: PmaManagedThreadCreateRequest,
 ) -> ManagedThreadCreateResolution:
     hub_root = request.app.state.config.root
-    pma_config = request.app.state.config.pma
     raw_agent_id = normalize_optional_text(payload.agent)
     raw_profile = normalize_optional_text(payload.profile)
     if raw_agent_id is not None:
@@ -471,7 +470,9 @@ def resolve_managed_thread_create_resolution(
     workspace_root = normalize_optional_text(payload.workspace_root)
     followup_policy = resolve_managed_thread_followup_policy(
         payload,
-        default_terminal_followup=pma_config.managed_thread_terminal_followup_default,
+        # Terminal follow-up defaults now apply when the thread is used, not at
+        # spawn time, so create-thread only honors explicit follow-up intent.
+        default_terminal_followup=False,
     )
 
     owner_present = resource_kind is not None and resource_id is not None

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -1055,6 +1055,7 @@ class PmaAutomationSubscriptionCreateRequest(Payload):
             "reason",
             "timestamp",
             "idempotency_key",
+            "confirm",
             "filter",
         }
     )
@@ -1104,6 +1105,7 @@ class PmaAutomationSubscriptionCreateRequest(Payload):
         default=None,
         validation_alias=AliasChoices("idempotency_key", "idempotencyKey"),
     )
+    confirm: bool = False
     filter: Optional[Dict[str, Any]] = None
 
     @model_validator(mode="before")

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
@@ -72,8 +72,8 @@ def resolve_managed_thread_followup_policy(
         enabled = True
     elif (
         getattr(payload, "notify_lane_explicit", False)
-        or getattr(payload, "notify_once_explicit", False)
-    ) and terminal_followup is not False:
+        and terminal_followup is not False
+    ):
         enabled = True
     elif terminal_followup is not False and default_terminal_followup:
         enabled = True
@@ -84,7 +84,6 @@ def resolve_managed_thread_followup_policy(
         and (
             getattr(payload, "notify_on_explicit", False)
             or getattr(payload, "notify_lane_explicit", False)
-            or getattr(payload, "notify_once_explicit", False)
             or terminal_followup is True
         ),
         event_mode="terminal" if enabled else None,

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
@@ -70,6 +70,11 @@ def resolve_managed_thread_followup_policy(
         enabled = True
     elif terminal_followup is True:
         enabled = True
+    elif (
+        getattr(payload, "notify_lane_explicit", False)
+        or getattr(payload, "notify_once_explicit", False)
+    ) and terminal_followup is not False:
+        enabled = True
     elif terminal_followup is not False and default_terminal_followup:
         enabled = True
 

--- a/tests/test_pma_managed_threads_routes.py
+++ b/tests/test_pma_managed_threads_routes.py
@@ -1039,6 +1039,32 @@ def test_create_managed_thread_default_followup_ignores_partial_automation_store
     assert "notification" not in payload
 
 
+def test_create_managed_thread_notify_once_only_does_not_opt_in_followup(
+    hub_env,
+) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    class PartialAutomationStore:
+        def create_subscription(self) -> None:
+            return None
+
+    app.state.hub_supervisor.get_pma_automation_store = lambda: PartialAutomationStore()
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                **_repo_owner(hub_env),
+                "notify_once": True,
+            },
+        )
+
+    assert create_resp.status_code == 200
+    payload = create_resp.json()
+    assert "notification" not in payload
+
+
 def test_managed_thread_routes_respect_pma_enabled_flag(hub_env) -> None:
     _disable_pma(hub_env.hub_root)
     app = create_hub_app(hub_env.hub_root)

--- a/tests/test_pma_managed_threads_routes.py
+++ b/tests/test_pma_managed_threads_routes.py
@@ -77,15 +77,13 @@ def test_create_managed_thread_with_repo_owner(hub_env) -> None:
     stored = store.get_thread(thread["managed_thread_id"])
     assert stored is not None
     assert stored.get("backend_thread_id") is None
-    notification = resp.json().get("notification") or {}
-    subscription = notification.get("subscription") or {}
-    assert subscription.get("thread_id") == thread["managed_thread_id"]
+    assert "notification" not in resp.json()
 
     automation_store = app.state.hub_supervisor.get_pma_automation_store()
     subscriptions = automation_store.list_subscriptions(
         thread_id=thread["managed_thread_id"]
     )
-    assert len(subscriptions) == 1
+    assert subscriptions == []
 
 
 def test_create_managed_thread_with_workspace_root(hub_env) -> None:
@@ -849,6 +847,87 @@ def test_create_subscription_auto_resolves_lane_from_bound_thread(hub_env) -> No
     subscription = subscription_resp.json()["subscription"]
     assert subscription["thread_id"] == thread_id
     assert subscription["lane_id"] == "discord"
+
+
+def test_create_subscription_warns_when_active_auto_subscription_covers_scope(
+    hub_env,
+) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                **_repo_owner(hub_env),
+                "notify_on": "terminal",
+                "notify_lane": "discord",
+            },
+        )
+        assert create_resp.status_code == 200
+        auto_subscription = (create_resp.json().get("notification") or {}).get(
+            "subscription"
+        ) or {}
+        thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+        subscription_resp = client.post(
+            "/hub/pma/subscriptions",
+            json={
+                "event_type": "managed_thread_completed",
+                "thread_id": thread_id,
+            },
+        )
+
+    assert subscription_resp.status_code == 200
+    payload = subscription_resp.json()
+    assert payload["deduped"] is True
+    assert "warning" in payload
+    assert "confirm=true" in payload["warning"]
+    assert payload["subscription"]["subscription_id"] == auto_subscription.get(
+        "subscription_id"
+    )
+
+    automation_store = app.state.hub_supervisor.get_pma_automation_store()
+    subscriptions = automation_store.list_subscriptions(thread_id=thread_id)
+    assert len(subscriptions) == 1
+
+
+def test_create_subscription_confirm_allows_duplicate_over_active_auto_subscription(
+    hub_env,
+) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                **_repo_owner(hub_env),
+                "notify_on": "terminal",
+                "notify_lane": "discord",
+            },
+        )
+        assert create_resp.status_code == 200
+        thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+        subscription_resp = client.post(
+            "/hub/pma/subscriptions",
+            json={
+                "event_type": "managed_thread_completed",
+                "thread_id": thread_id,
+                "confirm": True,
+            },
+        )
+
+    assert subscription_resp.status_code == 200
+    payload = subscription_resp.json()
+    assert payload["deduped"] is False
+    assert "warning" not in payload
+    assert payload["subscription"]["thread_id"] == thread_id
+
+    automation_store = app.state.hub_supervisor.get_pma_automation_store()
+    subscriptions = automation_store.list_subscriptions(thread_id=thread_id)
+    assert len(subscriptions) == 2
 
 
 def test_create_subscription_with_unknown_thread_returns_404(hub_env) -> None:


### PR DESCRIPTION
## Summary
- stop default managed-thread spawn requests from creating a terminal follow-up subscription unless follow-up intent was explicit
- add overlap detection for manual PMA subscriptions when an active managed-thread auto-subscription already covers the same event scope, with `confirm=true` to allow intentional duplicates
- cover the new behavior with managed-thread route regression tests

## Root cause
Managed-thread creation and managed-thread send could both establish terminal wake-up subscriptions, and manual subscriptions could silently stack on top of those auto-subscriptions.

## Validation
- `python -m pytest -q tests/test_pma_managed_threads_routes.py tests/test_pma_managed_threads_messages.py::test_send_message_notify_on_terminal_auto_subscribes_once tests/test_pma_managed_threads_messages.py::test_send_message_defaults_to_terminal_followup_subscription`
- repo commit hook: aggregate lane checks, repo-wide mypy, full pytest suite, static build, and frontend JS tests

Closes #1504