### PR TITLE
fix: increment match_count for unlimited PMA subscriptions

### DIFF
--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -2069,12 +2069,14 @@ class PmaAutomationStore:
                     )
                 )
                 created += 1
-                if entry.max_matches is not None:
-                    entry.match_count = max(0, int(entry.match_count)) + 1
-                    entry.updated_at = _iso_now()
-                    changed = True
-                    if entry.match_count >= entry.max_matches:
-                        entry.state = "cancelled"
+                entry.match_count = max(0, int(entry.match_count)) + 1
+                entry.updated_at = _iso_now()
+                changed = True
+                if (
+                    entry.max_matches is not None
+                    and entry.match_count >= entry.max_matches
+                ):
+                    entry.state = "cancelled"
 
             if created > 0 or changed:
                 self._save_structured_unlocked(state, subscriptions, timers, wakeups)


### PR DESCRIPTION
## Summary

- **Fix**: `PmaAutomationStore.notify_transition()` now increments `match_count` for *all* matching subscriptions, not just those with `max_matches` set.
- Unlimited subscriptions (the default) previously always reported `match_count: 0` even after successful matches, misleading PMAs and diagnostics into thinking subscriptions were broken.
- The `max_matches` cap check is preserved — cancellation on hitting the limit still only applies when `max_matches is not None`.

Closes #1497