### PR TITLE
[codex] Add PMA bulk thread archive support

### DIFF
--- a/src/codex_autorunner/surfaces/cli/pma_cli.py
+++ b/src/codex_autorunner/surfaces/cli/pma_cli.py
@@ -277,7 +277,8 @@ def _resolve_archive_thread_ids(
         )
 
     if managed_thread_id is not None:
-        resolved_ids = _parse_thread_id_list(managed_thread_id)
+        single_id = managed_thread_id.strip()
+        resolved_ids = [single_id] if single_id else []
     elif managed_thread_ids is not None:
         resolved_ids = _parse_thread_id_list(managed_thread_ids)
     else:

--- a/src/codex_autorunner/surfaces/cli/pma_cli.py
+++ b/src/codex_autorunner/surfaces/cli/pma_cli.py
@@ -242,6 +242,55 @@ def _resolve_message_body(
     return raw_message
 
 
+def _parse_thread_id_list(raw: str) -> list[str]:
+    thread_ids: list[str] = []
+    seen: set[str] = set()
+    for line in raw.replace(",", "\n").splitlines():
+        for token in line.split():
+            thread_id = token.strip()
+            if not thread_id or thread_id in seen:
+                continue
+            thread_ids.append(thread_id)
+            seen.add(thread_id)
+    return thread_ids
+
+
+def _resolve_archive_thread_ids(
+    *,
+    managed_thread_id: Optional[str],
+    managed_thread_ids: Optional[str],
+    managed_thread_ids_stdin: bool,
+) -> list[str]:
+    selected_inputs = sum(
+        1
+        for selected in (
+            managed_thread_id is not None,
+            managed_thread_ids is not None,
+            managed_thread_ids_stdin,
+        )
+        if selected
+    )
+    if selected_inputs != 1:
+        raise typer.BadParameter(
+            "Provide exactly one of --id, --ids, or --ids-stdin.",
+            param_hint="--id / --ids / --ids-stdin",
+        )
+
+    if managed_thread_id is not None:
+        resolved_ids = _parse_thread_id_list(managed_thread_id)
+    elif managed_thread_ids is not None:
+        resolved_ids = _parse_thread_id_list(managed_thread_ids)
+    else:
+        resolved_ids = _parse_thread_id_list(sys.stdin.read())
+
+    if not resolved_ids:
+        raise typer.BadParameter(
+            "Provide at least one managed thread id.",
+            param_hint="--id / --ids / --ids-stdin",
+        )
+    return resolved_ids
+
+
 def _echo_delivered_message(message: str) -> None:
     typer.echo("delivered message:")
     typer.echo(message, nl=False)
@@ -257,6 +306,18 @@ def _is_json_response_error(data: dict) -> Optional[str]:
     if data.get("error"):
         return str(data["error"])
     return None
+
+
+def _format_archived_thread_line(thread: dict[str, Any]) -> str:
+    managed_thread_id = str(thread.get("managed_thread_id") or "").strip()
+    name = str(thread.get("name") or "").strip()
+    if managed_thread_id and name:
+        return f"Archived {managed_thread_id} ({name})"
+    if managed_thread_id:
+        return f"Archived {managed_thread_id}"
+    if name:
+        return f"Archived managed thread ({name})"
+    return "Archived managed thread"
 
 
 def _extract_compact_summary_items(content: str, *, limit: int) -> list[str]:
@@ -2408,26 +2469,55 @@ def pma_thread_fork(
 
 @thread_app.command("archive")
 def pma_thread_archive(
-    managed_thread_id: str = typer.Option(
-        ..., "--id", help="Managed PMA thread id", show_default=False
+    managed_thread_id: Optional[str] = typer.Option(
+        None, "--id", help="Managed PMA thread id", show_default=False
+    ),
+    managed_thread_ids: Optional[str] = typer.Option(
+        None,
+        "--ids",
+        help="Comma- or whitespace-separated managed PMA thread ids",
+        show_default=False,
+    ),
+    managed_thread_ids_stdin: bool = typer.Option(
+        False,
+        "--ids-stdin",
+        help="Read managed PMA thread ids from stdin (comma- or whitespace-separated)",
     ),
     output_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
     path: Optional[Path] = hub_root_path_option(),
 ):
     """Archive a managed PMA thread."""
     hub_root = _resolve_hub_path(path)
+    thread_ids = _resolve_archive_thread_ids(
+        managed_thread_id=managed_thread_id,
+        managed_thread_ids=managed_thread_ids,
+        managed_thread_ids_stdin=managed_thread_ids_stdin,
+    )
     try:
         config = load_hub_config(hub_root)
-        archive_url = _build_pma_url(config, f"/threads/{managed_thread_id}/archive")
-        data = _request_json(
-            "POST",
-            archive_url,
-            token_env=config.server_auth_token_env,
-        )
+        if len(thread_ids) == 1:
+            archive_url = _build_pma_url(config, f"/threads/{thread_ids[0]}/archive")
+            data = _request_json(
+                "POST",
+                archive_url,
+                token_env=config.server_auth_token_env,
+            )
+        else:
+            archive_url = _build_pma_url(config, "/threads/archive")
+            data = _request_json(
+                "POST",
+                archive_url,
+                {"thread_ids": thread_ids},
+                token_env=config.server_auth_token_env,
+            )
     except httpx.HTTPError as exc:
         typer.echo(
             format_hub_request_error(
-                action=f"Failed to archive managed PMA thread {managed_thread_id}.",
+                action=(
+                    f"Failed to archive managed PMA thread {thread_ids[0]}."
+                    if len(thread_ids) == 1
+                    else "Failed to archive managed PMA threads."
+                ),
                 url=archive_url,
                 exc=exc,
             ),
@@ -2440,8 +2530,40 @@ def pma_thread_archive(
 
     if output_json:
         typer.echo(json.dumps(data, indent=2))
-    else:
-        typer.echo(f"Archived {managed_thread_id}")
+        if len(thread_ids) > 1 and isinstance(data, dict) and data.get("errors"):
+            raise typer.Exit(code=1) from None
+        return
+
+    if len(thread_ids) == 1:
+        thread = data.get("thread", {}) if isinstance(data, dict) else {}
+        if isinstance(thread, dict) and thread:
+            typer.echo(_format_archived_thread_line(thread))
+        else:
+            typer.echo(f"Archived {thread_ids[0]}")
+        return
+
+    threads = data.get("threads", []) if isinstance(data, dict) else []
+    errors = data.get("errors", []) if isinstance(data, dict) else []
+    archived_count = len(threads) if isinstance(threads, list) else 0
+
+    if isinstance(threads, list):
+        for thread in threads:
+            if isinstance(thread, dict):
+                typer.echo(_format_archived_thread_line(thread))
+
+    if isinstance(errors, list):
+        for error in errors:
+            if not isinstance(error, dict):
+                continue
+            thread_id = str(error.get("thread_id") or "unknown").strip()
+            detail = str(error.get("detail") or "Archive failed").strip()
+            typer.echo(f"Failed to archive {thread_id}: {detail}", err=True)
+
+    typer.echo(
+        f"Archived {archived_count} managed thread{'s' if archived_count != 1 else ''}."
+    )
+    if errors:
+        raise typer.Exit(code=1) from None
 
 
 @thread_app.command("interrupt")

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -24,6 +24,7 @@ from ...schemas import (
     PmaAutomationTimerCancelRequest,
     PmaAutomationTimerCreateRequest,
     PmaAutomationTimerTouchRequest,
+    PmaManagedThreadBulkArchiveRequest,
     PmaManagedThreadCompactRequest,
     PmaManagedThreadCreateRequest,
     PmaManagedThreadForkRequest,
@@ -679,6 +680,52 @@ def build_managed_thread_crud_routes(
                 updated,
                 binding_metadata_by_thread=binding_metadata,
             )
+        }
+
+    @router.post("/threads/archive")
+    def archive_managed_threads(
+        payload: PmaManagedThreadBulkArchiveRequest, request: Request
+    ) -> dict[str, Any]:
+        service = build_managed_thread_orchestration_service(request)
+        store = PmaThreadStore(request.app.state.config.root)
+        archived_threads: list[Any] = []
+        errors: list[dict[str, str]] = []
+
+        for managed_thread_id in payload.thread_ids:
+            thread = service.get_thread_target(managed_thread_id)
+            if thread is None:
+                errors.append(
+                    {
+                        "thread_id": managed_thread_id,
+                        "detail": "Managed thread not found",
+                    }
+                )
+                continue
+
+            old_status = normalize_optional_text(thread.lifecycle_status)
+            updated = service.archive_thread_target(managed_thread_id)
+            store.append_action(
+                "managed_thread_archive",
+                managed_thread_id=managed_thread_id,
+                payload_json=json.dumps({"old_status": old_status}, ensure_ascii=True),
+            )
+            archived_threads.append(updated)
+
+        binding_metadata = _load_chat_binding_metadata_by_thread(
+            request.app.state.config.root
+        )
+        return {
+            "threads": [
+                _serialize_thread_target(
+                    thread,
+                    binding_metadata_by_thread=binding_metadata,
+                )
+                for thread in archived_threads
+            ],
+            "archived_count": len(archived_threads),
+            "requested_count": len(payload.thread_ids),
+            "errors": errors,
+            "error_count": len(errors),
         }
 
     @router.get("/threads/{managed_thread_id}/turns")

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -978,6 +978,29 @@ class PmaManagedThreadResumeRequest(Payload):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
 
+class PmaManagedThreadBulkArchiveRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    thread_ids: List[str] = Field(
+        validation_alias=AliasChoices("thread_ids", "threadIds")
+    )
+
+    @field_validator("thread_ids")
+    @classmethod
+    def _normalize_thread_ids(cls, value: List[str]) -> List[str]:
+        normalized: List[str] = []
+        seen: set[str] = set()
+        for item in value:
+            thread_id = _normalize_text(item)
+            if not thread_id or thread_id in seen:
+                continue
+            normalized.append(thread_id)
+            seen.add(thread_id)
+        if not normalized:
+            raise ValueError("thread_ids must include at least one managed thread id")
+        return normalized
+
+
 class PmaManagedThreadForkRequest(Payload):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 

--- a/tests/test_pma_cli.py
+++ b/tests/test_pma_cli.py
@@ -123,6 +123,16 @@ def test_pma_cli_thread_fork_help_shows_json_option():
     assert "--name" in output
 
 
+def test_pma_cli_thread_archive_help_shows_bulk_options() -> None:
+    runner = CliRunner()
+    result = runner.invoke(pma_app, ["thread", "archive", "--help"])
+    assert result.exit_code == 0
+    output = result.stdout
+    assert "--id" in output
+    assert "--ids" in output
+    assert "--ids-stdin" in output
+
+
 def test_pma_chat_help_shows_json_option():
     """Verify PMA chat command supports JSON output mode."""
     runner = CliRunner()
@@ -2104,7 +2114,13 @@ def test_pma_cli_thread_control_commands_use_orchestration_routes(
                 }
             }
         if url.endswith("/archive"):
-            return {"thread": {"managed_thread_id": "thread-1", "status": "archived"}}
+            return {
+                "thread": {
+                    "managed_thread_id": "thread-1",
+                    "name": "CLI thread",
+                    "status": "archived",
+                }
+            }
         raise AssertionError(f"unexpected url: {url}")
 
     monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
@@ -2151,7 +2167,7 @@ def test_pma_cli_thread_control_commands_use_orchestration_routes(
     assert resume_result.exit_code == 0
     assert "Resumed thread-1" in resume_result.stdout
     assert archive_result.exit_code == 0
-    assert "Archived thread-1" in archive_result.stdout
+    assert "Archived thread-1 (CLI thread)" in archive_result.stdout
 
     assert calls == [
         (
@@ -2181,6 +2197,196 @@ def test_pma_cli_thread_control_commands_use_orchestration_routes(
             None,
         ),
     ]
+
+
+def test_pma_cli_thread_archive_bulk_uses_bulk_route(
+    monkeypatch, tmp_path: Path
+) -> None:
+    calls: list[tuple[str, str, dict[str, object] | None]] = []
+
+    monkeypatch.setattr(
+        pma_cli,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = token_env, params
+        calls.append((method, url, payload))
+        if url.endswith("/hub/pma/threads/archive"):
+            return {
+                "threads": [
+                    {
+                        "managed_thread_id": "thread-1",
+                        "name": "Thread One",
+                        "status": "archived",
+                    },
+                    {
+                        "managed_thread_id": "thread-2",
+                        "name": "Thread Two",
+                        "status": "archived",
+                    },
+                ],
+                "archived_count": 2,
+                "requested_count": 2,
+                "errors": [],
+                "error_count": 0,
+            }
+        raise AssertionError(f"unexpected url: {url}")
+
+    monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
+
+    result = CliRunner().invoke(
+        pma_app,
+        [
+            "thread",
+            "archive",
+            "--ids",
+            "thread-1,thread-2",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Archived thread-1 (Thread One)" in result.stdout
+    assert "Archived thread-2 (Thread Two)" in result.stdout
+    assert "Archived 2 managed threads." in result.stdout
+    assert calls == [
+        (
+            "POST",
+            "http://127.0.0.1:4321/hub/pma/threads/archive",
+            {"thread_ids": ["thread-1", "thread-2"]},
+        )
+    ]
+
+
+def test_pma_cli_thread_archive_reads_ids_from_stdin(
+    monkeypatch, tmp_path: Path
+) -> None:
+    calls: list[tuple[str, str, dict[str, object] | None]] = []
+
+    monkeypatch.setattr(
+        pma_cli,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = token_env, params
+        calls.append((method, url, payload))
+        if url.endswith("/hub/pma/threads/archive"):
+            return {
+                "threads": [
+                    {"managed_thread_id": "thread-1", "status": "archived"},
+                    {"managed_thread_id": "thread-2", "status": "archived"},
+                ],
+                "archived_count": 2,
+                "requested_count": 2,
+                "errors": [],
+                "error_count": 0,
+            }
+        raise AssertionError(f"unexpected url: {url}")
+
+    monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
+
+    result = CliRunner().invoke(
+        pma_app,
+        [
+            "thread",
+            "archive",
+            "--ids-stdin",
+            "--path",
+            str(tmp_path),
+        ],
+        input="thread-1\nthread-2\nthread-1\n",
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            "POST",
+            "http://127.0.0.1:4321/hub/pma/threads/archive",
+            {"thread_ids": ["thread-1", "thread-2"]},
+        )
+    ]
+
+
+def test_pma_cli_thread_archive_bulk_json_exits_nonzero_on_errors(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_cli,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = method, payload, token_env, params
+        if not url.endswith("/hub/pma/threads/archive"):
+            raise AssertionError(f"unexpected url: {url}")
+        return {
+            "threads": [{"managed_thread_id": "thread-1", "status": "archived"}],
+            "archived_count": 1,
+            "requested_count": 2,
+            "errors": [
+                {"thread_id": "missing-thread", "detail": "Managed thread not found"}
+            ],
+            "error_count": 1,
+        }
+
+    monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
+
+    result = CliRunner().invoke(
+        pma_app,
+        [
+            "thread",
+            "archive",
+            "--ids",
+            "thread-1,missing-thread",
+            "--json",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["archived_count"] == 1
+    assert payload["error_count"] == 1
 
 
 def test_pma_cli_thread_create_rejects_backend_id_option(tmp_path: Path) -> None:

--- a/tests/test_pma_cli.py
+++ b/tests/test_pma_cli.py
@@ -2272,6 +2272,67 @@ def test_pma_cli_thread_archive_bulk_uses_bulk_route(
     ]
 
 
+def test_pma_cli_thread_archive_id_is_single_value_not_split_on_commas(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """--id must name one thread id; commas are not list separators (use --ids)."""
+    calls: list[tuple[str, str, dict[str, object] | None]] = []
+
+    monkeypatch.setattr(
+        pma_cli,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = token_env, params
+        calls.append((method, url, payload))
+        if url.endswith("/hub/pma/threads/a,b/archive"):
+            return {
+                "thread": {
+                    "managed_thread_id": "a,b",
+                    "name": "comma id",
+                    "status": "archived",
+                }
+            }
+        raise AssertionError(f"unexpected url: {url}")
+
+    monkeypatch.setattr(pma_cli, "_request_json", _fake_request_json)
+
+    result = CliRunner().invoke(
+        pma_app,
+        [
+            "thread",
+            "archive",
+            "--id",
+            "a,b",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Archived a,b (comma id)" in result.stdout
+    assert calls == [
+        (
+            "POST",
+            "http://127.0.0.1:4321/hub/pma/threads/a,b/archive",
+            None,
+        )
+    ]
+
+
 def test_pma_cli_thread_archive_reads_ids_from_stdin(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_pma_managed_threads_routes.py
+++ b/tests/test_pma_managed_threads_routes.py
@@ -1221,6 +1221,59 @@ def test_resume_managed_thread_without_backend_binding_reactivates_thread(
     assert resumed_thread["backend_thread_id"] is None
 
 
+def test_archive_managed_threads_bulk_route_archives_multiple_threads(
+    hub_env,
+) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        first_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                **_repo_owner(hub_env),
+                "name": "First thread",
+            },
+        )
+        second_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                **_repo_owner(hub_env),
+                "name": "Second thread",
+            },
+        )
+        assert first_resp.status_code == 200
+        assert second_resp.status_code == 200
+
+        first_id = first_resp.json()["thread"]["managed_thread_id"]
+        second_id = second_resp.json()["thread"]["managed_thread_id"]
+
+        archive_resp = client.post(
+            "/hub/pma/threads/archive",
+            json={
+                "thread_ids": [first_id, second_id, "missing-thread", first_id],
+            },
+        )
+
+    assert archive_resp.status_code == 200
+    payload = archive_resp.json()
+    assert payload["requested_count"] == 3
+    assert payload["archived_count"] == 2
+    assert payload["error_count"] == 1
+    assert [thread["managed_thread_id"] for thread in payload["threads"]] == [
+        first_id,
+        second_id,
+    ]
+    assert payload["errors"] == [
+        {"thread_id": "missing-thread", "detail": "Managed thread not found"}
+    ]
+
+    store = PmaThreadStore(hub_env.hub_root)
+    assert store.get_thread(first_id)["lifecycle_status"] == "archived"
+    assert store.get_thread(second_id)["lifecycle_status"] == "archived"
+
+
 def test_managed_thread_crud_routes_use_orchestration_service(
     hub_env, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add a bulk PMA archive API at `/hub/pma/threads/archive` that accepts `thread_ids`, deduplicates input, archives each matching thread, and reports per-thread errors
- extend `car pma thread archive` to support `--ids` and `--ids-stdin`, while improving success output to include the archived thread name when available
- add focused CLI and route coverage for bulk archive success, stdin parsing, and nonzero JSON-mode exits when partial failures are reported

## Root Cause
The PMA archive flow only exposed a single-thread endpoint and CLI flag, so cleanup workflows had to pay startup and round-trip overhead once per thread. The single-thread CLI output also only emitted a bare ID, which made success harder to verify at a glance.

## Validation
- targeted pytest: `tests/test_pma_cli.py::test_pma_cli_thread_archive_help_shows_bulk_options`
- targeted pytest: `tests/test_pma_cli.py::test_pma_cli_thread_control_commands_use_orchestration_routes`
- targeted pytest: `tests/test_pma_cli.py::test_pma_cli_thread_archive_bulk_uses_bulk_route`
- targeted pytest: `tests/test_pma_cli.py::test_pma_cli_thread_archive_reads_ids_from_stdin`
- targeted pytest: `tests/test_pma_cli.py::test_pma_cli_thread_archive_bulk_json_exits_nonzero_on_errors`
- targeted pytest: `tests/test_pma_managed_threads_routes.py::test_archive_managed_threads_bulk_route_archives_multiple_threads`
- repository validation lane via commit hook: black, ruff, import/contracts checks, strict mypy, full pytest, frontend build/tests, chat-surface deterministic checks, chat latency budgets

Closes #1510