### PR TITLE
[codex] Prefer interrupts over managed-thread timeouts

### DIFF
--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -177,6 +177,7 @@ _DIRECT_RUN_EVENT_TYPES = (
 # from other threads.
 _LIVE_TIMELINE_BATCH_MAX_EVENTS = 25
 _LIVE_TIMELINE_BATCH_MAX_DELAY_SECONDS = 5.0
+_RECORDED_INTERRUPT_POLL_INTERVAL_SECONDS = 0.05
 
 
 def _runtime_raw_event_message(raw_event: Any) -> dict[str, Any]:
@@ -223,6 +224,30 @@ def _runtime_raw_event_content_summary(raw_event: Any) -> dict[str, Any]:
         "content_part_count": len(content) if isinstance(content, list) else None,
         "content_part_types": tuple(part_types),
     }
+
+
+async def _wait_for_recorded_execution_interrupt(
+    orchestration_service: Any,
+    *,
+    managed_thread_id: str,
+    managed_turn_id: str,
+) -> bool:
+    get_execution = getattr(orchestration_service, "get_execution", None)
+    if not callable(get_execution):
+        return False
+    while True:
+        try:
+            execution = get_execution(managed_thread_id, managed_turn_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return False
+        status = str(getattr(execution, "status", "") or "").strip().lower()
+        if status == "interrupted":
+            return True
+        if status and status != "running":
+            return False
+        await asyncio.sleep(_RECORDED_INTERRUPT_POLL_INTERVAL_SECONDS)
 
 
 @dataclass(frozen=True)
@@ -2285,15 +2310,66 @@ async def finalize_managed_thread_execution(
                 backend_turn_id=started.execution.backend_id,
             )
         else:
-            outcome = await await_runtime_thread_outcome(
-                started,
-                interrupt_event=None,
-                timeout_seconds=errors.timeout_seconds,
-                stall_timeout_seconds=errors.stall_timeout_seconds,
-                execution_error_message=errors.public_execution_error,
-                terminal_state=terminal_state,
-                observe_progress_events=False,
+            outcome_task = asyncio.create_task(
+                await_runtime_thread_outcome(
+                    started,
+                    interrupt_event=None,
+                    timeout_seconds=errors.timeout_seconds,
+                    stall_timeout_seconds=errors.stall_timeout_seconds,
+                    execution_error_message=errors.public_execution_error,
+                    terminal_state=terminal_state,
+                    observe_progress_events=False,
+                )
             )
+            recorded_interrupt_task = asyncio.create_task(
+                _wait_for_recorded_execution_interrupt(
+                    orchestration_service,
+                    managed_thread_id=managed_thread_id,
+                    managed_turn_id=managed_turn_id,
+                )
+            )
+            try:
+                done, _ = await asyncio.wait(
+                    {outcome_task, recorded_interrupt_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if recorded_interrupt_task in done and recorded_interrupt_task.result():
+                    outcome_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await outcome_task
+                    log_event(
+                        logger,
+                        logging.INFO,
+                        "chat.managed_thread.recorded_interrupt_preempted_runtime_wait",
+                        **_managed_thread_trace_fields(
+                            managed_thread_id=managed_thread_id,
+                            managed_turn_id=managed_turn_id,
+                            backend_thread_id=current_backend_thread_id or None,
+                            backend_turn_id=started.execution.backend_id,
+                            surface=surface,
+                        ),
+                        **_managed_thread_runtime_trace_fields(event_state),
+                    )
+                    outcome = RuntimeThreadOutcome(
+                        status="interrupted",
+                        assistant_text="",
+                        error=errors.interrupted_error,
+                        backend_thread_id=current_backend_thread_id,
+                        backend_turn_id=started.execution.backend_id,
+                        raw_events=tuple(terminal_state.raw_events),
+                        completion_source="interrupt",
+                        transport_request_return_timestamp=(
+                            terminal_state.transport_request_return_timestamp
+                        ),
+                        last_progress_timestamp=terminal_state.last_progress_timestamp,
+                        failure_cause=errors.interrupted_error,
+                    )
+                else:
+                    outcome = await outcome_task
+            finally:
+                recorded_interrupt_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await recorded_interrupt_task
     except asyncio.CancelledError:
         log_event(
             logger,

--- a/tests/chat_surface_lab/scenarios/interrupt_hung_turn_prefers_interrupted.json
+++ b/tests/chat_surface_lab/scenarios/interrupt_hung_turn_prefers_interrupted.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": 1,
+  "scenario_id": "interrupt_hung_turn_prefers_interrupted",
+  "description": "If Hermes emits progress but ignores cancel and never returns a terminal, an already-confirmed interrupt still wins over a later timeout.",
+  "surfaces": [
+    "discord"
+  ],
+  "runtime_fixture": {
+    "kind": "hermes",
+    "scenario": "official_progress_hang_ignore_cancel"
+  },
+  "harness_timeouts": {
+    "discord": 8.0
+  },
+  "faults": [
+    {
+      "kind": "set_surface_timeout",
+      "target": "surface",
+      "surfaces": [
+        "discord"
+      ],
+      "parameters": {
+        "seconds": 1.0
+      }
+    }
+  ],
+  "actions": [
+    {
+      "kind": "start_message",
+      "actor": "user",
+      "payload": {
+        "text": "echo hang after progress"
+      }
+    },
+    {
+      "kind": "wait_for_running_execution",
+      "actor": "system",
+      "payload": {
+        "timeout_seconds": 2.0
+      }
+    },
+    {
+      "kind": "interrupt_active_turn",
+      "actor": "user",
+      "payload": {}
+    },
+    {
+      "kind": "await_active_message",
+      "actor": "system",
+      "payload": {}
+    }
+  ],
+  "expected_terminal": {
+    "status": "interrupted"
+  },
+  "transcript_invariants": [
+    {
+      "kind": "log_event_exists",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "event_name": "discord.interrupt.completed",
+        "field": "interrupt_state",
+        "value": "confirmed"
+      }
+    },
+    {
+      "kind": "log_event_exists",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "event_name": "chat.managed_thread.turn_finalized",
+        "field": "status",
+        "value": "interrupted"
+      }
+    }
+  ],
+  "tags": [
+    "interrupt",
+    "timeout",
+    "discord",
+    "hermes",
+    "pma"
+  ],
+  "notes": "Models the production pattern where ACP progress arrives, the operator interrupt is acknowledged, but the backend ignores cancel and never returns a terminal."
+}

--- a/tests/chat_surface_lab/test_scenario_runner.py
+++ b/tests/chat_surface_lab/test_scenario_runner.py
@@ -119,6 +119,35 @@ async def test_runner_executes_queued_attachment_visibility(
 
 
 @pytest.mark.anyio
+async def test_runner_executes_interrupt_hung_turn_prefers_interrupted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = load_scenario_by_id("interrupt_hung_turn_prefers_interrupted")
+    runner = ChatSurfaceScenarioRunner(
+        output_root=tmp_path / "scenario-runs",
+        apply_runtime_patch=lambda runtime: patch_hermes_runtime(monkeypatch, runtime),
+    )
+
+    result = await runner.run_scenario(scenario)
+    assert result.skipped is False
+    assert len(result.surface_results) == 1
+    discord = result.surface_results[0]
+    assert discord.surface.value == "discord"
+    assert discord.execution_status == "interrupted"
+    assert any(
+        record.get("event") == "discord.interrupt.completed"
+        and record.get("interrupt_state") == "confirmed"
+        for record in discord.log_records
+    )
+    assert any(
+        record.get("event") == "chat.managed_thread.turn_finalized"
+        and record.get("status") == "interrupted"
+        for record in discord.log_records
+    )
+
+
+@pytest.mark.anyio
 async def test_runner_executes_attachment_download_visibility(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/fixtures/fake_acp_server.py
+++ b/tests/fixtures/fake_acp_server.py
@@ -369,6 +369,9 @@ class FakeACPServer:
                 },
             }
         )
+        if self._scenario == "official_progress_hang_ignore_cancel":
+            while True:
+                time.sleep(0.05)
         if self._scenario == "official_prompt_hang":
             return
         if self._scenario == "official_cancelled_before_return":

--- a/tests/integrations/chat/test_managed_thread_turns.py
+++ b/tests/integrations/chat/test_managed_thread_turns.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from pathlib import Path
 from types import SimpleNamespace
@@ -1698,6 +1699,102 @@ async def test_finalize_managed_thread_execution_logs_timeout_source(
     assert fake_hub_client.trace_requests[0].backend_turn_id == "turn-1"
     assert fake_hub_client.transcript_requests == []
     assert fake_hub_client.activity_requests == []
+
+
+@pytest.mark.anyio
+async def test_finalize_managed_thread_execution_prefers_recorded_interrupt_over_runtime_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = _started_execution_with_backend_ids(tmp_path)
+    fake_hub_client = _FakeHubPersistenceClient()
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "harness_supports_progress_event_stream",
+        lambda _harness: False,
+    )
+
+    outcome_wait_started = asyncio.Event()
+    execution_status = {"value": "running"}
+    record_execution_result_calls: list[Any] = []
+    record_execution_interrupted_calls: list[Any] = []
+
+    async def _slow_timeout_outcome(*args: Any, **kwargs: Any) -> RuntimeThreadOutcome:
+        _ = args, kwargs
+        outcome_wait_started.set()
+        await asyncio.sleep(10)
+        return RuntimeThreadOutcome(
+            status="error",
+            assistant_text="",
+            error=RUNTIME_THREAD_TIMEOUT_ERROR,
+            backend_thread_id="session-1",
+            backend_turn_id="turn-1",
+        )
+
+    async def _mark_interrupted() -> None:
+        await outcome_wait_started.wait()
+        await asyncio.sleep(0.05)
+        execution_status["value"] = "interrupted"
+
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "await_runtime_thread_outcome",
+        _slow_timeout_outcome,
+    )
+
+    orchestration_service = SimpleNamespace(
+        get_thread_target=lambda managed_thread_id: SimpleNamespace(
+            backend_thread_id="session-1"
+        ),
+        get_thread_runtime_binding=lambda managed_thread_id: SimpleNamespace(
+            backend_thread_id="session-1"
+        ),
+        get_execution=lambda managed_thread_id, managed_turn_id: SimpleNamespace(
+            status=execution_status["value"],
+            error=None,
+        ),
+        record_execution_result=lambda *args, **kwargs: record_execution_result_calls.append(
+            (args, kwargs)
+        ),
+        record_execution_interrupted=lambda *args, **kwargs: (
+            record_execution_interrupted_calls.append((args, kwargs))
+            or SimpleNamespace(status="interrupted", error=None)
+        ),
+    )
+
+    marker_task = asyncio.create_task(_mark_interrupted())
+    try:
+        result = await asyncio.wait_for(
+            managed_thread_turns_module.finalize_managed_thread_execution(
+                orchestration_service=orchestration_service,
+                started=started,
+                state_root=tmp_path,
+                hub_client=fake_hub_client,
+                surface=managed_thread_turns_module.ManagedThreadSurfaceInfo(
+                    log_label="Discord",
+                    surface_kind="discord",
+                    surface_key="discord:chan-1:msg-1",
+                ),
+                errors=managed_thread_turns_module.ManagedThreadErrorMessages(
+                    public_execution_error="Discord PMA execution failed",
+                    timeout_error="Discord PMA turn timed out",
+                    interrupted_error="Discord PMA turn interrupted",
+                    timeout_seconds=5,
+                ),
+                logger=logging.getLogger("test.managed_thread.recorded_interrupt"),
+                turn_preview="preview",
+            ),
+            timeout=1.0,
+        )
+    finally:
+        marker_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await marker_task
+
+    assert result.status == "interrupted"
+    assert result.error == "Discord PMA turn interrupted"
+    assert record_execution_result_calls == []
+    assert len(record_execution_interrupted_calls) == 1
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
This changes managed-thread finalization to prefer a recorded execution interrupt over waiting for a hung runtime to time out.

## Root Cause
Two Discord PMA turns timed out after Hermes emitted `session/update` progress but never returned a terminal completion. CAR had already recorded confirmed interrupts for those turns, but finalization still waited solely on runtime completion and degraded the result into a timeout.

## What Changed
- race runtime outcome waiting against the orchestration record switching to `interrupted`
- synthesize an interrupted outcome immediately when the interrupt is already recorded
- add a fake ACP scenario that emits progress and then hangs while ignoring cancel
- add unit and chat-lab coverage for the interrupt-beats-timeout behavior

## User Impact
Interrupted PMA turns no longer surface as misleading timeouts when the runtime hangs after progress has started.

## Validation
- full repo validation lane from `git commit`
- `.venv/bin/python -m pytest tests/integrations/chat/test_managed_thread_turns.py -q -k 'recorded_interrupt_over_runtime_timeout'`
- `.venv/bin/python -m pytest tests/chat_surface_lab/test_scenario_runner.py -q -k 'interrupt_hung_turn_prefers_interrupted'`
- `.venv/bin/python -m pytest tests/chat_surface_lab/test_scenario_corpus.py -q`