### PR TITLE
Fix PMA managed-thread followup defaults

### DIFF
--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -1117,14 +1117,38 @@ class PmaAutomationStore:
         *,
         thread_id: Optional[str],
         lane_id: Optional[str],
+        origin_thread_id: Optional[str] = None,
+        origin_lane_id: Optional[str] = None,
     ) -> str:
         normalized_thread_id = _normalize_text(thread_id)
         normalized_lane_id = _normalize_text(lane_id)
-        if normalized_thread_id is None or normalized_lane_id is not None:
+        normalized_origin_thread_id = _normalize_text(origin_thread_id)
+        normalized_origin_lane_id = _normalize_text(origin_lane_id)
+        if normalized_lane_id is not None:
             return _normalize_lane_id(normalized_lane_id)
 
-        resolved_lane_id = self._resolve_thread_lane_id(thread_id=normalized_thread_id)
-        return resolved_lane_id
+        if normalized_origin_thread_id is not None:
+            try:
+                resolved_origin_lane_id = self._resolve_thread_lane_id(
+                    thread_id=normalized_origin_thread_id
+                )
+            except PmaAutomationThreadNotFoundError:
+                resolved_origin_lane_id = DEFAULT_PMA_LANE_ID
+            if resolved_origin_lane_id != DEFAULT_PMA_LANE_ID:
+                return resolved_origin_lane_id
+
+        if normalized_thread_id is not None:
+            resolved_lane_id = self._resolve_thread_lane_id(
+                thread_id=normalized_thread_id
+            )
+            if resolved_lane_id != DEFAULT_PMA_LANE_ID:
+                return resolved_lane_id
+
+        if normalized_origin_lane_id is not None:
+            return _normalize_lane_id(normalized_origin_lane_id)
+        if normalized_thread_id is None:
+            return DEFAULT_PMA_LANE_ID
+        return DEFAULT_PMA_LANE_ID
 
     @staticmethod
     def _is_auto_subscription_key(idempotency_key: Optional[str]) -> bool:
@@ -1211,12 +1235,21 @@ class PmaAutomationStore:
         *,
         thread_id: Optional[str],
         metadata: Optional[dict[str, Any]],
+        origin_thread_id: Optional[str] = None,
     ) -> dict[str, Any]:
         resolved_metadata = dict(metadata or {})
         delivery_target = _normalize_delivery_target(
             resolved_metadata.get("delivery_target")
         )
         normalized_thread_id = _normalize_text(thread_id)
+        normalized_origin_thread_id = _normalize_text(origin_thread_id)
+        if delivery_target is None and normalized_origin_thread_id is not None:
+            try:
+                delivery_target = self._resolve_thread_delivery_target(
+                    thread_id=normalized_origin_thread_id
+                )
+            except PmaAutomationThreadNotFoundError:
+                delivery_target = None
         if delivery_target is None and normalized_thread_id is not None:
             try:
                 delivery_target = self._resolve_thread_delivery_target(
@@ -1245,6 +1278,8 @@ class PmaAutomationStore:
         notify_once: Optional[bool] = None,
         max_matches: Optional[int] = None,
         metadata: Optional[dict[str, Any]] = None,
+        origin_thread_id: Optional[str] = None,
+        origin_lane_id: Optional[str] = None,
     ) -> tuple[PmaLifecycleSubscription, bool]:
         key = _normalize_text(idempotency_key)
         normalized_event_types = self._normalize_subscription_event_types(event_types)
@@ -1252,10 +1287,13 @@ class PmaAutomationStore:
         resolved_lane_id = self._resolve_subscription_lane_id(
             thread_id=normalized_thread_id,
             lane_id=lane_id,
+            origin_thread_id=origin_thread_id,
+            origin_lane_id=origin_lane_id,
         )
         resolved_metadata = self._resolve_subscription_metadata(
             thread_id=normalized_thread_id,
             metadata=metadata,
+            origin_thread_id=origin_thread_id,
         )
         if not normalized_event_types:
             logger.warning(
@@ -1300,10 +1338,13 @@ class PmaAutomationStore:
         normalized_from_state = _normalize_text(data.get("from_state"))
         normalized_to_state = _normalize_text(data.get("to_state"))
         normalized_idempotency_key = _normalize_text(data.get("idempotency_key"))
+        normalized_origin_thread_id = _normalize_text(data.get("origin_thread_id"))
+        normalized_origin_lane_id = _normalize_text(data.get("origin_lane_id"))
         confirm_duplicate = _normalize_bool(data.get("confirm"), fallback=False)
-        if not confirm_duplicate and not self._is_auto_subscription_key(
+        is_auto_subscription = self._is_auto_subscription_key(
             normalized_idempotency_key
-        ):
+        )
+        if not confirm_duplicate:
             existing_auto = self._find_covering_auto_subscription(
                 event_types=normalized_event_types,
                 repo_id=normalized_repo_id,
@@ -1313,6 +1354,11 @@ class PmaAutomationStore:
                 to_state=normalized_to_state,
             )
             if existing_auto is not None:
+                if is_auto_subscription:
+                    return {
+                        "subscription": existing_auto.to_dict(),
+                        "deduped": True,
+                    }
                 scope_label = "this scope"
                 if normalized_thread_id is not None:
                     scope_label = "this thread"
@@ -1350,6 +1396,8 @@ class PmaAutomationStore:
             metadata=(
                 data.get("metadata") if isinstance(data.get("metadata"), dict) else None
             ),
+            origin_thread_id=normalized_origin_thread_id,
+            origin_lane_id=normalized_origin_lane_id,
         )
         return {"subscription": created.to_dict(), "deduped": deduped}
 

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -970,7 +970,10 @@ def build_managed_thread_runtime_routes(
 
         notification: Optional[dict[str, Any]] = None
         if options.notify_on == "terminal":
-            automation_client = ManagedThreadAutomationClient(request, lambda: None)
+            automation_client = ManagedThreadAutomationClient(
+                request,
+                get_runtime_state,
+            )
             try:
                 notification = await automation_client.create_terminal_followup(
                     managed_thread_id=managed_thread_id,

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
@@ -169,17 +169,12 @@ def _resolve_origin_followup_context(
     if runtime_state is None:
         return None, None
 
-    candidates = []
     current = getattr(runtime_state, "pma_current", None)
-    if isinstance(current, dict):
-        candidates.append(current)
-    last_result = getattr(runtime_state, "pma_last_result", None)
-    if isinstance(last_result, dict):
-        candidates.append(last_result)
+    if not isinstance(current, dict):
+        return None, None
 
-    for candidate in candidates:
-        origin_thread_id = normalize_optional_text(candidate.get("thread_id"))
-        origin_lane_id = normalize_optional_text(candidate.get("lane_id"))
-        if origin_thread_id or origin_lane_id:
-            return origin_thread_id, origin_lane_id
+    origin_thread_id = normalize_optional_text(current.get("thread_id"))
+    origin_lane_id = normalize_optional_text(current.get("lane_id"))
+    if origin_thread_id or origin_lane_id:
+        return origin_thread_id, origin_lane_id
     return None, None

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
@@ -33,6 +33,8 @@ def build_managed_thread_terminal_notify_payload(
     lane_id: Optional[str],
     notify_once: bool,
     idempotency_key: Optional[str],
+    origin_thread_id: Optional[str],
+    origin_lane_id: Optional[str],
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "event_types": [
@@ -47,6 +49,10 @@ def build_managed_thread_terminal_notify_payload(
     }
     if idempotency_key:
         payload["idempotency_key"] = idempotency_key
+    if origin_thread_id:
+        payload["origin_thread_id"] = origin_thread_id
+    if origin_lane_id:
+        payload["origin_lane_id"] = origin_lane_id
     return payload
 
 
@@ -107,6 +113,9 @@ class ManagedThreadAutomationClient:
         required: bool,
     ) -> Optional[dict[str, Any]]:
         runtime_state = self._get_runtime_state() if self._get_runtime_state else None
+        origin_thread_id, origin_lane_id = _resolve_origin_followup_context(
+            runtime_state
+        )
         try:
             store = await get_automation_store(
                 self._request,
@@ -126,6 +135,8 @@ class ManagedThreadAutomationClient:
                     lane_id=lane_id,
                     notify_once=notify_once,
                     idempotency_key=idempotency_key,
+                    origin_thread_id=origin_thread_id,
+                    origin_lane_id=origin_lane_id,
                 ),
             )
         except HTTPException as exc:
@@ -150,3 +161,25 @@ class ManagedThreadAutomationClient:
         if isinstance(created, dict) and "subscription" in created:
             return {"mode": "terminal", **created}
         return {"mode": "terminal", "subscription": created}
+
+
+def _resolve_origin_followup_context(
+    runtime_state: Any,
+) -> tuple[Optional[str], Optional[str]]:
+    if runtime_state is None:
+        return None, None
+
+    candidates = []
+    current = getattr(runtime_state, "pma_current", None)
+    if isinstance(current, dict):
+        candidates.append(current)
+    last_result = getattr(runtime_state, "pma_last_result", None)
+    if isinstance(last_result, dict):
+        candidates.append(last_result)
+
+    for candidate in candidates:
+        origin_thread_id = normalize_optional_text(candidate.get("thread_id"))
+        origin_lane_id = normalize_optional_text(candidate.get("lane_id"))
+        if origin_thread_id or origin_lane_id:
+            return origin_thread_id, origin_lane_id
+    return None, None

--- a/tests/chat_surface_lab/scenarios/interrupt_optimistic_acceptance.json
+++ b/tests/chat_surface_lab/scenarios/interrupt_optimistic_acceptance.json
@@ -8,11 +8,11 @@
   ],
   "runtime_fixture": {
     "kind": "hermes",
-    "scenario": "official"
+    "scenario": "official_prompt_hang"
   },
   "harness_timeouts": {
-    "discord": 8.0,
-    "telegram": 8.0
+    "discord": 15.0,
+    "telegram": 15.0
   },
   "approval_mode": "yolo",
   "actions": [

--- a/tests/chat_surface_lab/test_scenario_runner.py
+++ b/tests/chat_surface_lab/test_scenario_runner.py
@@ -64,6 +64,27 @@ async def test_runner_executes_queued_visibility_matrix(
 
 
 @pytest.mark.anyio
+async def test_runner_executes_interrupt_optimistic_acceptance_matrix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = load_scenario_by_id("interrupt_optimistic_acceptance")
+    runner = ChatSurfaceScenarioRunner(
+        output_root=tmp_path / "scenario-runs",
+        apply_runtime_patch=lambda runtime: patch_hermes_runtime(monkeypatch, runtime),
+    )
+
+    result = await runner.run_scenario(scenario)
+    assert result.skipped is False
+    assert len(result.surface_results) == 2
+    for surface in result.surface_results:
+        assert surface.execution_status == "interrupted"
+    assert any(
+        budget.budget_id == "interrupt_visible" for budget in result.observed_budgets
+    )
+
+
+@pytest.mark.anyio
 async def test_runner_keeps_visible_failure_note_when_final_delivery_is_outboxed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/core/test_pma_automation_store.py
+++ b/tests/core/test_pma_automation_store.py
@@ -366,6 +366,70 @@ def test_create_subscription_auto_resolves_lane_from_thread_binding(tmp_path) ->
     }
 
 
+def test_create_subscription_prefers_origin_thread_binding_for_defaults(
+    tmp_path,
+) -> None:
+    store = PmaAutomationStore(tmp_path)
+    managed_thread_id = _create_managed_thread(tmp_path)
+    origin_thread_id = _create_managed_thread(tmp_path, surface_kind="discord")
+
+    subscription = store.create_subscription(
+        {
+            "event_type": "managed_thread_completed",
+            "thread_id": managed_thread_id,
+            "origin_thread_id": origin_thread_id,
+        }
+    )["subscription"]
+
+    assert subscription["thread_id"] == managed_thread_id
+    assert subscription["lane_id"] == "discord"
+    assert subscription["metadata"]["delivery_target"] == {
+        "surface_kind": "discord",
+        "surface_key": "discord:binding-1",
+    }
+
+
+def test_create_subscription_reuses_covering_auto_subscription_for_auto_keys(
+    tmp_path,
+) -> None:
+    store = PmaAutomationStore(tmp_path)
+    thread_id = _create_managed_thread(tmp_path)
+
+    first = store.create_subscription(
+        {
+            "event_types": [
+                "managed_thread_completed",
+                "managed_thread_failed",
+                "managed_thread_interrupted",
+            ],
+            "thread_id": thread_id,
+            "idempotency_key": f"managed-thread-notify:{thread_id}",
+            "notify_once": True,
+        }
+    )
+    second = store.create_subscription(
+        {
+            "event_types": [
+                "managed_thread_completed",
+                "managed_thread_failed",
+                "managed_thread_interrupted",
+            ],
+            "thread_id": thread_id,
+            "idempotency_key": "managed-thread-send-notify:turn-1",
+            "notify_once": True,
+        }
+    )
+
+    assert first["deduped"] is False
+    assert second["deduped"] is True
+    assert (
+        second["subscription"]["subscription_id"]
+        == first["subscription"]["subscription_id"]
+    )
+    subscriptions = store.list_subscriptions(thread_id=thread_id)
+    assert len(subscriptions) == 1
+
+
 def test_notify_transition_copies_subscription_delivery_target_into_wakeup(
     tmp_path,
 ) -> None:

--- a/tests/surfaces/web/test_pma_common_service.py
+++ b/tests/surfaces/web/test_pma_common_service.py
@@ -341,3 +341,47 @@ async def test_managed_thread_automation_client_forwards_origin_thread_context(
     }
     assert captured["origin_thread_id"] == "pma-thread-1"
     assert captured["origin_lane_id"] == "discord"
+
+
+@pytest.mark.asyncio
+async def test_managed_thread_automation_client_ignores_stale_last_result_origin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+    runtime_state = SimpleNamespace(
+        pma_current=None,
+        pma_last_result={
+            "thread_id": "stale-thread",
+            "lane_id": "discord",
+        },
+    )
+    client = ManagedThreadAutomationClient(request, lambda: runtime_state)
+    captured: dict[str, object] = {}
+
+    async def _fake_get_store(_request, _runtime_state, *, required):
+        assert required is False
+        return object()
+
+    async def _fake_create(_store, _method_names, payload):
+        captured.update(payload)
+        return {"subscription": {"subscription_id": "sub-1"}}
+
+    monkeypatch.setattr(
+        "codex_autorunner.surfaces.web.services.pma.managed_thread_followup.get_automation_store",
+        _fake_get_store,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.surfaces.web.services.pma.managed_thread_followup.call_store_create_with_payload",
+        _fake_create,
+    )
+
+    await client.create_terminal_followup(
+        managed_thread_id="thread-1",
+        lane_id=None,
+        notify_once=True,
+        idempotency_key="managed-thread-notify:thread-1",
+        required=False,
+    )
+
+    assert "origin_thread_id" not in captured
+    assert "origin_lane_id" not in captured

--- a/tests/surfaces/web/test_pma_common_service.py
+++ b/tests/surfaces/web/test_pma_common_service.py
@@ -293,3 +293,51 @@ async def test_managed_thread_automation_client_downgrades_optional_missing_thre
     )
 
     assert created is None
+
+
+@pytest.mark.asyncio
+async def test_managed_thread_automation_client_forwards_origin_thread_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+    runtime_state = SimpleNamespace(
+        pma_current={
+            "thread_id": "pma-thread-1",
+            "lane_id": "discord",
+        }
+    )
+    client = ManagedThreadAutomationClient(request, lambda: runtime_state)
+    captured: dict[str, object] = {}
+
+    async def _fake_get_store(_request, _runtime_state, *, required):
+        assert required is False
+        assert _runtime_state is runtime_state
+        return object()
+
+    async def _fake_create(_store, _method_names, payload):
+        captured.update(payload)
+        return {"subscription": {"subscription_id": "sub-1"}}
+
+    monkeypatch.setattr(
+        "codex_autorunner.surfaces.web.services.pma.managed_thread_followup.get_automation_store",
+        _fake_get_store,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.surfaces.web.services.pma.managed_thread_followup.call_store_create_with_payload",
+        _fake_create,
+    )
+
+    created = await client.create_terminal_followup(
+        managed_thread_id="thread-1",
+        lane_id=None,
+        notify_once=True,
+        idempotency_key="managed-thread-notify:thread-1",
+        required=False,
+    )
+
+    assert created == {
+        "mode": "terminal",
+        "subscription": {"subscription_id": "sub-1"},
+    }
+    assert captured["origin_thread_id"] == "pma-thread-1"
+    assert captured["origin_lane_id"] == "discord"


### PR DESCRIPTION
## Summary
- default managed-thread terminal followups to the PMA origin thread's bound chat target when available instead of falling back to repo-bound delivery
- reuse the first managed-thread auto-subscription when a later auto followup covers the same thread scope, preventing duplicate wakeups
- cover the origin-context forwarding and auto-subscription reuse paths with focused tests

## Testing
- .venv/bin/pytest -q tests/core/test_pma_automation_store.py tests/surfaces/web/test_pma_common_service.py tests/test_pma_managed_threads_routes.py
- commit validation lane (repo-wide mypy, pytest, static build, JS tests, chat-surface lab checks)