### PR TITLE
[codex] Default subscriptions to the active chat thread

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -73,6 +73,13 @@ def _load_chat_binding_metadata_by_thread(hub_root):
         return {}
 
 
+def _subscription_request_has_explicit_routing(payload: dict[str, Any]) -> bool:
+    return any(
+        normalize_optional_text(payload.get(field)) is not None
+        for field in ("thread_id", "lane_id")
+    )
+
+
 def build_managed_thread_orchestration_service(request: Request):
     try:
         descriptors = get_registered_agents(request.app.state)
@@ -136,13 +143,14 @@ def build_automation_routes(
         store = await get_automation_store(request, runtime_state)
         try:
             normalized_payload = payload.normalized_payload()
-            origin_thread_id, origin_lane_id = resolve_origin_followup_context(
-                runtime_state
-            )
-            if origin_thread_id:
-                normalized_payload.setdefault("origin_thread_id", origin_thread_id)
-            if origin_lane_id:
-                normalized_payload.setdefault("origin_lane_id", origin_lane_id)
+            if not _subscription_request_has_explicit_routing(normalized_payload):
+                origin_thread_id, origin_lane_id = resolve_origin_followup_context(
+                    runtime_state
+                )
+                if origin_thread_id:
+                    normalized_payload.setdefault("origin_thread_id", origin_thread_id)
+                if origin_lane_id:
+                    normalized_payload.setdefault("origin_lane_id", origin_lane_id)
             created = await call_store_create_with_payload(
                 store,
                 (

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -33,6 +33,7 @@ from ...schemas import (
 from ...services.pma.managed_thread_followup import (
     ManagedThreadAutomationClient,
     ManagedThreadAutomationUnavailable,
+    resolve_origin_followup_context,
 )
 from .automation_adapter import (
     call_store_action_with_id,
@@ -131,9 +132,17 @@ def build_automation_routes(
     async def create_automation_subscription(
         request: Request, payload: PmaAutomationSubscriptionCreateRequest
     ) -> dict[str, Any]:
-        store = await get_automation_store(request, get_runtime_state())
+        runtime_state = get_runtime_state()
+        store = await get_automation_store(request, runtime_state)
         try:
             normalized_payload = payload.normalized_payload()
+            origin_thread_id, origin_lane_id = resolve_origin_followup_context(
+                runtime_state
+            )
+            if origin_thread_id:
+                normalized_payload.setdefault("origin_thread_id", origin_thread_id)
+            if origin_lane_id:
+                normalized_payload.setdefault("origin_lane_id", origin_lane_id)
             created = await call_store_create_with_payload(
                 store,
                 (

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
@@ -113,7 +113,7 @@ class ManagedThreadAutomationClient:
         required: bool,
     ) -> Optional[dict[str, Any]]:
         runtime_state = self._get_runtime_state() if self._get_runtime_state else None
-        origin_thread_id, origin_lane_id = _resolve_origin_followup_context(
+        origin_thread_id, origin_lane_id = resolve_origin_followup_context(
             runtime_state
         )
         try:
@@ -163,7 +163,7 @@ class ManagedThreadAutomationClient:
         return {"mode": "terminal", "subscription": created}
 
 
-def _resolve_origin_followup_context(
+def resolve_origin_followup_context(
     runtime_state: Any,
 ) -> tuple[Optional[str], Optional[str]]:
     if runtime_state is None:

--- a/tests/chat_surface_lab/scenario_runner.py
+++ b/tests/chat_surface_lab/scenario_runner.py
@@ -5,9 +5,14 @@ import contextlib
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Callable, Optional, Sequence
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
 from codex_autorunner.browser.runtime import BrowserRuntime
+from codex_autorunner.core.pma_automation_store import PmaAutomationStore
 from codex_autorunner.integrations.chat.ux_regression_contract import (
     CHAT_UX_LATENCY_BUDGETS,
 )
@@ -16,7 +21,11 @@ from codex_autorunner.integrations.telegram.adapter import TelegramUpdate
 from codex_autorunner.integrations.telegram.handlers.commands import (
     execution as telegram_execution,
 )
+from codex_autorunner.surfaces.web.routes.pma_routes.managed_threads import (
+    build_automation_routes,
+)
 from tests.chat_surface_integration.harness import (
+    DEFAULT_DISCORD_CHANNEL_ID,
     DEFAULT_TELEGRAM_THREAD_ID,
     DiscordSurfaceHarness,
     FakeDiscordRest,
@@ -155,6 +164,7 @@ class _SurfaceRunContext:
     thread_target_id: Optional[str] = None
     execution_id: Optional[str] = None
     telegram_thread_id: Optional[int] = DEFAULT_TELEGRAM_THREAD_ID
+    surface_metadata: dict[str, Any] = field(default_factory=dict)
 
 
 class ChatSurfaceScenarioRunner:
@@ -326,7 +336,8 @@ class ChatSurfaceScenarioRunner:
                 )
 
             transcript = context.result.to_normalized_transcript(
-                scenario_id=scenario.scenario_id
+                scenario_id=scenario.scenario_id,
+                metadata=context.surface_metadata,
             )
             artifact_manifest = context.result.write_artifacts(
                 output_dir=output_dir / "artifacts",
@@ -383,6 +394,31 @@ class ChatSurfaceScenarioRunner:
             agent="hermes",
             approval_mode=scenario.approval_mode,
         )
+
+    def _resolve_current_thread_target_id(
+        self,
+        context: _SurfaceRunContext,
+    ) -> Optional[str]:
+        if context.thread_target_id:
+            return context.thread_target_id
+        if context.surface == SurfaceKind.DISCORD:
+            assert isinstance(context.harness, DiscordSurfaceHarness)
+            binding = context.harness.orchestration_service().get_binding(
+                surface_kind="discord",
+                surface_key=DEFAULT_DISCORD_CHANNEL_ID,
+            )
+        else:
+            assert isinstance(context.harness, TelegramSurfaceHarness)
+            binding = context.harness.orchestration_service().get_binding(
+                surface_kind="telegram",
+                surface_key=f"chat-1:{context.telegram_thread_id or DEFAULT_TELEGRAM_THREAD_ID}",
+            )
+        thread_target_id = (
+            str(getattr(binding, "thread_target_id", "") or "").strip() or None
+        )
+        if thread_target_id:
+            context.thread_target_id = thread_target_id
+        return thread_target_id
 
     async def _await_surface_settled(self, context: _SurfaceRunContext) -> None:
         if context.surface != SurfaceKind.DISCORD:
@@ -622,6 +658,99 @@ class ChatSurfaceScenarioRunner:
                         else lambda record: record.get(field_name) == expected_value
                     ),
                 )
+            return
+
+        if action.kind == "create_automation_subscription":
+            origin_thread_id = self._resolve_current_thread_target_id(context)
+            if origin_thread_id is None:
+                raise AssertionError(
+                    "create_automation_subscription requires an active surface thread"
+                )
+            runtime_state = SimpleNamespace(
+                pma_current={
+                    "thread_id": origin_thread_id,
+                    "lane_id": context.surface.value,
+                }
+            )
+            with _build_automation_route_client(
+                context.harness.root,
+                runtime_state=runtime_state,
+            ) as client:
+                response = client.post(
+                    "/subscriptions",
+                    json=dict(action.payload),
+                )
+            assert (
+                response.status_code == 200
+            ), f"create_automation_subscription failed: {response.status_code} {response.text}"
+            payload = response.json()
+            subscription = payload.get("subscription") or {}
+            delivery_target = (
+                subscription.get("metadata", {}).get("delivery_target")
+                if isinstance(subscription.get("metadata"), dict)
+                else None
+            ) or {}
+            context.surface_metadata["subscription_lane_id"] = subscription.get(
+                "lane_id"
+            )
+            context.surface_metadata["subscription_delivery_surface_kind"] = (
+                delivery_target.get("surface_kind")
+            )
+            context.surface_metadata["subscription_delivery_surface_key"] = (
+                delivery_target.get("surface_key")
+            )
+            context.surface_metadata["subscription_deduped"] = payload.get("deduped")
+            return
+
+        if action.kind == "emit_automation_transition":
+            store = PmaAutomationStore(context.harness.root)
+            payload = dict(action.payload)
+            result = store.notify_transition(payload)
+            pending = store.list_pending_wakeups(limit=10)
+            event_type = self._normalize_optional_text(payload.get("event_type"))
+            repo_id = self._normalize_optional_text(payload.get("repo_id"))
+            run_id = self._normalize_optional_text(payload.get("run_id"))
+            matching_wakeup = next(
+                (
+                    wakeup
+                    for wakeup in reversed(pending)
+                    if (
+                        event_type is None
+                        or self._normalize_optional_text(wakeup.get("event_type"))
+                        == event_type
+                    )
+                    and (
+                        repo_id is None
+                        or self._normalize_optional_text(wakeup.get("repo_id"))
+                        == repo_id
+                    )
+                    and (
+                        run_id is None
+                        or self._normalize_optional_text(wakeup.get("run_id")) == run_id
+                    )
+                ),
+                None,
+            )
+            if matching_wakeup is None:
+                raise AssertionError(
+                    f"emit_automation_transition created no pending wakeup for {payload!r}"
+                )
+            wakeup_metadata = matching_wakeup.get("metadata")
+            delivery_target = (
+                wakeup_metadata.get("delivery_target")
+                if isinstance(wakeup_metadata, dict)
+                else None
+            ) or {}
+            context.surface_metadata["transition_created_wakeups"] = result.get(
+                "created"
+            )
+            context.surface_metadata["wakeup_lane_id"] = matching_wakeup.get("lane_id")
+            context.surface_metadata["wakeup_delivery_surface_kind"] = (
+                delivery_target.get("surface_kind")
+            )
+            context.surface_metadata["wakeup_delivery_surface_key"] = (
+                delivery_target.get("surface_key")
+            )
             return
 
         if action.kind == "stop_active_thread":
@@ -1501,7 +1630,21 @@ def _lookup_surface_attr(
             event.kind == TranscriptEventKind.CALLBACK
             for event in surface_result.transcript.events
         )
+    if attr in surface_result.transcript.metadata:
+        return surface_result.transcript.metadata.get(attr)
     raise AssertionError(f"unsupported surface attribute assertion: {attr}")
+
+
+def _build_automation_route_client(
+    hub_root: Path,
+    *,
+    runtime_state: object,
+) -> TestClient:
+    app = FastAPI()
+    app.state.config = SimpleNamespace(root=hub_root, raw={"pma": {"enabled": True}})
+    router = app.router
+    build_automation_routes(router, lambda: runtime_state)
+    return TestClient(app)
 
 
 def _discord_status_interaction(interaction_id: str) -> dict[str, Any]:

--- a/tests/chat_surface_lab/scenarios/subscription_defaults_to_current_thread.json
+++ b/tests/chat_surface_lab/scenarios/subscription_defaults_to_current_thread.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": 1,
+  "scenario_id": "subscription_defaults_to_current_thread",
+  "description": "Automation subscriptions created from an active Discord chat default back to that bound thread without requiring an explicit lane or delivery target.",
+  "surfaces": [
+    "discord"
+  ],
+  "runtime_fixture": {
+    "kind": "hermes",
+    "scenario": "official"
+  },
+  "actions": [
+    {
+      "kind": "send_message",
+      "actor": "user",
+      "payload": {
+        "text": "echo hello world"
+      }
+    },
+    {
+      "kind": "create_automation_subscription",
+      "actor": "user",
+      "payload": {
+        "event_type": "flow_completed",
+        "repo_id": "repo-1",
+        "run_id": "run-subscription-default"
+      }
+    },
+    {
+      "kind": "emit_automation_transition",
+      "actor": "system",
+      "payload": {
+        "event_type": "flow_completed",
+        "repo_id": "repo-1",
+        "run_id": "run-subscription-default",
+        "from_state": "running",
+        "to_state": "completed",
+        "reason": "surface-lab"
+      }
+    }
+  ],
+  "expected_terminal": {
+    "status": "ok"
+  },
+  "transcript_invariants": [
+    {
+      "kind": "contains_text",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "fixture reply"
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "subscription_lane_id",
+        "value": "discord"
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "subscription_delivery_surface_kind",
+        "value": "discord"
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "subscription_delivery_surface_key",
+        "value": "channel-1"
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "transition_created_wakeups",
+        "value": 1
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "wakeup_lane_id",
+        "value": "discord"
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "wakeup_delivery_surface_kind",
+        "value": "discord"
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "wakeup_delivery_surface_key",
+        "value": "channel-1"
+      }
+    }
+  ],
+  "tags": [
+    "automation",
+    "discord",
+    "subscriptions",
+    "pma"
+  ]
+}

--- a/tests/chat_surface_lab/test_scenario_runner.py
+++ b/tests/chat_surface_lab/test_scenario_runner.py
@@ -207,6 +207,31 @@ async def test_runner_handles_reference_only_scenarios_without_surface_execution
 
 
 @pytest.mark.anyio
+async def test_runner_executes_subscription_defaults_to_current_thread(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = load_scenario_by_id("subscription_defaults_to_current_thread")
+    runner = ChatSurfaceScenarioRunner(
+        output_root=tmp_path / "scenario-runs",
+        apply_runtime_patch=lambda runtime: patch_hermes_runtime(monkeypatch, runtime),
+    )
+
+    result = await runner.run_scenario(scenario)
+    assert result.skipped is False
+    assert len(result.surface_results) == 1
+    discord = result.surface_results[0]
+    assert discord.surface.value == "discord"
+    assert discord.execution_status == "ok"
+    assert discord.transcript.metadata["subscription_lane_id"] == "discord"
+    assert (
+        discord.transcript.metadata["subscription_delivery_surface_key"] == "channel-1"
+    )
+    assert discord.transcript.metadata["wakeup_lane_id"] == "discord"
+    assert discord.transcript.metadata["wakeup_delivery_surface_key"] == "channel-1"
+
+
+@pytest.mark.anyio
 async def test_runner_executes_restart_window_duplicate_delivery(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_pma_managed_threads_routes.py
+++ b/tests/test_pma_managed_threads_routes.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from codex_autorunner.agents.registry import AgentDescriptor
@@ -18,6 +19,9 @@ from codex_autorunner.core.pma_thread_store import PmaThreadStore
 from codex_autorunner.server import create_hub_app
 from codex_autorunner.surfaces.web.routes.pma_routes import (
     managed_threads,
+)
+from codex_autorunner.surfaces.web.routes.pma_routes.managed_threads import (
+    build_automation_routes,
 )
 from tests.conftest import write_test_config
 
@@ -40,6 +44,18 @@ def _set_default_terminal_followup(hub_root: Path, enabled: bool) -> None:
 
 def _repo_owner(hub_env) -> dict[str, str]:
     return {"resource_kind": "repo", "resource_id": hub_env.repo_id}
+
+
+def _build_automation_route_client(
+    hub_root: Path,
+    *,
+    runtime_state: object,
+) -> TestClient:
+    app = FastAPI()
+    app.state.config = SimpleNamespace(root=hub_root, raw={"pma": {"enabled": True}})
+    router = app.router
+    build_automation_routes(router, lambda: runtime_state)
+    return TestClient(app)
 
 
 def test_create_managed_thread_with_repo_owner(hub_env) -> None:
@@ -847,6 +863,53 @@ def test_create_subscription_auto_resolves_lane_from_bound_thread(hub_env) -> No
     subscription = subscription_resp.json()["subscription"]
     assert subscription["thread_id"] == thread_id
     assert subscription["lane_id"] == "discord"
+
+
+def test_create_subscription_defaults_to_current_runtime_chat_thread(hub_env) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={"agent": "codex", **_repo_owner(hub_env)},
+        )
+        assert create_resp.status_code == 200
+        origin_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+    OrchestrationBindingStore(hub_env.hub_root).upsert_binding(
+        surface_kind="discord",
+        surface_key="discord:subscription-default-thread",
+        thread_target_id=origin_thread_id,
+    )
+    runtime_state = SimpleNamespace(
+        pma_current={
+            "thread_id": origin_thread_id,
+            "lane_id": "discord",
+        }
+    )
+
+    with _build_automation_route_client(
+        hub_env.hub_root,
+        runtime_state=runtime_state,
+    ) as client:
+        subscription_resp = client.post(
+            "/subscriptions",
+            json={
+                "event_type": "flow_completed",
+                "repo_id": hub_env.repo_id,
+                "run_id": "run-subscription-default",
+            },
+        )
+
+    assert subscription_resp.status_code == 200
+    subscription = subscription_resp.json()["subscription"]
+    assert subscription["repo_id"] == hub_env.repo_id
+    assert subscription["run_id"] == "run-subscription-default"
+    assert subscription["lane_id"] == "discord"
+    assert subscription["metadata"]["delivery_target"] == {
+        "surface_kind": "discord",
+        "surface_key": "discord:subscription-default-thread",
+    }
 
 
 def test_create_subscription_warns_when_active_auto_subscription_covers_scope(

--- a/tests/test_pma_managed_threads_routes.py
+++ b/tests/test_pma_managed_threads_routes.py
@@ -912,6 +912,64 @@ def test_create_subscription_defaults_to_current_runtime_chat_thread(hub_env) ->
     }
 
 
+def test_create_subscription_keeps_explicit_thread_target(hub_env) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        origin_resp = client.post(
+            "/hub/pma/threads",
+            json={"agent": "codex", **_repo_owner(hub_env)},
+        )
+        assert origin_resp.status_code == 200
+        origin_thread_id = origin_resp.json()["thread"]["managed_thread_id"]
+
+        explicit_resp = client.post(
+            "/hub/pma/threads",
+            json={"agent": "codex", **_repo_owner(hub_env)},
+        )
+        assert explicit_resp.status_code == 200
+        explicit_thread_id = explicit_resp.json()["thread"]["managed_thread_id"]
+
+    bindings = OrchestrationBindingStore(hub_env.hub_root)
+    bindings.upsert_binding(
+        surface_kind="discord",
+        surface_key="discord:subscription-origin-thread",
+        thread_target_id=origin_thread_id,
+    )
+    bindings.upsert_binding(
+        surface_kind="telegram",
+        surface_key="telegram:subscription-explicit-thread",
+        thread_target_id=explicit_thread_id,
+    )
+    runtime_state = SimpleNamespace(
+        pma_current={
+            "thread_id": origin_thread_id,
+            "lane_id": "discord",
+        }
+    )
+
+    with _build_automation_route_client(
+        hub_env.hub_root,
+        runtime_state=runtime_state,
+    ) as client:
+        subscription_resp = client.post(
+            "/subscriptions",
+            json={
+                "event_type": "flow_completed",
+                "thread_id": explicit_thread_id,
+            },
+        )
+
+    assert subscription_resp.status_code == 200
+    subscription = subscription_resp.json()["subscription"]
+    assert subscription["thread_id"] == explicit_thread_id
+    assert subscription["lane_id"] == "telegram"
+    assert subscription["metadata"]["delivery_target"] == {
+        "surface_kind": "telegram",
+        "surface_key": "telegram:subscription-explicit-thread",
+    }
+
+
 def test_create_subscription_warns_when_active_auto_subscription_covers_scope(
     hub_env,
 ) -> None:


### PR DESCRIPTION
## Summary
- default automation subscription creation to the active runtime chat thread when one exists
- expose the follow-up origin-context resolver so the route can forward current thread binding into subscription creation
- extend chat lab so it can create subscriptions, emit automation transitions, and assert the wake-up targets the current thread

## Root cause
The automation store already knows how to derive the correct lane and delivery target from `origin_thread_id` / `origin_lane_id`. The managed-thread subscription route was creating subscriptions from the request payload alone, so subscriptions created from an active Discord/PMA thread dropped that origin context and could not default to the current chat thread.

## Validation
- `./.venv/bin/pytest -q tests/test_pma_managed_threads_routes.py::test_create_subscription_defaults_to_current_runtime_chat_thread tests/chat_surface_lab/test_scenario_runner.py::test_runner_executes_subscription_defaults_to_current_thread`
- `./.venv/bin/pytest -q tests/chat_surface_lab/test_scenario_runner.py tests/test_pma_managed_threads_routes.py::test_create_subscription_defaults_to_current_runtime_chat_thread`
- `make test-chat-surface-lab`
- commit hook validation including repo pytest, frontend checks, and chat-surface latency budget checks