### PR TITLE
[codex] Handle missing Discord progress anchors

### DIFF
--- a/src/codex_autorunner/integrations/discord/errors.py
+++ b/src/codex_autorunner/integrations/discord/errors.py
@@ -45,3 +45,10 @@ def is_unknown_interaction_error(error: BaseException | str | None) -> bool:
         return False
     normalized = str(error).lower()
     return "unknown interaction" in normalized or "10062" in normalized
+
+
+def is_unknown_message_error(error: BaseException | str | None) -> bool:
+    if error is None:
+        return False
+    normalized = str(error).lower()
+    return "unknown message" in normalized or "10008" in normalized

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -92,7 +92,11 @@ from .components import (
     build_cancel_turn_custom_id,
     build_queued_turn_progress_buttons,
 )
-from .errors import DiscordTransientError
+from .errors import (
+    DiscordPermanentError,
+    DiscordTransientError,
+    is_unknown_message_error,
+)
 from .managed_thread_routing import (
     _build_discord_managed_thread_coordinator,
     _build_discord_queue_worker_hooks,
@@ -1769,6 +1773,7 @@ async def _run_discord_orchestrated_turn_for_message(
         remove_components: bool = False,
         render_mode: str = "live",
     ) -> None:
+        nonlocal progress_message_id
         if not progress_message_id:
             return
         now = time.monotonic()
@@ -1812,6 +1817,20 @@ async def _run_discord_orchestrated_turn_for_message(
                 message_id=progress_message_id,
                 payload=payload,
             )
+        except DiscordPermanentError as exc:
+            if not is_unknown_message_error(exc):
+                raise
+            _logger.info(
+                "Discord progress anchor disappeared for channel=%s message=%s",
+                channel_id,
+                progress_message_id,
+            )
+            projector.note_render_attempt(now=now)
+            await _delete_progress_lease()
+            progress_message_id = None
+            if supervision is not None:
+                supervision.clear_progress_tracking()
+            return
         except (DiscordTransientError, RuntimeError, ConnectionError, OSError):
             _logger.debug(
                 "Discord progress edit failed for message=%s",

--- a/src/codex_autorunner/integrations/discord/progress_leases.py
+++ b/src/codex_autorunner/integrations/discord/progress_leases.py
@@ -6,7 +6,11 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Optional, cast
 
-from .errors import DiscordTransientError
+from .errors import (
+    DiscordPermanentError,
+    DiscordTransientError,
+    is_unknown_message_error,
+)
 from .rendering import (
     format_discord_message,
     truncate_for_discord,
@@ -459,6 +463,10 @@ async def _retire_discord_progress_message(
                 "components": [],
             },
         )
+    except DiscordPermanentError as exc:
+        if is_unknown_message_error(exc):
+            return True
+        return False
     except (DiscordTransientError, RuntimeError, ConnectionError, OSError):
         return False
     return True
@@ -759,6 +767,10 @@ async def _acknowledge_discord_progress_reuse(
                 "components": [],
             },
         )
+    except DiscordPermanentError as exc:
+        if is_unknown_message_error(exc):
+            return False
+        raise
     except (DiscordTransientError, RuntimeError, ConnectionError, OSError):
         return False
     return True

--- a/src/codex_autorunner/integrations/discord/progress_leases.py
+++ b/src/codex_autorunner/integrations/discord/progress_leases.py
@@ -466,7 +466,7 @@ async def _retire_discord_progress_message(
     except DiscordPermanentError as exc:
         if is_unknown_message_error(exc):
             return True
-        return False
+        raise
     except (DiscordTransientError, RuntimeError, ConnectionError, OSError):
         return False
     return True

--- a/tests/chat_surface_lab/discord_simulator.py
+++ b/tests/chat_surface_lab/discord_simulator.py
@@ -7,7 +7,10 @@ from pathlib import Path
 from typing import Any, Optional
 
 from codex_autorunner.browser.runtime import BrowserRuntime
-from codex_autorunner.integrations.discord.errors import DiscordTransientError
+from codex_autorunner.integrations.discord.errors import (
+    DiscordPermanentError,
+    DiscordTransientError,
+)
 
 from .artifact_manifests import ArtifactManifest
 from .evidence_artifacts import write_surface_evidence_artifacts
@@ -24,6 +27,7 @@ class DiscordSimulatorFaults:
     """Fault injection knobs for Discord simulator operations."""
 
     fail_delete_message_ids: set[str] = field(default_factory=set)
+    fail_unknown_message_edit_ids: set[str] = field(default_factory=set)
     retry_after_schedule: dict[str, list[int]] = field(default_factory=dict)
     duplicate_interaction_ids: set[str] = field(default_factory=set)
 
@@ -44,11 +48,17 @@ class DiscordSurfaceSimulator:
             for value in base_faults.fail_delete_message_ids
             if str(value).strip()
         }
+        merged_unknown_edit_ids = {
+            str(value).strip()
+            for value in base_faults.fail_unknown_message_edit_ids
+            if str(value).strip()
+        }
         if fail_delete_message_ids:
             merged_fail_ids.update(
                 str(value).strip() for value in fail_delete_message_ids if str(value)
             )
         base_faults.fail_delete_message_ids = merged_fail_ids
+        base_faults.fail_unknown_message_edit_ids = merged_unknown_edit_ids
         self._faults = base_faults
         self.attachment_data_by_url: dict[str, bytes] = {
             str(url): bytes(data)
@@ -260,6 +270,24 @@ class DiscordSurfaceSimulator:
             operation="edit_channel_message",
             metadata={"channel_id": channel_id, "message_id": message_id},
         )
+        if message_id in self._faults.fail_unknown_message_edit_ids:
+            error = DiscordPermanentError(
+                "Discord API request failed for "
+                f"PATCH /channels/{channel_id}/messages/{message_id}: "
+                'status=404 body=\'{"message": "Unknown Message", "code": 10008}\''
+            )
+            self._record_event(
+                kind="error",
+                party=TranscriptParty.PLATFORM,
+                text=str(error),
+                metadata={
+                    "operation": "edit_channel_message",
+                    "fault": "unknown_message",
+                    "channel_id": channel_id,
+                    "message_id": message_id,
+                },
+            )
+            raise error
         payload_copy = dict(payload)
         self.edited_channel_messages.append(
             {

--- a/tests/chat_surface_lab/scenario_runner.py
+++ b/tests/chat_surface_lab/scenario_runner.py
@@ -477,19 +477,28 @@ class ChatSurfaceScenarioRunner:
             if not fault.surfaces or context.surface in fault.surfaces
         ]
         if context.surface == SurfaceKind.DISCORD:
-            fail_ids: set[str] = set()
+            fail_delete_ids: set[str] = set()
+            fail_unknown_edit_ids: set[str] = set()
             for fault in active_faults:
-                if fault.kind != "fail_progress_delete":
-                    continue
                 message_id = str(fault.parameters.get("message_id") or "msg-1")
-                fail_ids.add(message_id)
+                if fault.kind == "fail_progress_delete":
+                    fail_delete_ids.add(message_id)
+                    continue
+                if fault.kind == "fail_progress_edit_unknown_message":
+                    fail_unknown_edit_ids.add(message_id)
             retry_after_schedule = _collect_retry_after_schedule(active_faults)
             attachment_data_by_url = _collect_discord_attachment_data(scenario.actions)
-            if fail_ids or retry_after_schedule or attachment_data_by_url:
+            if (
+                fail_delete_ids
+                or fail_unknown_edit_ids
+                or retry_after_schedule
+                or attachment_data_by_url
+            ):
                 context.rest_client = FakeDiscordRest(
                     attachment_data_by_url=attachment_data_by_url,
                     faults=DiscordSimulatorFaults(
-                        fail_delete_message_ids=fail_ids,
+                        fail_delete_message_ids=fail_delete_ids,
+                        fail_unknown_message_edit_ids=fail_unknown_edit_ids,
                         retry_after_schedule=retry_after_schedule,
                     ),
                 )

--- a/tests/chat_surface_lab/scenarios/subscription_defaults_missing_progress_anchor.json
+++ b/tests/chat_surface_lab/scenarios/subscription_defaults_missing_progress_anchor.json
@@ -1,0 +1,145 @@
+{
+  "schema_version": 1,
+  "scenario_id": "subscription_defaults_missing_progress_anchor",
+  "description": "Subscriptions created from an active Discord chat still bind to the current thread, and the turn completes even if the progress anchor disappears before Discord can edit it.",
+  "surfaces": [
+    "discord"
+  ],
+  "runtime_fixture": {
+    "kind": "hermes",
+    "scenario": "official"
+  },
+  "actions": [
+    {
+      "kind": "send_message",
+      "actor": "user",
+      "payload": {
+        "text": "echo hello world"
+      }
+    },
+    {
+      "kind": "create_automation_subscription",
+      "actor": "user",
+      "payload": {
+        "event_type": "flow_completed",
+        "repo_id": "repo-1",
+        "run_id": "run-subscription-default"
+      }
+    },
+    {
+      "kind": "emit_automation_transition",
+      "actor": "system",
+      "payload": {
+        "event_type": "flow_completed",
+        "repo_id": "repo-1",
+        "run_id": "run-subscription-default",
+        "from_state": "running",
+        "to_state": "completed",
+        "reason": "surface-lab"
+      }
+    }
+  ],
+  "faults": [
+    {
+      "kind": "fail_progress_edit_unknown_message",
+      "target": "surface",
+      "surfaces": [
+        "discord"
+      ],
+      "parameters": {
+        "message_id": "msg-1"
+      }
+    }
+  ],
+  "expected_terminal": {
+    "status": "ok"
+  },
+  "transcript_invariants": [
+    {
+      "kind": "contains_text",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "Received. Preparing turn..."
+      }
+    },
+    {
+      "kind": "contains_text",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "fixture reply"
+      }
+    },
+    {
+      "kind": "event_kind_at_least",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "event_kind": "error",
+        "min_count": 1
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "subscription_lane_id",
+        "value": "discord"
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "subscription_delivery_surface_key",
+        "value": "channel-1"
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "transition_created_wakeups",
+        "value": 1
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "wakeup_lane_id",
+        "value": "discord"
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "wakeup_delivery_surface_key",
+        "value": "channel-1"
+      }
+    }
+  ],
+  "tags": [
+    "automation",
+    "discord",
+    "subscriptions",
+    "fault",
+    "pma"
+  ],
+  "notes": "Models the production-style Discord 10008 path where the progress anchor vanishes before an edit lands, without regressing subscription routing to the active chat thread."
+}

--- a/tests/chat_surface_lab/test_discord_simulator.py
+++ b/tests/chat_surface_lab/test_discord_simulator.py
@@ -4,7 +4,10 @@ from pathlib import Path
 
 import pytest
 
-from codex_autorunner.integrations.discord.errors import DiscordTransientError
+from codex_autorunner.integrations.discord.errors import (
+    DiscordPermanentError,
+    DiscordTransientError,
+)
 from tests.chat_surface_lab.artifact_manifests import ArtifactKind
 from tests.chat_surface_lab.discord_simulator import (
     DiscordSimulatorFaults,
@@ -156,6 +159,33 @@ async def test_simulator_injects_retry_after_and_delete_failure() -> None:
         event.get("kind") == "error"
         and event.get("metadata", {}).get("fault") == "delete_failed"
         for event in timeline
+    )
+
+
+@pytest.mark.anyio
+async def test_simulator_injects_unknown_message_edit_failure() -> None:
+    simulator = DiscordSurfaceSimulator(
+        faults=DiscordSimulatorFaults(
+            fail_unknown_message_edit_ids={"msg-1"},
+        )
+    )
+
+    await simulator.create_channel_message(
+        channel_id="channel-1",
+        payload={"content": "preview"},
+    )
+    with pytest.raises(DiscordPermanentError, match="Unknown Message"):
+        await simulator.edit_channel_message(
+            channel_id="channel-1",
+            message_id="msg-1",
+            payload={"content": "updated"},
+        )
+
+    assert any(
+        event.get("kind") == "error"
+        and event.get("metadata", {}).get("fault") == "unknown_message"
+        and event.get("metadata", {}).get("operation") == "edit_channel_message"
+        for event in simulator.surface_timeline
     )
 
 

--- a/tests/chat_surface_lab/test_scenario_runner.py
+++ b/tests/chat_surface_lab/test_scenario_runner.py
@@ -232,6 +232,40 @@ async def test_runner_executes_subscription_defaults_to_current_thread(
 
 
 @pytest.mark.anyio
+async def test_runner_executes_subscription_defaults_with_missing_progress_anchor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = load_scenario_by_id("subscription_defaults_missing_progress_anchor")
+    runner = ChatSurfaceScenarioRunner(
+        output_root=tmp_path / "scenario-runs",
+        apply_runtime_patch=lambda runtime: patch_hermes_runtime(monkeypatch, runtime),
+    )
+
+    result = await runner.run_scenario(scenario)
+    assert result.skipped is False
+    assert len(result.surface_results) == 1
+    discord = result.surface_results[0]
+    assert discord.surface.value == "discord"
+    assert discord.execution_status == "ok"
+    assert discord.transcript.metadata["subscription_lane_id"] == "discord"
+    assert (
+        discord.transcript.metadata["subscription_delivery_surface_key"] == "channel-1"
+    )
+    assert discord.transcript.metadata["wakeup_lane_id"] == "discord"
+    assert discord.transcript.metadata["wakeup_delivery_surface_key"] == "channel-1"
+    assert any(
+        event.metadata.get("fault") == "unknown_message"
+        and event.metadata.get("operation") == "edit_channel_message"
+        for event in discord.transcript.events
+    )
+    assert not any(
+        record.get("event") == "chat.managed_thread.queue_worker_execution_failed"
+        for record in discord.log_records
+    )
+
+
+@pytest.mark.anyio
 async def test_runner_executes_restart_window_duplicate_delivery(
     tmp_path: Path,
 ) -> None:

--- a/tests/integrations/discord/test_message_turns_transient_progress.py
+++ b/tests/integrations/discord/test_message_turns_transient_progress.py
@@ -16,7 +16,10 @@ from codex_autorunner.integrations.chat.managed_thread_progress_projector import
     ManagedThreadProgressProjector,
 )
 from codex_autorunner.integrations.chat.progress_primitives import TurnProgressTracker
-from codex_autorunner.integrations.discord.errors import DiscordTransientError
+from codex_autorunner.integrations.discord.errors import (
+    DiscordPermanentError,
+    DiscordTransientError,
+)
 
 pytestmark = pytest.mark.slow
 
@@ -32,6 +35,22 @@ class _TransientEditProgressRest(support._FakeRest):
         _ = channel_id, message_id, payload
         self.edit_attempts += 1
         raise DiscordTransientError("simulated transient progress edit failure")
+
+
+class _UnknownMessageEditProgressRest(support._FakeRest):
+    def __init__(self) -> None:
+        super().__init__()
+        self.edit_attempts = 0
+
+    async def edit_channel_message(
+        self, *, channel_id: str, message_id: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        _ = channel_id, message_id, payload
+        self.edit_attempts += 1
+        raise DiscordPermanentError(
+            "Discord API request failed for PATCH /channels/channel-1/messages/msg-1: "
+            'status=404 body=\'{"message": "Unknown Message", "code": 10008}\''
+        )
 
 
 @pytest.mark.asyncio
@@ -823,6 +842,127 @@ async def test_orchestrated_turn_ignores_transient_progress_edit_failures(
     tmp_path,
 ) -> None:
     rest = _TransientEditProgressRest()
+    thread = SimpleNamespace(thread_target_id="thread-1")
+    started_execution = SimpleNamespace(
+        execution=SimpleNamespace(status="running"),
+        thread=thread,
+    )
+
+    class _Store:
+        async def get_binding(self, *, channel_id: str) -> dict[str, Any]:
+            assert channel_id == "channel-1"
+            return {}
+
+    class _Service:
+        def __init__(self) -> None:
+            self._config = support._config(tmp_path)
+            self._store = _Store()
+            self._rest = rest
+            self._logger = logging.getLogger(__name__)
+
+        async def _send_channel_message(
+            self, channel_id: str, payload: dict[str, Any]
+        ) -> dict[str, Any]:
+            return await rest.create_channel_message(
+                channel_id=channel_id,
+                payload=payload,
+            )
+
+        def _register_discord_turn_approval_context(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+        def _clear_discord_turn_approval_context(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+        def _resolve_agent_state(self, binding: Any) -> tuple[str, Optional[str]]:
+            _ = binding
+            return "codex", None
+
+        def _runtime_agent_for_binding(self, binding: Any) -> str:
+            _ = binding
+            return "codex"
+
+    async def _fake_begin(*args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        return started_execution
+
+    async def _fake_complete(*args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        await asyncio.sleep(0.03)
+        return SimpleNamespace(
+            finalized={
+                "status": "ok",
+                "assistant_text": "done",
+                "token_usage": None,
+            }
+        )
+
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "resolve_discord_thread_target",
+        lambda *args, **kwargs: (SimpleNamespace(), thread),
+    )
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "begin_runtime_thread_execution",
+        _fake_begin,
+    )
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "complete_managed_thread_execution",
+        _fake_complete,
+    )
+
+    loop = asyncio.get_running_loop()
+    loop_errors: list[dict[str, Any]] = []
+    previous_handler = loop.get_exception_handler()
+
+    def _capture_exception(
+        _loop: asyncio.AbstractEventLoop, context: dict[str, Any]
+    ) -> None:
+        loop_errors.append(context)
+
+    loop.set_exception_handler(_capture_exception)
+    try:
+        result = await support.discord_message_turns_module._run_discord_orchestrated_turn_for_message(
+            _Service(),
+            workspace_root=tmp_path,
+            prompt_text="hi",
+            input_items=None,
+            source_message_id=None,
+            agent="codex",
+            model_override=None,
+            reasoning_effort=None,
+            session_key="s1",
+            orchestrator_channel_key="channel-1",
+            managed_thread_surface_key=None,
+            mode="pma",
+            pma_enabled=True,
+            execution_prompt="<user_message>\nhi\n</user_message>\n",
+            public_execution_error="err",
+            timeout_error="timeout",
+            interrupted_error="interrupt",
+            approval_mode="never",
+            sandbox_policy="dangerFullAccess",
+            max_actions=12,
+            min_edit_interval_seconds=0.0,
+            heartbeat_interval_seconds=0.01,
+        )
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert result.final_message == "done"
+    assert rest.edit_attempts >= 1
+    assert loop_errors == []
+
+
+@pytest.mark.asyncio
+async def test_orchestrated_turn_ignores_unknown_message_progress_edit_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    rest = _UnknownMessageEditProgressRest()
     thread = SimpleNamespace(thread_target_id="thread-1")
     started_execution = SimpleNamespace(
         execution=SimpleNamespace(status="running"),


### PR DESCRIPTION
## What changed
- treat Discord `Unknown Message` (`10008`) responses on progress-anchor edits and retirement as a non-fatal missing-anchor condition instead of failing the whole managed-thread turn
- clear the stale Discord progress lease/tracking state when that happens so final delivery can continue normally
- extend the chat lab Discord simulator and scenario runner with a production-style `Unknown Message` edit fault, plus a new subscription-routing scenario that proves the current-thread default still holds while the missing-anchor fault is exercised
- add regression coverage for both the runtime fix and the new lab scenario

## Why
A dogfood Discord run completed visibly in-channel but then reported a turn failure because Discord returned `PATCH /channels/.../messages/... -> 404 Unknown Message` while CAR was trying to edit the progress anchor. That should not fail the turn; it means the anchor is already gone.

The existing subscription chat-lab scenario also only checked wakeup metadata. It did not exercise a realistic Discord progress-anchor failure, so it could not catch this class of issue.

## Impact
- Discord managed-thread completions no longer flip to failed just because the progress message disappeared before an edit landed
- subscription-routing coverage is more realistic: the lab now proves we still default to the active Discord thread while surviving the same missing-anchor failure mode seen in production

## Validation
- `./.venv/bin/pytest -q tests/chat_surface_lab/test_discord_simulator.py -k "unknown_message_edit_failure or retry_after_and_delete_failure"`
- `./.venv/bin/pytest -q tests/chat_surface_lab/test_scenario_runner.py -k "subscription_defaults_to_current_thread or subscription_defaults_with_missing_progress_anchor"`
- `./.venv/bin/pytest -q tests/integrations/discord/test_message_turns_transient_progress.py -k "unknown_message_progress_edit_failures or transient_progress_edit_failures or reconcile_progress_lease_retries_when_retire_edit_fails"`
- full pre-commit aggregate lane: black, ruff, import checks, strict mypy, full pytest suite, static build/tests, deterministic chat-surface checks, chat latency budget suite