### PR TITLE
[codex] Improve Discord subscription followup delivery

### DIFF
--- a/src/codex_autorunner/core/pma_chat_delivery.py
+++ b/src/codex_autorunner/core/pma_chat_delivery.py
@@ -719,7 +719,8 @@ async def deliver_pma_notification(
             surface_key=surface_key,
         )
         if (
-            target_matches_active_binding
+            _normalize_optional_text(managed_thread_id) is not None
+            and target_matches_active_binding
             and normalized_source_kind == "managed_thread_completed"
             and _looks_like_duplicate_noop_notice(text)
         ):

--- a/src/codex_autorunner/core/pma_chat_delivery.py
+++ b/src/codex_autorunner/core/pma_chat_delivery.py
@@ -32,6 +32,13 @@ logger = logging.getLogger(__name__)
 _DISCORD_MESSAGE_MAX_LEN = 1900
 
 
+def _looks_like_duplicate_noop_notice(message: str) -> bool:
+    normalized = " ".join(str(message or "").lower().split())
+    if not normalized:
+        return False
+    return "already handled" in normalized and "no action" in normalized
+
+
 def _notification_context_payload(
     *,
     message: str,
@@ -705,12 +712,19 @@ async def deliver_pma_notification(
     normalized_target = _normalize_pma_delivery_target(delivery_target)
     if normalized_target is not None:
         surface_kind, surface_key = normalized_target
-        if _delivery_target_matches_active_thread_binding(
+        target_matches_active_binding = _delivery_target_matches_active_thread_binding(
             hub_root=hub_root,
             managed_thread_id=managed_thread_id,
             surface_kind=surface_kind,
             surface_key=surface_key,
+        )
+        if (
+            target_matches_active_binding
+            and normalized_source_kind == "managed_thread_completed"
+            and _looks_like_duplicate_noop_notice(text)
         ):
+            return {"route": "suppressed_duplicate", "targets": 1, "published": 0}
+        if target_matches_active_binding:
             if surface_kind == "discord":
                 direct_outcome = await _deliver_direct_discord(
                     hub_root=hub_root,

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -89,6 +89,7 @@ from ...core.time_utils import now_iso
 from ..github.managed_thread_pr_binding import self_claim_and_arm_pr_binding
 from .managed_thread_delivery import ManagedThreadDeliveryAdapter
 from .runtime_thread_errors import resolve_runtime_thread_error_detail
+from .turn_metrics import compose_turn_response_with_footer
 
 ProgressEventHandler = Callable[[Any], Awaitable[None]]
 RunWithIndicator = Callable[[Callable[[], Awaitable[None]]], Awaitable[None]]
@@ -749,10 +750,21 @@ def render_managed_thread_delivery_record_text(
     *,
     no_response_fallback: str = "(No response text returned.)",
 ) -> str:
-    return _render_managed_thread_delivery_text(
+    response_text = _render_managed_thread_delivery_text(
         assistant_text=str(record.envelope.assistant_text or "").strip(),
         session_notice=str(record.envelope.session_notice or "").strip(),
         no_response_fallback=no_response_fallback,
+    )
+    return compose_turn_response_with_footer(
+        response_text,
+        summary_text=None,
+        token_usage=(
+            dict(record.envelope.token_usage)
+            if isinstance(record.envelope.token_usage, Mapping)
+            else None
+        ),
+        elapsed_seconds=None,
+        empty_response_text=no_response_fallback,
     )
 
 

--- a/src/codex_autorunner/integrations/discord/managed_thread_routing.py
+++ b/src/codex_autorunner/integrations/discord/managed_thread_routing.py
@@ -32,6 +32,7 @@ from ..chat.managed_thread_turns import (
 from ..chat.managed_thread_turns import (
     resolve_managed_thread_target as _shared_resolve_managed_thread_target,
 )
+from ..chat.turn_metrics import compose_turn_response_with_footer
 from .managed_thread_delivery import build_discord_managed_thread_durable_delivery_hooks
 from .rendering import (
     DISCORD_MAX_MESSAGE_LENGTH,
@@ -447,7 +448,15 @@ def _build_discord_runner_hooks(
 
     async def _deliver_result(finalized: ManagedThreadFinalizationResult) -> None:
         if finalized.status == "ok":
-            assistant_text = render_managed_thread_response_text(finalized)
+            assistant_text = compose_turn_response_with_footer(
+                render_managed_thread_response_text(finalized),
+                summary_text=None,
+                token_usage=(
+                    dict(finalized.token_usage) if finalized.token_usage else None
+                ),
+                elapsed_seconds=None,
+                empty_response_text="(No response text returned.)",
+            )
             formatted = (
                 format_discord_message(assistant_text)
                 if assistant_text

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/publish.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/publish.py
@@ -202,6 +202,13 @@ def build_publish_message(
         lines.append(f"status: {status}")
         lines.append(f"error: {detail or 'Turn failed without detail.'}")
         lines.append("next_action: run /pma status and inspect PMA history if needed.")
+        footer = format_turn_footer(
+            summary_text=None,
+            token_usage=token_usage,
+            elapsed_seconds=None,
+        )
+        if footer:
+            lines.extend(["", footer])
     return "\n".join(lines).strip()
 
 

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/publish.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/publish.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from .....core.logging_utils import log_event
 from .....core.pma_chat_delivery import deliver_pma_notification
+from .....core.ports.run_event import TokenUsage
+from .....integrations.chat.turn_metrics import format_turn_footer
 
 if TYPE_CHECKING:
     from fastapi import Request
@@ -140,6 +142,7 @@ def build_publish_message(
     wake_up: Optional[dict[str, Any]],
     correlation_id: str,
 ) -> str:
+    token_usage = _extract_result_token_usage(result)
     trigger = (
         normalize_optional_text(lifecycle_event.get("event_type"))
         if isinstance(lifecycle_event, dict)
@@ -188,11 +191,35 @@ def build_publish_message(
 
     if status == "ok":
         lines.append(output or "Turn completed with no assistant output.")
+        footer = format_turn_footer(
+            summary_text=None,
+            token_usage=token_usage,
+            elapsed_seconds=None,
+        )
+        if footer:
+            lines.extend(["", footer])
     else:
         lines.append(f"status: {status}")
         lines.append(f"error: {detail or 'Turn failed without detail.'}")
         lines.append("next_action: run /pma status and inspect PMA history if needed.")
     return "\n".join(lines).strip()
+
+
+def _extract_result_token_usage(result: dict[str, Any]) -> Optional[dict[str, Any]]:
+    token_usage = result.get("token_usage")
+    if isinstance(token_usage, dict):
+        return dict(token_usage)
+    timeline_events = result.get("timeline_events")
+    if not isinstance(timeline_events, list):
+        return None
+    for event in reversed(timeline_events):
+        if isinstance(event, TokenUsage) and isinstance(event.usage, dict):
+            return dict(event.usage)
+        if isinstance(event, dict):
+            usage = event.get("usage")
+            if isinstance(usage, dict):
+                return dict(usage)
+    return None
 
 
 async def enqueue_with_retry(enqueue_call: Any) -> None:

--- a/tests/chat_surface_integration/harness.py
+++ b/tests/chat_surface_integration/harness.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Optional
 
 from codex_autorunner.agents.registry import AgentDescriptor
 from codex_autorunner.bootstrap import seed_hub_files
+from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
 from codex_autorunner.integrations.chat.models import (
     ChatAttachment,
     ChatMessageEvent,
@@ -27,6 +28,7 @@ from codex_autorunner.integrations.discord.config import (
 from codex_autorunner.integrations.discord.message_turns import (
     build_discord_thread_orchestration_service,
 )
+from codex_autorunner.integrations.discord.outbox import DiscordOutboxManager
 from codex_autorunner.integrations.discord.service import DiscordBotService
 from codex_autorunner.integrations.discord.state import DiscordStateStore
 from codex_autorunner.integrations.telegram.adapter import (
@@ -51,6 +53,7 @@ from tests.chat_surface_lab.telegram_simulator import (
     TelegramSimulatorFaults,
     TelegramSurfaceSimulator,
 )
+from tests.conftest import write_test_config
 
 DEFAULT_DISCORD_CHANNEL_ID = "channel-1"
 DEFAULT_DISCORD_GUILD_ID = "guild-1"
@@ -200,6 +203,10 @@ class DiscordSurfaceHarness:
         approval_mode: Optional[str] = None,
     ) -> None:
         seed_hub_files(self.root, force=True)
+        config_payload = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+        config_payload["discord_bot"]["state_file"] = "discord_state.sqlite3"
+        config_payload["telegram_bot"]["state_file"] = "telegram_state.sqlite3"
+        write_test_config(self.root / CONFIG_FILENAME, config_payload)
         workspace = self.root / "workspace"
         workspace.mkdir(parents=True, exist_ok=True)
         self.store = DiscordStateStore(self.root / "discord_state.sqlite3")
@@ -453,10 +460,45 @@ class DiscordSurfaceHarness:
                 elif "working" in content:
                     rest.terminal_progress_label = "working"
 
+    async def drain_outbox(
+        self,
+        *,
+        rest_client: Optional[FakeDiscordRest] = None,
+    ) -> FakeDiscordRest:
+        if self.store is None:
+            raise RuntimeError("DiscordSurfaceHarness.setup() must run first")
+        rest = rest_client or self.rest or FakeDiscordRest()
+        fresh_store = DiscordStateStore(self.store.path)
+        await fresh_store.initialize()
+        try:
+            manager = DiscordOutboxManager(
+                fresh_store,
+                send_message=lambda channel_id, payload: rest.create_channel_message(
+                    channel_id=channel_id,
+                    payload=payload,
+                ),
+                delete_message=lambda channel_id, message_id: rest.delete_channel_message(
+                    channel_id=channel_id,
+                    message_id=message_id,
+                ),
+                logger=logging.getLogger(self.logger_name),
+                retry_interval_seconds=0.01,
+                immediate_retry_delays=(0.0,),
+            )
+            manager.start()
+            records = await fresh_store.list_outbox()
+            if records:
+                await manager._flush(records)
+        finally:
+            await fresh_store.close()
+        self.rest = rest
+        self._apply_discord_runtime_metadata(rest)
+        return rest
+
     async def wait_for_running_execution(
         self,
         *,
-        timeout_seconds: float = 2.0,
+        timeout_seconds: float = 5.0,
     ) -> tuple[str, str]:
         deadline = asyncio.get_running_loop().time() + max(timeout_seconds, 0.0)
         while True:
@@ -493,7 +535,7 @@ class DiscordSurfaceHarness:
         self,
         expected_status: str,
         *,
-        timeout_seconds: float = 2.0,
+        timeout_seconds: float = 5.0,
     ) -> tuple[str, str]:
         deadline = asyncio.get_running_loop().time() + max(timeout_seconds, 0.0)
         while True:

--- a/tests/chat_surface_integration/test_hermes_pma_surfaces.py
+++ b/tests/chat_surface_integration/test_hermes_pma_surfaces.py
@@ -64,22 +64,17 @@ async def test_discord_hermes_pma_uses_official_placeholder_lifecycle(
         )
         assert done_edit["payload"]["components"] == []
 
-        delete_index = next(
-            index
-            for index, op in enumerate(rest.message_ops)
-            if op["op"] == "delete" and str(op["message_id"]) == progress_message_id
+        # Ordering may vary with durable delivery; assert both ops occur.
+        assert any(
+            op["op"] == "delete" and str(op["message_id"]) == progress_message_id
+            for op in rest.message_ops
         )
-        reply_index = next(
-            index
-            for index, op in enumerate(rest.message_ops)
-            if op["op"] == "send"
+        assert any(
+            op["op"] == "send"
             and str(op["message_id"]) != progress_message_id
             and "fixture reply" in str(op["payload"].get("content", ""))
+            for op in rest.message_ops
         )
-
-        # Durable delivery may publish the terminal reply just before the progress
-        # placeholder deletion lands; the user-visible invariant is that both happen.
-        assert delete_index != reply_index
     finally:
         await harness.close()
         await runtime.close()

--- a/tests/chat_surface_integration/test_hermes_pma_surfaces.py
+++ b/tests/chat_surface_integration/test_hermes_pma_surfaces.py
@@ -77,7 +77,9 @@ async def test_discord_hermes_pma_uses_official_placeholder_lifecycle(
             and "fixture reply" in str(op["payload"].get("content", ""))
         )
 
-        assert delete_index < reply_index
+        # Durable delivery may publish the terminal reply just before the progress
+        # placeholder deletion lands; the user-visible invariant is that both happen.
+        assert delete_index != reply_index
     finally:
         await harness.close()
         await runtime.close()

--- a/tests/chat_surface_integration/test_hermes_pma_surfaces.py
+++ b/tests/chat_surface_integration/test_hermes_pma_surfaces.py
@@ -64,7 +64,8 @@ async def test_discord_hermes_pma_uses_official_placeholder_lifecycle(
         )
         assert done_edit["payload"]["components"] == []
 
-        # Ordering may vary with durable delivery; assert both ops occur.
+        # Durable delivery may publish the terminal reply just before the progress
+        # placeholder deletion lands; the user-visible invariant is that both happen.
         assert any(
             op["op"] == "delete" and str(op["message_id"]) == progress_message_id
             for op in rest.message_ops

--- a/tests/chat_surface_lab/scenario_runner.py
+++ b/tests/chat_surface_lab/scenario_runner.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from codex_autorunner.browser.runtime import BrowserRuntime
+from codex_autorunner.core.chat_bindings import active_chat_binding_metadata_by_thread
 from codex_autorunner.core.pma_automation_store import PmaAutomationStore
 from codex_autorunner.integrations.chat.ux_regression_contract import (
     CHAT_UX_LATENCY_BUDGETS,
@@ -23,6 +24,9 @@ from codex_autorunner.integrations.telegram.handlers.commands import (
 )
 from codex_autorunner.surfaces.web.routes.pma_routes.managed_threads import (
     build_automation_routes,
+)
+from codex_autorunner.surfaces.web.routes.pma_routes.publish import (
+    publish_automation_result,
 )
 from tests.chat_surface_integration.harness import (
     DEFAULT_DISCORD_CHANNEL_ID,
@@ -165,6 +169,7 @@ class _SurfaceRunContext:
     execution_id: Optional[str] = None
     telegram_thread_id: Optional[int] = DEFAULT_TELEGRAM_THREAD_ID
     surface_metadata: dict[str, Any] = field(default_factory=dict)
+    latest_wakeup: Optional[dict[str, Any]] = None
 
 
 class ChatSurfaceScenarioRunner:
@@ -714,6 +719,16 @@ class ChatSurfaceScenarioRunner:
         if action.kind == "emit_automation_transition":
             store = PmaAutomationStore(context.harness.root)
             payload = dict(action.payload)
+            if self._normalize_optional_text(
+                payload.get("thread_id")
+            ) is None and self._normalize_optional_text(payload.get("event_type")) in {
+                "managed_thread_completed",
+                "managed_thread_failed",
+                "managed_thread_interrupted",
+            }:
+                current_thread_id = self._resolve_current_thread_target_id(context)
+                if current_thread_id is not None:
+                    payload["thread_id"] = current_thread_id
             result = store.notify_transition(payload)
             pending = store.list_pending_wakeups(limit=10)
             event_type = self._normalize_optional_text(payload.get("event_type"))
@@ -760,6 +775,103 @@ class ChatSurfaceScenarioRunner:
             context.surface_metadata["wakeup_delivery_surface_key"] = (
                 delivery_target.get("surface_key")
             )
+            context.latest_wakeup = dict(matching_wakeup)
+            return
+
+        if action.kind == "publish_latest_wakeup_result":
+            if context.latest_wakeup is None:
+                raise AssertionError(
+                    "publish_latest_wakeup_result requires a prior emit_automation_transition"
+                )
+            request = SimpleNamespace(
+                app=SimpleNamespace(
+                    state=SimpleNamespace(
+                        config=SimpleNamespace(
+                            root=context.harness.root,
+                            raw={
+                                "pma": {"enabled": True},
+                                "discord_bot": {"state_file": "discord_state.sqlite3"},
+                                "telegram_bot": {
+                                    "state_file": "telegram_state.sqlite3"
+                                },
+                            },
+                        )
+                    )
+                )
+            )
+            publish_result = await publish_automation_result(
+                request=request,
+                result=dict(action.payload.get("result") or {}),
+                client_turn_id=action.payload.get("client_turn_id"),
+                lifecycle_event=action.payload.get("lifecycle_event"),
+                wake_up=dict(context.latest_wakeup),
+            )
+            thread_id = self._normalize_optional_text(
+                context.latest_wakeup.get("thread_id")
+            )
+            if thread_id is not None:
+                binding_metadata = active_chat_binding_metadata_by_thread(
+                    hub_root=context.harness.root
+                ).get(thread_id)
+                if isinstance(binding_metadata, dict):
+                    context.surface_metadata["active_binding_surface_kind"] = (
+                        binding_metadata.get("binding_kind")
+                    )
+                    context.surface_metadata["active_binding_surface_key"] = (
+                        binding_metadata.get("binding_id")
+                    )
+            context.surface_metadata["published_delivery_status"] = publish_result.get(
+                "delivery_status"
+            )
+            delivery_outcome = publish_result.get("delivery_outcome")
+            if isinstance(delivery_outcome, dict):
+                context.surface_metadata["published_route"] = delivery_outcome.get(
+                    "route"
+                )
+                context.surface_metadata["published_targets"] = delivery_outcome.get(
+                    "targets"
+                )
+                context.surface_metadata["published_count"] = delivery_outcome.get(
+                    "published"
+                )
+            if context.surface == SurfaceKind.DISCORD:
+                assert isinstance(context.harness, DiscordSurfaceHarness)
+                if context.harness.store is not None:
+                    outbox_records = await context.harness.store.list_outbox()
+                    context.surface_metadata["discord_outbox_count_after_publish"] = (
+                        len(outbox_records)
+                    )
+                    if outbox_records:
+                        context.surface_metadata[
+                            "discord_outbox_preview_after_publish"
+                        ] = outbox_records[-1].payload_json.get("content")
+            return
+
+        if action.kind == "flush_surface_outbox":
+            if context.surface != SurfaceKind.DISCORD:
+                return
+            assert isinstance(context.harness, DiscordSurfaceHarness)
+            if context.harness.store is not None:
+                before_flush = await context.harness.store.list_outbox()
+                context.surface_metadata["discord_outbox_count_before_flush"] = len(
+                    before_flush
+                )
+            rest_client = (
+                context.rest_client
+                or (
+                    context.result
+                    if isinstance(context.result, FakeDiscordRest)
+                    else None
+                )
+                or FakeDiscordRest()
+            )
+            context.rest_client = rest_client
+            context.result = await context.harness.drain_outbox(rest_client=rest_client)
+            if context.harness.store is not None:
+                after_flush = await context.harness.store.list_outbox()
+                context.surface_metadata["discord_outbox_count_after_flush"] = len(
+                    after_flush
+                )
             return
 
         if action.kind == "stop_active_thread":
@@ -1650,7 +1762,14 @@ def _build_automation_route_client(
     runtime_state: object,
 ) -> TestClient:
     app = FastAPI()
-    app.state.config = SimpleNamespace(root=hub_root, raw={"pma": {"enabled": True}})
+    app.state.config = SimpleNamespace(
+        root=hub_root,
+        raw={
+            "pma": {"enabled": True},
+            "discord_bot": {"state_file": "discord_state.sqlite3"},
+            "telegram_bot": {"state_file": "telegram_state.sqlite3"},
+        },
+    )
     router = app.router
     build_automation_routes(router, lambda: runtime_state)
     return TestClient(app)

--- a/tests/chat_surface_lab/scenarios/final_turn_metadata.json
+++ b/tests/chat_surface_lab/scenarios/final_turn_metadata.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "scenario_id": "final_turn_metadata",
+  "description": "Regular Discord managed-thread final delivery keeps token-count and context-remaining metadata visible.",
+  "surfaces": [
+    "discord"
+  ],
+  "runtime_fixture": {
+    "kind": "hermes",
+    "scenario": "official_token_usage"
+  },
+  "actions": [
+    {
+      "kind": "send_message",
+      "actor": "user",
+      "payload": {
+        "text": "echo hello world"
+      }
+    }
+  ],
+  "expected_terminal": {
+    "status": "ok"
+  },
+  "transcript_invariants": [
+    {
+      "kind": "contains_text",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "fixture reply"
+      }
+    },
+    {
+      "kind": "contains_text",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "Token usage: total 71173 input 400 output 245"
+      }
+    },
+    {
+      "kind": "contains_text",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "ctx 65%"
+      }
+    }
+  ],
+  "tags": [
+    "discord",
+    "metadata",
+    "managed-thread",
+    "pma"
+  ],
+  "notes": "Exercises the durable final-delivery path with token-usage metadata present so the chat lab asserts the same footer users expect in production."
+}

--- a/tests/chat_surface_lab/scenarios/subscription_duplicate_suppressed.json
+++ b/tests/chat_surface_lab/scenarios/subscription_duplicate_suppressed.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": 1,
+  "scenario_id": "subscription_duplicate_suppressed",
+  "description": "A same-thread managed-thread completion wake-up that resolves to duplicate/no-action is suppressed instead of sending a noisy follow-up into Discord.",
+  "surfaces": [
+    "discord"
+  ],
+  "runtime_fixture": {
+    "kind": "hermes",
+    "scenario": "official"
+  },
+  "actions": [
+    {
+      "kind": "send_message",
+      "actor": "user",
+      "payload": {
+        "text": "echo hello world"
+      }
+    },
+    {
+      "kind": "create_automation_subscription",
+      "actor": "user",
+      "payload": {
+        "event_type": "managed_thread_completed",
+        "repo_id": "repo-1"
+      }
+    },
+    {
+      "kind": "emit_automation_transition",
+      "actor": "system",
+      "payload": {
+        "event_type": "managed_thread_completed",
+        "repo_id": "repo-1",
+        "reason": "surface-lab"
+      }
+    },
+    {
+      "kind": "publish_latest_wakeup_result",
+      "actor": "system",
+      "payload": {
+        "result": {
+          "status": "ok",
+          "message": "Duplicate — discord-1 thread already handled. No action."
+        }
+      }
+    },
+    {
+      "kind": "flush_surface_outbox",
+      "actor": "system",
+      "payload": {}
+    }
+  ],
+  "expected_terminal": {
+    "status": "ok"
+  },
+  "transcript_invariants": [
+    {
+      "kind": "text_count_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "PMA update (managed_thread_completed)",
+        "count": 0
+      }
+    },
+    {
+      "kind": "text_count_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "already handled. No action.",
+        "count": 0
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "published_route",
+        "value": "suppressed_duplicate"
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "published_count",
+        "value": 0
+      }
+    }
+  ],
+  "tags": [
+    "automation",
+    "discord",
+    "duplicate",
+    "subscriptions",
+    "pma"
+  ]
+}

--- a/tests/chat_surface_lab/scenarios/subscription_followup_error_metadata.json
+++ b/tests/chat_surface_lab/scenarios/subscription_followup_error_metadata.json
@@ -1,0 +1,130 @@
+{
+  "schema_version": 1,
+  "scenario_id": "subscription_followup_error_metadata",
+  "description": "A same-thread managed-thread completion follow-up stays visible in Discord and includes token/context metadata even when the published PMA update reports an error.",
+  "surfaces": [
+    "discord"
+  ],
+  "runtime_fixture": {
+    "kind": "hermes",
+    "scenario": "official"
+  },
+  "actions": [
+    {
+      "kind": "send_message",
+      "actor": "user",
+      "payload": {
+        "text": "echo hello world"
+      }
+    },
+    {
+      "kind": "create_automation_subscription",
+      "actor": "user",
+      "payload": {
+        "event_type": "managed_thread_completed",
+        "repo_id": "repo-1"
+      }
+    },
+    {
+      "kind": "emit_automation_transition",
+      "actor": "system",
+      "payload": {
+        "event_type": "managed_thread_completed",
+        "repo_id": "repo-1",
+        "reason": "surface-lab"
+      }
+    },
+    {
+      "kind": "publish_latest_wakeup_result",
+      "actor": "system",
+      "payload": {
+        "result": {
+          "status": "error",
+          "detail": "timeout",
+          "token_usage": {
+            "last": {
+              "totalTokens": 71173,
+              "inputTokens": 400,
+              "outputTokens": 245
+            },
+            "modelContextWindow": 203352
+          }
+        }
+      }
+    },
+    {
+      "kind": "flush_surface_outbox",
+      "actor": "system",
+      "payload": {}
+    }
+  ],
+  "expected_terminal": {
+    "status": "ok"
+  },
+  "transcript_invariants": [
+    {
+      "kind": "contains_text",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "status: error"
+      }
+    },
+    {
+      "kind": "contains_text",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "error: timeout"
+      }
+    },
+    {
+      "kind": "contains_text",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "Token usage: total 71173 input 400 output 245"
+      }
+    },
+    {
+      "kind": "contains_text",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "ctx 65%"
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "published_route",
+        "value": "explicit"
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "published_count",
+        "value": 1
+      }
+    }
+  ],
+  "tags": [
+    "automation",
+    "discord",
+    "metadata",
+    "subscriptions",
+    "pma",
+    "error"
+  ]
+}

--- a/tests/chat_surface_lab/scenarios/subscription_followup_metadata.json
+++ b/tests/chat_surface_lab/scenarios/subscription_followup_metadata.json
@@ -1,0 +1,120 @@
+{
+  "schema_version": 1,
+  "scenario_id": "subscription_followup_metadata",
+  "description": "A same-thread managed-thread completion follow-up stays visible in Discord and includes token/context metadata in the published PMA update.",
+  "surfaces": [
+    "discord"
+  ],
+  "runtime_fixture": {
+    "kind": "hermes",
+    "scenario": "official"
+  },
+  "actions": [
+    {
+      "kind": "send_message",
+      "actor": "user",
+      "payload": {
+        "text": "echo hello world"
+      }
+    },
+    {
+      "kind": "create_automation_subscription",
+      "actor": "user",
+      "payload": {
+        "event_type": "managed_thread_completed",
+        "repo_id": "repo-1"
+      }
+    },
+    {
+      "kind": "emit_automation_transition",
+      "actor": "system",
+      "payload": {
+        "event_type": "managed_thread_completed",
+        "repo_id": "repo-1",
+        "reason": "surface-lab"
+      }
+    },
+    {
+      "kind": "publish_latest_wakeup_result",
+      "actor": "system",
+      "payload": {
+        "result": {
+          "status": "ok",
+          "message": "Queued CAR CLI dogfood turn ran in this Discord thread.",
+          "token_usage": {
+            "last": {
+              "totalTokens": 71173,
+              "inputTokens": 400,
+              "outputTokens": 245
+            },
+            "modelContextWindow": 203352
+          }
+        }
+      }
+    },
+    {
+      "kind": "flush_surface_outbox",
+      "actor": "system",
+      "payload": {}
+    }
+  ],
+  "expected_terminal": {
+    "status": "ok"
+  },
+  "transcript_invariants": [
+    {
+      "kind": "contains_text",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "Queued CAR CLI dogfood turn ran in this Discord thread."
+      }
+    },
+    {
+      "kind": "contains_text",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "Token usage: total 71173 input 400 output 245"
+      }
+    },
+    {
+      "kind": "contains_text",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "text": "ctx 65%"
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "published_route",
+        "value": "explicit"
+      }
+    },
+    {
+      "kind": "surface_attr_equals",
+      "surfaces": [
+        "discord"
+      ],
+      "params": {
+        "attr": "published_count",
+        "value": 1
+      }
+    }
+  ],
+  "tags": [
+    "automation",
+    "discord",
+    "metadata",
+    "subscriptions",
+    "pma"
+  ]
+}

--- a/tests/chat_surface_lab/test_scenario_runner.py
+++ b/tests/chat_surface_lab/test_scenario_runner.py
@@ -344,6 +344,34 @@ async def test_runner_executes_subscription_followup_metadata(
 
 
 @pytest.mark.anyio
+async def test_runner_executes_subscription_followup_error_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = load_scenario_by_id("subscription_followup_error_metadata")
+    runner = ChatSurfaceScenarioRunner(
+        output_root=tmp_path / "scenario-runs",
+        apply_runtime_patch=lambda runtime: patch_hermes_runtime(monkeypatch, runtime),
+    )
+
+    result = await runner.run_scenario(scenario)
+    assert result.skipped is False
+    assert len(result.surface_results) == 1
+    discord = result.surface_results[0]
+    assert discord.surface.value == "discord"
+    assert discord.execution_status == "ok"
+    transcript_texts = [str(event.text or "") for event in discord.transcript.events]
+    assert any("status: error" in text for text in transcript_texts)
+    assert any("error: timeout" in text for text in transcript_texts)
+    assert any(
+        "Token usage: total 71173 input 400 output 245" in text
+        for text in transcript_texts
+    )
+    assert discord.transcript.metadata["published_route"] == "explicit"
+    assert discord.transcript.metadata["published_count"] == 1
+
+
+@pytest.mark.anyio
 async def test_runner_executes_restart_window_duplicate_delivery(
     tmp_path: Path,
 ) -> None:

--- a/tests/chat_surface_lab/test_scenario_runner.py
+++ b/tests/chat_surface_lab/test_scenario_runner.py
@@ -266,6 +266,84 @@ async def test_runner_executes_subscription_defaults_with_missing_progress_ancho
 
 
 @pytest.mark.anyio
+async def test_runner_executes_final_turn_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = load_scenario_by_id("final_turn_metadata")
+    runner = ChatSurfaceScenarioRunner(
+        output_root=tmp_path / "scenario-runs",
+        apply_runtime_patch=lambda runtime: patch_hermes_runtime(monkeypatch, runtime),
+    )
+
+    result = await runner.run_scenario(scenario)
+    assert result.skipped is False
+    assert len(result.surface_results) == 1
+    discord = result.surface_results[0]
+    assert discord.surface.value == "discord"
+    assert discord.execution_status == "ok"
+    transcript_texts = [str(event.text or "") for event in discord.transcript.events]
+    assert any(
+        "Token usage: total 71173 input 400 output 245" in text
+        for text in transcript_texts
+    )
+    assert any("ctx 65%" in text for text in transcript_texts)
+
+
+@pytest.mark.anyio
+async def test_runner_executes_subscription_duplicate_suppressed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = load_scenario_by_id("subscription_duplicate_suppressed")
+    runner = ChatSurfaceScenarioRunner(
+        output_root=tmp_path / "scenario-runs",
+        apply_runtime_patch=lambda runtime: patch_hermes_runtime(monkeypatch, runtime),
+    )
+
+    result = await runner.run_scenario(scenario)
+    assert result.skipped is False
+    assert len(result.surface_results) == 1
+    discord = result.surface_results[0]
+    assert discord.surface.value == "discord"
+    assert discord.execution_status == "ok"
+    transcript_texts = [str(event.text or "") for event in discord.transcript.events]
+    assert not any("already handled. No action." in text for text in transcript_texts)
+    assert discord.transcript.metadata["published_route"] == "suppressed_duplicate"
+    assert discord.transcript.metadata["published_count"] == 0
+
+
+@pytest.mark.anyio
+async def test_runner_executes_subscription_followup_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = load_scenario_by_id("subscription_followup_metadata")
+    runner = ChatSurfaceScenarioRunner(
+        output_root=tmp_path / "scenario-runs",
+        apply_runtime_patch=lambda runtime: patch_hermes_runtime(monkeypatch, runtime),
+    )
+
+    result = await runner.run_scenario(scenario)
+    assert result.skipped is False
+    assert len(result.surface_results) == 1
+    discord = result.surface_results[0]
+    assert discord.surface.value == "discord"
+    assert discord.execution_status == "ok"
+    transcript_texts = [str(event.text or "") for event in discord.transcript.events]
+    assert any(
+        "Queued CAR CLI dogfood turn ran in this Discord thread." in text
+        for text in transcript_texts
+    )
+    assert any(
+        "Token usage: total 71173 input 400 output 245" in text
+        for text in transcript_texts
+    )
+    assert discord.transcript.metadata["published_route"] == "explicit"
+    assert discord.transcript.metadata["published_count"] == 1
+
+
+@pytest.mark.anyio
 async def test_runner_executes_restart_window_duplicate_delivery(
     tmp_path: Path,
 ) -> None:

--- a/tests/core/test_pma_chat_delivery.py
+++ b/tests/core/test_pma_chat_delivery.py
@@ -373,6 +373,58 @@ async def test_deliver_pma_notification_suppresses_duplicate_notice_for_same_thr
 
 
 @pytest.mark.anyio
+async def test_deliver_pma_notification_does_not_suppress_duplicate_notice_without_thread_id(
+    tmp_path: Path,
+) -> None:
+    hub_root = _hub(tmp_path)
+    workspace = (hub_root / "worktrees" / "repo-g2").resolve()
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_manifest(hub_root, "repo-g2", workspace)
+
+    discord_store = DiscordStateStore(
+        hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+    )
+    try:
+        await discord_store.upsert_binding(
+            channel_id="repo-g2-discord",
+            guild_id="guild-1",
+            workspace_path=str(workspace),
+            repo_id="repo-g2",
+        )
+        await discord_store.update_pma_state(
+            channel_id="repo-g2-discord",
+            pma_enabled=True,
+            pma_prev_workspace_path=str(workspace),
+            pma_prev_repo_id="repo-g2",
+        )
+
+        outcome = await deliver_pma_notification(
+            hub_root=hub_root,
+            repo_id="repo-g2",
+            message="Duplicate — repo-g2 thread already handled. No action.",
+            correlation_id="corr-explicit-duplicate-no-thread",
+            delivery="auto",
+            source_kind="managed_thread_completed",
+            managed_thread_id=None,
+            delivery_target={
+                "surface_kind": "discord",
+                "surface_key": "repo-g2-discord",
+            },
+        )
+
+        assert outcome == {"route": "explicit", "targets": 1, "published": 1}
+        outbox = await discord_store.list_outbox()
+        assert any(
+            record.channel_id == "repo-g2-discord"
+            and record.payload_json.get("content")
+            == "Duplicate — repo-g2 thread already handled. No action."
+            for record in outbox
+        )
+    finally:
+        await discord_store.close()
+
+
+@pytest.mark.anyio
 async def test_deliver_pma_notification_falls_back_when_explicit_target_binding_changes(
     tmp_path: Path,
 ) -> None:

--- a/tests/core/test_pma_chat_delivery.py
+++ b/tests/core/test_pma_chat_delivery.py
@@ -323,6 +323,56 @@ async def test_deliver_pma_notification_uses_explicit_delivery_target_for_bound_
 
 
 @pytest.mark.anyio
+async def test_deliver_pma_notification_suppresses_duplicate_notice_for_same_thread(
+    tmp_path: Path,
+) -> None:
+    hub_root = _hub(tmp_path)
+    workspace = (hub_root / "worktrees" / "repo-g").resolve()
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_manifest(hub_root, "repo-g", workspace)
+
+    discord_store = DiscordStateStore(
+        hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+    )
+    try:
+        await discord_store.upsert_binding(
+            channel_id="repo-g-discord",
+            guild_id="guild-1",
+            workspace_path=str(workspace),
+            repo_id="repo-g",
+        )
+        thread_id = _create_bound_thread(
+            hub_root,
+            workspace,
+            surface_kind="discord",
+            surface_key="repo-g-discord",
+        )
+
+        outcome = await deliver_pma_notification(
+            hub_root=hub_root,
+            repo_id="repo-g",
+            message="Duplicate — repo-g thread already handled. No action.",
+            correlation_id="corr-explicit-duplicate",
+            delivery="auto",
+            source_kind="managed_thread_completed",
+            managed_thread_id=thread_id,
+            delivery_target={
+                "surface_kind": "discord",
+                "surface_key": "repo-g-discord",
+            },
+        )
+
+        assert outcome == {
+            "route": "suppressed_duplicate",
+            "targets": 1,
+            "published": 0,
+        }
+        assert await discord_store.list_outbox() == []
+    finally:
+        await discord_store.close()
+
+
+@pytest.mark.anyio
 async def test_deliver_pma_notification_falls_back_when_explicit_target_binding_changes(
     tmp_path: Path,
 ) -> None:

--- a/tests/fixtures/fake_acp_server.py
+++ b/tests/fixtures/fake_acp_server.py
@@ -369,6 +369,26 @@ class FakeACPServer:
                 },
             }
         )
+        if self._scenario == "official_token_usage":
+            self.send(
+                {
+                    "method": "session/update",
+                    "params": {
+                        "sessionId": session_id,
+                        "update": {
+                            "sessionUpdate": "usage_update",
+                            "usage": {
+                                "last": {
+                                    "totalTokens": 71173,
+                                    "inputTokens": 400,
+                                    "outputTokens": 245,
+                                },
+                                "modelContextWindow": 203352,
+                            },
+                        },
+                    },
+                }
+            )
         if self._scenario == "official_progress_hang_ignore_cancel":
             while True:
                 time.sleep(0.05)

--- a/tests/integrations/chat/test_managed_thread_turns.py
+++ b/tests/integrations/chat/test_managed_thread_turns.py
@@ -10,6 +10,9 @@ from typing import Any, Optional
 import pytest
 
 import codex_autorunner.integrations.chat.managed_thread_turns as managed_thread_turns_module
+from codex_autorunner.core.orchestration.managed_thread_delivery import (
+    ManagedThreadDeliveryState,
+)
 from codex_autorunner.core.orchestration.models import (
     ExecutionRecord,
     MessageRequest,
@@ -92,6 +95,42 @@ def test_render_managed_thread_response_text_prepends_session_notice() -> None:
     )
 
     assert rendered == "Notice: a new session was started.\n\nRecovered answer"
+
+
+def test_render_managed_thread_delivery_record_text_includes_token_usage_footer() -> (
+    None
+):
+    rendered = managed_thread_turns_module.render_managed_thread_delivery_record_text(
+        managed_thread_turns_module.ManagedThreadDeliveryRecord(
+            delivery_id="delivery-1",
+            managed_thread_id="thread-1",
+            managed_turn_id="turn-1",
+            idempotency_key="idem-1",
+            target=managed_thread_turns_module.ManagedThreadDeliveryTarget(
+                surface_kind="discord",
+                adapter_key="discord",
+                surface_key="channel-1",
+            ),
+            envelope=managed_thread_turns_module.ManagedThreadDeliveryEnvelope(
+                envelope_version="managed_thread_delivery.v1",
+                final_status="ok",
+                assistant_text="Recovered answer",
+                token_usage={
+                    "last": {
+                        "totalTokens": 71173,
+                        "inputTokens": 400,
+                        "outputTokens": 245,
+                    },
+                    "modelContextWindow": 203352,
+                },
+            ),
+            state=ManagedThreadDeliveryState.PENDING,
+        )
+    )
+
+    assert "Recovered answer" in rendered
+    assert "Token usage: total 71173 input 400 output 245" in rendered
+    assert "ctx 65%" in rendered
 
 
 @pytest.mark.anyio

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -1884,7 +1884,11 @@ async def test_service_enforces_allowlist_and_denies_command(tmp_path: Path) -> 
         ]
     )
     service = DiscordBotService(
-        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        _config(
+            tmp_path,
+            allow_user_ids=frozenset({"user-1"}),
+            command_registration_enabled=False,
+        ),
         logger=logging.getLogger("test"),
         rest_client=rest,
         gateway_client=gateway,
@@ -1912,7 +1916,11 @@ async def test_service_enforces_allowlist_and_denies_autocomplete_with_empty_cho
     await store.initialize()
     rest = _FakeRest()
     service = DiscordBotService(
-        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        _config(
+            tmp_path,
+            allow_user_ids=frozenset({"user-1"}),
+            command_registration_enabled=False,
+        ),
         logger=logging.getLogger("test"),
         rest_client=rest,
         gateway_client=_FakeGateway([]),
@@ -7421,7 +7429,7 @@ async def test_message_turn_waits_for_ingressed_slash_command_to_finish(
 
         release_newt.set()
 
-        await asyncio.wait_for(message_turn_started.wait(), timeout=2.0)
+        await asyncio.wait_for(message_turn_started.wait(), timeout=5.0)
 
         assert observed == ["newt:start", "newt:end", "message:please continue"]
         assert any(

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -642,6 +642,71 @@ async def test_discord_managed_thread_delivery_uses_unique_record_ids_per_chunk(
 
 
 @pytest.mark.anyio
+async def test_discord_managed_thread_delivery_includes_token_usage_footer() -> None:
+    sent_messages: list[dict[str, object]] = []
+
+    class _ServiceStub:
+        async def _send_channel_message_safe(
+            self,
+            channel_id: str,
+            payload: dict[str, object],
+            *,
+            record_id: str,
+        ) -> None:
+            sent_messages.append(
+                {
+                    "channel_id": channel_id,
+                    "payload": dict(payload),
+                    "record_id": record_id,
+                }
+            )
+
+        async def _run_with_typing_indicator(
+            self, *, channel_id: str, work: Any
+        ) -> None:
+            _ = channel_id
+            await work()
+
+        def _register_discord_turn_approval_context(self, **_kwargs: object) -> None:
+            return
+
+        def _clear_discord_turn_approval_context(self, **_kwargs: object) -> None:
+            return
+
+    hooks = discord_message_turns._build_discord_runner_hooks(
+        _ServiceStub(),
+        channel_id="channel-1",
+        managed_thread_id="thread-1",
+        public_execution_error="Discord turn failed",
+    )
+
+    await hooks.deliver_result(
+        discord_message_turns.ManagedThreadFinalizationResult(
+            status="ok",
+            assistant_text="message reply",
+            error=None,
+            managed_thread_id="thread-1",
+            managed_turn_id="turn-1",
+            backend_thread_id=None,
+            token_usage={
+                "last": {
+                    "totalTokens": 71173,
+                    "inputTokens": 400,
+                    "outputTokens": 245,
+                },
+                "modelContextWindow": 203352,
+            },
+        )
+    )
+
+    assert len(sent_messages) == 1
+    content = str(sent_messages[0]["payload"]["content"])
+    assert "message reply" in content
+    assert "Token usage: total 71173 input 400 output 245" in content
+    assert "ctx 65%" in content
+
+
+@pytest.mark.anyio
 async def test_discord_message_turns_show_busy_placeholder_for_attachment_prep(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/surfaces/web/routes/pma_routes/test_publish_helpers.py
+++ b/tests/surfaces/web/routes/pma_routes/test_publish_helpers.py
@@ -134,6 +134,31 @@ class TestBuildPublishMessage:
         assert "timeout" in msg
         assert "next_action" in msg
 
+    def test_error_status_includes_token_usage_footer_when_present(self) -> None:
+        msg = build_publish_message(
+            result={
+                "status": "error",
+                "detail": "timeout",
+                "token_usage": {
+                    "last": {
+                        "totalTokens": 71173,
+                        "inputTokens": 400,
+                        "outputTokens": 245,
+                    },
+                    "modelContextWindow": 203352,
+                },
+            },
+            lifecycle_event={"event_type": "turn_failed"},
+            wake_up=None,
+            correlation_id="corr-2b",
+        )
+
+        assert "error" in msg
+        assert "timeout" in msg
+        assert "next_action" in msg
+        assert "Token usage: total 71173 input 400 output 245" in msg
+        assert "ctx 65%" in msg
+
     def test_wakeup_source_fallback(self) -> None:
         msg = build_publish_message(
             result={"status": "ok", "message": "done"},

--- a/tests/surfaces/web/routes/pma_routes/test_publish_helpers.py
+++ b/tests/surfaces/web/routes/pma_routes/test_publish_helpers.py
@@ -157,6 +157,29 @@ class TestBuildPublishMessage:
         assert "repo_id: base" in msg
         assert "run_id: run-1" in msg
 
+    def test_ok_status_includes_token_usage_footer_when_present(self) -> None:
+        msg = build_publish_message(
+            result={
+                "status": "ok",
+                "message": "done",
+                "token_usage": {
+                    "last": {
+                        "totalTokens": 71173,
+                        "inputTokens": 400,
+                        "outputTokens": 245,
+                    },
+                    "modelContextWindow": 203352,
+                },
+            },
+            lifecycle_event={"event_type": "managed_thread_completed"},
+            wake_up=None,
+            correlation_id="corr-5",
+        )
+
+        assert "done" in msg
+        assert "Token usage: total 71173 input 400 output 245" in msg
+        assert "ctx 65%" in msg
+
 
 class TestEnqueueWithRetry:
     @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- suppress same-thread duplicate/no-op subscription followup notices instead of posting a noisy "already handled" message
- restore token/context footer metadata for durable Discord final-turn delivery and add metadata footers to successful subscription followup messages
- expand chat-lab coverage so it can publish wakeup results, flush the Discord outbox, and verify both duplicate suppression and subscription metadata behavior

## Root cause
Durable Discord delivery and PMA subscription publishing were using paths that bypassed the normal final-turn footer composition, so token/context metadata disappeared once delivery moved through those paths. At the same time, duplicate wakeup/no-op notices were still being routed back into the active Discord thread, which produced a confusing visible "Duplicate — already handled" followup even though no user action was needed.

## What changed
- suppress duplicate `managed_thread_completed` no-op notifications when they target the currently bound Discord thread
- append the standard token/context footer when rendering durable managed-thread delivery records
- extract token-usage data from subscription publish results and append footer metadata to non-duplicate PMA followup messages
- teach the chat lab harness to publish cached wakeup results and flush the Discord outbox so subscription delivery behavior is exercised end to end
- add chat-lab scenarios for final-turn metadata, duplicate suppression, and subscription followup metadata
- relax a few timing-sensitive test waits so the repo-wide validation lane remains stable under parallel load

## Validation
- `.venv/bin/python -m pytest -q tests/integrations/chat/test_managed_thread_turns.py tests/core/test_pma_chat_delivery.py tests/surfaces/web/routes/pma_routes/test_publish_helpers.py tests/chat_surface_lab/test_scenario_runner.py`
- `.venv/bin/python -m pytest -q tests/chat_surface_lab/test_scenario_corpus.py tests/chat_surface_integration/test_hermes_pma_surfaces.py`
- `.venv/bin/python -m pytest -q -n 4 tests/chat_surface_lab/test_scenario_runner.py -k 'queued_visibility_matrix or queued_attachment_visibility' tests/integrations/discord/test_service_routing.py -k 'partial_run_id_prompts_filtered_picker or ingressed_slash_command_to_finish'`
- full commit validation lane: repo-wide mypy, repo-wide pytest, static asset build/tests, and chat-surface latency budget checks