### PR TITLE
[codex] add question-tool chat-lab harness support

### DIFF
--- a/src/codex_autorunner/integrations/app_server/client.py
+++ b/src/codex_autorunner/integrations/app_server/client.py
@@ -43,10 +43,12 @@ from .ids import extract_thread_id, extract_thread_id_for_turn, extract_turn_id
 from .protocol_helpers import (
     RawApprovalRequestAdapter,
     RawNotificationAdapter,
+    RawUserInputRequestAdapter,
     _maybe_await,
     normalize_approval_request,
     normalize_notification_envelope,
     normalize_response,
+    normalize_user_input_request,
 )
 from .recovery import RecoveryConfig, TurnRecoveryCoordinator
 from .transport import AppServerReadBuffer, build_message
@@ -60,6 +62,8 @@ from .turn_state import (
 
 ApprovalDecision = Union[str, Dict[str, Any]]
 ApprovalHandler = Callable[[Dict[str, Any]], Awaitable[ApprovalDecision]]
+UserInputResponse = Dict[str, Any]
+UserInputHandler = Callable[[Dict[str, Any]], Awaitable[UserInputResponse]]
 NotificationHandler = Callable[[Dict[str, Any]], Awaitable[None]]
 _TurnState = TurnState
 
@@ -112,6 +116,7 @@ class CodexAppServerClient:
         cwd: Optional[Path] = None,
         env: Optional[Dict[str, str]] = None,
         approval_handler: Optional[ApprovalHandler] = None,
+        question_handler: Optional[UserInputHandler] = None,
         default_approval_decision: str = "cancel",
         auto_restart: Optional[bool] = None,
         request_timeout: Optional[float] = None,
@@ -139,6 +144,7 @@ class CodexAppServerClient:
         self._cwd = str(cwd) if cwd is not None else None
         self._env = env
         self._approval_handler = approval_handler
+        self._question_handler = question_handler
         self._default_approval_decision = default_approval_decision
         disable_restart_env = os.environ.get(
             "CODEX_DISABLE_APP_SERVER_AUTORESTART_FOR_TESTS"
@@ -213,6 +219,10 @@ class CodexAppServerClient:
         self._approval_adapter = RawApprovalRequestAdapter(
             approval_handler,
             default_decision=default_approval_decision,
+        )
+        self._user_input_adapter = RawUserInputRequestAdapter(
+            question_handler,
+            default_result_factory=self._default_user_input_result,
         )
         self._notification_adapter = RawNotificationAdapter(notification_handler)
         self._next_id: str = str(uuid.uuid4())
@@ -988,6 +998,7 @@ class CodexAppServerClient:
 
     async def _handle_server_request(self, message: Dict[str, Any]) -> None:
         approval = normalize_approval_request(message)
+        user_input = normalize_user_input_request(message)
         method = message.get("method")
         req_id = message.get("id")
         if approval is not None:
@@ -1046,6 +1057,66 @@ class CodexAppServerClient:
             )
             await self._send_message(self._build_message(req_id=req_id, result=result))
             return
+        if user_input is not None:
+            method = user_input.method
+            req_id = user_input.request_id
+            log_event(
+                self._logger,
+                logging.INFO,
+                "app_server.user_input.requested",
+                request_id=req_id,
+                method=method,
+                turn_id=user_input.request.turn_id or user_input.params.get("turnId"),
+                question_count=len(user_input.request.questions),
+            )
+            try:
+                result = await self._user_input_adapter.decide(user_input)
+            except (
+                RuntimeError,
+                ValueError,
+                TypeError,
+                KeyError,
+                AttributeError,
+                OSError,
+                ConnectionError,
+            ) as exc:
+                log_event(
+                    self._logger,
+                    logging.WARNING,
+                    "app_server.user_input.failed",
+                    request_id=req_id,
+                    method=method,
+                    exc=exc,
+                )
+                await self._send_message(
+                    self._build_message(
+                        req_id=req_id,
+                        error={
+                            "code": -32002,
+                            "message": "user input handler failed",
+                        },
+                    )
+                )
+                return
+            result = self._normalize_user_input_result(result, user_input)
+            log_event(
+                self._logger,
+                logging.INFO,
+                "app_server.user_input.responded",
+                request_id=req_id,
+                method=method,
+                answer_keys=sorted(
+                    str(key)
+                    for key in (
+                        (result.get("answers") or {})
+                        if isinstance(result, dict)
+                        else {}
+                    )
+                    if isinstance(key, str) and key
+                ),
+            )
+            await self._send_message(self._build_message(req_id=req_id, result=result))
+            return
         if req_id is None or not isinstance(method, str):
             return
         await self._send_message(
@@ -1054,6 +1125,50 @@ class CodexAppServerClient:
                 error={"code": -32601, "message": f"Unsupported method: {method}"},
             )
         )
+
+    def _default_user_input_result(self, envelope: Any) -> dict[str, Any]:
+        return self._normalize_user_input_result({}, envelope)
+
+    def _normalize_user_input_result(
+        self, result: Any, envelope: Any
+    ) -> dict[str, Any]:
+        params = (
+            envelope.params
+            if hasattr(envelope, "params") and isinstance(envelope.params, dict)
+            else {}
+        )
+        questions_raw = params.get("questions")
+        answers: dict[str, dict[str, list[str]]] = {}
+        answers_raw = result.get("answers") if isinstance(result, dict) else None
+        if isinstance(questions_raw, list):
+            for question in questions_raw:
+                if not isinstance(question, dict):
+                    continue
+                question_id = question.get("id")
+                if not isinstance(question_id, str) or not question_id.strip():
+                    continue
+                normalized_id = question_id.strip()
+                raw_entry = (
+                    answers_raw.get(normalized_id)
+                    if isinstance(answers_raw, dict)
+                    else None
+                )
+                if isinstance(raw_entry, dict):
+                    raw_values = raw_entry.get("answers")
+                else:
+                    raw_values = raw_entry
+                if isinstance(raw_values, list):
+                    values = [
+                        str(value)
+                        for value in raw_values
+                        if isinstance(value, str) and value
+                    ]
+                elif isinstance(raw_values, str) and raw_values:
+                    values = [raw_values]
+                else:
+                    values = []
+                answers[normalized_id] = {"answers": values}
+        return {"answers": answers}
 
     async def _handle_notification(self, message: Dict[str, Any]) -> None:
         envelope = normalize_notification_envelope(message)

--- a/src/codex_autorunner/integrations/app_server/protocol_helpers.py
+++ b/src/codex_autorunner/integrations/app_server/protocol_helpers.py
@@ -6,7 +6,7 @@ from typing import Any, Awaitable, Callable, Optional
 
 from .event_decoder import APPROVAL_METHODS, decode_notification
 from .ids import extract_turn_id
-from .protocol_types import ApprovalRequest, NotificationResult
+from .protocol_types import ApprovalRequest, NotificationResult, UserInputRequest
 
 
 @dataclass(frozen=True)
@@ -35,6 +35,15 @@ class ApprovalRequestEnvelope:
     method: str
     params: dict[str, Any]
     request: ApprovalRequest
+    raw_message: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class UserInputRequestEnvelope:
+    request_id: Any
+    method: str
+    params: dict[str, Any]
+    request: UserInputRequest
     raw_message: dict[str, Any]
 
 
@@ -108,6 +117,43 @@ def normalize_approval_request(
     )
 
 
+def normalize_user_input_request(
+    message: dict[str, Any],
+) -> Optional[UserInputRequestEnvelope]:
+    normalized = normalize_server_request(message)
+    if normalized is None or normalized.method != "item/tool/requestUserInput":
+        return None
+    params = normalized.params
+    questions_raw = params.get("questions")
+    questions = (
+        tuple(question for question in questions_raw if isinstance(question, dict))
+        if isinstance(questions_raw, list)
+        else ()
+    )
+    return UserInputRequestEnvelope(
+        request_id=normalized.request_id,
+        method=normalized.method,
+        params=params,
+        request=UserInputRequest(
+            method=normalized.method,
+            item_id=(
+                str(params.get("itemId")).strip()
+                if isinstance(params.get("itemId"), str) and params.get("itemId")
+                else None
+            ),
+            turn_id=extract_turn_id(params),
+            thread_id=(
+                str(params.get("threadId")).strip()
+                if isinstance(params.get("threadId"), str) and params.get("threadId")
+                else None
+            ),
+            questions=questions,
+            context=params,
+        ),
+        raw_message=message,
+    )
+
+
 def normalize_notification_envelope(
     message: dict[str, Any],
 ) -> Optional[NotificationEnvelope]:
@@ -136,6 +182,25 @@ class RawApprovalRequestAdapter:
         if self._handler is None:
             return self._default_decision
         return await _maybe_await(self._handler(envelope.raw_message))
+
+
+class RawUserInputRequestAdapter:
+    def __init__(
+        self,
+        handler: Optional[Callable[[dict[str, Any]], Awaitable[Any]]],
+        *,
+        default_result_factory: Callable[[UserInputRequestEnvelope], dict[str, Any]],
+    ) -> None:
+        self._handler = handler
+        self._default_result_factory = default_result_factory
+
+    async def decide(self, envelope: UserInputRequestEnvelope) -> Any:
+        if self._handler is None:
+            return self._default_result_factory(envelope)
+        result = await _maybe_await(self._handler(envelope.raw_message))
+        if result is None:
+            return self._default_result_factory(envelope)
+        return result
 
 
 class RawNotificationAdapter:

--- a/src/codex_autorunner/integrations/app_server/protocol_types.py
+++ b/src/codex_autorunner/integrations/app_server/protocol_types.py
@@ -100,6 +100,18 @@ class ApprovalRequest:
     context: Optional[dict[str, Any]] = None
 
 
+@dataclass(frozen=True)
+class UserInputRequest:
+    """Structured user-input request payload."""
+
+    method: str
+    item_id: Optional[str] = None
+    turn_id: Optional[str] = None
+    thread_id: Optional[str] = None
+    questions: tuple[dict[str, Any], ...] = ()
+    context: Optional[dict[str, Any]] = None
+
+
 NotificationResult = Union[
     OutputDeltaNotification,
     ReasoningSummaryDeltaNotification,
@@ -109,5 +121,6 @@ NotificationResult = Union[
     TurnCompletedNotification,
     ErrorNotification,
     ApprovalRequest,
+    UserInputRequest,
     None,
 ]

--- a/tests/chat_surface_lab/backend_runtime.py
+++ b/tests/chat_surface_lab/backend_runtime.py
@@ -713,11 +713,12 @@ class OpenCodeFixtureRuntime(BaseBackendFixtureRuntime):
                     payload = json.loads(event.data) if event.data else {}
                 except Exception:
                     payload = {}
+                props = payload.get("properties") if isinstance(payload, dict) else None
+                props = props if isinstance(props, dict) else {}
+                event_turn_id = str(props.get("turnID") or "").strip()
+                if event_turn_id and event_turn_id != turn_id:
+                    continue
                 if event.event == "question.asked":
-                    props = (
-                        payload.get("properties") if isinstance(payload, dict) else None
-                    )
-                    props = props if isinstance(props, dict) else {}
                     request_id = str(props.get("id") or "").strip()
                     questions_raw = props.get("questions")
                     questions = (
@@ -785,7 +786,11 @@ class OpenCodeFixtureRuntime(BaseBackendFixtureRuntime):
         except asyncio.TimeoutError:
             pass
         prompt_task = asyncio.create_task(
-            self._client.prompt_async(conversation_id, message=text)
+            self._client.prompt_async(
+                conversation_id,
+                message=text,
+                variant=turn_id,
+            )
         )
         try:
             await asyncio.gather(prompt_task, stream_task)

--- a/tests/chat_surface_lab/backend_runtime.py
+++ b/tests/chat_surface_lab/backend_runtime.py
@@ -513,9 +513,10 @@ class ACPFixtureRuntime(BaseBackendFixtureRuntime):
             payload=event.payload,
         )
         decision = await self._wait_for_control(control_id)
-        if decision == "approve":
+        normalized = _normalize_decision(decision if isinstance(decision, str) else "")
+        if normalized == "approve":
             return "allow"
-        if decision == "deny":
+        if normalized == "deny":
             return "deny"
         return "cancel"
 

--- a/tests/chat_surface_lab/backend_runtime.py
+++ b/tests/chat_surface_lab/backend_runtime.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import sys
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, AsyncIterator, Callable, Optional
@@ -30,6 +32,7 @@ FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures"
 APP_SERVER_FIXTURE_PATH = FIXTURES_DIR / "app_server_fixture.py"
 FAKE_ACP_FIXTURE_PATH = FIXTURES_DIR / "fake_acp_server.py"
 FAKE_OPENCODE_FIXTURE_PATH = FIXTURES_DIR / "fake_opencode_server.py"
+_CONTROL_CANCELLED = object()
 
 
 def app_server_fixture_command(scenario: str = "basic") -> list[str]:
@@ -46,8 +49,14 @@ def fake_acp_command(scenario: str) -> list[str]:
     return [sys.executable, "-u", str(FAKE_ACP_FIXTURE_PATH), "--scenario", scenario]
 
 
-def fake_opencode_server_command() -> list[str]:
-    return [sys.executable, "-u", str(FAKE_OPENCODE_FIXTURE_PATH)]
+def fake_opencode_server_command(scenario: str = "smoke") -> list[str]:
+    return [
+        sys.executable,
+        "-u",
+        str(FAKE_OPENCODE_FIXTURE_PATH),
+        "--scenario",
+        scenario,
+    ]
 
 
 @dataclass
@@ -148,7 +157,7 @@ class BaseBackendFixtureRuntime:
         self._event_queue: asyncio.Queue[BackendRuntimeEvent] = asyncio.Queue()
         self._event_backlog: list[BackendRuntimeEvent] = []
         self._workspace_root: Optional[Path] = None
-        self._pending_controls: dict[str, asyncio.Future[str]] = {}
+        self._pending_controls: dict[str, asyncio.Future[Any]] = {}
 
     async def start(self, workspace_root: Path) -> None:
         self._workspace_root = workspace_root
@@ -162,12 +171,12 @@ class BaseBackendFixtureRuntime:
     async def interrupt(self, conversation_id: str, turn_id: str) -> None:
         raise NotImplementedError
 
-    async def respond_to_control(self, control_id: str, decision: str) -> None:
+    async def respond_to_control(self, control_id: str, decision: Any) -> None:
         future = self._pending_controls.get(control_id)
         if future is None:
             raise RuntimeError(f"Unknown control id: {control_id}")
         if not future.done():
-            future.set_result(_normalize_decision(decision))
+            future.set_result(decision)
 
     async def next_event(self, *, timeout: float = 2.0) -> BackendRuntimeEvent:
         if self._event_backlog:
@@ -206,7 +215,7 @@ class BaseBackendFixtureRuntime:
     async def _publish(self, **kwargs: Any) -> None:
         await self._event_queue.put(BackendRuntimeEvent(**kwargs))
 
-    async def _wait_for_control(self, control_id: str) -> str:
+    async def _wait_for_control(self, control_id: str) -> Any:
         future = asyncio.get_running_loop().create_future()
         self._pending_controls[control_id] = future
         try:
@@ -217,7 +226,7 @@ class BaseBackendFixtureRuntime:
     async def _cancel_pending_controls(self) -> None:
         for future in list(self._pending_controls.values()):
             if not future.done():
-                future.set_result("cancel")
+                future.set_result(_CONTROL_CANCELLED)
 
 
 class CodexAppServerFixtureRuntime(BaseBackendFixtureRuntime):
@@ -235,6 +244,7 @@ class CodexAppServerFixtureRuntime(BaseBackendFixtureRuntime):
             app_server_fixture_command(self._scenario),
             cwd=workspace_root,
             approval_handler=self._handle_approval_request,
+            question_handler=self._handle_question_request,
             notification_handler=self._handle_notification,
             auto_restart=False,
             request_timeout=2.0,
@@ -303,7 +313,49 @@ class CodexAppServerFixtureRuntime(BaseBackendFixtureRuntime):
             text=str(approval.params.get("reason") or approval.method),
             payload=approval.params,
         )
-        return await self._wait_for_control(control_id)
+        decision = await self._wait_for_control(control_id)
+        return _normalize_decision(decision if isinstance(decision, str) else "")
+
+    async def _handle_question_request(self, message: dict[str, Any]) -> dict[str, Any]:
+        params = message if isinstance(message, dict) else {}
+        payload = (
+            params.get("params") if isinstance(params.get("params"), dict) else params
+        )
+        control_id = str(message.get("id") or "").strip()
+        if not control_id:
+            return {"answers": {}}
+        turn_id = str(payload.get("turnId") or "").strip() or None
+        conversation_id = (
+            str(payload.get("threadId") or "").strip() or None
+        ) or self._turn_conversations.get(turn_id or "")
+        questions_raw = payload.get("questions")
+        questions = (
+            [question for question in questions_raw if isinstance(question, dict)]
+            if isinstance(questions_raw, list)
+            else []
+        )
+        prompt = ""
+        if questions:
+            first_question = questions[0]
+            prompt = str(
+                first_question.get("question")
+                or first_question.get("prompt")
+                or first_question.get("header")
+                or ""
+            )
+        await self._publish(
+            backend=self.backend_name,
+            kind="control.question_requested",
+            conversation_id=conversation_id,
+            turn_id=turn_id,
+            control_id=control_id,
+            text=prompt or "Question requested",
+            payload={**payload, "questions": questions},
+        )
+        response = await self._wait_for_control(control_id)
+        if response is _CONTROL_CANCELLED:
+            return {"answers": {}}
+        return _normalize_codex_question_response(questions, response)
 
     async def _handle_notification(self, message: dict[str, Any]) -> None:
         method = str(message.get("method") or "").strip()
@@ -542,23 +594,26 @@ class ACPFixtureRuntime(BaseBackendFixtureRuntime):
 class OpenCodeFixtureRuntime(BaseBackendFixtureRuntime):
     backend_name = "opencode"
 
-    def __init__(self) -> None:
+    def __init__(self, *, scenario: str = "smoke") -> None:
         super().__init__()
+        self._scenario = scenario
+        supports_turns = scenario == "question"
         self.capabilities = BackendRuntimeCapabilities(
-            can_create_conversation=False,
-            can_start_turn=False,
+            can_create_conversation=supports_turns,
+            can_start_turn=supports_turns,
             can_interrupt=False,
-            can_respond_to_control=False,
+            can_respond_to_control=supports_turns,
             streams_events=True,
         )
         self._supervisor: Optional[OpenCodeSupervisor] = None
         self._client: Optional[OpenCodeClient] = None
         self._openapi_spec: Optional[dict[str, Any]] = None
+        self._turn_tasks: dict[str, asyncio.Task[None]] = {}
 
     async def start(self, workspace_root: Path) -> None:
         await super().start(workspace_root)
         self._supervisor = OpenCodeSupervisor(
-            fake_opencode_server_command(),
+            fake_opencode_server_command(self._scenario),
             request_timeout=5.0,
         )
         self._client = await self._supervisor.get_client(workspace_root)
@@ -578,15 +633,56 @@ class OpenCodeFixtureRuntime(BaseBackendFixtureRuntime):
         )
 
     async def create_conversation(self) -> str:
-        raise RuntimeError("OpenCode fixture smoke runtime does not create sessions")
+        if not self.capabilities.can_create_conversation or self._client is None:
+            raise RuntimeError("OpenCode fixture runtime does not create sessions")
+        session = await self._client.create_session(directory=str(self._workspace_root))
+        conversation_id = _extract_opencode_session_id(session)
+        if not conversation_id:
+            raise RuntimeError("OpenCode fixture did not return a session id")
+        await self._publish(
+            backend=self.backend_name,
+            kind="conversation.started",
+            conversation_id=conversation_id,
+            payload=session if isinstance(session, dict) else {},
+        )
+        return conversation_id
 
     async def start_turn(self, conversation_id: str, text: str) -> str:
-        raise RuntimeError("OpenCode fixture smoke runtime does not start turns")
+        if not self.capabilities.can_start_turn or self._client is None:
+            raise RuntimeError("OpenCode fixture runtime does not start turns")
+        turn_id = f"{conversation_id}:turn:{uuid.uuid4().hex[:8]}"
+        task = asyncio.create_task(
+            self._run_question_turn(
+                conversation_id=conversation_id,
+                turn_id=turn_id,
+                text=text,
+            )
+        )
+        self._turn_tasks[turn_id] = task
+        task.add_done_callback(
+            lambda _task, tid=turn_id: self._turn_tasks.pop(tid, None)
+        )
+        await self._publish(
+            backend=self.backend_name,
+            kind="turn.started",
+            conversation_id=conversation_id,
+            turn_id=turn_id,
+            payload={"input": text},
+        )
+        return turn_id
 
     async def interrupt(self, conversation_id: str, turn_id: str) -> None:
         raise RuntimeError("OpenCode fixture smoke runtime does not interrupt turns")
 
     async def shutdown(self) -> None:
+        await self._cancel_pending_controls()
+        for task in list(self._turn_tasks.values()):
+            task.cancel()
+        if self._turn_tasks:
+            await asyncio.gather(
+                *tuple(self._turn_tasks.values()), return_exceptions=True
+            )
+        self._turn_tasks.clear()
         if self._client is not None:
             await self._client.close()
             self._client = None
@@ -594,6 +690,217 @@ class OpenCodeFixtureRuntime(BaseBackendFixtureRuntime):
             await self._supervisor.close_all()
             self._supervisor = None
         await self._publish(backend=self.backend_name, kind="runtime.closed")
+
+    async def _run_question_turn(
+        self,
+        *,
+        conversation_id: str,
+        turn_id: str,
+        text: str,
+    ) -> None:
+        assert self._client is not None
+        stream_ready = asyncio.Event()
+
+        async def _stream_events() -> None:
+            async for event in self._client.stream_events(
+                directory=str(self._workspace_root),
+                session_id=conversation_id,
+            ):
+                stream_ready.set()
+                payload = {}
+                try:
+                    payload = json.loads(event.data) if event.data else {}
+                except Exception:
+                    payload = {}
+                if event.event == "question.asked":
+                    props = (
+                        payload.get("properties") if isinstance(payload, dict) else None
+                    )
+                    props = props if isinstance(props, dict) else {}
+                    request_id = str(props.get("id") or "").strip()
+                    questions_raw = props.get("questions")
+                    questions = (
+                        [
+                            question
+                            for question in questions_raw
+                            if isinstance(question, dict)
+                        ]
+                        if isinstance(questions_raw, list)
+                        else []
+                    )
+                    prompt = ""
+                    if questions:
+                        first_question = questions[0]
+                        prompt = str(
+                            first_question.get("question")
+                            or first_question.get("prompt")
+                            or first_question.get("header")
+                            or ""
+                        )
+                    await self._publish(
+                        backend=self.backend_name,
+                        kind="control.question_requested",
+                        conversation_id=conversation_id,
+                        turn_id=turn_id,
+                        control_id=request_id,
+                        text=prompt or "Question requested",
+                        payload={**props, "questions": questions},
+                    )
+                    response = await self._wait_for_control(request_id)
+                    if response is _CONTROL_CANCELLED:
+                        await self._client.reject_question(request_id)
+                        continue
+                    answers = _normalize_opencode_question_answers(questions, response)
+                    await self._client.reply_question(request_id, answers=answers)
+                    continue
+                if event.event in {"message.part.delta", "message.part.updated"}:
+                    text_part = _extract_opencode_visible_text(event.event, payload)
+                    if text_part:
+                        await self._publish(
+                            backend=self.backend_name,
+                            kind="turn.output",
+                            conversation_id=conversation_id,
+                            turn_id=turn_id,
+                            text=text_part,
+                            payload=payload if isinstance(payload, dict) else {},
+                        )
+                if event.event in {
+                    "session.idle",
+                    "session.status",
+                } and _opencode_event_is_idle(payload):
+                    await self._publish(
+                        backend=self.backend_name,
+                        kind="turn.terminal",
+                        conversation_id=conversation_id,
+                        turn_id=turn_id,
+                        status="completed",
+                        payload=payload if isinstance(payload, dict) else {},
+                    )
+                    return
+
+        stream_task = asyncio.create_task(_stream_events())
+        try:
+            await asyncio.wait_for(stream_ready.wait(), timeout=2.0)
+        except asyncio.TimeoutError:
+            pass
+        prompt_task = asyncio.create_task(
+            self._client.prompt_async(conversation_id, message=text)
+        )
+        try:
+            await asyncio.gather(prompt_task, stream_task)
+        finally:
+            if not prompt_task.done():
+                prompt_task.cancel()
+                await asyncio.gather(prompt_task, return_exceptions=True)
+            if not stream_task.done():
+                stream_task.cancel()
+                await asyncio.gather(stream_task, return_exceptions=True)
+
+
+def _normalize_codex_question_response(
+    questions: list[dict[str, Any]], response: Any
+) -> dict[str, Any]:
+    if isinstance(response, dict):
+        answers_raw = response.get("answers")
+        if isinstance(answers_raw, dict):
+            normalized: dict[str, dict[str, list[str]]] = {}
+            for question_id, answer_payload in answers_raw.items():
+                if not isinstance(question_id, str) or not question_id.strip():
+                    continue
+                if isinstance(answer_payload, dict):
+                    values = answer_payload.get("answers")
+                else:
+                    values = answer_payload
+                normalized[question_id.strip()] = {
+                    "answers": _normalize_answer_list(values)
+                }
+            return {"answers": normalized}
+    if isinstance(response, list):
+        normalized = {}
+        for index, question in enumerate(questions):
+            question_id = question.get("id")
+            if not isinstance(question_id, str) or not question_id.strip():
+                continue
+            values = response[index] if index < len(response) else []
+            normalized[question_id.strip()] = {
+                "answers": _normalize_answer_list(values)
+            }
+        return {"answers": normalized}
+    if isinstance(response, str):
+        for question in questions:
+            question_id = question.get("id")
+            if isinstance(question_id, str) and question_id.strip():
+                return {"answers": {question_id.strip(): {"answers": [response]}}}
+    return {
+        "answers": {
+            str(question.get("id")).strip(): {"answers": []}
+            for question in questions
+            if isinstance(question.get("id"), str) and str(question.get("id")).strip()
+        }
+    }
+
+
+def _normalize_opencode_question_answers(
+    questions: list[dict[str, Any]], response: Any
+) -> list[list[str]]:
+    if isinstance(response, dict):
+        answers_raw = response.get("answers")
+        if isinstance(answers_raw, dict):
+            normalized: list[list[str]] = []
+            for question in questions:
+                question_id = question.get("id")
+                values = (
+                    answers_raw.get(question_id) if isinstance(question_id, str) else []
+                )
+                if isinstance(values, dict):
+                    values = values.get("answers")
+                normalized.append(_normalize_answer_list(values))
+            return normalized
+    if isinstance(response, list):
+        return [_normalize_answer_list(values) for values in response]
+    if isinstance(response, str):
+        return [[response]]
+    return [[] for _ in questions]
+
+
+def _normalize_answer_list(values: Any) -> list[str]:
+    if isinstance(values, list):
+        return [str(value) for value in values if isinstance(value, str) and value]
+    if isinstance(values, str) and values:
+        return [values]
+    return []
+
+
+def _extract_opencode_visible_text(event_name: str, payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    props = payload.get("properties")
+    if not isinstance(props, dict):
+        return ""
+    if event_name == "message.part.delta":
+        delta = props.get("delta")
+        return delta if isinstance(delta, str) else ""
+    part = props.get("part")
+    if not isinstance(part, dict):
+        return ""
+    if part.get("type") != "text":
+        return ""
+    text = part.get("text")
+    return text if isinstance(text, str) else ""
+
+
+def _opencode_event_is_idle(payload: Any) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("type") == "session.idle":
+        return True
+    props = payload.get("properties")
+    if not isinstance(props, dict):
+        return False
+    status = props.get("status")
+    if isinstance(status, dict):
+        status = status.get("type")
+    return isinstance(status, str) and status.strip().lower() == "idle"
 
 
 __all__ = [

--- a/tests/chat_surface_lab/test_backend_runtime_contract.py
+++ b/tests/chat_surface_lab/test_backend_runtime_contract.py
@@ -110,6 +110,55 @@ async def test_runtime_contract_normalizes_approval_controls(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
+    ("runtime_factory", "workspace_name", "prompt", "response"),
+    [
+        (
+            lambda: CodexAppServerFixtureRuntime(scenario="question"),
+            "app-server-question",
+            "needs question",
+            {"answers": {"framework": {"answers": ["pytest"]}}},
+        ),
+        (
+            lambda: OpenCodeFixtureRuntime(scenario="question"),
+            "opencode-question",
+            "needs question",
+            [["pytest"]],
+        ),
+    ],
+)
+async def test_runtime_contract_normalizes_question_controls(
+    tmp_path: Path,
+    runtime_factory,
+    workspace_name: str,
+    prompt: str,
+    response,
+) -> None:
+    runtime = runtime_factory()
+    await _start_runtime(runtime, _workspace_root(tmp_path, workspace_name))
+    try:
+        conversation_id = await runtime.create_conversation()
+        turn_id = await runtime.start_turn(conversation_id, prompt)
+
+        question = await runtime.wait_for_event(
+            lambda event: event.kind == "control.question_requested"
+            and event.turn_id == turn_id,
+            timeout=8.0,
+        )
+        assert question.control_id
+        assert question.payload.get("questions")
+
+        await runtime.respond_to_control(question.control_id, response)
+        terminal = await runtime.wait_for_event(
+            lambda event: event.kind == "turn.terminal" and event.turn_id == turn_id,
+            timeout=8.0,
+        )
+        assert terminal.status == "completed"
+    finally:
+        await _shutdown_runtime(runtime)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
     ("runtime_factory", "workspace_name", "prompt"),
     [
         (
@@ -145,6 +194,47 @@ async def test_runtime_contract_normalizes_interrupt_status(
             timeout=4.0,
         )
         assert terminal.status == "interrupted"
+    finally:
+        await _shutdown_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_opencode_question_runtime_supports_multiple_turns_per_conversation(
+    tmp_path: Path,
+) -> None:
+    runtime = OpenCodeFixtureRuntime(scenario="question")
+    await _start_runtime(runtime, _workspace_root(tmp_path, "opencode-multi-turn"))
+    try:
+        conversation_id = await runtime.create_conversation()
+
+        first_turn_id = await runtime.start_turn(conversation_id, "first question")
+        first_question = await runtime.wait_for_event(
+            lambda event: event.kind == "control.question_requested"
+            and event.turn_id == first_turn_id,
+            timeout=8.0,
+        )
+        await runtime.respond_to_control(first_question.control_id, [["pytest"]])
+        first_terminal = await runtime.wait_for_event(
+            lambda event: event.kind == "turn.terminal"
+            and event.turn_id == first_turn_id,
+            timeout=8.0,
+        )
+        assert first_terminal.status == "completed"
+
+        second_turn_id = await runtime.start_turn(conversation_id, "second question")
+        assert second_turn_id != first_turn_id
+        second_question = await runtime.wait_for_event(
+            lambda event: event.kind == "control.question_requested"
+            and event.turn_id == second_turn_id,
+            timeout=8.0,
+        )
+        await runtime.respond_to_control(second_question.control_id, [["unittest"]])
+        second_terminal = await runtime.wait_for_event(
+            lambda event: event.kind == "turn.terminal"
+            and event.turn_id == second_turn_id,
+            timeout=8.0,
+        )
+        assert second_terminal.status == "completed"
     finally:
         await _shutdown_runtime(runtime)
 

--- a/tests/chat_surface_lab/test_backend_runtime_contract.py
+++ b/tests/chat_surface_lab/test_backend_runtime_contract.py
@@ -240,6 +240,50 @@ async def test_opencode_question_runtime_supports_multiple_turns_per_conversatio
 
 
 @pytest.mark.anyio
+async def test_opencode_question_runtime_scopes_overlapping_turn_controls(
+    tmp_path: Path,
+) -> None:
+    runtime = OpenCodeFixtureRuntime(scenario="question")
+    await _start_runtime(runtime, _workspace_root(tmp_path, "opencode-overlap-turns"))
+    try:
+        conversation_id = await runtime.create_conversation()
+
+        first_turn_id = await runtime.start_turn(conversation_id, "first overlap")
+        second_turn_id = await runtime.start_turn(conversation_id, "second overlap")
+        assert second_turn_id != first_turn_id
+
+        first_question = await runtime.wait_for_event(
+            lambda event: event.kind == "control.question_requested"
+            and event.turn_id == first_turn_id,
+            timeout=8.0,
+        )
+        second_question = await runtime.wait_for_event(
+            lambda event: event.kind == "control.question_requested"
+            and event.turn_id == second_turn_id,
+            timeout=8.0,
+        )
+        assert first_question.control_id != second_question.control_id
+
+        await runtime.respond_to_control(first_question.control_id, [["pytest"]])
+        await runtime.respond_to_control(second_question.control_id, [["unittest"]])
+
+        first_terminal = await runtime.wait_for_event(
+            lambda event: event.kind == "turn.terminal"
+            and event.turn_id == first_turn_id,
+            timeout=8.0,
+        )
+        second_terminal = await runtime.wait_for_event(
+            lambda event: event.kind == "turn.terminal"
+            and event.turn_id == second_turn_id,
+            timeout=8.0,
+        )
+        assert first_terminal.status == "completed"
+        assert second_terminal.status == "completed"
+    finally:
+        await _shutdown_runtime(runtime)
+
+
+@pytest.mark.anyio
 async def test_opencode_runtime_smoke_starts_fixture_server(
     tmp_path: Path,
 ) -> None:

--- a/tests/fixtures/app_server_fixture.py
+++ b/tests/fixtures/app_server_fixture.py
@@ -24,6 +24,7 @@ class FixtureServer:
         self._next_turn = 1
         self._next_approval = 900
         self._pending_approvals: dict[int, str] = {}
+        self._pending_questions: dict[int, dict[str, str]] = {}
         self._pending_interrupts: set[str] = set()
         self._instance_id = uuid.uuid4().hex[:8]
         self._missing_turns: dict[str, str] = {}
@@ -310,6 +311,42 @@ class FixtureServer:
                     }
                 )
                 return
+            if self._scenario == "question":
+                question_id = self._next_approval
+                self._next_approval += 1
+                self._pending_questions[question_id] = {
+                    "turn_id": turn_id,
+                    "question_id": "framework",
+                }
+                self.send(
+                    {
+                        "id": question_id,
+                        "method": "item/tool/requestUserInput",
+                        "params": {
+                            "itemId": "tool-question-1",
+                            "threadId": params.get("threadId"),
+                            "turnId": turn_id,
+                            "questions": [
+                                {
+                                    "id": "framework",
+                                    "header": "Test Framework",
+                                    "question": "Which test framework should I use?",
+                                    "options": [
+                                        {
+                                            "label": "pytest",
+                                            "description": "Use pytest",
+                                        },
+                                        {
+                                            "label": "unittest",
+                                            "description": "Use unittest",
+                                        },
+                                    ],
+                                }
+                            ],
+                        },
+                    }
+                )
+                return
             if self._scenario == "interrupt":
                 self._pending_interrupts.add(turn_id)
                 return
@@ -515,6 +552,38 @@ class FixtureServer:
             if isinstance(result, dict):
                 decision = result.get("decision")
             self._send_turn_completed(turn_id, approval_decision=decision or "unknown")
+        if req_id in self._pending_questions:
+            pending = self._pending_questions.pop(req_id)
+            turn_id = pending["turn_id"]
+            question_id = pending["question_id"]
+            result = message.get("result") or {}
+            answers = result.get("answers") if isinstance(result, dict) else None
+            selected = "unanswered"
+            if isinstance(answers, dict):
+                entry = answers.get(question_id)
+                raw_answers = entry.get("answers") if isinstance(entry, dict) else None
+                if isinstance(raw_answers, list) and raw_answers:
+                    first = raw_answers[0]
+                    if isinstance(first, str) and first:
+                        selected = first
+            self.send(
+                {
+                    "method": "item/completed",
+                    "params": {
+                        "turnId": turn_id,
+                        "item": {
+                            "type": "agentMessage",
+                            "text": f"Selected framework: {selected}",
+                        },
+                    },
+                }
+            )
+            self.send(
+                {
+                    "method": "turn/completed",
+                    "params": {"turnId": turn_id, "status": "completed"},
+                }
+            )
 
     def _handle_notification(self, message: dict) -> None:
         if message.get("method") == "initialized":

--- a/tests/fixtures/fake_opencode_server.py
+++ b/tests/fixtures/fake_opencode_server.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+import argparse
 import base64
 import http.server
 import json
 import os
+import queue
+import re
 import subprocess
 import sys
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any, Optional
@@ -86,7 +93,6 @@ def _is_authorized(handler: http.server.BaseHTTPRequestHandler) -> bool:
         return True
     if not username_required:
         username_required = "opencode"
-
     header = handler.headers.get("Authorization", "")
     credentials = _parse_basic_auth_header(header)
     if credentials is None:
@@ -111,14 +117,355 @@ def _marker_path() -> Optional[str]:
     )
 
 
+@dataclass
+class _PendingQuestion:
+    request_id: str
+    session_id: str
+    assistant_message_id: str
+    tool_part_id: str
+    question: dict[str, Any]
+    answered: threading.Event = field(default_factory=threading.Event)
+    answers: Optional[list[list[str]]] = None
+    rejected: bool = False
+
+
+class _FakeOpenCodeState:
+    def __init__(self, scenario: str) -> None:
+        self.scenario = scenario
+        self._lock = threading.Lock()
+        self._sessions: dict[str, dict[str, Any]] = {}
+        self._pending_questions: dict[str, _PendingQuestion] = {}
+        self._subscribers: list[queue.Queue[Optional[dict[str, Any]]]] = []
+        self._next_id = 1
+
+    def create_session(self, directory: Optional[str]) -> dict[str, Any]:
+        with self._lock:
+            session_id = f"session-{self._next_id}"
+            self._next_id += 1
+            payload = {
+                "id": session_id,
+                "title": "fixture session",
+                "directory": directory,
+            }
+            self._sessions[session_id] = payload
+            return dict(payload)
+
+    def add_subscriber(self) -> queue.Queue[Optional[dict[str, Any]]]:
+        subscriber: queue.Queue[Optional[dict[str, Any]]] = queue.Queue()
+        with self._lock:
+            self._subscribers.append(subscriber)
+        subscriber.put({"type": "server.connected", "properties": {}})
+        return subscriber
+
+    def remove_subscriber(
+        self, subscriber: queue.Queue[Optional[dict[str, Any]]]
+    ) -> None:
+        with self._lock:
+            if subscriber in self._subscribers:
+                self._subscribers.remove(subscriber)
+
+    def emit(self, payload: dict[str, Any]) -> None:
+        with self._lock:
+            subscribers = list(self._subscribers)
+        for subscriber in subscribers:
+            subscriber.put(dict(payload))
+
+    def prompt_async(self, session_id: str, prompt_text: str) -> dict[str, Any]:
+        user_message_id = f"user-{uuid.uuid4().hex[:8]}"
+        assistant_message_id = f"assistant-{uuid.uuid4().hex[:8]}"
+        self.emit(
+            {
+                "type": "message.updated",
+                "properties": {
+                    "sessionID": session_id,
+                    "info": {
+                        "id": user_message_id,
+                        "role": "user",
+                        "sessionID": session_id,
+                    },
+                },
+            }
+        )
+        self.emit(
+            {
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": session_id,
+                    "part": {
+                        "id": f"part-{uuid.uuid4().hex[:8]}",
+                        "type": "text",
+                        "text": prompt_text,
+                        "messageID": user_message_id,
+                        "sessionID": session_id,
+                    },
+                },
+            }
+        )
+        self.emit(
+            {
+                "type": "session.status",
+                "properties": {
+                    "sessionID": session_id,
+                    "status": {"type": "busy"},
+                },
+            }
+        )
+        self.emit(
+            {
+                "type": "message.updated",
+                "properties": {
+                    "sessionID": session_id,
+                    "info": {
+                        "id": assistant_message_id,
+                        "role": "assistant",
+                        "sessionID": session_id,
+                    },
+                },
+            }
+        )
+        if self.scenario != "question":
+            self.emit(
+                {
+                    "type": "message.part.updated",
+                    "properties": {
+                        "sessionID": session_id,
+                        "part": {
+                            "id": f"part-{uuid.uuid4().hex[:8]}",
+                            "type": "text",
+                            "text": "fixture reply",
+                            "messageID": assistant_message_id,
+                            "sessionID": session_id,
+                        },
+                    },
+                }
+            )
+            self.emit(
+                {
+                    "type": "session.status",
+                    "properties": {
+                        "sessionID": session_id,
+                        "status": {"type": "idle"},
+                    },
+                }
+            )
+            self.emit({"type": "session.idle", "properties": {"sessionID": session_id}})
+            return {
+                "info": {
+                    "id": assistant_message_id,
+                    "role": "assistant",
+                    "sessionID": session_id,
+                },
+                "parts": [{"type": "text", "text": "fixture reply"}],
+            }
+
+        request_id = f"question-{uuid.uuid4().hex[:8]}"
+        tool_part_id = f"tool-{uuid.uuid4().hex[:8]}"
+        question = {
+            "id": "framework",
+            "header": "Testing Framework",
+            "question": "Which testing framework would you like to use?",
+            "options": [
+                {
+                    "label": "pytest",
+                    "description": "Use pytest as the testing framework",
+                },
+                {
+                    "label": "unittest",
+                    "description": "Use unittest (standard library) as the testing framework",
+                },
+            ],
+        }
+        pending = _PendingQuestion(
+            request_id=request_id,
+            session_id=session_id,
+            assistant_message_id=assistant_message_id,
+            tool_part_id=tool_part_id,
+            question=question,
+        )
+        with self._lock:
+            self._pending_questions[request_id] = pending
+        self.emit(
+            {
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": session_id,
+                    "part": {
+                        "id": tool_part_id,
+                        "messageID": assistant_message_id,
+                        "sessionID": session_id,
+                        "type": "tool",
+                        "tool": "question",
+                        "callID": "call-question-1",
+                        "state": {"status": "pending", "input": {}, "raw": ""},
+                    },
+                },
+            }
+        )
+        self.emit(
+            {
+                "type": "question.asked",
+                "properties": {
+                    "id": request_id,
+                    "sessionID": session_id,
+                    "questions": [question],
+                    "tool": {
+                        "messageID": assistant_message_id,
+                        "callID": "call-question-1",
+                    },
+                },
+            }
+        )
+        self.emit(
+            {
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": session_id,
+                    "part": {
+                        "id": tool_part_id,
+                        "messageID": assistant_message_id,
+                        "sessionID": session_id,
+                        "type": "tool",
+                        "tool": "question",
+                        "callID": "call-question-1",
+                        "state": {
+                            "status": "running",
+                            "input": {"questions": [question]},
+                            "raw": "",
+                            "time": {"start": int(time.time() * 1000)},
+                        },
+                    },
+                },
+            }
+        )
+        pending.answered.wait()
+        with self._lock:
+            self._pending_questions.pop(request_id, None)
+        answer_label = "unanswered"
+        if pending.answers and pending.answers[0]:
+            first = pending.answers[0][0]
+            if isinstance(first, str) and first:
+                answer_label = first
+        elif pending.rejected:
+            answer_label = "rejected"
+        self.emit(
+            {
+                "type": "question.replied",
+                "properties": {
+                    "sessionID": session_id,
+                    "requestID": request_id,
+                    "answers": pending.answers or [],
+                },
+            }
+        )
+        self.emit(
+            {
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": session_id,
+                    "part": {
+                        "id": tool_part_id,
+                        "messageID": assistant_message_id,
+                        "sessionID": session_id,
+                        "type": "tool",
+                        "tool": "question",
+                        "callID": "call-question-1",
+                        "state": {
+                            "status": "completed",
+                            "input": {"questions": [question]},
+                            "output": (
+                                "User has answered your questions: "
+                                f"\"{question['question']}\"=\"{answer_label}\"."
+                            ),
+                            "metadata": {
+                                "answers": pending.answers or [],
+                                "truncated": False,
+                            },
+                            "title": "Asked 1 question",
+                            "time": {
+                                "start": int(time.time() * 1000) - 10,
+                                "end": int(time.time() * 1000),
+                            },
+                        },
+                    },
+                },
+            }
+        )
+        final_text = f"Got it - {answer_label} it is. What would you like me to do?"
+        self.emit(
+            {
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": session_id,
+                    "part": {
+                        "id": f"text-{uuid.uuid4().hex[:8]}",
+                        "messageID": assistant_message_id,
+                        "sessionID": session_id,
+                        "type": "text",
+                        "text": final_text,
+                    },
+                },
+            }
+        )
+        self.emit(
+            {
+                "type": "session.status",
+                "properties": {
+                    "sessionID": session_id,
+                    "status": {"type": "idle"},
+                },
+            }
+        )
+        self.emit({"type": "session.idle", "properties": {"sessionID": session_id}})
+        return {
+            "info": {
+                "id": assistant_message_id,
+                "role": "assistant",
+                "sessionID": session_id,
+            },
+            "parts": [{"type": "text", "text": final_text}],
+        }
+
+    def reply_question(
+        self, request_id: str, answers: list[list[str]]
+    ) -> dict[str, Any]:
+        with self._lock:
+            pending = self._pending_questions.get(request_id)
+        if pending is None:
+            return {"accepted": False, "status_code": 404}
+        pending.answers = answers
+        pending.answered.set()
+        return {"accepted": True, "status_code": 200}
+
+    def reject_question(self, request_id: str) -> dict[str, Any]:
+        with self._lock:
+            pending = self._pending_questions.get(request_id)
+        if pending is None:
+            return {"accepted": False, "status_code": 404}
+        pending.answers = []
+        pending.rejected = True
+        pending.answered.set()
+        return {"accepted": True, "status_code": 200}
+
+
+_REQUEST_STATE: Optional[_FakeOpenCodeState] = None
+
+
 class _FakeRequestHandler(http.server.BaseHTTPRequestHandler):
     DOC_PATHS: dict[str, Any] = {
         "paths": {
-            "/global/health": {
-                "get": {"responses": {"200": {"description": "ok"}}},
+            "/global/health": {"get": {"responses": {"200": {"description": "ok"}}}},
+            "/global/event": {"get": {"responses": {"200": {"description": "ok"}}}},
+            "/session": {
+                "post": {"responses": {"200": {"description": "created"}}},
             },
-            "/global/event": {
-                "get": {"responses": {"200": {"description": "ok"}}},
+            "/session/{session_id}/prompt_async": {
+                "post": {"responses": {"200": {"description": "ok"}}},
+            },
+            "/question/{question_id}/reply": {
+                "post": {"responses": {"200": {"description": "ok"}}},
+            },
+            "/question/{question_id}/reject": {
+                "post": {"responses": {"200": {"description": "ok"}}},
             },
         }
     }
@@ -135,28 +482,118 @@ class _FakeRequestHandler(http.server.BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(payload)
 
-    def do_GET(self) -> None:  # noqa: N802 (HTTP handler API).
+    def _read_json_body(self) -> dict[str, Any]:
+        try:
+            content_length = int(self.headers.get("Content-Length") or "0")
+        except ValueError:
+            content_length = 0
+        raw = self.rfile.read(content_length) if content_length > 0 else b"{}"
+        try:
+            payload = json.loads(raw.decode("utf-8")) if raw else {}
+        except json.JSONDecodeError:
+            payload = {}
+        return payload if isinstance(payload, dict) else {}
+
+    def do_GET(self) -> None:  # noqa: N802
         if not _is_authorized(self):
             _write_unauthorized(self)
             return
-
         if self.path == "/doc":
             self._write_json(HTTPStatus.OK, self.DOC_PATHS)
             return
         if self.path in self.HEALTH_PATHS:
             self._write_json(HTTPStatus.OK, self.HEALTH_PATHS[self.path])
             return
+        if self.path.startswith("/event") or self.path.startswith("/global/event"):
+            self._handle_sse_stream()
+            return
+        self.send_error(HTTPStatus.NOT_FOUND, "Not Found")
 
-        self.send_error(
-            HTTPStatus.NOT_FOUND,
-            "Not Found",
-        )
+    def do_POST(self) -> None:  # noqa: N802
+        if not _is_authorized(self):
+            _write_unauthorized(self)
+            return
+        state = _REQUEST_STATE
+        if state is None:
+            self.send_error(HTTPStatus.INTERNAL_SERVER_ERROR, "State unavailable")
+            return
+        payload = self._read_json_body()
+        if self.path == "/session":
+            directory = payload.get("directory")
+            self._write_json(
+                HTTPStatus.OK,
+                state.create_session(directory if isinstance(directory, str) else None),
+            )
+            return
+        prompt_match = re.fullmatch(r"/session/([^/]+)/prompt_async", self.path)
+        if prompt_match:
+            session_id = prompt_match.group(1)
+            prompt_text = ""
+            parts_raw = payload.get("parts")
+            if isinstance(parts_raw, list):
+                prompt_text = "".join(
+                    part.get("text", "")
+                    for part in parts_raw
+                    if isinstance(part, dict) and isinstance(part.get("text"), str)
+                )
+            result = state.prompt_async(session_id, prompt_text)
+            self._write_json(HTTPStatus.OK, result)
+            return
+        reply_match = re.fullmatch(r"/question/([^/]+)/reply", self.path)
+        if reply_match:
+            request_id = reply_match.group(1)
+            answers_raw = payload.get("answers")
+            answers = (
+                [
+                    [str(answer) for answer in row if isinstance(answer, str)]
+                    for row in answers_raw
+                    if isinstance(row, list)
+                ]
+                if isinstance(answers_raw, list)
+                else []
+            )
+            self._write_json(HTTPStatus.OK, state.reply_question(request_id, answers))
+            return
+        reject_match = re.fullmatch(r"/question/([^/]+)/reject", self.path)
+        if reject_match:
+            request_id = reject_match.group(1)
+            self._write_json(HTTPStatus.OK, state.reject_question(request_id))
+            return
+        self.send_error(HTTPStatus.NOT_FOUND, "Not Found")
+
+    def _handle_sse_stream(self) -> None:
+        state = _REQUEST_STATE
+        if state is None:
+            self.send_error(HTTPStatus.INTERNAL_SERVER_ERROR, "State unavailable")
+            return
+        subscriber = state.add_subscriber()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "keep-alive")
+        self.end_headers()
+        try:
+            while True:
+                event = subscriber.get(timeout=30)
+                if event is None:
+                    break
+                event_type = event.get("type")
+                payload = json.dumps(event)
+                self.wfile.write(f"event: {event_type}\n".encode("utf-8"))
+                self.wfile.write(f"data: {payload}\n\n".encode("utf-8"))
+                self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError, queue.Empty):
+            return
+        finally:
+            state.remove_subscriber(subscriber)
 
     def log_message(self, *_args, **_kwargs) -> None:
         return
 
 
-def _serve() -> None:
+def _serve(scenario: str) -> None:
+    global _REQUEST_STATE
+    _REQUEST_STATE = _FakeOpenCodeState(scenario)
     server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _FakeRequestHandler)
     host, port = server.server_address
     base_url = f"http://{host}:{port}"
@@ -165,7 +602,7 @@ def _serve() -> None:
     _write_text_file(os.environ.get("OPENCODE_CHILD_PID_FILE"), f"{child_proc.pid}\n")
     _append_marker(
         _marker_path(),
-        f"{base_url} {os.getpid()} child={child_proc.pid}",
+        f"{base_url} {os.getpid()} child={child_proc.pid} scenario={scenario}",
     )
     print(f"listening on {base_url}", flush=True)
 
@@ -177,7 +614,10 @@ def _serve() -> None:
 
 
 def main() -> None:
-    _serve()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scenario", default="smoke")
+    args = parser.parse_args()
+    _serve(args.scenario)
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/fake_opencode_server.py
+++ b/tests/fixtures/fake_opencode_server.py
@@ -170,14 +170,24 @@ class _FakeOpenCodeState:
         for subscriber in subscribers:
             subscriber.put(dict(payload))
 
-    def prompt_async(self, session_id: str, prompt_text: str) -> dict[str, Any]:
+    def prompt_async(
+        self,
+        session_id: str,
+        prompt_text: str,
+        *,
+        turn_id: Optional[str] = None,
+    ) -> dict[str, Any]:
         user_message_id = f"user-{uuid.uuid4().hex[:8]}"
         assistant_message_id = f"assistant-{uuid.uuid4().hex[:8]}"
+        turn_props = (
+            {"turnID": turn_id} if isinstance(turn_id, str) and turn_id.strip() else {}
+        )
         self.emit(
             {
                 "type": "message.updated",
                 "properties": {
                     "sessionID": session_id,
+                    **turn_props,
                     "info": {
                         "id": user_message_id,
                         "role": "user",
@@ -191,6 +201,7 @@ class _FakeOpenCodeState:
                 "type": "message.part.updated",
                 "properties": {
                     "sessionID": session_id,
+                    **turn_props,
                     "part": {
                         "id": f"part-{uuid.uuid4().hex[:8]}",
                         "type": "text",
@@ -206,6 +217,7 @@ class _FakeOpenCodeState:
                 "type": "session.status",
                 "properties": {
                     "sessionID": session_id,
+                    **turn_props,
                     "status": {"type": "busy"},
                 },
             }
@@ -215,6 +227,7 @@ class _FakeOpenCodeState:
                 "type": "message.updated",
                 "properties": {
                     "sessionID": session_id,
+                    **turn_props,
                     "info": {
                         "id": assistant_message_id,
                         "role": "assistant",
@@ -229,6 +242,7 @@ class _FakeOpenCodeState:
                     "type": "message.part.updated",
                     "properties": {
                         "sessionID": session_id,
+                        **turn_props,
                         "part": {
                             "id": f"part-{uuid.uuid4().hex[:8]}",
                             "type": "text",
@@ -244,11 +258,17 @@ class _FakeOpenCodeState:
                     "type": "session.status",
                     "properties": {
                         "sessionID": session_id,
+                        **turn_props,
                         "status": {"type": "idle"},
                     },
                 }
             )
-            self.emit({"type": "session.idle", "properties": {"sessionID": session_id}})
+            self.emit(
+                {
+                    "type": "session.idle",
+                    "properties": {"sessionID": session_id, **turn_props},
+                }
+            )
             return {
                 "info": {
                     "id": assistant_message_id,
@@ -289,6 +309,7 @@ class _FakeOpenCodeState:
                 "type": "message.part.updated",
                 "properties": {
                     "sessionID": session_id,
+                    **turn_props,
                     "part": {
                         "id": tool_part_id,
                         "messageID": assistant_message_id,
@@ -307,6 +328,7 @@ class _FakeOpenCodeState:
                 "properties": {
                     "id": request_id,
                     "sessionID": session_id,
+                    **turn_props,
                     "questions": [question],
                     "tool": {
                         "messageID": assistant_message_id,
@@ -320,6 +342,7 @@ class _FakeOpenCodeState:
                 "type": "message.part.updated",
                 "properties": {
                     "sessionID": session_id,
+                    **turn_props,
                     "part": {
                         "id": tool_part_id,
                         "messageID": assistant_message_id,
@@ -352,6 +375,7 @@ class _FakeOpenCodeState:
                 "type": "question.replied",
                 "properties": {
                     "sessionID": session_id,
+                    **turn_props,
                     "requestID": request_id,
                     "answers": pending.answers or [],
                 },
@@ -362,6 +386,7 @@ class _FakeOpenCodeState:
                 "type": "message.part.updated",
                 "properties": {
                     "sessionID": session_id,
+                    **turn_props,
                     "part": {
                         "id": tool_part_id,
                         "messageID": assistant_message_id,
@@ -396,6 +421,7 @@ class _FakeOpenCodeState:
                 "type": "message.part.updated",
                 "properties": {
                     "sessionID": session_id,
+                    **turn_props,
                     "part": {
                         "id": f"text-{uuid.uuid4().hex[:8]}",
                         "messageID": assistant_message_id,
@@ -411,11 +437,17 @@ class _FakeOpenCodeState:
                 "type": "session.status",
                 "properties": {
                     "sessionID": session_id,
+                    **turn_props,
                     "status": {"type": "idle"},
                 },
             }
         )
-        self.emit({"type": "session.idle", "properties": {"sessionID": session_id}})
+        self.emit(
+            {
+                "type": "session.idle",
+                "properties": {"sessionID": session_id, **turn_props},
+            }
+        )
         return {
             "info": {
                 "id": assistant_message_id,
@@ -530,13 +562,18 @@ class _FakeRequestHandler(http.server.BaseHTTPRequestHandler):
             session_id = prompt_match.group(1)
             prompt_text = ""
             parts_raw = payload.get("parts")
+            turn_id = payload.get("variant")
             if isinstance(parts_raw, list):
                 prompt_text = "".join(
                     part.get("text", "")
                     for part in parts_raw
                     if isinstance(part, dict) and isinstance(part.get("text"), str)
                 )
-            result = state.prompt_async(session_id, prompt_text)
+            result = state.prompt_async(
+                session_id,
+                prompt_text,
+                turn_id=turn_id if isinstance(turn_id, str) else None,
+            )
             self._write_json(HTTPStatus.OK, result)
             return
         reply_match = re.fullmatch(r"/question/([^/]+)/reply", self.path)

--- a/tests/test_app_server_client.py
+++ b/tests/test_app_server_client.py
@@ -690,6 +690,53 @@ async def test_approval_flow(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
+async def test_request_user_input_flow(tmp_path: Path) -> None:
+    questions: list[dict] = []
+
+    async def answer(request: dict) -> dict:
+        questions.append(request)
+        return {"answers": {"framework": {"answers": ["pytest"]}}}
+
+    client = CodexAppServerClient(
+        fixture_command("question"),
+        cwd=tmp_path,
+        question_handler=answer,
+    )
+    try:
+        thread = await client.thread_start(str(tmp_path))
+        handle = await client.turn_start(thread["id"], "hi")
+        result = await handle.wait()
+        assert questions
+        assert result.status == "completed"
+        assert result.final_message == "Selected framework: pytest"
+        assert result.agent_messages == ["Selected framework: pytest"]
+    finally:
+        await client.close()
+
+
+@pytest.mark.anyio
+async def test_request_user_input_flow_normalizes_malformed_answers(
+    tmp_path: Path,
+) -> None:
+    async def answer(_request: dict) -> dict:
+        return {"answers": {"framework": "pytest"}}
+
+    client = CodexAppServerClient(
+        fixture_command("question"),
+        cwd=tmp_path,
+        question_handler=answer,
+    )
+    try:
+        thread = await client.thread_start(str(tmp_path))
+        handle = await client.turn_start(thread["id"], "hi")
+        result = await handle.wait()
+        assert result.status == "completed"
+        assert result.final_message == "Selected framework: pytest"
+    finally:
+        await client.close()
+
+
+@pytest.mark.anyio
 async def test_turn_interrupt(tmp_path: Path) -> None:
     client = CodexAppServerClient(fixture_command("interrupt"), cwd=tmp_path)
     try:


### PR DESCRIPTION
## What changed
This adds realistic question-tool support to the chat lab and fixture runtimes for both Codex-app-server and OpenCode paths.

Key changes:
- add app-server client support for `item/tool/requestUserInput`
- add a fixture scenario that emits question requests and accepts structured answers
- extend the chat-lab backend runtime contract to normalize question prompts into `control.question_requested`
- rework the fake OpenCode server to model the observed blocking question flow, including `question.asked`, tool-part state changes, reply/reject handling, and idle completion
- harden the runtime after review by:
  - generating unique OpenCode fixture turn ids per turn
  - waiting for the SSE stream to come up before sending prompts, to avoid losing early question events
  - normalizing malformed question-handler answer dicts before they go on the wire
  - treating teardown cancellation as cancellation/reject semantics instead of synthesizing `"cancel"` as a user answer

## Why
OpenCode currently blocks when the question tool is emitted and no reply is sent, which made the existing harness unrealistic and caused turns to appear to hang until timeout. This change makes the lab reflect the real interaction pattern closely enough to prototype and integration-test question support.

For Codex app-server specifically, the live default-mode behavior observed during investigation was different: the server reported that `request_user_input` is unavailable in Default mode and fell back to plain assistant text instead of emitting `item/tool/requestUserInput`. The new app-server client support is therefore protocol coverage plus fixture support for a path that is not yet exercised by the current live default-mode server.

## Review findings addressed
- fixed a real multi-turn collision in the OpenCode fixture runtime by making turn ids unique per turn
- fixed a race where question events could be emitted before the event stream subscriber was ready
- fixed teardown behavior so pending question controls are rejected/cancelled rather than converted into a literal `cancel` answer
- fixed question payload publication to preserve the normalized question list instead of letting raw payload values overwrite it
- tightened answer normalization so malformed handler dicts do not propagate directly to the protocol layer

## Teardown/tmpdir check
I also checked whether the post-success `multiprocessing` tempdir traceback in `tests/test_opencode_supervisor_process_management.py` indicates a disk-space leak.

Conclusion:
- I do not see evidence of accumulating temp files over repeated runs.
- Repeated runs still print the same `multiprocessing.util._remove_temp_dir` `FileNotFoundError` after success.
- Temp-root snapshots before and after the runs stayed empty.
- The most likely explanation is noisy double-cleanup after the hermetic temp root is already gone, not a persistent tmp-file leak.

## Validation
- `./.venv/bin/python -m pytest tests/test_app_server_client.py -q`
- `./.venv/bin/python -m pytest tests/chat_surface_lab/test_backend_runtime_contract.py -q`
- `./.venv/bin/python -m pytest tests/test_opencode_supervisor_process_management.py -q`
- `./.venv/bin/python -m pytest tests/test_app_server_client.py -q tests/chat_surface_lab -q`
- repo commit hook validation:
  - `black`
  - `ruff`
  - strict `mypy` on `src/codex_autorunner`
  - full `pytest` suite (`7509 passed, 8 xfailed`)
  - frontend build/tests
  - chat-surface deterministic checks and latency budget checks