### PR TITLE
[codex] Fix web repo settings modal wiring

### DIFF
--- a/src/codex_autorunner/static/assets.json
+++ b/src/codex_autorunner/static/assets.json
@@ -152,6 +152,9 @@
       "path": "generated/streamUtils.js"
     },
     {
+      "path": "generated/systemUpdateUi.js"
+    },
+    {
       "path": "generated/tabs.js"
     },
     {

--- a/src/codex_autorunner/static/generated/hubRefresh.js
+++ b/src/codex_autorunner/static/generated/hubRefresh.js
@@ -1,9 +1,9 @@
 // GENERATED FILE - do not edit directly. Source: static_src/
-import { api, flash, confirmModal } from "./utils.js";
+import { api, flash } from "./utils.js";
 import { HUB_CACHE_TTL_MS, HUB_USAGE_CACHE_KEY, saveSessionCache, loadSessionCache, loadHubBootstrapCache, saveHubBootstrapCache, indexHubUsage, } from "./hubCache.js";
 import { registerAutoRefresh } from "./autoRefresh.js";
 import { renderReposWithScroll, renderAgentWorkspaces, renderSummary, } from "./hubRepoCards.js";
-import { describeUpdateTarget, getUpdateTarget, includesWebUpdateTarget, normalizeUpdateTarget, updateRestartNotice, updateTargetOptionsFromResponse, } from "./updateTargets.js";
+import { loadUpdateTargetOptions, handleSystemUpdate, } from "./systemUpdateUi.js";
 import { getHubData, applyHubData, getHubChannelEntries, getPinnedParentRepoIds, startHubJob, } from "./hubActions.js";
 export const HUB_REFRESH_ACTIVE_MS = 5000;
 export const HUB_REFRESH_IDLE_MS = 30000;
@@ -217,107 +217,7 @@ async function checkUpdateStatus() {
         // Ignore update status failures; UI still renders.
     }
 }
-export async function loadUpdateTargetOptions(selectId) {
-    const select = selectId ? document.getElementById(selectId) : null;
-    if (!select)
-        return;
-    const isInitialized = select.dataset.updateTargetsInitialized === "1";
-    let payload;
-    try {
-        payload = await api("/system/update/targets", { method: "GET" });
-    }
-    catch (_err) {
-        return;
-    }
-    const { options, defaultTarget } = updateTargetOptionsFromResponse(payload);
-    if (!options.length)
-        return;
-    const previous = normalizeUpdateTarget(select.value || "all");
-    const hasPrevious = options.some((item) => item.value === previous);
-    const fallback = options.some((item) => item.value === defaultTarget)
-        ? defaultTarget
-        : options[0].value;
-    select.replaceChildren();
-    options.forEach((item) => {
-        const option = document.createElement("option");
-        option.value = item.value;
-        option.textContent = item.label;
-        select.appendChild(option);
-    });
-    if (isInitialized) {
-        select.value = hasPrevious ? previous : fallback;
-    }
-    else {
-        select.value = fallback;
-        select.dataset.updateTargetsInitialized = "1";
-    }
-}
-export async function handleSystemUpdate(btnId, targetSelectId) {
-    const btn = document.getElementById(btnId);
-    if (!btn)
-        return;
-    const originalText = btn.textContent;
-    btn.disabled = true;
-    btn.textContent = "Checking...";
-    const updateTarget = getUpdateTarget(targetSelectId);
-    const targetLabel = describeUpdateTarget(updateTarget);
-    let check;
-    try {
-        check = await api("/system/update/check");
-    }
-    catch (err) {
-        check = { update_available: true, message: err.message || "Unable to check for updates." };
-    }
-    if (!check?.update_available) {
-        flash(check?.message || "No update available.", "info");
-        btn.disabled = false;
-        btn.textContent = originalText;
-        return;
-    }
-    const restartNotice = updateRestartNotice(updateTarget);
-    const confirmed = await confirmModal(`${check?.message || "Update available."} Update Codex Autorunner (${targetLabel})? ${restartNotice}`);
-    if (!confirmed) {
-        btn.disabled = false;
-        btn.textContent = originalText;
-        return;
-    }
-    btn.textContent = "Updating...";
-    try {
-        let res = await api("/system/update", {
-            method: "POST",
-            body: { target: updateTarget },
-        });
-        if (res.requires_confirmation) {
-            const forceConfirmed = await confirmModal(res.message || "Active sessions are still running. Update anyway?", { confirmText: "Update anyway", cancelText: "Cancel", danger: true });
-            if (!forceConfirmed) {
-                btn.disabled = false;
-                btn.textContent = originalText;
-                return;
-            }
-            res = await api("/system/update", {
-                method: "POST",
-                body: { target: updateTarget, force: true },
-            });
-        }
-        flash(res.message || `Update started (${targetLabel}).`, "success");
-        if (!includesWebUpdateTarget(updateTarget)) {
-            btn.disabled = false;
-            btn.textContent = originalText;
-            return;
-        }
-        document.body.style.pointerEvents = "none";
-        setTimeout(() => {
-            const url = new URL(window.location.href);
-            url.searchParams.set("v", String(Date.now()));
-            window.location.replace(url.toString());
-        }, 8000);
-    }
-    catch (err) {
-        flash(err.message || "Update failed", "error");
-        btn.disabled = false;
-        btn.textContent = originalText;
-    }
-}
+export { loadUpdateTargetOptions, handleSystemUpdate };
 export function bootstrapHubData() {
     const hubData = getHubData();
     const cachedHub = loadHubBootstrapCache();

--- a/src/codex_autorunner/static/generated/settings.js
+++ b/src/codex_autorunner/static/generated/settings.js
@@ -1,7 +1,7 @@
 // GENERATED FILE - do not edit directly. Source: static_src/
 import { api, confirmModal, flash, resolvePath, openModal } from "./utils.js";
-import { initTemplateReposSettings, loadTemplateRepos } from "./templateReposSettings.js";
-import { describeUpdateTarget, getUpdateTarget, includesWebUpdateTarget, normalizeUpdateTarget, updateRestartNotice, updateTargetOptionsFromResponse, } from "./updateTargets.js";
+import { initTemplateReposSettings, loadTemplateRepos, } from "./templateReposSettings.js";
+import { handleSystemUpdate, loadUpdateTargetOptions, } from "./systemUpdateUi.js";
 const ui = {
     settingsBtn: document.getElementById("repo-settings"),
     threadList: document.getElementById("thread-tools-list"),
@@ -9,7 +9,81 @@ const ui = {
     threadArchive: document.getElementById("thread-archive-autorunner"),
     threadResetAll: document.getElementById("thread-reset-all"),
     threadDownload: document.getElementById("thread-backup-download"),
+    updateTarget: document.getElementById("repo-update-target"),
+    updateBtn: document.getElementById("repo-update-btn"),
+    closeBtn: document.getElementById("repo-settings-close"),
+    modelSelect: document.getElementById("autorunner-model-select"),
+    effortSelect: document.getElementById("autorunner-effort-select"),
+    approvalSelect: document.getElementById("autorunner-approval-select"),
+    sandboxSelect: document.getElementById("autorunner-sandbox-select"),
+    maxRunsInput: document.getElementById("autorunner-max-runs-input"),
+    networkToggle: document.getElementById("autorunner-network-toggle"),
+    saveBtn: document.getElementById("autorunner-settings-save"),
+    reloadBtn: document.getElementById("autorunner-settings-reload"),
 };
+const DEFAULT_OPTION_LABEL = "Default (inherit config)";
+const APPROVAL_OPTIONS = [
+    { value: "", label: DEFAULT_OPTION_LABEL },
+    { value: "never", label: "never" },
+    { value: "unlessTrusted", label: "unlessTrusted" },
+];
+const SANDBOX_OPTIONS = [
+    { value: "", label: DEFAULT_OPTION_LABEL },
+    { value: "dangerFullAccess", label: "dangerFullAccess" },
+    { value: "workspaceWrite", label: "workspaceWrite" },
+];
+let repoSettingsCloseModal = null;
+let currentCatalog = null;
+let currentCatalogAgent = "codex";
+let settingsBusy = false;
+let settingsLoaded = false;
+function normalizeOptionalString(value) {
+    if (typeof value !== "string")
+        return null;
+    const cleaned = value.trim();
+    return cleaned || null;
+}
+function normalizeOptionalBoolean(value) {
+    if (typeof value !== "boolean")
+        return null;
+    return value;
+}
+function normalizeOptionalInteger(value) {
+    if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+        return null;
+    }
+    return value;
+}
+function normalizeCatalog(raw) {
+    if (!raw || typeof raw !== "object") {
+        return { default_model: "", models: [] };
+    }
+    const rawObj = raw;
+    const models = Array.isArray(rawObj.models) ? rawObj.models : [];
+    const normalized = models
+        .map((entry) => {
+        if (!entry || typeof entry !== "object")
+            return null;
+        const entryObj = entry;
+        const id = normalizeOptionalString(entryObj.id);
+        if (!id)
+            return null;
+        const reasoningOptions = Array.isArray(entryObj.reasoning_options)
+            ? entryObj.reasoning_options.filter((option) => typeof option === "string" && option.trim().length > 0)
+            : [];
+        return {
+            id,
+            display_name: normalizeOptionalString(entryObj.display_name) || id,
+            supports_reasoning: Boolean(entryObj.supports_reasoning),
+            reasoning_options: reasoningOptions,
+        };
+    })
+        .filter((model) => model !== null);
+    return {
+        default_model: normalizeOptionalString(rawObj.default_model) || "",
+        models: normalized,
+    };
+}
 function renderThreadTools(data) {
     if (!ui.threadList)
         return;
@@ -31,7 +105,6 @@ function renderThreadTools(data) {
             value: data.file_chat_opencode || "—",
         });
     }
-    // Render any additional string/number keys to avoid hiding future entries.
     Object.keys(data).forEach((key) => {
         if (["autorunner", "file_chat", "file_chat_opencode", "corruption"].includes(key)) {
             return;
@@ -52,7 +125,7 @@ function renderThreadTools(data) {
       <span class="thread-tool-label">${entry.label}</span>
       <span class="thread-tool-value">${entry.value}</span>
     `;
-        ui.threadList.appendChild(row);
+        ui.threadList?.appendChild(row);
     });
     if (ui.threadArchive) {
         ui.threadArchive.disabled = !data.autorunner;
@@ -60,24 +133,219 @@ function renderThreadTools(data) {
 }
 async function loadThreadTools() {
     try {
-        const data = await api("/api/app-server/threads");
+        const data = (await api("/api/app-server/threads"));
         renderThreadTools(data);
         return data;
     }
     catch (err) {
         renderThreadTools(null);
-        const error = err;
-        flash(error.message || "Failed to load threads", "error");
+        flash(err.message || "Failed to load threads", "error");
         return null;
     }
 }
+function setSelectOptions(select, options, selectedValue, unknownLabel, preserveUnknown = true) {
+    if (!select)
+        return;
+    const normalizedSelected = normalizeOptionalString(selectedValue) || "";
+    const rendered = [...options];
+    if (preserveUnknown &&
+        normalizedSelected &&
+        !rendered.some((option) => option.value === normalizedSelected)) {
+        rendered.push({
+            value: normalizedSelected,
+            label: `${normalizedSelected} (${unknownLabel})`,
+        });
+    }
+    select.replaceChildren();
+    rendered.forEach((entry) => {
+        const option = document.createElement("option");
+        option.value = entry.value;
+        option.textContent = entry.label;
+        select.appendChild(option);
+    });
+    select.dataset.optionAvailable =
+        rendered.length <= 1 && rendered[0]?.value === "" ? "0" : "1";
+    select.value = rendered.some((entry) => entry.value === normalizedSelected)
+        ? normalizedSelected
+        : rendered[0]?.value || "";
+}
+function modelLabel(model) {
+    return model.display_name && model.display_name !== model.id
+        ? `${model.display_name} (${model.id})`
+        : model.id;
+}
+function currentEffectiveModelId() {
+    const selectedModel = normalizeOptionalString(ui.modelSelect?.value || null);
+    if (selectedModel)
+        return selectedModel;
+    if (currentCatalog?.default_model &&
+        currentCatalog.models.some((model) => model.id === currentCatalog.default_model)) {
+        return currentCatalog.default_model;
+    }
+    return currentCatalog?.models[0]?.id || null;
+}
+function currentEffectiveModel() {
+    const modelId = currentEffectiveModelId();
+    if (!modelId || !currentCatalog)
+        return null;
+    return currentCatalog.models.find((model) => model.id === modelId) || null;
+}
+function updateReasoningOptions(selectedValue, preserveUnknown = true) {
+    const model = currentEffectiveModel();
+    const options = [{ value: "", label: DEFAULT_OPTION_LABEL }];
+    if (model?.supports_reasoning) {
+        model.reasoning_options.forEach((optionValue) => {
+            options.push({ value: optionValue, label: optionValue });
+        });
+    }
+    setSelectOptions(ui.effortSelect, options, selectedValue, "current override", preserveUnknown);
+}
+function renderAutorunnerSettings(data) {
+    const modelOptions = [{ value: "", label: DEFAULT_OPTION_LABEL }];
+    currentCatalog?.models.forEach((model) => {
+        modelOptions.push({ value: model.id, label: modelLabel(model) });
+    });
+    setSelectOptions(ui.modelSelect, modelOptions, normalizeOptionalString(data.autorunner_model_override), "current override");
+    updateReasoningOptions(normalizeOptionalString(data.autorunner_effort_override), true);
+    setSelectOptions(ui.approvalSelect, APPROVAL_OPTIONS, normalizeOptionalString(data.autorunner_approval_policy), "current override");
+    setSelectOptions(ui.sandboxSelect, SANDBOX_OPTIONS, normalizeOptionalString(data.autorunner_sandbox_mode), "current override");
+    if (ui.maxRunsInput) {
+        const maxRuns = normalizeOptionalInteger(data.runner_stop_after_runs);
+        ui.maxRunsInput.value = maxRuns ? String(maxRuns) : "";
+    }
+    if (ui.networkToggle) {
+        const networkSetting = normalizeOptionalBoolean(data.autorunner_workspace_write_network);
+        ui.networkToggle.checked = networkSetting === true;
+        ui.networkToggle.indeterminate = networkSetting === null;
+    }
+    updateAutorunnerFormInteractivity();
+}
+async function resolveCatalogAgent() {
+    try {
+        const data = (await api("/api/agents", {
+            method: "GET",
+        }));
+        const agents = Array.isArray(data.agents) ? data.agents : [];
+        const supportsListing = (agent) => Array.isArray(agent?.capabilities) &&
+            agent.capabilities.includes("model_listing");
+        const defaultAgentId = normalizeOptionalString(data.default) || "codex";
+        const defaultAgent = agents.find((agent) => agent.id === defaultAgentId);
+        if (supportsListing(defaultAgent)) {
+            return defaultAgentId;
+        }
+        const codexAgent = agents.find((agent) => agent.id === "codex");
+        if (supportsListing(codexAgent)) {
+            return "codex";
+        }
+        const firstListed = agents.find((agent) => supportsListing(agent));
+        return normalizeOptionalString(firstListed?.id) || defaultAgentId;
+    }
+    catch (_err) {
+        return "codex";
+    }
+}
+async function loadCatalog(agentId) {
+    try {
+        const data = await api(`/api/agents/${encodeURIComponent(agentId)}/models`, {
+            method: "GET",
+        });
+        return normalizeCatalog(data);
+    }
+    catch (_err) {
+        return null;
+    }
+}
+function setAutorunnerBusy(busy) {
+    settingsBusy = busy;
+    updateAutorunnerFormInteractivity();
+}
+function updateAutorunnerFormInteractivity() {
+    const formDisabled = settingsBusy || !settingsLoaded;
+    const applySelectState = (select) => {
+        if (!select)
+            return;
+        select.disabled =
+            formDisabled || select.dataset.optionAvailable === "0";
+    };
+    applySelectState(ui.modelSelect);
+    applySelectState(ui.effortSelect);
+    applySelectState(ui.approvalSelect);
+    applySelectState(ui.sandboxSelect);
+    if (ui.maxRunsInput)
+        ui.maxRunsInput.disabled = formDisabled;
+    if (ui.networkToggle)
+        ui.networkToggle.disabled = formDisabled;
+    if (ui.saveBtn)
+        ui.saveBtn.disabled = settingsBusy || !settingsLoaded;
+    if (ui.reloadBtn)
+        ui.reloadBtn.disabled = settingsBusy;
+}
+async function loadAutorunnerSettings() {
+    settingsLoaded = false;
+    setAutorunnerBusy(true);
+    try {
+        const [settingsPayload, agentId] = await Promise.all([
+            api("/api/session/settings", { method: "GET" }),
+            resolveCatalogAgent(),
+        ]);
+        currentCatalogAgent = agentId;
+        currentCatalog = await loadCatalog(agentId);
+        settingsLoaded = true;
+        renderAutorunnerSettings(settingsPayload);
+    }
+    catch (err) {
+        currentCatalog = null;
+        settingsLoaded = false;
+        renderAutorunnerSettings({});
+        flash(err.message || "Failed to load autorunner settings", "error");
+    }
+    finally {
+        setAutorunnerBusy(false);
+    }
+}
+function collectAutorunnerSettingsPayload() {
+    const maxRunsRaw = ui.maxRunsInput?.value.trim() || "";
+    const parsedMaxRuns = maxRunsRaw ? Number.parseInt(maxRunsRaw, 10) : NaN;
+    return {
+        autorunner_model_override: normalizeOptionalString(ui.modelSelect?.value || null),
+        autorunner_effort_override: normalizeOptionalString(ui.effortSelect?.value || null),
+        autorunner_approval_policy: normalizeOptionalString(ui.approvalSelect?.value || null),
+        autorunner_sandbox_mode: normalizeOptionalString(ui.sandboxSelect?.value || null),
+        autorunner_workspace_write_network: ui.networkToggle && !ui.networkToggle.indeterminate
+            ? ui.networkToggle.checked
+            : null,
+        runner_stop_after_runs: Number.isInteger(parsedMaxRuns) && parsedMaxRuns > 0 ? parsedMaxRuns : null,
+    };
+}
+async function saveAutorunnerSettings() {
+    if (settingsBusy || !settingsLoaded)
+        return;
+    setAutorunnerBusy(true);
+    try {
+        const payload = collectAutorunnerSettingsPayload();
+        await api("/api/session/settings", {
+            method: "POST",
+            body: payload,
+        });
+        flash("Autorunner settings saved", "success");
+        await refreshSettings();
+    }
+    catch (err) {
+        flash(err.message || "Failed to save autorunner settings", "error");
+    }
+    finally {
+        setAutorunnerBusy(false);
+    }
+}
 async function refreshSettings() {
-    await loadThreadTools();
-    await loadTemplateRepos();
+    await Promise.all([
+        loadThreadTools(),
+        loadTemplateRepos(),
+        loadAutorunnerSettings(),
+    ]);
 }
 export function initRepoSettingsPanel() {
     window.__CAR_SETTINGS = { loadThreadTools, refreshSettings };
-    // Initialize the modal interaction
     initRepoSettingsModal();
     initTemplateReposSettings();
     if (ui.threadNew) {
@@ -91,8 +359,7 @@ export function initRepoSettingsPanel() {
                 await loadThreadTools();
             }
             catch (err) {
-                const error = err;
-                flash(error.message || "Failed to reset autorunner thread", "error");
+                flash(err.message || "Failed to reset autorunner thread", "error");
             }
         });
     }
@@ -120,8 +387,7 @@ export function initRepoSettingsPanel() {
                 await loadThreadTools();
             }
             catch (err) {
-                const error = err;
-                flash(error.message || "Failed to archive thread", "error");
+                flash(err.message || "Failed to archive thread", "error");
             }
         });
     }
@@ -136,8 +402,7 @@ export function initRepoSettingsPanel() {
                 await loadThreadTools();
             }
             catch (err) {
-                const error = err;
-                flash(error.message || "Failed to reset conversations", "error");
+                flash(err.message || "Failed to reset conversations", "error");
             }
         });
     }
@@ -146,7 +411,28 @@ export function initRepoSettingsPanel() {
             window.location.href = resolvePath("/api/app-server/threads/backup");
         });
     }
-    // Clear cached logs since log loading is no longer available
+    if (ui.modelSelect) {
+        ui.modelSelect.addEventListener("change", () => {
+            updateReasoningOptions(normalizeOptionalString(ui.effortSelect?.value || null), false);
+        });
+    }
+    if (ui.networkToggle) {
+        const clearIndeterminate = () => {
+            ui.networkToggle.indeterminate = false;
+        };
+        ui.networkToggle.addEventListener("change", clearIndeterminate);
+        ui.networkToggle.addEventListener("click", clearIndeterminate);
+    }
+    if (ui.saveBtn) {
+        ui.saveBtn.addEventListener("click", () => {
+            void saveAutorunnerSettings();
+        });
+    }
+    if (ui.reloadBtn) {
+        ui.reloadBtn.addEventListener("click", () => {
+            void refreshSettings();
+        });
+    }
     try {
         localStorage.removeItem("logs:tail");
     }
@@ -154,108 +440,6 @@ export function initRepoSettingsPanel() {
         // ignore
     }
 }
-async function loadUpdateTargetOptions(selectId) {
-    const select = selectId ? document.getElementById(selectId) : null;
-    if (!select)
-        return;
-    const isInitialized = select.dataset.updateTargetsInitialized === "1";
-    let payload;
-    try {
-        payload = await api("/system/update/targets", { method: "GET" });
-    }
-    catch (_err) {
-        return;
-    }
-    const { options, defaultTarget } = updateTargetOptionsFromResponse(payload);
-    if (!options.length)
-        return;
-    const previous = normalizeUpdateTarget(select.value || "all");
-    const hasPrevious = options.some((item) => item.value === previous);
-    const fallback = options.some((item) => item.value === defaultTarget)
-        ? defaultTarget
-        : options[0].value;
-    select.replaceChildren();
-    options.forEach((item) => {
-        const option = document.createElement("option");
-        option.value = item.value;
-        option.textContent = item.label;
-        select.appendChild(option);
-    });
-    if (isInitialized) {
-        select.value = hasPrevious ? previous : fallback;
-    }
-    else {
-        select.value = fallback;
-        select.dataset.updateTargetsInitialized = "1";
-    }
-}
-async function handleSystemUpdate(btnId, targetSelectId) {
-    const btn = document.getElementById(btnId);
-    if (!btn)
-        return;
-    const originalText = btn.textContent;
-    btn.disabled = true;
-    btn.textContent = "Checking...";
-    const updateTarget = getUpdateTarget(targetSelectId);
-    const targetLabel = describeUpdateTarget(updateTarget);
-    let check;
-    try {
-        check = await api("/system/update/check");
-    }
-    catch (err) {
-        check = { update_available: true, message: err.message || "Unable to check for updates." };
-    }
-    if (!check?.update_available) {
-        flash(check?.message || "No update available.", "info");
-        btn.disabled = false;
-        btn.textContent = originalText;
-        return;
-    }
-    const restartNotice = updateRestartNotice(updateTarget);
-    const confirmed = await confirmModal(`${check?.message || "Update available."} Update Codex Autorunner (${targetLabel})? ${restartNotice}`);
-    if (!confirmed) {
-        btn.disabled = false;
-        btn.textContent = originalText;
-        return;
-    }
-    btn.textContent = "Updating...";
-    try {
-        let res = await api("/system/update", {
-            method: "POST",
-            body: { target: updateTarget },
-        });
-        if (res.requires_confirmation) {
-            const forceConfirmed = await confirmModal(res.message || "Active sessions are still running. Update anyway?", { confirmText: "Update anyway", cancelText: "Cancel", danger: true });
-            if (!forceConfirmed) {
-                btn.disabled = false;
-                btn.textContent = originalText;
-                return;
-            }
-            res = await api("/system/update", {
-                method: "POST",
-                body: { target: updateTarget, force: true },
-            });
-        }
-        flash(res.message || `Update started (${targetLabel}).`, "success");
-        if (!includesWebUpdateTarget(updateTarget)) {
-            btn.disabled = false;
-            btn.textContent = originalText;
-            return;
-        }
-        document.body.style.pointerEvents = "none";
-        setTimeout(() => {
-            const url = new URL(window.location.href);
-            url.searchParams.set("v", String(Date.now()));
-            window.location.replace(url.toString());
-        }, 8000);
-    }
-    catch (err) {
-        flash(err.message || "Update failed", "error");
-        btn.disabled = false;
-        btn.textContent = originalText;
-    }
-}
-let repoSettingsCloseModal = null;
 function hideRepoSettingsModal() {
     if (repoSettingsCloseModal) {
         const close = repoSettingsCloseModal;
@@ -265,41 +449,45 @@ function hideRepoSettingsModal() {
 }
 export function openRepoSettings(triggerEl) {
     const modal = document.getElementById("repo-settings-modal");
-    const closeBtn = document.getElementById("repo-settings-close");
-    const updateBtn = document.getElementById("repo-update-btn");
-    const updateTarget = document.getElementById("repo-update-target");
     if (!modal)
         return;
     hideRepoSettingsModal();
     repoSettingsCloseModal = openModal(modal, {
-        initialFocus: closeBtn || updateBtn || modal,
+        initialFocus: ui.closeBtn || ui.updateBtn || modal,
         returnFocusTo: triggerEl || null,
         onRequestClose: hideRepoSettingsModal,
     });
-    // Trigger settings refresh when modal opens
-    const { refreshSettings } = window.__CAR_SETTINGS || {};
-    if (typeof refreshSettings === "function") {
-        refreshSettings();
-    }
-    void loadUpdateTargetOptions(updateTarget ? updateTarget.id : null);
+    void refreshSettings();
+    void loadUpdateTargetOptions(ui.updateTarget ? ui.updateTarget.id : null);
 }
 function initRepoSettingsModal() {
-    const settingsBtn = document.getElementById("repo-settings");
-    const closeBtn = document.getElementById("repo-settings-close");
-    const updateBtn = document.getElementById("repo-update-btn");
-    const updateTarget = document.getElementById("repo-update-target");
-    void loadUpdateTargetOptions(updateTarget ? updateTarget.id : null);
-    if (settingsBtn) {
-        settingsBtn.addEventListener("click", () => {
-            openRepoSettings(settingsBtn);
+    void loadUpdateTargetOptions(ui.updateTarget ? ui.updateTarget.id : null);
+    if (ui.settingsBtn) {
+        ui.settingsBtn.addEventListener("click", () => {
+            openRepoSettings(ui.settingsBtn);
         });
     }
-    if (closeBtn) {
-        closeBtn.addEventListener("click", () => {
+    if (ui.closeBtn) {
+        ui.closeBtn.addEventListener("click", () => {
             hideRepoSettingsModal();
         });
     }
-    if (updateBtn) {
-        updateBtn.addEventListener("click", () => handleSystemUpdate("repo-update-btn", updateTarget ? updateTarget.id : null));
+    if (ui.updateBtn) {
+        ui.updateBtn.addEventListener("click", () => handleSystemUpdate("repo-update-btn", ui.updateTarget ? ui.updateTarget.id : null));
     }
 }
+export const __settingsTest = {
+    collectAutorunnerSettingsPayload,
+    loadAutorunnerSettings,
+    refreshSettings,
+    reset() {
+        currentCatalog = null;
+        currentCatalogAgent = "codex";
+        settingsBusy = false;
+        settingsLoaded = false;
+        hideRepoSettingsModal();
+    },
+    getCurrentCatalogAgent() {
+        return currentCatalogAgent;
+    },
+};

--- a/src/codex_autorunner/static/generated/settings.js
+++ b/src/codex_autorunner/static/generated/settings.js
@@ -54,6 +54,18 @@ function normalizeOptionalInteger(value) {
     }
     return value;
 }
+/** Whole positive decimal integer string only (avoids parseInt silently truncating "1.5", "1e3", etc.). */
+function parsePositiveIntegerRuns(raw) {
+    const trimmed = raw.trim();
+    if (!trimmed)
+        return null;
+    if (!/^\d+$/.test(trimmed))
+        return undefined;
+    const n = Number.parseInt(trimmed, 10);
+    if (!Number.isFinite(n) || n <= 0)
+        return undefined;
+    return n;
+}
 function normalizeCatalog(raw) {
     if (!raw || typeof raw !== "object") {
         return { default_model: "", models: [] };
@@ -304,8 +316,8 @@ async function loadAutorunnerSettings() {
     }
 }
 function collectAutorunnerSettingsPayload() {
-    const maxRunsRaw = ui.maxRunsInput?.value.trim() || "";
-    const parsedMaxRuns = maxRunsRaw ? Number.parseInt(maxRunsRaw, 10) : NaN;
+    const maxRunsRaw = ui.maxRunsInput?.value ?? "";
+    const runs = parsePositiveIntegerRuns(maxRunsRaw);
     return {
         autorunner_model_override: normalizeOptionalString(ui.modelSelect?.value || null),
         autorunner_effort_override: normalizeOptionalString(ui.effortSelect?.value || null),
@@ -314,12 +326,17 @@ function collectAutorunnerSettingsPayload() {
         autorunner_workspace_write_network: ui.networkToggle && !ui.networkToggle.indeterminate
             ? ui.networkToggle.checked
             : null,
-        runner_stop_after_runs: Number.isInteger(parsedMaxRuns) && parsedMaxRuns > 0 ? parsedMaxRuns : null,
+        runner_stop_after_runs: runs === undefined ? null : runs,
     };
 }
 async function saveAutorunnerSettings() {
     if (settingsBusy || !settingsLoaded)
         return;
+    const maxRunsRaw = ui.maxRunsInput?.value ?? "";
+    if (parsePositiveIntegerRuns(maxRunsRaw) === undefined) {
+        flash("Stop after runs must be a positive whole number, or leave blank for no limit", "error");
+        return;
+    }
     setAutorunnerBusy(true);
     try {
         const payload = collectAutorunnerSettingsPayload();
@@ -478,6 +495,7 @@ function initRepoSettingsModal() {
 }
 export const __settingsTest = {
     collectAutorunnerSettingsPayload,
+    parsePositiveIntegerRuns,
     loadAutorunnerSettings,
     refreshSettings,
     reset() {

--- a/src/codex_autorunner/static/generated/systemUpdateUi.js
+++ b/src/codex_autorunner/static/generated/systemUpdateUi.js
@@ -1,0 +1,111 @@
+// GENERATED FILE - do not edit directly. Source: static_src/
+import { api, confirmModal, flash } from "./utils.js";
+import { describeUpdateTarget, getUpdateTarget, includesWebUpdateTarget, normalizeUpdateTarget, updateRestartNotice, updateTargetOptionsFromResponse, } from "./updateTargets.js";
+export async function loadUpdateTargetOptions(selectId) {
+    const select = selectId
+        ? document.getElementById(selectId)
+        : null;
+    if (!select)
+        return;
+    const isInitialized = select.dataset.updateTargetsInitialized === "1";
+    let payload;
+    try {
+        payload = (await api("/system/update/targets", {
+            method: "GET",
+        }));
+    }
+    catch (_err) {
+        return;
+    }
+    const { options, defaultTarget } = updateTargetOptionsFromResponse(payload);
+    if (!options.length)
+        return;
+    const previous = normalizeUpdateTarget(select.value || "all");
+    const hasPrevious = options.some((item) => item.value === previous);
+    const fallback = options.some((item) => item.value === defaultTarget)
+        ? defaultTarget
+        : options[0].value;
+    select.replaceChildren();
+    options.forEach((item) => {
+        const option = document.createElement("option");
+        option.value = item.value;
+        option.textContent = item.label;
+        select.appendChild(option);
+    });
+    if (isInitialized) {
+        select.value = hasPrevious ? previous : fallback;
+    }
+    else {
+        select.value = fallback;
+        select.dataset.updateTargetsInitialized = "1";
+    }
+}
+export async function handleSystemUpdate(btnId, targetSelectId) {
+    const btn = document.getElementById(btnId);
+    if (!btn)
+        return;
+    const originalText = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = "Checking...";
+    const updateTarget = getUpdateTarget(targetSelectId);
+    const targetLabel = describeUpdateTarget(updateTarget);
+    let check;
+    try {
+        check = (await api("/system/update/check"));
+    }
+    catch (err) {
+        check = {
+            update_available: true,
+            message: err.message || "Unable to check for updates.",
+        };
+    }
+    if (!check?.update_available) {
+        flash(check?.message || "No update available.", "info");
+        btn.disabled = false;
+        btn.textContent = originalText;
+        return;
+    }
+    const restartNotice = updateRestartNotice(updateTarget);
+    const confirmed = await confirmModal(`${check?.message || "Update available."} Update Codex Autorunner (${targetLabel})? ${restartNotice}`);
+    if (!confirmed) {
+        btn.disabled = false;
+        btn.textContent = originalText;
+        return;
+    }
+    btn.textContent = "Updating...";
+    try {
+        let res = (await api("/system/update", {
+            method: "POST",
+            body: { target: updateTarget },
+        }));
+        if (res.requires_confirmation) {
+            const forceConfirmed = await confirmModal(res.message || "Active sessions are still running. Update anyway?", { confirmText: "Update anyway", cancelText: "Cancel", danger: true });
+            if (!forceConfirmed) {
+                btn.disabled = false;
+                btn.textContent = originalText;
+                return;
+            }
+            res = (await api("/system/update", {
+                method: "POST",
+                body: { target: updateTarget, force: true },
+            }));
+        }
+        flash(res.message || `Update started (${targetLabel}).`, "success");
+        if (!includesWebUpdateTarget(updateTarget)) {
+            btn.disabled = false;
+            btn.textContent = originalText;
+            return;
+        }
+        document.body.style.pointerEvents = "none";
+        setTimeout(() => {
+            const url = new URL(window.location.href);
+            url.searchParams.set("v", String(Date.now()));
+            window.location.replace(url.toString());
+        }, 8000);
+    }
+    catch (err) {
+        flash(err.message || "Update failed", "error");
+        btn.disabled = false;
+        btn.textContent = originalText;
+    }
+}

--- a/src/codex_autorunner/static_src/hubRefresh.ts
+++ b/src/codex_autorunner/static_src/hubRefresh.ts
@@ -1,4 +1,4 @@
-import { api, flash, confirmModal } from "./utils.js";
+import { api, flash } from "./utils.js";
 import {
   HUB_CACHE_TTL_MS,
   HUB_USAGE_CACHE_KEY,
@@ -14,22 +14,15 @@ import {
   renderAgentWorkspaces,
   renderSummary,
 } from "./hubRepoCards.js";
-import {
-  describeUpdateTarget,
-  getUpdateTarget,
-  includesWebUpdateTarget,
-  normalizeUpdateTarget,
-  type UpdateTargetsResponse,
-  updateRestartNotice,
-  updateTargetOptionsFromResponse,
-} from "./updateTargets.js";
 import type {
   HubData,
   HubUsageData,
-  UpdateCheckResponse,
-  UpdateResponse,
   HubChannelDirectoryResponse,
 } from "./hubTypes.js";
+import {
+  loadUpdateTargetOptions,
+  handleSystemUpdate,
+} from "./systemUpdateUi.js";
 import {
   getHubData,
   applyHubData,
@@ -263,114 +256,7 @@ async function checkUpdateStatus(): Promise<void> {
   }
 }
 
-export async function loadUpdateTargetOptions(selectId: string | null): Promise<void> {
-  const select = selectId ? (document.getElementById(selectId) as HTMLSelectElement | null) : null;
-  if (!select) return;
-  const isInitialized = select.dataset.updateTargetsInitialized === "1";
-  let payload: UpdateTargetsResponse | null;
-  try {
-    payload = await api("/system/update/targets", { method: "GET" }) as UpdateTargetsResponse;
-  } catch (_err) {
-    return;
-  }
-  const { options, defaultTarget } = updateTargetOptionsFromResponse(payload);
-  if (!options.length) return;
-
-  const previous = normalizeUpdateTarget(select.value || "all");
-  const hasPrevious = options.some((item) => item.value === previous);
-  const fallback = options.some((item) => item.value === defaultTarget)
-    ? defaultTarget
-    : options[0].value;
-
-  select.replaceChildren();
-  options.forEach((item) => {
-    const option = document.createElement("option");
-    option.value = item.value;
-    option.textContent = item.label;
-    select.appendChild(option);
-  });
-  if (isInitialized) {
-    select.value = hasPrevious ? previous : fallback;
-  } else {
-    select.value = fallback;
-    select.dataset.updateTargetsInitialized = "1";
-  }
-}
-
-export async function handleSystemUpdate(btnId: string, targetSelectId: string | null): Promise<void> {
-  const btn = document.getElementById(btnId) as HTMLButtonElement | null;
-  if (!btn) return;
-
-  const originalText = btn.textContent;
-  btn.disabled = true;
-  btn.textContent = "Checking...";
-  const updateTarget = getUpdateTarget(targetSelectId);
-  const targetLabel = describeUpdateTarget(updateTarget);
-
-  let check: UpdateCheckResponse | undefined;
-  try {
-    check = await api("/system/update/check") as UpdateCheckResponse;
-  } catch (err) {
-    check = { update_available: true, message: (err as Error).message || "Unable to check for updates." };
-  }
-
-  if (!check?.update_available) {
-    flash(check?.message || "No update available.", "info");
-    btn.disabled = false;
-    btn.textContent = originalText;
-    return;
-  }
-
-  const restartNotice = updateRestartNotice(updateTarget);
-  const confirmed = await confirmModal(
-    `${check?.message || "Update available."} Update Codex Autorunner (${targetLabel})? ${restartNotice}`
-  );
-  if (!confirmed) {
-    btn.disabled = false;
-    btn.textContent = originalText;
-    return;
-  }
-
-  btn.textContent = "Updating...";
-
-  try {
-    let res = await api("/system/update", {
-      method: "POST",
-      body: { target: updateTarget },
-    }) as UpdateResponse;
-    if (res.requires_confirmation) {
-      const forceConfirmed = await confirmModal(
-        res.message || "Active sessions are still running. Update anyway?",
-        { confirmText: "Update anyway", cancelText: "Cancel", danger: true }
-      );
-      if (!forceConfirmed) {
-        btn.disabled = false;
-        btn.textContent = originalText;
-        return;
-      }
-      res = await api("/system/update", {
-        method: "POST",
-        body: { target: updateTarget, force: true },
-      }) as UpdateResponse;
-    }
-    flash(res.message || `Update started (${targetLabel}).`, "success");
-    if (!includesWebUpdateTarget(updateTarget)) {
-      btn.disabled = false;
-      btn.textContent = originalText;
-      return;
-    }
-    document.body.style.pointerEvents = "none";
-    setTimeout(() => {
-      const url = new URL(window.location.href);
-      url.searchParams.set("v", String(Date.now()));
-      window.location.replace(url.toString());
-    }, 8000);
-  } catch (err) {
-    flash((err as Error).message || "Update failed", "error");
-    btn.disabled = false;
-    btn.textContent = originalText;
-  }
-}
+export { loadUpdateTargetOptions, handleSystemUpdate };
 
 export function bootstrapHubData(): void {
   const hubData = getHubData();

--- a/src/codex_autorunner/static_src/settings.ts
+++ b/src/codex_autorunner/static_src/settings.ts
@@ -145,6 +145,16 @@ function normalizeOptionalInteger(value: unknown): number | null {
   return value;
 }
 
+/** Whole positive decimal integer string only (avoids parseInt silently truncating "1.5", "1e3", etc.). */
+function parsePositiveIntegerRuns(raw: string): number | null | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (!/^\d+$/.test(trimmed)) return undefined;
+  const n = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return n;
+}
+
 function normalizeCatalog(raw: unknown): ModelCatalog {
   if (!raw || typeof raw !== "object") {
     return { default_model: "", models: [] };
@@ -445,8 +455,8 @@ async function loadAutorunnerSettings(): Promise<void> {
 }
 
 function collectAutorunnerSettingsPayload(): SessionSettingsRequest {
-  const maxRunsRaw = ui.maxRunsInput?.value.trim() || "";
-  const parsedMaxRuns = maxRunsRaw ? Number.parseInt(maxRunsRaw, 10) : NaN;
+  const maxRunsRaw = ui.maxRunsInput?.value ?? "";
+  const runs = parsePositiveIntegerRuns(maxRunsRaw);
   return {
     autorunner_model_override: normalizeOptionalString(ui.modelSelect?.value || null),
     autorunner_effort_override: normalizeOptionalString(
@@ -462,13 +472,20 @@ function collectAutorunnerSettingsPayload(): SessionSettingsRequest {
       ui.networkToggle && !ui.networkToggle.indeterminate
         ? ui.networkToggle.checked
         : null,
-    runner_stop_after_runs:
-      Number.isInteger(parsedMaxRuns) && parsedMaxRuns > 0 ? parsedMaxRuns : null,
+    runner_stop_after_runs: runs === undefined ? null : runs,
   };
 }
 
 async function saveAutorunnerSettings(): Promise<void> {
   if (settingsBusy || !settingsLoaded) return;
+  const maxRunsRaw = ui.maxRunsInput?.value ?? "";
+  if (parsePositiveIntegerRuns(maxRunsRaw) === undefined) {
+    flash(
+      "Stop after runs must be a positive whole number, or leave blank for no limit",
+      "error"
+    );
+    return;
+  }
   setAutorunnerBusy(true);
   try {
     const payload = collectAutorunnerSettingsPayload();
@@ -653,6 +670,7 @@ function initRepoSettingsModal(): void {
 
 export const __settingsTest = {
   collectAutorunnerSettingsPayload,
+  parsePositiveIntegerRuns,
   loadAutorunnerSettings,
   refreshSettings,
   reset(): void {

--- a/src/codex_autorunner/static_src/settings.ts
+++ b/src/codex_autorunner/static_src/settings.ts
@@ -1,33 +1,180 @@
 import { api, confirmModal, flash, resolvePath, openModal } from "./utils.js";
-import { initTemplateReposSettings, loadTemplateRepos } from "./templateReposSettings.js";
 import {
-  describeUpdateTarget,
-  getUpdateTarget,
-  includesWebUpdateTarget,
-  normalizeUpdateTarget,
-  type UpdateTargetsResponse,
-  updateRestartNotice,
-  updateTargetOptionsFromResponse,
-} from "./updateTargets.js";
+  initTemplateReposSettings,
+  loadTemplateRepos,
+} from "./templateReposSettings.js";
+import {
+  handleSystemUpdate,
+  loadUpdateTargetOptions,
+} from "./systemUpdateUi.js";
 
 const ui = {
-  settingsBtn: document.getElementById("repo-settings"),
+  settingsBtn: document.getElementById("repo-settings") as HTMLButtonElement | null,
   threadList: document.getElementById("thread-tools-list") as HTMLElement | null,
-  threadNew: document.getElementById("thread-new-autorunner") as HTMLButtonElement | null,
-  threadArchive: document.getElementById("thread-archive-autorunner") as HTMLButtonElement | null,
-  threadResetAll: document.getElementById("thread-reset-all") as HTMLButtonElement | null,
-  threadDownload: document.getElementById("thread-backup-download") as HTMLAnchorElement | null,
+  threadNew: document.getElementById(
+    "thread-new-autorunner"
+  ) as HTMLButtonElement | null,
+  threadArchive: document.getElementById(
+    "thread-archive-autorunner"
+  ) as HTMLButtonElement | null,
+  threadResetAll: document.getElementById(
+    "thread-reset-all"
+  ) as HTMLButtonElement | null,
+  threadDownload: document.getElementById(
+    "thread-backup-download"
+  ) as HTMLAnchorElement | null,
+  updateTarget: document.getElementById(
+    "repo-update-target"
+  ) as HTMLSelectElement | null,
+  updateBtn: document.getElementById(
+    "repo-update-btn"
+  ) as HTMLButtonElement | null,
+  closeBtn: document.getElementById("repo-settings-close") as HTMLButtonElement | null,
+  modelSelect: document.getElementById(
+    "autorunner-model-select"
+  ) as HTMLSelectElement | null,
+  effortSelect: document.getElementById(
+    "autorunner-effort-select"
+  ) as HTMLSelectElement | null,
+  approvalSelect: document.getElementById(
+    "autorunner-approval-select"
+  ) as HTMLSelectElement | null,
+  sandboxSelect: document.getElementById(
+    "autorunner-sandbox-select"
+  ) as HTMLSelectElement | null,
+  maxRunsInput: document.getElementById(
+    "autorunner-max-runs-input"
+  ) as HTMLInputElement | null,
+  networkToggle: document.getElementById(
+    "autorunner-network-toggle"
+  ) as HTMLInputElement | null,
+  saveBtn: document.getElementById(
+    "autorunner-settings-save"
+  ) as HTMLButtonElement | null,
+  reloadBtn: document.getElementById(
+    "autorunner-settings-reload"
+  ) as HTMLButtonElement | null,
 };
-
-
 
 interface ThreadToolData {
   autorunner?: string | number;
   file_chat?: string | number;
   file_chat_opencode?: string | number;
   corruption?: Record<string, unknown>;
-  // Allow unknown keys for forwards compatibility.
   [key: string]: unknown;
+}
+
+interface SessionSettingsResponse {
+  autorunner_model_override?: string | null;
+  autorunner_effort_override?: string | null;
+  autorunner_approval_policy?: string | null;
+  autorunner_sandbox_mode?: string | null;
+  autorunner_workspace_write_network?: boolean | null;
+  runner_stop_after_runs?: number | null;
+}
+
+interface SessionSettingsRequest {
+  autorunner_model_override: string | null;
+  autorunner_effort_override: string | null;
+  autorunner_approval_policy: string | null;
+  autorunner_sandbox_mode: string | null;
+  autorunner_workspace_write_network: boolean | null;
+  runner_stop_after_runs: number | null;
+}
+
+interface AgentEntry {
+  id?: string;
+  capabilities?: string[];
+}
+
+interface AgentListResponse {
+  agents?: AgentEntry[];
+  default?: string;
+}
+
+interface ModelCatalogModel {
+  id: string;
+  display_name?: string;
+  supports_reasoning: boolean;
+  reasoning_options: string[];
+}
+
+interface ModelCatalog {
+  default_model: string;
+  models: ModelCatalogModel[];
+}
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+const DEFAULT_OPTION_LABEL = "Default (inherit config)";
+const APPROVAL_OPTIONS: SelectOption[] = [
+  { value: "", label: DEFAULT_OPTION_LABEL },
+  { value: "never", label: "never" },
+  { value: "unlessTrusted", label: "unlessTrusted" },
+];
+const SANDBOX_OPTIONS: SelectOption[] = [
+  { value: "", label: DEFAULT_OPTION_LABEL },
+  { value: "dangerFullAccess", label: "dangerFullAccess" },
+  { value: "workspaceWrite", label: "workspaceWrite" },
+];
+
+let repoSettingsCloseModal: (() => void) | null = null;
+let currentCatalog: ModelCatalog | null = null;
+let currentCatalogAgent = "codex";
+let settingsBusy = false;
+let settingsLoaded = false;
+
+function normalizeOptionalString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const cleaned = value.trim();
+  return cleaned || null;
+}
+
+function normalizeOptionalBoolean(value: unknown): boolean | null {
+  if (typeof value !== "boolean") return null;
+  return value;
+}
+
+function normalizeOptionalInteger(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return null;
+  }
+  return value;
+}
+
+function normalizeCatalog(raw: unknown): ModelCatalog {
+  if (!raw || typeof raw !== "object") {
+    return { default_model: "", models: [] };
+  }
+  const rawObj = raw as Record<string, unknown>;
+  const models = Array.isArray(rawObj.models) ? rawObj.models : [];
+  const normalized = models
+    .map((entry): ModelCatalogModel | null => {
+      if (!entry || typeof entry !== "object") return null;
+      const entryObj = entry as Record<string, unknown>;
+      const id = normalizeOptionalString(entryObj.id);
+      if (!id) return null;
+      const reasoningOptions = Array.isArray(entryObj.reasoning_options)
+        ? entryObj.reasoning_options.filter(
+            (option): option is string =>
+              typeof option === "string" && option.trim().length > 0
+          )
+        : [];
+      return {
+        id,
+        display_name: normalizeOptionalString(entryObj.display_name) || id,
+        supports_reasoning: Boolean(entryObj.supports_reasoning),
+        reasoning_options: reasoningOptions,
+      };
+    })
+    .filter((model): model is ModelCatalogModel => model !== null);
+  return {
+    default_model: normalizeOptionalString(rawObj.default_model) || "",
+    models: normalized,
+  };
 }
 
 function renderThreadTools(data: ThreadToolData | null): void {
@@ -50,9 +197,12 @@ function renderThreadTools(data: ThreadToolData | null): void {
       value: data.file_chat_opencode || "—",
     });
   }
-  // Render any additional string/number keys to avoid hiding future entries.
   Object.keys(data).forEach((key) => {
-    if (["autorunner", "file_chat", "file_chat_opencode", "corruption"].includes(key)) {
+    if (
+      ["autorunner", "file_chat", "file_chat_opencode", "corruption"].includes(
+        key
+      )
+    ) {
       return;
     }
     const value = data[key];
@@ -71,7 +221,7 @@ function renderThreadTools(data: ThreadToolData | null): void {
       <span class="thread-tool-label">${entry.label}</span>
       <span class="thread-tool-value">${entry.value}</span>
     `;
-    ui.threadList.appendChild(row);
+    ui.threadList?.appendChild(row);
   });
   if (ui.threadArchive) {
     ui.threadArchive.disabled = !data.autorunner;
@@ -80,29 +230,278 @@ function renderThreadTools(data: ThreadToolData | null): void {
 
 async function loadThreadTools(): Promise<ThreadToolData | null> {
   try {
-    const data = await api("/api/app-server/threads");
-    renderThreadTools(data as ThreadToolData);
-    return data as ThreadToolData;
+    const data = (await api("/api/app-server/threads")) as ThreadToolData;
+    renderThreadTools(data);
+    return data;
   } catch (err) {
     renderThreadTools(null);
-    const error = err as Error;
-    flash(error.message || "Failed to load threads", "error");
+    flash((err as Error).message || "Failed to load threads", "error");
     return null;
   }
 }
 
+function setSelectOptions(
+  select: HTMLSelectElement | null,
+  options: SelectOption[],
+  selectedValue: string | null,
+  unknownLabel: string,
+  preserveUnknown: boolean = true
+): void {
+  if (!select) return;
+  const normalizedSelected = normalizeOptionalString(selectedValue) || "";
+  const rendered = [...options];
+  if (
+    preserveUnknown &&
+    normalizedSelected &&
+    !rendered.some((option) => option.value === normalizedSelected)
+  ) {
+    rendered.push({
+      value: normalizedSelected,
+      label: `${normalizedSelected} (${unknownLabel})`,
+    });
+  }
+  select.replaceChildren();
+  rendered.forEach((entry) => {
+    const option = document.createElement("option");
+    option.value = entry.value;
+    option.textContent = entry.label;
+    select.appendChild(option);
+  });
+  select.dataset.optionAvailable =
+    rendered.length <= 1 && rendered[0]?.value === "" ? "0" : "1";
+  select.value = rendered.some((entry) => entry.value === normalizedSelected)
+    ? normalizedSelected
+    : rendered[0]?.value || "";
+}
+
+function modelLabel(model: ModelCatalogModel): string {
+  return model.display_name && model.display_name !== model.id
+    ? `${model.display_name} (${model.id})`
+    : model.id;
+}
+
+function currentEffectiveModelId(): string | null {
+  const selectedModel = normalizeOptionalString(ui.modelSelect?.value || null);
+  if (selectedModel) return selectedModel;
+  if (
+    currentCatalog?.default_model &&
+    currentCatalog.models.some((model) => model.id === currentCatalog.default_model)
+  ) {
+    return currentCatalog.default_model;
+  }
+  return currentCatalog?.models[0]?.id || null;
+}
+
+function currentEffectiveModel(): ModelCatalogModel | null {
+  const modelId = currentEffectiveModelId();
+  if (!modelId || !currentCatalog) return null;
+  return currentCatalog.models.find((model) => model.id === modelId) || null;
+}
+
+function updateReasoningOptions(
+  selectedValue: string | null,
+  preserveUnknown: boolean = true
+): void {
+  const model = currentEffectiveModel();
+  const options: SelectOption[] = [{ value: "", label: DEFAULT_OPTION_LABEL }];
+  if (model?.supports_reasoning) {
+    model.reasoning_options.forEach((optionValue) => {
+      options.push({ value: optionValue, label: optionValue });
+    });
+  }
+  setSelectOptions(
+    ui.effortSelect,
+    options,
+    selectedValue,
+    "current override",
+    preserveUnknown
+  );
+}
+
+function renderAutorunnerSettings(data: SessionSettingsResponse): void {
+  const modelOptions: SelectOption[] = [{ value: "", label: DEFAULT_OPTION_LABEL }];
+  currentCatalog?.models.forEach((model) => {
+    modelOptions.push({ value: model.id, label: modelLabel(model) });
+  });
+  setSelectOptions(
+    ui.modelSelect,
+    modelOptions,
+    normalizeOptionalString(data.autorunner_model_override),
+    "current override"
+  );
+  updateReasoningOptions(
+    normalizeOptionalString(data.autorunner_effort_override),
+    true
+  );
+  setSelectOptions(
+    ui.approvalSelect,
+    APPROVAL_OPTIONS,
+    normalizeOptionalString(data.autorunner_approval_policy),
+    "current override"
+  );
+  setSelectOptions(
+    ui.sandboxSelect,
+    SANDBOX_OPTIONS,
+    normalizeOptionalString(data.autorunner_sandbox_mode),
+    "current override"
+  );
+  if (ui.maxRunsInput) {
+    const maxRuns = normalizeOptionalInteger(data.runner_stop_after_runs);
+    ui.maxRunsInput.value = maxRuns ? String(maxRuns) : "";
+  }
+  if (ui.networkToggle) {
+    const networkSetting = normalizeOptionalBoolean(
+      data.autorunner_workspace_write_network
+    );
+    ui.networkToggle.checked = networkSetting === true;
+    ui.networkToggle.indeterminate = networkSetting === null;
+  }
+  updateAutorunnerFormInteractivity();
+}
+
+async function resolveCatalogAgent(): Promise<string> {
+  try {
+    const data = (await api("/api/agents", {
+      method: "GET",
+    })) as AgentListResponse;
+    const agents = Array.isArray(data.agents) ? data.agents : [];
+    const supportsListing = (agent: AgentEntry | undefined): boolean =>
+      Array.isArray(agent?.capabilities) &&
+      agent.capabilities.includes("model_listing");
+    const defaultAgentId =
+      normalizeOptionalString(data.default) || "codex";
+    const defaultAgent = agents.find((agent) => agent.id === defaultAgentId);
+    if (supportsListing(defaultAgent)) {
+      return defaultAgentId;
+    }
+    const codexAgent = agents.find((agent) => agent.id === "codex");
+    if (supportsListing(codexAgent)) {
+      return "codex";
+    }
+    const firstListed = agents.find((agent) => supportsListing(agent));
+    return normalizeOptionalString(firstListed?.id) || defaultAgentId;
+  } catch (_err) {
+    return "codex";
+  }
+}
+
+async function loadCatalog(agentId: string): Promise<ModelCatalog | null> {
+  try {
+    const data = await api(`/api/agents/${encodeURIComponent(agentId)}/models`, {
+      method: "GET",
+    });
+    return normalizeCatalog(data);
+  } catch (_err) {
+    return null;
+  }
+}
+
+function setAutorunnerBusy(busy: boolean): void {
+  settingsBusy = busy;
+  updateAutorunnerFormInteractivity();
+}
+
+function updateAutorunnerFormInteractivity(): void {
+  const formDisabled = settingsBusy || !settingsLoaded;
+  const applySelectState = (select: HTMLSelectElement | null): void => {
+    if (!select) return;
+    select.disabled =
+      formDisabled || select.dataset.optionAvailable === "0";
+  };
+
+  applySelectState(ui.modelSelect);
+  applySelectState(ui.effortSelect);
+  applySelectState(ui.approvalSelect);
+  applySelectState(ui.sandboxSelect);
+  if (ui.maxRunsInput) ui.maxRunsInput.disabled = formDisabled;
+  if (ui.networkToggle) ui.networkToggle.disabled = formDisabled;
+  if (ui.saveBtn) ui.saveBtn.disabled = settingsBusy || !settingsLoaded;
+  if (ui.reloadBtn) ui.reloadBtn.disabled = settingsBusy;
+}
+
+async function loadAutorunnerSettings(): Promise<void> {
+  settingsLoaded = false;
+  setAutorunnerBusy(true);
+  try {
+    const [settingsPayload, agentId] = await Promise.all([
+      api("/api/session/settings", { method: "GET" }) as Promise<SessionSettingsResponse>,
+      resolveCatalogAgent(),
+    ]);
+    currentCatalogAgent = agentId;
+    currentCatalog = await loadCatalog(agentId);
+    settingsLoaded = true;
+    renderAutorunnerSettings(settingsPayload);
+  } catch (err) {
+    currentCatalog = null;
+    settingsLoaded = false;
+    renderAutorunnerSettings({});
+    flash(
+      (err as Error).message || "Failed to load autorunner settings",
+      "error"
+    );
+  } finally {
+    setAutorunnerBusy(false);
+  }
+}
+
+function collectAutorunnerSettingsPayload(): SessionSettingsRequest {
+  const maxRunsRaw = ui.maxRunsInput?.value.trim() || "";
+  const parsedMaxRuns = maxRunsRaw ? Number.parseInt(maxRunsRaw, 10) : NaN;
+  return {
+    autorunner_model_override: normalizeOptionalString(ui.modelSelect?.value || null),
+    autorunner_effort_override: normalizeOptionalString(
+      ui.effortSelect?.value || null
+    ),
+    autorunner_approval_policy: normalizeOptionalString(
+      ui.approvalSelect?.value || null
+    ),
+    autorunner_sandbox_mode: normalizeOptionalString(
+      ui.sandboxSelect?.value || null
+    ),
+    autorunner_workspace_write_network:
+      ui.networkToggle && !ui.networkToggle.indeterminate
+        ? ui.networkToggle.checked
+        : null,
+    runner_stop_after_runs:
+      Number.isInteger(parsedMaxRuns) && parsedMaxRuns > 0 ? parsedMaxRuns : null,
+  };
+}
+
+async function saveAutorunnerSettings(): Promise<void> {
+  if (settingsBusy || !settingsLoaded) return;
+  setAutorunnerBusy(true);
+  try {
+    const payload = collectAutorunnerSettingsPayload();
+    await api("/api/session/settings", {
+      method: "POST",
+      body: payload,
+    });
+    flash("Autorunner settings saved", "success");
+    await refreshSettings();
+  } catch (err) {
+    flash(
+      (err as Error).message || "Failed to save autorunner settings",
+      "error"
+    );
+  } finally {
+    setAutorunnerBusy(false);
+  }
+}
+
 async function refreshSettings(): Promise<void> {
-  await loadThreadTools();
-  await loadTemplateRepos();
+  await Promise.all([
+    loadThreadTools(),
+    loadTemplateRepos(),
+    loadAutorunnerSettings(),
+  ]);
 }
 
 export function initRepoSettingsPanel(): void {
   window.__CAR_SETTINGS = { loadThreadTools, refreshSettings };
-  
-  // Initialize the modal interaction
+
   initRepoSettingsModal();
   initTemplateReposSettings();
-  
+
   if (ui.threadNew) {
     ui.threadNew.addEventListener("click", async () => {
       try {
@@ -113,8 +512,10 @@ export function initRepoSettingsPanel(): void {
         flash("Started a new autorunner thread", "success");
         await loadThreadTools();
       } catch (err) {
-        const error = err as Error;
-        flash(error.message || "Failed to reset autorunner thread", "error");
+        flash(
+          (err as Error).message || "Failed to reset autorunner thread",
+          "error"
+        );
       }
     });
   }
@@ -142,8 +543,7 @@ export function initRepoSettingsPanel(): void {
         flash("Autorunner thread archived", "success");
         await loadThreadTools();
       } catch (err) {
-        const error = err as Error;
-        flash(error.message || "Failed to archive thread", "error");
+        flash((err as Error).message || "Failed to archive thread", "error");
       }
     });
   }
@@ -159,8 +559,10 @@ export function initRepoSettingsPanel(): void {
         flash("Conversations reset", "success");
         await loadThreadTools();
       } catch (err) {
-        const error = err as Error;
-        flash(error.message || "Failed to reset conversations", "error");
+        flash(
+          (err as Error).message || "Failed to reset conversations",
+          "error"
+        );
       }
     });
   }
@@ -169,135 +571,38 @@ export function initRepoSettingsPanel(): void {
       window.location.href = resolvePath("/api/app-server/threads/backup");
     });
   }
+  if (ui.modelSelect) {
+    ui.modelSelect.addEventListener("change", () => {
+      updateReasoningOptions(
+        normalizeOptionalString(ui.effortSelect?.value || null),
+        false
+      );
+    });
+  }
+  if (ui.networkToggle) {
+    const clearIndeterminate = () => {
+      ui.networkToggle!.indeterminate = false;
+    };
+    ui.networkToggle.addEventListener("change", clearIndeterminate);
+    ui.networkToggle.addEventListener("click", clearIndeterminate);
+  }
+  if (ui.saveBtn) {
+    ui.saveBtn.addEventListener("click", () => {
+      void saveAutorunnerSettings();
+    });
+  }
+  if (ui.reloadBtn) {
+    ui.reloadBtn.addEventListener("click", () => {
+      void refreshSettings();
+    });
+  }
 
-  // Clear cached logs since log loading is no longer available
   try {
     localStorage.removeItem("logs:tail");
   } catch (_err) {
     // ignore
   }
 }
-
-interface UpdateCheckResponse {
-  update_available?: boolean;
-  message?: string;
-}
-
-interface UpdateResponse {
-  message?: string;
-  requires_confirmation?: boolean;
-}
-
-async function loadUpdateTargetOptions(selectId: string | null): Promise<void> {
-  const select = selectId ? document.getElementById(selectId) as HTMLSelectElement | null : null;
-  if (!select) return;
-  const isInitialized = select.dataset.updateTargetsInitialized === "1";
-  let payload: UpdateTargetsResponse | null;
-  try {
-    payload = await api("/system/update/targets", { method: "GET" }) as UpdateTargetsResponse;
-  } catch (_err) {
-    return;
-  }
-  const { options, defaultTarget } = updateTargetOptionsFromResponse(payload);
-  if (!options.length) return;
-
-  const previous = normalizeUpdateTarget(select.value || "all");
-  const hasPrevious = options.some((item) => item.value === previous);
-  const fallback = options.some((item) => item.value === defaultTarget)
-    ? defaultTarget
-    : options[0].value;
-
-  select.replaceChildren();
-  options.forEach((item) => {
-    const option = document.createElement("option");
-    option.value = item.value;
-    option.textContent = item.label;
-    select.appendChild(option);
-  });
-  if (isInitialized) {
-    select.value = hasPrevious ? previous : fallback;
-  } else {
-    select.value = fallback;
-    select.dataset.updateTargetsInitialized = "1";
-  }
-}
-
-async function handleSystemUpdate(btnId: string, targetSelectId: string | null): Promise<void> {
-  const btn = document.getElementById(btnId) as HTMLButtonElement | null;
-  if (!btn) return;
-  
-  const originalText = btn.textContent;
-  btn.disabled = true;
-  btn.textContent = "Checking...";
-  const updateTarget = getUpdateTarget(targetSelectId);
-  const targetLabel = describeUpdateTarget(updateTarget);
-  
-  let check: UpdateCheckResponse | undefined;
-  try {
-    check = await api("/system/update/check") as UpdateCheckResponse;
-  } catch (err) {
-    check = { update_available: true, message: (err as Error).message || "Unable to check for updates." };
-  }
-
-  if (!check?.update_available) {
-    flash(check?.message || "No update available.", "info");
-    btn.disabled = false;
-    btn.textContent = originalText;
-    return;
-  }
-
-  const restartNotice = updateRestartNotice(updateTarget);
-  const confirmed = await confirmModal(
-    `${check?.message || "Update available."} Update Codex Autorunner (${targetLabel})? ${restartNotice}`
-  );
-  if (!confirmed) {
-    btn.disabled = false;
-    btn.textContent = originalText;
-    return;
-  }
-
-  btn.textContent = "Updating...";
-
-  try {
-    let res = await api("/system/update", {
-      method: "POST",
-      body: { target: updateTarget },
-    }) as UpdateResponse;
-    if (res.requires_confirmation) {
-      const forceConfirmed = await confirmModal(
-        res.message || "Active sessions are still running. Update anyway?",
-        { confirmText: "Update anyway", cancelText: "Cancel", danger: true }
-      );
-      if (!forceConfirmed) {
-        btn.disabled = false;
-        btn.textContent = originalText;
-        return;
-      }
-      res = await api("/system/update", {
-        method: "POST",
-        body: { target: updateTarget, force: true },
-      }) as UpdateResponse;
-    }
-    flash(res.message || `Update started (${targetLabel}).`, "success");
-    if (!includesWebUpdateTarget(updateTarget)) {
-      btn.disabled = false;
-      btn.textContent = originalText;
-      return;
-    }
-    document.body.style.pointerEvents = "none";
-    setTimeout(() => {
-      const url = new URL(window.location.href);
-      url.searchParams.set("v", String(Date.now()));
-      window.location.replace(url.toString());
-    }, 8000);
-  } catch (err) {
-    flash((err as Error).message || "Update failed", "error");
-    btn.disabled = false;
-    btn.textContent = originalText;
-  }
-}
-
-let repoSettingsCloseModal: (() => void) | null = null;
 
 function hideRepoSettingsModal(): void {
   if (repoSettingsCloseModal) {
@@ -309,47 +614,55 @@ function hideRepoSettingsModal(): void {
 
 export function openRepoSettings(triggerEl?: HTMLElement | null): void {
   const modal = document.getElementById("repo-settings-modal");
-  const closeBtn = document.getElementById("repo-settings-close");
-  const updateBtn = document.getElementById("repo-update-btn") as HTMLButtonElement | null;
-  const updateTarget = document.getElementById("repo-update-target") as HTMLSelectElement | null;
   if (!modal) return;
 
   hideRepoSettingsModal();
   repoSettingsCloseModal = openModal(modal, {
-    initialFocus: closeBtn || updateBtn || modal,
+    initialFocus: ui.closeBtn || ui.updateBtn || modal,
     returnFocusTo: triggerEl || null,
     onRequestClose: hideRepoSettingsModal,
   });
-  // Trigger settings refresh when modal opens
-  const { refreshSettings } = window.__CAR_SETTINGS || {};
-  if (typeof refreshSettings === "function") {
-    refreshSettings();
-  }
-  void loadUpdateTargetOptions(updateTarget ? updateTarget.id : null);
+  void refreshSettings();
+  void loadUpdateTargetOptions(ui.updateTarget ? ui.updateTarget.id : null);
 }
 
 function initRepoSettingsModal(): void {
-  const settingsBtn = document.getElementById("repo-settings") as HTMLButtonElement | null;
-  const closeBtn = document.getElementById("repo-settings-close");
-  const updateBtn = document.getElementById("repo-update-btn") as HTMLButtonElement | null;
-  const updateTarget = document.getElementById("repo-update-target") as HTMLSelectElement | null;
-  void loadUpdateTargetOptions(updateTarget ? updateTarget.id : null);
+  void loadUpdateTargetOptions(ui.updateTarget ? ui.updateTarget.id : null);
 
-  if (settingsBtn) {
-    settingsBtn.addEventListener("click", () => {
-      openRepoSettings(settingsBtn);
+  if (ui.settingsBtn) {
+    ui.settingsBtn.addEventListener("click", () => {
+      openRepoSettings(ui.settingsBtn);
     });
   }
 
-  if (closeBtn) {
-    closeBtn.addEventListener("click", () => {
+  if (ui.closeBtn) {
+    ui.closeBtn.addEventListener("click", () => {
       hideRepoSettingsModal();
     });
   }
 
-  if (updateBtn) {
-    updateBtn.addEventListener("click", () =>
-      handleSystemUpdate("repo-update-btn", updateTarget ? updateTarget.id : null)
+  if (ui.updateBtn) {
+    ui.updateBtn.addEventListener("click", () =>
+      handleSystemUpdate(
+        "repo-update-btn",
+        ui.updateTarget ? ui.updateTarget.id : null
+      )
     );
   }
 }
+
+export const __settingsTest = {
+  collectAutorunnerSettingsPayload,
+  loadAutorunnerSettings,
+  refreshSettings,
+  reset(): void {
+    currentCatalog = null;
+    currentCatalogAgent = "codex";
+    settingsBusy = false;
+    settingsLoaded = false;
+    hideRepoSettingsModal();
+  },
+  getCurrentCatalogAgent(): string {
+    return currentCatalogAgent;
+  },
+};

--- a/src/codex_autorunner/static_src/systemUpdateUi.ts
+++ b/src/codex_autorunner/static_src/systemUpdateUi.ts
@@ -1,0 +1,142 @@
+import { api, confirmModal, flash } from "./utils.js";
+import {
+  describeUpdateTarget,
+  getUpdateTarget,
+  includesWebUpdateTarget,
+  normalizeUpdateTarget,
+  type UpdateTargetsResponse,
+  updateRestartNotice,
+  updateTargetOptionsFromResponse,
+} from "./updateTargets.js";
+
+interface UpdateCheckResponse {
+  update_available?: boolean;
+  message?: string;
+}
+
+interface UpdateResponse {
+  message?: string;
+  requires_confirmation?: boolean;
+}
+
+export async function loadUpdateTargetOptions(
+  selectId: string | null
+): Promise<void> {
+  const select = selectId
+    ? (document.getElementById(selectId) as HTMLSelectElement | null)
+    : null;
+  if (!select) return;
+  const isInitialized = select.dataset.updateTargetsInitialized === "1";
+  let payload: UpdateTargetsResponse | null;
+  try {
+    payload = (await api("/system/update/targets", {
+      method: "GET",
+    })) as UpdateTargetsResponse;
+  } catch (_err) {
+    return;
+  }
+  const { options, defaultTarget } = updateTargetOptionsFromResponse(payload);
+  if (!options.length) return;
+
+  const previous = normalizeUpdateTarget(select.value || "all");
+  const hasPrevious = options.some((item) => item.value === previous);
+  const fallback = options.some((item) => item.value === defaultTarget)
+    ? defaultTarget
+    : options[0].value;
+
+  select.replaceChildren();
+  options.forEach((item) => {
+    const option = document.createElement("option");
+    option.value = item.value;
+    option.textContent = item.label;
+    select.appendChild(option);
+  });
+  if (isInitialized) {
+    select.value = hasPrevious ? previous : fallback;
+  } else {
+    select.value = fallback;
+    select.dataset.updateTargetsInitialized = "1";
+  }
+}
+
+export async function handleSystemUpdate(
+  btnId: string,
+  targetSelectId: string | null
+): Promise<void> {
+  const btn = document.getElementById(btnId) as HTMLButtonElement | null;
+  if (!btn) return;
+
+  const originalText = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = "Checking...";
+  const updateTarget = getUpdateTarget(targetSelectId);
+  const targetLabel = describeUpdateTarget(updateTarget);
+
+  let check: UpdateCheckResponse | undefined;
+  try {
+    check = (await api("/system/update/check")) as UpdateCheckResponse;
+  } catch (err) {
+    check = {
+      update_available: true,
+      message:
+        (err as Error).message || "Unable to check for updates.",
+    };
+  }
+
+  if (!check?.update_available) {
+    flash(check?.message || "No update available.", "info");
+    btn.disabled = false;
+    btn.textContent = originalText;
+    return;
+  }
+
+  const restartNotice = updateRestartNotice(updateTarget);
+  const confirmed = await confirmModal(
+    `${check?.message || "Update available."} Update Codex Autorunner (${targetLabel})? ${restartNotice}`
+  );
+  if (!confirmed) {
+    btn.disabled = false;
+    btn.textContent = originalText;
+    return;
+  }
+
+  btn.textContent = "Updating...";
+
+  try {
+    let res = (await api("/system/update", {
+      method: "POST",
+      body: { target: updateTarget },
+    })) as UpdateResponse;
+    if (res.requires_confirmation) {
+      const forceConfirmed = await confirmModal(
+        res.message || "Active sessions are still running. Update anyway?",
+        { confirmText: "Update anyway", cancelText: "Cancel", danger: true }
+      );
+      if (!forceConfirmed) {
+        btn.disabled = false;
+        btn.textContent = originalText;
+        return;
+      }
+      res = (await api("/system/update", {
+        method: "POST",
+        body: { target: updateTarget, force: true },
+      })) as UpdateResponse;
+    }
+    flash(res.message || `Update started (${targetLabel}).`, "success");
+    if (!includesWebUpdateTarget(updateTarget)) {
+      btn.disabled = false;
+      btn.textContent = originalText;
+      return;
+    }
+    document.body.style.pointerEvents = "none";
+    setTimeout(() => {
+      const url = new URL(window.location.href);
+      url.searchParams.set("v", String(Date.now()));
+      window.location.replace(url.toString());
+    }, 8000);
+  } catch (err) {
+    flash((err as Error).message || "Update failed", "error");
+    btn.disabled = false;
+    btn.textContent = originalText;
+  }
+}

--- a/tests/js/repo_settings_modal.test.js
+++ b/tests/js/repo_settings_modal.test.js
@@ -1,0 +1,380 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM(
+  `<!doctype html><html><body>
+    <div id="toast"></div>
+    <div id="repo-shell"></div>
+    <button id="repo-settings" type="button">Settings</button>
+    <div id="repo-settings-modal" class="modal-overlay" hidden>
+      <div class="modal-dialog" role="dialog">
+        <button id="repo-settings-close" type="button">Close</button>
+        <select id="repo-update-target">
+          <option value="web">Web only</option>
+        </select>
+        <button id="repo-update-btn" type="button">Update</button>
+        <select id="autorunner-model-select"></select>
+        <select id="autorunner-effort-select"></select>
+        <select id="autorunner-approval-select"></select>
+        <select id="autorunner-sandbox-select"></select>
+        <input id="autorunner-max-runs-input" type="number" />
+        <input id="autorunner-network-toggle" type="checkbox" />
+        <button id="autorunner-settings-save" type="button">Save</button>
+        <button id="autorunner-settings-reload" type="button">Reload</button>
+      </div>
+    </div>
+    <div id="thread-tools-list"></div>
+    <button id="thread-new-autorunner" type="button"></button>
+    <button id="thread-archive-autorunner" type="button"></button>
+    <button id="thread-reset-all" type="button"></button>
+    <a id="thread-backup-download"></a>
+    <div id="confirm-modal" class="modal-overlay" hidden>
+      <div class="modal-dialog" role="dialog">
+        <div id="confirm-modal-message"></div>
+        <button id="confirm-modal-ok" type="button">OK</button>
+        <button id="confirm-modal-cancel" type="button">Cancel</button>
+      </div>
+    </div>
+  </body></html>`,
+  { url: "http://localhost/repos/demo/" }
+);
+
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.HTMLButtonElement = dom.window.HTMLButtonElement;
+globalThis.HTMLInputElement = dom.window.HTMLInputElement;
+globalThis.HTMLAnchorElement = dom.window.HTMLAnchorElement;
+globalThis.HTMLSelectElement = dom.window.HTMLSelectElement;
+globalThis.Event = dom.window.Event;
+globalThis.CustomEvent = dom.window.CustomEvent;
+globalThis.Node = dom.window.Node;
+globalThis.localStorage = dom.window.localStorage;
+globalThis.sessionStorage = dom.window.sessionStorage;
+
+const settingsModule = await import(
+  "../../src/codex_autorunner/static/generated/settings.js"
+);
+const { initRepoSettingsPanel, openRepoSettings, __settingsTest } = settingsModule;
+initRepoSettingsPanel();
+
+function jsonResponse(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function optionValues(select) {
+  return Array.from(select.options).map((option) => option.value);
+}
+
+async function flushUi(times = 6) {
+  for (let idx = 0; idx < times; idx += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+function resetDomState() {
+  document.getElementById("repo-settings-modal").hidden = true;
+  document.getElementById("confirm-modal").hidden = true;
+  document.getElementById("thread-tools-list").innerHTML = "";
+  document.getElementById("repo-update-target").replaceChildren();
+  document.getElementById("repo-update-target").appendChild(
+    Object.assign(document.createElement("option"), {
+      value: "web",
+      textContent: "Web only",
+    })
+  );
+  document.getElementById("repo-update-target").dataset.updateTargetsInitialized = "";
+  document.getElementById("autorunner-model-select").replaceChildren();
+  document.getElementById("autorunner-effort-select").replaceChildren();
+  document.getElementById("autorunner-approval-select").replaceChildren();
+  document.getElementById("autorunner-sandbox-select").replaceChildren();
+  document.getElementById("autorunner-max-runs-input").value = "";
+  document.getElementById("autorunner-network-toggle").checked = false;
+  document.getElementById("autorunner-network-toggle").indeterminate = false;
+}
+
+function installFetchMock({ sessionSettingsRef, updateTargets, modelCatalog, posts }) {
+  globalThis.fetch = async (url, options = {}) => {
+    const href = String(url);
+    const method = String(options.method || "GET").toUpperCase();
+    if (href.endsWith("/repos/demo/api/app-server/threads")) {
+      return jsonResponse({ autorunner: "thread-123" });
+    }
+    if (href.endsWith("/repos/demo/api/templates/repos")) {
+      return jsonResponse({ enabled: true, repos: [] });
+    }
+    if (href.endsWith("/repos/demo/system/update/targets")) {
+      return jsonResponse(updateTargets);
+    }
+    if (href.endsWith("/repos/demo/api/session/settings") && method === "GET") {
+      return jsonResponse(sessionSettingsRef.current);
+    }
+    if (href.endsWith("/repos/demo/api/session/settings") && method === "POST") {
+      const body = JSON.parse(String(options.body || "{}"));
+      posts.push(body);
+      sessionSettingsRef.current = { ...body };
+      return jsonResponse(sessionSettingsRef.current);
+    }
+    if (href.endsWith("/repos/demo/api/agents")) {
+      return jsonResponse({
+        default: "codex",
+        agents: [{ id: "codex", capabilities: ["model_listing"] }],
+      });
+    }
+    if (href.endsWith("/repos/demo/api/agents/codex/models")) {
+      return jsonResponse(modelCatalog);
+    }
+    throw new Error(`Unexpected fetch: ${method} ${href}`);
+  };
+}
+
+test("repo settings modal hydrates update targets and autorunner controls", async () => {
+  __settingsTest.reset();
+  localStorage.clear();
+  sessionStorage.clear();
+  resetDomState();
+
+  const posts = [];
+  const sessionSettingsRef = {
+    current: {
+      autorunner_model_override: "gpt-5.4",
+      autorunner_effort_override: "high",
+      autorunner_approval_policy: "never",
+      autorunner_sandbox_mode: "workspaceWrite",
+      autorunner_workspace_write_network: true,
+      runner_stop_after_runs: 3,
+    },
+  };
+  installFetchMock({
+    sessionSettingsRef,
+    updateTargets: {
+      targets: [
+        { value: "all", label: "all", description: "Web + Telegram + Discord" },
+        { value: "web", label: "web", description: "Web UI only" },
+        { value: "chat", label: "chat", description: "Telegram + Discord" },
+      ],
+      default_target: "all",
+    },
+    modelCatalog: {
+      default_model: "gpt-5.4",
+      models: [
+        {
+          id: "gpt-5.4",
+          display_name: "GPT-5.4",
+          supports_reasoning: true,
+          reasoning_options: ["medium", "high"],
+        },
+        {
+          id: "gpt-5.2",
+          display_name: "GPT-5.2",
+          supports_reasoning: true,
+          reasoning_options: ["medium"],
+        },
+      ],
+    },
+    posts,
+  });
+
+  openRepoSettings(document.getElementById("repo-settings"));
+  await flushUi();
+
+  assert.equal(document.getElementById("repo-settings-modal").hidden, false);
+  assert.deepEqual(optionValues(document.getElementById("repo-update-target")), [
+    "all",
+    "web",
+    "chat",
+  ]);
+  assert.match(
+    document.getElementById("thread-tools-list").textContent || "",
+    /thread-123/
+  );
+  assert.equal(__settingsTest.getCurrentCatalogAgent(), "codex");
+
+  const modelSelect = document.getElementById("autorunner-model-select");
+  const effortSelect = document.getElementById("autorunner-effort-select");
+  const approvalSelect = document.getElementById("autorunner-approval-select");
+  const sandboxSelect = document.getElementById("autorunner-sandbox-select");
+  const maxRunsInput = document.getElementById("autorunner-max-runs-input");
+  const networkToggle = document.getElementById("autorunner-network-toggle");
+
+  assert.deepEqual(optionValues(modelSelect), ["", "gpt-5.4", "gpt-5.2"]);
+  assert.equal(modelSelect.value, "gpt-5.4");
+  assert.deepEqual(optionValues(effortSelect), ["", "medium", "high"]);
+  assert.equal(effortSelect.value, "high");
+  assert.equal(approvalSelect.value, "never");
+  assert.equal(sandboxSelect.value, "workspaceWrite");
+  assert.equal(maxRunsInput.value, "3");
+  assert.equal(networkToggle.checked, true);
+  assert.equal(networkToggle.indeterminate, false);
+
+  modelSelect.value = "gpt-5.2";
+  modelSelect.dispatchEvent(new Event("change", { bubbles: true }));
+  await flushUi(2);
+  assert.deepEqual(optionValues(effortSelect), ["", "medium"]);
+  effortSelect.value = "medium";
+  approvalSelect.value = "unlessTrusted";
+  sandboxSelect.value = "dangerFullAccess";
+  maxRunsInput.value = "5";
+  networkToggle.indeterminate = false;
+  networkToggle.checked = false;
+
+  document
+    .getElementById("autorunner-settings-save")
+    .dispatchEvent(new Event("click", { bubbles: true }));
+  await flushUi();
+
+  assert.deepEqual(posts, [
+    {
+      autorunner_model_override: "gpt-5.2",
+      autorunner_effort_override: "medium",
+      autorunner_approval_policy: "unlessTrusted",
+      autorunner_sandbox_mode: "dangerFullAccess",
+      autorunner_workspace_write_network: false,
+      runner_stop_after_runs: 5,
+    },
+  ]);
+});
+
+test("repo settings reload refreshes session values and preserves default network state", async () => {
+  __settingsTest.reset();
+  localStorage.clear();
+  sessionStorage.clear();
+  resetDomState();
+
+  const posts = [];
+  const sessionSettingsRef = {
+    current: {
+      autorunner_model_override: null,
+      autorunner_effort_override: null,
+      autorunner_approval_policy: null,
+      autorunner_sandbox_mode: null,
+      autorunner_workspace_write_network: null,
+      runner_stop_after_runs: null,
+    },
+  };
+  installFetchMock({
+    sessionSettingsRef,
+    updateTargets: {
+      targets: [{ value: "web", label: "web", description: "Web UI only" }],
+      default_target: "web",
+    },
+    modelCatalog: {
+      default_model: "gpt-5.4",
+      models: [
+        {
+          id: "gpt-5.4",
+          display_name: "GPT-5.4",
+          supports_reasoning: true,
+          reasoning_options: ["medium", "high"],
+        },
+      ],
+    },
+    posts,
+  });
+
+  openRepoSettings(document.getElementById("repo-settings"));
+  await flushUi();
+
+  const modelSelect = document.getElementById("autorunner-model-select");
+  const approvalSelect = document.getElementById("autorunner-approval-select");
+  const sandboxSelect = document.getElementById("autorunner-sandbox-select");
+  const maxRunsInput = document.getElementById("autorunner-max-runs-input");
+  const networkToggle = document.getElementById("autorunner-network-toggle");
+
+  assert.equal(modelSelect.value, "");
+  assert.equal(approvalSelect.value, "");
+  assert.equal(sandboxSelect.value, "");
+  assert.equal(maxRunsInput.value, "");
+  assert.equal(networkToggle.checked, false);
+  assert.equal(networkToggle.indeterminate, true);
+
+  sessionSettingsRef.current = {
+    autorunner_model_override: "gpt-5.4",
+    autorunner_effort_override: "medium",
+    autorunner_approval_policy: "never",
+    autorunner_sandbox_mode: "workspaceWrite",
+    autorunner_workspace_write_network: false,
+    runner_stop_after_runs: 7,
+  };
+
+  document
+    .getElementById("autorunner-settings-reload")
+    .dispatchEvent(new Event("click", { bubbles: true }));
+  await flushUi();
+
+  assert.equal(modelSelect.value, "gpt-5.4");
+  assert.equal(document.getElementById("autorunner-effort-select").value, "medium");
+  assert.equal(approvalSelect.value, "never");
+  assert.equal(sandboxSelect.value, "workspaceWrite");
+  assert.equal(maxRunsInput.value, "7");
+  assert.equal(networkToggle.checked, false);
+  assert.equal(networkToggle.indeterminate, false);
+  assert.deepEqual(posts, []);
+});
+
+test("repo settings keeps save disabled when settings load fails", async () => {
+  __settingsTest.reset();
+  localStorage.clear();
+  sessionStorage.clear();
+  resetDomState();
+
+  const posts = [];
+  globalThis.fetch = async (url, options = {}) => {
+    const href = String(url);
+    const method = String(options.method || "GET").toUpperCase();
+    if (href.endsWith("/repos/demo/api/app-server/threads")) {
+      return jsonResponse({ autorunner: "thread-123" });
+    }
+    if (href.endsWith("/repos/demo/api/templates/repos")) {
+      return jsonResponse({ enabled: true, repos: [] });
+    }
+    if (href.endsWith("/repos/demo/system/update/targets")) {
+      return jsonResponse({
+        targets: [{ value: "web", label: "web", description: "Web UI only" }],
+        default_target: "web",
+      });
+    }
+    if (href.endsWith("/repos/demo/api/session/settings") && method === "GET") {
+      return jsonResponse({ detail: "load failed" }, 500);
+    }
+    if (href.endsWith("/repos/demo/api/session/settings") && method === "POST") {
+      posts.push(JSON.parse(String(options.body || "{}")));
+      return jsonResponse({});
+    }
+    if (href.endsWith("/repos/demo/api/agents")) {
+      return jsonResponse({
+        default: "codex",
+        agents: [{ id: "codex", capabilities: ["model_listing"] }],
+      });
+    }
+    if (href.endsWith("/repos/demo/api/agents/codex/models")) {
+      return jsonResponse({
+        default_model: "gpt-5.4",
+        models: [
+          {
+            id: "gpt-5.4",
+            display_name: "GPT-5.4",
+            supports_reasoning: true,
+            reasoning_options: ["medium", "high"],
+          },
+        ],
+      });
+    }
+    throw new Error(`Unexpected fetch: ${method} ${href}`);
+  };
+
+  openRepoSettings(document.getElementById("repo-settings"));
+  await flushUi();
+
+  const saveBtn = document.getElementById("autorunner-settings-save");
+  assert.equal(saveBtn.disabled, true);
+
+  saveBtn.dispatchEvent(new Event("click", { bubbles: true }));
+  await flushUi(2);
+
+  assert.deepEqual(posts, []);
+});

--- a/tests/js/repo_settings_modal.test.js
+++ b/tests/js/repo_settings_modal.test.js
@@ -56,7 +56,11 @@ globalThis.sessionStorage = dom.window.sessionStorage;
 const settingsModule = await import(
   "../../src/codex_autorunner/static/generated/settings.js"
 );
-const { initRepoSettingsPanel, openRepoSettings, __settingsTest } = settingsModule;
+const {
+  initRepoSettingsPanel,
+  openRepoSettings,
+  __settingsTest,
+} = settingsModule;
 initRepoSettingsPanel();
 
 function jsonResponse(payload, status = 200) {
@@ -131,6 +135,18 @@ function installFetchMock({ sessionSettingsRef, updateTargets, modelCatalog, pos
     throw new Error(`Unexpected fetch: ${method} ${href}`);
   };
 }
+
+test("parsePositiveIntegerRuns accepts whole positive numbers only", () => {
+  const p = __settingsTest.parsePositiveIntegerRuns;
+  assert.equal(p(""), null);
+  assert.equal(p("   "), null);
+  assert.equal(p("7"), 7);
+  assert.equal(p("01"), 1);
+  assert.equal(p("1.5"), undefined);
+  assert.equal(p("1e3"), undefined);
+  assert.equal(p("0"), undefined);
+  assert.equal(p("-2"), undefined);
+});
 
 test("repo settings modal hydrates update targets and autorunner controls", async () => {
   __settingsTest.reset();
@@ -237,6 +253,60 @@ test("repo settings modal hydrates update targets and autorunner controls", asyn
       runner_stop_after_runs: 5,
     },
   ]);
+});
+
+test("repo settings save rejects non-integer max runs without posting", async () => {
+  __settingsTest.reset();
+  localStorage.clear();
+  sessionStorage.clear();
+  resetDomState();
+
+  const posts = [];
+  const sessionSettingsRef = {
+    current: {
+      autorunner_model_override: "gpt-5.4",
+      autorunner_effort_override: "medium",
+      autorunner_approval_policy: "never",
+      autorunner_sandbox_mode: "workspaceWrite",
+      autorunner_workspace_write_network: false,
+      runner_stop_after_runs: 3,
+    },
+  };
+  installFetchMock({
+    sessionSettingsRef,
+    updateTargets: {
+      targets: [{ value: "web", label: "web", description: "Web UI only" }],
+      default_target: "web",
+    },
+    modelCatalog: {
+      default_model: "gpt-5.4",
+      models: [
+        {
+          id: "gpt-5.4",
+          display_name: "GPT-5.4",
+          supports_reasoning: true,
+          reasoning_options: ["medium", "high"],
+        },
+      ],
+    },
+    posts,
+  });
+
+  openRepoSettings(document.getElementById("repo-settings"));
+  await flushUi();
+
+  document.getElementById("autorunner-max-runs-input").value = "1.5";
+
+  document
+    .getElementById("autorunner-settings-save")
+    .dispatchEvent(new Event("click", { bubbles: true }));
+  await flushUi();
+
+  assert.deepEqual(posts, []);
+  assert.match(
+    document.getElementById("toast").textContent || "",
+    /positive whole number/i
+  );
 });
 
 test("repo settings reload refreshes session values and preserves default network state", async () => {

--- a/tests/routes/test_session_settings_routes.py
+++ b/tests/routes/test_session_settings_routes.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import PropertyMock, patch
+
+from fastapi.testclient import TestClient
+from tests.conftest import write_test_config
+
+from codex_autorunner.bootstrap import seed_hub_files, seed_repo_files
+from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
+from codex_autorunner.surfaces.web.app import create_repo_app
+from codex_autorunner.surfaces.web.runner_manager import RunnerManager
+
+
+def _client_for_repo(repo_root: Path) -> TestClient:
+    hub_root = repo_root
+    seed_hub_files(hub_root, force=True)
+    seed_repo_files(repo_root, git_required=False)
+    (repo_root / ".git").mkdir(exist_ok=True)
+    write_test_config(
+        hub_root / CONFIG_FILENAME, json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    )
+    return TestClient(create_repo_app(repo_root))
+
+
+def test_session_settings_round_trip_persists_values(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    client = _client_for_repo(repo_root)
+
+    initial = client.get("/api/session/settings")
+    assert initial.status_code == 200
+    assert initial.json() == {
+        "autorunner_model_override": None,
+        "autorunner_effort_override": None,
+        "autorunner_approval_policy": None,
+        "autorunner_sandbox_mode": None,
+        "autorunner_workspace_write_network": None,
+        "runner_stop_after_runs": None,
+    }
+
+    response = client.post(
+        "/api/session/settings",
+        json={
+            "autorunner_model_override": "gpt-5.4",
+            "autorunner_effort_override": "high",
+            "autorunner_approval_policy": "never",
+            "autorunner_sandbox_mode": "workspaceWrite",
+            "autorunner_workspace_write_network": True,
+            "runner_stop_after_runs": 4,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "autorunner_model_override": "gpt-5.4",
+        "autorunner_effort_override": "high",
+        "autorunner_approval_policy": "never",
+        "autorunner_sandbox_mode": "workspaceWrite",
+        "autorunner_workspace_write_network": True,
+        "runner_stop_after_runs": 4,
+    }
+
+    refreshed = client.get("/api/session/settings")
+    assert refreshed.status_code == 200
+    assert refreshed.json() == response.json()
+
+
+def test_session_settings_allow_clearing_values(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    client = _client_for_repo(repo_root)
+
+    seeded = client.post(
+        "/api/session/settings",
+        json={
+            "autorunner_model_override": "gpt-5.4",
+            "autorunner_effort_override": "high",
+            "autorunner_approval_policy": "never",
+            "autorunner_sandbox_mode": "workspaceWrite",
+            "autorunner_workspace_write_network": False,
+            "runner_stop_after_runs": 2,
+        },
+    )
+    assert seeded.status_code == 200
+
+    cleared = client.post(
+        "/api/session/settings",
+        json={
+            "autorunner_model_override": "",
+            "autorunner_effort_override": "",
+            "autorunner_approval_policy": "",
+            "autorunner_sandbox_mode": "",
+            "autorunner_workspace_write_network": None,
+            "runner_stop_after_runs": None,
+        },
+    )
+
+    assert cleared.status_code == 200
+    assert cleared.json() == {
+        "autorunner_model_override": None,
+        "autorunner_effort_override": None,
+        "autorunner_approval_policy": None,
+        "autorunner_sandbox_mode": None,
+        "autorunner_workspace_write_network": None,
+        "runner_stop_after_runs": None,
+    }
+
+
+def test_session_settings_reject_changes_while_run_is_active(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    client = _client_for_repo(repo_root)
+
+    with patch.object(RunnerManager, "running", new_callable=PropertyMock) as running:
+        running.return_value = True
+        response = client.post(
+            "/api/session/settings",
+            json={"autorunner_model_override": "gpt-5.4"},
+        )
+
+    assert response.status_code == 409
+    assert "Cannot change autorunner settings while a run is active" in response.text


### PR DESCRIPTION
## Summary
- factor web and repo settings update-target loading/update actions through one shared frontend module
- wire repo settings to hydrate and save autorunner model/effort/approval/sandbox state from `/api/session/settings`
- add frontend and route coverage for repo settings hydration, save/reload, and failure handling

## Root cause
The repo settings modal had backend routes for session settings, but the frontend never loaded them, so the select controls rendered blank and save behavior was incomplete. The web update surface also had duplicated client logic instead of reusing a shared path.

## Validation
- git commit hook lane `web-ui`
- repo-wide `mypy`
- repo-wide `pytest` (`7517 passed`)
- `pnpm run build`
- `pnpm test:markdown`
