### PR TITLE
[codex] Cover SCM review-comment regressions

### DIFF
--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import logging
 import threading
 from collections.abc import Mapping
 from pathlib import Path
@@ -22,6 +23,8 @@ from .publish_journal import PublishOperation
 from .scm_events import ScmEvent, ScmEventStore
 from .scm_observability import correlation_id_for_operation, correlation_id_from_payload
 from .text_utils import _coerce_int, _normalize_optional_text
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _require_text(value: Any, *, field_name: str) -> str:
@@ -184,6 +187,12 @@ def _active_thread_record(
     if lifecycle_status != "active":
         return None, thread
     return normalized_thread_target_id, thread
+
+
+def _thread_runtime_status(thread: Optional[Mapping[str, Any]]) -> Optional[str]:
+    if not isinstance(thread, Mapping):
+        return None
+    return _normalize_optional_text(thread.get("normalized_status"))
 
 
 def _resolve_manifest_workspace(
@@ -392,10 +401,11 @@ def _repair_scm_thread_binding(
     current_thread_target_id: str,
     request: MessageRequest,
     tracking: Mapping[str, Any],
+    source_status: Optional[str] = None,
 ) -> tuple[str, MessageRequest]:
     binding = _resolve_scm_binding(hub_root, tracking=tracking)
     if binding is None:
-        raise ManagedThreadNotActiveError(current_thread_target_id, None)
+        raise ManagedThreadNotActiveError(current_thread_target_id, source_status)
     source_thread = store.get_thread(current_thread_target_id)
     workspace_root = _resolve_scm_workspace_root(
         hub_root,
@@ -403,7 +413,7 @@ def _repair_scm_thread_binding(
         source_thread=source_thread,
     )
     if workspace_root is None:
-        raise ManagedThreadNotActiveError(current_thread_target_id, None)
+        raise ManagedThreadNotActiveError(current_thread_target_id, source_status)
     try:
         default_agent = load_hub_config(hub_root).pma.default_agent
     except (OSError, ValueError):
@@ -519,6 +529,13 @@ def build_enqueue_managed_turn_executor(*, hub_root: Path) -> PublishActionExecu
                 existed=True,
                 correlation_id=correlation_id,
             )
+        runtime_status = _thread_runtime_status(_active_thread)
+        log_context = (
+            correlation_id,
+            _normalize_optional_text(tracking.get("binding_id")),
+            _normalize_optional_text(tracking.get("repo_slug")),
+            _coerce_int(tracking.get("pr_number")),
+        )
 
         request, sandbox_policy = _managed_turn_request(thread_target_id, payload)
         queue_payload = {
@@ -528,6 +545,15 @@ def build_enqueue_managed_turn_executor(*, hub_root: Path) -> PublishActionExecu
         }
         rebound_from_thread_target_id: Optional[str] = None
         try:
+            if tracking and runtime_status not in {None, "idle"}:
+                _LOGGER.info(
+                    "scm.enqueue_managed_turn.reusing_thread "
+                    "thread_target_id=%s lifecycle_status=active normalized_status=%s "
+                    "correlation_id=%s binding_id=%s repo_slug=%s pr_number=%s",
+                    thread_target_id,
+                    runtime_status,
+                    *log_context,
+                )
             created = store.create_turn(
                 thread_target_id,
                 prompt=request.message_text,
@@ -538,21 +564,38 @@ def build_enqueue_managed_turn_executor(*, hub_root: Path) -> PublishActionExecu
                 client_turn_id=client_request_id,
                 queue_payload=queue_payload,
             )
-        except ManagedThreadNotActiveError:
+        except ManagedThreadNotActiveError as exc:
             if not tracking:
                 raise
             rebound_from_thread_target_id = thread_target_id
+            _LOGGER.info(
+                "scm.enqueue_managed_turn.rebinding_thread "
+                "previous_thread_target_id=%s status=%s "
+                "correlation_id=%s binding_id=%s repo_slug=%s pr_number=%s",
+                thread_target_id,
+                exc.status,
+                *log_context,
+            )
             thread_target_id, request = _repair_scm_thread_binding(
                 hub_root,
                 store,
                 current_thread_target_id=thread_target_id,
                 request=request,
                 tracking=tracking,
+                source_status=exc.status,
             )
             existing = store.get_turn_by_client_turn_id(
                 thread_target_id, client_request_id
             )
             if existing is not None:
+                _LOGGER.info(
+                    "scm.enqueue_managed_turn.rebound_to_existing_turn "
+                    "previous_thread_target_id=%s thread_target_id=%s "
+                    "correlation_id=%s binding_id=%s repo_slug=%s pr_number=%s",
+                    rebound_from_thread_target_id,
+                    thread_target_id,
+                    *log_context,
+                )
                 result = _managed_turn_result(
                     thread_target_id=thread_target_id,
                     client_request_id=client_request_id,
@@ -576,6 +619,14 @@ def build_enqueue_managed_turn_executor(*, hub_root: Path) -> PublishActionExecu
                 reasoning=request.reasoning,
                 client_turn_id=client_request_id,
                 queue_payload=queue_payload,
+            )
+            _LOGGER.info(
+                "scm.enqueue_managed_turn.rebound_thread "
+                "previous_thread_target_id=%s thread_target_id=%s "
+                "correlation_id=%s binding_id=%s repo_slug=%s pr_number=%s",
+                rebound_from_thread_target_id,
+                thread_target_id,
+                *log_context,
             )
         result = _managed_turn_result(
             thread_target_id=thread_target_id,

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -517,6 +517,7 @@ def build_enqueue_managed_turn_executor(*, hub_root: Path) -> PublishActionExecu
                 else requested_thread_target_id
             ),
         )
+        active_lifecycle_match_id = thread_target_id
         if thread_target_id is None:
             thread_target_id = requested_thread_target_id
         client_request_id = _operation_digest(operation, prefix="publish-turn")
@@ -545,7 +546,11 @@ def build_enqueue_managed_turn_executor(*, hub_root: Path) -> PublishActionExecu
         }
         rebound_from_thread_target_id: Optional[str] = None
         try:
-            if tracking and runtime_status not in {None, "idle"}:
+            if (
+                tracking
+                and active_lifecycle_match_id is not None
+                and runtime_status not in {None, "idle"}
+            ):
                 _LOGGER.info(
                     "scm.enqueue_managed_turn.reusing_thread "
                     "thread_target_id=%s lifecycle_status=active normalized_status=%s "

--- a/tests/core/test_publish_executor.py
+++ b/tests/core/test_publish_executor.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import sqlite3
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -98,6 +100,50 @@ def _publish_hub(tmp_path: Path) -> tuple[Path, Path, str]:
         encoding="utf-8",
     )
     return hub_root, workspace_root, "repo-publish"
+
+
+def _create_scm_enqueue_operation(
+    *,
+    journal: PublishJournalStore,
+    thread_target_id: str,
+    binding_id: str,
+    repo_id: str,
+    operation_key: str,
+) -> PublishOperation:
+    operation, _ = journal.create_operation(
+        operation_key=operation_key,
+        operation_kind="enqueue_managed_turn",
+        payload={
+            "thread_target_id": thread_target_id,
+            "request": {
+                "kind": "message",
+                "message_text": "New PR review feedback arrived on acme/widgets#42.",
+                "metadata": {
+                    "scm": {
+                        "binding_id": binding_id,
+                        "event_id": "github:event-review-comment",
+                        "provider": "github",
+                        "repo_slug": "acme/widgets",
+                        "repo_id": repo_id,
+                        "pr_number": 42,
+                    }
+                },
+            },
+            "scm_reaction": {
+                "binding_id": binding_id,
+                "event_id": "github:event-review-comment",
+                "provider": "github",
+                "reaction_kind": "review_comment",
+                "repo_slug": "acme/widgets",
+                "repo_id": repo_id,
+                "pr_number": 42,
+                "head_branch": "feature/scm-rebind",
+                "base_branch": "main",
+                "thread_target_id": thread_target_id,
+            },
+        },
+    )
+    return operation
 
 
 def test_drain_pending_publish_operations_marks_success_and_does_not_replay_same_call(
@@ -589,8 +635,130 @@ def test_enqueue_managed_turn_executor_reuses_existing_execution_for_same_operat
     assert turns[0]["client_turn_id"] == first["client_request_id"]
 
 
+@pytest.mark.parametrize(
+    ("turn_status", "expected_runtime_status"),
+    [("ok", "completed"), ("interrupted", "interrupted")],
+)
+def test_enqueue_managed_turn_executor_reuses_reusable_scm_thread_statuses(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    turn_status: str,
+    expected_runtime_status: str,
+) -> None:
+    hub_root, workspace_root, repo_id = _publish_hub(tmp_path)
+    thread_store = PmaThreadStore(hub_root)
+    thread = thread_store.create_thread(
+        "codex",
+        workspace_root,
+        repo_id=repo_id,
+        metadata={"head_branch": "feature/scm-rebind"},
+    )
+    first_turn = thread_store.create_turn(
+        thread["managed_thread_id"], prompt="existing work"
+    )
+    if turn_status == "ok":
+        assert thread_store.mark_turn_finished(
+            first_turn["managed_turn_id"], status="ok"
+        )
+    else:
+        assert thread_store.mark_turn_interrupted(first_turn["managed_turn_id"])
+
+    binding = PrBindingStore(hub_root).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        repo_id=repo_id,
+        pr_number=42,
+        pr_state="open",
+        head_branch="feature/scm-rebind",
+        base_branch="main",
+        thread_target_id=thread["managed_thread_id"],
+    )
+    operation = _create_scm_enqueue_operation(
+        journal=PublishJournalStore(hub_root),
+        thread_target_id=thread["managed_thread_id"],
+        binding_id=binding.binding_id,
+        repo_id=repo_id,
+        operation_key=f"enqueue:scm:{expected_runtime_status}",
+    )
+
+    with caplog.at_level(
+        logging.INFO, logger="codex_autorunner.core.publish_operation_executors"
+    ):
+        result = build_enqueue_managed_turn_executor(hub_root=hub_root)(operation)
+
+    assert result["thread_target_id"] == thread["managed_thread_id"]
+    assert result["queued"] is False
+    turns = thread_store.list_turns(thread["managed_thread_id"], limit=10)
+    assert len(turns) == 2
+    assert turns[0]["managed_turn_id"] == result["managed_turn_id"]
+    assert turns[0]["status"] == "running"
+    assert any(
+        "scm.enqueue_managed_turn.reusing_thread" in message
+        and f"normalized_status={expected_runtime_status}" in message
+        for message in caplog.messages
+    )
+
+
+def test_enqueue_managed_turn_executor_queues_on_running_scm_thread(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    hub_root, workspace_root, repo_id = _publish_hub(tmp_path)
+    thread_store = PmaThreadStore(hub_root)
+    thread = thread_store.create_thread(
+        "codex",
+        workspace_root,
+        repo_id=repo_id,
+        metadata={"head_branch": "feature/scm-rebind"},
+    )
+    existing_turn = thread_store.create_turn(
+        thread["managed_thread_id"], prompt="already running"
+    )
+    binding = PrBindingStore(hub_root).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        repo_id=repo_id,
+        pr_number=42,
+        pr_state="open",
+        head_branch="feature/scm-rebind",
+        base_branch="main",
+        thread_target_id=thread["managed_thread_id"],
+    )
+    operation = _create_scm_enqueue_operation(
+        journal=PublishJournalStore(hub_root),
+        thread_target_id=thread["managed_thread_id"],
+        binding_id=binding.binding_id,
+        repo_id=repo_id,
+        operation_key="enqueue:scm:running-thread",
+    )
+
+    with caplog.at_level(
+        logging.INFO, logger="codex_autorunner.core.publish_operation_executors"
+    ):
+        result = build_enqueue_managed_turn_executor(hub_root=hub_root)(operation)
+
+    assert result["thread_target_id"] == thread["managed_thread_id"]
+    assert result["queued"] is True
+    turns = thread_store.list_turns(thread["managed_thread_id"], limit=10)
+    assert len(turns) == 2
+    assert {turn["managed_turn_id"] for turn in turns} == {
+        existing_turn["managed_turn_id"],
+        result["managed_turn_id"],
+    }
+    queued = [
+        turn for turn in turns if turn["managed_turn_id"] == result["managed_turn_id"]
+    ][0]
+    assert queued["status"] == "queued"
+    assert any(
+        "scm.enqueue_managed_turn.reusing_thread" in message
+        and "normalized_status=running" in message
+        for message in caplog.messages
+    )
+
+
 def test_enqueue_managed_turn_executor_rebinds_archived_scm_thread_with_bootstrap_prompt(
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     hub_root, workspace_root, repo_id = _publish_hub(tmp_path)
     thread_store = PmaThreadStore(hub_root)
@@ -631,42 +799,37 @@ def test_enqueue_managed_turn_executor_rebinds_archived_scm_thread_with_bootstra
             "line": 371,
         },
     )
-    journal = PublishJournalStore(hub_root)
-    operation, _ = journal.create_operation(
+    operation = _create_scm_enqueue_operation(
+        journal=PublishJournalStore(hub_root),
+        thread_target_id=archived_thread["managed_thread_id"],
+        binding_id=binding.binding_id,
+        repo_id=repo_id,
         operation_key="enqueue:scm:archived-thread",
-        operation_kind="enqueue_managed_turn",
+    )
+    operation = replace(
+        operation,
         payload={
-            "thread_target_id": archived_thread["managed_thread_id"],
+            **operation.payload,
             "request": {
-                "kind": "message",
-                "message_text": "New PR review feedback arrived on acme/widgets#42.",
+                **operation.payload["request"],
                 "metadata": {
                     "scm": {
-                        "binding_id": binding.binding_id,
+                        **operation.payload["request"]["metadata"]["scm"],
                         "event_id": event.event_id,
-                        "provider": "github",
-                        "repo_slug": "acme/widgets",
-                        "repo_id": repo_id,
-                        "pr_number": 42,
                     }
                 },
             },
             "scm_reaction": {
-                "binding_id": binding.binding_id,
+                **operation.payload["scm_reaction"],
                 "event_id": event.event_id,
-                "provider": "github",
-                "reaction_kind": "review_comment",
-                "repo_slug": "acme/widgets",
-                "repo_id": repo_id,
-                "pr_number": 42,
-                "head_branch": "feature/scm-rebind",
-                "base_branch": "main",
-                "thread_target_id": archived_thread["managed_thread_id"],
             },
         },
     )
 
-    result = build_enqueue_managed_turn_executor(hub_root=hub_root)(operation)
+    with caplog.at_level(
+        logging.INFO, logger="codex_autorunner.core.publish_operation_executors"
+    ):
+        result = build_enqueue_managed_turn_executor(hub_root=hub_root)(operation)
 
     assert result["thread_target_id"] != archived_thread["managed_thread_id"]
     assert (
@@ -697,6 +860,20 @@ def test_enqueue_managed_turn_executor_rebinds_archived_scm_thread_with_bootstra
         "https://github.com/acme/widgets/pull/42"
     )
     assert replacement_thread["metadata"]["head_branch"] == "feature/scm-rebind"
+    assert any(
+        "scm.enqueue_managed_turn.rebinding_thread" in message
+        and f"previous_thread_target_id={archived_thread['managed_thread_id']}"
+        in message
+        and "status=archived" in message
+        for message in caplog.messages
+    )
+    assert any(
+        "scm.enqueue_managed_turn.rebound_thread" in message
+        and f"previous_thread_target_id={archived_thread['managed_thread_id']}"
+        in message
+        and f"thread_target_id={result['thread_target_id']}" in message
+        for message in caplog.messages
+    )
 
 
 def test_enqueue_managed_turn_executor_dedupes_retry_after_scm_rebind_to_new_thread(

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -1336,9 +1336,11 @@ def test_process_due_watches_emits_new_pr_comment_and_inline_review_comment(
     }
 
 
+@pytest.mark.parametrize("pr_state", ["open", "draft"])
 def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    pr_state: str,
 ) -> None:
     hub_root = tmp_path / "hub"
     workspace_root = hub_root / "repo"
@@ -1376,7 +1378,7 @@ def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
         repo_slug="acme/widgets",
         repo_id="repo-1",
         pr_number=17,
-        pr_state="open",
+        pr_state=pr_state,
         head_branch="feature/scm-polling",
         base_branch="main",
         thread_target_id=str(thread["managed_thread_id"]),
@@ -1396,7 +1398,7 @@ def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
         reaction_config={"enabled": True},
         snapshot={
             "head_sha": "oldsha",
-            "pr_state": "open",
+            "pr_state": pr_state,
             "review_thread_comments": {},
         },
     )
@@ -1407,7 +1409,7 @@ def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
             raw_config,
             pr_view_payload={
                 "state": "OPEN",
-                "isDraft": False,
+                "isDraft": pr_state == "draft",
                 "headRefOid": "newsha",
                 "author": {"login": "pr-author"},
             },


### PR DESCRIPTION
## Summary

Closes #1526.

This locks down the two SCM review-comment seams the issue calls out:

- add explicit polling coverage for `draft` PRs so inline review comments still emit reactions and wake the bound thread
- add executor regression coverage showing SCM follow-ups reuse `completed` and `interrupted` threads, and queue correctly when the thread is already `running`
- add structured `enqueue_managed_turn` logs for non-idle SCM thread reuse and archived-thread rebinding, while preserving the original non-active status if a rebind cannot be repaired

## Why

The current code already treats `draft` PRs as active and admits turns on threads whose lifecycle is still `active`, but that behavior was only implicit. This PR makes the intended behavior explicit with regression tests and improves observability when SCM follow-ups are routed onto reusable or busy managed threads.

## Validation

- `.venv/bin/pytest -q tests/core/test_publish_executor.py tests/integrations/github/test_polling.py`
- repo commit hook validation:
  - `black`
  - `ruff`
  - repo-wide `mypy src/codex_autorunner`
  - repo-wide `pytest` (`7518 passed`)
  - frontend build and JS tests
  - chat-surface deterministic checks and latency budget script