### PR TITLE
[codex] avoid pma bootstrap prompt on same-session retries

### DIFF
--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -791,6 +791,15 @@ class _ThreadExecutionLifecycle:
             runtime_prompt = raw_runtime_prompt
         return runtime_prompt
 
+    @staticmethod
+    def resolve_existing_session_runtime_prompt(
+        request: MessageRequest,
+    ) -> Optional[str]:
+        raw_runtime_prompt = request.metadata.get("existing_session_runtime_prompt")
+        if isinstance(raw_runtime_prompt, str) and raw_runtime_prompt.strip():
+            return raw_runtime_prompt
+        return None
+
     def build_rehydration_prefix(
         self, thread: ThreadTarget, *, include_compact_seed: bool
     ) -> Optional[str]:
@@ -861,7 +870,11 @@ class _ThreadExecutionLifecycle:
         workspace_root: Path,
         sandbox_policy: Optional[Any],
     ) -> ExecutionRecord:
-        runtime_prompt = self.resolve_runtime_prompt(request)
+        new_session_runtime_prompt = self.resolve_runtime_prompt(request)
+        existing_session_runtime_prompt = (
+            self.resolve_existing_session_runtime_prompt(request)
+            or new_session_runtime_prompt
+        )
         fresh_conversation_retry_attempted = False
         rehydrated_runtime_prompt = False
         fresh_backend_session_reason: Optional[str] = None
@@ -890,6 +903,11 @@ class _ThreadExecutionLifecycle:
                 )
             while True:
                 used_existing_conversation = conversation_id is not None
+                attempt_runtime_prompt = (
+                    existing_session_runtime_prompt
+                    if used_existing_conversation
+                    else new_session_runtime_prompt
+                )
                 try:
                     if conversation_id:
                         try:
@@ -952,7 +970,7 @@ class _ThreadExecutionLifecycle:
                             prefix = self.build_rehydration_prefix(
                                 thread,
                                 include_compact_seed="Context summary (from compaction):"
-                                not in runtime_prompt,
+                                not in new_session_runtime_prompt,
                             )
                             should_mark_fresh_backend_session = bool(
                                 previous_backend_thread_id
@@ -987,7 +1005,9 @@ class _ThreadExecutionLifecycle:
                                     rehydrated=bool(prefix),
                                 )
                             if prefix:
-                                runtime_prompt = f"{prefix}\n\n{runtime_prompt}"
+                                attempt_runtime_prompt = (
+                                    f"{prefix}\n\n{new_session_runtime_prompt}"
+                                )
                             rehydrated_runtime_prompt = True
                         conversation = await harness.new_conversation(
                             workspace_root,
@@ -1020,7 +1040,7 @@ class _ThreadExecutionLifecycle:
                         turn = await harness.start_review(
                             workspace_root,
                             conversation_id,
-                            runtime_prompt,
+                            attempt_runtime_prompt,
                             request.model,
                             request.reasoning,
                             approval_mode=request.approval_mode,
@@ -1030,7 +1050,7 @@ class _ThreadExecutionLifecycle:
                         turn = await harness.start_turn(
                             workspace_root,
                             conversation_id,
-                            runtime_prompt,
+                            attempt_runtime_prompt,
                             request.model,
                             request.reasoning,
                             approval_mode=request.approval_mode,

--- a/src/codex_autorunner/core/pma_context.py
+++ b/src/codex_autorunner/core/pma_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional, cast
 
@@ -50,6 +51,14 @@ from .pma_workspace_docs import load_pma_prompt, load_pma_workspace_docs
 from .state import now_iso
 
 _logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PmaPromptVariants:
+    """Prompt variants for new-session bootstrap versus same-session continuation."""
+
+    new_session_prompt: str
+    existing_session_prompt: str
 
 
 def format_pma_discoverability_preamble(
@@ -136,6 +145,46 @@ def format_pma_prompt(
     )
 
 
+def format_pma_prompt_variants(
+    base_prompt: str,
+    snapshot: dict[str, Any],
+    message: str,
+    hub_root: Optional[Path] = None,
+    *,
+    prompt_state_key: Optional[str] = None,
+    force_full_context: bool = False,
+) -> PmaPromptVariants:
+    """Build prompt variants for fresh-session bootstrap and existing sessions.
+
+    The first render intentionally primes prompt-state tracking. A second render
+    with the same state key then produces the compact existing-session variant,
+    which is safe to use when the backend session already has the full PMA
+    bootstrap in context.
+    """
+
+    new_session_prompt = format_pma_prompt(
+        base_prompt,
+        snapshot,
+        message,
+        hub_root=hub_root,
+        prompt_state_key=prompt_state_key,
+        force_full_context=force_full_context,
+    )
+    existing_session_prompt = new_session_prompt
+    if hub_root is not None and prompt_state_key and not force_full_context:
+        existing_session_prompt = format_pma_prompt(
+            base_prompt,
+            snapshot,
+            message,
+            hub_root=hub_root,
+            prompt_state_key=prompt_state_key,
+        )
+    return PmaPromptVariants(
+        new_session_prompt=new_session_prompt,
+        existing_session_prompt=existing_session_prompt,
+    )
+
+
 def build_hub_unavailable_snapshot(
     *,
     detail: str,
@@ -200,6 +249,7 @@ __all__ = [
     "PMA_MAX_REPOS",
     "PMA_MAX_TEMPLATE_FIELD_CHARS",
     "PMA_MAX_TEMPLATE_REPOS",
+    "PmaPromptVariants",
     "PMA_MAX_TEXT",
     "PMA_PROMPT_SECTION_META",
     "TicketFlowRunState",
@@ -231,6 +281,7 @@ __all__ = [
     "enrich_pma_file_inbox_entry",
     "format_pma_discoverability_preamble",
     "format_pma_prompt",
+    "format_pma_prompt_variants",
     "get_active_context_auto_prune_meta",
     "get_latest_ticket_flow_run_state_with_record",
     "list_pma_prompt_state_session_keys",

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -39,7 +39,8 @@ from ...core.orchestration.runtime_threads import (
 from ...core.pma_context import (
     build_hub_unavailable_snapshot,
     format_pma_discoverability_preamble,
-    format_pma_prompt,
+    format_pma_prompt,  # noqa: F401  re-export for test monkeypatch compat
+    format_pma_prompt_variants,
     load_pma_prompt,
 )
 from ...core.pma_notification_store import (
@@ -898,6 +899,7 @@ async def _execute_discord_thread_message(
                 message_id=dispatch.event.message.message_id,
             )
 
+    existing_session_prompt_text: Optional[str] = None
     if dispatch.effective_pma_enabled:
         try:
             hub_client = getattr(dispatch.service, "_hub_client", None)
@@ -933,13 +935,15 @@ async def _execute_discord_thread_message(
                     f"{build_notification_context_block(dispatch.notification_reply)}\n\n"
                     f"{prompt_text}"
                 )
-            prompt_text = format_pma_prompt(
+            prompt_variants = format_pma_prompt_variants(
                 prompt_base,
                 snapshot,
                 prompt_text,
                 hub_root=dispatch.service._config.root,
                 prompt_state_key=dispatch.session_key,
             )
+            prompt_text = prompt_variants.new_session_prompt
+            existing_session_prompt_text = prompt_variants.existing_session_prompt
         except (OSError, ValueError, KeyError, TypeError) as exc:
             dispatch.log_event_fn(
                 dispatch.service._logger,
@@ -964,6 +968,15 @@ async def _execute_discord_thread_message(
         link_source_text=dispatch.turn_text,
         allow_cross_repo=dispatch.pma_enabled,
     )
+    if existing_session_prompt_text is not None:
+        existing_session_prompt_text, _ = (
+            await dispatch.service._maybe_inject_github_context(
+                existing_session_prompt_text,
+                request_workspace_root,
+                link_source_text=dispatch.turn_text,
+                allow_cross_repo=dispatch.pma_enabled,
+            )
+        )
     if dispatch.pending_compact_seed:
         prompt_text = f"{dispatch.pending_compact_seed}\n\n{prompt_text}"
 
@@ -1001,6 +1014,8 @@ async def _execute_discord_thread_message(
         run_turn_kwargs["supervision"] = supervision
     if turn_input_items:
         run_turn_kwargs["input_items"] = turn_input_items
+    if existing_session_prompt_text is not None:
+        run_turn_kwargs["existing_session_prompt_text"] = existing_session_prompt_text
     run_turn_kwargs["chat_ux_snapshot"] = dispatch.chat_ux_snapshot
     try:
         try:
@@ -1009,9 +1024,13 @@ async def _execute_discord_thread_message(
                 await dispatch.service._run_agent_turn_for_message(**run_turn_kwargs),
             )
         except TypeError as exc:
-            if "supervision" not in str(exc):
+            error_text = str(exc)
+            if "supervision" in error_text:
+                run_turn_kwargs.pop("supervision", None)
+            elif "existing_session_prompt_text" in error_text:
+                run_turn_kwargs.pop("existing_session_prompt_text", None)
+            else:
                 raise
-            run_turn_kwargs.pop("supervision", None)
             return cast(
                 DiscordMessageTurnResult,
                 await dispatch.service._run_agent_turn_for_message(**run_turn_kwargs),
@@ -1613,6 +1632,7 @@ async def _run_discord_orchestrated_turn_for_message(
     min_edit_interval_seconds: float,
     heartbeat_interval_seconds: float,
     supervision: Optional[_DiscordTurnExecutionSupervision] = None,
+    existing_session_prompt_text: Optional[str] = None,
     chat_ux_snapshot: Optional[ChatUxTimingSnapshot] = None,
 ) -> DiscordMessageTurnResult:
     _ = session_key
@@ -2262,6 +2282,15 @@ async def _run_discord_orchestrated_turn_for_message(
     async def _after_completion(_flow: Any) -> None:
         await _stop_progress_heartbeat()
 
+    metadata = {
+        "runtime_prompt": execution_prompt,
+        "execution_error_message": public_execution_error,
+    }
+    if (
+        isinstance(existing_session_prompt_text, str)
+        and existing_session_prompt_text.strip()
+    ):
+        metadata["existing_session_runtime_prompt"] = existing_session_prompt_text
     return await run_managed_surface_turn(
         MessageRequest(
             target_id=thread.thread_target_id,
@@ -2272,10 +2301,7 @@ async def _run_discord_orchestrated_turn_for_message(
             reasoning=reasoning_effort,
             approval_mode=approval_mode,
             input_items=execution_input_items,
-            metadata={
-                "runtime_prompt": execution_prompt,
-                "execution_error_message": public_execution_error,
-            },
+            metadata=metadata,
         ),
         config=ManagedSurfaceRunnerConfig(
             coordinator=coordinator,
@@ -2374,6 +2400,7 @@ async def run_managed_thread_turn_for_message(
     managed_thread_surface_key: Optional[str] = None,
     suppress_managed_thread_delivery: bool = False,
     supervision: Optional[_DiscordTurnExecutionSupervision] = None,
+    existing_session_prompt_text: Optional[str] = None,
     chat_ux_snapshot: Optional[ChatUxTimingSnapshot] = None,
 ) -> DiscordMessageTurnResult:
 
@@ -2405,6 +2432,7 @@ async def run_managed_thread_turn_for_message(
         mode="pma",
         pma_enabled=True,
         execution_prompt=execution_prompt,
+        existing_session_prompt_text=existing_session_prompt_text,
         public_execution_error=DISCORD_PMA_PUBLIC_EXECUTION_ERROR,
         timeout_error="Discord PMA turn timed out",
         interrupted_error="Discord PMA turn interrupted",

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -3646,6 +3646,7 @@ class DiscordBotService:
         managed_thread_surface_key: Optional[str] = None,
         suppress_managed_thread_delivery: bool = False,
         supervision: Optional[Any] = None,
+        existing_session_prompt_text: Optional[str] = None,
         chat_ux_snapshot: Optional[Any] = None,
     ) -> DiscordMessageTurnResult:
         async def _run_turn() -> DiscordMessageTurnResult:
@@ -3664,6 +3665,7 @@ class DiscordBotService:
                     managed_thread_surface_key=managed_thread_surface_key,
                     suppress_managed_thread_delivery=suppress_managed_thread_delivery,
                     supervision=supervision,
+                    existing_session_prompt_text=existing_session_prompt_text,
                     chat_ux_snapshot=chat_ux_snapshot,
                 )
             return await run_agent_turn_for_message(

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -62,7 +62,7 @@ from .....core.orchestration.runtime_threads import (
 from .....core.pma_context import (
     build_hub_unavailable_snapshot,
     format_pma_discoverability_preamble,
-    format_pma_prompt,
+    format_pma_prompt_variants,
     load_pma_prompt,
 )
 from .....core.state import now_iso
@@ -978,6 +978,7 @@ async def _run_telegram_managed_thread_turn(
     interrupted_error: str = TELEGRAM_PMA_INTERRUPTED_ERROR,
     approval_policy: Optional[str] = None,
     sandbox_policy: Optional[Any] = None,
+    existing_session_prompt_text: Optional[str] = None,
     chat_ux_snapshot: Optional[ChatUxTimingSnapshot] = None,
 ) -> _TurnRunResult | _TurnRunFailure:
     if chat_ux_snapshot is not None:
@@ -1406,6 +1407,15 @@ async def _run_telegram_managed_thread_turn(
             _first_progress_recorded = True
             chat_ux_snapshot.record(ChatUxMilestone.FIRST_SEMANTIC_PROGRESS)
 
+    metadata = {
+        "runtime_prompt": execution_prompt,
+        "execution_error_message": public_execution_error,
+    }
+    if (
+        isinstance(existing_session_prompt_text, str)
+        and existing_session_prompt_text.strip()
+    ):
+        metadata["existing_session_runtime_prompt"] = existing_session_prompt_text
     return await run_managed_surface_turn(
         MessageRequest(
             target_id=thread.thread_target_id,
@@ -1416,10 +1426,7 @@ async def _run_telegram_managed_thread_turn(
             reasoning=record.effort,
             approval_mode=approval_policy,
             input_items=execution_input_items,
-            metadata={
-                "runtime_prompt": execution_prompt,
-                "execution_error_message": public_execution_error,
-            },
+            metadata=metadata,
         ),
         config=ManagedSurfaceRunnerConfig(
             coordinator=coordinator,
@@ -2852,7 +2859,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
         *,
         record: "TelegramTopicRecord",
         message: TelegramMessage,
-    ) -> Optional[str]:
+    ) -> Optional[tuple[str, str]]:
         hub_root = getattr(self, "_hub_root", None)
         if hub_root is None:
             return None
@@ -2888,12 +2895,16 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 )
             base_prompt = load_pma_prompt(hub_root)
             prompt_state_key = self._pma_registry_key(record, message)
-            return format_pma_prompt(
+            prompt_variants = format_pma_prompt_variants(
                 base_prompt,
                 snapshot,
                 message_text,
                 hub_root=hub_root,
                 prompt_state_key=prompt_state_key,
+            )
+            return (
+                prompt_variants.new_session_prompt,
+                prompt_variants.existing_session_prompt,
             )
         except (OSError, ValueError, RuntimeError, ConfigError):
             return None
@@ -3129,18 +3140,19 @@ class ExecutionCommands(TelegramCommandSupportMixin):
         prompt_text = self._prepare_turn_prompt(
             prompt_text, transcript_text=transcript_text
         )
+        existing_session_prompt_text: Optional[str] = None
         if pma_enabled:
             user_message_prompt = prompt_text
             if isinstance(pma_context_prefix, str) and pma_context_prefix.strip():
                 user_message_prompt = (
                     f"{pma_context_prefix.strip()}\n\n{user_message_prompt}"
                 )
-            pma_prompt = await self._prepare_pma_prompt(
+            pma_prompt_variants = await self._prepare_pma_prompt(
                 user_message_prompt,
                 record=record,
                 message=message,
             )
-            if pma_prompt is None:
+            if pma_prompt_variants is None:
                 return await self._maybe_send_failure(
                     message,
                     "PMA unavailable; hub snapshot failed.",
@@ -3149,12 +3161,22 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                     transcript_message_id=transcript_message_id,
                     transcript_text=transcript_text,
                 )
+            pma_prompt, existing_session_prompt_text = pma_prompt_variants
             prompt_text, injected = await self._maybe_inject_github_context(
                 pma_prompt,
                 record,
                 link_source_text=user_message_prompt,
                 allow_cross_repo=True,
             )
+            if existing_session_prompt_text:
+                existing_session_prompt_text, _ = (
+                    await self._maybe_inject_github_context(
+                        existing_session_prompt_text,
+                        record,
+                        link_source_text=user_message_prompt,
+                        allow_cross_repo=True,
+                    )
+                )
             if injected:
                 await self._send_message(
                     message.chat_id,
@@ -3192,6 +3214,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 missing_thread_message=missing_thread_message,
                 approval_policy=approval_policy,
                 sandbox_policy=sandbox_policy,
+                existing_session_prompt_text=existing_session_prompt_text,
                 chat_ux_snapshot=_chat_ux_snapshot,
             )
 

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -565,6 +565,36 @@ async def test_send_message_persists_canonical_resumed_conversation_id(
     assert binding.backend_thread_id == "backend-canonical-2"
 
 
+async def test_send_message_uses_existing_session_runtime_prompt_for_live_backend(
+    tmp_path: Path,
+) -> None:
+    harness = _FakeHarness()
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target(
+        "codex",
+        workspace_root,
+        backend_thread_id="backend-existing-1",
+    )
+
+    await service.send_message(
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="raw user message",
+            metadata={
+                "runtime_prompt": "full PMA bootstrap prompt",
+                "existing_session_runtime_prompt": "compact same-session prompt",
+            },
+        )
+    )
+
+    assert harness.resume_conversation_calls == [(workspace_root, "backend-existing-1")]
+    assert harness.start_turn_calls[0]["conversation_id"] == "backend-existing-1"
+    assert harness.start_turn_calls[0]["prompt"] == "compact same-session prompt"
+
+
 async def test_send_message_starts_fresh_when_resume_conversation_is_missing(
     tmp_path: Path,
 ) -> None:
@@ -596,6 +626,37 @@ async def test_send_message_starts_fresh_when_resume_conversation_is_missing(
     binding = _thread_runtime_binding(service, thread.thread_target_id)
     assert binding is not None
     assert binding.backend_thread_id == "backend-conversation-1"
+
+
+async def test_send_message_uses_full_runtime_prompt_after_resume_recovery(
+    tmp_path: Path,
+) -> None:
+    harness = _FakeHarness(resume_conversation_error=RuntimeError("missing thread"))
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target(
+        "codex",
+        workspace_root,
+        backend_thread_id="backend-existing-1",
+    )
+
+    await service.send_message(
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="raw user message",
+            metadata={
+                "runtime_prompt": "full PMA bootstrap prompt",
+                "existing_session_runtime_prompt": "compact same-session prompt",
+            },
+        )
+    )
+
+    assert harness.resume_conversation_calls == [(workspace_root, "backend-existing-1")]
+    assert harness.new_conversation_calls == [(workspace_root, None)]
+    assert harness.start_turn_calls[0]["conversation_id"] == "backend-conversation-1"
+    assert harness.start_turn_calls[0]["prompt"] == "full PMA bootstrap prompt"
 
 
 async def test_send_message_reuses_conversation_when_backend_runtime_instance_changes(
@@ -1065,7 +1126,10 @@ async def test_claim_next_queued_execution_context_preserves_typed_request_paylo
                 {"type": "image", "image_url": "https://example.com/diagram.png"},
             ],
             context_profile="car_core",
-            metadata={"runtime_prompt": "Use the saved context first."},
+            metadata={
+                "runtime_prompt": "Use the saved context first.",
+                "existing_session_runtime_prompt": "Use the cached context.",
+            },
         ),
         client_request_id="client-2",
         sandbox_policy={"mode": "workspace-write"},
@@ -1091,7 +1155,8 @@ async def test_claim_next_queued_execution_context_preserves_typed_request_paylo
     ]
     assert claimed.request.context_profile == "car_core"
     assert claimed.request.metadata == {
-        "runtime_prompt": "Use the saved context first."
+        "runtime_prompt": "Use the saved context first.",
+        "existing_session_runtime_prompt": "Use the cached context.",
     }
     assert claimed.client_request_id == "client-2"
     assert claimed.sandbox_policy == {"mode": "workspace-write"}

--- a/tests/pma_context_support.py
+++ b/tests/pma_context_support.py
@@ -24,6 +24,7 @@ from codex_autorunner.core.pma_context import (
     PMA_ACTIVE_CONTEXT_MAX_LINES,
     build_hub_snapshot,
     format_pma_prompt,
+    format_pma_prompt_variants,
     get_active_context_auto_prune_meta,
 )
 from codex_autorunner.core.pma_thread_store import PmaThreadStore
@@ -1941,6 +1942,34 @@ class TestIssue975DeltaPmaPromptAssembly:
         assert "- changed=none" in result2
         assert "PMA Action Queue:" in result2
         assert "recommended_action=reply_and_resume" in result2
+
+    def test_format_pma_prompt_variants_preserve_bootstrap_and_existing_session_forms(
+        self, tmp_path: Path
+    ) -> None:
+        seed_hub_files(tmp_path, force=True)
+
+        snapshot = {
+            "generated_at": "2026-03-16T00:00:00Z",
+            "action_queue": [],
+            "inbox": [],
+            "repos": [],
+            "pma_files": {"inbox": [], "outbox": []},
+        }
+
+        variants = format_pma_prompt_variants(
+            "Base prompt",
+            snapshot,
+            "Turn 1",
+            hub_root=tmp_path,
+            prompt_state_key="pma.test-variants",
+        )
+
+        assert "<pma_workspace_docs>" in variants.new_session_prompt
+        assert "<hub_snapshot>" in variants.new_session_prompt
+        assert "<pma_workspace_docs>" not in variants.existing_session_prompt
+        assert "\n<hub_snapshot>\n" not in variants.existing_session_prompt
+        assert "<hub_snapshot_ref " in variants.existing_session_prompt
+        assert "- cached=" in variants.existing_session_prompt
 
     def test_format_pma_prompt_delta_surfaces_only_changed_docs(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary
- add PMA runtime prompt variants so existing backend sessions get a compact same-session prompt instead of replaying the full bootstrap prompt
- teach orchestration to choose the existing-session prompt when reusing a live conversation, while falling back to the full bootstrap prompt after resume recovery starts a fresh backend session
- thread the new metadata through Discord and Telegram managed-thread flows and cover the behavior with orchestration and PMA prompt tests

## Root Cause
Retries within the same backend session reused the same runtime prompt path that was designed for fresh sessions, so PMA bootstrap context could be injected again even when the conversation already existed.

## Validation
- full aggregate commit validation lane
- `.venv/bin/python -m pytest -q tests/core/orchestration/test_service.py -k "existing_session_runtime_prompt or claim_next_queued_execution_context_preserves_typed_request_payload or resume_conversation_is_missing"`
- `.venv/bin/python -m pytest -q tests/pma_context_support.py -k "format_pma_prompt_variants_preserve_bootstrap_and_existing_session_forms or test_format_pma_prompt_reuses_durable_context_by_digest_after_first_turn"`
- `.venv/bin/python -m pytest -q tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py -k "runtime_prompt or compact_seed or literal_message_whitespace"`
- `.venv/bin/python -m pytest -q tests/test_pma_context.py`
- `.venv/bin/python -m pytest -q tests/integrations/discord/test_message_turns.py`
- `.venv/bin/python -m pytest -q tests/integrations/discord/test_service_routing.py -k "forwards_managed_thread_delivery_suppression or wraps_typing_indicator or discord_notification_reply_routes_to_pma_thread_with_context"`

Closes #1528