### PR TITLE
[codex] flush discord outbox after durable delivery

### DIFF
--- a/src/codex_autorunner/integrations/chat/managed_thread_delivery_support.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_delivery_support.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Mapping, Optional
 
@@ -50,6 +51,8 @@ ManagedThreadDeliveryCleanupFn = Callable[
     Awaitable[None],
 ]
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def deliver_managed_thread_terminal_record(
     record: Any,
@@ -77,7 +80,19 @@ async def deliver_managed_thread_terminal_record(
                 error=send_result.error,
             )
         if cleanup is not None and status in cleanup_statuses:
-            await cleanup(context)
+            try:
+                await cleanup(context)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _LOGGER.warning(
+                    "Post-delivery cleanup failed after terminal send (best-effort; "
+                    "delivery still counted as succeeded): delivery_id=%s thread=%s turn=%s",
+                    context.delivery_id,
+                    context.managed_thread_id,
+                    context.managed_turn_id,
+                    exc_info=True,
+                )
     except asyncio.CancelledError:
         raise
     except Exception as exc:

--- a/src/codex_autorunner/integrations/chat/managed_thread_delivery_support.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_delivery_support.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Mapping, Optional
+
+from ...core.orchestration import (
+    ManagedThreadDeliveryAttemptResult,
+    ManagedThreadDeliveryOutcome,
+)
+
+
+@dataclass(frozen=True)
+class ManagedThreadDeliveryCleanupContext:
+    delivery_id: str
+    managed_thread_id: str
+    managed_turn_id: str
+    final_status: str
+    transport_target: Mapping[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_record(cls, record: Any) -> "ManagedThreadDeliveryCleanupContext":
+        return cls(
+            delivery_id=str(getattr(record, "delivery_id", "") or ""),
+            managed_thread_id=str(getattr(record, "managed_thread_id", "") or ""),
+            managed_turn_id=str(getattr(record, "managed_turn_id", "") or ""),
+            final_status=str(
+                getattr(getattr(record, "envelope", None), "final_status", "") or ""
+            ),
+            transport_target=dict(
+                getattr(getattr(record, "target", None), "transport_target", {}) or {}
+            ),
+            metadata=dict(getattr(record, "metadata", {}) or {}),
+        )
+
+
+@dataclass(frozen=True)
+class ManagedThreadDeliverySendResult:
+    error: Optional[str] = None
+    adapter_cursor: Optional[Mapping[str, Any]] = None
+
+
+ManagedThreadDeliverySendFn = Callable[
+    [ManagedThreadDeliveryCleanupContext],
+    Awaitable[Optional[ManagedThreadDeliverySendResult]],
+]
+ManagedThreadDeliveryCleanupFn = Callable[
+    [ManagedThreadDeliveryCleanupContext],
+    Awaitable[None],
+]
+
+
+async def deliver_managed_thread_terminal_record(
+    record: Any,
+    *,
+    send_success: ManagedThreadDeliverySendFn,
+    send_failure: ManagedThreadDeliverySendFn,
+    cleanup: Optional[ManagedThreadDeliveryCleanupFn] = None,
+    cleanup_statuses: frozenset[str] = frozenset({"ok"}),
+) -> ManagedThreadDeliveryAttemptResult:
+    context = ManagedThreadDeliveryCleanupContext.from_record(record)
+    status = context.final_status
+    if status == "interrupted":
+        return ManagedThreadDeliveryAttemptResult(
+            outcome=ManagedThreadDeliveryOutcome.ABANDONED,
+            error="interrupted_turn_has_no_terminal_delivery",
+        )
+    send = send_success if status == "ok" else send_failure
+    try:
+        send_result = await send(context)
+        if send_result is None:
+            send_result = ManagedThreadDeliverySendResult()
+        if send_result.error:
+            return ManagedThreadDeliveryAttemptResult(
+                outcome=ManagedThreadDeliveryOutcome.FAILED,
+                error=send_result.error,
+            )
+        if cleanup is not None and status in cleanup_statuses:
+            await cleanup(context)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        return ManagedThreadDeliveryAttemptResult(
+            outcome=ManagedThreadDeliveryOutcome.FAILED,
+            error=str(exc) or exc.__class__.__name__,
+        )
+    return ManagedThreadDeliveryAttemptResult(
+        outcome=ManagedThreadDeliveryOutcome.DELIVERED,
+        adapter_cursor=(
+            dict(send_result.adapter_cursor)
+            if send_result.adapter_cursor is not None
+            else None
+        ),
+    )
+
+
+__all__ = [
+    "ManagedThreadDeliveryCleanupContext",
+    "ManagedThreadDeliveryCleanupFn",
+    "ManagedThreadDeliverySendFn",
+    "ManagedThreadDeliverySendResult",
+    "deliver_managed_thread_terminal_record",
+]

--- a/src/codex_autorunner/integrations/discord/managed_thread_delivery.py
+++ b/src/codex_autorunner/integrations/discord/managed_thread_delivery.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 from typing import Any, Optional
 
-from ...core.logging_utils import log_event
 from ...core.orchestration import (
     ManagedThreadDeliveryAttemptResult,
     ManagedThreadDeliveryOutcome,
@@ -114,23 +112,7 @@ async def deliver_discord_managed_thread_record(
         if not callable(flush):
             return
         workspace_root = Path(raw_path)
-        try:
-            await flush(workspace_root=workspace_root, channel_id=target_channel_id)
-        except (
-            Exception
-        ) as exc:  # intentional: do not surface cleanup failures after reply
-            logger = getattr(service, "_logger", None)
-            if logger is not None:
-                log_event(
-                    logger,
-                    logging.WARNING,
-                    "discord.managed_thread.delivery_cleanup_failed",
-                    channel_id=target_channel_id,
-                    workspace_root=str(workspace_root),
-                    managed_thread_id=record.managed_thread_id,
-                    managed_turn_id=record.managed_turn_id,
-                    exc=exc,
-                )
+        await flush(workspace_root=workspace_root, channel_id=target_channel_id)
 
     return await deliver_managed_thread_terminal_record(
         record,

--- a/src/codex_autorunner/integrations/discord/managed_thread_delivery.py
+++ b/src/codex_autorunner/integrations/discord/managed_thread_delivery.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from pathlib import Path
 from typing import Any, Optional
@@ -12,6 +11,11 @@ from ...core.orchestration import (
     ManagedThreadDeliveryAttemptResult,
     ManagedThreadDeliveryOutcome,
     SQLiteManagedThreadDeliveryEngine,
+)
+from ..chat.managed_thread_delivery_support import (
+    ManagedThreadDeliveryCleanupContext,
+    ManagedThreadDeliverySendResult,
+    deliver_managed_thread_terminal_record,
 )
 from ...integrations.chat.managed_thread_turns import (
     ManagedThreadDurableDeliveryHooks,
@@ -33,18 +37,20 @@ async def deliver_discord_managed_thread_record(
     error_record_label: str,
     default_execution_error: str,
 ) -> ManagedThreadDeliveryAttemptResult:
-    """Deliver a managed-thread delivery record to Discord (chunks ok-path; errors → message)."""
+    """Deliver a managed-thread delivery record to Discord (chunks ok-path; errors -> message)."""
     _ = claim
     target_channel_id = _resolve_delivery_channel_id(
         record, fallback=channel_id_fallback
     )
-    workspace_root = _resolve_delivery_workspace_root(record)
     if not target_channel_id:
         return ManagedThreadDeliveryAttemptResult(
             outcome=ManagedThreadDeliveryOutcome.ABANDONED,
             error="missing_discord_channel_id",
         )
-    if record.envelope.final_status == "ok":
+
+    async def _send_success(
+        _context: ManagedThreadDeliveryCleanupContext,
+    ) -> ManagedThreadDeliverySendResult:
         assistant_text = render_managed_thread_delivery_record_text(record)
         formatted = (
             format_discord_message(assistant_text)
@@ -61,63 +67,28 @@ async def deliver_discord_managed_thread_record(
         base_record_id = (
             f"{base_record_label}:{record.managed_thread_id}:{record.managed_turn_id}"
         )
-        try:
-            for chunk_index, chunk in enumerate(chunks, start=1):
-                record_id = (
-                    f"{base_record_id}:chunk:{chunk_index}"
-                    if len(chunks) > 1
-                    else base_record_id
-                )
-                delivered = await service._send_channel_message_safe(
-                    target_channel_id,
-                    {"content": chunk},
-                    record_id=record_id,
-                )
-                if not delivered:
-                    return ManagedThreadDeliveryAttemptResult(
-                        outcome=ManagedThreadDeliveryOutcome.FAILED,
-                        error=f"discord_send_deferred:{record_id}",
-                    )
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            return ManagedThreadDeliveryAttemptResult(
-                outcome=ManagedThreadDeliveryOutcome.FAILED,
-                error=str(exc) or exc.__class__.__name__,
+        for chunk_index, chunk in enumerate(chunks, start=1):
+            record_id = (
+                f"{base_record_id}:chunk:{chunk_index}"
+                if len(chunks) > 1
+                else base_record_id
             )
-        try:
-            await _flush_delivery_outbox_files(
-                service,
-                workspace_root=workspace_root,
-                channel_id=target_channel_id,
+            delivered = await service._send_channel_message_safe(
+                target_channel_id,
+                {"content": chunk},
+                record_id=record_id,
             )
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:  # intentional: do not surface cleanup failures after reply
-            logger = getattr(service, "_logger", None)
-            if logger is not None:
-                log_event(
-                    logger,
-                    logging.WARNING,
-                    "discord.managed_thread.delivery_cleanup_failed",
-                    channel_id=target_channel_id,
-                    workspace_root=(
-                        str(workspace_root) if workspace_root is not None else None
-                    ),
-                    managed_thread_id=record.managed_thread_id,
-                    managed_turn_id=record.managed_turn_id,
-                    exc=exc,
+            if not delivered:
+                return ManagedThreadDeliverySendResult(
+                    error=f"discord_send_deferred:{record_id}",
                 )
-        return ManagedThreadDeliveryAttemptResult(
-            outcome=ManagedThreadDeliveryOutcome.DELIVERED,
+        return ManagedThreadDeliverySendResult(
             adapter_cursor={"chunk_count": len(chunks)},
         )
-    if record.envelope.final_status == "interrupted":
-        return ManagedThreadDeliveryAttemptResult(
-            outcome=ManagedThreadDeliveryOutcome.ABANDONED,
-            error="interrupted_turn_has_no_terminal_delivery",
-        )
-    try:
+
+    async def _send_failure(
+        _context: ManagedThreadDeliveryCleanupContext,
+    ) -> ManagedThreadDeliverySendResult:
         delivered = await service._send_channel_message_safe(
             target_channel_id,
             {
@@ -130,42 +101,43 @@ async def deliver_discord_managed_thread_record(
             ),
         )
         if not delivered:
-            return ManagedThreadDeliveryAttemptResult(
-                outcome=ManagedThreadDeliveryOutcome.FAILED,
+            return ManagedThreadDeliverySendResult(
                 error="discord_error_notice_deferred",
             )
-    except asyncio.CancelledError:
-        raise
-    except Exception as exc:
-        return ManagedThreadDeliveryAttemptResult(
-            outcome=ManagedThreadDeliveryOutcome.FAILED,
-            error=str(exc) or exc.__class__.__name__,
-        )
-    try:
-        await _flush_delivery_outbox_files(
-            service,
-            workspace_root=workspace_root,
-            channel_id=target_channel_id,
-        )
-    except asyncio.CancelledError:
-        raise
-    except Exception as exc:  # intentional: do not surface cleanup failures after reply
-        logger = getattr(service, "_logger", None)
-        if logger is not None:
-            log_event(
-                logger,
-                logging.WARNING,
-                "discord.managed_thread.delivery_cleanup_failed",
-                channel_id=target_channel_id,
-                workspace_root=(
-                    str(workspace_root) if workspace_root is not None else None
-                ),
-                managed_thread_id=record.managed_thread_id,
-                managed_turn_id=record.managed_turn_id,
-                exc=exc,
-            )
-    return ManagedThreadDeliveryAttemptResult(
-        outcome=ManagedThreadDeliveryOutcome.DELIVERED
+        return ManagedThreadDeliverySendResult()
+
+    async def _cleanup(context: ManagedThreadDeliveryCleanupContext) -> None:
+        raw_path = context.metadata.get("workspace_root")
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            return
+        flush = getattr(service, "_flush_outbox_files", None)
+        if not callable(flush):
+            return
+        workspace_root = Path(raw_path)
+        try:
+            await flush(workspace_root=workspace_root, channel_id=target_channel_id)
+        except (
+            Exception
+        ) as exc:  # intentional: do not surface cleanup failures after reply
+            logger = getattr(service, "_logger", None)
+            if logger is not None:
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "discord.managed_thread.delivery_cleanup_failed",
+                    channel_id=target_channel_id,
+                    workspace_root=str(workspace_root),
+                    managed_thread_id=record.managed_thread_id,
+                    managed_turn_id=record.managed_turn_id,
+                    exc=exc,
+                )
+
+    return await deliver_managed_thread_terminal_record(
+        record,
+        send_success=_send_success,
+        send_failure=_send_failure,
+        cleanup=_cleanup,
+        cleanup_statuses=frozenset({"ok", "error"}),
     )
 
 
@@ -174,30 +146,6 @@ def _resolve_delivery_channel_id(record: Any, *, fallback: Optional[str]) -> str
     if fallback is not None:
         return str(tt.get("channel_id") or fallback).strip()
     return str(tt.get("channel_id", "")).strip()
-
-
-def _resolve_delivery_workspace_root(record: Any) -> Optional[Path]:
-    metadata = getattr(record, "metadata", None)
-    if not isinstance(metadata, dict):
-        return None
-    raw_path = metadata.get("workspace_root")
-    if not isinstance(raw_path, str) or not raw_path.strip():
-        return None
-    return Path(raw_path)
-
-
-async def _flush_delivery_outbox_files(
-    service: Any,
-    *,
-    workspace_root: Optional[Path],
-    channel_id: str,
-) -> None:
-    if workspace_root is None:
-        return
-    flush = getattr(service, "_flush_outbox_files", None)
-    if not callable(flush):
-        return
-    await flush(workspace_root=workspace_root, channel_id=channel_id)
 
 
 def build_discord_managed_thread_durable_delivery_hooks(

--- a/src/codex_autorunner/integrations/discord/managed_thread_delivery.py
+++ b/src/codex_autorunner/integrations/discord/managed_thread_delivery.py
@@ -12,16 +12,16 @@ from ...core.orchestration import (
     ManagedThreadDeliveryOutcome,
     SQLiteManagedThreadDeliveryEngine,
 )
-from ..chat.managed_thread_delivery_support import (
-    ManagedThreadDeliveryCleanupContext,
-    ManagedThreadDeliverySendResult,
-    deliver_managed_thread_terminal_record,
-)
 from ...integrations.chat.managed_thread_turns import (
     ManagedThreadDurableDeliveryHooks,
     ManagedThreadSurfaceInfo,
     build_managed_thread_delivery_intent,
     render_managed_thread_delivery_record_text,
+)
+from ..chat.managed_thread_delivery_support import (
+    ManagedThreadDeliveryCleanupContext,
+    ManagedThreadDeliverySendResult,
+    deliver_managed_thread_terminal_record,
 )
 from .constants import DISCORD_MAX_MESSAGE_LENGTH
 from .rendering import chunk_discord_message, format_discord_message

--- a/src/codex_autorunner/integrations/discord/managed_thread_delivery.py
+++ b/src/codex_autorunner/integrations/discord/managed_thread_delivery.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 from typing import Any, Optional
 
+from ...core.logging_utils import log_event
 from ...core.orchestration import (
     ManagedThreadDeliveryAttemptResult,
     ManagedThreadDeliveryOutcome,
@@ -83,11 +85,29 @@ async def deliver_discord_managed_thread_record(
                 outcome=ManagedThreadDeliveryOutcome.FAILED,
                 error=str(exc) or exc.__class__.__name__,
             )
-        await _flush_delivery_outbox_files(
-            service,
-            workspace_root=workspace_root,
-            channel_id=target_channel_id,
-        )
+        try:
+            await _flush_delivery_outbox_files(
+                service,
+                workspace_root=workspace_root,
+                channel_id=target_channel_id,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # intentional: do not surface cleanup failures after reply
+            logger = getattr(service, "_logger", None)
+            if logger is not None:
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "discord.managed_thread.delivery_cleanup_failed",
+                    channel_id=target_channel_id,
+                    workspace_root=(
+                        str(workspace_root) if workspace_root is not None else None
+                    ),
+                    managed_thread_id=record.managed_thread_id,
+                    managed_turn_id=record.managed_turn_id,
+                    exc=exc,
+                )
         return ManagedThreadDeliveryAttemptResult(
             outcome=ManagedThreadDeliveryOutcome.DELIVERED,
             adapter_cursor={"chunk_count": len(chunks)},
@@ -121,11 +141,29 @@ async def deliver_discord_managed_thread_record(
             outcome=ManagedThreadDeliveryOutcome.FAILED,
             error=str(exc) or exc.__class__.__name__,
         )
-    await _flush_delivery_outbox_files(
-        service,
-        workspace_root=workspace_root,
-        channel_id=target_channel_id,
-    )
+    try:
+        await _flush_delivery_outbox_files(
+            service,
+            workspace_root=workspace_root,
+            channel_id=target_channel_id,
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # intentional: do not surface cleanup failures after reply
+        logger = getattr(service, "_logger", None)
+        if logger is not None:
+            log_event(
+                logger,
+                logging.WARNING,
+                "discord.managed_thread.delivery_cleanup_failed",
+                channel_id=target_channel_id,
+                workspace_root=(
+                    str(workspace_root) if workspace_root is not None else None
+                ),
+                managed_thread_id=record.managed_thread_id,
+                managed_turn_id=record.managed_turn_id,
+                exc=exc,
+            )
     return ManagedThreadDeliveryAttemptResult(
         outcome=ManagedThreadDeliveryOutcome.DELIVERED
     )

--- a/src/codex_autorunner/integrations/discord/managed_thread_delivery.py
+++ b/src/codex_autorunner/integrations/discord/managed_thread_delivery.py
@@ -36,6 +36,7 @@ async def deliver_discord_managed_thread_record(
     target_channel_id = _resolve_delivery_channel_id(
         record, fallback=channel_id_fallback
     )
+    workspace_root = _resolve_delivery_workspace_root(record)
     if not target_channel_id:
         return ManagedThreadDeliveryAttemptResult(
             outcome=ManagedThreadDeliveryOutcome.ABANDONED,
@@ -82,6 +83,11 @@ async def deliver_discord_managed_thread_record(
                 outcome=ManagedThreadDeliveryOutcome.FAILED,
                 error=str(exc) or exc.__class__.__name__,
             )
+        await _flush_delivery_outbox_files(
+            service,
+            workspace_root=workspace_root,
+            channel_id=target_channel_id,
+        )
         return ManagedThreadDeliveryAttemptResult(
             outcome=ManagedThreadDeliveryOutcome.DELIVERED,
             adapter_cursor={"chunk_count": len(chunks)},
@@ -115,6 +121,11 @@ async def deliver_discord_managed_thread_record(
             outcome=ManagedThreadDeliveryOutcome.FAILED,
             error=str(exc) or exc.__class__.__name__,
         )
+    await _flush_delivery_outbox_files(
+        service,
+        workspace_root=workspace_root,
+        channel_id=target_channel_id,
+    )
     return ManagedThreadDeliveryAttemptResult(
         outcome=ManagedThreadDeliveryOutcome.DELIVERED
     )
@@ -127,11 +138,36 @@ def _resolve_delivery_channel_id(record: Any, *, fallback: Optional[str]) -> str
     return str(tt.get("channel_id", "")).strip()
 
 
+def _resolve_delivery_workspace_root(record: Any) -> Optional[Path]:
+    metadata = getattr(record, "metadata", None)
+    if not isinstance(metadata, dict):
+        return None
+    raw_path = metadata.get("workspace_root")
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    return Path(raw_path)
+
+
+async def _flush_delivery_outbox_files(
+    service: Any,
+    *,
+    workspace_root: Optional[Path],
+    channel_id: str,
+) -> None:
+    if workspace_root is None:
+        return
+    flush = getattr(service, "_flush_outbox_files", None)
+    if not callable(flush):
+        return
+    await flush(workspace_root=workspace_root, channel_id=channel_id)
+
+
 def build_discord_managed_thread_durable_delivery_hooks(
     service: Any,
     *,
     channel_id: str,
     managed_thread_id: str,
+    workspace_root: Path,
     public_execution_error: str,
 ) -> ManagedThreadDurableDeliveryHooks:
     state_root = Path(getattr(getattr(service, "_config", None), "root", Path.cwd()))
@@ -169,7 +205,10 @@ def build_discord_managed_thread_durable_delivery_hooks(
                     surface_key=channel_id,
                 ),
                 transport_target={"channel_id": channel_id},
-                metadata={"managed_thread_id": managed_thread_id},
+                metadata={
+                    "managed_thread_id": managed_thread_id,
+                    "workspace_root": str(workspace_root),
+                },
             )
         ),
     )

--- a/src/codex_autorunner/integrations/discord/managed_thread_routing.py
+++ b/src/codex_autorunner/integrations/discord/managed_thread_routing.py
@@ -417,6 +417,7 @@ def _build_discord_runner_hooks(
     *,
     channel_id: str,
     managed_thread_id: str,
+    workspace_root: Path,
     public_execution_error: str,
 ) -> ManagedThreadCoordinatorHooks:
     async def _run_with_discord_typing_indicator(work: Any) -> None:
@@ -443,6 +444,7 @@ def _build_discord_runner_hooks(
         service,
         channel_id=channel_id,
         managed_thread_id=managed_thread_id,
+        workspace_root=workspace_root,
         public_execution_error=public_execution_error,
     )
 
@@ -508,11 +510,13 @@ def _build_discord_queue_worker_hooks(
     *,
     channel_id: str,
     managed_thread_id: str,
+    workspace_root: Path,
     public_execution_error: str,
 ) -> Any:
     return _build_discord_runner_hooks(
         service,
         channel_id=channel_id,
         managed_thread_id=managed_thread_id,
+        workspace_root=workspace_root,
         public_execution_error=public_execution_error,
     ).queue_worker_hooks()

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -1976,12 +1976,14 @@ async def _run_discord_orchestrated_turn_for_message(
         service,
         channel_id=channel_id,
         managed_thread_id=managed_thread_id,
+        workspace_root=workspace_root,
         public_execution_error=public_execution_error,
     )
     queue_worker_hooks = _build_discord_queue_worker_hooks(
         service,
         channel_id=channel_id,
         managed_thread_id=managed_thread_id,
+        workspace_root=workspace_root,
         public_execution_error=public_execution_error,
     )
     _first_progress_recorded = False

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -7114,6 +7114,108 @@ class DiscordBotService:
     def _list_paths_in_dir(self, folder: Path) -> list[Path]:
         return list_regular_files(folder)
 
+    def _build_outbox_sent_destination(self, *, sent_dir: Path, path: Path) -> Path:
+        destination = sent_dir / path.name
+        if destination.exists():
+            destination = sent_dir / f"{path.stem}-{uuid.uuid4().hex[:6]}{path.suffix}"
+        return destination
+
+    def _find_matching_sent_outbox_copy(
+        self,
+        *,
+        sent_dir: Path,
+        path: Path,
+        data: bytes,
+    ) -> Path | None:
+        if not sent_dir.exists():
+            return None
+        expected_size = len(data)
+        expected_digest = hashlib.sha256(data).digest()
+        candidates: list[Path] = []
+        exact = sent_dir / path.name
+        if exact.is_file():
+            candidates.append(exact)
+        with contextlib.suppress(OSError):
+            for candidate in sent_dir.glob(f"{path.stem}-*{path.suffix}"):
+                if candidate.is_file() and candidate != exact:
+                    candidates.append(candidate)
+        for candidate in candidates:
+            try:
+                if candidate.stat().st_size != expected_size:
+                    continue
+                if hashlib.sha256(candidate.read_bytes()).digest() == expected_digest:
+                    return candidate
+            except OSError:
+                continue
+        return None
+
+    def _cleanup_delivered_outbox_source(
+        self,
+        *,
+        path: Path,
+        channel_id: str,
+        archived_path: Path,
+    ) -> bool:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return True
+        except OSError as exc:
+            log_event(
+                self._logger,
+                logging.WARNING,
+                "discord.files.outbox.cleanup_failed",
+                channel_id=channel_id,
+                path=str(path),
+                archived_path=str(archived_path),
+                exc=exc,
+            )
+            return False
+        return True
+
+    def _archive_sent_outbox_file(
+        self,
+        *,
+        path: Path,
+        data: bytes,
+        sent_dir: Path,
+        channel_id: str,
+    ) -> bool:
+        sent_dir.mkdir(parents=True, exist_ok=True)
+        destination = self._build_outbox_sent_destination(sent_dir=sent_dir, path=path)
+        try:
+            path.replace(destination)
+            return True
+        except OSError as exc:
+            log_event(
+                self._logger,
+                logging.WARNING,
+                "discord.files.outbox.move_failed",
+                channel_id=channel_id,
+                path=str(path),
+                destination=str(destination),
+                exc=exc,
+            )
+        try:
+            destination.write_bytes(data)
+        except OSError as exc:
+            log_event(
+                self._logger,
+                logging.WARNING,
+                "discord.files.outbox.copy_failed",
+                channel_id=channel_id,
+                path=str(path),
+                destination=str(destination),
+                exc=exc,
+            )
+            return False
+        self._cleanup_delivered_outbox_source(
+            path=path,
+            channel_id=channel_id,
+            archived_path=destination,
+        )
+        return True
+
     async def _send_outbox_file(
         self,
         path: Path,
@@ -7133,6 +7235,26 @@ class DiscordBotService:
                 exc=exc,
             )
             return False
+        archived_copy = self._find_matching_sent_outbox_copy(
+            sent_dir=sent_dir,
+            path=path,
+            data=data,
+        )
+        if archived_copy is not None:
+            self._cleanup_delivered_outbox_source(
+                path=path,
+                channel_id=channel_id,
+                archived_path=archived_copy,
+            )
+            log_event(
+                self._logger,
+                logging.INFO,
+                "discord.files.outbox.already_archived",
+                channel_id=channel_id,
+                path=str(path),
+                archived_path=str(archived_copy),
+            )
+            return True
         try:
             await self._rest.create_channel_message_with_attachment(
                 channel_id=channel_id,
@@ -7149,23 +7271,13 @@ class DiscordBotService:
                 exc=exc,
             )
             return False
-        try:
-            sent_dir.mkdir(parents=True, exist_ok=True)
-            destination = sent_dir / path.name
-            if destination.exists():
-                destination = (
-                    sent_dir / f"{path.stem}-{uuid.uuid4().hex[:6]}{path.suffix}"
-                )
-            path.replace(destination)
-        except OSError as exc:
-            log_event(
-                self._logger,
-                logging.WARNING,
-                "discord.files.outbox.move_failed",
-                channel_id=channel_id,
-                path=str(path),
-                exc=exc,
-            )
+        archived = self._archive_sent_outbox_file(
+            path=path,
+            data=data,
+            sent_dir=sent_dir,
+            channel_id=channel_id,
+        )
+        if not archived:
             return False
         log_event(
             self._logger,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -45,8 +45,6 @@ from .....core.hub_control_plane import (
 from .....core.injected_context import wrap_injected_context
 from .....core.logging_utils import log_event
 from .....core.orchestration import (
-    ManagedThreadDeliveryAttemptResult,
-    ManagedThreadDeliveryOutcome,
     MessageRequest,
     SQLiteManagedThreadDeliveryEngine,
     build_harness_backed_orchestration_service,
@@ -83,6 +81,11 @@ from .....integrations.chat.compaction import match_pending_compact_seed
 from .....integrations.chat.constants import (
     APP_SERVER_UNAVAILABLE_MESSAGE,
     TOPIC_NOT_BOUND_MESSAGE,
+)
+from .....integrations.chat.managed_thread_delivery_support import (
+    ManagedThreadDeliveryCleanupContext,
+    ManagedThreadDeliverySendResult,
+    deliver_managed_thread_terminal_record,
 )
 from .....integrations.chat.managed_thread_lifecycle import (
     replace_surface_thread,
@@ -803,41 +806,21 @@ def _build_telegram_runner_hooks(
             transport_target = dict(record.target.transport_target or {})
             target_chat_id = int(transport_target.get("chat_id") or chat_id)
             target_thread_id = transport_target.get("thread_id", thread_id)
-            if record.envelope.final_status == "ok":
-                message_text = render_managed_thread_delivery_record_text(record)
-                try:
-                    await handlers._send_message(
-                        target_chat_id,
-                        message_text,
-                        thread_id=target_thread_id,
-                        reply_to=None,
-                    )
-                    await handlers._flush_outbox_files(
-                        SimpleNamespace(
-                            workspace_path=transport_target.get("workspace_path"),
-                            pma_enabled=bool(transport_target.get("pma_enabled")),
-                        ),
-                        chat_id=target_chat_id,
-                        thread_id=target_thread_id,
-                        reply_to=None,
-                        topic_key=str(transport_target.get("topic_key") or topic_key),
-                    )
-                except asyncio.CancelledError:
-                    raise
-                except Exception as exc:
-                    return ManagedThreadDeliveryAttemptResult(
-                        outcome=ManagedThreadDeliveryOutcome.FAILED,
-                        error=str(exc) or exc.__class__.__name__,
-                    )
-                return ManagedThreadDeliveryAttemptResult(
-                    outcome=ManagedThreadDeliveryOutcome.DELIVERED
+
+            async def _send_success(
+                _context: ManagedThreadDeliveryCleanupContext,
+            ) -> ManagedThreadDeliverySendResult:
+                await handlers._send_message(
+                    target_chat_id,
+                    render_managed_thread_delivery_record_text(record),
+                    thread_id=target_thread_id,
+                    reply_to=None,
                 )
-            if record.envelope.final_status == "interrupted":
-                return ManagedThreadDeliveryAttemptResult(
-                    outcome=ManagedThreadDeliveryOutcome.ABANDONED,
-                    error="interrupted_turn_has_no_terminal_delivery",
-                )
-            try:
+                return ManagedThreadDeliverySendResult()
+
+            async def _send_failure(
+                _context: ManagedThreadDeliveryCleanupContext,
+            ) -> ManagedThreadDeliverySendResult:
                 await handlers._send_message(
                     target_chat_id,
                     (
@@ -846,15 +829,27 @@ def _build_telegram_runner_hooks(
                     thread_id=target_thread_id,
                     reply_to=None,
                 )
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                return ManagedThreadDeliveryAttemptResult(
-                    outcome=ManagedThreadDeliveryOutcome.FAILED,
-                    error=str(exc) or exc.__class__.__name__,
+                return ManagedThreadDeliverySendResult()
+
+            async def _cleanup(context: ManagedThreadDeliveryCleanupContext) -> None:
+                await handlers._flush_outbox_files(
+                    SimpleNamespace(
+                        workspace_path=context.transport_target.get("workspace_path"),
+                        pma_enabled=bool(context.transport_target.get("pma_enabled")),
+                    ),
+                    chat_id=target_chat_id,
+                    thread_id=target_thread_id,
+                    reply_to=None,
+                    topic_key=str(
+                        context.transport_target.get("topic_key") or topic_key
+                    ),
                 )
-            return ManagedThreadDeliveryAttemptResult(
-                outcome=ManagedThreadDeliveryOutcome.DELIVERED
+
+            return await deliver_managed_thread_terminal_record(
+                record,
+                send_success=_send_success,
+                send_failure=_send_failure,
+                cleanup=_cleanup,
             )
 
     durable_delivery = ManagedThreadDurableDeliveryHooks(

--- a/src/codex_autorunner/integrations/telegram/service.py
+++ b/src/codex_autorunner/integrations/telegram/service.py
@@ -73,6 +73,11 @@ from ..chat.collaboration_policy import (
     build_telegram_collaboration_policy,
     evaluate_collaboration_policy,
 )
+from ..chat.managed_thread_delivery_support import (
+    ManagedThreadDeliveryCleanupContext,
+    ManagedThreadDeliverySendResult,
+    deliver_managed_thread_terminal_record,
+)
 from ..chat.managed_thread_delivery_worker import (
     ManagedThreadDeliveryWorker,
 )
@@ -521,41 +526,21 @@ class TelegramBotService(
                         outcome=ManagedThreadDeliveryOutcome.ABANDONED,
                         error="missing_telegram_chat_id",
                     )
-                if record.envelope.final_status == "ok":
-                    message_text = render_managed_thread_delivery_record_text(record)
-                    try:
-                        await service._send_message(
-                            target_chat_id,
-                            message_text,
-                            thread_id=target_thread_id,
-                            reply_to=None,
-                        )
-                        await service._flush_outbox_files(
-                            SimpleNamespace(
-                                workspace_path=transport_target.get("workspace_path"),
-                                pma_enabled=bool(transport_target.get("pma_enabled")),
-                            ),
-                            chat_id=target_chat_id,
-                            thread_id=target_thread_id,
-                            reply_to=None,
-                            topic_key=str(transport_target.get("topic_key") or ""),
-                        )
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception as exc:
-                        return ManagedThreadDeliveryAttemptResult(
-                            outcome=ManagedThreadDeliveryOutcome.FAILED,
-                            error=str(exc) or exc.__class__.__name__,
-                        )
-                    return ManagedThreadDeliveryAttemptResult(
-                        outcome=ManagedThreadDeliveryOutcome.DELIVERED
+
+                async def _send_success(
+                    _context: ManagedThreadDeliveryCleanupContext,
+                ) -> ManagedThreadDeliverySendResult:
+                    await service._send_message(
+                        target_chat_id,
+                        render_managed_thread_delivery_record_text(record),
+                        thread_id=target_thread_id,
+                        reply_to=None,
                     )
-                if record.envelope.final_status == "interrupted":
-                    return ManagedThreadDeliveryAttemptResult(
-                        outcome=ManagedThreadDeliveryOutcome.ABANDONED,
-                        error="interrupted_turn_has_no_terminal_delivery",
-                    )
-                try:
+                    return ManagedThreadDeliverySendResult()
+
+                async def _send_failure(
+                    _context: ManagedThreadDeliveryCleanupContext,
+                ) -> ManagedThreadDeliverySendResult:
                     await service._send_message(
                         target_chat_id,
                         (
@@ -564,15 +549,31 @@ class TelegramBotService(
                         thread_id=target_thread_id,
                         reply_to=None,
                     )
-                except asyncio.CancelledError:
-                    raise
-                except Exception as exc:
-                    return ManagedThreadDeliveryAttemptResult(
-                        outcome=ManagedThreadDeliveryOutcome.FAILED,
-                        error=str(exc) or exc.__class__.__name__,
+                    return ManagedThreadDeliverySendResult()
+
+                async def _cleanup(
+                    context: ManagedThreadDeliveryCleanupContext,
+                ) -> None:
+                    await service._flush_outbox_files(
+                        SimpleNamespace(
+                            workspace_path=context.transport_target.get(
+                                "workspace_path"
+                            ),
+                            pma_enabled=bool(
+                                context.transport_target.get("pma_enabled")
+                            ),
+                        ),
+                        chat_id=target_chat_id,
+                        thread_id=target_thread_id,
+                        reply_to=None,
+                        topic_key=str(context.transport_target.get("topic_key") or ""),
                     )
-                return ManagedThreadDeliveryAttemptResult(
-                    outcome=ManagedThreadDeliveryOutcome.DELIVERED
+
+                return await deliver_managed_thread_terminal_record(
+                    record,
+                    send_success=_send_success,
+                    send_failure=_send_failure,
+                    cleanup=_cleanup,
                 )
 
         state_root = Path(self._hub_root or self._config.root)

--- a/tests/chat_surface_integration/harness.py
+++ b/tests/chat_surface_integration/harness.py
@@ -761,6 +761,11 @@ class TelegramSurfaceHarness:
         approval_mode: Optional[str] = None,
         pma_enabled: bool = True,
     ) -> None:
+        seed_hub_files(self.root, force=True)
+        config_payload = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+        config_payload["discord_bot"]["state_file"] = "discord_state.sqlite3"
+        config_payload["telegram_bot"]["state_file"] = "telegram_state.sqlite3"
+        write_test_config(self.root / CONFIG_FILENAME, config_payload)
         self.service = TelegramBotService(
             make_telegram_config(self.root),
             hub_root=self.root,

--- a/tests/integrations/chat/test_managed_thread_delivery_support.py
+++ b/tests/integrations/chat/test_managed_thread_delivery_support.py
@@ -1,0 +1,62 @@
+"""Tests for shared managed-thread terminal delivery wrapper."""
+
+from __future__ import annotations
+
+import pytest
+
+from codex_autorunner.core.orchestration import (
+    ManagedThreadDeliveryAttemptResult,
+    ManagedThreadDeliveryEnvelope,
+    ManagedThreadDeliveryOutcome,
+    ManagedThreadDeliveryRecord,
+    ManagedThreadDeliveryState,
+    ManagedThreadDeliveryTarget,
+)
+from codex_autorunner.integrations.chat.managed_thread_delivery_support import (
+    ManagedThreadDeliveryCleanupContext,
+    deliver_managed_thread_terminal_record,
+)
+
+
+def _ok_record() -> ManagedThreadDeliveryRecord:
+    return ManagedThreadDeliveryRecord(
+        delivery_id="d-1",
+        managed_thread_id="mt-1",
+        managed_turn_id="t-1",
+        idempotency_key="id-1",
+        target=ManagedThreadDeliveryTarget(
+            surface_kind="discord",
+            adapter_key="discord",
+            surface_key="c1",
+            transport_target={},
+            metadata={"workspace_root": "/tmp"},
+        ),
+        envelope=ManagedThreadDeliveryEnvelope(
+            envelope_version="managed_thread_delivery.v1",
+            final_status="ok",
+            assistant_text="hi",
+        ),
+        state=ManagedThreadDeliveryState.PENDING,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_after_send_still_delivers() -> None:
+    """Post-send cleanup must not fail the attempt (avoids duplicate retries)."""
+
+    async def send_ok(_ctx: ManagedThreadDeliveryCleanupContext):
+        return None
+
+    async def cleanup_raises(_ctx: ManagedThreadDeliveryCleanupContext) -> None:
+        raise RuntimeError("flush exploded")
+
+    result = await deliver_managed_thread_terminal_record(
+        _ok_record(),
+        send_success=send_ok,
+        send_failure=send_ok,
+        cleanup=cleanup_raises,
+        cleanup_statuses=frozenset({"ok"}),
+    )
+    assert isinstance(result, ManagedThreadDeliveryAttemptResult)
+    assert result.outcome == ManagedThreadDeliveryOutcome.DELIVERED
+    assert result.error is None

--- a/tests/integrations/discord/test_discord_managed_thread_delivery_adapter.py
+++ b/tests/integrations/discord/test_discord_managed_thread_delivery_adapter.py
@@ -62,6 +62,7 @@ class _DiscordServiceStub:
         self._send_side_effect = send_side_effect
         self._send_safe_result = send_safe_result
         self.sent_messages: list[dict[str, Any]] = []
+        self.flushed_outboxes: list[dict[str, Any]] = []
 
     async def _send_channel_message_safe(
         self,
@@ -89,6 +90,19 @@ class _DiscordServiceStub:
     def _clear_discord_turn_approval_context(self, **_kwargs: Any) -> None:
         pass
 
+    async def _flush_outbox_files(
+        self,
+        *,
+        workspace_root: Path,
+        channel_id: str,
+    ) -> None:
+        self.flushed_outboxes.append(
+            {
+                "workspace_root": workspace_root,
+                "channel_id": channel_id,
+            }
+        )
+
 
 def _build_hooks(
     tmp_path: Path,
@@ -101,6 +115,7 @@ def _build_hooks(
         service,
         channel_id=channel_id,
         managed_thread_id=managed_thread_id,
+        workspace_root=tmp_path,
         public_execution_error="Turn failed",
     )
     assert hooks.durable_delivery is not None
@@ -176,6 +191,9 @@ async def test_discord_adapter_initial_delivery_marks_delivered(
     assert len(service.sent_messages) == 1
     assert service.sent_messages[0]["channel_id"] == "channel-1"
     assert "Hello from the agent" in service.sent_messages[0]["payload"]["content"]
+    assert service.flushed_outboxes == [
+        {"workspace_root": tmp_path, "channel_id": "channel-1"}
+    ]
 
 
 @pytest.mark.anyio
@@ -553,6 +571,7 @@ async def test_discord_direct_turn_intent_before_transport_ordering(
         service,
         channel_id="channel-1",
         managed_thread_id="thread-1",
+        workspace_root=tmp_path,
         public_execution_error="Turn failed",
     )
     assert hooks.durable_delivery is not None
@@ -587,6 +606,7 @@ async def test_discord_direct_turn_error_status_uses_durable_path(
         service,
         channel_id="channel-1",
         managed_thread_id="thread-1",
+        workspace_root=tmp_path,
         public_execution_error="Turn failed",
     )
     assert hooks.durable_delivery is not None
@@ -616,6 +636,7 @@ async def test_discord_direct_turn_cancellation_leaves_durable_record(
         service,
         channel_id="channel-1",
         managed_thread_id="thread-1",
+        workspace_root=tmp_path,
         public_execution_error="Turn failed",
     )
     assert hooks.durable_delivery is not None

--- a/tests/integrations/discord/test_discord_managed_thread_delivery_adapter.py
+++ b/tests/integrations/discord/test_discord_managed_thread_delivery_adapter.py
@@ -14,7 +14,9 @@ from types import SimpleNamespace
 from typing import Any, Optional
 
 import pytest
+from tests.discord_message_turns_support import _FakeRest
 
+from codex_autorunner.core.filebox import outbox_dir, outbox_sent_dir
 from codex_autorunner.core.orchestration import (
     ManagedThreadDeliveryAttemptResult,
     ManagedThreadDeliveryOutcome,
@@ -30,6 +32,7 @@ from codex_autorunner.integrations.chat.managed_thread_turns import (
     handoff_managed_thread_final_delivery,
 )
 from codex_autorunner.integrations.discord import message_turns as discord_message_turns
+from codex_autorunner.integrations.discord.service import DiscordBotService
 
 
 def _make_engine(
@@ -57,12 +60,45 @@ class _DiscordServiceStub:
         state_root: Path,
         send_side_effect: Optional[BaseException] = None,
         send_safe_result: bool = True,
+        real_outbox_flush: bool = False,
     ) -> None:
         self._config = SimpleNamespace(root=str(state_root))
         self._send_side_effect = send_side_effect
         self._send_safe_result = send_safe_result
+        self._logger = logging.getLogger("test.discord.adapter")
+        self._rest = _FakeRest()
         self.sent_messages: list[dict[str, Any]] = []
         self.flushed_outboxes: list[dict[str, Any]] = []
+        if real_outbox_flush:
+            self._list_paths_in_dir = DiscordBotService._list_paths_in_dir.__get__(
+                self, _DiscordServiceStub
+            )
+            self._build_outbox_sent_destination = (
+                DiscordBotService._build_outbox_sent_destination.__get__(
+                    self, _DiscordServiceStub
+                )
+            )
+            self._find_matching_sent_outbox_copy = (
+                DiscordBotService._find_matching_sent_outbox_copy.__get__(
+                    self, _DiscordServiceStub
+                )
+            )
+            self._cleanup_delivered_outbox_source = (
+                DiscordBotService._cleanup_delivered_outbox_source.__get__(
+                    self, _DiscordServiceStub
+                )
+            )
+            self._archive_sent_outbox_file = (
+                DiscordBotService._archive_sent_outbox_file.__get__(
+                    self, _DiscordServiceStub
+                )
+            )
+            self._send_outbox_file = DiscordBotService._send_outbox_file.__get__(
+                self, _DiscordServiceStub
+            )
+            self._flush_outbox_files = DiscordBotService._flush_outbox_files.__get__(
+                self, _DiscordServiceStub
+            )
 
     async def _send_channel_message_safe(
         self,
@@ -194,6 +230,88 @@ async def test_discord_adapter_initial_delivery_marks_delivered(
     assert service.flushed_outboxes == [
         {"workspace_root": tmp_path, "channel_id": "channel-1"}
     ]
+
+
+@pytest.mark.anyio
+async def test_discord_adapter_initial_delivery_flushes_real_outbox_files(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    root_outbox = outbox_dir(workspace)
+    root_outbox.mkdir(parents=True, exist_ok=True)
+    root_file = root_outbox / "result.txt"
+    root_file.write_text("artifact payload\n", encoding="utf-8")
+
+    service = _DiscordServiceStub(state_root=tmp_path, real_outbox_flush=True)
+    delivery = _build_hooks(workspace, service=service)
+    finalized = _finalized_ok()
+
+    record = await handoff_managed_thread_final_delivery(
+        finalized,
+        delivery=delivery,
+        logger=logging.getLogger("test"),
+    )
+
+    assert record is not None
+    assert record.state is ManagedThreadDeliveryState.DELIVERED
+    assert len(service.sent_messages) == 1
+    assert len(service._rest.attachment_messages) == 1
+    assert service._rest.attachment_messages[0]["filename"] == "result.txt"
+    sent_files = list(outbox_sent_dir(workspace).glob("result*.txt"))
+    assert sent_files
+    assert sent_files[0].read_text(encoding="utf-8") == "artifact payload\n"
+    assert not root_file.exists()
+
+
+@pytest.mark.anyio
+async def test_send_outbox_file_skips_duplicate_resend_when_archive_copy_exists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    root_outbox = outbox_dir(workspace)
+    root_outbox.mkdir(parents=True, exist_ok=True)
+    root_file = root_outbox / "result.txt"
+    root_file.write_text("artifact payload\n", encoding="utf-8")
+
+    service = _DiscordServiceStub(state_root=tmp_path, real_outbox_flush=True)
+    sent_dir = outbox_sent_dir(workspace)
+    original_replace = Path.replace
+    original_unlink = Path.unlink
+
+    def _replace(self: Path, target: Path) -> Path:
+        if self == root_file:
+            raise OSError("simulated move failure")
+        return original_replace(self, target)
+
+    def _unlink(self: Path, missing_ok: bool = False) -> None:
+        if self == root_file:
+            raise OSError("simulated cleanup failure")
+        return original_unlink(self, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "replace", _replace)
+    monkeypatch.setattr(Path, "unlink", _unlink)
+
+    first = await service._send_outbox_file(
+        root_file,
+        sent_dir=sent_dir,
+        channel_id="channel-1",
+    )
+    second = await service._send_outbox_file(
+        root_file,
+        sent_dir=sent_dir,
+        channel_id="channel-1",
+    )
+
+    assert first is True
+    assert second is True
+    assert len(service._rest.attachment_messages) == 1
+    sent_files = list(sent_dir.glob("result*.txt"))
+    assert sent_files
+    assert sent_files[0].read_text(encoding="utf-8") == "artifact payload\n"
+    assert root_file.exists()
 
 
 @pytest.mark.anyio

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -610,6 +610,7 @@ async def test_discord_managed_thread_delivery_uses_unique_record_ids_per_chunk(
         _ServiceStub(),
         channel_id="channel-1",
         managed_thread_id="thread-1",
+        workspace_root=Path.cwd(),
         public_execution_error="Discord turn failed",
     )
     content = ("a" * 1500) + "\n" + ("b" * 1500)
@@ -677,6 +678,7 @@ async def test_discord_managed_thread_delivery_includes_token_usage_footer() -> 
         _ServiceStub(),
         channel_id="channel-1",
         managed_thread_id="thread-1",
+        workspace_root=Path.cwd(),
         public_execution_error="Discord turn failed",
     )
 


### PR DESCRIPTION
## What changed
Managed-thread Discord durable delivery now carries the originating `workspace_root` in the delivery intent metadata and flushes FileBox outbox artifacts after a successful durable terminal delivery.

## Why it changed
Agents can place reply artifacts in `.codex-autorunner/filebox/outbox/` instead of `outbox/pending/`. Normal Discord turn cleanup already flushes those files, but managed-thread durable delivery bypassed that cleanup path when `send_final_message` was false.

## Root cause
The durable managed-thread adapter delivered the final Discord message without performing the post-turn FileBox flush, so outbox-root artifacts could be stranded even though the text response was delivered.

## Impact
Discord managed-thread runs now send outbox-root artifacts after durable terminal delivery, including replayed durable deliveries. The regression test coverage now asserts that the durable adapter triggers the outbox flush with the correct workspace path.

## Validation
- Commit hook lane `chat-apps`
- `python -m pytest -q tests/integrations/discord/test_discord_managed_thread_delivery_adapter.py`
- `python -m pytest -q tests/integrations/discord/test_message_turns_message_flow.py`
- `python -m pytest -q tests/integrations/discord/test_service_routing.py -k "managed_thread_delivery or token_usage_footer"`
- Repo hook checks: black, ruff, import/contracts, mypy, full pytest (`7556 passed`), chat-surface deterministic checks
