### PR TITLE
[codex] Coalesce SCM feedback wakeups

### DIFF
--- a/src/codex_autorunner/core/config_layering.py
+++ b/src/codex_autorunner/core/config_layering.py
@@ -306,6 +306,8 @@ def _default_github_automation_section() -> Dict[str, Any]:
         "reactions": {
             "enabled": True,
             "ci_failed": True,
+            "ci_failed_batch_window_seconds": 60,
+            "ci_failed_batch_max_window_seconds": 180,
             "changes_requested": True,
             "review_comment": True,
             "approved_and_green": True,

--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -1436,7 +1436,10 @@ class PmaThreadStore:
                     ),
                 )
                 if queue_cursor.rowcount == 0:
-                    return None
+                    raise RuntimeError(
+                        "Queued turn execution was updated but no matching queue item "
+                        "was found; refusing partial commit"
+                    )
                 row = conn.execute(
                     """
                     SELECT *

--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -60,7 +60,7 @@ from .pma_thread_store_rows import (
 from .pma_thread_store_rows import (
     workspace_head_branch as _workspace_head_branch,
 )
-from .text_utils import _json_dumps
+from .text_utils import _json_dumps, _json_loads_object
 from .time_utils import now_iso
 
 _BACKEND_RUNTIME_INSTANCE_ID_KEY = "backend_runtime_instance_id"
@@ -1361,6 +1361,91 @@ class PmaThreadStore:
                 managed_thread_id,
                 limit=limit,
             )
+
+    def get_queued_turn_queue_payload(
+        self, managed_thread_id: str, managed_turn_id: str
+    ) -> Optional[dict[str, Any]]:
+        with self._read_conn() as conn:
+            row = conn.execute(
+                """
+                SELECT q.payload_json
+                  FROM orch_queue_items AS q
+                  JOIN orch_thread_executions AS e
+                    ON e.execution_id = q.source_key
+                 WHERE q.source_kind = 'thread_execution'
+                   AND e.thread_target_id = ?
+                   AND e.execution_id = ?
+                   AND e.status = 'queued'
+                   AND q.lane_id = ?
+                   AND q.state IN ('pending', 'queued', 'waiting')
+                 ORDER BY COALESCE(q.visible_at, q.created_at) ASC, q.rowid ASC
+                 LIMIT 1
+                """,
+                (
+                    managed_thread_id,
+                    managed_turn_id,
+                    thread_queue_lane_id(managed_thread_id),
+                ),
+            ).fetchone()
+        if row is None:
+            return None
+        return _json_loads_object(row["payload_json"])
+
+    def update_queued_turn_request(
+        self,
+        managed_thread_id: str,
+        managed_turn_id: str,
+        *,
+        prompt: str,
+        queue_payload: dict[str, Any],
+    ) -> Optional[dict[str, Any]]:
+        updated_at = now_iso()
+        with self._write_conn() as conn:
+            with conn:
+                execution_cursor = conn.execute(
+                    """
+                    UPDATE orch_thread_executions
+                       SET prompt_text = ?
+                     WHERE execution_id = ?
+                       AND thread_target_id = ?
+                       AND status = 'queued'
+                    """,
+                    (
+                        prompt,
+                        managed_turn_id,
+                        managed_thread_id,
+                    ),
+                )
+                if execution_cursor.rowcount == 0:
+                    return None
+                queue_cursor = conn.execute(
+                    """
+                    UPDATE orch_queue_items
+                       SET payload_json = ?,
+                           updated_at = ?
+                     WHERE source_kind = 'thread_execution'
+                       AND source_key = ?
+                       AND lane_id = ?
+                       AND state IN ('pending', 'queued', 'waiting')
+                    """,
+                    (
+                        _json_dumps(queue_payload),
+                        updated_at,
+                        managed_turn_id,
+                        thread_queue_lane_id(managed_thread_id),
+                    ),
+                )
+                if queue_cursor.rowcount == 0:
+                    return None
+                row = conn.execute(
+                    """
+                    SELECT *
+                      FROM orch_thread_executions
+                     WHERE execution_id = ?
+                    """,
+                    (managed_turn_id,),
+                ).fetchone()
+        return _execution_row_to_record(row) if row is not None else None
 
     def get_queue_depth(self, managed_thread_id: str) -> int:
         with self._read_conn() as conn:

--- a/src/codex_autorunner/core/publish_journal.py
+++ b/src/codex_autorunner/core/publish_journal.py
@@ -155,6 +155,63 @@ class PublishJournalStore:
             raise RuntimeError("publish operation row missing after insert")
         return _operation_from_row(created), False
 
+    def update_pending_operation(
+        self,
+        operation_id: str,
+        *,
+        payload: Optional[dict[str, Any]] = None,
+        next_attempt_at: Optional[str] = None,
+    ) -> Optional[PublishOperation]:
+        normalized_operation_id = _normalize_text(operation_id)
+        if normalized_operation_id is None:
+            return None
+        payload_object = (
+            _normalize_json_object(payload, field_name="payload")
+            if payload is not None
+            else None
+        )
+        normalized_next_attempt = (
+            _normalize_timestamp(next_attempt_at, field_name="next_attempt_at")
+            if next_attempt_at is not None
+            else None
+        )
+        updated_at = now_iso()
+        with open_orchestration_sqlite(self._hub_root, durable=True) as conn:
+            row = self._load_operation_row(conn, normalized_operation_id)
+            if row is None or str(row["state"]) != "pending":
+                return None
+            resolved_payload = (
+                payload_object
+                if payload_object is not None
+                else _json_loads_object(row["payload_json"])
+            )
+            resolved_next_attempt = (
+                normalized_next_attempt
+                if normalized_next_attempt is not None
+                else _normalize_text(row["next_attempt_at"]) or updated_at
+            )
+            with conn:
+                cursor = conn.execute(
+                    """
+                    UPDATE orch_publish_operations
+                       SET payload_json = ?,
+                           next_attempt_at = ?,
+                           updated_at = ?
+                     WHERE operation_id = ?
+                       AND state = 'pending'
+                    """,
+                    (
+                        _json_dumps(resolved_payload),
+                        resolved_next_attempt,
+                        updated_at,
+                        normalized_operation_id,
+                    ),
+                )
+                if cursor.rowcount == 0:
+                    return None
+                refreshed = self._load_operation_row(conn, normalized_operation_id)
+        return _operation_from_row(refreshed) if refreshed is not None else None
+
     def claim_pending_operations(
         self,
         *,

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -21,6 +21,11 @@ from .pr_bindings import PrBinding, PrBindingStore
 from .publish_executor import PublishActionExecutor, TerminalPublishError
 from .publish_journal import PublishOperation
 from .scm_events import ScmEvent, ScmEventStore
+from .scm_feedback_bundle import (
+    apply_feedback_bundle_to_publish_payload,
+    extract_feedback_bundle,
+    merge_feedback_bundles,
+)
 from .scm_observability import correlation_id_for_operation, correlation_id_from_payload
 from .text_utils import _coerce_int, _normalize_optional_text
 
@@ -141,6 +146,50 @@ def _managed_turn_result(
     if correlation_id is not None:
         result["correlation_id"] = correlation_id
     return result
+
+
+def _merge_into_existing_queued_scm_turn(
+    store: PmaThreadStore,
+    *,
+    thread_target_id: str,
+    payload: dict[str, Any],
+) -> Optional[dict[str, Any]]:
+    incoming_bundle = extract_feedback_bundle(payload)
+    if incoming_bundle is None:
+        return None
+    queued_turns = store.list_queued_turns(thread_target_id, limit=1)
+    if not queued_turns:
+        return None
+    queued_turn = queued_turns[0]
+    existing_payload = store.get_queued_turn_queue_payload(
+        thread_target_id,
+        queued_turn["managed_turn_id"],
+    )
+    if existing_payload is None:
+        return None
+    existing_bundle = extract_feedback_bundle(existing_payload)
+    if existing_bundle is None:
+        return None
+    merged_bundle = merge_feedback_bundles(existing_bundle, incoming_bundle)
+    updated_payload = apply_feedback_bundle_to_publish_payload(
+        existing_payload,
+        merged_bundle,
+    )
+    updated_request = updated_payload.get("request")
+    if not isinstance(updated_request, Mapping):
+        return None
+    updated_prompt = _normalize_optional_text(updated_request.get("message_text"))
+    if updated_prompt is None:
+        return None
+    updated_turn = store.update_queued_turn_request(
+        thread_target_id,
+        queued_turn["managed_turn_id"],
+        prompt=updated_prompt,
+        queue_payload=updated_payload,
+    )
+    if updated_turn is None:
+        return None
+    return updated_turn
 
 
 def _resolve_scm_binding(
@@ -559,6 +608,23 @@ def build_enqueue_managed_turn_executor(*, hub_root: Path) -> PublishActionExecu
                     runtime_status,
                     *log_context,
                 )
+            if active_lifecycle_match_id is not None:
+                merged_turn = _merge_into_existing_queued_scm_turn(
+                    store,
+                    thread_target_id=thread_target_id,
+                    payload=queue_payload,
+                )
+                if merged_turn is not None:
+                    return _managed_turn_result(
+                        thread_target_id=thread_target_id,
+                        client_request_id=(
+                            _normalize_optional_text(merged_turn.get("client_turn_id"))
+                            or client_request_id
+                        ),
+                        turn=merged_turn,
+                        existed=True,
+                        correlation_id=correlation_id,
+                    )
             created = store.create_turn(
                 thread_target_id,
                 prompt=request.message_text,

--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -353,6 +353,18 @@ def _ci_failed_head_sha_from_payload(
     return _normalize_text(bundle.get("ci_head_sha"))
 
 
+def _merged_feedback_publish_payload(
+    base_payload: Mapping[str, Any],
+    incoming_payload: Mapping[str, Any],
+) -> Optional[dict[str, Any]]:
+    existing_bundle = extract_feedback_bundle(base_payload)
+    incoming_bundle = extract_feedback_bundle(incoming_payload)
+    if existing_bundle is None or incoming_bundle is None:
+        return None
+    merged_bundle = merge_feedback_bundles(existing_bundle, incoming_bundle)
+    return apply_feedback_bundle_to_publish_payload(base_payload, merged_bundle)
+
+
 def _default_binding_resolver(hub_root: Path) -> ScmBindingResolver:
     def resolver(
         event: ScmEvent,
@@ -677,22 +689,29 @@ class ScmAutomationService:
         operation: PublishOperation,
         incoming_payload: Mapping[str, Any],
         next_attempt_at: Optional[str] = None,
+        operation_key: str,
+        operation_kind: str,
     ) -> PublishOperation:
-        existing_bundle = extract_feedback_bundle(operation.payload)
-        incoming_bundle = extract_feedback_bundle(incoming_payload)
-        if existing_bundle is None or incoming_bundle is None:
-            return operation
-        merged_bundle = merge_feedback_bundles(existing_bundle, incoming_bundle)
-        updated_payload = apply_feedback_bundle_to_publish_payload(
+        merged_payload = _merged_feedback_publish_payload(
             operation.payload,
-            merged_bundle,
+            incoming_payload,
         )
+        if merged_payload is None:
+            return operation
         updated = self._journal.update_pending_operation(
             operation.operation_id,
-            payload=updated_payload,
+            payload=merged_payload,
             next_attempt_at=next_attempt_at,
         )
-        return updated or operation
+        if updated is not None:
+            return updated
+        created, _deduped = self._journal.create_operation(
+            operation_key=operation_key,
+            operation_kind=operation_kind,
+            payload=merged_payload,
+            next_attempt_at=next_attempt_at,
+        )
+        return created
 
     def _review_comment_notice_key(
         self,
@@ -948,6 +967,8 @@ class ScmAutomationService:
                             operation=existing_ci_batch,
                             incoming_payload=payload,
                             next_attempt_at=next_attempt_at,
+                            operation_key=operation_key,
+                            operation_kind=intent.operation_kind,
                         )
                         deduped = True
                     else:
@@ -985,6 +1006,8 @@ class ScmAutomationService:
                         operation=operation,
                         incoming_payload=payload,
                         next_attempt_at=next_attempt_at,
+                        operation_key=operation_key,
+                        operation_kind=intent.operation_kind,
                     )
             if (
                 next_attempt_at is not None

--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -9,7 +9,7 @@ import re
 import threading
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional, Protocol
 
@@ -28,6 +28,12 @@ from .scm_escalation import (
     format_failure_escalation_message,
 )
 from .scm_events import ScmEvent, ScmEventStore
+from .scm_feedback_bundle import (
+    apply_feedback_bundle_to_publish_payload,
+    build_feedback_bundle,
+    extract_feedback_bundle,
+    merge_feedback_bundles,
+)
 from .scm_observability import (
     SCM_AUDIT_BINDING_RESOLVED,
     SCM_AUDIT_PUBLISH_CREATED,
@@ -91,6 +97,23 @@ class PublishJournalWriter(Protocol):
         payload: Optional[dict[str, Any]] = None,
         next_attempt_at: Optional[str] = None,
     ) -> tuple[PublishOperation, bool]: ...
+
+    def update_pending_operation(
+        self,
+        operation_id: str,
+        *,
+        payload: Optional[dict[str, Any]] = None,
+        next_attempt_at: Optional[str] = None,
+    ) -> Optional[PublishOperation]: ...
+
+    def list_operations(
+        self,
+        *,
+        state: Optional[str] = None,
+        operation_kind: Optional[str] = None,
+        limit: Optional[int] = None,
+        newest_first: bool = False,
+    ) -> list[PublishOperation]: ...
 
 
 class PublishOperationDrainer(Protocol):
@@ -321,6 +344,15 @@ def _tracking_from_payload(payload: Mapping[str, Any] | None) -> dict[str, Any]:
     return dict(tracking) if isinstance(tracking, Mapping) else {}
 
 
+def _ci_failed_head_sha_from_payload(
+    payload: Mapping[str, Any] | None,
+) -> Optional[str]:
+    bundle = extract_feedback_bundle(payload)
+    if bundle is None:
+        return None
+    return _normalize_text(bundle.get("ci_head_sha"))
+
+
 def _default_binding_resolver(hub_root: Path) -> ScmBindingResolver:
     def resolver(
         event: ScmEvent,
@@ -481,7 +513,7 @@ class ScmAutomationService:
                 self._record_publish_finished_audit_entries(escalation_results)
         except Exception:
             _LOGGER.warning(
-                "Deferred publish drain after review-comment batch window failed",
+                "Deferred publish drain after SCM batch window failed",
                 exc_info=True,
             )
         finally:
@@ -565,6 +597,102 @@ class ScmAutomationService:
                 tz=timezone.utc,
             )
         )
+
+    def _ci_failed_enqueue_next_attempt_at(
+        self,
+        *,
+        event: ScmEvent,
+        bundle: Mapping[str, Any],
+    ) -> Optional[str]:
+        batch_window_seconds = self._reaction_config.ci_failed_batch_window_seconds
+        if batch_window_seconds <= 0:
+            return None
+        event_time = (
+            _parse_iso_datetime(event.received_at)
+            or _parse_iso_datetime(event.occurred_at)
+            or _parse_iso_datetime(event.created_at)
+            or datetime.now(timezone.utc)
+        )
+        next_attempt_at = event_time + timedelta(seconds=batch_window_seconds)
+        max_window_seconds = self._reaction_config.ci_failed_batch_max_window_seconds
+        opened_at = _parse_iso_datetime(bundle.get("opened_at")) or event_time
+        if max_window_seconds > 0:
+            max_attempt_at = opened_at + timedelta(seconds=max_window_seconds)
+            if next_attempt_at > max_attempt_at:
+                next_attempt_at = max_attempt_at
+        return _isoformat_z(next_attempt_at)
+
+    def _build_feedback_payload(
+        self,
+        *,
+        event: ScmEvent,
+        intent: ReactionIntent,
+        binding: Optional[PrBinding],
+        payload: Mapping[str, Any],
+        tracking: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        if intent.operation_kind != "enqueue_managed_turn":
+            return copy.deepcopy(dict(payload))
+        request_payload = payload.get("request")
+        request_mapping = (
+            request_payload if isinstance(request_payload, Mapping) else {}
+        )
+        bundle = build_feedback_bundle(
+            event=event,
+            intent=intent,
+            binding=binding,
+            message_text=_normalize_text(request_mapping.get("message_text")) or "",
+            tracking=tracking,
+        )
+        return apply_feedback_bundle_to_publish_payload(payload, bundle)
+
+    def _find_pending_ci_failed_batch_operation(
+        self,
+        *,
+        binding: PrBinding,
+        head_sha: str,
+    ) -> Optional[PublishOperation]:
+        for operation in self._journal.list_operations(
+            state="pending",
+            operation_kind="enqueue_managed_turn",
+            limit=500,
+            newest_first=True,
+        ):
+            tracking = _tracking_from_payload(operation.payload)
+            if _normalize_text(tracking.get("binding_id")) != binding.binding_id:
+                continue
+            bundle = extract_feedback_bundle(operation.payload)
+            if bundle is None:
+                continue
+            if _normalize_text(bundle.get("batch_mode")) != "ci_failed":
+                continue
+            if _normalize_text(bundle.get("ci_head_sha")) != head_sha:
+                continue
+            return operation
+        return None
+
+    def _merge_pending_feedback_operation(
+        self,
+        *,
+        operation: PublishOperation,
+        incoming_payload: Mapping[str, Any],
+        next_attempt_at: Optional[str] = None,
+    ) -> PublishOperation:
+        existing_bundle = extract_feedback_bundle(operation.payload)
+        incoming_bundle = extract_feedback_bundle(incoming_payload)
+        if existing_bundle is None or incoming_bundle is None:
+            return operation
+        merged_bundle = merge_feedback_bundles(existing_bundle, incoming_bundle)
+        updated_payload = apply_feedback_bundle_to_publish_payload(
+            operation.payload,
+            merged_bundle,
+        )
+        updated = self._journal.update_pending_operation(
+            operation.operation_id,
+            payload=updated_payload,
+            next_attempt_at=next_attempt_at,
+        )
+        return updated or operation
 
     def _review_comment_notice_key(
         self,
@@ -782,21 +910,84 @@ class ScmAutomationService:
             if operation_key in seen_operation_keys:
                 continue
             seen_operation_keys.add(operation_key)
-            payload = with_correlation_id(
-                copy.deepcopy(intent.payload),
-                correlation_id=correlation_id,
+            payload = self._build_feedback_payload(
+                event=event,
+                intent=intent,
+                binding=binding,
+                payload=with_correlation_id(
+                    copy.deepcopy(intent.payload),
+                    correlation_id=correlation_id,
+                ),
+                tracking=tracking,
             )
             if tracking:
                 payload["scm_reaction"] = tracking
-            operation, deduped = self._journal.create_operation(
-                operation_key=operation_key,
-                operation_kind=intent.operation_kind,
-                payload=payload,
-                next_attempt_at=next_attempt_at,
-            )
+            operation: PublishOperation
+            deduped = False
+            if (
+                binding is not None
+                and intent.reaction_kind == "ci_failed"
+                and intent.operation_kind == "enqueue_managed_turn"
+            ):
+                head_sha = _ci_failed_head_sha_from_payload(payload)
+                if head_sha is not None:
+                    existing_ci_batch = self._find_pending_ci_failed_batch_operation(
+                        binding=binding,
+                        head_sha=head_sha,
+                    )
+                    if existing_ci_batch is not None:
+                        next_attempt_at = self._ci_failed_enqueue_next_attempt_at(
+                            event=event,
+                            bundle=merge_feedback_bundles(
+                                extract_feedback_bundle(existing_ci_batch.payload)
+                                or {},
+                                extract_feedback_bundle(payload) or {},
+                            ),
+                        )
+                        operation = self._merge_pending_feedback_operation(
+                            operation=existing_ci_batch,
+                            incoming_payload=payload,
+                            next_attempt_at=next_attempt_at,
+                        )
+                        deduped = True
+                    else:
+                        next_attempt_at = self._ci_failed_enqueue_next_attempt_at(
+                            event=event,
+                            bundle=extract_feedback_bundle(payload) or {},
+                        )
+                        operation, deduped = self._journal.create_operation(
+                            operation_key=operation_key,
+                            operation_kind=intent.operation_kind,
+                            payload=payload,
+                            next_attempt_at=next_attempt_at,
+                        )
+                else:
+                    operation, deduped = self._journal.create_operation(
+                        operation_key=operation_key,
+                        operation_kind=intent.operation_kind,
+                        payload=payload,
+                        next_attempt_at=next_attempt_at,
+                    )
+            else:
+                operation, deduped = self._journal.create_operation(
+                    operation_key=operation_key,
+                    operation_kind=intent.operation_kind,
+                    payload=payload,
+                    next_attempt_at=next_attempt_at,
+                )
+                if (
+                    deduped
+                    and operation.state == "pending"
+                    and intent.operation_kind == "enqueue_managed_turn"
+                    and extract_feedback_bundle(payload) is not None
+                ):
+                    operation = self._merge_pending_feedback_operation(
+                        operation=operation,
+                        incoming_payload=payload,
+                        next_attempt_at=next_attempt_at,
+                    )
             if (
                 next_attempt_at is not None
-                and intent.reaction_kind == "review_comment"
                 and intent.operation_kind == "enqueue_managed_turn"
             ):
                 drain_at = operation.next_attempt_at
@@ -809,7 +1000,7 @@ class ScmAutomationService:
                 binding=binding,
                 intent=intent,
                 operation=operation,
-                payload={"deduped": deduped},
+                payload={"deduped": deduped, "coalesced": deduped},
             )
             if fingerprint is not None and binding_id is not None and rsk is not None:
                 self._reaction_state_store.mark_reaction_emitted(

--- a/src/codex_autorunner/core/scm_feedback_bundle.py
+++ b/src/codex_autorunner/core/scm_feedback_bundle.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from .pr_bindings import PrBinding
+from .scm_events import ScmEvent
+from .scm_reaction_types import ReactionIntent
+from .text_utils import _normalize_text
+
+_GENERIC_CI_CHECK_NAMES = frozenset({"check", "aggregate"})
+
+
+def _event_payload(event: ScmEvent) -> Mapping[str, Any]:
+    payload = event.payload
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def _parse_iso_datetime(value: Any) -> Optional[datetime]:
+    text = _normalize_text(value)
+    if text is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _isoformat_z(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _max_iso_datetime(*values: Any) -> Optional[str]:
+    parsed = [
+        candidate for candidate in (_parse_iso_datetime(v) for v in values) if candidate
+    ]
+    if not parsed:
+        return None
+    return _isoformat_z(max(parsed))
+
+
+def _subject(*, binding: Optional[PrBinding], event: ScmEvent) -> str:
+    repo_slug = (
+        _normalize_text(binding.repo_slug) if binding is not None else None
+    ) or _normalize_text(event.repo_slug)
+    pr_number = binding.pr_number if binding is not None else event.pr_number
+    if repo_slug is not None and isinstance(pr_number, int):
+        return f"{repo_slug}#{pr_number}"
+    return repo_slug or "SCM binding"
+
+
+def _tracking_value(
+    tracking: Optional[Mapping[str, Any]],
+    key: str,
+    fallback: Any = None,
+) -> Any:
+    if isinstance(tracking, Mapping) and key in tracking:
+        return tracking.get(key)
+    return fallback
+
+
+def build_feedback_bundle(
+    *,
+    event: ScmEvent,
+    intent: ReactionIntent,
+    binding: Optional[PrBinding],
+    message_text: str,
+    tracking: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    payload = _event_payload(event)
+    event_at = (
+        _normalize_text(event.received_at)
+        or _normalize_text(event.occurred_at)
+        or _normalize_text(event.created_at)
+        or _isoformat_z(datetime.now(timezone.utc))
+    )
+    item = {
+        "event_id": event.event_id,
+        "event_type": event.event_type,
+        "reaction_kind": intent.reaction_kind,
+        "message_text": message_text,
+        "received_at": _normalize_text(event.received_at),
+        "occurred_at": _normalize_text(event.occurred_at),
+    }
+    if intent.reaction_kind == "ci_failed":
+        check_name = _normalize_text(payload.get("name")) or _normalize_text(
+            payload.get("check_name")
+        )
+        if check_name is not None:
+            item["check_name"] = check_name
+        conclusion = _normalize_text(payload.get("conclusion"))
+        if conclusion is not None:
+            item["conclusion"] = conclusion
+        head_sha = _normalize_text(payload.get("head_sha"))
+        if head_sha is not None:
+            item["head_sha"] = head_sha
+
+    bundle = {
+        "version": 1,
+        "subject": _subject(binding=binding, event=event),
+        "binding_id": _tracking_value(
+            tracking, "binding_id", binding.binding_id if binding is not None else None
+        ),
+        "thread_target_id": _tracking_value(
+            tracking,
+            "thread_target_id",
+            binding.thread_target_id if binding is not None else None,
+        ),
+        "repo_slug": _tracking_value(
+            tracking,
+            "repo_slug",
+            binding.repo_slug if binding is not None else event.repo_slug,
+        ),
+        "pr_number": _tracking_value(
+            tracking,
+            "pr_number",
+            binding.pr_number if binding is not None else event.pr_number,
+        ),
+        "opened_at": event_at,
+        "last_event_at": event_at,
+        "batch_mode": "ci_failed" if intent.reaction_kind == "ci_failed" else "general",
+        "items": [item],
+    }
+    if intent.reaction_kind == "ci_failed":
+        head_sha = item.get("head_sha")
+        if isinstance(head_sha, str) and head_sha:
+            bundle["ci_head_sha"] = head_sha
+    return {key: value for key, value in bundle.items() if value is not None}
+
+
+def extract_feedback_bundle(
+    payload: Mapping[str, Any] | None,
+) -> Optional[dict[str, Any]]:
+    if not isinstance(payload, Mapping):
+        return None
+    request = payload.get("request")
+    if not isinstance(request, Mapping):
+        return None
+    metadata = request.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return None
+    bundle = metadata.get("scm_feedback_bundle")
+    return copy.deepcopy(dict(bundle)) if isinstance(bundle, Mapping) else None
+
+
+def _bundle_item_identity(item: Mapping[str, Any]) -> str:
+    event_id = _normalize_text(item.get("event_id"))
+    if event_id is not None:
+        return event_id
+    reaction_kind = _normalize_text(item.get("reaction_kind")) or ""
+    message_text = _normalize_text(item.get("message_text")) or ""
+    return f"{reaction_kind}:{message_text}"
+
+
+def merge_feedback_bundles(
+    existing: Mapping[str, Any],
+    incoming: Mapping[str, Any],
+) -> dict[str, Any]:
+    merged = copy.deepcopy(dict(existing))
+    existing_items_raw = merged.get("items")
+    incoming_items_raw = incoming.get("items")
+    existing_items = (
+        [dict(item) for item in existing_items_raw if isinstance(item, Mapping)]
+        if isinstance(existing_items_raw, list)
+        else []
+    )
+    incoming_items = (
+        [dict(item) for item in incoming_items_raw if isinstance(item, Mapping)]
+        if isinstance(incoming_items_raw, list)
+        else []
+    )
+    seen = {_bundle_item_identity(item) for item in existing_items}
+    for item in incoming_items:
+        identity = _bundle_item_identity(item)
+        if identity in seen:
+            continue
+        existing_items.append(item)
+        seen.add(identity)
+    merged["items"] = existing_items
+    merged["last_event_at"] = (
+        _max_iso_datetime(
+            existing.get("last_event_at"),
+            incoming.get("last_event_at"),
+        )
+        or _normalize_text(existing.get("last_event_at"))
+        or _normalize_text(incoming.get("last_event_at"))
+    )
+    if _normalize_text(merged.get("opened_at")) is None:
+        merged["opened_at"] = _normalize_text(incoming.get("opened_at"))
+    if _normalize_text(merged.get("subject")) is None:
+        merged["subject"] = _normalize_text(incoming.get("subject"))
+    if _normalize_text(merged.get("binding_id")) is None:
+        merged["binding_id"] = _normalize_text(incoming.get("binding_id"))
+    if _normalize_text(merged.get("thread_target_id")) is None:
+        merged["thread_target_id"] = _normalize_text(incoming.get("thread_target_id"))
+    if _normalize_text(merged.get("repo_slug")) is None:
+        merged["repo_slug"] = _normalize_text(incoming.get("repo_slug"))
+    if merged.get("pr_number") is None and incoming.get("pr_number") is not None:
+        merged["pr_number"] = incoming.get("pr_number")
+    if _normalize_text(merged.get("batch_mode")) is None:
+        merged["batch_mode"] = _normalize_text(incoming.get("batch_mode"))
+    if _normalize_text(merged.get("ci_head_sha")) is None:
+        merged["ci_head_sha"] = _normalize_text(incoming.get("ci_head_sha"))
+    return {key: value for key, value in merged.items() if value is not None}
+
+
+def _ci_action_text(check_count: int) -> str:
+    return (
+        "Inspect the failing check and push a fix."
+        if check_count == 1
+        else "Inspect the failing checks and push a fix."
+    )
+
+
+def _render_ci_failed_bundle(bundle: Mapping[str, Any]) -> str:
+    items_raw = bundle.get("items")
+    items = (
+        [item for item in items_raw if isinstance(item, Mapping)]
+        if isinstance(items_raw, list)
+        else []
+    )
+    if len(items) <= 1:
+        message_text = _normalize_text(items[0].get("message_text")) if items else None
+        if message_text is not None:
+            return message_text
+    subject = _normalize_text(bundle.get("subject")) or "SCM binding"
+    checks: list[str] = []
+    for item in items:
+        check_name = _normalize_text(item.get("check_name"))
+        if check_name is None or check_name in checks:
+            continue
+        checks.append(check_name)
+    if len(checks) > 1:
+        filtered = [
+            check_name
+            for check_name in checks
+            if check_name.lower() not in _GENERIC_CI_CHECK_NAMES
+        ]
+        if filtered:
+            checks = filtered
+    conclusions = {
+        _normalize_text(item.get("conclusion"))
+        for item in items
+        if _normalize_text(item.get("conclusion")) is not None
+    }
+    conclusion = conclusions.pop() if len(conclusions) == 1 else "failure"
+    if checks:
+        return (
+            f"CI failed for {subject}: {', '.join(checks)} ({conclusion}). "
+            f"{_ci_action_text(len(checks))}"
+        )
+    return f"CI failed for {subject}. {_ci_action_text(1)}"
+
+
+def render_feedback_bundle_message(bundle: Mapping[str, Any]) -> str:
+    items_raw = bundle.get("items")
+    items = (
+        [item for item in items_raw if isinstance(item, Mapping)]
+        if isinstance(items_raw, list)
+        else []
+    )
+    if not items:
+        subject = _normalize_text(bundle.get("subject")) or "SCM binding"
+        return f"SCM updates arrived for {subject}."
+    if len(items) == 1:
+        message_text = _normalize_text(items[0].get("message_text"))
+        if message_text is not None:
+            return message_text
+    reaction_kinds = {
+        _normalize_text(item.get("reaction_kind"))
+        for item in items
+        if _normalize_text(item.get("reaction_kind")) is not None
+    }
+    if reaction_kinds == {"ci_failed"}:
+        return _render_ci_failed_bundle(bundle)
+    subject = _normalize_text(bundle.get("subject")) or "SCM binding"
+    lines = [f"Multiple SCM updates arrived for {subject}:"]
+    seen_messages: set[str] = set()
+    for item in items:
+        message_text = _normalize_text(item.get("message_text"))
+        if message_text is None or message_text in seen_messages:
+            continue
+        lines.append(f"- {message_text}")
+        seen_messages.add(message_text)
+    if len(lines) == 1:
+        return f"SCM updates arrived for {subject}."
+    return "\n".join(lines)
+
+
+def apply_feedback_bundle_to_publish_payload(
+    payload: Mapping[str, Any],
+    bundle: Mapping[str, Any],
+) -> dict[str, Any]:
+    updated = copy.deepcopy(dict(payload))
+    request_value = updated.get("request")
+    request = (
+        copy.deepcopy(dict(request_value)) if isinstance(request_value, Mapping) else {}
+    )
+    metadata_value = request.get("metadata")
+    metadata = (
+        copy.deepcopy(dict(metadata_value))
+        if isinstance(metadata_value, Mapping)
+        else {}
+    )
+    materialized_bundle = copy.deepcopy(dict(bundle))
+    metadata["scm_feedback_bundle"] = materialized_bundle
+    request["metadata"] = metadata
+    request["message_text"] = render_feedback_bundle_message(materialized_bundle)
+    updated["request"] = request
+    if "message_text" in updated:
+        updated["message_text"] = request["message_text"]
+    return updated
+
+
+__all__ = [
+    "apply_feedback_bundle_to_publish_payload",
+    "build_feedback_bundle",
+    "extract_feedback_bundle",
+    "merge_feedback_bundles",
+    "render_feedback_bundle_message",
+]

--- a/src/codex_autorunner/core/scm_reaction_types.py
+++ b/src/codex_autorunner/core/scm_reaction_types.py
@@ -86,6 +86,8 @@ def _login_list_from_mapping(mapping: Mapping[str, Any], *keys: str) -> tuple[st
 @dataclass(frozen=True)
 class ScmReactionConfig:
     ci_failed: bool = True
+    ci_failed_batch_window_seconds: int = 60
+    ci_failed_batch_max_window_seconds: int = 180
     changes_requested: bool = True
     review_comment: bool = True
     review_comment_batch_window_seconds: int = 15
@@ -120,6 +122,16 @@ class ScmReactionConfig:
                 default=(
                     defaults["ci_failed"] if default_enabled is None else default_value
                 ),
+            ),
+            ci_failed_batch_window_seconds=_int_from_mapping(
+                mapping,
+                "ci_failed_batch_window_seconds",
+                default=60,
+            ),
+            ci_failed_batch_max_window_seconds=_int_from_mapping(
+                mapping,
+                "ci_failed_batch_max_window_seconds",
+                default=180,
             ),
             changes_requested=_bool_from_mapping(
                 mapping,

--- a/tests/core/test_publish_executor.py
+++ b/tests/core/test_publish_executor.py
@@ -756,6 +756,263 @@ def test_enqueue_managed_turn_executor_queues_on_running_scm_thread(
     )
 
 
+def test_enqueue_managed_turn_executor_merges_into_existing_queued_scm_turn(
+    tmp_path: Path,
+) -> None:
+    hub_root, workspace_root, repo_id = _publish_hub(tmp_path)
+    thread_store = PmaThreadStore(hub_root)
+    thread = thread_store.create_thread(
+        "codex",
+        workspace_root,
+        repo_id=repo_id,
+        metadata={"head_branch": "feature/scm-rebind"},
+    )
+    running_turn = thread_store.create_turn(
+        thread["managed_thread_id"], prompt="already running"
+    )
+    binding = PrBindingStore(hub_root).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        repo_id=repo_id,
+        pr_number=42,
+        pr_state="open",
+        head_branch="feature/scm-rebind",
+        base_branch="main",
+        thread_target_id=thread["managed_thread_id"],
+    )
+    journal = PublishJournalStore(hub_root)
+    first = _create_scm_enqueue_operation(
+        journal=journal,
+        thread_target_id=thread["managed_thread_id"],
+        binding_id=binding.binding_id,
+        repo_id=repo_id,
+        operation_key="enqueue:scm:queued-merge-1",
+    )
+    first = replace(
+        first,
+        payload={
+            **first.payload,
+            "request": {
+                **first.payload["request"],
+                "message_text": "New PR review feedback arrived on acme/widgets#42.",
+                "metadata": {
+                    **first.payload["request"]["metadata"],
+                    "scm_feedback_bundle": {
+                        "version": 1,
+                        "subject": "acme/widgets#42",
+                        "binding_id": binding.binding_id,
+                        "thread_target_id": thread["managed_thread_id"],
+                        "repo_slug": "acme/widgets",
+                        "pr_number": 42,
+                        "opened_at": "2026-03-26T00:00:01Z",
+                        "last_event_at": "2026-03-26T00:00:01Z",
+                        "batch_mode": "general",
+                        "items": [
+                            {
+                                "event_id": "github:event-review-comment-1",
+                                "event_type": "pull_request_review_comment",
+                                "reaction_kind": "review_comment",
+                                "message_text": "New PR review feedback arrived on acme/widgets#42.",
+                                "received_at": "2026-03-26T00:00:01Z",
+                            }
+                        ],
+                    },
+                },
+            },
+        },
+    )
+    second = _create_scm_enqueue_operation(
+        journal=journal,
+        thread_target_id=thread["managed_thread_id"],
+        binding_id=binding.binding_id,
+        repo_id=repo_id,
+        operation_key="enqueue:scm:queued-merge-2",
+    )
+    second = replace(
+        second,
+        payload={
+            **second.payload,
+            "request": {
+                **second.payload["request"],
+                "message_text": "CI failed for acme/widgets#42: chat-apps (failure). Inspect the failing check and push a fix.",
+                "metadata": {
+                    **second.payload["request"]["metadata"],
+                    "scm_feedback_bundle": {
+                        "version": 1,
+                        "subject": "acme/widgets#42",
+                        "binding_id": binding.binding_id,
+                        "thread_target_id": thread["managed_thread_id"],
+                        "repo_slug": "acme/widgets",
+                        "pr_number": 42,
+                        "opened_at": "2026-03-26T00:00:15Z",
+                        "last_event_at": "2026-03-26T00:00:15Z",
+                        "batch_mode": "ci_failed",
+                        "ci_head_sha": "abc123",
+                        "items": [
+                            {
+                                "event_id": "github:event-ci-1",
+                                "event_type": "check_run",
+                                "reaction_kind": "ci_failed",
+                                "message_text": "CI failed for acme/widgets#42: chat-apps (failure). Inspect the failing check and push a fix.",
+                                "received_at": "2026-03-26T00:00:15Z",
+                                "check_name": "chat-apps",
+                                "conclusion": "failure",
+                                "head_sha": "abc123",
+                            }
+                        ],
+                    },
+                },
+            },
+        },
+    )
+
+    executor = build_enqueue_managed_turn_executor(hub_root=hub_root)
+    first_result = executor(first)
+    second_result = executor(second)
+
+    assert first_result["queued"] is True
+    assert second_result["queued"] is True
+    assert second_result["deduped"] is True
+    assert first_result["managed_turn_id"] == second_result["managed_turn_id"]
+    assert first_result["client_request_id"] == second_result["client_request_id"]
+
+    turns = thread_store.list_turns(thread["managed_thread_id"], limit=10)
+    assert len(turns) == 2
+    assert {turn["managed_turn_id"] for turn in turns} == {
+        running_turn["managed_turn_id"],
+        first_result["managed_turn_id"],
+    }
+    queued_turn = [
+        turn
+        for turn in turns
+        if turn["managed_turn_id"] == first_result["managed_turn_id"]
+    ][0]
+    assert queued_turn["prompt"].startswith(
+        "Multiple SCM updates arrived for acme/widgets#42:"
+    )
+    assert "New PR review feedback arrived on acme/widgets#42." in queued_turn["prompt"]
+    assert (
+        "CI failed for acme/widgets#42: chat-apps (failure). Inspect the failing check and push a fix."
+        in queued_turn["prompt"]
+    )
+    queued_payload = thread_store.get_queued_turn_queue_payload(
+        thread["managed_thread_id"],
+        queued_turn["managed_turn_id"],
+    )
+    assert queued_payload is not None
+    assert queued_payload["request"]["message_text"] == queued_turn["prompt"]
+
+
+def test_enqueue_managed_turn_executor_rebinds_instead_of_merging_stale_archived_queue(
+    tmp_path: Path,
+) -> None:
+    hub_root, workspace_root, repo_id = _publish_hub(tmp_path)
+    thread_store = PmaThreadStore(hub_root)
+    archived_thread = thread_store.create_thread(
+        "codex",
+        workspace_root,
+        repo_id=repo_id,
+        metadata={"head_branch": "feature/scm-rebind"},
+    )
+    thread_store.create_turn(archived_thread["managed_thread_id"], prompt="running")
+    thread_store.create_turn(
+        archived_thread["managed_thread_id"],
+        prompt="queued stale scm turn",
+        busy_policy="queue",
+    )
+    thread_store.archive_thread(archived_thread["managed_thread_id"])
+
+    binding = PrBindingStore(hub_root).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        repo_id=repo_id,
+        pr_number=42,
+        pr_state="open",
+        head_branch="feature/scm-rebind",
+        base_branch="main",
+        thread_target_id=archived_thread["managed_thread_id"],
+    )
+    event = ScmEventStore(hub_root).record_event(
+        provider="github",
+        event_type="check_run",
+        event_id="github:event-archived-ci",
+        occurred_at="2026-03-25T00:00:00Z",
+        received_at="2026-03-25T00:00:01Z",
+        repo_slug="acme/widgets",
+        repo_id=repo_id,
+        pr_number=42,
+        payload={
+            "action": "completed",
+            "status": "completed",
+            "conclusion": "failure",
+            "name": "chat-apps",
+            "head_sha": "abc123",
+        },
+    )
+    operation = _create_scm_enqueue_operation(
+        journal=PublishJournalStore(hub_root),
+        thread_target_id=archived_thread["managed_thread_id"],
+        binding_id=binding.binding_id,
+        repo_id=repo_id,
+        operation_key="enqueue:scm:archived-queued-merge",
+    )
+    operation = replace(
+        operation,
+        payload={
+            **operation.payload,
+            "request": {
+                **operation.payload["request"],
+                "message_text": "CI failed for acme/widgets#42: chat-apps (failure). Inspect the failing check and push a fix.",
+                "metadata": {
+                    "scm": {
+                        **operation.payload["request"]["metadata"]["scm"],
+                        "event_id": event.event_id,
+                    },
+                    "scm_feedback_bundle": {
+                        "version": 1,
+                        "subject": "acme/widgets#42",
+                        "binding_id": binding.binding_id,
+                        "thread_target_id": archived_thread["managed_thread_id"],
+                        "repo_slug": "acme/widgets",
+                        "pr_number": 42,
+                        "opened_at": "2026-03-25T00:00:01Z",
+                        "last_event_at": "2026-03-25T00:00:01Z",
+                        "batch_mode": "ci_failed",
+                        "ci_head_sha": "abc123",
+                        "items": [
+                            {
+                                "event_id": event.event_id,
+                                "event_type": "check_run",
+                                "reaction_kind": "ci_failed",
+                                "message_text": "CI failed for acme/widgets#42: chat-apps (failure). Inspect the failing check and push a fix.",
+                                "received_at": "2026-03-25T00:00:01Z",
+                                "check_name": "chat-apps",
+                                "conclusion": "failure",
+                                "head_sha": "abc123",
+                            }
+                        ],
+                    },
+                },
+            },
+            "scm_reaction": {
+                **operation.payload["scm_reaction"],
+                "event_id": event.event_id,
+            },
+        },
+    )
+
+    result = build_enqueue_managed_turn_executor(hub_root=hub_root)(operation)
+
+    assert result["thread_target_id"] != archived_thread["managed_thread_id"]
+    rebound_binding = PrBindingStore(hub_root).get_binding_by_pr(
+        provider="github",
+        repo_slug="acme/widgets",
+        pr_number=42,
+    )
+    assert rebound_binding is not None
+    assert rebound_binding.thread_target_id == result["thread_target_id"]
+
+
 def test_enqueue_managed_turn_executor_rebinds_archived_scm_thread_with_bootstrap_prompt(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/core/test_scm_automation_service.py
+++ b/tests/core/test_scm_automation_service.py
@@ -145,6 +145,7 @@ class _JournalFake:
         self.operations_by_key: dict[str, PublishOperation] = {}
         self.create_calls: list[tuple[str, str]] = []
         self.next_attempts_by_key: dict[str, Optional[str]] = {}
+        self.update_calls: list[str] = []
 
     def create_operation(
         self,
@@ -173,6 +174,51 @@ class _JournalFake:
         )
         self.operations_by_key[operation_key] = created
         return created, False
+
+    def update_pending_operation(
+        self,
+        operation_id: str,
+        *,
+        payload: Optional[dict] = None,
+        next_attempt_at: Optional[str] = None,
+    ) -> Optional[PublishOperation]:
+        self.update_calls.append(operation_id)
+        for key, operation in list(self.operations_by_key.items()):
+            if operation.operation_id != operation_id or operation.state != "pending":
+                continue
+            updated = PublishOperation(
+                **{
+                    **operation.to_dict(),
+                    "payload": dict(payload or operation.payload),
+                    "next_attempt_at": next_attempt_at or operation.next_attempt_at,
+                }
+            )
+            self.operations_by_key[key] = updated
+            self.next_attempts_by_key[key] = updated.next_attempt_at
+            return updated
+        return None
+
+    def list_operations(
+        self,
+        *,
+        state: Optional[str] = None,
+        operation_kind: Optional[str] = None,
+        limit: Optional[int] = None,
+        newest_first: bool = False,
+    ) -> list[PublishOperation]:
+        operations = list(self.operations_by_key.values())
+        if state is not None:
+            operations = [op for op in operations if op.state == state]
+        if operation_kind is not None:
+            operations = [
+                op for op in operations if op.operation_kind == operation_kind
+            ]
+        operations.sort(
+            key=lambda op: (op.created_at, op.operation_id), reverse=newest_first
+        )
+        if limit is not None:
+            operations = operations[:limit]
+        return operations
 
 
 class _ProcessorFake:
@@ -954,6 +1000,123 @@ def test_ingest_event_dedupes_review_comment_enqueue_within_same_batch_window(
         )
         == 2
     )
+
+
+def test_ingest_event_batches_ci_failures_for_same_head_and_refreshes_timer(
+    tmp_path: Path,
+) -> None:
+    first = ScmEvent(
+        event_id="github:check-1",
+        provider="github",
+        event_type="check_run",
+        occurred_at="2026-03-26T00:00:00Z",
+        received_at="2026-03-26T00:00:01Z",
+        created_at="2026-03-26T00:00:02Z",
+        repo_slug="acme/widgets",
+        repo_id="repo-1",
+        pr_number=42,
+        delivery_id="delivery-1",
+        payload={
+            "action": "completed",
+            "status": "completed",
+            "conclusion": "failure",
+            "name": "chat-apps",
+            "head_sha": "abc123",
+        },
+        raw_payload=None,
+    )
+    second = ScmEvent(
+        **{
+            **first.to_dict(),
+            "event_id": "github:check-2",
+            "received_at": "2026-03-26T00:00:40Z",
+            "payload": {
+                **first.payload,
+                "name": "check",
+            },
+        }
+    )
+    binding = _binding()
+    journal = _JournalFake()
+    service = ScmAutomationService(
+        tmp_path,
+        event_store=_EventStoreFake(first, second),
+        binding_resolver=_BindingResolverFake(binding),
+        reaction_router=route_scm_reactions,
+        reaction_state_store=_PermissiveReactionStateFake(),
+        journal=journal,
+        publish_processor=_ProcessorFake(processed=[]),
+    )
+
+    first_result = service.ingest_event(first.event_id)
+    second_result = service.ingest_event(second.event_id)
+
+    assert len(first_result.publish_operations) == 1
+    assert len(second_result.publish_operations) == 1
+    assert first_result.publish_operations[0].operation_id == "op-1"
+    assert second_result.publish_operations[0].operation_id == "op-1"
+    assert journal.create_calls == [
+        (first_result.publish_operations[0].operation_key, "enqueue_managed_turn")
+    ]
+    assert journal.update_calls == ["op-1"]
+    assert first_result.publish_operations[0].next_attempt_at == "2026-03-26T00:01:01Z"
+    assert second_result.publish_operations[0].next_attempt_at == "2026-03-26T00:01:40Z"
+    assert (
+        second_result.publish_operations[0].payload["request"]["message_text"]
+        == "CI failed for acme/widgets#42: chat-apps (failure). Inspect the failing check and push a fix."
+    )
+
+
+def test_ingest_event_ci_failure_batch_refresh_honors_max_window(
+    tmp_path: Path,
+) -> None:
+    first = ScmEvent(
+        event_id="github:ci-cap-1",
+        provider="github",
+        event_type="check_run",
+        occurred_at="2026-03-26T00:00:00Z",
+        received_at="2026-03-26T00:00:01Z",
+        created_at="2026-03-26T00:00:02Z",
+        repo_slug="acme/widgets",
+        repo_id="repo-1",
+        pr_number=42,
+        delivery_id="delivery-1",
+        payload={
+            "action": "completed",
+            "status": "completed",
+            "conclusion": "failure",
+            "name": "chat-apps",
+            "head_sha": "abc123",
+        },
+        raw_payload=None,
+    )
+    second = ScmEvent(
+        **{
+            **first.to_dict(),
+            "event_id": "github:ci-cap-2",
+            "received_at": "2026-03-26T00:02:50Z",
+            "payload": {
+                **first.payload,
+                "name": "check",
+            },
+        }
+    )
+    binding = _binding()
+    journal = _JournalFake()
+    service = ScmAutomationService(
+        tmp_path,
+        event_store=_EventStoreFake(first, second),
+        binding_resolver=_BindingResolverFake(binding),
+        reaction_router=route_scm_reactions,
+        reaction_state_store=_PermissiveReactionStateFake(),
+        journal=journal,
+        publish_processor=_ProcessorFake(processed=[]),
+    )
+
+    service.ingest_event(first.event_id)
+    second_result = service.ingest_event(second.event_id)
+
+    assert second_result.publish_operations[0].next_attempt_at == "2026-03-26T00:03:01Z"
 
 
 def test_handle_processed_operations_creates_truthful_review_comment_notice_on_success(

--- a/tests/core/test_scm_automation_service.py
+++ b/tests/core/test_scm_automation_service.py
@@ -13,6 +13,33 @@ from codex_autorunner.core.scm_reaction_state import ScmReactionStateStore
 from codex_autorunner.core.scm_reaction_types import ReactionIntent, ScmReactionConfig
 
 
+def _ci_failed_event(
+    *,
+    event_id: str,
+    head_sha: str = "deadbeef",
+) -> ScmEvent:
+    return ScmEvent(
+        event_id=event_id,
+        provider="github",
+        event_type="check_run",
+        occurred_at="2026-03-26T00:00:00Z",
+        received_at="2026-03-26T00:00:01Z",
+        created_at="2026-03-26T00:00:02Z",
+        repo_slug="acme/widgets",
+        repo_id="repo-1",
+        pr_number=42,
+        delivery_id="delivery-1",
+        payload={
+            "action": "completed",
+            "status": "completed",
+            "conclusion": "failure",
+            "name": "ci / test",
+            "head_sha": head_sha,
+        },
+        raw_payload=None,
+    )
+
+
 def _event(
     *,
     event_id: str = "github:event-1",
@@ -219,6 +246,34 @@ class _JournalFake:
         if limit is not None:
             operations = operations[:limit]
         return operations
+
+
+class _JournalUpdateRaceFake(_JournalFake):
+    """Simulates losing a race when merging into a pending publish operation."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._fail_next_update_for: set[str] = set()
+
+    def arm_fail_next_update(self, operation_id: str) -> None:
+        self._fail_next_update_for.add(operation_id)
+
+    def update_pending_operation(
+        self,
+        operation_id: str,
+        *,
+        payload: Optional[dict] = None,
+        next_attempt_at: Optional[str] = None,
+    ) -> Optional[PublishOperation]:
+        self.update_calls.append(operation_id)
+        if operation_id in self._fail_next_update_for:
+            self._fail_next_update_for.discard(operation_id)
+            return None
+        return super().update_pending_operation(
+            operation_id,
+            payload=payload,
+            next_attempt_at=next_attempt_at,
+        )
 
 
 class _ProcessorFake:
@@ -490,6 +545,48 @@ def test_ingest_event_loads_persisted_event_routes_reactions_and_dedupes_publish
     assert len(reaction_state_store.should_calls) == 6
     assert len(reaction_state_store.mark_calls) == 4
     assert sorted(journal.operations_by_key) == ["scm:key-1", "scm:key-2"]
+
+
+def test_ci_failed_pending_merge_falls_back_to_create_when_update_races(
+    tmp_path: Path,
+) -> None:
+    head_sha = "abc123deadbeef0000"
+    event_a = _ci_failed_event(event_id="github:event-a", head_sha=head_sha)
+    event_b = _ci_failed_event(event_id="github:event-b", head_sha=head_sha)
+    binding = _binding()
+    journal = _JournalUpdateRaceFake()
+    service = ScmAutomationService(
+        tmp_path,
+        event_store=_EventStoreFake(event_a, event_b),
+        binding_resolver=_BindingResolverFake(binding),
+        reaction_router=route_scm_reactions,
+        reaction_state_store=_PermissiveReactionStateFake(),
+        journal=journal,
+        publish_processor=_ProcessorFake(processed=[]),
+    )
+
+    first = service.ingest_event("github:event-a")
+    assert len(first.publish_operations) == 1
+    pending = first.publish_operations[0]
+    journal.arm_fail_next_update(pending.operation_id)
+
+    second = service.ingest_event("github:event-b")
+    assert len(second.publish_operations) == 1
+    merged_op = second.publish_operations[0]
+    assert merged_op.operation_id != pending.operation_id
+    request = merged_op.payload.get("request")
+    assert isinstance(request, dict)
+    metadata = request.get("metadata")
+    assert isinstance(metadata, dict)
+    bundle = metadata.get("scm_feedback_bundle")
+    assert isinstance(bundle, dict)
+    event_ids = {
+        item["event_id"]
+        for item in bundle.get("items", [])
+        if isinstance(item, dict) and "event_id" in item
+    }
+    assert event_ids == {"github:event-a", "github:event-b"}
+    assert journal.create_calls[-1][1] == "enqueue_managed_turn"
 
 
 def test_ingest_event_suppresses_repeated_semantic_reaction_conditions_using_durable_state(

--- a/tests/core/test_scm_reaction_types.py
+++ b/tests/core/test_scm_reaction_types.py
@@ -28,6 +28,23 @@ def test_scm_reaction_config_profile_allows_explicit_overrides() -> None:
     assert config.merged is False
 
 
+def test_scm_reaction_config_includes_ci_batch_defaults_and_overrides() -> None:
+    defaults = ScmReactionConfig.from_mapping({})
+    overridden = ScmReactionConfig.from_mapping(
+        {
+            "reactions": {
+                "ci_failed_batch_window_seconds": 90,
+                "ci_failed_batch_max_window_seconds": 240,
+            }
+        }
+    )
+
+    assert defaults.ci_failed_batch_window_seconds == 60
+    assert defaults.ci_failed_batch_max_window_seconds == 180
+    assert overridden.ci_failed_batch_window_seconds == 90
+    assert overridden.ci_failed_batch_max_window_seconds == 240
+
+
 def test_scm_reaction_config_normalizes_and_deduplicates_login_lists() -> None:
     config = ScmReactionConfig.from_mapping(
         {

--- a/tests/fixtures/default_hub_config.v2.json
+++ b/tests/fixtures/default_hub_config.v2.json
@@ -307,6 +307,8 @@
           "approved_and_green": true,
           "changes_requested": true,
           "ci_failed": true,
+          "ci_failed_batch_max_window_seconds": 180,
+          "ci_failed_batch_window_seconds": 60,
           "delivery_failure_escalation_threshold": 3,
           "duplicate_escalation_threshold": 3,
           "enabled": true,

--- a/tests/fixtures/default_repo_config.v2.json
+++ b/tests/fixtures/default_repo_config.v2.json
@@ -153,6 +153,8 @@
         "approved_and_green": true,
         "changes_requested": true,
         "ci_failed": true,
+        "ci_failed_batch_max_window_seconds": 180,
+        "ci_failed_batch_window_seconds": 60,
         "delivery_failure_escalation_threshold": 3,
         "duplicate_escalation_threshold": 3,
         "enabled": true,


### PR DESCRIPTION
## Summary
- coalesce CI failure SCM wakeups into a sliding 60s batch per PR head, capped at 180s
- bundle queued SCM feedback into a single managed-turn message instead of stacking extra queued SCM turns
- add durable bundle helpers, queued-turn rewrite support, and regression coverage for batching, stale archived threads, and queued-turn merge behavior

## Root Cause
SCM automation was emitting one managed-turn wake per failed `check_run`, and once a thread already had queued SCM work, later SCM events would create sibling queued turns instead of folding into the existing queued wake.

## Validation
- `.venv/bin/python -m pytest -q tests/core/test_publish_executor.py tests/core/test_scm_automation_service.py tests/core/test_scm_reaction_types.py tests/core/test_publish_journal.py tests/core/test_scm_cross_seam_regression.py`
- `.venv/bin/python -m pytest -q tests/test_config_default_snapshots.py`
- `.venv/bin/python -m pytest -q 'tests/integrations/chat/test_hermes_official_completion.py::test_discord_pma_turn_completes_for_official_hermes_prompt[asyncio]' 'tests/integrations/discord/test_service_routing.py::test_dispatch_deferred_slash_commands_ack_before_prior_handler_finishes[asyncio]' 'tests/chat_surface_lab/test_scenario_runner.py::test_runner_executes_queued_visibility_matrix[asyncio]' 'tests/chat_surface_lab/test_scenario_runner.py::test_runner_executes_interrupt_optimistic_acceptance_matrix[asyncio]' 'tests/chat_surface_lab/test_latency_budgets.py::test_latency_budget_suite_writes_artifacts_and_covers_required_budgets[asyncio]'`
- full commit gate: strict mypy, full pytest suite, frontend build/tests, chat-surface deterministic checks

Closes #1534
