### PR TITLE
[codex] Fix Discord PMA progress anchor cleanup

### DIFF
--- a/src/codex_autorunner/integrations/discord/managed_thread_delivery.py
+++ b/src/codex_autorunner/integrations/discord/managed_thread_delivery.py
@@ -22,6 +22,7 @@ from ..chat.managed_thread_delivery_support import (
     deliver_managed_thread_terminal_record,
 )
 from .constants import DISCORD_MAX_MESSAGE_LENGTH
+from .progress_leases import cleanup_discord_terminal_progress_leases
 from .rendering import chunk_discord_message, format_discord_message
 
 
@@ -107,12 +108,28 @@ async def deliver_discord_managed_thread_record(
     async def _cleanup(context: ManagedThreadDeliveryCleanupContext) -> None:
         raw_path = context.metadata.get("workspace_root")
         if not isinstance(raw_path, str) or not raw_path.strip():
-            return
+            workspace_root = None
+        else:
+            workspace_root = Path(raw_path)
         flush = getattr(service, "_flush_outbox_files", None)
-        if not callable(flush):
-            return
-        workspace_root = Path(raw_path)
-        await flush(workspace_root=workspace_root, channel_id=target_channel_id)
+        if callable(flush) and workspace_root is not None:
+            await flush(workspace_root=workspace_root, channel_id=target_channel_id)
+        completion_note = (
+            "Status: this turn already failed."
+            if str(record.envelope.final_status or "").strip().lower() == "error"
+            else "Status: this turn already completed."
+        )
+        await cleanup_discord_terminal_progress_leases(
+            service,
+            managed_thread_id=record.managed_thread_id,
+            execution_id=record.managed_turn_id,
+            channel_id=target_channel_id,
+            note=completion_note,
+            record_prefix=(
+                "discord:managed-thread-progress-cleanup:"
+                f"{record.managed_thread_id}:{record.managed_turn_id}"
+            ),
+        )
 
     return await deliver_managed_thread_terminal_record(
         record,

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -1277,15 +1277,26 @@ async def _deliver_discord_turn_result(
         )
     if visible_terminal_delivery:
         if not preserve_progress_lease:
-            cleaned_progress = await cleanup_discord_terminal_progress_leases(
-                dispatch.service,
-                managed_thread_id=managed_thread_id,
-                execution_id=execution_id,
-                channel_id=dispatch.channel_id,
-                note="Status: this turn already completed.",
-                record_prefix=(
-                    f"turn:delete_progress:{dispatch.session_key}:{uuid.uuid4().hex[:8]}"
-                ),
+            # Require execution_id or managed_thread_id so listing does not fall back to
+            # channel_id-only (matches every lease on the channel).
+            _can_cleanup_terminal_leases = (
+                isinstance(execution_id, str)
+                and execution_id
+                or (isinstance(managed_thread_id, str) and managed_thread_id.strip())
+            )
+            cleaned_progress = (
+                await cleanup_discord_terminal_progress_leases(
+                    dispatch.service,
+                    managed_thread_id=managed_thread_id,
+                    execution_id=execution_id,
+                    channel_id=dispatch.channel_id,
+                    note="Status: this turn already completed.",
+                    record_prefix=(
+                        f"turn:delete_progress:{dispatch.session_key}:{uuid.uuid4().hex[:8]}"
+                    ),
+                )
+                if _can_cleanup_terminal_leases
+                else 0
             )
             preview_message_deleted = bool(
                 cleaned_progress
@@ -1315,9 +1326,9 @@ async def _deliver_discord_turn_result(
                         dispatch.service,
                         lease_id=current_lease_id,
                     )
-            if cleaned_progress and supervision is not None:
-                supervision.clear_progress_tracking()
-            elif preview_message_deleted and supervision is not None:
+            if (
+                cleaned_progress or preview_message_deleted
+            ) and supervision is not None:
                 supervision.clear_progress_tracking()
     elif isinstance(preview_message_id, str) and preview_message_id:
         failure_note = (

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -134,6 +134,7 @@ from .progress_leases import (  # noqa: F401  re-export for backward compat
     _update_discord_progress_lease,
     _upsert_discord_progress_lease,
     bind_discord_progress_task_context,
+    cleanup_discord_terminal_progress_leases,
     clear_discord_turn_progress_leases,
     clear_discord_turn_progress_reuse,
     reconcile_discord_turn_progress_leases,
@@ -561,6 +562,33 @@ def _resolve_discord_managed_thread_status(
     return _DiscordManagedThreadStatus(thread_target_id=thread_target_id, busy=busy)
 
 
+async def _delete_discord_progress_message_safe(
+    service: Any,
+    *,
+    channel_id: str,
+    message_id: str,
+    record_id: str,
+) -> bool:
+    delete_safe = getattr(service, "_delete_channel_message_safe", None)
+    if not callable(delete_safe):
+        return False
+    try:
+        deleted = await delete_safe(
+            channel_id=channel_id,
+            message_id=message_id,
+            record_id=record_id,
+        )
+    except (
+        DiscordTransientError,
+        DiscordPermanentError,
+        RuntimeError,
+        ConnectionError,
+        OSError,
+    ):
+        return False
+    return deleted is not False
+
+
 async def _submit_discord_thread_message(
     request: SurfaceThreadMessageRequest,
     *,
@@ -641,7 +669,8 @@ async def _submit_discord_thread_message(
                 supervision.task_context, "message_id"
             )
             if progress_message_id:
-                await dispatch.service._delete_channel_message_safe(
+                await _delete_discord_progress_message_safe(
+                    dispatch.service,
                     channel_id=dispatch.channel_id,
                     message_id=progress_message_id,
                     record_id=(
@@ -658,14 +687,22 @@ async def _submit_discord_thread_message(
                     else f"Turn failed: {failure_message}"
                 )
             )
-            await dispatch.service._send_channel_message_safe(
-                dispatch.channel_id,
-                {"content": fallback_text},
-                record_id=(
-                    f"turn:background_failure:{dispatch.session_key}:"
-                    f"{uuid.uuid4().hex[:8]}"
-                ),
-            )
+            try:
+                await dispatch.service._send_channel_message_safe(
+                    dispatch.channel_id,
+                    {"content": fallback_text},
+                    record_id=(
+                        f"turn:background_failure:{dispatch.session_key}:"
+                        f"{uuid.uuid4().hex[:8]}"
+                    ),
+                )
+            except TypeError as exc:
+                if "record_id" not in str(exc):
+                    raise
+                await dispatch.service._send_channel_message_safe(
+                    dispatch.channel_id,
+                    {"content": fallback_text},
+                )
 
     async def _send_initial_progress_placeholder() -> Optional[str]:
         initial_content = "Received. Preparing turn..."
@@ -1239,54 +1276,49 @@ async def _deliver_discord_turn_result(
             attachment_caption="Final response too long; attached as final-response.md.",
         )
     if visible_terminal_delivery:
-        if isinstance(preview_message_id, str) and preview_message_id:
-            preview_message_deleted = await dispatch.service._delete_channel_message_safe(
+        if not preserve_progress_lease:
+            cleaned_progress = await cleanup_discord_terminal_progress_leases(
+                dispatch.service,
+                managed_thread_id=managed_thread_id,
+                execution_id=execution_id,
                 channel_id=dispatch.channel_id,
-                message_id=preview_message_id,
-                record_id=(
+                note="Status: this turn already completed.",
+                record_prefix=(
                     f"turn:delete_progress:{dispatch.session_key}:{uuid.uuid4().hex[:8]}"
                 ),
             )
-            if preview_message_deleted:
-                if current_lease_id:
-                    await _delete_discord_progress_lease(
-                        dispatch.service,
-                        lease_id=current_lease_id,
-                    )
-                elif (
-                    isinstance(execution_id, str)
-                    and execution_id
-                    and not preserve_progress_lease
-                ):
-                    for lease in await _list_discord_progress_leases(
-                        dispatch.service,
-                        execution_id=execution_id,
-                    ):
-                        orphaned_lease_id = _execution_field(lease, "lease_id")
-                        if orphaned_lease_id:
-                            await _delete_discord_progress_lease(
-                                dispatch.service,
-                                lease_id=orphaned_lease_id,
-                            )
-                if supervision is not None:
-                    supervision.clear_progress_tracking()
-        elif (
-            isinstance(execution_id, str)
-            and execution_id
-            and not preserve_progress_lease
-        ):
-            for lease in await _list_discord_progress_leases(
-                dispatch.service,
-                execution_id=execution_id,
+            preview_message_deleted = bool(
+                cleaned_progress
+                and isinstance(preview_message_id, str)
+                and preview_message_id
+                and (
+                    preview_message_id == current_message_id
+                    or not isinstance(current_message_id, str)
+                )
+            )
+            if (
+                not preview_message_deleted
+                and isinstance(preview_message_id, str)
+                and preview_message_id
             ):
-                current_lease_id = _execution_field(lease, "lease_id")
-                if current_lease_id:
+                preview_message_deleted = await _delete_discord_progress_message_safe(
+                    dispatch.service,
+                    channel_id=dispatch.channel_id,
+                    message_id=preview_message_id,
+                    record_id=(
+                        "turn:delete_preview:"
+                        f"{dispatch.session_key}:{uuid.uuid4().hex[:8]}"
+                    ),
+                )
+                if preview_message_deleted and current_lease_id:
                     await _delete_discord_progress_lease(
                         dispatch.service,
                         lease_id=current_lease_id,
                     )
-            if supervision is not None:
-                supervision.set_lease_id(None)
+            if cleaned_progress and supervision is not None:
+                supervision.clear_progress_tracking()
+            elif preview_message_deleted and supervision is not None:
+                supervision.clear_progress_tracking()
     elif isinstance(preview_message_id, str) and preview_message_id:
         failure_note = (
             "Status: this turn finished, but Discord failed before the final reply "

--- a/src/codex_autorunner/integrations/discord/progress_leases.py
+++ b/src/codex_autorunner/integrations/discord/progress_leases.py
@@ -413,6 +413,66 @@ async def _delete_discord_progress_lease(service: Any, *, lease_id: str) -> None
     await deleter(lease_id=lease_id)
 
 
+async def cleanup_discord_terminal_progress_leases(
+    service: Any,
+    *,
+    managed_thread_id: Optional[str] = None,
+    execution_id: Optional[str] = None,
+    channel_id: Optional[str] = None,
+    note: str,
+    record_prefix: str,
+) -> int:
+    leases = await _list_discord_progress_leases(
+        service,
+        managed_thread_id=managed_thread_id,
+        execution_id=execution_id,
+        channel_id=channel_id,
+    )
+    if not leases:
+        return 0
+    cleaned = 0
+    for lease in leases:
+        current_lease_id = _execution_field(lease, "lease_id")
+        current_channel_id = _execution_field(lease, "channel_id")
+        current_message_id = _execution_field(lease, "message_id")
+        if not current_lease_id or not current_channel_id or not current_message_id:
+            continue
+        delete_safe = getattr(service, "_delete_channel_message_safe", None)
+        try:
+            deleted = (
+                await delete_safe(
+                    channel_id=current_channel_id,
+                    message_id=current_message_id,
+                    record_id=f"{record_prefix}:{current_lease_id}",
+                )
+                if callable(delete_safe)
+                else False
+            )
+        except (
+            DiscordTransientError,
+            DiscordPermanentError,
+            RuntimeError,
+            ConnectionError,
+            OSError,
+        ):
+            deleted = False
+        deleted = deleted is not False
+        if deleted:
+            await _delete_discord_progress_lease(service, lease_id=current_lease_id)
+            cleaned += 1
+            continue
+        retired = await _retire_discord_progress_message(
+            service,
+            channel_id=current_channel_id,
+            message_id=current_message_id,
+            note=note,
+        )
+        if retired:
+            await _delete_discord_progress_lease(service, lease_id=current_lease_id)
+            cleaned += 1
+    return cleaned
+
+
 async def _retire_discord_progress_message(
     service: Any,
     *,

--- a/tests/integrations/discord/test_discord_managed_thread_delivery_adapter.py
+++ b/tests/integrations/discord/test_discord_managed_thread_delivery_adapter.py
@@ -14,7 +14,12 @@ from types import SimpleNamespace
 from typing import Any, Optional
 
 import pytest
-from tests.discord_message_turns_support import _FakeRest
+from tests.discord_message_turns_support import (
+    _config,
+    _FakeGateway,
+    _FakeOutboxManager,
+    _FakeRest,
+)
 
 from codex_autorunner.core.filebox import outbox_dir, outbox_sent_dir
 from codex_autorunner.core.orchestration import (
@@ -33,6 +38,7 @@ from codex_autorunner.integrations.chat.managed_thread_turns import (
 )
 from codex_autorunner.integrations.discord import message_turns as discord_message_turns
 from codex_autorunner.integrations.discord.service import DiscordBotService
+from codex_autorunner.integrations.discord.state import DiscordStateStore
 
 
 def _make_engine(
@@ -599,6 +605,70 @@ async def test_discord_adapter_session_notice_included_in_delivery(
     content = service.sent_messages[0]["payload"]["content"]
     assert "A new session was started." in content
     assert "Hello from the agent" in content
+
+
+@pytest.mark.anyio
+async def test_discord_adapter_clears_progress_anchor_after_terminal_delivery(
+    tmp_path: Path,
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-1",
+        managed_thread_id="thread-1",
+        execution_id="turn-1",
+        channel_id="channel-1",
+        message_id="preview-1",
+        state="active",
+        progress_label="working",
+    )
+
+    async def _delete_preview(
+        channel_id: str,
+        message_id: str,
+        *,
+        record_id: Optional[str] = None,
+    ) -> bool:
+        _ = record_id
+        await rest.delete_channel_message(
+            channel_id=channel_id,
+            message_id=message_id,
+        )
+        return True
+
+    service._delete_channel_message_safe = _delete_preview  # type: ignore[method-assign]
+    delivery = _build_hooks(tmp_path, service=service)
+    finalized = _finalized_ok(managed_turn_id="turn-1")
+
+    try:
+        record = await handoff_managed_thread_final_delivery(
+            finalized,
+            delivery=delivery,
+            logger=logging.getLogger("test"),
+        )
+
+        assert record is not None
+        assert record.state is ManagedThreadDeliveryState.DELIVERED
+        assert len(rest.deleted_channel_messages) == 1
+        assert rest.deleted_channel_messages[0]["message_id"] == "preview-1"
+        assert (
+            await store.list_turn_progress_leases(
+                managed_thread_id="thread-1",
+                execution_id="turn-1",
+            )
+            == []
+        )
+    finally:
+        await store.close()
 
 
 @pytest.mark.anyio

--- a/tests/test_discord_message_turn_background_failures.py
+++ b/tests/test_discord_message_turn_background_failures.py
@@ -545,6 +545,96 @@ async def test_queued_delivery_preserves_progress_lease_until_terminal_delivery(
 
 
 @pytest.mark.anyio
+async def test_terminal_delivery_retire_progress_anchor_when_preview_delete_fails(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-1",
+        managed_thread_id="thread-1",
+        execution_id="exec-1",
+        channel_id="channel-1",
+        message_id="progress-1",
+        state="active",
+        progress_label="working",
+    )
+
+    async def _fail_delete(
+        channel_id: str,
+        message_id: str,
+        *,
+        record_id: str | None = None,
+    ) -> bool:
+        _ = (channel_id, message_id, record_id)
+        return False
+
+    service._delete_channel_message_safe = _fail_delete  # type: ignore[method-assign]
+    dispatch = SimpleNamespace(
+        service=service,
+        channel_id="channel-1",
+        session_key="session-1",
+        pending_compact_seed=None,
+        agent="codex",
+        model_override=None,
+    )
+    supervision = SimpleNamespace(
+        task_context={
+            "managed_thread_id": "thread-1",
+            "lease_id": "lease-1",
+            "message_id": "progress-1",
+            "execution_id": "exec-1",
+        },
+        set_message_id=lambda _value: None,
+        set_execution_id=lambda _value: None,
+        set_failure_note=lambda _value: None,
+        clear_progress_tracking=lambda **_kwargs: None,
+    )
+
+    try:
+        await discord_message_turns_module._deliver_discord_turn_result(
+            dispatch,
+            workspace_root=workspace,
+            turn_result=DiscordMessageTurnResult(
+                final_message="final response",
+                preview_message_id="progress-1",
+                execution_id="exec-1",
+                send_final_message=True,
+            ),
+            supervision=supervision,
+        )
+
+        assert len(rest.channel_messages) == 1
+        assert rest.channel_messages[0]["payload"]["content"] == "final response"
+        assert rest.deleted_channel_messages == []
+        assert rest.edited_channel_messages
+        retired = rest.edited_channel_messages[-1]
+        assert retired["message_id"] == "progress-1"
+        assert "already completed" in retired["payload"]["content"].lower()
+        assert retired["payload"]["components"] == []
+        assert (
+            await store.list_turn_progress_leases(
+                managed_thread_id="thread-1",
+                execution_id="exec-1",
+            )
+            == []
+        )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_shutdown_timeout_reconciles_supervised_progress_leases(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
Fix Discord PMA terminal cleanup so progress anchors are retired consistently after terminal delivery and do not get stuck showing `working`.

## Root cause
The Discord PMA timeout and stale-`working` incidents shared a terminal-cleanup gap:
- queued/durable terminal delivery could leave the original progress anchor lease behind
- direct terminal delivery assumed a real Discord REST test double for delete bookkeeping instead of handling preview cleanup directly
- background-failure cleanup could recurse into itself when fallback sends rejected `record_id`, causing duplicate placeholder deletes in early-exit paths

## What changed
- added shared terminal progress-anchor cleanup for durable Discord managed-thread delivery
- taught direct Discord terminal delivery to delete the preview anchor even when no persisted lease exists
- normalized best-effort delete handling so `None` from `_delete_channel_message_safe` still counts as a successful delete
- hardened background cleanup so fallback notice delivery stays compatible with older call sites that do not accept `record_id`
- added regression coverage for durable replay cleanup and direct preview-retire behavior

## Validation
- full commit hook lane `chat-apps`
- repo-wide `mypy`
- repo-wide `pytest` (`7568 passed`)
- deterministic chat-surface checks (`21 passed`)
- targeted repros:
  - `tests/chat_surface_integration/test_hermes_pma_official_timeout.py::test_discord_hermes_pma_times_out_for_missing_terminal_and_missing_return`
  - `tests/chat_surface_integration/test_hermes_pma_official_timeout.py::test_discord_hermes_pma_stall_timeout_surfaces_timeout_for_silent_hang`
  - `tests/chat_surface_integration/test_hermes_pma_surfaces.py::test_discord_hermes_pma_characterizes_stale_preview_when_delivery_cleanup_fails`
  - `tests/integrations/discord/test_discord_managed_thread_delivery_adapter.py::test_discord_adapter_clears_progress_anchor_after_terminal_delivery`
  - `tests/test_discord_message_turn_background_failures.py::test_terminal_delivery_retire_progress_anchor_when_preview_delete_fails`
  - `tests/integrations/discord/test_service_routing.py::test_discord_message_turns_delete_immediate_placeholder_when_background_turn_exits_early`
