### PR TITLE
[codex] Fix orchestration restart recovery and retry jitter

### DIFF
--- a/src/codex_autorunner/core/hub_control_plane/handshake_startup.py
+++ b/src/codex_autorunner/core/hub_control_plane/handshake_startup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
 import time
 from typing import Optional, Tuple
 
@@ -14,6 +15,18 @@ from .models import (
     HandshakeRequest,
     evaluate_handshake_compatibility,
 )
+
+_STARTUP_RETRY_JITTER_RATIO = 0.1
+
+
+def _jittered_retry_delay(delay_seconds: float) -> float:
+    normalized_delay = max(delay_seconds, 0.0)
+    if normalized_delay == 0.0:
+        return 0.0
+    jitter = normalized_delay * _STARTUP_RETRY_JITTER_RATIO
+    if jitter <= 0.0:
+        return normalized_delay
+    return normalized_delay + random.uniform(0.0, jitter)
 
 
 async def perform_startup_hub_handshake(
@@ -87,18 +100,19 @@ async def perform_startup_hub_handshake(
                 and time.monotonic() < startup_retry_deadline
             )
             if should_retry:
+                sleep_seconds = _jittered_retry_delay(delay_seconds)
                 log_event(
                     logger,
-                    logging.WARNING,
+                    logging.INFO,
                     f"{log_event_name_prefix}.hub_control_plane.handshake_retrying",
                     hub_root=hub_root_str,
                     attempt=attempt,
-                    delay_seconds=round(delay_seconds, 2),
+                    delay_seconds=round(sleep_seconds, 2),
                     error_code=exc.code,
                     message=str(exc),
                     expected_schema_generation=expected_schema_generation,
                 )
-                await asyncio.sleep(delay_seconds)
+                await asyncio.sleep(sleep_seconds)
                 delay_seconds = min(
                     max(delay_seconds, 0.1) * 2.0,
                     retry_max_delay_seconds,

--- a/src/codex_autorunner/core/hub_lifecycle_routing.py
+++ b/src/codex_autorunner/core/hub_lifecycle_routing.py
@@ -116,6 +116,8 @@ class LifecycleEventRouter:
                             event, reason="dispatch_created"
                         )
         elif event.event_type in (
+            LifecycleEventType.FLOW_STARTED,
+            LifecycleEventType.FLOW_RESUMED,
             LifecycleEventType.FLOW_PAUSED,
             LifecycleEventType.FLOW_COMPLETED,
             LifecycleEventType.FLOW_FAILED,
@@ -198,6 +200,8 @@ class LifecycleEventRouter:
     ) -> dict[str, Optional[str]]:
         data = event.data if isinstance(event.data, dict) else {}
         to_state_fallback = {
+            LifecycleEventType.FLOW_STARTED: "running",
+            LifecycleEventType.FLOW_RESUMED: "running",
             LifecycleEventType.FLOW_PAUSED: "blocked",
             LifecycleEventType.FLOW_COMPLETED: "completed",
             LifecycleEventType.FLOW_FAILED: "failed",
@@ -216,6 +220,10 @@ class LifecycleEventRouter:
         )
         if from_state is None:
             if event.event_type == LifecycleEventType.DISPATCH_CREATED:
+                from_state = "paused"
+            elif event.event_type == LifecycleEventType.FLOW_STARTED:
+                from_state = "pending"
+            elif event.event_type == LifecycleEventType.FLOW_RESUMED:
                 from_state = "paused"
             elif to_state in {"paused", "blocked", "completed", "failed", "stopped"}:
                 from_state = "running"

--- a/src/codex_autorunner/core/orchestration/recovery_lifecycle.py
+++ b/src/codex_autorunner/core/orchestration/recovery_lifecycle.py
@@ -22,8 +22,11 @@ from .models import (
     ThreadTarget,
 )
 
-LOST_BACKEND_THREAD_ERROR = "Backend thread lost after restart"
-MISSING_BACKEND_THREAD_ERROR = "Backend thread missing from orchestration state"
+LOST_BACKEND_THREAD_ERROR = "Running execution could not be reattached after restart"
+MISSING_BACKEND_THREAD_ERROR = (
+    "Running execution could not be reattached after restart because no backend "
+    "thread binding was persisted"
+)
 logger = logging.getLogger(__name__)
 
 
@@ -362,20 +365,29 @@ class _ThreadRecoveryHelper:
             self.thread_store, thread_target_id
         )
         backend_thread_id = (
-            runtime_binding.backend_thread_id if runtime_binding is not None else None
+            runtime_binding.backend_thread_id
+            if runtime_binding is not None and runtime_binding.backend_thread_id
+            else (
+                thread.backend_thread_id.strip()
+                if isinstance(thread.backend_thread_id, str)
+                and thread.backend_thread_id.strip()
+                else None
+            )
         )
         return self.recover_lost_backend_execution(
             thread_target_id=thread_target_id,
             execution=execution,
             backend_thread_id=backend_thread_id,
-            error_message=(
-                LOST_BACKEND_THREAD_ERROR
-                if backend_thread_id
-                else MISSING_BACKEND_THREAD_ERROR
-            ),
+            error_message=LOST_BACKEND_THREAD_ERROR,
             reason=(
                 "startup_lost_backend_binding"
-                if backend_thread_id
+                if (
+                    backend_thread_id
+                    or (
+                        isinstance(execution.backend_id, str)
+                        and execution.backend_id.strip()
+                    )
+                )
                 else "startup_missing_backend_thread_id"
             ),
         )

--- a/src/codex_autorunner/core/retry.py
+++ b/src/codex_autorunner/core/retry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import random
 from functools import wraps
 from typing import Any, Callable, Coroutine, TypeVar, cast
 
@@ -8,7 +9,6 @@ from tenacity import (
     before_sleep_log,
     retry_if_exception_type,
     stop_after_attempt,
-    wait_exponential,
 )
 from tenacity import (
     retry as tenacity_retry,
@@ -17,6 +17,45 @@ from tenacity import (
 from .exceptions import TransientError
 
 T = TypeVar("T")
+
+
+def _compute_exponential_retry_delay(
+    *,
+    attempt_number: int,
+    base_wait: float,
+    max_wait: float,
+    jitter: float,
+) -> float:
+    resolved_max_wait: float = max_wait if max_wait > 0.0 else 0.0
+    resolved_base_wait: float = base_wait if base_wait > 0.0 else 0.0
+    base_delay: float = min(
+        resolved_base_wait * (2 ** max(attempt_number - 1, 0)),
+        resolved_max_wait,
+    )
+    if base_delay <= 0.0 or jitter <= 0.0:
+        return base_delay
+    jittered_ceiling: float = min(base_delay * (1.0 + jitter), resolved_max_wait)
+    if jittered_ceiling <= base_delay:
+        return base_delay
+    return float(random.uniform(base_delay, jittered_ceiling))
+
+
+def _build_wait_strategy(
+    *,
+    base_wait: float,
+    max_wait: float,
+    jitter: float,
+) -> Callable[[Any], float]:
+    def _wait(retry_state: Any) -> float:
+        attempt_number = int(getattr(retry_state, "attempt_number", 1) or 1)
+        return _compute_exponential_retry_delay(
+            attempt_number=attempt_number,
+            base_wait=base_wait,
+            max_wait=max_wait,
+            jitter=jitter,
+        )
+
+    return _wait
 
 
 def retry_transient(
@@ -48,7 +87,11 @@ def retry_transient(
         @wraps(func)
         @tenacity_retry(
             stop=stop_after_attempt(max_attempts),
-            wait=wait_exponential(multiplier=base_wait, max=max_wait, exp_base=2),
+            wait=_build_wait_strategy(
+                base_wait=base_wait,
+                max_wait=max_wait,
+                jitter=jitter,
+            ),
             retry=retry_if_exception_type(TransientError),
             before_sleep=before_sleep_log(logger, logging.WARNING),
             reraise=True,

--- a/src/codex_autorunner/integrations/app_server/client.py
+++ b/src/codex_autorunner/integrations/app_server/client.py
@@ -1508,6 +1508,22 @@ class CodexAppServerClient:
         if self._restart_task is not None and not self._restart_task.done():
             return
         self._restart_task = asyncio.create_task(self._restart_after_disconnect())
+        self._restart_task.add_done_callback(self._log_restart_task_result)
+
+    def _log_restart_task_result(self, task: asyncio.Future[Any]) -> None:
+        if task.cancelled():
+            return
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:
+            log_event(
+                self._logger,
+                logging.ERROR,
+                "app_server.restart.task_failed",
+                exc=exc,
+            )
 
     @retry_transient(max_attempts=10, base_wait=0.5, max_wait=30.0)
     async def _restart_after_disconnect(self) -> None:

--- a/src/codex_autorunner/integrations/discord/progress_lease_state.py
+++ b/src/codex_autorunner/integrations/discord/progress_lease_state.py
@@ -1,0 +1,314 @@
+"""State and task-context helpers for Discord progress lease workflows."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Optional, cast
+
+
+@dataclass(frozen=True)
+class _DiscordProgressReuseRequest:
+    source_message_id: str
+    acknowledgement: str
+
+
+@dataclass(frozen=True)
+class _DiscordReusableProgressMessage:
+    source_message_id: str
+    channel_id: str
+    message_id: str
+
+
+@dataclass
+class _DiscordOrchestrationState:
+    progress_reuse_requests: dict[str, _DiscordProgressReuseRequest]
+    reusable_progress_messages: dict[str, _DiscordReusableProgressMessage]
+    thread_queue_tasks: dict[str, asyncio.Task[Any]]
+
+
+@dataclass
+class _DiscordTurnExecutionSupervision:
+    service: Any
+    channel_id: str
+    task_context: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self._set_text_field("channel_id", self.channel_id)
+
+    def _set_text_field(self, key: str, value: Optional[str]) -> None:
+        normalized = str(value or "").strip()
+        if normalized:
+            self.task_context[key] = normalized
+            return
+        self.task_context.pop(key, None)
+
+    def _set_bool_field(self, key: str, value: bool) -> None:
+        if value:
+            self.task_context[key] = True
+            return
+        self.task_context.pop(key, None)
+
+    def bind_task(self, task: asyncio.Task[Any]) -> asyncio.Task[Any]:
+        cast(Any, task)._discord_progress_task_context = self.task_context
+        return task
+
+    def set_managed_thread_id(self, managed_thread_id: Optional[str]) -> None:
+        self._set_text_field("managed_thread_id", managed_thread_id)
+
+    def set_execution_id(self, execution_id: Optional[str]) -> None:
+        self._set_text_field("execution_id", execution_id)
+
+    def set_lease_id(self, lease_id: Optional[str]) -> None:
+        self._set_text_field("lease_id", lease_id)
+
+    def set_message_id(self, message_id: Optional[str]) -> None:
+        self._set_text_field("message_id", message_id)
+
+    def set_failure_note(self, failure_note: Optional[str]) -> None:
+        self._set_text_field("failure_note", failure_note)
+
+    def set_shutdown_note(self, shutdown_note: Optional[str]) -> None:
+        self._set_text_field("shutdown_note", shutdown_note)
+
+    def set_orphaned(self, orphaned: bool) -> None:
+        self._set_bool_field("orphaned", orphaned)
+
+    def clear_progress_tracking(self, *, keep_execution_id: bool = True) -> None:
+        self.task_context.pop("lease_id", None)
+        self.task_context.pop("message_id", None)
+        if not keep_execution_id:
+            self.task_context.pop("execution_id", None)
+
+    async def reconcile_failure(
+        self,
+        *,
+        failure_note: Optional[str] = None,
+        allow_channel_fallback: bool = True,
+    ) -> int:
+        context = dict(self.task_context)
+        if isinstance(failure_note, str) and failure_note.strip():
+            context["failure_note"] = failure_note.strip()
+        reconciler = getattr(self.service, "_reconcile_background_task_failure", None)
+        if not callable(reconciler):
+            return 0
+        return int(
+            await reconciler(
+                context,
+                allow_channel_fallback=allow_channel_fallback,
+            )
+            or 0
+        )
+
+
+def _discord_orchestration_state(service: Any) -> _DiscordOrchestrationState:
+    requests = getattr(service, "_discord_turn_progress_reuse_requests", None)
+    if not isinstance(requests, dict):
+        requests = {}
+        service._discord_turn_progress_reuse_requests = requests
+    messages = getattr(service, "_discord_reusable_progress_messages", None)
+    if not isinstance(messages, dict):
+        messages = {}
+        service._discord_reusable_progress_messages = messages
+    task_map = getattr(service, "_discord_thread_queue_tasks", None)
+    if not isinstance(task_map, dict):
+        task_map = {}
+        service._discord_thread_queue_tasks = task_map
+        service._discord_managed_thread_queue_tasks = task_map
+    return _DiscordOrchestrationState(
+        progress_reuse_requests=requests,
+        reusable_progress_messages=messages,
+        thread_queue_tasks=task_map,
+    )
+
+
+def _get_discord_progress_reuse_requests(
+    service: Any,
+) -> dict[str, _DiscordProgressReuseRequest]:
+    return _discord_orchestration_state(service).progress_reuse_requests
+
+
+def _get_discord_reusable_progress_messages(
+    service: Any,
+) -> dict[str, _DiscordReusableProgressMessage]:
+    return _discord_orchestration_state(service).reusable_progress_messages
+
+
+def request_discord_turn_progress_reuse(
+    service: Any,
+    *,
+    thread_target_id: str,
+    source_message_id: str,
+    acknowledgement: str,
+) -> None:
+    normalized_thread_target_id = str(thread_target_id or "").strip()
+    normalized_source_message_id = str(source_message_id or "").strip()
+    normalized_acknowledgement = str(acknowledgement or "").strip()
+    if (
+        not normalized_thread_target_id
+        or not normalized_source_message_id
+        or not normalized_acknowledgement
+    ):
+        return
+    _get_discord_progress_reuse_requests(service)[normalized_thread_target_id] = (
+        _DiscordProgressReuseRequest(
+            source_message_id=normalized_source_message_id,
+            acknowledgement=normalized_acknowledgement,
+        )
+    )
+
+
+def clear_discord_turn_progress_reuse(
+    service: Any,
+    *,
+    thread_target_id: str,
+) -> None:
+    normalized_thread_target_id = str(thread_target_id or "").strip()
+    if not normalized_thread_target_id:
+        return
+    _get_discord_progress_reuse_requests(service).pop(normalized_thread_target_id, None)
+    _get_discord_reusable_progress_messages(service).pop(
+        normalized_thread_target_id, None
+    )
+
+
+def _peek_discord_progress_reuse_request(
+    service: Any,
+    *,
+    thread_target_id: str,
+) -> Optional[_DiscordProgressReuseRequest]:
+    normalized_thread_target_id = str(thread_target_id or "").strip()
+    if not normalized_thread_target_id:
+        return None
+    request = _get_discord_progress_reuse_requests(service).get(
+        normalized_thread_target_id
+    )
+    if isinstance(request, _DiscordProgressReuseRequest):
+        return request
+    return None
+
+
+def _stash_discord_reusable_progress_message(
+    service: Any,
+    *,
+    thread_target_id: str,
+    source_message_id: str,
+    channel_id: str,
+    message_id: str,
+) -> None:
+    normalized_thread_target_id = str(thread_target_id or "").strip()
+    normalized_source_message_id = str(source_message_id or "").strip()
+    normalized_channel_id = str(channel_id or "").strip()
+    normalized_message_id = str(message_id or "").strip()
+    if (
+        not normalized_thread_target_id
+        or not normalized_source_message_id
+        or not normalized_channel_id
+        or not normalized_message_id
+    ):
+        return
+    _get_discord_reusable_progress_messages(service)[normalized_thread_target_id] = (
+        _DiscordReusableProgressMessage(
+            source_message_id=normalized_source_message_id,
+            channel_id=normalized_channel_id,
+            message_id=normalized_message_id,
+        )
+    )
+
+
+def _claim_discord_reusable_progress_message(
+    service: Any,
+    *,
+    thread_target_id: str,
+    source_message_id: Optional[str],
+) -> Optional[str]:
+    normalized_thread_target_id = str(thread_target_id or "").strip()
+    normalized_source_message_id = str(source_message_id or "").strip()
+    if not normalized_thread_target_id or not normalized_source_message_id:
+        return None
+    requests = _get_discord_progress_reuse_requests(service)
+    request = requests.get(normalized_thread_target_id)
+    if isinstance(request, _DiscordProgressReuseRequest):
+        if request.source_message_id != normalized_source_message_id:
+            return None
+        requests.pop(normalized_thread_target_id, None)
+    reusable = _get_discord_reusable_progress_messages(service).pop(
+        normalized_thread_target_id, None
+    )
+    if (
+        isinstance(reusable, _DiscordReusableProgressMessage)
+        and reusable.source_message_id == normalized_source_message_id
+    ):
+        return reusable.message_id
+    return None
+
+
+def _execution_field(record: Any, field: str) -> Optional[str]:
+    if isinstance(record, dict):
+        value = record.get(field)
+    else:
+        value = getattr(record, field, None)
+    normalized = str(value or "").strip()
+    return normalized or None
+
+
+def _progress_task_context(
+    *,
+    managed_thread_id: Optional[str] = None,
+    execution_id: Optional[str] = None,
+    lease_id: Optional[str] = None,
+    channel_id: Optional[str] = None,
+    message_id: Optional[str] = None,
+    failure_note: Optional[str] = None,
+    shutdown_note: Optional[str] = None,
+    orphaned: bool = False,
+) -> dict[str, Any]:
+    context: dict[str, Any] = {}
+    if isinstance(managed_thread_id, str) and managed_thread_id.strip():
+        context["managed_thread_id"] = managed_thread_id.strip()
+    if isinstance(execution_id, str) and execution_id.strip():
+        context["execution_id"] = execution_id.strip()
+    if isinstance(lease_id, str) and lease_id.strip():
+        context["lease_id"] = lease_id.strip()
+    if isinstance(channel_id, str) and channel_id.strip():
+        context["channel_id"] = channel_id.strip()
+    if isinstance(message_id, str) and message_id.strip():
+        context["message_id"] = message_id.strip()
+    if isinstance(failure_note, str) and failure_note.strip():
+        context["failure_note"] = failure_note.strip()
+    if isinstance(shutdown_note, str) and shutdown_note.strip():
+        context["shutdown_note"] = shutdown_note.strip()
+    if orphaned:
+        context["orphaned"] = True
+    return context
+
+
+def bind_discord_progress_task_context(
+    task: asyncio.Task[Any],
+    *,
+    managed_thread_id: Optional[str] = None,
+    execution_id: Optional[str] = None,
+    lease_id: Optional[str] = None,
+    channel_id: Optional[str] = None,
+    message_id: Optional[str] = None,
+    failure_note: Optional[str] = None,
+    shutdown_note: Optional[str] = None,
+    orphaned: bool = False,
+) -> asyncio.Task[Any]:
+    context = _progress_task_context(
+        managed_thread_id=managed_thread_id,
+        execution_id=execution_id,
+        lease_id=lease_id,
+        channel_id=channel_id,
+        message_id=message_id,
+        failure_note=failure_note,
+        shutdown_note=shutdown_note,
+        orphaned=orphaned,
+    )
+    if context:
+        cast(Any, task)._discord_progress_task_context = context
+    return task
+
+
+def _get_discord_thread_queue_task_map(service: Any) -> dict[str, asyncio.Task[Any]]:
+    return _discord_orchestration_state(service).thread_queue_tasks

--- a/src/codex_autorunner/integrations/discord/progress_leases.py
+++ b/src/codex_autorunner/integrations/discord/progress_leases.py
@@ -34,9 +34,13 @@ _claim_discord_reusable_progress_message = (
 _DiscordOrchestrationState = _progress_lease_state._DiscordOrchestrationState
 _DiscordProgressReuseRequest = _progress_lease_state._DiscordProgressReuseRequest
 _DiscordReusableProgressMessage = _progress_lease_state._DiscordReusableProgressMessage
-_DiscordTurnExecutionSupervision = _progress_lease_state._DiscordTurnExecutionSupervision
+_DiscordTurnExecutionSupervision = (
+    _progress_lease_state._DiscordTurnExecutionSupervision
+)
 _execution_field = _progress_lease_state._execution_field
-_get_discord_thread_queue_task_map = _progress_lease_state._get_discord_thread_queue_task_map
+_get_discord_thread_queue_task_map = (
+    _progress_lease_state._get_discord_thread_queue_task_map
+)
 _peek_discord_progress_reuse_request = (
     _progress_lease_state._peek_discord_progress_reuse_request
 )

--- a/src/codex_autorunner/integrations/discord/progress_leases.py
+++ b/src/codex_autorunner/integrations/discord/progress_leases.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from dataclasses import dataclass, field
 from typing import Any, Awaitable, Optional, cast
 
 from ...core.ports.run_event import TokenUsage
@@ -18,6 +17,7 @@ from ..chat.managed_thread_progress_projector import (
     ManagedThreadProgressProjector,
 )
 from ..chat.turn_metrics import _extract_context_usage_percent
+from . import progress_lease_state as _progress_lease_state
 from .errors import (
     DiscordPermanentError,
     DiscordTransientError,
@@ -28,6 +28,32 @@ from .rendering import (
     truncate_for_discord,
 )
 
+_claim_discord_reusable_progress_message = (
+    _progress_lease_state._claim_discord_reusable_progress_message
+)
+_DiscordOrchestrationState = _progress_lease_state._DiscordOrchestrationState
+_DiscordProgressReuseRequest = _progress_lease_state._DiscordProgressReuseRequest
+_DiscordReusableProgressMessage = _progress_lease_state._DiscordReusableProgressMessage
+_DiscordTurnExecutionSupervision = _progress_lease_state._DiscordTurnExecutionSupervision
+_execution_field = _progress_lease_state._execution_field
+_get_discord_thread_queue_task_map = _progress_lease_state._get_discord_thread_queue_task_map
+_peek_discord_progress_reuse_request = (
+    _progress_lease_state._peek_discord_progress_reuse_request
+)
+_progress_task_context = _progress_lease_state._progress_task_context
+_stash_discord_reusable_progress_message = (
+    _progress_lease_state._stash_discord_reusable_progress_message
+)
+bind_discord_progress_task_context = (
+    _progress_lease_state.bind_discord_progress_task_context
+)
+clear_discord_turn_progress_reuse = (
+    _progress_lease_state.clear_discord_turn_progress_reuse
+)
+request_discord_turn_progress_reuse = (
+    _progress_lease_state.request_discord_turn_progress_reuse
+)
+
 _logger = logging.getLogger(__name__)
 
 _DISCORD_PROGRESS_LIVE_STATES = frozenset({"pending", "active"})
@@ -36,309 +62,6 @@ _DISCORD_PROGRESS_RECONCILABLE_STATES = frozenset({"pending", "active", "retirin
 
 class DiscordTurnStartupFailure(RuntimeError):
     """Raised after a Discord turn startup failure has been surfaced to the user."""
-
-
-@dataclass(frozen=True)
-class _DiscordProgressReuseRequest:
-    source_message_id: str
-    acknowledgement: str
-
-
-@dataclass(frozen=True)
-class _DiscordReusableProgressMessage:
-    source_message_id: str
-    channel_id: str
-    message_id: str
-
-
-@dataclass
-class _DiscordOrchestrationState:
-    progress_reuse_requests: dict[str, _DiscordProgressReuseRequest]
-    reusable_progress_messages: dict[str, _DiscordReusableProgressMessage]
-    thread_queue_tasks: dict[str, asyncio.Task[Any]]
-
-
-@dataclass
-class _DiscordTurnExecutionSupervision:
-    service: Any
-    channel_id: str
-    task_context: dict[str, Any] = field(default_factory=dict)
-
-    def __post_init__(self) -> None:
-        self._set_text_field("channel_id", self.channel_id)
-
-    def _set_text_field(self, key: str, value: Optional[str]) -> None:
-        normalized = str(value or "").strip()
-        if normalized:
-            self.task_context[key] = normalized
-            return
-        self.task_context.pop(key, None)
-
-    def _set_bool_field(self, key: str, value: bool) -> None:
-        if value:
-            self.task_context[key] = True
-            return
-        self.task_context.pop(key, None)
-
-    def bind_task(self, task: asyncio.Task[Any]) -> asyncio.Task[Any]:
-        cast(Any, task)._discord_progress_task_context = self.task_context
-        return task
-
-    def set_managed_thread_id(self, managed_thread_id: Optional[str]) -> None:
-        self._set_text_field("managed_thread_id", managed_thread_id)
-
-    def set_execution_id(self, execution_id: Optional[str]) -> None:
-        self._set_text_field("execution_id", execution_id)
-
-    def set_lease_id(self, lease_id: Optional[str]) -> None:
-        self._set_text_field("lease_id", lease_id)
-
-    def set_message_id(self, message_id: Optional[str]) -> None:
-        self._set_text_field("message_id", message_id)
-
-    def set_failure_note(self, failure_note: Optional[str]) -> None:
-        self._set_text_field("failure_note", failure_note)
-
-    def set_shutdown_note(self, shutdown_note: Optional[str]) -> None:
-        self._set_text_field("shutdown_note", shutdown_note)
-
-    def set_orphaned(self, orphaned: bool) -> None:
-        self._set_bool_field("orphaned", orphaned)
-
-    def clear_progress_tracking(self, *, keep_execution_id: bool = True) -> None:
-        self.task_context.pop("lease_id", None)
-        self.task_context.pop("message_id", None)
-        if not keep_execution_id:
-            self.task_context.pop("execution_id", None)
-
-    async def reconcile_failure(
-        self,
-        *,
-        failure_note: Optional[str] = None,
-        allow_channel_fallback: bool = True,
-    ) -> int:
-        context = dict(self.task_context)
-        if isinstance(failure_note, str) and failure_note.strip():
-            context["failure_note"] = failure_note.strip()
-        reconciler = getattr(self.service, "_reconcile_background_task_failure", None)
-        if not callable(reconciler):
-            return 0
-        return int(
-            await reconciler(
-                context,
-                allow_channel_fallback=allow_channel_fallback,
-            )
-            or 0
-        )
-
-
-def _discord_orchestration_state(service: Any) -> _DiscordOrchestrationState:
-    requests = getattr(service, "_discord_turn_progress_reuse_requests", None)
-    if not isinstance(requests, dict):
-        requests = {}
-        service._discord_turn_progress_reuse_requests = requests
-    messages = getattr(service, "_discord_reusable_progress_messages", None)
-    if not isinstance(messages, dict):
-        messages = {}
-        service._discord_reusable_progress_messages = messages
-    task_map = getattr(service, "_discord_thread_queue_tasks", None)
-    if not isinstance(task_map, dict):
-        task_map = {}
-        service._discord_thread_queue_tasks = task_map
-        service._discord_managed_thread_queue_tasks = task_map
-    return _DiscordOrchestrationState(
-        progress_reuse_requests=requests,
-        reusable_progress_messages=messages,
-        thread_queue_tasks=task_map,
-    )
-
-
-def _get_discord_progress_reuse_requests(
-    service: Any,
-) -> dict[str, _DiscordProgressReuseRequest]:
-    return _discord_orchestration_state(service).progress_reuse_requests
-
-
-def _get_discord_reusable_progress_messages(
-    service: Any,
-) -> dict[str, _DiscordReusableProgressMessage]:
-    return _discord_orchestration_state(service).reusable_progress_messages
-
-
-def request_discord_turn_progress_reuse(
-    service: Any,
-    *,
-    thread_target_id: str,
-    source_message_id: str,
-    acknowledgement: str,
-) -> None:
-    normalized_thread_target_id = str(thread_target_id or "").strip()
-    normalized_source_message_id = str(source_message_id or "").strip()
-    normalized_acknowledgement = str(acknowledgement or "").strip()
-    if (
-        not normalized_thread_target_id
-        or not normalized_source_message_id
-        or not normalized_acknowledgement
-    ):
-        return
-    _get_discord_progress_reuse_requests(service)[normalized_thread_target_id] = (
-        _DiscordProgressReuseRequest(
-            source_message_id=normalized_source_message_id,
-            acknowledgement=normalized_acknowledgement,
-        )
-    )
-
-
-def clear_discord_turn_progress_reuse(
-    service: Any,
-    *,
-    thread_target_id: str,
-) -> None:
-    normalized_thread_target_id = str(thread_target_id or "").strip()
-    if not normalized_thread_target_id:
-        return
-    _get_discord_progress_reuse_requests(service).pop(normalized_thread_target_id, None)
-    _get_discord_reusable_progress_messages(service).pop(
-        normalized_thread_target_id, None
-    )
-
-
-def _peek_discord_progress_reuse_request(
-    service: Any,
-    *,
-    thread_target_id: str,
-) -> Optional[_DiscordProgressReuseRequest]:
-    normalized_thread_target_id = str(thread_target_id or "").strip()
-    if not normalized_thread_target_id:
-        return None
-    request = _get_discord_progress_reuse_requests(service).get(
-        normalized_thread_target_id
-    )
-    if isinstance(request, _DiscordProgressReuseRequest):
-        return request
-    return None
-
-
-def _stash_discord_reusable_progress_message(
-    service: Any,
-    *,
-    thread_target_id: str,
-    source_message_id: str,
-    channel_id: str,
-    message_id: str,
-) -> None:
-    normalized_thread_target_id = str(thread_target_id or "").strip()
-    normalized_source_message_id = str(source_message_id or "").strip()
-    normalized_channel_id = str(channel_id or "").strip()
-    normalized_message_id = str(message_id or "").strip()
-    if (
-        not normalized_thread_target_id
-        or not normalized_source_message_id
-        or not normalized_channel_id
-        or not normalized_message_id
-    ):
-        return
-    _get_discord_reusable_progress_messages(service)[normalized_thread_target_id] = (
-        _DiscordReusableProgressMessage(
-            source_message_id=normalized_source_message_id,
-            channel_id=normalized_channel_id,
-            message_id=normalized_message_id,
-        )
-    )
-
-
-def _claim_discord_reusable_progress_message(
-    service: Any,
-    *,
-    thread_target_id: str,
-    source_message_id: Optional[str],
-) -> Optional[str]:
-    normalized_thread_target_id = str(thread_target_id or "").strip()
-    normalized_source_message_id = str(source_message_id or "").strip()
-    if not normalized_thread_target_id or not normalized_source_message_id:
-        return None
-    requests = _get_discord_progress_reuse_requests(service)
-    request = requests.get(normalized_thread_target_id)
-    if isinstance(request, _DiscordProgressReuseRequest):
-        if request.source_message_id != normalized_source_message_id:
-            return None
-        requests.pop(normalized_thread_target_id, None)
-    reusable = _get_discord_reusable_progress_messages(service).pop(
-        normalized_thread_target_id, None
-    )
-    if (
-        isinstance(reusable, _DiscordReusableProgressMessage)
-        and reusable.source_message_id == normalized_source_message_id
-    ):
-        return reusable.message_id
-    return None
-
-
-def _execution_field(record: Any, field: str) -> Optional[str]:
-    if isinstance(record, dict):
-        value = record.get(field)
-    else:
-        value = getattr(record, field, None)
-    normalized = str(value or "").strip()
-    return normalized or None
-
-
-def _progress_task_context(
-    *,
-    managed_thread_id: Optional[str] = None,
-    execution_id: Optional[str] = None,
-    lease_id: Optional[str] = None,
-    channel_id: Optional[str] = None,
-    message_id: Optional[str] = None,
-    failure_note: Optional[str] = None,
-    shutdown_note: Optional[str] = None,
-    orphaned: bool = False,
-) -> dict[str, Any]:
-    context: dict[str, Any] = {}
-    if isinstance(managed_thread_id, str) and managed_thread_id.strip():
-        context["managed_thread_id"] = managed_thread_id.strip()
-    if isinstance(execution_id, str) and execution_id.strip():
-        context["execution_id"] = execution_id.strip()
-    if isinstance(lease_id, str) and lease_id.strip():
-        context["lease_id"] = lease_id.strip()
-    if isinstance(channel_id, str) and channel_id.strip():
-        context["channel_id"] = channel_id.strip()
-    if isinstance(message_id, str) and message_id.strip():
-        context["message_id"] = message_id.strip()
-    if isinstance(failure_note, str) and failure_note.strip():
-        context["failure_note"] = failure_note.strip()
-    if isinstance(shutdown_note, str) and shutdown_note.strip():
-        context["shutdown_note"] = shutdown_note.strip()
-    if orphaned:
-        context["orphaned"] = True
-    return context
-
-
-def bind_discord_progress_task_context(
-    task: asyncio.Task[Any],
-    *,
-    managed_thread_id: Optional[str] = None,
-    execution_id: Optional[str] = None,
-    lease_id: Optional[str] = None,
-    channel_id: Optional[str] = None,
-    message_id: Optional[str] = None,
-    failure_note: Optional[str] = None,
-    shutdown_note: Optional[str] = None,
-    orphaned: bool = False,
-) -> asyncio.Task[Any]:
-    context = _progress_task_context(
-        managed_thread_id=managed_thread_id,
-        execution_id=execution_id,
-        lease_id=lease_id,
-        channel_id=channel_id,
-        message_id=message_id,
-        failure_note=failure_note,
-        shutdown_note=shutdown_note,
-        orphaned=orphaned,
-    )
-    if context:
-        cast(Any, task)._discord_progress_task_context = context
-    return task
 
 
 async def _upsert_discord_progress_lease(
@@ -919,7 +642,3 @@ def _spawn_discord_progress_background_task(
         failure_note=failure_note,
         orphaned=orphaned,
     )
-
-
-def _get_discord_thread_queue_task_map(service: Any) -> dict[str, asyncio.Task[Any]]:
-    return _discord_orchestration_state(service).thread_queue_tasks

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -1670,7 +1670,7 @@ async def test_stop_thread_marks_interrupted_when_runtime_binding_is_lost_after_
     assert outcome.execution.error is None
 
 
-async def test_recover_running_execution_after_restart_marks_missing_backend_binding(
+async def test_recover_running_execution_after_restart_marks_restart_reattach_failure(
     tmp_path: Path,
 ) -> None:
     harness = _FakeHarness()
@@ -1696,7 +1696,40 @@ async def test_recover_running_execution_after_restart_marks_missing_backend_bin
     assert recovered is not None
     assert recovered.execution_id == execution.execution_id
     assert recovered.status == "error"
-    assert recovered.error == "Backend thread missing from orchestration state"
+    assert recovered.error == "Running execution could not be reattached after restart"
+    assert _thread_runtime_binding(restarted_service, thread.thread_target_id) is None
+    assert restarted_service.get_running_execution(thread.thread_target_id) is None
+
+
+async def test_recover_running_execution_after_restart_without_binding_stays_restart_specific(
+    tmp_path: Path,
+) -> None:
+    harness = _FakeHarness()
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target("codex", workspace_root)
+    execution = await service.send_message(
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="Need an answer",
+        )
+    )
+
+    clear_runtime_thread_binding(tmp_path / "hub", thread.thread_target_id)
+    service.thread_store.set_thread_backend_id(thread.thread_target_id, None)
+    service.thread_store.set_execution_backend_id(execution.execution_id, None)
+    restarted_service = _build_service(tmp_path, harness)
+
+    recovered = restarted_service.recover_running_execution_after_restart(
+        thread.thread_target_id
+    )
+
+    assert recovered is not None
+    assert recovered.execution_id == execution.execution_id
+    assert recovered.status == "error"
+    assert recovered.error == "Running execution could not be reattached after restart"
     assert _thread_runtime_binding(restarted_service, thread.thread_target_id) is None
     assert restarted_service.get_running_execution(thread.thread_target_id) is None
 

--- a/tests/core/test_hub_control_plane_handshake_startup.py
+++ b/tests/core/test_hub_control_plane_handshake_startup.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from codex_autorunner.core.hub_control_plane.errors import HubControlPlaneError
+from codex_autorunner.core.hub_control_plane.handshake_startup import (
+    perform_startup_hub_handshake,
+)
+from codex_autorunner.core.orchestration import ORCHESTRATION_SCHEMA_VERSION
+
+
+@pytest.mark.anyio
+async def test_startup_handshake_retries_with_jittered_info_logging(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    attempts = 0
+    slept: list[float] = []
+
+    class _FlakyHubClient:
+        async def handshake(self, request: Any) -> Any:
+            nonlocal attempts
+            _ = request
+            attempts += 1
+            if attempts == 1:
+                raise HubControlPlaneError(
+                    "transport_failure",
+                    "temporary startup transport failure",
+                    retryable=True,
+                )
+            return SimpleNamespace(
+                api_version="1.0.0",
+                minimum_client_api_version="1.0.0",
+                schema_generation=ORCHESTRATION_SCHEMA_VERSION,
+                capabilities=("compatibility_handshake",),
+                hub_build_version=None,
+                hub_asset_version=None,
+            )
+
+    async def _fake_sleep(delay: float) -> None:
+        slept.append(delay)
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.hub_control_plane.handshake_startup.random.uniform",
+        lambda start, end: end,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.hub_control_plane.handshake_startup.asyncio.sleep",
+        _fake_sleep,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.hub_control_plane.handshake_startup.time.monotonic",
+        lambda: 0.0,
+    )
+
+    logger = logging.getLogger("test.handshake_startup.retry")
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        ok, compatibility = await perform_startup_hub_handshake(
+            hub_client=_FlakyHubClient(),
+            log_event_name_prefix="test",
+            handshake_client_name="test-client",
+            hub_root_str="/tmp/hub",
+            startup_monotonic=0.0,
+            retry_window_seconds=1.0,
+            retry_delay_seconds=0.5,
+            retry_max_delay_seconds=2.0,
+            client_api_version="1.0.0",
+            logger=logger,
+        )
+
+    assert ok is True
+    assert compatibility is not None
+    assert slept == [0.55]
+    assert any(
+        '"event":"test.hub_control_plane.handshake_retrying"' in record.message
+        and record.levelno == logging.INFO
+        for record in caplog.records
+    )

--- a/tests/core/test_hub_lifecycle_routing.py
+++ b/tests/core/test_hub_lifecycle_routing.py
@@ -204,7 +204,7 @@ def test_route_event_flow_stopped_enqueues_pma(tmp_path: Path) -> None:
     assert event.event_id in store.marked_processed_ids
 
 
-def test_route_event_unhandled_type_not_processed(tmp_path: Path) -> None:
+def test_route_event_flow_started_enqueues_pma(tmp_path: Path) -> None:
     router, store = _make_router(tmp_path)
     event = LifecycleEvent(
         event_type=LifecycleEventType.FLOW_STARTED,
@@ -212,7 +212,44 @@ def test_route_event_unhandled_type_not_processed(tmp_path: Path) -> None:
         run_id="run-1",
     )
     router.route_event(event)
-    assert event.event_id not in store.marked_processed_ids
+    assert event.event_id in store.marked_processed_ids
+
+
+def test_route_event_flow_resumed_enqueues_pma(tmp_path: Path) -> None:
+    router, store = _make_router(tmp_path)
+    event = LifecycleEvent(
+        event_type=LifecycleEventType.FLOW_RESUMED,
+        repo_id="repo-1",
+        run_id="run-1",
+    )
+    router.route_event(event)
+    assert event.event_id in store.marked_processed_ids
+
+
+def test_build_transition_payload_defaults_for_flow_started_and_resumed(
+    tmp_path: Path,
+) -> None:
+    router, _ = _make_router(tmp_path)
+
+    started_payload = router._build_transition_payload(
+        LifecycleEvent(
+            event_type=LifecycleEventType.FLOW_STARTED,
+            repo_id="repo-1",
+            run_id="run-1",
+        )
+    )
+    resumed_payload = router._build_transition_payload(
+        LifecycleEvent(
+            event_type=LifecycleEventType.FLOW_RESUMED,
+            repo_id="repo-1",
+            run_id="run-1",
+        )
+    )
+
+    assert started_payload["from_state"] == "pending"
+    assert started_payload["to_state"] == "running"
+    assert resumed_payload["from_state"] == "paused"
+    assert resumed_payload["to_state"] == "running"
 
 
 def test_check_reactive_gate_returns_allowed_by_default(tmp_path: Path) -> None:

--- a/tests/core/test_retry.py
+++ b/tests/core/test_retry.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from codex_autorunner.core.retry import _compute_exponential_retry_delay
+
+
+def test_compute_exponential_retry_delay_applies_jitter_within_cap(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "codex_autorunner.core.retry.random.uniform",
+        lambda start, end: end,
+    )
+
+    delay = _compute_exponential_retry_delay(
+        attempt_number=2,
+        base_wait=1.0,
+        max_wait=10.0,
+        jitter=0.25,
+    )
+
+    assert delay == 2.5
+
+
+def test_compute_exponential_retry_delay_respects_max_wait_cap(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "codex_autorunner.core.retry.random.uniform",
+        lambda start, end: end,
+    )
+
+    delay = _compute_exponential_retry_delay(
+        attempt_number=10,
+        base_wait=1.0,
+        max_wait=10.0,
+        jitter=0.5,
+    )
+
+    assert delay == 10.0

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
@@ -100,7 +100,10 @@ async def test_recover_orphaned_managed_thread_executions_unblocks_restart_queue
     updated_queued = store.get_turn(managed_thread_id, queued["managed_turn_id"])
     assert updated_running is not None
     assert updated_running["status"] == "error"
-    assert updated_running["error"] == "Backend thread missing from orchestration state"
+    assert (
+        updated_running["error"]
+        == "Running execution could not be reattached after restart"
+    )
     assert updated_queued is not None
     assert updated_queued["status"] == "queued"
 
@@ -280,7 +283,10 @@ async def test_recover_orphaned_managed_thread_executions_recovers_pma_runs_on_c
     updated_queued = store.get_turn(managed_thread_id, queued["managed_turn_id"])
     assert updated_running is not None
     assert updated_running["status"] == "error"
-    assert updated_running["error"] == "Backend thread missing from orchestration state"
+    assert (
+        updated_running["error"]
+        == "Running execution could not be reattached after restart"
+    )
     assert updated_queued is not None
     assert updated_queued["status"] == "queued"
 

--- a/tests/test_app_server_client.py
+++ b/tests/test_app_server_client.py
@@ -1,4 +1,6 @@
 import asyncio
+import json
+import logging
 import sys
 import time
 from pathlib import Path
@@ -129,6 +131,31 @@ async def test_turn_result_defaults_to_last_agent_message(tmp_path: Path) -> Non
         assert result.final_message == "final reply"
     finally:
         await client.close()
+
+
+@pytest.mark.anyio
+async def test_restart_task_failure_is_logged_and_harvested(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    logger = logging.getLogger("test.app_server.restart")
+    client = CodexAppServerClient(
+        fixture_command("basic"),
+        cwd=tmp_path,
+        logger=logger,
+    )
+    task = asyncio.get_running_loop().create_future()
+    task.set_exception(RuntimeError("restart boom"))
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        client._log_restart_task_result(task)
+
+    events = [json.loads(record.message) for record in caplog.records]
+    assert any(
+        event["event"] == "app_server.restart.task_failed"
+        and event["error"] == "restart boom"
+        and event["error_type"] == "RuntimeError"
+        for event in events
+    )
 
 
 @pytest.mark.anyio

--- a/tests/test_pma_managed_threads_interrupt.py
+++ b/tests/test_pma_managed_threads_interrupt.py
@@ -209,7 +209,10 @@ def test_interrupt_managed_thread_recovers_when_runtime_binding_is_lost_after_re
     updated_turn = store.get_turn(managed_thread_id, managed_turn_id)
     assert updated_turn is not None
     assert updated_turn["status"] == "error"
-    assert updated_turn["error"] == "Backend thread missing from orchestration state"
+    assert (
+        updated_turn["error"]
+        == "Running execution could not be reattached after restart"
+    )
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
- route `flow_started` and `flow_resumed` lifecycle events through the hub router so they are acknowledged and projected like the other flow transitions
- record restart fallout as restart-specific reattach failures, add startup-handshake jitter with lower retry log noise, implement real jitter in `retry_transient()`, and harvest app-server restart task exceptions deterministically
- add regression coverage for the lifecycle router, restart recovery, retry math, handshake retries, and app-server restart-task logging
- extract Discord progress-lease state helpers into `progress_lease_state.py` to satisfy the repo hotspot budget guard that otherwise blocks the validated commit path

## Root Cause
Issue #1539 combined four confirmed defects: lifecycle projections skipped `flow_started`/`flow_resumed`, restart recovery surfaced misleading lost-backend failures, handshake retries were synchronized and noisy, and app-server restart retries could leak unharvested task exceptions while `retry_transient()` ignored its advertised jitter parameter.

## Validation
- full repository commit hook passed, including strict mypy, full pytest, static asset build, frontend JS tests, and chat-surface deterministic checks
- focused regression runs covered lifecycle routing, handshake startup retries, retry jitter math, restart recovery, managed-thread runtime recovery, app-server restart-task logging, and Discord progress lease helpers

Closes #1539