### PR TITLE
[codex] Fix Discord progress cancellation reconciliation

### DIFF
--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -597,6 +597,7 @@ async def _submit_discord_thread_message(
         channel_id=dispatch.channel_id,
     )
     supervision.set_orphaned(True)
+    supervision.set_reconcile_on_cancel(True)
     supervision.set_failure_note(
         "Turn failed: background task terminated unexpectedly."
     )
@@ -2351,6 +2352,7 @@ async def _run_discord_orchestrated_turn_for_message(
                         "no longer live. Please retry if needed."
                     ),
                     orphaned=True,
+                    reconcile_on_cancel=True,
                     await_on_shutdown=True,
                 ),
                 begin_next_execution=cast(

--- a/src/codex_autorunner/integrations/discord/progress_lease_state.py
+++ b/src/codex_autorunner/integrations/discord/progress_lease_state.py
@@ -74,6 +74,9 @@ class _DiscordTurnExecutionSupervision:
     def set_orphaned(self, orphaned: bool) -> None:
         self._set_bool_field("orphaned", orphaned)
 
+    def set_reconcile_on_cancel(self, reconcile_on_cancel: bool) -> None:
+        self._set_bool_field("reconcile_on_cancel", reconcile_on_cancel)
+
     def clear_progress_tracking(self, *, keep_execution_id: bool = True) -> None:
         self.task_context.pop("lease_id", None)
         self.task_context.pop("message_id", None)
@@ -262,6 +265,7 @@ def _progress_task_context(
     failure_note: Optional[str] = None,
     shutdown_note: Optional[str] = None,
     orphaned: bool = False,
+    reconcile_on_cancel: bool = False,
 ) -> dict[str, Any]:
     context: dict[str, Any] = {}
     if isinstance(managed_thread_id, str) and managed_thread_id.strip():
@@ -280,6 +284,8 @@ def _progress_task_context(
         context["shutdown_note"] = shutdown_note.strip()
     if orphaned:
         context["orphaned"] = True
+    if reconcile_on_cancel:
+        context["reconcile_on_cancel"] = True
     return context
 
 
@@ -294,6 +300,7 @@ def bind_discord_progress_task_context(
     failure_note: Optional[str] = None,
     shutdown_note: Optional[str] = None,
     orphaned: bool = False,
+    reconcile_on_cancel: bool = False,
 ) -> asyncio.Task[Any]:
     context = _progress_task_context(
         managed_thread_id=managed_thread_id,
@@ -304,6 +311,7 @@ def bind_discord_progress_task_context(
         failure_note=failure_note,
         shutdown_note=shutdown_note,
         orphaned=orphaned,
+        reconcile_on_cancel=reconcile_on_cancel,
     )
     if context:
         cast(Any, task)._discord_progress_task_context = context

--- a/src/codex_autorunner/integrations/discord/progress_leases.py
+++ b/src/codex_autorunner/integrations/discord/progress_leases.py
@@ -629,6 +629,7 @@ def _spawn_discord_progress_background_task(
     message_id: Optional[str] = None,
     failure_note: Optional[str] = None,
     orphaned: bool = False,
+    reconcile_on_cancel: bool = False,
     await_on_shutdown: bool = False,
 ) -> asyncio.Task[Any]:
     task = _spawn_discord_background_task(
@@ -645,4 +646,5 @@ def _spawn_discord_progress_background_task(
         message_id=message_id,
         failure_note=failure_note,
         orphaned=orphaned,
+        reconcile_on_cancel=reconcile_on_cancel,
     )

--- a/src/codex_autorunner/integrations/discord/service_lifecycle.py
+++ b/src/codex_autorunner/integrations/discord/service_lifecycle.py
@@ -376,6 +376,8 @@ def on_background_task_done(service: Any, task: asyncio.Task[Any]) -> None:
             return
         if bool(getattr(service, "_background_shutdown_in_progress", False)):
             return
+        if not bool(task_context.get("reconcile_on_cancel")):
+            return
         log_event(
             service._logger,
             logging.WARNING,

--- a/tests/test_discord_message_turn_background_failures.py
+++ b/tests/test_discord_message_turn_background_failures.py
@@ -485,6 +485,144 @@ async def test_background_task_done_reconciles_progress_lease(
 
 
 @pytest.mark.anyio
+async def test_background_task_done_ignores_expected_progress_task_cancellation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-1",
+        managed_thread_id="thread-1",
+        execution_id="exec-1",
+        channel_id="channel-1",
+        message_id="preview-1",
+        state="active",
+        progress_label="working",
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "build_discord_thread_orchestration_service",
+        lambda _service: _FakeThreadService(execution_status="running"),
+    )
+
+    blocker = asyncio.Event()
+
+    async def _hang_forever() -> None:
+        await blocker.wait()
+
+    try:
+        task = service._spawn_task(_hang_forever())
+        bind_discord_progress_task_context(
+            task,
+            managed_thread_id="thread-1",
+            execution_id="exec-1",
+            lease_id="lease-1",
+            channel_id="channel-1",
+            message_id="preview-1",
+            failure_note="Status: this progress message lost its worker.",
+            orphaned=True,
+        )
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        while service._background_tasks:
+            await asyncio.gather(
+                *list(service._background_tasks),
+                return_exceptions=True,
+            )
+
+        assert rest.edited_channel_messages == []
+        leases = await store.list_turn_progress_leases(
+            managed_thread_id="thread-1",
+            execution_id="exec-1",
+        )
+        assert [lease.lease_id for lease in leases] == ["lease-1"]
+    finally:
+        blocker.set()
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_background_task_done_reconciles_cancel_sensitive_progress_task(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-1",
+        managed_thread_id="thread-1",
+        execution_id="exec-1",
+        channel_id="channel-1",
+        message_id="preview-1",
+        state="active",
+        progress_label="working",
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "build_discord_thread_orchestration_service",
+        lambda _service: _FakeThreadService(execution_status="running"),
+    )
+
+    blocker = asyncio.Event()
+
+    async def _hang_forever() -> None:
+        await blocker.wait()
+
+    try:
+        task = service._spawn_task(_hang_forever())
+        bind_discord_progress_task_context(
+            task,
+            managed_thread_id="thread-1",
+            execution_id="exec-1",
+            lease_id="lease-1",
+            channel_id="channel-1",
+            message_id="preview-1",
+            failure_note="Status: this progress message lost its queue worker.",
+            orphaned=True,
+            reconcile_on_cancel=True,
+        )
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        while service._background_tasks:
+            await asyncio.gather(
+                *list(service._background_tasks),
+                return_exceptions=True,
+            )
+
+        assert rest.edited_channel_messages
+        assert "lost its queue worker" in (
+            rest.edited_channel_messages[-1]["payload"]["content"].lower()
+        )
+        assert (
+            await store.list_turn_progress_leases(
+                managed_thread_id="thread-1",
+                execution_id="exec-1",
+            )
+            == []
+        )
+    finally:
+        blocker.set()
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_queued_delivery_preserves_progress_lease_until_terminal_delivery(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- stop treating every cancelled Discord background task as a lost worker
- add an explicit `reconcile_on_cancel` task-context flag and enable it only for cancellation-sensitive worker tasks
- cover both the expected heartbeat-cancel path and the real cancel-sensitive reconciliation path in Discord background-failure tests

## Root Cause
Commit `8196bb074a2cec5fcb71e3472a1ab11a8f0aa1a8` changed `on_background_task_done()` so any non-shutdown `CancelledError` reconciled the progress lease as a worker failure.

That caught the normal progress-heartbeat cleanup path in `message_turns.py`, where `_stop_progress_heartbeat()` intentionally cancels the heartbeat task after a turn completes or transitions. The done callback then retired the live progress message with `Status: this progress message lost its worker.` even though the worker had not been lost.

## Validation
- `.venv/bin/pytest -q tests/test_discord_message_turn_background_failures.py`
- `.venv/bin/pytest -q tests/test_discord_message_turn_background_failures.py -k 'background_task_done or shutdown_timeout'`
- `.venv/bin/pytest -q tests/integrations/discord/test_message_turns_transient_progress.py -k 'reused_progress_message_lease or queued'`
- repo validation lane from `git commit`:
  - `mypy src/codex_autorunner`
  - full `pytest` suite (`7627 passed`)
  - chat-surface deterministic checks (`21 passed`)
