### PR TITLE
[codex] Repair legacy worktree registration and cleanup

### DIFF
--- a/src/codex_autorunner/core/git_utils.py
+++ b/src/codex_autorunner/core/git_utils.py
@@ -96,14 +96,34 @@ def git_linked_worktree_base_root(repo_root: Path) -> Optional[Path]:
     return common_git_dir.parent.resolve()
 
 
+def _resolved_git_directory_from_gitfile(repo_root: Path) -> Optional[Path]:
+    """Resolve the git directory when ``.git`` is a gitfile (not a directory)."""
+    git_path = repo_root.resolve() / ".git"
+    if not git_path.exists() or git_path.is_dir():
+        return None
+    try:
+        raw = git_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not raw.lower().startswith("gitdir:"):
+        return None
+    git_dir = Path(raw.split(":", 1)[1].strip())
+    if not git_dir.is_absolute():
+        git_dir = (repo_root.resolve() / git_dir).resolve()
+    return git_dir.resolve()
+
+
 def git_mutation_lock_path(repo_root: Path) -> Path:
     git_path = repo_root.resolve() / ".git"
     if git_path.is_dir():
         return git_path / "codex-autorunner-git-mutation.lock"
     common_git_dir = git_linked_worktree_common_dir(repo_root)
-    if common_git_dir is None:
-        return git_path / "codex-autorunner-git-mutation.lock"
-    return common_git_dir / "codex-autorunner-git-mutation.lock"
+    if common_git_dir is not None:
+        return common_git_dir / "codex-autorunner-git-mutation.lock"
+    resolved_git_dir = _resolved_git_directory_from_gitfile(repo_root)
+    if resolved_git_dir is not None:
+        return resolved_git_dir / "codex-autorunner-git-mutation.lock"
+    return git_path / "codex-autorunner-git-mutation.lock"
 
 
 @contextmanager

--- a/src/codex_autorunner/core/git_utils.py
+++ b/src/codex_autorunner/core/git_utils.py
@@ -63,24 +63,46 @@ def run_git(
     return proc
 
 
+def git_linked_worktree_git_dir(repo_root: Path) -> Optional[Path]:
+    """Return the linked-worktree gitdir when ``repo_root`` is a non-main worktree."""
+    git_path = repo_root.resolve() / ".git"
+    if not git_path.exists() or git_path.is_dir():
+        return None
+    try:
+        raw = git_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not raw.lower().startswith("gitdir:"):
+        return None
+    git_dir = Path(raw.split(":", 1)[1].strip())
+    if not git_dir.is_absolute():
+        git_dir = (repo_root.resolve() / git_dir).resolve()
+    if git_dir.parent.name != "worktrees":
+        return None
+    return git_dir.resolve()
+
+
+def git_linked_worktree_common_dir(repo_root: Path) -> Optional[Path]:
+    git_dir = git_linked_worktree_git_dir(repo_root)
+    if git_dir is None:
+        return None
+    return git_dir.parent.parent.resolve()
+
+
+def git_linked_worktree_base_root(repo_root: Path) -> Optional[Path]:
+    common_git_dir = git_linked_worktree_common_dir(repo_root)
+    if common_git_dir is None:
+        return None
+    return common_git_dir.parent.resolve()
+
+
 def git_mutation_lock_path(repo_root: Path) -> Path:
     git_path = repo_root.resolve() / ".git"
     if git_path.is_dir():
         return git_path / "codex-autorunner-git-mutation.lock"
-    try:
-        raw = git_path.read_text(encoding="utf-8").strip()
-    except OSError:
+    common_git_dir = git_linked_worktree_common_dir(repo_root)
+    if common_git_dir is None:
         return git_path / "codex-autorunner-git-mutation.lock"
-    if not raw.lower().startswith("gitdir:"):
-        return git_path / "codex-autorunner-git-mutation.lock"
-    git_dir = Path(raw.split(":", 1)[1].strip())
-    if not git_dir.is_absolute():
-        git_dir = (repo_root.resolve() / git_dir).resolve()
-    common_git_dir = (
-        git_dir.parent.parent.resolve()
-        if git_dir.parent.name == "worktrees"
-        else git_dir.resolve()
-    )
     return common_git_dir / "codex-autorunner-git-mutation.lock"
 
 

--- a/src/codex_autorunner/core/hub_repo_manager.py
+++ b/src/codex_autorunner/core/hub_repo_manager.py
@@ -36,6 +36,7 @@ from .git_utils import (
 )
 from .orchestration.sqlite import open_orchestration_sqlite
 from .pma_thread_store import PmaThreadStore
+from .utils import is_within
 
 if TYPE_CHECKING:
     from .hub import RepoSnapshot
@@ -628,6 +629,11 @@ class RepoManager:
             raise ValueError(
                 f"Repo path must live under repos_root ({base_dir})"
             ) from exc
+        if is_within(root=self._hub_config.worktrees_root, target=target):
+            raise ValueError(
+                "Repo path must not live under worktrees_root; "
+                "use `car hub worktree create` instead"
+            )
         return target
 
     def _validate_no_id_conflict(

--- a/src/codex_autorunner/core/hub_worktree_manager.py
+++ b/src/codex_autorunner/core/hub_worktree_manager.py
@@ -20,7 +20,7 @@ from ..bootstrap import seed_repo_files
 from ..manifest import (
     Manifest,
     load_manifest,
-    sanitize_repo_id,
+    match_base_repo_id,
     save_manifest,
 )
 from .archive import (
@@ -624,26 +624,6 @@ class WorktreeManager:
             repo_id=repo_id,
         )
 
-    def _match_base_repo_id(
-        self,
-        *,
-        manifest: Manifest,
-        base_name: str,
-        base_path: Optional[Path],
-    ) -> str:
-        normalized_base = sanitize_repo_id(base_name)
-        if base_path is not None:
-            existing = manifest.get_by_path(self._hub_config.root, base_path)
-            if existing is not None:
-                return existing.id
-        for repo in manifest.repos:
-            if repo.kind != "base":
-                continue
-            display_name = (repo.display_name or "").strip()
-            if display_name == base_name or repo.id == normalized_base:
-                return repo.id
-        return normalized_base
-
     def _infer_worktree_metadata(
         self,
         *,
@@ -661,9 +641,10 @@ class WorktreeManager:
 
         worktree_of = None
         if base_name:
-            worktree_of = self._match_base_repo_id(
-                manifest=manifest,
-                base_name=base_name,
+            worktree_of = match_base_repo_id(
+                manifest,
+                self._hub_config.root,
+                base_name,
                 base_path=base_path,
             )
 

--- a/src/codex_autorunner/core/hub_worktree_manager.py
+++ b/src/codex_autorunner/core/hub_worktree_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+import shutil
 import sqlite3
 import subprocess
 from pathlib import Path
@@ -19,6 +20,7 @@ from ..bootstrap import seed_repo_files
 from ..manifest import (
     Manifest,
     load_manifest,
+    sanitize_repo_id,
     save_manifest,
 )
 from .archive import (
@@ -47,6 +49,7 @@ from .git_utils import (
     git_failure_detail,
     git_head_sha,
     git_is_clean,
+    git_linked_worktree_base_root,
     git_mutation_lock,
     resolve_ref_sha,
     run_git,
@@ -621,6 +624,166 @@ class WorktreeManager:
             repo_id=repo_id,
         )
 
+    def _match_base_repo_id(
+        self,
+        *,
+        manifest: Manifest,
+        base_name: str,
+        base_path: Optional[Path],
+    ) -> str:
+        normalized_base = sanitize_repo_id(base_name)
+        if base_path is not None:
+            existing = manifest.get_by_path(self._hub_config.root, base_path)
+            if existing is not None:
+                return existing.id
+        for repo in manifest.repos:
+            if repo.kind != "base":
+                continue
+            display_name = (repo.display_name or "").strip()
+            if display_name == base_name or repo.id == normalized_base:
+                return repo.id
+        return normalized_base
+
+    def _infer_worktree_metadata(
+        self,
+        *,
+        manifest: Manifest,
+        display_name: str,
+        worktree_path: Path,
+        existing_branch: Optional[str],
+    ) -> tuple[Optional[str], Optional[str]]:
+        base_path = git_linked_worktree_base_root(worktree_path)
+        base_name: Optional[str] = None
+        if base_path is not None:
+            base_name = base_path.name
+        elif "--" in display_name:
+            base_name = display_name.split("--", 1)[0] or None
+
+        worktree_of = None
+        if base_name:
+            worktree_of = self._match_base_repo_id(
+                manifest=manifest,
+                base_name=base_name,
+                base_path=base_path,
+            )
+
+        branch = existing_branch or git_branch(worktree_path)
+        if not branch and "--" in display_name:
+            _, branch_suffix = display_name.split("--", 1)
+            branch = branch_suffix or None
+        return worktree_of, branch
+
+    def _normalize_manifest_worktree_entries(self, manifest: Manifest) -> bool:
+        changed = False
+        for entry in manifest.repos:
+            repo_path = (self._hub_config.root / entry.path).resolve()
+            if not repo_path.exists():
+                continue
+            base_path = git_linked_worktree_base_root(repo_path)
+            if base_path is None and entry.kind != "worktree":
+                continue
+
+            display_name = entry.display_name or entry.id or repo_path.name
+            worktree_of, branch = self._infer_worktree_metadata(
+                manifest=manifest,
+                display_name=display_name,
+                worktree_path=repo_path,
+                existing_branch=entry.branch,
+            )
+            if entry.kind != "worktree":
+                entry.kind = "worktree"
+                changed = True
+            if worktree_of and entry.worktree_of != worktree_of:
+                entry.worktree_of = worktree_of
+                changed = True
+            if branch and entry.branch != branch:
+                entry.branch = branch
+                changed = True
+        return changed
+
+    def _inspect_orphaned_worktree_dir(self, worktree_path: Path) -> dict[str, object]:
+        if not worktree_path.exists():
+            return {
+                "status": "missing",
+                "message": "worktree directory already missing",
+            }
+        if not worktree_path.is_dir():
+            return {
+                "status": "safe_to_remove",
+                "message": "worktree path is not a directory",
+            }
+
+        unexpected_entries: list[str] = []
+        for child in sorted(worktree_path.iterdir(), key=lambda item: item.name):
+            if child.name in {".codex-autorunner", ".git"}:
+                continue
+            unexpected_entries.append(child.name)
+
+        if unexpected_entries:
+            rendered = ", ".join(unexpected_entries[:5])
+            if len(unexpected_entries) > 5:
+                rendered = f"{rendered}, ..."
+            return {
+                "status": "blocked_non_car_files",
+                "message": (
+                    "orphaned worktree directory still has non-CAR files: "
+                    f"{rendered}"
+                ),
+            }
+        return {
+            "status": "safe_to_remove",
+            "message": "orphaned worktree directory only contains CAR metadata",
+        }
+
+    def _remove_orphaned_worktree_dir(self, worktree_path: Path) -> dict[str, object]:
+        inspection = self._inspect_orphaned_worktree_dir(worktree_path)
+        if inspection["status"] != "safe_to_remove":
+            return inspection
+        if worktree_path.exists():
+            if worktree_path.is_dir():
+                shutil.rmtree(worktree_path)
+            else:
+                worktree_path.unlink()
+        return {
+            "status": "removed",
+            "message": "removed orphaned worktree directory",
+        }
+
+    def _cleanup_orphaned_worktree_entry(
+        self,
+        *,
+        entry,
+        dry_run: bool,
+    ) -> dict[str, str]:
+        worktree_path = (self._hub_config.root / entry.path).resolve()
+        branch_name = entry.branch
+        if (
+            branch_name is None
+            and worktree_path.exists()
+            and git_available(worktree_path)
+        ):
+            branch_name = git_branch(worktree_path)
+        branch_name = branch_name or "unknown"
+
+        inspection = self._inspect_orphaned_worktree_dir(worktree_path)
+        if inspection["status"] == "blocked_non_car_files":
+            raise ValueError(str(inspection["message"]))
+        if dry_run:
+            return {"id": entry.id, "branch": branch_name}
+
+        if worktree_path.exists():
+            self._ctx.stop_runner(repo_id=entry.id, repo_path=worktree_path)
+        self._archive_bound_pma_threads(
+            worktree_repo_id=entry.id,
+            worktree_path=worktree_path,
+        )
+        self._remove_orphaned_worktree_dir(worktree_path)
+
+        manifest = load_manifest(self._hub_config.manifest_path, self._hub_config.root)
+        manifest.repos = [repo for repo in manifest.repos if repo.id != entry.id]
+        save_manifest(self._hub_config.manifest_path, manifest, self._hub_config.root)
+        return {"id": entry.id, "branch": branch_name}
+
     def _remove_worktree_git_refs(
         self,
         *,
@@ -819,6 +982,18 @@ class WorktreeManager:
             "archive_pma_threads", "ok", detail=f"archived={len(archived_thread_ids)}"
         )
 
+        orphan_dir_cleanup = self._remove_orphaned_worktree_dir(worktree_path)
+        orphan_dir_status = str(orphan_dir_cleanup.get("status", "unknown"))
+        report.add_step(
+            "worktree_dir_cleanup",
+            "ok" if orphan_dir_status in {"removed", "missing"} else "error",
+            detail=(
+                None
+                if orphan_dir_status in {"removed", "missing"}
+                else str(orphan_dir_cleanup.get("message") or "")
+            ),
+        )
+
         resolved.manifest.repos = [
             r for r in resolved.manifest.repos if r.id != worktree_repo_id
         ]
@@ -927,10 +1102,17 @@ class WorktreeManager:
         worktree_items: list[dict[str, str]] = []
         worktree_errors: list[dict[str, str]] = []
         for entry in manifest.repos:
-            if entry.kind != "worktree":
+            worktree_path = (self._hub_config.root / entry.path).resolve()
+            is_legacy_linked_worktree = (
+                entry.kind != "worktree"
+                and worktree_path.exists()
+                and git_linked_worktree_base_root(worktree_path) is not None
+            )
+            if entry.kind != "worktree" and not is_legacy_linked_worktree:
                 continue
             if not entry.worktree_of:
-                continue
+                if not is_legacy_linked_worktree:
+                    continue
             try:
                 if self._has_active_chat_binding(entry.id):
                     continue
@@ -941,9 +1123,24 @@ class WorktreeManager:
                     exc_info=exc,
                 )
                 continue
-            worktree_path = (self._hub_config.root / entry.path).resolve()
-            if not worktree_path.exists():
+
+            if not worktree_path.exists() or not git_available(worktree_path):
+                try:
+                    worktree_items.append(
+                        self._cleanup_orphaned_worktree_entry(
+                            entry=entry,
+                            dry_run=dry_run,
+                        )
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "cleanup_all: orphaned worktree cleanup failed for %s",
+                        entry.id,
+                        exc_info=exc,
+                    )
+                    worktree_errors.append({"id": entry.id, "error": str(exc)})
                 continue
+
             if git_available(worktree_path):
                 try:
                     if not git_is_clean(worktree_path):
@@ -1034,6 +1231,11 @@ class WorktreeManager:
 
     def cleanup_all(self, *, dry_run: bool = False) -> Dict[str, object]:
         manifest = load_manifest(self._hub_config.manifest_path, self._hub_config.root)
+        manifest_changed = self._normalize_manifest_worktree_entries(manifest)
+        if manifest_changed and not dry_run:
+            save_manifest(
+                self._hub_config.manifest_path, manifest, self._hub_config.root
+            )
         unbound_threads_by_repo = self._ctx.collect_unbound_repo_threads(
             manifest=manifest
         )
@@ -1065,7 +1267,10 @@ class WorktreeManager:
         )
 
         if not dry_run and (
-            total_thread_count or len(worktree_items) or total_flow_count
+            manifest_changed
+            or total_thread_count
+            or len(worktree_items)
+            or total_flow_count
         ):
             self._ctx.invalidate_cache()
 

--- a/src/codex_autorunner/discovery.py
+++ b/src/codex_autorunner/discovery.py
@@ -11,6 +11,7 @@ from .manifest import (
     ensure_unique_repo_id,
     is_safe_repo_id,
     load_manifest,
+    match_base_repo_id,
     sanitize_repo_id,
     save_manifest,
 )
@@ -34,20 +35,6 @@ def discover_and_init(hub_config: HubConfig) -> Tuple[Manifest, List[DiscoveryRe
     manifest = load_manifest(hub_config.manifest_path, hub_config.root)
     records: List[DiscoveryRecord] = []
     seen_ids: set[str] = set()
-
-    def _match_base_repo_id(base_name: str, *, base_path: Optional[Path]) -> str:
-        normalized_base = sanitize_repo_id(base_name)
-        if base_path is not None:
-            existing = manifest.get_by_path(hub_config.root, base_path)
-            if existing is not None:
-                return existing.id
-        for repo in manifest.repos:
-            if repo.kind != "base":
-                continue
-            display_name = (repo.display_name or "").strip()
-            if display_name == base_name or repo.id == normalized_base:
-                return repo.id
-        return normalized_base
 
     def _infer_repo_shape(
         repo_path: Path,
@@ -78,7 +65,9 @@ def discover_and_init(hub_config: HubConfig) -> Tuple[Manifest, List[DiscoveryRe
 
         worktree_of = None
         if kind == "worktree" and base_name:
-            worktree_of = _match_base_repo_id(base_name, base_path=base_path)
+            worktree_of = match_base_repo_id(
+                manifest, hub_config.root, base_name, base_path=base_path
+            )
         return kind, worktree_of, branch or branch_from_name
 
     def _normalize_manifest_ids() -> None:

--- a/src/codex_autorunner/discovery.py
+++ b/src/codex_autorunner/discovery.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Tuple
 
 from .bootstrap import seed_repo_files
 from .core.config import HubConfig
+from .core.git_utils import git_branch, git_linked_worktree_base_root
 from .manifest import (
     Manifest,
     ManifestRepo,
@@ -33,6 +34,52 @@ def discover_and_init(hub_config: HubConfig) -> Tuple[Manifest, List[DiscoveryRe
     manifest = load_manifest(hub_config.manifest_path, hub_config.root)
     records: List[DiscoveryRecord] = []
     seen_ids: set[str] = set()
+
+    def _match_base_repo_id(base_name: str, *, base_path: Optional[Path]) -> str:
+        normalized_base = sanitize_repo_id(base_name)
+        if base_path is not None:
+            existing = manifest.get_by_path(hub_config.root, base_path)
+            if existing is not None:
+                return existing.id
+        for repo in manifest.repos:
+            if repo.kind != "base":
+                continue
+            display_name = (repo.display_name or "").strip()
+            if display_name == base_name or repo.id == normalized_base:
+                return repo.id
+        return normalized_base
+
+    def _infer_repo_shape(
+        repo_path: Path,
+        *,
+        display_name: str,
+        default_kind: str,
+    ) -> tuple[str, Optional[str], Optional[str]]:
+        branch = git_branch(repo_path)
+        branch_from_name: Optional[str] = None
+        if "--" in display_name:
+            _, branch_suffix = display_name.split("--", 1)
+            branch_from_name = branch_suffix or None
+
+        base_path = git_linked_worktree_base_root(repo_path)
+        if base_path is None and default_kind != "worktree":
+            return default_kind, None, branch or branch_from_name
+
+        kind = (
+            "worktree"
+            if base_path is not None or default_kind == "worktree"
+            else default_kind
+        )
+        base_name: Optional[str] = None
+        if base_path is not None:
+            base_name = base_path.name
+        elif "--" in display_name:
+            base_name = display_name.split("--", 1)[0]
+
+        worktree_of = None
+        if kind == "worktree" and base_name:
+            worktree_of = _match_base_repo_id(base_name, base_path=base_path)
+        return kind, worktree_of, branch or branch_from_name
 
     def _normalize_manifest_ids() -> None:
         reserved_ids = {repo.id for repo in manifest.repos}
@@ -91,37 +138,31 @@ def discover_and_init(hub_config: HubConfig) -> Tuple[Manifest, List[DiscoveryRe
             existing_entry = manifest.get_by_path(hub_config.root, child)
             if not existing_entry:
                 existing_entry = manifest.get(display_name)
+            detected_kind, detected_worktree_of, detected_branch = _infer_repo_shape(
+                child,
+                display_name=display_name,
+                default_kind=kind,
+            )
             added = False
             if not existing_entry:
-                # Best-effort grouping inference for worktrees created outside of CAR:
-                # name convention: <base_repo_id>--<branch>
-                worktree_of: Optional[str] = None
-                branch: Optional[str] = None
-                if kind == "worktree" and "--" in display_name:
-                    base_id, rest = display_name.split("--", 1)
-                    if base_id:
-                        matched_base = next(
-                            (
-                                repo.id
-                                for repo in manifest.repos
-                                if repo.display_name == base_id
-                            ),
-                            None,
-                        )
-                        worktree_of = matched_base or sanitize_repo_id(base_id)
-                    branch = rest or None
                 existing_entry = manifest.ensure_repo(
                     hub_config.root,
                     child,
                     repo_id=display_name,
                     display_name=display_name,
-                    kind=kind,
-                    worktree_of=worktree_of,
-                    branch=branch,
+                    kind=detected_kind,
+                    worktree_of=detected_worktree_of,
+                    branch=detected_branch,
                 )
                 added = True
             if existing_entry.display_name is None:
                 existing_entry.display_name = display_name
+            if detected_kind == "worktree":
+                existing_entry.kind = "worktree"
+                if detected_worktree_of:
+                    existing_entry.worktree_of = detected_worktree_of
+                if detected_branch:
+                    existing_entry.branch = detected_branch
             repo_entry = existing_entry
             _record_repo(repo_entry, added=added)
 

--- a/src/codex_autorunner/manifest.py
+++ b/src/codex_autorunner/manifest.py
@@ -275,6 +275,27 @@ class Manifest:
         return workspace
 
 
+def match_base_repo_id(
+    manifest: Manifest,
+    hub_root: Path,
+    base_name: str,
+    *,
+    base_path: Optional[Path],
+) -> str:
+    normalized_base = sanitize_repo_id(base_name)
+    if base_path is not None:
+        existing = manifest.get_by_path(hub_root, base_path)
+        if existing is not None:
+            return existing.id
+    for repo in manifest.repos:
+        if repo.kind != "base":
+            continue
+        display_name = (repo.display_name or "").strip()
+        if display_name == base_name or repo.id == normalized_base:
+            return repo.id
+    return normalized_base
+
+
 def _relative_to_hub_root(hub_root: Path, target: Path) -> Path:
     if not target.is_absolute():
         target = (hub_root / target).resolve()

--- a/tests/core/test_git_utils.py
+++ b/tests/core/test_git_utils.py
@@ -206,6 +206,21 @@ def test_git_mutation_lock_path_uses_common_git_dir_for_worktrees(
     )
 
 
+def test_git_mutation_lock_path_uses_resolved_git_dir_for_gitfile_non_worktree(
+    tmp_path: Path,
+) -> None:
+    """git init --separate-git-dir: .git is a file; lock must live in the real git dir."""
+    repo_root = tmp_path / "checkout"
+    repo_root.mkdir()
+    actual_git = tmp_path / "git-dir"
+    actual_git.mkdir()
+    (repo_root / ".git").write_text(f"gitdir: {actual_git}\n", encoding="utf-8")
+
+    assert git_utils.git_mutation_lock_path(repo_root) == (
+        actual_git / "codex-autorunner-git-mutation.lock"
+    )
+
+
 def test_git_linked_worktree_base_root_returns_parent_repo_for_linked_worktrees(
     tmp_path: Path,
 ) -> None:

--- a/tests/core/test_git_utils.py
+++ b/tests/core/test_git_utils.py
@@ -206,6 +206,23 @@ def test_git_mutation_lock_path_uses_common_git_dir_for_worktrees(
     )
 
 
+def test_git_linked_worktree_base_root_returns_parent_repo_for_linked_worktrees(
+    tmp_path: Path,
+) -> None:
+    common_git_dir = tmp_path / "main-repo" / ".git"
+    common_git_dir.mkdir(parents=True)
+    worktree_root = tmp_path / "worktree"
+    worktree_root.mkdir()
+    (worktree_root / ".git").write_text(
+        f"gitdir: {common_git_dir / 'worktrees' / 'topic'}\n",
+        encoding="utf-8",
+    )
+
+    assert git_utils.git_linked_worktree_base_root(worktree_root) == (
+        tmp_path / "main-repo"
+    )
+
+
 def test_describe_newt_reject_reasons_summarizes_git_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_hub_create.py
+++ b/tests/test_hub_create.py
@@ -90,6 +90,22 @@ def test_hub_create_repo_rejects_duplicate_id(tmp_path: Path):
         supervisor.create_repo("demo", repo_path=Path("other"))
 
 
+def test_hub_create_repo_rejects_paths_under_worktrees_root(tmp_path: Path):
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg["hub"]["repos_root"] = "."
+    cfg["hub"]["worktrees_root"] = "worktrees"
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+    )
+    with pytest.raises(ValueError, match="must not live under worktrees_root"):
+        supervisor.create_repo("bad", repo_path=Path("worktrees/bad"))
+
+
 def test_hub_clone_repo_cli(tmp_path: Path):
     hub_root = tmp_path / "hub"
     cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))

--- a/tests/test_hub_foundation.py
+++ b/tests/test_hub_foundation.py
@@ -10,6 +10,7 @@ from codex_autorunner.core.config import (
     load_hub_config,
     load_repo_config,
 )
+from codex_autorunner.core.git_utils import run_git
 from codex_autorunner.discovery import discover_and_init
 from codex_autorunner.manifest import (
     MANIFEST_VERSION,
@@ -328,6 +329,64 @@ def test_discovery_sanitizes_repo_ids(tmp_path: Path):
     )
     repo_entry = next(r for r in manifest_data["repos"] if r["id"] == entry.repo.id)
     assert repo_entry["display_name"] == "demo#repo"
+
+
+def test_discovery_repairs_linked_worktrees_misregistered_as_base(tmp_path: Path):
+    hub_root = tmp_path / "hub"
+    config = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    config["hub"]["repos_root"] = "workspace"
+    config_path = hub_root / CONFIG_FILENAME
+    write_test_config(config_path, config)
+
+    repos_root = hub_root / "workspace"
+    base_dir = repos_root / "base"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    run_git(["init"], base_dir, check=True)
+    (base_dir / "README.md").write_text("hello\n", encoding="utf-8")
+    run_git(["add", "README.md"], base_dir, check=True)
+    run_git(
+        [
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            "init",
+        ],
+        base_dir,
+        check=True,
+    )
+
+    legacy_worktree = repos_root / "base--legacy-branch"
+    run_git(
+        ["worktree", "add", "-b", "legacy/branch", str(legacy_worktree), "HEAD"],
+        base_dir,
+        check=True,
+    )
+
+    manifest = load_manifest(hub_root / ".codex-autorunner" / "manifest.yml", hub_root)
+    manifest.ensure_repo(
+        hub_root,
+        legacy_worktree,
+        repo_id="base--legacy-branch",
+        kind="base",
+    )
+    save_manifest(hub_root / ".codex-autorunner" / "manifest.yml", manifest, hub_root)
+
+    hub_config = load_hub_config(hub_root)
+    manifest, records = discover_and_init(hub_config)
+
+    entry = next(r for r in records if r.repo.id == "base--legacy-branch")
+    assert entry.repo.kind == "worktree"
+    assert entry.repo.worktree_of == "base"
+    assert entry.repo.branch == "legacy/branch"
+
+    manifest_entry = manifest.get("base--legacy-branch")
+    assert manifest_entry is not None
+    assert manifest_entry.kind == "worktree"
+    assert manifest_entry.worktree_of == "base"
+    assert manifest_entry.branch == "legacy/branch"
 
 
 def test_discovery_skips_hub_root_repo_by_default(tmp_path: Path):

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -1757,6 +1757,75 @@ def test_cleanup_all_skips_worktree_when_binding_lookup_raises_runtime_error(
     assert worktree.path.exists()
 
 
+def test_cleanup_all_repairs_legacy_worktree_entries_before_cleanup(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg["pma"]["cleanup_require_archive"] = False
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id=base.id,
+        branch="feature/legacy-cleanup-all",
+        start_point="HEAD",
+    )
+
+    manifest_path = hub_root / ".codex-autorunner" / "manifest.yml"
+    manifest = load_manifest(manifest_path, hub_root)
+    entry = manifest.get(worktree.id)
+    assert entry is not None
+    entry.kind = "base"
+    entry.worktree_of = None
+    save_manifest(manifest_path, manifest, hub_root)
+
+    preview = supervisor.cleanup_all(dry_run=True)
+    assert preview["worktrees"]["archived_count"] == 1
+
+    result = supervisor.cleanup_all(dry_run=False)
+
+    assert result["worktrees"]["archived_count"] == 1
+    assert not worktree.path.exists()
+    manifest = load_manifest(manifest_path, hub_root)
+    assert manifest.get(worktree.id) is None
+
+
+def test_cleanup_all_removes_missing_worktree_manifest_entries(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg["pma"]["cleanup_require_archive"] = False
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id=base.id,
+        branch="feature/missing-worktree-entry",
+        start_point="HEAD",
+    )
+    run_git(
+        ["worktree", "remove", "--force", str(worktree.path)], base.path, check=True
+    )
+
+    result = supervisor.cleanup_all(dry_run=False)
+
+    assert result["worktrees"]["archived_count"] == 1
+    manifest = load_manifest(hub_root / ".codex-autorunner" / "manifest.yml", hub_root)
+    assert manifest.get(worktree.id) is None
+
+
 def test_hub_api_cleanup_all_preview_and_job(tmp_path: Path, monkeypatch):
     hub_root = tmp_path / "hub"
     cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
@@ -3027,6 +3096,49 @@ def test_cleanup_worktree_failure_keeps_bound_pma_threads_active(
     assert thread is not None
     assert thread["lifecycle_status"] == "active"
     assert worktree.path.exists()
+
+
+def test_cleanup_worktree_removes_leftover_car_state_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg["pma"]["cleanup_require_archive"] = False
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/leftover-car-state",
+        start_point="HEAD",
+    )
+
+    def _leave_only_car_state(**kwargs) -> None:
+        worktree_path = kwargs["worktree_path"]
+        for child in worktree_path.iterdir():
+            if child.name == ".codex-autorunner":
+                continue
+            if child.is_dir():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+
+    monkeypatch.setattr(
+        supervisor._worktree_manager,
+        "_remove_worktree_git_refs",
+        _leave_only_car_state,
+    )
+
+    supervisor.cleanup_worktree(worktree_repo_id=worktree.id, archive=False)
+
+    assert not worktree.path.exists()
 
 
 def test_cleanup_worktree_archives_pma_threads_before_manifest_removal(


### PR DESCRIPTION
## Summary
This repairs legacy worktree lifecycle gaps in CAR so linked worktrees are classified and cleaned up consistently.

## What Changed
- added linked-worktree Git helpers so CAR can distinguish a linked worktree from a base repo
- taught discovery to repair misregistered linked worktrees by promoting them to `kind: worktree` and backfilling `worktree_of` and `branch`
- blocked `create_repo` from placing base repos under `worktrees_root`, which preserves a single supported worktree layout
- taught cleanup to normalize legacy worktree manifest entries, remove missing orphaned worktree entries, and delete leftover worktree directories when they only contain CAR-managed metadata

## Root Cause
CAR had two related gaps:
- scan and registration logic trusted the configured root path more than the actual Git metadata, so linked worktrees could remain registered as `kind: base`
- cleanup only considered manifest `worktree` entries with live directories, so missing or orphaned worktree paths were skipped indefinitely

## Impact
- legacy linked worktrees no longer stay invisible to cleanup just because they were misregistered
- cleanup can remove safe orphaned worktree entries instead of leaving stale manifest state behind
- future base repo creation is prevented from reusing the dedicated worktree area

## Validation
- `pytest tests/core/test_git_utils.py tests/test_hub_foundation.py tests/test_hub_create.py tests/test_hub_supervisor.py -q`
- repo hooks during commit:
  - strict mypy on `src/codex_autorunner`
  - full pytest suite: `7628 passed`
  - static build and frontend JS tests
  - chat-surface deterministic checks and latency budget suite
