### PR TITLE
Fix Hermes PMA stalled-turn recovery for profiled dumps

### DIFF
--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -1066,7 +1066,11 @@ def _probe_hermes_session_store_root(
         key: str
         value: str
         if ":" in stripped:
-            key, _, value = stripped.partition(":")
+            before_colon, _, after_colon = stripped.partition(":")
+            if " " not in before_colon.strip():
+                key, value = before_colon, after_colon
+            else:
+                key, _, value = stripped.partition(" ")
         else:
             key, _, value = stripped.partition(" ")
         if key.strip().lower().rstrip(":") != "hermes_home":

--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -1060,8 +1060,16 @@ def _probe_hermes_session_store_root(
     if result.returncode != 0:
         return None
     for line in result.stdout.splitlines():
-        key, _, value = line.partition(" ")
-        if key.strip().lower() != "hermes_home":
+        stripped = line.strip()
+        if not stripped:
+            continue
+        key: str
+        value: str
+        if ":" in stripped:
+            key, _, value = stripped.partition(":")
+        else:
+            key, _, value = stripped.partition(" ")
+        if key.strip().lower().rstrip(":") != "hermes_home":
             continue
         normalized = _normalize_optional_text(value)
         if normalized:

--- a/tests/agents/hermes/test_hermes_supervisor_official_prompt_hang.py
+++ b/tests/agents/hermes/test_hermes_supervisor_official_prompt_hang.py
@@ -2,11 +2,52 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from tests.chat_surface_harness.hermes import fake_acp_command
 
-from codex_autorunner.agents.hermes.supervisor import HermesSupervisor
+from codex_autorunner.agents.hermes.supervisor import (
+    HermesSupervisor,
+    _probe_hermes_session_store_root,
+)
+
+
+@pytest.mark.parametrize(
+    ("stdout", "relative_path"),
+    [
+        (
+            "hermes_home ~/.hermes/profiles/hermes-m4-pma\n",
+            Path(".hermes/profiles/hermes-m4-pma"),
+        ),
+        (
+            "--- hermes dump ---\n"
+            "profile: hermes-m4-pma\n"
+            "hermes_home:      ~/.hermes/profiles/hermes-m4-pma\n"
+            "--- end dump ---\n",
+            Path(".hermes/profiles/hermes-m4-pma"),
+        ),
+    ],
+)
+def test_probe_hermes_session_store_root_parses_dump_output(
+    monkeypatch: pytest.MonkeyPatch,
+    stdout: str,
+    relative_path: Path,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    def _fake_run(*args, **kwargs):
+        _ = args, kwargs
+        return SimpleNamespace(returncode=0, stdout=stdout)
+
+    monkeypatch.setattr(
+        "codex_autorunner.agents.hermes.supervisor.subprocess.run",
+        _fake_run,
+    )
+
+    expected = (tmp_path / "home" / relative_path).resolve()
+    assert _probe_hermes_session_store_root("/tmp/hermes", {}) == expected
 
 
 @pytest.mark.slow

--- a/tests/agents/hermes/test_hermes_supervisor_official_prompt_hang.py
+++ b/tests/agents/hermes/test_hermes_supervisor_official_prompt_hang.py
@@ -21,6 +21,10 @@ from codex_autorunner.agents.hermes.supervisor import (
             Path(".hermes/profiles/hermes-m4-pma"),
         ),
         (
+            "hermes_home ~/.hermes/profiles/with:colon\n",
+            Path(".hermes/profiles/with:colon"),
+        ),
+        (
             "--- hermes dump ---\n"
             "profile: hermes-m4-pma\n"
             "hermes_home:      ~/.hermes/profiles/hermes-m4-pma\n"


### PR DESCRIPTION
## Summary
- fix `_probe_hermes_session_store_root()` so it parses real `hermes dump` output with `key: value` lines
- restore stalled-turn recovery for profiled Hermes PMA binaries like `hermes-m4-pma`
- add a regression test covering both legacy whitespace and current colon-delimited dump output

## Root cause
The Discord PMA failures for `discord:1475097865088139386:708566559182028821` and `discord:1488827014600331415:708566559182028821` were not context exhaustion. Both turns entered Hermes, emitted sparse `session/update` progress, and then hit the shared 30-minute PMA stall timeout.

CAR tried to recover stalled Hermes turns from the Hermes session store before timing out, but the recovery probe was broken for real profiled binaries. `hermes-m4-pma dump` prints lines like `hermes_home: ~/.hermes/profiles/hermes-m4-pma`; our parser only accepted `hermes_home <path>`, so it returned `None`, never found the session store, and skipped recovery even when the completed answer was already persisted on disk.

## Validation
- `./.venv/bin/pytest -q tests/agents/hermes/test_hermes_supervisor_official_prompt_hang.py`
- `./.venv/bin/pytest -q tests/chat_surface_integration/test_hermes_pma_official_timeout.py`
- full repo commit validation lane passed during `git commit` (mypy, pytest, frontend/build, chat-surface lab)