### PR TITLE
Add ACP conformance runner and harden Hermes profile launch

### DIFF
--- a/scripts/acp_conformance.py
+++ b/scripts/acp_conformance.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Run ACP conformance checks against fixture and configured repo targets."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPT_DIR.parent
+sys.path.insert(0, str(_REPO_ROOT))
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from tests.chat_surface_lab.acp_conformance import (  # noqa: E402
+    DEFAULT_ARTIFACT_DIR,
+    discover_repo_acp_targets,
+    format_acp_conformance_report,
+    run_acp_conformance_report,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run ACP conformance checks against the deterministic fixture and "
+            "configured ACP-backed runtimes in this repo."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=_REPO_ROOT,
+        help="Repo root used for config discovery.",
+    )
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        default=DEFAULT_ARTIFACT_DIR,
+        help="Directory used for latest.json and per-run suite_report.json artifacts.",
+    )
+    parser.add_argument(
+        "--target",
+        action="append",
+        dest="target_ids",
+        default=None,
+        help="Optional target id filter. Repeat to run multiple targets.",
+    )
+    parser.add_argument(
+        "--list-targets",
+        action="store_true",
+        help="List discovered target ids and exit.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging.",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.WARNING,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        force=True,
+    )
+
+    repo_root = Path(args.repo_root).resolve()
+    discovered = discover_repo_acp_targets(repo_root)
+    if args.list_targets:
+        for target in discovered:
+            print(f"{target.id}\t{target.label}\t{' '.join(target.command)}")
+        return 0
+
+    target_ids = {str(value).strip() for value in (args.target_ids or []) if str(value).strip()}
+    selected = [target for target in discovered if not target_ids or target.id in target_ids]
+    if target_ids and not selected:
+        parser.error("No discovered targets matched --target filters.")
+
+    report = asyncio.run(
+        run_acp_conformance_report(
+            repo_root,
+            targets=selected,
+            artifact_dir=Path(args.artifact_dir),
+        )
+    )
+    print(format_acp_conformance_report(report))
+    return 0 if report.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -40,6 +40,50 @@ HERMES_ACP_COMMAND = "acp"
 HERMES_APPROVAL_TIMEOUT_SECONDS = 300.0
 
 
+def _prepend_path_entries(entries: Sequence[str], path: str) -> str:
+    merged: list[str] = []
+    for value in entries:
+        if value and value not in merged:
+            merged.append(value)
+    for value in path.split(os.pathsep):
+        if value and value not in merged:
+            merged.append(value)
+    return os.pathsep.join(merged)
+
+
+def _hermes_launch_path_entries(command: Sequence[str]) -> list[str]:
+    if not command:
+        return []
+    binary = str(command[0] or "").strip()
+    if not binary:
+        return []
+    resolved = resolve_executable(binary)
+    candidate: Optional[Path] = Path(resolved) if resolved else None
+    if candidate is None:
+        raw_candidate = Path(binary).expanduser()
+        if raw_candidate.is_absolute() and raw_candidate.exists():
+            candidate = raw_candidate
+    if candidate is None or not candidate.exists():
+        return []
+    return [str(candidate.parent)]
+
+
+def _build_hermes_base_env(
+    command: Sequence[str],
+    *,
+    base_env: Optional[Mapping[str, str]] = None,
+) -> dict[str, str]:
+    extra_paths = _hermes_launch_path_entries(command)
+    if not base_env and not extra_paths:
+        return {}
+    env = os.environ.copy()
+    if base_env:
+        env.update({str(key): str(value) for key, value in base_env.items()})
+    if extra_paths:
+        env["PATH"] = _prepend_path_entries(extra_paths, env.get("PATH", ""))
+    return env
+
+
 def _extract_session_summary(payload: Mapping[str, Any]) -> Optional[str]:
     for key in ("summary", "subtitle", "description"):
         value = _normalize_optional_text(payload.get(key))
@@ -105,7 +149,10 @@ class HermesSupervisor:
             raise ValueError("Hermes command must not be empty")
         self._logger = logger or logging.getLogger(__name__)
         self._command = tuple(str(part) for part in command)
-        self._base_env = dict(base_env or {})
+        self._base_env = _build_hermes_base_env(
+            self._command,
+            base_env=base_env,
+        )
         self._approval_handler = approval_handler
         self._default_approval_decision = _normalize_approval_decision(
             default_approval_decision,

--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -180,6 +180,11 @@ class HermesSupervisor:
     def launch_command(self) -> tuple[str, ...]:
         return self._command
 
+    @property
+    def launch_env(self) -> dict[str, str]:
+        """Environment passed to the ACP subprocess (PATH additions for profile wrappers)."""
+        return dict(self._base_env)
+
     async def ensure_ready(self, workspace_root: Path) -> None:
         started_at = time.monotonic()
         log_event(

--- a/tests/agents/hermes/test_hermes_supervisor.py
+++ b/tests/agents/hermes/test_hermes_supervisor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -59,6 +60,18 @@ class _HermesCustomAliasConfig:
         if agent_id == "hermes-special":
             return "/opt/hermes/special-launcher"
         raise AssertionError(f"unexpected agent_id: {agent_id}")
+
+
+class _HermesProfileBinaryConfig:
+    def __init__(self, profile_binary: str) -> None:
+        self._profile_binary = profile_binary
+
+    def agent_binary(self, agent_id: str, *, profile: str | None = None) -> str:
+        if agent_id == "hermes" and profile == "m4-pma":
+            return self._profile_binary
+        if agent_id == "hermes":
+            return "hermes"
+        raise AssertionError(f"unexpected agent_id={agent_id!r} profile={profile!r}")
 
 
 async def _collect_events(
@@ -343,6 +356,34 @@ def test_build_hermes_supervisor_preserves_custom_alias_binary(
         "/opt/hermes/special-launcher",
         "acp",
     ]
+
+
+def test_build_hermes_supervisor_prepends_profile_binary_dir_to_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    wrapper = bin_dir / "hermes-m4-pma"
+    wrapper.write_text('#!/bin/sh\nexec hermes -p hermes-m4-pma "$@"\n')
+    wrapper.chmod(0o755)
+    sibling = bin_dir / "hermes"
+    sibling.write_text("#!/bin/sh\nexit 0\n")
+    sibling.chmod(0o755)
+
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    supervisor = build_hermes_supervisor_from_config(
+        _HermesProfileBinaryConfig(str(wrapper)),
+        agent_id="hermes",
+        profile="m4-pma",
+    )
+
+    assert supervisor is not None
+    path_value = supervisor._base_env["PATH"]
+    entries = [entry for entry in path_value.split(os.pathsep) if entry]
+    assert str(bin_dir) in entries
+    assert entries.index(str(bin_dir)) < entries.index("/usr/bin")
 
 
 @pytest.mark.slow

--- a/tests/agents/hermes/test_hermes_supervisor.py
+++ b/tests/agents/hermes/test_hermes_supervisor.py
@@ -384,6 +384,7 @@ def test_build_hermes_supervisor_prepends_profile_binary_dir_to_path(
     entries = [entry for entry in path_value.split(os.pathsep) if entry]
     assert str(bin_dir) in entries
     assert entries.index(str(bin_dir)) < entries.index("/usr/bin")
+    assert supervisor.launch_env == supervisor._base_env
 
 
 @pytest.mark.slow

--- a/tests/chat_surface_lab/__init__.py
+++ b/tests/chat_surface_lab/__init__.py
@@ -1,5 +1,20 @@
 """Shared contracts for the chat-surface lab test package."""
 
+from .acp_conformance import (
+    DEFAULT_ARTIFACT_DIR as ACP_CONFORMANCE_ARTIFACT_DIR,
+)
+from .acp_conformance import (
+    DEFAULT_COMPLETION_PROMPT as ACP_CONFORMANCE_DEFAULT_PROMPT,
+)
+from .acp_conformance import (
+    ACPCaseResult,
+    ACPConformanceReport,
+    ACPConformanceTarget,
+    ACPTargetResult,
+    discover_repo_acp_targets,
+    format_acp_conformance_report,
+    run_acp_conformance_report,
+)
 from .artifact_manifests import ArtifactKind, ArtifactManifest, ArtifactRecord
 from .backend_runtime import (
     ACPFixtureRuntime,
@@ -36,6 +51,12 @@ __all__ = [
     "ArtifactKind",
     "ArtifactManifest",
     "ArtifactRecord",
+    "ACPCaseResult",
+    "ACPConformanceReport",
+    "ACPConformanceTarget",
+    "ACPTargetResult",
+    "ACP_CONFORMANCE_ARTIFACT_DIR",
+    "ACP_CONFORMANCE_DEFAULT_PROMPT",
     "ACPFixtureRuntime",
     "BackendRuntimeCapabilities",
     "BackendRuntimeEvent",
@@ -58,6 +79,9 @@ __all__ = [
     "TranscriptParty",
     "TranscriptTimeline",
     "app_server_fixture_command",
+    "discover_repo_acp_targets",
     "fake_acp_command",
     "fake_opencode_server_command",
+    "format_acp_conformance_report",
+    "run_acp_conformance_report",
 ]

--- a/tests/chat_surface_lab/acp_conformance.py
+++ b/tests/chat_surface_lab/acp_conformance.py
@@ -1,0 +1,636 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Literal, Optional
+
+from codex_autorunner.agents.acp import ACPClient
+from codex_autorunner.agents.acp.errors import ACPError, ACPMissingSessionError
+from codex_autorunner.agents.hermes.supervisor import (
+    build_hermes_supervisor_from_config,
+    hermes_runtime_preflight,
+)
+from codex_autorunner.core.config import load_repo_config
+from tests.chat_surface_lab.backend_runtime import fake_acp_command
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ARTIFACT_DIR = Path(".codex-autorunner") / "diagnostics" / "acp-conformance"
+DEFAULT_COMPLETION_PROMPT = (
+    "Return only the token CONFORMANCE_OK. Do not add punctuation or extra words."
+)
+
+
+@dataclass(frozen=True)
+class ACPConformanceTarget:
+    id: str
+    label: str
+    command: tuple[str, ...]
+    source: Literal["fixture", "repo_config"]
+    env: dict[str, str] = field(default_factory=dict)
+    notes: tuple[str, ...] = ()
+    scenario: Optional[str] = None
+    agent_id: Optional[str] = None
+    profile: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ACPCaseResult:
+    case_id: str
+    passed: bool
+    status: str
+    elapsed_ms: Optional[int]
+    details: dict[str, Any] = field(default_factory=dict)
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ACPTargetResult:
+    target: ACPConformanceTarget
+    passed: bool
+    status: str
+    summary: str
+    cases: tuple[ACPCaseResult, ...]
+    started_at: str
+    finished_at: str
+
+
+@dataclass(frozen=True)
+class ACPConformanceReport:
+    run_id: str
+    repo_root: str
+    created_at: str
+    portable_case_ids: tuple[str, ...]
+    fixture_case_ids: tuple[str, ...]
+    results: tuple[ACPTargetResult, ...]
+    artifact_dir: str
+
+    @property
+    def passed(self) -> bool:
+        return all(result.passed for result in self.results)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "repo_root": self.repo_root,
+            "created_at": self.created_at,
+            "portable_case_ids": list(self.portable_case_ids),
+            "fixture_case_ids": list(self.fixture_case_ids),
+            "passed": self.passed,
+            "results": [self._target_result_dict(result) for result in self.results],
+            "artifact_dir": self.artifact_dir,
+        }
+
+    @staticmethod
+    def _target_result_dict(result: ACPTargetResult) -> dict[str, Any]:
+        payload = asdict(result)
+        payload["target"]["command"] = list(result.target.command)
+        payload["target"]["notes"] = list(result.target.notes)
+        return payload
+
+
+def discover_repo_acp_targets(repo_root: Path) -> list[ACPConformanceTarget]:
+    repo_root = repo_root.resolve()
+    config = load_repo_config(repo_root)
+    targets: list[ACPConformanceTarget] = [
+        ACPConformanceTarget(
+            id="fixture.official",
+            label="Fixture ACP (official)",
+            command=tuple(fake_acp_command("official")),
+            source="fixture",
+            scenario="official",
+            notes=("Deterministic fake ACP server used for CAR protocol coverage.",),
+        )
+    ]
+
+    base_preflight = hermes_runtime_preflight(config, agent_id="hermes")
+    if base_preflight.status == "ready":
+        supervisor = build_hermes_supervisor_from_config(config, agent_id="hermes")
+        if supervisor is not None:
+            targets.append(
+                ACPConformanceTarget(
+                    id="hermes",
+                    label="Hermes",
+                    command=supervisor.launch_command,
+                    source="repo_config",
+                    agent_id="hermes",
+                    notes=_notes_from_preflight(
+                        base_preflight.message, base_preflight.version
+                    ),
+                )
+            )
+
+    hermes_cfg = getattr(config, "agents", {}).get("hermes")
+    profiles = getattr(hermes_cfg, "profiles", {}) if hermes_cfg is not None else {}
+    if isinstance(profiles, dict):
+        for profile_name in sorted(profiles.keys()):
+            preflight = hermes_runtime_preflight(
+                config,
+                agent_id="hermes",
+                profile=profile_name,
+            )
+            if preflight.status != "ready":
+                continue
+            supervisor = build_hermes_supervisor_from_config(
+                config,
+                agent_id="hermes",
+                profile=profile_name,
+            )
+            if supervisor is None:
+                continue
+            targets.append(
+                ACPConformanceTarget(
+                    id=f"hermes.{profile_name}",
+                    label=f"Hermes [{profile_name}]",
+                    command=supervisor.launch_command,
+                    source="repo_config",
+                    agent_id="hermes",
+                    profile=profile_name,
+                    notes=_notes_from_preflight(
+                        preflight.message,
+                        preflight.version,
+                    ),
+                )
+            )
+    return targets
+
+
+async def run_acp_conformance_report(
+    repo_root: Path,
+    *,
+    targets: Optional[Iterable[ACPConformanceTarget]] = None,
+    artifact_dir: Path = DEFAULT_ARTIFACT_DIR,
+    portable_prompt: str = DEFAULT_COMPLETION_PROMPT,
+) -> ACPConformanceReport:
+    repo_root = repo_root.resolve()
+    selected_targets = list(targets or discover_repo_acp_targets(repo_root))
+    run_id = f"{_utc_now().strftime('%Y%m%dT%H%M%S%fZ')}-{uuid.uuid4().hex[:8]}"
+    run_root = artifact_dir / "runs" / run_id
+    run_root.mkdir(parents=True, exist_ok=True)
+
+    results = [
+        await _run_target_conformance(
+            target,
+            portable_prompt=portable_prompt,
+            artifact_root=run_root / target.id.replace("/", "_"),
+        )
+        for target in selected_targets
+    ]
+    report = ACPConformanceReport(
+        run_id=run_id,
+        repo_root=str(repo_root),
+        created_at=_utc_now().isoformat(),
+        portable_case_ids=(
+            "initialize",
+            "session_roundtrip",
+            "prompt_completion",
+            "prompt_reuse",
+        ),
+        fixture_case_ids=(
+            "fixture.permission_flow",
+            "fixture.interrupt_flow",
+            "fixture.prompt_hang_timeout",
+            "fixture.empty_load_result",
+            "fixture.null_load_result",
+        ),
+        results=tuple(results),
+        artifact_dir=str(run_root),
+    )
+    _write_report_artifacts(report, artifact_dir=artifact_dir, run_root=run_root)
+    return report
+
+
+def format_acp_conformance_report(report: ACPConformanceReport) -> str:
+    lines = [
+        f"ACP conformance run {report.run_id}: {'PASS' if report.passed else 'FAIL'}",
+        f"repo_root={report.repo_root}",
+        f"artifacts={report.artifact_dir}",
+    ]
+    for target_result in report.results:
+        lines.append(
+            f"- {target_result.target.label}: {target_result.status} ({target_result.summary})"
+        )
+        for case in target_result.cases:
+            elapsed = f"{case.elapsed_ms}ms" if case.elapsed_ms is not None else "n/a"
+            suffix = ""
+            if case.error_message:
+                suffix = f" error={case.error_message}"
+            lines.append(
+                f"  - {case.case_id}: {case.status} passed={case.passed} elapsed={elapsed}{suffix}"
+            )
+    return "\n".join(lines)
+
+
+async def _run_target_conformance(
+    target: ACPConformanceTarget,
+    *,
+    portable_prompt: str,
+    artifact_root: Path,
+) -> ACPTargetResult:
+    started_at = _utc_now().isoformat()
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    portable_results = await _run_portable_cases(
+        target,
+        artifact_root=artifact_root,
+        portable_prompt=portable_prompt,
+    )
+    fixture_results: list[ACPCaseResult] = []
+    if target.source == "fixture":
+        fixture_results = await _run_fixture_cases(target, artifact_root=artifact_root)
+
+    all_results = tuple([*portable_results, *fixture_results])
+    passed = all(case.passed for case in all_results)
+    status = "passed" if passed else "failed"
+    failed = [case.case_id for case in all_results if not case.passed]
+    summary = "all cases passed" if not failed else f"failed cases: {', '.join(failed)}"
+    return ACPTargetResult(
+        target=target,
+        passed=passed,
+        status=status,
+        summary=summary,
+        cases=all_results,
+        started_at=started_at,
+        finished_at=_utc_now().isoformat(),
+    )
+
+
+async def _run_portable_cases(
+    target: ACPConformanceTarget,
+    *,
+    artifact_root: Path,
+    portable_prompt: str,
+) -> list[ACPCaseResult]:
+    workspace_root = artifact_root / "portable_workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    client = ACPClient(
+        list(target.command),
+        cwd=workspace_root,
+        env=target.env or None,
+        request_timeout=120.0,
+        permission_handler=_allow_permission_request,
+    )
+    try:
+        initialize = await _measure_case(
+            "initialize",
+            lambda: _portable_initialize_case(client),
+        )
+        session_roundtrip = await _measure_case(
+            "session_roundtrip",
+            lambda: _portable_session_roundtrip_case(client, workspace_root),
+        )
+        prompt_completion = await _measure_case(
+            "prompt_completion",
+            lambda: _portable_prompt_completion_case(
+                client,
+                workspace_root,
+                portable_prompt,
+            ),
+        )
+        prompt_reuse = await _measure_case(
+            "prompt_reuse",
+            lambda: _portable_prompt_reuse_case(
+                client,
+                workspace_root,
+                portable_prompt,
+            ),
+        )
+        return [initialize, session_roundtrip, prompt_completion, prompt_reuse]
+    finally:
+        await client.close()
+
+
+async def _run_fixture_cases(
+    target: ACPConformanceTarget,
+    *,
+    artifact_root: Path,
+) -> list[ACPCaseResult]:
+    async def _run_case(case_id: str, scenario: str, func):
+        case_root = artifact_root / case_id.replace(".", "_")
+        case_root.mkdir(parents=True, exist_ok=True)
+        client = ACPClient(
+            list(fake_acp_command(scenario)),
+            cwd=case_root,
+            env=target.env or None,
+            request_timeout=2.0,
+            permission_handler=_allow_permission_request,
+        )
+        try:
+            return await _measure_case(case_id, lambda: func(client, case_root))
+        finally:
+            await client.close()
+
+    return [
+        await _run_case(
+            "fixture.permission_flow",
+            "official",
+            _fixture_permission_case,
+        ),
+        await _run_case(
+            "fixture.interrupt_flow",
+            "official",
+            _fixture_interrupt_case,
+        ),
+        await _run_case(
+            "fixture.prompt_hang_timeout",
+            "official_prompt_hang",
+            _fixture_prompt_hang_case,
+        ),
+        await _run_case(
+            "fixture.empty_load_result",
+            "official_empty_load_result",
+            _fixture_empty_load_case,
+        ),
+        await _run_case(
+            "fixture.null_load_result",
+            "official_missing_load_result",
+            _fixture_null_load_case,
+        ),
+    ]
+
+
+async def _portable_initialize_case(client: ACPClient) -> dict[str, Any]:
+    initialize = await client.start()
+    capabilities = dict(initialize.capabilities or {})
+    return {
+        "server_name": initialize.server_name,
+        "server_version": initialize.server_version,
+        "protocol_version": initialize.protocol_version,
+        "capabilities": capabilities,
+        "advertised_commands": [command.name for command in client.advertised_commands],
+        "session_capabilities": asdict(client.session_capabilities),
+    }
+
+
+async def _portable_session_roundtrip_case(
+    client: ACPClient,
+    workspace_root: Path,
+) -> dict[str, Any]:
+    created = await client.create_session(
+        cwd=str(workspace_root), title="ACP Conformance"
+    )
+    loaded = await client.load_session(created.session_id)
+    listed = await client.list_sessions()
+    listed_ids = [session.session_id for session in listed]
+    if created.session_id not in listed_ids:
+        raise AssertionError("Created session id was missing from list_sessions()")
+    return {
+        "created_session_id": created.session_id,
+        "loaded_session_id": loaded.session_id,
+        "listed_session_count": len(listed_ids),
+        "listed_contains_created": created.session_id in listed_ids,
+    }
+
+
+async def _portable_prompt_completion_case(
+    client: ACPClient,
+    workspace_root: Path,
+    prompt: str,
+) -> dict[str, Any]:
+    created = await client.create_session(cwd=str(workspace_root))
+    handle = await client.start_prompt(created.session_id, prompt)
+    collector = _EventCollector()
+    collector_task = asyncio.create_task(collector.collect(handle))
+    try:
+        result = await handle.wait(timeout=60.0)
+    finally:
+        await collector_task
+
+    final_output = str(result.final_output or "")
+    if result.status.lower() not in {
+        "completed",
+        "complete",
+        "done",
+        "success",
+        "succeeded",
+    }:
+        raise AssertionError(f"Unexpected prompt status: {result.status}")
+    if not final_output.strip():
+        raise AssertionError("Prompt completed without any final output")
+
+    return {
+        "session_id": created.session_id,
+        "turn_id": handle.turn_id,
+        "status": result.status,
+        "final_output": final_output,
+        "contains_conformance_token": "CONFORMANCE_OK" in final_output.upper(),
+        "event_methods": collector.event_methods,
+        "event_kinds": collector.event_kinds,
+        "first_event_latency_ms": collector.first_event_latency_ms,
+    }
+
+
+async def _portable_prompt_reuse_case(
+    client: ACPClient,
+    workspace_root: Path,
+    prompt: str,
+) -> dict[str, Any]:
+    created = await client.create_session(cwd=str(workspace_root))
+    turn_ids: list[str] = []
+    outputs: list[str] = []
+    for _ in range(2):
+        handle = await client.start_prompt(created.session_id, prompt)
+        result = await handle.wait(timeout=60.0)
+        turn_ids.append(handle.turn_id)
+        outputs.append(str(result.final_output or ""))
+    if len(set(turn_ids)) != 2:
+        raise AssertionError("Prompt reuse did not produce distinct turn ids")
+    return {
+        "session_id": created.session_id,
+        "turn_ids": turn_ids,
+        "outputs": outputs,
+    }
+
+
+async def _fixture_permission_case(
+    client: ACPClient,
+    workspace_root: Path,
+) -> dict[str, Any]:
+    created = await client.create_session(cwd=str(workspace_root))
+    handle = await client.start_prompt(created.session_id, "needs permission")
+    result = await handle.wait(timeout=5.0)
+    if result.status.lower() not in {
+        "completed",
+        "complete",
+        "done",
+        "success",
+        "succeeded",
+    }:
+        raise AssertionError(
+            f"Permission flow did not complete cleanly: {result.status}"
+        )
+    return {
+        "session_id": created.session_id,
+        "turn_id": handle.turn_id,
+        "status": result.status,
+        "event_count": len(handle.snapshot_events()),
+    }
+
+
+async def _fixture_interrupt_case(
+    client: ACPClient,
+    workspace_root: Path,
+) -> dict[str, Any]:
+    created = await client.create_session(cwd=str(workspace_root))
+    handle = await client.start_prompt(created.session_id, "cancel me")
+    await asyncio.sleep(0.1)
+    await client.cancel_prompt(created.session_id, handle.turn_id)
+    result = await handle.wait(timeout=5.0)
+    status = str(result.status or "").strip().lower()
+    if status not in {"cancelled", "canceled", "interrupted"}:
+        raise AssertionError(
+            f"Interrupt flow returned unexpected status: {result.status}"
+        )
+    return {
+        "session_id": created.session_id,
+        "turn_id": handle.turn_id,
+        "status": result.status,
+    }
+
+
+async def _fixture_prompt_hang_case(
+    client: ACPClient,
+    workspace_root: Path,
+) -> dict[str, Any]:
+    created = await client.create_session(cwd=str(workspace_root))
+    handle = await client.start_prompt(created.session_id, "Reply with exactly OK.")
+    try:
+        await handle.wait(timeout=0.2)
+    except asyncio.TimeoutError:
+        pass
+    else:
+        raise AssertionError("Hanging prompt unexpectedly completed")
+    return {
+        "session_id": created.session_id,
+        "turn_id": handle.turn_id,
+        "snapshot_event_kinds": [event.kind for event in handle.snapshot_events()],
+    }
+
+
+async def _fixture_empty_load_case(
+    client: ACPClient,
+    workspace_root: Path,
+) -> dict[str, Any]:
+    created = await client.create_session(cwd=str(workspace_root))
+    loaded = await client.load_session(created.session_id)
+    return {
+        "session_id": loaded.session_id,
+        "raw": loaded.raw,
+    }
+
+
+async def _fixture_null_load_case(
+    client: ACPClient,
+    workspace_root: Path,
+) -> dict[str, Any]:
+    await client.start()
+    try:
+        await client.load_session("missing-session")
+    except ACPMissingSessionError as exc:
+        return {"error": str(exc)}
+    raise AssertionError("Null load result unexpectedly succeeded")
+
+
+async def _measure_case(
+    case_id: str,
+    run,
+) -> ACPCaseResult:
+    started = time.monotonic()
+    try:
+        details = await run()
+        return ACPCaseResult(
+            case_id=case_id,
+            passed=True,
+            status="passed",
+            elapsed_ms=_elapsed_ms(started),
+            details=details,
+        )
+    except (AssertionError, ACPError, asyncio.TimeoutError) as exc:
+        return ACPCaseResult(
+            case_id=case_id,
+            passed=False,
+            status="failed",
+            elapsed_ms=_elapsed_ms(started),
+            details={},
+            error_type=type(exc).__name__,
+            error_message=str(exc),
+        )
+    except Exception as exc:  # intentional: preserve unexpected crash type in report
+        logger.exception("ACP conformance case crashed: %s", case_id)
+        return ACPCaseResult(
+            case_id=case_id,
+            passed=False,
+            status="crashed",
+            elapsed_ms=_elapsed_ms(started),
+            details={},
+            error_type=type(exc).__name__,
+            error_message=str(exc),
+        )
+
+
+def _write_report_artifacts(
+    report: ACPConformanceReport,
+    *,
+    artifact_dir: Path,
+    run_root: Path,
+) -> None:
+    payload = report.to_dict()
+    run_root.mkdir(parents=True, exist_ok=True)
+    report_path = run_root / "suite_report.json"
+    report_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    latest_path = artifact_dir / "latest.json"
+    latest_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _notes_from_preflight(message: str, version: Optional[str]) -> tuple[str, ...]:
+    notes = [str(message or "").strip()]
+    if version:
+        notes.append(version)
+    return tuple(note for note in notes if note)
+
+
+def _elapsed_ms(started: float) -> int:
+    return max(int((time.monotonic() - started) * 1000), 0)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+async def _allow_permission_request(_event: Any) -> str:
+    return "allow"
+
+
+class _EventCollector:
+    def __init__(self) -> None:
+        self.event_methods: list[str] = []
+        self.event_kinds: list[str] = []
+        self.first_event_latency_ms: Optional[int] = None
+        self._started = time.monotonic()
+
+    async def collect(self, handle: Any) -> None:
+        async for event in handle.events():
+            if self.first_event_latency_ms is None:
+                self.first_event_latency_ms = _elapsed_ms(self._started)
+            self.event_methods.append(str(getattr(event, "method", "") or ""))
+            self.event_kinds.append(str(getattr(event, "kind", "") or ""))
+
+
+__all__ = [
+    "ACPCaseResult",
+    "ACPConformanceReport",
+    "ACPConformanceTarget",
+    "ACPTargetResult",
+    "DEFAULT_ARTIFACT_DIR",
+    "DEFAULT_COMPLETION_PROMPT",
+    "discover_repo_acp_targets",
+    "format_acp_conformance_report",
+    "run_acp_conformance_report",
+]

--- a/tests/chat_surface_lab/acp_conformance.py
+++ b/tests/chat_surface_lab/acp_conformance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import time
@@ -25,6 +26,25 @@ DEFAULT_ARTIFACT_DIR = Path(".codex-autorunner") / "diagnostics" / "acp-conforma
 DEFAULT_COMPLETION_PROMPT = (
     "Return only the token CONFORMANCE_OK. Do not add punctuation or extra words."
 )
+
+_PROMPT_COMPLETION_STATUSES = frozenset(
+    {
+        "completed",
+        "complete",
+        "done",
+        "success",
+        "succeeded",
+    }
+)
+
+
+def _assert_prompt_completed_ok(result: Any) -> None:
+    status = str(getattr(result, "status", "") or "").strip().lower()
+    if status not in _PROMPT_COMPLETION_STATUSES:
+        raise AssertionError(f"Unexpected prompt status: {result.status}")
+    final_output = str(getattr(result, "final_output", "") or "")
+    if not final_output.strip():
+        raise AssertionError("Prompt completed without any final output")
 
 
 @dataclass(frozen=True)
@@ -121,6 +141,7 @@ def discover_repo_acp_targets(repo_root: Path) -> list[ACPConformanceTarget]:
                     command=supervisor.launch_command,
                     source="repo_config",
                     agent_id="hermes",
+                    env=supervisor.launch_env,
                     notes=_notes_from_preflight(
                         base_preflight.message, base_preflight.version
                     ),
@@ -153,6 +174,7 @@ def discover_repo_acp_targets(repo_root: Path) -> list[ACPConformanceTarget]:
                     source="repo_config",
                     agent_id="hermes",
                     profile=profile_name,
+                    env=supervisor.launch_env,
                     notes=_notes_from_preflight(
                         preflight.message,
                         preflight.version,
@@ -391,28 +413,21 @@ async def _portable_session_roundtrip_case(
 async def _portable_prompt_completion_case(
     client: ACPClient,
     workspace_root: Path,
-    prompt: str,
+    portable_prompt: str,
 ) -> dict[str, Any]:
     created = await client.create_session(cwd=str(workspace_root))
-    handle = await client.start_prompt(created.session_id, prompt)
+    handle = await client.start_prompt(created.session_id, portable_prompt)
     collector = _EventCollector()
     collector_task = asyncio.create_task(collector.collect(handle))
     try:
         result = await handle.wait(timeout=60.0)
     finally:
-        await collector_task
+        collector_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await collector_task
 
     final_output = str(result.final_output or "")
-    if result.status.lower() not in {
-        "completed",
-        "complete",
-        "done",
-        "success",
-        "succeeded",
-    }:
-        raise AssertionError(f"Unexpected prompt status: {result.status}")
-    if not final_output.strip():
-        raise AssertionError("Prompt completed without any final output")
+    _assert_prompt_completed_ok(result)
 
     return {
         "session_id": created.session_id,
@@ -429,14 +444,15 @@ async def _portable_prompt_completion_case(
 async def _portable_prompt_reuse_case(
     client: ACPClient,
     workspace_root: Path,
-    prompt: str,
+    portable_prompt: str,
 ) -> dict[str, Any]:
     created = await client.create_session(cwd=str(workspace_root))
     turn_ids: list[str] = []
     outputs: list[str] = []
     for _ in range(2):
-        handle = await client.start_prompt(created.session_id, prompt)
+        handle = await client.start_prompt(created.session_id, portable_prompt)
         result = await handle.wait(timeout=60.0)
+        _assert_prompt_completed_ok(result)
         turn_ids.append(handle.turn_id)
         outputs.append(str(result.final_output or ""))
     if len(set(turn_ids)) != 2:

--- a/tests/chat_surface_lab/test_acp_conformance.py
+++ b/tests/chat_surface_lab/test_acp_conformance.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.chat_surface_lab.acp_conformance import (
+    ACPConformanceReport,
+    ACPConformanceTarget,
+    format_acp_conformance_report,
+    run_acp_conformance_report,
+)
+from tests.chat_surface_lab.backend_runtime import fake_acp_command
+
+
+@pytest.mark.anyio
+async def test_acp_conformance_runner_passes_fixture_target(tmp_path: Path) -> None:
+    report = await run_acp_conformance_report(
+        tmp_path,
+        targets=[
+            ACPConformanceTarget(
+                id="fixture.official",
+                label="Fixture ACP (official)",
+                command=tuple(fake_acp_command("official")),
+                source="fixture",
+                scenario="official",
+            )
+        ],
+        artifact_dir=tmp_path / "artifacts",
+    )
+
+    assert report.passed is True
+    assert len(report.results) == 1
+    target_result = report.results[0]
+    assert target_result.passed is True
+    assert {case.case_id for case in target_result.cases} >= {
+        "initialize",
+        "session_roundtrip",
+        "prompt_completion",
+        "prompt_reuse",
+        "fixture.permission_flow",
+        "fixture.interrupt_flow",
+        "fixture.prompt_hang_timeout",
+        "fixture.empty_load_result",
+        "fixture.null_load_result",
+    }
+
+    latest = json.loads((tmp_path / "artifacts" / "latest.json").read_text())
+    assert latest["passed"] is True
+    assert latest["results"][0]["target"]["id"] == "fixture.official"
+
+
+def test_acp_conformance_report_formatter_mentions_targets_and_case_ids(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    artifact_dir = tmp_path / "report"
+    report = ACPConformanceReport(
+        run_id="run-1",
+        repo_root=str(repo_root),
+        created_at="2026-01-01T00:00:00+00:00",
+        portable_case_ids=("initialize",),
+        fixture_case_ids=(),
+        results=(),
+        artifact_dir=str(artifact_dir),
+    )
+
+    formatted = format_acp_conformance_report(report)
+
+    assert "ACP conformance run run-1" in formatted
+    assert f"repo_root={repo_root}" in formatted


### PR DESCRIPTION
## Summary
- add a reusable ACP conformance runner and CLI for fixture and configured Hermes targets
- harden Hermes supervisor launch env handling so profile wrappers can resolve sibling binaries via PATH
- export the chat-surface lab conformance helpers and cover the new behavior with focused tests

## Conformance report
Latest run: `.codex-autorunner/diagnostics/acp-conformance/runs/20260421T164959498156Z-5fa19b9b`
- Fixture ACP (official): pass
- Hermes: pass
- Hermes [m4-pma]: pass

Latest timings:
- Hermes: `prompt_completion` 6086 ms, `prompt_reuse` 11547 ms
- Hermes [m4-pma]: `prompt_completion` 4351 ms, `prompt_reuse` 10934 ms

Current interpretation:
- the earlier Hermes profile path failure was caused by the conformance runner stripping `PATH`, not by CAR's normal launch path
- with production-like request timeouts, this branch does not reproduce a stable `hermes [m4-pma]` parity failure relative to base Hermes

## Validation
- `.venv/bin/python -m pytest tests/agents/hermes/test_hermes_supervisor.py tests/chat_surface_lab/test_acp_conformance.py -q`
- `.venv/bin/python scripts/acp_conformance.py`