### PR TITLE
Fix Hermes PMA silent-stream recovery

### DIFF
--- a/src/codex_autorunner/core/orchestration/runtime_threads.py
+++ b/src/codex_autorunner/core/orchestration/runtime_threads.py
@@ -16,6 +16,7 @@ from .service import HarnessBackedOrchestrationService
 
 _INTERRUPT_POLL_INTERVAL_SECONDS = 0.05
 _STALL_POLL_INTERVAL_SECONDS = 0.25
+_STALL_RECOVERY_PROBE_INTERVAL_SECONDS = 15.0
 RUNTIME_THREAD_TIMEOUT_ERROR = "Runtime thread timed out"
 RUNTIME_THREAD_INTERRUPTED_ERROR = "Runtime thread interrupted"
 RUNTIME_THREAD_MISSING_BACKEND_IDS_ERROR = (
@@ -67,6 +68,10 @@ def _looks_like_terminal_turn_result(result: Any) -> bool:
         and isinstance(raw_events, list)
         and isinstance(errors, list)
     )
+
+
+def _harness_supports_stall_recovery(harness: Any) -> bool:
+    return callable(getattr(harness, "recover_stalled_turn", None))
 
 
 @dataclass(frozen=True)
@@ -217,6 +222,16 @@ async def await_runtime_thread_outcome(
         if stall_timeout_seconds is not None and float(stall_timeout_seconds) > 0.0
         else None
     )
+    recovery_probe_task = None
+    recovery_probe_interval = _stall_recovery_probe_interval_seconds(
+        stall_timeout_seconds
+    )
+    if recovery_probe_interval is not None and _harness_supports_stall_recovery(
+        execution.harness
+    ):
+        recovery_probe_task = asyncio.create_task(
+            _wait_for_progress_recovery_probe(state, recovery_probe_interval)
+        )
     stream_task = None
     if observe_progress_events and _harness_supports_progress_event_stream(
         execution.harness
@@ -232,6 +247,8 @@ async def await_runtime_thread_outcome(
         wait_tasks.add(terminal_wait_task)
         if stall_task is not None:
             wait_tasks.add(stall_task)
+        if recovery_probe_task is not None:
+            wait_tasks.add(recovery_probe_task)
         while True:
             done, _ = await asyncio.wait(
                 wait_tasks,
@@ -257,6 +274,18 @@ async def await_runtime_thread_outcome(
                     backend_turn_id,
                 )
                 return state.build_timeout_outcome(RUNTIME_THREAD_TIMEOUT_ERROR)
+            if recovery_probe_task is not None and recovery_probe_task in done:
+                wait_tasks.discard(recovery_probe_task)
+                recovered = await _recover_stalled_turn(execution)
+                if recovered is not None:
+                    state.note_transport_result(recovered)
+                    return state.build_outcome(execution_error_message)
+                assert recovery_probe_interval is not None
+                recovery_probe_task = asyncio.create_task(
+                    _wait_for_progress_recovery_probe(state, recovery_probe_interval)
+                )
+                wait_tasks.add(recovery_probe_task)
+                continue
             if stall_task is not None and stall_task in done:
                 recovered = await _recover_stalled_turn(execution)
                 if recovered is not None:
@@ -281,6 +310,8 @@ async def await_runtime_thread_outcome(
             cleanup_tasks.append(interrupt_task)
         if stall_task is not None:
             cleanup_tasks.append(stall_task)
+        if recovery_probe_task is not None:
+            cleanup_tasks.append(recovery_probe_task)
         if stream_task is not None:
             cleanup_tasks.append(stream_task)
         for task in cleanup_tasks:
@@ -304,6 +335,38 @@ async def _wait_for_progress_stall(
         last_progress = state.last_progress_monotonic
         if last_progress is not None:
             deadline = max(deadline, last_progress + timeout_seconds)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        await asyncio.sleep(min(remaining, _STALL_POLL_INTERVAL_SECONDS))
+
+
+def _stall_recovery_probe_interval_seconds(
+    stall_timeout_seconds: Optional[float],
+) -> Optional[float]:
+    interval = float(_STALL_RECOVERY_PROBE_INTERVAL_SECONDS)
+    if interval <= 0.0:
+        return None
+    if stall_timeout_seconds is None:
+        return interval
+    timeout_seconds = float(stall_timeout_seconds)
+    if timeout_seconds <= 0.0:
+        return None
+    if timeout_seconds <= interval:
+        return None
+    return interval
+
+
+async def _wait_for_progress_recovery_probe(
+    state: RuntimeTurnTerminalStateMachine,
+    probe_interval_seconds: float,
+) -> None:
+    timeout_seconds = max(float(probe_interval_seconds), 0.0)
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        last_progress = state.last_progress_monotonic
+        if last_progress is not None:
+            deadline = last_progress + timeout_seconds
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             return

--- a/src/codex_autorunner/core/orchestration/runtime_threads.py
+++ b/src/codex_autorunner/core/orchestration/runtime_threads.py
@@ -366,7 +366,7 @@ async def _wait_for_progress_recovery_probe(
     while True:
         last_progress = state.last_progress_monotonic
         if last_progress is not None:
-            deadline = last_progress + timeout_seconds
+            deadline = max(deadline, last_progress + timeout_seconds)
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             return

--- a/tests/chat_surface_integration/test_hermes_pma_official_timeout.py
+++ b/tests/chat_surface_integration/test_hermes_pma_official_timeout.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import pytest
 
+from codex_autorunner.core.orchestration import (
+    runtime_threads as runtime_threads_module,
+)
 from codex_autorunner.integrations.discord import message_turns as discord_message_turns
 from codex_autorunner.integrations.telegram.handlers.commands import (
     execution as telegram_execution,
@@ -118,6 +121,59 @@ async def test_discord_hermes_pma_recovers_second_turn_from_persisted_session_st
         )
         assert finalized["status"] == "ok"
         assert finalized["completion_source"] == "prompt_return"
+    finally:
+        await harness.close()
+        await runtime.close()
+
+
+@pytest.mark.anyio
+async def test_discord_hermes_pma_recovers_from_persisted_completion_before_stall_timeout(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = HermesFixtureRuntime(
+        "official_second_prompt_hang_with_persisted_completion",
+        base_env={"HERMES_HOME": str(tmp_path / "hermes-home")},
+    )
+    patch_hermes_runtime(monkeypatch, runtime)
+    monkeypatch.setattr(
+        runtime_threads_module,
+        "_STALL_RECOVERY_PROBE_INTERVAL_SECONDS",
+        0.05,
+    )
+    monkeypatch.setattr(discord_message_turns, "DISCORD_PMA_TIMEOUT_SECONDS", 30.0)
+    monkeypatch.setattr(
+        discord_message_turns,
+        "DISCORD_PMA_STALL_TIMEOUT_SECONDS",
+        30.0,
+    )
+    harness = DiscordSurfaceHarness(tmp_path / "discord-recover-early")
+    await harness.setup(agent="hermes")
+    try:
+        first = await harness.run_message("echo hello world")
+        second = await harness.run_message("echo hello world again")
+
+        assert first.execution_status == "ok"
+        assert second.execution_status == "ok"
+        assert second.execution_error is None
+        assert any(
+            op["op"] == "send"
+            and "identical fixture output" in str(op["payload"].get("content", ""))
+            for op in second.message_ops
+        )
+        finalized = next(
+            record
+            for record in reversed(second.log_records)
+            if record.get("event") == "chat.managed_thread.turn_finalized"
+        )
+        assert finalized["status"] == "ok"
+        assert finalized["completion_source"] == "prompt_return"
+        assert not any(
+            op["op"] == "send"
+            and "discord pma turn timed out"
+            in str(op["payload"].get("content", "")).lower()
+            for op in second.message_ops
+        )
     finally:
         await harness.close()
         await runtime.close()

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -19,6 +20,9 @@ from codex_autorunner.core.orchestration import (
     MappingAgentDefinitionCatalog,
     MessageRequest,
     PmaThreadExecutionStore,
+)
+from codex_autorunner.core.orchestration import (
+    runtime_threads as runtime_threads_module,
 )
 from codex_autorunner.core.orchestration.models import ExecutionRecord, ThreadTarget
 from codex_autorunner.core.orchestration.runtime_threads import (
@@ -1640,6 +1644,88 @@ async def test_runtime_thread_stall_can_recover_from_harness_before_timeout(
     assert harness.recovery_calls == [
         (workspace_root, "backend-thread-1", "backend-turn-1")
     ]
+    assert harness.interrupt_calls == []
+    assert harness.wait_cancelled.is_set()
+
+
+async def test_runtime_thread_recovery_probe_can_finish_before_stall_deadline(
+    tmp_path: Path,
+) -> None:
+    @dataclass
+    class _HarnessWithDelayedRecovery(_HarnessWithBlockingWait):
+        capabilities: frozenset[str] = frozenset(
+            ["durable_threads", "message_turns", "interrupt", "event_streaming"]
+        )
+        recovery_calls: list[float] = field(default_factory=list)
+
+        async def stream_events(
+            self, workspace_root: Path, conversation_id: str, turn_id: str
+        ):
+            _ = workspace_root, conversation_id, turn_id
+            yield {
+                "message": {
+                    "method": "session/update",
+                    "params": {
+                        "update": {"sessionUpdate": "agent_message_chunk"},
+                        "text": "partial output",
+                    },
+                }
+            }
+            await asyncio.Future()
+
+        async def recover_stalled_turn(
+            self, workspace_root: Path, conversation_id: str, turn_id: str
+        ) -> Optional[TerminalTurnResult]:
+            _ = workspace_root, conversation_id, turn_id
+            self.recovery_calls.append(time.monotonic())
+            if len(self.recovery_calls) < 2:
+                return None
+            return TerminalTurnResult(
+                status="ok",
+                assistant_text="recovered before hard stall",
+                raw_events=[],
+                errors=[],
+            )
+
+    original_interval = runtime_threads_module._STALL_RECOVERY_PROBE_INTERVAL_SECONDS
+    runtime_threads_module._STALL_RECOVERY_PROBE_INTERVAL_SECONDS = 0.03
+    try:
+        harness = _HarnessWithDelayedRecovery()
+        service = _build_service(tmp_path, harness)
+        workspace_root = tmp_path / "workspace"
+        workspace_root.mkdir()
+        thread = service.create_thread_target("codex", workspace_root)
+
+        started = await begin_runtime_thread_execution(
+            service,
+            MessageRequest(
+                target_id=thread.thread_target_id,
+                target_kind="thread",
+                message_text="user-visible prompt",
+            ),
+        )
+        started_at = time.monotonic()
+        outcome = await asyncio.wait_for(
+            await_runtime_thread_outcome(
+                started,
+                interrupt_event=None,
+                timeout_seconds=5,
+                stall_timeout_seconds=0.3,
+                execution_error_message="Managed thread execution failed",
+            ),
+            timeout=1,
+        )
+    finally:
+        runtime_threads_module._STALL_RECOVERY_PROBE_INTERVAL_SECONDS = (
+            original_interval
+        )
+
+    elapsed = time.monotonic() - started_at
+    assert outcome.status == "ok"
+    assert outcome.assistant_text == "recovered before hard stall"
+    assert outcome.completion_source == "prompt_return"
+    assert len(harness.recovery_calls) == 2
+    assert elapsed < 0.25
     assert harness.interrupt_calls == []
     assert harness.wait_cancelled.is_set()
 


### PR DESCRIPTION
## Summary
- add a short internal no-progress recovery probe for harnesses that expose `recover_stalled_turn()` so long PMA stall budgets do not delay Hermes session-store recovery
- keep short explicit stall budgets on the old single-deadline path so timeout behavior stays unchanged
- cover the new behavior with runtime-level and Discord Hermes PMA regressions

## Testing
- .venv/bin/pytest tests/core/orchestration/test_runtime_threads.py tests/chat_surface_integration/test_hermes_pma_official_timeout.py -q
- aggregate commit validation lane (mypy, full pytest suite, frontend checks, chat-surface lab checks)

Closes #1549