### PR TITLE
Clarify live commentary progress

### DIFF
--- a/src/codex_autorunner/integrations/chat/progress_primitives.py
+++ b/src/codex_autorunner/integrations/chat/progress_primitives.py
@@ -410,12 +410,23 @@ def render_progress_text(
             block = [f"🧠 {action.text}"]
             if blocks:
                 block.insert(0, "")
-        elif action.label in {"output", "commentary"}:
+        elif action.label == "output":
             output_lines = action.text.split("\n")
             if not output_lines:
                 block = [action.text]
             else:
                 block = output_lines
+            if blocks:
+                block.insert(0, "")
+        elif action.label == "commentary":
+            commentary_lines = action.text.split("\n")
+            if not commentary_lines:
+                commentary_lines = [action.text]
+            block = [
+                "Interim note from agent while this turn is still running:",
+                *commentary_lines,
+                "Final reply will be sent separately when the turn completes.",
+            ]
             if blocks:
                 block.insert(0, "")
         else:

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -2314,9 +2314,13 @@ async def _run_discord_orchestrated_turn_for_message(
             intermediate_message=intermediate_message,
             token_usage=finalized.token_usage,
             elapsed_seconds=max(0.0, time.monotonic() - tracker.started_at),
-            send_final_message=not (
-                getattr(_flow, "durable_delivery_performed", False)
-                or getattr(_flow, "durable_delivery_pending", False)
+            # Match Telegram semantics: only suppress the visible terminal reply
+            # after a confirmed durable delivery, not while durable delivery is
+            # merely pending or retry-scheduled.
+            send_final_message=not getattr(
+                _flow,
+                "durable_delivery_performed",
+                False,
             ),
             delivery_visibility_pending=getattr(
                 _flow,

--- a/tests/chat_surface_lab/scenarios/final_delivery_retry_after_visibility.json
+++ b/tests/chat_surface_lab/scenarios/final_delivery_retry_after_visibility.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "scenario_id": "final_delivery_retry_after_visibility",
-  "description": "Discord keeps a visible terminal failure note when the final reply send is rate-limited after turn finalization.",
+  "description": "Discord falls back to a direct final reply when durable terminal delivery is rate-limited after turn finalization.",
   "surfaces": [
     "discord"
   ],
@@ -57,7 +57,7 @@
       ],
       "params": {
         "event_name": "discord.turn.delivery_finished",
-        "field": "visible_failure_notice",
+        "field": "send_final_message",
         "value": true
       }
     },
@@ -77,7 +77,7 @@
       ],
       "params": {
         "attr": "has_delete_event",
-        "value": false
+        "value": true
       }
     },
     {
@@ -98,5 +98,5 @@
     "hermes",
     "pma"
   ],
-  "notes": "Characterizes the case where final Discord delivery falls back to the outbox after the turn has already finalized."
+  "notes": "Characterizes the case where the durable Discord send is retried in the outbox, but the direct PMA surface still posts the final reply immediately."
 }

--- a/tests/chat_surface_lab/test_scenario_runner.py
+++ b/tests/chat_surface_lab/test_scenario_runner.py
@@ -86,7 +86,7 @@ async def test_runner_executes_interrupt_optimistic_acceptance_matrix(
 
 
 @pytest.mark.anyio
-async def test_runner_keeps_visible_failure_note_when_final_delivery_is_outboxed(
+async def test_runner_falls_back_to_direct_final_reply_when_durable_delivery_is_outboxed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -107,7 +107,7 @@ async def test_runner_keeps_visible_failure_note_when_final_delivery_is_outboxed
     )
     assert any(
         record.get("event") == "discord.turn.delivery_finished"
-        and record.get("visible_failure_notice") is True
+        and record.get("send_final_message") is True
         for record in discord.log_records
     )
 

--- a/tests/integrations/discord/test_message_turns_transient_progress.py
+++ b/tests/integrations/discord/test_message_turns_transient_progress.py
@@ -54,6 +54,109 @@ class _UnknownMessageEditProgressRest(support._FakeRest):
 
 
 @pytest.mark.asyncio
+async def test_orchestrated_turn_pending_durable_delivery_keeps_direct_final_message(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    thread = SimpleNamespace(thread_target_id="thread-1")
+
+    class _Store:
+        async def get_binding(self, *, channel_id: str) -> dict[str, Any]:
+            assert channel_id == "channel-1"
+            return {}
+
+    class _Service:
+        def __init__(self) -> None:
+            self._config = support._config(tmp_path)
+            self._store = _Store()
+            self._rest = support._FakeRest()
+            self._logger = logging.getLogger(__name__)
+
+        async def _send_channel_message(
+            self, channel_id: str, payload: dict[str, Any]
+        ) -> dict[str, Any]:
+            return await self._rest.create_channel_message(
+                channel_id=channel_id,
+                payload=payload,
+            )
+
+        def _resolve_agent_state(self, binding: Any) -> tuple[str, Optional[str]]:
+            _ = binding
+            return "hermes", None
+
+        def _runtime_agent_for_binding(self, binding: Any) -> str:
+            _ = binding
+            return "hermes"
+
+    async def _fake_run_managed_surface_turn(
+        _request: Any,
+        *,
+        config: Any,
+    ) -> support.discord_message_turns_module.DiscordMessageTurnResult:
+        finalized = support.managed_thread_turns_module.ManagedThreadFinalizationResult(
+            status="ok",
+            assistant_text="fixture reply",
+            error=None,
+            managed_thread_id="thread-1",
+            managed_turn_id="exec-1",
+            backend_thread_id="backend-1",
+            token_usage={"input_tokens": 1, "output_tokens": 1},
+        )
+        return await config.on_finalized(
+            SimpleNamespace(
+                durable_delivery_performed=False,
+                durable_delivery_pending=True,
+            ),
+            finalized,
+        )
+
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "resolve_discord_thread_target",
+        lambda *args, **kwargs: (SimpleNamespace(), thread),
+    )
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "_build_discord_managed_thread_coordinator",
+        lambda *args, **kwargs: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        support.discord_message_turns_module,
+        "run_managed_surface_turn",
+        _fake_run_managed_surface_turn,
+    )
+
+    result = await support.discord_message_turns_module._run_discord_orchestrated_turn_for_message(
+        _Service(),
+        workspace_root=tmp_path,
+        prompt_text="echo hello world",
+        input_items=None,
+        source_message_id=None,
+        agent="hermes",
+        model_override=None,
+        reasoning_effort=None,
+        session_key="session-1",
+        orchestrator_channel_key="channel-1",
+        managed_thread_surface_key=None,
+        mode="pma",
+        pma_enabled=True,
+        execution_prompt="<user_message>\necho hello world\n</user_message>\n",
+        public_execution_error="Discord PMA turn failed",
+        timeout_error="Discord PMA turn timed out",
+        interrupted_error="Discord PMA turn interrupted",
+        approval_mode="never",
+        sandbox_policy="dangerFullAccess",
+        max_actions=12,
+        min_edit_interval_seconds=1.0,
+        heartbeat_interval_seconds=2.0,
+    )
+
+    assert result.send_final_message is True
+    assert result.delivery_visibility_pending is True
+    assert "fixture reply" in result.final_message
+
+
+@pytest.mark.asyncio
 async def test_spawn_discord_progress_background_task_uses_service_tracking() -> None:
     class _Service:
         def __init__(self) -> None:

--- a/tests/test_managed_thread_progress.py
+++ b/tests/test_managed_thread_progress.py
@@ -242,7 +242,10 @@ def test_apply_run_event_to_progress_tracker_renders_commentary_live_only() -> N
     live = render_progress_text(tracker, max_length=2000, now=1.0)
     final = render_progress_text(tracker, max_length=2000, now=1.0, render_mode="final")
 
+    assert "Interim note from agent while this turn is still running:" in live
     assert "Checking the ACP event path" in live
+    assert "Final reply will be sent separately when the turn completes." in live
+    assert "Interim note from agent while this turn is still running:" not in final
     assert "Checking the ACP event path" not in final
 
 

--- a/tests/test_telegram_progress_stream.py
+++ b/tests/test_telegram_progress_stream.py
@@ -322,8 +322,11 @@ def test_render_progress_text_keeps_commentary_live_only() -> None:
     final = render_progress_text(tracker, max_length=2000, now=1.0, render_mode="final")
 
     assert "streamed output" in live
+    assert "Interim note from agent while this turn is still running:" in live
     assert "interim commentary block" in live
+    assert "Final reply will be sent separately when the turn completes." in live
     assert "streamed output" in final
+    assert "Interim note from agent while this turn is still running:" not in final
     assert "interim commentary block" not in final
 
 


### PR DESCRIPTION
## Summary
- make shared chat progress rendering label commentary as explicitly in-progress rather than looking like a normal assistant reply
- stop Discord PMA from suppressing the visible final reply when durable delivery is only pending or retry-scheduled
- add regression coverage for the pending durable-delivery case and update the chat-surface lab scenario to expect the new direct-fallback behavior

## Why
Two issues were compounding the confusing UX:
1. Hermes commentary looked too much like a finished answer while the turn was still running.
2. Discord PMA treated pending durable delivery as if final visibility was already handled, which could delay the user-visible final reply until a later retry.

The second issue is the root-cause fix here: Discord now matches Telegram semantics and only suppresses its visible final reply after a confirmed durable delivery.

## Impact
- Discord managed-thread progress is clearer while a turn is still running
- Discord PMA no longer delays the visible final reply just because durable delivery is pending
- Telegram and Discord now align on the durable-delivery suppression rule

## Checks
- `pytest tests/discord_message_turns_support.py -q -k pending_durable_delivery`
- `pytest tests/integrations/discord/test_message_turns_transient_progress.py -q -k pending_durable_delivery`
- `pytest tests/chat_surface_integration/test_hermes_pma_surface_parity.py -q -k official_completion`
- `pytest tests/chat_surface_integration/test_hermes_pma_ux_regressions.py -q -k 'fast_visible_feedback_and_reuse_progress_anchor or make_busy_thread_queue_visible_before_recovery'`
- `pytest tests/chat_surface_lab/test_scenario_runner.py -q -k final_delivery_retry_after_visibility`
- `pytest tests/test_hotspot_budgets.py -q -k hotspot_file_budgets`
- aggregate commit lane passed, including strict mypy, full pytest, frontend checks, and chat-surface lab/latency checks