### PR TITLE
[codex] Fix PMA duplicate delivery and Hermes progress UX

### DIFF
--- a/src/codex_autorunner/integrations/chat/managed_thread_progress.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_progress.py
@@ -14,7 +14,12 @@ from ...core.ports.run_event import (
     RunNotice,
     ToolCall,
 )
-from .progress_primitives import ProgressAction, TurnProgressTracker
+from .progress_primitives import (
+    ProgressAction,
+    TurnProgressTracker,
+    _normalize_output_text,
+    _output_matches_final_message,
+)
 
 
 @dataclass
@@ -123,6 +128,18 @@ def apply_run_event_to_progress_tracker(
             if already_streamed:
                 return ProgressTrackerEventOutcome(changed=False)
             if not notice:
+                return ProgressTrackerEventOutcome(changed=False)
+            latest_output = _normalize_output_text(tracker.latest_output_text()).strip()
+            notice_text = _normalize_output_text(notice).strip()
+            if (
+                latest_output
+                and notice_text
+                and (
+                    latest_output == notice_text
+                    or _output_matches_final_message(latest_output, notice_text)
+                    or _output_matches_final_message(notice_text, latest_output)
+                )
+            ):
                 return ProgressTrackerEventOutcome(changed=False)
             tracker.note_commentary(notice)
             return ProgressTrackerEventOutcome(changed=True, force=True)

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -223,6 +223,7 @@ class ManagedThreadExecutionFlowResult:
     finalized: Optional[ManagedThreadFinalizationResult] = None
     durable_delivery_performed: bool = False
     durable_delivery_pending: bool = False
+    durable_delivery_id: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/src/codex_autorunner/integrations/chat/managed_turn_runner.py
+++ b/src/codex_autorunner/integrations/chat/managed_turn_runner.py
@@ -190,6 +190,7 @@ async def run_managed_surface_turn(
             raise RuntimeError("Managed-thread turn finalized without a result")
         durable_delivery_performed = False
         durable_delivery_pending = False
+        durable_delivery_id: Optional[str] = None
         if config.hooks.durable_delivery is not None:
             try:
                 delivery_record = await handoff_managed_thread_final_delivery(
@@ -197,6 +198,7 @@ async def run_managed_surface_turn(
                     delivery=config.hooks.durable_delivery,
                     logger=_runner_logger,
                 )
+                durable_delivery_id = getattr(delivery_record, "delivery_id", None)
                 durable_delivery_performed = (
                     delivery_record is not None
                     and delivery_record.state is ManagedThreadDeliveryState.DELIVERED
@@ -215,13 +217,18 @@ async def run_managed_surface_turn(
                 raise
             except Exception:
                 pass
-        if durable_delivery_performed or durable_delivery_pending:
+        if (
+            durable_delivery_performed
+            or durable_delivery_pending
+            or durable_delivery_id is not None
+        ):
             finalized_flow = ManagedThreadExecutionFlowResult(
                 started_execution=finalized_flow.started_execution,
                 queued=finalized_flow.queued,
                 finalized=finalized_flow.finalized,
                 durable_delivery_performed=durable_delivery_performed,
                 durable_delivery_pending=durable_delivery_pending,
+                durable_delivery_id=durable_delivery_id,
             )
         if config.on_finalized is None:
             raise RuntimeError("Managed-surface turn requires on_finalized")

--- a/src/codex_autorunner/integrations/chat/progress_primitives.py
+++ b/src/codex_autorunner/integrations/chat/progress_primitives.py
@@ -422,11 +422,7 @@ def render_progress_text(
             commentary_lines = action.text.split("\n")
             if not commentary_lines:
                 commentary_lines = [action.text]
-            block = [
-                "Interim note from agent while this turn is still running:",
-                *commentary_lines,
-                "Final reply will be sent separately when the turn completes.",
-            ]
+            block = commentary_lines
             if blocks:
                 block.insert(0, "")
         else:

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -36,6 +36,7 @@ from ...core.orchestration import (
     FlowTarget,
     MessageRequest,
     PausedFlowTarget,
+    SQLiteManagedThreadDeliveryEngine,
     SurfaceThreadMessageRequest,
     build_surface_orchestration_ingress,
 )
@@ -175,6 +176,47 @@ DISCORD_PMA_PROGRESS_HEARTBEAT_INTERVAL_SECONDS = 2.0
 _sanitize_runtime_thread_result_error = sanitize_runtime_thread_error
 
 
+def _abandon_pending_discord_delivery(
+    service: Any,
+    *,
+    delivery_id: Optional[str],
+    channel_id: str,
+    session_key: str,
+) -> None:
+    if not isinstance(delivery_id, str) or not delivery_id.strip():
+        return
+    state_root = getattr(getattr(service, "_config", None), "root", None)
+    if state_root is None:
+        state_root = Path(".")
+    try:
+        engine = SQLiteManagedThreadDeliveryEngine(Path(state_root))
+        abandoned = engine.abandon_delivery(
+            delivery_id,
+            detail="abandoned_after_direct_discord_delivery",
+        )
+    except Exception as exc:
+        log_event(
+            service._logger,
+            logging.WARNING,
+            "discord.turn.delivery_abandon_failed",
+            channel_id=channel_id,
+            session_key=session_key,
+            delivery_id=delivery_id,
+            exc=exc,
+        )
+        return
+    if abandoned is not None:
+        log_event(
+            service._logger,
+            logging.INFO,
+            "discord.turn.delivery_abandoned",
+            channel_id=channel_id,
+            session_key=session_key,
+            delivery_id=delivery_id,
+            delivery_state=abandoned.state.value,
+        )
+
+
 @dataclass(frozen=True)
 class DiscordMessageTurnResult:
     final_message: str
@@ -185,6 +227,7 @@ class DiscordMessageTurnResult:
     elapsed_seconds: Optional[float] = None
     send_final_message: bool = True
     delivery_visibility_pending: bool = False
+    durable_delivery_id: Optional[str] = None
     deferred_delivery: bool = False
     preserve_progress_lease: bool = False
 
@@ -1181,6 +1224,7 @@ async def _deliver_discord_turn_result(
         execution_id = turn_result.execution_id
         send_final_message = turn_result.send_final_message
         delivery_visibility_pending = turn_result.delivery_visibility_pending
+        durable_delivery_id = turn_result.durable_delivery_id
         preserve_progress_lease = turn_result.preserve_progress_lease
         intermediate_text = (
             turn_result.intermediate_message.strip()
@@ -1201,6 +1245,7 @@ async def _deliver_discord_turn_result(
         execution_id = None
         send_final_message = True
         delivery_visibility_pending = False
+        durable_delivery_id = None
         preserve_progress_lease = False
 
     managed_thread_id = None
@@ -1261,6 +1306,13 @@ async def _deliver_discord_turn_result(
             record_prefix=f"turn:final:{dispatch.session_key}",
             attachment_filename="final-response.md",
             attachment_caption="Final response too long; attached as final-response.md.",
+        )
+    if visible_terminal_delivery and delivery_visibility_pending:
+        _abandon_pending_discord_delivery(
+            dispatch.service,
+            delivery_id=durable_delivery_id,
+            channel_id=dispatch.channel_id,
+            session_key=dispatch.session_key,
         )
     if visible_terminal_delivery:
         if not preserve_progress_lease:
@@ -2326,6 +2378,11 @@ async def _run_discord_orchestrated_turn_for_message(
                 _flow,
                 "durable_delivery_pending",
                 False,
+            ),
+            durable_delivery_id=getattr(
+                _flow,
+                "durable_delivery_id",
+                None,
             ),
         )
 

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -200,6 +200,7 @@ class _TurnRunResult:
     interrupt_status_turn_id: Optional[str] = None
     interrupt_status_fallback_text: Optional[str] = None
     durable_delivery_handled: bool = False
+    durable_delivery_id: Optional[str] = None
 
 
 @dataclass
@@ -286,6 +287,44 @@ def _telegram_state_root(handlers: Any) -> Path:
     if state_root is None:
         state_root = Path(".")
     return Path(state_root)
+
+
+def _abandon_pending_telegram_delivery(
+    handlers: Any,
+    *,
+    delivery_id: Optional[str],
+    chat_id: int,
+    thread_id: Optional[int],
+) -> None:
+    if not isinstance(delivery_id, str) or not delivery_id.strip():
+        return
+    try:
+        engine = SQLiteManagedThreadDeliveryEngine(_telegram_state_root(handlers))
+        abandoned = engine.abandon_delivery(
+            delivery_id,
+            detail="abandoned_after_direct_telegram_delivery",
+        )
+    except Exception as exc:
+        log_event(
+            handlers._logger,
+            logging.WARNING,
+            "telegram.response.delivery_abandon_failed",
+            chat_id=chat_id,
+            thread_id=thread_id,
+            delivery_id=delivery_id,
+            exc=exc,
+        )
+        return
+    if abandoned is not None:
+        log_event(
+            handlers._logger,
+            logging.INFO,
+            "telegram.response.delivery_abandoned",
+            chat_id=chat_id,
+            thread_id=thread_id,
+            delivery_id=delivery_id,
+            delivery_state=abandoned.state.value,
+        )
 
 
 def _spawn_telegram_background_task(handlers: Any, coro: Any) -> asyncio.Task[Any]:
@@ -1274,6 +1313,13 @@ async def _run_telegram_managed_thread_turn(
                     placeholder_id=prepared_placeholder_id,
                     response=failure_message,
                 )
+                if response_sent and getattr(_flow, "durable_delivery_pending", False):
+                    _abandon_pending_telegram_delivery(
+                        handlers,
+                        delivery_id=getattr(_flow, "durable_delivery_id", None),
+                        chat_id=message.chat_id,
+                        thread_id=message.thread_id,
+                    )
             elif send_failure_response and prepared_placeholder_id is not None:
                 await handlers._delete_message(
                     message.chat_id,
@@ -1382,6 +1428,7 @@ async def _run_telegram_managed_thread_turn(
             interrupt_status_turn_id=backend_turn_id or None,
             interrupt_status_fallback_text=interrupt_status_fallback_text,
             durable_delivery_handled=_delivery_handled,
+            durable_delivery_id=getattr(_flow, "durable_delivery_id", None),
         )
 
     queue_task_map = getattr(handlers, "_telegram_managed_thread_queue_tasks", None)

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -14,6 +14,7 @@ from ....agents.opencode.supervisor import OpenCodeSupervisorError
 from ....core.coercion import coerce_int
 from ....core.config import load_hub_config
 from ....core.logging_utils import log_event
+from ....core.orchestration import SQLiteManagedThreadDeliveryEngine
 from ....core.orchestration.chat_operation_state import ChatOperationState
 from ....core.state import now_iso
 from ....core.update import (
@@ -147,6 +148,50 @@ from .commands import (
 )
 from .commands.execution import _TurnRunFailure
 from .commands.shared import _RuntimeStub  # noqa: F401
+
+
+def _abandon_pending_telegram_delivery(
+    handlers: Any,
+    *,
+    delivery_id: Optional[str],
+    chat_id: int,
+    thread_id: Optional[int],
+) -> None:
+    if not isinstance(delivery_id, str) or not delivery_id.strip():
+        return
+    state_root = getattr(getattr(handlers, "_config", None), "root", None)
+    if state_root is None:
+        state_root = getattr(handlers, "_hub_root", None)
+    if state_root is None:
+        state_root = Path(".")
+    try:
+        engine = SQLiteManagedThreadDeliveryEngine(Path(state_root))
+        abandoned = engine.abandon_delivery(
+            delivery_id,
+            detail="abandoned_after_direct_telegram_delivery",
+        )
+    except Exception as exc:
+        log_event(
+            handlers._logger,
+            logging.WARNING,
+            "telegram.response.delivery_abandon_failed",
+            chat_id=chat_id,
+            thread_id=thread_id,
+            delivery_id=delivery_id,
+            exc=exc,
+        )
+        return
+    if abandoned is not None:
+        log_event(
+            handlers._logger,
+            logging.INFO,
+            "telegram.response.delivery_abandoned",
+            chat_id=chat_id,
+            thread_id=thread_id,
+            delivery_id=delivery_id,
+            delivery_state=abandoned.state.value,
+        )
+
 
 PROMPT_CONTEXT_RE = re.compile("\\bprompt\\b", re.IGNORECASE)
 PROMPT_CONTEXT_HINT = (
@@ -442,6 +487,13 @@ class TelegramCommandHandlers(
             )
         if _durable_handled:
             response_sent = True
+        elif response_sent:
+            _abandon_pending_telegram_delivery(
+                self,
+                delivery_id=getattr(outcome, "durable_delivery_id", None),
+                chat_id=message.chat_id,
+                thread_id=message.thread_id,
+            )
         if response_sent:
             key = await self._resolve_topic_key(message.chat_id, message.thread_id)
             log_event(

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -14,7 +14,6 @@ from ....agents.opencode.supervisor import OpenCodeSupervisorError
 from ....core.coercion import coerce_int
 from ....core.config import load_hub_config
 from ....core.logging_utils import log_event
-from ....core.orchestration import SQLiteManagedThreadDeliveryEngine
 from ....core.orchestration.chat_operation_state import ChatOperationState
 from ....core.state import now_iso
 from ....core.update import (
@@ -146,52 +145,11 @@ from .commands import (
     VoiceCommands,
     WorkspaceCommands,
 )
-from .commands.execution import _TurnRunFailure
+from .commands.execution import (
+    _abandon_pending_telegram_delivery,
+    _TurnRunFailure,
+)
 from .commands.shared import _RuntimeStub  # noqa: F401
-
-
-def _abandon_pending_telegram_delivery(
-    handlers: Any,
-    *,
-    delivery_id: Optional[str],
-    chat_id: int,
-    thread_id: Optional[int],
-) -> None:
-    if not isinstance(delivery_id, str) or not delivery_id.strip():
-        return
-    state_root = getattr(getattr(handlers, "_config", None), "root", None)
-    if state_root is None:
-        state_root = getattr(handlers, "_hub_root", None)
-    if state_root is None:
-        state_root = Path(".")
-    try:
-        engine = SQLiteManagedThreadDeliveryEngine(Path(state_root))
-        abandoned = engine.abandon_delivery(
-            delivery_id,
-            detail="abandoned_after_direct_telegram_delivery",
-        )
-    except Exception as exc:
-        log_event(
-            handlers._logger,
-            logging.WARNING,
-            "telegram.response.delivery_abandon_failed",
-            chat_id=chat_id,
-            thread_id=thread_id,
-            delivery_id=delivery_id,
-            exc=exc,
-        )
-        return
-    if abandoned is not None:
-        log_event(
-            handlers._logger,
-            logging.INFO,
-            "telegram.response.delivery_abandoned",
-            chat_id=chat_id,
-            thread_id=thread_id,
-            delivery_id=delivery_id,
-            delivery_state=abandoned.state.value,
-        )
-
 
 PROMPT_CONTEXT_RE = re.compile("\\bprompt\\b", re.IGNORECASE)
 PROMPT_CONTEXT_HINT = (
@@ -1846,9 +1804,9 @@ class TelegramCommandHandlers(
                 return None
             return _format_feature_flags(result)
 
-        async def _fetch_codex_features() -> (
-            tuple[list[CodexFeatureRow], Optional[str]]
-        ):
+        async def _fetch_codex_features() -> tuple[
+            list[CodexFeatureRow], Optional[str]
+        ]:
             features_command = derive_codex_features_command(
                 self._config.app_server_command
             )

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -1804,9 +1804,9 @@ class TelegramCommandHandlers(
                 return None
             return _format_feature_flags(result)
 
-        async def _fetch_codex_features() -> tuple[
-            list[CodexFeatureRow], Optional[str]
-        ]:
+        async def _fetch_codex_features() -> (
+            tuple[list[CodexFeatureRow], Optional[str]]
+        ):
             features_command = derive_codex_features_command(
                 self._config.app_server_command
             )

--- a/tests/integrations/chat/test_managed_turn_runner.py
+++ b/tests/integrations/chat/test_managed_turn_runner.py
@@ -191,6 +191,90 @@ async def test_run_managed_surface_turn_does_not_treat_finalize_callback_errors_
 
 
 @pytest.mark.anyio
+async def test_run_managed_surface_turn_preserves_durable_delivery_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = _build_started_execution(tmp_path)
+    finalized = ManagedThreadFinalizationResult(
+        status="ok",
+        assistant_text="done",
+        error=None,
+        managed_thread_id="thread-1",
+        managed_turn_id="exec-1",
+        backend_thread_id="backend-thread-1",
+    )
+
+    async def _submit_execution(
+        *args: Any, **kwargs: Any
+    ) -> ManagedThreadSubmissionResult:
+        _ = args, kwargs
+        return ManagedThreadSubmissionResult(started_execution=started, queued=False)
+
+    async def _fake_complete(
+        coordinator: Any,
+        submission: ManagedThreadSubmissionResult,
+        **kwargs: Any,
+    ) -> ManagedThreadExecutionFlowResult:
+        _ = coordinator, submission, kwargs
+        return ManagedThreadExecutionFlowResult(
+            started_execution=started,
+            queued=False,
+            finalized=finalized,
+        )
+
+    async def _fake_handoff(*args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        return SimpleNamespace(
+            delivery_id="delivery-1",
+            state=ManagedThreadDeliveryState.RETRY_SCHEDULED,
+        )
+
+    monkeypatch.setattr(
+        managed_turn_runner_module,
+        "complete_managed_thread_execution",
+        _fake_complete,
+    )
+    monkeypatch.setattr(
+        managed_turn_runner_module,
+        "handoff_managed_thread_final_delivery",
+        _fake_handoff,
+    )
+
+    captured_flow: ManagedThreadExecutionFlowResult | None = None
+
+    def _on_finalized(
+        flow: ManagedThreadExecutionFlowResult,
+        finalized: ManagedThreadFinalizationResult,
+    ) -> str:
+        nonlocal captured_flow
+        captured_flow = flow
+        return finalized.assistant_text
+
+    result = await managed_turn_runner_module.run_managed_surface_turn(
+        started.request,
+        config=managed_turn_runner_module.ManagedSurfaceRunnerConfig[str](
+            coordinator=SimpleNamespace(
+                submit_execution=_submit_execution,
+                ensure_queue_worker=lambda **kwargs: None,
+            ),
+            client_request_id="req-1",
+            sandbox_policy=None,
+            hooks=ManagedThreadCoordinatorHooks(
+                durable_delivery=_make_durable_hooks(tmp_path),
+            ),
+            on_finalized=_on_finalized,
+        ),
+    )
+
+    assert result == "done"
+    assert captured_flow is not None
+    assert captured_flow.durable_delivery_pending is True
+    assert captured_flow.durable_delivery_performed is False
+    assert captured_flow.durable_delivery_id == "delivery-1"
+
+
+@pytest.mark.anyio
 async def test_run_managed_surface_turn_reraises_cancelled_submission(
     tmp_path: Path,
 ) -> None:

--- a/tests/integrations/discord/test_message_turns_transient_progress.py
+++ b/tests/integrations/discord/test_message_turns_transient_progress.py
@@ -7,6 +7,10 @@ from typing import Any, Optional
 import pytest
 from tests import discord_message_turns_support as support
 
+from codex_autorunner.core.orchestration import SQLiteManagedThreadDeliveryEngine
+from codex_autorunner.core.orchestration.managed_thread_delivery import (
+    ManagedThreadDeliveryState,
+)
 from codex_autorunner.core.ports.run_event import (
     ApprovalRequested,
     Completed,
@@ -528,6 +532,77 @@ async def test_deliver_result_reconciles_stale_siblings_without_final_message(
             in edited["payload"]["content"].lower()
             for edited in rest.edited_channel_messages
         )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_deliver_result_abandons_pending_durable_delivery_after_visible_final_send(
+    tmp_path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = support.DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = support._FakeRest()
+    service = support.DiscordBotService(
+        support._config(tmp_path, allowed_channel_ids=frozenset({"channel-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=support._FakeGateway([]),
+        state_store=store,
+        outbox_manager=support._FakeOutboxManager(),
+    )
+    engine = SQLiteManagedThreadDeliveryEngine(tmp_path)
+    finalized = support.managed_thread_turns_module.ManagedThreadFinalizationResult(
+        status="ok",
+        assistant_text="fixture reply",
+        error=None,
+        managed_thread_id="thread-1",
+        managed_turn_id="exec-1",
+        backend_thread_id="backend-1",
+    )
+    intent = support.managed_thread_turns_module.build_managed_thread_delivery_intent(
+        finalized,
+        surface=support.managed_thread_turns_module.ManagedThreadSurfaceInfo(
+            log_label="Discord",
+            surface_kind="discord",
+            surface_key="channel-1",
+        ),
+        transport_target={"channel_id": "channel-1"},
+    )
+    record = engine.create_intent(intent).record
+    patched = engine._ledger.patch_delivery(
+        record.delivery_id,
+        state=ManagedThreadDeliveryState.RETRY_SCHEDULED,
+    )
+    assert patched is not None
+    dispatch = SimpleNamespace(
+        service=service,
+        channel_id="channel-1",
+        session_key="session-1",
+        pending_compact_seed=None,
+        agent="codex",
+        model_override=None,
+    )
+
+    try:
+        await support.discord_message_turns_module._deliver_discord_turn_result(
+            dispatch,
+            workspace_root=workspace,
+            turn_result=support.DiscordMessageTurnResult(
+                final_message="done",
+                execution_id="exec-1",
+                send_final_message=True,
+                delivery_visibility_pending=True,
+                durable_delivery_id=record.delivery_id,
+            ),
+        )
+
+        abandoned = engine._ledger.get_delivery(record.delivery_id)
+        assert abandoned is not None
+        assert abandoned.state is ManagedThreadDeliveryState.ABANDONED
+        assert len(rest.channel_messages) == 1
     finally:
         await store.close()
 

--- a/tests/telegram_pma_managed_thread_support.py
+++ b/tests/telegram_pma_managed_thread_support.py
@@ -10,6 +10,10 @@ import pytest
 
 from codex_autorunner.agents.registry import AgentDescriptor
 from codex_autorunner.core.hub_control_plane import HubSharedStateService
+from codex_autorunner.core.orchestration import SQLiteManagedThreadDeliveryEngine
+from codex_autorunner.core.orchestration.managed_thread_delivery import (
+    ManagedThreadDeliveryState,
+)
 from codex_autorunner.core.orchestration.sqlite import prepare_orchestration_sqlite
 from codex_autorunner.core.pma_context import (
     build_hub_snapshot,
@@ -1376,6 +1380,85 @@ async def test_pma_managed_thread_turn_recovers_if_wait_disconnects_after_comple
     for task in remaining_tasks:
         with contextlib.suppress(asyncio.CancelledError):
             await task
+
+
+@pytest.mark.anyio
+async def test_handle_normal_message_abandons_pending_durable_delivery_after_direct_send(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    record = TelegramTopicRecord(
+        pma_enabled=True,
+        workspace_path=None,
+        repo_id="repo-1",
+        agent="codex",
+    )
+    handler = _ManagedThreadPMAHandler(record, tmp_path)
+    engine = SQLiteManagedThreadDeliveryEngine(tmp_path)
+    finalized = execution_commands_module.ManagedThreadFinalizationResult(
+        status="ok",
+        assistant_text="telegram managed final reply",
+        error=None,
+        managed_thread_id="thread-1",
+        managed_turn_id="exec-1",
+        backend_thread_id="backend-1",
+    )
+    intent = execution_commands_module.build_managed_thread_delivery_intent(
+        finalized,
+        surface=execution_commands_module.ManagedThreadSurfaceInfo(
+            log_label="Telegram",
+            surface_kind="telegram",
+            surface_key="-1001:101",
+        ),
+        transport_target={"chat_id": -1001, "thread_id": 101},
+    )
+    record_entry = engine.create_intent(intent).record
+    patched = engine._ledger.patch_delivery(
+        record_entry.delivery_id,
+        state=ManagedThreadDeliveryState.RETRY_SCHEDULED,
+    )
+    assert patched is not None
+
+    async def _fake_run_turn_and_collect_result(
+        *args: Any, **kwargs: Any
+    ) -> _TurnRunResult:
+        _ = args, kwargs
+        return _TurnRunResult(
+            record=record,
+            thread_id="backend-1",
+            turn_id="exec-1",
+            response="telegram managed final reply",
+            placeholder_id=None,
+            elapsed_seconds=None,
+            token_usage=None,
+            transcript_message_id=None,
+            transcript_text=None,
+            durable_delivery_handled=False,
+            durable_delivery_id=record_entry.delivery_id,
+        )
+
+    monkeypatch.setattr(
+        handler,
+        "_run_turn_and_collect_result",
+        _fake_run_turn_and_collect_result,
+    )
+
+    message = TelegramMessage(
+        update_id=1,
+        message_id=10,
+        chat_id=-1001,
+        thread_id=101,
+        from_user_id=42,
+        text="hello",
+        date=None,
+        is_topic_message=True,
+    )
+
+    await handler._handle_normal_message(message, runtime=_RuntimeStub())
+
+    abandoned = engine._ledger.get_delivery(record_entry.delivery_id)
+    assert abandoned is not None
+    assert abandoned.state is ManagedThreadDeliveryState.ABANDONED
+    assert "telegram managed final reply" in handler._sent
 
 
 @pytest.mark.anyio

--- a/tests/test_managed_thread_progress.py
+++ b/tests/test_managed_thread_progress.py
@@ -242,10 +242,9 @@ def test_apply_run_event_to_progress_tracker_renders_commentary_live_only() -> N
     live = render_progress_text(tracker, max_length=2000, now=1.0)
     final = render_progress_text(tracker, max_length=2000, now=1.0, render_mode="final")
 
-    assert "Interim note from agent while this turn is still running:" in live
     assert "Checking the ACP event path" in live
-    assert "Final reply will be sent separately when the turn completes." in live
-    assert "Interim note from agent while this turn is still running:" not in final
+    assert "Interim note from agent while this turn is still running:" not in live
+    assert "Final reply will be sent separately when the turn completes." not in live
     assert "Checking the ACP event path" not in final
 
 
@@ -300,6 +299,36 @@ def test_apply_run_event_to_progress_tracker_already_streamed_commentary_only_en
     assert outcome.changed is False
     assert [action.label for action in tracker.actions] == ["output"]
     assert tracker.last_output_index is None
+
+
+def test_apply_run_event_to_progress_tracker_skips_commentary_that_matches_live_output() -> (
+    None
+):
+    tracker = _tracker()
+    runtime_state = ProgressRuntimeState()
+
+    apply_run_event_to_progress_tracker(
+        tracker,
+        OutputDelta(
+            timestamp="t0",
+            content="same live text",
+            delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
+        ),
+        runtime_state=runtime_state,
+    )
+
+    outcome = apply_run_event_to_progress_tracker(
+        tracker,
+        RunNotice(
+            timestamp="t1",
+            kind="commentary",
+            message="same live text",
+        ),
+        runtime_state=runtime_state,
+    )
+
+    assert outcome.changed is False
+    assert [action.label for action in tracker.actions] == ["output"]
 
 
 def test_tool_call_ends_output_segment_before_later_commentary_and_snapshot() -> None:

--- a/tests/test_telegram_progress_stream.py
+++ b/tests/test_telegram_progress_stream.py
@@ -322,11 +322,10 @@ def test_render_progress_text_keeps_commentary_live_only() -> None:
     final = render_progress_text(tracker, max_length=2000, now=1.0, render_mode="final")
 
     assert "streamed output" in live
-    assert "Interim note from agent while this turn is still running:" in live
     assert "interim commentary block" in live
-    assert "Final reply will be sent separately when the turn completes." in live
+    assert "Interim note from agent while this turn is still running:" not in live
+    assert "Final reply will be sent separately when the turn completes." not in live
     assert "streamed output" in final
-    assert "Interim note from agent while this turn is still running:" not in final
     assert "interim commentary block" not in final
 
 


### PR DESCRIPTION
## What changed
- preserve the durable managed-thread `delivery_id` through finalization so surfaces know which pending terminal delivery record belongs to the current turn
- abandon pending durable deliveries after a direct visible final reply succeeds on Discord and Telegram, preventing the background delivery worker from replaying the same finalized turn later
- remove the commentary decorator wrapper from the shared progress renderer and let Hermes commentary use the normal working edit streaming flow
- dedupe commentary that matches already-streamed live output so the progress card does not show the same text twice
- add regression coverage for the shared runner, Discord final delivery, Telegram PMA delivery, and commentary rendering behavior

## Why
Hermes PMA turns could show two bad behaviors after deployment:
- duplicate replies in Discord and Telegram when a direct final reply succeeded but a pending durable delivery record was still retried later
- apparent off-by-one replies where a past finalized turn arrived after a newer user message, because the replay path stayed alive

The interim commentary wrapper also made Hermes progress noisier than Codex/OpenCode and could visually duplicate text already present in the working stream.

## Root cause
The shared managed-turn flow only carried boolean durable-delivery state, not the actual durable `delivery_id`. That meant Discord and Telegram could not retire a pending durable terminal delivery after a direct visible reply succeeded, so the worker could replay the same turn later. Separately, commentary was rendered as a second decorated block instead of flowing through the existing live working-edit UX.

## Impact
- fixes duplicate final delivery and stale-turn replay on Discord and Telegram PMA turns
- keeps direct final reply fallback behavior fast while closing the replay window
- makes Hermes commentary match the existing working progress UX instead of adding extra wrapper text

## Validation
- aggregate commit lane passed locally
- `.venv/bin/pytest -q tests/integrations/chat/test_managed_turn_runner.py`
- `.venv/bin/pytest -q tests/integrations/discord/test_message_turns_transient_progress.py`
- `.venv/bin/pytest -q tests/telegram_pma_managed_thread_support.py`
- `.venv/bin/pytest -q tests/test_managed_thread_progress.py -k commentary`
- `.venv/bin/pytest -q tests/test_telegram_progress_stream.py -k commentary`
- `.venv/bin/pytest -q tests/chat_surface_lab/test_scenario_runner.py -k durable_delivery_is_outboxed`
- `.venv/bin/python -m py_compile src/codex_autorunner/integrations/chat/managed_thread_progress.py src/codex_autorunner/integrations/chat/managed_thread_turns.py src/codex_autorunner/integrations/chat/managed_turn_runner.py src/codex_autorunner/integrations/chat/progress_primitives.py src/codex_autorunner/integrations/discord/message_turns.py src/codex_autorunner/integrations/telegram/handlers/commands/execution.py src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py tests/integrations/chat/test_managed_turn_runner.py tests/integrations/discord/test_message_turns_transient_progress.py tests/telegram_pma_managed_thread_support.py tests/test_managed_thread_progress.py tests/test_telegram_progress_stream.py`