### PR TITLE
[codex] Add direct-surface delivery ledger state

### DIFF
--- a/src/codex_autorunner/core/orchestration/managed_thread_delivery.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_delivery.py
@@ -39,6 +39,7 @@ class ManagedThreadDeliveryState(str, Enum):
     DELIVERING = "delivering"
     RETRY_SCHEDULED = "retry_scheduled"
     DELIVERED = "delivered"
+    DIRECT_SURFACE_DELIVERED = "direct_surface_delivered"
     FAILED = "failed"
     ABANDONED = "abandoned"
     EXPIRED = "expired"
@@ -47,6 +48,7 @@ class ManagedThreadDeliveryState(str, Enum):
 MANAGED_THREAD_DELIVERY_TERMINAL_STATES = frozenset(
     {
         ManagedThreadDeliveryState.DELIVERED,
+        ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED,
         ManagedThreadDeliveryState.FAILED,
         ManagedThreadDeliveryState.ABANDONED,
         ManagedThreadDeliveryState.EXPIRED,
@@ -63,6 +65,7 @@ MANAGED_THREAD_DELIVERY_ALLOWED_TRANSITIONS: dict[
             ManagedThreadDeliveryState.CLAIMED,
             ManagedThreadDeliveryState.DELIVERING,
             ManagedThreadDeliveryState.RETRY_SCHEDULED,
+            ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED,
             ManagedThreadDeliveryState.ABANDONED,
             ManagedThreadDeliveryState.EXPIRED,
         }
@@ -71,6 +74,7 @@ MANAGED_THREAD_DELIVERY_ALLOWED_TRANSITIONS: dict[
         {
             ManagedThreadDeliveryState.DELIVERING,
             ManagedThreadDeliveryState.RETRY_SCHEDULED,
+            ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED,
             ManagedThreadDeliveryState.ABANDONED,
             ManagedThreadDeliveryState.EXPIRED,
         }
@@ -78,6 +82,7 @@ MANAGED_THREAD_DELIVERY_ALLOWED_TRANSITIONS: dict[
     ManagedThreadDeliveryState.DELIVERING: frozenset(
         {
             ManagedThreadDeliveryState.DELIVERED,
+            ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED,
             ManagedThreadDeliveryState.RETRY_SCHEDULED,
             ManagedThreadDeliveryState.FAILED,
             ManagedThreadDeliveryState.ABANDONED,
@@ -87,11 +92,13 @@ MANAGED_THREAD_DELIVERY_ALLOWED_TRANSITIONS: dict[
         {
             ManagedThreadDeliveryState.CLAIMED,
             ManagedThreadDeliveryState.DELIVERING,
+            ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED,
             ManagedThreadDeliveryState.ABANDONED,
             ManagedThreadDeliveryState.EXPIRED,
         }
     ),
     ManagedThreadDeliveryState.DELIVERED: frozenset(),
+    ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED: frozenset(),
     ManagedThreadDeliveryState.FAILED: frozenset(),
     ManagedThreadDeliveryState.ABANDONED: frozenset(),
     ManagedThreadDeliveryState.EXPIRED: frozenset(),
@@ -102,6 +109,7 @@ class ManagedThreadDeliveryOutcome(str, Enum):
     """Engine-owned result classification for one adapter delivery attempt."""
 
     DELIVERED = "delivered"
+    DIRECT_SURFACE_DELIVERED = "direct_surface_delivered"
     DUPLICATE = "duplicate"
     RETRY = "retry"
     FAILED = "failed"

--- a/src/codex_autorunner/core/orchestration/managed_thread_delivery_ledger.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_delivery_ledger.py
@@ -478,10 +478,12 @@ class SQLiteManagedThreadDeliveryEngine:
             return None
         if record.claim_token != claim_token:
             return None
+        metadata_updates = dict(result.metadata or {})
         if record.state == ManagedThreadDeliveryState.CLAIMED:
             self._ledger.patch_delivery(
                 delivery_id,
                 state=ManagedThreadDeliveryState.DELIVERING,
+                metadata_updates=metadata_updates or None,
             )
         outcome = result.outcome
         if outcome == ManagedThreadDeliveryOutcome.DELIVERED:
@@ -491,6 +493,16 @@ class SQLiteManagedThreadDeliveryEngine:
                 delivered_at=now_iso(),
                 adapter_cursor=result.adapter_cursor,
                 claim_token=None,
+                metadata_updates=metadata_updates or None,
+            )
+        if outcome == ManagedThreadDeliveryOutcome.DIRECT_SURFACE_DELIVERED:
+            return self._ledger.patch_delivery(
+                delivery_id,
+                state=ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED,
+                delivered_at=now_iso(),
+                adapter_cursor=result.adapter_cursor,
+                claim_token=None,
+                metadata_updates=metadata_updates or None,
             )
         if outcome == ManagedThreadDeliveryOutcome.DUPLICATE:
             return self._ledger.patch_delivery(
@@ -499,6 +511,7 @@ class SQLiteManagedThreadDeliveryEngine:
                 delivered_at=now_iso(),
                 adapter_cursor=result.adapter_cursor,
                 claim_token=None,
+                metadata_updates=metadata_updates or None,
             )
         if outcome == ManagedThreadDeliveryOutcome.RETRY:
             next_attempt_at = _compute_next_attempt_at(
@@ -514,6 +527,7 @@ class SQLiteManagedThreadDeliveryEngine:
                 last_error=result.error,
                 adapter_cursor=result.adapter_cursor,
                 claim_token=None,
+                metadata_updates=metadata_updates or None,
             )
         if outcome == ManagedThreadDeliveryOutcome.FAILED:
             if record.attempt_count >= self._max_attempts:
@@ -522,6 +536,7 @@ class SQLiteManagedThreadDeliveryEngine:
                     state=ManagedThreadDeliveryState.FAILED,
                     last_error=result.error or "max_attempts_exceeded",
                     claim_token=None,
+                    metadata_updates=metadata_updates or None,
                 )
             next_attempt_at = _compute_next_attempt_at(
                 record.attempt_count,
@@ -536,6 +551,7 @@ class SQLiteManagedThreadDeliveryEngine:
                 last_error=result.error,
                 adapter_cursor=result.adapter_cursor,
                 claim_token=None,
+                metadata_updates=metadata_updates or None,
             )
         if outcome == ManagedThreadDeliveryOutcome.ABANDONED:
             return self._ledger.patch_delivery(
@@ -543,6 +559,7 @@ class SQLiteManagedThreadDeliveryEngine:
                 state=ManagedThreadDeliveryState.ABANDONED,
                 last_error=result.error or "abandoned_by_adapter",
                 claim_token=None,
+                metadata_updates=metadata_updates or None,
             )
         return None
 

--- a/src/codex_autorunner/core/orchestration/managed_thread_delivery_ledger.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_delivery_ledger.py
@@ -562,9 +562,7 @@ class SQLiteManagedThreadDeliveryEngine:
         parsed = None
         try:
             if str(due_at).endswith("Z"):
-                parsed = datetime.fromisoformat(
-                    str(due_at).replace("Z", "+00:00")
-                )
+                parsed = datetime.fromisoformat(str(due_at).replace("Z", "+00:00"))
             else:
                 parsed = datetime.fromisoformat(str(due_at))
         except ValueError:

--- a/src/codex_autorunner/core/orchestration/managed_thread_delivery_ledger.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_delivery_ledger.py
@@ -30,6 +30,7 @@ from .managed_thread_delivery import (
     ManagedThreadDeliveryIntent,
     ManagedThreadDeliveryOutcome,
     ManagedThreadDeliveryRecord,
+    ManagedThreadDeliveryRecoveryAction,
     ManagedThreadDeliveryRecoverySweepResult,
     ManagedThreadDeliveryRegistration,
     ManagedThreadDeliveryState,
@@ -464,6 +465,120 @@ class SQLiteManagedThreadDeliveryEngine:
             claim_token=claim_token,
             claimed_at=claimed_at,
             claim_expires_at=claim_expires_at,
+        )
+
+    def ensure_direct_delivery_claim(
+        self,
+        delivery_id: str,
+        *,
+        proposed_token: Optional[str] = None,
+        now: Optional[datetime] = None,
+    ) -> Optional[ManagedThreadDeliveryClaim]:
+        """Return a claim suitable for direct-surface delivery bookkeeping.
+
+        Validates *proposed_token* against the ledger when it still matches an
+        active lease; otherwise recovers expired claims for this adapter and
+        issues a fresh claim (same policy as :meth:`claim_delivery`).
+        """
+        current_at = now or datetime.now(timezone.utc)
+        normalized_id = str(delivery_id or "").strip()
+        if not normalized_id:
+            return None
+
+        record = self._ledger.get_delivery(normalized_id)
+        if record is None:
+            return None
+        if record.state in MANAGED_THREAD_DELIVERY_TERMINAL_STATES:
+            return None
+
+        proposed = str(proposed_token or "").strip()
+        if proposed and record.claim_token == proposed:
+            decision = plan_managed_thread_delivery_recovery(
+                record,
+                now=current_at,
+                claim_ttl=self._claim_ttl,
+                max_attempts=self._max_attempts,
+            )
+            if (
+                decision.action == ManagedThreadDeliveryRecoveryAction.NOOP
+                and decision.reason == "claim_active"
+            ):
+                claimed_at = str(record.claimed_at or current_at.isoformat())
+                claim_expires_at = str(
+                    record.claim_expires_at
+                    or default_claim_expiry(
+                        claimed_at=current_at, claim_ttl=self._claim_ttl
+                    )
+                )
+                return ManagedThreadDeliveryClaim(
+                    record=record,
+                    claim_token=proposed,
+                    claimed_at=claimed_at,
+                    claim_expires_at=claim_expires_at,
+                )
+
+        if proposed and record.claim_token and proposed != record.claim_token:
+            if record.state in {
+                ManagedThreadDeliveryState.CLAIMED,
+                ManagedThreadDeliveryState.DELIVERING,
+            }:
+                self._ledger.patch_delivery(
+                    normalized_id,
+                    state=ManagedThreadDeliveryState.RETRY_SCHEDULED,
+                    claim_token=None,
+                    claimed_at=None,
+                    claim_expires_at=None,
+                    next_attempt_at=current_at.isoformat(),
+                    last_error="direct_delivery_claim_token_mismatch",
+                )
+
+        refreshed = self._ledger.get_delivery(normalized_id)
+        adapter_key = refreshed.target.adapter_key if refreshed is not None else ""
+        if adapter_key:
+            self._recover_expired_claims(
+                adapter_key=str(adapter_key),
+                now=current_at,
+                limit=64,
+            )
+        self._force_delivery_due_for_direct_claim(normalized_id, now=current_at)
+        return self.claim_delivery(normalized_id, now=current_at)
+
+    def _force_delivery_due_for_direct_claim(
+        self, delivery_id: str, *, now: datetime
+    ) -> None:
+        """Make PENDING/RETRY_SCHEDULED rows claimable immediately for direct-send."""
+
+        record = self._ledger.get_delivery(delivery_id)
+        if record is None:
+            return
+        if record.state not in {
+            ManagedThreadDeliveryState.PENDING,
+            ManagedThreadDeliveryState.RETRY_SCHEDULED,
+        }:
+            return
+        due_at = record.next_attempt_at
+        if due_at is None:
+            return
+        parsed = None
+        try:
+            if str(due_at).endswith("Z"):
+                parsed = datetime.fromisoformat(
+                    str(due_at).replace("Z", "+00:00")
+                )
+            else:
+                parsed = datetime.fromisoformat(str(due_at))
+        except ValueError:
+            return
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        else:
+            parsed = parsed.astimezone(timezone.utc)
+        if parsed <= now:
+            return
+        self._ledger.patch_delivery(
+            delivery_id,
+            next_attempt_at=now.isoformat(),
+            validate_transition=False,
         )
 
     def record_attempt_result(

--- a/src/codex_autorunner/integrations/app_server/threads.py
+++ b/src/codex_autorunner/integrations/app_server/threads.py
@@ -50,6 +50,7 @@ PMA_HERMES_KEY = "pma.hermes"
 PMA_PREFIX = "pma."
 PMA_OPENCODE_PREFIX = "pma.opencode."
 PMA_HERMES_PREFIX = "pma.hermes."
+PMA_AUTOMATION_SEGMENT = "automation"
 
 LOGGER = logging.getLogger("codex_autorunner.app_server")
 
@@ -102,6 +103,11 @@ def pma_base_key(agent: str, profile: Optional[str] = None) -> str:
     normalized = _normalize_pma_agent_family(agent)
     base_key = PMA_KEY if normalized is None else f"{PMA_KEY}.{normalized}"
     return _append_profile_suffix(base_key, profile)
+
+
+def pma_automation_key(agent: str, profile: Optional[str] = None) -> str:
+    """Return the PMA registry key reserved for automation-triggered turns."""
+    return f"{pma_base_key(agent, profile)}.{PMA_AUTOMATION_SEGMENT}"
 
 
 def pma_legacy_alias_keys(agent: str, profile: Optional[str]) -> tuple[str, ...]:

--- a/src/codex_autorunner/integrations/chat/managed_thread_direct_delivery.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_direct_delivery.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from ...core.orchestration.managed_thread_delivery import (
+    ManagedThreadDeliveryAttemptResult,
+    ManagedThreadDeliveryOutcome,
+    ManagedThreadDeliveryRecord,
+)
+from ...core.orchestration.managed_thread_delivery_ledger import (
+    SQLiteManagedThreadDeliveryEngine,
+)
+
+
+@dataclass(frozen=True)
+class ManagedThreadDirectDeliveryReservation:
+    engine: SQLiteManagedThreadDeliveryEngine
+    delivery_id: str
+    claim_token: str
+
+
+def reserve_managed_thread_direct_delivery(
+    state_root: Path,
+    *,
+    delivery_id: Optional[str],
+    claim_token: Optional[str] = None,
+) -> Optional[ManagedThreadDirectDeliveryReservation]:
+    normalized_delivery_id = str(delivery_id or "").strip()
+    if not normalized_delivery_id:
+        return None
+    engine = SQLiteManagedThreadDeliveryEngine(Path(state_root))
+    normalized_claim_token = str(claim_token or "").strip()
+    if normalized_claim_token:
+        return ManagedThreadDirectDeliveryReservation(
+            engine=engine,
+            delivery_id=normalized_delivery_id,
+            claim_token=normalized_claim_token,
+        )
+    claim = engine.claim_delivery(normalized_delivery_id)
+    if claim is None:
+        return None
+    return ManagedThreadDirectDeliveryReservation(
+        engine=engine,
+        delivery_id=normalized_delivery_id,
+        claim_token=claim.claim_token,
+    )
+
+
+def record_managed_thread_direct_delivery(
+    reservation: ManagedThreadDirectDeliveryReservation,
+    *,
+    delivered: bool,
+    detail: Optional[str],
+    metadata: Optional[Mapping[str, Any]] = None,
+) -> Optional[ManagedThreadDeliveryRecord]:
+    outcome = (
+        ManagedThreadDeliveryOutcome.DIRECT_SURFACE_DELIVERED
+        if delivered
+        else ManagedThreadDeliveryOutcome.RETRY
+    )
+    result = ManagedThreadDeliveryAttemptResult(
+        outcome=outcome,
+        error=str(detail or "").strip() or None,
+        metadata=dict(metadata or {}),
+    )
+    return reservation.engine.record_attempt_result(
+        reservation.delivery_id,
+        claim_token=reservation.claim_token,
+        result=result,
+    )
+
+
+__all__ = [
+    "ManagedThreadDirectDeliveryReservation",
+    "record_managed_thread_direct_delivery",
+    "reserve_managed_thread_direct_delivery",
+]

--- a/src/codex_autorunner/integrations/chat/managed_thread_direct_delivery.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_direct_delivery.py
@@ -32,13 +32,10 @@ def reserve_managed_thread_direct_delivery(
         return None
     engine = SQLiteManagedThreadDeliveryEngine(Path(state_root))
     normalized_claim_token = str(claim_token or "").strip()
-    if normalized_claim_token:
-        return ManagedThreadDirectDeliveryReservation(
-            engine=engine,
-            delivery_id=normalized_delivery_id,
-            claim_token=normalized_claim_token,
-        )
-    claim = engine.claim_delivery(normalized_delivery_id)
+    claim = engine.ensure_direct_delivery_claim(
+        normalized_delivery_id,
+        proposed_token=normalized_claim_token or None,
+    )
     if claim is None:
         return None
     return ManagedThreadDirectDeliveryReservation(

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -224,6 +224,23 @@ class ManagedThreadExecutionFlowResult:
     durable_delivery_performed: bool = False
     durable_delivery_pending: bool = False
     durable_delivery_id: Optional[str] = None
+    durable_delivery_claim_token: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ManagedThreadDeliveryHandoffResult:
+    """Outcome of the initial durable-delivery handoff after finalization.
+
+    The common path returns a terminal record. When a direct surface fallback
+    should finish the delivery, the original claim token can be retained here so
+    the surface completes the same durable obligation without reopening a race.
+    """
+
+    record: ManagedThreadDeliveryRecord
+    direct_delivery_claim_token: Optional[str] = None
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.record, name)
 
 
 @dataclass(frozen=True)
@@ -767,7 +784,8 @@ async def handoff_managed_thread_final_delivery(
     *,
     delivery: ManagedThreadDurableDeliveryHooks,
     logger: logging.Logger,
-) -> Optional[ManagedThreadDeliveryRecord]:
+    retain_claim_for_direct_delivery: bool = False,
+) -> Optional[ManagedThreadDeliveryHandoffResult]:
     """Persist and hand off one finalized result to the durable delivery engine."""
 
     intent = delivery.build_delivery_intent(finalized)
@@ -777,7 +795,7 @@ async def handoff_managed_thread_final_delivery(
     record = registration.record
     claim = delivery.engine.claim_delivery(record.delivery_id)
     if claim is None:
-        return record
+        return ManagedThreadDeliveryHandoffResult(record=record)
     try:
         result = await delivery.adapter.deliver_managed_thread_record(
             claim.record,
@@ -826,6 +844,23 @@ async def handoff_managed_thread_final_delivery(
             outcome=ManagedThreadDeliveryOutcome.FAILED,
             error=str(exc) or exc.__class__.__name__,
         )
+        if retain_claim_for_direct_delivery:
+            log_event(
+                logger,
+                logging.INFO,
+                "chat.managed_thread.delivery_claim_held_for_direct_fallback",
+                **_managed_thread_delivery_trace_fields(
+                    record,
+                    claim_token=claim.claim_token,
+                    adapter_key=delivery.adapter.adapter_key,
+                ),
+                outcome=attempt_result.outcome.value,
+                attempted_error=attempt_result.error,
+            )
+            return ManagedThreadDeliveryHandoffResult(
+                record=claim.record,
+                direct_delivery_claim_token=claim.claim_token,
+            )
         updated: Optional[ManagedThreadDeliveryRecord] = None
         try:
             updated = delivery.engine.record_attempt_result(
@@ -860,7 +895,27 @@ async def handoff_managed_thread_final_delivery(
             attempted_error=attempt_result.error,
             exc=exc,
         )
-        return updated or record
+        return ManagedThreadDeliveryHandoffResult(record=updated or record)
+    if retain_claim_for_direct_delivery and result.outcome not in (
+        ManagedThreadDeliveryOutcome.DELIVERED,
+        ManagedThreadDeliveryOutcome.DUPLICATE,
+    ):
+        log_event(
+            logger,
+            logging.INFO,
+            "chat.managed_thread.delivery_claim_held_for_direct_fallback",
+            **_managed_thread_delivery_trace_fields(
+                record,
+                claim_token=claim.claim_token,
+                adapter_key=delivery.adapter.adapter_key,
+            ),
+            outcome=result.outcome.value,
+            attempted_error=result.error,
+        )
+        return ManagedThreadDeliveryHandoffResult(
+            record=claim.record,
+            direct_delivery_claim_token=claim.claim_token,
+        )
     try:
         updated = delivery.engine.record_attempt_result(
             record.delivery_id,
@@ -882,7 +937,7 @@ async def handoff_managed_thread_final_delivery(
             exc=bookkeeping_exc,
         )
         raise
-    return updated or record
+    return ManagedThreadDeliveryHandoffResult(record=updated or record)
 
 
 def resolve_managed_thread_target(

--- a/src/codex_autorunner/integrations/chat/managed_turn_runner.py
+++ b/src/codex_autorunner/integrations/chat/managed_turn_runner.py
@@ -211,9 +211,12 @@ async def run_managed_surface_turn(
                     "direct_delivery_claim_token",
                     None,
                 )
-                durable_delivery_performed = (
-                    delivery_record is not None
-                    and delivery_record.state is ManagedThreadDeliveryState.DELIVERED
+                durable_delivery_performed = delivery_record is not None and (
+                    delivery_record.state
+                    in (
+                        ManagedThreadDeliveryState.DELIVERED,
+                        ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED,
+                    )
                 )
                 durable_delivery_pending = durable_delivery_claim_token is not None or (
                     delivery_record is not None

--- a/src/codex_autorunner/integrations/chat/managed_turn_runner.py
+++ b/src/codex_autorunner/integrations/chat/managed_turn_runner.py
@@ -191,19 +191,31 @@ async def run_managed_surface_turn(
         durable_delivery_performed = False
         durable_delivery_pending = False
         durable_delivery_id: Optional[str] = None
+        durable_delivery_claim_token: Optional[str] = None
         if config.hooks.durable_delivery is not None:
             try:
-                delivery_record = await handoff_managed_thread_final_delivery(
+                delivery_handoff = await handoff_managed_thread_final_delivery(
                     finalized,
                     delivery=config.hooks.durable_delivery,
                     logger=_runner_logger,
+                    retain_claim_for_direct_delivery=True,
+                )
+                delivery_record = (
+                    getattr(delivery_handoff, "record", delivery_handoff)
+                    if delivery_handoff is not None
+                    else None
                 )
                 durable_delivery_id = getattr(delivery_record, "delivery_id", None)
+                durable_delivery_claim_token = getattr(
+                    delivery_handoff,
+                    "direct_delivery_claim_token",
+                    None,
+                )
                 durable_delivery_performed = (
                     delivery_record is not None
                     and delivery_record.state is ManagedThreadDeliveryState.DELIVERED
                 )
-                durable_delivery_pending = (
+                durable_delivery_pending = durable_delivery_claim_token is not None or (
                     delivery_record is not None
                     and delivery_record.state
                     in {
@@ -229,6 +241,7 @@ async def run_managed_surface_turn(
                 durable_delivery_performed=durable_delivery_performed,
                 durable_delivery_pending=durable_delivery_pending,
                 durable_delivery_id=durable_delivery_id,
+                durable_delivery_claim_token=durable_delivery_claim_token,
             )
         if config.on_finalized is None:
             raise RuntimeError("Managed-surface turn requires on_finalized")

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -36,7 +36,6 @@ from ...core.orchestration import (
     FlowTarget,
     MessageRequest,
     PausedFlowTarget,
-    SQLiteManagedThreadDeliveryEngine,
     SurfaceThreadMessageRequest,
     build_surface_orchestration_ingress,
 )
@@ -71,6 +70,10 @@ from ...integrations.chat.dispatcher import DispatchContext
 from ...integrations.chat.forwarding import (
     compose_forwarded_message_text,
     compose_inbound_message_text,
+)
+from ...integrations.chat.managed_thread_direct_delivery import (
+    record_managed_thread_direct_delivery,
+    reserve_managed_thread_direct_delivery,
 )
 from ...integrations.chat.models import ChatMessageEvent
 from ...integrations.chat.runtime_thread_errors import (
@@ -176,12 +179,14 @@ DISCORD_PMA_PROGRESS_HEARTBEAT_INTERVAL_SECONDS = 2.0
 _sanitize_runtime_thread_result_error = sanitize_runtime_thread_error
 
 
-def _abandon_pending_discord_delivery(
+def _record_pending_discord_direct_delivery(
     service: Any,
     *,
     delivery_id: Optional[str],
+    claim_token: Optional[str],
     channel_id: str,
     session_key: str,
+    delivered: bool,
 ) -> None:
     if not isinstance(delivery_id, str) or not delivery_id.strip():
         return
@@ -189,31 +194,45 @@ def _abandon_pending_discord_delivery(
     if state_root is None:
         state_root = Path(".")
     try:
-        engine = SQLiteManagedThreadDeliveryEngine(Path(state_root))
-        abandoned = engine.abandon_delivery(
-            delivery_id,
-            detail="abandoned_after_direct_discord_delivery",
+        reservation = reserve_managed_thread_direct_delivery(
+            Path(state_root),
+            delivery_id=delivery_id,
+            claim_token=claim_token,
+        )
+        if reservation is None:
+            return
+        updated = record_managed_thread_direct_delivery(
+            reservation,
+            delivered=delivered,
+            detail=(
+                "direct_discord_surface_delivery"
+                if delivered
+                else "direct_discord_surface_delivery_failed"
+            ),
+            metadata={"delivery_surface": "discord"},
         )
     except Exception as exc:
         log_event(
             service._logger,
             logging.WARNING,
-            "discord.turn.delivery_abandon_failed",
+            "discord.turn.direct_delivery_record_failed",
             channel_id=channel_id,
             session_key=session_key,
             delivery_id=delivery_id,
+            delivered=delivered,
             exc=exc,
         )
         return
-    if abandoned is not None:
+    if updated is not None:
         log_event(
             service._logger,
             logging.INFO,
-            "discord.turn.delivery_abandoned",
+            "discord.turn.direct_delivery_recorded",
             channel_id=channel_id,
             session_key=session_key,
             delivery_id=delivery_id,
-            delivery_state=abandoned.state.value,
+            delivered=delivered,
+            delivery_state=updated.state.value,
         )
 
 
@@ -228,6 +247,7 @@ class DiscordMessageTurnResult:
     send_final_message: bool = True
     delivery_visibility_pending: bool = False
     durable_delivery_id: Optional[str] = None
+    durable_delivery_claim_token: Optional[str] = None
     deferred_delivery: bool = False
     preserve_progress_lease: bool = False
 
@@ -1225,6 +1245,7 @@ async def _deliver_discord_turn_result(
         send_final_message = turn_result.send_final_message
         delivery_visibility_pending = turn_result.delivery_visibility_pending
         durable_delivery_id = turn_result.durable_delivery_id
+        durable_delivery_claim_token = turn_result.durable_delivery_claim_token
         preserve_progress_lease = turn_result.preserve_progress_lease
         intermediate_text = (
             turn_result.intermediate_message.strip()
@@ -1246,6 +1267,7 @@ async def _deliver_discord_turn_result(
         send_final_message = True
         delivery_visibility_pending = False
         durable_delivery_id = None
+        durable_delivery_claim_token = None
         preserve_progress_lease = False
 
     managed_thread_id = None
@@ -1307,12 +1329,14 @@ async def _deliver_discord_turn_result(
             attachment_filename="final-response.md",
             attachment_caption="Final response too long; attached as final-response.md.",
         )
-    if visible_terminal_delivery and delivery_visibility_pending:
-        _abandon_pending_discord_delivery(
+    if delivery_visibility_pending:
+        _record_pending_discord_direct_delivery(
             dispatch.service,
             delivery_id=durable_delivery_id,
+            claim_token=durable_delivery_claim_token,
             channel_id=dispatch.channel_id,
             session_key=dispatch.session_key,
+            delivered=visible_terminal_delivery,
         )
     if visible_terminal_delivery:
         if not preserve_progress_lease:
@@ -2382,6 +2406,11 @@ async def _run_discord_orchestrated_turn_for_message(
             durable_delivery_id=getattr(
                 _flow,
                 "durable_delivery_id",
+                None,
+            ),
+            durable_delivery_claim_token=getattr(
+                _flow,
+                "durable_delivery_claim_token",
                 None,
             ),
         )

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -87,6 +87,10 @@ from .....integrations.chat.managed_thread_delivery_support import (
     ManagedThreadDeliverySendResult,
     deliver_managed_thread_terminal_record,
 )
+from .....integrations.chat.managed_thread_direct_delivery import (
+    record_managed_thread_direct_delivery,
+    reserve_managed_thread_direct_delivery,
+)
 from .....integrations.chat.managed_thread_lifecycle import (
     replace_surface_thread,
     resolve_surface_thread_binding,
@@ -201,6 +205,7 @@ class _TurnRunResult:
     interrupt_status_fallback_text: Optional[str] = None
     durable_delivery_handled: bool = False
     durable_delivery_id: Optional[str] = None
+    durable_delivery_claim_token: Optional[str] = None
 
 
 @dataclass
@@ -289,41 +294,57 @@ def _telegram_state_root(handlers: Any) -> Path:
     return Path(state_root)
 
 
-def _abandon_pending_telegram_delivery(
+def _record_pending_telegram_direct_delivery(
     handlers: Any,
     *,
     delivery_id: Optional[str],
+    claim_token: Optional[str],
     chat_id: int,
     thread_id: Optional[int],
+    delivered: bool,
 ) -> None:
     if not isinstance(delivery_id, str) or not delivery_id.strip():
         return
     try:
-        engine = SQLiteManagedThreadDeliveryEngine(_telegram_state_root(handlers))
-        abandoned = engine.abandon_delivery(
-            delivery_id,
-            detail="abandoned_after_direct_telegram_delivery",
+        reservation = reserve_managed_thread_direct_delivery(
+            _telegram_state_root(handlers),
+            delivery_id=delivery_id,
+            claim_token=claim_token,
+        )
+        if reservation is None:
+            return
+        updated = record_managed_thread_direct_delivery(
+            reservation,
+            delivered=delivered,
+            detail=(
+                "direct_telegram_surface_delivery"
+                if delivered
+                else "direct_telegram_surface_delivery_failed"
+            ),
+            metadata={"delivery_surface": "telegram"},
         )
     except Exception as exc:
         log_event(
             handlers._logger,
             logging.WARNING,
-            "telegram.response.delivery_abandon_failed",
+            "telegram.response.direct_delivery_record_failed",
             chat_id=chat_id,
             thread_id=thread_id,
             delivery_id=delivery_id,
+            delivered=delivered,
             exc=exc,
         )
         return
-    if abandoned is not None:
+    if updated is not None:
         log_event(
             handlers._logger,
             logging.INFO,
-            "telegram.response.delivery_abandoned",
+            "telegram.response.direct_delivery_recorded",
             chat_id=chat_id,
             thread_id=thread_id,
             delivery_id=delivery_id,
-            delivery_state=abandoned.state.value,
+            delivered=delivered,
+            delivery_state=updated.state.value,
         )
 
 
@@ -1314,11 +1335,30 @@ async def _run_telegram_managed_thread_turn(
                     response=failure_message,
                 )
                 if response_sent and getattr(_flow, "durable_delivery_pending", False):
-                    _abandon_pending_telegram_delivery(
+                    _record_pending_telegram_direct_delivery(
                         handlers,
                         delivery_id=getattr(_flow, "durable_delivery_id", None),
+                        claim_token=getattr(
+                            _flow,
+                            "durable_delivery_claim_token",
+                            None,
+                        ),
                         chat_id=message.chat_id,
                         thread_id=message.thread_id,
+                        delivered=True,
+                    )
+                elif getattr(_flow, "durable_delivery_pending", False):
+                    _record_pending_telegram_direct_delivery(
+                        handlers,
+                        delivery_id=getattr(_flow, "durable_delivery_id", None),
+                        claim_token=getattr(
+                            _flow,
+                            "durable_delivery_claim_token",
+                            None,
+                        ),
+                        chat_id=message.chat_id,
+                        thread_id=message.thread_id,
+                        delivered=False,
                     )
             elif send_failure_response and prepared_placeholder_id is not None:
                 await handlers._delete_message(
@@ -1429,6 +1469,11 @@ async def _run_telegram_managed_thread_turn(
             interrupt_status_fallback_text=interrupt_status_fallback_text,
             durable_delivery_handled=_delivery_handled,
             durable_delivery_id=getattr(_flow, "durable_delivery_id", None),
+            durable_delivery_claim_token=getattr(
+                _flow,
+                "durable_delivery_claim_token",
+                None,
+            ),
         )
 
     queue_task_map = getattr(handlers, "_telegram_managed_thread_queue_tasks", None)

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -146,7 +146,7 @@ from .commands import (
     WorkspaceCommands,
 )
 from .commands.execution import (
-    _abandon_pending_telegram_delivery,
+    _record_pending_telegram_direct_delivery,
     _TurnRunFailure,
 )
 from .commands.shared import _RuntimeStub  # noqa: F401
@@ -446,11 +446,30 @@ class TelegramCommandHandlers(
         if _durable_handled:
             response_sent = True
         elif response_sent:
-            _abandon_pending_telegram_delivery(
+            _record_pending_telegram_direct_delivery(
                 self,
                 delivery_id=getattr(outcome, "durable_delivery_id", None),
+                claim_token=getattr(
+                    outcome,
+                    "durable_delivery_claim_token",
+                    None,
+                ),
                 chat_id=message.chat_id,
                 thread_id=message.thread_id,
+                delivered=True,
+            )
+        elif getattr(outcome, "durable_delivery_id", None):
+            _record_pending_telegram_direct_delivery(
+                self,
+                delivery_id=getattr(outcome, "durable_delivery_id", None),
+                claim_token=getattr(
+                    outcome,
+                    "durable_delivery_claim_token",
+                    None,
+                ),
+                chat_id=message.chat_id,
+                thread_id=message.thread_id,
+                delivered=False,
             )
         if response_sent:
             key = await self._resolve_topic_key(message.chat_id, message.thread_id)

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_queue_execution.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_queue_execution.py
@@ -15,7 +15,7 @@ from .....core.pma_context import (
     load_pma_prompt,
 )
 from .....core.text_utils import _normalize_optional_text
-from .....integrations.app_server.threads import pma_base_key
+from .....integrations.app_server.threads import pma_automation_key, pma_base_key
 from ...services.pma.common import pma_config_from_raw
 from ..agent_profile_validation import resolve_requested_agent_profile
 from ..agents import _available_agents
@@ -30,6 +30,17 @@ logger = logging.getLogger(__name__)
 def _get_pma_config(request: Any) -> dict[str, Any]:
     raw = getattr(request.app.state.config, "raw", {})
     return pma_config_from_raw(raw)
+
+
+def resolve_pma_session_key(
+    agent_id: str,
+    profile: Optional[str],
+    *,
+    automation_trigger: bool,
+) -> str:
+    if automation_trigger:
+        return pma_automation_key(agent_id, profile)
+    return pma_base_key(agent_id, profile)
 
 
 async def execute_queue_item(
@@ -207,7 +218,11 @@ async def execute_queue_item(
             github_context_injector = _default_injector
 
         snapshot = await snapshot_builder(supervisor, hub_root=hub_root)
-        prompt_state_key = pma_base_key(agent_id, profile)
+        prompt_state_key = resolve_pma_session_key(
+            agent_id,
+            profile,
+            automation_trigger=automation_trigger,
+        )
 
         async def _rebuild_prompt(force_full_base_prompt: bool) -> str:
             built = format_pma_prompt(
@@ -329,7 +344,11 @@ async def execute_queue_item(
             model=model,
             reasoning=reasoning,
             thread_registry=registry,
-            thread_key=pma_base_key(agent_id, profile),
+            thread_key=resolve_pma_session_key(
+                agent_id,
+                profile,
+                automation_trigger=automation_trigger,
+            ),
             on_meta=_meta,
             timeout_seconds=turn_timeout_seconds,
             rebuild_prompt=_rebuild_prompt,

--- a/tests/core/orchestration/test_managed_thread_delivery_ledger.py
+++ b/tests/core/orchestration/test_managed_thread_delivery_ledger.py
@@ -418,6 +418,92 @@ class TestEngineClaimDelivery:
         assert claim is None
 
 
+class TestEngineEnsureDirectDeliveryClaim:
+    def test_accepts_matching_active_claim_token(self, tmp_path: Path) -> None:
+        engine = _engine(tmp_path)
+        engine.create_intent(_intent(adapter_key="telegram"))
+        first = engine.claim_delivery(
+            "delivery-1",
+            now=datetime(2026, 4, 18, 1, 0, 0, tzinfo=timezone.utc),
+        )
+        assert first is not None
+        ensured = engine.ensure_direct_delivery_claim(
+            "delivery-1",
+            proposed_token=first.claim_token,
+            now=datetime(2026, 4, 18, 1, 2, 0, tzinfo=timezone.utc),
+        )
+        assert ensured is not None
+        assert ensured.claim_token == first.claim_token
+
+    def test_reclaims_when_proposed_token_is_stale(self, tmp_path: Path) -> None:
+        engine = _engine(tmp_path)
+        engine.create_intent(_intent(adapter_key="telegram"))
+        first = engine.claim_delivery(
+            "delivery-1",
+            now=datetime(2026, 4, 18, 1, 0, 0, tzinfo=timezone.utc),
+        )
+        assert first is not None
+        reclaimed = engine.ensure_direct_delivery_claim(
+            "delivery-1",
+            proposed_token="stale-token",
+            now=datetime(2026, 4, 18, 1, 1, 0, tzinfo=timezone.utc),
+        )
+        assert reclaimed is not None
+        assert reclaimed.claim_token != "stale-token"
+        assert reclaimed.claim_token != first.claim_token
+        assert reclaimed.record.state is ManagedThreadDeliveryState.CLAIMED
+
+    def test_recovers_expired_claim_then_issues_fresh_token(self, tmp_path: Path) -> None:
+        engine = _engine(tmp_path)
+        engine.create_intent(_intent(adapter_key="telegram"))
+        first = engine.claim_delivery(
+            "delivery-1",
+            now=datetime(2026, 4, 18, 1, 0, 0, tzinfo=timezone.utc),
+        )
+        assert first is not None
+        late = datetime(2026, 4, 18, 1, 10, 0, tzinfo=timezone.utc)
+        recovered = engine.ensure_direct_delivery_claim(
+            "delivery-1",
+            proposed_token=first.claim_token,
+            now=late,
+        )
+        assert recovered is not None
+        assert recovered.claim_token != first.claim_token
+
+    def test_without_proposed_token_claims_pending_record(self, tmp_path: Path) -> None:
+        engine = _engine(tmp_path)
+        engine.create_intent(_intent(adapter_key="telegram"))
+        ensured = engine.ensure_direct_delivery_claim(
+            "delivery-1",
+            proposed_token=None,
+            now=datetime(2026, 4, 18, 1, 0, 0, tzinfo=timezone.utc),
+        )
+        assert ensured is not None
+        assert ensured.record.state is ManagedThreadDeliveryState.CLAIMED
+
+    def test_returns_none_for_terminal_records(self, tmp_path: Path) -> None:
+        engine = _engine(tmp_path)
+        engine.create_intent(_intent(adapter_key="telegram"))
+        claim = engine.claim_next_delivery(
+            adapter_key="telegram",
+            now=datetime(2026, 4, 18, 1, 0, 0, tzinfo=timezone.utc),
+        )
+        assert claim is not None
+        engine.record_attempt_result(
+            "delivery-1",
+            claim_token=claim.claim_token,
+            result=ManagedThreadDeliveryAttemptResult(
+                outcome=ManagedThreadDeliveryOutcome.DIRECT_SURFACE_DELIVERED,
+            ),
+        )
+        ensured = engine.ensure_direct_delivery_claim(
+            "delivery-1",
+            proposed_token=claim.claim_token,
+            now=datetime(2026, 4, 18, 1, 5, 0, tzinfo=timezone.utc),
+        )
+        assert ensured is None
+
+
 class TestEngineRecordAttemptResult:
     def test_success_marks_delivered(self, tmp_path: Path) -> None:
         engine = _engine(tmp_path)

--- a/tests/core/orchestration/test_managed_thread_delivery_ledger.py
+++ b/tests/core/orchestration/test_managed_thread_delivery_ledger.py
@@ -461,6 +461,30 @@ class TestEngineRecordAttemptResult:
         assert updated is not None
         assert updated.state is ManagedThreadDeliveryState.DELIVERED
 
+    def test_direct_surface_delivery_marks_terminal(self, tmp_path: Path) -> None:
+        engine = _engine(tmp_path)
+        engine.create_intent(_intent(adapter_key="telegram"))
+        claim = engine.claim_next_delivery(
+            adapter_key="telegram",
+            now=datetime(2026, 4, 18, 1, 0, 0, tzinfo=timezone.utc),
+        )
+        assert claim is not None
+
+        result = ManagedThreadDeliveryAttemptResult(
+            outcome=ManagedThreadDeliveryOutcome.DIRECT_SURFACE_DELIVERED,
+            metadata={"delivery_surface": "telegram"},
+        )
+        updated = engine.record_attempt_result(
+            "delivery-1",
+            claim_token=claim.claim_token,
+            result=result,
+        )
+        assert updated is not None
+        assert updated.state is ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED
+        assert updated.delivered_at is not None
+        assert updated.claim_token is None
+        assert updated.metadata["delivery_surface"] == "telegram"
+
     def test_retry_schedules_next_attempt(self, tmp_path: Path) -> None:
         engine = _engine(tmp_path)
         engine.create_intent(_intent(adapter_key="telegram"))

--- a/tests/core/orchestration/test_managed_thread_delivery_ledger.py
+++ b/tests/core/orchestration/test_managed_thread_delivery_ledger.py
@@ -453,7 +453,9 @@ class TestEngineEnsureDirectDeliveryClaim:
         assert reclaimed.claim_token != first.claim_token
         assert reclaimed.record.state is ManagedThreadDeliveryState.CLAIMED
 
-    def test_recovers_expired_claim_then_issues_fresh_token(self, tmp_path: Path) -> None:
+    def test_recovers_expired_claim_then_issues_fresh_token(
+        self, tmp_path: Path
+    ) -> None:
         engine = _engine(tmp_path)
         engine.create_intent(_intent(adapter_key="telegram"))
         first = engine.claim_delivery(

--- a/tests/core/orchestration/test_managed_thread_delivery_recovery.py
+++ b/tests/core/orchestration/test_managed_thread_delivery_recovery.py
@@ -796,9 +796,21 @@ class TestLedgerExpiredClaimQueries:
                 surface_key="chat-2",
             )
         )
+        ledger.register_intent(
+            _intent(
+                delivery_id="d-direct",
+                managed_turn_id="turn-3",
+                surface_key="chat-3",
+            )
+        )
         ledger.patch_delivery(
             "d-terminal",
             state=ManagedThreadDeliveryState.DELIVERED,
+            validate_transition=False,
+        )
+        ledger.patch_delivery(
+            "d-direct",
+            state=ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED,
             validate_transition=False,
         )
 

--- a/tests/integrations/chat/test_managed_thread_direct_delivery.py
+++ b/tests/integrations/chat/test_managed_thread_direct_delivery.py
@@ -22,7 +22,9 @@ from codex_autorunner.integrations.chat.managed_thread_direct_delivery import (
 )
 
 
-def _intent(tmp_path: Path, *, adapter_key: str = "telegram") -> ManagedThreadDeliveryIntent:
+def _intent(
+    tmp_path: Path, *, adapter_key: str = "telegram"
+) -> ManagedThreadDeliveryIntent:
     hub_root = tmp_path / "hub"
     initialize_orchestration_sqlite(hub_root, durable=False)
     return ManagedThreadDeliveryIntent(
@@ -79,7 +81,9 @@ def test_reserve_refreshes_stale_claim_token_before_recording(tmp_path: Path) ->
     assert updated.state is ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED
 
 
-def test_reserve_returns_none_when_already_direct_surface_delivered(tmp_path: Path) -> None:
+def test_reserve_returns_none_when_already_direct_surface_delivered(
+    tmp_path: Path,
+) -> None:
     intent = _intent(tmp_path)
     hub_root = tmp_path / "hub"
     engine = SQLiteManagedThreadDeliveryEngine(hub_root, durable=False)

--- a/tests/integrations/chat/test_managed_thread_direct_delivery.py
+++ b/tests/integrations/chat/test_managed_thread_direct_delivery.py
@@ -1,0 +1,104 @@
+"""Tests for direct-surface durable delivery reservation helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from codex_autorunner.core.orchestration import (
+    ManagedThreadDeliveryAttemptResult,
+    ManagedThreadDeliveryEnvelope,
+    ManagedThreadDeliveryIntent,
+    ManagedThreadDeliveryOutcome,
+    ManagedThreadDeliveryState,
+    ManagedThreadDeliveryTarget,
+    SQLiteManagedThreadDeliveryEngine,
+    build_managed_thread_delivery_idempotency_key,
+    initialize_orchestration_sqlite,
+)
+from codex_autorunner.integrations.chat.managed_thread_direct_delivery import (
+    record_managed_thread_direct_delivery,
+    reserve_managed_thread_direct_delivery,
+)
+
+
+def _intent(tmp_path: Path, *, adapter_key: str = "telegram") -> ManagedThreadDeliveryIntent:
+    hub_root = tmp_path / "hub"
+    initialize_orchestration_sqlite(hub_root, durable=False)
+    return ManagedThreadDeliveryIntent(
+        delivery_id="delivery-1",
+        managed_thread_id="thread-1",
+        managed_turn_id="turn-1",
+        idempotency_key=build_managed_thread_delivery_idempotency_key(
+            managed_thread_id="thread-1",
+            managed_turn_id="turn-1",
+            surface_kind="telegram",
+            surface_key="chat-1",
+        ),
+        target=ManagedThreadDeliveryTarget(
+            surface_kind="telegram",
+            adapter_key=adapter_key,
+            surface_key="chat-1",
+        ),
+        envelope=ManagedThreadDeliveryEnvelope(
+            envelope_version="managed_thread_delivery.v1",
+            final_status="ok",
+            assistant_text="hello",
+        ),
+    )
+
+
+def test_reserve_refreshes_stale_claim_token_before_recording(tmp_path: Path) -> None:
+    intent = _intent(tmp_path)
+    hub_root = tmp_path / "hub"
+    engine = SQLiteManagedThreadDeliveryEngine(
+        hub_root,
+        durable=False,
+        claim_ttl=timedelta(minutes=5),
+    )
+    engine.create_intent(intent)
+    first = engine.claim_delivery(
+        "delivery-1",
+        now=datetime(2026, 4, 18, 1, 0, 0, tzinfo=timezone.utc),
+    )
+    assert first is not None
+    reservation = reserve_managed_thread_direct_delivery(
+        hub_root,
+        delivery_id="delivery-1",
+        claim_token="stale-token",
+    )
+    assert reservation is not None
+    assert reservation.claim_token != "stale-token"
+    updated = record_managed_thread_direct_delivery(
+        reservation,
+        delivered=True,
+        detail="test",
+        metadata={"delivery_surface": "telegram"},
+    )
+    assert updated is not None
+    assert updated.state is ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED
+
+
+def test_reserve_returns_none_when_already_direct_surface_delivered(tmp_path: Path) -> None:
+    intent = _intent(tmp_path)
+    hub_root = tmp_path / "hub"
+    engine = SQLiteManagedThreadDeliveryEngine(hub_root, durable=False)
+    engine.create_intent(intent)
+    claim = engine.claim_delivery(
+        "delivery-1",
+        now=datetime(2026, 4, 18, 1, 0, 0, tzinfo=timezone.utc),
+    )
+    assert claim is not None
+    engine.record_attempt_result(
+        "delivery-1",
+        claim_token=claim.claim_token,
+        result=ManagedThreadDeliveryAttemptResult(
+            outcome=ManagedThreadDeliveryOutcome.DIRECT_SURFACE_DELIVERED,
+        ),
+    )
+    reservation = reserve_managed_thread_direct_delivery(
+        hub_root,
+        delivery_id="delivery-1",
+        claim_token=claim.claim_token,
+    )
+    assert reservation is None

--- a/tests/integrations/chat/test_managed_turn_runner.py
+++ b/tests/integrations/chat/test_managed_turn_runner.py
@@ -277,6 +277,93 @@ async def test_run_managed_surface_turn_preserves_durable_delivery_id(
 
 
 @pytest.mark.anyio
+async def test_run_managed_surface_turn_counts_direct_surface_delivered_as_performed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = _build_started_execution(tmp_path)
+    finalized = ManagedThreadFinalizationResult(
+        status="ok",
+        assistant_text="done",
+        error=None,
+        managed_thread_id="thread-1",
+        managed_turn_id="exec-1",
+        backend_thread_id="backend-thread-1",
+    )
+
+    async def _submit_execution(
+        *args: Any, **kwargs: Any
+    ) -> ManagedThreadSubmissionResult:
+        _ = args, kwargs
+        return ManagedThreadSubmissionResult(started_execution=started, queued=False)
+
+    async def _fake_complete(
+        coordinator: Any,
+        submission: ManagedThreadSubmissionResult,
+        **kwargs: Any,
+    ) -> ManagedThreadExecutionFlowResult:
+        _ = coordinator, submission, kwargs
+        return ManagedThreadExecutionFlowResult(
+            started_execution=started,
+            queued=False,
+            finalized=finalized,
+        )
+
+    async def _fake_handoff(*args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        return SimpleNamespace(
+            delivery_id="delivery-1",
+            record=SimpleNamespace(
+                delivery_id="delivery-1",
+                state=ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED,
+            ),
+        )
+
+    monkeypatch.setattr(
+        managed_turn_runner_module,
+        "complete_managed_thread_execution",
+        _fake_complete,
+    )
+    monkeypatch.setattr(
+        managed_turn_runner_module,
+        "handoff_managed_thread_final_delivery",
+        _fake_handoff,
+    )
+
+    captured_flow: ManagedThreadExecutionFlowResult | None = None
+
+    def _on_finalized(
+        flow: ManagedThreadExecutionFlowResult,
+        finalized: ManagedThreadFinalizationResult,
+    ) -> str:
+        nonlocal captured_flow
+        captured_flow = flow
+        return finalized.assistant_text
+
+    result = await managed_turn_runner_module.run_managed_surface_turn(
+        started.request,
+        config=managed_turn_runner_module.ManagedSurfaceRunnerConfig[str](
+            coordinator=SimpleNamespace(
+                submit_execution=_submit_execution,
+                ensure_queue_worker=lambda **kwargs: None,
+            ),
+            client_request_id="req-1",
+            sandbox_policy=None,
+            hooks=ManagedThreadCoordinatorHooks(
+                durable_delivery=_make_durable_hooks(tmp_path),
+            ),
+            on_finalized=_on_finalized,
+        ),
+    )
+
+    assert result == "done"
+    assert captured_flow is not None
+    assert captured_flow.durable_delivery_performed is True
+    assert captured_flow.durable_delivery_pending is False
+    assert captured_flow.durable_delivery_id == "delivery-1"
+
+
+@pytest.mark.anyio
 async def test_run_managed_surface_turn_reraises_cancelled_submission(
     tmp_path: Path,
 ) -> None:

--- a/tests/integrations/chat/test_managed_turn_runner.py
+++ b/tests/integrations/chat/test_managed_turn_runner.py
@@ -228,6 +228,7 @@ async def test_run_managed_surface_turn_preserves_durable_delivery_id(
         return SimpleNamespace(
             delivery_id="delivery-1",
             state=ManagedThreadDeliveryState.RETRY_SCHEDULED,
+            direct_delivery_claim_token="claim-token-1",
         )
 
     monkeypatch.setattr(
@@ -272,6 +273,7 @@ async def test_run_managed_surface_turn_preserves_durable_delivery_id(
     assert captured_flow.durable_delivery_pending is True
     assert captured_flow.durable_delivery_performed is False
     assert captured_flow.durable_delivery_id == "delivery-1"
+    assert captured_flow.durable_delivery_claim_token == "claim-token-1"
 
 
 @pytest.mark.anyio

--- a/tests/integrations/discord/test_message_turns_transient_progress.py
+++ b/tests/integrations/discord/test_message_turns_transient_progress.py
@@ -537,7 +537,7 @@ async def test_deliver_result_reconciles_stale_siblings_without_final_message(
 
 
 @pytest.mark.anyio
-async def test_deliver_result_abandons_pending_durable_delivery_after_visible_final_send(
+async def test_deliver_result_marks_pending_durable_delivery_direct_surface_delivered_after_visible_final_send(
     tmp_path,
 ) -> None:
     workspace = tmp_path / "workspace"
@@ -577,6 +577,8 @@ async def test_deliver_result_abandons_pending_durable_delivery_after_visible_fi
         state=ManagedThreadDeliveryState.RETRY_SCHEDULED,
     )
     assert patched is not None
+    claim = engine.claim_delivery(record.delivery_id)
+    assert claim is not None
     dispatch = SimpleNamespace(
         service=service,
         channel_id="channel-1",
@@ -596,12 +598,13 @@ async def test_deliver_result_abandons_pending_durable_delivery_after_visible_fi
                 send_final_message=True,
                 delivery_visibility_pending=True,
                 durable_delivery_id=record.delivery_id,
+                durable_delivery_claim_token=claim.claim_token,
             ),
         )
 
-        abandoned = engine._ledger.get_delivery(record.delivery_id)
-        assert abandoned is not None
-        assert abandoned.state is ManagedThreadDeliveryState.ABANDONED
+        delivered = engine._ledger.get_delivery(record.delivery_id)
+        assert delivered is not None
+        assert delivered.state is ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED
         assert len(rest.channel_messages) == 1
     finally:
         await store.close()

--- a/tests/surfaces/web/routes/pma_routes/test_chat_runtime_execution_fresh_base_prompt.py
+++ b/tests/surfaces/web/routes/pma_routes/test_chat_runtime_execution_fresh_base_prompt.py
@@ -9,6 +9,9 @@ from types import SimpleNamespace
 import pytest
 
 from codex_autorunner.core.orchestration import FreshConversationRequiredError
+from codex_autorunner.surfaces.web.routes.pma_routes.chat_queue_execution import (
+    resolve_pma_session_key,
+)
 from codex_autorunner.surfaces.web.routes.pma_routes.chat_runtime_execution import (
     execute_harness_turn,
 )
@@ -98,3 +101,20 @@ async def test_fresh_conversation_uses_rebuild_prompt_for_base_prompt_injection(
     assert result["status"] == "ok"
     assert rebuild_calls == [True]
     assert prompts_seen == ["DELTA_PROMPT\n\nCORE PMA FROM PROMPT_MD\n\n"]
+
+
+def test_resolve_pma_session_key_isolates_automation_from_interactive_pma() -> None:
+    interactive = resolve_pma_session_key(
+        "hermes",
+        "m4-pma",
+        automation_trigger=False,
+    )
+    automation = resolve_pma_session_key(
+        "hermes",
+        "m4-pma",
+        automation_trigger=True,
+    )
+
+    assert interactive == "pma.hermes.profile.m4-pma"
+    assert automation == "pma.hermes.profile.m4-pma.automation"
+    assert automation != interactive

--- a/tests/telegram_pma_managed_thread_support.py
+++ b/tests/telegram_pma_managed_thread_support.py
@@ -1383,7 +1383,7 @@ async def test_pma_managed_thread_turn_recovers_if_wait_disconnects_after_comple
 
 
 @pytest.mark.anyio
-async def test_handle_normal_message_abandons_pending_durable_delivery_after_direct_send(
+async def test_handle_normal_message_marks_pending_durable_delivery_direct_surface_delivered_after_direct_send(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     record = TelegramTopicRecord(
@@ -1417,6 +1417,8 @@ async def test_handle_normal_message_abandons_pending_durable_delivery_after_dir
         state=ManagedThreadDeliveryState.RETRY_SCHEDULED,
     )
     assert patched is not None
+    claim = engine.claim_delivery(record_entry.delivery_id)
+    assert claim is not None
 
     async def _fake_run_turn_and_collect_result(
         *args: Any, **kwargs: Any
@@ -1434,6 +1436,7 @@ async def test_handle_normal_message_abandons_pending_durable_delivery_after_dir
             transcript_text=None,
             durable_delivery_handled=False,
             durable_delivery_id=record_entry.delivery_id,
+            durable_delivery_claim_token=claim.claim_token,
         )
 
     monkeypatch.setattr(
@@ -1455,9 +1458,9 @@ async def test_handle_normal_message_abandons_pending_durable_delivery_after_dir
 
     await handler._handle_normal_message(message, runtime=_RuntimeStub())
 
-    abandoned = engine._ledger.get_delivery(record_entry.delivery_id)
-    assert abandoned is not None
-    assert abandoned.state is ManagedThreadDeliveryState.ABANDONED
+    delivered = engine._ledger.get_delivery(record_entry.delivery_id)
+    assert delivered is not None
+    assert delivered.state is ManagedThreadDeliveryState.DIRECT_SURFACE_DELIVERED
     assert "telegram managed final reply" in handler._sent
 
 

--- a/tests/test_app_server_thread_registry.py
+++ b/tests/test_app_server_thread_registry.py
@@ -15,6 +15,7 @@ from codex_autorunner.integrations.app_server.threads import (
     file_chat_discord_key,
     file_chat_target_key,
     normalize_feature_key,
+    pma_automation_key,
     pma_base_key,
     pma_legacy_alias_keys,
     pma_legacy_migration_fallback_keys,
@@ -301,6 +302,16 @@ class TestPmaBaseKeyHelper:
     def test_none_profile_omits_suffix(self) -> None:
         assert pma_base_key("hermes", None) == "pma.hermes"
         assert pma_base_key("codex", None) == PMA_KEY
+
+
+class TestPmaAutomationKeyHelper:
+    def test_automation_key_appends_reserved_suffix(self) -> None:
+        assert pma_automation_key("codex") == "pma.automation"
+        assert pma_automation_key("opencode") == "pma.opencode.automation"
+        assert (
+            pma_automation_key("hermes", "m4-pma")
+            == "pma.hermes.profile.m4-pma.automation"
+        )
 
 
 class TestPmaTopicScopedKeyHelper:


### PR DESCRIPTION
## What changed
- add a first-class durable ledger terminal state for direct surface delivery: `direct_surface_delivered`
- retain the original durable claim when the initial direct durable handoff fails on managed-thread turns, and pass that claim token through the shared managed-turn flow to Discord and Telegram
- replace the old post-send abandon path with shared direct-delivery bookkeeping that records either `direct_surface_delivered` after a successful visible fallback send or `retry_scheduled` if that fallback send fails
- add shared core and surface regressions covering the new terminal state, direct-send claim preservation, and worker/recovery exclusion of direct-delivered records

## Why
Issue #1553 called out a remaining race in the PMA duplicate-delivery fix: the surface could send a visible final reply and only abandon the durable record afterward, leaving a narrow window where the worker could still claim and replay the same finalized turn.

This change closes that race on the primary path by keeping the durable record claimed through the direct fallback send and then committing an explicit terminal ledger state when the direct surface delivery succeeds.

## Impact
- Discord and Telegram direct fallback sends now complete the same durable delivery obligation instead of abandoning it after the fact
- replay/recovery logic treats direct-surface-delivered records as terminal and non-deliverable
- managed-surface flows preserve the delivery claim token needed to finish direct fallback bookkeeping cleanly

## Validation
- aggregate commit lane passed locally, including strict mypy, full pytest, frontend build/tests, and chat-surface lab checks
- `.venv/bin/pytest -q tests/core/orchestration/test_managed_thread_delivery_ledger.py tests/core/orchestration/test_managed_thread_delivery_recovery.py`
- `.venv/bin/pytest -q tests/integrations/chat/test_managed_turn_runner.py`
- `.venv/bin/pytest -q tests/integrations/discord/test_discord_managed_thread_delivery_adapter.py`
- `.venv/bin/pytest -q tests/integrations/discord/test_message_turns_transient_progress.py -k durable_delivery`
- `.venv/bin/pytest -q tests/integrations/telegram/test_telegram_managed_thread_delivery_adapter.py`
- `.venv/bin/pytest -q tests/telegram_pma_managed_thread_support.py -k durable_delivery`

## Scope note
- this addresses the direct-delivery ledger-state slice of #1553
- the Telegram queue teardown warnings and the other follow-up items in #1553 remain separate work