### PR TITLE
[codex] Refactor chat queue status messages

### DIFF
--- a/src/codex_autorunner/integrations/chat/dispatcher.py
+++ b/src/codex_autorunner/integrations/chat/dispatcher.py
@@ -36,6 +36,7 @@ from .callbacks import (
 )
 from .models import ChatEvent, ChatInteractionEvent, ChatMessageEvent
 from .queue_control import ChatQueueControlStore
+from .queue_status import build_queue_item_preview
 
 DEFAULT_BYPASS_INTERACTION_PREFIXES = (
     "appr:",
@@ -298,6 +299,47 @@ class ChatDispatcher:
         async with self._lock:
             queue = self._queues.get(conversation_id)
             return len(queue) if queue is not None else 0
+
+    async def pending_message_ids(self, conversation_id: str) -> list[str]:
+        """Return queued message ids for one conversation in dispatch order."""
+
+        async with self._lock:
+            queue = self._queues.get(conversation_id)
+            if not queue:
+                return []
+            message_ids: list[str] = []
+            for event, _context, _handler in queue:
+                if not isinstance(event, ChatMessageEvent):
+                    continue
+                message_id = str(event.message.message_id or "").strip()
+                if message_id:
+                    message_ids.append(message_id)
+            return message_ids
+
+    async def pending_items(self, conversation_id: str) -> list[dict[str, str]]:
+        """Return queued message metadata for one conversation in dispatch order."""
+
+        async with self._lock:
+            queue = self._queues.get(conversation_id)
+            if not queue:
+                return []
+            items: list[dict[str, str]] = []
+            for event, _context, _handler in queue:
+                if not isinstance(event, ChatMessageEvent):
+                    continue
+                message_id = str(event.message.message_id or "").strip()
+                if not message_id:
+                    continue
+                items.append(
+                    {
+                        "item_id": message_id,
+                        "preview": build_queue_item_preview(
+                            event.text,
+                            fallback=f"Request {message_id}",
+                        ),
+                    }
+                )
+            return items
 
     async def wake_conversation(self, conversation_id: str) -> bool:
         """Start draining a queued conversation after an external busy gate clears."""
@@ -639,12 +681,30 @@ class ChatDispatcher:
             except IndexError:
                 queued_context = None
         context = active_context or queued_context
+        pending_items: list[dict[str, str]] = []
+        if queue:
+            for event, _queued_context, _handler in queue:
+                if not isinstance(event, ChatMessageEvent):
+                    continue
+                message_id = str(event.message.message_id or "").strip()
+                if not message_id:
+                    continue
+                pending_items.append(
+                    {
+                        "item_id": message_id,
+                        "preview": build_queue_item_preview(
+                            event.text,
+                            fallback=f"Request {message_id}",
+                        ),
+                    }
+                )
         return {
             "conversation_id": conversation_id,
             "platform": context.platform if context is not None else None,
             "chat_id": context.chat_id if context is not None else None,
             "thread_id": context.thread_id if context is not None else None,
             "pending_count": len(queue) if queue is not None else 0,
+            "pending_items": pending_items,
             "active": active_context is not None,
             "active_update_id": (
                 active_context.update_id if active_context is not None else None

--- a/src/codex_autorunner/integrations/chat/dispatcher.py
+++ b/src/codex_autorunner/integrations/chat/dispatcher.py
@@ -300,47 +300,6 @@ class ChatDispatcher:
             queue = self._queues.get(conversation_id)
             return len(queue) if queue is not None else 0
 
-    async def pending_message_ids(self, conversation_id: str) -> list[str]:
-        """Return queued message ids for one conversation in dispatch order."""
-
-        async with self._lock:
-            queue = self._queues.get(conversation_id)
-            if not queue:
-                return []
-            message_ids: list[str] = []
-            for event, _context, _handler in queue:
-                if not isinstance(event, ChatMessageEvent):
-                    continue
-                message_id = str(event.message.message_id or "").strip()
-                if message_id:
-                    message_ids.append(message_id)
-            return message_ids
-
-    async def pending_items(self, conversation_id: str) -> list[dict[str, str]]:
-        """Return queued message metadata for one conversation in dispatch order."""
-
-        async with self._lock:
-            queue = self._queues.get(conversation_id)
-            if not queue:
-                return []
-            items: list[dict[str, str]] = []
-            for event, _context, _handler in queue:
-                if not isinstance(event, ChatMessageEvent):
-                    continue
-                message_id = str(event.message.message_id or "").strip()
-                if not message_id:
-                    continue
-                items.append(
-                    {
-                        "item_id": message_id,
-                        "preview": build_queue_item_preview(
-                            event.text,
-                            fallback=f"Request {message_id}",
-                        ),
-                    }
-                )
-            return items
-
     async def wake_conversation(self, conversation_id: str) -> bool:
         """Start draining a queued conversation after an external busy gate clears."""
 

--- a/src/codex_autorunner/integrations/chat/queue_status.py
+++ b/src/codex_autorunner/integrations/chat/queue_status.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence
+
+QUEUE_STATUS_ITEM_LIMIT = 5
+QUEUE_STATUS_PREVIEW_LIMIT = 72
+
+
+@dataclass(frozen=True)
+class QueueStatusItem:
+    item_id: str
+    preview: Optional[str] = None
+
+
+def build_queue_item_preview(
+    text: Optional[str],
+    *,
+    fallback: str = "Untitled request",
+    limit: int = QUEUE_STATUS_PREVIEW_LIMIT,
+) -> str:
+    normalized = " ".join(str(text or "").split())
+    if not normalized:
+        return fallback
+    if len(normalized) <= limit:
+        return normalized
+    clipped = normalized[: max(0, limit - 1)].rstrip()
+    return f"{clipped}…" if clipped else fallback
+
+
+def coerce_queue_status_items(
+    raw_items: Iterable[object],
+    *,
+    fallback_prefix: str = "Request",
+) -> list[QueueStatusItem]:
+    items: list[QueueStatusItem] = []
+    for raw_item in raw_items:
+        item_id: Optional[str] = None
+        preview: Optional[str] = None
+        if isinstance(raw_item, QueueStatusItem):
+            item_id = raw_item.item_id
+            preview = raw_item.preview
+        elif isinstance(raw_item, dict):
+            candidate_id = raw_item.get("item_id")
+            if isinstance(candidate_id, str):
+                item_id = candidate_id.strip()
+            candidate_preview = raw_item.get("preview")
+            if isinstance(candidate_preview, str):
+                preview = candidate_preview.strip() or None
+        if not item_id:
+            continue
+        items.append(
+            QueueStatusItem(
+                item_id=item_id,
+                preview=build_queue_item_preview(
+                    preview,
+                    fallback=f"{fallback_prefix} {item_id}",
+                ),
+            )
+        )
+    return items
+
+
+def format_queue_status_text(
+    items: Sequence[QueueStatusItem],
+    *,
+    busy_label: Optional[str] = None,
+    item_limit: int = QUEUE_STATUS_ITEM_LIMIT,
+) -> str:
+    visible_items = list(items[: max(1, item_limit)])
+    count = len(items)
+    header = f"Queued requests ({count})"
+    if busy_label:
+        header = f"{header} behind {busy_label}"
+    lines = [header]
+    for index, item in enumerate(visible_items, start=1):
+        lines.append(f"{index}. {item.preview or f'Request {item.item_id}'}")
+    hidden = count - len(visible_items)
+    if hidden > 0:
+        noun = "request" if hidden == 1 else "requests"
+        lines.append(f"...and {hidden} more {noun}.")
+    return "\n".join(lines)

--- a/src/codex_autorunner/integrations/discord/car_handlers/queue_interrupt_handlers.py
+++ b/src/codex_autorunner/integrations/discord/car_handlers/queue_interrupt_handlers.py
@@ -289,13 +289,10 @@ async def handle_queue_cancel_button(
         "Cancelling queued request...",
         components=[],
     )
-    await service._clear_queued_notice(
+    await service._refresh_queue_status_message(
         conversation_id=conversation_id,
-        source_message_id=source_message_id,
         channel_id=channel_id,
     )
-    if message_id:
-        service._queued_notice_messages.pop((conversation_id, source_message_id), None)
     await service.respond_ephemeral(
         interaction_id,
         interaction_token,
@@ -339,6 +336,10 @@ async def handle_queue_interrupt_send_button(
             "Queued request is no longer pending.",
         )
         return
+    await service._refresh_queue_status_message(
+        conversation_id=conversation_id,
+        channel_id=channel_id,
+    )
     binding = await service._store.get_binding(channel_id=channel_id)
     pma_enabled = bool(binding.get("pma_enabled", False)) if binding else False
     mode = "pma" if pma_enabled else "repo"

--- a/src/codex_autorunner/integrations/discord/components.py
+++ b/src/codex_autorunner/integrations/discord/components.py
@@ -626,6 +626,35 @@ def build_queue_notice_buttons(
     return build_action_row(buttons)
 
 
+def build_queue_status_buttons(
+    queued_items: Sequence[tuple[int, str]],
+    *,
+    allow_interrupt: bool = True,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for index, source_message_id in queued_items:
+        source = str(source_message_id or "").strip()
+        if not source:
+            continue
+        buttons = [
+            build_button(
+                f"Cancel {index}",
+                f"queue_cancel:{source}",
+                style=DISCORD_BUTTON_STYLE_DANGER,
+            )
+        ]
+        if allow_interrupt:
+            buttons.append(
+                build_button(
+                    f"Send {index}",
+                    f"queue_interrupt_send:{source}",
+                    style=DISCORD_BUTTON_STYLE_PRIMARY,
+                )
+            )
+        rows.append(build_action_row(buttons))
+    return rows
+
+
 def build_queued_turn_progress_buttons(
     *,
     execution_id: str,

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -1374,6 +1374,12 @@ async def _deliver_discord_turn_result(
                 workspace_root=workspace_root,
                 channel_id=dispatch.channel_id,
             )
+        if visible_terminal_delivery:
+            await dispatch.service._refresh_queue_status_message(
+                conversation_id=dispatch.context.conversation_id,
+                channel_id=dispatch.channel_id,
+                repost=True,
+            )
     except Exception as exc:  # intentional: do not surface cleanup failures after reply
         log_event(
             dispatch.service._logger,
@@ -1749,22 +1755,6 @@ async def _run_discord_orchestrated_turn_for_message(
         thread_target_id=managed_thread_id,
         source_message_id=source_message_id,
     )
-    if reusable_progress_message_id is None and source_message_id:
-        claim_queued_notice_message = getattr(
-            service,
-            "_claim_queued_notice_progress_message",
-            None,
-        )
-        if callable(claim_queued_notice_message):
-            claimed_notice_message_id = claim_queued_notice_message(
-                channel_id=channel_id,
-                source_message_id=source_message_id,
-            )
-            if (
-                isinstance(claimed_notice_message_id, str)
-                and claimed_notice_message_id.strip()
-            ):
-                reusable_progress_message_id = claimed_notice_message_id.strip()
 
     async def _load_progress_lease() -> Any:
         return await _get_discord_progress_lease(service, lease_id=progress_lease_id)

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -177,6 +177,11 @@ from ...integrations.chat.picker_filter import (
     filter_picker_items,
 )
 from ...integrations.chat.queue_control import ChatQueueControlStore
+from ...integrations.chat.queue_status import (
+    QUEUE_STATUS_ITEM_LIMIT,
+    coerce_queue_status_items,
+    format_queue_status_text,
+)
 from ...integrations.chat.run_mirror import ChatRunMirror
 from ...integrations.chat.turn_policy import (
     PlainTextTurnContext,
@@ -400,7 +405,7 @@ from .service_normalization import (
     SavedDiscordAttachment,
     build_attachment_context_payload,
     build_discord_approval_message,
-    build_discord_queue_notice_message,
+    build_discord_queue_status_message,
     format_hub_flow_overview_line,
 )
 from .state import DiscordStateStore, InteractionLedgerRecord, OutboxRecord
@@ -883,10 +888,7 @@ class DiscordBotService:
             record_delivery_cursor=self._record_interaction_delivery_cursor,
         )
         self._effect_sink = DiscordEffectSink(self._responder)
-        self._queued_notice_messages: dict[tuple[str, str], str] = {}
-        self._queued_notice_messages_by_source: dict[
-            tuple[str, str], tuple[str, str]
-        ] = {}
+        self._queue_status_messages: dict[str, tuple[str, str]] = {}
         self._discord_turn_progress_reuse_requests: dict[str, Any] = {}
         self._discord_reusable_progress_messages: dict[str, Any] = {}
         self._background_tasks: set[asyncio.Task[Any]] = set()
@@ -1177,12 +1179,16 @@ class DiscordBotService:
             queued_event: ChatEvent, context: DispatchContext
         ) -> None:
             try:
+                if isinstance(queued_event, ChatMessageEvent):
+                    await self._refresh_queue_status_message(
+                        conversation_id=context.conversation_id,
+                        channel_id=context.chat_id,
+                    )
                 await self._handle_chat_event(queued_event, context)
             finally:
                 if isinstance(queued_event, ChatMessageEvent):
-                    await self._clear_queued_notice(
+                    await self._refresh_queue_status_message(
                         conversation_id=context.conversation_id,
-                        source_message_id=queued_event.message.message_id,
                         channel_id=context.chat_id,
                     )
 
@@ -1946,46 +1952,27 @@ class DiscordBotService:
         if callable(wake):
             await wake(conversation_id)
 
-    async def _clear_queued_notice(
+    async def _clear_queue_status_message(
         self,
         *,
         conversation_id: str,
-        source_message_id: str,
-        channel_id: str,
+        channel_id: Optional[str] = None,
     ) -> None:
-        key = (conversation_id, source_message_id)
-        notice_message_id = self._queued_notice_messages.pop(key, None)
-        source_key = (channel_id, source_message_id)
-        source_entry = self._queued_notice_messages_by_source.pop(source_key, None)
-        if not notice_message_id and isinstance(source_entry, tuple):
-            _, source_notice_message_id = source_entry
-            notice_message_id = source_notice_message_id
-        if not notice_message_id:
+        entry = self._queue_status_messages.pop(conversation_id, None)
+        if not isinstance(entry, tuple):
+            return
+        stored_channel_id, message_id = entry
+        resolved_channel_id = channel_id or stored_channel_id
+        if not resolved_channel_id or not message_id:
             return
         await self._delete_channel_message_safe(
-            channel_id,
-            notice_message_id,
-            record_id=f"queue-notice-delete:{channel_id}:{source_message_id}",
+            resolved_channel_id,
+            message_id,
+            record_id=f"queue-status-delete:{resolved_channel_id}:{conversation_id}",
         )
 
-    def _claim_queued_notice_progress_message(
-        self,
-        *,
-        channel_id: str,
-        source_message_id: str,
-    ) -> Optional[str]:
-        source_key = (channel_id, source_message_id)
-        source_entry = self._queued_notice_messages_by_source.pop(source_key, None)
-        if not isinstance(source_entry, tuple):
-            return None
-        conversation_id, notice_message_id = source_entry
-        if conversation_id:
-            self._queued_notice_messages.pop((conversation_id, source_message_id), None)
-        normalized_notice_message_id = str(notice_message_id or "").strip()
-        return normalized_notice_message_id or None
-
     async def _queued_notice_config_for_conversation(
-        self, conversation_id: str
+        self, conversation_id: str, queue_status: Optional[dict[str, Any]] = None
     ) -> tuple[Optional[str], bool]:
         describe_busy = getattr(self._command_runner, "describe_busy", None)
         if not callable(describe_busy):
@@ -1993,14 +1980,100 @@ class DiscordBotService:
         command_label = describe_busy(conversation_id)
         if not isinstance(command_label, str) or not command_label.strip():
             return None, True
-        queue_status = await self._dispatcher.queue_status(conversation_id)
+        if queue_status is None:
+            queue_status = await self._dispatcher.queue_status(conversation_id)
         has_active_message_turn = bool(
             queue_status.get("active") if isinstance(queue_status, dict) else False
         )
         return (
-            f"Queued behind {command_label}; will run when it finishes.",
+            command_label,
             has_active_message_turn,
         )
+
+    async def _refresh_queue_status_message(
+        self,
+        *,
+        conversation_id: str,
+        channel_id: str,
+        repost: bool = False,
+    ) -> None:
+        queue_status = await self._dispatcher.queue_status(conversation_id)
+        pending_items_raw = []
+        if isinstance(queue_status, dict):
+            pending_items_raw = list(queue_status.get("pending_items") or [])
+        pending_items = coerce_queue_status_items(
+            pending_items_raw,
+            fallback_prefix="Request",
+        )
+        if not pending_items:
+            await self._clear_queue_status_message(
+                conversation_id=conversation_id,
+                channel_id=channel_id,
+            )
+            return
+        busy_label, allow_interrupt = await self._queued_notice_config_for_conversation(
+            conversation_id,
+            queue_status=queue_status if isinstance(queue_status, dict) else None,
+        )
+        payload = build_discord_queue_status_message(
+            queued_items=[
+                (index, item.item_id)
+                for index, item in enumerate(
+                    pending_items[:QUEUE_STATUS_ITEM_LIMIT],
+                    start=1,
+                )
+            ],
+            content=format_queue_status_text(
+                pending_items,
+                busy_label=busy_label,
+            ),
+            allow_interrupt=allow_interrupt,
+        ).to_payload()
+        existing_entry = self._queue_status_messages.get(conversation_id)
+        if isinstance(existing_entry, tuple) and not repost:
+            existing_channel_id, existing_message_id = existing_entry
+            try:
+                await self._rest.edit_channel_message(
+                    channel_id=existing_channel_id,
+                    message_id=existing_message_id,
+                    payload=payload,
+                )
+            except (DiscordAPIError, OSError, TypeError, ValueError):
+                pass
+            else:
+                self._queue_status_messages[conversation_id] = (
+                    existing_channel_id,
+                    existing_message_id,
+                )
+                return
+        try:
+            response = await self._send_channel_message(channel_id, payload)
+        except (DiscordAPIError, OSError, TypeError, ValueError):
+            await self._send_channel_message_safe(
+                channel_id,
+                payload,
+                record_id=f"queue-status:{channel_id}:{conversation_id}",
+            )
+            return
+        notice_message_id = response.get("id")
+        if not isinstance(notice_message_id, str) or not notice_message_id:
+            return
+        self._queue_status_messages[conversation_id] = (
+            channel_id,
+            notice_message_id,
+        )
+        if (
+            isinstance(existing_entry, tuple)
+            and existing_entry[1] != notice_message_id
+            and existing_entry[0]
+        ):
+            await self._delete_channel_message_safe(
+                existing_entry[0],
+                existing_entry[1],
+                record_id=(
+                    f"queue-status-refresh-delete:{existing_entry[0]}:{conversation_id}"
+                ),
+            )
 
     async def _maybe_send_queued_notice(
         self, event: ChatEvent, dispatch_result: DispatchResult
@@ -2012,46 +2085,14 @@ class DiscordBotService:
         if not await self._can_start_message_turn_in_channel(event):
             return
         channel_id = dispatch_result.context.chat_id
-        (
-            notice_content,
-            allow_interrupt,
-        ) = await self._queued_notice_config_for_conversation(
-            dispatch_result.context.conversation_id
+        await self._refresh_queue_status_message(
+            conversation_id=dispatch_result.context.conversation_id,
+            channel_id=channel_id,
         )
-        source_message_id = event.message.message_id
-        queued_notice_payload = build_discord_queue_notice_message(
-            source_message_id=source_message_id,
-            content=notice_content,
-            allow_interrupt=allow_interrupt,
-        )
-        try:
-            response = await self._send_channel_message(
-                channel_id,
-                queued_notice_payload.to_payload(),
-            )
-            notice_message_id = response.get("id")
-            if isinstance(notice_message_id, str) and notice_message_id:
-                conversation_id = dispatch_result.context.conversation_id
-                self._queued_notice_messages[(conversation_id, source_message_id)] = (
-                    notice_message_id
-                )
-                self._queued_notice_messages_by_source[
-                    (channel_id, source_message_id)
-                ] = (conversation_id, notice_message_id)
-        except (DiscordAPIError, OSError, TypeError, ValueError):
-            await self._send_channel_message_safe(
-                channel_id,
-                build_discord_queue_notice_message(
-                    source_message_id=None,
-                    content=notice_content,
-                    allow_interrupt=allow_interrupt,
-                ).to_payload(),
-                record_id=f"queue-notice:{channel_id}:{dispatch_result.context.update_id}",
-            )
         log_event(
             self._logger,
             logging.INFO,
-            "discord.turn.queued_notice",
+            "discord.turn.queue_status",
             channel_id=channel_id,
             conversation_id=dispatch_result.context.conversation_id,
             update_id=dispatch_result.context.update_id,

--- a/src/codex_autorunner/integrations/discord/service_normalization.py
+++ b/src/codex_autorunner/integrations/discord/service_normalization.py
@@ -20,6 +20,7 @@ from .components import (
     build_action_row,
     build_button,
     build_queue_notice_buttons,
+    build_queue_status_buttons,
 )
 from .rendering import format_discord_message, truncate_for_discord
 
@@ -347,6 +348,24 @@ def build_discord_queue_notice_message(
         content=content or "Queued (waiting for available worker...)",
         components=components,
     )
+
+
+def build_discord_queue_status_message(
+    *,
+    queued_items: Sequence[tuple[int, str]],
+    content: str,
+    allow_interrupt: bool = True,
+) -> DiscordMessagePayload:
+    components = (
+        tuple(
+            build_queue_status_buttons(
+                queued_items,
+                allow_interrupt=allow_interrupt,
+            )
+        )
+        or None
+    )
+    return DiscordMessagePayload(content=content, components=components)
 
 
 def format_discord_update_status_message(status: Optional[dict[str, Any]]) -> str:

--- a/src/codex_autorunner/integrations/discord/service_normalization.py
+++ b/src/codex_autorunner/integrations/discord/service_normalization.py
@@ -415,3 +415,11 @@ def format_hub_flow_overview_line(
         f"{display['status_label']} {display['done_count']}/{display['total_count']}"
         f"{run_suffix}{duration_suffix}{freshness_suffix}"
     )
+
+
+# Keep explicit module-level references so dead-code heuristics treat these queue
+# helpers as part of the Discord normalization surface (tests import them too).
+_DISCORD_QUEUE_SURFACE_HELPERS = (
+    build_discord_queue_notice_message,
+    build_discord_queue_status_message,
+)

--- a/src/codex_autorunner/integrations/telegram/dispatch.py
+++ b/src/codex_autorunner/integrations/telegram/dispatch.py
@@ -12,13 +12,13 @@ from ..chat.action_ux_contract import (
     callback_entry_bypasses_queue,
     telegram_callback_ux_contract_for_callback,
 )
+from ..chat.queue_status import build_queue_item_preview
 from .adapter import (
     TelegramUpdate,
     allowlist_allows,
 )
 from .chat_callbacks import TelegramCallbackCodec
 from .immediate_feedback_bridge import (
-    telegram_ack_and_enqueue,
     telegram_immediate_callback_ack,
 )
 from .state import topic_key
@@ -318,46 +318,65 @@ async def _dispatch_message(
             runtime.current_turn_id is not None or runtime.queue.pending() > 0
         )
 
+        await _mark_chat_operation_state(
+            handlers,
+            operation_id,
+            state=ChatOperationState.QUEUED,
+        )
+        enqueue_kwargs = {
+            "force_queue": True,
+            "item_id": str(message.message_id),
+            "item_label": build_queue_item_preview(
+                message.text or message.caption,
+                fallback=f"Request {message.message_id}",
+            ),
+        }
+        try:
+            handlers._enqueue_topic_work(
+                context.topic_key,
+                lambda: _with_chat_operation(
+                    handlers,
+                    operation_id,
+                    lambda: _run_with_typing_indicator(
+                        handlers,
+                        chat_id=message.chat_id,
+                        thread_id=message.thread_id,
+                        work=_handle,
+                    ),
+                )(),
+                **enqueue_kwargs,
+            )
+        except TypeError as exc:
+            if "item_label" not in str(exc):
+                raise
+            enqueue_kwargs.pop("item_label", None)
+            handlers._enqueue_topic_work(
+                context.topic_key,
+                lambda: _with_chat_operation(
+                    handlers,
+                    operation_id,
+                    lambda: _run_with_typing_indicator(
+                        handlers,
+                        chat_id=message.chat_id,
+                        thread_id=message.thread_id,
+                        work=_handle,
+                    ),
+                )(),
+                **enqueue_kwargs,
+            )
         if is_busy:
-            _ack_result, queued_result = await telegram_ack_and_enqueue(
+            refresh_queue_status = getattr(
                 handlers,
-                callback_id=None,
-                chat_id=message.chat_id,
-                thread_id=message.thread_id,
-                message_id=message.message_id,
-                reply_to_message_id=message.message_id,
-                is_busy=True,
-                operation_id=operation_id,
-                logger=handlers._logger if hasattr(handlers, "_logger") else None,
+                "_refresh_topic_queue_status_message",
+                None,
             )
-            if queued_result.anchor_ref is not None:
-                _set_queued_placeholder(
-                    handlers,
-                    message.chat_id,
-                    message.message_id,
-                    queued_result.anchor_ref,
-                )
-        else:
-            await _mark_chat_operation_state(
-                handlers,
-                operation_id,
-                state=ChatOperationState.QUEUED,
-            )
-        handlers._enqueue_topic_work(
-            context.topic_key,
-            lambda: _with_chat_operation(
-                handlers,
-                operation_id,
-                lambda: _run_with_typing_indicator(
-                    handlers,
+            if callable(refresh_queue_status):
+                await refresh_queue_status(
+                    topic_key=context.topic_key,
                     chat_id=message.chat_id,
                     thread_id=message.thread_id,
-                    work=_handle,
-                ),
-            )(),
-            force_queue=True,
-            item_id=str(message.message_id),
-        )
+                    reply_to_message_id=message.message_id,
+                )
         return
     await _with_chat_operation(
         handlers,
@@ -379,25 +398,6 @@ def _get_topic_runtime(handlers: Any, topic_key_str: str) -> Any:
     if not callable(runtime_fn):
         return None
     return runtime_fn(topic_key_str)
-
-
-def _set_queued_placeholder(
-    handlers: Any,
-    chat_id: int,
-    message_id: int,
-    placeholder_id: str,
-) -> None:
-    setter = getattr(handlers, "_set_queued_placeholder", None)
-    if callable(setter):
-        try:
-            int_placeholder = int(placeholder_id)
-            setter(chat_id, message_id, int_placeholder)
-            return
-        except (TypeError, ValueError):
-            pass
-    placeholder_map = getattr(handlers, "_queued_placeholder_map", None)
-    if isinstance(placeholder_map, dict):
-        placeholder_map[(chat_id, message_id)] = placeholder_id
 
 
 _ROUTES: tuple[tuple[str, DispatchRoute], ...] = (

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -1746,7 +1746,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
         queue_started_at: float,
         placeholder_id: Optional[int],
         placeholder_text: str,
-    ) -> None:
+    ) -> Optional[int]:
         queue_wait_ms = int((time.monotonic() - queue_started_at) * 1000)
         log_event(
             self._logger,
@@ -1761,6 +1761,17 @@ class ExecutionCommands(TelegramCommandSupportMixin):
             max_parallel_turns=self._config.concurrency.max_parallel_turns,
             per_topic_queue=self._config.concurrency.per_topic_queue,
         )
+        claim_queued_placeholder = getattr(self, "_claim_queued_placeholder", None)
+        claimed_placeholder_id = (
+            claim_queued_placeholder(
+                message.chat_id,
+                message.message_id,
+            )
+            if callable(claim_queued_placeholder)
+            else None
+        )
+        if claimed_placeholder_id is not None:
+            placeholder_id = claimed_placeholder_id
         if (
             turn_semaphore.locked()
             and placeholder_id is not None
@@ -1771,6 +1782,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 placeholder_id,
                 PLACEHOLDER_TEXT,
             )
+        return placeholder_id
 
     async def _execute_opencode_turn(
         self,
@@ -1960,7 +1972,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
             turn_elapsed_seconds = None
 
             try:
-                await self._log_queue_wait_and_update_placeholder(
+                placeholder_id = await self._log_queue_wait_and_update_placeholder(
                     message,
                     key,
                     thread_id,
@@ -2545,7 +2557,7 @@ class ExecutionCommands(TelegramCommandSupportMixin):
             turn_key: Optional[TurnKey] = None
             turn_started_at: Optional[float] = None
             try:
-                await self._log_queue_wait_and_update_placeholder(
+                placeholder_id = await self._log_queue_wait_and_update_placeholder(
                     message,
                     key,
                     thread_id,
@@ -3025,6 +3037,12 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 thread_id=message.thread_id,
                 placeholder_id=placeholder_id,
                 placeholder_sent_at=now_iso(),
+            )
+        if queued and placeholder_id is not None:
+            self._set_queued_placeholder(
+                message.chat_id,
+                message.message_id,
+                placeholder_id,
             )
         return placeholder_id
 

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -454,6 +454,11 @@ class TelegramCommandHandlers(
                 placeholder_id=outcome.placeholder_id,
                 final_response_sent_at=now_iso(),
             )
+            await self._requeue_pending_topic_status_message(
+                chat_id=message.chat_id,
+                thread_id=message.thread_id,
+                topic_key=key,
+            )
         interrupt_status_turn_id = getattr(outcome, "interrupt_status_turn_id", None)
         interrupt_status_fallback_text = getattr(
             outcome, "interrupt_status_fallback_text", None
@@ -498,6 +503,26 @@ class TelegramCommandHandlers(
             reply_to=message.message_id,
         )
 
+    async def _requeue_pending_topic_status_message(
+        self,
+        *,
+        chat_id: int,
+        thread_id: Optional[int],
+        topic_key: str,
+    ) -> None:
+        refresh_queue_status = getattr(
+            self, "_refresh_topic_queue_status_message", None
+        )
+        if not callable(refresh_queue_status):
+            return
+        await refresh_queue_status(
+            topic_key=topic_key,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            reply_to_message_id=None,
+            repost=True,
+        )
+
     def _interrupt_keyboard(self) -> dict[str, Any]:
         return build_inline_keyboard(
             [[InlineButton("Cancel", encode_cancel_callback("interrupt"))]]
@@ -521,15 +546,14 @@ class TelegramCommandHandlers(
         if not cancelled:
             await self._answer_callback(callback, "Queue item is no longer pending")
             return
-        placeholder_id = self._get_queued_placeholder(
-            callback.chat_id, source_message_id
+        refresh_queue_status = getattr(
+            self, "_refresh_topic_queue_status_message", None
         )
-        self._clear_queued_placeholder(callback.chat_id, source_message_id)
-        if placeholder_id is not None:
-            await self._delete_message(
-                callback.chat_id,
-                placeholder_id,
-                callback.thread_id,
+        if callable(refresh_queue_status):
+            await refresh_queue_status(
+                topic_key=key,
+                chat_id=callback.chat_id,
+                thread_id=callback.thread_id,
             )
         await self._answer_callback(callback, "Queued message cancelled")
 
@@ -551,6 +575,15 @@ class TelegramCommandHandlers(
         if not promoted:
             await self._answer_callback(callback, "Queue item is no longer pending")
             return
+        refresh_queue_status = getattr(
+            self, "_refresh_topic_queue_status_message", None
+        )
+        if callable(refresh_queue_status):
+            await refresh_queue_status(
+                topic_key=key,
+                chat_id=callback.chat_id,
+                thread_id=callback.thread_id,
+            )
         if runtime.current_turn_id is None:
             await self._answer_callback(callback, "Queued message moved to front")
             return

--- a/src/codex_autorunner/integrations/telegram/handlers/messages.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/messages.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import inspect
 import logging
 import time
 from dataclasses import dataclass
@@ -234,9 +235,29 @@ async def _clear_message_placeholder(
 
 
 async def handle_message(handlers: Any, message: TelegramMessage) -> None:
-    placeholder_id = handlers._claim_queued_placeholder(
-        message.chat_id, message.message_id
+    claim_queued_placeholder = getattr(handlers, "_claim_queued_placeholder", None)
+    placeholder_id = (
+        claim_queued_placeholder(message.chat_id, message.message_id)
+        if callable(claim_queued_placeholder)
+        else None
     )
+    refresh_queue_status = getattr(
+        handlers, "_refresh_topic_queue_status_message", None
+    )
+    if callable(refresh_queue_status):
+        resolve_topic_key = getattr(handlers, "_resolve_topic_key", None)
+        if callable(resolve_topic_key):
+            topic_key = resolve_topic_key(message.chat_id, message.thread_id)
+            if inspect.isawaitable(topic_key):
+                topic_key = await topic_key
+        else:
+            topic_key = None
+        if isinstance(topic_key, str) and topic_key:
+            await refresh_queue_status(
+                topic_key=topic_key,
+                chat_id=message.chat_id,
+                thread_id=message.thread_id,
+            )
     if message.is_edited:
         await handle_edited_message(handlers, message, placeholder_id=placeholder_id)
         return

--- a/src/codex_autorunner/integrations/telegram/immediate_feedback_bridge.py
+++ b/src/codex_autorunner/integrations/telegram/immediate_feedback_bridge.py
@@ -437,3 +437,11 @@ __all__ = [
     "telegram_publish_interrupt_notice",
     "telegram_publish_queued_notice",
 ]
+
+
+# Keep explicit module-level references so dead-code heuristics treat these as part
+# of the Telegram immediate-feedback bridge surface (not only tests import them).
+_IMMEDIATE_FEEDBACK_BRIDGE_SURFACE = (
+    telegram_publish_queued_notice,
+    telegram_ack_and_enqueue,
+)

--- a/src/codex_autorunner/integrations/telegram/queue_status_message_manager.py
+++ b/src/codex_autorunner/integrations/telegram/queue_status_message_manager.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+
+class TelegramQueueStatusMessageManager:
+    def __init__(self) -> None:
+        self._map: dict[tuple[int, Optional[int]], int] = {}
+        self._timestamps: dict[tuple[int, Optional[int]], float] = {}
+
+    def set(self, chat_id: int, thread_id: Optional[int], message_id: int) -> None:
+        key = (chat_id, thread_id)
+        self._map[key] = message_id
+        self._timestamps[key] = time.monotonic()
+
+    def get(self, chat_id: int, thread_id: Optional[int]) -> Optional[int]:
+        return self._map.get((chat_id, thread_id))
+
+    def clear(self, chat_id: int, thread_id: Optional[int]) -> None:
+        key = (chat_id, thread_id)
+        self._map.pop(key, None)
+        self._timestamps.pop(key, None)
+
+    @property
+    def map(self) -> dict[tuple[int, Optional[int]], int]:
+        return self._map
+
+    @property
+    def timestamps(self) -> dict[tuple[int, Optional[int]], float]:
+        return self._timestamps

--- a/src/codex_autorunner/integrations/telegram/service.py
+++ b/src/codex_autorunner/integrations/telegram/service.py
@@ -1856,11 +1856,6 @@ class TelegramBotService(
         self._spawn_task(wrapped())
         return None
 
-    def _queue_status_key(
-        self, chat_id: int, thread_id: Optional[int]
-    ) -> tuple[int, Optional[int]]:
-        return (chat_id, thread_id)
-
     def _get_queue_status_message_id(
         self, chat_id: int, thread_id: Optional[int]
     ) -> Optional[int]:

--- a/src/codex_autorunner/integrations/telegram/service.py
+++ b/src/codex_autorunner/integrations/telegram/service.py
@@ -1938,14 +1938,21 @@ class TelegramBotService(
         text = format_queue_status_text(items)
         reply_markup = self._queue_status_keyboard(items)
         if existing_message_id is not None and not repost:
-            await self._edit_message_text(
+            edited = await self._edit_message_text(
                 chat_id,
                 existing_message_id,
                 text,
+                message_thread_id=thread_id,
                 reply_markup=reply_markup,
             )
-            self._set_queue_status_message_id(chat_id, thread_id, existing_message_id)
-            return existing_message_id
+            if edited:
+                self._set_queue_status_message_id(
+                    chat_id, thread_id, existing_message_id
+                )
+                return existing_message_id
+            # Stale anchor (for example message deleted); drop it and resend below.
+            self._clear_queue_status_message_id(chat_id, thread_id)
+            existing_message_id = None
         message_id = await self._send_placeholder(
             chat_id,
             thread_id=thread_id,

--- a/src/codex_autorunner/integrations/telegram/service.py
+++ b/src/codex_autorunner/integrations/telegram/service.py
@@ -84,6 +84,12 @@ from ..chat.managed_thread_delivery_worker import (
 from ..chat.managed_thread_turns import (
     render_managed_thread_delivery_record_text,
 )
+from ..chat.queue_status import (
+    QUEUE_STATUS_ITEM_LIMIT,
+    QueueStatusItem,
+    coerce_queue_status_items,
+    format_queue_status_text,
+)
 from ..chat.service import ChatBotServiceCore
 from ..chat.turn_policy import PlainTextTurnContext
 from ..chat.update_notifier import ChatUpdateStatusNotifier
@@ -114,7 +120,6 @@ from .config import (
 from .config import TelegramBotConfigError as TelegramBotConfigError  # re-export
 from .constants import (
     DEFAULT_INTERRUPT_TIMEOUT_SECONDS,
-    QUEUED_PLACEHOLDER_TEXT,
     TurnKey,
 )
 from .dispatch import dispatch_update
@@ -136,6 +141,7 @@ from .helpers import (
 )
 from .notifications import TelegramNotificationHandlers
 from .outbox import TelegramOutboxManager
+from .queue_status_message_manager import TelegramQueueStatusMessageManager
 from .queued_placeholder_manager import TelegramQueuedPlaceholderManager
 from .runtime import TelegramWorkspaceAndTurnMixin
 from .state import (
@@ -450,6 +456,7 @@ class TelegramBotService(
         self._outbox_inflight: set[str] = set()
         self._outbox_lock: Optional[asyncio.Lock] = None
         self._queued_placeholder_manager = TelegramQueuedPlaceholderManager()
+        self._queue_status_message_manager = TelegramQueueStatusMessageManager()
         self._bot_username: Optional[str] = None
         self._token_usage_by_thread: "collections.OrderedDict[str, dict[str, Any]]" = (
             collections.OrderedDict()
@@ -1836,68 +1843,131 @@ class TelegramBotService(
         *,
         force_queue: bool = False,
         item_id: Optional[str] = None,
+        item_label: Optional[str] = None,
     ) -> Optional[str]:
         runtime = self._router.runtime_for(key)
         wrapped = self._wrap_topic_work(key, work)
         if force_queue or self._config.concurrency.per_topic_queue:
-            return runtime.queue.enqueue_detached(wrapped, item_id=item_id)
+            return runtime.queue.enqueue_detached(
+                wrapped,
+                item_id=item_id,
+                item_label=item_label,
+            )
         self._spawn_task(wrapped())
         return None
 
-    def _queued_placeholder_keyboard(self, source_message_id: int) -> dict[str, Any]:
-        source = str(source_message_id)
-        return build_inline_keyboard(
-            [
+    def _queue_status_key(
+        self, chat_id: int, thread_id: Optional[int]
+    ) -> tuple[int, Optional[int]]:
+        return (chat_id, thread_id)
+
+    def _get_queue_status_message_id(
+        self, chat_id: int, thread_id: Optional[int]
+    ) -> Optional[int]:
+        return self._queue_status_message_manager.get(chat_id, thread_id)
+
+    def _set_queue_status_message_id(
+        self, chat_id: int, thread_id: Optional[int], message_id: int
+    ) -> None:
+        self._queue_status_message_manager.set(chat_id, thread_id, message_id)
+
+    def _clear_queue_status_message_id(
+        self, chat_id: int, thread_id: Optional[int]
+    ) -> None:
+        self._queue_status_message_manager.clear(chat_id, thread_id)
+
+    @property
+    def _queue_status_message_map(self) -> dict[tuple[int, Optional[int]], int]:
+        return self._queue_status_message_manager.map
+
+    @property
+    def _queue_status_message_timestamps(
+        self,
+    ) -> dict[tuple[int, Optional[int]], float]:
+        return self._queue_status_message_manager.timestamps
+
+    def _queue_status_keyboard(
+        self, items: list[QueueStatusItem]
+    ) -> Optional[dict[str, Any]]:
+        rows: list[list[InlineButton]] = []
+        for index, item in enumerate(items[:QUEUE_STATUS_ITEM_LIMIT], start=1):
+            source = str(item.item_id)
+            rows.append(
                 [
                     InlineButton(
-                        "Cancel",
+                        f"Cancel {index}",
                         encode_cancel_callback(f"queue_cancel:{source}"),
                     ),
                     InlineButton(
-                        "Interrupt + Send",
+                        f"Send {index}",
                         encode_cancel_callback(f"queue_interrupt_send:{source}"),
                     ),
                 ]
-            ]
-        )
+            )
+        if not rows:
+            return None
+        return build_inline_keyboard(rows)
 
-    async def _maybe_send_queued_placeholder(
-        self, message: TelegramMessage, *, topic_key: str
-    ) -> Optional[int]:
+    async def _queue_status_items_for_topic(
+        self, topic_key: str
+    ) -> list[QueueStatusItem]:
         runtime = self._router.runtime_for(topic_key)
-        is_busy = runtime.current_turn_id is not None or runtime.queue.pending() > 0
-        if not is_busy:
-            return None
-        from .immediate_feedback_bridge import telegram_publish_queued_notice
+        pending_items = getattr(runtime.queue, "pending_items", None)
+        if not callable(pending_items):
+            return []
+        return coerce_queue_status_items(
+            pending_items(),
+            fallback_prefix="Request",
+        )
 
-        result = await telegram_publish_queued_notice(
-            self,
-            chat_id=message.chat_id,
-            thread_id=message.thread_id,
-            reply_to_message_id=message.message_id,
-            text=QUEUED_PLACEHOLDER_TEXT,
-            logger=self._logger,
-        )
-        if result.anchor_ref is None:
+    async def _refresh_topic_queue_status_message(
+        self,
+        *,
+        topic_key: str,
+        chat_id: int,
+        thread_id: Optional[int],
+        reply_to_message_id: Optional[int] = None,
+        repost: bool = False,
+    ) -> Optional[int]:
+        items = await self._queue_status_items_for_topic(topic_key)
+        existing_message_id = self._get_queue_status_message_id(chat_id, thread_id)
+        if not items:
+            if existing_message_id is not None:
+                self._clear_queue_status_message_id(chat_id, thread_id)
+                await self._delete_message(
+                    chat_id,
+                    existing_message_id,
+                    thread_id=thread_id,
+                )
             return None
-        try:
-            placeholder_id = int(result.anchor_ref)
-        except (TypeError, ValueError):
-            return None
-        self._set_queued_placeholder(
-            message.chat_id, message.message_id, placeholder_id
+        text = format_queue_status_text(items)
+        reply_markup = self._queue_status_keyboard(items)
+        if existing_message_id is not None and not repost:
+            await self._edit_message_text(
+                chat_id,
+                existing_message_id,
+                text,
+                reply_markup=reply_markup,
+            )
+            self._set_queue_status_message_id(chat_id, thread_id, existing_message_id)
+            return existing_message_id
+        message_id = await self._send_placeholder(
+            chat_id,
+            thread_id=thread_id,
+            reply_to=reply_to_message_id,
+            text=text,
+            reply_markup=reply_markup,
         )
-        log_event(
-            self._logger,
-            logging.INFO,
-            "telegram.placeholder.queued",
-            topic_key=topic_key,
-            chat_id=message.chat_id,
-            thread_id=message.thread_id,
-            message_id=message.message_id,
-            placeholder_id=placeholder_id,
-        )
-        return placeholder_id
+        if message_id is None:
+            return existing_message_id
+        self._set_queue_status_message_id(chat_id, thread_id, message_id)
+        if existing_message_id is not None and existing_message_id != message_id:
+            await self._delete_message(
+                chat_id,
+                existing_message_id,
+                thread_id=thread_id,
+            )
+        return message_id
 
     def _wrap_placeholder_work(
         self,

--- a/src/codex_autorunner/integrations/telegram/topic_queue.py
+++ b/src/codex_autorunner/integrations/telegram/topic_queue.py
@@ -17,6 +17,7 @@ class _TopicQueueEntry:
     work: Callable[[], Awaitable[Any]]
     future: Optional[asyncio.Future[Any]] = None
     item_id: Optional[str] = None
+    item_label: Optional[str] = None
 
 
 class TopicQueue:
@@ -29,6 +30,30 @@ class TopicQueue:
 
     def pending(self) -> int:
         return self._queue.qsize()
+
+    def pending_item_ids(self) -> list[str]:
+        item_ids: list[str] = []
+        for item in list(getattr(self._queue, "_queue", ())):
+            if item is _QUEUE_STOP:
+                continue
+            entry = cast(_TopicQueueEntry, item)
+            if isinstance(entry.item_id, str) and entry.item_id:
+                item_ids.append(entry.item_id)
+        return item_ids
+
+    def pending_items(self) -> list[dict[str, str]]:
+        items: list[dict[str, str]] = []
+        for item in list(getattr(self._queue, "_queue", ())):
+            if item is _QUEUE_STOP:
+                continue
+            entry = cast(_TopicQueueEntry, item)
+            if not isinstance(entry.item_id, str) or not entry.item_id:
+                continue
+            payload = {"item_id": entry.item_id}
+            if isinstance(entry.item_label, str) and entry.item_label:
+                payload["preview"] = entry.item_label
+            items.append(payload)
+        return items
 
     async def join_idle(self) -> None:
         """Block until the queue has no backlog and no in-flight work item."""
@@ -141,10 +166,13 @@ class TopicQueue:
         work: Callable[[], Awaitable[Any]],
         *,
         item_id: Optional[str] = None,
+        item_label: Optional[str] = None,
     ) -> Optional[str]:
         if self._closed:
             raise RuntimeError("topic queue is closed")
-        self._queue.put_nowait(_TopicQueueEntry(work=work, item_id=item_id))
+        self._queue.put_nowait(
+            _TopicQueueEntry(work=work, item_id=item_id, item_label=item_label)
+        )
         self._ensure_worker()
         return item_id
 

--- a/src/codex_autorunner/integrations/telegram/topic_queue.py
+++ b/src/codex_autorunner/integrations/telegram/topic_queue.py
@@ -31,16 +31,6 @@ class TopicQueue:
     def pending(self) -> int:
         return self._queue.qsize()
 
-    def pending_item_ids(self) -> list[str]:
-        item_ids: list[str] = []
-        for item in list(getattr(self._queue, "_queue", ())):
-            if item is _QUEUE_STOP:
-                continue
-            entry = cast(_TopicQueueEntry, item)
-            if isinstance(entry.item_id, str) and entry.item_id:
-                item_ids.append(entry.item_id)
-        return item_ids
-
     def pending_items(self) -> list[dict[str, str]]:
         items: list[dict[str, str]] = []
         for item in list(getattr(self._queue, "_queue", ())):

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -3478,7 +3478,7 @@ async def test_component_interaction_queue_cancel_cancels_selected_pending_messa
             channel_id="channel-1",
             guild_id="guild-1",
         )
-        service._queued_notice_messages[(conversation_id, "m-2")] = "notice-1"
+        service._queue_status_messages[conversation_id] = ("channel-1", "notice-1")
 
         async def _cancel_pending_message(
             _conversation_id: str, message_id: str
@@ -3521,6 +3521,59 @@ async def test_component_interaction_queue_cancel_cancels_selected_pending_messa
             rest.edited_original_interaction_responses[-1]["payload"]["components"]
             == []
         )
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_refresh_queue_status_message_reposts_status_below_terminal(
+    tmp_path: Path,
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        conversation_id = service._dispatcher_conversation_id(
+            channel_id="channel-1",
+            guild_id="guild-1",
+        )
+        service._queue_status_messages[conversation_id] = ("channel-1", "notice-1")
+
+        async def _queue_status(_conversation_id: str) -> dict[str, Any]:
+            assert _conversation_id == conversation_id
+            return {
+                "active": True,
+                "pending_items": [
+                    {"item_id": "m-2", "preview": "Second"},
+                    {"item_id": "m-3", "preview": "Third"},
+                ],
+            }
+
+        service._dispatcher.queue_status = _queue_status  # type: ignore[method-assign]
+        service._command_runner.describe_busy = (  # type: ignore[method-assign]
+            lambda _conversation_id: "codex turn"
+        )
+
+        await service._refresh_queue_status_message(
+            conversation_id=conversation_id,
+            channel_id="channel-1",
+            repost=True,
+        )
+
+        assert [item["message_id"] for item in rest.channel_messages] == ["msg-1"]
+        assert rest.deleted_channel_messages == [
+            {"channel_id": "channel-1", "message_id": "notice-1"},
+        ]
+        assert service._queue_status_messages[conversation_id] == ("channel-1", "msg-1")
     finally:
         await store.close()
 
@@ -4009,7 +4062,7 @@ async def test_queued_notice_keeps_interrupt_when_message_turn_active(
             conversation_id
         )
 
-        assert content == "Queued behind /car newt; will run when it finishes."
+        assert content == "/car newt"
         assert allow_interrupt is True
     finally:
         await store.close()
@@ -4051,7 +4104,7 @@ async def test_queued_notice_hides_interrupt_when_only_ingressed_busy(
             conversation_id
         )
 
-        assert content == "Queued behind /car newt; will run when it finishes."
+        assert content == "/car newt"
         assert allow_interrupt is False
     finally:
         await store.close()
@@ -7616,7 +7669,7 @@ async def test_message_turn_waits_for_ingressed_slash_command_to_finish(
             (
                 item["payload"]
                 for item in rest.channel_messages
-                if "Queued behind /car newt; will run when it finishes."
+                if "Queued requests (1) behind /car newt"
                 in item["payload"].get("content", "")
             ),
             None,
@@ -7753,7 +7806,7 @@ async def test_run_forever_drains_message_queued_behind_ingressed_slash_command(
             (
                 item["payload"]
                 for item in rest.channel_messages
-                if "Queued behind /car newt; will run when it finishes."
+                if "Queued requests (1) behind /car newt"
                 in item["payload"].get("content", "")
             ),
             None,

--- a/tests/test_telegram_fast_ack.py
+++ b/tests/test_telegram_fast_ack.py
@@ -25,9 +25,15 @@ from codex_autorunner.integrations.chat.models import (
     ChatMessageRef,
     ChatThreadRef,
 )
+from codex_autorunner.integrations.chat.queue_status import (
+    coerce_queue_status_items,
+    format_queue_status_text,
+)
 from codex_autorunner.integrations.telegram.adapter import (
+    InlineButton,
     TelegramCallbackQuery,
     TelegramMessage,
+    build_inline_keyboard,
     encode_cancel_callback,
 )
 from codex_autorunner.integrations.telegram.dispatch import (
@@ -117,6 +123,7 @@ class _ServiceStub:
         self._bot = _BotStub()
         self._allowlist = None
         self._queued_placeholder_map: dict[tuple[int, int], int] = {}
+        self._queue_status_messages: dict[tuple[int, Optional[int]], int] = {}
         self._coalesced_buffers: dict = {}
         self._coalesce_locks: dict = {}
         self._media_batch_buffers: dict = {}
@@ -196,13 +203,72 @@ class _ServiceStub:
         *,
         force_queue: bool = False,
         item_id: Optional[str] = None,
+        item_label: Optional[str] = None,
     ) -> Optional[str]:
         runtime = self._router.runtime_for(key)
         wrapped = self._wrap_topic_work(key, work)
         if force_queue:
-            return runtime.queue.enqueue_detached(wrapped, item_id=item_id)
+            return runtime.queue.enqueue_detached(
+                wrapped,
+                item_id=item_id,
+                item_label=item_label,
+            )
         self._spawn_task(wrapped())
         return None
+
+    async def _refresh_topic_queue_status_message(
+        self,
+        *,
+        topic_key: str,
+        chat_id: int,
+        thread_id: Optional[int],
+        reply_to_message_id: Optional[int] = None,
+        repost: bool = False,
+    ) -> Optional[int]:
+        runtime = self._router.runtime_for(topic_key)
+        items = coerce_queue_status_items(runtime.queue.pending_items())
+        key = (chat_id, thread_id)
+        if not items:
+            self._queue_status_messages.pop(key, None)
+            return None
+        rows = []
+        for index, item in enumerate(items[:5], start=1):
+            rows.append(
+                [
+                    InlineButton(
+                        f"Cancel {index}",
+                        encode_cancel_callback(f"queue_cancel:{item.item_id}"),
+                    )
+                ]
+            )
+            rows.append(
+                [
+                    InlineButton(
+                        f"Send {index}",
+                        encode_cancel_callback(f"queue_interrupt_send:{item.item_id}"),
+                    )
+                ]
+            )
+        reply_markup = build_inline_keyboard(rows)
+        if key in self._queue_status_messages and not repost:
+            message_id = self._queue_status_messages[key]
+            await self._bot.edit_message_text(
+                chat_id=chat_id,
+                message_id=message_id,
+                text=format_queue_status_text(items),
+                reply_markup=reply_markup,
+            )
+            return message_id
+        response = await self._bot.send_message(
+            chat_id,
+            format_queue_status_text(items),
+            message_thread_id=thread_id,
+            reply_to_message_id=reply_to_message_id,
+            reply_markup=reply_markup,
+        )
+        message_id = int(response["message_id"])
+        self._queue_status_messages[key] = message_id
+        return message_id
 
     def _wrap_topic_work(self, key: str, work):
         async def wrapped():
@@ -259,12 +325,11 @@ async def test_fast_ack_sent_when_topic_has_current_turn() -> None:
 
     assert len(handler._bot.sent_messages) == 1
     sent = handler._bot.sent_messages[0]
-    assert sent["text"] == QUEUED_NOTICE_TEXT
+    assert sent["text"].startswith("Queued requests (1)")
     assert sent["chat_id"] == 10
     assert sent["reply_to"] == 1
     assert sent["reply_markup"] is not None
-
-    assert handler._queued_placeholder_map.get((10, 1)) is not None
+    assert handler._queue_status_messages[(10, 11)] == 1000
 
 
 @pytest.mark.anyio
@@ -296,12 +361,11 @@ async def test_fast_ack_sent_when_topic_queue_has_depth(
 
     assert len(handler._bot.sent_messages) == 1
     sent = handler._bot.sent_messages[0]
-    assert sent["text"] == QUEUED_NOTICE_TEXT
+    assert sent["text"].startswith("Queued requests (1)")
     assert sent["chat_id"] == 10
     assert sent["reply_to"] == 1
     assert sent["reply_markup"] is not None
-
-    assert handler._queued_placeholder_map.get((10, 1)) is not None
+    assert handler._queue_status_messages[(10, 11)] == 1000
 
 
 @pytest.mark.anyio
@@ -328,6 +392,7 @@ async def test_fast_ack_not_sent_when_topic_is_idle() -> None:
 
     assert len(handler._bot.sent_messages) == 0
     assert (10, 1) not in handler._queued_placeholder_map
+    assert (10, 11) not in handler._queue_status_messages
 
 
 @pytest.mark.anyio
@@ -356,10 +421,7 @@ async def test_fast_ack_marks_operation_queued_after_visible_notice() -> None:
 
     await _dispatch_message(handler, update, context)
 
-    assert [change["state"].value for change in handler.state_changes] == [
-        "visible",
-        "queued",
-    ]
+    assert [change["state"].value for change in handler.state_changes] == ["queued"]
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_queue_status_refresh.py
+++ b/tests/test_telegram_queue_status_refresh.py
@@ -1,0 +1,70 @@
+"""Regression tests for Telegram topic queue status message refresh."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from codex_autorunner.integrations.chat.queue_status import QueueStatusItem
+from codex_autorunner.integrations.telegram.config import TelegramBotConfig
+from codex_autorunner.integrations.telegram.service import TelegramBotService
+
+
+def _config(root: Path) -> TelegramBotConfig:
+    return TelegramBotConfig.from_raw(
+        {
+            "enabled": True,
+            "allowed_chat_ids": [123],
+            "allowed_user_ids": [456],
+        },
+        root=root,
+        env={"CAR_TELEGRAM_BOT_TOKEN": "test-token"},
+    )
+
+
+@pytest.mark.anyio
+async def test_refresh_topic_queue_status_resends_when_edit_fails(
+    tmp_path: Path,
+) -> None:
+    """If the stored status message was deleted, recreate it instead of looping on edit."""
+    service = TelegramBotService(_config(tmp_path), hub_root=tmp_path)
+    try:
+        edit = AsyncMock(return_value=False)
+        placeholder = AsyncMock(return_value=200)
+        clear_mock = MagicMock()
+        set_mock = MagicMock()
+
+        items = [QueueStatusItem(item_id="m1", preview="hello")]
+
+        with (
+            patch.object(
+                service,
+                "_queue_status_items_for_topic",
+                new=AsyncMock(return_value=items),
+            ),
+            patch.object(service, "_get_queue_status_message_id", return_value=100),
+            patch.object(service, "_edit_message_text", new=edit),
+            patch.object(service, "_send_placeholder", new=placeholder),
+            patch.object(service, "_delete_message", new=AsyncMock(return_value=True)),
+            patch.object(service, "_clear_queue_status_message_id", new=clear_mock),
+            patch.object(service, "_set_queue_status_message_id", new=set_mock),
+        ):
+            mid = await service._refresh_topic_queue_status_message(
+                topic_key="10:11",
+                chat_id=10,
+                thread_id=11,
+                repost=False,
+            )
+
+        assert mid == 200
+        clear_mock.assert_called_once_with(10, 11)
+        edit.assert_awaited_once()
+        call = edit.await_args
+        assert call.args[0] == 10 and call.args[1] == 100
+        assert call.kwargs.get("message_thread_id") == 11
+        placeholder.assert_awaited_once()
+        set_mock.assert_called_once_with(10, 11, 200)
+    finally:
+        await service._bot.close()

--- a/tests/test_telegram_turn_queue.py
+++ b/tests/test_telegram_turn_queue.py
@@ -1,12 +1,17 @@
 import asyncio
 import logging
 import tempfile
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
 
 import pytest
 
+from codex_autorunner.integrations.chat.queue_status import (
+    coerce_queue_status_items,
+    format_queue_status_text,
+)
 from codex_autorunner.integrations.telegram.adapter import TelegramMessage
 from codex_autorunner.integrations.telegram.constants import (
     PLACEHOLDER_TEXT,
@@ -74,8 +79,14 @@ class _ClientStub:
 
 
 class _RouterStub:
-    def __init__(self, records: dict[str, TelegramTopicRecord]) -> None:
+    def __init__(
+        self,
+        records: dict[str, TelegramTopicRecord],
+        *,
+        runtimes: Optional[dict[str, object]] = None,
+    ) -> None:
         self._records = records
+        self._runtimes = runtimes or {}
 
     async def get_topic(self, key: str) -> Optional[TelegramTopicRecord]:
         return self._records.get(key)
@@ -97,6 +108,17 @@ class _RouterStub:
         if callable(apply):
             apply(record)
 
+    def runtime_for(self, key: str) -> object:
+        return self._runtimes.setdefault(
+            key,
+            SimpleNamespace(
+                queue=SimpleNamespace(
+                    pending_item_ids=lambda: [],
+                    pending_items=lambda: [],
+                )
+            ),
+        )
+
 
 class _HandlerStub(TelegramCommandHandlers):
     def __init__(
@@ -107,6 +129,7 @@ class _HandlerStub(TelegramCommandHandlers):
         records: dict[str, TelegramTopicRecord],
         placeholder_events: Optional[dict[int, asyncio.Event]] = None,
         deliver_result: bool = True,
+        runtimes: Optional[dict[str, object]] = None,
     ) -> None:
         self._logger = logging.getLogger("test")
         self._config = SimpleNamespace(
@@ -118,8 +141,14 @@ class _HandlerStub(TelegramCommandHandlers):
             agent_turn_timeout_seconds={"codex": None, "opencode": None},
             message_overflow="document",
         )
-        self._router = _RouterStub(records)
+        self._router = _RouterStub(records, runtimes=runtimes)
         self._turn_semaphore = asyncio.Semaphore(max_parallel_turns)
+        self._queued_placeholder_map: dict[tuple[int, int], int] = {}
+        self._queued_placeholder_timestamps: dict[tuple[int, int], float] = {}
+        self._queue_status_message_map: dict[tuple[int, Optional[int]], int] = {}
+        self._queue_status_message_timestamps: dict[
+            tuple[int, Optional[int]], float
+        ] = {}
         self._turn_contexts: dict[tuple[str, str], object] = {}
         self._turn_preview_text: dict[tuple[str, str], str] = {}
         self._turn_preview_updated_at: dict[tuple[str, str], float] = {}
@@ -223,20 +252,76 @@ class _HandlerStub(TelegramCommandHandlers):
             "reply_markup": reply_markup,
         }
         self._placeholder_calls.append(call)
+        placeholder_id = 100 + len(self._placeholder_calls)
         if reply_to is not None:
-            placeholder_id = 100 + len(self._placeholder_calls)
             self._placeholder_ids[reply_to] = placeholder_id
             event = self._placeholder_events.get(reply_to)
             if event is not None:
                 event.set()
-            return placeholder_id
-        return 0
+        return placeholder_id
 
     async def _edit_message_text(
-        self, _chat_id: int, message_id: int, text: str
+        self,
+        _chat_id: int,
+        message_id: int,
+        text: str,
+        *,
+        reply_markup: Optional[dict[str, object]] = None,
     ) -> bool:
         self._edit_calls.append((message_id, text))
         return True
+
+    async def _refresh_topic_queue_status_message(
+        self,
+        *,
+        topic_key: str,
+        chat_id: int,
+        thread_id: Optional[int],
+        reply_to_message_id: Optional[int] = None,
+        repost: bool = False,
+    ) -> Optional[int]:
+        runtime = self._router.runtime_for(topic_key)
+        pending_items = getattr(runtime.queue, "pending_items", lambda: [])()
+        items = coerce_queue_status_items(pending_items)
+        key = (chat_id, thread_id)
+        if not items:
+            self._queue_status_message_map.pop(key, None)
+            return None
+        existing = self._queue_status_message_map.get(key)
+        if existing is not None and not repost:
+            await self._edit_message_text(
+                chat_id,
+                existing,
+                format_queue_status_text(items),
+            )
+            return existing
+        message_id = await self._send_placeholder(
+            chat_id,
+            thread_id=thread_id,
+            reply_to=reply_to_message_id,
+            text=format_queue_status_text(items),
+        )
+        self._queue_status_message_map[key] = message_id
+        if existing is not None and existing != message_id:
+            await self._delete_message(chat_id, existing, thread_id=thread_id)
+        return message_id
+
+    def _get_queued_placeholder(self, chat_id: int, message_id: int) -> Optional[int]:
+        return self._queued_placeholder_map.get((chat_id, message_id))
+
+    def _set_queued_placeholder(
+        self, chat_id: int, message_id: int, placeholder_id: int
+    ) -> None:
+        self._queued_placeholder_map[(chat_id, message_id)] = placeholder_id
+
+    def _clear_queued_placeholder(self, chat_id: int, message_id: int) -> None:
+        self._queued_placeholder_map.pop((chat_id, message_id), None)
+
+    def _claim_queued_placeholder(self, chat_id: int, message_id: int) -> Optional[int]:
+        return self._queued_placeholder_map.pop((chat_id, message_id), None)
+
+    def _queued_placeholder_keyboard(self, source_message_id: int) -> dict[str, object]:
+        return {"source_message_id": source_message_id}
 
     def _format_turn_metrics_text(
         self,
@@ -436,6 +521,65 @@ async def test_turn_placeholder_sent_while_queued() -> None:
 
     placeholder_id = handler._placeholder_ids[2]
     assert (placeholder_id, PLACEHOLDER_TEXT) in handler._edit_calls
+
+
+@pytest.mark.anyio
+async def test_queue_wait_uses_refreshed_placeholder_when_available() -> None:
+    client = _ClientStub(turn_wait_events=[asyncio.Event()])
+    records = {"10:11": _record("thread-1")}
+    handler = _HandlerStub(client=client, max_parallel_turns=1, records=records)
+
+    handler._set_queued_placeholder(10, 2, 222)
+    await handler._turn_semaphore.acquire()
+
+    try:
+        resolved_placeholder_id = await handler._log_queue_wait_and_update_placeholder(
+            _message(message_id=2, thread_id=11),
+            "10:11",
+            "thread-1",
+            handler._turn_semaphore,
+            time.monotonic(),
+            111,
+            QUEUED_PLACEHOLDER_TEXT,
+        )
+    finally:
+        handler._turn_semaphore.release()
+
+    assert resolved_placeholder_id == 222
+    assert handler._edit_calls[-1] == (222, PLACEHOLDER_TEXT)
+
+
+@pytest.mark.anyio
+async def test_terminal_delivery_requeues_pending_placeholders_in_order() -> None:
+    client = _ClientStub(turn_wait_events=[asyncio.Event()])
+    records = {"10:11": _record("thread-1")}
+    runtimes = {
+        "10:11": SimpleNamespace(
+            queue=SimpleNamespace(
+                pending_item_ids=lambda: ["2", "3"],
+                pending_items=lambda: [
+                    {"item_id": "2", "preview": "Second request"},
+                    {"item_id": "3", "preview": "Third request"},
+                ],
+            )
+        )
+    }
+    handler = _HandlerStub(
+        client=client,
+        max_parallel_turns=1,
+        records=records,
+        runtimes=runtimes,
+    )
+    handler._queue_status_message_map[(10, 11)] = 502
+
+    await handler._requeue_pending_topic_status_message(
+        chat_id=10,
+        thread_id=11,
+        topic_key="10:11",
+    )
+
+    assert handler._queue_status_message_map[(10, 11)] == 101
+    assert handler._delete_calls == [(10, 502)]
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_turn_queue.py
+++ b/tests/test_telegram_turn_queue.py
@@ -113,7 +113,6 @@ class _RouterStub:
             key,
             SimpleNamespace(
                 queue=SimpleNamespace(
-                    pending_item_ids=lambda: [],
                     pending_items=lambda: [],
                 )
             ),
@@ -556,7 +555,6 @@ async def test_terminal_delivery_requeues_pending_placeholders_in_order() -> Non
     runtimes = {
         "10:11": SimpleNamespace(
             queue=SimpleNamespace(
-                pending_item_ids=lambda: ["2", "3"],
                 pending_items=lambda: [
                     {"item_id": "2", "preview": "Second request"},
                     {"item_id": "3", "preview": "Third request"},


### PR DESCRIPTION
## What changed
- replaced per-request queued placeholders/notices with a single conversation-scoped queue status message on both Telegram and Discord
- moved queue-status formatting into a shared chat helper and carried pending item previews through the queue backends
- updated Telegram topic-queue rendering, cancellation, and repost-after-terminal behavior to operate on one shared status message
- updated Discord queue rendering, cancellation, and repost-after-terminal behavior to operate on one shared status message
- kept queued-item actions on the shared message by rendering indexed cancel/send controls for the visible queued items

## Why
Queued messages were being represented as separate visible placeholders. After a turn finished, the final reply could appear below older queued placeholders, and later queue updates would edit content that now appeared above the final reply. That made submission ordering look wrong in both Telegram and Discord.

The cleaner model is one visible queue status message per conversation. That gives the user a single queue surface to track, and when a visible terminal reply lands we only need to repost one queue status message underneath it instead of trying to re-anchor every queued placeholder.

## User impact
- queued requests now show up in one shared queue status message per conversation
- when a final visible reply lands and more work is still queued, the queue status is reposted underneath that final reply to preserve visible ordering
- queued request controls still work from the shared queue status message

## Root cause
The old model coupled queue visibility to each individual queued message. That spread queue-anchor ownership across platform-specific maps and created ordering repair logic per queued item. The shared queue-status model reduces that to one anchor per conversation.

## Validation
Focused regression coverage:
- `.venv/bin/pytest -q tests/test_telegram_fast_ack.py tests/test_telegram_turn_queue.py tests/integrations/discord/test_service_routing.py -k 'queue or queued or fast_ack or refresh_queue_status_message_reposts_status_below_terminal or component_interaction_queue_cancel_cancels_selected_pending_message or component_interaction_queue_interrupt_send_promotes_and_interrupts or component_interaction_queue_interrupt_send_wakes_dispatcher_without_active_thread or run_forever_drains_message_queued_behind_ingressed_slash_command or queued_notice_keeps_interrupt_when_message_turn_active or queued_notice_hides_interrupt_when_only_ingressed_busy'`
- `.venv/bin/pytest -q tests/integrations/test_chat_dispatcher_queueing.py tests/test_telegram_topic_queue.py tests/integrations/discord/test_service_normalization.py tests/test_telegram_cache_cleanup.py`
- `.venv/bin/pytest -q tests/test_telegram_dispatch_regression.py tests/test_telegram_handlers_messages.py tests/test_telegram_pma_managed_threads.py -k 'dispatch_message_enqueues_and_handles or dispatch_registers_operation or dispatch_resolves_topic_key or dispatch_checks_dedup or audio_message_bypasses_coalescing_like_voice or pma_missing_thread_resets_registry_and_recovers'`

Repo validation from the commit hook:
- strict repo-wide mypy on `src/codex_autorunner`
- `pytest` full `chat-apps` lane: `7644 passed`
- deterministic chat-surface lab checks: `21 passed`

## Notes
A mini subagent reviewed the final design after the refactor and the remaining blocker findings were fixed before opening this PR.