### PR TITLE
[codex] Fix Hermes PMA turn recovery

### DIFF
--- a/src/codex_autorunner/agents/hermes/harness.py
+++ b/src/codex_autorunner/agents/hermes/harness.py
@@ -142,18 +142,6 @@ class HermesHarness(AgentHarness):
     ) -> None:
         await self._supervisor.interrupt_turn(workspace_root, conversation_id, turn_id)
 
-    async def recover_stalled_turn(
-        self,
-        workspace_root: Path,
-        conversation_id: str,
-        turn_id: str,
-    ) -> Optional[TerminalTurnResult]:
-        return await self._supervisor.recover_turn_from_session_store(
-            workspace_root,
-            conversation_id,
-            turn_id,
-        )
-
     async def stream_events(
         self, workspace_root: Path, conversation_id: str, turn_id: str
     ) -> AsyncIterator[dict[str, Any]]:

--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
-import subprocess
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from os.path import basename
 from pathlib import Path
 from typing import Any, AsyncIterator, Awaitable, Callable, Mapping, Optional, Sequence
@@ -33,7 +30,6 @@ from ..managed_runtime import RuntimePreflightResult
 from ..types import TerminalTurnResult
 
 _logger = logging.getLogger(__name__)
-_SESSION_STORE_TIMESTAMP_SLOP_SECONDS = 1.0
 
 HERMES_RUNTIME_ID = "hermes"
 HERMES_ACP_COMMAND = "acp"
@@ -92,27 +88,6 @@ def _extract_session_summary(payload: Mapping[str, Any]) -> Optional[str]:
     return None
 
 
-def _build_session_store_recovered_raw_events(
-    *,
-    session_id: str,
-    turn_id: str,
-    assistant_text: str,
-    recovery_source: str,
-) -> list[dict[str, Any]]:
-    return [
-        {
-            "method": "prompt/completed",
-            "params": {
-                "sessionId": session_id,
-                "turnId": turn_id,
-                "status": "completed",
-                "finalOutput": assistant_text,
-                "recoveredFrom": recovery_source,
-            },
-        }
-    ]
-
-
 class HermesSupervisorError(RuntimeError):
     pass
 
@@ -140,15 +115,6 @@ class _HermesTurnState:
     last_session_update_kind: Optional[str] = None
     last_progress_at: Optional[str] = None
     started_at_unix: float = field(default_factory=time.time)
-    baseline_message_count: Optional[int] = None
-    baseline_last_assistant_text: Optional[str] = None
-
-
-@dataclass(frozen=True)
-class _HermesSessionStoreSnapshot:
-    message_count: Optional[int]
-    last_updated_unix: Optional[float]
-    last_assistant_text: Optional[str]
 
 
 class HermesSupervisor:
@@ -193,8 +159,6 @@ class HermesSupervisor:
         )
         self._turn_states: dict[tuple[str, str], _HermesTurnState] = {}
         self._session_turns: dict[tuple[str, str], str] = {}
-        self._session_store_root: Optional[Path] = None
-        self._session_store_probe_attempted = False
         self._lock = asyncio.Lock()
 
     @property
@@ -445,7 +409,6 @@ class HermesSupervisor:
             model=_normalize_optional_text(model),
             launch_command=list(self._command),
         )
-        baseline_snapshot = await self._read_session_store_snapshot(session_id)
         handle = await self._acp.start_prompt(
             workspace_root,
             session_id,
@@ -470,9 +433,6 @@ class HermesSupervisor:
             self._session_turns[(workspace, session_id)] = handle.turn_id
         if previous_state is not None:
             await self._cancel_pending_approval_task(previous_state)
-        if baseline_snapshot is not None:
-            state.baseline_message_count = baseline_snapshot.message_count
-            state.baseline_last_assistant_text = baseline_snapshot.last_assistant_text
         for event in await self._acp.prompt_events_snapshot(
             workspace_root, handle.turn_id
         ):
@@ -512,133 +472,41 @@ class HermesSupervisor:
         )
         workspace = _workspace_key(workspace_root)
         started_at = time.monotonic()
+        state = await self._require_turn_state(workspace_root, resolved_turn_id)
         try:
-            state = await self._require_turn_state(workspace_root, resolved_turn_id)
-        except HermesSupervisorError:
-            recovered = (
-                await self._recover_turn_result_from_session_store_without_state(
-                    session_id=session_id,
-                    turn_id=resolved_turn_id,
-                )
-            )
-            if recovered is None:
-                raise
+            result = await state.handle.wait(timeout=timeout)
+        except asyncio.TimeoutError:
             log_event(
                 self._logger,
                 logging.WARNING,
-                "hermes.turn.wait_missing_state_recovered",
+                "hermes.turn.wait_timeout",
+                workspace_root=workspace,
+                session_id=session_id,
+                turn_id=resolved_turn_id,
+                timeout_seconds=timeout,
+                elapsed_ms=_elapsed_ms(started_at),
+                last_event_method=state.last_event_method,
+                last_runtime_method=state.last_event_method,
+                last_session_update_kind=state.last_session_update_kind,
+                last_progress_at=state.last_progress_at,
+            )
+            raise
+        except Exception as exc:
+            log_event(
+                self._logger,
+                logging.WARNING,
+                "hermes.turn.wait_error",
                 workspace_root=workspace,
                 session_id=session_id,
                 turn_id=resolved_turn_id,
                 elapsed_ms=_elapsed_ms(started_at),
+                last_event_method=state.last_event_method,
+                last_runtime_method=state.last_event_method,
+                last_session_update_kind=state.last_session_update_kind,
+                last_progress_at=state.last_progress_at,
+                detail=str(exc) or exc.__class__.__name__,
             )
-            return recovered
-        try:
-            result = await state.handle.wait(timeout=timeout)
-        except asyncio.TimeoutError:
-            recovered = await self._recover_turn_from_session_store(
-                workspace_root,
-                state,
-            )
-            if recovered is not None:
-                result = recovered
-                log_event(
-                    self._logger,
-                    logging.WARNING,
-                    "hermes.turn.wait_timeout_recovered",
-                    workspace_root=_workspace_key(workspace_root),
-                    session_id=session_id,
-                    turn_id=resolved_turn_id,
-                    timeout_seconds=timeout,
-                    elapsed_ms=_elapsed_ms(started_at),
-                    last_event_method=state.last_event_method,
-                    last_runtime_method=state.last_event_method,
-                    last_session_update_kind=state.last_session_update_kind,
-                    last_progress_at=state.last_progress_at,
-                )
-            else:
-                recovered_without_state = (
-                    await self._recover_turn_result_from_session_store_without_state(
-                        session_id=session_id,
-                        turn_id=resolved_turn_id,
-                    )
-                )
-                if recovered_without_state is not None:
-                    log_event(
-                        self._logger,
-                        logging.WARNING,
-                        "hermes.turn.wait_timeout_recovered_without_state",
-                        workspace_root=workspace,
-                        session_id=session_id,
-                        turn_id=resolved_turn_id,
-                        timeout_seconds=timeout,
-                        elapsed_ms=_elapsed_ms(started_at),
-                        last_event_method=state.last_event_method,
-                        last_runtime_method=state.last_event_method,
-                        last_session_update_kind=state.last_session_update_kind,
-                        last_progress_at=state.last_progress_at,
-                    )
-                    return recovered_without_state
-                log_event(
-                    self._logger,
-                    logging.WARNING,
-                    "hermes.turn.wait_timeout",
-                    workspace_root=workspace,
-                    session_id=session_id,
-                    turn_id=resolved_turn_id,
-                    timeout_seconds=timeout,
-                    elapsed_ms=_elapsed_ms(started_at),
-                    last_event_method=state.last_event_method,
-                    last_runtime_method=state.last_event_method,
-                    last_session_update_kind=state.last_session_update_kind,
-                    last_progress_at=state.last_progress_at,
-                )
-                raise
-        except Exception as exc:
-            recovered = await self._recover_turn_from_session_store(
-                workspace_root,
-                state,
-            )
-            if recovered is not None:
-                result = recovered
-                log_event(
-                    self._logger,
-                    logging.WARNING,
-                    "hermes.turn.wait_error_recovered",
-                    workspace_root=workspace,
-                    session_id=session_id,
-                    turn_id=resolved_turn_id,
-                    elapsed_ms=_elapsed_ms(started_at),
-                    last_event_method=state.last_event_method,
-                    last_runtime_method=state.last_event_method,
-                    last_session_update_kind=state.last_session_update_kind,
-                    last_progress_at=state.last_progress_at,
-                    detail=str(exc) or exc.__class__.__name__,
-                )
-            else:
-                recovered_without_state = (
-                    await self._recover_turn_result_from_session_store_without_state(
-                        session_id=session_id,
-                        turn_id=resolved_turn_id,
-                    )
-                )
-                if recovered_without_state is not None:
-                    log_event(
-                        self._logger,
-                        logging.WARNING,
-                        "hermes.turn.wait_error_recovered_without_state",
-                        workspace_root=workspace,
-                        session_id=session_id,
-                        turn_id=resolved_turn_id,
-                        elapsed_ms=_elapsed_ms(started_at),
-                        last_event_method=state.last_event_method,
-                        last_runtime_method=state.last_event_method,
-                        last_session_update_kind=state.last_session_update_kind,
-                        last_progress_at=state.last_progress_at,
-                        detail=str(exc) or exc.__class__.__name__,
-                    )
-                    return recovered_without_state
-                raise
+            raise
         await self._sync_prompt_snapshot_into_event_buffer(workspace_root, state)
         await state.event_buffer.close()
         errors = [result.error_message] if result.error_message else []
@@ -658,15 +526,6 @@ class HermesSupervisor:
             last_session_update_kind=state.last_session_update_kind,
             last_progress_at=state.last_progress_at,
             error_message=result.error_message,
-            recovered_from_session_store=(
-                "session_store"
-                if any(
-                    event.get("params", {}).get("recoveredFrom") == "session_store"
-                    for event in raw_events
-                    if isinstance(event, dict)
-                )
-                else False
-            ),
         )
         return TerminalTurnResult(
             status=result.status,
@@ -689,40 +548,6 @@ class HermesSupervisor:
         state = await self._require_turn_state(workspace_root, resolved_turn_id)
         async for event in state.event_buffer.tail():
             yield event
-
-    async def recover_turn_from_session_store(
-        self,
-        workspace_root: Path,
-        session_id: str,
-        turn_id: str,
-    ) -> Optional[TerminalTurnResult]:
-        resolved_turn_id = await self._resolve_turn_id(
-            workspace_root,
-            session_id,
-            turn_id,
-        )
-        try:
-            state = await self._require_turn_state(workspace_root, resolved_turn_id)
-        except HermesSupervisorError:
-            return await self._recover_turn_result_from_session_store_without_state(
-                session_id=session_id,
-                turn_id=resolved_turn_id,
-            )
-        result = await self._recover_turn_from_session_store(workspace_root, state)
-        if result is None:
-            return await self._recover_turn_result_from_session_store_without_state(
-                session_id=session_id,
-                turn_id=resolved_turn_id,
-            )
-        await self._sync_prompt_snapshot_into_event_buffer(workspace_root, state)
-        await state.event_buffer.close()
-        errors = [result.error_message] if result.error_message else []
-        return TerminalTurnResult(
-            status=result.status,
-            assistant_text=result.final_output,
-            errors=errors,
-            raw_events=state.event_buffer.snapshot(),
-        )
 
     async def list_turn_events_snapshot(self, turn_id: str) -> list[dict[str, Any]]:
         async with self._lock:
@@ -819,120 +644,6 @@ class HermesSupervisor:
         if state is None:
             raise HermesSupervisorError(f"Unknown Hermes turn '{turn_id}'")
         return state
-
-    async def _recover_turn_from_session_store(
-        self,
-        workspace_root: Path,
-        state: _HermesTurnState,
-    ) -> Optional[Any]:
-        await self._sync_prompt_snapshot_into_event_buffer(workspace_root, state)
-        snapshot = await self._read_session_store_snapshot(state.session_id)
-        if snapshot is None:
-            return None
-        assistant_text = _normalize_optional_text(snapshot.last_assistant_text)
-        if not assistant_text:
-            return None
-        if snapshot.last_updated_unix is None:
-            return None
-        if (
-            snapshot.last_updated_unix
-            < state.started_at_unix - _SESSION_STORE_TIMESTAMP_SLOP_SECONDS
-        ):
-            return None
-        baseline_count = state.baseline_message_count
-        if (
-            baseline_count is not None
-            and snapshot.message_count is not None
-            and snapshot.message_count <= baseline_count
-        ):
-            return None
-        recovered = await self._acp.recover_prompt_completion(
-            workspace_root,
-            state.turn_id,
-            final_output=assistant_text,
-            recovery_source="session_store",
-        )
-        if not recovered:
-            return None
-        log_event(
-            self._logger,
-            logging.WARNING,
-            "hermes.turn.recovered_from_session_store",
-            workspace_root=_workspace_key(workspace_root),
-            session_id=state.session_id,
-            turn_id=state.turn_id,
-            recovered_output_chars=len(assistant_text),
-            baseline_message_count=baseline_count,
-            recovered_message_count=snapshot.message_count,
-            last_event_method=state.last_event_method,
-            last_session_update_kind=state.last_session_update_kind,
-            last_progress_at=state.last_progress_at,
-        )
-        return await state.handle.wait(timeout=0.1)
-
-    async def _recover_turn_result_from_session_store_without_state(
-        self,
-        *,
-        session_id: str,
-        turn_id: str,
-    ) -> Optional[TerminalTurnResult]:
-        snapshot = await self._read_session_store_snapshot(session_id)
-        if snapshot is None:
-            return None
-        assistant_text = _normalize_optional_text(snapshot.last_assistant_text)
-        if not assistant_text or snapshot.last_updated_unix is None:
-            return None
-        raw_events = _build_session_store_recovered_raw_events(
-            session_id=session_id,
-            turn_id=turn_id,
-            assistant_text=assistant_text,
-            recovery_source="session_store_missing_state",
-        )
-        log_event(
-            self._logger,
-            logging.WARNING,
-            "hermes.turn.recovered_from_session_store_without_state",
-            session_id=session_id,
-            turn_id=turn_id,
-            recovered_output_chars=len(assistant_text),
-            recovered_message_count=snapshot.message_count,
-        )
-        return TerminalTurnResult(
-            status="completed",
-            assistant_text=assistant_text,
-            errors=[],
-            raw_events=raw_events,
-        )
-
-    async def _read_session_store_snapshot(
-        self,
-        session_id: str,
-    ) -> Optional[_HermesSessionStoreSnapshot]:
-        session_store_root = await self._resolve_session_store_root()
-        if session_store_root is None:
-            return None
-        session_file = session_store_root / "sessions" / f"session_{session_id}.json"
-        return await asyncio.to_thread(_read_session_store_snapshot, session_file)
-
-    async def _resolve_session_store_root(self) -> Optional[Path]:
-        if self._session_store_probe_attempted:
-            return self._session_store_root
-        self._session_store_probe_attempted = True
-        configured_home = _normalize_optional_text(
-            self._base_env.get("HERMES_HOME") or os.environ.get("HERMES_HOME")
-        )
-        if configured_home:
-            self._session_store_root = Path(configured_home).expanduser()
-            return self._session_store_root
-        binary = _normalize_optional_text(self._command[0] if self._command else None)
-        if binary is None or not basename(binary).lower().startswith("hermes"):
-            return None
-        self._session_store_root = await asyncio.to_thread(
-            _probe_hermes_session_store_root,
-            binary,
-            self._base_env,
-        )
-        return self._session_store_root
 
     async def _wait_for_turn_state(
         self,
@@ -1170,119 +881,6 @@ class HermesSupervisor:
             decision,
             reason,
         )
-
-
-def _read_session_store_snapshot(
-    session_file: Path,
-) -> Optional[_HermesSessionStoreSnapshot]:
-    try:
-        payload = json.loads(session_file.read_text())
-    except (OSError, ValueError, TypeError):
-        return None
-    if not isinstance(payload, dict):
-        return None
-    messages = payload.get("messages")
-    message_count = payload.get("message_count")
-    if not isinstance(message_count, int):
-        message_count = len(messages) if isinstance(messages, list) else None
-    last_assistant_text: Optional[str] = None
-    if isinstance(messages, list):
-        for message in reversed(messages):
-            if not isinstance(message, dict):
-                continue
-            if _normalize_optional_text(message.get("role")) != "assistant":
-                continue
-            last_assistant_text = _extract_session_message_text(message)
-            if last_assistant_text:
-                break
-    last_updated = _parse_session_timestamp(payload.get("last_updated"))
-    return _HermesSessionStoreSnapshot(
-        message_count=message_count,
-        last_updated_unix=last_updated,
-        last_assistant_text=last_assistant_text,
-    )
-
-
-def _extract_session_message_text(message: Mapping[str, Any]) -> Optional[str]:
-    extracted: list[str] = []
-
-    def _walk(value: Any) -> None:
-        if isinstance(value, str):
-            normalized = value.strip()
-            if normalized:
-                extracted.append(normalized)
-            return
-        if isinstance(value, list):
-            for item in value:
-                _walk(item)
-            return
-        if isinstance(value, dict):
-            for key in ("text", "content"):
-                if key in value:
-                    _walk(value.get(key))
-            for key in ("parts", "items"):
-                if key in value:
-                    _walk(value.get(key))
-
-    _walk(message.get("content"))
-    _walk(message.get("parts"))
-    if not extracted:
-        return None
-    return "\n".join(extracted).strip() or None
-
-
-def _parse_session_timestamp(value: Any) -> Optional[float]:
-    normalized = _normalize_optional_text(value)
-    if normalized is None:
-        return None
-    try:
-        parsed = normalized.replace("Z", "+00:00")
-        dt = datetime.fromisoformat(parsed)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt.timestamp()
-    except (TypeError, ValueError):
-        return None
-
-
-def _probe_hermes_session_store_root(
-    binary: str,
-    base_env: Mapping[str, str],
-) -> Optional[Path]:
-    env = os.environ.copy()
-    env.update({key: value for key, value in base_env.items() if value})
-    try:
-        result = subprocess.run(
-            [binary, "dump"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            env=env,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    for line in result.stdout.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            continue
-        key: str
-        value: str
-        if ":" in stripped:
-            before_colon, _, after_colon = stripped.partition(":")
-            if " " not in before_colon.strip():
-                key, value = before_colon, after_colon
-            else:
-                key, _, value = stripped.partition(" ")
-        else:
-            key, _, value = stripped.partition(" ")
-        if key.strip().lower().rstrip(":") != "hermes_home":
-            continue
-        normalized = _normalize_optional_text(value)
-        if normalized:
-            return Path(normalized).expanduser()
-    return None
 
 
 def _normalize_approval_decision(value: Any, *, default: str) -> str:

--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -114,7 +114,6 @@ class _HermesTurnState:
     last_event_method: Optional[str] = None
     last_session_update_kind: Optional[str] = None
     last_progress_at: Optional[str] = None
-    started_at_unix: float = field(default_factory=time.time)
 
 
 class HermesSupervisor:

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -170,6 +170,7 @@ DISCORD_PMA_TIMEOUT_SECONDS = 7200
 _DEFAULT_DISCORD_PMA_TIMEOUT_SECONDS = 7200
 DISCORD_PMA_STALL_TIMEOUT_SECONDS = 1800
 _DEFAULT_DISCORD_PMA_STALL_TIMEOUT_SECONDS = 1800
+DISCORD_PMA_SUBMISSION_TIMEOUT_SECONDS = 300.0
 DISCORD_MANAGED_THREAD_SUBMISSION_TIMEOUT_SECONDS = 45.0
 DISCORD_PMA_PROGRESS_MAX_ACTIONS = 12
 DISCORD_PMA_PROGRESS_MIN_EDIT_INTERVAL_SECONDS = 1.0
@@ -2018,6 +2019,12 @@ async def _run_discord_orchestrated_turn_for_message(
             sandbox_policy=sandbox_policy,
         )
 
+    submission_timeout_seconds = (
+        DISCORD_PMA_SUBMISSION_TIMEOUT_SECONDS
+        if pma_enabled
+        else DISCORD_MANAGED_THREAD_SUBMISSION_TIMEOUT_SECONDS
+    )
+
     try:
         if reusable_progress_message_id:
             progress_message_id = reusable_progress_message_id
@@ -2179,7 +2186,7 @@ async def _run_discord_orchestrated_turn_for_message(
                 "discord.turn.submission_timeout",
                 channel_id=channel_id,
                 thread_target_id=managed_thread_id,
-                timeout_seconds=DISCORD_MANAGED_THREAD_SUBMISSION_TIMEOUT_SECONDS,
+                timeout_seconds=submission_timeout_seconds,
                 pma_enabled=pma_enabled,
                 workspace_root=str(workspace_root),
                 agent=logical_agent,
@@ -2456,11 +2463,7 @@ async def _run_discord_orchestrated_turn_for_message(
             ),
             begin_execution=_begin_execution,
             complete_execution=complete_managed_thread_execution,
-            submission_timeout_seconds=(
-                None
-                if pma_enabled
-                else DISCORD_MANAGED_THREAD_SUBMISSION_TIMEOUT_SECONDS
-            ),
+            submission_timeout_seconds=submission_timeout_seconds,
             runtime_event_state=RuntimeThreadRunEventState(),
             after_submission=_after_submission,
             on_submission_error=_on_submission_error,

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -2456,7 +2456,11 @@ async def _run_discord_orchestrated_turn_for_message(
             ),
             begin_execution=_begin_execution,
             complete_execution=complete_managed_thread_execution,
-            submission_timeout_seconds=DISCORD_MANAGED_THREAD_SUBMISSION_TIMEOUT_SECONDS,
+            submission_timeout_seconds=(
+                None
+                if pma_enabled
+                else DISCORD_MANAGED_THREAD_SUBMISSION_TIMEOUT_SECONDS
+            ),
             runtime_event_state=RuntimeThreadRunEventState(),
             after_submission=_after_submission,
             on_submission_error=_on_submission_error,

--- a/tests/agents/hermes/test_hermes_supervisor_official_prompt_hang.py
+++ b/tests/agents/hermes/test_hermes_supervisor_official_prompt_hang.py
@@ -1,58 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-import time
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 from tests.chat_surface_harness.hermes import fake_acp_command
 
 from codex_autorunner.agents.hermes.supervisor import (
+    HermesSupervisorError,
     HermesSupervisor,
-    _probe_hermes_session_store_root,
 )
-
-
-@pytest.mark.parametrize(
-    ("stdout", "relative_path"),
-    [
-        (
-            "hermes_home ~/.hermes/profiles/hermes-m4-pma\n",
-            Path(".hermes/profiles/hermes-m4-pma"),
-        ),
-        (
-            "hermes_home ~/.hermes/profiles/with:colon\n",
-            Path(".hermes/profiles/with:colon"),
-        ),
-        (
-            "--- hermes dump ---\n"
-            "profile: hermes-m4-pma\n"
-            "hermes_home:      ~/.hermes/profiles/hermes-m4-pma\n"
-            "--- end dump ---\n",
-            Path(".hermes/profiles/hermes-m4-pma"),
-        ),
-    ],
-)
-def test_probe_hermes_session_store_root_parses_dump_output(
-    monkeypatch: pytest.MonkeyPatch,
-    stdout: str,
-    relative_path: Path,
-    tmp_path: Path,
-) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
-
-    def _fake_run(*args, **kwargs):
-        _ = args, kwargs
-        return SimpleNamespace(returncode=0, stdout=stdout)
-
-    monkeypatch.setattr(
-        "codex_autorunner.agents.hermes.supervisor.subprocess.run",
-        _fake_run,
-    )
-
-    expected = (tmp_path / "home" / relative_path).resolve()
-    assert _probe_hermes_session_store_root("/tmp/hermes", {}) == expected
 
 
 @pytest.mark.slow
@@ -134,7 +91,7 @@ async def test_hermes_supervisor_completes_from_terminal_event_without_request_r
 
 @pytest.mark.slow
 @pytest.mark.asyncio
-async def test_hermes_supervisor_recovers_second_prompt_from_persisted_session_store(
+async def test_hermes_supervisor_does_not_treat_persisted_session_store_as_terminal_completion(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -159,110 +116,43 @@ async def test_hermes_supervisor_recovers_second_prompt_from_persisted_session_s
         second_turn_id = await supervisor.start_turn(
             tmp_path, session.session_id, "second"
         )
-        second_result = await asyncio.wait_for(
-            supervisor.wait_for_turn(
-                tmp_path,
-                session.session_id,
-                second_turn_id,
-                timeout=0.2,
-            ),
-            timeout=2.0,
-        )
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                supervisor.wait_for_turn(
+                    tmp_path,
+                    session.session_id,
+                    second_turn_id,
+                    timeout=0.2,
+                ),
+                timeout=2.0,
+            )
 
         events = await supervisor.list_turn_events_snapshot(second_turn_id)
         same_text = "identical fixture output"
         assert first_result.assistant_text == same_text
-        assert second_result.status == "completed"
-        assert second_result.assistant_text == same_text
         assert [event.get("method") for event in events] == [
             "prompt/started",
             "session/update",
             "session/update",
-            "prompt/completed",
         ]
-        assert events[-1].get("params", {}).get("recoveredFrom") == "session_store"
-        assert "hermes.turn.recovered_from_session_store" in caplog.text
-        assert "hermes.turn.wait_timeout_recovered" in caplog.text
+        assert "hermes.turn.recovered_from_session_store" not in caplog.text
+        assert "hermes.turn.wait_timeout_recovered" not in caplog.text
+        assert "hermes.turn.wait_timeout" in caplog.text
     finally:
         await supervisor.close_all()
 
 
 @pytest.mark.asyncio
-async def test_hermes_supervisor_wait_for_turn_recovers_without_active_turn_state(
+async def test_hermes_supervisor_wait_for_turn_requires_active_turn_state(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     supervisor = HermesSupervisor(fake_acp_command("official_prompt_hang"))
     try:
-
-        async def _fake_snapshot(_session_id: str) -> SimpleNamespace:
-            return SimpleNamespace(
-                message_count=4,
-                last_updated_unix=time.time(),
-                last_assistant_text="persisted reply",
+        with pytest.raises(HermesSupervisorError, match="Unknown Hermes turn"):
+            await supervisor.wait_for_turn(
+                tmp_path,
+                "session-1",
+                "turn-9",
             )
-
-        monkeypatch.setattr(
-            supervisor,
-            "_read_session_store_snapshot",
-            _fake_snapshot,
-        )
-
-        result = await supervisor.wait_for_turn(
-            tmp_path,
-            "session-1",
-            "turn-9",
-        )
-
-        assert result.status == "completed"
-        assert result.assistant_text == "persisted reply"
-        assert [event.get("method") for event in result.raw_events] == [
-            "prompt/completed"
-        ]
-        assert (
-            result.raw_events[0].get("params", {}).get("recoveredFrom")
-            == "session_store_missing_state"
-        )
-    finally:
-        await supervisor.close_all()
-
-
-@pytest.mark.asyncio
-async def test_hermes_supervisor_recovers_session_store_without_active_turn_state(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    supervisor = HermesSupervisor(fake_acp_command("official_prompt_hang"))
-    try:
-
-        async def _fake_snapshot(_session_id: str) -> SimpleNamespace:
-            return SimpleNamespace(
-                message_count=4,
-                last_updated_unix=time.time(),
-                last_assistant_text="persisted reply",
-            )
-
-        monkeypatch.setattr(
-            supervisor,
-            "_read_session_store_snapshot",
-            _fake_snapshot,
-        )
-
-        result = await supervisor.recover_turn_from_session_store(
-            tmp_path,
-            "session-1",
-            "turn-9",
-        )
-
-        assert result is not None
-        assert result.status == "completed"
-        assert result.assistant_text == "persisted reply"
-        assert [event.get("method") for event in result.raw_events] == [
-            "prompt/completed"
-        ]
-        assert (
-            result.raw_events[0].get("params", {}).get("recoveredFrom")
-            == "session_store_missing_state"
-        )
     finally:
         await supervisor.close_all()

--- a/tests/agents/hermes/test_hermes_supervisor_official_prompt_hang.py
+++ b/tests/agents/hermes/test_hermes_supervisor_official_prompt_hang.py
@@ -7,8 +7,8 @@ import pytest
 from tests.chat_surface_harness.hermes import fake_acp_command
 
 from codex_autorunner.agents.hermes.supervisor import (
-    HermesSupervisorError,
     HermesSupervisor,
+    HermesSupervisorError,
 )
 
 

--- a/tests/chat_surface_integration/test_hermes_pma_official_timeout.py
+++ b/tests/chat_surface_integration/test_hermes_pma_official_timeout.py
@@ -85,7 +85,7 @@ async def test_discord_hermes_pma_stall_timeout_surfaces_timeout_for_silent_hang
 
 
 @pytest.mark.anyio
-async def test_discord_hermes_pma_recovers_second_turn_from_persisted_session_store(
+async def test_discord_hermes_pma_does_not_replay_second_turn_from_persisted_session_store(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -107,9 +107,14 @@ async def test_discord_hermes_pma_recovers_second_turn_from_persisted_session_st
         second = await harness.run_message("echo hello world again")
 
         assert first.execution_status == "ok"
-        assert second.execution_status == "ok"
-        assert second.execution_error is None
+        assert second.execution_status == "error"
         assert any(
+            op["op"] == "send"
+            and "discord pma turn timed out"
+            in str(op["payload"].get("content", "")).lower()
+            for op in second.message_ops
+        )
+        assert not any(
             op["op"] == "send"
             and "identical fixture output" in str(op["payload"].get("content", ""))
             for op in second.message_ops
@@ -119,15 +124,15 @@ async def test_discord_hermes_pma_recovers_second_turn_from_persisted_session_st
             for record in reversed(second.log_records)
             if record.get("event") == "chat.managed_thread.turn_finalized"
         )
-        assert finalized["status"] == "ok"
-        assert finalized["completion_source"] == "prompt_return"
+        assert finalized["status"] == "error"
+        assert finalized["completion_source"] == "timeout"
     finally:
         await harness.close()
         await runtime.close()
 
 
 @pytest.mark.anyio
-async def test_discord_hermes_pma_recovers_from_persisted_completion_before_stall_timeout(
+async def test_discord_hermes_pma_does_not_recover_from_persisted_completion_before_timeout(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -141,7 +146,7 @@ async def test_discord_hermes_pma_recovers_from_persisted_completion_before_stal
         "_STALL_RECOVERY_PROBE_INTERVAL_SECONDS",
         0.05,
     )
-    monkeypatch.setattr(discord_message_turns, "DISCORD_PMA_TIMEOUT_SECONDS", 30.0)
+    monkeypatch.setattr(discord_message_turns, "DISCORD_PMA_TIMEOUT_SECONDS", 0.2)
     monkeypatch.setattr(
         discord_message_turns,
         "DISCORD_PMA_STALL_TIMEOUT_SECONDS",
@@ -154,9 +159,14 @@ async def test_discord_hermes_pma_recovers_from_persisted_completion_before_stal
         second = await harness.run_message("echo hello world again")
 
         assert first.execution_status == "ok"
-        assert second.execution_status == "ok"
-        assert second.execution_error is None
+        assert second.execution_status == "error"
         assert any(
+            op["op"] == "send"
+            and "discord pma turn timed out"
+            in str(op["payload"].get("content", "")).lower()
+            for op in second.message_ops
+        )
+        assert not any(
             op["op"] == "send"
             and "identical fixture output" in str(op["payload"].get("content", ""))
             for op in second.message_ops
@@ -166,14 +176,8 @@ async def test_discord_hermes_pma_recovers_from_persisted_completion_before_stal
             for record in reversed(second.log_records)
             if record.get("event") == "chat.managed_thread.turn_finalized"
         )
-        assert finalized["status"] == "ok"
-        assert finalized["completion_source"] == "prompt_return"
-        assert not any(
-            op["op"] == "send"
-            and "discord pma turn timed out"
-            in str(op["payload"].get("content", "")).lower()
-            for op in second.message_ops
-        )
+        assert finalized["status"] == "error"
+        assert finalized["completion_source"] == "timeout"
     finally:
         await harness.close()
         await runtime.close()

--- a/tests/chat_surface_integration/test_hermes_pma_official_timeout.py
+++ b/tests/chat_surface_integration/test_hermes_pma_official_timeout.py
@@ -63,7 +63,7 @@ async def test_discord_hermes_pma_stall_timeout_surfaces_timeout_for_silent_hang
     monkeypatch.setattr(
         discord_message_turns,
         "DISCORD_PMA_STALL_TIMEOUT_SECONDS",
-        0.15,
+        1.0,
     )
     harness = DiscordSurfaceHarness(tmp_path / "discord-stall")
     await harness.setup(agent="hermes")
@@ -98,7 +98,7 @@ async def test_discord_hermes_pma_does_not_replay_second_turn_from_persisted_ses
     monkeypatch.setattr(
         discord_message_turns,
         "DISCORD_PMA_STALL_TIMEOUT_SECONDS",
-        0.15,
+        1.0,
     )
     harness = DiscordSurfaceHarness(tmp_path / "discord-recover")
     await harness.setup(agent="hermes")

--- a/tests/discord_message_turns_support.py
+++ b/tests/discord_message_turns_support.py
@@ -1143,7 +1143,7 @@ async def test_orchestrated_turn_submission_timeout_deletes_progress_placeholder
     )
     monkeypatch.setattr(
         discord_message_turns_module,
-        "DISCORD_MANAGED_THREAD_SUBMISSION_TIMEOUT_SECONDS",
+        "DISCORD_PMA_SUBMISSION_TIMEOUT_SECONDS",
         0.01,
     )
     monkeypatch.setattr(

--- a/tests/integrations/discord/test_timeout_recovery.py
+++ b/tests/integrations/discord/test_timeout_recovery.py
@@ -1,34 +1,24 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Optional
 
 import pytest
-from tests.discord_message_turns_support import _config, _FakeRest
 
 import codex_autorunner.integrations.discord.message_turns as discord_message_turns_module
+from tests.discord_message_turns_support import _config, _FakeRest
 
 
 @pytest.mark.asyncio
-async def test_orchestrated_turn_submission_timeout_evicts_cached_runtime_supervisor(
+async def test_discord_pma_turn_does_not_apply_submission_timeout(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     rest = _FakeRest()
     thread = SimpleNamespace(thread_target_id="thread-1")
-    submit_started = asyncio.Event()
-
-    class _FakeSupervisor:
-        def __init__(self) -> None:
-            self.closed_workspaces: list[Path] = []
-
-        async def close_workspace(self, workspace_root: Path) -> None:
-            self.closed_workspaces.append(workspace_root)
-
-    fake_supervisor = _FakeSupervisor()
+    captured_timeout: Optional[float] = 123.0
 
     class _Store:
         async def get_binding(self, *, channel_id: str) -> dict[str, Any]:
@@ -41,9 +31,7 @@ async def test_orchestrated_turn_submission_timeout_evicts_cached_runtime_superv
             self._store = _Store()
             self._rest = rest
             self._logger = logging.getLogger(__name__)
-            self._agent_runtime_supervisors = {
-                ("hermes", "hermes", "m4-pma"): fake_supervisor
-            }
+            self._agent_runtime_supervisors = {}
 
         async def _send_channel_message(
             self, channel_id: str, payload: dict[str, Any]
@@ -67,10 +55,24 @@ async def test_orchestrated_turn_submission_timeout_evicts_cached_runtime_superv
             _ = binding
             return "hermes"
 
-    async def _hanging_submit(self, *args: Any, **kwargs: Any) -> Any:
-        _ = args, kwargs
-        submit_started.set()
-        await asyncio.Future()
+    async def _fake_run_managed_surface_turn(request: Any, *, config: Any) -> Any:
+        nonlocal captured_timeout
+        _ = request
+        captured_timeout = config.submission_timeout_seconds
+        return SimpleNamespace(
+            final_message="ok",
+            preview_message_id=None,
+            execution_id=None,
+            intermediate_message=None,
+            token_usage=None,
+            elapsed_seconds=0.0,
+            send_final_message=True,
+            delivery_visibility_pending=False,
+            durable_delivery_id=None,
+            durable_delivery_claim_token=None,
+            deferred_delivery=False,
+            preserve_progress_lease=False,
+        )
 
     monkeypatch.setattr(
         discord_message_turns_module,
@@ -87,20 +89,12 @@ async def test_orchestrated_turn_submission_timeout_evicts_cached_runtime_superv
     )
     monkeypatch.setattr(
         discord_message_turns_module,
-        "DISCORD_MANAGED_THREAD_SUBMISSION_TIMEOUT_SECONDS",
-        0.01,
-    )
-    monkeypatch.setattr(
-        discord_message_turns_module.ManagedThreadTurnCoordinator,
-        "submit_execution",
-        _hanging_submit,
+        "run_managed_surface_turn",
+        _fake_run_managed_surface_turn,
     )
 
     service = _Service()
-    with pytest.raises(
-        RuntimeError,
-        match="Turn failed to start in time. Please retry.",
-    ):
+    result = (
         await discord_message_turns_module._run_discord_orchestrated_turn_for_message(
             service,
             workspace_root=tmp_path,
@@ -125,7 +119,7 @@ async def test_orchestrated_turn_submission_timeout_evicts_cached_runtime_superv
             min_edit_interval_seconds=1.0,
             heartbeat_interval_seconds=2.0,
         )
+    )
 
-    assert submit_started.is_set()
-    assert fake_supervisor.closed_workspaces == [tmp_path]
-    assert service._agent_runtime_supervisors == {}
+    assert result.final_message == "ok"
+    assert captured_timeout is None

--- a/tests/integrations/discord/test_timeout_recovery.py
+++ b/tests/integrations/discord/test_timeout_recovery.py
@@ -6,13 +6,13 @@ from types import SimpleNamespace
 from typing import Any, Optional
 
 import pytest
+from tests.discord_message_turns_support import _config, _FakeRest
 
 import codex_autorunner.integrations.discord.message_turns as discord_message_turns_module
-from tests.discord_message_turns_support import _config, _FakeRest
 
 
 @pytest.mark.asyncio
-async def test_discord_pma_turn_does_not_apply_submission_timeout(
+async def test_discord_pma_turn_uses_pma_submission_timeout(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -76,6 +76,11 @@ async def test_discord_pma_turn_does_not_apply_submission_timeout(
 
     monkeypatch.setattr(
         discord_message_turns_module,
+        "DISCORD_PMA_SUBMISSION_TIMEOUT_SECONDS",
+        123.0,
+    )
+    monkeypatch.setattr(
+        discord_message_turns_module,
         "resolve_discord_thread_target",
         lambda *args, **kwargs: (SimpleNamespace(), thread),
     )
@@ -122,4 +127,4 @@ async def test_discord_pma_turn_does_not_apply_submission_timeout(
     )
 
     assert result.final_message == "ok"
-    assert captured_timeout is None
+    assert captured_timeout == 123.0

--- a/tests/test_discord_message_turn_startup_pending.py
+++ b/tests/test_discord_message_turn_startup_pending.py
@@ -15,7 +15,6 @@ from codex_autorunner.integrations.discord import (
 )
 from codex_autorunner.integrations.discord.service import DiscordBotService
 from codex_autorunner.integrations.discord.state import DiscordStateStore
-from tests.chat_surface_harness.discord import drain_spawned_tasks
 from tests.discord_message_turns_support import (
     _config,
     _FakeOutboxManager,
@@ -84,7 +83,19 @@ async def test_message_create_startup_failure_keeps_generic_error_without_raw_de
             timeout=3,
         )
         await asyncio.wait_for(submit_started.wait(), timeout=1)
-        await asyncio.wait_for(drain_spawned_tasks(service), timeout=1)
+        task = next(
+            pending
+            for pending in service._background_tasks
+            if isinstance(
+                getattr(pending, "_discord_progress_task_context", None),
+                dict,
+            )
+            and getattr(pending, "_discord_progress_task_context", {}).get(
+                "failure_note"
+            )
+        )
+        with contextlib.suppress(RuntimeError, asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=1)
         assert submit_started.is_set()
         assert rest.edited_channel_messages
         assert any(


### PR DESCRIPTION
## Summary
- remove CAR's Hermes session-store replay path and keep Hermes completion strictly bound to the live ACP prompt lifecycle
- stop advertising unsupported Hermes stalled-turn recovery and let lost turn state resolve as timeout/error instead of synthetic success
- skip the Discord managed-thread submission timeout for PMA so Hermes startup is governed by real PMA timeout and stall handling

## Root Cause
CAR was treating Hermes' persisted session transcript as if it were a durable turn-completion record. Hermes persists session history, not turn-scoped completion state, so replaying the latest assistant text from session storage could resend stale output on a new managed turn. Separately, Discord PMA was applying a 45 second submission timeout that could cancel a valid Hermes startup before the runtime settled.

## Validation
- full repo commit hook passed, including format/lint/mypy/full pytest/frontend checks
- `python -m pytest -q tests/agents/hermes/test_hermes_supervisor_official_prompt_hang.py tests/chat_surface_integration/test_hermes_pma_official_timeout.py tests/integrations/discord/test_timeout_recovery.py tests/agents/hermes/test_hermes_supervisor.py tests/agents/hermes/test_hermes_harness.py tests/core/orchestration/test_runtime_threads.py tests/test_discord_message_turn_startup_pending.py`

Closes #1556