### PR TITLE
Refactor bound chat execution recovery

### DIFF
--- a/src/codex_autorunner/core/hub_control_plane/_executions.py
+++ b/src/codex_autorunner/core/hub_control_plane/_executions.py
@@ -24,6 +24,7 @@ class ExecutionCreateRequest:
     model: Optional[str] = None
     reasoning: Optional[str] = None
     client_request_id: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
     queue_payload: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -42,11 +43,12 @@ class ExecutionCreateRequest:
             model=normalize_optional_text(data.get("model")),
             reasoning=normalize_optional_text(data.get("reasoning")),
             client_request_id=normalize_optional_text(data.get("client_request_id")),
+            metadata=copy_mapping(data.get("metadata")),
             queue_payload=copy_mapping(data.get("queue_payload")),
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "thread_target_id": self.thread_target_id,
             "prompt": self.prompt,
             "request_kind": self.request_kind,
@@ -56,6 +58,9 @@ class ExecutionCreateRequest:
             "client_request_id": self.client_request_id,
             "queue_payload": dict(self.queue_payload),
         }
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
 
 
 @dataclass(frozen=True)

--- a/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
+++ b/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
@@ -331,6 +331,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
         model: Optional[str] = None,
         reasoning: Optional[str] = None,
         client_request_id: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
         queue_payload: Optional[dict[str, Any]] = None,
     ) -> ExecutionRecord:
         response = self._run(
@@ -344,6 +345,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
                     model=model,
                     reasoning=reasoning,
                     client_request_id=client_request_id,
+                    metadata=dict(metadata or {}),
                     queue_payload=dict(queue_payload or {}),
                 )
             ),

--- a/src/codex_autorunner/core/hub_control_plane/service.py
+++ b/src/codex_autorunner/core/hub_control_plane/service.py
@@ -492,6 +492,7 @@ class HubSharedStateService:
                 model=request.model,
                 reasoning=request.reasoning,
                 client_request_id=request.client_request_id,
+                metadata=request.metadata or None,
                 queue_payload=request.queue_payload or None,
             )
         except (KeyError, RuntimeError, ValueError) as exc:

--- a/src/codex_autorunner/core/orchestration/interfaces.py
+++ b/src/codex_autorunner/core/orchestration/interfaces.py
@@ -206,6 +206,7 @@ class ThreadExecutionStore(Protocol):
         model: Optional[str] = None,
         reasoning: Optional[str] = None,
         client_request_id: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
         queue_payload: Optional[dict[str, Any]] = None,
     ) -> ExecutionRecord: ...
 

--- a/src/codex_autorunner/core/orchestration/migrations.py
+++ b/src/codex_autorunner/core/orchestration/migrations.py
@@ -8,7 +8,7 @@ from typing import Callable
 from ..time_utils import now_iso
 from .models import OrchestrationTableDefinition
 
-ORCHESTRATION_SCHEMA_VERSION = 22
+ORCHESTRATION_SCHEMA_VERSION = 23
 
 
 @dataclass(frozen=True)
@@ -1303,6 +1303,15 @@ def _apply_v22(conn: sqlite3.Connection) -> None:
     )
 
 
+def _apply_v23(conn: sqlite3.Connection) -> None:
+    _ensure_column(
+        conn,
+        "orch_thread_executions",
+        "metadata_json",
+        "metadata_json TEXT NOT NULL DEFAULT '{}'",
+    )
+
+
 _MIGRATIONS = (
     _MigrationStep(1, "create_core_orchestration_schema", _apply_v1),
     _MigrationStep(2, "add_binding_and_flow_projection_scaffolding", _apply_v2),
@@ -1338,6 +1347,7 @@ _MIGRATIONS = (
     ),
     _MigrationStep(21, "add_chat_operation_ledger", _apply_v21),
     _MigrationStep(22, "add_managed_thread_delivery_ledger", _apply_v22),
+    _MigrationStep(23, "add_execution_metadata", _apply_v23),
 )
 
 

--- a/src/codex_autorunner/core/orchestration/models.py
+++ b/src/codex_autorunner/core/orchestration/models.py
@@ -4,7 +4,7 @@ from dataclasses import asdict, dataclass, field
 from typing import Any, Literal, Mapping, Optional
 
 from ..car_context import CarContextProfile, normalize_car_context_profile
-from ..text_utils import _normalize_optional_text
+from ..text_utils import _json_loads_object, _normalize_optional_text
 
 TargetCapability = Literal[
     "durable_threads",
@@ -371,6 +371,7 @@ class ExecutionRecord:
     finished_at: Optional[str] = None
     error: Optional[str] = None
     output_text: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "ExecutionRecord":
@@ -386,6 +387,9 @@ class ExecutionRecord:
             raise ValueError(
                 "ExecutionRecord requires execution_id/managed_turn_id and target_id/managed_thread_id"
             )
+        metadata = data.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = _json_loads_object(data.get("metadata_json"))
         return cls(
             execution_id=execution_id,
             target_id=target_id,
@@ -401,6 +405,7 @@ class ExecutionRecord:
             output_text=_normalize_optional_text(
                 data.get("output_text") or data.get("assistant_text")
             ),
+            metadata=dict(metadata),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -270,6 +270,7 @@ class PmaThreadExecutionStore(ThreadExecutionStore):
         model: Optional[str] = None,
         reasoning: Optional[str] = None,
         client_request_id: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
         queue_payload: Optional[dict[str, Any]] = None,
     ) -> ExecutionRecord:
         created = self._store.create_turn(
@@ -280,6 +281,7 @@ class PmaThreadExecutionStore(ThreadExecutionStore):
             model=model,
             reasoning=reasoning,
             client_turn_id=client_request_id,
+            metadata=metadata,
             queue_payload=queue_payload,
         )
         return _execution_record_from_store_row(created)
@@ -1047,6 +1049,7 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
             model=request.model,
             reasoning=request.reasoning,
             client_request_id=client_request_id,
+            metadata=request.metadata,
             queue_payload=queue_payload,
         )
         _record_thread_activity_best_effort(

--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -936,6 +936,7 @@ class PmaThreadStore:
         model: Optional[str] = None,
         reasoning: Optional[str] = None,
         client_turn_id: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
         queue_payload: Optional[dict[str, Any]] = None,
     ) -> dict[str, Any]:
         managed_turn_id = str(uuid.uuid4())
@@ -988,11 +989,12 @@ class PmaThreadStore:
                         error_text,
                         model_id,
                         reasoning_level,
+                        metadata_json,
                         transcript_mirror_id,
                         started_at,
                         finished_at,
                         created_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         managed_turn_id,
@@ -1006,6 +1008,7 @@ class PmaThreadStore:
                         None,
                         model,
                         reasoning,
+                        _json_dumps(dict(metadata or {})),
                         None,
                         started_at,
                         None,

--- a/src/codex_autorunner/core/pma_thread_store_rows.py
+++ b/src/codex_autorunner/core/pma_thread_store_rows.py
@@ -364,9 +364,15 @@ class PmaExecutionRecord:
     error: Optional[str]
     started_at: Optional[str]
     finished_at: Optional[str]
+    metadata: dict[str, Any]
 
     @classmethod
     def from_orchestration_row(cls, row: Any) -> "PmaExecutionRecord":
+        metadata = (
+            _json_loads_object(row["metadata_json"])
+            if "metadata_json" in row.keys()
+            else {}
+        )
         return cls(
             managed_turn_id=str(row["execution_id"]),
             managed_thread_id=str(row["thread_target_id"]),
@@ -382,6 +388,7 @@ class PmaExecutionRecord:
             error=coerce_text(row["error_text"]),
             started_at=coerce_text(row["started_at"]),
             finished_at=coerce_text(row["finished_at"]),
+            metadata=metadata,
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/codex_autorunner/integrations/chat/bound_chat_execution_metadata.py
+++ b/src/codex_autorunner/integrations/chat/bound_chat_execution_metadata.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional, Sequence
+
+_BOUND_CHAT_EXECUTION_KEY = "bound_chat_execution"
+_SUPPORTED_SURFACE_KINDS = frozenset({"discord", "telegram"})
+
+
+def _normalize_optional_text(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _normalize_surface_kind(value: Any) -> Optional[str]:
+    normalized = _normalize_optional_text(value)
+    if normalized is None:
+        return None
+    lowered = normalized.lower()
+    if lowered not in _SUPPORTED_SURFACE_KINDS:
+        return None
+    return lowered
+
+
+def normalize_bound_chat_surface_targets(
+    surface_targets: Sequence[tuple[str, str]] | None,
+) -> tuple[tuple[str, str], ...]:
+    normalized_targets: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for surface_kind, surface_key in surface_targets or ():
+        normalized_surface_kind = _normalize_surface_kind(surface_kind)
+        normalized_surface_key = _normalize_optional_text(surface_key)
+        if normalized_surface_kind is None or normalized_surface_key is None:
+            continue
+        pair = (normalized_surface_kind, normalized_surface_key)
+        if pair in seen:
+            continue
+        seen.add(pair)
+        normalized_targets.append(pair)
+    return tuple(normalized_targets)
+
+
+def build_bound_chat_execution_metadata(
+    *,
+    origin_kind: str,
+    origin_surface_kind: Optional[str] = None,
+    origin_surface_key: Optional[str] = None,
+    progress_targets: Sequence[tuple[str, str]] | None = None,
+) -> dict[str, Any]:
+    normalized_origin_kind = _normalize_optional_text(origin_kind)
+    if normalized_origin_kind is None:
+        return {}
+    payload: dict[str, Any] = {}
+    if normalized_origin_kind == "surface":
+        normalized_surface_kind = _normalize_surface_kind(origin_surface_kind)
+        normalized_surface_key = _normalize_optional_text(origin_surface_key)
+        if normalized_surface_kind is not None and normalized_surface_key is not None:
+            payload["origin"] = {
+                "kind": "surface",
+                "surface_kind": normalized_surface_kind,
+                "surface_key": normalized_surface_key,
+            }
+    else:
+        payload["origin"] = {"kind": normalized_origin_kind}
+    normalized_targets = normalize_bound_chat_surface_targets(progress_targets)
+    if normalized_targets:
+        payload["progress_targets"] = [
+            {
+                "surface_kind": surface_kind,
+                "surface_key": surface_key,
+            }
+            for surface_kind, surface_key in normalized_targets
+        ]
+    if not payload:
+        return {}
+    return {_BOUND_CHAT_EXECUTION_KEY: payload}
+
+
+def merge_bound_chat_execution_metadata(
+    metadata: Mapping[str, Any] | None,
+    *,
+    origin_kind: str,
+    origin_surface_kind: Optional[str] = None,
+    origin_surface_key: Optional[str] = None,
+    progress_targets: Sequence[tuple[str, str]] | None = None,
+) -> dict[str, Any]:
+    merged = dict(metadata or {})
+    payload = build_bound_chat_execution_metadata(
+        origin_kind=origin_kind,
+        origin_surface_kind=origin_surface_kind,
+        origin_surface_key=origin_surface_key,
+        progress_targets=progress_targets,
+    )
+    if payload:
+        merged.update(payload)
+    return merged
+
+
+def _bound_chat_execution_payload(
+    metadata: Mapping[str, Any] | None,
+) -> Mapping[str, Any]:
+    if not isinstance(metadata, Mapping):
+        return {}
+    payload = metadata.get(_BOUND_CHAT_EXECUTION_KEY)
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def legacy_bound_chat_origin(client_request_id: Any) -> Optional[tuple[str, str]]:
+    normalized_client_request_id = _normalize_optional_text(client_request_id)
+    if normalized_client_request_id is None:
+        return None
+    for surface_kind in _SUPPORTED_SURFACE_KINDS:
+        prefix = f"{surface_kind}:"
+        if not normalized_client_request_id.lower().startswith(prefix):
+            continue
+        remainder = normalized_client_request_id[len(prefix) :]
+        surface_key, separator, _nonce = remainder.rpartition(":")
+        if not separator:
+            continue
+        normalized_surface_key = _normalize_optional_text(surface_key)
+        if normalized_surface_key is None:
+            continue
+        return surface_kind, normalized_surface_key
+    return None
+
+
+def bound_chat_execution_origin(
+    metadata: Mapping[str, Any] | None,
+    *,
+    client_request_id: Any = None,
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    payload = _bound_chat_execution_payload(metadata)
+    origin = payload.get("origin")
+    if isinstance(origin, Mapping):
+        origin_kind = _normalize_optional_text(origin.get("kind"))
+        if origin_kind == "surface":
+            surface_kind = _normalize_surface_kind(origin.get("surface_kind"))
+            surface_key = _normalize_optional_text(origin.get("surface_key"))
+            if surface_kind is not None and surface_key is not None:
+                return "surface", surface_kind, surface_key
+        elif origin_kind is not None:
+            return origin_kind, None, None
+    legacy = legacy_bound_chat_origin(client_request_id)
+    if legacy is None:
+        return None, None, None
+    return "surface", legacy[0], legacy[1]
+
+
+def bound_chat_execution_progress_targets(
+    metadata: Mapping[str, Any] | None,
+    *,
+    client_request_id: Any = None,
+) -> tuple[tuple[str, str], ...]:
+    payload = _bound_chat_execution_payload(metadata)
+    raw_targets = payload.get("progress_targets")
+    if isinstance(raw_targets, list):
+        normalized_targets = normalize_bound_chat_surface_targets(
+            [
+                (
+                    str(item.get("surface_kind") or ""),
+                    str(item.get("surface_key") or ""),
+                )
+                for item in raw_targets
+                if isinstance(item, Mapping)
+            ]
+        )
+        if normalized_targets:
+            return normalized_targets
+    origin_kind, origin_surface_kind, origin_surface_key = bound_chat_execution_origin(
+        metadata,
+        client_request_id=client_request_id,
+    )
+    if (
+        origin_kind == "surface"
+        and origin_surface_kind is not None
+        and origin_surface_key is not None
+    ):
+        return ((origin_surface_kind, origin_surface_key),)
+    return ()
+
+
+def bound_chat_execution_origin_matches_surface(
+    metadata: Mapping[str, Any] | None,
+    *,
+    surface_kind: str,
+    surface_key: str,
+    client_request_id: Any = None,
+) -> bool:
+    origin_kind, origin_surface_kind, origin_surface_key = bound_chat_execution_origin(
+        metadata,
+        client_request_id=client_request_id,
+    )
+    return (
+        origin_kind == "surface"
+        and origin_surface_kind == _normalize_surface_kind(surface_kind)
+        and origin_surface_key == _normalize_optional_text(surface_key)
+    )
+
+
+def bound_chat_progress_targets_from_execution_mapping(
+    execution: Mapping[str, Any] | None,
+) -> tuple[tuple[str, str], ...]:
+    if not isinstance(execution, Mapping):
+        return ()
+    metadata = execution.get("metadata")
+    return bound_chat_execution_progress_targets(
+        metadata if isinstance(metadata, Mapping) else None,
+        client_request_id=(
+            execution.get("client_turn_id") or execution.get("client_request_id")
+        ),
+    )
+
+
+def bound_chat_origin_matches_surface_from_execution_mapping(
+    execution: Mapping[str, Any] | None,
+    *,
+    surface_kind: str,
+    surface_key: str,
+) -> bool:
+    if not isinstance(execution, Mapping):
+        return False
+    metadata = execution.get("metadata")
+    return bound_chat_execution_origin_matches_surface(
+        metadata if isinstance(metadata, Mapping) else None,
+        surface_kind=surface_kind,
+        surface_key=surface_key,
+        client_request_id=(
+            execution.get("client_turn_id") or execution.get("client_request_id")
+        ),
+    )
+
+
+def execution_mapping_has_chat_surface_origin(
+    execution: Mapping[str, Any] | None,
+) -> bool:
+    if not isinstance(execution, Mapping):
+        return False
+    metadata = execution.get("metadata")
+    origin_kind, _surface_kind, _surface_key = bound_chat_execution_origin(
+        metadata if isinstance(metadata, Mapping) else None,
+        client_request_id=(
+            execution.get("client_turn_id") or execution.get("client_request_id")
+        ),
+    )
+    return origin_kind == "surface"
+
+
+__all__ = [
+    "bound_chat_execution_origin",
+    "bound_chat_execution_origin_matches_surface",
+    "bound_chat_execution_progress_targets",
+    "bound_chat_origin_matches_surface_from_execution_mapping",
+    "bound_chat_progress_targets_from_execution_mapping",
+    "build_bound_chat_execution_metadata",
+    "execution_mapping_has_chat_surface_origin",
+    "legacy_bound_chat_origin",
+    "merge_bound_chat_execution_metadata",
+    "normalize_bound_chat_surface_targets",
+]

--- a/src/codex_autorunner/integrations/chat/managed_thread_startup_recovery.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_startup_recovery.py
@@ -6,6 +6,9 @@ from types import SimpleNamespace
 from typing import Any, Callable, Optional
 
 from ...core.logging_utils import log_event
+from .bound_chat_execution_metadata import (
+    bound_chat_origin_matches_surface_from_execution_mapping,
+)
 from .managed_thread_turns import (
     ManagedThreadDurableDeliveryHooks,
     ManagedThreadExecutionHooks,
@@ -36,10 +39,6 @@ def _normalized_optional_text(value: Any) -> Optional[str]:
     return normalized or None
 
 
-def _surface_client_turn_prefix(*, surface_kind: str, surface_key: str) -> str:
-    return f"{surface_kind}:{surface_key}:"
-
-
 def _safe_list_bindings(binding_store: Any, **kwargs: Any) -> tuple[Any, ...]:
     list_bindings = getattr(binding_store, "list_bindings", None)
     if not callable(list_bindings):
@@ -61,16 +60,10 @@ def surface_owns_running_execution(
     if not callable(get_running_turn):
         return False
     running_turn = get_running_turn(managed_thread_id)
-    client_turn_id = _normalized_optional_text(
-        running_turn.get("client_turn_id") if running_turn is not None else None
-    )
-    if client_turn_id is None:
-        return False
-    return client_turn_id.lower().startswith(
-        _surface_client_turn_prefix(
-            surface_kind=surface_kind,
-            surface_key=surface_key,
-        ).lower()
+    return bound_chat_origin_matches_surface_from_execution_mapping(
+        running_turn,
+        surface_kind=surface_kind,
+        surface_key=surface_key,
     )
 
 
@@ -113,19 +106,16 @@ def surface_owns_pending_queue(
     get_turn = getattr(thread_store, "get_turn", None)
     if not callable(list_pending) or not callable(get_turn):
         return False
-    prefix = _surface_client_turn_prefix(
-        surface_kind=surface_kind,
-        surface_key=surface_key,
-    ).lower()
     for item in list_pending(managed_thread_id, limit=_PENDING_QUEUE_SCAN_LIMIT) or ():
         managed_turn_id = _normalized_optional_text(item.get("managed_turn_id"))
         if managed_turn_id is None:
             continue
         turn = get_turn(managed_thread_id, managed_turn_id)
-        client_turn_id = _normalized_optional_text(
-            turn.get("client_turn_id") if turn is not None else None
-        )
-        if client_turn_id is not None and client_turn_id.lower().startswith(prefix):
+        if bound_chat_origin_matches_surface_from_execution_mapping(
+            turn,
+            surface_kind=surface_kind,
+            surface_key=surface_key,
+        ):
             return True
     return False
 

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -79,6 +79,7 @@ from ...integrations.chat.models import ChatMessageEvent
 from ...integrations.chat.runtime_thread_errors import (
     sanitize_runtime_thread_error,
 )
+from ..chat.bound_chat_execution_metadata import merge_bound_chat_execution_metadata
 from ..chat.managed_thread_progress_projector import (
     ManagedThreadProgressProjector,
 )
@@ -2419,6 +2420,7 @@ async def _run_discord_orchestrated_turn_for_message(
         and existing_session_prompt_text.strip()
     ):
         metadata["existing_session_runtime_prompt"] = existing_session_prompt_text
+    surface_key = managed_thread_surface_key or channel_id
     return await run_managed_surface_turn(
         MessageRequest(
             target_id=thread.thread_target_id,
@@ -2429,7 +2431,13 @@ async def _run_discord_orchestrated_turn_for_message(
             reasoning=reasoning_effort,
             approval_mode=approval_mode,
             input_items=execution_input_items,
-            metadata=metadata,
+            metadata=merge_bound_chat_execution_metadata(
+                metadata,
+                origin_kind="surface",
+                origin_surface_kind="discord",
+                origin_surface_key=surface_key,
+                progress_targets=(("discord", surface_key),),
+            ),
         ),
         config=ManagedSurfaceRunnerConfig(
             coordinator=coordinator,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -71,6 +71,9 @@ from .....integrations.app_server.threads import (
     pma_legacy_migration_fallback_keys,
     pma_topic_scoped_key,
 )
+from .....integrations.chat.bound_chat_execution_metadata import (
+    merge_bound_chat_execution_metadata,
+)
 from .....integrations.chat.bound_live_progress import (
     build_bound_chat_queue_execution_controller,
     cleanup_bound_chat_live_progress_success,
@@ -1570,7 +1573,13 @@ async def _run_telegram_managed_thread_turn(
             reasoning=record.effort,
             approval_mode=approval_policy,
             input_items=execution_input_items,
-            metadata=metadata,
+            metadata=merge_bound_chat_execution_metadata(
+                metadata,
+                origin_kind="surface",
+                origin_surface_kind="telegram",
+                origin_surface_key=topic_key,
+                progress_targets=(("telegram", topic_key),),
+            ),
         ),
         config=ManagedSurfaceRunnerConfig(
             coordinator=coordinator,

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -24,13 +24,14 @@ from .....core.pma_thread_store import (
     PmaThreadStore,
 )
 from .....core.text_utils import _truncate_text
+from .....integrations.chat.bound_chat_execution_metadata import (
+    bound_chat_progress_targets_from_execution_mapping,
+    merge_bound_chat_execution_metadata,
+)
 from .....integrations.chat.bound_live_progress import (
     build_bound_chat_queue_execution_controller,
     cleanup_bound_chat_live_progress_failure,
     cleanup_bound_chat_live_progress_success,
-)
-from .....integrations.chat.managed_thread_startup_recovery import (
-    find_surface_key_for_running_execution,
 )
 from .....integrations.chat.managed_thread_turns import (
     ManagedThreadCoordinatorHooks,
@@ -139,6 +140,62 @@ def _track_managed_thread_task(app: Any, task: asyncio.Task[Any]) -> None:
     task.add_done_callback(lambda done: task_pool.discard(done))
 
 
+async def _recover_pma_bound_chat_execution(
+    app: Any,
+    *,
+    service: Any,
+    thread_store: PmaThreadStore,
+    managed_thread_id: str,
+    thread: Any,
+    execution: Any,
+) -> bool:
+    workspace_root = normalize_optional_text(getattr(thread, "workspace_root", None))
+    execution_id = normalize_optional_text(getattr(execution, "execution_id", None))
+    if workspace_root is None or execution_id is None:
+        return False
+    running_turn = thread_store.get_turn(managed_thread_id, execution_id)
+    if running_turn is None:
+        return False
+    harness_for_thread = getattr(service, "_harness_for_thread", None)
+    if not callable(harness_for_thread):
+        return False
+    metadata = running_turn.get("metadata")
+    request_kind = str(running_turn.get("request_kind") or "").strip().lower()
+    request = MessageRequest(
+        target_id=managed_thread_id,
+        target_kind="thread",
+        message_text=normalize_optional_text(running_turn.get("prompt")) or "",
+        kind="review" if request_kind == "review" else "message",
+        model=normalize_optional_text(running_turn.get("model")),
+        reasoning=normalize_optional_text(running_turn.get("reasoning")),
+        metadata=dict(metadata) if isinstance(metadata, dict) else {},
+    )
+    started = RuntimeThreadExecution(
+        service=service,
+        harness=harness_for_thread(thread),
+        thread=thread,
+        execution=execution,
+        workspace_root=Path(workspace_root),
+        request=request,
+    )
+    current_thread_row = thread_store.get_thread(managed_thread_id) or {}
+
+    async def _runner() -> None:
+        await _run_managed_thread_execution(
+            _managed_thread_request_for_app(app),
+            service=service,
+            thread_store=thread_store,
+            thread=current_thread_row,
+            started=started,
+            fallback_backend_thread_id=normalize_optional_text(
+                getattr(thread, "backend_thread_id", None)
+            ),
+        )
+
+    _track_managed_thread_task(app, asyncio.create_task(_runner()))
+    return True
+
+
 def _resolve_repo_raw_config_for_workspace(
     request: Request,
     *,
@@ -209,28 +266,43 @@ def _resolve_pma_chat_bound_surface_targets(
     *,
     service: Any,
     managed_thread_id: str,
+    started: Any | None = None,
 ) -> tuple[tuple[str, str], ...]:
+    started_execution = getattr(started, "execution", None)
+    started_metadata = getattr(started_execution, "metadata", None)
+    if isinstance(started_metadata, dict):
+        explicit_targets = bound_chat_progress_targets_from_execution_mapping(
+            {"metadata": started_metadata}
+        )
+        if explicit_targets:
+            return explicit_targets
     thread_store = getattr(service, "thread_store", None)
-    if thread_store is None:
+    if thread_store is not None:
+        running_turn = thread_store.get_running_turn(managed_thread_id)
+        explicit_targets = bound_chat_progress_targets_from_execution_mapping(
+            running_turn
+        )
+        if explicit_targets:
+            return explicit_targets
+    list_bindings = getattr(service, "list_bindings", None)
+    if not callable(list_bindings):
         return ()
     targets: list[tuple[str, str]] = []
-    for surface_kind in ("discord", "telegram"):
-        surface_key = find_surface_key_for_running_execution(
-            service,
-            thread_store,
-            managed_thread_id=managed_thread_id,
-            surface_kind=surface_kind,
-            limit=1000,
-        )
-        if surface_key is not None:
-            targets.append((surface_kind, surface_key))
-    if len(targets) > 1:
-        logger.warning(
-            "Ambiguous PMA chat-bound surface ownership; suppressing live progress fanout (managed_thread_id=%s, targets=%s)",
-            managed_thread_id,
-            targets,
-        )
-        return ()
+    seen: set[tuple[str, str]] = set()
+    for binding in list_bindings(
+        thread_target_id=managed_thread_id,
+        include_disabled=False,
+        limit=1000,
+    ):
+        surface_kind = normalize_optional_text(getattr(binding, "surface_kind", None))
+        surface_key = normalize_optional_text(getattr(binding, "surface_key", None))
+        if surface_kind not in {"discord", "telegram"} or surface_key is None:
+            continue
+        pair = (surface_kind, surface_key)
+        if pair in seen:
+            continue
+        seen.add(pair)
+        targets.append(pair)
     return tuple(targets)
 
 
@@ -279,6 +351,7 @@ async def _run_managed_thread_execution(
         surface_target_resolver=lambda _started: _resolve_pma_chat_bound_surface_targets(
             service=service,
             managed_thread_id=managed_thread_id,
+            started=_started,
         ),
         retain_completed_surface_targets=True,
     )
@@ -577,6 +650,7 @@ def ensure_managed_thread_queue_worker(app: Any, managed_thread_id: str) -> None
         return _resolve_pma_chat_bound_surface_targets(
             service=service,
             managed_thread_id=managed_thread_id,
+            started=_started,
         )
 
     queue_progress = build_bound_chat_queue_execution_controller(
@@ -626,6 +700,7 @@ async def recover_orphaned_managed_thread_executions(app: Any) -> None:
     await recover_orphaned_executions(
         app,
         build_service_for_app=_build_managed_thread_orchestration_service_for_app,
+        recover_bound_progress_execution=_recover_pma_bound_chat_execution,
     )
 
 
@@ -685,6 +760,10 @@ def build_managed_thread_runtime_routes(
             )
         sync_zeroclaw_context_if_needed(thread=thread, options=options)
         try:
+            progress_targets = _resolve_pma_chat_bound_surface_targets(
+                service=service,
+                managed_thread_id=managed_thread_id,
+            )
             started_execution = await begin_runtime_thread_execution(
                 service,
                 MessageRequest(
@@ -697,10 +776,14 @@ def build_managed_thread_runtime_routes(
                     reasoning=options.reasoning,
                     approval_mode=options.approval_policy,
                     context_profile=options.context_profile,
-                    metadata={
-                        "runtime_prompt": options.execution_prompt,
-                        "execution_error_message": MANAGED_THREAD_PUBLIC_EXECUTION_ERROR,
-                    },
+                    metadata=merge_bound_chat_execution_metadata(
+                        {
+                            "runtime_prompt": options.execution_prompt,
+                            "execution_error_message": MANAGED_THREAD_PUBLIC_EXECUTION_ERROR,
+                        },
+                        origin_kind="pma_web",
+                        progress_targets=progress_targets,
+                    ),
                 ),
                 sandbox_policy=options.sandbox_policy,
             )

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -267,6 +267,7 @@ def _resolve_pma_chat_bound_surface_targets(
     service: Any,
     managed_thread_id: str,
     started: Any | None = None,
+    allow_running_turn_fallback: bool = True,
 ) -> tuple[tuple[str, str], ...]:
     started_execution = getattr(started, "execution", None)
     started_metadata = getattr(started_execution, "metadata", None)
@@ -277,7 +278,7 @@ def _resolve_pma_chat_bound_surface_targets(
         if explicit_targets:
             return explicit_targets
     thread_store = getattr(service, "thread_store", None)
-    if thread_store is not None:
+    if allow_running_turn_fallback and thread_store is not None:
         running_turn = thread_store.get_running_turn(managed_thread_id)
         explicit_targets = bound_chat_progress_targets_from_execution_mapping(
             running_turn
@@ -763,6 +764,7 @@ def build_managed_thread_runtime_routes(
             progress_targets = _resolve_pma_chat_bound_surface_targets(
                 service=service,
                 managed_thread_id=managed_thread_id,
+                allow_running_turn_fallback=False,
             )
             started_execution = await begin_runtime_thread_execution(
                 service,

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime_control.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime_control.py
@@ -20,11 +20,12 @@ from .....core.orchestration.cold_trace_store import ColdTraceStore
 from .....core.pma_thread_store import PmaThreadStore
 from .....core.time_utils import now_iso
 from .....integrations.app_server.event_buffer import AppServerEventBuffer
+from .....integrations.chat.bound_chat_execution_metadata import (
+    bound_chat_progress_targets_from_execution_mapping,
+    execution_mapping_has_chat_surface_origin,
+)
 from .....integrations.chat.bound_live_progress import (
     build_bound_chat_progress_cleanup_metadata,
-)
-from .....integrations.chat.managed_thread_startup_recovery import (
-    find_surface_key_for_running_execution,
 )
 from .....integrations.chat.managed_thread_turns import (
     ManagedThreadCoordinatorHooks,
@@ -52,7 +53,6 @@ MANAGED_THREAD_INTERRUPT_FAILED_DETAIL = (
     "Interrupt attempt failed; the active managed turn is still running"
 )
 BOUND_CHAT_SURFACE_KINDS = frozenset({"discord", "telegram"})
-BOUND_CHAT_CLIENT_TURN_PREFIXES = ("discord:", "telegram:")
 
 
 @dataclass(frozen=True)
@@ -347,16 +347,33 @@ def _has_owning_bound_chat_surface(
     *,
     thread_store: PmaThreadStore,
 ) -> bool:
+    running_turn = thread_store.get_running_turn(managed_thread_id)
+    progress_targets = set(
+        bound_chat_progress_targets_from_execution_mapping(running_turn)
+    )
+    if progress_targets:
+        for binding in binding_store.list_bindings(
+            thread_target_id=managed_thread_id,
+            include_disabled=False,
+            limit=1000,
+        ):
+            surface_kind = normalize_optional_text(
+                getattr(binding, "surface_kind", None)
+            )
+            surface_key = normalize_optional_text(getattr(binding, "surface_key", None))
+            if surface_kind is None or surface_key is None:
+                continue
+            if (surface_kind, surface_key) in progress_targets:
+                return True
+        return False
     return any(
-        find_surface_key_for_running_execution(
-            binding_store,
-            thread_store,
-            managed_thread_id=managed_thread_id,
-            surface_kind=surface_kind,
+        normalize_optional_text(getattr(binding, "surface_kind", None))
+        in BOUND_CHAT_SURFACE_KINDS
+        for binding in binding_store.list_bindings(
+            thread_target_id=managed_thread_id,
+            include_disabled=False,
             limit=1000,
         )
-        is not None
-        for surface_kind in BOUND_CHAT_SURFACE_KINDS
     )
 
 
@@ -364,21 +381,14 @@ def _is_chat_origin_running_execution(
     thread_store: PmaThreadStore, managed_thread_id: str
 ) -> bool:
     running_turn = thread_store.get_running_turn(managed_thread_id)
-    client_turn_id = normalize_optional_text(
-        running_turn.get("client_turn_id") if running_turn is not None else None
-    )
-    if not client_turn_id:
-        return False
-    client_turn_id = client_turn_id.lower()
-    return any(
-        client_turn_id.startswith(prefix) for prefix in BOUND_CHAT_CLIENT_TURN_PREFIXES
-    )
+    return execution_mapping_has_chat_surface_origin(running_turn)
 
 
 async def recover_orphaned_executions(
     app: Any,
     *,
     build_service_for_app: Any,
+    recover_bound_progress_execution: Any | None = None,
 ) -> None:
     thread_store = PmaThreadStore(app.state.config.root)
     checkpoint_store = ColdTraceStore(app.state.config.root)
@@ -428,8 +438,21 @@ async def recover_orphaned_executions(
                 binding_store,
                 managed_thread_id,
                 thread_store=thread_store,
-            ) and _is_chat_origin_running_execution(thread_store, managed_thread_id):
-                continue
+            ):
+                if _is_chat_origin_running_execution(thread_store, managed_thread_id):
+                    continue
+                if (
+                    recover_bound_progress_execution is not None
+                    and await recover_bound_progress_execution(
+                        app,
+                        service=service,
+                        thread_store=thread_store,
+                        managed_thread_id=managed_thread_id,
+                        thread=thread,
+                        execution=execution,
+                    )
+                ):
+                    continue
             has_turn = getattr(app_server_events, "has_turn", None)
             if (
                 callable(has_turn)

--- a/tests/integrations/chat/test_managed_thread_startup_recovery.py
+++ b/tests/integrations/chat/test_managed_thread_startup_recovery.py
@@ -349,6 +349,73 @@ def test_find_surface_key_for_running_execution_returns_none_without_matching_bi
     )
 
 
+def test_find_surface_key_for_running_execution_uses_metadata_origin() -> None:
+    class FakeBindingStore:
+        def list_bindings(self, **kwargs: object):
+            assert kwargs["surface_kind"] == "discord"
+            return [
+                SimpleNamespace(surface_key="channel-other"),
+                SimpleNamespace(surface_key="channel-owned"),
+            ]
+
+    class FakeThreadStore:
+        def get_running_turn(self, managed_thread_id: str):
+            assert managed_thread_id == "thread-1"
+            return {
+                "metadata": {
+                    "bound_chat_execution": {
+                        "origin": {
+                            "kind": "surface",
+                            "surface_kind": "discord",
+                            "surface_key": "channel-owned",
+                        }
+                    }
+                }
+            }
+
+    assert (
+        recovery_module.find_surface_key_for_running_execution(
+            FakeBindingStore(),
+            FakeThreadStore(),
+            managed_thread_id="thread-1",
+            surface_kind="discord",
+        )
+        == "channel-owned"
+    )
+
+
+def test_surface_owns_pending_queue_uses_metadata_origin_without_client_turn_id() -> (
+    None
+):
+    class FakeThreadStore:
+        def list_pending_turn_queue_items(self, managed_thread_id: str, limit=200):
+            assert managed_thread_id == "thread-1"
+            assert limit == recovery_module._PENDING_QUEUE_SCAN_LIMIT
+            return [{"managed_turn_id": "turn-queued-1"}]
+
+        def get_turn(self, managed_thread_id: str, managed_turn_id: str):
+            assert managed_thread_id == "thread-1"
+            assert managed_turn_id == "turn-queued-1"
+            return {
+                "metadata": {
+                    "bound_chat_execution": {
+                        "origin": {
+                            "kind": "surface",
+                            "surface_kind": "telegram",
+                            "surface_key": "100:200",
+                        }
+                    }
+                }
+            }
+
+    assert recovery_module.surface_owns_pending_queue(
+        FakeThreadStore(),
+        managed_thread_id="thread-1",
+        surface_kind="telegram",
+        surface_key="100:200",
+    )
+
+
 @pytest.mark.anyio
 async def test_startup_recovery_rearms_pending_queue_for_single_owned_binding(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
@@ -410,6 +410,76 @@ async def test_recover_orphaned_managed_thread_executions_skips_chat_bound_threa
     assert updated_running["error"] is None
 
 
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("surface_kind", "surface_key"),
+    (
+        ("discord", "channel-123"),
+        ("telegram", "123:456"),
+    ),
+)
+async def test_recover_orphaned_managed_thread_executions_skips_chat_bound_threads_with_metadata(
+    hub_env,
+    surface_kind: str,
+    surface_key: str,
+) -> None:
+    app = build_pma_hub_app(hub_env.hub_root)
+    store = PmaThreadStore(hub_env.hub_root)
+    bindings = OrchestrationBindingStore(hub_env.hub_root)
+    created = store.create_thread(
+        "codex",
+        hub_env.repo_root.resolve(),
+        repo_id=hub_env.repo_id,
+    )
+    managed_thread_id = str(created["managed_thread_id"])
+    running = store.create_turn(
+        managed_thread_id,
+        prompt="running",
+        metadata={
+            "bound_chat_execution": {
+                "origin": {
+                    "kind": "surface",
+                    "surface_kind": surface_kind,
+                    "surface_key": surface_key,
+                },
+                "progress_targets": [
+                    {
+                        "surface_kind": surface_kind,
+                        "surface_key": surface_key,
+                    }
+                ],
+            }
+        },
+    )
+    bindings.upsert_binding(
+        surface_kind=surface_kind,
+        surface_key=surface_key,
+        thread_target_id=managed_thread_id,
+        agent_id="codex",
+        repo_id=hub_env.repo_id,
+    )
+    store.set_thread_backend_id(managed_thread_id, "backend-thread-1")
+    clear_runtime_thread_binding(hub_env.hub_root, managed_thread_id)
+    with open_orchestration_sqlite(hub_env.hub_root) as conn:
+        with conn:
+            conn.execute(
+                """
+                UPDATE orch_thread_targets
+                   SET runtime_status = 'idle',
+                       status_turn_id = NULL
+                 WHERE thread_target_id = ?
+                """,
+                (managed_thread_id,),
+            )
+
+    await managed_thread_runtime.recover_orphaned_managed_thread_executions(app)
+
+    updated_running = store.get_turn(managed_thread_id, running["managed_turn_id"])
+    assert updated_running is not None
+    assert updated_running["status"] == "running"
+    assert updated_running["error"] is None
+
+
 def test_managed_thread_list_route_filters_by_status(hub_env) -> None:
     app = build_pma_hub_app(hub_env.hub_root)
     store = PmaThreadStore(hub_env.hub_root)
@@ -452,6 +522,7 @@ async def test_recover_orphaned_managed_thread_executions_recovers_pma_runs_on_c
     hub_env,
     surface_kind: str,
     surface_key: str,
+    monkeypatch,
 ) -> None:
     app = build_pma_hub_app(hub_env.hub_root)
     store = PmaThreadStore(hub_env.hub_root)
@@ -484,24 +555,37 @@ async def test_recover_orphaned_managed_thread_executions_recovers_pma_runs_on_c
                 """,
                 (managed_thread_id,),
             )
+    recovered: list[str] = []
+
+    async def _fake_recover_bound_progress_execution(
+        app_arg,
+        *,
+        service,
+        thread_store,
+        managed_thread_id: str,
+        thread,
+        execution,
+    ) -> bool:
+        _ = app_arg, service, thread_store, thread, execution
+        recovered.append(managed_thread_id)
+        return True
+
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "_recover_pma_bound_chat_execution",
+        _fake_recover_bound_progress_execution,
+    )
 
     await managed_thread_runtime.recover_orphaned_managed_thread_executions(app)
 
     updated_running = store.get_turn(managed_thread_id, running["managed_turn_id"])
     updated_queued = store.get_turn(managed_thread_id, queued["managed_turn_id"])
     assert updated_running is not None
-    assert updated_running["status"] == "error"
-    assert (
-        updated_running["error"]
-        == "Running execution could not be reattached after restart"
-    )
+    assert updated_running["status"] == "running"
+    assert updated_running["error"] is None
     assert updated_queued is not None
     assert updated_queued["status"] == "queued"
-
-    claimed = store.claim_next_queued_turn(managed_thread_id)
-    assert claimed is not None
-    claimed_turn, _queue_payload = claimed
-    assert claimed_turn["managed_turn_id"] == queued["managed_turn_id"]
+    assert recovered == [managed_thread_id]
 
 
 def test_managed_thread_message_route_uses_orchestration_service_seam(
@@ -1034,25 +1118,161 @@ def test_pma_queue_worker_uses_contextual_delivery_helper_for_progress_targets(
     assert callable(captured["controller_kwargs"]["surface_target_resolver"])
 
 
-def test_resolve_pma_chat_bound_surface_targets_selects_single_owner() -> None:
-    thread_store = SimpleNamespace(
-        get_running_turn=lambda managed_thread_id: {
-            "client_turn_id": f"discord:channel-1:{managed_thread_id}"
-        }
+def test_resolve_pma_chat_bound_surface_targets_uses_execution_metadata() -> None:
+    started = SimpleNamespace(
+        execution=SimpleNamespace(
+            metadata={
+                "bound_chat_execution": {
+                    "origin": {"kind": "pma_web"},
+                    "progress_targets": [
+                        {
+                            "surface_kind": "discord",
+                            "surface_key": "channel-1",
+                        },
+                        {
+                            "surface_kind": "telegram",
+                            "surface_key": "chat-1:55",
+                        },
+                    ],
+                }
+            }
+        )
     )
     service = SimpleNamespace(
-        thread_store=thread_store,
-        list_bindings=lambda **kwargs: (
-            [SimpleNamespace(surface_key="channel-1")]
-            if kwargs["surface_kind"] == "discord"
-            else [SimpleNamespace(surface_key="chat-1:55")]
-        ),
+        thread_store=SimpleNamespace(get_running_turn=lambda managed_thread_id: None),
+        list_bindings=lambda **kwargs: [],
     )
 
     assert managed_thread_runtime._resolve_pma_chat_bound_surface_targets(
         service=service,
         managed_thread_id="thread-1",
-    ) == (("discord", "channel-1"),)
+        started=started,
+    ) == (("discord", "channel-1"), ("telegram", "chat-1:55"))
+
+
+def test_managed_thread_message_route_persists_pma_bound_chat_execution_metadata(
+    hub_env,
+    monkeypatch,
+) -> None:
+    app = build_pma_hub_app(hub_env.hub_root)
+    store = PmaThreadStore(hub_env.hub_root)
+    bindings = OrchestrationBindingStore(hub_env.hub_root)
+    created = store.create_thread(
+        "codex",
+        hub_env.repo_root.resolve(),
+        repo_id=hub_env.repo_id,
+    )
+    managed_thread_id = str(created["managed_thread_id"])
+    bindings.upsert_binding(
+        surface_kind="discord",
+        surface_key="channel-1",
+        thread_target_id=managed_thread_id,
+        agent_id="codex",
+        repo_id=hub_env.repo_id,
+    )
+    bindings.upsert_binding(
+        surface_kind="telegram",
+        surface_key="100:200",
+        thread_target_id=managed_thread_id,
+        agent_id="codex",
+        repo_id=hub_env.repo_id,
+    )
+    captured: dict[str, Any] = {}
+
+    class FakeService:
+        def get_thread_target(self, thread_target_id: str):
+            return SimpleNamespace(
+                thread_target_id=thread_target_id,
+                backend_thread_id="backend-thread-1",
+            )
+
+        def record_execution_result(
+            self,
+            thread_target_id: str,
+            execution_id: str,
+            *,
+            status: str,
+            assistant_text: Optional[str] = None,
+            error: Optional[str] = None,
+            backend_turn_id: Optional[str] = None,
+            transcript_turn_id: Optional[str] = None,
+        ):
+            _ = (
+                thread_target_id,
+                execution_id,
+                assistant_text,
+                error,
+                backend_turn_id,
+                transcript_turn_id,
+            )
+            return SimpleNamespace(status=status, error=None)
+
+        def get_execution(self, thread_target_id: str, execution_id: str):
+            _ = thread_target_id, execution_id
+            return None
+
+        def list_bindings(self, **kwargs: Any):
+            return bindings.list_bindings(**kwargs)
+
+        thread_store = store
+
+    async def _fake_begin(
+        service, request, *, client_request_id=None, sandbox_policy=None
+    ):
+        _ = service, client_request_id, sandbox_policy
+        captured["request"] = request
+        return SimpleNamespace(
+            execution=SimpleNamespace(
+                execution_id="managed-turn-1",
+                backend_id="backend-turn-1",
+                metadata=request.metadata,
+            ),
+            thread=SimpleNamespace(
+                backend_thread_id="backend-thread-1",
+            ),
+            workspace_root=hub_env.repo_root.resolve(),
+            request=request,
+        )
+
+    async def _fake_await(*args, **kwargs):
+        _ = args, kwargs
+        return RuntimeThreadOutcome(
+            status="ok",
+            assistant_text="assistant-output",
+            error=None,
+            backend_thread_id="backend-thread-1",
+            backend_turn_id="backend-turn-1",
+        )
+
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "_build_managed_thread_orchestration_service",
+        lambda request, *, thread_store=None: FakeService(),
+    )
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "begin_runtime_thread_execution",
+        _fake_begin,
+    )
+    _patch_outcome_driven_finalization(
+        monkeypatch,
+        outcome_builder=_fake_await,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/messages",
+            json={"message": "hello from route"},
+        )
+
+    assert response.status_code == 200
+    assert captured["request"].metadata["bound_chat_execution"] == {
+        "origin": {"kind": "pma_web"},
+        "progress_targets": [
+            {"surface_kind": "discord", "surface_key": "channel-1"},
+            {"surface_kind": "telegram", "surface_key": "100:200"},
+        ],
+    }
 
 
 def test_managed_thread_message_route_honors_explicit_core_context_profile(

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
@@ -1150,6 +1150,42 @@ def test_resolve_pma_chat_bound_surface_targets_uses_execution_metadata() -> Non
     ) == (("discord", "channel-1"), ("telegram", "chat-1:55"))
 
 
+def test_resolve_pma_chat_bound_surface_targets_skips_running_turn_for_pre_submit_requests() -> (
+    None
+):
+    service = SimpleNamespace(
+        thread_store=SimpleNamespace(
+            get_running_turn=lambda managed_thread_id: {
+                "metadata": {
+                    "bound_chat_execution": {
+                        "origin": {
+                            "kind": "surface",
+                            "surface_kind": "discord",
+                            "surface_key": "active-channel",
+                        },
+                        "progress_targets": [
+                            {
+                                "surface_kind": "discord",
+                                "surface_key": "active-channel",
+                            }
+                        ],
+                    }
+                }
+            }
+        ),
+        list_bindings=lambda **kwargs: [
+            SimpleNamespace(surface_kind="telegram", surface_key="chat-1:55")
+        ],
+    )
+
+    assert managed_thread_runtime._resolve_pma_chat_bound_surface_targets(
+        service=service,
+        managed_thread_id="thread-1",
+        started=None,
+        allow_running_turn_fallback=False,
+    ) == (("telegram", "chat-1:55"),)
+
+
 def test_managed_thread_message_route_persists_pma_bound_chat_execution_metadata(
     hub_env,
     monkeypatch,
@@ -1270,6 +1306,141 @@ def test_managed_thread_message_route_persists_pma_bound_chat_execution_metadata
         "origin": {"kind": "pma_web"},
         "progress_targets": [
             {"surface_kind": "discord", "surface_key": "channel-1"},
+            {"surface_kind": "telegram", "surface_key": "100:200"},
+        ],
+    }
+
+
+def test_managed_thread_message_route_uses_binding_targets_for_queued_pma_execution(
+    hub_env,
+    monkeypatch,
+) -> None:
+    app = build_pma_hub_app(hub_env.hub_root)
+    store = PmaThreadStore(hub_env.hub_root)
+    bindings = OrchestrationBindingStore(hub_env.hub_root)
+    created = store.create_thread(
+        "codex",
+        hub_env.repo_root.resolve(),
+        repo_id=hub_env.repo_id,
+    )
+    managed_thread_id = str(created["managed_thread_id"])
+    bindings.upsert_binding(
+        surface_kind="telegram",
+        surface_key="100:200",
+        thread_target_id=managed_thread_id,
+        agent_id="codex",
+        repo_id=hub_env.repo_id,
+    )
+    captured: dict[str, Any] = {}
+
+    class FakeService:
+        def get_thread_target(self, thread_target_id: str):
+            return SimpleNamespace(
+                thread_target_id=thread_target_id,
+                backend_thread_id="backend-thread-1",
+            )
+
+        def record_execution_result(
+            self,
+            thread_target_id: str,
+            execution_id: str,
+            *,
+            status: str,
+            assistant_text: Optional[str] = None,
+            error: Optional[str] = None,
+            backend_turn_id: Optional[str] = None,
+            transcript_turn_id: Optional[str] = None,
+        ):
+            _ = (
+                thread_target_id,
+                execution_id,
+                assistant_text,
+                error,
+                backend_turn_id,
+                transcript_turn_id,
+            )
+            return SimpleNamespace(status=status, error=None)
+
+        def get_execution(self, thread_target_id: str, execution_id: str):
+            _ = thread_target_id, execution_id
+            return None
+
+        def list_bindings(self, **kwargs: Any):
+            return bindings.list_bindings(**kwargs)
+
+        thread_store = SimpleNamespace(
+            get_running_turn=lambda managed_thread_id: {
+                "metadata": {
+                    "bound_chat_execution": {
+                        "origin": {
+                            "kind": "surface",
+                            "surface_kind": "discord",
+                            "surface_key": "active-channel",
+                        },
+                        "progress_targets": [
+                            {
+                                "surface_kind": "discord",
+                                "surface_key": "active-channel",
+                            }
+                        ],
+                    }
+                }
+            }
+        )
+
+    async def _fake_begin(
+        service, request, *, client_request_id=None, sandbox_policy=None
+    ):
+        _ = service, client_request_id, sandbox_policy
+        captured["request"] = request
+        return SimpleNamespace(
+            execution=SimpleNamespace(
+                execution_id="managed-turn-1",
+                backend_id="backend-turn-1",
+                metadata=request.metadata,
+            ),
+            thread=SimpleNamespace(
+                backend_thread_id="backend-thread-1",
+            ),
+            workspace_root=hub_env.repo_root.resolve(),
+            request=request,
+        )
+
+    async def _fake_await(*args, **kwargs):
+        _ = args, kwargs
+        return RuntimeThreadOutcome(
+            status="ok",
+            assistant_text="assistant-output",
+            error=None,
+            backend_thread_id="backend-thread-1",
+            backend_turn_id="backend-turn-1",
+        )
+
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "_build_managed_thread_orchestration_service",
+        lambda request, *, thread_store=None: FakeService(),
+    )
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "begin_runtime_thread_execution",
+        _fake_begin,
+    )
+    _patch_outcome_driven_finalization(
+        monkeypatch,
+        outcome_builder=_fake_await,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/messages",
+            json={"message": "hello from route"},
+        )
+
+    assert response.status_code == 200
+    assert captured["request"].metadata["bound_chat_execution"] == {
+        "origin": {"kind": "pma_web"},
+        "progress_targets": [
             {"surface_kind": "telegram", "surface_key": "100:200"},
         ],
     }

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -234,6 +234,7 @@ def test_create_finish_turn_and_query(tmp_path: Path) -> None:
         model="gpt-test",
         reasoning="high",
         client_turn_id="client-1",
+        metadata={"bound_chat_execution": {"origin": {"kind": "pma_web"}}},
     )
     assert turn["status"] == "running"
     assert turn["request_kind"] == "review"
@@ -255,6 +256,9 @@ def test_create_finish_turn_and_query(tmp_path: Path) -> None:
     assert fetched["backend_turn_id"] == "backend-turn-1"
     assert fetched["transcript_turn_id"] == "transcript-1"
     assert fetched["finished_at"]
+    assert fetched["metadata"] == {
+        "bound_chat_execution": {"origin": {"kind": "pma_web"}}
+    }
 
     listed = store.list_turns(thread["managed_thread_id"])
     assert len(listed) == 1


### PR DESCRIPTION
## Summary
- persist durable bound-chat execution metadata on orchestration execution rows so chat ownership and live-progress targets no longer depend on `client_turn_id` naming conventions
- switch PMA, Discord, Telegram, startup recovery, and orphan recovery to shared metadata-first resolution with legacy `client_turn_id` fallback
- reattach PMA-owned bound-chat executions during startup recovery and add regression coverage for storage, PMA runtime, and chat recovery paths

## Root Cause
PR #1558 improved the shared live-progress plumbing, but PMA-managed-thread submissions still dropped chat ownership on the execution row. The live-progress and recovery logic only knew how to infer ownership from `client_turn_id`, so PMA-dispatched chat-bound threads could deliver final output while streaming no intermediate progress.

## Testing
- `.venv/bin/python -m pytest -q tests/test_pma_thread_store.py tests/integrations/chat/test_managed_thread_startup_recovery.py tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py`
- `.venv/bin/python -m pytest -q tests/surfaces/web/test_pma_common_service.py tests/core/orchestration/test_legacy_state_backfill.py`
- `.venv/bin/python -m pytest -q tests/core/test_hub_control_plane_contract.py::test_execution_models_round_trip_with_existing_execution_record tests/core/test_remote_execution_store.py::test_remote_execution_store_delegates_to_hub_client_for_thread_and_execution_ops`
- full aggregate validation lane via `git commit` hook (`7692 passed`)

## Review
- subagent review completed after implementation; no actionable findings remained in the final diff
