### PR TITLE
[codex] Clean up PMA managed-thread canonical schema

### DIFF
--- a/src/codex_autorunner/core/managed_thread_status.py
+++ b/src/codex_autorunner/core/managed_thread_status.py
@@ -177,22 +177,16 @@ class ManagedThreadStatusSnapshot:
     ) -> "ManagedThreadStatusSnapshot":
         if not isinstance(data, Mapping):
             return cls()
-        status = _normalize_text(data.get("normalized_status")) or _normalize_text(
-            data.get("status")
-        )
+        status = _normalize_text(data.get("normalized_status"))
         if status is None:
             status = _STATUS_IDLE
-        reason_code = _normalize_text(
-            data.get("status_reason_code") or data.get("status_reason")
-        ) or (
+        reason_code = _normalize_text(data.get("status_reason_code")) or (
             ManagedThreadStatusReason.THREAD_ARCHIVED.value
             if status == _STATUS_ARCHIVED
             else ManagedThreadStatusReason.THREAD_CREATED.value
         )
         changed_at = normalize_status_timestamp(
-            _normalize_text(
-                data.get("status_updated_at") or data.get("status_changed_at")
-            )
+            _normalize_text(data.get("status_updated_at"))
         )
         terminal_raw = data.get("status_terminal")
         terminal = (

--- a/src/codex_autorunner/core/pma_action_queue.py
+++ b/src/codex_autorunner/core/pma_action_queue.py
@@ -296,7 +296,11 @@ def _build_thread_queue_items(
     for entry in pma_threads:
         if not isinstance(entry, dict):
             continue
-        status = str(entry.get("status") or "").strip().lower()
+        status = (
+            str(entry.get("normalized_status") or entry.get("status") or "")
+            .strip()
+            .lower()
+        )
         if status in {"", "archived"}:
             continue
         freshness = _extract_entry_freshness(entry)

--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -61,6 +61,61 @@ def _normalize_delivery_target(value: Any) -> Optional[dict[str, str]]:
     }
 
 
+def _resolve_subscription_max_matches(
+    *,
+    max_matches: Any,
+    notify_once: Any = None,
+    metadata: Optional[dict[str, Any]] = None,
+) -> Optional[int]:
+    resolved_max = _normalize_positive_int(max_matches, fallback=None)
+    if resolved_max is not None:
+        return resolved_max
+    if _normalize_bool(notify_once, fallback=False):
+        return 1
+    if isinstance(metadata, dict) and _normalize_bool(
+        metadata.get("notify_once"), fallback=False
+    ):
+        return 1
+    return None
+
+
+def _canonicalize_subscription_entry(data: dict[str, Any]) -> dict[str, Any]:
+    canonical = dict(data)
+    canonical.pop("notify_once", None)
+    metadata_raw = data.get("metadata")
+    metadata = dict(metadata_raw) if isinstance(metadata_raw, dict) else {}
+    metadata.pop("notify_once", None)
+    return {
+        **canonical,
+        "metadata": metadata,
+        "max_matches": _resolve_subscription_max_matches(
+            max_matches=data.get("max_matches"),
+            notify_once=data.get("notify_once"),
+            metadata=metadata,
+        ),
+    }
+
+
+def _canonicalize_automation_state(state: dict[str, Any]) -> dict[str, Any]:
+    canonical = default_pma_automation_state()
+    canonical["version"] = int(state.get("version", PMA_AUTOMATION_VERSION) or 1)
+    canonical["updated_at"] = (
+        _normalize_text(state.get("updated_at")) or canonical["updated_at"]
+    )
+    canonical["subscriptions"] = [
+        _canonicalize_subscription_entry(entry)
+        for entry in (state.get("subscriptions") or [])
+        if isinstance(entry, dict)
+    ]
+    canonical["timers"] = [
+        dict(entry) for entry in (state.get("timers") or []) if isinstance(entry, dict)
+    ]
+    canonical["wakeups"] = [
+        dict(entry) for entry in (state.get("wakeups") or []) if isinstance(entry, dict)
+    ]
+    return canonical
+
+
 @dataclass
 class PmaLifecycleSubscription:
     subscription_id: str
@@ -93,15 +148,10 @@ class PmaLifecycleSubscription:
         to_state: Optional[str] = None,
         reason: Optional[str] = None,
         idempotency_key: Optional[str] = None,
-        notify_once: Optional[bool] = None,
         max_matches: Optional[int] = None,
         metadata: Optional[dict[str, Any]] = None,
     ) -> "PmaLifecycleSubscription":
         stamp = _iso_now()
-        resolved_once = _normalize_bool(notify_once, fallback=None)
-        resolved_max = _normalize_positive_int(max_matches, fallback=None)
-        if resolved_max is None and resolved_once:
-            resolved_max = 1
         return cls(
             subscription_id=str(uuid.uuid4()),
             created_at=stamp,
@@ -116,49 +166,46 @@ class PmaLifecycleSubscription:
             to_state=_normalize_text(to_state),
             reason=_normalize_text(reason),
             idempotency_key=_normalize_text(idempotency_key),
-            max_matches=resolved_max,
+            max_matches=_normalize_positive_int(max_matches, fallback=None),
             match_count=0,
             metadata=dict(metadata or {}),
         )
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "PmaLifecycleSubscription":
+        canonical = _canonicalize_subscription_entry(data)
         subscription_id = _normalize_text(data.get("subscription_id")) or str(
             uuid.uuid4()
         )
         created_at = _normalize_text(data.get("created_at")) or _iso_now()
         updated_at = _normalize_text(data.get("updated_at")) or created_at
         state = _normalize_text(data.get("state")) or "active"
-        max_matches = _normalize_positive_int(data.get("max_matches"), fallback=None)
-        if max_matches is None and _normalize_bool(
-            data.get("notify_once"), fallback=False
-        ):
-            max_matches = 1
-        match_count = _normalize_non_negative_int(data.get("match_count"), fallback=0)
+        max_matches = _normalize_positive_int(
+            canonical.get("max_matches"), fallback=None
+        )
+        match_count = _normalize_non_negative_int(
+            canonical.get("match_count"), fallback=0
+        )
         if match_count is None:
             match_count = 0
-        metadata_raw = data.get("metadata")
+        metadata_raw = canonical.get("metadata")
         metadata: dict[str, Any] = (
             dict(metadata_raw) if isinstance(metadata_raw, dict) else {}
         )
-        if max_matches is None and _normalize_bool(
-            metadata.get("notify_once"), fallback=False
-        ):
-            max_matches = 1
         return cls(
             subscription_id=subscription_id,
             created_at=created_at,
             updated_at=updated_at,
             state=state.lower(),
-            event_types=_normalize_text_list(data.get("event_types") or []),
-            repo_id=_normalize_text(data.get("repo_id")),
-            run_id=_normalize_text(data.get("run_id")),
-            thread_id=_normalize_text(data.get("thread_id")),
-            lane_id=_normalize_lane_id(data.get("lane_id")),
-            from_state=_normalize_text(data.get("from_state")),
-            to_state=_normalize_text(data.get("to_state")),
-            reason=_normalize_text(data.get("reason")),
-            idempotency_key=_normalize_text(data.get("idempotency_key")),
+            event_types=_normalize_text_list(canonical.get("event_types") or []),
+            repo_id=_normalize_text(canonical.get("repo_id")),
+            run_id=_normalize_text(canonical.get("run_id")),
+            thread_id=_normalize_text(canonical.get("thread_id")),
+            lane_id=_normalize_lane_id(canonical.get("lane_id")),
+            from_state=_normalize_text(canonical.get("from_state")),
+            to_state=_normalize_text(canonical.get("to_state")),
+            reason=_normalize_text(canonical.get("reason")),
+            idempotency_key=_normalize_text(canonical.get("idempotency_key")),
             max_matches=max_matches,
             match_count=int(match_count),
             metadata=metadata,
@@ -399,7 +446,10 @@ class PmaAutomationStore:
                 return state
             state = self._persistence._load_unlocked()
             if state is not None:
-                return state
+                canonical_state = _canonicalize_automation_state(state)
+                if canonical_state != state:
+                    self._persistence._save_unlocked(canonical_state)
+                return canonical_state
             state = default_pma_automation_state()
             self._persistence._save_unlocked(state)
             return state
@@ -1319,8 +1369,10 @@ class PmaAutomationStore:
                         to_state=to_state,
                         reason=reason,
                         idempotency_key=key,
-                        notify_once=notify_once,
-                        max_matches=max_matches,
+                        max_matches=_resolve_subscription_max_matches(
+                            max_matches=max_matches,
+                            notify_once=notify_once,
+                        ),
                         metadata=resolved_metadata,
                     )
                     self._insert_subscription_row(conn, created)

--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -84,15 +84,16 @@ def _canonicalize_subscription_entry(data: dict[str, Any]) -> dict[str, Any]:
     canonical.pop("notify_once", None)
     metadata_raw = data.get("metadata")
     metadata = dict(metadata_raw) if isinstance(metadata_raw, dict) else {}
+    resolved_max = _resolve_subscription_max_matches(
+        max_matches=data.get("max_matches"),
+        notify_once=data.get("notify_once"),
+        metadata=metadata,
+    )
     metadata.pop("notify_once", None)
     return {
         **canonical,
         "metadata": metadata,
-        "max_matches": _resolve_subscription_max_matches(
-            max_matches=data.get("max_matches"),
-            notify_once=data.get("notify_once"),
-            metadata=metadata,
-        ),
+        "max_matches": resolved_max,
     }
 
 

--- a/src/codex_autorunner/core/pma_hygiene.py
+++ b/src/codex_autorunner/core/pma_hygiene.py
@@ -198,22 +198,15 @@ def _build_thread_candidates(
         managed_thread_id = str(thread.get("managed_thread_id") or "").strip()
         if not managed_thread_id:
             continue
-        lifecycle_status = str(
-            thread.get("lifecycle_status") or thread.get("status") or ""
-        )
-        normalized_status = str(
-            thread.get("normalized_status") or thread.get("status") or ""
-        ).strip()
+        lifecycle_status = str(thread.get("lifecycle_status") or "")
+        normalized_status = str(thread.get("normalized_status") or "").strip()
         if lifecycle_status == "archived" or normalized_status == "archived":
             continue
         freshness = build_freshness_payload(
             generated_at=generated_at,
             stale_threshold_seconds=stale_threshold_seconds,
             candidates=[
-                (
-                    "thread_status_changed_at",
-                    thread.get("status_changed_at") or thread.get("status_updated_at"),
-                ),
+                ("thread_status_changed_at", thread.get("status_updated_at")),
                 ("thread_updated_at", thread.get("updated_at")),
             ],
         )
@@ -580,9 +573,7 @@ def _revalidate_managed_thread_cleanup(
     if not isinstance(thread, dict):
         return "managed thread no longer exists"
 
-    lifecycle_status = str(
-        thread.get("lifecycle_status") or thread.get("status") or ""
-    ).strip()
+    lifecycle_status = str(thread.get("lifecycle_status") or "").strip()
     normalized_status = str(thread.get("normalized_status") or "").strip()
     if lifecycle_status != "active":
         return f"managed thread lifecycle is {lifecycle_status or 'unknown'}"

--- a/src/codex_autorunner/core/pma_rendering.py
+++ b/src/codex_autorunner/core/pma_rendering.py
@@ -653,7 +653,7 @@ def _render_pma_threads_section(
             thread, max_field_chars=max_field_chars
         )
         agent = _field(thread, "agent", max_field_chars)
-        raw_status = str(thread.get("status") or "")
+        raw_status = str(thread.get("normalized_status") or thread.get("status") or "")
         precomputed = _field(thread, "operator_status", max_field_chars)
         if precomputed:
             status_display = precomputed
@@ -674,7 +674,8 @@ def _render_pma_threads_section(
             max_field_chars,
         )
         status_reason = _truncate(
-            str(thread.get("status_reason") or "-"), max_field_chars
+            str(thread.get("status_reason_code") or thread.get("status_reason") or "-"),
+            max_field_chars,
         )
         name = _field(thread, "name", max_field_chars) or "-"
         preview = _field(thread, "last_message_preview", max_field_chars) or "-"

--- a/src/codex_autorunner/core/pma_thread_classification.py
+++ b/src/codex_autorunner/core/pma_thread_classification.py
@@ -72,8 +72,14 @@ def classify_thread_followup(
     is_chat_bound: bool,
     is_self_thread: bool = False,
 ) -> dict[str, Any]:
-    status = str(entry.get("status") or "").strip().lower()
-    status_reason = str(entry.get("status_reason") or "").strip().lower()
+    status = (
+        str(entry.get("normalized_status") or entry.get("status") or "").strip().lower()
+    )
+    status_reason = (
+        str(entry.get("status_reason_code") or entry.get("status_reason") or "")
+        .strip()
+        .lower()
+    )
     last_turn_id = str(entry.get("last_turn_id") or "").strip()
 
     if status == "running":

--- a/src/codex_autorunner/core/pma_thread_mirror.py
+++ b/src/codex_autorunner/core/pma_thread_mirror.py
@@ -97,7 +97,7 @@ def sync_legacy_mirror(
                         legacy["workspace_root"],
                         legacy["name"],
                         canonical_backend_thread_id,
-                        legacy["status"],
+                        legacy["lifecycle_status"],
                         legacy["normalized_status"],
                         legacy["status_reason_code"],
                         legacy["status_updated_at"],

--- a/src/codex_autorunner/core/pma_thread_snapshot.py
+++ b/src/codex_autorunner/core/pma_thread_snapshot.py
@@ -61,13 +61,11 @@ def snapshot_pma_threads(
             "resource_id": thread.get("resource_id"),
             "workspace_root": workspace_root,
             "name": thread.get("name"),
-            "status": thread.get("normalized_status") or thread.get("status"),
-            "lifecycle_status": thread.get("lifecycle_status") or thread.get("status"),
-            "status_reason": thread.get("status_reason")
-            or thread.get("status_reason_code"),
+            "status": thread.get("normalized_status"),
+            "lifecycle_status": thread.get("lifecycle_status"),
+            "status_reason": thread.get("status_reason_code"),
             "status_terminal": bool(thread.get("status_terminal")),
-            "status_changed_at": thread.get("status_changed_at")
-            or thread.get("status_updated_at"),
+            "status_changed_at": thread.get("status_updated_at"),
             "last_turn_id": thread.get("last_turn_id"),
             "last_message_preview": _truncate(
                 str(thread.get("last_message_preview") or ""),

--- a/src/codex_autorunner/core/pma_thread_store_rows.py
+++ b/src/codex_autorunner/core/pma_thread_store_rows.py
@@ -226,6 +226,26 @@ def enrich_thread_metadata_for_workspace(
     return payload
 
 
+def _canonicalize_thread_mapping(data: Mapping[str, Any]) -> dict[str, Any]:
+    record = dict(data)
+    lifecycle_status = (
+        coerce_text(record.get("lifecycle_status") or record.get("status")) or "active"
+    )
+    return {
+        **record,
+        "lifecycle_status": lifecycle_status,
+        "normalized_status": coerce_text(record.get("normalized_status")),
+        "status_reason_code": coerce_text(
+            record.get("status_reason_code") or record.get("status_reason")
+        ),
+        "status_updated_at": coerce_text(
+            record.get("status_updated_at") or record.get("status_changed_at")
+        ),
+        "status_terminal": bool(record.get("status_terminal")),
+        "status_turn_id": coerce_text(record.get("status_turn_id")),
+    }
+
+
 @dataclass(frozen=True)
 class PmaThreadRecord:
     managed_thread_id: str
@@ -235,13 +255,10 @@ class PmaThreadRecord:
     resource_id: Optional[str]
     workspace_root: str
     name: Optional[str]
-    status: str
     lifecycle_status: str
     normalized_status: str
     status_reason_code: Optional[str]
-    status_reason: Optional[str]
     status_updated_at: Optional[str]
-    status_changed_at: Optional[str]
     status_terminal: bool
     status_turn_id: Optional[str]
     last_turn_id: Optional[str]
@@ -253,13 +270,8 @@ class PmaThreadRecord:
 
     @classmethod
     def from_store_mapping(cls, data: Mapping[str, Any]) -> "PmaThreadRecord":
-        record = dict(data)
-        lifecycle_status = (
-            coerce_text(record.get("lifecycle_status") or record.get("status"))
-            or "active"
-        )
-        record["status"] = lifecycle_status
-        record["lifecycle_status"] = lifecycle_status
+        record = _canonicalize_thread_mapping(data)
+        lifecycle_status = str(record["lifecycle_status"])
         snapshot = ManagedThreadStatusSnapshot.from_mapping(record)
         raw_metadata = record.get("metadata")
         metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
@@ -285,13 +297,10 @@ class PmaThreadRecord:
             resource_id=resource_id,
             workspace_root=workspace_root,
             name=coerce_text(record.get("name") or record.get("display_name")),
-            status=lifecycle_status,
             lifecycle_status=lifecycle_status,
             normalized_status=snapshot.status,
             status_reason_code=snapshot.reason_code,
-            status_reason=snapshot.reason_code,
             status_updated_at=snapshot.changed_at,
-            status_changed_at=snapshot.changed_at,
             status_terminal=bool(snapshot.terminal),
             status_turn_id=coerce_text(record.get("status_turn_id"))
             or snapshot.turn_id,
@@ -345,7 +354,26 @@ class PmaThreadRecord:
         return asdict(self)
 
     def to_thread_target(self) -> ThreadTarget:
-        return ThreadTarget.from_mapping(self.to_dict())
+        return ThreadTarget(
+            thread_target_id=self.managed_thread_id,
+            agent_id=self.agent,
+            repo_id=self.repo_id,
+            resource_kind=self.resource_kind,
+            resource_id=self.resource_id,
+            workspace_root=self.workspace_root,
+            display_name=self.name,
+            status=self.normalized_status,
+            lifecycle_status=self.lifecycle_status,
+            status_reason=self.status_reason_code,
+            status_changed_at=self.status_updated_at,
+            status_terminal=self.status_terminal,
+            status_turn_id=self.status_turn_id,
+            last_execution_id=self.last_turn_id,
+            last_message_preview=self.last_message_preview,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+            compact_seed=self.compact_seed,
+        )
 
 
 @dataclass(frozen=True)

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -230,9 +230,7 @@ def _active_thread_record(
     thread = store.get_thread(normalized_thread_target_id)
     if thread is None:
         return None, None
-    lifecycle_status = _normalize_optional_text(
-        thread.get("lifecycle_status") or thread.get("status")
-    )
+    lifecycle_status = _normalize_optional_text(thread.get("lifecycle_status"))
     if lifecycle_status != "active":
         return None, thread
     return normalized_thread_target_id, thread

--- a/src/codex_autorunner/integrations/github/polling_discovery.py
+++ b/src/codex_autorunner/integrations/github/polling_discovery.py
@@ -57,7 +57,7 @@ def thread_has_pr_open_hint(thread: Mapping[str, Any]) -> bool:
     for context in thread_contexts(metadata):
         if _pr_hint_present_in_context(context):
             return True
-    for key in ("status_reason", "last_message_preview"):
+    for key in ("status_reason_code", "status_reason", "last_message_preview"):
         value = _normalize_lower_text(thread.get(key))
         if value is None:
             continue
@@ -103,7 +103,11 @@ def is_recent_terminal_thread_candidate(
         return False
     if thread_has_pr_open_hint(thread):
         return True
-    status_reason = _normalize_lower_text(thread.get("status_reason")) or ""
+    status_reason = (
+        _normalize_lower_text(thread.get("status_reason_code"))
+        or _normalize_lower_text(thread.get("status_reason"))
+        or ""
+    )
     if status_reason in {"managed_turn_completed", "completed"}:
         return thread_head_branch_hint(thread) is not None
     return False

--- a/src/codex_autorunner/surfaces/cli/pma_thread_commands.py
+++ b/src/codex_autorunner/surfaces/cli/pma_thread_commands.py
@@ -534,7 +534,12 @@ class _PmaThreadStatusSnapshot:
         thread: dict[str, Any] = raw_thread if isinstance(raw_thread, dict) else {}
         raw_turn = payload.get("turn")
         turn: dict[str, Any] = raw_turn if isinstance(raw_turn, dict) else {}
-        raw_thread_status = str(payload.get("status") or thread.get("status") or "-")
+        raw_thread_status = str(
+            payload.get("status")
+            or thread.get("normalized_status")
+            or thread.get("status")
+            or "-"
+        )
         queue_depth_raw = payload.get("queue_depth")
         recent_progress = payload.get("recent_progress")
         queued_turns = payload.get("queued_turns")
@@ -553,7 +558,11 @@ class _PmaThreadStatusSnapshot:
             ),
             is_alive=bool(payload.get("is_alive")),
             status_reason=str(
-                payload.get("status_reason") or thread.get("status_reason") or "-"
+                payload.get("status_reason")
+                or payload.get("status_reason_code")
+                or thread.get("status_reason_code")
+                or thread.get("status_reason")
+                or "-"
             ),
             managed_turn_id=str(turn.get("managed_turn_id") or "-"),
             turn_state=str(turn.get("status") or "-"),
@@ -681,8 +690,8 @@ def _thread_compact_target_line(thread: dict[str, Any]) -> str:
     parts = [
         str(thread.get("managed_thread_id") or ""),
         f"agent={thread.get('agent') or ''}",
-        f"status={thread.get('status') or ''}",
-        f"reason={thread.get('status_reason') or '-'}",
+        f"status={thread.get('normalized_status') or thread.get('status') or ''}",
+        f"reason={thread.get('status_reason_code') or thread.get('status_reason') or '-'}",
         _format_resource_owner_label(thread),
     ]
     if bool(thread.get("chat_bound")):
@@ -973,8 +982,8 @@ def pma_thread_list(
                 [
                     str(thread.get("managed_thread_id") or ""),
                     f"agent={thread.get('agent') or ''}",
-                    f"status={thread.get('status') or ''}",
-                    f"reason={thread.get('status_reason') or '-'}",
+                    f"status={thread.get('normalized_status') or thread.get('status') or ''}",
+                    f"reason={thread.get('status_reason_code') or thread.get('status_reason') or '-'}",
                     _format_resource_owner_label(thread),
                 ]
             ).strip()
@@ -1537,7 +1546,10 @@ def pma_thread_compact(
                 for thread in threads
                 if str(thread.get("lifecycle_status") or "").strip().lower()
                 != "archived"
-                and str(thread.get("status") or "").strip().lower() != "archived"
+                and str(thread.get("normalized_status") or thread.get("status") or "")
+                .strip()
+                .lower()
+                != "archived"
             ]
 
         target_ids = [

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -748,7 +748,7 @@ def build_managed_thread_runtime_routes(
             service=service,
         )
 
-        if (thread.get("status") or "") == "archived":
+        if str(thread.get("lifecycle_status") or "").strip().lower() == "archived":
             return JSONResponse(
                 status_code=409,
                 content=build_archived_thread_payload(

--- a/tests/core/test_pma_automation_store.py
+++ b/tests/core/test_pma_automation_store.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import json
 import logging
 
 import pytest
 
 from codex_autorunner.core.orchestration import OrchestrationBindingStore
+from codex_autorunner.core.pma_automation_persistence import PmaAutomationPersistence
 from codex_autorunner.core.pma_automation_store import (
     PmaAutomationStore,
     PmaAutomationThreadNotFoundError,
 )
+from codex_autorunner.core.pma_automation_types import default_pma_automation_state
 from codex_autorunner.core.pma_thread_store import (
     PmaThreadStore,
     prepare_pma_thread_store,
@@ -536,6 +539,38 @@ def test_notify_once_subscription_cancels_after_first_match(tmp_path) -> None:
     )
     assert second["matched"] == 0
     assert second["created"] == 0
+
+
+def test_load_migrates_legacy_notify_once_json_to_canonical_max_matches(
+    tmp_path,
+) -> None:
+    persistence = PmaAutomationPersistence(tmp_path)
+    legacy_state = default_pma_automation_state()
+    legacy_state["subscriptions"] = [
+        {
+            "subscription_id": "sub-1",
+            "created_at": "2026-03-13T00:00:00Z",
+            "updated_at": "2026-03-13T00:00:00Z",
+            "state": "active",
+            "event_types": ["managed_thread_completed"],
+            "thread_id": "thread-1",
+            "lane_id": "pma:lane-next",
+            "notify_once": True,
+            "metadata": {"notify_once": True, "source": "legacy"},
+        }
+    ]
+    persistence.save(legacy_state)
+
+    state = PmaAutomationStore(tmp_path).load()
+
+    assert state["subscriptions"][0]["max_matches"] == 1
+    assert "notify_once" not in state["subscriptions"][0]
+    assert state["subscriptions"][0]["metadata"] == {"source": "legacy"}
+
+    persisted = json.loads(persistence.path.read_text(encoding="utf-8"))
+    assert persisted["subscriptions"][0]["max_matches"] == 1
+    assert "notify_once" not in persisted["subscriptions"][0]
+    assert persisted["subscriptions"][0]["metadata"] == {"source": "legacy"}
 
 
 def test_timer_rejects_invalid_due_at_timestamp(tmp_path) -> None:

--- a/tests/core/test_pma_automation_store.py
+++ b/tests/core/test_pma_automation_store.py
@@ -573,6 +573,33 @@ def test_load_migrates_legacy_notify_once_json_to_canonical_max_matches(
     assert persisted["subscriptions"][0]["metadata"] == {"source": "legacy"}
 
 
+def test_load_migrates_notify_once_from_metadata_only_to_max_matches(
+    tmp_path,
+) -> None:
+    """Regression: metadata.notify_once must migrate even without a top-level key."""
+    persistence = PmaAutomationPersistence(tmp_path)
+    legacy_state = default_pma_automation_state()
+    legacy_state["subscriptions"] = [
+        {
+            "subscription_id": "sub-1",
+            "created_at": "2026-03-13T00:00:00Z",
+            "updated_at": "2026-03-13T00:00:00Z",
+            "state": "active",
+            "event_types": ["managed_thread_completed"],
+            "thread_id": "thread-1",
+            "lane_id": "pma:lane-next",
+            "metadata": {"notify_once": True, "source": "legacy"},
+        }
+    ]
+    persistence.save(legacy_state)
+
+    state = PmaAutomationStore(tmp_path).load()
+
+    assert state["subscriptions"][0]["max_matches"] == 1
+    assert "notify_once" not in state["subscriptions"][0]
+    assert state["subscriptions"][0]["metadata"] == {"source": "legacy"}
+
+
 def test_timer_rejects_invalid_due_at_timestamp(tmp_path) -> None:
     store = PmaAutomationStore(tmp_path)
     with pytest.raises(ValueError):

--- a/tests/core/test_pma_hygiene.py
+++ b/tests/core/test_pma_hygiene.py
@@ -259,7 +259,7 @@ def test_apply_pma_hygiene_report_can_include_reviewed_thread_cleanup(hub_env) -
 
     blocked = apply_pma_hygiene_report(hub_root, report)
     assert blocked["attempted"] == 0
-    assert thread_store.get_thread(managed_thread_id)["status"] == "active"
+    assert thread_store.get_thread(managed_thread_id)["lifecycle_status"] == "active"
 
     applied = apply_pma_hygiene_report(
         hub_root, report, include_needs_confirmation=True
@@ -269,7 +269,7 @@ def test_apply_pma_hygiene_report_can_include_reviewed_thread_cleanup(hub_env) -
     assert applied["reviewed_attempted"] == 1
     assert applied["applied"] == 1
     assert applied["failed"] == 0
-    assert thread_store.get_thread(managed_thread_id)["status"] == "archived"
+    assert thread_store.get_thread(managed_thread_id)["lifecycle_status"] == "archived"
 
 
 def test_apply_pma_hygiene_report_revalidates_reviewed_thread_binding(hub_env) -> None:
@@ -303,7 +303,7 @@ def test_apply_pma_hygiene_report_revalidates_reviewed_thread_binding(hub_env) -
         applied["results"][0]["error"]
         == "Managed thread cleanup no longer safe: managed thread has an active binding"
     )
-    assert thread_store.get_thread(managed_thread_id)["status"] == "active"
+    assert thread_store.get_thread(managed_thread_id)["lifecycle_status"] == "active"
 
 
 def test_apply_pma_hygiene_report_revalidates_reviewed_thread_busy_state(
@@ -333,7 +333,7 @@ def test_apply_pma_hygiene_report_revalidates_reviewed_thread_busy_state(
         applied["results"][0]["error"]
         == "Managed thread cleanup no longer safe: managed thread has running work"
     )
-    assert thread_store.get_thread(managed_thread_id)["status"] == "active"
+    assert thread_store.get_thread(managed_thread_id)["lifecycle_status"] == "active"
 
 
 def test_apply_pma_hygiene_report_revalidates_reviewed_thread_lifecycle(
@@ -363,7 +363,7 @@ def test_apply_pma_hygiene_report_revalidates_reviewed_thread_lifecycle(
         applied["results"][0]["error"]
         == "Managed thread cleanup no longer safe: managed thread lifecycle is archived"
     )
-    assert thread_store.get_thread(managed_thread_id)["status"] == "archived"
+    assert thread_store.get_thread(managed_thread_id)["lifecycle_status"] == "archived"
 
 
 def test_build_pma_hygiene_report_canonicalizes_category_order(hub_env) -> None:

--- a/tests/integrations/github/test_polling_discovery.py
+++ b/tests/integrations/github/test_polling_discovery.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from codex_autorunner.integrations.github.polling_discovery import (
+    is_recent_terminal_thread_candidate,
+    thread_has_pr_open_hint,
+)
+
+
+def _parse_optional_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def test_is_recent_terminal_thread_candidate_reads_status_reason_code() -> None:
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    cutoff = now - timedelta(hours=1)
+    thread = {
+        "status_terminal": True,
+        "status_updated_at": now.isoformat().replace("+00:00", "Z"),
+        "status_reason_code": "managed_turn_completed",
+        "metadata": {"head_branch": "feature/foo"},
+    }
+    assert is_recent_terminal_thread_candidate(
+        thread, cutoff=cutoff, parse_optional_iso=_parse_optional_iso
+    )
+
+
+def test_is_recent_terminal_thread_candidate_legacy_status_reason_fallback() -> None:
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    cutoff = now - timedelta(hours=1)
+    thread = {
+        "status_terminal": True,
+        "status_updated_at": now.isoformat().replace("+00:00", "Z"),
+        "status_reason": "managed_turn_completed",
+        "metadata": {"head_branch": "feature/foo"},
+    }
+    assert is_recent_terminal_thread_candidate(
+        thread, cutoff=cutoff, parse_optional_iso=_parse_optional_iso
+    )
+
+
+def test_thread_has_pr_open_hint_scans_status_reason_code() -> None:
+    thread = {
+        "status_reason_code": "see https://github.com/org/repo/pull/42 for details",
+    }
+    assert thread_has_pr_open_hint(thread) is True

--- a/tests/pma_context_support.py
+++ b/tests/pma_context_support.py
@@ -3131,14 +3131,7 @@ class TestIssue975CharacterizationManagedThreadPayload:
     """
 
     def test_pma_thread_payload_includes_all_status_fields(self, hub_env) -> None:
-        """Document that managed thread payloads include all status fields.
-
-        Note: The 'status' field contains lifecycle_status (e.g., 'active'),
-        while 'normalized_status' contains the runtime status (e.g., 'idle').
-        This baseline documents the status model where:
-        - status == lifecycle_status (machine-level lifecycle)
-        - normalized_status == runtime status (operator-facing runtime state)
-        """
+        """Document the canonical managed-thread store payload."""
         store = PmaThreadStore(hub_env.hub_root)
         thread = store.create_thread(
             "codex",
@@ -3148,11 +3141,12 @@ class TestIssue975CharacterizationManagedThreadPayload:
         )
 
         assert "managed_thread_id" in thread
-        assert thread["status"] == "active"
         assert thread["lifecycle_status"] == "active"
         assert thread["normalized_status"] == "idle"
-        assert thread["status_reason"] == "thread_created"
+        assert thread["status_reason_code"] == "thread_created"
         assert thread["status_terminal"] is False
+        assert "status" not in thread
+        assert "status_reason" not in thread
 
     def test_completed_thread_shows_completed_normalized_status_with_active_lifecycle(
         self, hub_env
@@ -3185,7 +3179,6 @@ class TestIssue975CharacterizationManagedThreadPayload:
         )
 
         updated = store.get_thread(thread_id)
-        assert updated["status"] == "active"
         assert updated["lifecycle_status"] == "active"
         assert updated["normalized_status"] == "completed"
         assert updated["status_terminal"] is True

--- a/tests/test_cli_ticket_flow_archive.py
+++ b/tests/test_cli_ticket_flow_archive.py
@@ -276,10 +276,20 @@ def test_ticket_flow_archive_also_archives_ticket_flow_pma_threads(
             legacy["managed_thread_id"],
         ]
     )
-    assert store.get_thread(matching["managed_thread_id"])["status"] == "archived"
-    assert store.get_thread(legacy["managed_thread_id"])["status"] == "archived"
-    assert store.get_thread(other_run["managed_thread_id"])["status"] == "active"
-    assert store.get_thread(non_ticket_flow["managed_thread_id"])["status"] == "active"
+    assert (
+        store.get_thread(matching["managed_thread_id"])["lifecycle_status"]
+        == "archived"
+    )
+    assert (
+        store.get_thread(legacy["managed_thread_id"])["lifecycle_status"] == "archived"
+    )
+    assert (
+        store.get_thread(other_run["managed_thread_id"])["lifecycle_status"] == "active"
+    )
+    assert (
+        store.get_thread(non_ticket_flow["managed_thread_id"])["lifecycle_status"]
+        == "active"
+    )
 
 
 def test_ticket_flow_archive_skips_pma_archival_without_hub_manifest(

--- a/tests/test_pma_managed_threads_lifecycle.py
+++ b/tests/test_pma_managed_threads_lifecycle.py
@@ -141,9 +141,9 @@ def test_managed_thread_compact_archive_resume_lifecycle(hub_env) -> None:
 
         archived_thread = store.get_thread(managed_thread_id)
         assert archived_thread is not None
-        assert archived_thread["status"] == "archived"
+        assert archived_thread["lifecycle_status"] == "archived"
         assert archived_thread["normalized_status"] == "archived"
-        assert archived_thread["status_reason"] == "thread_archived"
+        assert archived_thread["status_reason_code"] == "thread_archived"
 
         blocked = client.post(
             f"/hub/pma/threads/{managed_thread_id}/messages",
@@ -158,9 +158,9 @@ def test_managed_thread_compact_archive_resume_lifecycle(hub_env) -> None:
 
         resumed_thread = store.get_thread(managed_thread_id)
         assert resumed_thread is not None
-        assert resumed_thread["status"] == "active"
+        assert resumed_thread["lifecycle_status"] == "active"
         assert resumed_thread["normalized_status"] == "idle"
-        assert resumed_thread["status_reason"] == "thread_resumed"
+        assert resumed_thread["status_reason_code"] == "thread_resumed"
         assert resumed_thread.get("backend_thread_id") is None
 
         prior_thread_start_count = fake_supervisor.client.thread_start_calls

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -37,10 +37,10 @@ def test_create_list_get_thread(tmp_path: Path) -> None:
     )
 
     assert store.path == default_pma_threads_db_path(hub_root)
-    assert created["status"] == "active"
     assert created["lifecycle_status"] == "active"
     assert created["normalized_status"] == "idle"
-    assert created["status_reason"] == "thread_created"
+    assert created["status_reason_code"] == "thread_created"
+    assert "status" not in created
     assert created["status_terminal"] is False
     assert created["repo_id"] == "repo-123"
     assert created["name"] == "Primary"
@@ -268,7 +268,7 @@ def test_create_finish_turn_and_query(tmp_path: Path) -> None:
     thread_after = store.get_thread(thread["managed_thread_id"])
     assert thread_after is not None
     assert thread_after["normalized_status"] == "completed"
-    assert thread_after["status_reason"] == "managed_turn_completed"
+    assert thread_after["status_reason_code"] == "managed_turn_completed"
     assert thread_after["status_terminal"] is True
 
 
@@ -968,7 +968,7 @@ def test_mark_turn_finished_does_not_override_interrupted_status(
     thread_after = store.get_thread(thread["managed_thread_id"])
     assert thread_after is not None
     assert thread_after["normalized_status"] == "interrupted"
-    assert thread_after["status_reason"] == "managed_turn_interrupted"
+    assert thread_after["status_reason_code"] == "managed_turn_interrupted"
     assert thread_after["status_terminal"] is True
 
 
@@ -1015,10 +1015,9 @@ def test_archive_thread_changes_status(tmp_path: Path) -> None:
 
     archived = store.get_thread(thread["managed_thread_id"])
     assert archived is not None
-    assert archived["status"] == "archived"
     assert archived["lifecycle_status"] == "archived"
     assert archived["normalized_status"] == "archived"
-    assert archived["status_reason"] == "thread_archived"
+    assert archived["status_reason_code"] == "thread_archived"
     assert archived["status_terminal"] is True
 
 
@@ -1106,20 +1105,20 @@ def test_transient_failure_recovery_promotes_status_back_to_completed(
     failed_thread = store.get_thread(thread["managed_thread_id"])
     assert failed_thread is not None
     assert failed_thread["normalized_status"] == "failed"
-    assert failed_thread["status_reason"] == "managed_turn_failed"
+    assert failed_thread["status_reason_code"] == "managed_turn_failed"
 
     second_turn = store.create_turn(thread["managed_thread_id"], prompt="retry")
     running_thread = store.get_thread(thread["managed_thread_id"])
     assert running_thread is not None
     assert running_thread["normalized_status"] == "running"
-    assert running_thread["status_reason"] == "turn_started"
+    assert running_thread["status_reason_code"] == "turn_started"
     assert running_thread["status_terminal"] is False
 
     assert store.mark_turn_finished(second_turn["managed_turn_id"], status="ok") is True
     recovered_thread = store.get_thread(thread["managed_thread_id"])
     assert recovered_thread is not None
     assert recovered_thread["normalized_status"] == "completed"
-    assert recovered_thread["status_reason"] == "managed_turn_completed"
+    assert recovered_thread["status_reason_code"] == "managed_turn_completed"
     assert recovered_thread["status_terminal"] is True
 
 
@@ -1132,10 +1131,9 @@ def test_archive_then_activate_restores_ready_status(tmp_path: Path) -> None:
 
     resumed = store.get_thread(thread["managed_thread_id"])
     assert resumed is not None
-    assert resumed["status"] == "active"
     assert resumed["lifecycle_status"] == "active"
     assert resumed["normalized_status"] == "idle"
-    assert resumed["status_reason"] == "thread_resumed"
+    assert resumed["status_reason_code"] == "thread_resumed"
     assert resumed["status_terminal"] is False
 
 
@@ -1147,14 +1145,14 @@ def test_duplicate_completion_event_is_idempotent(tmp_path: Path) -> None:
     assert store.mark_turn_finished(turn["managed_turn_id"], status="ok") is True
     first_thread = store.get_thread(thread["managed_thread_id"])
     assert first_thread is not None
-    first_changed_at = first_thread["status_changed_at"]
+    first_changed_at = first_thread["status_updated_at"]
 
     assert store.mark_turn_finished(turn["managed_turn_id"], status="ok") is False
     second_thread = store.get_thread(thread["managed_thread_id"])
     assert second_thread is not None
     assert second_thread["normalized_status"] == "completed"
-    assert second_thread["status_reason"] == "managed_turn_completed"
-    assert second_thread["status_changed_at"] == first_changed_at
+    assert second_thread["status_reason_code"] == "managed_turn_completed"
+    assert second_thread["status_updated_at"] == first_changed_at
 
 
 def test_schema_creation_is_idempotent(tmp_path: Path) -> None:
@@ -1209,15 +1207,41 @@ def test_thread_record_normalizes_legacy_status_aliases(tmp_path: Path) -> None:
     assert row is not None
     record = PmaThreadRecord.from_orchestration_row(row).to_dict()
 
-    assert record["status"] == "active"
     assert record["lifecycle_status"] == "active"
     assert record["normalized_status"] == "idle"
     assert record["status_reason_code"] == "thread_created"
-    assert record["status_reason"] == "thread_created"
     assert record["status_updated_at"] == created["status_updated_at"]
-    assert record["status_changed_at"] == created["status_changed_at"]
+    assert "status" not in record
+    assert "status_reason" not in record
+    assert "status_changed_at" not in record
     assert record["status_terminal"] is False
     assert record["metadata"]["head_branch"] == "feature/demo"
+
+
+def test_thread_record_migrates_alias_only_status_fields_to_canonical_schema() -> None:
+    record = PmaThreadRecord.from_store_mapping(
+        {
+            "managed_thread_id": "thread-1",
+            "agent": "codex",
+            "workspace_root": "/tmp/workspace",
+            "status": "active",
+            "normalized_status": "completed",
+            "status_reason": "managed_turn_completed",
+            "status_changed_at": "2026-03-08T00:00:20Z",
+            "status_terminal": True,
+            "status_turn_id": "turn-1",
+        }
+    ).to_dict()
+
+    assert record["lifecycle_status"] == "active"
+    assert record["normalized_status"] == "completed"
+    assert record["status_reason_code"] == "managed_turn_completed"
+    assert record["status_updated_at"] == "2026-03-08T00:00:20Z"
+    assert record["status_turn_id"] == "turn-1"
+    assert record["status_terminal"] is True
+    assert "status" not in record
+    assert "status_reason" not in record
+    assert "status_changed_at" not in record
 
 
 def test_concurrentish_writes_smoke(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- remove managed-thread status compatibility aliases from the core PMA thread record and make the store/domain layer use a single canonical schema
- move legacy translation to migration/load boundaries, including canonicalizing legacy automation `notify_once` state into `max_matches`
- update PMA consumers and contract tests so legacy thread/automation inputs still migrate cleanly while canonical outputs stay stable

## Why
Issue #1566 calls for a canonical managed-thread domain schema with no compatibility aliases in the core model layer. Before this change, PMA thread records and automation state accepted and emitted overlapping alias fields, which kept old shapes alive across the domain boundary and made migration behavior implicit.

## Impact
- core PMA managed-thread records now expose canonical fields only (`lifecycle_status`, `normalized_status`, `status_reason_code`, `status_updated_at`)
- legacy PMA thread and automation shapes are normalized at the migration/load boundary instead of being carried through the core domain model
- PMA snapshots and route helpers continue projecting the edge payloads they need without depending on alias-heavy store rows

## Validation
- `pytest -q tests/test_pma_thread_store.py tests/core/test_pma_automation_store.py tests/core/test_managed_thread_status.py tests/core/orchestration/test_legacy_state_backfill.py tests/core/test_pma_persistence_invariants.py tests/core/test_pma_hygiene.py tests/surfaces/web/routes/pma_routes/test_managed_thread_route_helpers.py`
- `pytest -q tests/test_cli_ticket_flow_archive.py tests/test_pma_context_issue975.py tests/test_pma_managed_threads_lifecycle.py`
- `ruff check src/codex_autorunner/core/managed_thread_status.py src/codex_autorunner/core/pma_automation_store.py src/codex_autorunner/core/pma_hygiene.py src/codex_autorunner/core/pma_thread_mirror.py src/codex_autorunner/core/pma_thread_snapshot.py src/codex_autorunner/core/pma_thread_store_rows.py src/codex_autorunner/core/publish_operation_executors.py tests/core/test_pma_automation_store.py tests/core/test_pma_hygiene.py tests/test_pma_thread_store.py tests/test_cli_ticket_flow_archive.py tests/pma_context_support.py tests/test_pma_managed_threads_lifecycle.py`
- `black src/codex_autorunner/core/managed_thread_status.py src/codex_autorunner/core/pma_automation_store.py src/codex_autorunner/core/pma_hygiene.py src/codex_autorunner/core/pma_thread_mirror.py src/codex_autorunner/core/pma_thread_snapshot.py src/codex_autorunner/core/pma_thread_store_rows.py src/codex_autorunner/core/publish_operation_executors.py tests/core/test_pma_automation_store.py tests/core/test_pma_hygiene.py tests/test_pma_thread_store.py tests/test_cli_ticket_flow_archive.py tests/pma_context_support.py tests/test_pma_managed_threads_lifecycle.py`

Closes #1566.