### PR TITLE
Fix PMA managed thread timeout semantics

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime.py
@@ -137,6 +137,36 @@ async def _register_pma_result_future(
     return result_future
 
 
+async def _await_pma_result_future(
+    runtime: PmaRuntimeState,
+    queue: Any,
+    *,
+    lane_id: str,
+    item_id: str,
+    result_future: asyncio.Future[dict[str, Any]],
+    poll_interval_seconds: float = 0.25,
+) -> dict[str, Any]:
+    while True:
+        if result_future.done():
+            return await result_future
+        worker = runtime.lane_workers.get(lane_id)
+        if worker is None or not worker.is_running:
+            late_result = await _resolve_terminal_queue_item_result(
+                queue,
+                lane_id=lane_id,
+                item_id=item_id,
+            )
+            if late_result is not None:
+                if not result_future.done():
+                    result_future.set_result(late_result)
+                return late_result
+            return {
+                "status": "error",
+                "detail": "PMA lane worker stopped before delivering a result",
+            }
+        await asyncio.sleep(max(0.05, float(poll_interval_seconds)))
+
+
 def _build_idempotency_key(
     *,
     lane_id: str,
@@ -405,12 +435,13 @@ def build_chat_runtime_router(
         )
 
         try:
-            result = await asyncio.wait_for(
-                result_future,
-                timeout=_pma_turn_idle_timeout_seconds(request),
+            result = await _await_pma_result_future(
+                runtime,
+                queue,
+                lane_id=lane_id,
+                item_id=item.item_id,
+                result_future=result_future,
             )
-        except asyncio.TimeoutError:
-            return {"status": "error", "detail": "PMA chat timed out"}
         except Exception:
             logger.exception("PMA chat error")
             return {

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -383,11 +383,14 @@ async def _run_managed_thread_execution(
 
 
 def _pma_finalization_errors(request: Request) -> ManagedThreadErrorMessages:
+    timeout_seconds = _pma_turn_idle_timeout_seconds(request)
     return ManagedThreadErrorMessages(
         public_execution_error=MANAGED_THREAD_PUBLIC_EXECUTION_ERROR,
         timeout_error="PMA chat timed out",
         interrupted_error="PMA chat interrupted",
-        timeout_seconds=_pma_turn_idle_timeout_seconds(request),
+        timeout_seconds=timeout_seconds,
+        stall_timeout_seconds=timeout_seconds,
+        idle_timeout_only=True,
     )
 
 

--- a/tests/test_pma_turn_timeouts.py
+++ b/tests/test_pma_turn_timeouts.py
@@ -107,6 +107,24 @@ def test_web_pma_turn_idle_timeout_reads_request_config() -> None:
     assert managed_thread_runtime._pma_turn_idle_timeout_seconds(request) == 345
 
 
+def test_web_managed_thread_pma_surface_uses_idle_timeout_only() -> None:
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                config=SimpleNamespace(
+                    pma=SimpleNamespace(turn_idle_timeout_seconds=345)
+                )
+            )
+        )
+    )
+
+    errors = managed_thread_runtime._pma_finalization_errors(request)
+
+    assert errors.timeout_seconds == 345.0
+    assert errors.stall_timeout_seconds == 345.0
+    assert errors.idle_timeout_only is True
+
+
 class TestPmaTimeoutIsolationInvariants:
     def test_discord_pma_surface_uses_hub_config_timeout(self, tmp_path: Path) -> None:
         _write_hub_config(tmp_path, timeout_seconds=42)

--- a/tests/test_pma_turn_timeouts.py
+++ b/tests/test_pma_turn_timeouts.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
 from codex_autorunner.integrations.discord import message_turns as discord_message_turns
@@ -123,6 +126,55 @@ def test_web_managed_thread_pma_surface_uses_idle_timeout_only() -> None:
     assert errors.timeout_seconds == 345.0
     assert errors.stall_timeout_seconds == 345.0
     assert errors.idle_timeout_only is True
+
+
+@pytest.mark.anyio
+async def test_web_pma_chat_waits_for_result_without_wall_clock_timeout() -> None:
+    result_future: asyncio.Future[dict[str, str]] = (
+        asyncio.get_running_loop().create_future()
+    )
+    result_future.set_result({"status": "ok"})
+    runtime = SimpleNamespace(lane_workers={})
+    queue = SimpleNamespace()
+
+    result = await chat_runtime._await_pma_result_future(
+        runtime,
+        queue,
+        lane_id="pma:default",
+        item_id="item-1",
+        result_future=result_future,  # type: ignore[arg-type]
+    )
+
+    assert result == {"status": "ok"}
+
+
+@pytest.mark.anyio
+async def test_web_pma_chat_returns_worker_stopped_error_when_no_result(
+    monkeypatch,
+) -> None:
+    future = SimpleNamespace(done=lambda: False)
+    runtime = SimpleNamespace(
+        lane_workers={"pma:default": SimpleNamespace(is_running=False)}
+    )
+    queue = SimpleNamespace()
+
+    async def _no_late_result(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        chat_runtime, "_resolve_terminal_queue_item_result", _no_late_result
+    )
+
+    result = await chat_runtime._await_pma_result_future(
+        runtime,
+        queue,
+        lane_id="pma:default",
+        item_id="item-1",
+        result_future=future,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "error"
+    assert "lane worker stopped" in result["detail"]
 
 
 class TestPmaTimeoutIsolationInvariants:


### PR DESCRIPTION
## Summary
- switch PMA web managed-thread finalization to idle/stall timeout semantics instead of a hard 30 minute wall-clock timeout
- fix the non-managed PMA web chat route so it no longer returns a 30 minute wall-clock timeout while an active turn is still running
- keep PMA web chat failure behavior bounded by surfacing a clear error if the lane worker stops before delivering a result
- add regression coverage for both the managed-thread and PMA web chat timeout behavior

## Audit Result
- Discord PMA managed threads: already used idle-only timeout semantics
- Telegram PMA managed threads: already used idle-only timeout semantics
- PMA web managed threads: was incorrect, now fixed
- PMA web chat route: had the same wall-clock issue at the request layer, now fixed

## Testing
- python -m pytest -q tests/test_pma_turn_timeouts.py
- python -m pytest -q tests/pma_support/core.py::test_pma_chat_returns_completed_queue_result_when_future_is_registered_late tests/pma_support/core.py::test_pma_chat_response_omits_legacy_delivery_fields tests/pma_support/core.py::test_pma_chat_register_turn_failure_is_best_effort
- python -m pytest -q tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
- repo aggregate commit hooks (mypy, pytest, frontend checks, chat-surface lab)