### PR TITLE
[codex] Preserve PMA origin for managed thread followups

### DIFF
--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -33,6 +33,7 @@ from .pma_automation_types import (
     _parse_iso,
     default_pma_automation_state,
 )
+from .pma_origin import extract_pma_origin_metadata, merge_pma_origin_metadata
 from .pma_thread_store import PmaThreadStore
 from .text_utils import _normalize_pma_delivery_target, lock_path_for
 
@@ -1196,15 +1197,23 @@ class PmaAutomationStore:
         *,
         thread_id: Optional[str],
         lane_id: Optional[str],
+        metadata: Optional[dict[str, Any]] = None,
         origin_thread_id: Optional[str] = None,
         origin_lane_id: Optional[str] = None,
     ) -> str:
+        origin_metadata = extract_pma_origin_metadata(metadata)
         normalized_thread_id = _normalize_text(thread_id)
         normalized_lane_id = _normalize_text(lane_id)
-        normalized_origin_thread_id = _normalize_text(origin_thread_id)
-        normalized_origin_lane_id = _normalize_text(origin_lane_id)
+        normalized_origin_thread_id = _normalize_text(origin_thread_id) or (
+            origin_metadata.thread_id if origin_metadata else None
+        )
+        normalized_origin_lane_id = _normalize_text(origin_lane_id) or (
+            origin_metadata.lane_id if origin_metadata else None
+        )
         if normalized_lane_id is not None:
             return _normalize_lane_id(normalized_lane_id)
+        if normalized_origin_lane_id is not None:
+            return _normalize_lane_id(normalized_origin_lane_id)
 
         if normalized_origin_thread_id is not None:
             try:
@@ -1222,9 +1231,6 @@ class PmaAutomationStore:
             )
             if resolved_lane_id != DEFAULT_PMA_LANE_ID:
                 return resolved_lane_id
-
-        if normalized_origin_lane_id is not None:
-            return _normalize_lane_id(normalized_origin_lane_id)
         if normalized_thread_id is None:
             return DEFAULT_PMA_LANE_ID
         return DEFAULT_PMA_LANE_ID
@@ -1315,13 +1321,21 @@ class PmaAutomationStore:
         thread_id: Optional[str],
         metadata: Optional[dict[str, Any]],
         origin_thread_id: Optional[str] = None,
+        origin_lane_id: Optional[str] = None,
     ) -> dict[str, Any]:
-        resolved_metadata = dict(metadata or {})
+        resolved_metadata = merge_pma_origin_metadata(
+            metadata,
+            origin_thread_id=origin_thread_id,
+            origin_lane_id=origin_lane_id,
+        )
         delivery_target = _normalize_delivery_target(
             resolved_metadata.get("delivery_target")
         )
         normalized_thread_id = _normalize_text(thread_id)
-        normalized_origin_thread_id = _normalize_text(origin_thread_id)
+        origin_metadata = extract_pma_origin_metadata(resolved_metadata)
+        normalized_origin_thread_id = _normalize_text(origin_thread_id) or (
+            origin_metadata.thread_id if origin_metadata else None
+        )
         if delivery_target is None and normalized_origin_thread_id is not None:
             try:
                 delivery_target = self._resolve_thread_delivery_target(
@@ -1366,6 +1380,7 @@ class PmaAutomationStore:
         resolved_lane_id = self._resolve_subscription_lane_id(
             thread_id=normalized_thread_id,
             lane_id=lane_id,
+            metadata=metadata,
             origin_thread_id=origin_thread_id,
             origin_lane_id=origin_lane_id,
         )
@@ -1373,6 +1388,7 @@ class PmaAutomationStore:
             thread_id=normalized_thread_id,
             metadata=metadata,
             origin_thread_id=origin_thread_id,
+            origin_lane_id=origin_lane_id,
         )
         if not normalized_event_types:
             logger.warning(

--- a/src/codex_autorunner/core/pma_origin.py
+++ b/src/codex_autorunner/core/pma_origin.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from .text_utils import _normalize_optional_text
+
+PMA_ORIGIN_METADATA_KEY = "pma_origin"
+
+
+@dataclass(frozen=True)
+class PmaOriginContext:
+    thread_id: Optional[str] = None
+    lane_id: Optional[str] = None
+    agent: Optional[str] = None
+    profile: Optional[str] = None
+
+    def is_empty(self) -> bool:
+        return not any((self.thread_id, self.lane_id, self.agent, self.profile))
+
+    def to_metadata(self) -> dict[str, str]:
+        metadata: dict[str, str] = {}
+        if self.thread_id:
+            metadata["thread_id"] = self.thread_id
+        if self.lane_id:
+            metadata["lane_id"] = self.lane_id
+        if self.agent:
+            metadata["agent"] = self.agent
+        if self.profile:
+            metadata["profile"] = self.profile
+        return metadata
+
+
+def normalize_pma_origin_context(value: Any) -> Optional[PmaOriginContext]:
+    if not isinstance(value, dict):
+        return None
+    origin = PmaOriginContext(
+        thread_id=_normalize_optional_text(value.get("thread_id")),
+        lane_id=_normalize_optional_text(value.get("lane_id")),
+        agent=_normalize_optional_text(value.get("agent")),
+        profile=_normalize_optional_text(value.get("profile")),
+    )
+    return None if origin.is_empty() else origin
+
+
+def extract_pma_origin_metadata(metadata: Any) -> Optional[PmaOriginContext]:
+    if not isinstance(metadata, dict):
+        return None
+    return normalize_pma_origin_context(metadata.get(PMA_ORIGIN_METADATA_KEY))
+
+
+def resolve_runtime_pma_origin(runtime_state: Any) -> Optional[PmaOriginContext]:
+    current = getattr(runtime_state, "pma_current", None)
+    return normalize_pma_origin_context(current)
+
+
+def merge_pma_origin_metadata(
+    metadata: Optional[dict[str, Any]],
+    *,
+    origin: Optional[PmaOriginContext] = None,
+    origin_thread_id: Optional[str] = None,
+    origin_lane_id: Optional[str] = None,
+) -> dict[str, Any]:
+    resolved = dict(metadata or {})
+    existing_origin = extract_pma_origin_metadata(resolved)
+    merged_origin = PmaOriginContext(
+        thread_id=(
+            _normalize_optional_text(origin_thread_id)
+            or (origin.thread_id if origin else None)
+            or (existing_origin.thread_id if existing_origin else None)
+        ),
+        lane_id=(
+            _normalize_optional_text(origin_lane_id)
+            or (origin.lane_id if origin else None)
+            or (existing_origin.lane_id if existing_origin else None)
+        ),
+        agent=(
+            (origin.agent if origin else None)
+            or (existing_origin.agent if existing_origin else None)
+        ),
+        profile=(
+            (origin.profile if origin else None)
+            or (existing_origin.profile if existing_origin else None)
+        ),
+    )
+    if merged_origin.is_empty():
+        resolved.pop(PMA_ORIGIN_METADATA_KEY, None)
+        return resolved
+    resolved[PMA_ORIGIN_METADATA_KEY] = merged_origin.to_metadata()
+    return resolved

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_queue_execution.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_queue_execution.py
@@ -5,6 +5,8 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from fastapi import HTTPException
+
 from .....core.orchestration import (
     SurfaceThreadMessageRequest,
     build_surface_orchestration_ingress,
@@ -54,6 +56,52 @@ def resolve_pma_session_key(
     if automation_trigger:
         return pma_automation_key(agent_id, profile)
     return pma_base_key(agent_id, profile)
+
+
+def _resolve_profile_with_stale_pma_origin_fallback(
+    request: Any,
+    agent_id: str,
+    payload_profile: Optional[str],
+    requested_origin: Optional[PmaOriginContext],
+    *,
+    default_profile: Optional[str],
+) -> Optional[str]:
+    """Resolve profile for queue execution; ignore invalid stored ``pma_origin.profile`` when drifted.
+
+    Durable wakeups may carry a persisted origin profile that was renamed or removed after the
+    subscription was created. In that case :func:`resolve_requested_agent_profile` raises
+    ``HTTPException(400)``. When the client did not specify an explicit payload profile, fall
+    back to default resolution so the automation can still run.
+    """
+
+    origin_profile = requested_origin.profile if requested_origin is not None else None
+    effective = payload_profile if payload_profile is not None else origin_profile
+    try:
+        return resolve_requested_agent_profile(
+            request,
+            agent_id,
+            effective,
+            default_profile=default_profile,
+        )
+    except HTTPException as exc:
+        if (
+            exc.status_code == 400
+            and origin_profile is not None
+            and payload_profile is None
+        ):
+            logger.warning(
+                "Ignoring stale pma_origin.profile for PMA queue item "
+                "(falling back to default profile resolution): agent=%s origin_profile=%s",
+                agent_id,
+                origin_profile,
+            )
+            return resolve_requested_agent_profile(
+                request,
+                agent_id,
+                None,
+                default_profile=default_profile,
+            )
+        raise
 
 
 def resolve_pma_execution_origin(
@@ -213,14 +261,11 @@ async def execute_queue_item(
     except ValueError:
         agent_id = _resolve_default_agent(available_ids, available_default)
 
-    profile = resolve_requested_agent_profile(
+    profile = _resolve_profile_with_stale_pma_origin_fallback(
         request,
         agent_id,
-        (
-            profile
-            if profile is not None
-            else requested_origin.profile if requested_origin is not None else None
-        ),
+        profile,
+        requested_origin,
         default_profile=_normalize_optional_text(defaults.get("profile")),
     )
     execution_origin = resolve_pma_execution_origin(
@@ -391,8 +436,6 @@ async def execute_queue_item(
         try:
             harness = build_runtime_harness(request, agent_id, profile)
         except Exception as exc:
-            from fastapi import HTTPException
-
             detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
             return {"status": "error", "detail": str(detail)}
         if not callable(getattr(harness, "supports", None)):

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_queue_execution.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_queue_execution.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from dataclasses import dataclass
 from typing import Any, Optional
 
 from .....core.orchestration import (
@@ -14,6 +15,7 @@ from .....core.pma_context import (
     format_pma_prompt,
     load_pma_prompt,
 )
+from .....core.pma_origin import PmaOriginContext, extract_pma_origin_metadata
 from .....core.text_utils import _normalize_optional_text
 from .....integrations.app_server.threads import pma_automation_key, pma_base_key
 from .....integrations.github.context_injection import maybe_inject_github_context
@@ -29,6 +31,12 @@ from .runtime_state import PmaRuntimeState
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class PmaExecutionOrigin:
+    session_key: str
+    backend_thread_id: Optional[str] = None
+
+
 def _get_pma_config(request: Any) -> dict[str, Any]:
     context = get_pma_request_context(request)
     return pma_config_from_raw(context.raw_config)
@@ -39,10 +47,43 @@ def resolve_pma_session_key(
     profile: Optional[str],
     *,
     automation_trigger: bool,
+    pma_origin: Optional[PmaOriginContext] = None,
 ) -> str:
+    if automation_trigger and pma_origin and pma_origin.thread_id:
+        return pma_base_key(agent_id, profile)
     if automation_trigger:
         return pma_automation_key(agent_id, profile)
     return pma_base_key(agent_id, profile)
+
+
+def resolve_pma_execution_origin(
+    agent_id: str,
+    profile: Optional[str],
+    *,
+    automation_trigger: bool,
+    wake_up: Optional[dict[str, Any]],
+) -> PmaExecutionOrigin:
+    pma_origin = extract_pma_origin_metadata(
+        wake_up.get("metadata") if isinstance(wake_up, dict) else None
+    )
+    should_resume_origin = (
+        automation_trigger
+        and pma_origin is not None
+        and pma_origin.thread_id is not None
+        and (pma_origin.agent is None or pma_origin.agent == agent_id)
+        and (pma_origin.profile is None or pma_origin.profile == profile)
+    )
+    if not should_resume_origin:
+        pma_origin = None
+    return PmaExecutionOrigin(
+        session_key=resolve_pma_session_key(
+            agent_id,
+            profile,
+            automation_trigger=automation_trigger,
+            pma_origin=pma_origin,
+        ),
+        backend_thread_id=pma_origin.thread_id if pma_origin else None,
+    )
 
 
 async def execute_queue_item(
@@ -69,6 +110,9 @@ async def execute_queue_item(
     if not isinstance(wake_up, dict):
         wake_up = None
     automation_trigger = lifecycle_event is not None or wake_up is not None
+    requested_origin = extract_pma_origin_metadata(
+        wake_up.get("metadata") if isinstance(wake_up, dict) else None
+    )
 
     store = runtime.get_state_store(hub_root)
     defaults = _get_pma_config(request)
@@ -162,15 +206,28 @@ async def execute_queue_item(
     }
 
     try:
-        agent_id = validate_agent_id(agent or "", context.agent_context)
+        requested_agent = agent
+        if requested_agent is None and requested_origin is not None:
+            requested_agent = requested_origin.agent
+        agent_id = validate_agent_id(requested_agent or "", context.agent_context)
     except ValueError:
         agent_id = _resolve_default_agent(available_ids, available_default)
 
     profile = resolve_requested_agent_profile(
         request,
         agent_id,
-        profile,
+        (
+            profile
+            if profile is not None
+            else requested_origin.profile if requested_origin is not None else None
+        ),
         default_profile=_normalize_optional_text(defaults.get("profile")),
+    )
+    execution_origin = resolve_pma_execution_origin(
+        agent_id,
+        profile,
+        automation_trigger=automation_trigger,
+        wake_up=wake_up,
     )
 
     safety_checker = runtime.get_safety_checker(hub_root, context)
@@ -220,11 +277,7 @@ async def execute_queue_item(
         )
 
         snapshot = await snapshot_builder(supervisor, hub_root=hub_root)
-        prompt_state_key = resolve_pma_session_key(
-            agent_id,
-            profile,
-            automation_trigger=automation_trigger,
-        )
+        prompt_state_key = execution_origin.session_key
 
         async def _rebuild_prompt(force_full_base_prompt: bool) -> str:
             built = format_pma_prompt(
@@ -359,11 +412,8 @@ async def execute_queue_item(
             model=model,
             reasoning=reasoning,
             thread_registry=registry,
-            thread_key=resolve_pma_session_key(
-                agent_id,
-                profile,
-                automation_trigger=automation_trigger,
-            ),
+            thread_key=execution_origin.session_key,
+            backend_thread_id=execution_origin.backend_thread_id,
             on_meta=_meta,
             timeout_seconds=turn_timeout_seconds,
             rebuild_prompt=_rebuild_prompt,

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -33,7 +33,7 @@ from ...services.pma import get_pma_request_context
 from ...services.pma.managed_thread_followup import (
     ManagedThreadAutomationClient,
     ManagedThreadAutomationUnavailable,
-    resolve_origin_followup_context,
+    apply_origin_followup_context,
 )
 from .automation_adapter import (
     call_store_action_with_id,
@@ -146,13 +146,10 @@ def build_automation_routes(
         try:
             normalized_payload = payload.normalized_payload()
             if not _subscription_request_has_explicit_routing(normalized_payload):
-                origin_thread_id, origin_lane_id = resolve_origin_followup_context(
-                    runtime_state
+                normalized_payload = apply_origin_followup_context(
+                    normalized_payload,
+                    runtime_state,
                 )
-                if origin_thread_id:
-                    normalized_payload.setdefault("origin_thread_id", origin_thread_id)
-                if origin_lane_id:
-                    normalized_payload.setdefault("origin_lane_id", origin_lane_id)
             created = await call_store_create_with_payload(
                 store,
                 (

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
@@ -167,15 +167,6 @@ class ManagedThreadAutomationClient:
         return {"mode": "terminal", "subscription": created}
 
 
-def resolve_origin_followup_context(
-    runtime_state: Any,
-) -> tuple[Optional[str], Optional[str]]:
-    origin = resolve_runtime_pma_origin(runtime_state)
-    if origin is None:
-        return None, None
-    return origin.thread_id, origin.lane_id
-
-
 def apply_origin_followup_context(
     payload: dict[str, Any],
     runtime_state: Any,

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
@@ -6,6 +6,11 @@ from typing import Any, Literal, Optional
 from fastapi import HTTPException, Request
 
 from .....core.pma_automation_store import PmaAutomationThreadNotFoundError
+from .....core.pma_origin import (
+    PmaOriginContext,
+    merge_pma_origin_metadata,
+    resolve_runtime_pma_origin,
+)
 from ...routes.pma_routes.automation_adapter import (
     call_store_create_with_payload,
     get_automation_store,
@@ -33,8 +38,7 @@ def build_managed_thread_terminal_notify_payload(
     lane_id: Optional[str],
     notify_once: bool,
     idempotency_key: Optional[str],
-    origin_thread_id: Optional[str],
-    origin_lane_id: Optional[str],
+    origin: Optional[PmaOriginContext],
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "event_types": [
@@ -45,14 +49,17 @@ def build_managed_thread_terminal_notify_payload(
         "thread_id": managed_thread_id,
         "lane_id": lane_id,
         "notify_once": notify_once,
-        "metadata": {"notify_once": notify_once},
+        "metadata": merge_pma_origin_metadata(
+            {"notify_once": notify_once},
+            origin=origin,
+        ),
     }
     if idempotency_key:
         payload["idempotency_key"] = idempotency_key
-    if origin_thread_id:
-        payload["origin_thread_id"] = origin_thread_id
-    if origin_lane_id:
-        payload["origin_lane_id"] = origin_lane_id
+    if origin and origin.thread_id:
+        payload["origin_thread_id"] = origin.thread_id
+    if origin and origin.lane_id:
+        payload["origin_lane_id"] = origin.lane_id
     return payload
 
 
@@ -113,9 +120,7 @@ class ManagedThreadAutomationClient:
         required: bool,
     ) -> Optional[dict[str, Any]]:
         runtime_state = self._get_runtime_state() if self._get_runtime_state else None
-        origin_thread_id, origin_lane_id = resolve_origin_followup_context(
-            runtime_state
-        )
+        origin = resolve_runtime_pma_origin(runtime_state)
         try:
             store = await get_automation_store(
                 self._request,
@@ -135,8 +140,7 @@ class ManagedThreadAutomationClient:
                     lane_id=lane_id,
                     notify_once=notify_once,
                     idempotency_key=idempotency_key,
-                    origin_thread_id=origin_thread_id,
-                    origin_lane_id=origin_lane_id,
+                    origin=origin,
                 ),
             )
         except HTTPException as exc:
@@ -166,15 +170,30 @@ class ManagedThreadAutomationClient:
 def resolve_origin_followup_context(
     runtime_state: Any,
 ) -> tuple[Optional[str], Optional[str]]:
-    if runtime_state is None:
+    origin = resolve_runtime_pma_origin(runtime_state)
+    if origin is None:
         return None, None
+    return origin.thread_id, origin.lane_id
 
-    current = getattr(runtime_state, "pma_current", None)
-    if not isinstance(current, dict):
-        return None, None
 
-    origin_thread_id = normalize_optional_text(current.get("thread_id"))
-    origin_lane_id = normalize_optional_text(current.get("lane_id"))
-    if origin_thread_id or origin_lane_id:
-        return origin_thread_id, origin_lane_id
-    return None, None
+def apply_origin_followup_context(
+    payload: dict[str, Any],
+    runtime_state: Any,
+) -> dict[str, Any]:
+    resolved_payload = dict(payload)
+    origin = resolve_runtime_pma_origin(runtime_state)
+    if origin is None:
+        return resolved_payload
+    if origin.thread_id:
+        resolved_payload.setdefault("origin_thread_id", origin.thread_id)
+    if origin.lane_id:
+        resolved_payload.setdefault("origin_lane_id", origin.lane_id)
+    resolved_payload["metadata"] = merge_pma_origin_metadata(
+        (
+            resolved_payload.get("metadata")
+            if isinstance(resolved_payload.get("metadata"), dict)
+            else None
+        ),
+        origin=origin,
+    )
+    return resolved_payload

--- a/tests/core/test_pma_automation_store.py
+++ b/tests/core/test_pma_automation_store.py
@@ -429,6 +429,39 @@ def test_create_subscription_prefers_origin_thread_binding_for_defaults(
     }
 
 
+def test_create_subscription_prefers_explicit_origin_lane_and_persists_pma_origin(
+    tmp_path,
+) -> None:
+    store = PmaAutomationStore(tmp_path, durable=False)
+    origin_thread_id = _create_managed_thread(tmp_path, surface_kind="discord")
+
+    subscription = store.create_subscription(
+        {
+            "event_type": "managed_thread_completed",
+            "origin_thread_id": origin_thread_id,
+            "origin_lane_id": "pma:lane-origin",
+            "metadata": {
+                "pma_origin": {
+                    "agent": "hermes",
+                    "profile": "m4-pma",
+                }
+            },
+        }
+    )["subscription"]
+
+    assert subscription["lane_id"] == "pma:lane-origin"
+    assert subscription["metadata"]["delivery_target"] == {
+        "surface_kind": "discord",
+        "surface_key": "discord:binding-1",
+    }
+    assert subscription["metadata"]["pma_origin"] == {
+        "thread_id": origin_thread_id,
+        "lane_id": "pma:lane-origin",
+        "agent": "hermes",
+        "profile": "m4-pma",
+    }
+
+
 def test_create_subscription_reuses_covering_auto_subscription_for_auto_keys(
     tmp_path,
 ) -> None:
@@ -502,6 +535,45 @@ def test_notify_transition_copies_subscription_delivery_target_into_wakeup(
     assert pending[0]["metadata"]["delivery_target"] == {
         "surface_kind": "telegram",
         "surface_key": "telegram:binding-1",
+    }
+
+
+def test_notify_transition_copies_pma_origin_metadata_into_wakeup(tmp_path) -> None:
+    store = PmaAutomationStore(tmp_path, durable=False)
+    thread_id = _create_managed_thread(tmp_path)
+
+    store.create_subscription(
+        {
+            "event_type": "managed_thread_completed",
+            "thread_id": thread_id,
+            "metadata": {
+                "pma_origin": {
+                    "thread_id": "backend-thread-123",
+                    "lane_id": "pma:lane-origin",
+                    "agent": "hermes",
+                    "profile": "m4-pma",
+                }
+            },
+        }
+    )
+
+    store.notify_transition(
+        {
+            "event_type": "managed_thread_completed",
+            "thread_id": thread_id,
+            "from_state": "running",
+            "to_state": "completed",
+            "transition_id": f"{thread_id}:completed",
+        }
+    )
+
+    pending = store.list_pending_wakeups(limit=10)
+    assert len(pending) == 1
+    assert pending[0]["metadata"]["pma_origin"] == {
+        "thread_id": "backend-thread-123",
+        "lane_id": "pma:lane-origin",
+        "agent": "hermes",
+        "profile": "m4-pma",
     }
 
 

--- a/tests/surfaces/web/routes/pma_routes/test_chat_runtime_execution_fresh_base_prompt.py
+++ b/tests/surfaces/web/routes/pma_routes/test_chat_runtime_execution_fresh_base_prompt.py
@@ -7,10 +7,12 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 from codex_autorunner.core.orchestration import FreshConversationRequiredError
 from codex_autorunner.core.pma_origin import PmaOriginContext
 from codex_autorunner.surfaces.web.routes.pma_routes.chat_queue_execution import (
+    _resolve_profile_with_stale_pma_origin_fallback,
     resolve_pma_execution_origin,
     resolve_pma_session_key,
 )
@@ -173,3 +175,64 @@ def test_resolve_pma_execution_origin_ignores_mismatched_origin_session() -> Non
 
     assert execution_origin.session_key == "pma.profile.m4-pma.automation"
     assert execution_origin.backend_thread_id is None
+
+
+def test_queue_profile_resolution_falls_back_when_stored_origin_profile_is_stale() -> (
+    None
+):
+    """Invalid persisted ``pma_origin.profile`` must not fail the lane when payload omits profile."""
+
+    class _Config:
+        def agent_profiles(self, agent_id: str) -> dict[str, object]:
+            _ = agent_id
+            return {"good": {}}
+
+        def agent_default_profile(self, agent_id: str) -> str:
+            _ = agent_id
+            return "good"
+
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(config=_Config()))
+    )
+    origin = PmaOriginContext(
+        thread_id="t1",
+        agent="codex",
+        profile="removed-profile",
+    )
+
+    resolved = _resolve_profile_with_stale_pma_origin_fallback(
+        request,
+        "codex",
+        None,
+        origin,
+        default_profile=None,
+    )
+    assert resolved == "good"
+
+
+def test_queue_profile_resolution_does_not_swallow_explicit_invalid_payload_profile() -> (
+    None
+):
+    class _Config:
+        def agent_profiles(self, agent_id: str) -> dict[str, object]:
+            _ = agent_id
+            return {"good": {}}
+
+        def agent_default_profile(self, agent_id: str) -> str:
+            _ = agent_id
+            return "good"
+
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(config=_Config()))
+    )
+    origin = PmaOriginContext(thread_id="t1", agent="codex", profile="good")
+
+    with pytest.raises(HTTPException) as excinfo:
+        _resolve_profile_with_stale_pma_origin_fallback(
+            request,
+            "codex",
+            "bad-payload-profile",
+            origin,
+            default_profile=None,
+        )
+    assert excinfo.value.status_code == 400

--- a/tests/surfaces/web/routes/pma_routes/test_chat_runtime_execution_fresh_base_prompt.py
+++ b/tests/surfaces/web/routes/pma_routes/test_chat_runtime_execution_fresh_base_prompt.py
@@ -9,7 +9,9 @@ from types import SimpleNamespace
 import pytest
 
 from codex_autorunner.core.orchestration import FreshConversationRequiredError
+from codex_autorunner.core.pma_origin import PmaOriginContext
 from codex_autorunner.surfaces.web.routes.pma_routes.chat_queue_execution import (
+    resolve_pma_execution_origin,
     resolve_pma_session_key,
 )
 from codex_autorunner.surfaces.web.routes.pma_routes.chat_runtime_execution import (
@@ -118,3 +120,56 @@ def test_resolve_pma_session_key_isolates_automation_from_interactive_pma() -> N
     assert interactive == "pma.hermes.profile.m4-pma"
     assert automation == "pma.hermes.profile.m4-pma.automation"
     assert automation != interactive
+
+
+def test_resolve_pma_session_key_reuses_interactive_session_for_origin_wakeups() -> (
+    None
+):
+    session_key = resolve_pma_session_key(
+        "hermes",
+        "m4-pma",
+        automation_trigger=True,
+        pma_origin=PmaOriginContext(thread_id="backend-thread-123"),
+    )
+
+    assert session_key == "pma.hermes.profile.m4-pma"
+
+
+def test_resolve_pma_execution_origin_resumes_matching_origin_session() -> None:
+    execution_origin = resolve_pma_execution_origin(
+        "hermes",
+        "m4-pma",
+        automation_trigger=True,
+        wake_up={
+            "metadata": {
+                "pma_origin": {
+                    "thread_id": "backend-thread-123",
+                    "agent": "hermes",
+                    "profile": "m4-pma",
+                }
+            }
+        },
+    )
+
+    assert execution_origin.session_key == "pma.hermes.profile.m4-pma"
+    assert execution_origin.backend_thread_id == "backend-thread-123"
+
+
+def test_resolve_pma_execution_origin_ignores_mismatched_origin_session() -> None:
+    execution_origin = resolve_pma_execution_origin(
+        "codex",
+        "m4-pma",
+        automation_trigger=True,
+        wake_up={
+            "metadata": {
+                "pma_origin": {
+                    "thread_id": "backend-thread-123",
+                    "agent": "hermes",
+                    "profile": "m4-pma",
+                }
+            }
+        },
+    )
+
+    assert execution_origin.session_key == "pma.profile.m4-pma.automation"
+    assert execution_origin.backend_thread_id is None

--- a/tests/surfaces/web/test_pma_common_service.py
+++ b/tests/surfaces/web/test_pma_common_service.py
@@ -304,6 +304,8 @@ async def test_managed_thread_automation_client_forwards_origin_thread_context(
         pma_current={
             "thread_id": "pma-thread-1",
             "lane_id": "discord",
+            "agent": "hermes",
+            "profile": "m4-pma",
         }
     )
     client = ManagedThreadAutomationClient(request, lambda: runtime_state)
@@ -341,6 +343,12 @@ async def test_managed_thread_automation_client_forwards_origin_thread_context(
     }
     assert captured["origin_thread_id"] == "pma-thread-1"
     assert captured["origin_lane_id"] == "discord"
+    assert captured["metadata"]["pma_origin"] == {
+        "thread_id": "pma-thread-1",
+        "lane_id": "discord",
+        "agent": "hermes",
+        "profile": "m4-pma",
+    }
 
 
 @pytest.mark.asyncio
@@ -385,3 +393,4 @@ async def test_managed_thread_automation_client_ignores_stale_last_result_origin
 
     assert "origin_thread_id" not in captured
     assert "origin_lane_id" not in captured
+    assert "pma_origin" not in captured["metadata"]

--- a/tests/test_pma_managed_threads_routes.py
+++ b/tests/test_pma_managed_threads_routes.py
@@ -910,6 +910,47 @@ def test_create_subscription_defaults_to_current_runtime_chat_thread(hub_env) ->
         "surface_kind": "discord",
         "surface_key": "discord:subscription-default-thread",
     }
+    assert subscription["metadata"]["pma_origin"] == {
+        "thread_id": origin_thread_id,
+        "lane_id": "discord",
+    }
+
+
+def test_create_subscription_preserves_runtime_pma_origin_metadata_without_thread_binding(
+    hub_env,
+) -> None:
+    runtime_state = SimpleNamespace(
+        pma_current={
+            "thread_id": "backend-thread-123",
+            "lane_id": "pma:lane-origin",
+            "agent": "hermes",
+            "profile": "m4-pma",
+        }
+    )
+
+    with _build_automation_route_client(
+        hub_env.hub_root,
+        runtime_state=runtime_state,
+    ) as client:
+        subscription_resp = client.post(
+            "/subscriptions",
+            json={
+                "event_type": "flow_completed",
+                "repo_id": hub_env.repo_id,
+                "run_id": "run-subscription-origin",
+            },
+        )
+
+    assert subscription_resp.status_code == 200
+    subscription = subscription_resp.json()["subscription"]
+    assert subscription["lane_id"] == "pma:lane-origin"
+    assert "delivery_target" not in subscription["metadata"]
+    assert subscription["metadata"]["pma_origin"] == {
+        "thread_id": "backend-thread-123",
+        "lane_id": "pma:lane-origin",
+        "agent": "hermes",
+        "profile": "m4-pma",
+    }
 
 
 def test_create_subscription_keeps_explicit_thread_target(hub_env) -> None:


### PR DESCRIPTION
## Summary
This fixes PMA managed-thread terminal followups that were waking the default PMA lane instead of the PMA session that created the followup.

## Root Cause
The followup path captured `runtime_state.pma_current`, but only persisted loose `origin_thread_id` / `origin_lane_id` fields. That broke down in two ways:

1. PMA web stores the backend PMA session id in `pma_current.thread_id`, but automation-store lane inference treated `origin_thread_id` like a managed-thread id and fell back to `pma:default` when it was not chat-bound.
2. Wakeup execution always used the shared automation session key, so even when the originating PMA context existed in-process, the durable wakeup no longer knew how to resume that PMA conversation.

## What Changed
- Added a normalized `pma_origin` metadata payload to preserve PMA origin context durably.
- Reused that helper from both managed-thread auto-followups and generic PMA subscription creation.
- Updated automation-store resolution to preserve `pma_origin` metadata and prefer explicit `origin_lane_id` over thread-binding inference.
- Updated PMA wakeup execution to reuse the originating PMA base session and backend thread when the stored origin context matches the executing agent/profile.
- Added regression coverage for subscription creation, metadata persistence, wakeup propagation, and PMA session-key selection.

## User Impact
Managed-thread completion/failure/interruption followups now return to the PMA lane/session that dispatched them instead of collapsing to the default PMA lane.

## Validation
- `python -m pytest -q tests/surfaces/web/test_pma_common_service.py tests/core/test_pma_automation_store.py tests/test_pma_managed_threads_routes.py tests/surfaces/web/routes/pma_routes/test_chat_runtime_execution_fresh_base_prompt.py tests/core/test_lifecycle_event_processing.py tests/surfaces/web/routes/pma_routes/test_publish_helpers.py`
- repo commit hook validation
  - `mypy src/codex_autorunner`
  - full `pytest` suite (`7086 passed`)
  - `pnpm run build`
  - `pnpm test:markdown`
  - chat-surface lab deterministic checks and latency budgets