### PR TITLE
Fix #1576: add get_running_turn delegation to PmaThreadExecutionStore

### DIFF
--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -300,6 +300,9 @@ class PmaThreadExecutionStore(ThreadExecutionStore):
             return None
         return _execution_record_from_store_row(record)
 
+    def get_running_turn(self, thread_target_id: str) -> Optional[dict[str, Any]]:
+        return self._store.get_running_turn(thread_target_id)
+
     def get_latest_execution(self, thread_target_id: str) -> Optional[ExecutionRecord]:
         record = self._store.get_running_turn(thread_target_id)
         if record is None:


### PR DESCRIPTION
## Summary

Fix #1576: Add `get_running_turn` delegation to `PmaThreadExecutionStore`.

Delegates the `get_running_turn` call through the orchestration service layer, ensuring the execution store's `get_running_turn` method is properly wired into the runtime delegation chain (consistent with other store methods after the domain model cleanup in #1573).

### Changes

- **1 file** changed, **+3 lines**
- `src/codex_autorunner/core/orchestration/service.py` — add `get_running_turn` delegation
