### PR TITLE
[codex] Fix PMA idle-timeout race at the stall boundary

### DIFF
--- a/src/codex_autorunner/core/orchestration/runtime_threads.py
+++ b/src/codex_autorunner/core/orchestration/runtime_threads.py
@@ -17,6 +17,7 @@ from .service import HarnessBackedOrchestrationService
 _INTERRUPT_POLL_INTERVAL_SECONDS = 0.05
 _STALL_POLL_INTERVAL_SECONDS = 0.25
 _STALL_RECOVERY_PROBE_INTERVAL_SECONDS = 15.0
+_STALL_COMPLETION_GRACE_SECONDS = 2.0
 RUNTIME_THREAD_TIMEOUT_ERROR = "Runtime thread timed out"
 RUNTIME_THREAD_INTERRUPTED_ERROR = "Runtime thread interrupted"
 RUNTIME_THREAD_MISSING_BACKEND_IDS_ERROR = (
@@ -72,6 +73,24 @@ def _looks_like_terminal_turn_result(result: Any) -> bool:
 
 def _harness_supports_stall_recovery(harness: Any) -> bool:
     return callable(getattr(harness, "recover_stalled_turn", None))
+
+
+async def _wait_for_late_collector_result(
+    collector_task: asyncio.Task[Any],
+    grace_seconds: float,
+) -> Optional[Any]:
+    if collector_task.done():
+        return await collector_task
+    timeout_seconds = max(float(grace_seconds), 0.0)
+    if timeout_seconds <= 0.0:
+        return None
+    try:
+        return await asyncio.wait_for(
+            asyncio.shield(collector_task),
+            timeout=timeout_seconds,
+        )
+    except asyncio.TimeoutError:
+        return None
 
 
 @dataclass(frozen=True)
@@ -315,6 +334,13 @@ async def await_runtime_thread_outcome(
                 recovered = await _recover_stalled_turn(execution)
                 if recovered is not None:
                     state.note_transport_result(recovered)
+                    return state.build_outcome(execution_error_message)
+                late_result = await _wait_for_late_collector_result(
+                    collector_task,
+                    _STALL_COMPLETION_GRACE_SECONDS,
+                )
+                if late_result is not None:
+                    state.note_transport_result(late_result)
                     return state.build_outcome(execution_error_message)
                 await execution.harness.interrupt(
                     execution.workspace_root,

--- a/tests/chat_surface_integration/test_hermes_pma_official_timeout.py
+++ b/tests/chat_surface_integration/test_hermes_pma_official_timeout.py
@@ -85,6 +85,49 @@ async def test_discord_hermes_pma_stall_timeout_surfaces_timeout_for_silent_hang
 
 
 @pytest.mark.anyio
+async def test_discord_hermes_pma_accepts_prompt_return_arriving_just_after_idle_gap(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = HermesFixtureRuntime("official_prompt_return_after_idle_gap")
+    patch_hermes_runtime(monkeypatch, runtime)
+    monkeypatch.setattr(
+        runtime_threads_module,
+        "_STALL_COMPLETION_GRACE_SECONDS",
+        0.08,
+    )
+    monkeypatch.setattr(discord_message_turns, "DISCORD_PMA_TIMEOUT_SECONDS", 30.0)
+    monkeypatch.setattr(
+        discord_message_turns,
+        "DISCORD_PMA_STALL_TIMEOUT_SECONDS",
+        0.05,
+    )
+    harness = DiscordSurfaceHarness(tmp_path / "discord-late-return")
+    await harness.setup(agent="hermes")
+    try:
+        rest = await harness.run_message("echo hello world")
+
+        assert rest.execution_status == "ok"
+        assert rest.preview_deleted is True
+        assert not any(
+            op["op"] == "send"
+            and "discord pma turn timed out"
+            in str(op["payload"].get("content", "")).lower()
+            for op in rest.message_ops
+        )
+        finalized = next(
+            record
+            for record in reversed(rest.log_records)
+            if record.get("event") == "chat.managed_thread.turn_finalized"
+        )
+        assert finalized["status"] == "ok"
+        assert finalized["completion_source"] == "prompt_return"
+    finally:
+        await harness.close()
+        await runtime.close()
+
+
+@pytest.mark.anyio
 async def test_discord_hermes_pma_does_not_replay_second_turn_from_persisted_session_store(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -1730,6 +1730,83 @@ async def test_runtime_thread_recovery_probe_can_finish_before_stall_deadline(
     assert harness.wait_cancelled.is_set()
 
 
+async def test_runtime_thread_stall_timeout_allows_short_prompt_return_grace(
+    tmp_path: Path,
+) -> None:
+    @dataclass
+    class _HarnessWithLatePromptReturn(_HarnessWithWait):
+        capabilities: frozenset[str] = frozenset(
+            ["durable_threads", "message_turns", "interrupt", "event_streaming"]
+        )
+
+        async def wait_for_turn(
+            self,
+            workspace_root: Path,
+            conversation_id: str,
+            turn_id: Optional[str],
+            *,
+            timeout: Optional[float] = None,
+        ) -> TerminalTurnResult:
+            _ = workspace_root, conversation_id, turn_id, timeout
+            await asyncio.sleep(0.03)
+            return TerminalTurnResult(
+                status="ok",
+                assistant_text="late prompt return",
+                raw_events=[],
+                errors=[],
+            )
+
+        async def stream_events(
+            self, workspace_root: Path, conversation_id: str, turn_id: str
+        ):
+            _ = workspace_root, conversation_id, turn_id
+            yield {
+                "message": {
+                    "method": "session/update",
+                    "params": {
+                        "update": {"sessionUpdate": "agent_message_chunk"},
+                        "text": "partial output",
+                    },
+                }
+            }
+            await asyncio.Future()
+
+    original_grace = runtime_threads_module._STALL_COMPLETION_GRACE_SECONDS
+    runtime_threads_module._STALL_COMPLETION_GRACE_SECONDS = 0.05
+    try:
+        harness = _HarnessWithLatePromptReturn()
+        service = _build_service(tmp_path, harness)
+        workspace_root = tmp_path / "workspace"
+        workspace_root.mkdir()
+        thread = service.create_thread_target("codex", workspace_root)
+
+        started = await begin_runtime_thread_execution(
+            service,
+            MessageRequest(
+                target_id=thread.thread_target_id,
+                target_kind="thread",
+                message_text="user-visible prompt",
+            ),
+        )
+        outcome = await asyncio.wait_for(
+            await_runtime_thread_outcome(
+                started,
+                interrupt_event=None,
+                timeout_seconds=5,
+                stall_timeout_seconds=0.01,
+                execution_error_message="Managed thread execution failed",
+            ),
+            timeout=1,
+        )
+    finally:
+        runtime_threads_module._STALL_COMPLETION_GRACE_SECONDS = original_grace
+
+    assert outcome.status == "ok"
+    assert outcome.assistant_text == "late prompt return"
+    assert outcome.completion_source == "prompt_return"
+    assert harness.interrupt_calls == []
+
+
 async def test_runtime_thread_timeout_cancels_wait_collector(
     tmp_path: Path,
 ) -> None:

--- a/tests/fixtures/fake_acp_server.py
+++ b/tests/fixtures/fake_acp_server.py
@@ -495,6 +495,14 @@ class FakeACPServer:
                 {"stopReason": "end_turn", "userMessageId": turn_id},
             )
             return
+        if self._scenario == "official_prompt_return_after_idle_gap":
+            time.sleep(0.06)
+            cancel_event.clear()
+            self._send_result(
+                request_id,
+                {"stopReason": "end_turn", "userMessageId": turn_id},
+            )
+            return
         if self._scenario == "official_cancelled_before_return":
             self.send(
                 {


### PR DESCRIPTION
## Summary
Fix the Discord/Hermes PMA idle-timeout race where a silent stream can hit the stall deadline just before the runtime returns a valid terminal prompt result.

## Root Cause
This was not caused by PR #1580.

The failure was in managed-thread orchestration:
- the PMA stream could go idle after partial `session/update` traffic
- `await_runtime_thread_outcome(...)` would hit the stall timeout first
- the stall branch immediately interrupted the harness and finalized as `completion_source="timeout"`
- in the failing shape, Hermes could still return a valid terminal `prompt_return` moments later, but we never gave that in-flight collector result a chance to win

The terminal-state reconciler was not the primary problem. The bug was the orchestration decision made at the stall boundary.

## What Changed
- add a short post-stall collector grace window before forcing interrupt/timeout
- keep the existing timeout behavior for truly hung turns
- add a runtime-thread regression covering a late prompt return arriving just after the idle gap
- add a Discord/Hermes integration regression for the same shape
- add a fixture scenario that reproduces the late-prompt-return timing

## Impact
Discord PMA turns that briefly cross the idle boundary but still complete through the runtime request path now finalize successfully instead of being converted into false timeouts.

## Validation
- `python -m pytest -q tests/core/orchestration/test_runtime_threads.py -k 'stall_timeout_allows_short_prompt_return_grace or recovery_probe_can_finish_before_stall_deadline or progress_stall_timeout'`
- `python -m pytest -q tests/chat_surface_integration/test_hermes_pma_official_timeout.py`
- `python -m pytest -q tests/agents/hermes/test_hermes_supervisor_official_prompt_hang.py`
- repo validation lane from `git commit`:
  - formatting
  - ruff
  - import boundary / contract checks
  - mypy
  - repo-wide pytest (`7531 passed`)
  - frontend build/tests
  - chat-surface lab deterministic checks
