### PR TITLE
Fix #1583: resolve lane_id in dispatch decision for notification routing

### DIFF
--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -7,9 +7,14 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import Any, Optional, Sequence, cast
 
-from .chat_bindings import active_chat_binding_metadata_by_thread
+from .chat_bindings import (
+    active_chat_binding_metadata_by_thread,
+    preferred_non_pma_chat_notification_source_for_workspace,
+)
+from .config import load_hub_config
+from .config_contract import ConfigError
 from .locks import file_lock
 from .orchestration.sqlite import open_orchestration_sqlite
 from .pma_automation_persistence import PmaAutomationPersistence
@@ -32,6 +37,18 @@ from .pma_automation_types import (
     _normalize_timer_type,
     _parse_iso,
     default_pma_automation_state,
+)
+from .pma_dispatch_decision import (
+    build_pma_dispatch_decision,
+    pma_dispatch_decision_to_dict,
+)
+from .pma_domain.models import PmaSubscription
+from .pma_domain.subscription_reducer import (
+    ReduceTransitionResult,
+    TimerFiredEvent,
+    TransitionEvent,
+    reduce_timer_fired,
+    reduce_transition,
 )
 from .pma_origin import extract_pma_origin_metadata, merge_pma_origin_metadata
 from .pma_thread_store import PmaThreadStore
@@ -1115,6 +1132,161 @@ class PmaAutomationStore:
                 merged[key] = value
         return merged
 
+    def _compute_dispatch_decision_for_wakeup(
+        self, wakeup: PmaAutomationWakeup
+    ) -> None:
+        try:
+            binding_metadata_by_thread = active_chat_binding_metadata_by_thread(
+                hub_root=self._hub_root
+            )
+        except (OSError, RuntimeError, ValueError):
+            binding_metadata_by_thread = {}
+
+        delivery_target = wakeup.metadata.get("delivery_target")
+        workspace_root: Optional[Path] = None
+        if wakeup.thread_id:
+            try:
+                thread_store = PmaThreadStore(self._hub_root)
+                thread = thread_store.get_thread(wakeup.thread_id)
+                if isinstance(thread, dict):
+                    raw_ws = _normalize_text(thread.get("workspace_root"))
+                    if raw_ws:
+                        workspace_root = Path(raw_ws)
+            except (OSError, RuntimeError, ValueError):
+                pass
+
+        preferred_bound_surface_kinds: tuple[str, ...] = ("discord", "telegram")
+        if workspace_root is not None:
+            try:
+                raw_config = load_hub_config(self._hub_root).raw
+            except (OSError, ValueError, ConfigError):
+                raw_config = {}
+            try:
+                preferred = preferred_non_pma_chat_notification_source_for_workspace(
+                    hub_root=self._hub_root,
+                    raw_config=raw_config,
+                    workspace_root=workspace_root,
+                )
+            except (OSError, RuntimeError, ValueError, TypeError, KeyError):
+                preferred = None
+            if preferred in {"discord", "telegram"}:
+                ordered = [preferred]
+                ordered.extend(s for s in ("discord", "telegram") if s != preferred)
+                preferred_bound_surface_kinds = tuple(ordered)
+
+        decision = build_pma_dispatch_decision(
+            message="",
+            requested_delivery="auto",
+            source_kind=wakeup.source or "automation",
+            repo_id=wakeup.repo_id,
+            workspace_root=workspace_root,
+            lane_id=wakeup.lane_id,
+            managed_thread_id=wakeup.thread_id,
+            delivery_target=(
+                delivery_target if isinstance(delivery_target, dict) else None
+            ),
+            context_payload={"wake_up": wakeup.to_dict()},
+            binding_metadata_by_thread=binding_metadata_by_thread,
+            preferred_bound_surface_kinds=preferred_bound_surface_kinds,
+        )
+        wakeup.metadata["dispatch_decision"] = pma_dispatch_decision_to_dict(decision)
+
+    @staticmethod
+    def _lifecycle_sub_to_domain(
+        entry: PmaLifecycleSubscription,
+    ) -> PmaSubscription:
+        return PmaSubscription(
+            subscription_id=entry.subscription_id,
+            created_at=entry.created_at,
+            updated_at=entry.updated_at,
+            state=entry.state,
+            event_types=tuple(entry.event_types),
+            repo_id=entry.repo_id,
+            run_id=entry.run_id,
+            thread_id=entry.thread_id,
+            lane_id=entry.lane_id,
+            from_state=entry.from_state,
+            to_state=entry.to_state,
+            reason=entry.reason,
+            idempotency_key=entry.idempotency_key,
+            max_matches=entry.max_matches,
+            match_count=entry.match_count,
+            metadata=dict(entry.metadata),
+        )
+
+    def _apply_reduce_result(
+        self,
+        subscriptions: list[PmaLifecycleSubscription],
+        wakeups: list[PmaAutomationWakeup],
+        result: ReduceTransitionResult,
+        timestamp: str,
+        *,
+        compute_dispatch: bool = True,
+    ) -> list[PmaAutomationWakeup]:
+        sub_by_id = {entry.subscription_id: entry for entry in subscriptions}
+        now = _iso_now()
+        for domain_sub in result.subscriptions:
+            existing = sub_by_id.get(domain_sub.subscription_id)
+            if existing is None:
+                continue
+            if existing.match_count != domain_sub.match_count:
+                existing.match_count = domain_sub.match_count
+                existing.updated_at = now
+            if existing.state != domain_sub.state:
+                existing.state = domain_sub.state
+                existing.updated_at = now
+        appended: list[PmaAutomationWakeup] = []
+        for intent in result.wakeup_intents:
+            wakeup = PmaAutomationWakeup.create(
+                source=intent.source,
+                repo_id=intent.repo_id,
+                run_id=intent.run_id,
+                thread_id=intent.thread_id,
+                lane_id=intent.lane_id,
+                from_state=intent.from_state,
+                to_state=intent.to_state,
+                reason=intent.reason,
+                timestamp=timestamp,
+                idempotency_key=intent.idempotency_key,
+                subscription_id=intent.subscription_id,
+                event_type=intent.event_type,
+                event_id=intent.event_id,
+                event_data=intent.event_data,
+                metadata=intent.metadata,
+            )
+            if compute_dispatch:
+                self._compute_dispatch_decision_for_wakeup(wakeup)
+            wakeups.append(wakeup)
+            appended.append(wakeup)
+        return appended
+
+    def _persist_wakeup_dispatch_decisions(
+        self, wakeups_with_decisions: Sequence[PmaAutomationWakeup]
+    ) -> None:
+        if not wakeups_with_decisions:
+            return
+        by_id: dict[str, dict[str, Any]] = {}
+        for w in wakeups_with_decisions:
+            raw_dd = w.metadata.get("dispatch_decision")
+            if isinstance(raw_dd, dict):
+                by_id[w.wakeup_id] = dict(raw_dd)
+        if not by_id:
+            return
+        with file_lock(self._lock_path()):
+            state, subscriptions, timers, wakeups = self._load_structured_unlocked()
+            changed = False
+            now = _iso_now()
+            for entry in wakeups:
+                new_dd = by_id.get(entry.wakeup_id)
+                if new_dd is None:
+                    continue
+                entry.metadata = dict(entry.metadata)
+                entry.metadata["dispatch_decision"] = new_dd
+                entry.updated_at = now
+                changed = True
+            if changed:
+                self._save_structured_unlocked(state, subscriptions, timers, wakeups)
+
     @staticmethod
     def _normalize_subscription_event_types(
         value: Any,
@@ -2112,7 +2284,9 @@ class PmaAutomationStore:
             )
             wakeups.append(created)
             self._save_structured_unlocked(state, subscriptions, timers, wakeups)
-            return created, False
+        self._compute_dispatch_decision_for_wakeup(created)
+        self._persist_wakeup_dispatch_decisions((created,))
+        return created, False
 
     def enqueue_event(self, **kwargs: Any) -> tuple[PmaAutomationWakeup, bool]:
         return self.enqueue_wakeup(**kwargs)
@@ -2132,13 +2306,21 @@ class PmaAutomationStore:
             wakeups = wakeups[:limit]
         return [entry.to_dict() for entry in wakeups]
 
-    def list_pending_wakeups(self, *, limit: int = 100) -> list[dict[str, Any]]:
+    def list_pending_wakeups(
+        self, *, limit: int = 100, require_dispatch_decision: bool = False
+    ) -> list[dict[str, Any]]:
         take = max(0, int(limit))
         if take <= 0:
             return []
         state = self.load()
         wakeups = self._normalize_wakeups(state.get("wakeups"))
         pending = [entry.to_dict() for entry in wakeups if entry.state == "pending"]
+        if require_dispatch_decision:
+            pending = [
+                d
+                for d in pending
+                if isinstance((d.get("metadata") or {}).get("dispatch_decision"), dict)
+            ]
         return pending[:take]
 
     def list_pending_events(self, *, limit: int = 100) -> list[dict[str, Any]]:
@@ -2178,84 +2360,54 @@ class PmaAutomationStore:
                 "timestamp",
             }
         }
+        new_wakeups: list[PmaAutomationWakeup] = []
         with file_lock(self._lock_path()):
             state, subscriptions, timers, wakeups = self._load_structured_unlocked()
-            matched = 0
-            created = 0
-            changed = False
 
-            for entry in subscriptions:
-                if entry.state != "active":
-                    continue
-                if (
-                    entry.max_matches is not None
-                    and entry.match_count >= entry.max_matches
-                ):
-                    entry.state = "cancelled"
-                    entry.updated_at = _iso_now()
-                    changed = True
-                    continue
-                if entry.event_types and event_type_norm not in entry.event_types:
-                    continue
-                if entry.repo_id is not None and entry.repo_id != repo_id:
-                    continue
-                if entry.run_id is not None and entry.run_id != run_id:
-                    continue
-                if entry.thread_id is not None and entry.thread_id != thread_id:
-                    continue
-                if entry.from_state is not None and entry.from_state != from_state:
-                    continue
-                if entry.to_state is not None and entry.to_state != to_state:
-                    continue
+            event = TransitionEvent(
+                repo_id=repo_id,
+                run_id=run_id,
+                thread_id=thread_id,
+                from_state=from_state,
+                to_state=to_state,
+                reason=reason,
+                event_type=event_type_norm,
+                transition_id=transition_id,
+                extra_metadata=metadata_payload,
+            )
 
-                matched += 1
-                subscription_id = entry.subscription_id
-                key = (
-                    transition_id
-                    or f"{event_type_norm}:{repo_id or ''}:{run_id or ''}:{thread_id or ''}:{from_state or ''}:{to_state or ''}:{timestamp}"
-                )
-                wakeup_key = f"transition:{key}:{subscription_id or 'all'}"
-                deduped = any(
-                    existing.idempotency_key == wakeup_key for existing in wakeups
-                )
-                if deduped:
-                    continue
+            domain_subs = [
+                self._lifecycle_sub_to_domain(entry) for entry in subscriptions
+            ]
+            existing_keys = frozenset(
+                existing.idempotency_key
+                for existing in wakeups
+                if existing.idempotency_key
+            )
+            result = reduce_transition(
+                domain_subs,
+                existing_keys,
+                event,
+                event_timestamp=timestamp,
+            )
 
-                wakeup_metadata = dict(entry.metadata or {})
-                wakeup_metadata.update(metadata_payload)
-                wakeups.append(
-                    PmaAutomationWakeup.create(
-                        source="transition",
-                        repo_id=repo_id,
-                        run_id=run_id,
-                        thread_id=thread_id,
-                        lane_id=entry.lane_id,
-                        from_state=from_state,
-                        to_state=to_state,
-                        reason=reason,
-                        timestamp=timestamp,
-                        idempotency_key=wakeup_key,
-                        subscription_id=subscription_id,
-                        event_type=event_type_norm,
-                        metadata=wakeup_metadata,
-                    )
-                )
-                created += 1
-                entry.match_count = max(0, int(entry.match_count)) + 1
-                entry.updated_at = _iso_now()
-                changed = True
-                if (
-                    entry.max_matches is not None
-                    and entry.match_count >= entry.max_matches
-                ):
-                    entry.state = "cancelled"
+            new_wakeups = self._apply_reduce_result(
+                subscriptions,
+                wakeups,
+                result,
+                timestamp,
+                compute_dispatch=False,
+            )
 
-            if created > 0 or changed:
+            if result.created > 0 or result.subscriptions_changed > 0:
                 self._save_structured_unlocked(state, subscriptions, timers, wakeups)
+        for w in new_wakeups:
+            self._compute_dispatch_decision_for_wakeup(w)
+        self._persist_wakeup_dispatch_decisions(new_wakeups)
         return {
             "status": "ok",
-            "matched": matched,
-            "created": created,
+            "matched": result.matched,
+            "created": result.created,
             "repo_id": repo_id,
             "run_id": run_id,
             "thread_id": thread_id,
@@ -2264,6 +2416,54 @@ class PmaAutomationStore:
             "reason": reason,
             "timestamp": timestamp,
         }
+
+    def notify_timer_fired(
+        self, timer: dict[str, Any]
+    ) -> tuple[Optional[PmaAutomationWakeup], bool]:
+        timer_id = _normalize_text(timer.get("timer_id"))
+        if timer_id is None:
+            return None, True
+
+        fired_at = _normalize_text(timer.get("fired_at")) or _iso_now()
+
+        timer_event = TimerFiredEvent(
+            timer_id=timer_id,
+            timer_type=_normalize_timer_type(timer.get("timer_type")),
+            fired_at=fired_at,
+            repo_id=_normalize_text(timer.get("repo_id")),
+            run_id=_normalize_text(timer.get("run_id")),
+            thread_id=_normalize_text(timer.get("thread_id")),
+            lane_id=_normalize_lane_id(timer.get("lane_id")),
+            from_state=_normalize_text(timer.get("from_state")),
+            to_state=_normalize_text(timer.get("to_state")),
+            reason=_normalize_text(timer.get("reason")),
+            subscription_id=_normalize_text(timer.get("subscription_id")),
+            metadata=(
+                dict(timer["metadata"])
+                if isinstance(timer.get("metadata"), dict)
+                else {}
+            ),
+        )
+
+        result = reduce_timer_fired(timer_event)
+        intent = result.wakeup_intent
+
+        return self.enqueue_wakeup(
+            source=intent.source,
+            repo_id=intent.repo_id,
+            run_id=intent.run_id,
+            thread_id=intent.thread_id,
+            lane_id=intent.lane_id,
+            from_state=intent.from_state,
+            to_state=intent.to_state,
+            reason=intent.reason,
+            timestamp=intent.timestamp or fired_at,
+            idempotency_key=intent.idempotency_key,
+            subscription_id=intent.subscription_id,
+            timer_id=timer_id,
+            event_type=intent.event_type,
+            metadata=intent.metadata,
+        )
 
     def mark_wakeup_dispatched(
         self, wakeup_id: str, *, dispatched_at: Optional[str] = None

--- a/src/codex_autorunner/core/pma_dispatch_decision.py
+++ b/src/codex_autorunner/core/pma_dispatch_decision.py
@@ -1,0 +1,249 @@
+"""PMA dispatch decision builder (thin adapter over domain types).
+
+Canonical domain types live in ``pma_domain.models`` and
+``pma_domain.serialization``.  This module keeps the builder function and
+binding-matching helpers that require live adapter data, but delegates all
+type definitions, normalization, and serialization to the domain package.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from .pma_domain.models import (
+    PmaDispatchAttempt,
+    PmaDispatchDecision,
+)
+from .pma_domain.serialization import (
+    normalize_pma_dispatch_decision as _domain_normalize,
+)
+from .pma_domain.serialization import (
+    pma_dispatch_decision_to_dict as _domain_to_dict,
+)
+from .pma_origin import extract_pma_origin_metadata
+from .text_utils import _normalize_optional_text, _normalize_pma_delivery_target
+
+PmaDispatchAttemptSpec = PmaDispatchAttempt
+
+
+def normalize_pma_dispatch_decision(value: Any) -> Optional[PmaDispatchDecision]:
+    return _domain_normalize(value)
+
+
+def pma_dispatch_decision_to_dict(decision: PmaDispatchDecision) -> dict[str, Any]:
+    return _domain_to_dict(decision)
+
+
+def _thread_binding_matches(
+    *,
+    binding_metadata_by_thread: Mapping[str, Mapping[str, Any]],
+    thread_id: Optional[str],
+    surface_kind: str,
+    surface_key: str,
+) -> bool:
+    normalized_thread_id = _normalize_optional_text(thread_id)
+    if normalized_thread_id is None:
+        return True
+    binding_metadata = binding_metadata_by_thread.get(normalized_thread_id)
+    if not isinstance(binding_metadata, Mapping):
+        return False
+    return (
+        _normalize_optional_text(binding_metadata.get("binding_kind")) == surface_kind
+        and _normalize_optional_text(binding_metadata.get("binding_id")) == surface_key
+    )
+
+
+def _origin_thread_ids_from_payload(payload: Any) -> tuple[str, ...]:
+    if not isinstance(payload, Mapping):
+        return ()
+    thread_ids: list[str] = []
+
+    def _append(candidate: Any) -> None:
+        normalized = _normalize_optional_text(candidate)
+        if normalized is not None and normalized not in thread_ids:
+            thread_ids.append(normalized)
+
+    _append(payload.get("origin_thread_id"))
+    metadata = payload.get("metadata")
+    origin = extract_pma_origin_metadata(
+        metadata if isinstance(metadata, Mapping) else None
+    )
+    if origin is not None:
+        _append(origin.thread_id)
+    return tuple(thread_ids)
+
+
+def _explicit_delivery_target_thread_ids(
+    *,
+    managed_thread_id: Optional[str],
+    context_payload: Optional[Mapping[str, Any]],
+) -> tuple[str, ...]:
+    thread_ids: list[str] = []
+
+    def _append(candidate: Any) -> None:
+        normalized = _normalize_optional_text(candidate)
+        if normalized is not None and normalized not in thread_ids:
+            thread_ids.append(normalized)
+
+    _append(managed_thread_id)
+    if isinstance(context_payload, Mapping):
+        for candidate in _origin_thread_ids_from_payload(context_payload):
+            _append(candidate)
+        wake_up = context_payload.get("wake_up")
+        if isinstance(wake_up, Mapping):
+            for candidate in _origin_thread_ids_from_payload(wake_up):
+                _append(candidate)
+    return tuple(thread_ids)
+
+
+def _delivery_target_matches_any_thread_binding(
+    *,
+    binding_metadata_by_thread: Mapping[str, Mapping[str, Any]],
+    thread_ids: tuple[str, ...],
+    surface_kind: str,
+    surface_key: str,
+) -> bool:
+    if not thread_ids:
+        return True
+    return any(
+        _thread_binding_matches(
+            binding_metadata_by_thread=binding_metadata_by_thread,
+            thread_id=thread_id,
+            surface_kind=surface_kind,
+            surface_key=surface_key,
+        )
+        for thread_id in thread_ids
+    )
+
+
+def _surface_binding_from_lane_id(
+    lane_id: Optional[str],
+) -> Optional[tuple[str, str]]:
+    normalized_lane_id = _normalize_optional_text(lane_id)
+    if normalized_lane_id is None or ":" not in normalized_lane_id:
+        return None
+    surface_kind_raw, surface_key_raw = normalized_lane_id.split(":", 1)
+    surface_kind = _normalize_optional_text(surface_kind_raw)
+    surface_key = _normalize_optional_text(surface_key_raw)
+    if surface_kind not in {"discord", "telegram"} or surface_key is None:
+        return None
+    return surface_kind, surface_key
+
+
+def build_pma_dispatch_decision(
+    *,
+    message: str,
+    requested_delivery: str,
+    source_kind: str,
+    repo_id: Optional[str],
+    workspace_root: Optional[Path],
+    managed_thread_id: Optional[str],
+    delivery_target: Optional[dict[str, Any]],
+    context_payload: Optional[Mapping[str, Any]],
+    binding_metadata_by_thread: Mapping[str, Mapping[str, Any]],
+    preferred_bound_surface_kinds: tuple[str, ...] = (),
+    lane_id: Optional[str] = None,
+) -> PmaDispatchDecision:
+    from .pma_domain.publish_policy import evaluate_publish_suppression
+
+    normalized_delivery = (
+        _normalize_optional_text(requested_delivery) or "auto"
+    ).lower()
+    normalized_source_kind = _normalize_optional_text(source_kind) or "automation"
+    normalized_repo_id = _normalize_optional_text(repo_id)
+    lane_surface_binding = _surface_binding_from_lane_id(lane_id)
+
+    if normalized_delivery == "none":
+        return PmaDispatchDecision(requested_delivery="none")
+
+    attempts: list[PmaDispatchAttempt] = []
+    normalized_target = _normalize_pma_delivery_target(delivery_target)
+    if normalized_target is not None:
+        surface_kind, surface_key = normalized_target
+        explicit_target_thread_ids = _explicit_delivery_target_thread_ids(
+            managed_thread_id=managed_thread_id,
+            context_payload=context_payload,
+        )
+        target_matches_managed_thread_binding = _thread_binding_matches(
+            binding_metadata_by_thread=binding_metadata_by_thread,
+            thread_id=managed_thread_id,
+            surface_kind=surface_kind,
+            surface_key=surface_key,
+        )
+        target_matches_known_binding = _delivery_target_matches_any_thread_binding(
+            binding_metadata_by_thread=binding_metadata_by_thread,
+            thread_ids=explicit_target_thread_ids,
+            surface_kind=surface_kind,
+            surface_key=surface_key,
+        )
+        suppression = evaluate_publish_suppression(
+            source_kind=normalized_source_kind,
+            message_text=message,
+            managed_thread_id=managed_thread_id,
+            target_matches_thread_binding=target_matches_managed_thread_binding,
+        )
+        if suppression.suppressed:
+            return PmaDispatchDecision(
+                requested_delivery="suppressed_duplicate",
+                suppress_publish=True,
+            )
+        if explicit_target_thread_ids and target_matches_known_binding:
+            attempts.append(
+                PmaDispatchAttempt(
+                    route="explicit",
+                    delivery_mode="bound",
+                    surface_kind=surface_kind,
+                    surface_key=surface_key,
+                    repo_id=normalized_repo_id,
+                )
+            )
+
+    if normalized_delivery in {"auto", "primary_pma"} and normalized_repo_id:
+        attempts.extend(
+            PmaDispatchAttempt(
+                route="primary_pma",
+                delivery_mode="primary_pma",
+                surface_kind=surface_kind,
+                surface_key=(
+                    lane_surface_binding[1]
+                    if lane_surface_binding is not None
+                    and lane_surface_binding[0] == surface_kind
+                    else None
+                ),
+                repo_id=normalized_repo_id,
+            )
+            for surface_kind in ("discord", "telegram")
+        )
+
+    if normalized_delivery in {"auto", "bound"} and workspace_root is not None:
+        attempts.extend(
+            PmaDispatchAttempt(
+                route="bound",
+                delivery_mode="bound",
+                surface_kind=surface_kind,
+                surface_key=(
+                    lane_surface_binding[1]
+                    if lane_surface_binding is not None
+                    and lane_surface_binding[0] == surface_kind
+                    else None
+                ),
+                repo_id=normalized_repo_id,
+                workspace_root=str(workspace_root),
+            )
+            for surface_kind in preferred_bound_surface_kinds
+        )
+
+    return PmaDispatchDecision(
+        requested_delivery=normalized_delivery,
+        attempts=tuple(attempts),
+    )
+
+
+__all__ = [
+    "PmaDispatchAttemptSpec",
+    "PmaDispatchDecision",
+    "build_pma_dispatch_decision",
+    "normalize_pma_dispatch_decision",
+    "pma_dispatch_decision_to_dict",
+]

--- a/src/codex_autorunner/core/pma_dispatch_decision.py
+++ b/src/codex_autorunner/core/pma_dispatch_decision.py
@@ -16,19 +16,10 @@ from .pma_domain.models import (
     PmaDispatchDecision,
 )
 from .pma_domain.serialization import (
-    normalize_pma_dispatch_decision as _domain_normalize,
-)
-from .pma_domain.serialization import (
     pma_dispatch_decision_to_dict as _domain_to_dict,
 )
 from .pma_origin import extract_pma_origin_metadata
 from .text_utils import _normalize_optional_text, _normalize_pma_delivery_target
-
-PmaDispatchAttemptSpec = PmaDispatchAttempt
-
-
-def normalize_pma_dispatch_decision(value: Any) -> Optional[PmaDispatchDecision]:
-    return _domain_normalize(value)
 
 
 def pma_dispatch_decision_to_dict(decision: PmaDispatchDecision) -> dict[str, Any]:
@@ -241,9 +232,7 @@ def build_pma_dispatch_decision(
 
 
 __all__ = [
-    "PmaDispatchAttemptSpec",
     "PmaDispatchDecision",
     "build_pma_dispatch_decision",
-    "normalize_pma_dispatch_decision",
     "pma_dispatch_decision_to_dict",
 ]

--- a/tests/core/test_pma_automation_store.py
+++ b/tests/core/test_pma_automation_store.py
@@ -12,6 +12,7 @@ from codex_autorunner.core.pma_automation_store import (
     PmaAutomationThreadNotFoundError,
 )
 from codex_autorunner.core.pma_automation_types import default_pma_automation_state
+from codex_autorunner.core.pma_domain.models import PmaDispatchDecision
 from codex_autorunner.core.pma_thread_store import (
     PmaThreadStore,
     prepare_pma_thread_store,
@@ -699,3 +700,232 @@ def test_timer_rejects_invalid_due_at_timestamp(tmp_path) -> None:
     store = PmaAutomationStore(tmp_path)
     with pytest.raises(ValueError):
         store.create_timer({"timer_type": "one_shot", "due_at": "not-a-timestamp"})
+
+
+def test_notify_transition_persists_dispatch_decision_in_wakeup_metadata(
+    tmp_path,
+) -> None:
+    store = PmaAutomationStore(tmp_path, durable=False)
+    thread_id = _create_managed_thread(tmp_path, surface_kind="discord")
+
+    store.create_subscription(
+        {
+            "event_type": "managed_thread_completed",
+            "thread_id": thread_id,
+        }
+    )
+
+    store.notify_transition(
+        {
+            "event_type": "managed_thread_completed",
+            "thread_id": thread_id,
+            "from_state": "running",
+            "to_state": "completed",
+            "transition_id": f"{thread_id}:completed",
+        }
+    )
+
+    pending = store.list_pending_wakeups(limit=10)
+    assert len(pending) == 1
+    wakeup = pending[0]
+    assert "dispatch_decision" in wakeup["metadata"]
+    decision = wakeup["metadata"]["dispatch_decision"]
+    assert decision["requested_delivery"] == "auto"
+    assert decision["suppress_publish"] is False
+    assert isinstance(decision["attempts"], list)
+    assert len(decision["attempts"]) > 0
+
+
+def test_enqueue_wakeup_persists_dispatch_decision(tmp_path) -> None:
+    store = PmaAutomationStore(tmp_path, durable=False)
+
+    wakeup, deduped = store.enqueue_wakeup(
+        source="automation",
+        repo_id="repo-1",
+        metadata={
+            "delivery_target": {"surface_kind": "discord", "surface_key": "ch-1"}
+        },
+    )
+    assert deduped is False
+    assert "dispatch_decision" in wakeup.metadata
+    decision = wakeup.metadata["dispatch_decision"]
+    assert decision["requested_delivery"] == "auto"
+    assert isinstance(decision["attempts"], list)
+
+
+def test_compute_dispatch_decision_for_wakeup_passes_lane_id(
+    tmp_path, monkeypatch
+) -> None:
+    store = PmaAutomationStore(tmp_path, durable=False)
+    captured: dict[str, object] = {}
+
+    def _fake_build_pma_dispatch_decision(**kwargs):
+        captured.update(kwargs)
+        return PmaDispatchDecision(requested_delivery="auto")
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.pma_automation_store.build_pma_dispatch_decision",
+        _fake_build_pma_dispatch_decision,
+    )
+
+    wakeup, deduped = store.enqueue_wakeup(
+        source="automation",
+        repo_id="repo-1",
+        lane_id="discord:12345",
+    )
+
+    assert deduped is False
+    assert captured["lane_id"] == "discord:12345"
+    assert captured["managed_thread_id"] == wakeup.thread_id
+
+
+def test_enqueue_wakeup_dispatch_decision_uses_wakeup_lane_id_surface_key(
+    tmp_path,
+) -> None:
+    store = PmaAutomationStore(tmp_path, durable=False)
+
+    wakeup, deduped = store.enqueue_wakeup(
+        source="automation",
+        repo_id="repo-1",
+        lane_id="discord:12345",
+    )
+
+    assert deduped is False
+    decision = wakeup.metadata["dispatch_decision"]
+    attempts_by_surface = {
+        (attempt["route"], attempt["surface_kind"]): attempt.get("surface_key")
+        for attempt in decision["attempts"]
+    }
+    assert attempts_by_surface[("primary_pma", "discord")] == "12345"
+    assert attempts_by_surface[("primary_pma", "telegram")] is None
+
+
+def test_enqueue_wakeup_tolerates_runtime_error_while_loading_binding_metadata(
+    tmp_path, monkeypatch
+) -> None:
+    store = PmaAutomationStore(tmp_path, durable=False)
+
+    def _raise_runtime_error(*args, **kwargs):
+        _ = args, kwargs
+        raise RuntimeError("bindings unavailable")
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.pma_automation_store.active_chat_binding_metadata_by_thread",
+        _raise_runtime_error,
+    )
+
+    wakeup, deduped = store.enqueue_wakeup(
+        source="automation",
+        repo_id="repo-1",
+    )
+
+    assert deduped is False
+    assert wakeup.wakeup_id
+    assert store.list_pending_wakeups(limit=10)[0]["wakeup_id"] == wakeup.wakeup_id
+    assert isinstance(wakeup.metadata.get("dispatch_decision"), dict)
+
+
+def test_notify_transition_tolerates_runtime_error_while_loading_workspace_preference(
+    tmp_path, monkeypatch
+) -> None:
+    store = PmaAutomationStore(tmp_path, durable=False)
+    thread_id = _create_managed_thread(tmp_path)
+
+    store.create_subscription(
+        {
+            "event_type": "managed_thread_completed",
+            "thread_id": thread_id,
+        }
+    )
+
+    def _raise_runtime_error(*args, **kwargs):
+        _ = args, kwargs
+        raise RuntimeError("workspace preference unavailable")
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.pma_automation_store.preferred_non_pma_chat_notification_source_for_workspace",
+        _raise_runtime_error,
+    )
+
+    result = store.notify_transition(
+        {
+            "event_type": "managed_thread_completed",
+            "thread_id": thread_id,
+            "from_state": "running",
+            "to_state": "completed",
+            "transition_id": f"{thread_id}:completed",
+        }
+    )
+
+    assert result["created"] == 1
+    pending = store.list_pending_wakeups(limit=10)
+    assert len(pending) == 1
+    assert pending[0]["thread_id"] == thread_id
+
+
+def test_dispatch_decision_survives_round_trip(tmp_path) -> None:
+    store = PmaAutomationStore(tmp_path, durable=False)
+    thread_id = _create_managed_thread(tmp_path, surface_kind="telegram")
+
+    store.create_subscription(
+        {"event_type": "managed_thread_completed", "thread_id": thread_id}
+    )
+    store.notify_transition(
+        {
+            "event_type": "managed_thread_completed",
+            "thread_id": thread_id,
+            "from_state": "running",
+            "to_state": "completed",
+            "transition_id": f"{thread_id}:completed",
+        }
+    )
+
+    pending = store.list_pending_wakeups(limit=10)
+    assert len(pending) == 1
+    original_decision = pending[0]["metadata"]["dispatch_decision"]
+
+    store2 = PmaAutomationStore(tmp_path, durable=False)
+    reloaded = store2.list_pending_wakeups(limit=10)
+    assert len(reloaded) == 1
+    assert reloaded[0]["metadata"]["dispatch_decision"] == original_decision
+
+
+def test_post_wakeup_rebind_does_not_mutate_dispatch_decision(tmp_path) -> None:
+    store = PmaAutomationStore(tmp_path, durable=False)
+    binding_store = OrchestrationBindingStore(tmp_path)
+    thread_id = _create_managed_thread(
+        tmp_path, surface_kind="discord", binding_store=binding_store
+    )
+
+    store.create_subscription(
+        {"event_type": "managed_thread_completed", "thread_id": thread_id}
+    )
+    store.notify_transition(
+        {
+            "event_type": "managed_thread_completed",
+            "thread_id": thread_id,
+            "from_state": "running",
+            "to_state": "completed",
+            "transition_id": f"{thread_id}:completed",
+        }
+    )
+
+    pending = store.list_pending_wakeups(limit=10)
+    assert len(pending) == 1
+    original_decision = pending[0]["metadata"]["dispatch_decision"]
+    original_surface = original_decision["attempts"][0]["surface_kind"]
+    assert original_surface == "discord"
+
+    binding_store.upsert_binding(
+        surface_kind="telegram",
+        surface_key="telegram:rebound-channel",
+        thread_target_id=thread_id,
+    )
+
+    reloaded = store.list_pending_wakeups(limit=10)
+    assert len(reloaded) == 1
+    assert reloaded[0]["metadata"]["dispatch_decision"] == original_decision
+    assert (
+        reloaded[0]["metadata"]["dispatch_decision"]["attempts"][0]["surface_kind"]
+        == "discord"
+    )

--- a/tests/core/test_pma_dispatch_decision.py
+++ b/tests/core/test_pma_dispatch_decision.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_autorunner.core.pma_dispatch_decision import build_pma_dispatch_decision
+
+
+def test_build_pma_dispatch_decision_accepts_origin_thread_delivery_target(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo-a"
+
+    decision = build_pma_dispatch_decision(
+        message="Terminal follow-up",
+        requested_delivery="auto",
+        source_kind="managed_thread_completed",
+        repo_id="repo-a",
+        workspace_root=workspace,
+        managed_thread_id="watched-thread",
+        delivery_target={
+            "surface_kind": "discord",
+            "surface_key": "origin-discord",
+        },
+        context_payload={
+            "wake_up": {
+                "metadata": {
+                    "pma_origin": {
+                        "thread_id": "origin-thread",
+                    }
+                }
+            }
+        },
+        binding_metadata_by_thread={
+            "origin-thread": {
+                "binding_kind": "discord",
+                "binding_id": "origin-discord",
+            }
+        },
+        preferred_bound_surface_kinds=("discord", "telegram"),
+    )
+
+    assert decision.suppress_publish is False
+    assert [attempt.route for attempt in decision.attempts] == [
+        "explicit",
+        "primary_pma",
+        "primary_pma",
+        "bound",
+        "bound",
+    ]
+    assert decision.attempts[0].surface_kind == "discord"
+    assert decision.attempts[0].surface_key == "origin-discord"
+
+
+def test_build_pma_dispatch_decision_suppresses_duplicate_only_for_managed_thread_match() -> (
+    None
+):
+    decision = build_pma_dispatch_decision(
+        message="Already handled. No action needed.",
+        requested_delivery="auto",
+        source_kind="managed_thread_completed",
+        repo_id="repo-a",
+        workspace_root=None,
+        managed_thread_id="watched-thread",
+        delivery_target={
+            "surface_kind": "discord",
+            "surface_key": "watched-discord",
+        },
+        context_payload=None,
+        binding_metadata_by_thread={
+            "watched-thread": {
+                "binding_kind": "discord",
+                "binding_id": "watched-discord",
+            }
+        },
+    )
+
+    assert decision.suppress_publish is True
+    assert decision.requested_delivery == "suppressed_duplicate"
+    assert decision.attempts == ()
+
+
+def test_build_pma_dispatch_decision_rejects_unknown_explicit_target_and_falls_back(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo-a"
+
+    decision = build_pma_dispatch_decision(
+        message="Fallback",
+        requested_delivery="auto",
+        source_kind="managed_thread_completed",
+        repo_id="repo-a",
+        workspace_root=workspace,
+        managed_thread_id="watched-thread",
+        delivery_target={
+            "surface_kind": "discord",
+            "surface_key": "missing-discord",
+        },
+        context_payload={
+            "wake_up": {
+                "metadata": {
+                    "pma_origin": {
+                        "thread_id": "origin-thread",
+                    }
+                }
+            }
+        },
+        binding_metadata_by_thread={
+            "origin-thread": {
+                "binding_kind": "telegram",
+                "binding_id": "origin-telegram",
+            }
+        },
+        preferred_bound_surface_kinds=("telegram", "discord"),
+    )
+
+    assert [attempt.route for attempt in decision.attempts] == [
+        "primary_pma",
+        "primary_pma",
+        "bound",
+        "bound",
+    ]
+    assert [attempt.surface_kind for attempt in decision.attempts] == [
+        "discord",
+        "telegram",
+        "telegram",
+        "discord",
+    ]
+
+
+def test_build_pma_dispatch_decision_does_not_suppress_non_terminal_source() -> None:
+    decision = build_pma_dispatch_decision(
+        message="Already handled. No action needed.",
+        requested_delivery="auto",
+        source_kind="automation",
+        repo_id="repo-a",
+        workspace_root=None,
+        managed_thread_id="watched-thread",
+        delivery_target={
+            "surface_kind": "discord",
+            "surface_key": "watched-discord",
+        },
+        context_payload=None,
+        binding_metadata_by_thread={
+            "watched-thread": {
+                "binding_kind": "discord",
+                "binding_id": "watched-discord",
+            }
+        },
+    )
+
+    assert decision.suppress_publish is False
+    assert any(a.route == "explicit" for a in decision.attempts)
+
+
+def test_build_pma_dispatch_decision_does_not_suppress_normal_completion_message() -> (
+    None
+):
+    decision = build_pma_dispatch_decision(
+        message="Changes pushed successfully.",
+        requested_delivery="auto",
+        source_kind="managed_thread_completed",
+        repo_id="repo-a",
+        workspace_root=None,
+        managed_thread_id="watched-thread",
+        delivery_target={
+            "surface_kind": "discord",
+            "surface_key": "watched-discord",
+        },
+        context_payload=None,
+        binding_metadata_by_thread={
+            "watched-thread": {
+                "binding_kind": "discord",
+                "binding_id": "watched-discord",
+            }
+        },
+    )
+
+    assert decision.suppress_publish is False
+    assert any(a.route == "explicit" for a in decision.attempts)
+
+
+def test_build_pma_dispatch_decision_does_not_suppress_when_binding_mismatches(
+    tmp_path: Path,
+) -> None:
+    decision = build_pma_dispatch_decision(
+        message="Already handled. No action needed.",
+        requested_delivery="auto",
+        source_kind="managed_thread_completed",
+        repo_id="repo-a",
+        workspace_root=tmp_path / "repo-a",
+        managed_thread_id="watched-thread",
+        delivery_target={
+            "surface_kind": "discord",
+            "surface_key": "other-discord",
+        },
+        context_payload=None,
+        binding_metadata_by_thread={
+            "watched-thread": {
+                "binding_kind": "discord",
+                "binding_id": "watched-discord",
+            }
+        },
+        preferred_bound_surface_kinds=("discord", "telegram"),
+    )
+
+    assert decision.suppress_publish is False
+    assert any(a.route == "primary_pma" for a in decision.attempts)
+
+
+def test_build_pma_dispatch_decision_does_not_suppress_without_managed_thread() -> None:
+    decision = build_pma_dispatch_decision(
+        message="Already handled. No action needed.",
+        requested_delivery="auto",
+        source_kind="managed_thread_completed",
+        repo_id="repo-a",
+        workspace_root=None,
+        managed_thread_id=None,
+        delivery_target={
+            "surface_kind": "discord",
+            "surface_key": "some-discord",
+        },
+        context_payload=None,
+        binding_metadata_by_thread={},
+    )
+
+    assert decision.suppress_publish is False
+
+
+def test_build_pma_dispatch_decision_skips_explicit_without_binding_thread_ids(
+    tmp_path: Path,
+) -> None:
+    """No managed thread or origin thread ids: do not persist an explicit attempt."""
+    decision = build_pma_dispatch_decision(
+        message="Hello",
+        requested_delivery="auto",
+        source_kind="automation",
+        repo_id="repo-a",
+        workspace_root=tmp_path / "repo-a",
+        managed_thread_id=None,
+        delivery_target={
+            "surface_kind": "discord",
+            "surface_key": "orphan-discord",
+        },
+        context_payload=None,
+        binding_metadata_by_thread={
+            "some-thread": {
+                "binding_kind": "discord",
+                "binding_id": "orphan-discord",
+            }
+        },
+        preferred_bound_surface_kinds=("discord", "telegram"),
+    )
+
+    assert not any(a.route == "explicit" for a in decision.attempts)
+    assert any(a.route == "primary_pma" for a in decision.attempts)
+
+
+def test_build_pma_dispatch_decision_resolves_discord_lane_surface_key(
+    tmp_path: Path,
+) -> None:
+    decision = build_pma_dispatch_decision(
+        message="Lane-targeted follow-up",
+        requested_delivery="auto",
+        source_kind="automation",
+        repo_id="repo-a",
+        workspace_root=tmp_path / "repo-a",
+        managed_thread_id="watched-thread",
+        delivery_target=None,
+        context_payload=None,
+        binding_metadata_by_thread={},
+        preferred_bound_surface_kinds=("discord", "telegram"),
+        lane_id="discord:12345",
+    )
+
+    attempts_by_surface = {
+        (attempt.route, attempt.surface_kind): attempt.surface_key
+        for attempt in decision.attempts
+    }
+
+    assert attempts_by_surface[("primary_pma", "discord")] == "12345"
+    assert attempts_by_surface[("primary_pma", "telegram")] is None
+    assert attempts_by_surface[("bound", "discord")] == "12345"
+    assert attempts_by_surface[("bound", "telegram")] is None
+
+
+def test_build_pma_dispatch_decision_resolves_telegram_lane_surface_key(
+    tmp_path: Path,
+) -> None:
+    decision = build_pma_dispatch_decision(
+        message="Lane-targeted follow-up",
+        requested_delivery="auto",
+        source_kind="automation",
+        repo_id="repo-a",
+        workspace_root=tmp_path / "repo-a",
+        managed_thread_id="watched-thread",
+        delivery_target=None,
+        context_payload=None,
+        binding_metadata_by_thread={},
+        preferred_bound_surface_kinds=("discord", "telegram"),
+        lane_id="telegram:chat-id",
+    )
+
+    attempts_by_surface = {
+        (attempt.route, attempt.surface_kind): attempt.surface_key
+        for attempt in decision.attempts
+    }
+
+    assert attempts_by_surface[("primary_pma", "discord")] is None
+    assert attempts_by_surface[("primary_pma", "telegram")] == "chat-id"
+    assert attempts_by_surface[("bound", "discord")] is None
+    assert attempts_by_surface[("bound", "telegram")] == "chat-id"
+
+
+def test_build_pma_dispatch_decision_keeps_surface_keys_empty_without_lane_id(
+    tmp_path: Path,
+) -> None:
+    decision = build_pma_dispatch_decision(
+        message="Lane-targeted follow-up",
+        requested_delivery="auto",
+        source_kind="automation",
+        repo_id="repo-a",
+        workspace_root=tmp_path / "repo-a",
+        managed_thread_id="watched-thread",
+        delivery_target=None,
+        context_payload=None,
+        binding_metadata_by_thread={},
+        preferred_bound_surface_kinds=("discord", "telegram"),
+    )
+
+    assert [attempt.surface_key for attempt in decision.attempts] == [
+        None,
+        None,
+        None,
+        None,
+    ]


### PR DESCRIPTION
Fixes #1583.

## Summary
- resolve `lane_id` values like `discord:<id>` and `telegram:<id>` into dispatch `surface_key` values
- thread the wakeup `lane_id` into PMA dispatch decision generation so wakeup-backed notifications keep their bound lane
- add coverage for lane-aware dispatch decisions and wakeup dispatch persistence

## Validation
- `.venv/bin/python -m pytest tests/core/test_pma_dispatch_decision.py tests/core/test_pma_automation_store.py -q`
- `git commit` hook validation passed on this branch, including formatting, mypy, staged pytest, frontend build/tests, and chat-surface lab checks