### PR TITLE
Fix #1583: resolve lane_id in dispatch decision for notification routing

### DIFF
--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -1180,6 +1180,7 @@ class PmaAutomationStore:
             source_kind=wakeup.source or "automation",
             repo_id=wakeup.repo_id,
             workspace_root=workspace_root,
+            lane_id=wakeup.lane_id,
             managed_thread_id=wakeup.thread_id,
             delivery_target=(
                 delivery_target if isinstance(delivery_target, dict) else None

--- a/src/codex_autorunner/core/pma_dispatch_decision.py
+++ b/src/codex_autorunner/core/pma_dispatch_decision.py
@@ -117,6 +117,20 @@ def _delivery_target_matches_any_thread_binding(
     )
 
 
+def _surface_binding_from_lane_id(
+    lane_id: Optional[str],
+) -> Optional[tuple[str, str]]:
+    normalized_lane_id = _normalize_optional_text(lane_id)
+    if normalized_lane_id is None or ":" not in normalized_lane_id:
+        return None
+    surface_kind_raw, surface_key_raw = normalized_lane_id.split(":", 1)
+    surface_kind = _normalize_optional_text(surface_kind_raw)
+    surface_key = _normalize_optional_text(surface_key_raw)
+    if surface_kind not in {"discord", "telegram"} or surface_key is None:
+        return None
+    return surface_kind, surface_key
+
+
 def build_pma_dispatch_decision(
     *,
     message: str,
@@ -129,6 +143,7 @@ def build_pma_dispatch_decision(
     context_payload: Optional[Mapping[str, Any]],
     binding_metadata_by_thread: Mapping[str, Mapping[str, Any]],
     preferred_bound_surface_kinds: tuple[str, ...] = (),
+    lane_id: Optional[str] = None,
 ) -> PmaDispatchDecision:
     from .pma_domain.publish_policy import evaluate_publish_suppression
 
@@ -137,6 +152,7 @@ def build_pma_dispatch_decision(
     ).lower()
     normalized_source_kind = _normalize_optional_text(source_kind) or "automation"
     normalized_repo_id = _normalize_optional_text(repo_id)
+    lane_surface_binding = _surface_binding_from_lane_id(lane_id)
 
     if normalized_delivery == "none":
         return PmaDispatchDecision(requested_delivery="none")
@@ -189,6 +205,12 @@ def build_pma_dispatch_decision(
                 route="primary_pma",
                 delivery_mode="primary_pma",
                 surface_kind=surface_kind,
+                surface_key=(
+                    lane_surface_binding[1]
+                    if lane_surface_binding is not None
+                    and lane_surface_binding[0] == surface_kind
+                    else None
+                ),
                 repo_id=normalized_repo_id,
             )
             for surface_kind in ("discord", "telegram")
@@ -200,6 +222,12 @@ def build_pma_dispatch_decision(
                 route="bound",
                 delivery_mode="bound",
                 surface_kind=surface_kind,
+                surface_key=(
+                    lane_surface_binding[1]
+                    if lane_surface_binding is not None
+                    and lane_surface_binding[0] == surface_kind
+                    else None
+                ),
                 repo_id=normalized_repo_id,
                 workspace_root=str(workspace_root),
             )

--- a/tests/core/test_pma_automation_store.py
+++ b/tests/core/test_pma_automation_store.py
@@ -12,6 +12,7 @@ from codex_autorunner.core.pma_automation_store import (
     PmaAutomationThreadNotFoundError,
 )
 from codex_autorunner.core.pma_automation_types import default_pma_automation_state
+from codex_autorunner.core.pma_domain.models import PmaDispatchDecision
 from codex_autorunner.core.pma_thread_store import (
     PmaThreadStore,
     prepare_pma_thread_store,
@@ -750,6 +751,53 @@ def test_enqueue_wakeup_persists_dispatch_decision(tmp_path) -> None:
     decision = wakeup.metadata["dispatch_decision"]
     assert decision["requested_delivery"] == "auto"
     assert isinstance(decision["attempts"], list)
+
+
+def test_compute_dispatch_decision_for_wakeup_passes_lane_id(
+    tmp_path, monkeypatch
+) -> None:
+    store = PmaAutomationStore(tmp_path, durable=False)
+    captured: dict[str, object] = {}
+
+    def _fake_build_pma_dispatch_decision(**kwargs):
+        captured.update(kwargs)
+        return PmaDispatchDecision(requested_delivery="auto")
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.pma_automation_store.build_pma_dispatch_decision",
+        _fake_build_pma_dispatch_decision,
+    )
+
+    wakeup, deduped = store.enqueue_wakeup(
+        source="automation",
+        repo_id="repo-1",
+        lane_id="discord:12345",
+    )
+
+    assert deduped is False
+    assert captured["lane_id"] == "discord:12345"
+    assert captured["managed_thread_id"] == wakeup.thread_id
+
+
+def test_enqueue_wakeup_dispatch_decision_uses_wakeup_lane_id_surface_key(
+    tmp_path,
+) -> None:
+    store = PmaAutomationStore(tmp_path, durable=False)
+
+    wakeup, deduped = store.enqueue_wakeup(
+        source="automation",
+        repo_id="repo-1",
+        lane_id="discord:12345",
+    )
+
+    assert deduped is False
+    decision = wakeup.metadata["dispatch_decision"]
+    attempts_by_surface = {
+        (attempt["route"], attempt["surface_kind"]): attempt.get("surface_key")
+        for attempt in decision["attempts"]
+    }
+    assert attempts_by_surface[("primary_pma", "discord")] == "12345"
+    assert attempts_by_surface[("primary_pma", "telegram")] is None
 
 
 def test_enqueue_wakeup_tolerates_runtime_error_while_loading_binding_metadata(

--- a/tests/core/test_pma_dispatch_decision.py
+++ b/tests/core/test_pma_dispatch_decision.py
@@ -253,3 +253,83 @@ def test_build_pma_dispatch_decision_skips_explicit_without_binding_thread_ids(
 
     assert not any(a.route == "explicit" for a in decision.attempts)
     assert any(a.route == "primary_pma" for a in decision.attempts)
+
+
+def test_build_pma_dispatch_decision_resolves_discord_lane_surface_key(
+    tmp_path: Path,
+) -> None:
+    decision = build_pma_dispatch_decision(
+        message="Lane-targeted follow-up",
+        requested_delivery="auto",
+        source_kind="automation",
+        repo_id="repo-a",
+        workspace_root=tmp_path / "repo-a",
+        managed_thread_id="watched-thread",
+        delivery_target=None,
+        context_payload=None,
+        binding_metadata_by_thread={},
+        preferred_bound_surface_kinds=("discord", "telegram"),
+        lane_id="discord:12345",
+    )
+
+    attempts_by_surface = {
+        (attempt.route, attempt.surface_kind): attempt.surface_key
+        for attempt in decision.attempts
+    }
+
+    assert attempts_by_surface[("primary_pma", "discord")] == "12345"
+    assert attempts_by_surface[("primary_pma", "telegram")] is None
+    assert attempts_by_surface[("bound", "discord")] == "12345"
+    assert attempts_by_surface[("bound", "telegram")] is None
+
+
+def test_build_pma_dispatch_decision_resolves_telegram_lane_surface_key(
+    tmp_path: Path,
+) -> None:
+    decision = build_pma_dispatch_decision(
+        message="Lane-targeted follow-up",
+        requested_delivery="auto",
+        source_kind="automation",
+        repo_id="repo-a",
+        workspace_root=tmp_path / "repo-a",
+        managed_thread_id="watched-thread",
+        delivery_target=None,
+        context_payload=None,
+        binding_metadata_by_thread={},
+        preferred_bound_surface_kinds=("discord", "telegram"),
+        lane_id="telegram:chat-id",
+    )
+
+    attempts_by_surface = {
+        (attempt.route, attempt.surface_kind): attempt.surface_key
+        for attempt in decision.attempts
+    }
+
+    assert attempts_by_surface[("primary_pma", "discord")] is None
+    assert attempts_by_surface[("primary_pma", "telegram")] == "chat-id"
+    assert attempts_by_surface[("bound", "discord")] is None
+    assert attempts_by_surface[("bound", "telegram")] == "chat-id"
+
+
+def test_build_pma_dispatch_decision_keeps_surface_keys_empty_without_lane_id(
+    tmp_path: Path,
+) -> None:
+    decision = build_pma_dispatch_decision(
+        message="Lane-targeted follow-up",
+        requested_delivery="auto",
+        source_kind="automation",
+        repo_id="repo-a",
+        workspace_root=tmp_path / "repo-a",
+        managed_thread_id="watched-thread",
+        delivery_target=None,
+        context_payload=None,
+        binding_metadata_by_thread={},
+        preferred_bound_surface_kinds=("discord", "telegram"),
+    )
+
+    assert [attempt.surface_key for attempt in decision.attempts] == [
+        None,
+        None,
+        None,
+        None,
+    ]


### PR DESCRIPTION
Fixes #1583. Lane-based notification dispatch was ignoring lane_id, causing all surface_key values to be null in dispatch attempts. This made Discord delivery fall through to Telegram DM.

## Changes
- Add lane_id parsing to build_pma_dispatch_decision() in pma_dispatch_decision.py
- Wire wakeup.lane_id through _compute_dispatch_decision_for_wakeup() in pma_automation_store.py
- Add tests for lane-based routing when no binding exists

Replaces conflicted #1584 with a clean branch off current main.
