### PR TITLE
Prefer fresh origin/main worktrees for new repo PMA threads

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+import uuid
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Optional
@@ -45,6 +46,12 @@ class ManagedThreadCreateResolution:
 
 
 @dataclass(frozen=True)
+class ManagedThreadWorkspaceProvision:
+    workspace_root: Path
+    worktree_repo_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
 class ManagedThreadListQuery:
     agent_id: Optional[str]
     lifecycle_status: Optional[str]
@@ -83,18 +90,43 @@ def _normalize_workspace_root_input(workspace_root: str) -> PurePosixPath:
 
 
 def _resolve_workspace_from_repo_id(request: Request, repo_id: str) -> Path:
+    snapshot = _resolve_repo_snapshot(request, repo_id)
+    repo_path = getattr(snapshot, "path", None)
+    if isinstance(repo_path, str):
+        repo_path = Path(repo_path)
+    if isinstance(repo_path, Path):
+        return repo_path.absolute()
+    raise HTTPException(status_code=404, detail=f"Repo not found: {repo_id}")
+
+
+def _resolve_repo_snapshot(request: Request, repo_id: str) -> Any:
     supervisor = get_pma_request_context(request).hub_supervisor
     if supervisor is None:
         raise HTTPException(status_code=500, detail="Hub supervisor unavailable")
     for snapshot in supervisor.list_repos():
         if getattr(snapshot, "id", None) != repo_id:
             continue
-        repo_path = getattr(snapshot, "path", None)
-        if isinstance(repo_path, str):
-            repo_path = Path(repo_path)
-        if isinstance(repo_path, Path):
-            return repo_path.absolute()
+        return snapshot
     raise HTTPException(status_code=404, detail=f"Repo not found: {repo_id}")
+
+
+def _slugify_worktree_branch_component(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    cleaned = re.sub(r"[^a-z0-9._-]+", "-", text).strip("-")
+    return cleaned or "thread"
+
+
+def _build_managed_thread_worktree_branch_name(
+    *,
+    repo_id: str,
+    agent_id: str,
+    display_name: Optional[str],
+) -> str:
+    label = _slugify_worktree_branch_component(display_name or agent_id or repo_id)
+    return (
+        f"pma/{_slugify_worktree_branch_component(repo_id)}/"
+        f"{label}-{uuid.uuid4().hex[:10]}"
+    )
 
 
 def _resolve_workspace_from_resource_owner(
@@ -572,6 +604,52 @@ def resolve_managed_thread_create_resolution(
     )
 
 
+def provision_managed_thread_workspace(
+    request: Request,
+    *,
+    resolution: ManagedThreadCreateResolution,
+    display_name: Optional[str] = None,
+) -> ManagedThreadWorkspaceProvision:
+    fallback = ManagedThreadWorkspaceProvision(workspace_root=resolution.workspace_root)
+    if resolution.resource_kind != "repo" or resolution.repo_id is None:
+        return fallback
+
+    context = get_pma_request_context(request)
+    supervisor = context.hub_supervisor
+    if supervisor is None:
+        return fallback
+
+    try:
+        snapshot = _resolve_repo_snapshot(request, resolution.repo_id)
+    except HTTPException:
+        return fallback
+    if normalize_optional_text(getattr(snapshot, "kind", None)) != "base":
+        return fallback
+
+    branch_name = _build_managed_thread_worktree_branch_name(
+        repo_id=resolution.repo_id,
+        agent_id=resolution.agent_id,
+        display_name=display_name,
+    )
+    try:
+        created = supervisor.create_worktree(
+            base_repo_id=resolution.repo_id,
+            branch=branch_name,
+        )
+    except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+        return fallback
+
+    worktree_path = getattr(created, "path", None)
+    if isinstance(worktree_path, str):
+        worktree_path = Path(worktree_path)
+    if not isinstance(worktree_path, Path):
+        return fallback
+    return ManagedThreadWorkspaceProvision(
+        workspace_root=worktree_path.absolute(),
+        worktree_repo_id=normalize_optional_text(getattr(created, "id", None)),
+    )
+
+
 def resolve_managed_thread_list_query(
     *,
     agent: Optional[str],
@@ -686,11 +764,13 @@ __all__ = [
     "ManagedThreadCreateResolution",
     "ManagedThreadListQuery",
     "ManagedThreadOwnerScopedQuery",
+    "ManagedThreadWorkspaceProvision",
     "_attach_latest_execution_fields",
     "_load_chat_binding_metadata_by_thread",
     "_normalize_resource_owner",
     "_serialize_managed_thread",
     "_serialize_thread_target",
+    "provision_managed_thread_workspace",
     "resolve_managed_thread_create_resolution",
     "resolve_managed_thread_list_query",
     "resolve_owner_scoped_query",

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -98,10 +98,11 @@ async def _cleanup_failed_provisioned_worktree(
             supervisor.cleanup_worktree,
             worktree_repo_id=normalized_repo_id,
             delete_branch=True,
-            archive=False,
-            force=True,
+            archive=True,
         )
-    except Exception as exc:  # intentional: cleanup must not mask caller's original error
+    except (
+        Exception
+    ) as exc:  # intentional: cleanup must not mask caller's original error
         _logger.warning(
             "Failed to clean up provisioned PMA worktree %s after thread creation failed: %s",
             normalized_repo_id,

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -101,7 +101,7 @@ async def _cleanup_failed_provisioned_worktree(
             archive=False,
             force=True,
         )
-    except (AttributeError, OSError, RuntimeError, TypeError, ValueError) as exc:
+    except Exception as exc:  # intentional: cleanup must not mask caller's original error
         _logger.warning(
             "Failed to clean up provisioned PMA worktree %s after thread creation failed: %s",
             normalized_repo_id,

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -48,6 +49,7 @@ from .managed_thread_route_helpers import (
     _attach_latest_execution_fields,
     _serialize_managed_thread,
     _serialize_thread_target,
+    provision_managed_thread_workspace,
     resolve_managed_thread_create_resolution,
     resolve_managed_thread_list_query,
     resolve_owner_scoped_query,
@@ -78,6 +80,33 @@ def _subscription_request_has_explicit_routing(payload: dict[str, Any]) -> bool:
         normalize_optional_text(payload.get(field)) is not None
         for field in ("thread_id", "lane_id")
     )
+
+
+async def _cleanup_failed_provisioned_worktree(
+    request: Request,
+    *,
+    worktree_repo_id: Optional[str],
+) -> None:
+    normalized_repo_id = normalize_optional_text(worktree_repo_id)
+    if normalized_repo_id is None:
+        return
+    supervisor = get_pma_request_context(request).hub_supervisor
+    if supervisor is None:
+        return
+    try:
+        await asyncio.to_thread(
+            supervisor.cleanup_worktree,
+            worktree_repo_id=normalized_repo_id,
+            delete_branch=True,
+            archive=False,
+            force=True,
+        )
+    except (AttributeError, OSError, RuntimeError, TypeError, ValueError) as exc:
+        _logger.warning(
+            "Failed to clean up provisioned PMA worktree %s after thread creation failed: %s",
+            normalized_repo_id,
+            exc,
+        )
 
 
 def build_managed_thread_orchestration_service(request: Request):
@@ -354,18 +383,31 @@ def build_managed_thread_crud_routes(
         context = get_pma_request_context(request)
         hub_root = context.hub_root
         resolved = resolve_managed_thread_create_resolution(request, payload)
+        provisioned_workspace = await asyncio.to_thread(
+            provision_managed_thread_workspace,
+            request,
+            resolution=resolved,
+            display_name=normalize_optional_text(payload.name),
+        )
 
         service = build_managed_thread_orchestration_service(request)
         try:
-            thread = service.create_thread_target(
-                resolved.agent_id,
-                resolved.workspace_root,
-                repo_id=resolved.repo_id,
-                resource_kind=resolved.resource_kind,
-                resource_id=resolved.resource_id,
-                display_name=normalize_optional_text(payload.name),
-                metadata=resolved.metadata,
-            )
+            try:
+                thread = service.create_thread_target(
+                    resolved.agent_id,
+                    provisioned_workspace.workspace_root,
+                    repo_id=resolved.repo_id,
+                    resource_kind=resolved.resource_kind,
+                    resource_id=resolved.resource_id,
+                    display_name=normalize_optional_text(payload.name),
+                    metadata=resolved.metadata,
+                )
+            except Exception:
+                await _cleanup_failed_provisioned_worktree(
+                    request,
+                    worktree_repo_id=provisioned_workspace.worktree_repo_id,
+                )
+                raise
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         notification: Optional[dict[str, Any]] = None

--- a/tests/test_pma_managed_threads_routes.py
+++ b/tests/test_pma_managed_threads_routes.py
@@ -157,6 +157,62 @@ def test_create_managed_thread_with_repo_owner_prefers_fresh_worktree(
     assert stored["workspace_root"] == str(fresh_worktree_root.resolve())
 
 
+def test_create_managed_thread_failure_cleanup_worktree_uses_archive(
+    hub_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rollback cleanup must satisfy PMA cleanup policy (archive) and must not use force without attestation."""
+    app = create_hub_app(hub_env.hub_root)
+    fresh_worktree_root = hub_env.hub_root / "worktrees" / "repo--pma-fresh"
+    fresh_worktree_root.mkdir(parents=True, exist_ok=True)
+    cleanup_calls: list[dict[str, object]] = []
+
+    def _fake_create_worktree(
+        *, base_repo_id: str, branch: str, force: bool = False, start_point=None
+    ):
+        return SimpleNamespace(
+            id="repo--pma-fresh",
+            path=fresh_worktree_root,
+            branch=branch,
+            kind="worktree",
+        )
+
+    def _fake_cleanup_worktree(
+        worktree_repo_id: str, **kwargs: object
+    ) -> dict[str, object]:
+        cleanup_calls.append({"worktree_repo_id": worktree_repo_id, **kwargs})
+        return {"status": "ok"}
+
+    class _BrokenOrchestration:
+        def create_thread_target(self, *_a: object, **_k: object) -> None:
+            raise ValueError("simulated thread creation failure")
+
+    monkeypatch.setattr(
+        app.state.hub_supervisor, "create_worktree", _fake_create_worktree
+    )
+    monkeypatch.setattr(
+        app.state.hub_supervisor, "cleanup_worktree", _fake_cleanup_worktree
+    )
+    monkeypatch.setattr(
+        managed_threads,
+        "build_managed_thread_orchestration_service",
+        lambda _request: _BrokenOrchestration(),
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/hub/pma/threads",
+            json={"agent": "codex", **_repo_owner(hub_env), "name": "rollback"},
+        )
+
+    assert resp.status_code == 400
+    assert len(cleanup_calls) == 1
+    call = cleanup_calls[0]
+    assert call["worktree_repo_id"] == "repo--pma-fresh"
+    assert call.get("delete_branch") is True
+    assert call.get("archive") is True
+    assert call.get("force") is not True
+
+
 def test_create_managed_thread_with_workspace_root(hub_env) -> None:
     app = create_hub_app(hub_env.hub_root)
     rel_workspace = str(Path("worktrees") / hub_env.repo_id)

--- a/tests/test_pma_managed_threads_routes.py
+++ b/tests/test_pma_managed_threads_routes.py
@@ -102,6 +102,61 @@ def test_create_managed_thread_with_repo_owner(hub_env) -> None:
     assert subscriptions == []
 
 
+def test_create_managed_thread_with_repo_owner_prefers_fresh_worktree(
+    hub_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = create_hub_app(hub_env.hub_root)
+    fresh_worktree_root = hub_env.hub_root / "worktrees" / "repo--pma-fresh"
+    fresh_worktree_root.mkdir(parents=True, exist_ok=True)
+    observed: dict[str, object] = {}
+
+    def _fake_create_worktree(
+        *, base_repo_id: str, branch: str, force: bool = False, start_point=None
+    ):
+        observed["base_repo_id"] = base_repo_id
+        observed["branch"] = branch
+        observed["force"] = force
+        observed["start_point"] = start_point
+        return SimpleNamespace(
+            id="repo--pma-fresh",
+            path=fresh_worktree_root,
+            branch=branch,
+            kind="worktree",
+        )
+
+    monkeypatch.setattr(
+        app.state.hub_supervisor,
+        "create_worktree",
+        _fake_create_worktree,
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                **_repo_owner(hub_env),
+                "name": "Primary thread",
+            },
+        )
+
+    assert resp.status_code == 200
+    thread = resp.json()["thread"]
+    assert observed["base_repo_id"] == hub_env.repo_id
+    assert observed["force"] is False
+    assert observed["start_point"] is None
+    assert str(observed["branch"]).startswith(f"pma/{hub_env.repo_id}/")
+    assert thread["workspace_root"] == str(fresh_worktree_root.resolve())
+    assert thread["repo_id"] == hub_env.repo_id
+    assert thread["resource_kind"] == "repo"
+    assert thread["resource_id"] == hub_env.repo_id
+
+    store = PmaThreadStore(hub_env.hub_root)
+    stored = store.get_thread(thread["managed_thread_id"])
+    assert stored is not None
+    assert stored["workspace_root"] == str(fresh_worktree_root.resolve())
+
+
 def test_create_managed_thread_with_workspace_root(hub_env) -> None:
     app = create_hub_app(hub_env.hub_root)
     rel_workspace = str(Path("worktrees") / hub_env.repo_id)


### PR DESCRIPTION
## Summary
- provision a fresh repo worktree for new repo-owned PMA threads when the selected repo is a base repo
- keep the existing workspace as a fallback when a fresh worktree cannot be provisioned
- add route coverage that asserts PMA thread creation prefers a fresh worktree while still preserving the current fallback path

## Validation
- .venv/bin/pytest -q tests/test_pma_managed_threads_routes.py -k "create_managed_thread_with_repo_owner"
- .venv/bin/pytest -q tests/test_hub_supervisor.py -k "create_worktree_defaults_to_origin_default_branch_without_start_point"
- repo pre-commit aggregate lane (format, lint, mypy, full pytest, frontend build/tests, chat-surface checks)

Closes #1585