### PR TITLE
[codex] Fix Discord queued progress and Telegram update guard

### DIFF
--- a/src/codex_autorunner/integrations/chat/update_guards.py
+++ b/src/codex_autorunner/integrations/chat/update_guards.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def update_thread_blocks_restart_warning(thread: Any) -> bool:
+    thread_kind = str(getattr(thread, "thread_kind", "") or "").strip().lower()
+    return thread_kind != "ticket_flow"
+
+
+def active_managed_update_session_count(orchestration_service: Any) -> int:
+    try:
+        threads = orchestration_service.list_thread_targets(lifecycle_status="active")
+    except (AttributeError, TypeError, RuntimeError):
+        return 0
+    get_running_execution = getattr(
+        orchestration_service, "get_running_execution", None
+    )
+    if not callable(get_running_execution):
+        return sum(
+            1
+            for thread in threads
+            if update_thread_blocks_restart_warning(thread)
+            if str(getattr(thread, "status", "") or "").strip().lower() == "running"
+        )
+
+    active_count = 0
+    for thread in threads:
+        if not update_thread_blocks_restart_warning(thread):
+            continue
+        thread_target_id = str(getattr(thread, "thread_target_id", "") or "").strip()
+        if not thread_target_id:
+            continue
+        try:
+            if get_running_execution(thread_target_id) is not None:
+                active_count += 1
+        except (AttributeError, TypeError, RuntimeError):
+            if str(getattr(thread, "status", "") or "").strip().lower() == "running":
+                active_count += 1
+    return active_count

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -1847,21 +1847,22 @@ async def _run_discord_orchestrated_turn_for_message(
     progress_lease_id = uuid.uuid4().hex
     active_progress_labels = {"working", "queued", "running", "review"}
     reusable_progress_message_id: Optional[str] = None
-    claim_queued_notice_progress_message = getattr(
-        service, "_claim_queued_notice_progress_message", None
-    )
-    if callable(claim_queued_notice_progress_message):
-        with contextlib.suppress(TypeError):
-            reusable_progress_message_id = claim_queued_notice_progress_message(
-                channel_id=channel_id,
+    if not pma_enabled:
+        claim_queued_notice_progress_message = getattr(
+            service, "_claim_queued_notice_progress_message", None
+        )
+        if callable(claim_queued_notice_progress_message):
+            with contextlib.suppress(TypeError):
+                reusable_progress_message_id = claim_queued_notice_progress_message(
+                    channel_id=channel_id,
+                    source_message_id=source_message_id,
+                )
+        if not reusable_progress_message_id:
+            reusable_progress_message_id = _claim_discord_reusable_progress_message(
+                service,
+                thread_target_id=managed_thread_id,
                 source_message_id=source_message_id,
             )
-    if not reusable_progress_message_id:
-        reusable_progress_message_id = _claim_discord_reusable_progress_message(
-            service,
-            thread_target_id=managed_thread_id,
-            source_message_id=source_message_id,
-        )
 
     async def _load_progress_lease() -> Any:
         return await _get_discord_progress_lease(service, lease_id=progress_lease_id)

--- a/src/codex_autorunner/integrations/discord/update_service.py
+++ b/src/codex_autorunner/integrations/discord/update_service.py
@@ -15,6 +15,10 @@ from ...core.update import (
     _update_target_restarts_surface,
 )
 from ...core.update_paths import resolve_update_paths
+from ..chat.update_guards import (
+    active_managed_update_session_count,
+    update_thread_blocks_restart_warning,
+)
 from ..chat.update_notifier import (
     ChatUpdateStatusNotifier,
     mark_update_status_notified,
@@ -47,42 +51,12 @@ __all__ = [
 ]
 
 
-def update_thread_blocks_restart_warning(thread: Any) -> bool:
-    thread_kind = str(getattr(thread, "thread_kind", "") or "").strip().lower()
-    return thread_kind != "ticket_flow"
-
-
 def active_update_session_count(service: Any) -> int:
     try:
         orchestration_service = service._discord_thread_service()
-        threads = orchestration_service.list_thread_targets(lifecycle_status="active")
     except (AttributeError, TypeError, RuntimeError):
         return 0
-    get_running_execution = getattr(
-        orchestration_service, "get_running_execution", None
-    )
-    if not callable(get_running_execution):
-        return sum(
-            1
-            for thread in threads
-            if update_thread_blocks_restart_warning(thread)
-            if str(getattr(thread, "status", "") or "").strip().lower() == "running"
-        )
-
-    active_count = 0
-    for thread in threads:
-        if not update_thread_blocks_restart_warning(thread):
-            continue
-        thread_target_id = str(getattr(thread, "thread_target_id", "") or "").strip()
-        if not thread_target_id:
-            continue
-        try:
-            if get_running_execution(thread_target_id) is not None:
-                active_count += 1
-        except (AttributeError, TypeError, RuntimeError):
-            if str(getattr(thread, "status", "") or "").strip().lower() == "running":
-                active_count += 1
-    return active_count
+    return active_managed_update_session_count(orchestration_service)
 
 
 def build_update_confirmation_components(

--- a/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands_runtime.py
@@ -54,6 +54,7 @@ from ...chat.session_messages import (
 )
 from ...chat.status_diagnostics import build_process_monitor_lines_for_root
 from ...chat.turn_metrics import compose_turn_response_with_footer
+from ...chat.update_guards import active_managed_update_session_count
 from ...chat.update_notifier import mark_update_status_notified
 from ..adapter import (
     CompactCallback,
@@ -2988,10 +2989,18 @@ Summary applied.""",
         return UPDATE_TARGET_OPTIONS
 
     def _has_active_turns(self) -> bool:
-        return bool(self._turn_contexts)
+        return self._active_update_session_count() > 0
+
+    def _active_managed_update_session_count(self) -> int:
+        from .commands.execution import _build_telegram_thread_orchestration_service
+
+        orchestration_service = _build_telegram_thread_orchestration_service(self)
+        if orchestration_service is None:
+            return 0
+        return active_managed_update_session_count(orchestration_service)
 
     def _active_update_session_count(self) -> int:
-        return len(self._turn_contexts)
+        return len(self._turn_contexts) + self._active_managed_update_session_count()
 
     async def _prompt_update_confirmation(
         self,

--- a/tests/discord_message_turns_queue_notice_support.py
+++ b/tests/discord_message_turns_queue_notice_support.py
@@ -13,7 +13,7 @@ from tests.support.discord_turn_fakes import _config, _FakeRest
 
 
 @pytest.mark.asyncio
-async def test_orchestrated_turn_queued_reuses_claimed_queue_notice(
+async def test_orchestrated_turn_pma_queued_sends_fresh_progress_placeholder(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -132,9 +132,9 @@ async def test_orchestrated_turn_queued_reuses_claimed_queue_notice(
 
     assert result.send_final_message is False
     assert "Queued" in (result.final_message or "")
-    assert service.claim_calls == [("channel-1", "m-2")]
-    assert rest.channel_messages == []
+    assert service.claim_calls == []
+    assert len(rest.channel_messages) == 1
+    assert "working" in rest.channel_messages[0]["payload"]["content"].lower()
     assert rest.edited_channel_messages
-    assert rest.edited_channel_messages[0]["message_id"] == "notice-1"
-    assert "working" in rest.edited_channel_messages[0]["payload"]["content"].lower()
+    assert rest.edited_channel_messages[0]["message_id"] != "notice-1"
     assert "queued" in rest.edited_channel_messages[-1]["payload"]["content"].lower()

--- a/tests/integrations/discord/test_message_turns.py
+++ b/tests/integrations/discord/test_message_turns.py
@@ -2,7 +2,7 @@
 
 import pytest
 from tests.discord_message_turns_queue_notice_support import (
-    test_orchestrated_turn_queued_reuses_claimed_queue_notice,
+    test_orchestrated_turn_pma_queued_sends_fresh_progress_placeholder,
 )
 from tests.discord_message_turns_support import (
     test_build_attachment_filename_does_not_infer_audio_suffix_for_video,

--- a/tests/test_telegram_bot_integration.py
+++ b/tests/test_telegram_bot_integration.py
@@ -1502,6 +1502,32 @@ async def test_update_with_all_target_prompts_for_confirmation_when_turn_active(
 
 
 @pytest.mark.anyio
+async def test_update_with_all_target_prompts_for_confirmation_when_managed_thread_active(
+    tmp_path: Path,
+) -> None:
+    config = make_config(tmp_path, fixture_command("basic"))
+    service = TelegramBotService(config, hub_root=tmp_path)
+    message = build_message("/update all", message_id=30)
+    captured: dict[str, object] = {}
+
+    async def _fake_prompt_update_confirmation(
+        msg: TelegramMessage, *, update_target: Optional[str] = None
+    ) -> None:
+        captured["message_id"] = msg.message_id
+        captured["update_target"] = update_target
+
+    service._active_managed_update_session_count = lambda: 1  # type: ignore[method-assign]
+    service._prompt_update_confirmation = _fake_prompt_update_confirmation  # type: ignore[assignment]
+
+    try:
+        await service._handle_update(message, "all", None)
+    finally:
+        await service._app_server_supervisor.close_all()
+
+    assert captured == {"message_id": 30, "update_target": "all"}
+
+
+@pytest.mark.anyio
 async def test_update_web_target_skips_confirmation_when_turn_active(
     tmp_path: Path,
 ) -> None:
@@ -1544,6 +1570,60 @@ async def test_update_web_target_skips_confirmation_when_turn_active(
         "update_target": "web",
         "reply_to": 21,
     }
+
+
+@pytest.mark.anyio
+async def test_update_callback_prompts_for_confirmation_when_managed_thread_active(
+    tmp_path: Path,
+) -> None:
+    config = make_config(tmp_path, fixture_command("basic"))
+    service = TelegramBotService(config, hub_root=tmp_path)
+    callback = TelegramCallbackQuery(
+        update_id=1,
+        callback_id="cb-managed",
+        from_user_id=456,
+        data="update:all",
+        message_id=31,
+        chat_id=123,
+        thread_id=None,
+    )
+    events: list[tuple[str, object]] = []
+
+    async def _fake_answer_callback(
+        cb: Optional[TelegramCallbackQuery], text: str
+    ) -> None:
+        assert cb == callback
+        events.append(("answer", text))
+
+    async def _fake_prompt_update_confirmation(
+        msg: TelegramMessage, *, update_target: Optional[str] = None
+    ) -> None:
+        events.append(("prompt_message_id", msg.message_id))
+        events.append(("prompt_target", update_target))
+
+    topic_key = "123:"
+    service._update_options[topic_key] = SelectionState(
+        items=[("all", "All")],
+        requester_user_id="456",
+    )
+    service._active_managed_update_session_count = lambda: 1  # type: ignore[method-assign]
+    service._answer_callback = _fake_answer_callback  # type: ignore[assignment]
+    service._prompt_update_confirmation = _fake_prompt_update_confirmation  # type: ignore[assignment]
+
+    try:
+        await service._handle_update_callback(
+            topic_key,
+            callback,
+            type("ParsedUpdate", (), {"target": "all"})(),
+        )
+    finally:
+        await service._app_server_supervisor.close_all()
+
+    assert events == [
+        ("answer", "Confirm update"),
+        ("prompt_message_id", 31),
+        ("prompt_target", "all"),
+    ]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- stop PMA-spawned Discord turns from claiming reusable progress anchors and always send a fresh progress placeholder instead
- move restart-blocking managed-thread detection into a shared helper and have Telegram `/update` confirmation count active managed threads across surfaces
- add regression tests for the Discord PMA queue path and the Telegram update handler/callback flow

## Root Cause
- PMA-spawned Discord turns were trying to reuse progress messages that are only valid for direct user-triggered turns, so stale or missing anchors could leave Discord with no visible streaming progress
- Telegram `/update` only checked Telegram-local turn contexts and missed active managed threads running on Discord, so restart confirmation could be skipped while those threads were still live

## Validation
- `.venv/bin/python -m pytest -q tests/integrations/discord/test_message_turns.py -k 'pma_queued_sends_fresh_progress_placeholder'`
- `.venv/bin/python -m pytest -q tests/integrations/discord/test_service_routing.py -k 'active_update_session_count'`
- `.venv/bin/python -m pytest -q tests/test_telegram_bot_integration.py -k 'managed_thread_active or turns_active or update_callback_acknowledged_before_spawn'`
- commit hook lane: repo `mypy`, repo `pytest` (`7544 passed`), chat-surface lab (`21 passed`), chat latency budget suite (`PASS`)

Fixes #1591