### PR TITLE
[codex] Clear queued Discord placeholder when work starts

### DIFF
--- a/src/codex_autorunner/integrations/chat/bound_live_progress.py
+++ b/src/codex_autorunner/integrations/chat/bound_live_progress.py
@@ -60,9 +60,9 @@ class BoundChatLiveProgressSession:
             (adapter.surface_kind, adapter.surface_key) for adapter in self.adapters
         )
 
-    async def start(self) -> None:
+    async def start(self) -> bool:
         if not self.adapters:
-            return
+            return False
         self.projector.mark_working(force=True)
         rendered = self.projector.render(
             max_length=self.max_length,
@@ -81,6 +81,7 @@ class BoundChatLiveProgressSession:
                 )
         if published:
             self.projector.note_rendered(rendered, now=time.monotonic())
+        return published
 
     async def apply_run_events(self, events: list[RunEvent]) -> None:
         if not self.adapters:
@@ -1063,6 +1064,7 @@ def build_bound_chat_queue_execution_controller(
         Callable[[Any], tuple[tuple[str, str], ...]]
     ] = None,
     base_hooks: Optional[ManagedThreadExecutionHooks] = None,
+    on_progress_session_started: Optional[Callable[[Any], object]] = None,
     retain_completed_surface_targets: bool = False,
 ) -> BoundChatQueueExecutionController:
     current_session: Optional[BoundChatLiveProgressSession] = None
@@ -1097,7 +1099,11 @@ def build_bound_chat_queue_execution_controller(
                     else surface_targets
                 ),
             )
-            await current_session.start()
+            published = await current_session.start()
+            if published and on_progress_session_started is not None:
+                result = on_progress_session_started(started)
+                if inspect.isawaitable(result):
+                    await result
         except Exception:
             logger.exception(
                 "Failed to start bound chat live progress session (managed_thread_id=%s, managed_turn_id=%s)",

--- a/src/codex_autorunner/integrations/chat/managed_thread_surface_kernel.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_surface_kernel.py
@@ -83,6 +83,7 @@ def build_managed_thread_surface_queue_execution_hooks(
     managed_thread_id: str,
     surface_targets: tuple[tuple[str, str], ...],
     base_hooks: Optional[ManagedThreadExecutionHooks] = None,
+    on_progress_session_started: Optional[Callable[[Any], object]] = None,
 ) -> ManagedThreadExecutionHooks:
     return build_bound_chat_queue_execution_controller(
         hub_root=hub_root,
@@ -90,6 +91,7 @@ def build_managed_thread_surface_queue_execution_hooks(
         managed_thread_id=managed_thread_id,
         surface_targets=surface_targets,
         base_hooks=base_hooks or ManagedThreadExecutionHooks(),
+        on_progress_session_started=on_progress_session_started,
     ).hooks
 
 

--- a/src/codex_autorunner/integrations/discord/managed_thread_routing.py
+++ b/src/codex_autorunner/integrations/discord/managed_thread_routing.py
@@ -431,6 +431,14 @@ def _build_discord_runner_hooks(
             channel_id=channel_id,
         )
 
+    async def _on_queue_execution_started(started_execution: Any) -> None:
+        await _on_execution_started(started_execution)
+        await _cleanup_stale_queued_progress_placeholder(
+            service,
+            managed_thread_id=managed_thread_id,
+            started_execution=started_execution,
+        )
+
     def _on_execution_finished(started_execution: Any) -> None:
         service._clear_discord_turn_approval_context(
             started_execution=started_execution
@@ -453,7 +461,7 @@ def _build_discord_runner_hooks(
         managed_thread_id=managed_thread_id,
         surface_targets=(("discord", channel_id),),
         base_hooks=ManagedThreadExecutionHooks(
-            on_execution_started=_on_execution_started,
+            on_execution_started=_on_queue_execution_started,
             on_execution_finished=_on_execution_finished,
         ),
     )
@@ -514,3 +522,32 @@ def _build_discord_runner_hooks(
         run_with_indicator=_run_with_discord_typing_indicator,
         queue_execution_hooks=queue_execution_hooks,
     )
+
+
+async def _cleanup_stale_queued_progress_placeholder(
+    service: Any,
+    *,
+    managed_thread_id: str,
+    started_execution: Any,
+) -> None:
+    from .progress_leases import cleanup_discord_terminal_progress_leases
+
+    execution = getattr(started_execution, "execution", None)
+    execution_id = str(getattr(execution, "execution_id", "") or "").strip()
+    if not execution_id:
+        return
+    try:
+        await cleanup_discord_terminal_progress_leases(
+            service,
+            managed_thread_id=managed_thread_id,
+            execution_id=execution_id,
+            note="Status: this queued turn moved into active work.",
+            record_prefix="discord:queued-progress-transition",
+        )
+    except Exception:
+        _logger.debug(
+            "Failed to clear stale queued Discord progress placeholder for thread=%s execution=%s",
+            managed_thread_id,
+            execution_id,
+            exc_info=True,
+        )

--- a/src/codex_autorunner/integrations/discord/managed_thread_routing.py
+++ b/src/codex_autorunner/integrations/discord/managed_thread_routing.py
@@ -431,14 +431,6 @@ def _build_discord_runner_hooks(
             channel_id=channel_id,
         )
 
-    async def _on_queue_execution_started(started_execution: Any) -> None:
-        await _on_execution_started(started_execution)
-        await _cleanup_stale_queued_progress_placeholder(
-            service,
-            managed_thread_id=managed_thread_id,
-            started_execution=started_execution,
-        )
-
     def _on_execution_finished(started_execution: Any) -> None:
         service._clear_discord_turn_approval_context(
             started_execution=started_execution
@@ -461,8 +453,15 @@ def _build_discord_runner_hooks(
         managed_thread_id=managed_thread_id,
         surface_targets=(("discord", channel_id),),
         base_hooks=ManagedThreadExecutionHooks(
-            on_execution_started=_on_queue_execution_started,
+            on_execution_started=_on_execution_started,
             on_execution_finished=_on_execution_finished,
+        ),
+        on_progress_session_started=lambda started_execution: (
+            _cleanup_stale_queued_progress_placeholder(
+                service,
+                managed_thread_id=managed_thread_id,
+                started_execution=started_execution,
+            )
         ),
     )
 

--- a/tests/discord_message_turns_support.py
+++ b/tests/discord_message_turns_support.py
@@ -56,6 +56,7 @@ from codex_autorunner.integrations.chat.collaboration_policy import (
 from codex_autorunner.integrations.chat.compaction import build_compact_seed_prompt
 from codex_autorunner.integrations.chat.dispatcher import build_dispatch_context
 from codex_autorunner.integrations.chat.managed_thread_turns import (
+    ManagedThreadExecutionHooks,
     ManagedThreadQueueWorkerHooks,
 )
 from codex_autorunner.integrations.discord.managed_thread_routing import (
@@ -250,7 +251,12 @@ async def test_queue_worker_start_clears_stale_queued_progress_placeholder(
 
     monkeypatch.setattr(
         "codex_autorunner.integrations.discord.managed_thread_routing.build_managed_thread_surface_queue_execution_hooks",
-        lambda **kwargs: kwargs["base_hooks"],
+        lambda **kwargs: ManagedThreadExecutionHooks(
+            on_execution_started=lambda started_execution: _run_queue_execution_start(
+                kwargs, started_execution
+            ),
+            on_execution_finished=kwargs["base_hooks"].on_execution_finished,
+        ),
     )
 
     await store.upsert_turn_progress_lease(
@@ -292,6 +298,23 @@ async def test_queue_worker_start_clears_stale_queued_progress_placeholder(
         )
     finally:
         await store.close()
+
+
+async def _run_queue_execution_start(
+    kwargs: dict[str, Any],
+    started_execution: Any,
+) -> None:
+    base_hooks = kwargs["base_hooks"]
+    on_execution_started = getattr(base_hooks, "on_execution_started", None)
+    if on_execution_started is not None:
+        result = on_execution_started(started_execution)
+        if asyncio.iscoroutine(result):
+            await result
+    on_progress_session_started = kwargs.get("on_progress_session_started")
+    if on_progress_session_started is not None:
+        result = on_progress_session_started(started_execution)
+        if asyncio.iscoroutine(result):
+            await result
 
 
 @pytest.mark.asyncio

--- a/tests/discord_message_turns_support.py
+++ b/tests/discord_message_turns_support.py
@@ -205,6 +205,96 @@ def test_resolve_discord_turn_policies_prefers_explicit_binding_values() -> None
 
 
 @pytest.mark.asyncio
+async def test_queue_worker_start_clears_stale_queued_progress_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+
+    class _Service:
+        def __init__(self) -> None:
+            self._config = _config(tmp_path)
+            self._store = store
+            self._rest = rest
+            self._logger = logging.getLogger(__name__)
+            self.approval_contexts: list[tuple[str, str]] = []
+
+        def _register_discord_turn_approval_context(
+            self,
+            *,
+            started_execution: Any,
+            channel_id: str,
+        ) -> None:
+            execution = getattr(started_execution, "execution", None)
+            execution_id = str(getattr(execution, "execution_id", "") or "").strip()
+            self.approval_contexts.append((channel_id, execution_id))
+
+        def _clear_discord_turn_approval_context(self, **kwargs: Any) -> None:
+            _ = kwargs
+
+        async def _delete_channel_message_safe(
+            self,
+            channel_id: str,
+            message_id: str,
+            *,
+            record_id: Optional[str] = None,
+        ) -> bool:
+            _ = record_id
+            await rest.delete_channel_message(
+                channel_id=channel_id,
+                message_id=message_id,
+            )
+            return True
+
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.discord.managed_thread_routing.build_managed_thread_surface_queue_execution_hooks",
+        lambda **kwargs: kwargs["base_hooks"],
+    )
+
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-1",
+        managed_thread_id="thread-1",
+        execution_id="turn-1",
+        channel_id="channel-1",
+        message_id="queued-msg-1",
+        source_message_id="source-1",
+        state="active",
+        progress_label="queued",
+    )
+    service = _Service()
+    runner_hooks = _build_discord_runner_hooks(
+        service,
+        channel_id="channel-1",
+        managed_thread_id="thread-1",
+        workspace_root=tmp_path,
+        public_execution_error="Discord PMA turn failed",
+    )
+    started_execution = SimpleNamespace(
+        execution=SimpleNamespace(execution_id="turn-1")
+    )
+
+    try:
+        assert runner_hooks.queue_execution_hooks is not None
+        await runner_hooks.queue_execution_hooks.on_execution_started(started_execution)
+
+        assert service.approval_contexts == [("channel-1", "turn-1")]
+        assert rest.deleted_channel_messages == [
+            {"channel_id": "channel-1", "message_id": "queued-msg-1"}
+        ]
+        assert (
+            await store.list_turn_progress_leases(
+                managed_thread_id="thread-1",
+                execution_id="turn-1",
+            )
+            == []
+        )
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
 async def test_run_managed_thread_turn_for_message_uses_binding_policies(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_bound_chat_live_progress.py
+++ b/tests/test_bound_chat_live_progress.py
@@ -51,8 +51,9 @@ async def test_bound_chat_queue_execution_controller_records_completed_targets_o
     class FakeSession:
         surface_targets = (("discord", "channel-1"),)
 
-        async def start(self) -> None:
+        async def start(self) -> bool:
             calls.append("start")
+            return True
 
         async def apply_run_events(self, events: list[object]) -> None:
             _ = events
@@ -125,8 +126,8 @@ async def test_bound_chat_queue_execution_controller_does_not_retain_targets_by_
     class FakeSession:
         surface_targets = (("discord", "channel-1"),)
 
-        async def start(self) -> None:
-            return None
+        async def start(self) -> bool:
+            return True
 
         async def apply_run_events(self, events: list[object]) -> None:
             _ = events
@@ -187,8 +188,9 @@ async def test_bound_chat_queue_execution_controller_finalizes_error_session(
     class FakeSession:
         surface_targets = (("telegram", "123:55"),)
 
-        async def start(self) -> None:
+        async def start(self) -> bool:
             calls.append("start")
+            return True
 
         async def apply_run_events(self, events: list[object]) -> None:
             _ = events
@@ -336,7 +338,7 @@ async def test_bound_chat_queue_execution_controller_ignores_startup_failures(
     class FakeSession:
         surface_targets = (("discord", "channel-1"),)
 
-        async def start(self) -> None:
+        async def start(self) -> bool:
             calls.append("start")
             raise RuntimeError("boom")
 
@@ -374,6 +376,60 @@ async def test_bound_chat_queue_execution_controller_ignores_startup_failures(
     await controller.hooks.on_execution_started(started)
 
     assert controller.surface_targets_for("turn-3") == ()
+    assert calls == ["start", "close"]
+
+
+@pytest.mark.anyio
+async def test_bound_chat_queue_execution_controller_only_runs_post_start_hook_after_visible_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    class FakeSession:
+        surface_targets = (("discord", "channel-1"),)
+
+        async def start(self) -> bool:
+            calls.append("start")
+            return False
+
+        async def apply_run_events(self, events: list[object]) -> None:
+            _ = events
+
+        async def finalize(
+            self,
+            *,
+            status: str,
+            failure_message: str | None = None,
+        ) -> None:
+            _ = status, failure_message
+
+        async def close(self) -> None:
+            calls.append("close")
+
+    monkeypatch.setattr(
+        progress_module,
+        "build_bound_chat_live_progress_session",
+        lambda **_: FakeSession(),
+    )
+    controller = build_bound_chat_queue_execution_controller(
+        hub_root=tmp_path,
+        raw_config={},
+        managed_thread_id="thread-1",
+        on_progress_session_started=lambda _started: calls.append("post-start"),
+    )
+    started = SimpleNamespace(
+        execution=SimpleNamespace(execution_id="turn-4"),
+        thread=SimpleNamespace(agent_id="codex"),
+        request=SimpleNamespace(model="gpt-5"),
+    )
+
+    assert controller.hooks.on_execution_started is not None
+    assert controller.hooks.on_execution_finished is not None
+
+    await controller.hooks.on_execution_started(started)
+    await controller.hooks.on_execution_finished(started)
+
     assert calls == ["start", "close"]
 
 


### PR DESCRIPTION
## Summary
- clear stale queued Discord progress placeholders when a queue-worker starts the queued execution
- keep the approval-context registration path intact for queue-worker starts
- add a regression test covering the queued-to-working transition

## Why
Queued Discord turns could leave their queued placeholder and `Interrupt + Send` controls visible while a separate working progress message was already running. The stale queued message only disappeared at final delivery, which left the wrong controls on screen during active work.

## Validation
- `.venv/bin/python -m pytest -q tests/discord_message_turns_support.py -k queue_worker_start_clears_stale_queued_progress_placeholder`
- `.venv/bin/python -m pytest -q tests/integrations/discord/test_message_turns.py`
- repo commit hook: `black`, `ruff`, import-boundary checks, strict `mypy`, full `pytest` suite, chat-surface lab checks, latency budget suite