### PR TITLE
[codex] Deduplicate transient thinking updates

### DIFF
--- a/src/codex_autorunner/integrations/chat/managed_thread_progress.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_progress.py
@@ -114,7 +114,9 @@ def apply_run_event_to_progress_tracker(
             notice = run_event.kind.strip() if run_event.kind else "notice"
         if run_event.kind in {"thinking", "reasoning"}:
             prior_transient = tracker.transient_action
-            tracker.note_thinking(notice)
+            changed = tracker.note_thinking(notice)
+            if not changed:
+                return ProgressTrackerEventOutcome(changed=False)
             return ProgressTrackerEventOutcome(
                 changed=True,
                 force=prior_transient is None or prior_transient.label != "thinking",

--- a/src/codex_autorunner/integrations/chat/progress_primitives.py
+++ b/src/codex_autorunner/integrations/chat/progress_primitives.py
@@ -222,6 +222,25 @@ class TurnProgressTracker:
                 return action.text
         return ""
 
+    def transient_matches(
+        self,
+        label: str,
+        text: str,
+        *,
+        subagent_label: Optional[str] = None,
+    ) -> bool:
+        normalized = _normalize_inline_text(text)
+        if not normalized:
+            return False
+        action = self.transient_action
+        if action is None:
+            return False
+        return (
+            action.label == label
+            and action.text == normalized
+            and action.subagent_label == subagent_label
+        )
+
     def drop_terminal_output_if_duplicate(self, final_text: str) -> bool:
         if not isinstance(final_text, str) or not final_text.strip():
             return False
@@ -247,11 +266,14 @@ class TurnProgressTracker:
             return True
         return False
 
-    def note_thinking(self, text: str) -> None:
+    def note_thinking(self, text: str) -> bool:
         normalized = _normalize_inline_text(text)
         if not normalized:
-            return
+            return False
+        if self.transient_matches("thinking", normalized):
+            return False
         self.add_action("thinking", normalized, "update")
+        return True
 
     def note_output(
         self,

--- a/tests/test_managed_thread_progress.py
+++ b/tests/test_managed_thread_progress.py
@@ -85,6 +85,39 @@ def test_apply_run_event_to_progress_tracker_forces_first_thinking_notice() -> N
     assert second.force is False
 
 
+def test_apply_run_event_to_progress_tracker_ignores_exact_duplicate_thinking_notice() -> (
+    None
+):
+    tracker = _tracker()
+    runtime_state = ProgressRuntimeState()
+
+    first = apply_run_event_to_progress_tracker(
+        tracker,
+        RunNotice(
+            timestamp="2026-03-15T00:00:00Z",
+            kind="thinking",
+            message="checking Discord progress updates",
+        ),
+        runtime_state=runtime_state,
+    )
+    second = apply_run_event_to_progress_tracker(
+        tracker,
+        RunNotice(
+            timestamp="2026-03-15T00:00:01Z",
+            kind="thinking",
+            message="checking Discord progress updates",
+        ),
+        runtime_state=runtime_state,
+    )
+
+    assert first.changed is True
+    assert second.changed is False
+    assert tracker.transient_action is not None
+    assert tracker.transient_action.label == "thinking"
+    assert tracker.transient_action.text == "checking Discord progress updates"
+    assert tracker.step == 1
+
+
 def test_apply_run_event_to_progress_tracker_updates_log_line_output() -> None:
     tracker = _tracker()
 

--- a/tests/test_telegram_progress_stream.py
+++ b/tests/test_telegram_progress_stream.py
@@ -104,6 +104,27 @@ def test_note_thinking_is_transient_and_cleared_by_output() -> None:
     assert "Final response text" in rendered_after_output
 
 
+def test_note_thinking_ignores_exact_duplicate_transient_update() -> None:
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="codex",
+        model="mock-model",
+        label="working",
+        max_actions=10,
+        max_output_chars=200,
+    )
+
+    first = tracker.note_thinking("Checking out-of-order completion handling")
+    second = tracker.note_thinking("Checking out-of-order completion handling")
+
+    assert first is True
+    assert second is False
+    assert tracker.transient_action is not None
+    assert tracker.transient_action.label == "thinking"
+    assert tracker.transient_action.text == "Checking out-of-order completion handling"
+    assert tracker.step == 1
+
+
 def test_note_tool_streams_without_persisting_history() -> None:
     tracker = TurnProgressTracker(
         started_at=0.0,


### PR DESCRIPTION
## What changed
This narrows duplicate-progress suppression in the shared managed-thread progress layer.

The change makes exact duplicate transient `thinking` updates a no-op in `TurnProgressTracker`, and updates the shared `apply_run_event_to_progress_tracker()` path to avoid surfacing those duplicate notices again when the incoming normalized event text is identical to the currently displayed transient thinking text.

## Why
Users were seeing repeated thinking summaries for Codex and Hermes/Claude-style runs. The safest shared fix is to suppress only exact duplicate transient thinking updates at the agent-agnostic progress layer, rather than trying to merge broader event text or alter final/output paths.

## Impact
User-facing progress summaries should stop repeating identical consecutive thinking lines when the same transient notice is replayed or emitted twice.

This does not change:
- assistant output accumulation
- final replies
- errors
- approvals
- tool calls
- distinct thinking updates

## Root cause
The progress tracker treated every incoming `thinking` notice as a fresh transient update, even when the text exactly matched the already-visible transient thinking state. That made replayed or duplicated transient notices look like repeated user-visible progress.

## Validation
- `python -m pytest -q tests/test_managed_thread_progress.py tests/test_telegram_progress_stream.py`
- repo commit hook aggregate lane
- repo-wide `mypy`
- repo-wide `pytest` (7547 passed)
- `pnpm run build`
- `pnpm test:markdown`
- chat-surface lab deterministic checks
- latency budget suite
