### PR TITLE
[codex] Handle item/started in runtime decoder

### DIFF
--- a/src/codex_autorunner/core/orchestration/runtime_thread_decoders.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_decoders.py
@@ -604,6 +604,7 @@ class CodexItemDecoder(MessageDecoder):
         return (
             frozenset(
                 {
+                    "item/started",
                     "item/reasoning/summaryTextDelta",
                     "item/completed",
                     "item/agentMessage/delta",
@@ -616,6 +617,18 @@ class CodexItemDecoder(MessageDecoder):
 
     def decode(self, method, params, state, ctx):
         ts = ctx.timestamp
+
+        if method == "item/started":
+            item = _coerce_dict(params.get("item"))
+            if item.get("enteredReviewMode"):
+                return [
+                    RunNotice(
+                        timestamp=ts,
+                        kind="progress",
+                        message="entered review mode",
+                    )
+                ]
+            return []
 
         if method == "item/reasoning/summaryTextDelta":
             delta = params.get("delta")

--- a/tests/core/orchestration/test_runtime_thread_decoders.py
+++ b/tests/core/orchestration/test_runtime_thread_decoders.py
@@ -99,6 +99,7 @@ class TestCodexItemDecoder:
 
     def test_methods_covers_item_family(self) -> None:
         methods = self.decoder.methods()
+        assert "item/started" in methods
         assert "item/reasoning/summaryTextDelta" in methods
         assert "item/completed" in methods
         assert "item/agentMessage/delta" in methods
@@ -106,6 +107,51 @@ class TestCodexItemDecoder:
         assert "item/toolCall/end" in methods
         assert "item/commandExecution/requestApproval" in methods
         assert "item/fileChange/requestApproval" in methods
+
+    def test_item_started_structural_event_returns_empty(self) -> None:
+        state, ctx = _ctx(
+            "item/started",
+            {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "item": {"type": "reasoning"},
+            },
+        )
+        events = self.decoder.decode(
+            "item/started",
+            {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "item": {"type": "reasoning"},
+            },
+            state,
+            ctx,
+        )
+        assert events == []
+
+    def test_item_started_review_mode_returns_progress_notice(self) -> None:
+        state, ctx = _ctx(
+            "item/started",
+            {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "item": {"enteredReviewMode": True},
+            },
+        )
+        events = self.decoder.decode(
+            "item/started",
+            {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "item": {"enteredReviewMode": True},
+            },
+            state,
+            ctx,
+        )
+        assert len(events) == 1
+        assert isinstance(events[0], RunNotice)
+        assert events[0].kind == "progress"
+        assert events[0].message == "entered review mode"
 
     def test_reasoning_delta(self) -> None:
         state, ctx = _ctx(

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -2699,6 +2699,7 @@ class TestRegistryIsSoleDispatchPath:
     """
 
     EXPECTED_REGISTRY_METHODS: list[str] = [
+        "item/started",
         "item/reasoning/summaryTextDelta",
         "item/completed",
         "item/agentMessage/delta",
@@ -2755,6 +2756,7 @@ class TestRegistryIsSoleDispatchPath:
 
     async def test_all_supported_methods_produce_events_or_empty(self) -> None:
         minimal_payloads: dict[str, dict[str, object]] = {
+            "item/started": {"item": {"type": "reasoning"}},
             "item/reasoning/summaryTextDelta": {"delta": "thinking"},
             "item/completed": {"item": {"type": "agentMessage", "text": "hi"}},
             "item/agentMessage/delta": {"delta": "msg"},


### PR DESCRIPTION
## Summary
- register `item/started` in the runtime-thread decoder registry
- treat structural `item/started` lifecycle events as silent progress rather than decode failures
- preserve a human-facing progress notice when an item enters review mode
- add regression coverage for the decoder registry and supported-method characterization tests

## Root Cause
Managed-thread progress re-normalizes raw app-server events through the runtime-thread decoder registry. `item/started` is a documented lifecycle notification and the app-server client already tracks it internally, but the runtime decoder registry did not recognize it. That caused the progress path to emit `RunNotice(kind="decode_failure")`, which surfaced in working summaries as `No decoder for method: item/started`.

## Impact
Working summaries stop showing a noisy internal decoder warning for normal item lifecycle events. Real protocol drift still remains observable through decode-failure notices for genuinely unknown methods.

## Validation
- `.venv/bin/python -m pytest -q tests/core/orchestration/test_runtime_thread_decoders.py tests/core/orchestration/test_runtime_thread_events.py tests/test_managed_thread_progress.py`
- core validation lane from the repo commit hook, including repo-wide `mypy` and `pytest` (`7827 passed` on retry after an unrelated teardown flake)
