### PR TITLE
[codex] Fix PMA thread CLI UX

### DIFF
--- a/src/codex_autorunner/surfaces/cli/pma_thread_commands.py
+++ b/src/codex_autorunner/surfaces/cli/pma_thread_commands.py
@@ -321,6 +321,28 @@ def _assistant_text_lines(text: str) -> list[str]:
     return text.splitlines()
 
 
+def _thread_payload(data: Any) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        return {}
+    thread = data.get("thread")
+    return thread if isinstance(thread, dict) else {}
+
+
+def _normalized_thread_runtime_status(data: Any) -> str:
+    thread = _thread_payload(data)
+    return str(
+        thread.get("normalized_status")
+        or thread.get("status")
+        or data.get("status")
+        or ""
+    ).strip()
+
+
+def _normalized_thread_lifecycle_status(data: Any) -> str:
+    thread = _thread_payload(data)
+    return str(thread.get("lifecycle_status") or thread.get("status") or "").strip()
+
+
 def _resolve_assistant_text_window(
     *,
     assistant_text: str,
@@ -455,7 +477,12 @@ def _render_assistant_text_window(
             typer.echo(f"Wrote empty {label} to {output_file}")
         return
 
-    typer.echo(f"{label}:")
+    if window.total_lines > 0:
+        typer.echo(
+            f"{label} lines {window.start_line}:{window.end_line} of {window.total_lines}:"
+        )
+    else:
+        typer.echo(f"{label}:")
     if window.text:
         typer.echo(window.text, nl=False)
         if not window.text.endswith("\n"):
@@ -942,6 +969,26 @@ def _render_thread_status_snapshot(data: dict[str, Any]) -> None:
         typer.echo(line)
 
 
+def _resume_noop_message(managed_thread_id: str, thread_data: Any) -> str:
+    status = _normalized_thread_runtime_status(thread_data)
+    if status and status.lower() != "active":
+        return f"Thread {managed_thread_id} is already active (status: {status})"
+    return f"Thread {managed_thread_id} is already active"
+
+
+def _interrupt_conflict_message(managed_thread_id: str, thread_data: Any) -> str:
+    status = _normalized_thread_runtime_status(thread_data)
+    if status:
+        return f"Cannot interrupt: thread is not running (status: {status})"
+    lifecycle_status = _normalized_thread_lifecycle_status(thread_data)
+    if lifecycle_status:
+        return (
+            "Cannot interrupt: thread is not running "
+            f"(lifecycle: {lifecycle_status})"
+        )
+    return f"Cannot interrupt: thread {managed_thread_id} is not running"
+
+
 def _resolve_latest_managed_turn_id(config, *, managed_thread_id: str) -> str:
     turns_data = _request_json(
         "GET",
@@ -1366,7 +1413,7 @@ def pma_thread_status(
     output_lines: Optional[str] = typer.Option(
         None,
         "--lines",
-        help="assistant_text line range (1-based), for example 1:80 or 100:",
+        help="assistant_text-only line range (1-based), for example 1:80 or 100:",
     ),
     continue_output: bool = typer.Option(
         False,
@@ -2178,8 +2225,32 @@ def pma_thread_resume(
 ):
     """Set a managed thread active."""
     hub_root = _resolve_hub_path(path)
+    thread_data: dict[str, Any] = {}
     try:
         config = load_hub_config(hub_root)
+        thread_data = _request_json(
+            "GET",
+            _build_pma_url(config, f"/threads/{managed_thread_id}"),
+            token_env=config.server_auth_token_env,
+        )
+        if _normalized_thread_lifecycle_status(thread_data).lower() == "active":
+            if output_json:
+                typer.echo(
+                    json.dumps(
+                        {
+                            "status": "ok",
+                            "resumed": False,
+                            "detail": _resume_noop_message(
+                                managed_thread_id, thread_data
+                            ),
+                            "thread": _thread_payload(thread_data),
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                typer.echo(_resume_noop_message(managed_thread_id, thread_data))
+            return
         data = _request_json(
             "POST",
             _build_pma_url(config, f"/threads/{managed_thread_id}/resume"),
@@ -2344,6 +2415,7 @@ def pma_thread_interrupt(
 ):
     """Interrupt a running managed PMA thread turn."""
     hub_root = _resolve_hub_path(path)
+    thread_data: dict[str, Any] = {}
     try:
         config = load_hub_config(hub_root)
     except (OSError, ValueError) as exc:
@@ -2373,16 +2445,30 @@ def pma_thread_interrupt(
                 raise typer.Exit(code=1) from None
 
     try:
-        data = _request_json(
+        status_code, data = _request_json_with_status(
             "POST",
             _build_pma_url(config, f"/threads/{managed_thread_id}/interrupt"),
             token_env=config.server_auth_token_env,
         )
-    except httpx.HTTPError as exc:
-        typer.echo(f"HTTP error: {exc}", err=True)
-        raise typer.Exit(code=1) from None
     except (ValueError, OSError) as exc:
         typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+
+    if status_code >= 400:
+        if output_json:
+            typer.echo(json.dumps(data, indent=2))
+        else:
+            detail = str(data.get("detail") or "").strip()
+            if status_code == 409 and detail == "Managed thread has no running turn":
+                typer.echo(
+                    _interrupt_conflict_message(managed_thread_id, thread_data),
+                    err=True,
+                )
+            else:
+                typer.echo(
+                    detail or f"Managed thread interrupt failed (HTTP {status_code})",
+                    err=True,
+                )
         raise typer.Exit(code=1) from None
 
     if output_json:

--- a/src/codex_autorunner/surfaces/cli/pma_thread_commands.py
+++ b/src/codex_autorunner/surfaces/cli/pma_thread_commands.py
@@ -2450,7 +2450,7 @@ def pma_thread_interrupt(
             _build_pma_url(config, f"/threads/{managed_thread_id}/interrupt"),
             token_env=config.server_auth_token_env,
         )
-    except (ValueError, OSError) as exc:
+    except (httpx.HTTPError, ValueError, OSError) as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from None
 

--- a/tests/surfaces/cli/test_pma_thread_commands.py
+++ b/tests/surfaces/cli/test_pma_thread_commands.py
@@ -73,6 +73,7 @@ def test_pma_cli_thread_status_help_shows_json_option():
     assert "--json" in output, "PMA thread status should support --json"
     assert "--output" in output
     assert "--lines" in output
+    assert "assistant_text-only" in output
     assert "--continue" in output
     assert "--output-file" in output
 
@@ -583,11 +584,83 @@ def test_pma_cli_thread_status_output_renders_paginated_assistant_text(
     )
 
     assert result.exit_code == 0, result.output
-    assert "assistant_text:" in result.stdout
+    assert "assistant_text lines 1:20 of 25:" in result.stdout
     assert "line 1" in result.stdout
     assert "line 20" in result.stdout
     assert "line 21" not in result.stdout
     assert "--continue or --lines 21:25" in result.stdout
+
+
+def test_pma_cli_thread_status_lines_header_clarifies_slice(
+    monkeypatch, tmp_path: Path
+) -> None:
+    assistant_text = "\n".join(f"line {index}" for index in range(1, 6))
+
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = method, payload, token_env, params
+        if url.endswith("/threads/thread-1/status"):
+            return {
+                "managed_thread_id": "thread-1",
+                "status": "completed",
+                "operator_status": "reusable",
+                "status_reason": "managed_turn_completed",
+                "thread": {
+                    "agent": "codex",
+                    "repo_id": "repo-1",
+                    "status": "completed",
+                    "lifecycle_status": "active",
+                },
+                "turn": {
+                    "managed_turn_id": "turn-1",
+                    "status": "ok",
+                    "activity": "completed",
+                    "phase": "finalize",
+                },
+                "latest_turn_id": "turn-1",
+                "latest_assistant_text": assistant_text,
+                "latest_output_excerpt": "line 1",
+            }
+        raise AssertionError(f"unexpected url: {url}")
+
+    monkeypatch.setattr(pma_thread_commands, "_request_json", _fake_request_json)
+
+    result = CliRunner().invoke(
+        pma_app,
+        [
+            "thread",
+            "status",
+            "--id",
+            "thread-1",
+            "--output",
+            "--lines",
+            "2:3",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "assistant_text lines 2:3 of 5:" in result.stdout
+    assert "line 2" in result.stdout
+    assert "line 3" in result.stdout
+    assert "line 1\nline 2\nline 3" not in result.stdout
 
 
 def test_pma_cli_thread_output_supports_continue_and_output_file(
@@ -2027,6 +2100,14 @@ def test_pma_cli_thread_control_commands_use_orchestration_routes(
         calls.append((method, url, payload))
         if url.endswith("/hub/pma/threads"):
             return {"thread": {"managed_thread_id": "thread-1"}}
+        if url.endswith("/hub/pma/threads/thread-1"):
+            return {
+                "thread": {
+                    "managed_thread_id": "thread-1",
+                    "lifecycle_status": "archived",
+                    "status": "archived",
+                }
+            }
         if url.endswith("/resume"):
             return {
                 "thread": {
@@ -2107,6 +2188,11 @@ def test_pma_cli_thread_control_commands_use_orchestration_routes(
             },
         ),
         (
+            "GET",
+            "http://127.0.0.1:4321/hub/pma/threads/thread-1",
+            None,
+        ),
+        (
             "POST",
             "http://127.0.0.1:4321/hub/pma/threads/thread-1/resume",
             {},
@@ -2117,6 +2203,119 @@ def test_pma_cli_thread_control_commands_use_orchestration_routes(
             None,
         ),
     ]
+
+
+def test_pma_cli_thread_resume_reports_already_active_noop(
+    monkeypatch, tmp_path: Path
+) -> None:
+    calls: list[tuple[str, str, dict[str, object] | None]] = []
+
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = token_env, params
+        calls.append((method, url, payload))
+        if url.endswith("/hub/pma/threads/thread-1"):
+            return {
+                "thread": {
+                    "managed_thread_id": "thread-1",
+                    "lifecycle_status": "active",
+                    "status": "completed",
+                }
+            }
+        raise AssertionError(f"unexpected url: {url}")
+
+    monkeypatch.setattr(pma_thread_commands, "_request_json", _fake_request_json)
+
+    result = CliRunner().invoke(
+        pma_app,
+        ["thread", "resume", "--id", "thread-1", "--path", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Thread thread-1 is already active (status: completed)" in result.stdout
+    assert calls == [
+        (
+            "GET",
+            "http://127.0.0.1:4321/hub/pma/threads/thread-1",
+            None,
+        )
+    ]
+
+
+def test_pma_cli_thread_interrupt_reports_running_conflict_cleanly(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "_fetch_agent_capabilities",
+        lambda config, path: {"codex": {"interrupt"}},
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = method, payload, token_env, params
+        if url.endswith("/threads/thread-1"):
+            return {
+                "thread": {
+                    "managed_thread_id": "thread-1",
+                    "agent": "codex",
+                    "status": "completed",
+                    "lifecycle_status": "active",
+                }
+            }
+        raise AssertionError(f"unexpected url: {url}")
+
+    monkeypatch.setattr(pma_thread_commands, "_request_json", _fake_request_json)
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "_request_json_with_status",
+        lambda method, url, payload=None, token_env=None, params=None, timeout=30.0: (
+            409,
+            {"detail": "Managed thread has no running turn"},
+        ),
+    )
+
+    result = CliRunner().invoke(
+        pma_app,
+        ["thread", "interrupt", "--id", "thread-1", "--path", str(tmp_path)],
+    )
+
+    assert result.exit_code == 1
+    assert (
+        "Cannot interrupt: thread is not running (status: completed)" in result.output
+    )
+    assert "409 Conflict" not in result.output
 
 
 def test_pma_cli_thread_archive_bulk_uses_bulk_route(


### PR DESCRIPTION
## Summary
- detect `car pma thread resume` no-op cases up front and report when a thread is already active instead of printing a misleading resume success line
- clarify `car pma thread status --lines` as an assistant-text-only slice and show the rendered line window in terminal output
- surface a friendly PMA interrupt conflict message when a thread has no running turn instead of leaking the raw HTTP 409 text

## Root Cause
The CLI treated resume as unconditional success, `status --output` did not visually identify the selected assistant-text slice, and interrupt used the strict JSON helper that raised raw `httpx` status errors before the CLI could translate thread-state conflicts.

## Validation
- `tests/surfaces/cli/test_pma_thread_commands.py -q`
- repo validation hook on commit, including `ruff`, strict `mypy`, and full `pytest` (`7830 passed`)

Closes #1598