### PR TITLE
Fix Discord PMA placeholder and recovery state leaks

### DIFF
--- a/src/codex_autorunner/core/orchestration/chat_operation_ledger.py
+++ b/src/codex_autorunner/core/orchestration/chat_operation_ledger.py
@@ -293,7 +293,7 @@ class SQLiteChatOperationLedger(ChatOperationStore):
         limit: int = 200,
     ) -> list[ChatOperationSnapshot]:
         params: list[Any] = []
-        clauses = ["terminal_outcome IS NULL"]
+        clauses = ["(terminal_outcome IS NULL OR terminal_outcome = 'delivery_failed')"]
         placeholders = ", ".join("?" for _ in CHAT_OPERATION_TERMINAL_STATES)
         clauses.append(f"state NOT IN ({placeholders})")
         params.extend(state.value for state in CHAT_OPERATION_TERMINAL_STATES)

--- a/src/codex_autorunner/integrations/discord/managed_thread_startup_recovery.py
+++ b/src/codex_autorunner/integrations/discord/managed_thread_startup_recovery.py
@@ -10,6 +10,7 @@ from ...integrations.chat.bound_live_progress import (
 from ...integrations.chat.managed_thread_startup_recovery import (
     recover_managed_thread_executions_on_startup as recover_surface_managed_thread_executions_on_startup,
 )
+from ...integrations.chat.managed_thread_turns import ManagedThreadExecutionHooks
 from .managed_thread_delivery import build_discord_managed_thread_durable_delivery_hooks
 from .managed_thread_routing import (
     _build_discord_managed_thread_coordinator,
@@ -19,6 +20,7 @@ from .message_turns import build_discord_thread_orchestration_service
 from .progress_leases import (
     _get_discord_thread_queue_task_map,
     _spawn_discord_progress_background_task,
+    cleanup_discord_terminal_progress_leases,
 )
 
 
@@ -35,11 +37,37 @@ async def recover_managed_thread_executions_on_startup(service: Any) -> None:
             owner,
             fallback_root=Path(owner._config.root),
         )
+
+        async def _cleanup_interrupted_progress(
+            _started: Any,
+            finalized: Any,
+        ) -> None:
+            status = str(getattr(finalized, "status", "") or "").strip().lower()
+            managed_turn_id = str(
+                getattr(finalized, "managed_turn_id", "") or ""
+            ).strip()
+            if status != "interrupted" or not managed_turn_id:
+                return
+            await cleanup_discord_terminal_progress_leases(
+                owner,
+                managed_thread_id=managed_thread_id,
+                execution_id=managed_turn_id,
+                channel_id=surface_key,
+                note="Status: this turn was interrupted.",
+                record_prefix=(
+                    "discord:startup-recovery-interrupted-progress-cleanup:"
+                    f"{managed_thread_id}:{managed_turn_id}"
+                ),
+            )
+
         return build_bound_chat_queue_execution_controller(
             hub_root=hub_root,
             raw_config=raw_config,
             managed_thread_id=managed_thread_id,
             surface_targets=(("discord", surface_key),),
+            base_hooks=ManagedThreadExecutionHooks(
+                on_execution_finalized=_cleanup_interrupted_progress
+            ),
         ).hooks
 
     def _recover_pending_queue(

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -1859,12 +1859,16 @@ async def _run_discord_orchestrated_turn_for_message(
                     channel_id=channel_id,
                     source_message_id=source_message_id,
                 )
-        if not reusable_progress_message_id:
-            reusable_progress_message_id = _claim_discord_reusable_progress_message(
-                service,
-                thread_target_id=managed_thread_id,
-                source_message_id=source_message_id,
-            )
+    if not reusable_progress_message_id:
+        # PMA message ingress posts an immediate "Received. Preparing turn..."
+        # placeholder before the managed-turn runner starts. Claim it here so the
+        # runner edits/deletes that original message instead of creating a second,
+        # untracked progress anchor that leaves the first placeholder behind.
+        reusable_progress_message_id = _claim_discord_reusable_progress_message(
+            service,
+            thread_target_id=managed_thread_id,
+            source_message_id=source_message_id,
+        )
 
     async def _load_progress_lease() -> Any:
         return await _get_discord_progress_lease(service, lease_id=progress_lease_id)

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -5313,6 +5313,7 @@ class DiscordBotService:
         shared_state = None
         delivery_state = None
         delivery_attempt_count = None
+        clear_delivery_failure_marker = False
         if isinstance(cursor, dict):
             delivery_state = str(cursor.get("state") or "").strip() or None
             if delivery_state in {"pending", "failed"}:
@@ -5321,6 +5322,8 @@ class DiscordBotService:
                 record = await self._store.get_interaction(interaction_id)
                 if record is not None and record.execution_status == "completed":
                     shared_state = ChatOperationState.COMPLETED
+            if delivery_state in {"pending", "completed"}:
+                clear_delivery_failure_marker = True
             record = await self._store.get_interaction(interaction_id)
             if record is not None:
                 delivery_attempt_count = int(record.attempt_count or 0)
@@ -5329,12 +5332,19 @@ class DiscordBotService:
             if record is not None and record.execution_status == "completed":
                 shared_state = ChatOperationState.COMPLETED
             delivery_state = "delivered"
+            clear_delivery_failure_marker = True
+        patch_kwargs: dict[str, Any] = {
+            "state": shared_state,
+            "delivery_state": delivery_state,
+            "delivery_cursor": cursor,
+            "delivery_attempt_count": delivery_attempt_count,
+        }
+        if clear_delivery_failure_marker:
+            patch_kwargs["terminal_outcome"] = None
+            patch_kwargs["terminal_detail"] = None
         await self._patch_chat_operation(
             interaction_id,
-            state=shared_state,
-            delivery_state=delivery_state,
-            delivery_cursor=cursor,
-            delivery_attempt_count=delivery_attempt_count,
+            **patch_kwargs,
         )
 
     async def _mark_interaction_scheduler_state(

--- a/tests/chat_surface_integration/test_hermes_pma_surfaces.py
+++ b/tests/chat_surface_integration/test_hermes_pma_surfaces.py
@@ -46,6 +46,20 @@ async def test_discord_hermes_pma_uses_official_placeholder_lifecycle(
         )
 
         progress_message_id = str(rest.message_ops[0]["message_id"])
+        finalized_record = next(
+            record
+            for record in rest.log_records
+            if record.get("event") == "discord.turn.managed_thread_finalized"
+        )
+        assert finalized_record.get("preview_message_id") == progress_message_id
+
+        delivery_started = next(
+            record
+            for record in rest.log_records
+            if record.get("event") == "discord.turn.delivery_started"
+        )
+        assert delivery_started.get("preview_message_id") == progress_message_id
+
         working_edits = [
             op
             for op in rest.message_ops

--- a/tests/core/orchestration/test_chat_operation_ledger.py
+++ b/tests/core/orchestration/test_chat_operation_ledger.py
@@ -159,6 +159,30 @@ def test_recovery_plan_replays_pending_delivery(tmp_path: Path) -> None:
     assert decision.action == ChatOperationRecoveryAction.REPLAY_DELIVERY
 
 
+def test_list_recoverable_operations_includes_delivery_failed_replay_state(
+    tmp_path: Path,
+) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.upsert_operation(
+        ChatOperationSnapshot(
+            operation_id="recover-delivery-failed",
+            surface_kind="discord",
+            surface_operation_key="interaction-delivery-failed",
+            state=ChatOperationState.DELIVERING,
+            delivery_state="failed",
+            delivery_cursor={"operation": "send_followup", "state": "failed"},
+            delivery_attempt_count=1,
+            terminal_outcome="delivery_failed",
+            created_at="2026-04-15T01:00:00Z",
+            updated_at="2026-04-15T01:00:00Z",
+        )
+    )
+
+    recoverable = ledger.list_recoverable_operations(surface_kind="discord")
+
+    assert [item.operation_id for item in recoverable] == ["recover-delivery-failed"]
+
+
 def test_recovery_plan_expires_unacknowledged_operations(tmp_path: Path) -> None:
     ledger = _ledger(tmp_path)
     snapshot = ledger.upsert_operation(

--- a/tests/integrations/discord/test_service_startup.py
+++ b/tests/integrations/discord/test_service_startup.py
@@ -8,6 +8,9 @@ from types import SimpleNamespace
 import pytest
 
 from codex_autorunner.integrations.app_server.event_buffer import AppServerEventBuffer
+from codex_autorunner.integrations.discord import (
+    managed_thread_startup_recovery as discord_startup_recovery_module,
+)
 from codex_autorunner.integrations.discord import service as discord_service_module
 from codex_autorunner.integrations.discord.config import (
     DiscordBotConfig,
@@ -170,6 +173,91 @@ async def test_service_startup_runs_managed_thread_recovery_hook(
         assert called == ["DiscordBotService"]
     finally:
         await store.close()
+
+
+@pytest.mark.anyio
+async def test_startup_recovery_cleans_interrupted_progress_leases(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    cleanup_calls: list[dict[str, object]] = []
+
+    async def _fake_recover_surface_managed_thread_executions_on_startup(
+        service: object,
+        **kwargs: object,
+    ) -> None:
+        _ = service
+        captured.update(kwargs)
+
+    async def _fake_cleanup_discord_terminal_progress_leases(
+        owner: object,
+        *,
+        managed_thread_id: str,
+        execution_id: str | None,
+        channel_id: str,
+        note: str,
+        record_prefix: str,
+    ) -> int:
+        cleanup_calls.append(
+            {
+                "owner": owner,
+                "managed_thread_id": managed_thread_id,
+                "execution_id": execution_id,
+                "channel_id": channel_id,
+                "note": note,
+                "record_prefix": record_prefix,
+            }
+        )
+        return 1
+
+    monkeypatch.setattr(
+        discord_startup_recovery_module,
+        "recover_surface_managed_thread_executions_on_startup",
+        _fake_recover_surface_managed_thread_executions_on_startup,
+    )
+    monkeypatch.setattr(
+        discord_startup_recovery_module,
+        "cleanup_discord_terminal_progress_leases",
+        _fake_cleanup_discord_terminal_progress_leases,
+    )
+
+    service = SimpleNamespace(
+        _config=SimpleNamespace(root=tmp_path),
+        _logger=logging.getLogger("test.discord.startup.interrupted_cleanup"),
+    )
+
+    await discord_startup_recovery_module.recover_managed_thread_executions_on_startup(
+        service
+    )
+
+    build_execution_hooks = captured["build_execution_hooks"]
+    hooks = build_execution_hooks(
+        service,
+        "channel-1",
+        "thread-1",
+        SimpleNamespace(workspace_root=tmp_path),
+    )
+    assert hooks.on_execution_finalized is not None
+
+    await hooks.on_execution_finalized(
+        SimpleNamespace(execution=SimpleNamespace(execution_id="turn-1")),
+        SimpleNamespace(status="interrupted", managed_turn_id="turn-1"),
+    )
+
+    assert cleanup_calls == [
+        {
+            "owner": service,
+            "managed_thread_id": "thread-1",
+            "execution_id": "turn-1",
+            "channel_id": "channel-1",
+            "note": "Status: this turn was interrupted.",
+            "record_prefix": (
+                "discord:startup-recovery-interrupted-progress-cleanup:"
+                "thread-1:turn-1"
+            ),
+        }
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/integrations/discord/test_single_owner_invariants.py
+++ b/tests/integrations/discord/test_single_owner_invariants.py
@@ -32,6 +32,8 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from codex_autorunner.core.orchestration import (
+    ChatOperationSnapshot,
+    ChatOperationState,
     SQLiteChatOperationLedger,
     initialize_orchestration_sqlite,
 )
@@ -419,6 +421,59 @@ async def test_on_dispatch_rejected_normalization_sends_error_and_skips_schedule
         error_text = service._respond_ephemeral.call_args[0][2]
         assert "parse" in error_text.lower() or "retry" in error_text.lower()
         service._command_runner.submit.assert_not_called()
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_delivery_cursor_clears_stale_delivery_failed_marker(
+    tmp_path: Path,
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    operation_store = SQLiteChatOperationLedger(tmp_path, durable=False)
+    try:
+        service = _build_recovery_service(
+            store=store,
+            rest=_ChaosRest(),
+            operation_store=operation_store,
+        )
+        await store.register_interaction(
+            interaction_id="inter-delivery-1",
+            interaction_token="token-1",
+            interaction_kind=InteractionKind.SLASH_COMMAND.value,
+            channel_id="chan-1",
+            guild_id="guild-1",
+            user_id="user-1",
+            metadata_json={},
+        )
+        operation_store.upsert_operation(
+            ChatOperationSnapshot(
+                operation_id="inter-delivery-1",
+                surface_kind="discord",
+                surface_operation_key="interaction:inter-delivery-1",
+                state=ChatOperationState.DELIVERING,
+                delivery_state="failed",
+                delivery_cursor={"operation": "send_followup", "state": "failed"},
+                delivery_attempt_count=1,
+                terminal_outcome="delivery_failed",
+                terminal_detail="discord_send_deferred",
+                created_at="2026-04-15T01:00:00Z",
+                updated_at="2026-04-15T01:00:00Z",
+            )
+        )
+
+        await service._record_interaction_delivery_cursor(
+            "inter-delivery-1",
+            {"operation": "send_followup", "state": "pending"},
+        )
+
+        snapshot = operation_store.get_operation("inter-delivery-1")
+        assert snapshot is not None
+        assert snapshot.state is ChatOperationState.DELIVERING
+        assert snapshot.delivery_state == "pending"
+        assert snapshot.terminal_outcome is None
+        assert snapshot.terminal_detail is None
     finally:
         await store.close()
 


### PR DESCRIPTION
## Summary
- reuse the original Discord PMA `Received. Preparing turn...` placeholder instead of creating a second progress anchor
- keep `delivery_failed` operations recoverable and clear stale failure markers once delivery resumes or completes
- clean interrupted Discord startup-recovery turns so stale progress leases do not survive restart

## Root cause
The PMA ingress path stashed the first placeholder for reuse, but managed-turn execution in PMA mode skipped claiming that reusable placeholder and created a second anchor. Final delivery and cleanup only tracked the second message, so the original placeholder leaked.

A separate shared-ledger mismatch also existed: recovery planning explicitly treated `terminal_outcome=delivery_failed` as replayable, but the recoverable query filtered those rows out entirely. Discord delivery-cursor updates also left stale `delivery_failed` markers behind after a retry had already moved back to pending or completed.

## Testing
- repo commit gate: formatting, ruff, import boundaries, strict mypy, repo-wide pytest, static build/tests, chat-surface lab checks
- `.venv/bin/python -m pytest -q tests/chat_surface_integration/test_hermes_pma_surfaces.py tests/chat_surface_integration/test_hermes_pma_official_timeout.py`
- `.venv/bin/python -m pytest -q tests/core/orchestration/test_chat_operation_ledger.py tests/core/orchestration/test_chat_operation_recovery.py`
- `.venv/bin/python -m pytest -q tests/integrations/discord/test_single_owner_invariants.py tests/integrations/discord/test_service_startup.py`
- `.venv/bin/python -m pytest -q tests/integrations/discord/test_message_turns_transient_progress.py -k "interrupt_send_acknowledges_when_progress_message_missing or ignores_transient_progress_edit_failures"`