### PR TITLE
[codex] fix bot review whitelist routing

### DIFF
--- a/src/codex_autorunner/core/scm_reaction_router.py
+++ b/src/codex_autorunner/core/scm_reaction_router.py
@@ -191,10 +191,18 @@ def _github_review_author_login(event: ScmEvent) -> Optional[str]:
     )
 
 
+def _github_login_explicitly_whitelisted(
+    config: ScmReactionConfig,
+    login: Optional[str],
+) -> bool:
+    return login is not None and login in config.github_login_whitelist
+
+
 def _match_reaction_kind(
     event: ScmEvent,
     *,
     binding: Optional[PrBinding],
+    config: ScmReactionConfig,
 ) -> Optional[ReactionKind]:
     payload = _event_payload(event)
 
@@ -221,7 +229,7 @@ def _match_reaction_kind(
 
     if event.event_type in {"issue_comment", "pull_request_review_comment"}:
         action = _normalize_lower_text(payload.get("action"))
-        author_login = _normalize_lower_text(payload.get("author_login"))
+        author_login = _github_review_author_login(event)
         issue_author_login = _normalize_lower_text(payload.get("issue_author_login"))
         author_type = _normalize_lower_text(payload.get("author_type"))
         if action != "created":
@@ -232,9 +240,10 @@ def _match_reaction_kind(
             and author_login == issue_author_login
         ):
             return None
-        if author_type == "bot" or (
-            author_login is not None and author_login.endswith("[bot]")
-        ):
+        if (
+            author_type == "bot"
+            or (author_login is not None and author_login.endswith("[bot]"))
+        ) and not _github_login_explicitly_whitelisted(config, author_login):
             return None
         return "review_comment"
 
@@ -261,7 +270,11 @@ def route_scm_reactions(
     config: ScmReactionConfig | Mapping[str, Any] | None = None,
 ) -> list[ReactionIntent]:
     resolved_config = ScmReactionConfig.from_mapping(config)
-    reaction_kind = _match_reaction_kind(event, binding=binding)
+    reaction_kind = _match_reaction_kind(
+        event,
+        binding=binding,
+        config=resolved_config,
+    )
     if reaction_kind is None or not resolved_config.is_enabled(reaction_kind):
         return []
     if (

--- a/tests/core/test_scm_reaction_router.py
+++ b/tests/core/test_scm_reaction_router.py
@@ -431,7 +431,9 @@ def test_route_scm_reactions_parses_review_comment_id_from_api_url() -> None:
     assert intents[1].payload["comment_id"] == "77123"
 
 
-def test_route_scm_reactions_routes_bot_pull_request_review_comment() -> None:
+def test_route_scm_reactions_skips_non_whitelisted_bot_pull_request_review_comment() -> (
+    None
+):
     event = _event(
         "pull_request_review_comment",
         event_id="github:event-inline-bot-comment",
@@ -452,6 +454,38 @@ def test_route_scm_reactions_routes_bot_pull_request_review_comment() -> None:
     )
 
     assert len(intents) == 0
+
+
+def test_route_scm_reactions_routes_whitelisted_bot_pull_request_review_comment() -> (
+    None
+):
+    event = _event(
+        "pull_request_review_comment",
+        event_id="github:event-inline-whitelisted-bot-comment",
+        payload={
+            "action": "created",
+            "comment_id": "2846",
+            "author_login": "chatgpt-codex-connector",
+            "author_type": "Bot",
+            "issue_author_login": "pr-author",
+            "body": "Please cover the whitelist override path.",
+            "path": "src/codex_autorunner/core/scm_reaction_router.py",
+            "line": 239,
+        },
+    )
+
+    intents = route_scm_reactions(
+        event,
+        binding=_binding(thread_target_id="thread-inline-bot"),
+        config=ScmReactionConfig(github_login_whitelist=("chatgpt-codex-connector",)),
+    )
+
+    assert len(intents) == 2
+    assert intents[0].reaction_kind == "review_comment"
+    assert intents[0].operation_kind == "enqueue_managed_turn"
+    assert intents[1].reaction_kind == "review_comment"
+    assert intents[1].operation_kind == "react_pr_review_comment"
+    assert intents[1].payload["comment_id"] == "2846"
 
 
 def test_route_scm_reactions_still_reacts_to_review_comment_without_chat_target() -> (


### PR DESCRIPTION
## Summary
- allow bot-authored `review_comment` reactions to route when the bot login is explicitly listed in `github_login_whitelist`
- keep the default bot exclusion in place for non-whitelisted bot comments
- add a regression test covering the whitelisted bot review-comment path

## Root Cause
`_match_reaction_kind()` returned `None` for bot-authored review comments before `route_scm_reactions()` could apply the GitHub login whitelist. That made `github_login_whitelist` ineffective for bot review comments discovered by SCM polling.

## Impact
Whitelisted review bots such as `chatgpt-codex-connector` can now wake bound managed threads and produce the expected publish operations from SCM polling.

## Validation
- `tests/core/test_scm_reaction_router.py -q`
- `tests/core/test_scm_automation_service.py -k review_comment -q`
- `tests/integrations/github/test_polling.py -k review_comment -q`
- repo commit hook validation including full `pytest` run (`7833 passed`)

Closes #1602