### PR TITLE
Fix PMA queued-turn worker startup for coordinator-only hooks

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime_control.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime_control.py
@@ -283,7 +283,12 @@ def ensure_queue_worker(
     if hooks is None:
         resolved_hooks = None
     elif isinstance(hooks, ManagedThreadCoordinatorHooks):
-        resolved_hooks = hooks.queue_worker_hooks()
+        resolved_hooks = ManagedThreadQueueWorkerHooks(
+            durable_delivery=hooks.durable_delivery,
+            deliver_result=hooks.deliver_result,
+            run_with_indicator=hooks.run_with_indicator,
+            execution_hooks=hooks.queue_execution_hooks or hooks.execution_hooks(),
+        )
     else:
         resolved_hooks = hooks
 


### PR DESCRIPTION
## Summary
- stop PMA queue-worker setup from calling the strict coordinator queue-hook coercion path
- preserve `queue_execution_hooks` while letting the web PMA route continue supplying delivery handlers separately
- unblock queued managed-thread sends so the worker starts instead of returning a 500 and orphaning the queued turn

## Testing
- .venv/bin/pytest -q tests/test_pma_managed_threads_messages.py -k queued_message_runs_after_background_turn_finishes
- .venv/bin/pytest -q tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py -k "starts_queue_worker_for_queued_turns or direct_execution_starts_queue_worker_for_followups or pma_queue_worker_uses_contextual_delivery_helper_for_progress_targets"
- git commit validation lane (`web-ui`): 7833 passed

Closes #1604