### PR TITLE
[codex] Fix decode failure progress leaks

### DIFF
--- a/src/codex_autorunner/core/orchestration/runtime_thread_decoders.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_decoders.py
@@ -742,6 +742,22 @@ class CodexItemDecoder(MessageDecoder):
         return []
 
 
+class LifecycleBoundaryDecoder(MessageDecoder):
+
+    def methods(self) -> frozenset[str]:
+        return frozenset(
+            {
+                "turn/started",
+                "prompt/started",
+                "session/created",
+                "session/loaded",
+            }
+        )
+
+    def decode(self, method, params, state, ctx):
+        return []
+
+
 class ACPPromptTurnDecoder(MessageDecoder):
     _PROMPT_OUTPUT_METHODS = frozenset(
         {
@@ -1155,6 +1171,7 @@ class ErrorDecoder(MessageDecoder):
 def build_default_decoder_registry() -> DecoderRegistry:
     registry = DecoderRegistry()
     registry.register(CodexItemDecoder())
+    registry.register(LifecycleBoundaryDecoder())
     registry.register(ACPPromptTurnDecoder())
     registry.register(PermissionDecoder())
     registry.register(UsageDecoder())
@@ -1170,6 +1187,7 @@ __all__ = [
     "DecoderRegistry",
     "MessageDecoder",
     "CodexItemDecoder",
+    "LifecycleBoundaryDecoder",
     "ACPPromptTurnDecoder",
     "PermissionDecoder",
     "UsageDecoder",

--- a/src/codex_autorunner/integrations/chat/managed_thread_progress.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_progress.py
@@ -112,6 +112,8 @@ def apply_run_event_to_progress_tracker(
         notice = run_event.message.strip() if run_event.message else ""
         if not notice:
             notice = run_event.kind.strip() if run_event.kind else "notice"
+        if run_event.kind == "decode_failure":
+            return ProgressTrackerEventOutcome(changed=False)
         if run_event.kind in {"thinking", "reasoning"}:
             prior_transient = tracker.transient_action
             changed = tracker.note_thinking(notice)

--- a/tests/core/orchestration/test_runtime_thread_decoders.py
+++ b/tests/core/orchestration/test_runtime_thread_decoders.py
@@ -8,6 +8,7 @@ from codex_autorunner.core.orchestration.runtime_thread_decoders import (
     CodexItemDecoder,
     DecoderContext,
     ErrorDecoder,
+    LifecycleBoundaryDecoder,
     MessageDecoder,
     OpenCodeMessageDecoder,
     PermissionDecoder,
@@ -54,6 +55,8 @@ class TestDecoderRegistry:
         assert registry._exact.get("token/usage") is not None
         assert registry._exact.get("item/completed") is not None
         assert registry._exact.get("session/update") is not None
+        assert registry._exact.get("turn/started") is not None
+        assert registry._exact.get("session/created") is not None
 
     def test_unknown_method_returns_empty(self) -> None:
         registry = build_default_decoder_registry()
@@ -90,7 +93,32 @@ class TestDecoderRegistry:
 
     def test_all_decoders_registered(self) -> None:
         registry = build_default_decoder_registry()
-        assert len(registry._decoders) == 8
+        assert len(registry._decoders) == 9
+
+
+class TestLifecycleBoundaryDecoder:
+    def setup_method(self) -> None:
+        self.decoder = LifecycleBoundaryDecoder()
+
+    def test_methods_cover_acp_lifecycle_boundaries(self) -> None:
+        assert self.decoder.methods() == frozenset(
+            {
+                "turn/started",
+                "prompt/started",
+                "session/created",
+                "session/loaded",
+            }
+        )
+
+    def test_decode_silently_consumes_lifecycle_boundary_events(self) -> None:
+        state, ctx = _ctx("turn/started", {"turnId": "turn-1", "promptId": "prompt-1"})
+        events = self.decoder.decode(
+            "turn/started",
+            {"turnId": "turn-1", "promptId": "prompt-1"},
+            state,
+            ctx,
+        )
+        assert events == []
 
 
 class TestCodexItemDecoder:

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -2674,6 +2674,16 @@ class TestDecodeFailureObservability:
         assert len(events) == 1
         assert isinstance(events[0], TokenUsage)
 
+    async def test_lifecycle_boundary_method_is_silently_consumed(self) -> None:
+        state = RuntimeThreadRunEventState()
+
+        events = await normalize_runtime_thread_raw_event(
+            {"method": "turn/started", "params": {"turnId": "turn-1"}},
+            state,
+        )
+
+        assert events == []
+
     async def test_session_status_idle_does_not_emit_decode_failure(self) -> None:
         state = RuntimeThreadRunEventState()
 
@@ -2707,6 +2717,10 @@ class TestRegistryIsSoleDispatchPath:
         "item/toolCall/end",
         "item/commandExecution/requestApproval",
         "item/fileChange/requestApproval",
+        "session/created",
+        "session/loaded",
+        "prompt/started",
+        "turn/started",
         "prompt/output",
         "prompt/delta",
         "prompt/progress",
@@ -2764,6 +2778,10 @@ class TestRegistryIsSoleDispatchPath:
             "item/toolCall/end": {"name": "t", "result": {}},
             "item/commandExecution/requestApproval": {"command": ["ls"]},
             "item/fileChange/requestApproval": {"files": ["a.py"]},
+            "session/created": {"sessionId": "s1"},
+            "session/loaded": {"sessionId": "s1"},
+            "prompt/started": {"sessionId": "s1"},
+            "turn/started": {"turnId": "t1", "promptId": "p1"},
             "prompt/output": {"delta": "out"},
             "prompt/delta": {"delta": "d"},
             "prompt/progress": {"delta": "prog"},

--- a/tests/test_managed_thread_progress.py
+++ b/tests/test_managed_thread_progress.py
@@ -429,6 +429,24 @@ def test_progress_notice_shows_when_no_transient_action() -> None:
     assert len(tracker.actions) == 0
 
 
+def test_decode_failure_notice_is_ignored() -> None:
+    tracker = _tracker()
+
+    outcome = apply_run_event_to_progress_tracker(
+        tracker,
+        RunNotice(
+            timestamp="2026-03-15T00:00:00Z",
+            kind="decode_failure",
+            message="No decoder for method: future/unknownMethod",
+        ),
+        runtime_state=ProgressRuntimeState(),
+    )
+
+    assert outcome.changed is False
+    assert tracker.transient_action is None
+    assert len(tracker.actions) == 0
+
+
 def test_progress_notice_does_not_overwrite_tool_trace() -> None:
     tracker = _tracker()
 


### PR DESCRIPTION
## Summary
- add a dedicated lifecycle-boundary decoder so `turn/started`, `prompt/started`, `session/created`, and `session/loaded` are silently consumed again
- suppress `RunNotice(kind="decode_failure")` in managed-thread progress so future registry misses stay in logs instead of leaking into Discord/Telegram working-turn edits
- extend orchestration and chat regressions to cover the silent lifecycle path and the UI-side guard

## Root Cause
The decoder registry refactor stopped silently dropping ACP lifecycle boundary events that carry no user-visible content. Those events fell through the registry-miss path, emitted `decode_failure` notices, and the managed-thread progress renderer surfaced them as visible `↻ notice` lines.

## Validation
- `.venv/bin/python -m pytest -q tests/core/orchestration/test_runtime_thread_decoders.py tests/core/orchestration/test_runtime_thread_events.py tests/test_managed_thread_progress.py`
- aggregate pre-commit validation lane (`mypy`, `pytest`, `pnpm test:markdown`, chat-surface checks)

Closes #1605