### PR TITLE
fix(#1609): add queued-turn management commands and --no-wait send flag

### DIFF
--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -489,7 +489,7 @@ class PmaThreadExecutionStore(ThreadExecutionStore):
         return execution
 
     def cancel_queued_executions(self, thread_target_id: str) -> int:
-        return self._store.cancel_queued_turns(thread_target_id)
+        return len(self._store.cancel_queued_turns(thread_target_id))
 
     def record_thread_activity(
         self,

--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -55,6 +55,28 @@ logger = logging.getLogger(__name__)
 HarnessFactory = Callable[..., RuntimeThreadHarness]
 
 
+@dataclass(frozen=True)
+class PreparedThreadExecution:
+    """Execution row plus enough context to start the runtime turn later."""
+
+    thread: ThreadTarget
+    request: MessageRequest
+    execution: ExecutionRecord
+    workspace_root: Path
+    sandbox_policy: Optional[Any]
+    harness: Optional[RuntimeThreadHarness] = None
+
+    def to_claimed_request(self) -> _ClaimedThreadExecutionRequest:
+        return _ClaimedThreadExecutionRequest(
+            thread=self.thread,
+            execution=self.execution,
+            queued_request=QueuedExecutionRequest(
+                request=self.request,
+                sandbox_policy=self.sandbox_policy,
+            ),
+        )
+
+
 def _thread_target_from_store_row(record: Mapping[str, Any]) -> ThreadTarget:
     return ThreadTarget.from_mapping(record)
 
@@ -988,6 +1010,25 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
         sandbox_policy: Optional[Any] = None,
         harness: Optional[RuntimeThreadHarness] = None,
     ) -> tuple[ExecutionRecord, Optional[RuntimeThreadHarness]]:
+        prepared = await self.prepare_thread_execution(
+            request,
+            client_request_id=client_request_id,
+            sandbox_policy=sandbox_policy,
+            harness=harness,
+        )
+        if prepared.execution.status != "running":
+            return prepared.execution, None
+        started, resolved_harness = await self.start_prepared_thread_execution(prepared)
+        return started, resolved_harness
+
+    async def prepare_thread_execution(
+        self,
+        request: MessageRequest,
+        *,
+        client_request_id: Optional[str] = None,
+        sandbox_policy: Optional[Any] = None,
+        harness: Optional[RuntimeThreadHarness] = None,
+    ) -> PreparedThreadExecution:
         if request.target_kind != "thread":
             raise ValueError("Thread orchestration service only handles thread targets")
 
@@ -1061,21 +1102,32 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
             execution_id=execution.execution_id,
             message_preview=_truncate_text(request.message_text, MessagePreviewLimit),
         )
-        if execution.status != "running":
-            return execution, None
-        resolved_harness = harness or self._harness_for_agent(
-            definition.agent_id,
-            request.agent_profile,
-        )
-        started = await self._start_execution(
-            thread,
-            request,
-            execution,
-            harness=resolved_harness,
+        resolved_harness = harness if execution.status == "running" else None
+        if resolved_harness is None and execution.status == "running":
+            resolved_harness = self._harness_for_agent(
+                definition.agent_id,
+                request.agent_profile,
+            )
+        return PreparedThreadExecution(
+            thread=thread,
+            request=request,
+            execution=execution,
             workspace_root=workspace_root,
             sandbox_policy=sandbox_policy,
+            harness=resolved_harness,
         )
-        return started, resolved_harness
+
+    async def start_prepared_thread_execution(
+        self,
+        prepared: PreparedThreadExecution,
+    ) -> tuple[ExecutionRecord, RuntimeThreadHarness]:
+        if prepared.execution.status != "running":
+            raise ValueError("Only running executions can be started")
+        return await self._execution_lifecycle.start_claimed_execution_request(
+            prepared.to_claimed_request(),
+            harness=prepared.harness,
+            workspace_root=prepared.workspace_root,
+        )
 
     def claim_next_queued_execution_context(
         self, thread_target_id: str

--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -1495,7 +1495,7 @@ class PmaThreadStore:
             if isinstance(row["thread_target_id"], str) and row["thread_target_id"]
         ]
 
-    def cancel_queued_turns(self, managed_thread_id: str) -> int:
+    def cancel_queued_turns(self, managed_thread_id: str) -> list[str]:
         with self._write_conn() as conn:
             return self._lifecycle.cancel_queued_turns(conn, managed_thread_id)
 

--- a/src/codex_autorunner/core/pma_thread_store_lifecycle.py
+++ b/src/codex_autorunner/core/pma_thread_store_lifecycle.py
@@ -187,7 +187,7 @@ class PmaThreadStoreLifecycle:
         ).fetchall()
         return [PmaPendingQueueItem.from_queue_row(row).to_dict() for row in rows]
 
-    def cancel_queued_turns(self, conn: Any, managed_thread_id: str) -> int:
+    def cancel_queued_turns(self, conn: Any, managed_thread_id: str) -> list[str]:
         cancelled_at = now_iso()
         rows = conn.execute(
             """
@@ -209,7 +209,7 @@ class PmaThreadStoreLifecycle:
         ).fetchall()
         execution_ids = [str(row["execution_id"]) for row in rows]
         if not execution_ids:
-            return 0
+            return []
         placeholders = ",".join("?" for _ in execution_ids)
         with conn:
             conn.execute(
@@ -230,7 +230,7 @@ class PmaThreadStoreLifecycle:
                 completed_at=cancelled_at,
                 error_text="interrupted",
             )
-        return len(execution_ids)
+        return execution_ids
 
     def cancel_queued_turn(
         self,

--- a/src/codex_autorunner/core/text_utils.py
+++ b/src/codex_autorunner/core/text_utils.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from .redaction import redact_text
+
 
 def _normalize_text(value: Any) -> Optional[str]:
     if not isinstance(value, str):
@@ -50,6 +52,13 @@ def _truncate_text(text: str, limit: int, *, suffix: str = "...") -> str:
     if not suffix or limit <= len(suffix):
         return text[:limit]
     return text[: limit - len(suffix)] + suffix
+
+
+def _redacted_prompt_preview_for_match(value: Any, *, max_length: int = 120) -> str:
+    text = str(value or "")
+    if not text:
+        return ""
+    return _truncate_text(redact_text(text), max_length).strip()
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:

--- a/src/codex_autorunner/surfaces/cli/pma_control_plane.py
+++ b/src/codex_autorunner/surfaces/cli/pma_control_plane.py
@@ -19,7 +19,7 @@ import typer
 from ...agents.registry import get_registered_agents
 from ...core.config import load_hub_config
 from ...core.config_contract import ConfigError
-from ...core.text_utils import _truncate_text
+from ...core.text_utils import _redacted_prompt_preview_for_match
 
 logger = logging.getLogger(__name__)
 
@@ -417,6 +417,7 @@ class ManagedThreadSendTimeoutProbe:
     last_message_preview: str
     active_managed_turn_id: str
     active_turn_status: str
+    active_prompt_preview: str
     queue_depth: int
     queued_turn_ids: tuple[str, ...]
     queued_prompt_previews: tuple[str, ...]
@@ -428,12 +429,14 @@ class ManagedThreadSendTimeoutProbe:
         thread: dict[str, Any] = raw_thread if isinstance(raw_thread, dict) else {}
         raw_turn = payload.get("turn")
         turn: dict[str, Any] = raw_turn if isinstance(raw_turn, dict) else {}
+        raw_diagnostics = payload.get("active_turn_diagnostics")
+        diagnostics = raw_diagnostics if isinstance(raw_diagnostics, dict) else {}
         raw_queued_turns = payload.get("queued_turns")
         queued_turns = raw_queued_turns if isinstance(raw_queued_turns, list) else []
         normalized_queued_turns = tuple(
             (
                 str(item.get("managed_turn_id") or "").strip(),
-                str(item.get("prompt_preview") or "").strip(),
+                _redacted_prompt_preview_for_match(item.get("prompt_preview")),
             )
             for item in queued_turns
             if isinstance(item, dict) and str(item.get("managed_turn_id") or "").strip()
@@ -445,9 +448,14 @@ class ManagedThreadSendTimeoutProbe:
                 or payload.get("latest_turn_id")
                 or ""
             ).strip(),
-            last_message_preview=str(thread.get("last_message_preview") or "").strip(),
+            last_message_preview=_redacted_prompt_preview_for_match(
+                thread.get("last_message_preview")
+            ),
             active_managed_turn_id=str(turn.get("managed_turn_id") or "").strip(),
             active_turn_status=str(turn.get("status") or "").strip(),
+            active_prompt_preview=_redacted_prompt_preview_for_match(
+                diagnostics.get("prompt_preview")
+            ),
             queue_depth=coerce_optional_int(payload.get("queue_depth")) or 0,
             queued_turn_ids=tuple(
                 managed_turn_id for managed_turn_id, _ in normalized_queued_turns
@@ -497,8 +505,9 @@ def recover_managed_thread_send_timeout(
     if baseline is None:
         return None
 
-    expected_preview = _truncate_text(
-        message_body, MANAGED_THREAD_SEND_PREVIEW_LIMIT
+    expected_preview = _redacted_prompt_preview_for_match(
+        message_body,
+        max_length=MANAGED_THREAD_SEND_PREVIEW_LIMIT,
     ).strip()
     if not expected_preview:
         return None
@@ -521,12 +530,23 @@ def recover_managed_thread_send_timeout(
 
         recovered_turn_id = ""
         queued = False
+        active_prompt_matches = (
+            current.queue_depth == 0
+            and bool(baseline.active_prompt_preview)
+            and current.active_prompt_preview == expected_preview
+            and (
+                current.active_managed_turn_id != baseline.active_managed_turn_id
+                or baseline.active_prompt_preview != expected_preview
+            )
+        )
         if current.last_turn_id != baseline.last_turn_id and current.last_turn_id:
             recovered_turn_id = current.last_turn_id
             queued = recovered_turn_id in current.queued_turn_ids or (
                 bool(current.active_managed_turn_id)
                 and current.active_managed_turn_id != recovered_turn_id
             )
+        elif active_prompt_matches and current.active_managed_turn_id:
+            recovered_turn_id = current.active_managed_turn_id
         elif (
             current.last_message_preview == expected_preview
             and baseline.last_message_preview != expected_preview

--- a/src/codex_autorunner/surfaces/cli/pma_control_plane.py
+++ b/src/codex_autorunner/surfaces/cli/pma_control_plane.py
@@ -295,6 +295,7 @@ class ManagedThreadSendRequest:
     message: str
     busy_policy: str
     defer_execution: bool
+    wait_for_confirmation: bool = True
     model: Optional[str] = None
     reasoning: Optional[str] = None
     notify_on: Optional[str] = None
@@ -306,6 +307,7 @@ class ManagedThreadSendRequest:
             "message": self.message,
             "busy_policy": self.busy_policy,
             "defer_execution": self.defer_execution,
+            "wait_for_confirmation": self.wait_for_confirmation,
         }
         if self.model:
             payload["model"] = self.model

--- a/src/codex_autorunner/surfaces/cli/pma_thread_commands.py
+++ b/src/codex_autorunner/surfaces/cli/pma_thread_commands.py
@@ -1,8 +1,9 @@
 """PMA thread command implementations.
 
-Managed-thread CLI commands (spawn, list, info, status, send, turns, output,
-tail, compact, resume, fork, archive, interrupt) and supporting helpers and
-dataclasses.  Registered on the ``thread_app`` typer via
+Managed-thread CLI commands (spawn, list, info, status, send, turns, queue,
+cancel-queued, clear-queue, output, tail, compact, resume, fork, archive,
+interrupt) and supporting helpers and dataclasses.  Registered on the
+``thread_app`` typer via
 :func:`register_thread_commands`.
 """
 
@@ -234,6 +235,41 @@ def _echo_delivered_message(message: str) -> None:
     typer.echo(message, nl=False)
     if not message.endswith("\n"):
         typer.echo()
+
+
+def _quoted_prompt_preview(value: Any, *, max_chars: int = 72) -> str:
+    text = str(value or "")
+    if len(text) > max_chars:
+        text = text[: max_chars - 3] + "..."
+    return json.dumps(text)
+
+
+def _queued_turn_table_lines(queued_turns: list[dict[str, Any]]) -> list[str]:
+    rows: list[tuple[str, str, str, str]] = []
+    for item in queued_turns:
+        rows.append(
+            (
+                str(item.get("managed_turn_id") or "").strip() or "-",
+                _quoted_prompt_preview(
+                    item.get("prompt") or item.get("prompt_preview")
+                ),
+                str(item.get("enqueued_at") or "-"),
+                str(item.get("position") or "-"),
+            )
+        )
+    headers = ("queued_turn_id", "prompt", "enqueued_at", "position")
+    widths = [
+        max(len(headers[index]), *(len(row[index]) for row in rows))
+        for index in range(len(headers))
+    ]
+    table_lines = [
+        "  ".join(headers[index].ljust(widths[index]) for index in range(len(headers)))
+    ]
+    table_lines.extend(
+        "  ".join(row[index].ljust(widths[index]) for index in range(len(headers)))
+        for row in rows
+    )
+    return table_lines
 
 
 def _thread_output_cursor_path(hub_root: Path) -> Path:
@@ -1736,6 +1772,11 @@ def pma_thread_send(
         "--watch",
         help="Opt into synchronous foreground tailing until terminal state",
     ),
+    no_wait: bool = typer.Option(
+        False,
+        "--no-wait",
+        help="Return after durable enqueue instead of waiting for send confirmation",
+    ),
     notify_on: Optional[str] = typer.Option(
         None,
         "--notify-on",
@@ -1769,6 +1810,11 @@ def pma_thread_send(
     normalized_if_busy = (if_busy or "").strip().lower() or "queue"
     if normalized_if_busy not in {"queue", "interrupt", "reject"}:
         raise typer.BadParameter("if-busy must be queue, interrupt, or reject")
+    if watch and no_wait:
+        raise typer.BadParameter(
+            "--watch cannot be combined with --no-wait",
+            param_hint="--watch / --no-wait",
+        )
     hub_root = _resolve_hub_path(path)
     config = None
     timeout_probe: Optional[_ManagedThreadSendTimeoutProbe] = None
@@ -1783,6 +1829,7 @@ def pma_thread_send(
             message=message_body,
             busy_policy=normalized_if_busy,
             defer_execution=should_defer,
+            wait_for_confirmation=(not no_wait),
             model=model,
             reasoning=reasoning,
             notify_on=normalized_notify_on,
@@ -1807,6 +1854,25 @@ def pma_thread_send(
             baseline=timeout_probe,
         )
         if recovered_response is not None:
+            if no_wait:
+                recovered_payload = {
+                    "status": recovered_response.status,
+                    "send_state": "enqueued",
+                    "execution_state": recovered_response.execution_state or "running",
+                    "managed_turn_id": recovered_response.managed_turn_id,
+                    "active_managed_turn_id": recovered_response.active_managed_turn_id,
+                    "queue_depth": recovered_response.queue_depth,
+                    "delivered_message": recovered_response.delivered_message,
+                    "assistant_text": recovered_response.assistant_text,
+                    "detail": recovered_response.detail,
+                    "error": recovered_response.error,
+                    "next_step": recovered_response.next_step,
+                }
+                recovered_response = _ManagedThreadSendResponse.from_http(
+                    200,
+                    recovered_payload,
+                    default_message=message_body,
+                )
             response = recovered_response
             data = {
                 "status": response.status,
@@ -1822,13 +1888,39 @@ def pma_thread_send(
                 "next_step": response.next_step,
             }
         else:
-            detail = (
-                "Timed out waiting for send confirmation. The message may still "
-                "have been delivered. Check `car pma thread status --id "
-                f"{managed_thread_id} --path {hub_root}` before retrying."
-            )
-            typer.echo(f"Error: {detail}", err=True)
-            raise typer.Exit(code=1) from exc
+            if no_wait:
+                data = {
+                    "status": "ok",
+                    "send_state": "enqueued",
+                    "execution_state": "unknown",
+                    "managed_turn_id": "",
+                    "active_managed_turn_id": "",
+                    "queue_depth": None,
+                    "delivered_message": message_body,
+                    "assistant_text": "",
+                    "detail": (
+                        "Timed out waiting for enqueue confirmation. The message may "
+                        "still have been delivered; check thread status before retrying."
+                    ),
+                    "error": "",
+                    "next_step": (
+                        "Use `car pma thread status` to confirm whether the turn was "
+                        "accepted."
+                    ),
+                }
+                response = _ManagedThreadSendResponse.from_http(
+                    200,
+                    data,
+                    default_message=message_body,
+                )
+            else:
+                detail = (
+                    "Timed out waiting for send confirmation. The message may still "
+                    "have been delivered. Check `car pma thread status --id "
+                    f"{managed_thread_id} --path {hub_root}` before retrying."
+                )
+                typer.echo(f"Error: {detail}", err=True)
+                raise typer.Exit(code=1) from exc
     except (httpx.HTTPError, ValueError, OSError, TypeError) as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from None
@@ -1901,6 +1993,8 @@ def pma_thread_send(
 
     typer.echo(response.completion_line())
     _echo_delivered_message(response.delivered_message)
+    if response.detail:
+        typer.echo(f"note: {response.detail}")
     if response.assistant_text:
         typer.echo("\nassistant:")
         typer.echo(response.assistant_text)
@@ -1952,6 +2046,120 @@ def pma_thread_turns(
                 ]
             ).strip()
         )
+
+
+def pma_thread_queue(
+    managed_thread_id: str = typer.Option(
+        ..., "--id", help="Managed PMA thread id", show_default=False
+    ),
+    limit: int = typer.Option(200, "--limit", min=1, help="Maximum rows to return"),
+    output_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+    path: Optional[Path] = hub_root_path_option(),
+):
+    """List queued managed-thread turns waiting to execute."""
+    hub_root = _resolve_hub_path(path)
+    try:
+        config = load_hub_config(hub_root)
+        data = _request_json(
+            "GET",
+            _build_pma_url(config, f"/threads/{managed_thread_id}/queue"),
+            token_env=config.server_auth_token_env,
+            params={"limit": limit},
+        )
+    except httpx.HTTPError as exc:
+        typer.echo(f"HTTP error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+    except (ValueError, OSError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+
+    if output_json:
+        typer.echo(json.dumps(data, indent=2))
+        return
+
+    queued_turns = data.get("queued_turns", []) if isinstance(data, dict) else []
+    if not isinstance(queued_turns, list) or not queued_turns:
+        typer.echo("No queued turns")
+        return
+    for line in _queued_turn_table_lines(
+        [item for item in queued_turns if isinstance(item, dict)]
+    ):
+        typer.echo(line)
+
+
+def pma_thread_cancel_queued(
+    managed_thread_id: str = typer.Option(
+        ..., "--id", help="Managed PMA thread id", show_default=False
+    ),
+    managed_turn_id: str = typer.Option(
+        ..., "--turn", help="Queued managed turn id", show_default=False
+    ),
+    output_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+    path: Optional[Path] = hub_root_path_option(),
+):
+    """Cancel one queued managed-thread turn."""
+    hub_root = _resolve_hub_path(path)
+    try:
+        config = load_hub_config(hub_root)
+        status_code, data = _request_json_with_status(
+            "POST",
+            _build_pma_url(
+                config, f"/threads/{managed_thread_id}/queue/{managed_turn_id}/cancel"
+            ),
+            token_env=config.server_auth_token_env,
+        )
+    except (httpx.HTTPError, ValueError, OSError, TypeError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+
+    if status_code >= 400:
+        detail = str(
+            data.get("detail") or data.get("error") or "Failed to cancel queued turn"
+        )
+        if output_json:
+            typer.echo(json.dumps(data, indent=2))
+        else:
+            typer.echo(detail, err=True)
+        raise typer.Exit(code=1) from None
+
+    if output_json:
+        typer.echo(json.dumps(data, indent=2))
+        return
+
+    typer.echo(
+        f"Cancelled queued turn {managed_turn_id} "
+        f"(was position {data.get('position') or '?'})"
+    )
+
+
+def pma_thread_clear_queue(
+    managed_thread_id: str = typer.Option(
+        ..., "--id", help="Managed PMA thread id", show_default=False
+    ),
+    output_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+    path: Optional[Path] = hub_root_path_option(),
+):
+    """Clear all queued managed-thread turns."""
+    hub_root = _resolve_hub_path(path)
+    try:
+        config = load_hub_config(hub_root)
+        data = _request_json(
+            "POST",
+            _build_pma_url(config, f"/threads/{managed_thread_id}/queue/clear"),
+            token_env=config.server_auth_token_env,
+        )
+    except httpx.HTTPError as exc:
+        typer.echo(f"HTTP error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+    except (ValueError, OSError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+
+    if output_json:
+        typer.echo(json.dumps(data, indent=2))
+        return
+
+    typer.echo(f"Cleared {data.get('cleared_count') or 0} queued turns")
 
 
 def pma_thread_output(
@@ -2764,6 +2972,9 @@ def register_thread_commands(app: typer.Typer) -> None:
     app.command("status")(pma_thread_status)
     app.command("send")(pma_thread_send)
     app.command("turns")(pma_thread_turns)
+    app.command("queue")(pma_thread_queue)
+    app.command("cancel-queued")(pma_thread_cancel_queued)
+    app.command("clear-queue")(pma_thread_clear_queue)
     app.command("output")(pma_thread_output)
     app.command("subscribe")(pma_thread_subscribe)
     app.command("tail")(pma_thread_tail)

--- a/src/codex_autorunner/surfaces/cli/pma_thread_commands.py
+++ b/src/codex_autorunner/surfaces/cli/pma_thread_commands.py
@@ -257,6 +257,8 @@ def _queued_turn_table_lines(queued_turns: list[dict[str, Any]]) -> list[str]:
                 str(item.get("position") or "-"),
             )
         )
+    if not rows:
+        return []
     headers = ("queued_turn_id", "prompt", "enqueued_at", "position")
     widths = [
         max(len(headers[index]), *(len(row[index]) for row in rows))
@@ -1020,6 +1022,9 @@ class _PmaTailSnapshot:
 @dataclass(frozen=True)
 class _PmaQueuedTurnSnapshot:
     managed_turn_id: str
+    request_kind: str
+    state: str
+    position: Optional[int]
     enqueued_at: str
     prompt_preview: str
 
@@ -1029,14 +1034,24 @@ class _PmaQueuedTurnSnapshot:
             return None
         return cls(
             managed_turn_id=str(data.get("managed_turn_id") or "-"),
+            request_kind=str(data.get("request_kind") or "-"),
+            state=str(data.get("state") or "-"),
+            position=_coerce_optional_int(data.get("position")),
             enqueued_at=str(data.get("enqueued_at") or "-"),
             prompt_preview=str(data.get("prompt_preview") or "")[:80],
         )
 
     def render_line(self) -> str:
+        position = self.position if self.position is not None else "-"
         return (
             "queued_turn_id="
             + self.managed_turn_id
+            + " position="
+            + str(position)
+            + " state="
+            + self.state
+            + " kind="
+            + self.request_kind
             + " enqueued="
             + self.enqueued_at
             + " prompt="
@@ -2081,9 +2096,13 @@ def pma_thread_queue(
     if not isinstance(queued_turns, list) or not queued_turns:
         typer.echo("No queued turns")
         return
-    for line in _queued_turn_table_lines(
+    rendered_lines = _queued_turn_table_lines(
         [item for item in queued_turns if isinstance(item, dict)]
-    ):
+    )
+    if not rendered_lines:
+        typer.echo("No queued turns")
+        return
+    for line in rendered_lines:
         typer.echo(line)
 
 

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -62,6 +62,7 @@ from .managed_thread_runtime_payloads import (
     MANAGED_THREAD_PUBLIC_EXECUTION_ERROR,
     build_accepted_send_payload,
     build_archived_thread_payload,
+    build_enqueued_send_payload,
     build_execution_result_payload,
     build_execution_setup_error_payload,
     build_interrupt_failure_payload,
@@ -138,6 +139,28 @@ def _track_managed_thread_task(app: Any, task: asyncio.Task[Any]) -> None:
     task_pool = _managed_thread_task_pool(app)
     task_pool.add(task)
     task.add_done_callback(lambda done: task_pool.discard(done))
+
+
+def _runtime_thread_execution_from_started_pair(
+    *,
+    service: Any,
+    prepared: Any,
+    started_pair: tuple[Any, Any],
+) -> RuntimeThreadExecution:
+    started_execution, started_harness = started_pair
+    refreshed_thread = service.get_thread_target(prepared.thread.thread_target_id)
+    if refreshed_thread is None:
+        raise KeyError(
+            f"Unknown thread target '{prepared.thread.thread_target_id}' after start"
+        )
+    return RuntimeThreadExecution(
+        service=service,
+        harness=started_harness,
+        thread=refreshed_thread,
+        execution=started_execution,
+        workspace_root=prepared.workspace_root,
+        request=prepared.request,
+    )
 
 
 async def _recover_pma_bound_chat_execution(
@@ -763,35 +786,44 @@ def build_managed_thread_runtime_routes(
                 ),
             )
         sync_zeroclaw_context_if_needed(thread=thread, options=options)
+        prepared_execution = None
         try:
             progress_targets = _resolve_pma_chat_bound_surface_targets(
                 service=service,
                 managed_thread_id=managed_thread_id,
                 allow_running_turn_fallback=False,
             )
-            started_execution = await begin_runtime_thread_execution(
-                service,
-                MessageRequest(
-                    target_id=managed_thread_id,
-                    target_kind="thread",
-                    message_text=options.message,
-                    busy_policy=options.busy_policy,
-                    agent_profile=options.agent_profile,
-                    model=options.model,
-                    reasoning=options.reasoning,
-                    approval_mode=options.approval_policy,
-                    context_profile=options.context_profile,
-                    metadata=merge_bound_chat_execution_metadata(
-                        {
-                            "runtime_prompt": options.execution_prompt,
-                            "execution_error_message": MANAGED_THREAD_PUBLIC_EXECUTION_ERROR,
-                        },
-                        origin_kind="pma_web",
-                        progress_targets=progress_targets,
-                    ),
+            message_request = MessageRequest(
+                target_id=managed_thread_id,
+                target_kind="thread",
+                message_text=options.message,
+                busy_policy=options.busy_policy,
+                agent_profile=options.agent_profile,
+                model=options.model,
+                reasoning=options.reasoning,
+                approval_mode=options.approval_policy,
+                context_profile=options.context_profile,
+                metadata=merge_bound_chat_execution_metadata(
+                    {
+                        "runtime_prompt": options.execution_prompt,
+                        "execution_error_message": MANAGED_THREAD_PUBLIC_EXECUTION_ERROR,
+                    },
+                    origin_kind="pma_web",
+                    progress_targets=progress_targets,
                 ),
-                sandbox_policy=options.sandbox_policy,
             )
+            if payload.wait_for_confirmation:
+                started_execution = await begin_runtime_thread_execution(
+                    service,
+                    message_request,
+                    sandbox_policy=options.sandbox_policy,
+                )
+            else:
+                prepared_execution = await service.prepare_thread_execution(
+                    message_request,
+                    sandbox_policy=options.sandbox_policy,
+                )
+                started_execution = None
         except ManagedThreadNotActiveError as exc:
             return JSONResponse(
                 status_code=409,
@@ -834,21 +866,26 @@ def build_managed_thread_runtime_routes(
                 backend_thread_id=options.live_backend_thread_id,
                 delivery_payload=options.delivery_payload,
             )
-        managed_turn_id = started_execution.execution.execution_id
+        if prepared_execution is not None:
+            execution = prepared_execution.execution
+            thread_after_send = prepared_execution.thread
+        else:
+            assert started_execution is not None
+            execution = started_execution.execution
+            thread_after_send = started_execution.thread
+        managed_turn_id = execution.execution_id
         if not managed_turn_id:
             raise HTTPException(status_code=500, detail="Failed to create managed turn")
         backend_thread_id = (
-            normalize_optional_text(started_execution.thread.backend_thread_id)
+            normalize_optional_text(thread_after_send.backend_thread_id)
             or options.live_backend_thread_id
             or ""
         )
         execution_status = str(
-            getattr(started_execution.execution, "status", "running") or "running"
+            getattr(execution, "status", "running") or "running"
         ).strip()
         if execution_status not in {"running", "queued"}:
-            detail = sanitize_managed_thread_result_error(
-                started_execution.execution.error
-            )
+            detail = sanitize_managed_thread_result_error(execution.error)
             await notify_managed_thread_terminal_transition(
                 request,
                 thread=thread,
@@ -905,6 +942,74 @@ def build_managed_thread_runtime_routes(
                 return 0
             return int(resolver(managed_thread_id))
 
+        if not payload.wait_for_confirmation:
+            running_execution = service.get_running_execution(managed_thread_id)
+            if execution_status == "queued":
+                queued_payload = build_enqueued_send_payload(
+                    managed_thread_id=managed_thread_id,
+                    managed_turn_id=managed_turn_id,
+                    backend_thread_id=backend_thread_id or "",
+                    delivery_payload=options.delivery_payload,
+                    execution_state="queued",
+                    queue_depth=_queue_depth(),
+                    active_managed_turn_id=(
+                        running_execution.execution_id
+                        if running_execution is not None
+                        else None
+                    ),
+                    notification=notification,
+                )
+                ensure_managed_thread_queue_worker(request.app, managed_thread_id)
+                return queued_payload
+
+            enqueued_payload = build_enqueued_send_payload(
+                managed_thread_id=managed_thread_id,
+                managed_turn_id=managed_turn_id,
+                backend_thread_id=backend_thread_id or "",
+                delivery_payload=options.delivery_payload,
+                execution_state="running",
+                notification=notification,
+            )
+
+            async def _background_enqueue_only_run() -> None:
+                try:
+                    started_pair = await service.start_prepared_thread_execution(
+                        prepared_execution
+                    )
+                    runtime_execution = _runtime_thread_execution_from_started_pair(
+                        service=service,
+                        prepared=prepared_execution,
+                        started_pair=started_pair,
+                    )
+                    await _run_execution(runtime_execution)
+                    if _queue_depth() > 0:
+                        ensure_managed_thread_queue_worker(
+                            request.app,
+                            managed_thread_id,
+                        )
+                except BaseException:
+                    logger.exception(
+                        "Managed-thread enqueue-only background execution failed (managed_thread_id=%s, managed_turn_id=%s)",
+                        managed_thread_id,
+                        managed_turn_id,
+                    )
+                    await notify_managed_thread_terminal_transition(
+                        request,
+                        thread=thread,
+                        managed_thread_id=managed_thread_id,
+                        managed_turn_id=managed_turn_id,
+                        to_state="failed",
+                        reason=MANAGED_THREAD_PUBLIC_EXECUTION_ERROR,
+                    )
+                    raise
+
+            _track_managed_thread_task(
+                request.app,
+                asyncio.create_task(_background_enqueue_only_run()),
+            )
+            return enqueued_payload
+
+        assert started_execution is not None
         if getattr(started_execution.execution, "status", "running") == "queued":
             running_execution = service.get_running_execution(managed_thread_id)
             queued_payload = build_queued_send_payload(

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -993,14 +993,19 @@ def build_managed_thread_runtime_routes(
                         managed_thread_id,
                         managed_turn_id,
                     )
-                    await notify_managed_thread_terminal_transition(
-                        request,
-                        thread=thread,
-                        managed_thread_id=managed_thread_id,
-                        managed_turn_id=managed_turn_id,
-                        to_state="failed",
-                        reason=MANAGED_THREAD_PUBLIC_EXECUTION_ERROR,
-                    )
+                    turn = thread_store.get_turn(managed_thread_id, managed_turn_id)
+                    if (
+                        str((turn or {}).get("status") or "").strip().lower()
+                        == "running"
+                    ):
+                        await notify_managed_thread_terminal_transition(
+                            request,
+                            thread=thread,
+                            managed_thread_id=managed_thread_id,
+                            managed_turn_id=managed_turn_id,
+                            to_state="failed",
+                            reason=MANAGED_THREAD_PUBLIC_EXECUTION_ERROR,
+                        )
                     raise
 
             _track_managed_thread_task(

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime_payloads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime_payloads.py
@@ -437,6 +437,37 @@ def build_accepted_send_payload(
     return payload
 
 
+def build_enqueued_send_payload(
+    *,
+    managed_thread_id: str,
+    managed_turn_id: str,
+    backend_thread_id: str,
+    delivery_payload: dict[str, Any],
+    execution_state: str,
+    queue_depth: Optional[int] = None,
+    active_managed_turn_id: Optional[str] = None,
+    notification: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "status": "ok",
+        "send_state": "enqueued",
+        "execution_state": execution_state,
+        "managed_thread_id": managed_thread_id,
+        "managed_turn_id": managed_turn_id,
+        "backend_thread_id": backend_thread_id,
+        "assistant_text": "",
+        "error": None,
+        **delivery_payload,
+    }
+    if queue_depth is not None:
+        payload["queue_depth"] = queue_depth
+    if active_managed_turn_id is not None:
+        payload["active_managed_turn_id"] = active_managed_turn_id
+    if notification is not None:
+        payload["notification"] = notification
+    return payload
+
+
 def build_execution_result_payload(
     *,
     status: str,
@@ -463,6 +494,7 @@ __all__ = [
     "ManagedThreadMessageOptions",
     "build_accepted_send_payload",
     "build_archived_thread_payload",
+    "build_enqueued_send_payload",
     "build_execution_result_payload",
     "build_execution_setup_error_payload",
     "build_interrupt_failure_payload",

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -18,6 +18,7 @@ from .....core.orchestration import build_harness_backed_orchestration_service
 from .....core.orchestration.catalog import RuntimeAgentDescriptor
 from .....core.orchestration.turn_timeline import list_turn_timeline
 from .....core.pma_automation_store import PmaAutomationThreadNotFoundError
+from .....core.text_utils import _truncate_text
 from .....integrations.chat.execution_event_journal import list_chat_execution_journal
 from ...schemas import (
     PmaAutomationSubscriptionCreateRequest,
@@ -80,6 +81,25 @@ def _subscription_request_has_explicit_routing(payload: dict[str, Any]) -> bool:
         normalize_optional_text(payload.get(field)) is not None
         for field in ("thread_id", "lane_id")
     )
+
+
+def _serialize_managed_thread_queue_item(
+    item: dict[str, Any], *, position: int
+) -> dict[str, Any]:
+    return {
+        "managed_turn_id": item.get("managed_turn_id"),
+        "request_kind": item.get("request_kind"),
+        "state": item.get("state"),
+        "position": position,
+        "enqueued_at": item.get("enqueued_at"),
+        "visible_at": item.get("visible_at"),
+        "prompt": item.get("prompt") or "",
+        "prompt_preview": _truncate_text(item.get("prompt") or "", 120),
+        "model": item.get("model"),
+        "reasoning": item.get("reasoning"),
+        "client_turn_id": item.get("client_turn_id"),
+        "queue_item_id": item.get("queue_item_id"),
+    }
 
 
 async def _cleanup_failed_provisioned_worktree(
@@ -801,6 +821,99 @@ def build_managed_thread_crud_routes(
         turns = store.list_turns(managed_thread_id, limit=limit)
         return {
             "turns": [serialize_managed_thread_turn_summary(turn) for turn in turns]
+        }
+
+    @router.get("/threads/{managed_thread_id}/queue")
+    def list_managed_thread_queue(
+        managed_thread_id: str,
+        request: Request,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        if limit <= 0:
+            raise HTTPException(status_code=400, detail="limit must be greater than 0")
+        limit = min(limit, 500)
+
+        store = get_pma_request_context(request).thread_store()
+        thread = store.get_thread(managed_thread_id)
+        if thread is None:
+            raise HTTPException(status_code=404, detail="Managed thread not found")
+
+        queued_items = store.list_pending_turn_queue_items(
+            managed_thread_id, limit=limit
+        )
+        return {
+            "managed_thread_id": managed_thread_id,
+            "queue_depth": store.get_queue_depth(managed_thread_id),
+            "queued_turns": [
+                _serialize_managed_thread_queue_item(item, position=index)
+                for index, item in enumerate(queued_items, start=1)
+            ],
+        }
+
+    @router.post("/threads/{managed_thread_id}/queue/{managed_turn_id}/cancel")
+    def cancel_managed_thread_queued_turn(
+        managed_thread_id: str,
+        managed_turn_id: str,
+        request: Request,
+    ) -> dict[str, Any]:
+        store = get_pma_request_context(request).thread_store()
+        thread = store.get_thread(managed_thread_id)
+        if thread is None:
+            raise HTTPException(status_code=404, detail="Managed thread not found")
+
+        queued_items = store.list_pending_turn_queue_items(managed_thread_id, limit=500)
+        queued_lookup = {
+            str(item.get("managed_turn_id") or "").strip(): index
+            for index, item in enumerate(queued_items, start=1)
+        }
+        position = queued_lookup.get(managed_turn_id)
+        if position is None:
+            turn = store.get_turn(managed_thread_id, managed_turn_id)
+            if turn is None:
+                raise HTTPException(status_code=404, detail="Managed turn not found")
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Managed turn {managed_turn_id} is not queued "
+                    f"(status: {turn.get('status') or 'unknown'})"
+                ),
+            )
+        if not store.cancel_queued_turn(managed_thread_id, managed_turn_id):
+            raise HTTPException(
+                status_code=409,
+                detail=f"Managed turn {managed_turn_id} is no longer queued",
+            )
+        return {
+            "status": "ok",
+            "managed_thread_id": managed_thread_id,
+            "managed_turn_id": managed_turn_id,
+            "cancelled": True,
+            "position": position,
+            "queue_depth": store.get_queue_depth(managed_thread_id),
+        }
+
+    @router.post("/threads/{managed_thread_id}/queue/clear")
+    def clear_managed_thread_queue(
+        managed_thread_id: str,
+        request: Request,
+    ) -> dict[str, Any]:
+        store = get_pma_request_context(request).thread_store()
+        thread = store.get_thread(managed_thread_id)
+        if thread is None:
+            raise HTTPException(status_code=404, detail="Managed thread not found")
+
+        queued_items = store.list_pending_turn_queue_items(managed_thread_id, limit=500)
+        cleared_count = store.cancel_queued_turns(managed_thread_id)
+        return {
+            "status": "ok",
+            "managed_thread_id": managed_thread_id,
+            "cleared_count": cleared_count,
+            "cleared_turn_ids": [
+                str(item.get("managed_turn_id") or "").strip()
+                for item in queued_items[:cleared_count]
+                if str(item.get("managed_turn_id") or "").strip()
+            ],
+            "queue_depth": store.get_queue_depth(managed_thread_id),
         }
 
     @router.get("/threads/{managed_thread_id}/turns/{managed_turn_id}")

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -861,7 +861,10 @@ def build_managed_thread_crud_routes(
         if thread is None:
             raise HTTPException(status_code=404, detail="Managed thread not found")
 
-        queued_items = store.list_pending_turn_queue_items(managed_thread_id, limit=500)
+        queued_items = store.list_pending_turn_queue_items(
+            managed_thread_id,
+            limit=max(store.get_queue_depth(managed_thread_id), 1),
+        )
         queued_lookup = {
             str(item.get("managed_turn_id") or "").strip(): index
             for index, item in enumerate(queued_items, start=1)
@@ -902,17 +905,12 @@ def build_managed_thread_crud_routes(
         if thread is None:
             raise HTTPException(status_code=404, detail="Managed thread not found")
 
-        queued_items = store.list_pending_turn_queue_items(managed_thread_id, limit=500)
-        cleared_count = store.cancel_queued_turns(managed_thread_id)
+        cleared_turn_ids = store.cancel_queued_turns(managed_thread_id)
         return {
             "status": "ok",
             "managed_thread_id": managed_thread_id,
-            "cleared_count": cleared_count,
-            "cleared_turn_ids": [
-                str(item.get("managed_turn_id") or "").strip()
-                for item in queued_items[:cleared_count]
-                if str(item.get("managed_turn_id") or "").strip()
-            ],
+            "cleared_count": len(cleared_turn_ids),
+            "cleared_turn_ids": cleared_turn_ids,
             "queue_depth": store.get_queue_depth(managed_thread_id),
         }
 

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -911,6 +911,13 @@ class PmaManagedThreadMessageRequest(Payload):
         default=False,
         validation_alias=AliasChoices("defer_execution", "deferExecution"),
     )
+    wait_for_confirmation: bool = Field(
+        default=True,
+        validation_alias=AliasChoices(
+            "wait_for_confirmation",
+            "waitForConfirmation",
+        ),
+    )
     notify_on: Optional[Literal["terminal"]] = Field(
         default=None, validation_alias=AliasChoices("notify_on", "notifyOn")
     )

--- a/tests/surfaces/cli/test_pma_thread_commands.py
+++ b/tests/surfaces/cli/test_pma_thread_commands.py
@@ -221,6 +221,9 @@ def test_pma_thread_status_snapshot_render_lines_include_queue_and_excerpt() -> 
             "queued_turns": [
                 {
                     "managed_turn_id": "turn-2",
+                    "request_kind": "message",
+                    "state": "queued",
+                    "position": 1,
                     "enqueued_at": "2026-03-17T10:12:00Z",
                     "prompt_preview": "follow up on the same thread",
                 }
@@ -251,8 +254,8 @@ def test_pma_thread_status_snapshot_render_lines_include_queue_and_excerpt() -> 
     assert "[10:11:13] #3 assistant_output: Drafted a reply" in lines
     assert "queued=2" in lines
     assert (
-        "queued_turn_id=turn-2 enqueued=2026-03-17T10:12:00Z prompt=follow up on the same thread"
-        in lines
+        "queued_turn_id=turn-2 position=1 state=queued kind=message "
+        "enqueued=2026-03-17T10:12:00Z prompt=follow up on the same thread" in lines
     )
     assert lines[-2:] == ["assistant_text_excerpt:", "assistant conclusion"]
 
@@ -628,6 +631,7 @@ def test_pma_cli_thread_query_commands_use_orchestration_routes(
         ),
     ]
 
+
 def test_pma_cli_thread_status_info_applies_post_filter_limit(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -789,6 +793,46 @@ def test_pma_cli_thread_queue_renders_table(monkeypatch, tmp_path: Path) -> None
     assert '"Reply: queue-B-r3"' in result.stdout
     assert "2026-04-26T14:44:06Z" in result.stdout
     assert "turn-3" in result.stdout
+
+
+def test_pma_cli_thread_queue_handles_only_malformed_rows(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = method, payload, token_env, params
+        assert url.endswith("/hub/pma/threads/thread-1/queue")
+        return {
+            "managed_thread_id": "thread-1",
+            "queue_depth": 2,
+            "queued_turns": ["bad-row", 123],
+        }
+
+    monkeypatch.setattr(pma_thread_commands, "_request_json", _fake_request_json)
+
+    result = CliRunner().invoke(
+        pma_app,
+        ["thread", "queue", "--id", "thread-1", "--path", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "No queued turns"
 
 
 def test_pma_cli_thread_cancel_and_clear_queue_commands(
@@ -2338,6 +2382,199 @@ def test_pma_cli_thread_send_timeout_recovery_preview_match_prefers_queued_turn_
         "send_state=queued managed_turn_id=turn-new active_managed_turn_id=turn-1 "
         "queue_depth=1" in result.stdout
     )
+
+
+def test_pma_cli_thread_send_recovers_timeout_from_redacted_active_prompt(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json_with_status(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        timeout=None,
+    ):
+        _ = method, url, payload, token_env, timeout
+        raise httpx.TimeoutException("timed out")
+
+    message_body = "please use sk-abcdefghijklmnopqrstuvwxyz1234567890 now"
+    status_payloads = iter(
+        [
+            {
+                "thread": {
+                    "last_turn_id": "turn-1",
+                    "latest_turn_id": "turn-1",
+                    "last_message_preview": "previous prompt",
+                },
+                "turn": {"managed_turn_id": "turn-1", "status": "running"},
+                "active_turn_diagnostics": {"prompt_preview": "previous prompt"},
+                "queue_depth": 0,
+                "queued_turns": [],
+            },
+            {
+                "thread": {
+                    "last_turn_id": "turn-1",
+                    "latest_turn_id": "turn-1",
+                    "last_message_preview": "previous prompt",
+                },
+                "turn": {"managed_turn_id": "turn-2", "status": "running"},
+                "active_turn_diagnostics": {
+                    "prompt_preview": "please use sk-[REDACTED] now"
+                },
+                "queue_depth": 0,
+                "queued_turns": [],
+            },
+        ]
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = method, url, payload, token_env, params
+        return next(status_payloads)
+
+    monkeypatch.setattr(
+        pma_thread_commands, "_request_json_with_status", _fake_request_json_with_status
+    )
+    monkeypatch.setattr(pma_thread_commands, "_request_json", _fake_request_json)
+    monkeypatch.setattr(pma_control_plane, "request_json", _fake_request_json)
+    monotonic_values = iter([100.0, 103.0])
+    monkeypatch.setattr(
+        pma_control_plane.time, "monotonic", lambda: next(monotonic_values, 103.0)
+    )
+    monkeypatch.setattr(pma_control_plane.time, "sleep", lambda seconds: None)
+
+    result = CliRunner().invoke(
+        pma_app,
+        [
+            "thread",
+            "send",
+            "--id",
+            "thread-1",
+            "--message",
+            message_body,
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "send_state=accepted managed_turn_id=turn-2" in result.stdout
+    assert "recovered delivery from thread status" in result.stdout
+
+
+def test_pma_cli_thread_send_active_prompt_recovery_ignores_preexisting_queue(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json_with_status(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        timeout=None,
+    ):
+        _ = method, url, payload, token_env, timeout
+        raise httpx.TimeoutException("timed out")
+
+    baseline_payload = {
+        "thread": {
+            "last_turn_id": "turn-1",
+            "latest_turn_id": "turn-1",
+            "last_message_preview": "previous prompt",
+        },
+        "turn": {"managed_turn_id": "turn-1", "status": "running"},
+        "active_turn_diagnostics": {"prompt_preview": "previous prompt"},
+        "queue_depth": 1,
+        "queued_turns": [
+            {
+                "managed_turn_id": "turn-old",
+                "prompt_preview": "follow up",
+                "state": "queued",
+            }
+        ],
+    }
+    current_payload = {
+        "thread": {
+            "last_turn_id": "turn-1",
+            "latest_turn_id": "turn-1",
+            "last_message_preview": "previous prompt",
+        },
+        "turn": {"managed_turn_id": "turn-1", "status": "running"},
+        "active_turn_diagnostics": {"prompt_preview": "follow up"},
+        "queue_depth": 1,
+        "queued_turns": [
+            {
+                "managed_turn_id": "turn-old",
+                "prompt_preview": "follow up",
+                "state": "queued",
+            }
+        ],
+    }
+    status_payloads = iter([baseline_payload, current_payload])
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = method, url, payload, token_env, params
+        return next(status_payloads, current_payload)
+
+    monkeypatch.setattr(
+        pma_thread_commands, "_request_json_with_status", _fake_request_json_with_status
+    )
+    monkeypatch.setattr(pma_thread_commands, "_request_json", _fake_request_json)
+    monkeypatch.setattr(pma_control_plane, "request_json", _fake_request_json)
+    monotonic_seq = itertools.count(100.0, 1.0)
+    monkeypatch.setattr(
+        pma_control_plane.time, "monotonic", lambda: next(monotonic_seq)
+    )
+    monkeypatch.setattr(pma_control_plane.time, "sleep", lambda seconds: None)
+
+    result = CliRunner().invoke(
+        pma_app,
+        [
+            "thread",
+            "send",
+            "--id",
+            "thread-1",
+            "--message",
+            "follow up",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Timed out waiting for send confirmation." in result.output
 
 
 def test_pma_cli_thread_send_retries_timeout_recovery_until_status_catches_up(

--- a/tests/surfaces/cli/test_pma_thread_commands.py
+++ b/tests/surfaces/cli/test_pma_thread_commands.py
@@ -24,6 +24,9 @@ def test_pma_cli_thread_group_has_required_commands():
     assert "status" in output, "PMA thread should have 'status' command"
     assert "send" in output, "PMA thread should have 'send' command"
     assert "turns" in output, "PMA thread should have 'turns' command"
+    assert "queue" in output, "PMA thread should have 'queue' command"
+    assert "cancel-queued" in output, "PMA thread should have 'cancel-queued' command"
+    assert "clear-queue" in output, "PMA thread should have 'clear-queue' command"
     assert "output" in output, "PMA thread should have 'output' command"
     assert "subscribe" in output, "PMA thread should have 'subscribe' command"
     assert "tail" in output, "PMA thread should have 'tail' command"
@@ -59,6 +62,7 @@ def test_pma_cli_thread_send_help_shows_json_option():
     output = result.stdout
     assert "--json" in output, "PMA thread send should support --json"
     assert "--watch" in output, "PMA thread send should support --watch"
+    assert "--no-wait" in output, "PMA thread send should support --no-wait"
     assert "--if-busy" in output, "PMA thread send should support busy-thread policy"
     assert "--notify-on" in output, "PMA thread send should support --notify-on"
     assert "--message-file" in output, "PMA thread send should support file input"
@@ -87,6 +91,15 @@ def test_pma_cli_thread_output_help_shows_pagination_options() -> None:
     assert "--lines" in output
     assert "--continue" in output
     assert "--output-file" in output
+
+
+def test_pma_cli_thread_queue_help_shows_json_option() -> None:
+    runner = CliRunner()
+    result = runner.invoke(pma_app, ["thread", "queue", "--help"])
+    assert result.exit_code == 0
+    output = result.stdout
+    assert "--json" in output
+    assert "--limit" in output
 
 
 def test_pma_cli_thread_subscribe_help_mentions_thread_scope() -> None:
@@ -348,6 +361,7 @@ def test_pma_thread_send_request_and_response_helpers() -> None:
         message="follow up",
         busy_policy="interrupt",
         defer_execution=True,
+        wait_for_confirmation=True,
         model="gpt-5",
         reasoning="high",
         notify_on="terminal",
@@ -359,6 +373,7 @@ def test_pma_thread_send_request_and_response_helpers() -> None:
         "message": "follow up",
         "busy_policy": "interrupt",
         "defer_execution": True,
+        "wait_for_confirmation": True,
         "model": "gpt-5",
         "reasoning": "high",
         "notify_on": "terminal",
@@ -613,12 +628,10 @@ def test_pma_cli_thread_query_commands_use_orchestration_routes(
         ),
     ]
 
-
 def test_pma_cli_thread_status_info_applies_post_filter_limit(
     monkeypatch, tmp_path: Path
 ) -> None:
     seen_params: list[dict[str, object] | None] = []
-
     monkeypatch.setattr(
         pma_thread_commands,
         "load_hub_config",
@@ -722,6 +735,143 @@ def test_pma_cli_thread_status_info_applies_post_filter_limit(
     assert "[10:11:12] #27-#28 tool_started: tool: bash (x2)" in result.stdout
     assert "[10:11:14] #30 tool_completed: tool: bash" in result.stdout
     assert "No decoder for method: session.diff" not in result.stdout
+
+
+def test_pma_cli_thread_queue_renders_table(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = method, payload, token_env, params
+        assert url.endswith("/hub/pma/threads/thread-1/queue")
+        return {
+            "managed_thread_id": "thread-1",
+            "queue_depth": 2,
+            "queued_turns": [
+                {
+                    "managed_turn_id": "turn-2",
+                    "prompt": "Reply: queue-B-r3",
+                    "enqueued_at": "2026-04-26T14:44:06Z",
+                    "position": 1,
+                },
+                {
+                    "managed_turn_id": "turn-3",
+                    "prompt": "Reply: stress-C",
+                    "enqueued_at": "2026-04-26T14:46:04Z",
+                    "position": 2,
+                },
+            ],
+        }
+
+    monkeypatch.setattr(pma_thread_commands, "_request_json", _fake_request_json)
+
+    result = CliRunner().invoke(
+        pma_app,
+        ["thread", "queue", "--id", "thread-1", "--path", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    assert "queued_turn_id" in result.stdout
+    assert '"Reply: queue-B-r3"' in result.stdout
+    assert "2026-04-26T14:44:06Z" in result.stdout
+    assert "turn-3" in result.stdout
+
+
+def test_pma_cli_thread_cancel_and_clear_queue_commands(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+    calls: list[tuple[str, str]] = []
+
+    def _fake_request_json_with_status(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+        timeout=30.0,
+    ):
+        _ = payload, token_env, params, timeout
+        calls.append((method, url))
+        return (
+            200,
+            {
+                "status": "ok",
+                "managed_turn_id": "turn-2",
+                "position": 1,
+            },
+        )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = payload, token_env, params
+        calls.append((method, url))
+        return {
+            "status": "ok",
+            "managed_thread_id": "thread-1",
+            "cleared_count": 2,
+        }
+
+    monkeypatch.setattr(
+        pma_thread_commands, "_request_json_with_status", _fake_request_json_with_status
+    )
+    monkeypatch.setattr(pma_thread_commands, "_request_json", _fake_request_json)
+
+    runner = CliRunner()
+    cancel_result = runner.invoke(
+        pma_app,
+        [
+            "thread",
+            "cancel-queued",
+            "--id",
+            "thread-1",
+            "--turn",
+            "turn-2",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+    clear_result = runner.invoke(
+        pma_app,
+        ["thread", "clear-queue", "--id", "thread-1", "--path", str(tmp_path)],
+    )
+
+    assert cancel_result.exit_code == 0
+    assert "Cancelled queued turn turn-2 (was position 1)" in cancel_result.stdout
+    assert clear_result.exit_code == 0
+    assert "Cleared 2 queued turns" in clear_result.stdout
+    assert calls == [
+        ("POST", "http://127.0.0.1:4321/hub/pma/threads/thread-1/queue/turn-2/cancel"),
+        ("POST", "http://127.0.0.1:4321/hub/pma/threads/thread-1/queue/clear"),
+    ]
 
 
 def test_pma_cli_thread_status_output_renders_paginated_assistant_text(
@@ -1353,6 +1503,7 @@ def test_pma_cli_thread_send_reports_queued_busy_thread(
         "message": "follow up",
         "busy_policy": "queue",
         "defer_execution": True,
+        "wait_for_confirmation": True,
     }
 
 
@@ -1418,6 +1569,7 @@ def test_pma_cli_thread_send_reads_message_from_file(
         "message": "literal `glm-5-turbo`\nsecond line\n",
         "busy_policy": "queue",
         "defer_execution": True,
+        "wait_for_confirmation": True,
     }
     assert "delivered message:\nliteral `glm-5-turbo`\nsecond line\n" in result.stdout
     assert "\nassistant:\n" not in result.stdout
@@ -1483,11 +1635,76 @@ def test_pma_cli_thread_send_reads_message_from_stdin(
         "message": "stdin payload with backticks `glm-5-turbo`\n",
         "busy_policy": "queue",
         "defer_execution": True,
+        "wait_for_confirmation": True,
     }
     assert (
         "delivered message:\nstdin payload with backticks `glm-5-turbo`\n"
         in result.stdout
     )
+
+
+def test_pma_cli_thread_send_no_wait_sets_enqueue_mode(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+    captured: dict[str, object] = {}
+
+    def _fake_request_json_with_status(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        timeout=None,
+    ):
+        _ = method, url, token_env, timeout
+        captured["payload"] = payload
+        return (
+            200,
+            {
+                "status": "ok",
+                "send_state": "enqueued",
+                "execution_state": "running",
+                "managed_turn_id": "turn-5",
+                "delivered_message": "follow up",
+            },
+        )
+
+    monkeypatch.setattr(
+        pma_thread_commands, "_request_json_with_status", _fake_request_json_with_status
+    )
+
+    result = CliRunner().invoke(
+        pma_app,
+        [
+            "thread",
+            "send",
+            "--id",
+            "thread-1",
+            "--message",
+            "follow up",
+            "--no-wait",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "send_state=enqueued managed_turn_id=turn-5" in result.stdout
+    assert captured["payload"] == {
+        "message": "follow up",
+        "busy_policy": "queue",
+        "defer_execution": True,
+        "wait_for_confirmation": False,
+    }
 
 
 def test_pma_cli_thread_send_uses_extended_post_timeout(
@@ -1550,6 +1767,86 @@ def test_pma_cli_thread_send_uses_extended_post_timeout(
         captured["timeout"]
         == pma_control_plane.MANAGED_THREAD_SEND_REQUEST_TIMEOUT_SECONDS
     )
+
+
+def test_pma_cli_thread_send_no_wait_does_not_error_when_timeout_recovery_fails(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json_with_status(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        timeout=None,
+    ):
+        _ = method, url, payload, token_env, timeout
+        raise httpx.TimeoutException("timed out")
+
+    status_payloads = itertools.cycle(
+        [
+            {
+                "thread": {
+                    "last_turn_id": "turn-1",
+                    "latest_turn_id": "turn-1",
+                    "last_message_preview": "previous prompt",
+                },
+                "turn": {"managed_turn_id": "turn-1", "status": "running"},
+                "queue_depth": 0,
+                "queued_turns": [],
+            }
+        ]
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = method, url, payload, token_env, params
+        return next(status_payloads)
+
+    monkeypatch.setattr(
+        pma_thread_commands, "_request_json_with_status", _fake_request_json_with_status
+    )
+    monkeypatch.setattr(pma_thread_commands, "_request_json", _fake_request_json)
+    monkeypatch.setattr(pma_control_plane, "request_json", _fake_request_json)
+    monotonic_values = iter([100.0, 116.0])
+    monkeypatch.setattr(
+        pma_control_plane.time, "monotonic", lambda: next(monotonic_values, 116.0)
+    )
+    monkeypatch.setattr(pma_control_plane.time, "sleep", lambda seconds: None)
+
+    result = CliRunner().invoke(
+        pma_app,
+        [
+            "thread",
+            "send",
+            "--id",
+            "thread-1",
+            "--message",
+            "follow up",
+            "--no-wait",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "send_state=enqueued managed_turn_id=" in result.stdout
+    assert "Timed out waiting for enqueue confirmation" in result.stdout
 
 
 def test_pma_cli_thread_send_recovers_timeout_from_status_probe(

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from types import SimpleNamespace
 from typing import Any, Optional
 
@@ -822,6 +823,161 @@ def test_managed_thread_message_route_no_wait_returns_after_enqueue(
     assert observed["prepare_request"].message_text == "hello from route"
     assert observed["sandbox_policy"] == "dangerFullAccess"
     assert observed["background_started"] is True
+
+
+def test_managed_thread_message_route_no_wait_does_not_emit_false_failed_transition(
+    hub_env,
+    monkeypatch,
+) -> None:
+    app = build_pma_hub_app(hub_env.hub_root)
+    store = PmaThreadStore(hub_env.hub_root)
+    created = store.create_thread(
+        "codex", hub_env.repo_root.resolve(), repo_id=hub_env.repo_id
+    )
+    managed_thread_id = str(created["managed_thread_id"])
+    notifications: list[dict[str, Any]] = []
+    observed: dict[str, bool] = {
+        "background_started": False,
+        "ensure_attempted": False,
+    }
+
+    thread_obj = SimpleNamespace(
+        thread_target_id=managed_thread_id,
+        backend_thread_id="backend-thread-1",
+        workspace_root=str(hub_env.repo_root.resolve()),
+    )
+    execution_obj = SimpleNamespace(
+        execution_id="managed-turn-1",
+        status="running",
+        error=None,
+    )
+
+    class FakeService:
+        async def prepare_thread_execution(
+            self,
+            request: Any,
+            *,
+            client_request_id: Optional[str] = None,
+            sandbox_policy: Optional[Any] = None,
+            harness: Optional[Any] = None,
+        ) -> Any:
+            _ = client_request_id, sandbox_policy, harness
+            return SimpleNamespace(
+                thread=thread_obj,
+                request=request,
+                execution=execution_obj,
+                workspace_root=hub_env.repo_root.resolve(),
+                harness="fake-harness",
+            )
+
+        async def start_prepared_thread_execution(
+            self, prepared: Any
+        ) -> tuple[Any, Any]:
+            _ = prepared
+            return execution_obj, "fake-harness"
+
+        def get_thread_target(self, thread_target_id: str) -> Any:
+            _ = thread_target_id
+            return thread_obj
+
+        def get_running_execution(self, thread_target_id: str) -> None:
+            _ = thread_target_id
+            return None
+
+        def get_queue_depth(self, thread_target_id: str) -> int:
+            _ = thread_target_id
+            return 1
+
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "_build_managed_thread_orchestration_service",
+        lambda request, *, thread_store=None: FakeService(),
+    )
+
+    async def _unexpected_begin(*args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        raise AssertionError("wait-for-confirmation path should not be used")
+
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "begin_runtime_thread_execution",
+        _unexpected_begin,
+    )
+
+    async def _fake_run_execution(
+        request: Any,
+        *,
+        service: Any,
+        thread_store: Any,
+        thread: Any,
+        started: Any,
+        fallback_backend_thread_id: Optional[str] = None,
+        delivery_payload: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        _ = (
+            request,
+            service,
+            thread_store,
+            thread,
+            fallback_backend_thread_id,
+            delivery_payload,
+        )
+        observed["background_started"] = True
+        return {"status": "ok"}
+
+    async def _fake_notify(*args: Any, **kwargs: Any) -> None:
+        _ = args
+        notifications.append(dict(kwargs))
+
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "_run_managed_thread_execution",
+        _fake_run_execution,
+    )
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "notify_managed_thread_terminal_transition",
+        _fake_notify,
+    )
+    monkeypatch.setattr(
+        PmaThreadStore,
+        "get_turn",
+        lambda self, thread_target_id, execution_id: (
+            {"status": "ok"}
+            if thread_target_id == managed_thread_id
+            and execution_id == "managed-turn-1"
+            else None
+        ),
+    )
+
+    def _failing_ensure(app_obj: Any, thread_target_id: str) -> None:
+        _ = app_obj, thread_target_id
+        observed["ensure_attempted"] = True
+        raise RuntimeError("queue worker failed")
+
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "ensure_managed_thread_queue_worker",
+        _failing_ensure,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/messages",
+            json={
+                "message": "hello from route",
+                "wait_for_confirmation": False,
+            },
+        )
+
+    assert response.status_code == 200
+    for _ in range(50):
+        if observed["background_started"] and observed["ensure_attempted"]:
+            break
+        time.sleep(0.01)
+    assert observed["background_started"] is True
+    assert observed["ensure_attempted"] is True
+    assert notifications == []
 
 
 def test_managed_thread_message_route_uses_bound_progress_controller_for_direct_execution(

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
@@ -715,6 +715,115 @@ def test_managed_thread_message_route_uses_orchestration_service_seam(
     assert fake_service.record_calls[0]["execution_id"] == "managed-turn-1"
 
 
+def test_managed_thread_message_route_no_wait_returns_after_enqueue(
+    hub_env,
+    monkeypatch,
+) -> None:
+    app = build_pma_hub_app(hub_env.hub_root)
+    store = PmaThreadStore(hub_env.hub_root)
+    created = store.create_thread(
+        "codex", hub_env.repo_root.resolve(), repo_id=hub_env.repo_id
+    )
+    managed_thread_id = str(created["managed_thread_id"])
+    observed: dict[str, Any] = {}
+
+    thread_obj = SimpleNamespace(
+        thread_target_id=managed_thread_id,
+        backend_thread_id="backend-thread-1",
+        workspace_root=str(hub_env.repo_root.resolve()),
+    )
+    execution_obj = SimpleNamespace(
+        execution_id="managed-turn-1",
+        status="running",
+        error=None,
+    )
+
+    class FakeService:
+        async def prepare_thread_execution(
+            self,
+            request: Any,
+            *,
+            client_request_id: Optional[str] = None,
+            sandbox_policy: Optional[Any] = None,
+            harness: Optional[Any] = None,
+        ) -> Any:
+            _ = client_request_id, harness
+            observed["prepare_request"] = request
+            observed["sandbox_policy"] = sandbox_policy
+            return SimpleNamespace(
+                thread=thread_obj,
+                request=request,
+                execution=execution_obj,
+                workspace_root=hub_env.repo_root.resolve(),
+                harness="fake-harness",
+            )
+
+        async def start_prepared_thread_execution(
+            self, prepared: Any
+        ) -> tuple[Any, Any]:
+            observed["prepared"] = prepared
+            return execution_obj, "fake-harness"
+
+        def get_thread_target(self, thread_target_id: str) -> Any:
+            _ = thread_target_id
+            return thread_obj
+
+        def get_running_execution(self, thread_target_id: str) -> None:
+            _ = thread_target_id
+            return None
+
+        def get_queue_depth(self, thread_target_id: str) -> int:
+            _ = thread_target_id
+            return 0
+
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "_build_managed_thread_orchestration_service",
+        lambda request, *, thread_store=None: FakeService(),
+    )
+
+    async def _unexpected_begin(*args: Any, **kwargs: Any) -> Any:
+        _ = args, kwargs
+        raise AssertionError("wait-for-confirmation path should not be used")
+
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "begin_runtime_thread_execution",
+        _unexpected_begin,
+    )
+
+    async def _fake_run_execution(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        _ = args, kwargs
+        observed["background_started"] = True
+        return {"status": "ok"}
+
+    monkeypatch.setattr(
+        managed_thread_runtime,
+        "_run_managed_thread_execution",
+        _fake_run_execution,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/messages",
+            json={
+                "message": "hello from route",
+                "wait_for_confirmation": False,
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["send_state"] == "enqueued"
+    assert payload["execution_state"] == "running"
+    assert payload["managed_turn_id"] == "managed-turn-1"
+    assert payload["delivered_message"] == "hello from route"
+    assert observed["prepare_request"].message_text == "hello from route"
+    assert observed["sandbox_policy"] == "dangerFullAccess"
+    assert observed["background_started"] is True
+
+
 def test_managed_thread_message_route_uses_bound_progress_controller_for_direct_execution(
     hub_env,
     monkeypatch,

--- a/tests/test_pma_managed_threads_routes.py
+++ b/tests/test_pma_managed_threads_routes.py
@@ -1699,11 +1699,45 @@ def test_managed_thread_queue_routes_list_cancel_and_clear(hub_env) -> None:
         clear_resp = client.post(f"/threads/{managed_thread_id}/queue/clear")
         assert clear_resp.status_code == 200
         assert clear_resp.json()["cleared_count"] == 1
+        assert clear_resp.json()["cleared_turn_ids"] == [queued_c["managed_turn_id"]]
 
         empty_queue_resp = client.get(f"/threads/{managed_thread_id}/queue")
         assert empty_queue_resp.status_code == 200
         assert empty_queue_resp.json()["queue_depth"] == 0
         assert empty_queue_resp.json()["queued_turns"] == []
+
+
+def test_managed_thread_cancel_queue_route_supports_positions_beyond_500(
+    hub_env,
+) -> None:
+    store = PmaThreadStore(hub_env.hub_root)
+    created = store.create_thread(
+        "codex", hub_env.repo_root.resolve(), repo_id=hub_env.repo_id
+    )
+    managed_thread_id = str(created["managed_thread_id"])
+    store.create_turn(
+        managed_thread_id,
+        prompt="turn A",
+        busy_policy="queue",
+    )
+    queued_turns = [
+        store.create_turn(
+            managed_thread_id,
+            prompt=f"queued turn {index}",
+            busy_policy="queue",
+        )
+        for index in range(1, 502)
+    ]
+    target = queued_turns[-1]
+
+    with _build_managed_thread_crud_client(hub_env.hub_root) as client:
+        response = client.post(
+            f"/threads/{managed_thread_id}/queue/{target['managed_turn_id']}/cancel"
+        )
+
+    assert response.status_code == 200
+    assert response.json()["managed_turn_id"] == target["managed_turn_id"]
+    assert response.json()["position"] == 501
 
 
 def test_managed_thread_cancel_queue_route_rejects_nonqueued_turn(hub_env) -> None:

--- a/tests/test_pma_managed_threads_routes.py
+++ b/tests/test_pma_managed_threads_routes.py
@@ -22,6 +22,7 @@ from codex_autorunner.surfaces.web.routes.pma_routes import (
 )
 from codex_autorunner.surfaces.web.routes.pma_routes.managed_threads import (
     build_automation_routes,
+    build_managed_thread_crud_routes,
 )
 from tests.conftest import write_test_config
 
@@ -55,6 +56,13 @@ def _build_automation_route_client(
     app.state.config = SimpleNamespace(root=hub_root, raw={"pma": {"enabled": True}})
     router = app.router
     build_automation_routes(router, lambda: runtime_state)
+    return TestClient(app)
+
+
+def _build_managed_thread_crud_client(hub_root: Path) -> TestClient:
+    app = FastAPI()
+    app.state.config = SimpleNamespace(root=hub_root, raw={"pma": {"enabled": True}})
+    build_managed_thread_crud_routes(app.router, lambda: None)
     return TestClient(app)
 
 
@@ -1614,6 +1622,109 @@ def test_archive_managed_threads_bulk_route_archives_multiple_threads(
     store = PmaThreadStore(hub_env.hub_root)
     assert store.get_thread(first_id)["lifecycle_status"] == "archived"
     assert store.get_thread(second_id)["lifecycle_status"] == "archived"
+
+
+def test_managed_thread_queue_routes_list_cancel_and_clear(hub_env) -> None:
+    store = PmaThreadStore(hub_env.hub_root)
+    created = store.create_thread(
+        "codex", hub_env.repo_root.resolve(), repo_id=hub_env.repo_id
+    )
+    managed_thread_id = str(created["managed_thread_id"])
+
+    running = store.create_turn(
+        managed_thread_id,
+        prompt="turn A",
+        busy_policy="queue",
+    )
+    queued_payload_b = {
+        "request": {
+            "target_id": managed_thread_id,
+            "target_kind": "thread",
+            "message_text": "Reply: queue-B-r3",
+            "kind": "message",
+            "busy_policy": "queue",
+        }
+    }
+    queued_b = store.create_turn(
+        managed_thread_id,
+        prompt="Reply: queue-B-r3",
+        busy_policy="queue",
+        queue_payload=queued_payload_b,
+    )
+    queued_payload_c = {
+        "request": {
+            "target_id": managed_thread_id,
+            "target_kind": "thread",
+            "message_text": "Reply: stress-C",
+            "kind": "message",
+            "busy_policy": "queue",
+        }
+    }
+    queued_c = store.create_turn(
+        managed_thread_id,
+        prompt="Reply: stress-C",
+        busy_policy="queue",
+        queue_payload=queued_payload_c,
+    )
+    assert running["status"] == "running"
+    assert queued_b["status"] == "queued"
+    assert queued_c["status"] == "queued"
+
+    with _build_managed_thread_crud_client(hub_env.hub_root) as client:
+        queue_resp = client.get(f"/threads/{managed_thread_id}/queue")
+        assert queue_resp.status_code == 200
+        queue_payload = queue_resp.json()
+        assert queue_payload["queue_depth"] == 2
+        assert [item["managed_turn_id"] for item in queue_payload["queued_turns"]] == [
+            queued_b["managed_turn_id"],
+            queued_c["managed_turn_id"],
+        ]
+        assert [item["position"] for item in queue_payload["queued_turns"]] == [1, 2]
+        assert queue_payload["queued_turns"][0]["prompt"] == "Reply: queue-B-r3"
+
+        cancel_resp = client.post(
+            f"/threads/{managed_thread_id}/queue/{queued_b['managed_turn_id']}/cancel"
+        )
+        assert cancel_resp.status_code == 200
+        assert cancel_resp.json()["position"] == 1
+
+        queue_after_cancel = client.get(f"/threads/{managed_thread_id}/queue").json()
+        assert queue_after_cancel["queue_depth"] == 1
+        assert (
+            queue_after_cancel["queued_turns"][0]["managed_turn_id"]
+            == queued_c["managed_turn_id"]
+        )
+        assert queue_after_cancel["queued_turns"][0]["position"] == 1
+
+        clear_resp = client.post(f"/threads/{managed_thread_id}/queue/clear")
+        assert clear_resp.status_code == 200
+        assert clear_resp.json()["cleared_count"] == 1
+
+        empty_queue_resp = client.get(f"/threads/{managed_thread_id}/queue")
+        assert empty_queue_resp.status_code == 200
+        assert empty_queue_resp.json()["queue_depth"] == 0
+        assert empty_queue_resp.json()["queued_turns"] == []
+
+
+def test_managed_thread_cancel_queue_route_rejects_nonqueued_turn(hub_env) -> None:
+    store = PmaThreadStore(hub_env.hub_root)
+    created = store.create_thread(
+        "codex", hub_env.repo_root.resolve(), repo_id=hub_env.repo_id
+    )
+    managed_thread_id = str(created["managed_thread_id"])
+    running = store.create_turn(
+        managed_thread_id,
+        prompt="turn A",
+        busy_policy="queue",
+    )
+
+    with _build_managed_thread_crud_client(hub_env.hub_root) as client:
+        response = client.post(
+            f"/threads/{managed_thread_id}/queue/{running['managed_turn_id']}/cancel"
+        )
+
+    assert response.status_code == 409
+    assert "is not queued" in response.json()["detail"]
 
 
 def test_managed_thread_crud_routes_use_orchestration_service(

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -536,7 +536,7 @@ def test_cancel_queued_turns_marks_only_pending_queue_items_interrupted(
     )
 
     cancelled = store.cancel_queued_turns(thread["managed_thread_id"])
-    assert cancelled == 1
+    assert cancelled == [queued_turn["managed_turn_id"]]
 
     running_after = store.get_turn(
         thread["managed_thread_id"], running_turn["managed_turn_id"]


### PR DESCRIPTION
Fixes #1609.

## Summary
- add `car pma thread queue`, `cancel-queued`, and `clear-queue` with JSON/text output and queued-only cancellation semantics
- add queued-turn runtime/web API support so queue positions, cancellation, and clear-all are surfaced consistently
- add `car pma thread send --no-wait` so automation can enqueue immediately without the false-negative timeout path

## Validation
- `.venv/bin/python -m pytest tests/surfaces/cli/test_pma_thread_commands.py -q`
- `.venv/bin/python -m pytest tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py -q`
- `.venv/bin/python -m pytest tests/test_pma_managed_threads_routes.py -q`

## Note
- The exact broad command requested in the issue, `.venv/bin/python -m pytest tests/ -x --timeout=30 -q 2>&1 | tail -20`, still stops on unrelated failure `tests/core/test_flow_controller_e2e.py::test_ticket_flow_orchestration_wrapper_preserves_pause_resume_lifecycle` (`AttributeError` while monkeypatching `codex_autorunner.flows.ticket_flow.runtime_helpers.ensure_worker`).
