### PR TITLE
fix(#1611): fix queued turn stall in booting_runtime phase

### DIFF
--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -1555,6 +1555,19 @@ async def _dispatch_finalized_delivery(
         await deliver_result(finalized)
 
 
+def _queue_worker_task_cancellation_requested() -> bool:
+    current = asyncio.current_task()
+    if current is None:
+        return False
+    cancelling = getattr(current, "cancelling", None)
+    if not callable(cancelling):
+        return False
+    try:
+        return bool(cancelling())
+    except TypeError:
+        return False
+
+
 async def _process_queued_execution(
     started_execution: RuntimeThreadExecution,
     *,
@@ -1611,6 +1624,16 @@ async def _process_queued_execution(
                     durable_delivery=durable_delivery,
                     deliver_result=deliver_result,
                 )
+            except asyncio.CancelledError:
+                if _queue_worker_task_cancellation_requested():
+                    raise
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "chat.managed_thread.queue_worker_failure_delivery_cancelled",
+                    **_queue_worker_trace_fields(started_execution),
+                    finalized_status=finalized.status,
+                )
             except Exception as delivery_exc:
                 log_event(
                     logger,
@@ -1631,6 +1654,16 @@ async def _process_queued_execution(
             finalized,
             durable_delivery=durable_delivery,
             deliver_result=deliver_result,
+        )
+    except asyncio.CancelledError:
+        if _queue_worker_task_cancellation_requested():
+            raise
+        log_event(
+            logger,
+            logging.WARNING,
+            "chat.managed_thread.queue_worker_delivery_cancelled_post_finalization",
+            **_queue_worker_trace_fields(started_execution),
+            finalized_status=finalized.status,
         )
     except Exception as delivery_exc:
         log_event(

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -1560,12 +1560,14 @@ def _queue_worker_task_cancellation_requested() -> bool:
     if current is None:
         return False
     cancelling = getattr(current, "cancelling", None)
-    if not callable(cancelling):
-        return False
-    try:
-        return bool(cancelling())
-    except TypeError:
-        return False
+    if callable(cancelling):
+        try:
+            return bool(cancelling())
+        except TypeError:
+            return False
+    # Python 3.9–3.10: Task.cancelling() is absent; CPython's _must_cancel tracks
+    # a pending cancel() on this task (same gap noted near stream_task handling).
+    return bool(getattr(current, "_must_cancel", False))
 
 
 async def _process_queued_execution(

--- a/tests/integrations/chat/test_managed_thread_turns.py
+++ b/tests/integrations/chat/test_managed_thread_turns.py
@@ -507,18 +507,24 @@ async def test_managed_thread_queue_worker_persists_delivery_before_adapter_io(
 
 
 @pytest.mark.anyio
-async def test_managed_thread_queue_worker_cancellation_after_finalization_records_retry(
+async def test_managed_thread_queue_worker_cancellation_after_finalization_records_retry_and_continues(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    started = _build_started_execution(tmp_path)
+    first = _build_started_execution(tmp_path)
+    second = _replace_started_execution(
+        first,
+        execution_id="exec-2",
+        message_text="second queued message",
+    )
     begin_calls = 0
     recorded_outcomes: list[Any] = []
 
     async def _fake_finalize(
         **kwargs: Any,
     ) -> managed_thread_turns_module.ManagedThreadFinalizationResult:
-        _ = kwargs
+        started = kwargs["started"]
         return managed_thread_turns_module.ManagedThreadFinalizationResult(
             status="ok",
             assistant_text="Final answer",
@@ -534,29 +540,32 @@ async def test_managed_thread_queue_worker_cancellation_after_finalization_recor
     ) -> Optional[RuntimeThreadExecution]:
         nonlocal begin_calls
         _ = orchestration_service, managed_thread_id
-        if begin_calls == 0:
-            begin_calls += 1
-            return started
+        begin_calls += 1
+        if begin_calls == 1:
+            return first
+        if begin_calls == 2:
+            return second
         return None
 
     class _Engine:
         def __init__(self) -> None:
-            self._record: Any = None
+            self._records: dict[str, Any] = {}
 
         def create_intent(self, intent: Any) -> Any:
-            self._record = SimpleNamespace(
+            record = SimpleNamespace(
                 delivery_id=intent.delivery_id,
                 managed_thread_id=intent.managed_thread_id,
                 managed_turn_id=intent.managed_turn_id,
                 target=intent.target,
                 envelope=intent.envelope,
             )
-            return SimpleNamespace(record=self._record, inserted=True)
+            self._records[record.delivery_id] = record
+            return SimpleNamespace(record=record, inserted=True)
 
         def claim_delivery(self, delivery_id: str, *, now: Any = None) -> Any:
             _ = delivery_id, now
             return SimpleNamespace(
-                record=self._record,
+                record=self._records[delivery_id],
                 claim_token="claim-1",
             )
 
@@ -568,18 +577,26 @@ async def test_managed_thread_queue_worker_cancellation_after_finalization_recor
             result: Any,
         ) -> Any:
             recorded_outcomes.append((delivery_id, claim_token, result.outcome))
-            return self._record
+            return self._records[delivery_id]
 
     class _Adapter:
         @property
         def adapter_key(self) -> str:
             return "test"
 
+        def __init__(self) -> None:
+            self.calls = 0
+
         async def deliver_managed_thread_record(
             self, record: Any, *, claim: Any
         ) -> Any:
             _ = record, claim
-            raise asyncio.CancelledError()
+            self.calls += 1
+            if self.calls == 1:
+                raise asyncio.CancelledError()
+            return managed_thread_turns_module.ManagedThreadDeliveryAttemptResult(
+                outcome=managed_thread_turns_module.ManagedThreadDeliveryOutcome.DELIVERED
+            )
 
     monkeypatch.setattr(
         managed_thread_turns_module,
@@ -610,6 +627,7 @@ async def test_managed_thread_queue_worker_cancellation_after_finalization_recor
         turn_preview="preview",
     )
 
+    caplog.set_level(logging.INFO)
     coordinator.ensure_queue_worker(
         task_map=task_map,
         managed_thread_id="thread-1",
@@ -628,18 +646,25 @@ async def test_managed_thread_queue_worker_cancellation_after_finalization_recor
                     ),
                     transport_target={"chat_id": -1001, "thread_id": 101},
                 ),
-            )
+            ),
         ),
         begin_next_execution=_fake_begin_next,
     )
 
-    with pytest.raises(asyncio.CancelledError):
-        await asyncio.gather(*spawned_tasks)
+    await asyncio.gather(*spawned_tasks)
 
-    assert len(recorded_outcomes) == 1
+    assert len(recorded_outcomes) == 2
     assert recorded_outcomes[0][1] == "claim-1"
     assert recorded_outcomes[0][2] is (
         managed_thread_turns_module.ManagedThreadDeliveryOutcome.RETRY
+    )
+    assert recorded_outcomes[1][1] == "claim-1"
+    assert recorded_outcomes[1][2] is (
+        managed_thread_turns_module.ManagedThreadDeliveryOutcome.DELIVERED
+    )
+    assert (
+        "chat.managed_thread.queue_worker_delivery_cancelled_post_finalization"
+        in caplog.text
     )
     assert task_map == {}
 

--- a/tests/test_pma_managed_threads_messages.py
+++ b/tests/test_pma_managed_threads_messages.py
@@ -1528,6 +1528,146 @@ def test_send_message_defaults_to_terminal_followup_subscription(hub_env) -> Non
 
 
 @pytest.mark.anyio
+async def test_send_message_defer_execution_drains_five_rapid_messages_in_order(
+    hub_env,
+) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+    blockers = [asyncio.Event() for _ in range(5)]
+    prompts = [f"rapid message {index}" for index in range(1, 6)]
+
+    class FakeTurnHandle:
+        def __init__(self, turn_id: str, blocker: asyncio.Event, text: str) -> None:
+            self.turn_id = turn_id
+            self._blocker = blocker
+            self._text = text
+
+        async def wait(self, timeout=None):
+            _ = timeout
+            await self._blocker.wait()
+            return type(
+                "Result",
+                (),
+                {
+                    "agent_messages": [self._text],
+                    "raw_events": [],
+                    "errors": [],
+                },
+            )()
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.turn_start_calls: list[str] = []
+            self._turn_index = 0
+
+        async def thread_resume(self, thread_id: str) -> None:
+            _ = thread_id
+
+        async def thread_start(self, root: str) -> dict[str, str]:
+            _ = root
+            return {"id": "backend-thread-1"}
+
+        async def turn_start(
+            self,
+            thread_id: str,
+            prompt: str,
+            approval_policy: str,
+            sandbox_policy: str,
+            **turn_kwargs,
+        ):
+            _ = thread_id, approval_policy, sandbox_policy, turn_kwargs
+            turn_index = self._turn_index
+            self._turn_index += 1
+            self.turn_start_calls.append(prompt)
+            return FakeTurnHandle(
+                f"backend-turn-{turn_index + 1}",
+                blockers[turn_index],
+                f"assistant-output-{turn_index + 1}",
+            )
+
+        async def turn_interrupt(
+            self, turn_id: str, *, thread_id: str | None = None
+        ) -> None:
+            _ = turn_id, thread_id
+            raise RuntimeError("backend interrupt exploded")
+
+    fake_supervisor = FakeSupervisor(FakeClient())
+    app.state.app_server_supervisor = fake_supervisor
+    app.state.app_server_events = object()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
+        create_resp = await client.post(
+            "/hub/pma/threads",
+            json={"agent": "codex", **_repo_owner(hub_env)},
+        )
+        assert create_resp.status_code == 200
+        managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+        payloads: list[dict[str, object]] = []
+        active_turn_id: object | None = None
+        for index, prompt in enumerate(prompts):
+            response = await client.post(
+                f"/hub/pma/threads/{managed_thread_id}/messages",
+                json={"message": prompt, "defer_execution": True},
+            )
+            assert response.status_code == 200
+            payload = response.json()
+            payloads.append(payload)
+            if index == 0:
+                active_turn_id = payload["managed_turn_id"]
+                assert payload["send_state"] == "accepted"
+                assert payload["execution_state"] == "running"
+            else:
+                assert payload["send_state"] == "queued"
+                assert payload["execution_state"] == "queued"
+                assert payload["queue_depth"] == index
+                assert payload["active_managed_turn_id"] == active_turn_id
+
+        store = PmaThreadStore(hub_env.hub_root)
+        for index, payload in enumerate(payloads):
+            turn = store.get_turn(managed_thread_id, str(payload["managed_turn_id"]))
+            assert turn is not None
+            assert turn["status"] == ("running" if index == 0 else "queued")
+
+        for index, payload in enumerate(payloads):
+            blockers[index].set()
+            managed_turn_id = str(payload["managed_turn_id"])
+            with anyio.fail_after(2):
+                while True:
+                    turn = store.get_turn(managed_thread_id, managed_turn_id)
+                    if turn is not None and turn.get("status") == "ok":
+                        break
+                    await anyio.sleep(0.05)
+            if index < len(payloads) - 1:
+                next_turn_id = str(payloads[index + 1]["managed_turn_id"])
+                with anyio.fail_after(2):
+                    while True:
+                        next_turn = store.get_turn(managed_thread_id, next_turn_id)
+                        if (
+                            next_turn is not None
+                            and next_turn.get("status") == "running"
+                        ):
+                            break
+                        await anyio.sleep(0.05)
+
+    store = PmaThreadStore(hub_env.hub_root)
+    for index, payload in enumerate(payloads, start=1):
+        turn = store.get_turn(managed_thread_id, str(payload["managed_turn_id"]))
+        assert turn is not None
+        assert turn["status"] == "ok"
+        assert turn["assistant_text"] == f"assistant-output-{index}"
+        assert turn["backend_turn_id"] == f"backend-turn-{index}"
+    assert store.get_running_turn(managed_thread_id) is None
+    assert store.get_queue_depth(managed_thread_id) == 0
+    assert len(fake_supervisor.client.turn_start_calls) == 5
+    for prompt, runtime_prompt in zip(prompts, fake_supervisor.client.turn_start_calls):
+        assert prompt in runtime_prompt
+
+
+@pytest.mark.anyio
 async def test_send_message_defer_execution_completes_in_background(hub_env) -> None:
     _enable_pma(hub_env.hub_root)
     app = create_hub_app(hub_env.hub_root)


### PR DESCRIPTION
## Summary
- keep the managed-thread queue worker alive when final delivery raises a non-task-directed `CancelledError` after the turn is already finalized
- preserve real task cancellation by re-raising only when the queue worker itself is actively being cancelled
- add regression coverage for the post-finalization cancellation path and a 5-message rapid-send drain sequence

Closes #1611

## Testing
- `.venv/bin/pytest -q tests/integrations/chat/test_managed_thread_turns.py -k queue_worker`
- `.venv/bin/pytest -q tests/test_pma_managed_threads_messages.py -k drains_five_rapid_messages_in_order`
- `.venv/bin/pytest -q tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py -k queue_worker`
- `.venv/bin/pytest -q tests/core/orchestration/test_runtime_threads.py`
- full pre-commit aggregate validation (mypy, pytest shard run, JS tests, chat-surface lab, latency budgets)