### PR TITLE
fix(#1609): add queued-turn management surface and fix send timeout detection

### DIFF
--- a/src/codex_autorunner/core/text_utils.py
+++ b/src/codex_autorunner/core/text_utils.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from .redaction import redact_text
+
 
 def _normalize_text(value: Any) -> Optional[str]:
     if not isinstance(value, str):
@@ -50,6 +52,14 @@ def _truncate_text(text: str, limit: int, *, suffix: str = "...") -> str:
     if not suffix or limit <= len(suffix):
         return text[:limit]
     return text[: limit - len(suffix)] + suffix
+
+
+def _redacted_prompt_preview_for_match(value: Any, *, max_length: int = 120) -> str:
+    """Shape a prompt like PMA ``active_turn_diagnostics.prompt_preview`` for comparisons."""
+    text = str(value or "")
+    if not text:
+        return ""
+    return _truncate_text(redact_text(text), max_length).strip()
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:

--- a/src/codex_autorunner/surfaces/cli/pma_control_plane.py
+++ b/src/codex_autorunner/surfaces/cli/pma_control_plane.py
@@ -415,6 +415,7 @@ class ManagedThreadSendTimeoutProbe:
     last_message_preview: str
     active_managed_turn_id: str
     active_turn_status: str
+    active_prompt_preview: str
     queue_depth: int
     queued_turn_ids: tuple[str, ...]
     queued_prompt_previews: tuple[str, ...]
@@ -426,6 +427,8 @@ class ManagedThreadSendTimeoutProbe:
         thread: dict[str, Any] = raw_thread if isinstance(raw_thread, dict) else {}
         raw_turn = payload.get("turn")
         turn: dict[str, Any] = raw_turn if isinstance(raw_turn, dict) else {}
+        raw_diagnostics = payload.get("active_turn_diagnostics")
+        diagnostics = raw_diagnostics if isinstance(raw_diagnostics, dict) else {}
         raw_queued_turns = payload.get("queued_turns")
         queued_turns = raw_queued_turns if isinstance(raw_queued_turns, list) else []
         normalized_queued_turns = tuple(
@@ -446,6 +449,7 @@ class ManagedThreadSendTimeoutProbe:
             last_message_preview=str(thread.get("last_message_preview") or "").strip(),
             active_managed_turn_id=str(turn.get("managed_turn_id") or "").strip(),
             active_turn_status=str(turn.get("status") or "").strip(),
+            active_prompt_preview=str(diagnostics.get("prompt_preview") or "").strip(),
             queue_depth=coerce_optional_int(payload.get("queue_depth")) or 0,
             queued_turn_ids=tuple(
                 managed_turn_id for managed_turn_id, _ in normalized_queued_turns
@@ -519,12 +523,18 @@ def recover_managed_thread_send_timeout(
 
         recovered_turn_id = ""
         queued = False
+        active_prompt_matches = current.active_prompt_preview == expected_preview and (
+            current.active_managed_turn_id != baseline.active_managed_turn_id
+            or baseline.active_prompt_preview != expected_preview
+        )
         if current.last_turn_id != baseline.last_turn_id and current.last_turn_id:
             recovered_turn_id = current.last_turn_id
             queued = recovered_turn_id in current.queued_turn_ids or (
                 bool(current.active_managed_turn_id)
                 and current.active_managed_turn_id != recovered_turn_id
             )
+        elif active_prompt_matches and current.active_managed_turn_id:
+            recovered_turn_id = current.active_managed_turn_id
         elif (
             current.last_message_preview == expected_preview
             and baseline.last_message_preview != expected_preview

--- a/src/codex_autorunner/surfaces/cli/pma_control_plane.py
+++ b/src/codex_autorunner/surfaces/cli/pma_control_plane.py
@@ -19,7 +19,7 @@ import typer
 from ...agents.registry import get_registered_agents
 from ...core.config import load_hub_config
 from ...core.config_contract import ConfigError
-from ...core.text_utils import _truncate_text
+from ...core.text_utils import _redacted_prompt_preview_for_match
 
 logger = logging.getLogger(__name__)
 
@@ -499,9 +499,9 @@ def recover_managed_thread_send_timeout(
     if baseline is None:
         return None
 
-    expected_preview = _truncate_text(
-        message_body, MANAGED_THREAD_SEND_PREVIEW_LIMIT
-    ).strip()
+    expected_preview = _redacted_prompt_preview_for_match(
+        message_body, max_length=MANAGED_THREAD_SEND_PREVIEW_LIMIT
+    )
     if not expected_preview:
         return None
 
@@ -523,9 +523,12 @@ def recover_managed_thread_send_timeout(
 
         recovered_turn_id = ""
         queued = False
+        baseline_preview_signal = bool(baseline.active_prompt_preview) and (
+            baseline.active_prompt_preview != expected_preview
+        )
         active_prompt_matches = current.active_prompt_preview == expected_preview and (
             current.active_managed_turn_id != baseline.active_managed_turn_id
-            or baseline.active_prompt_preview != expected_preview
+            or baseline_preview_signal
         )
         if current.last_turn_id != baseline.last_turn_id and current.last_turn_id:
             recovered_turn_id = current.last_turn_id

--- a/src/codex_autorunner/surfaces/cli/pma_thread_commands.py
+++ b/src/codex_autorunner/surfaces/cli/pma_thread_commands.py
@@ -781,6 +781,9 @@ class _PmaTailSnapshot:
 @dataclass(frozen=True)
 class _PmaQueuedTurnSnapshot:
     managed_turn_id: str
+    request_kind: str
+    state: str
+    position: Optional[int]
     enqueued_at: str
     prompt_preview: str
 
@@ -790,14 +793,24 @@ class _PmaQueuedTurnSnapshot:
             return None
         return cls(
             managed_turn_id=str(data.get("managed_turn_id") or "-"),
+            request_kind=str(data.get("request_kind") or "-"),
+            state=str(data.get("state") or "-"),
+            position=_coerce_optional_int(data.get("position")),
             enqueued_at=str(data.get("enqueued_at") or "-"),
             prompt_preview=str(data.get("prompt_preview") or "")[:80],
         )
 
     def render_line(self) -> str:
+        position = self.position if self.position is not None else "-"
         return (
             "queued_turn_id="
             + self.managed_turn_id
+            + " position="
+            + str(position)
+            + " state="
+            + self.state
+            + " kind="
+            + self.request_kind
             + " enqueued="
             + self.enqueued_at
             + " prompt="
@@ -1675,6 +1688,110 @@ def pma_thread_send(
         typer.echo(response.assistant_text)
 
 
+def pma_thread_queue(
+    managed_thread_id: str = typer.Option(
+        ..., "--id", help="Managed PMA thread id", show_default=False
+    ),
+    limit: int = typer.Option(
+        200, "--limit", min=1, help="Maximum queued turns to list"
+    ),
+    output_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+    path: Optional[Path] = hub_root_path_option(),
+):
+    """List pending queued turns for one managed PMA thread."""
+    hub_root = _resolve_hub_path(path)
+    try:
+        config = load_hub_config(hub_root)
+        data = _request_json(
+            "GET",
+            _build_pma_url(config, f"/threads/{managed_thread_id}/queue"),
+            token_env=config.server_auth_token_env,
+            params={"limit": limit},
+        )
+    except httpx.HTTPError as exc:
+        typer.echo(f"HTTP error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+    except (ValueError, OSError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+
+    if output_json:
+        typer.echo(json.dumps(data, indent=2))
+        return
+
+    queue_depth = _coerce_optional_int(data.get("queue_depth")) or 0
+    raw_queued_turns = data.get("queued_turns")
+    queued_turns = tuple(
+        turn_item
+        for item in (raw_queued_turns if isinstance(raw_queued_turns, list) else [])
+        if (turn_item := _PmaQueuedTurnSnapshot.from_dict(item)) is not None
+    )
+    if queue_depth <= 0 or not queued_turns:
+        typer.echo(f"No queued turns for {managed_thread_id}")
+        return
+
+    typer.echo(f"managed_thread_id={managed_thread_id} queue_depth={queue_depth}")
+    for queued_turn in queued_turns:
+        typer.echo(queued_turn.render_line())
+
+
+def pma_thread_cancel_turn(
+    managed_thread_id: str = typer.Option(
+        ..., "--id", help="Managed PMA thread id", show_default=False
+    ),
+    queued_turn_id: str = typer.Option(
+        ...,
+        "--queued",
+        "--turn",
+        help="Queued managed turn id to cancel",
+        show_default=False,
+    ),
+    output_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+    path: Optional[Path] = hub_root_path_option(),
+):
+    """Cancel one queued turn without interrupting the active turn."""
+    hub_root = _resolve_hub_path(path)
+    try:
+        config = load_hub_config(hub_root)
+        status_code, data = _request_json_with_status(
+            "POST",
+            _build_pma_url(
+                config,
+                f"/threads/{managed_thread_id}/queue/{queued_turn_id}/cancel",
+            ),
+            token_env=config.server_auth_token_env,
+        )
+    except httpx.HTTPError as exc:
+        typer.echo(f"HTTP error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+    except (ValueError, OSError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+
+    if status_code >= 400:
+        if output_json:
+            typer.echo(json.dumps(data, indent=2))
+        else:
+            detail = str(data.get("detail") or "").strip()
+            typer.echo(
+                detail or f"Queued turn cancellation failed (HTTP {status_code})",
+                err=True,
+            )
+        raise typer.Exit(code=1) from None
+
+    if output_json:
+        typer.echo(json.dumps(data, indent=2))
+        return
+
+    position = _coerce_optional_int(data.get("position"))
+    queue_depth = _coerce_optional_int(data.get("queue_depth")) or 0
+    line = f"Cancelled queued turn {queued_turn_id}"
+    if position is not None:
+        line += f" (position was {position})"
+    line += f" remaining={queue_depth}"
+    typer.echo(line)
+
+
 def pma_thread_turns(
     managed_thread_id: str = typer.Option(
         ..., "--id", help="Managed PMA thread id", show_default=False
@@ -2501,7 +2618,10 @@ def register_thread_commands(app: typer.Typer) -> None:
     app.command("list")(pma_thread_list)
     app.command("info")(pma_thread_info)
     app.command("status")(pma_thread_status)
+    app.command("queue")(pma_thread_queue)
     app.command("send")(pma_thread_send)
+    app.command("cancel-turn")(pma_thread_cancel_turn)
+    app.command("cancel-queued")(pma_thread_cancel_turn)
     app.command("turns")(pma_thread_turns)
     app.command("output")(pma_thread_output)
     app.command("subscribe")(pma_thread_subscribe)

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_tail_serializers.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_tail_serializers.py
@@ -764,16 +764,7 @@ def build_managed_thread_status_response(
             "lifecycle_events": snapshot.get("lifecycle_events"),
         },
         "queue_depth": queue_depth,
-        "queued_turns": [
-            {
-                "managed_turn_id": item.get("managed_turn_id"),
-                "request_kind": item.get("request_kind"),
-                "state": item.get("state"),
-                "enqueued_at": item.get("enqueued_at"),
-                "prompt_preview": truncate_text(item.get("prompt") or "", 120),
-            }
-            for item in queued_turns
-        ],
+        "queued_turns": serialize_queued_turns(queued_turns),
         "recent_progress": snapshot.get("events") or [],
         "latest_turn_id": serialized_thread.get("latest_turn_id"),
         "latest_turn_status": serialized_thread.get("latest_turn_status"),
@@ -784,10 +775,28 @@ def build_managed_thread_status_response(
     }
 
 
+def serialize_queued_turns(queued_turns: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "managed_turn_id": item.get("managed_turn_id"),
+            "request_kind": item.get("request_kind"),
+            "state": item.get("state"),
+            "position": index,
+            "enqueued_at": item.get("enqueued_at"),
+            "prompt_preview": truncate_text(item.get("prompt") or "", 120),
+            "model": item.get("model"),
+            "reasoning": item.get("reasoning"),
+            "client_turn_id": item.get("client_turn_id"),
+        }
+        for index, item in enumerate(queued_turns, start=1)
+    ]
+
+
 __all__ = [
     "build_managed_thread_status_response",
     "coerce_dict",
     "iso_from_event_ms",
+    "serialize_queued_turns",
     "parse_iso_datetime",
     "truncate_text",
     "_derive_active_turn_diagnostics",

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -57,6 +57,7 @@ from .managed_thread_route_helpers import (
     serialize_binding_record,
     serialize_managed_thread_turn_summary,
 )
+from .managed_thread_tail_serializers import serialize_queued_turns
 
 if TYPE_CHECKING:
     pass
@@ -801,6 +802,75 @@ def build_managed_thread_crud_routes(
         turns = store.list_turns(managed_thread_id, limit=limit)
         return {
             "turns": [serialize_managed_thread_turn_summary(turn) for turn in turns]
+        }
+
+    @router.get("/threads/{managed_thread_id}/queue")
+    def list_managed_thread_queue(
+        managed_thread_id: str,
+        request: Request,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        if limit <= 0:
+            raise HTTPException(status_code=400, detail="limit must be greater than 0")
+        limit = min(limit, 1000)
+
+        store = get_pma_request_context(request).thread_store()
+        thread = store.get_thread(managed_thread_id)
+        if thread is None:
+            raise HTTPException(status_code=404, detail="Managed thread not found")
+
+        queued_turns = store.list_pending_turn_queue_items(
+            managed_thread_id,
+            limit=limit,
+        )
+        return {
+            "managed_thread_id": managed_thread_id,
+            "queue_depth": store.get_queue_depth(managed_thread_id),
+            "queued_turns": serialize_queued_turns(queued_turns),
+        }
+
+    @router.post("/threads/{managed_thread_id}/queue/{managed_turn_id}/cancel")
+    def cancel_managed_thread_queued_turn(
+        managed_thread_id: str,
+        managed_turn_id: str,
+        request: Request,
+    ) -> dict[str, Any]:
+        store = get_pma_request_context(request).thread_store()
+        thread = store.get_thread(managed_thread_id)
+        if thread is None:
+            raise HTTPException(status_code=404, detail="Managed thread not found")
+
+        queue_depth = store.get_queue_depth(managed_thread_id)
+        queued_turns = store.list_pending_turn_queue_items(
+            managed_thread_id,
+            limit=max(queue_depth, 1),
+        )
+        position = next(
+            (
+                index
+                for index, item in enumerate(queued_turns, start=1)
+                if str(item.get("managed_turn_id") or "").strip() == managed_turn_id
+            ),
+            None,
+        )
+        if position is None:
+            if store.get_turn(managed_thread_id, managed_turn_id) is None:
+                raise HTTPException(status_code=404, detail="Managed turn not found")
+            raise HTTPException(status_code=409, detail="Managed turn is not queued")
+
+        if not store.cancel_queued_turn(managed_thread_id, managed_turn_id):
+            raise HTTPException(
+                status_code=409,
+                detail="Managed turn is no longer queued",
+            )
+
+        return {
+            "status": "ok",
+            "managed_thread_id": managed_thread_id,
+            "managed_turn_id": managed_turn_id,
+            "cancelled": True,
+            "position": position,
+            "queue_depth": store.get_queue_depth(managed_thread_id),
         }
 
     @router.get("/threads/{managed_thread_id}/turns/{managed_turn_id}")

--- a/tests/pma_support/core.py
+++ b/tests/pma_support/core.py
@@ -445,7 +445,130 @@ def test_pma_thread_status_includes_queued_turns(hub_env) -> None:
     )
     assert payload["queued_turns"][0]["request_kind"] == "message"
     assert payload["queued_turns"][0]["state"] == "queued"
+    assert payload["queued_turns"][0]["position"] == 1
     assert payload["queued_turns"][0]["prompt_preview"] == "second"
+
+
+def test_pma_thread_queue_route_lists_pending_turns(hub_env) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                "resource_kind": "repo",
+                "resource_id": hub_env.repo_id,
+            },
+        )
+        assert create_resp.status_code == 200
+        managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+    store = PmaThreadStore(hub_env.hub_root)
+    store.create_turn(managed_thread_id, prompt="first")
+    first_queued_turn = store.create_turn(
+        managed_thread_id,
+        prompt="second",
+        busy_policy="queue",
+        queue_payload={"request": {"message_text": "second"}},
+    )
+    second_queued_turn = store.create_turn(
+        managed_thread_id,
+        prompt="third",
+        request_kind="review",
+        busy_policy="queue",
+        queue_payload={"request": {"message_text": "third", "kind": "review"}},
+    )
+    queued_items = store.list_pending_turn_queue_items(managed_thread_id)
+
+    client = TestClient(app)
+    resp = client.get(f"/hub/pma/threads/{managed_thread_id}/queue")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["managed_thread_id"] == managed_thread_id
+    assert payload["queue_depth"] == 2
+    assert payload["queued_turns"] == [
+        {
+            "managed_turn_id": first_queued_turn["managed_turn_id"],
+            "request_kind": "message",
+            "state": "queued",
+            "position": 1,
+            "enqueued_at": queued_items[0]["enqueued_at"],
+            "prompt_preview": "second",
+            "model": None,
+            "reasoning": None,
+            "client_turn_id": None,
+        },
+        {
+            "managed_turn_id": second_queued_turn["managed_turn_id"],
+            "request_kind": "review",
+            "state": "queued",
+            "position": 2,
+            "enqueued_at": queued_items[1]["enqueued_at"],
+            "prompt_preview": "third",
+            "model": None,
+            "reasoning": None,
+            "client_turn_id": None,
+        },
+    ]
+
+
+def test_pma_thread_queue_cancel_route_cancels_specific_turn(hub_env) -> None:
+    _enable_pma(hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                "resource_kind": "repo",
+                "resource_id": hub_env.repo_id,
+            },
+        )
+        assert create_resp.status_code == 200
+        managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+    store = PmaThreadStore(hub_env.hub_root)
+    store.create_turn(managed_thread_id, prompt="first")
+    queued_turn = store.create_turn(
+        managed_thread_id,
+        prompt="second",
+        busy_policy="queue",
+        queue_payload={"request": {"message_text": "second"}},
+    )
+    trailing_turn = store.create_turn(
+        managed_thread_id,
+        prompt="third",
+        busy_policy="queue",
+        queue_payload={"request": {"message_text": "third"}},
+    )
+
+    client = TestClient(app)
+    resp = client.post(
+        f"/hub/pma/threads/{managed_thread_id}/queue/{queued_turn['managed_turn_id']}/cancel"
+    )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload == {
+        "status": "ok",
+        "managed_thread_id": managed_thread_id,
+        "managed_turn_id": queued_turn["managed_turn_id"],
+        "cancelled": True,
+        "position": 1,
+        "queue_depth": 1,
+    }
+
+    cancelled_turn = store.get_turn(managed_thread_id, queued_turn["managed_turn_id"])
+    assert cancelled_turn is not None
+    assert cancelled_turn["status"] == "interrupted"
+    remaining = store.list_pending_turn_queue_items(managed_thread_id)
+    assert [item["managed_turn_id"] for item in remaining] == [
+        trailing_turn["managed_turn_id"]
+    ]
 
 
 def test_pma_chat_rejects_oversize_message(hub_env) -> None:

--- a/tests/surfaces/cli/test_pma_thread_commands.py
+++ b/tests/surfaces/cli/test_pma_thread_commands.py
@@ -22,7 +22,9 @@ def test_pma_cli_thread_group_has_required_commands():
     assert "list" in output, "PMA thread should have 'list' command"
     assert "info" in output, "PMA thread should have 'info' command"
     assert "status" in output, "PMA thread should have 'status' command"
+    assert "queue" in output, "PMA thread should have 'queue' command"
     assert "send" in output, "PMA thread should have 'send' command"
+    assert "cancel-turn" in output, "PMA thread should have 'cancel-turn' command"
     assert "turns" in output, "PMA thread should have 'turns' command"
     assert "output" in output, "PMA thread should have 'output' command"
     assert "subscribe" in output, "PMA thread should have 'subscribe' command"
@@ -76,6 +78,25 @@ def test_pma_cli_thread_status_help_shows_json_option():
     assert "assistant_text-only" in output
     assert "--continue" in output
     assert "--output-file" in output
+
+
+def test_pma_cli_thread_queue_help_shows_json_option() -> None:
+    runner = CliRunner()
+    result = runner.invoke(pma_app, ["thread", "queue", "--help"])
+    assert result.exit_code == 0
+    output = result.stdout
+    assert "--json" in output
+    assert "--limit" in output
+
+
+def test_pma_cli_thread_cancel_turn_help_shows_queue_selector() -> None:
+    runner = CliRunner()
+    result = runner.invoke(pma_app, ["thread", "cancel-turn", "--help"])
+    assert result.exit_code == 0
+    output = result.stdout
+    assert "--queued" in output
+    assert "--turn" in output
+    assert "--json" in output
 
 
 def test_pma_cli_thread_output_help_shows_pagination_options() -> None:
@@ -208,6 +229,9 @@ def test_pma_thread_status_snapshot_render_lines_include_queue_and_excerpt() -> 
             "queued_turns": [
                 {
                     "managed_turn_id": "turn-2",
+                    "request_kind": "message",
+                    "state": "queued",
+                    "position": 1,
                     "enqueued_at": "2026-03-17T10:12:00Z",
                     "prompt_preview": "follow up on the same thread",
                 }
@@ -238,8 +262,8 @@ def test_pma_thread_status_snapshot_render_lines_include_queue_and_excerpt() -> 
     assert "[10:11:13] #3 assistant_output: Drafted a reply" in lines
     assert "queued=2" in lines
     assert (
-        "queued_turn_id=turn-2 enqueued=2026-03-17T10:12:00Z prompt=follow up on the same thread"
-        in lines
+        "queued_turn_id=turn-2 position=1 state=queued kind=message "
+        "enqueued=2026-03-17T10:12:00Z prompt=follow up on the same thread" in lines
     )
     assert lines[-2:] == ["assistant_text_excerpt:", "assistant conclusion"]
 
@@ -1147,6 +1171,150 @@ def test_pma_cli_thread_send_reports_queued_busy_thread(
     }
 
 
+def test_pma_cli_thread_queue_lists_pending_turns(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = method, payload, token_env
+        captured["url"] = url
+        captured["params"] = params
+        return {
+            "managed_thread_id": "thread-1",
+            "queue_depth": 2,
+            "queued_turns": [
+                {
+                    "managed_turn_id": "turn-2",
+                    "request_kind": "message",
+                    "state": "queued",
+                    "position": 1,
+                    "enqueued_at": "2026-04-26T15:10:00Z",
+                    "prompt_preview": "follow up",
+                },
+                {
+                    "managed_turn_id": "turn-3",
+                    "request_kind": "review",
+                    "state": "waiting",
+                    "position": 2,
+                    "enqueued_at": "2026-04-26T15:10:05Z",
+                    "prompt_preview": "review current diff",
+                },
+            ],
+        }
+
+    monkeypatch.setattr(pma_thread_commands, "_request_json", _fake_request_json)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pma_app,
+        [
+            "thread",
+            "queue",
+            "--id",
+            "thread-1",
+            "--limit",
+            "10",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "managed_thread_id=thread-1 queue_depth=2" in result.stdout
+    assert (
+        "queued_turn_id=turn-2 position=1 state=queued kind=message "
+        "enqueued=2026-04-26T15:10:00Z prompt=follow up" in result.stdout
+    )
+    assert (
+        "queued_turn_id=turn-3 position=2 state=waiting kind=review "
+        "enqueued=2026-04-26T15:10:05Z prompt=review current diff" in result.stdout
+    )
+    assert captured["url"] == "http://127.0.0.1:4321/hub/pma/threads/thread-1/queue"
+    assert captured["params"] == {"limit": 10}
+
+
+def test_pma_cli_thread_cancel_turn_cancels_specific_queue_entry(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_request_json_with_status(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        timeout=None,
+    ):
+        _ = payload, token_env, timeout
+        captured["method"] = method
+        captured["url"] = url
+        return (
+            200,
+            {
+                "status": "ok",
+                "managed_thread_id": "thread-1",
+                "managed_turn_id": "turn-2",
+                "cancelled": True,
+                "position": 1,
+                "queue_depth": 1,
+            },
+        )
+
+    monkeypatch.setattr(
+        pma_thread_commands, "_request_json_with_status", _fake_request_json_with_status
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pma_app,
+        [
+            "thread",
+            "cancel-turn",
+            "--id",
+            "thread-1",
+            "--queued",
+            "turn-2",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Cancelled queued turn turn-2 (position was 1) remaining=1" in result.stdout
+    assert captured["method"] == "POST"
+    assert (
+        captured["url"]
+        == "http://127.0.0.1:4321/hub/pma/threads/thread-1/queue/turn-2/cancel"
+    )
+
+
 def test_pma_cli_thread_send_reads_message_from_file(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -1430,6 +1598,98 @@ def test_pma_cli_thread_send_recovers_timeout_from_status_probe(
     assert result.exit_code == 0
     assert "send_state=accepted managed_turn_id=turn-2" in result.stdout
     assert "delivered message:\nfollow up\n" in result.stdout
+    assert "recovered delivery from thread status" in result.stdout
+
+
+def test_pma_cli_thread_send_recovers_timeout_when_active_turn_prompt_matches(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        pma_thread_commands,
+        "load_hub_config",
+        lambda hub_root: SimpleNamespace(
+            server_base_path="",
+            server_host="127.0.0.1",
+            server_port=4321,
+            server_auth_token_env=None,
+        ),
+    )
+
+    def _fake_request_json_with_status(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        timeout=None,
+    ):
+        _ = method, url, payload, token_env, timeout
+        raise httpx.TimeoutException("timed out")
+
+    status_payloads = iter(
+        [
+            {
+                "thread": {
+                    "last_turn_id": "turn-1",
+                    "latest_turn_id": "turn-1",
+                    "last_message_preview": "repeat prompt",
+                },
+                "turn": {"managed_turn_id": "turn-1", "status": "running"},
+                "queue_depth": 0,
+                "queued_turns": [],
+                "active_turn_diagnostics": {"prompt_preview": "repeat prompt"},
+            },
+            {
+                "thread": {
+                    "last_turn_id": "turn-1",
+                    "latest_turn_id": "turn-1",
+                    "last_message_preview": "repeat prompt",
+                },
+                "turn": {"managed_turn_id": "turn-2", "status": "running"},
+                "queue_depth": 0,
+                "queued_turns": [],
+                "active_turn_diagnostics": {"prompt_preview": "repeat prompt"},
+            },
+        ]
+    )
+
+    def _fake_request_json(
+        method: str,
+        url: str,
+        payload=None,
+        token_env=None,
+        params=None,
+    ):
+        _ = method, url, payload, token_env, params
+        return next(status_payloads)
+
+    monkeypatch.setattr(
+        pma_thread_commands, "_request_json_with_status", _fake_request_json_with_status
+    )
+    monkeypatch.setattr(pma_thread_commands, "_request_json", _fake_request_json)
+    monkeypatch.setattr(pma_control_plane, "request_json", _fake_request_json)
+    monotonic_values = iter([100.0, 103.0])
+    monkeypatch.setattr(
+        pma_control_plane.time, "monotonic", lambda: next(monotonic_values, 103.0)
+    )
+    monkeypatch.setattr(pma_control_plane.time, "sleep", lambda seconds: None)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pma_app,
+        [
+            "thread",
+            "send",
+            "--id",
+            "thread-1",
+            "--message",
+            "repeat prompt",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "send_state=accepted managed_turn_id=turn-2" in result.stdout
     assert "recovered delivery from thread status" in result.stdout
 
 

--- a/tests/test_pma_routes.py
+++ b/tests/test_pma_routes.py
@@ -44,6 +44,8 @@ from tests.pma_support.core import (
     test_pma_second_lane_item_does_not_clobber_active_turn,
     test_pma_stop_creates_artifact,
     test_pma_target_endpoints_are_removed,
+    test_pma_thread_queue_cancel_route_cancels_specific_turn,
+    test_pma_thread_queue_route_lists_pending_turns,
     test_pma_thread_reset_clears_registry,
     test_pma_thread_status_includes_queued_turns,
     test_pma_turn_events_stream_codex_respects_resume_cursor,


### PR DESCRIPTION
## Summary
- add queued-turn inspection and cancellation surfaces for PMA managed threads
- expose queued turn state and position in thread status output
- recover send timeouts when thread status proves the message was accepted or queued

## Testing
- .venv/bin/pytest -q tests/surfaces/cli/test_pma_thread_commands.py
- .venv/bin/pytest -q tests/test_pma_routes.py -k "thread_queue or thread_status_includes_queued_turns"
- commit hook validation suite (mypy, repo pytest, frontend, chat-surface checks)

Closes #1608.