### PR TITLE
[codex] Clear stale Discord interaction components

### DIFF
--- a/src/codex_autorunner/integrations/discord/effects.py
+++ b/src/codex_autorunner/integrations/discord/effects.py
@@ -74,6 +74,14 @@ DiscordEffect = Union[
 ]
 
 
+def _replacement_components(
+    components: Optional[list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    # Component interactions should retire stale buttons unless the caller
+    # explicitly provides replacement components for the updated message.
+    return [] if components is None else components
+
+
 @dataclass
 class DiscordHandlerResult:
     effects: list[DiscordEffect] = field(default_factory=list)
@@ -205,18 +213,19 @@ class DiscordEffectSink:
             return
 
         if isinstance(effect, DiscordComponentResponseEffect):
+            components = _replacement_components(effect.components)
             if effect.deferred:
                 updated = await self._responder.edit_original_component_message(
                     interaction_token=interaction_token,
                     text=effect.text,
-                    components=effect.components,
+                    components=components,
                 )
                 if updated:
                     return
                 sent = await self._responder.send_followup(
                     interaction_token=interaction_token,
                     content=effect.text,
-                    components=effect.components,
+                    components=components,
                     ephemeral=True,
                 )
                 if not sent:
@@ -231,7 +240,7 @@ class DiscordEffectSink:
                 interaction_token=interaction_token,
                 effect=DiscordComponentUpdateEffect(
                     text=effect.text,
-                    components=effect.components or [],
+                    components=components,
                 ),
             )
             return

--- a/tests/integrations/discord/test_effects.py
+++ b/tests/integrations/discord/test_effects.py
@@ -203,6 +203,37 @@ async def test_deferred_component_response_effect_edits_original_message() -> No
 
 
 @pytest.mark.anyio
+async def test_deferred_component_response_effect_clears_components_by_default() -> (
+    None
+):
+    rest, responder, sink = _build_sink()
+    session = responder.start_session(
+        interaction_id="inter-1",
+        interaction_token="token-1",
+        kind=InteractionSessionKind.COMPONENT,
+    )
+    session.restore_initial_response(InteractionInitialResponse.DEFER_COMPONENT_UPDATE)
+
+    await sink.apply(
+        interaction_id="inter-1",
+        interaction_token="token-1",
+        effect=DiscordComponentResponseEffect(
+            text="after defer",
+            deferred=True,
+        ),
+    )
+
+    assert rest.interaction_responses == []
+    assert rest.edited_original_interaction_responses == [
+        {
+            "application_id": "app-1",
+            "interaction_token": "token-1",
+            "payload": {"content": "after defer", "components": []},
+        }
+    ]
+
+
+@pytest.mark.anyio
 async def test_original_message_edit_effect_translates_to_original_edit() -> None:
     rest, responder, sink = _build_sink()
     session = responder.start_session(

--- a/tests/integrations/discord/test_service_routing.py
+++ b/tests/integrations/discord/test_service_routing.py
@@ -9444,10 +9444,51 @@ async def test_component_interaction_update_target_uses_component_defer(
         assert len(rest.interaction_responses) == 1
         assert rest.interaction_responses[0]["payload"]["type"] == 6
         assert len(rest.edited_original_interaction_responses) == 1
-        content = rest.edited_original_interaction_responses[0]["payload"][
-            "content"
-        ].lower()
+        payload = rest.edited_original_interaction_responses[0]["payload"]
+        content = payload["content"].lower()
         assert "preparing update (all)" in content
+        assert payload["components"] == []
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_component_interaction_update_confirm_clears_confirmation_buttons(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    rest = _FakeRest()
+    gateway = _FakeGateway([_component_interaction(custom_id="update_confirm:all")])
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    observed: dict[str, Any] = {}
+
+    def _fake_spawn_update_process(**kwargs: Any) -> None:
+        observed.update(kwargs)
+
+    monkeypatch.setattr(
+        discord_service_module,
+        "_spawn_update_process",
+        _fake_spawn_update_process,
+    )
+
+    try:
+        await service.run_forever()
+        assert observed["update_target"] == "all"
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
+        assert len(rest.edited_original_interaction_responses) == 1
+        payload = rest.edited_original_interaction_responses[0]["payload"]
+        assert "preparing update (all)" in payload["content"].lower()
+        assert payload["components"] == []
     finally:
         await store.close()
 


### PR DESCRIPTION
## What changed

This updates the shared Discord component-response path so deferred component interactions clear stale action rows by default when no replacement components are provided.

It also adds regressions for:
- the shared deferred component-response effect
- the `/car update` confirmation path after clicking `Update anyway`

## Why

After a user clicks a Discord component like `Update anyway`, the action can start while the original buttons remain visible. That leaves stale controls on-screen and makes it look like the message is still awaiting input.

The root cause was that deferred component responses which edited the original interaction message without an explicit `components` payload preserved the existing action row.

## Impact

Users now see the confirmation buttons disappear once the update flow starts. The same shared guardrail also protects other Discord component flows that rely on the same helper, which makes future regressions less likely.

I also did a spark subagent command sweep across the Discord interaction layer after the fix. It did not find another confirmed live stale-component bug beyond this shared helper path.

## Validation

Targeted checks:
- `.venv/bin/pytest -q tests/integrations/discord/test_effects.py -k deferred_component_response`
- `.venv/bin/pytest -q tests/integrations/discord/test_service_routing.py -k "update_target_uses_component_defer or update_confirm_clears_confirmation_buttons"`

Repo validation from the commit hook:
- `black`
- `ruff`
- import boundary and contract checks
- `mypy src/codex_autorunner`
- full `pytest` suite (`7849 passed`)
- chat-surface lab deterministic checks (`21 passed`)
- chat latency budget suite (`PASS`)
