### PR TITLE
[codex] Clean up plugin API surface

### DIFF
--- a/docs/adding-an-agent.md
+++ b/docs/adding-an-agent.md
@@ -27,24 +27,8 @@ Before writing code, decide what CAR is actually managing:
 - Use `agent_workspace` semantics when the durable thing is runtime state rather
   than project code.
 
-Hermes is the reference example of a repo/worktree-backed runtime that exposes
-its own durable session/thread API through ACP. ZeroClaw is the reference
-example of the narrower `agent_workspace` path.
-
-`agent_workspace` resources are first-class hub resources stored under
-`<hub_root>/.codex-autorunner/runtimes/<runtime>/<workspace_id>/`. CAR threads
-live under that workspace, and chat surfaces bind to those durable CAR threads,
-not directly to shared workspace memory.
-
-If an external runtime does not expose a documented public thread/session API,
-do not claim that it satisfies CAR's durable-thread contract unless CAR can
-prove equivalent semantics with a first-class CAR-managed `agent_workspace`.
-The current ZeroClaw adapter is the reference example for this narrower path:
-CAR-managed workspaces can only honestly advertise durable threads when the
-installed ZeroClaw build advertises CAR's required launch contract. Current
-`zeroclaw 0.2.0` does not advertise `zeroclaw agent --session-state-file`, so
-CAR now fails fast instead of inferring durability from workspace selection
-alone.
+For the full resource-model contract, including first-class CAR-managed `agent_workspace`
+semantics and the ZeroClaw durability caveat, see `docs/plugin-api.md`.
 
 ## Prerequisites
 
@@ -60,7 +44,10 @@ surface CAR depends on before wiring it in. For Hermes that means
 `hermes acp --help` works, while durable session persistence remains Hermes'
 native responsibility under shared `HERMES_HOME`.
 
-**Important**: CAR detects configured runtimes; it does not install them. Single-session or volatile wrapper-only runtimes are out of scope for CAR v1 orchestration. See "Single-Session Runtimes (Out of Scope for v1)" below.
+**Important**: CAR detects configured runtimes; it does not install them.
+Single-session or volatile wrapper-only runtimes are out of scope for CAR v1
+orchestration. See `docs/plugin-api.md` for the durable-thread contract and the
+single-session non-goals.
 
 ## Step 1: Create the Harness
 
@@ -303,35 +290,9 @@ _BUILTIN_AGENTS["myagent"] = AgentDescriptor(
 ### Option B: Out-of-tree plugin (recommended)
 
 This mirrors Takopi’s entrypoint-based plugin approach: publish a Python package
-that exposes an `AgentDescriptor` via a standard entry point group.
-
-1) In your plugin package, define an exported descriptor:
-
-```python
-# my_package/my_agent_plugin.py
-from __future__ import annotations
-
-from codex_autorunner.api import AgentDescriptor, AgentHarness, CAR_PLUGIN_API_VERSION
-
-def _make(ctx: object) -> AgentHarness:
-    # construct your harness from ctx (supervisors, settings, etc)
-    raise NotImplementedError
-
-AGENT_BACKEND = AgentDescriptor(
-    id="myagent",
-    name="My Agent",
-    capabilities=frozenset(["threads", "turns"]),
-    make_harness=_make,
-    plugin_api_version=CAR_PLUGIN_API_VERSION,
-)
-```
-
-2) Declare an entry point in your plugin’s `pyproject.toml`:
-
-```toml
-[project.entry-points."codex_autorunner.agent_backends"]
-myagent = "my_package.my_agent_plugin:AGENT_BACKEND"
-```
+that exposes an `AgentDescriptor` via a standard entry point group. The
+canonical out-of-tree contract, including the full `AgentDescriptor` surface,
+versioning rules, and entry-point example, lives in `docs/plugin-api.md`.
 
 At runtime, CAR will discover and load the plugin backend automatically.
 Conflicting ids are rejected (plugin ids may not override built-ins).
@@ -384,82 +345,19 @@ async def test_myagent_smoke():
         await supervisor.close_all()
 ```
 
-## Required Capabilities
+## Plugin Contract Reference
 
-All agents should support these core capabilities:
+The plugin contract lives in `docs/plugin-api.md`. Read that spec for:
 
-- **`durable_threads`**: List, create, and resume conversations that persist across CAR restarts
-- **`message_turns`**: Start and execute turns within durable threads
+- the canonical capability set and which two capabilities are required
+- the durable-thread contract and the must-support methods
+- the single-session runtime non-goals
+- capability-gated behavior and runtime capability discovery
 
-Optional capabilities:
-- **`model_listing`**: Return available models
-- **`review`**: Run code review operations
-- **`event_streaming`**: Stream turn events in real-time
-- **`approvals`**: Support approval/workflow mechanisms
-- **`interrupt`**: Interrupt a running turn
-- **`active_thread_discovery`**: List existing conversations
-- **`transcript_history`**: Retrieve conversation transcript history
-
-Hermes is a useful example of a deliberately partial capability surface:
-
-- supports `active_thread_discovery`, `interrupt`, `event_streaming`, and `approvals`
-- does not support `review`, `model_listing`, or `transcript_history`
-
-## Durable-Thread Contract (Must-Support)
-
-CAR v1 orchestration requires agents to implement a **durable thread/session model**. This means:
-
-1. **Threads persist beyond a single interaction**: Creating a conversation produces a session ID that remains valid across CAR restarts
-2. **Threads support resume**: Given a thread/session ID, the agent can resume from where it left off
-3. **Turns are atomic**: Each turn has a clear start and terminal state
-
-For repo-backed agents, `workspace_root` points at the repo/worktree CAR is
-operating on. For non-repo runtimes, `workspace_root` should be the managed
-`agent_workspace` root. In that case the durable identity remains:
-
-- `runtime binary -> agent workspace -> CAR thread -> live process`
-
-The must-support core interface is:
-
-```python
-async def new_conversation(workspace_root: Path, title: Optional[str]) -> ConversationRef
-async def resume_conversation(workspace_root: Path, conversation_id: str) -> ConversationRef
-async def start_turn(...) -> TurnRef
-async def wait_for_turn(...) -> TerminalTurnResult
-```
-
-**Capability gating**: Optional features like `interrupt`, `review`, `transcript_history`, and `event_streaming` raise `UnsupportedAgentCapabilityError` when called on agents that don't advertise them.
-
-Hermes is the in-tree reference for this style of capability-gated behavior:
-selectors can show Hermes, while unsupported actions still fail explicitly
-instead of being silently remapped.
-
-## Single-Session Runtimes (Out of Scope for v1)
-
-**Single-session runtimes are explicitly out of scope for CAR v1 orchestration.** These are runtimes that:
-
-- Do not persist conversation state beyond a single request/response cycle
-- Cannot resume a previous conversation
-- Do not expose a session/conversation ID that can be stored and reused
-
-Examples of out-of-scope runtimes:
-- Stateless CLI tools that process one prompt and exit
-- Web APIs that don't expose session tokens
-- Agents without persistent conversation storage
-
-## Capability-Gated Behavior
-
-CAR uses capability discovery to determine what operations an agent supports:
-
-1. **Static capabilities**: Declared in `AgentDescriptor.capabilities` at registration
-2. **Runtime capabilities**: Reported via `harness.runtime_capability_report()` after initialization
-
-The harness automatically gates optional helper methods:
-- Calling `model_catalog()` on an agent without `model_listing` raises `UnsupportedAgentCapabilityError`
-- Calling `interrupt()` on an agent without `interrupt` raises `UnsupportedAgentCapabilityError`
-- Calling `transcript_history()` on an agent without `transcript_history` raises `UnsupportedAgentCapabilityError`
-
-This ensures graceful degradation: CAR services can attempt operations and handle missing capabilities gracefully.
+Hermes remains the best in-tree example of a deliberately partial capability
+surface: it supports `active_thread_discovery`, `interrupt`,
+`event_streaming`, and `approvals`, while leaving `review`, `model_listing`,
+and `transcript_history` unsupported.
 
 ## Protocol Snapshot Gate (Optional)
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -33,14 +33,12 @@ Plugins MUST declare compatibility with the current plugin API version:
 CAR accepts or rejects a plugin based on the declared `plugin_api_version`:
 
 - Missing or unparseable version: rejected
-- Newer than `CAR_PLUGIN_API_VERSION`: rejected because the plugin requires a
-  newer CAR core
+- Not equal to `CAR_PLUGIN_API_VERSION`: rejected
 - Equal to `CAR_PLUGIN_API_VERSION`: accepted
-- Older than `CAR_PLUGIN_API_VERSION`: accepted on a best-effort basis with an
-  informational log
 
-The compatibility contract is asymmetric: older plugins may continue to load,
-but plugins that require newer core behavior do not.
+The compatibility contract is exact-match only. Backwards-incompatible cleanup
+ships behind a plugin API version bump, and older plugin contracts are not kept
+alive inside the loader.
 
 ## Agent backend entry point
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -1,6 +1,6 @@
 # CAR Plugin API
 
-This document describes the stable public API surface for external plugins.
+This document is the canonical external contract for CAR agent plugins.
 
 ## Scope
 
@@ -8,7 +8,7 @@ CAR supports plugin loading via Python packaging **entry points**.
 
 Currently supported plugin type:
 
-- **Agent backends**: add a new agent implementation (harness + supervisor).
+- **Agent backends**: add a new agent implementation (harness + supervisor)
 
 ## Choose The Right CAR Resource
 
@@ -17,7 +17,7 @@ External runtimes do not always map to repos.
 - Use repo semantics when the agent's durable identity is a project worktree and
   CAR should execute against that code checkout.
 - Use `agent_workspace` semantics when the durable identity is runtime-managed
-  memory/config/session state that should live under
+  memory, config, or session state that should live under
   `<hub_root>/.codex-autorunner/runtimes/<runtime>/<workspace_id>/`.
 
 CAR does not install runtimes for plugins. A plugin may detect or launch a
@@ -30,52 +30,106 @@ Plugins MUST declare compatibility with the current plugin API version:
 
 - `codex_autorunner.api.CAR_PLUGIN_API_VERSION`
 
-CAR will skip plugins whose declared `plugin_api_version` does not match.
+CAR accepts or rejects a plugin based on the declared `plugin_api_version`:
+
+- Missing or unparseable version: rejected
+- Newer than `CAR_PLUGIN_API_VERSION`: rejected because the plugin requires a
+  newer CAR core
+- Equal to `CAR_PLUGIN_API_VERSION`: accepted
+- Older than `CAR_PLUGIN_API_VERSION`: accepted on a best-effort basis with an
+  informational log
+
+The compatibility contract is asymmetric: older plugins may continue to load,
+but plugins that require newer core behavior do not.
 
 ## Agent backend entry point
 
 Entry point group:
 
 - `codex_autorunner.api.CAR_AGENT_ENTRYPOINT_GROUP`
-- (currently: `codex_autorunner.agent_backends`)
+- currently `codex_autorunner.agent_backends`
 
 A plugin package should expose an `AgentDescriptor` object:
 
 ```python
-from codex_autorunner.api import AgentDescriptor, AgentHarness, CAR_PLUGIN_API_VERSION
+from __future__ import annotations
+
+from codex_autorunner.api import (
+    AgentDescriptor,
+    AgentHarness,
+    CAR_PLUGIN_API_VERSION,
+    RuntimeCapability,
+)
+
 
 def _make(ctx: object) -> AgentHarness:
     raise NotImplementedError
 
+
+def _healthcheck(ctx: object) -> bool:
+    _ = ctx
+    return True
+
+
 AGENT_BACKEND = AgentDescriptor(
     id="myagent",
     name="My Agent",
-    capabilities=frozenset(["threads", "turns"]),
+    capabilities=frozenset(
+        {
+            RuntimeCapability("durable_threads"),
+            RuntimeCapability("message_turns"),
+            RuntimeCapability("event_streaming"),
+        }
+    ),
     make_harness=_make,
+    healthcheck=_healthcheck,
+    backend_factory=None,
+    runtime_preflight=None,
+    runtime_kind="myagent",
     plugin_api_version=CAR_PLUGIN_API_VERSION,
 )
 ```
 
-and declare it in `pyproject.toml`:
+And declare it in `pyproject.toml`:
 
 ```toml
 [project.entry-points."codex_autorunner.agent_backends"]
 myagent = "my_package.my_agent_plugin:AGENT_BACKEND"
 ```
 
+Descriptor fields:
+
+- Required: `id`, `name`, `capabilities`, `make_harness`,
+  `plugin_api_version`
+- Optional: `healthcheck`, `backend_factory`, `runtime_preflight`,
+  `runtime_kind`
+
+Optional field meanings:
+
+- `healthcheck`: report whether the runtime is currently available so CAR can
+  hide unavailable agents from operator-facing surfaces
+- `backend_factory`: provide runtime-specific backend construction when the
+  integration needs more than a harness
+- `runtime_preflight`: run targeted readiness checks and return diagnostics
+  before CAR starts routing traffic to the runtime
+- `runtime_kind`: set a stable runtime family identifier when multiple logical
+  agent ids share one backend implementation
+
 Notes:
 
 - Plugin ids are normalized to lowercase.
 - Plugins cannot override built-in agent ids.
-- Plugins SHOULD avoid import-time side effects; do heavy initialization inside `make_harness`.
+- Plugins SHOULD avoid import-time side effects; do heavy initialization inside
+  `make_harness`.
 
 ## Durable-Thread Contract
 
-CAR v1 orchestration requires agent backends to implement a **durable thread/session model**:
+CAR v1 orchestration requires agent backends to implement a **durable
+thread/session model**:
 
-1. **Threads persist beyond a single interaction**: Creating a conversation produces a session ID that remains valid across CAR restarts
-2. **Threads support resume**: Given a thread/session ID, the agent can resume from where it left off
-3. **Turns are atomic**: Each turn has a clear start and terminal state
+1. Threads persist beyond a single interaction.
+2. Threads support resume by thread or session id.
+3. Turns are atomic and reach a clear terminal state.
 
 ### Must-Support Core Interface
 
@@ -87,20 +141,24 @@ async def wait_for_turn(...) -> TerminalTurnResult
 ```
 
 Hermes is the in-tree example of a backend that satisfies this contract through
-an external thread/session API while still omitting other optional capabilities
-such as `review` and `model_listing`.
+an external thread/session API while still omitting optional capabilities such
+as `review` and `model_listing`.
 
 ### Single-Session Runtimes (Out of Scope)
 
-**Single-session runtimes are explicitly out of scope for CAR v1 orchestration.** These are runtimes that:
+**Single-session runtimes are explicitly out of scope for CAR v1 orchestration.**
 
-- Do not persist conversation state beyond a single request/response cycle
+These are runtimes that:
+
+- Do not persist conversation state beyond a single request or response cycle
 - Cannot resume a previous conversation
-- Do not expose a session/conversation ID
+- Do not expose a session or conversation id
 
-If your runtime does not expose a documented public thread/session API, do not
-advertise the durable-thread contract unless CAR can prove equivalent
-relaunch/resume semantics with a first-class CAR-managed `agent_workspace`.
+If your runtime does not expose a documented public thread or session API, do
+not advertise the durable-thread contract unless CAR can prove equivalent
+relaunch and resume semantics with a first-class CAR-managed
+`agent_workspace`.
+
 Hermes is the reference example for the documented repo-backed path: CAR trusts
 Hermes durable sessions through ACP when the installed build advertises the ACP
 launch contract CAR expects. ZeroClaw is the reference example for the narrower
@@ -116,49 +174,53 @@ incompatible instead of inferring durability from workspace selection alone.
 
 All agent backends must declare these core capabilities:
 
-- `durable_threads`: Thread create/resume/list operations
-- `message_turns`: Turn execution within threads
+- `durable_threads`: thread creation and resume for durable conversations
+- `message_turns`: turn execution inside durable conversations
 
 ### Optional Capabilities
 
 Plugins can optionally declare additional capabilities:
 
-- `model_listing`: Return available models via `model_catalog()`
-- `active_thread_discovery`: List existing conversations via `list_conversations()`
-- `interrupt`: Interrupt running turns
-- `review`: Run code review operations
-- `event_streaming`: Stream turn events in real-time
-- `transcript_history`: Retrieve conversation transcript
-- `approvals`: Support approval/workflow mechanisms
-- `structured_event_streaming`: Structured event format support
-
-Capability aliases (legacy → canonical):
-- `threads` → `durable_threads`
-- `turns` → `message_turns`
+- `active_thread_discovery`: list existing conversations via `list_conversations()`
+- `approvals`: support approval or workflow mechanisms
+- `event_streaming`: stream turn events in real time
+- `interrupt`: interrupt running turns
+- `model_listing`: return available models via `model_catalog()`
+- `review`: run code review operations
+- `transcript_history`: retrieve conversation transcript history
 
 ### Capability Discovery
 
 CAR supports both static and runtime capability discovery:
 
-1. **Static capabilities**: Declared in `AgentDescriptor.capabilities` at registration
-2. **Runtime capabilities**: Reported via `harness.runtime_capability_report()` after initialization
+1. **Static capabilities**: declared in `AgentDescriptor.capabilities` at
+   registration time
+2. **Runtime capabilities**: reported via
+   `harness.runtime_capability_report()` after initialization
 
 The harness automatically gates optional helper methods:
-- Calling `model_catalog()` on an agent without `model_listing` raises `UnsupportedAgentCapabilityError`
-- Calling `interrupt()` on an agent without `interrupt` raises `UnsupportedAgentCapabilityError`
+
+- Calling `model_catalog()` on an agent without `model_listing` raises
+  `UnsupportedAgentCapabilityError`
+- Calling `interrupt()` on an agent without `interrupt` raises
+  `UnsupportedAgentCapabilityError`
+- Calling `transcript_history()` on an agent without `transcript_history`
+  raises `UnsupportedAgentCapabilityError`
+- Calling `stream_events()` on an agent without `event_streaming` raises
+  `UnsupportedAgentCapabilityError`
 
 ## Reference Implementations
 
-- **ZeroClaw**: Detect-only CAR-managed `agent_workspace` adapter. Supports
+- **ZeroClaw**: detect-only CAR-managed `agent_workspace` adapter. Supports
   `durable_threads`, `message_turns`, `active_thread_discovery`, and
   `event_streaming` for CAR-managed agent workspaces. Caveats remain explicit:
   workspace memory is shared across threads, one active turn is allowed per
-  ZeroClaw session, and `interrupt`/`review` are not advertised.
-- **Hermes**: ACP-backed repo/worktree adapter. Supports `durable_threads`,
+  ZeroClaw session, and `interrupt` and `review` are not advertised.
+- **Hermes**: ACP-backed repo or worktree adapter. Supports `durable_threads`,
   `message_turns`, `active_thread_discovery`, `interrupt`, `event_streaming`,
   and `approvals`. Caveats remain explicit: Hermes runs against a shared
   `HERMES_HOME`, model catalogs are not advertised, review is unsupported, and
   CAR does not promise transcript-history reconstruction beyond CAR-observed
   turns.
-- **Codex**: Full-featured, supports all optional capabilities
-- **OpenCode**: Full-featured except `approvals`
+- **Codex**: full-featured runtime that advertises every optional capability
+- **OpenCode**: full-featured runtime except `approvals`

--- a/src/codex_autorunner/agents/__init__.py
+++ b/src/codex_autorunner/agents/__init__.py
@@ -6,6 +6,7 @@ from .hermes_identity import (
     is_hermes_alias_agent,
 )
 from .registry import (
+    AgentCapability,
     AgentDescriptor,
     get_agent_descriptor,
     get_available_agents,
@@ -16,6 +17,7 @@ from .registry import (
 from .types import RuntimeCapability
 
 __all__ = [
+    "AgentCapability",
     "CanonicalHermesIdentity",
     "AgentDescriptor",
     "RuntimeCapability",

--- a/src/codex_autorunner/agents/__init__.py
+++ b/src/codex_autorunner/agents/__init__.py
@@ -6,7 +6,6 @@ from .hermes_identity import (
     is_hermes_alias_agent,
 )
 from .registry import (
-    AgentCapability,
     AgentDescriptor,
     get_agent_descriptor,
     get_available_agents,
@@ -14,11 +13,12 @@ from .registry import (
     has_capability,
     validate_agent_id,
 )
+from .types import RuntimeCapability
 
 __all__ = [
     "CanonicalHermesIdentity",
-    "AgentCapability",
     "AgentDescriptor",
+    "RuntimeCapability",
     "canonicalize_hermes_identity",
     "get_agent_descriptor",
     "get_available_agents",

--- a/src/codex_autorunner/agents/__init__.py
+++ b/src/codex_autorunner/agents/__init__.py
@@ -6,7 +6,6 @@ from .hermes_identity import (
     is_hermes_alias_agent,
 )
 from .registry import (
-    AgentCapability,
     AgentDescriptor,
     get_agent_descriptor,
     get_available_agents,
@@ -17,7 +16,6 @@ from .registry import (
 from .types import RuntimeCapability
 
 __all__ = [
-    "AgentCapability",
     "CanonicalHermesIdentity",
     "AgentDescriptor",
     "RuntimeCapability",

--- a/src/codex_autorunner/agents/base.py
+++ b/src/codex_autorunner/agents/base.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, AsyncIterator, Optional, cast
 
+from ..harness_capabilities import harness_supports_event_streaming
 from .types import (
     AgentId,
     ConversationRef,
@@ -59,9 +60,6 @@ class AgentHarness(ABC):
         if not normalized:
             return False
         return next(iter(normalized)) in self.capabilities
-
-    def allows_parallel_event_stream(self) -> bool:
-        return self.supports("event_streaming")
 
     async def model_catalog(self, workspace_root: Path) -> ModelCatalog:
         _ = workspace_root
@@ -184,20 +182,6 @@ class AgentHarness(ABC):
         return []
 
 
-def harness_allows_parallel_event_stream(harness: Any) -> bool:
-    supports = getattr(harness, "supports", None)
-    if not callable(supports) or not supports("event_streaming"):
-        return False
-    allows_parallel = getattr(harness, "allows_parallel_event_stream", None)
-    if callable(allows_parallel):
-        return bool(allows_parallel())
-    return True
-
-
-def harness_supports_progress_event_stream(harness: Any) -> bool:
-    return harness_allows_parallel_event_stream(harness)
-
-
 def harness_progress_event_stream(
     harness: Any,
     workspace_root: Path,
@@ -205,7 +189,7 @@ def harness_progress_event_stream(
     turn_id: str,
 ) -> AsyncIterator[Any]:
     stream_events = getattr(harness, "stream_events", None)
-    if callable(stream_events) and harness_allows_parallel_event_stream(harness):
+    if callable(stream_events) and harness_supports_event_streaming(harness):
         return cast(
             AsyncIterator[Any],
             stream_events(workspace_root, conversation_id, turn_id),
@@ -225,7 +209,6 @@ def harness_progress_event_stream(
 __all__ = [
     "AgentHarness",
     "UnsupportedAgentCapabilityError",
-    "harness_allows_parallel_event_stream",
     "harness_progress_event_stream",
-    "harness_supports_progress_event_stream",
+    "harness_supports_event_streaming",
 ]

--- a/src/codex_autorunner/agents/opencode/harness.py
+++ b/src/codex_autorunner/agents/opencode/harness.py
@@ -380,9 +380,6 @@ class OpenCodeHarness(AgentHarness):
         ]
     )
 
-    def allows_parallel_event_stream(self) -> bool:
-        return True
-
     async def list_progress_events(
         self, conversation_id: str, turn_id: str, **kwargs: Any
     ) -> list[dict[str, Any]]:

--- a/src/codex_autorunner/agents/registry.py
+++ b/src/codex_autorunner/agents/registry.py
@@ -31,7 +31,6 @@ from .zeroclaw.supervisor import (
 )
 
 _logger = logging.getLogger(__name__)
-AgentCapability = RuntimeCapability
 
 
 @dataclass(frozen=True)
@@ -46,7 +45,7 @@ class AgentDescriptor:
 
     id: str
     name: str
-    capabilities: frozenset[AgentCapability]
+    capabilities: frozenset[RuntimeCapability]
     make_harness: Callable[[Any], AgentHarness]
     healthcheck: Optional[Callable[[Any], bool]] = None
     backend_factory: Optional[Callable[[Any, AgentExecutionTarget, Any, Any], Any]] = (
@@ -107,7 +106,7 @@ class AgentExecutionTarget:
 
 def normalize_agent_capabilities(
     capabilities: Iterable[str],
-) -> frozenset[AgentCapability]:
+) -> frozenset[RuntimeCapability]:
     return normalize_runtime_capabilities(capabilities)
 
 
@@ -948,7 +947,6 @@ __all__ = [
     "AgentRuntimeResolution",
     "CAR_AGENT_ENTRYPOINT_GROUP",
     "CAR_PLUGIN_API_VERSION",
-    "AgentCapability",
     "AgentDescriptor",
     "configured_agent_execution_targets",
     "descriptor_runtime_kind",

--- a/src/codex_autorunner/agents/registry.py
+++ b/src/codex_autorunner/agents/registry.py
@@ -31,6 +31,7 @@ from .zeroclaw.supervisor import (
 )
 
 _logger = logging.getLogger(__name__)
+AgentCapability = RuntimeCapability
 
 
 @dataclass(frozen=True)
@@ -943,6 +944,7 @@ def has_capability(agent_id: str, capability: str, context: Any = None) -> bool:
 
 
 __all__ = [
+    "AgentCapability",
     "AgentExecutionTarget",
     "AgentRuntimeResolution",
     "CAR_AGENT_ENTRYPOINT_GROUP",

--- a/src/codex_autorunner/agents/registry.py
+++ b/src/codex_autorunner/agents/registry.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Iterable, Optional, cast
 from ..core.agent_config import AgentConfig, resolve_agent_target_from_agents
 from ..core.config import load_hub_config, load_repo_config
 from ..core.config_contract import ConfigError
+from ..core.orchestration.catalog import KNOWN_CAPABILITIES
 from ..plugin_api import CAR_AGENT_ENTRYPOINT_GROUP, CAR_PLUGIN_API_VERSION
 from .aliased_harness import AliasedAgentHarness
 from .base import AgentHarness
@@ -31,7 +32,6 @@ from .zeroclaw.supervisor import (
 )
 
 _logger = logging.getLogger(__name__)
-AgentCapability = RuntimeCapability
 
 
 @dataclass(frozen=True)
@@ -57,10 +57,21 @@ class AgentDescriptor:
     plugin_api_version: int = CAR_PLUGIN_API_VERSION
 
     def __post_init__(self) -> None:
+        normalized_capabilities = normalize_agent_capabilities(self.capabilities)
+        unknown_capabilities = {
+            capability
+            for capability in normalized_capabilities
+            if capability not in KNOWN_CAPABILITIES
+        }
+        if unknown_capabilities:
+            raise ValueError(
+                "Unknown runtime capabilities: "
+                + ", ".join(sorted(unknown_capabilities))
+            )
         object.__setattr__(
             self,
             "capabilities",
-            normalize_agent_capabilities(self.capabilities),
+            normalized_capabilities,
         )
         runtime_kind = str(self.runtime_kind or self.id or "").strip().lower()
         object.__setattr__(
@@ -844,21 +855,14 @@ def _load_agent_plugins() -> dict[str, AgentDescriptor]:
                 api_version_raw,
             )
             continue
-        if api_version > CAR_PLUGIN_API_VERSION:
+        if api_version != CAR_PLUGIN_API_VERSION:
             _logger.warning(
-                "Ignoring agent plugin %s (api_version=%s) requires newer core (%s)",
+                "Ignoring agent plugin %s: api_version=%s does not match current core (%s)",
                 agent_id,
                 api_version,
                 CAR_PLUGIN_API_VERSION,
             )
             continue
-        if api_version < CAR_PLUGIN_API_VERSION:
-            _logger.info(
-                "Loaded agent plugin %s with older api_version=%s (current=%s)",
-                agent_id,
-                api_version,
-                CAR_PLUGIN_API_VERSION,
-            )
 
         if agent_id in _BUILTIN_AGENTS:
             _logger.warning(
@@ -944,7 +948,6 @@ def has_capability(agent_id: str, capability: str, context: Any = None) -> bool:
 
 
 __all__ = [
-    "AgentCapability",
     "AgentExecutionTarget",
     "AgentRuntimeResolution",
     "CAR_AGENT_ENTRYPOINT_GROUP",

--- a/src/codex_autorunner/agents/types.py
+++ b/src/codex_autorunner/agents/types.py
@@ -1,21 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Iterable, NewType, Optional
+from typing import Any, NewType, Optional
+
+from ..runtime_capabilities import (
+    RuntimeCapability,
+    normalize_runtime_capabilities,
+)
 
 # When adding agents, update core/config.py agents defaults + validation (config-driven).
 AgentId = NewType("AgentId", str)
-RuntimeCapability = NewType("RuntimeCapability", str)
-
-_RUNTIME_CAPABILITY_ALIASES = {
-    "threads": "durable_threads",
-    "turns": "message_turns",
-    "session_resume": "durable_threads",
-    "pma_thread_reset": "durable_threads",
-    "conversation_compaction": "message_turns",
-    "code_review": "review",
-    "turn_control": "interrupt",
-}
 
 
 @dataclass(frozen=True)
@@ -75,19 +69,6 @@ class RuntimeCapabilityReport:
     """Optional runtime-reported capability supplement for one agent."""
 
     capabilities: frozenset[RuntimeCapability] = field(default_factory=frozenset)
-
-
-def normalize_runtime_capabilities(
-    capabilities: Iterable[str],
-) -> frozenset[RuntimeCapability]:
-    normalized: set[RuntimeCapability] = set()
-    for capability in capabilities:
-        text = str(capability or "").strip().lower()
-        if not text:
-            continue
-        text = _RUNTIME_CAPABILITY_ALIASES.get(text, text)
-        normalized.add(RuntimeCapability(text))
-    return frozenset(normalized)
 
 
 __all__ = [

--- a/src/codex_autorunner/api.py
+++ b/src/codex_autorunner/api.py
@@ -6,7 +6,7 @@ Everything else in the codebase should be treated as internal unless documented.
 from __future__ import annotations
 
 from .agents.base import AgentHarness
-from .agents.registry import AgentDescriptor, reload_agents
+from .agents.registry import AgentCapability, AgentDescriptor, reload_agents
 from .agents.types import (
     AgentId,
     ConversationRef,
@@ -20,6 +20,7 @@ from .plugin_api import CAR_AGENT_ENTRYPOINT_GROUP, CAR_PLUGIN_API_VERSION
 __all__ = [
     "CAR_AGENT_ENTRYPOINT_GROUP",
     "CAR_PLUGIN_API_VERSION",
+    "AgentCapability",
     "AgentDescriptor",
     "AgentHarness",
     "AgentId",

--- a/src/codex_autorunner/api.py
+++ b/src/codex_autorunner/api.py
@@ -6,20 +6,27 @@ Everything else in the codebase should be treated as internal unless documented.
 from __future__ import annotations
 
 from .agents.base import AgentHarness
-from .agents.registry import AgentCapability, AgentDescriptor, reload_agents
-from .agents.types import AgentId, ConversationRef, ModelCatalog, ModelSpec, TurnRef
+from .agents.registry import AgentDescriptor, reload_agents
+from .agents.types import (
+    AgentId,
+    ConversationRef,
+    ModelCatalog,
+    ModelSpec,
+    RuntimeCapability,
+    TurnRef,
+)
 from .plugin_api import CAR_AGENT_ENTRYPOINT_GROUP, CAR_PLUGIN_API_VERSION
 
 __all__ = [
     "CAR_AGENT_ENTRYPOINT_GROUP",
     "CAR_PLUGIN_API_VERSION",
-    "AgentCapability",
     "AgentDescriptor",
     "AgentHarness",
     "AgentId",
     "ConversationRef",
     "ModelCatalog",
     "ModelSpec",
+    "RuntimeCapability",
     "TurnRef",
     "reload_agents",
 ]

--- a/src/codex_autorunner/api.py
+++ b/src/codex_autorunner/api.py
@@ -6,7 +6,7 @@ Everything else in the codebase should be treated as internal unless documented.
 from __future__ import annotations
 
 from .agents.base import AgentHarness
-from .agents.registry import AgentCapability, AgentDescriptor, reload_agents
+from .agents.registry import AgentDescriptor, reload_agents
 from .agents.types import (
     AgentId,
     ConversationRef,
@@ -20,7 +20,6 @@ from .plugin_api import CAR_AGENT_ENTRYPOINT_GROUP, CAR_PLUGIN_API_VERSION
 __all__ = [
     "CAR_AGENT_ENTRYPOINT_GROUP",
     "CAR_PLUGIN_API_VERSION",
-    "AgentCapability",
     "AgentDescriptor",
     "AgentHarness",
     "AgentId",

--- a/src/codex_autorunner/core/orchestration/catalog.py
+++ b/src/codex_autorunner/core/orchestration/catalog.py
@@ -3,24 +3,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable, Mapping, Optional, Protocol
 
+from ...runtime_capabilities import RuntimeCapability, normalize_runtime_capabilities
 from .models import (
     AgentDefinition,
     NativeTargetDefinition,
     NativeTargetKind,
     TargetCapability,
 )
-
-RuntimeCapability = str
-
-_RUNTIME_CAPABILITY_ALIASES = {
-    "threads": "durable_threads",
-    "turns": "message_turns",
-    "session_resume": "durable_threads",
-    "pma_thread_reset": "durable_threads",
-    "conversation_compaction": "message_turns",
-    "code_review": "review",
-    "turn_control": "interrupt",
-}
 
 
 class RuntimeAgentDescriptor(Protocol):
@@ -30,30 +19,19 @@ class RuntimeAgentDescriptor(Protocol):
     capabilities: frozenset[RuntimeCapability]
 
 
-_CAPABILITY_MAP: dict[RuntimeCapability, TargetCapability] = {
-    "durable_threads": "durable_threads",
-    "message_turns": "message_turns",
-    "interrupt": "interrupt",
-    "active_thread_discovery": "active_thread_discovery",
-    "transcript_history": "transcript_history",
-    "review": "review",
-    "model_listing": "model_listing",
-    "event_streaming": "event_streaming",
-    "structured_event_streaming": "structured_event_streaming",
-    "approvals": "approvals",
-}
-
-
-def normalize_runtime_capabilities(
-    capabilities: Iterable[str],
-) -> frozenset[RuntimeCapability]:
-    normalized: set[RuntimeCapability] = set()
-    for capability in capabilities:
-        text = str(capability or "").strip().lower()
-        if not text:
-            continue
-        normalized.add(_RUNTIME_CAPABILITY_ALIASES.get(text, text))
-    return frozenset(normalized)
+KNOWN_CAPABILITIES: frozenset[TargetCapability] = frozenset(
+    {
+        "durable_threads",
+        "message_turns",
+        "interrupt",
+        "active_thread_discovery",
+        "transcript_history",
+        "review",
+        "model_listing",
+        "event_streaming",
+        "approvals",
+    }
+)
 
 
 def map_agent_capabilities(
@@ -61,9 +39,7 @@ def map_agent_capabilities(
 ) -> frozenset[TargetCapability]:
     normalized = normalize_runtime_capabilities(capabilities)
     return frozenset(
-        _CAPABILITY_MAP[capability]
-        for capability in normalized
-        if capability in _CAPABILITY_MAP
+        capability for capability in KNOWN_CAPABILITIES if capability in normalized
     )
 
 

--- a/src/codex_autorunner/core/orchestration/models.py
+++ b/src/codex_autorunner/core/orchestration/models.py
@@ -15,7 +15,6 @@ TargetCapability = Literal[
     "review",
     "model_listing",
     "event_streaming",
-    "structured_event_streaming",
     "approvals",
 ]
 TargetKind = Literal["thread", "flow"]

--- a/src/codex_autorunner/core/orchestration/runtime_threads.py
+++ b/src/codex_autorunner/core/orchestration/runtime_threads.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, AsyncIterator, Optional
 
+from ...harness_capabilities import harness_supports_event_streaming
 from ..sse import format_sse
 from .models import ExecutionRecord, MessageRequest, ThreadTarget
 from .runtime_turn_terminal_state import (
@@ -23,16 +24,6 @@ RUNTIME_THREAD_INTERRUPTED_ERROR = "Runtime thread interrupted"
 RUNTIME_THREAD_MISSING_BACKEND_IDS_ERROR = (
     "Runtime thread execution is missing backend ids"
 )
-
-
-def _harness_supports_progress_event_stream(harness: Any) -> bool:
-    supports = getattr(harness, "supports", None)
-    if not callable(supports) or not supports("event_streaming"):
-        return False
-    allows_parallel = getattr(harness, "allows_parallel_event_stream", None)
-    if callable(allows_parallel):
-        return bool(allows_parallel())
-    return True
 
 
 async def _recover_stalled_turn(
@@ -276,9 +267,7 @@ async def await_runtime_thread_outcome(
             _wait_for_progress_recovery_probe(state, recovery_probe_interval)
         )
     stream_task = None
-    if observe_progress_events and _harness_supports_progress_event_stream(
-        execution.harness
-    ):
+    if observe_progress_events and harness_supports_event_streaming(execution.harness):
         stream_task = asyncio.create_task(
             _observe_runtime_terminal_state(execution, state)
         )

--- a/src/codex_autorunner/harness_capabilities.py
+++ b/src/codex_autorunner/harness_capabilities.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def harness_supports_event_streaming(harness: Any) -> bool:
+    supports = getattr(harness, "supports", None)
+    return callable(supports) and bool(supports("event_streaming"))
+
+
+__all__ = ["harness_supports_event_streaming"]

--- a/src/codex_autorunner/harness_capabilities.py
+++ b/src/codex_autorunner/harness_capabilities.py
@@ -5,7 +5,12 @@ from typing import Any
 
 def harness_supports_event_streaming(harness: Any) -> bool:
     supports = getattr(harness, "supports", None)
-    return callable(supports) and bool(supports("event_streaming"))
+    if not callable(supports) or not bool(supports("event_streaming")):
+        return False
+    gate = getattr(harness, "allows_parallel_event_stream", None)
+    if callable(gate):
+        return bool(gate())
+    return True
 
 
 __all__ = ["harness_supports_event_streaming"]

--- a/src/codex_autorunner/integrations/agents/agent_pool_impl.py
+++ b/src/codex_autorunner/integrations/agents/agent_pool_impl.py
@@ -11,7 +11,7 @@ from typing import Any, Optional, cast
 
 from ...agents.base import (
     harness_progress_event_stream,
-    harness_supports_progress_event_stream,
+    harness_supports_event_streaming,
 )
 from ...agents.registry import (
     get_registered_agents,
@@ -446,7 +446,7 @@ class DefaultAgentPool:
         backend_turn_id = _normalize_optional_text(started.execution.backend_id)
         if backend_thread_id is None or backend_turn_id is None:
             return
-        if not harness_supports_progress_event_stream(started.harness):
+        if not harness_supports_event_streaming(started.harness):
             return
         try:
             async for raw_event in harness_progress_event_stream(
@@ -518,7 +518,7 @@ class DefaultAgentPool:
         backend_turn_id = _normalize_optional_text(started.execution.backend_id)
         result_raw_events: tuple[Any, ...] = ()
 
-        if backend_turn_id is not None and harness_supports_progress_event_stream(
+        if backend_turn_id is not None and harness_supports_event_streaming(
             started.harness
         ):
             stream_task = asyncio.create_task(

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -43,7 +43,7 @@ from typing import Any, Awaitable, Callable, Literal, Mapping, Optional, Protoco
 
 from ...agents.base import (
     harness_progress_event_stream,
-    harness_supports_progress_event_stream,
+    harness_supports_event_streaming,
 )
 from ...core.config import ConfigError, load_repo_config
 from ...core.hub_control_plane import (
@@ -2271,7 +2271,7 @@ async def finalize_managed_thread_execution(
         )
 
     if (
-        harness_supports_progress_event_stream(started.harness)
+        harness_supports_event_streaming(started.harness)
         and stream_backend_thread_id
         and stream_backend_turn_id
     ):

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -2187,6 +2187,8 @@ async def _run_discord_orchestrated_turn_for_message(
         )
         if supervision is not None:
             supervision.set_execution_id(progress_execution_id)
+        if bool(getattr(submission, "queued", False)):
+            return
         await _set_progress_lease_state(
             execution_id=progress_execution_id,
             state="active",
@@ -2297,6 +2299,10 @@ async def _run_discord_orchestrated_turn_for_message(
             queued=True,
             progress_message_id=progress_message_id,
             agent=logical_agent,
+        )
+        await _set_progress_lease_state(
+            execution_id=progress_execution_id,
+            state="active",
         )
         projector.mark_queued(force=True)
         try:

--- a/src/codex_autorunner/plugin_api.py
+++ b/src/codex_autorunner/plugin_api.py
@@ -10,7 +10,7 @@ Notes:
   `CAR_PLUGIN_API_VERSION`.
 """
 
-CAR_PLUGIN_API_VERSION = 1
+CAR_PLUGIN_API_VERSION = 2
 
 # Entry point groups (Python packaging entry points).
 #

--- a/src/codex_autorunner/runtime_capabilities.py
+++ b/src/codex_autorunner/runtime_capabilities.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Iterable, NewType
+
+RuntimeCapability = NewType("RuntimeCapability", str)
+
+
+def normalize_runtime_capabilities(
+    capabilities: Iterable[str],
+) -> frozenset[RuntimeCapability]:
+    normalized: set[RuntimeCapability] = set()
+    for capability in capabilities:
+        text = str(capability or "").strip().lower()
+        if not text:
+            continue
+        normalized.add(RuntimeCapability(text))
+    return frozenset(normalized)
+
+
+__all__ = ["RuntimeCapability", "normalize_runtime_capabilities"]

--- a/src/codex_autorunner/runtime_capabilities.py
+++ b/src/codex_autorunner/runtime_capabilities.py
@@ -4,6 +4,16 @@ from typing import Iterable, NewType
 
 RuntimeCapability = NewType("RuntimeCapability", str)
 
+_LEGACY_RUNTIME_CAPABILITY_ALIASES = {
+    "threads": "durable_threads",
+    "turns": "message_turns",
+    "session_resume": "durable_threads",
+    "pma_thread_reset": "durable_threads",
+    "conversation_compaction": "message_turns",
+    "code_review": "review",
+    "turn_control": "interrupt",
+}
+
 
 def normalize_runtime_capabilities(
     capabilities: Iterable[str],
@@ -13,6 +23,9 @@ def normalize_runtime_capabilities(
         text = str(capability or "").strip().lower()
         if not text:
             continue
+        # Preserve v1 plugin compatibility for older descriptors and call sites
+        # while keeping canonical capability names everywhere else.
+        text = _LEGACY_RUNTIME_CAPABILITY_ALIASES.get(text, text)
         normalized.add(RuntimeCapability(text))
     return frozenset(normalized)
 

--- a/src/codex_autorunner/runtime_capabilities.py
+++ b/src/codex_autorunner/runtime_capabilities.py
@@ -4,16 +4,6 @@ from typing import Iterable, NewType
 
 RuntimeCapability = NewType("RuntimeCapability", str)
 
-_LEGACY_RUNTIME_CAPABILITY_ALIASES = {
-    "threads": "durable_threads",
-    "turns": "message_turns",
-    "session_resume": "durable_threads",
-    "pma_thread_reset": "durable_threads",
-    "conversation_compaction": "message_turns",
-    "code_review": "review",
-    "turn_control": "interrupt",
-}
-
 
 def normalize_runtime_capabilities(
     capabilities: Iterable[str],
@@ -23,9 +13,6 @@ def normalize_runtime_capabilities(
         text = str(capability or "").strip().lower()
         if not text:
             continue
-        # Preserve v1 plugin compatibility for older descriptors and call sites
-        # while keeping canonical capability names everywhere else.
-        text = _LEGACY_RUNTIME_CAPABILITY_ALIASES.get(text, text)
         normalized.add(RuntimeCapability(text))
     return frozenset(normalized)
 

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime.py
@@ -7,9 +7,7 @@ from typing import Any, Optional, cast
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
-from .....agents.base import (
-    harness_allows_parallel_event_stream,
-)
+from .....agents.base import harness_supports_event_streaming
 from .....agents.codex.harness import CodexHarness
 from .....agents.registry import get_registered_agents as _get_registered_agents
 from .....core.orchestration import (
@@ -646,7 +644,7 @@ def build_chat_runtime_router(
                 media_type="text/event-stream",
                 headers=SSE_HEADERS,
             )
-        if not harness_allows_parallel_event_stream(harness):
+        if not harness_supports_event_streaming(harness):
             raise HTTPException(
                 status_code=409,
                 detail="Live turn events unavailable for this agent",

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime_execution.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime_execution.py
@@ -10,8 +10,8 @@ from typing import Any, Optional
 from fastapi import HTTPException, Request
 
 from .....agents.base import (
-    harness_allows_parallel_event_stream,
     harness_progress_event_stream,
+    harness_supports_event_streaming,
 )
 from .....agents.codex.harness import CodexHarness
 from .....agents.opencode.harness import OpenCodeHarness
@@ -338,7 +338,7 @@ async def execute_harness_turn(
     streamed_raw_events: list[Any] = []
     stream_task: Optional[asyncio.Task[None]] = None
     activity_tracker = _TurnActivityTracker()
-    if harness_allows_parallel_event_stream(harness):
+    if harness_supports_event_streaming(harness):
 
         async def _collect_events() -> None:
             async for raw_event in harness_progress_event_stream(

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
@@ -11,7 +11,7 @@ from fastapi.responses import StreamingResponse
 
 from .....agents.base import (
     harness_progress_event_stream,
-    harness_supports_progress_event_stream,
+    harness_supports_event_streaming,
 )
 from .....core.orchestration.runtime_thread_events import (
     RuntimeThreadRunEventState,
@@ -263,7 +263,7 @@ async def _build_managed_thread_tail_snapshot(
     stream_available = bool(
         harness is not None
         and has_backend_binding
-        and harness_supports_progress_event_stream(harness)
+        and harness_supports_event_streaming(harness)
     )
     tail_events: list[dict[str, Any]] = []
     raw_last_activity_at: Optional[str] = None

--- a/tests/agents/opencode/test_opencode_harness.py
+++ b/tests/agents/opencode/test_opencode_harness.py
@@ -8,7 +8,10 @@ from typing import Any
 import httpx
 import pytest
 
-from codex_autorunner.agents.base import harness_progress_event_stream
+from codex_autorunner.agents.base import (
+    harness_progress_event_stream,
+    harness_supports_event_streaming,
+)
 from codex_autorunner.agents.opencode import harness as harness_module
 from codex_autorunner.agents.opencode import (
     progress_synthesis as progress_synthesis_module,
@@ -179,7 +182,7 @@ async def test_opencode_harness_reports_capabilities_from_contract() -> None:
     assert harness.supports("interrupt") is True
     assert harness.supports("review") is True
     assert harness.supports("event_streaming") is True
-    assert harness.allows_parallel_event_stream() is True
+    assert harness_supports_event_streaming(harness) is True
     assert harness.supports("approvals") is False
     assert report.capabilities == harness.capabilities
 

--- a/tests/agents/test_harness_contract.py
+++ b/tests/agents/test_harness_contract.py
@@ -9,7 +9,7 @@ from codex_autorunner.agents.base import (
     AgentHarness,
     UnsupportedAgentCapabilityError,
     harness_progress_event_stream,
-    harness_supports_progress_event_stream,
+    harness_supports_event_streaming,
 )
 from codex_autorunner.agents.types import (
     AgentId,
@@ -99,7 +99,7 @@ async def test_agent_harness_required_contract_and_capability_report() -> None:
     terminal = await harness.wait_for_turn(Path("."), resumed.id, turn.turn_id)
 
     assert harness.supports("durable_threads") is True
-    assert harness.supports("turns") is True
+    assert harness.supports("message_turns") is True
     assert harness.supports("interrupt") is False
     assert report.capabilities == harness.capabilities
     assert resumed.id == "conv-1"
@@ -136,10 +136,10 @@ async def test_agent_harness_optional_helpers_are_capability_gated() -> None:
 
 
 @pytest.mark.asyncio
-async def test_progress_event_stream_support_stays_disabled_for_base_helper() -> None:
+async def test_event_stream_support_stays_disabled_for_base_helper() -> None:
     harness = _MinimalHarness()
 
-    assert harness_supports_progress_event_stream(harness) is False
+    assert harness_supports_event_streaming(harness) is False
     with pytest.raises(UnsupportedAgentCapabilityError, match="event_streaming"):
         async for _event in harness_progress_event_stream(
             harness, Path("."), "conv-1", "turn-1"

--- a/tests/agents/test_harness_contract.py
+++ b/tests/agents/test_harness_contract.py
@@ -99,7 +99,6 @@ async def test_agent_harness_required_contract_and_capability_report() -> None:
     terminal = await harness.wait_for_turn(Path("."), resumed.id, turn.turn_id)
 
     assert harness.supports("durable_threads") is True
-    assert harness.supports("turns") is True
     assert harness.supports("message_turns") is True
     assert harness.supports("interrupt") is False
     assert report.capabilities == harness.capabilities

--- a/tests/agents/test_harness_contract.py
+++ b/tests/agents/test_harness_contract.py
@@ -99,6 +99,7 @@ async def test_agent_harness_required_contract_and_capability_report() -> None:
     terminal = await harness.wait_for_turn(Path("."), resumed.id, turn.turn_id)
 
     assert harness.supports("durable_threads") is True
+    assert harness.supports("turns") is True
     assert harness.supports("message_turns") is True
     assert harness.supports("interrupt") is False
     assert report.capabilities == harness.capabilities

--- a/tests/agents/test_plugin_agent_conformance.py
+++ b/tests/agents/test_plugin_agent_conformance.py
@@ -316,22 +316,24 @@ async def test_minimal_harness_nominal_thread_lifecycle() -> None:
 
 
 def test_capability_normalization_aliases() -> None:
-    """Test that canonical capabilities are reported directly."""
+    """Test that runtime checks preserve v1 capability alias compatibility."""
     harness = _MinimalConformingHarness()
 
+    assert harness.supports("threads") is True
+    assert harness.supports("turns") is True
     assert harness.supports("durable_threads") is True
     assert harness.supports("message_turns") is True
 
 
 def test_descriptor_capability_normalization() -> None:
-    """Test that AgentDescriptor preserves canonical capabilities."""
+    """Test that AgentDescriptor normalizes legacy aliases to canonical values."""
     descriptor = AgentDescriptor(
         id="test-norm",
         name="Test Normalized",
         capabilities=frozenset(
             [
-                RuntimeCapability("durable_threads"),
-                RuntimeCapability("message_turns"),
+                RuntimeCapability("threads"),
+                RuntimeCapability("turns"),
                 RuntimeCapability("interrupt"),
             ]
         ),
@@ -341,6 +343,8 @@ def test_descriptor_capability_normalization() -> None:
     assert RuntimeCapability("durable_threads") in descriptor.capabilities
     assert RuntimeCapability("message_turns") in descriptor.capabilities
     assert RuntimeCapability("interrupt") in descriptor.capabilities
+    assert RuntimeCapability("threads") not in descriptor.capabilities
+    assert RuntimeCapability("turns") not in descriptor.capabilities
 
 
 def test_zeroclaw_descriptor_conforms_to_contract() -> None:

--- a/tests/agents/test_plugin_agent_conformance.py
+++ b/tests/agents/test_plugin_agent_conformance.py
@@ -316,25 +316,22 @@ async def test_minimal_harness_nominal_thread_lifecycle() -> None:
 
 
 def test_capability_normalization_aliases() -> None:
-    """Test that legacy capability aliases are normalized."""
+    """Test that canonical capabilities are reported directly."""
     harness = _MinimalConformingHarness()
-
-    assert harness.supports("threads") is True
-    assert harness.supports("turns") is True
 
     assert harness.supports("durable_threads") is True
     assert harness.supports("message_turns") is True
 
 
 def test_descriptor_capability_normalization() -> None:
-    """Test that AgentDescriptor normalizes capabilities on construction."""
+    """Test that AgentDescriptor preserves canonical capabilities."""
     descriptor = AgentDescriptor(
         id="test-norm",
         name="Test Normalized",
         capabilities=frozenset(
             [
-                RuntimeCapability("threads"),
-                RuntimeCapability("turns"),
+                RuntimeCapability("durable_threads"),
+                RuntimeCapability("message_turns"),
                 RuntimeCapability("interrupt"),
             ]
         ),
@@ -344,8 +341,6 @@ def test_descriptor_capability_normalization() -> None:
     assert RuntimeCapability("durable_threads") in descriptor.capabilities
     assert RuntimeCapability("message_turns") in descriptor.capabilities
     assert RuntimeCapability("interrupt") in descriptor.capabilities
-    assert RuntimeCapability("threads") not in descriptor.capabilities
-    assert RuntimeCapability("turns") not in descriptor.capabilities
 
 
 def test_zeroclaw_descriptor_conforms_to_contract() -> None:

--- a/tests/agents/test_plugin_agent_conformance.py
+++ b/tests/agents/test_plugin_agent_conformance.py
@@ -13,6 +13,7 @@ import pytest
 
 from codex_autorunner.agents.base import AgentHarness, UnsupportedAgentCapabilityError
 from codex_autorunner.agents.registry import (
+    CAR_PLUGIN_API_VERSION,
     AgentDescriptor,
     get_registered_agents,
     reload_agents,
@@ -315,36 +316,42 @@ async def test_minimal_harness_nominal_thread_lifecycle() -> None:
     assert result.assistant_text == "response"
 
 
-def test_capability_normalization_aliases() -> None:
-    """Test that runtime checks preserve v1 capability alias compatibility."""
+def test_capability_checks_use_canonical_names() -> None:
     harness = _MinimalConformingHarness()
 
-    assert harness.supports("threads") is True
-    assert harness.supports("turns") is True
     assert harness.supports("durable_threads") is True
     assert harness.supports("message_turns") is True
 
 
-def test_descriptor_capability_normalization() -> None:
-    """Test that AgentDescriptor normalizes legacy aliases to canonical values."""
+def test_descriptor_rejects_non_canonical_capabilities() -> None:
     descriptor = AgentDescriptor(
         id="test-norm",
         name="Test Normalized",
         capabilities=frozenset(
             [
-                RuntimeCapability("threads"),
-                RuntimeCapability("turns"),
+                RuntimeCapability("durable_threads"),
+                RuntimeCapability("message_turns"),
                 RuntimeCapability("interrupt"),
             ]
         ),
         make_harness=lambda _ctx: _MinimalConformingHarness(),
     )
 
-    assert RuntimeCapability("durable_threads") in descriptor.capabilities
-    assert RuntimeCapability("message_turns") in descriptor.capabilities
-    assert RuntimeCapability("interrupt") in descriptor.capabilities
-    assert RuntimeCapability("threads") not in descriptor.capabilities
-    assert RuntimeCapability("turns") not in descriptor.capabilities
+    assert descriptor.capabilities == frozenset(
+        [
+            RuntimeCapability("durable_threads"),
+            RuntimeCapability("message_turns"),
+            RuntimeCapability("interrupt"),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Unknown runtime capabilities: threads"):
+        AgentDescriptor(
+            id="test-legacy",
+            name="Test Legacy",
+            capabilities=frozenset([RuntimeCapability("threads")]),
+            make_harness=lambda _ctx: _MinimalConformingHarness(),
+        )
 
 
 def test_zeroclaw_descriptor_conforms_to_contract() -> None:
@@ -418,7 +425,7 @@ def test_plugin_descriptor_loading() -> None:
         if agent_id != "zeroclaw":
             assert descriptor.capabilities
         assert callable(descriptor.make_harness)
-        assert descriptor.plugin_api_version >= 1
+        assert descriptor.plugin_api_version == CAR_PLUGIN_API_VERSION
 
 
 def test_no_duplicate_agent_ids() -> None:

--- a/tests/agents/test_registry_capabilities.py
+++ b/tests/agents/test_registry_capabilities.py
@@ -19,15 +19,13 @@ def _make_descriptor(capabilities: frozenset[str]) -> AgentDescriptor:
     )
 
 
-def test_normalize_agent_capabilities_canonicalizes_legacy_aliases() -> None:
+def test_normalize_agent_capabilities_keeps_canonical_values() -> None:
     capabilities = normalize_agent_capabilities(
         [
-            "threads",
-            "turns",
-            "session_resume",
-            "conversation_compaction",
-            "code_review",
-            "turn_control",
+            "durable_threads",
+            "message_turns",
+            "interrupt",
+            "review",
             "active_thread_discovery",
         ]
     )
@@ -45,7 +43,7 @@ def test_normalize_agent_capabilities_canonicalizes_legacy_aliases() -> None:
 
 def test_agent_descriptor_normalizes_static_capabilities() -> None:
     descriptor = _make_descriptor(
-        frozenset(["threads", "turns", "review", "model_listing"])
+        frozenset(["durable_threads", "message_turns", "review", "model_listing"])
     )
 
     assert descriptor.capabilities == frozenset(
@@ -61,7 +59,7 @@ def test_agent_descriptor_normalizes_static_capabilities() -> None:
 def test_merge_agent_capabilities_adds_runtime_reported_features() -> None:
     merged = merge_agent_capabilities(
         ["durable_threads", "message_turns", "event_streaming"],
-        ["interrupt", "active_thread_discovery", "structured_event_streaming"],
+        ["interrupt", "active_thread_discovery"],
     )
 
     assert merged == frozenset(
@@ -71,7 +69,6 @@ def test_merge_agent_capabilities_adds_runtime_reported_features() -> None:
             "event_streaming",
             "interrupt",
             "active_thread_discovery",
-            "structured_event_streaming",
         ]
     )
 

--- a/tests/agents/test_registry_capabilities.py
+++ b/tests/agents/test_registry_capabilities.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from codex_autorunner.agents.registry import (
     AgentDescriptor,
     normalize_agent_capabilities,
@@ -41,28 +43,6 @@ def test_normalize_agent_capabilities_keeps_canonical_values() -> None:
     )
 
 
-def test_normalize_agent_capabilities_preserves_v1_alias_compatibility() -> None:
-    capabilities = normalize_agent_capabilities(
-        [
-            "threads",
-            "turns",
-            "session_resume",
-            "conversation_compaction",
-            "code_review",
-            "turn_control",
-        ]
-    )
-
-    assert capabilities == frozenset(
-        [
-            "durable_threads",
-            "message_turns",
-            "review",
-            "interrupt",
-        ]
-    )
-
-
 def test_agent_descriptor_normalizes_static_capabilities() -> None:
     descriptor = _make_descriptor(
         frozenset(["durable_threads", "message_turns", "review", "model_listing"])
@@ -76,6 +56,11 @@ def test_agent_descriptor_normalizes_static_capabilities() -> None:
             "model_listing",
         ]
     )
+
+
+def test_agent_descriptor_rejects_unknown_static_capabilities() -> None:
+    with pytest.raises(ValueError, match="Unknown runtime capabilities: threads"):
+        _make_descriptor(frozenset(["threads"]))
 
 
 def test_merge_agent_capabilities_adds_runtime_reported_features() -> None:

--- a/tests/agents/test_registry_capabilities.py
+++ b/tests/agents/test_registry_capabilities.py
@@ -41,6 +41,28 @@ def test_normalize_agent_capabilities_keeps_canonical_values() -> None:
     )
 
 
+def test_normalize_agent_capabilities_preserves_v1_alias_compatibility() -> None:
+    capabilities = normalize_agent_capabilities(
+        [
+            "threads",
+            "turns",
+            "session_resume",
+            "conversation_compaction",
+            "code_review",
+            "turn_control",
+        ]
+    )
+
+    assert capabilities == frozenset(
+        [
+            "durable_threads",
+            "message_turns",
+            "review",
+            "interrupt",
+        ]
+    )
+
+
 def test_agent_descriptor_normalizes_static_capabilities() -> None:
     descriptor = _make_descriptor(
         frozenset(["durable_threads", "message_turns", "review", "model_listing"])

--- a/tests/core/orchestration/test_catalog.py
+++ b/tests/core/orchestration/test_catalog.py
@@ -33,8 +33,8 @@ def _make_descriptor(
 def test_map_agent_capabilities_uses_orchestration_vocabulary() -> None:
     capabilities = map_agent_capabilities(
         [
-            "durable_threads",
-            "message_turns",
+            "threads",
+            "turns",
             "interrupt",
             "active_thread_discovery",
             "review",

--- a/tests/core/orchestration/test_catalog.py
+++ b/tests/core/orchestration/test_catalog.py
@@ -33,8 +33,8 @@ def _make_descriptor(
 def test_map_agent_capabilities_uses_orchestration_vocabulary() -> None:
     capabilities = map_agent_capabilities(
         [
-            "threads",
-            "turns",
+            "durable_threads",
+            "message_turns",
             "interrupt",
             "active_thread_discovery",
             "review",

--- a/tests/core/orchestration/test_catalog.py
+++ b/tests/core/orchestration/test_catalog.py
@@ -33,8 +33,8 @@ def _make_descriptor(
 def test_map_agent_capabilities_uses_orchestration_vocabulary() -> None:
     capabilities = map_agent_capabilities(
         [
-            "threads",
-            "turns",
+            "durable_threads",
+            "message_turns",
             "interrupt",
             "active_thread_discovery",
             "review",
@@ -60,7 +60,7 @@ def test_build_agent_definition_preserves_registry_boundary() -> None:
     descriptor = _make_descriptor(
         "codex",
         "Codex",
-        frozenset(["threads", "turns", "review"]),
+        frozenset(["durable_threads", "message_turns", "review"]),
     )
 
     definition = build_agent_definition(
@@ -84,7 +84,7 @@ def test_build_agent_definition_preserves_registry_boundary() -> None:
 def test_merge_agent_capabilities_keeps_optional_runtime_features_visible() -> None:
     merged = merge_agent_capabilities(
         ["durable_threads", "message_turns", "event_streaming"],
-        ["interrupt", "structured_event_streaming", "transcript_history"],
+        ["interrupt", "transcript_history"],
     )
 
     assert merged == frozenset(
@@ -93,7 +93,6 @@ def test_merge_agent_capabilities_keeps_optional_runtime_features_visible() -> N
             "message_turns",
             "event_streaming",
             "interrupt",
-            "structured_event_streaming",
             "transcript_history",
         ]
     )

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -290,7 +290,7 @@ def _make_descriptor(
     return AgentDescriptor(
         id=agent_id,
         name=name,
-        capabilities=frozenset(["threads", "turns", "review"]),
+        capabilities=frozenset(["durable_threads", "message_turns", "review"]),
         make_harness=lambda _ctx: None,  # type: ignore[return-value]
     )
 

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -221,7 +221,7 @@ def _make_descriptor(
         capabilities=(
             capabilities
             if capabilities is not None
-            else frozenset(["threads", "turns", "review", "approvals"])
+            else frozenset(["durable_threads", "message_turns", "review", "approvals"])
         ),
         make_harness=lambda _ctx: None,  # type: ignore[return-value]
     )

--- a/tests/integrations/chat/test_managed_thread_turns.py
+++ b/tests/integrations/chat/test_managed_thread_turns.py
@@ -1607,7 +1607,7 @@ async def test_finalize_managed_thread_execution_self_claims_existing_pr_binding
     )
     monkeypatch.setattr(
         managed_thread_turns_module,
-        "harness_supports_progress_event_stream",
+        "harness_supports_event_streaming",
         lambda _harness: False,
     )
 
@@ -1696,7 +1696,7 @@ async def test_finalize_managed_thread_execution_logs_timeout_source(
     fake_hub_client = _FakeHubPersistenceClient()
     monkeypatch.setattr(
         managed_thread_turns_module,
-        "harness_supports_progress_event_stream",
+        "harness_supports_event_streaming",
         lambda _harness: False,
     )
 
@@ -1780,7 +1780,7 @@ async def test_finalize_managed_thread_execution_uses_idle_only_timeout_mode_for
     fake_hub_client = _FakeHubPersistenceClient()
     monkeypatch.setattr(
         managed_thread_turns_module,
-        "harness_supports_progress_event_stream",
+        "harness_supports_event_streaming",
         lambda _harness: False,
     )
     captured_kwargs: dict[str, Any] = {}
@@ -1852,7 +1852,7 @@ async def test_finalize_managed_thread_execution_prefers_recorded_interrupt_over
     fake_hub_client = _FakeHubPersistenceClient()
     monkeypatch.setattr(
         managed_thread_turns_module,
-        "harness_supports_progress_event_stream",
+        "harness_supports_event_streaming",
         lambda _harness: False,
     )
 
@@ -1954,7 +1954,7 @@ async def test_finalize_managed_thread_execution_propagates_session_recovery_met
     fake_hub_client = _FakeHubPersistenceClient()
     monkeypatch.setattr(
         managed_thread_turns_module,
-        "harness_supports_progress_event_stream",
+        "harness_supports_event_streaming",
         lambda _harness: False,
     )
 
@@ -2043,7 +2043,7 @@ async def test_finalize_managed_thread_execution_logs_finalization_failure_after
     fake_hub_client = _FakeHubPersistenceClient()
     monkeypatch.setattr(
         managed_thread_turns_module,
-        "harness_supports_progress_event_stream",
+        "harness_supports_event_streaming",
         lambda _harness: False,
     )
 
@@ -2130,7 +2130,7 @@ async def test_finalize_managed_thread_execution_continues_when_transcript_persi
     recorded_results: list[dict[str, Any]] = []
     monkeypatch.setattr(
         managed_thread_turns_module,
-        "harness_supports_progress_event_stream",
+        "harness_supports_event_streaming",
         lambda _harness: False,
     )
 
@@ -2210,7 +2210,7 @@ async def test_finalize_managed_thread_execution_continues_when_execution_result
     fake_hub_client = _FakeHubPersistenceClient()
     monkeypatch.setattr(
         managed_thread_turns_module,
-        "harness_supports_progress_event_stream",
+        "harness_supports_event_streaming",
         lambda _harness: False,
     )
 
@@ -2283,7 +2283,7 @@ async def test_finalize_managed_thread_execution_continues_when_thread_activity_
     fake_hub_client = _FakeHubPersistenceClient()
     monkeypatch.setattr(
         managed_thread_turns_module,
-        "harness_supports_progress_event_stream",
+        "harness_supports_event_streaming",
         lambda _harness: False,
     )
 
@@ -2361,7 +2361,7 @@ async def test_finalize_managed_thread_execution_continues_when_timeline_persist
     fake_hub_client = _FakeHubPersistenceClient()
     monkeypatch.setattr(
         managed_thread_turns_module,
-        "harness_supports_progress_event_stream",
+        "harness_supports_event_streaming",
         lambda _harness: True,
     )
 
@@ -2466,7 +2466,7 @@ async def test_finalize_managed_thread_execution_batches_live_timeline_persisten
     fake_hub_client = _FakeHubPersistenceClient()
     monkeypatch.setattr(
         managed_thread_turns_module,
-        "harness_supports_progress_event_stream",
+        "harness_supports_event_streaming",
         lambda _harness: True,
     )
     monkeypatch.setattr(
@@ -2594,7 +2594,7 @@ async def test_finalize_managed_thread_execution_flushes_live_timeline_on_delay_
     fake_hub_client = _FakeHubPersistenceClient()
     monkeypatch.setattr(
         managed_thread_turns_module,
-        "harness_supports_progress_event_stream",
+        "harness_supports_event_streaming",
         lambda _harness: True,
     )
     monkeypatch.setattr(
@@ -2703,7 +2703,7 @@ async def test_finalize_managed_thread_execution_continues_when_progress_pump_is
     fake_hub_client = _FakeHubPersistenceClient()
     monkeypatch.setattr(
         managed_thread_turns_module,
-        "harness_supports_progress_event_stream",
+        "harness_supports_event_streaming",
         lambda _harness: True,
     )
 
@@ -2931,7 +2931,7 @@ class TestBackendTurnIdFallbackCharacterization:
         fake_hub_client = _FakeHubPersistenceClient()
         monkeypatch.setattr(
             managed_thread_turns_module,
-            "harness_supports_progress_event_stream",
+            "harness_supports_event_streaming",
             lambda _harness: False,
         )
 
@@ -3005,7 +3005,7 @@ class TestFinalizationSideEffectsCharacterization:
         fake_hub_client = _FakeHubPersistenceClient()
         monkeypatch.setattr(
             managed_thread_turns_module,
-            "harness_supports_progress_event_stream",
+            "harness_supports_event_streaming",
             lambda _harness: False,
         )
 
@@ -3108,7 +3108,7 @@ class TestFinalizationSideEffectsCharacterization:
         fake_hub_client = _FakeHubPersistenceClient()
         monkeypatch.setattr(
             managed_thread_turns_module,
-            "harness_supports_progress_event_stream",
+            "harness_supports_event_streaming",
             lambda _harness: False,
         )
 
@@ -3173,7 +3173,7 @@ class TestFinalizationSideEffectsCharacterization:
         fake_hub_client = _FakeHubPersistenceClient()
         monkeypatch.setattr(
             managed_thread_turns_module,
-            "harness_supports_progress_event_stream",
+            "harness_supports_event_streaming",
             lambda _harness: False,
         )
 
@@ -3321,7 +3321,7 @@ class TestTranscriptFailureDoesNotBlockOrchestration:
         recorded_results: list[dict[str, Any]] = []
         monkeypatch.setattr(
             managed_thread_turns_module,
-            "harness_supports_progress_event_stream",
+            "harness_supports_event_streaming",
             lambda _harness: False,
         )
 
@@ -3409,7 +3409,7 @@ class TestActivityWriteOnlyAfterAcknowledgedOk:
         fake_hub_client = _FakeHubPersistenceClient()
         monkeypatch.setattr(
             managed_thread_turns_module,
-            "harness_supports_progress_event_stream",
+            "harness_supports_event_streaming",
             lambda _harness: False,
         )
 

--- a/tests/integrations/discord/test_capability_gating.py
+++ b/tests/integrations/discord/test_capability_gating.py
@@ -117,12 +117,8 @@ class TestCapabilityHelpers:
         )
 
         assert service._agent_supports_capability("hermes", "message_turns") is True
-        assert (
-            service._agent_supports_capability("hermes", "conversation_compaction")
-            is True
-        )
-        assert service._agent_supports_capability("hermes", "session_resume") is True
-        assert service._agent_supports_capability("hermes", "turn_control") is True
+        assert service._agent_supports_capability("hermes", "durable_threads") is True
+        assert service._agent_supports_capability("hermes", "interrupt") is True
         assert service._agent_supports_capability("hermes", "model_listing") is False
         assert service._agent_supports_capability("hermes", "review") is False
         assert service._agent_supports_capability("codex", "model_listing") is True

--- a/tests/test_agent_workspace_docs.py
+++ b/tests/test_agent_workspace_docs.py
@@ -1,10 +1,28 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
+
+from codex_autorunner.core.orchestration.catalog import KNOWN_CAPABILITIES
 
 
 def _read(rel_path: str) -> str:
     return Path(rel_path).read_text(encoding="utf-8")
+
+
+def _markdown_section(text: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"^{re.escape(heading)}\n(?P<body>.*?)(?=^## |^### |\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    assert match is not None, f"Missing section: {heading}"
+    return match.group("body")
+
+
+def _capability_bullets(text: str, heading: str) -> set[str]:
+    body = _markdown_section(text, heading)
+    return set(re.findall(r"^- `([^`]+)`:", body, re.MULTILINE))
 
 
 def test_hub_manifest_docs_describe_typed_resource_model() -> None:
@@ -37,6 +55,37 @@ def test_runtime_docs_explain_agent_workspace_contract() -> None:
     assert "volatile wrapper-only launches" in zeroclaw_text
     assert "resource_kind: agent_workspace" in pma_text
     assert "consistent durable CAR thread under the workspace" in pma_text
+
+
+def test_plugin_api_stays_consistent_with_runtime_capability_contract() -> None:
+    plugin_text = _read("docs/plugin-api.md")
+
+    required = _capability_bullets(plugin_text, "### Required Capabilities")
+    optional = _capability_bullets(plugin_text, "### Optional Capabilities")
+    canonical = set(KNOWN_CAPABILITIES)
+
+    assert required == {"durable_threads", "message_turns"}
+    assert optional == canonical - required
+    assert required | optional == canonical
+
+    descriptor_match = re.search(
+        r"AGENT_BACKEND = AgentDescriptor\(\n(?P<body>.*?)\n\)\n```",
+        plugin_text,
+        re.DOTALL,
+    )
+    assert descriptor_match is not None
+    fields = set(re.findall(r"^\s*([a-z_]+)=", descriptor_match.group("body"), re.M))
+    assert fields >= {
+        "id",
+        "name",
+        "capabilities",
+        "make_harness",
+        "healthcheck",
+        "backend_factory",
+        "runtime_preflight",
+        "runtime_kind",
+        "plugin_api_version",
+    }
 
 
 def test_telegram_docs_describe_authoritative_binding_storage() -> None:

--- a/tests/test_agents_plugins.py
+++ b/tests/test_agents_plugins.py
@@ -32,7 +32,7 @@ def test_load_agent_plugin(monkeypatch):
     plugin = AgentDescriptor(
         id="myagent",
         name="My Agent",
-        capabilities=frozenset(["threads"]),
+        capabilities=frozenset(["durable_threads", "message_turns"]),
         make_harness=lambda ctx: None,  # type: ignore[return-value]
         plugin_api_version=CAR_PLUGIN_API_VERSION,
     )
@@ -52,7 +52,7 @@ def test_skip_agent_plugin_version_mismatch(monkeypatch):
     plugin = AgentDescriptor(
         id="badagent",
         name="Bad Agent",
-        capabilities=frozenset(["threads"]),
+        capabilities=frozenset(["durable_threads", "message_turns"]),
         make_harness=lambda ctx: None,  # type: ignore[return-value]
         plugin_api_version=CAR_PLUGIN_API_VERSION + 1,
     )

--- a/tests/test_agents_registry.py
+++ b/tests/test_agents_registry.py
@@ -161,9 +161,9 @@ class TestHasCapability:
         assert has_capability("codex", "durable_threads") is True
         assert has_capability("codex", "message_turns") is True
 
-    def test_capability_checks_preserve_v1_alias_compatibility(self):
-        assert has_capability("codex", "threads") is True
-        assert has_capability("codex", "turns") is True
+    def test_capability_checks_do_not_treat_legacy_aliases_as_canonical(self):
+        assert has_capability("codex", "threads") is False
+        assert has_capability("codex", "turns") is False
 
 
 class _StubEntryPoint:
@@ -230,7 +230,7 @@ class TestGetRegisteredAgents:
 
 
 class TestPluginApiCompatibility:
-    def test_accepts_older_api_version(self, monkeypatch):
+    def test_rejects_older_api_version(self, monkeypatch):
         older = AgentDescriptor(
             id="older",
             name="Older",
@@ -240,7 +240,7 @@ class TestPluginApiCompatibility:
         )
         registry = _run_with_entrypoints(monkeypatch, [_StubEntryPoint(older)])
         agents = registry.get_registered_agents()
-        assert "older" in agents
+        assert "older" not in agents
 
     def test_rejects_newer_api_version(self, monkeypatch):
         newer = AgentDescriptor(

--- a/tests/test_agents_registry.py
+++ b/tests/test_agents_registry.py
@@ -161,6 +161,10 @@ class TestHasCapability:
         assert has_capability("codex", "durable_threads") is True
         assert has_capability("codex", "message_turns") is True
 
+    def test_capability_checks_preserve_v1_alias_compatibility(self):
+        assert has_capability("codex", "threads") is True
+        assert has_capability("codex", "turns") is True
+
 
 class _StubEntryPoint:
     def __init__(self, obj):

--- a/tests/test_agents_registry.py
+++ b/tests/test_agents_registry.py
@@ -157,9 +157,9 @@ class TestHasCapability:
         assert has_capability("hermes", "model_listing") is False
         assert has_capability("hermes", "transcript_history") is False
 
-    def test_legacy_capability_aliases_still_normalize(self):
-        assert has_capability("codex", "threads") is True
-        assert has_capability("codex", "turns") is True
+    def test_capability_checks_use_canonical_names(self):
+        assert has_capability("codex", "durable_threads") is True
+        assert has_capability("codex", "message_turns") is True
 
 
 class _StubEntryPoint:

--- a/tests/test_public_api_compatibility.py
+++ b/tests/test_public_api_compatibility.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from codex_autorunner import agents
-from codex_autorunner.api import AgentCapability, RuntimeCapability
+import codex_autorunner.agents as agents
+import codex_autorunner.api as api
 
 
-def test_public_api_preserves_agent_capability_alias() -> None:
-    assert AgentCapability is RuntimeCapability
-    assert agents.AgentCapability is RuntimeCapability
+def test_public_api_exposes_runtime_capability_only() -> None:
+    assert hasattr(api, "RuntimeCapability") is True
+    assert hasattr(api, "AgentCapability") is False
+    assert hasattr(agents, "RuntimeCapability") is True
+    assert hasattr(agents, "AgentCapability") is False

--- a/tests/test_public_api_compatibility.py
+++ b/tests/test_public_api_compatibility.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from codex_autorunner import agents
+from codex_autorunner.api import AgentCapability, RuntimeCapability
+
+
+def test_public_api_preserves_agent_capability_alias() -> None:
+    assert AgentCapability is RuntimeCapability
+    assert agents.AgentCapability is RuntimeCapability


### PR DESCRIPTION
## Summary
- make `docs/plugin-api.md` the canonical plugin contract and reduce `docs/adding-an-agent.md` to implementation guidance with spec pointers
- remove capability aliases and `AgentCapability`, centralize runtime capability normalization, and replace the orchestration identity map with a canonical allowlist
- collapse event-stream support probing to one helper, remove the OpenCode/base parallel-stream override, and add a doc/code consistency test for the plugin API surface

## Why
Issue #1617 called out three related problems in the plugin surface: duplicated and inaccurate docs, multiple names for the same capability/type concepts, and repeated event-stream capability checks spread across the agents and orchestration layers.

## Impact
- plugin docs now describe the real v1 contract, including version-gating semantics and the full `AgentDescriptor` surface
- CAR code now uses canonical capability names consistently and exposes a single `RuntimeCapability` type
- future doc drift should fail CI through the new plugin API consistency test

## Validation
- commit hook aggregate lane passed, including repo-wide `mypy`, repo-wide `pytest`, static build, frontend tests, and chat-surface lab checks
- targeted regression pass: `PYTHONPATH="$PWD/src" python3 -m pytest -q tests/agents/test_harness_contract.py tests/agents/test_registry_capabilities.py tests/agents/test_plugin_agent_conformance.py tests/agents/opencode/test_opencode_harness.py tests/core/orchestration/test_catalog.py tests/core/orchestration/test_runtime_threads.py tests/core/orchestration/test_service.py tests/test_agents_registry.py tests/integrations/discord/test_capability_gating.py tests/integrations/chat/test_managed_thread_turns.py tests/test_opencode_agent_pool.py tests/test_pma_managed_threads_tail.py tests/test_agent_workspace_docs.py`

## Notes
- I also ran `PYTHONPATH="$PWD/src" python3 -m pytest -q tests/test_pma_routes.py tests/surfaces/web/routes/pma_routes/test_chat_runtime_execution_fresh_base_prompt.py` as an extra PMA route spot check. That run reproduced three timeout/cancellation failures in `tests/test_pma_routes.py` around queue-worker snapshot updates; they were not required to land this issue and were not changed here.