### PR TITLE
Fix SCM wake-up notification ordering

### DIFF
--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -352,6 +352,9 @@ class PmaThreadStore:
             stale_running_threshold_seconds=self._stale_running_threshold_seconds,
             execution_row_to_record=_execution_row_to_record,
             transition_thread_status=self._transition_thread_status,
+            transition_thread_status_in_transaction=(
+                self._transition_thread_status_in_transaction
+            ),
         )
         self._initialize()
 
@@ -422,6 +425,24 @@ class PmaThreadStore:
         changed_at: Optional[str] = None,
         turn_id: Optional[str] = None,
     ) -> Optional[dict[str, Any]]:
+        with conn:
+            return self._transition_thread_status_in_transaction(
+                conn,
+                managed_thread_id,
+                reason=reason,
+                changed_at=changed_at,
+                turn_id=turn_id,
+            )
+
+    def _transition_thread_status_in_transaction(
+        self,
+        conn: Any,
+        managed_thread_id: str,
+        *,
+        reason: str | ManagedThreadStatusReason,
+        changed_at: Optional[str] = None,
+        turn_id: Optional[str] = None,
+    ) -> Optional[dict[str, Any]]:
         thread = self._fetch_thread(conn, managed_thread_id)
         if thread is None:
             return None
@@ -435,28 +456,27 @@ class PmaThreadStore:
         )
         if snapshot == current:
             return thread
-        with conn:
-            conn.execute(
-                """
-                UPDATE orch_thread_targets
-                   SET runtime_status = ?,
-                       status_reason = ?,
-                       status_updated_at = ?,
-                       status_terminal = ?,
-                       status_turn_id = ?,
-                       updated_at = ?
-                 WHERE thread_target_id = ?
-                """,
-                (
-                    snapshot.status,
-                    snapshot.reason_code,
-                    snapshot.changed_at,
-                    1 if snapshot.terminal else 0,
-                    snapshot.turn_id,
-                    resolved_changed_at,
-                    managed_thread_id,
-                ),
-            )
+        conn.execute(
+            """
+            UPDATE orch_thread_targets
+               SET runtime_status = ?,
+                   status_reason = ?,
+                   status_updated_at = ?,
+                   status_terminal = ?,
+                   status_turn_id = ?,
+                   updated_at = ?
+             WHERE thread_target_id = ?
+            """,
+            (
+                snapshot.status,
+                snapshot.reason_code,
+                snapshot.changed_at,
+                1 if snapshot.terminal else 0,
+                snapshot.turn_id,
+                resolved_changed_at,
+                managed_thread_id,
+            ),
+        )
         return self._fetch_thread(conn, managed_thread_id)
 
     def _recover_stale_running_turns(
@@ -928,17 +948,17 @@ class PmaThreadStore:
             if thread_status != "active":
                 raise ManagedThreadNotActiveError(managed_thread_id, thread_status)
             self._recover_stale_running_turns(conn, managed_thread_id)
-            running_exists = conn.execute(
-                """
-                SELECT 1
-                  FROM orch_thread_executions
-                 WHERE thread_target_id = ?
-                   AND status = 'running'
-                 LIMIT 1
-                """,
-                (managed_thread_id,),
-            ).fetchone()
             with conn:
+                running_exists = conn.execute(
+                    """
+                    SELECT 1
+                      FROM orch_thread_executions
+                     WHERE thread_target_id = ?
+                       AND status = 'running'
+                     LIMIT 1
+                    """,
+                    (managed_thread_id,),
+                ).fetchone()
                 execution_status = "queued" if running_exists is not None else "running"
                 if execution_status == "queued" and busy_policy != "queue":
                     raise ManagedThreadAlreadyHasRunningTurnError(managed_thread_id)
@@ -995,8 +1015,7 @@ class PmaThreadStore:
                         created_at=started_at,
                         idempotency_key=client_turn_id or managed_turn_id,
                     )
-            if execution_status == "running":
-                with conn:
+                else:
                     conn.execute(
                         """
                         UPDATE orch_thread_targets
@@ -1006,13 +1025,13 @@ class PmaThreadStore:
                         """,
                         (managed_turn_id, started_at, managed_thread_id),
                     )
-                self._transition_thread_status(
-                    conn,
-                    managed_thread_id,
-                    reason=ManagedThreadStatusReason.TURN_STARTED,
-                    changed_at=started_at,
-                    turn_id=managed_turn_id,
-                )
+                    self._transition_thread_status_in_transaction(
+                        conn,
+                        managed_thread_id,
+                        reason=ManagedThreadStatusReason.TURN_STARTED,
+                        changed_at=started_at,
+                        turn_id=managed_turn_id,
+                    )
             row = conn.execute(
                 """
                 SELECT *

--- a/src/codex_autorunner/core/pma_thread_store_lifecycle.py
+++ b/src/codex_autorunner/core/pma_thread_store_lifecycle.py
@@ -27,10 +27,16 @@ class PmaThreadStoreLifecycle:
         stale_running_threshold_seconds: int,
         execution_row_to_record: Callable[[Any], dict[str, Any]],
         transition_thread_status: Callable[..., Optional[dict[str, Any]]],
+        transition_thread_status_in_transaction: Optional[
+            Callable[..., Optional[dict[str, Any]]]
+        ] = None,
     ) -> None:
         self._stale_running_threshold_seconds = stale_running_threshold_seconds
         self._execution_row_to_record = execution_row_to_record
         self._transition_thread_status = transition_thread_status
+        self._transition_thread_status_in_transaction = (
+            transition_thread_status_in_transaction
+        )
 
     def find_stale_running_turn_ids(
         self,
@@ -363,43 +369,43 @@ class PmaThreadStoreLifecycle:
     ) -> Optional[tuple[dict[str, Any], dict[str, Any]]]:
         claimed_at = now_iso()
         self.recover_stale_running_turns(conn, managed_thread_id)
-        running = conn.execute(
-            """
-            SELECT 1
-              FROM orch_thread_executions
-             WHERE thread_target_id = ?
-               AND status = 'running'
-             LIMIT 1
-            """,
-            (managed_thread_id,),
-        ).fetchone()
-        if running is not None:
-            return None
-        row = conn.execute(
-            """
-            SELECT
-                q.queue_item_id,
-                q.payload_json,
-                e.execution_id
-              FROM orch_queue_items AS q
-              JOIN orch_thread_executions AS e
-                ON e.execution_id = q.source_key
-             WHERE q.source_kind = 'thread_execution'
-               AND q.lane_id = ?
-               AND e.thread_target_id = ?
-               AND e.status = 'queued'
-               AND q.state IN ('pending', 'queued', 'waiting')
-             ORDER BY COALESCE(q.visible_at, q.created_at) ASC, q.rowid ASC
-             LIMIT 1
-            """,
-            (
-                thread_queue_lane_id(managed_thread_id),
-                managed_thread_id,
-            ),
-        ).fetchone()
-        if row is None:
-            return None
         with conn:
+            running = conn.execute(
+                """
+                SELECT 1
+                  FROM orch_thread_executions
+                 WHERE thread_target_id = ?
+                   AND status = 'running'
+                 LIMIT 1
+                """,
+                (managed_thread_id,),
+            ).fetchone()
+            if running is not None:
+                return None
+            row = conn.execute(
+                """
+                SELECT
+                    q.queue_item_id,
+                    q.payload_json,
+                    e.execution_id
+                  FROM orch_queue_items AS q
+                  JOIN orch_thread_executions AS e
+                    ON e.execution_id = q.source_key
+                 WHERE q.source_kind = 'thread_execution'
+                   AND q.lane_id = ?
+                   AND e.thread_target_id = ?
+                   AND e.status = 'queued'
+                   AND q.state IN ('pending', 'queued', 'waiting')
+                 ORDER BY COALESCE(q.visible_at, q.created_at) ASC, q.rowid ASC
+                 LIMIT 1
+                """,
+                (
+                    thread_queue_lane_id(managed_thread_id),
+                    managed_thread_id,
+                ),
+            ).fetchone()
+            if row is None:
+                return None
             cursor = conn.execute(
                 """
                 UPDATE orch_queue_items
@@ -428,25 +434,29 @@ class PmaThreadStoreLifecycle:
                 UPDATE orch_thread_targets
                    SET last_execution_id = ?,
                        updated_at = ?
-                 WHERE thread_target_id = ?
+                WHERE thread_target_id = ?
                 """,
                 (str(row["execution_id"]), claimed_at, managed_thread_id),
             )
-        self._transition_thread_status(
-            conn,
-            managed_thread_id,
-            reason=ManagedThreadStatusReason.TURN_STARTED,
-            changed_at=claimed_at,
-            turn_id=str(row["execution_id"]),
-        )
-        execution_row = conn.execute(
-            """
-            SELECT *
-              FROM orch_thread_executions
-             WHERE execution_id = ?
-            """,
-            (str(row["execution_id"]),),
-        ).fetchone()
+            transition = (
+                self._transition_thread_status_in_transaction
+                or self._transition_thread_status
+            )
+            transition(
+                conn,
+                managed_thread_id,
+                reason=ManagedThreadStatusReason.TURN_STARTED,
+                changed_at=claimed_at,
+                turn_id=str(row["execution_id"]),
+            )
+            execution_row = conn.execute(
+                """
+                SELECT *
+                  FROM orch_thread_executions
+                 WHERE execution_id = ?
+                """,
+                (str(row["execution_id"]),),
+            ).fetchone()
         if execution_row is None:
             return None
         return (

--- a/src/codex_autorunner/core/publish_executor.py
+++ b/src/codex_autorunner/core/publish_executor.py
@@ -151,6 +151,9 @@ def _resolve_retry_at(
 ) -> Optional[str]:
     if isinstance(exc, TerminalPublishError):
         return None
+    if isinstance(exc, PublishExecutionError) and exc.retry_after_seconds is not None:
+        retry_at = current_time + timedelta(seconds=max(exc.retry_after_seconds, 0.0))
+        return _format_timestamp(retry_at)
     attempt_index = max(operation.attempt_count - 1, 0)
     if attempt_index >= len(retry_delays_seconds):
         return None

--- a/src/codex_autorunner/core/publish_journal.py
+++ b/src/codex_autorunner/core/publish_journal.py
@@ -224,6 +224,14 @@ class PublishJournalStore:
                 refreshed = self._load_operation_row(conn, normalized_operation_id)
         return _operation_from_row(refreshed) if refreshed is not None else None
 
+    def get_operation(self, operation_id: str) -> Optional[PublishOperation]:
+        normalized_operation_id = _normalize_text(operation_id)
+        if normalized_operation_id is None:
+            return None
+        with open_orchestration_sqlite(self._hub_root, durable=True) as conn:
+            row = self._load_operation_row(conn, normalized_operation_id)
+        return _operation_from_row(row) if row is not None else None
+
     def claim_pending_operations(
         self,
         *,

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -194,6 +194,7 @@ def _managed_turn_dependency_deadline(
     if base is None:
         base = datetime.now(timezone.utc)
     timeout_seconds = _coerce_int(dependency.get("timeout_seconds"))
+    # Missing or non-positive values use the default; explicit positive values are not clamped.
     if timeout_seconds <= 0:
         timeout_seconds = _MANAGED_TURN_START_CONFIRMATION_TIMEOUT_SECONDS
     return base + timedelta(seconds=timeout_seconds)
@@ -903,7 +904,26 @@ def build_notify_chat_executor(
     coroutine_runner = run_coroutine or _run_coroutine_sync
 
     def executor(operation: PublishOperation) -> dict[str, Any]:
-        payload = _normalize_mapping(operation.payload)
+        payload = dict(_normalize_mapping(operation.payload))
+        dependency_for_delivery = _normalize_mapping(
+            payload.get("managed_turn_dependency")
+        )
+        if (
+            _normalize_optional_text(dependency_for_delivery.get("dependency_kind"))
+            == "enqueue_managed_turn_started"
+        ):
+            dep_operation_id = _normalize_optional_text(
+                dependency_for_delivery.get("operation_id")
+            )
+            if dep_operation_id:
+                enqueue_operation = journal.get_operation(dep_operation_id)
+                if enqueue_operation is not None:
+                    enqueue_response = _normalize_mapping(enqueue_operation.response)
+                    resolved_thread_id = _normalize_optional_text(
+                        enqueue_response.get("thread_target_id")
+                    )
+                    if resolved_thread_id is not None:
+                        payload["thread_target_id"] = resolved_thread_id
         message = _normalize_optional_text(
             _resolve_notify_message(
                 operation=operation,

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -196,9 +196,7 @@ def _managed_turn_dependency_deadline(
     timeout_seconds = _coerce_int(dependency.get("timeout_seconds"))
     if timeout_seconds <= 0:
         timeout_seconds = _MANAGED_TURN_START_CONFIRMATION_TIMEOUT_SECONDS
-    return base + timedelta(
-        seconds=max(timeout_seconds, _MANAGED_TURN_START_CONFIRMATION_TIMEOUT_SECONDS)
-    )
+    return base + timedelta(seconds=timeout_seconds)
 
 
 def _resolve_notify_message(

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -5,6 +5,7 @@ import hashlib
 import logging
 import threading
 from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Coroutine, Optional
 
@@ -18,8 +19,12 @@ from .pma_chat_delivery import (
 )
 from .pma_thread_store import ManagedThreadNotActiveError, PmaThreadStore
 from .pr_bindings import PrBinding, PrBindingStore
-from .publish_executor import PublishActionExecutor, TerminalPublishError
-from .publish_journal import PublishOperation
+from .publish_executor import (
+    PublishActionExecutor,
+    RetryablePublishError,
+    TerminalPublishError,
+)
+from .publish_journal import PublishJournalStore, PublishOperation
 from .scm_events import ScmEvent, ScmEventStore
 from .scm_feedback_bundle import (
     apply_feedback_bundle_to_publish_payload,
@@ -30,6 +35,8 @@ from .scm_observability import correlation_id_for_operation, correlation_id_from
 from .text_utils import _coerce_int, _normalize_optional_text
 
 _LOGGER = logging.getLogger(__name__)
+_MANAGED_TURN_START_CONFIRMATION_TIMEOUT_SECONDS = 300
+_MANAGED_TURN_START_CONFIRMATION_RETRY_SECONDS = 5
 
 
 def _require_text(value: Any, *, field_name: str) -> str:
@@ -146,6 +153,156 @@ def _managed_turn_result(
     if correlation_id is not None:
         result["correlation_id"] = correlation_id
     return result
+
+
+def _parse_iso_datetime(value: Any) -> Optional[datetime]:
+    normalized = _normalize_optional_text(value)
+    if normalized is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _managed_turn_dependency_deadline(
+    dependency: Mapping[str, Any],
+    *,
+    enqueue_operation: Optional[PublishOperation],
+    turn: Optional[Mapping[str, Any]],
+) -> datetime:
+    explicit_deadline = _parse_iso_datetime(dependency.get("deadline_at"))
+    if explicit_deadline is not None:
+        return explicit_deadline
+    bases = [
+        _parse_iso_datetime(dependency.get("created_at")),
+        _parse_iso_datetime((turn or {}).get("started_at")),
+        _parse_iso_datetime(
+            enqueue_operation.finished_at if enqueue_operation is not None else None
+        ),
+        _parse_iso_datetime(
+            enqueue_operation.started_at if enqueue_operation is not None else None
+        ),
+        _parse_iso_datetime(
+            enqueue_operation.created_at if enqueue_operation is not None else None
+        ),
+    ]
+    base = next((value for value in bases if value is not None), None)
+    if base is None:
+        base = datetime.now(timezone.utc)
+    timeout_seconds = _coerce_int(dependency.get("timeout_seconds"))
+    if timeout_seconds <= 0:
+        timeout_seconds = _MANAGED_TURN_START_CONFIRMATION_TIMEOUT_SECONDS
+    return base + timedelta(
+        seconds=max(timeout_seconds, _MANAGED_TURN_START_CONFIRMATION_TIMEOUT_SECONDS)
+    )
+
+
+def _resolve_notify_message(
+    *,
+    operation: PublishOperation,
+    payload: dict[str, Any],
+    journal: PublishJournalStore,
+    thread_store: PmaThreadStore,
+) -> str:
+    dependency = _normalize_mapping(payload.get("managed_turn_dependency"))
+    if not dependency:
+        return _require_text(
+            payload.get("message") or payload.get("body") or payload.get("text"),
+            field_name="notify_chat message",
+        )
+
+    if (
+        _normalize_optional_text(dependency.get("dependency_kind"))
+        != "enqueue_managed_turn_started"
+    ):
+        raise TerminalPublishError(
+            "notify_chat has unsupported managed_turn_dependency"
+        )
+
+    dependency_operation_id = _require_text(
+        dependency.get("operation_id"),
+        field_name="managed_turn_dependency.operation_id",
+    )
+    enqueue_operation = journal.get_operation(dependency_operation_id)
+    if enqueue_operation is None:
+        raise TerminalPublishError(
+            f"notify_chat dependency operation '{dependency_operation_id}' was not found"
+        )
+    if enqueue_operation.state in {"pending", "running"}:
+        raise RetryablePublishError(
+            "Waiting for enqueue_managed_turn to finish",
+            retry_after_seconds=_MANAGED_TURN_START_CONFIRMATION_RETRY_SECONDS,
+        )
+
+    failure_message = _normalize_optional_text(dependency.get("failure_message"))
+    if enqueue_operation.state != "succeeded":
+        if failure_message is not None:
+            return failure_message
+        raise TerminalPublishError(
+            "notify_chat dependency enqueue_managed_turn did not succeed"
+        )
+
+    enqueue_response = _normalize_mapping(enqueue_operation.response)
+    thread_target_id = _normalize_optional_text(
+        enqueue_response.get("thread_target_id")
+    ) or _normalize_optional_text(dependency.get("thread_target_id"))
+    managed_turn_id = _normalize_optional_text(enqueue_response.get("managed_turn_id"))
+    if thread_target_id is None or managed_turn_id is None:
+        if failure_message is not None:
+            return failure_message
+        raise TerminalPublishError(
+            "notify_chat dependency is missing managed-turn identifiers"
+        )
+
+    turn = thread_store.get_turn(thread_target_id, managed_turn_id)
+    if turn is None:
+        deadline = _managed_turn_dependency_deadline(
+            dependency,
+            enqueue_operation=enqueue_operation,
+            turn=None,
+        )
+        if datetime.now(timezone.utc) >= deadline:
+            if failure_message is not None:
+                return failure_message
+            raise TerminalPublishError(
+                "Managed turn record never became visible before timeout"
+            )
+        raise RetryablePublishError(
+            "Waiting for managed turn record to become visible",
+            retry_after_seconds=_MANAGED_TURN_START_CONFIRMATION_RETRY_SECONDS,
+        )
+    turn_status = _normalize_optional_text(turn.get("status")) or "unknown"
+    if _normalize_optional_text(turn.get("backend_turn_id")) is not None:
+        return _require_text(
+            payload.get("message") or payload.get("body") or payload.get("text"),
+            field_name="notify_chat message",
+        )
+    if turn_status in {"error", "interrupted", "ok"}:
+        if failure_message is not None:
+            return failure_message
+        raise TerminalPublishError(
+            f"Managed turn reached terminal status '{turn_status}' before start confirmation"
+        )
+
+    deadline = _managed_turn_dependency_deadline(
+        dependency,
+        enqueue_operation=enqueue_operation,
+        turn=turn,
+    )
+    if datetime.now(timezone.utc) >= deadline:
+        if failure_message is not None:
+            return failure_message
+        raise TerminalPublishError(
+            "Managed turn did not reach a confirmed running state before timeout"
+        )
+    raise RetryablePublishError(
+        "Waiting for managed turn start confirmation",
+        retry_after_seconds=_MANAGED_TURN_START_CONFIRMATION_RETRY_SECONDS,
+    )
 
 
 def _merge_into_existing_queued_scm_turn(
@@ -741,14 +898,21 @@ def build_notify_chat_executor(
     hub_root: Path,
     run_coroutine: Optional[Callable[[Coroutine[Any, Any, Any]], Any]] = None,
     thread_store: Optional[PmaThreadStore] = None,
+    journal_store: Optional[PublishJournalStore] = None,
 ) -> PublishActionExecutor:
     store = thread_store or PmaThreadStore(hub_root)
+    journal = journal_store or PublishJournalStore(hub_root)
     coroutine_runner = run_coroutine or _run_coroutine_sync
 
     def executor(operation: PublishOperation) -> dict[str, Any]:
         payload = _normalize_mapping(operation.payload)
         message = _normalize_optional_text(
-            payload.get("message") or payload.get("body") or payload.get("text")
+            _resolve_notify_message(
+                operation=operation,
+                payload=payload,
+                journal=journal,
+                thread_store=store,
+            )
         )
         if message is None:
             raise TerminalPublishError("Publish payload is missing notify_chat message")

--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -515,22 +515,24 @@ class ScmAutomationService:
         if not isinstance(self._journal, PublishJournalStore):
             return
         now = datetime.now(timezone.utc)
-        pending = self._journal.list_operations(
-            state="pending",
-            operation_kind="enqueue_managed_turn",
-            limit=500,
-        )
+        pending_kinds = ("enqueue_managed_turn", "notify_chat")
         earliest_future: Optional[datetime] = None
-        for op in pending:
-            if not op.next_attempt_at:
-                continue
-            parsed = _parse_iso_datetime(op.next_attempt_at)
-            if parsed is None:
-                continue
-            if parsed <= now:
-                continue
-            if earliest_future is None or parsed < earliest_future:
-                earliest_future = parsed
+        for operation_kind in pending_kinds:
+            pending = self._journal.list_operations(
+                state="pending",
+                operation_kind=operation_kind,
+                limit=500,
+            )
+            for op in pending:
+                if not op.next_attempt_at:
+                    continue
+                parsed = _parse_iso_datetime(op.next_attempt_at)
+                if parsed is None:
+                    continue
+                if parsed <= now:
+                    continue
+                if earliest_future is None or parsed < earliest_future:
+                    earliest_future = parsed
         if earliest_future is None:
             self._cancel_deferred_publish_drain()
             return

--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -329,20 +329,21 @@ def _trimmed_summary(value: Any, *, limit: int = 120) -> Optional[str]:
     return f"{text[: limit - 3].rstrip()}..."
 
 
-def _review_comment_notice_message(
-    tracking: Mapping[str, Any],
-    *,
-    enqueue_status: str,
-) -> str:
+def _review_comment_notice_message(tracking: Mapping[str, Any]) -> str:
     subject = _reaction_subject(tracking)
-    if enqueue_status == "queued":
-        return (
-            f"Queued the latest PR review batch for {subject}.\n"
-            "The bound agent thread has the work item and will pick it up next."
-        )
     return (
         f"Started the latest PR review batch for {subject}.\n"
         "The bound agent thread is working on the latest review feedback now."
+    )
+
+
+def _review_comment_notice_failure_message(
+    tracking: Mapping[str, Any],
+) -> str:
+    subject = _reaction_subject(tracking)
+    return (
+        f"Failed to wake the bound agent thread for {subject}.\n"
+        "The SCM-triggered turn never reached a confirmed running state."
     )
 
 
@@ -755,12 +756,10 @@ class ScmAutomationService:
         tracking: Mapping[str, Any],
         enqueue_operation: PublishOperation,
         seen_operation_keys: set[str],
+        next_attempt_at: Optional[str] = None,
     ) -> Optional[PublishOperation]:
-        thread_target_id = _normalize_text(
-            enqueue_operation.response.get("thread_target_id")
-        ) or _normalize_text(tracking.get("thread_target_id"))
-        enqueue_status = _normalize_text(enqueue_operation.response.get("status"))
-        if thread_target_id is None or enqueue_status not in {"queued", "running"}:
+        thread_target_id = _normalize_text(tracking.get("thread_target_id"))
+        if thread_target_id is None:
             return None
         operation_key = self._review_comment_notice_key(
             enqueue_operation_key=enqueue_operation.operation_key
@@ -778,21 +777,35 @@ class ScmAutomationService:
             operation_key=operation_key,
         )
         payload = with_correlation_id(
-            _publish_notice_payload(
-                hub_root=self._hub_root,
-                thread_target_id=thread_target_id,
-                message=_review_comment_notice_message(
-                    tracking,
-                    enqueue_status=enqueue_status,
+            {
+                **_publish_notice_payload(
+                    hub_root=self._hub_root,
+                    thread_target_id=thread_target_id,
+                    message=_review_comment_notice_message(tracking),
                 ),
-            ),
+                "managed_turn_dependency": {
+                    "dependency_kind": "enqueue_managed_turn_started",
+                    "operation_id": enqueue_operation.operation_id,
+                    "thread_target_id": thread_target_id,
+                    "failure_message": _review_comment_notice_failure_message(tracking),
+                },
+            },
             correlation_id=notice_correlation_id,
         )
         operation, deduped = self._journal.create_operation(
             operation_key=operation_key,
             operation_kind="notify_chat",
             payload=payload,
+            next_attempt_at=next_attempt_at,
         )
+        if deduped and operation.state == "pending":
+            updated = self._journal.update_pending_operation(
+                operation.operation_id,
+                payload=payload,
+                next_attempt_at=next_attempt_at,
+            )
+            if updated is not None:
+                operation = updated
         self._audit_recorder.record(
             action_type=SCM_AUDIT_PUBLISH_CREATED,
             correlation_id=correlation_id,
@@ -802,7 +815,7 @@ class ScmAutomationService:
                 "auxiliary": True,
                 "enqueue_notice": True,
                 "source_operation_key": enqueue_operation.operation_key,
-                "enqueue_status": enqueue_status,
+                "dependency_operation_id": enqueue_operation.operation_id,
             },
         )
         return operation
@@ -1060,6 +1073,19 @@ class ScmAutomationService:
                     metadata=tracking,
                 )
             publish_operations.append(operation)
+            if (
+                binding is not None
+                and intent.reaction_kind == "review_comment"
+                and intent.operation_kind == "enqueue_managed_turn"
+            ):
+                notice_operation = self._create_review_comment_notice_operation(
+                    tracking=tracking,
+                    enqueue_operation=operation,
+                    seen_operation_keys=seen_operation_keys,
+                    next_attempt_at=operation.next_attempt_at,
+                )
+                if notice_operation is not None:
+                    publish_operations.append(notice_operation)
 
         return ScmAutomationIngestResult(
             event=event,
@@ -1097,18 +1123,6 @@ class ScmAutomationService:
             event_id = _normalize_text(tracking.get("event_id"))
             try:
                 if operation.state == "succeeded":
-                    if (
-                        operation.operation_kind == "enqueue_managed_turn"
-                        and _normalize_text(tracking.get("reaction_kind"))
-                        == "review_comment"
-                    ):
-                        notice_operation = self._create_review_comment_notice_operation(
-                            tracking=tracking,
-                            enqueue_operation=operation,
-                            seen_operation_keys=seen_operation_keys,
-                        )
-                        if notice_operation is not None:
-                            escalations.append(notice_operation)
                     self._reaction_state_store.mark_reaction_delivery_succeeded(
                         binding_id=binding_id,
                         reaction_kind=rsk,

--- a/tests/core/test_publish_executor.py
+++ b/tests/core/test_publish_executor.py
@@ -1585,6 +1585,185 @@ def test_process_now_runs_first_publish_operation_types(
     assert comment_attempts[0]["state"] == "succeeded"
 
 
+def test_notify_chat_waits_for_managed_turn_start_confirmation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hub_root, workspace_root, repo_id = _publish_hub(tmp_path)
+    thread_store = PmaThreadStore(hub_root)
+    thread = thread_store.create_thread("codex", workspace_root, repo_id=repo_id)
+    journal = PublishJournalStore(hub_root)
+    enqueue_operation, _ = journal.create_operation(
+        operation_key="enqueue:dep:start",
+        operation_kind="enqueue_managed_turn",
+        payload={
+            "thread_target_id": thread["managed_thread_id"],
+            "message_text": "Handle the latest SCM review.",
+        },
+        next_attempt_at="2026-03-25T00:00:00Z",
+    )
+    notify_operation, _ = journal.create_operation(
+        operation_key="notify:dep:start",
+        operation_kind="notify_chat",
+        payload={
+            "delivery": "primary_pma",
+            "repo_id": repo_id,
+            "message": "Started the latest PR review batch for acme/widgets#42.",
+            "managed_turn_dependency": {
+                "dependency_kind": "enqueue_managed_turn_started",
+                "operation_id": enqueue_operation.operation_id,
+                "thread_target_id": thread["managed_thread_id"],
+                "failure_message": "Failed to wake the bound agent thread for acme/widgets#42.",
+            },
+        },
+        next_attempt_at="2026-03-25T00:00:00Z",
+    )
+
+    calls: list[str] = []
+
+    async def _fake_notify_primary_pma_chat_for_repo(
+        *,
+        hub_root: Path,
+        repo_id: str | None,
+        message: str,
+        correlation_id: str,
+    ) -> dict[str, int]:
+        _ = (hub_root, repo_id, correlation_id)
+        calls.append(message)
+        return {"targets": 1, "published": 1}
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.publish_operation_executors.notify_primary_pma_chat_for_repo",
+        _fake_notify_primary_pma_chat_for_repo,
+    )
+
+    processor = PublishOperationProcessor(
+        journal,
+        executors=PublishExecutorRegistry(
+            {
+                "enqueue_managed_turn": build_enqueue_managed_turn_executor(
+                    hub_root=hub_root,
+                    thread_store=thread_store,
+                ),
+                "notify_chat": build_notify_chat_executor(
+                    hub_root=hub_root,
+                    thread_store=thread_store,
+                    journal_store=journal,
+                ),
+            }
+        ),
+        now_fn=_QueuedClock(
+            "2026-03-25T00:00:00Z",
+            "2026-03-25T00:00:05Z",
+        ),
+    )
+
+    first = processor.process_now(limit=10)
+    processed_by_id = {operation.operation_id: operation for operation in first}
+    assert processed_by_id[enqueue_operation.operation_id].state == "succeeded"
+    assert processed_by_id[notify_operation.operation_id].state == "pending"
+    assert calls == []
+
+    enqueue_result = processed_by_id[enqueue_operation.operation_id].response
+    thread_store.set_turn_backend_turn_id(
+        enqueue_result["managed_turn_id"],
+        "backend-turn-1",
+    )
+
+    second = processor.process_now(limit=10)
+    assert [operation.operation_id for operation in second] == [
+        notify_operation.operation_id
+    ]
+    assert second[0].state == "succeeded"
+    assert calls == ["Started the latest PR review batch for acme/widgets#42."]
+
+
+def test_notify_chat_reports_failure_when_managed_turn_is_interrupted_before_start(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hub_root, workspace_root, repo_id = _publish_hub(tmp_path)
+    thread_store = PmaThreadStore(hub_root)
+    thread = thread_store.create_thread("codex", workspace_root, repo_id=repo_id)
+    journal = PublishJournalStore(hub_root)
+    enqueue_operation, _ = journal.create_operation(
+        operation_key="enqueue:dep:failure",
+        operation_kind="enqueue_managed_turn",
+        payload={
+            "thread_target_id": thread["managed_thread_id"],
+            "message_text": "Handle the latest SCM review.",
+        },
+        next_attempt_at="2026-03-25T00:00:00Z",
+    )
+    notify_operation, _ = journal.create_operation(
+        operation_key="notify:dep:failure",
+        operation_kind="notify_chat",
+        payload={
+            "delivery": "primary_pma",
+            "repo_id": repo_id,
+            "message": "Started the latest PR review batch for acme/widgets#42.",
+            "managed_turn_dependency": {
+                "dependency_kind": "enqueue_managed_turn_started",
+                "operation_id": enqueue_operation.operation_id,
+                "thread_target_id": thread["managed_thread_id"],
+                "failure_message": "Failed to wake the bound agent thread for acme/widgets#42.",
+            },
+        },
+        next_attempt_at="2026-03-25T00:00:00Z",
+    )
+
+    calls: list[str] = []
+
+    async def _fake_notify_primary_pma_chat_for_repo(
+        *,
+        hub_root: Path,
+        repo_id: str | None,
+        message: str,
+        correlation_id: str,
+    ) -> dict[str, int]:
+        _ = (hub_root, repo_id, correlation_id)
+        calls.append(message)
+        return {"targets": 1, "published": 1}
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.publish_operation_executors.notify_primary_pma_chat_for_repo",
+        _fake_notify_primary_pma_chat_for_repo,
+    )
+
+    processor = PublishOperationProcessor(
+        journal,
+        executors=PublishExecutorRegistry(
+            {
+                "enqueue_managed_turn": build_enqueue_managed_turn_executor(
+                    hub_root=hub_root,
+                    thread_store=thread_store,
+                ),
+                "notify_chat": build_notify_chat_executor(
+                    hub_root=hub_root,
+                    thread_store=thread_store,
+                    journal_store=journal,
+                ),
+            }
+        ),
+        now_fn=_QueuedClock(
+            "2026-03-25T00:00:00Z",
+            "2026-03-25T00:00:05Z",
+        ),
+    )
+
+    first = processor.process_now(limit=10)
+    processed_by_id = {operation.operation_id: operation for operation in first}
+    assert processed_by_id[notify_operation.operation_id].state == "pending"
+
+    enqueue_result = processed_by_id[enqueue_operation.operation_id].response
+    assert thread_store.mark_turn_interrupted(enqueue_result["managed_turn_id"])
+
+    second = processor.process_now(limit=10)
+    assert [operation.operation_id for operation in second] == [
+        notify_operation.operation_id
+    ]
+    assert second[0].state == "succeeded"
+    assert calls == ["Failed to wake the bound agent thread for acme/widgets#42."]
+
+
 @pytest.mark.asyncio
 async def test_notify_chat_executor_runs_while_event_loop_is_active(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/core/test_publish_executor.py
+++ b/tests/core/test_publish_executor.py
@@ -1677,6 +1677,107 @@ def test_notify_chat_waits_for_managed_turn_start_confirmation(
     assert calls == ["Started the latest PR review batch for acme/widgets#42."]
 
 
+def test_notify_chat_uses_enqueue_thread_target_id_for_bound_delivery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rebound enqueue can return a different thread than ingest-time tracking; delivery must use the response id."""
+    hub_root, workspace_root, repo_id = _publish_hub(tmp_path)
+    thread_store = PmaThreadStore(hub_root)
+    stale_thread = thread_store.create_thread("codex", workspace_root, repo_id=repo_id)
+    replacement_thread = thread_store.create_thread(
+        "codex-rebound", workspace_root, repo_id=repo_id
+    )
+    journal = PublishJournalStore(hub_root)
+    enqueue_operation, _ = journal.create_operation(
+        operation_key="enqueue:dep:rebound-thread",
+        operation_kind="enqueue_managed_turn",
+        payload={
+            "thread_target_id": stale_thread["managed_thread_id"],
+            "message_text": "Handle the latest SCM review.",
+        },
+        next_attempt_at="2026-03-25T00:00:00Z",
+    )
+    notify_operation, _ = journal.create_operation(
+        operation_key="notify:dep:rebound-thread",
+        operation_kind="notify_chat",
+        payload={
+            "delivery": "bound",
+            "thread_target_id": stale_thread["managed_thread_id"],
+            "message": "Wake notice.",
+            "managed_turn_dependency": {
+                "dependency_kind": "enqueue_managed_turn_started",
+                "operation_id": enqueue_operation.operation_id,
+                "thread_target_id": stale_thread["managed_thread_id"],
+                "failure_message": "Failed wake.",
+            },
+        },
+        next_attempt_at="2026-03-25T00:00:00Z",
+    )
+
+    inbound_calls: list[tuple[str | None, Path | None]] = []
+
+    async def _fake_notify_preferred_bound_chat_for_workspace(
+        *,
+        hub_root: Path,
+        workspace_root: Path,
+        repo_id: str | None,
+        message: str,
+        correlation_id: str,
+    ) -> dict[str, int]:
+        inbound_calls.append((repo_id, workspace_root))
+        return {"targets": 1, "published": 1}
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.publish_operation_executors.notify_preferred_bound_chat_for_workspace",
+        _fake_notify_preferred_bound_chat_for_workspace,
+    )
+
+    processor = PublishOperationProcessor(
+        journal,
+        executors=PublishExecutorRegistry(
+            {
+                "enqueue_managed_turn": build_enqueue_managed_turn_executor(
+                    hub_root=hub_root,
+                    thread_store=thread_store,
+                ),
+                "notify_chat": build_notify_chat_executor(
+                    hub_root=hub_root,
+                    thread_store=thread_store,
+                    journal_store=journal,
+                ),
+            }
+        ),
+        now_fn=_QueuedClock(
+            "2026-03-25T00:00:00Z",
+            "2026-03-25T00:00:05Z",
+            "2026-03-25T00:00:10Z",
+        ),
+    )
+
+    first = processor.process_now(limit=10)
+    processed_by_id = {operation.operation_id: operation for operation in first}
+    enqueue_done = processed_by_id[enqueue_operation.operation_id]
+    assert enqueue_done.state == "succeeded"
+    replaced = journal.mark_succeeded(
+        enqueue_operation.operation_id,
+        response={
+            **enqueue_done.response,
+            "thread_target_id": replacement_thread["managed_thread_id"],
+        },
+    )
+    assert replaced is not None
+
+    managed_turn_id = replaced.response["managed_turn_id"]
+    thread_store.set_turn_backend_turn_id(managed_turn_id, "backend-turn-rebound")
+
+    second = processor.process_now(limit=10)
+    assert [operation.operation_id for operation in second] == [
+        notify_operation.operation_id
+    ]
+    assert second[0].state == "succeeded"
+    assert inbound_calls == [(repo_id, workspace_root.resolve())]
+
+
 def test_notify_chat_reports_failure_when_managed_turn_is_interrupted_before_start(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/core/test_scm_automation_service.py
+++ b/tests/core/test_scm_automation_service.py
@@ -947,6 +947,7 @@ def test_ingest_event_tracks_review_comment_operations_in_separate_state_namespa
     assert [operation.operation_kind for operation in result.publish_operations] == [
         "react_pr_review_comment",
         "enqueue_managed_turn",
+        "notify_chat",
     ]
     assert state_store.should_calls == [
         (
@@ -1021,7 +1022,13 @@ def test_ingest_event_batches_review_comment_enqueue_for_15_seconds(
         for operation in result.publish_operations
         if operation.operation_kind == "enqueue_managed_turn"
     )
+    notify_op = next(
+        operation
+        for operation in result.publish_operations
+        if operation.operation_kind == "notify_chat"
+    )
     assert enqueue_op.next_attempt_at == "2026-03-26T00:00:15Z"
+    assert notify_op.next_attempt_at == "2026-03-26T00:00:15Z"
     assert journal.next_attempts_by_key[enqueue_op.operation_key] == (
         "2026-03-26T00:00:15Z"
     )
@@ -1216,63 +1223,62 @@ def test_ingest_event_ci_failure_batch_refresh_honors_max_window(
     assert second_result.publish_operations[0].next_attempt_at == "2026-03-26T00:03:01Z"
 
 
-def test_handle_processed_operations_creates_truthful_review_comment_notice_on_success(
+def test_ingest_event_creates_review_comment_notice_dependency(
     tmp_path: Path,
 ) -> None:
-    state_store = ScmReactionStateStore(tmp_path)
-    state_store.mark_reaction_emitted(
-        binding_id="binding-1",
-        reaction_kind="review_comment:enqueue_managed_turn",
-        fingerprint="fp-inline",
-        event_id="github:event-inline-comment",
-        operation_key="scm:key-inline",
-    )
     journal = _JournalFake()
     service = ScmAutomationService(
         tmp_path,
-        event_store=_EventStoreFake(),
-        binding_resolver=_BindingResolverFake(None),
-        reaction_router=_ReactionRouterFake([]),
-        reaction_state_store=state_store,
+        event_store=_EventStoreFake(
+            ScmEvent(
+                event_id="github:event-inline-comment",
+                provider="github",
+                event_type="pull_request_review_comment",
+                occurred_at="2026-03-26T00:00:00Z",
+                received_at="2026-03-26T00:00:01Z",
+                created_at="2026-03-26T00:00:02Z",
+                repo_slug="acme/widgets",
+                repo_id="repo-1",
+                pr_number=42,
+                delivery_id="delivery-1",
+                payload={
+                    "action": "created",
+                    "comment_id": "2844",
+                    "author_login": "reviewer",
+                    "author_type": "User",
+                    "issue_author_login": "pr-author",
+                    "body": "Please cover the inline review-comment webhook path too.",
+                },
+                raw_payload=None,
+            )
+        ),
+        binding_resolver=_BindingResolverFake(_binding()),
+        reaction_router=route_scm_reactions,
+        reaction_state_store=_PermissiveReactionStateFake(),
         journal=journal,
         publish_processor=_ProcessorFake(processed=[]),
     )
-    succeeded = PublishOperation(
-        **{
-            **_operation(
-                operation_id="op-inline",
-                operation_key="scm:key-inline",
-                operation_kind="enqueue_managed_turn",
-                state="succeeded",
-            ).to_dict(),
-            "payload": {
-                "scm_reaction": {
-                    "binding_id": "binding-1",
-                    "reaction_kind": "review_comment",
-                    "reaction_state_kind": "review_comment:enqueue_managed_turn",
-                    "fingerprint": "fp-inline",
-                    "event_id": "github:event-inline-comment",
-                    "operation_kind": "enqueue_managed_turn",
-                    "repo_slug": "acme/widgets",
-                    "pr_number": 42,
-                    "thread_target_id": "thread-1",
-                }
-            },
-            "response": {
-                "status": "queued",
-                "thread_target_id": "thread-2",
-            },
-        }
+
+    result = service.ingest_event("github:event-inline-comment")
+
+    enqueue_op = next(
+        operation
+        for operation in result.publish_operations
+        if operation.operation_kind == "enqueue_managed_turn"
+    )
+    notify_op = next(
+        operation
+        for operation in result.publish_operations
+        if operation.operation_kind == "notify_chat"
     )
 
-    follow_ups = service._handle_processed_operations([succeeded])
-
-    assert len(follow_ups) == 1
-    assert follow_ups[0].operation_kind == "notify_chat"
-    assert follow_ups[0].payload["thread_target_id"] == "thread-2"
+    assert notify_op.payload["thread_target_id"] == "thread-123"
+    dependency = notify_op.payload["managed_turn_dependency"]
+    assert dependency["dependency_kind"] == "enqueue_managed_turn_started"
+    assert dependency["operation_id"] == enqueue_op.operation_id
     assert (
-        "Queued the latest PR review batch for acme/widgets#42."
-        in follow_ups[0].payload["message"]
+        "Started the latest PR review batch for acme/widgets#42."
+        in notify_op.payload["message"]
     )
 
 

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -1680,13 +1680,26 @@ def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
         "enqueue_managed_turn",
         "notify_chat",
     ]
+    enqueue_result = processed_operations[1]
     notify_result = processed_operations[2]
-    assert notify_result.state == "succeeded"
-    assert notify_result.response["delivery"] == "bound"
-    assert notify_result.response["repo_id"] == "repo-1"
-    assert notify_result.response["route"] == "bound"
-    assert notify_result.response["targets"] == 1
-    assert notify_result.response["published"] == 1
+    assert enqueue_result.state == "succeeded"
+    assert notify_result.state == "pending"
+
+    managed_turn_id = enqueue_result.response["managed_turn_id"]
+    _thread_store.set_turn_backend_turn_id(managed_turn_id, "backend-turn-1")
+    refreshed_notify = journal.update_pending_operation(
+        notify_result.operation_id,
+        next_attempt_at="2000-01-01T00:00:00Z",
+    )
+    assert refreshed_notify is not None
+    confirmed = automation.process_now(limit=10)
+    assert [operation.operation_kind for operation in confirmed] == ["notify_chat"]
+    assert confirmed[0].state == "succeeded"
+    assert confirmed[0].response["delivery"] == "bound"
+    assert confirmed[0].response["repo_id"] == "repo-1"
+    assert confirmed[0].response["route"] == "bound"
+    assert confirmed[0].response["targets"] == 1
+    assert confirmed[0].response["published"] == 1
     assert reaction_calls == [("acme", "widgets", str(hub_root), 2844, "eyes")]
 
     turns = _thread_store.list_turns(thread["managed_thread_id"], limit=10)
@@ -1890,10 +1903,37 @@ def test_process_due_watches_keeps_distinct_bound_notices_for_multiple_review_co
         if operation.operation_kind == "notify_chat"
     ]
     assert len(notify_results) == 2
-    assert all(operation.state == "succeeded" for operation in notify_results)
+    assert all(operation.state == "pending" for operation in notify_results)
     assert (
         len({operation.payload["correlation_id"] for operation in notify_results}) == 2
     )
+
+    enqueue_results = [
+        operation
+        for operation in processed_operations
+        if operation.operation_kind == "enqueue_managed_turn"
+    ]
+    assert len(enqueue_results) == 2
+    first_turn_id = enqueue_results[0].response["managed_turn_id"]
+    second_turn_id = enqueue_results[1].response["managed_turn_id"]
+    _thread_store.set_turn_backend_turn_id(first_turn_id, "backend-turn-1")
+    assert _thread_store.mark_turn_finished(first_turn_id, status="ok")
+    claimed = _thread_store.claim_next_queued_turn(thread["managed_thread_id"])
+    assert claimed is not None
+    claimed_execution, _payload = claimed
+    assert claimed_execution["managed_turn_id"] == second_turn_id
+    _thread_store.set_turn_backend_turn_id(second_turn_id, "backend-turn-2")
+    for operation in notify_results:
+        refreshed = journal.update_pending_operation(
+            operation.operation_id,
+            next_attempt_at="2000-01-01T00:00:00Z",
+        )
+        assert refreshed is not None
+
+    confirmed = automation.process_now(limit=10)
+    assert len(confirmed) == 2
+    assert all(operation.operation_kind == "notify_chat" for operation in confirmed)
+    assert all(operation.state == "succeeded" for operation in confirmed)
 
     outbox = _read_outbox_records(
         hub_root / ".codex-autorunner" / "discord_state.sqlite3"
@@ -1905,12 +1945,15 @@ def test_process_due_watches_keeps_distinct_bound_notices_for_multiple_review_co
     ]
     assert len(contents) == 2
     normalized_contents = [content.lower() for content in contents]
-    assert all("latest pr review batch" in content for content in normalized_contents)
+    assert len(set(contents)) == 2
+    assert any(
+        "started the latest pr review batch" in content
+        for content in normalized_contents
+    )
     assert any(
         "working on the latest review feedback now" in content
         for content in normalized_contents
     )
-    assert any("will pick it up next" in content for content in normalized_contents)
 
 
 def test_process_due_watches_does_not_reemit_when_thread_is_reopened_without_new_comments(

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -597,6 +597,43 @@ def test_create_turn_recovers_stale_running_execution_before_admission(
     assert stale_after["finished_at"]
 
 
+def test_create_turn_hides_new_running_execution_until_status_transition_commits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = PmaThreadStore(tmp_path / "hub")
+    thread = store.create_thread("codex", tmp_path / "workspace")
+    first_turn = store.create_turn(thread["managed_thread_id"], prompt="first")
+    assert store.mark_turn_finished(first_turn["managed_turn_id"], status="ok")
+
+    observed_running_counts: list[int] = []
+    original = store._transition_thread_status_in_transaction
+
+    def _observing_transition(*args, **kwargs):  # type: ignore[no-untyped-def]
+        with open_orchestration_sqlite(store.hub_root) as conn:
+            count = conn.execute(
+                """
+                SELECT COUNT(*) AS c
+                  FROM orch_thread_executions
+                 WHERE thread_target_id = ?
+                   AND status = 'running'
+                """,
+                (thread["managed_thread_id"],),
+            ).fetchone()
+        observed_running_counts.append(int((count or {})["c"] or 0))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        store,
+        "_transition_thread_status_in_transaction",
+        _observing_transition,
+    )
+
+    created = store.create_turn(thread["managed_thread_id"], prompt="second")
+
+    assert created["status"] == "running"
+    assert observed_running_counts == [0]
+
+
 def test_claim_next_queued_turn_recovers_stale_running_execution(
     tmp_path: Path,
 ) -> None:
@@ -646,6 +683,54 @@ def test_claim_next_queued_turn_recovers_stale_running_execution(
     assert stale_after["status"] == "interrupted"
     assert stale_after["error"] == "stale_running_execution_recovered"
     assert stale_after["finished_at"]
+
+
+def test_claim_next_queued_turn_hides_promoted_execution_until_status_transition_commits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = PmaThreadStore(tmp_path / "hub")
+    thread = store.create_thread("codex", tmp_path / "workspace")
+    first_turn = store.create_turn(thread["managed_thread_id"], prompt="first")
+    queued_turn = store.create_turn(
+        thread["managed_thread_id"],
+        prompt="queued",
+        busy_policy="queue",
+        queue_payload={"request": {"message_text": "queued"}},
+    )
+    assert queued_turn["status"] == "queued"
+    assert store.mark_turn_finished(first_turn["managed_turn_id"], status="ok")
+
+    observed_running_counts: list[int] = []
+    original = store._lifecycle._transition_thread_status_in_transaction
+    assert original is not None
+
+    def _observing_transition(*args, **kwargs):  # type: ignore[no-untyped-def]
+        with open_orchestration_sqlite(store.hub_root) as conn:
+            count = conn.execute(
+                """
+                SELECT COUNT(*) AS c
+                  FROM orch_thread_executions
+                 WHERE thread_target_id = ?
+                   AND status = 'running'
+                """,
+                (thread["managed_thread_id"],),
+            ).fetchone()
+        observed_running_counts.append(int((count or {})["c"] or 0))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        store._lifecycle,
+        "_transition_thread_status_in_transaction",
+        _observing_transition,
+    )
+
+    claimed = store.claim_next_queued_turn(thread["managed_thread_id"])
+
+    assert claimed is not None
+    execution, _payload = claimed
+    assert execution["managed_turn_id"] == queued_turn["managed_turn_id"]
+    assert execution["status"] == "running"
+    assert observed_running_counts == [0]
 
 
 def test_create_turn_recovers_old_running_execution_when_status_turn_matches(


### PR DESCRIPTION
Closes #1627.

## Summary
- make SCM review wake-up notifications depend on the corresponding `enqueue_managed_turn` reaching a confirmed started state instead of firing immediately on enqueue success
- serialize turn promotion/start visibility so stale-running recovery cannot observe and interrupt a freshly created execution before the thread status transition is committed
- add coverage for false wake-up notifications, interrupted-before-start failures, queued turn promotion visibility, and SCM polling/coalescing behavior

## Architectural approach
The core change is to treat wake-up notifications as dependent publish operations rather than independent side effects.

`ScmAutomationService` now creates the review-comment `notify_chat` operation alongside the enqueue operation, but attaches explicit dependency metadata pointing at the `enqueue_managed_turn` op. `build_notify_chat_executor()` resolves that dependency before delivering anything user-visible:
- it waits while the enqueue op is still pending/running
- it waits until the managed turn record exists and has a confirmed `backend_turn_id`
- it emits the failure notification if the enqueue op fails, the turn terminates before start confirmation, or the confirmation deadline expires

That removes the false-positive "agent woken up" path and also gives SCM-triggered turns a visible failure path instead of silent loss.

The second part of the fix is in `PmaThreadStore` and `PmaThreadStoreLifecycle`. Fresh `running` executions and queued-turn promotions now update `orch_thread_executions`, `orch_thread_targets.last_execution_id`, and the thread status transition inside the same transaction. That means stale-running cleanup finishes before a new execution becomes externally visible as `running`, so recovery no longer sacrifices the incoming SCM turn.

## Validation
- pre-commit aggregate lane passed end-to-end
- repo-wide strict mypy passed in hook
- repo-wide pytest passed in hook: `7853 passed`
- frontend build/tests passed in hook
- chat-surface lab latency checks passed in hook
