### PR TITLE
fix: add confirmed_start tracking to prevent premature SCM wake-up notifications

### DIFF
--- a/src/codex_autorunner/core/hub_control_plane/_executions.py
+++ b/src/codex_autorunner/core/hub_control_plane/_executions.py
@@ -7,6 +7,7 @@ from ..orchestration.models import BusyThreadPolicy, ExecutionRecord, MessageReq
 from ._normalizers import (
     coerce_int,
     copy_mapping,
+    normalize_bool,
     normalize_busy_thread_policy,
     normalize_message_request_kind,
     normalize_optional_text,
@@ -337,6 +338,7 @@ class ExecutionCancelAllRequest:
 class ExecutionBackendIdUpdateRequest:
     execution_id: str
     backend_turn_id: Optional[str] = None
+    confirmed_start: bool = True
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "ExecutionBackendIdUpdateRequest":
@@ -348,12 +350,17 @@ class ExecutionBackendIdUpdateRequest:
             backend_turn_id=normalize_optional_text(
                 data.get("backend_turn_id") or data.get("backend_id")
             ),
+            confirmed_start=normalize_bool(
+                data.get("confirmed_start"),
+                fallback=True,
+            ),
         )
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "execution_id": self.execution_id,
             "backend_turn_id": self.backend_turn_id,
+            "confirmed_start": self.confirmed_start,
         }
 
 

--- a/src/codex_autorunner/core/hub_control_plane/_normalizers.py
+++ b/src/codex_autorunner/core/hub_control_plane/_normalizers.py
@@ -90,9 +90,22 @@ def normalize_run_event_payloads(value: Any) -> tuple[dict[str, Any], ...]:
     return tuple(events)
 
 
+def normalize_bool(value: Any, *, fallback: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return fallback
+
+
 __all__ = [
     "coerce_int",
     "copy_mapping",
+    "normalize_bool",
     "normalize_busy_thread_policy",
     "normalize_message_request_kind",
     "normalize_optional_identifier",

--- a/src/codex_autorunner/core/hub_control_plane/_normalizers.py
+++ b/src/codex_autorunner/core/hub_control_plane/_normalizers.py
@@ -93,6 +93,11 @@ def normalize_run_event_payloads(value: Any) -> tuple[dict[str, Any], ...]:
 def normalize_bool(value: Any, *, fallback: bool) -> bool:
     if isinstance(value, bool):
         return value
+    if isinstance(value, int):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
     if isinstance(value, str):
         normalized = value.strip().lower()
         if normalized in {"1", "true", "yes", "on"}:

--- a/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
+++ b/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
@@ -461,7 +461,11 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
         return response.execution, dict(response.queue_payload)
 
     def set_execution_backend_id(
-        self, execution_id: str, backend_turn_id: Optional[str]
+        self,
+        execution_id: str,
+        backend_turn_id: Optional[str],
+        *,
+        confirmed_start: bool = True,
     ) -> None:
         self._run(
             operation="set_execution_backend_id",
@@ -470,6 +474,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
                 ExecutionBackendIdUpdateRequest(
                     execution_id=execution_id,
                     backend_turn_id=backend_turn_id,
+                    confirmed_start=confirmed_start,
                 )
             ),
         )

--- a/src/codex_autorunner/core/hub_control_plane/service.py
+++ b/src/codex_autorunner/core/hub_control_plane/service.py
@@ -623,6 +623,7 @@ class HubSharedStateService:
         self._execution_store.set_execution_backend_id(
             request.execution_id,
             request.backend_turn_id,
+            confirmed_start=request.confirmed_start,
         )
 
     def claim_next_queued_execution(

--- a/src/codex_autorunner/core/orchestration/execution_lifecycle.py
+++ b/src/codex_autorunner/core/orchestration/execution_lifecycle.py
@@ -393,7 +393,9 @@ class _ThreadExecutionLifecycle:
                         )
                     provisional_turn_id = f"{conversation_id}:{int(time.time() * 1000)}"
                     self.thread_store.set_execution_backend_id(
-                        execution.execution_id, provisional_turn_id
+                        execution.execution_id,
+                        provisional_turn_id,
+                        confirmed_start=False,
                     )
                     log_event(
                         self._log,
@@ -586,7 +588,9 @@ class _ThreadExecutionLifecycle:
                 backend_runtime_instance_id=runtime_instance_id,
             )
         self.thread_store.set_execution_backend_id(
-            execution.execution_id, resolved_turn_id
+            execution.execution_id,
+            resolved_turn_id,
+            confirmed_start=True,
         )
         log_event(
             self._log,

--- a/src/codex_autorunner/core/orchestration/interfaces.py
+++ b/src/codex_autorunner/core/orchestration/interfaces.py
@@ -241,7 +241,11 @@ class ThreadExecutionStore(Protocol):
     ) -> Optional[tuple[ExecutionRecord, dict[str, Any]]]: ...
 
     def set_execution_backend_id(
-        self, execution_id: str, backend_turn_id: Optional[str]
+        self,
+        execution_id: str,
+        backend_turn_id: Optional[str],
+        *,
+        confirmed_start: bool = True,
     ) -> None: ...
 
     def record_execution_result(

--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -362,9 +362,17 @@ class PmaThreadExecutionStore(ThreadExecutionStore):
         return _execution_record_from_store_row(execution), payload
 
     def set_execution_backend_id(
-        self, execution_id: str, backend_turn_id: Optional[str]
+        self,
+        execution_id: str,
+        backend_turn_id: Optional[str],
+        *,
+        confirmed_start: bool = True,
     ) -> None:
-        self._store.set_turn_backend_turn_id(execution_id, backend_turn_id)
+        self._store.set_turn_backend_turn_id(
+            execution_id,
+            backend_turn_id,
+            confirmed_start=confirmed_start,
+        )
 
     def _notify_terminal_transition(
         self,

--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -65,6 +65,7 @@ from .text_utils import _json_dumps, _json_loads_object
 from .time_utils import now_iso
 
 _BACKEND_RUNTIME_INSTANCE_ID_KEY = "backend_runtime_instance_id"
+_RUNTIME_STARTED_AT_KEY = "runtime_started_at"
 
 
 class ManagedThreadAlreadyHasRunningTurnError(RuntimeError):
@@ -1125,18 +1126,56 @@ class PmaThreadStore:
         return True
 
     def set_turn_backend_turn_id(
-        self, managed_turn_id: str, backend_turn_id: Optional[str]
+        self,
+        managed_turn_id: str,
+        backend_turn_id: Optional[str],
+        *,
+        confirmed_start: bool = True,
     ) -> None:
+        normalized_backend_turn_id = _coerce_text(backend_turn_id)
+        runtime_started_at = now_iso()
         with self._write_conn() as conn:
+            row = conn.execute(
+                """
+                SELECT metadata_json
+                  FROM orch_thread_executions
+                 WHERE execution_id = ?
+                """,
+                (managed_turn_id,),
+            ).fetchone()
+            metadata = (
+                _json_loads_object(row["metadata_json"]) if row is not None else {}
+            )
+            if (
+                confirmed_start
+                and normalized_backend_turn_id is not None
+                and _coerce_text(metadata.get(_RUNTIME_STARTED_AT_KEY)) is None
+            ):
+                metadata[_RUNTIME_STARTED_AT_KEY] = runtime_started_at
             with conn:
-                conn.execute(
-                    """
-                    UPDATE orch_thread_executions
-                       SET backend_turn_id = ?
-                     WHERE execution_id = ?
-                    """,
-                    (backend_turn_id, managed_turn_id),
-                )
+                if metadata:
+                    conn.execute(
+                        """
+                        UPDATE orch_thread_executions
+                           SET backend_turn_id = ?,
+                               metadata_json = ?
+                         WHERE execution_id = ?
+                        """,
+                        (
+                            normalized_backend_turn_id,
+                            _json_dumps(metadata),
+                            managed_turn_id,
+                        ),
+                    )
+                else:
+                    conn.execute(
+                        """
+                        UPDATE orch_thread_executions
+                           SET backend_turn_id = ?
+                         WHERE execution_id = ?
+                        """,
+                        (normalized_backend_turn_id, managed_turn_id),
+                    )
 
     def mark_turn_interrupted(self, managed_turn_id: str) -> bool:
         finished_at = now_iso()

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -37,6 +37,7 @@ from .text_utils import _coerce_int, _normalize_optional_text
 _LOGGER = logging.getLogger(__name__)
 _MANAGED_TURN_START_CONFIRMATION_TIMEOUT_SECONDS = 300
 _MANAGED_TURN_START_CONFIRMATION_RETRY_SECONDS = 5
+_RUNTIME_STARTED_AT_KEY = "runtime_started_at"
 
 
 def _require_text(value: Any, *, field_name: str) -> str:
@@ -275,7 +276,9 @@ def _resolve_notify_message(
             retry_after_seconds=_MANAGED_TURN_START_CONFIRMATION_RETRY_SECONDS,
         )
     turn_status = _normalize_optional_text(turn.get("status")) or "unknown"
-    if _normalize_optional_text(turn.get("backend_turn_id")) is not None:
+    metadata = _normalize_mapping(turn.get("metadata"))
+    runtime_started_at = _normalize_optional_text(metadata.get(_RUNTIME_STARTED_AT_KEY))
+    if runtime_started_at is not None:
         return _require_text(
             payload.get("message") or payload.get("body") or payload.get("text"),
             field_name="notify_chat message",
@@ -701,7 +704,9 @@ def _repair_scm_thread_binding(
 
 
 def build_enqueue_managed_turn_executor(
-    *, hub_root: Path, thread_store: Optional[PmaThreadStore] = None
+    *,
+    hub_root: Path,
+    thread_store: Optional[PmaThreadStore] = None,
 ) -> PublishActionExecutor:
     store = thread_store or PmaThreadStore(hub_root)
 

--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -19,6 +19,7 @@ from .pr_bindings import PrBinding
 from .publish_executor import PublishActionExecutor, PublishOperationProcessor
 from .publish_journal import PublishJournalStore, PublishOperation
 from .publish_operation_executors import (
+    _normalize_mapping,
     build_enqueue_managed_turn_executor,
     build_notify_chat_executor,
 )
@@ -366,10 +367,6 @@ def _tracking_from_payload(payload: Mapping[str, Any] | None) -> dict[str, Any]:
         return {}
     tracking = payload.get("scm_reaction")
     return dict(tracking) if isinstance(tracking, Mapping) else {}
-
-
-def _normalize_mapping(payload: object) -> dict[str, Any]:
-    return dict(payload) if isinstance(payload, Mapping) else {}
 
 
 def _operation_waiting_for_managed_turn_start(operation: PublishOperation) -> bool:

--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -63,6 +63,7 @@ _REVIEW_BADGE_RE = re.compile(r"!\s*(P\d+)\s+Badge\b", re.IGNORECASE)
 _REVIEW_HTML_TAG_RE = re.compile(
     r"</?(?:sub|sup|strong|b|em|i|code|br)\b[^>\n]*>", re.IGNORECASE
 )
+_SCM_PUBLISH_RETRY_DELAYS_SECONDS = (0.0, 10.0, 30.0, 60.0, 300.0)
 
 
 class ScmEventLookup(Protocol):
@@ -367,6 +368,35 @@ def _tracking_from_payload(payload: Mapping[str, Any] | None) -> dict[str, Any]:
     return dict(tracking) if isinstance(tracking, Mapping) else {}
 
 
+def _normalize_mapping(payload: object) -> dict[str, Any]:
+    return dict(payload) if isinstance(payload, Mapping) else {}
+
+
+def _operation_waiting_for_managed_turn_start(operation: PublishOperation) -> bool:
+    if operation.state != "pending" or operation.operation_kind != "notify_chat":
+        return False
+    payload = _normalize_mapping(operation.payload)
+    dependency = _normalize_mapping(payload.get("managed_turn_dependency"))
+    if (
+        _normalize_text(dependency.get("dependency_kind"))
+        != "enqueue_managed_turn_started"
+        and _normalize_text(payload.get("managed_turn_id")) is None
+    ):
+        return False
+    error_text = _normalize_text(operation.last_error_text)
+    if error_text is None or not error_text.startswith("RetryablePublishError: "):
+        return False
+    return any(
+        phrase in error_text
+        for phrase in (
+            "Waiting for enqueue_managed_turn to finish",
+            "Waiting for managed turn record to become visible",
+            "Waiting for managed turn start confirmation",
+            "Managed turn has not confirmed runtime start",
+        )
+    )
+
+
 def _ci_failed_head_sha_from_payload(
     payload: Mapping[str, Any] | None,
 ) -> Optional[str]:
@@ -427,6 +457,7 @@ def _default_publish_processor(
     return PublishOperationProcessor(
         journal,
         executors=executors,
+        retry_delays_seconds=_SCM_PUBLISH_RETRY_DELAYS_SECONDS,
         mutation_policy_config=raw_config,
     )
 
@@ -515,24 +546,21 @@ class ScmAutomationService:
         if not isinstance(self._journal, PublishJournalStore):
             return
         now = datetime.now(timezone.utc)
-        pending_kinds = ("enqueue_managed_turn", "notify_chat")
+        pending = self._journal.list_operations(
+            state="pending",
+            limit=500,
+        )
         earliest_future: Optional[datetime] = None
-        for operation_kind in pending_kinds:
-            pending = self._journal.list_operations(
-                state="pending",
-                operation_kind=operation_kind,
-                limit=500,
-            )
-            for op in pending:
-                if not op.next_attempt_at:
-                    continue
-                parsed = _parse_iso_datetime(op.next_attempt_at)
-                if parsed is None:
-                    continue
-                if parsed <= now:
-                    continue
-                if earliest_future is None or parsed < earliest_future:
-                    earliest_future = parsed
+        for op in pending:
+            if not op.next_attempt_at:
+                continue
+            parsed = _parse_iso_datetime(op.next_attempt_at)
+            if parsed is None:
+                continue
+            if parsed <= now:
+                continue
+            if earliest_future is None or parsed < earliest_future:
+                earliest_future = parsed
         if earliest_future is None:
             self._cancel_deferred_publish_drain()
             return
@@ -1133,6 +1161,11 @@ class ScmAutomationService:
                         operation_key=operation.operation_key,
                         metadata=tracking,
                     )
+                    continue
+                if (
+                    operation.state == "pending"
+                    and _operation_waiting_for_managed_turn_start(operation)
+                ):
                     continue
                 if operation.state not in {"failed", "pending"}:
                     continue

--- a/tests/core/orchestration/test_interfaces.py
+++ b/tests/core/orchestration/test_interfaces.py
@@ -144,8 +144,13 @@ class _FakeStore:
         return None
 
     def set_execution_backend_id(
-        self, execution_id: str, backend_turn_id: Optional[str]
+        self,
+        execution_id: str,
+        backend_turn_id: Optional[str],
+        *,
+        confirmed_start: bool = True,
     ) -> None:
+        _ = execution_id, backend_turn_id, confirmed_start
         return None
 
     def record_execution_result(

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -384,6 +384,7 @@ class _SerializedHubClient:
         self._store.set_execution_backend_id(
             request.execution_id,
             request.backend_turn_id,
+            confirmed_start=getattr(request, "confirmed_start", True),
         )
 
     async def record_thread_activity(self, request: Any) -> None:

--- a/tests/core/test_hub_control_plane_contract.py
+++ b/tests/core/test_hub_control_plane_contract.py
@@ -341,6 +341,7 @@ def test_execution_models_round_trip_with_existing_execution_record() -> None:
     assert backend_update.to_dict() == {
         "execution_id": "exec-2",
         "backend_turn_id": "backend-2",
+        "confirmed_start": True,
     }
 
 
@@ -515,6 +516,7 @@ async def test_http_client_uses_extended_timeout_for_backend_id_updates() -> Non
             "json": {
                 "execution_id": "exec-1",
                 "backend_turn_id": "turn-2",
+                "confirmed_start": True,
             },
             "params": None,
             "timeout": 30.0,

--- a/tests/core/test_publish_executor.py
+++ b/tests/core/test_publish_executor.py
@@ -1654,6 +1654,7 @@ def test_notify_chat_waits_for_managed_turn_start_confirmation(
         now_fn=_QueuedClock(
             "2026-03-25T00:00:00Z",
             "2026-03-25T00:00:05Z",
+            "2026-03-25T00:00:10Z",
         ),
     )
 
@@ -1666,14 +1667,28 @@ def test_notify_chat_waits_for_managed_turn_start_confirmation(
     enqueue_result = processed_by_id[enqueue_operation.operation_id].response
     thread_store.set_turn_backend_turn_id(
         enqueue_result["managed_turn_id"],
-        "backend-turn-1",
+        "backend-thread-1:1234567890",
+        confirmed_start=False,
     )
 
     second = processor.process_now(limit=10)
     assert [operation.operation_id for operation in second] == [
         notify_operation.operation_id
     ]
-    assert second[0].state == "succeeded"
+    assert second[0].state == "pending"
+    assert calls == []
+
+    thread_store.set_turn_backend_turn_id(
+        enqueue_result["managed_turn_id"],
+        "backend-turn-1",
+        confirmed_start=True,
+    )
+
+    third = processor.process_now(limit=10)
+    assert [operation.operation_id for operation in third] == [
+        notify_operation.operation_id
+    ]
+    assert third[0].state == "succeeded"
     assert calls == ["Started the latest PR review batch for acme/widgets#42."]
 
 
@@ -1768,7 +1783,11 @@ def test_notify_chat_uses_enqueue_thread_target_id_for_bound_delivery(
     assert replaced is not None
 
     managed_turn_id = replaced.response["managed_turn_id"]
-    thread_store.set_turn_backend_turn_id(managed_turn_id, "backend-turn-rebound")
+    thread_store.set_turn_backend_turn_id(
+        managed_turn_id,
+        "backend-turn-rebound",
+        confirmed_start=True,
+    )
 
     second = processor.process_now(limit=10)
     assert [operation.operation_id for operation in second] == [
@@ -1828,7 +1847,6 @@ def test_notify_chat_reports_failure_when_managed_turn_is_interrupted_before_sta
         "codex_autorunner.core.publish_operation_executors.notify_primary_pma_chat_for_repo",
         _fake_notify_primary_pma_chat_for_repo,
     )
-
     processor = PublishOperationProcessor(
         journal,
         executors=PublishExecutorRegistry(

--- a/tests/core/test_scm_automation_service.py
+++ b/tests/core/test_scm_automation_service.py
@@ -1282,6 +1282,78 @@ def test_ingest_event_creates_review_comment_notice_dependency(
     )
 
 
+def test_handle_processed_operations_skips_pending_notify_start_retries(
+    tmp_path: Path,
+) -> None:
+    class _TrackingReactionStateFake(_PermissiveReactionStateFake):
+        def __init__(self) -> None:
+            super().__init__()
+            self.failed_calls: list[tuple[str, str, str, Optional[str]]] = []
+
+        def mark_reaction_delivery_failed(
+            self,
+            *,
+            binding_id: str,
+            reaction_kind: str,
+            fingerprint: str,
+            event_id: Optional[str] = None,
+            error_text: Optional[str] = None,
+            metadata: Optional[dict] = None,
+        ) -> object:
+            _ = metadata
+            self.failed_calls.append(
+                (binding_id, reaction_kind, fingerprint, error_text)
+            )
+            return SimpleNamespace(escalated_at=None, delivery_failure_count=1)
+
+    reaction_state = _TrackingReactionStateFake()
+    service = ScmAutomationService(
+        tmp_path,
+        event_store=_EventStoreFake(),
+        binding_resolver=_BindingResolverFake(None),
+        reaction_router=_ReactionRouterFake([]),
+        reaction_state_store=reaction_state,
+        journal=_JournalFake(),
+        publish_processor=_ProcessorFake(processed=[]),
+    )
+    pending_notify = PublishOperation(
+        **{
+            **_operation(
+                operation_id="op-notify-pending",
+                operation_key="scm:notify-pending",
+                operation_kind="notify_chat",
+                state="pending",
+            ).to_dict(),
+            "payload": {
+                "scm_reaction": {
+                    "binding_id": "binding-1",
+                    "reaction_kind": "review_comment",
+                    "reaction_state_kind": "review_comment:notify_chat",
+                    "fingerprint": "fp-inline",
+                    "event_id": "github:event-inline-comment",
+                    "operation_kind": "notify_chat",
+                    "repo_slug": "acme/widgets",
+                    "pr_number": 42,
+                    "thread_target_id": "thread-123",
+                },
+                "managed_turn_dependency": {
+                    "dependency_kind": "enqueue_managed_turn_started",
+                    "operation_id": "op-enqueue-1",
+                    "thread_target_id": "thread-123",
+                },
+            },
+            "last_error_text": (
+                "RetryablePublishError: Waiting for managed turn start confirmation"
+            ),
+        }
+    )
+
+    follow_ups = service._handle_processed_operations([pending_notify])
+
+    assert follow_ups == []
+    assert reaction_state.failed_calls == []
+
+
 def test_handle_processed_operations_uses_reaction_state_kind_tracking_key(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_pma_thread_store.py
+++ b/tests/test_pma_thread_store.py
@@ -1057,6 +1057,34 @@ def test_mark_turn_finished_does_not_override_interrupted_status(
     assert thread_after["status_terminal"] is True
 
 
+def test_set_turn_backend_turn_id_tracks_confirmed_runtime_start(
+    tmp_path: Path,
+) -> None:
+    store = PmaThreadStore(tmp_path / "hub")
+    thread = store.create_thread("codex", tmp_path / "workspace")
+    turn = store.create_turn(thread["managed_thread_id"], prompt="hello")
+
+    store.set_turn_backend_turn_id(
+        turn["managed_turn_id"],
+        "backend-thread-1:1234567890",
+        confirmed_start=False,
+    )
+    provisional = store.get_turn(thread["managed_thread_id"], turn["managed_turn_id"])
+    assert provisional is not None
+    assert provisional["backend_turn_id"] == "backend-thread-1:1234567890"
+    assert provisional["metadata"].get("runtime_started_at") is None
+
+    store.set_turn_backend_turn_id(
+        turn["managed_turn_id"],
+        "backend-turn-1",
+        confirmed_start=True,
+    )
+    confirmed = store.get_turn(thread["managed_thread_id"], turn["managed_turn_id"])
+    assert confirmed is not None
+    assert confirmed["backend_turn_id"] == "backend-turn-1"
+    assert confirmed["metadata"].get("runtime_started_at")
+
+
 def test_concurrent_create_turn_admission_is_atomic(tmp_path: Path) -> None:
     hub_root = tmp_path / "hub"
     store_a = PmaThreadStore(hub_root)


### PR DESCRIPTION
Follow-up deep fix to #1627 (closed via symptom-fix #1635).

## Problem
#1635 reordered notify_chat to fire after enqueue_managed_turn confirms. This follow-up goes further: it distinguishes a provisional backend turn id from an execution that has actually started. A turn can still have a backend id assigned before runtime start is confirmed, so wake-up notifications must wait for confirmed_start metadata rather than backend_turn_id alone.

## Changes
- add `confirmed_start` to execution backend-id updates and plumb it through the hub control plane + orchestration interfaces
- write provisional backend ids with `confirmed_start=False`, then stamp `runtime_started_at` only when start is confirmed
- gate SCM notify_chat start confirmation on `runtime_started_at` instead of any backend turn id
- keep pending SCM wake-up notifications out of delivery-failure escalation while they are legitimately retrying
- add regression coverage for provisional ids, confirmed start tracking, and pending-notify retry handling

Closes #1627 (follow-up to #1635)