### PR TITLE
[codex] Fix PMA hygiene safe worktree purge

### DIFF
--- a/src/codex_autorunner/core/hub_worktree_manager.py
+++ b/src/codex_autorunner/core/hub_worktree_manager.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import json
 import logging
 import re
-import shutil
 import sqlite3
 import subprocess
+import sys
+import tempfile
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -723,15 +725,126 @@ class WorktreeManager:
         inspection = self._inspect_orphaned_worktree_dir(worktree_path)
         if inspection["status"] != "safe_to_remove":
             return inspection
-        if worktree_path.exists():
-            if worktree_path.is_dir():
-                shutil.rmtree(worktree_path)
-            else:
-                worktree_path.unlink()
-        return {
-            "status": "removed",
-            "message": "removed orphaned worktree directory",
+        return self._remove_path_cwd_safe(worktree_path)
+
+    def _remove_path_cwd_safe(self, target_path: Path) -> dict[str, object]:
+        resolved_target = target_path.expanduser().resolve()
+        script = """
+import json
+import shutil
+import sys
+from pathlib import Path
+
+
+def _path_size_bytes(path: Path) -> int:
+    if not path.exists():
+        return 0
+    if path.is_symlink() or path.is_file():
+        return path.lstat().st_size
+    total = 0
+    for child in path.rglob("*"):
+        try:
+            total += child.lstat().st_size
+        except FileNotFoundError:
+            continue
+    return total
+
+
+target = Path(sys.argv[1]).expanduser()
+bytes_before = _path_size_bytes(target)
+if not target.exists():
+    print(
+        json.dumps(
+            {
+                "status": "missing",
+                "message": "worktree directory already missing",
+                "bytes_before": bytes_before,
+            }
+        )
+    )
+    raise SystemExit(0)
+
+errors = []
+
+
+def _onerror(func, path, exc_info):
+    err = exc_info[1]
+    errors.append(f"{func.__name__}:{path}:{err}")
+
+
+if target.is_dir() and not target.is_symlink():
+    shutil.rmtree(target, onerror=_onerror)
+else:
+    target.unlink()
+
+if target.exists():
+    print(
+        json.dumps(
+            {
+                "status": "verification_failed",
+                "message": f"post-delete verification failed for {target}",
+                "bytes_before": bytes_before,
+                "errors": errors,
+            }
+        )
+    )
+    raise SystemExit(0)
+
+status = "removed" if not errors else "error"
+message = (
+    "removed orphaned worktree directory"
+    if not errors
+    else "; ".join(errors)
+)
+print(
+    json.dumps(
+        {
+            "status": status,
+            "message": message,
+            "bytes_before": bytes_before,
+            "errors": errors,
         }
+    )
+)
+"""
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", script, str(resolved_target)],
+                capture_output=True,
+                text=True,
+                check=False,
+                cwd=tempfile.gettempdir(),
+                env=subprocess_env(),
+                timeout=_GIT_WORKTREE_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return {
+                "status": "error",
+                "message": f"cwd-safe worktree removal failed: {exc}",
+            }
+        stdout = (proc.stdout or "").strip()
+        if proc.returncode != 0:
+            detail = (proc.stderr or stdout or "unknown error").strip()
+            return {
+                "status": "error",
+                "message": f"cwd-safe worktree removal failed: {detail}",
+            }
+        try:
+            payload = json.loads(stdout) if stdout else {}
+        except ValueError:
+            return {
+                "status": "error",
+                "message": (
+                    "cwd-safe worktree removal returned non-JSON output: "
+                    f"{stdout or '<empty>'}"
+                ),
+            }
+        if not isinstance(payload, dict):
+            return {
+                "status": "error",
+                "message": "cwd-safe worktree removal returned invalid payload",
+            }
+        return payload
 
     def _cleanup_orphaned_worktree_entry(
         self,
@@ -833,20 +946,33 @@ class WorktreeManager:
         force_archive: bool,
         force_attestation: Optional[Mapping[str, object]],
     ) -> ResolvedWorktreeEntry:
+        self._ctx.invalidate_cache()
+        resolved: Optional[ResolvedWorktreeEntry] = None
         if self._hub_config.pma.cleanup_require_archive and not archive:
-            raise ValueError(
-                "Worktree cleanup requires archiving per PMA policy "
-                "(pma.cleanup_require_archive is enabled). "
-                "Use archive=True or omit the --no-archive flag."
-            )
+            try:
+                resolved = self._resolve_worktree_entry(worktree_repo_id)
+            except ValueError as exc:
+                raise ValueError(
+                    "Worktree cleanup requires archiving per PMA policy "
+                    "(pma.cleanup_require_archive is enabled). "
+                    "Use archive=True or omit the --no-archive flag."
+                ) from exc
+            worktree_path = resolved.worktree_path
+            archive_possible = worktree_path.exists() and git_available(worktree_path)
+            if archive_possible:
+                raise ValueError(
+                    "Worktree cleanup requires archiving per PMA policy "
+                    "(pma.cleanup_require_archive is enabled). "
+                    "Use archive=True or omit the --no-archive flag."
+                )
+        if resolved is None:
+            resolved = self._resolve_worktree_entry(worktree_repo_id)
         enforce_force_attestation(
             force=force or force_archive,
             force_attestation=force_attestation,
             logger=logger,
             action="hub.cleanup_worktree",
         )
-        self._ctx.invalidate_cache()
-        resolved = self._resolve_worktree_entry(worktree_repo_id)
         branch_name = resolved.entry.branch or "unknown"
         try:
             has_active_chat_binding = self._has_active_chat_binding(worktree_repo_id)
@@ -977,6 +1103,8 @@ class WorktreeManager:
                 else str(orphan_dir_cleanup.get("message") or "")
             ),
         )
+        if orphan_dir_status not in {"removed", "missing"}:
+            raise ValueError(str(orphan_dir_cleanup.get("message") or ""))
 
         resolved.manifest.repos = [
             r for r in resolved.manifest.repos if r.id != worktree_repo_id

--- a/src/codex_autorunner/core/hub_worktree_manager.py
+++ b/src/codex_autorunner/core/hub_worktree_manager.py
@@ -78,6 +78,24 @@ _DOCKER_STOP_TIMEOUT_SECONDS = 15
 _DOCKER_RM_TIMEOUT_SECONDS = 30
 _WORKTREE_SETUP_COMMAND_TIMEOUT_SECONDS = 600
 
+_WORKTREE_CAR_METADATA_DIR_NAMES = frozenset({".codex-autorunner", ".git"})
+
+
+def worktree_non_metadata_child_names(worktree_path: Path) -> list[str]:
+    """Return sorted child names under a worktree path excluding CAR metadata dirs.
+
+    Used for consistent eligibility checks between hygiene classification and
+    orphaned worktree cleanup. Returns an empty list when the path is missing
+    or not a directory.
+    """
+    if not worktree_path.exists() or not worktree_path.is_dir():
+        return []
+    return [
+        child.name
+        for child in sorted(worktree_path.iterdir(), key=lambda item: item.name)
+        if child.name not in _WORKTREE_CAR_METADATA_DIR_NAMES
+    ]
+
 
 class WorktreeManager:
     def __init__(
@@ -699,11 +717,7 @@ class WorktreeManager:
                 "message": "worktree path is not a directory",
             }
 
-        unexpected_entries: list[str] = []
-        for child in sorted(worktree_path.iterdir(), key=lambda item: item.name):
-            if child.name in {".codex-autorunner", ".git"}:
-                continue
-            unexpected_entries.append(child.name)
+        unexpected_entries = worktree_non_metadata_child_names(worktree_path)
 
         if unexpected_entries:
             rendered = ", ".join(unexpected_entries[:5])
@@ -1104,7 +1118,12 @@ print(
             ),
         )
         if orphan_dir_status not in {"removed", "missing"}:
-            raise ValueError(str(orphan_dir_cleanup.get("message") or ""))
+            detail = str(orphan_dir_cleanup.get("message") or "").strip()
+            if detail:
+                raise ValueError(f"{orphan_dir_status}: {detail}")
+            raise ValueError(
+                f"worktree directory cleanup did not complete (status={orphan_dir_status})"
+            )
 
         resolved.manifest.repos = [
             r for r in resolved.manifest.repos if r.id != worktree_repo_id

--- a/src/codex_autorunner/core/hub_worktree_manager.py
+++ b/src/codex_autorunner/core/hub_worktree_manager.py
@@ -888,7 +888,15 @@ print(
             worktree_repo_id=entry.id,
             worktree_path=worktree_path,
         )
-        self._remove_orphaned_worktree_dir(worktree_path)
+        orphan = self._remove_orphaned_worktree_dir(worktree_path)
+        orphan_status = str(orphan.get("status", "unknown"))
+        if orphan_status not in {"removed", "missing"}:
+            detail = str(orphan.get("message") or "").strip()
+            if detail:
+                raise ValueError(f"{orphan_status}: {detail}")
+            raise ValueError(
+                f"{orphan_status}: orphaned worktree directory cleanup did not complete"
+            )
 
         manifest = self._topology_repository.load_manifest()
         manifest.repos = [repo for repo in manifest.repos if repo.id != entry.id]

--- a/src/codex_autorunner/core/pma_hygiene.py
+++ b/src/codex_autorunner/core/pma_hygiene.py
@@ -13,11 +13,14 @@ from __future__ import annotations
 
 from collections import Counter
 from pathlib import Path
-from typing import Any, Iterable, Optional, Sequence
+from typing import Any, Callable, Iterable, Optional, Sequence
 
+from ..manifest import load_manifest
+from .chat_bindings import repo_has_active_non_pma_chat_binding
 from .config import load_hub_config
 from .filebox import delete_file, list_filebox
 from .freshness import build_freshness_payload, iso_now, resolve_stale_threshold_seconds
+from .git_utils import git_available, git_is_clean
 from .orchestration.bindings import OrchestrationBindingStore
 from .pma_automation_store import PmaAutomationStore
 from .pma_dispatches import list_pma_dispatches
@@ -183,6 +186,8 @@ def _build_thread_candidates(
     stale_threshold_seconds: int,
 ) -> list[dict[str, Any]]:
     try:
+        config = load_hub_config(hub_root)
+        manifest = load_manifest(config.manifest_path, hub_root)
         store = PmaThreadStore(hub_root)
         threads = store.list_threads(limit=500)
         busy_ids = set(store.list_thread_ids_with_running_executions(limit=None))
@@ -194,6 +199,7 @@ def _build_thread_candidates(
         return []
 
     candidates: list[dict[str, Any]] = []
+    worktree_candidates: dict[str, dict[str, Any]] = {}
     for thread in threads:
         managed_thread_id = str(thread.get("managed_thread_id") or "").strip()
         if not managed_thread_id:
@@ -229,6 +235,48 @@ def _build_thread_candidates(
         )
         has_binding = bool(bindings)
         has_busy_work = managed_thread_id in busy_ids
+        workspace_text = str(thread.get("workspace_root") or "").strip()
+        worktree_repo_id = str(thread.get("repo_id") or "").strip()
+        worktree_entry = manifest.get(worktree_repo_id) if worktree_repo_id else None
+        if (
+            worktree_entry is not None
+            and getattr(worktree_entry, "kind", None) == "worktree"
+        ):
+            worktree_path = (hub_root / worktree_entry.path).resolve()
+            repo_chat_bound = repo_has_active_non_pma_chat_binding(
+                hub_root=hub_root,
+                raw_config=config.raw,
+                repo_id=worktree_repo_id,
+            )
+            state = worktree_candidates.setdefault(
+                worktree_repo_id,
+                {
+                    "repo_id": worktree_repo_id,
+                    "branch": worktree_entry.branch,
+                    "path": str(worktree_path),
+                    "thread_ids": [],
+                    "thread_count": 0,
+                    "all_idle_archive_candidates": True,
+                    "has_active_thread_binding": False,
+                    "has_busy_work": False,
+                    "chat_bound": repo_chat_bound,
+                },
+            )
+            state["thread_ids"].append(managed_thread_id)
+            state["thread_count"] += 1
+            state["has_active_thread_binding"] = (
+                bool(state["has_active_thread_binding"]) or has_binding
+            )
+            state["has_busy_work"] = bool(state["has_busy_work"]) or has_busy_work
+            followup = classify_thread_followup(
+                {**thread, "status": normalized_status or lifecycle_status},
+                is_stale=freshness.get("is_stale") is True,
+                is_chat_bound=repo_chat_bound,
+            )
+            if str(followup.get("followup_state") or "") != "idle_archive_candidate":
+                state["all_idle_archive_candidates"] = False
+            continue
+
         is_protected = is_thread_cleanup_protected(
             has_binding=has_binding,
             has_busy_work=has_busy_work,
@@ -265,8 +313,72 @@ def _build_thread_candidates(
                     "repo_id": thread.get("repo_id"),
                     "resource_kind": thread.get("resource_kind"),
                     "resource_id": thread.get("resource_id"),
+                    "workspace_root": workspace_text or None,
                 },
                 target={"managed_thread_id": managed_thread_id},
+            )
+        )
+    for worktree_repo_id, state in worktree_candidates.items():
+        if not bool(state["all_idle_archive_candidates"]):
+            continue
+        path = Path(str(state["path"]))
+        group = "safe"
+        reason = "Dormant worktree has only stale managed threads and is safe to purge."
+        archive_requested = False
+        if bool(state["chat_bound"]):
+            group = "protected"
+            reason = (
+                "Chat-bound worktree is protected from cleanup without explicit force."
+            )
+        elif bool(state["has_active_thread_binding"]) or bool(state["has_busy_work"]):
+            group = "protected"
+            reason = "Managed thread still has an active binding or work in flight."
+        elif path.exists() and git_available(path):
+            archive_requested = True
+            try:
+                if not git_is_clean(path):
+                    group = "needs-confirmation"
+                    reason = "Dormant worktree still has uncommitted changes; review before purge."
+            except OSError:
+                group = "needs-confirmation"
+                reason = "Unable to verify worktree cleanliness; review before purge."
+        elif path.exists() and path.is_dir():
+            unexpected_entries = [
+                child.name
+                for child in sorted(path.iterdir(), key=lambda item: item.name)
+                if child.name not in {".codex-autorunner", ".git"}
+            ]
+            if unexpected_entries:
+                rendered = ", ".join(unexpected_entries[:5])
+                if len(unexpected_entries) > 5:
+                    rendered = f"{rendered}, ..."
+                group = "needs-confirmation"
+                reason = (
+                    "Worktree is no longer a git checkout but still has non-CAR files: "
+                    f"{rendered}"
+                )
+        candidates.append(
+            _build_candidate(
+                group=group,
+                category="threads",
+                candidate_id=f"threads:worktree:{worktree_repo_id}",
+                label=worktree_repo_id,
+                action="purge_worktree",
+                reason=reason,
+                path=str(path),
+                evidence={
+                    "branch": state.get("branch"),
+                    "thread_count": state.get("thread_count"),
+                    "managed_thread_ids": list(state.get("thread_ids") or []),
+                    "has_active_thread_binding": state.get("has_active_thread_binding"),
+                    "has_busy_work": state.get("has_busy_work"),
+                    "chat_bound": state.get("chat_bound"),
+                    "archive_requested": archive_requested,
+                },
+                target={
+                    "worktree_repo_id": worktree_repo_id,
+                    "archive_requested": archive_requested,
+                },
             )
         )
     return candidates
@@ -517,7 +629,8 @@ def _is_reviewed_thread_cleanup_candidate(item: dict[str, Any]) -> bool:
     return (
         str(item.get("group") or "") == "needs-confirmation"
         and str(item.get("category") or "") == "threads"
-        and str(item.get("action") or "") == "archive_managed_thread"
+        and str(item.get("action") or "")
+        in {"archive_managed_thread", "purge_worktree"}
     )
 
 
@@ -607,6 +720,7 @@ def apply_pma_hygiene_report(
     report: dict[str, Any],
     *,
     include_needs_confirmation: bool = False,
+    cleanup_worktree: Optional[Callable[[str, bool], dict[str, Any]]] = None,
 ) -> dict[str, Any]:
     selected_items = _collect_hygiene_apply_items(
         report, include_needs_confirmation=include_needs_confirmation
@@ -676,6 +790,14 @@ def apply_pma_hygiene_report(
                         f"Managed thread cleanup no longer safe: {blocked_reason}"
                     )
                 thread_store.archive_thread(managed_thread_id)
+                ok = True
+            elif action == "purge_worktree":
+                if cleanup_worktree is None:
+                    raise RuntimeError("Worktree cleanup callback not configured")
+                cleanup_worktree(
+                    str(target.get("worktree_repo_id") or ""),
+                    bool(target.get("archive_requested")),
+                )
                 ok = True
         except (
             Exception

--- a/src/codex_autorunner/core/pma_hygiene.py
+++ b/src/codex_autorunner/core/pma_hygiene.py
@@ -21,6 +21,7 @@ from .config import load_hub_config
 from .filebox import delete_file, list_filebox
 from .freshness import build_freshness_payload, iso_now, resolve_stale_threshold_seconds
 from .git_utils import git_available, git_is_clean
+from .hub_worktree_manager import worktree_non_metadata_child_names
 from .orchestration.bindings import OrchestrationBindingStore
 from .pma_automation_store import PmaAutomationStore
 from .pma_dispatches import list_pma_dispatches
@@ -187,6 +188,10 @@ def _build_thread_candidates(
 ) -> list[dict[str, Any]]:
     try:
         config = load_hub_config(hub_root)
+        pma_cfg = getattr(config, "pma", None)
+        cleanup_require_archive = bool(
+            getattr(pma_cfg, "cleanup_require_archive", True)
+        )
         manifest = load_manifest(config.manifest_path, hub_root)
         store = PmaThreadStore(hub_root)
         threads = store.list_threads(limit=500)
@@ -319,7 +324,11 @@ def _build_thread_candidates(
             )
         )
     for worktree_repo_id, state in worktree_candidates.items():
-        if not bool(state["all_idle_archive_candidates"]):
+        if not bool(state["all_idle_archive_candidates"]) and not (
+            bool(state["chat_bound"])
+            or bool(state["has_active_thread_binding"])
+            or bool(state["has_busy_work"])
+        ):
             continue
         path = Path(str(state["path"]))
         group = "safe"
@@ -334,7 +343,7 @@ def _build_thread_candidates(
             group = "protected"
             reason = "Managed thread still has an active binding or work in flight."
         elif path.exists() and git_available(path):
-            archive_requested = True
+            archive_requested = cleanup_require_archive
             try:
                 if not git_is_clean(path):
                     group = "needs-confirmation"
@@ -343,11 +352,7 @@ def _build_thread_candidates(
                 group = "needs-confirmation"
                 reason = "Unable to verify worktree cleanliness; review before purge."
         elif path.exists() and path.is_dir():
-            unexpected_entries = [
-                child.name
-                for child in sorted(path.iterdir(), key=lambda item: item.name)
-                if child.name not in {".codex-autorunner", ".git"}
-            ]
+            unexpected_entries = worktree_non_metadata_child_names(path)
             if unexpected_entries:
                 rendered = ", ".join(unexpected_entries[:5])
                 if len(unexpected_entries) > 5:
@@ -794,11 +799,24 @@ def apply_pma_hygiene_report(
             elif action == "purge_worktree":
                 if cleanup_worktree is None:
                     raise RuntimeError("Worktree cleanup callback not configured")
-                cleanup_worktree(
+                cleanup_result = cleanup_worktree(
                     str(target.get("worktree_repo_id") or ""),
                     bool(target.get("archive_requested")),
                 )
-                ok = True
+                if isinstance(cleanup_result, dict):
+                    status = str(cleanup_result.get("status") or "").strip().lower()
+                    if status in {"error", "failed"}:
+                        ok = False
+                        msg = str(cleanup_result.get("message") or "").strip()
+                        error = msg or status or "worktree cleanup failed"
+                    elif status in {"ok", "success", "applied", ""}:
+                        ok = True
+                    else:
+                        ok = False
+                        msg = str(cleanup_result.get("message") or "").strip()
+                        error = msg or f"unexpected worktree cleanup status: {status}"
+                else:
+                    ok = True
         except (
             Exception
         ) as exc:  # intentional: multi-action apply; records per-item failure

--- a/src/codex_autorunner/core/pma_hygiene.py
+++ b/src/codex_autorunner/core/pma_hygiene.py
@@ -204,6 +204,7 @@ def _build_thread_candidates(
         return []
 
     candidates: list[dict[str, Any]] = []
+    worktree_non_stale_active: set[str] = set()
     worktree_candidates: dict[str, dict[str, Any]] = {}
     for thread in threads:
         managed_thread_id = str(thread.get("managed_thread_id") or "").strip()
@@ -221,7 +222,17 @@ def _build_thread_candidates(
                 ("thread_updated_at", thread.get("updated_at")),
             ],
         )
+        worktree_repo_id_early = str(thread.get("repo_id") or "").strip()
+        worktree_entry_early = (
+            manifest.get(worktree_repo_id_early) if worktree_repo_id_early else None
+        )
+        is_worktree_backed = (
+            worktree_entry_early is not None
+            and getattr(worktree_entry_early, "kind", None) == "worktree"
+        )
         if freshness.get("is_stale") is not True:
+            if is_worktree_backed and worktree_repo_id_early:
+                worktree_non_stale_active.add(worktree_repo_id_early)
             continue
         try:
             bindings = binding_store.list_bindings(
@@ -324,16 +335,22 @@ def _build_thread_candidates(
             )
         )
     for worktree_repo_id, state in worktree_candidates.items():
-        if not bool(state["all_idle_archive_candidates"]) and not (
-            bool(state["chat_bound"])
-            or bool(state["has_active_thread_binding"])
-            or bool(state["has_busy_work"])
-        ):
-            continue
         path = Path(str(state["path"]))
         group = "safe"
         reason = "Dormant worktree has only stale managed threads and is safe to purge."
         archive_requested = False
+        if worktree_repo_id in worktree_non_stale_active:
+            group = "protected"
+            reason = (
+                "Worktree still has at least one non-stale active managed thread; "
+                "purge is blocked until all threads in this repo are stale or archived."
+            )
+        elif not bool(state["all_idle_archive_candidates"]):
+            group = "needs-confirmation"
+            reason = (
+                "Not all stale threads on this worktree are idle archive candidates; "
+                "review before purging the entire worktree."
+            )
         if bool(state["chat_bound"]):
             group = "protected"
             reason = (
@@ -816,7 +833,9 @@ def apply_pma_hygiene_report(
                         msg = str(cleanup_result.get("message") or "").strip()
                         error = msg or f"unexpected worktree cleanup status: {status}"
                 else:
-                    ok = True
+                    raise ValueError(
+                        "Worktree cleanup callback must return a dict with a status field"
+                    )
         except (
             Exception
         ) as exc:  # intentional: multi-action apply; records per-item failure

--- a/src/codex_autorunner/surfaces/cli/pma_cli.py
+++ b/src/codex_autorunner/surfaces/cli/pma_cli.py
@@ -18,6 +18,7 @@ from ...core.pma_hygiene import (
     hygiene_lock_path,
     render_pma_hygiene_report,
 )
+from .commands.utils import build_hub_supervisor
 from .hub_path_option import hub_root_path_option
 from .pma_binding_commands import register_binding_commands
 from .pma_context_commands import register_context_commands
@@ -432,7 +433,7 @@ def pma_hygiene(
         "--include-needs-confirmation",
         "--force-non-safe",
         help=(
-            "Also apply reviewed needs-confirmation managed-thread cleanup candidates."
+            "Also apply reviewed needs-confirmation managed-thread/worktree cleanup candidates."
         ),
     ),
     summary: bool = typer.Option(
@@ -452,6 +453,17 @@ def pma_hygiene(
     """Review PMA hygiene candidates and optionally clean only the safe ones."""
     hub_root = resolve_hub_path(path)
     apply_result: Optional[dict[str, Any]] = None
+    supervisor = None
+
+    def _cleanup_worktree(worktree_repo_id: str, archive: bool) -> dict[str, Any]:
+        nonlocal supervisor
+        if supervisor is None:
+            supervisor = build_hub_supervisor(load_hub_config(hub_root))
+        return supervisor.cleanup_worktree(
+            worktree_repo_id=worktree_repo_id,
+            archive=archive,
+        )
+
     try:
         lock_ctx = file_lock(hygiene_lock_path(hub_root)) if apply else nullcontext()
         with lock_ctx:
@@ -465,6 +477,7 @@ def pma_hygiene(
                     hub_root,
                     report,
                     include_needs_confirmation=include_needs_confirmation,
+                    cleanup_worktree=_cleanup_worktree,
                 )
     except ValueError as exc:
         typer.echo(str(exc), err=True)

--- a/tests/core/test_pma_hygiene.py
+++ b/tests/core/test_pma_hygiene.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+import json
 import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from typer.testing import CliRunner
 
+from codex_autorunner.core.config import (
+    CONFIG_FILENAME,
+    DEFAULT_HUB_CONFIG,
+    load_hub_config,
+)
 from codex_autorunner.core.filebox import ensure_structure, inbox_dir
+from codex_autorunner.core.git_utils import run_git
+from codex_autorunner.core.hub import HubSupervisor
 from codex_autorunner.core.orchestration.bindings import OrchestrationBindingStore
 from codex_autorunner.core.pma_automation_store import PmaAutomationStore
 from codex_autorunner.core.pma_dispatches import ensure_pma_dispatches_dir
@@ -15,7 +23,16 @@ from codex_autorunner.core.pma_hygiene import (
     build_pma_hygiene_report,
 )
 from codex_autorunner.core.pma_thread_store import PmaThreadStore
+from codex_autorunner.integrations.agents.backend_orchestrator import (
+    build_backend_orchestrator,
+)
+from codex_autorunner.integrations.agents.wiring import (
+    build_agent_backend_factory,
+    build_app_server_supervisor_factory,
+)
+from codex_autorunner.manifest import load_manifest
 from codex_autorunner.surfaces.cli.pma_cli import pma_app
+from tests.conftest import write_test_config
 
 
 def _iso(dt: datetime) -> str:
@@ -72,6 +89,37 @@ def _reviewed_thread_cleanup_report(managed_thread_id: str) -> dict[str, object]
             ],
         }
     }
+
+
+def _init_git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    run_git(["init"], path, check=True)
+    (path / "README.md").write_text("hello\n", encoding="utf-8")
+    run_git(["add", "README.md"], path, check=True)
+    run_git(
+        [
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            "init",
+        ],
+        path,
+        check=True,
+    )
+
+
+def _build_supervisor(hub_root: Path) -> HubSupervisor:
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+    return HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
 
 
 def test_build_pma_hygiene_report_groups_candidates(hub_env) -> None:
@@ -364,6 +412,132 @@ def test_apply_pma_hygiene_report_revalidates_reviewed_thread_lifecycle(
         == "Managed thread cleanup no longer safe: managed thread lifecycle is archived"
     )
     assert thread_store.get_thread(managed_thread_id)["lifecycle_status"] == "archived"
+
+
+def test_build_pma_hygiene_report_marks_clean_stale_worktree_safe(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    supervisor = _build_supervisor(hub_root)
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/stale-clean-worktree",
+        start_point="HEAD",
+    )
+    PmaThreadStore(hub_root).create_thread(
+        "codex",
+        worktree.path,
+        repo_id=worktree.id,
+        name="stale-clean-thread",
+    )
+
+    now = datetime.now(timezone.utc)
+    report = build_pma_hygiene_report(
+        hub_root,
+        categories=["threads"],
+        generated_at=_iso(now + timedelta(hours=2)),
+        stale_threshold_seconds=60,
+    )
+
+    safe_items = [item for item in report["groups"]["safe"] if isinstance(item, dict)]
+    assert {item["candidate_id"] for item in safe_items} == {
+        f"threads:worktree:{worktree.id}"
+    }
+    assert safe_items[0]["action"] == "purge_worktree"
+    assert safe_items[0]["target"]["archive_requested"] is True
+
+
+def test_build_pma_hygiene_report_marks_dirty_stale_worktree_needs_confirmation(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    supervisor = _build_supervisor(hub_root)
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/stale-dirty-worktree",
+        start_point="HEAD",
+    )
+    PmaThreadStore(hub_root).create_thread(
+        "codex",
+        worktree.path,
+        repo_id=worktree.id,
+        name="stale-dirty-thread",
+    )
+    (worktree.path / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+
+    now = datetime.now(timezone.utc)
+    report = build_pma_hygiene_report(
+        hub_root,
+        categories=["threads"],
+        generated_at=_iso(now + timedelta(hours=2)),
+        stale_threshold_seconds=60,
+    )
+
+    needs_confirmation = [
+        item
+        for item in report["groups"]["needs-confirmation"]
+        if isinstance(item, dict)
+    ]
+    assert {item["candidate_id"] for item in needs_confirmation} == {
+        f"threads:worktree:{worktree.id}"
+    }
+    assert needs_confirmation[0]["action"] == "purge_worktree"
+
+
+def test_apply_pma_hygiene_report_purges_safe_worktree_candidate(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    supervisor = _build_supervisor(hub_root)
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/purge-safe-worktree",
+        start_point="HEAD",
+    )
+    thread_store = PmaThreadStore(hub_root)
+    created = thread_store.create_thread(
+        "codex",
+        worktree.path,
+        repo_id=worktree.id,
+        name="safe-worktree-thread",
+    )
+
+    now = datetime.now(timezone.utc)
+    report = build_pma_hygiene_report(
+        hub_root,
+        categories=["threads"],
+        generated_at=_iso(now + timedelta(hours=2)),
+        stale_threshold_seconds=60,
+    )
+    apply_result = apply_pma_hygiene_report(
+        hub_root,
+        report,
+        cleanup_worktree=lambda repo_id, archive: supervisor.cleanup_worktree(
+            worktree_repo_id=repo_id,
+            archive=archive,
+        ),
+    )
+
+    assert apply_result["attempted"] == 1
+    assert apply_result["applied"] == 1
+    assert apply_result["failed"] == 0
+    assert not worktree.path.exists()
+    assert (
+        load_manifest(
+            load_hub_config(hub_root).manifest_path,
+            hub_root,
+        ).get(worktree.id)
+        is None
+    )
+    assert thread_store.get_thread(created["managed_thread_id"])[
+        "lifecycle_status"
+    ] == ("archived")
 
 
 def test_build_pma_hygiene_report_canonicalizes_category_order(hub_env) -> None:

--- a/tests/core/test_pma_hygiene.py
+++ b/tests/core/test_pma_hygiene.py
@@ -16,6 +16,7 @@ from codex_autorunner.core.filebox import ensure_structure, inbox_dir
 from codex_autorunner.core.git_utils import run_git
 from codex_autorunner.core.hub import HubSupervisor
 from codex_autorunner.core.orchestration.bindings import OrchestrationBindingStore
+from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.pma_automation_store import PmaAutomationStore
 from codex_autorunner.core.pma_dispatches import ensure_pma_dispatches_dir
 from codex_autorunner.core.pma_hygiene import (
@@ -412,6 +413,154 @@ def test_apply_pma_hygiene_report_revalidates_reviewed_thread_lifecycle(
         == "Managed thread cleanup no longer safe: managed thread lifecycle is archived"
     )
     assert thread_store.get_thread(managed_thread_id)["lifecycle_status"] == "archived"
+
+
+def _bump_thread_status_timestamps(
+    hub_root: Path, managed_thread_id: str, when: datetime
+) -> None:
+    ts = _iso(when)
+    with open_orchestration_sqlite(hub_root, durable=False) as conn:
+        conn.execute(
+            """
+            UPDATE orch_thread_targets
+               SET status_updated_at = ?,
+                   updated_at = ?
+             WHERE thread_target_id = ?
+            """,
+            (ts, ts, managed_thread_id),
+        )
+        conn.commit()
+
+
+def test_build_pma_hygiene_report_blocks_worktree_purge_when_repo_has_fresh_thread(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    supervisor = _build_supervisor(hub_root)
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/mixed-fresh-stale",
+        start_point="HEAD",
+    )
+    store = PmaThreadStore(hub_root)
+    stale_thread = store.create_thread(
+        "codex",
+        worktree.path,
+        repo_id=worktree.id,
+        name="stale-only",
+    )
+    store.create_thread(
+        "codex",
+        worktree.path,
+        repo_id=worktree.id,
+        name="still-fresh",
+    )
+    now = datetime.now(timezone.utc)
+    _bump_thread_status_timestamps(
+        hub_root, stale_thread["managed_thread_id"], now - timedelta(hours=2)
+    )
+    # Keep the second thread recent so only one thread is stale for this report.
+    with open_orchestration_sqlite(hub_root, durable=False) as conn:
+        cur = conn.execute(
+            """
+            SELECT thread_target_id
+              FROM orch_thread_targets
+             WHERE display_name = 'still-fresh'
+            """
+        )
+        row = cur.fetchone()
+        assert row is not None
+        _bump_thread_status_timestamps(
+            hub_root, str(row[0]), now - timedelta(seconds=30)
+        )
+
+    report = build_pma_hygiene_report(
+        hub_root,
+        categories=["threads"],
+        generated_at=_iso(now),
+        stale_threshold_seconds=60,
+    )
+    protected = [
+        item
+        for item in report["groups"]["protected"]
+        if isinstance(item, dict)
+        and item.get("candidate_id") == f"threads:worktree:{worktree.id}"
+    ]
+    assert len(protected) == 1
+    assert "non-stale" in str(protected[0].get("reason") or "").lower()
+
+
+def test_build_pma_hygiene_report_marks_mixed_idle_followup_stale_worktree_needs_confirmation(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    supervisor = _build_supervisor(hub_root)
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/mixed-followup-states",
+        start_point="HEAD",
+    )
+    store = PmaThreadStore(hub_root)
+    idleish = store.create_thread(
+        "codex",
+        worktree.path,
+        repo_id=worktree.id,
+        name="idleish",
+    )
+    failedish = store.create_thread(
+        "codex",
+        worktree.path,
+        repo_id=worktree.id,
+        name="failedish",
+    )
+    now = datetime.now(timezone.utc)
+    old = now - timedelta(hours=2)
+    ts = _iso(old)
+    with open_orchestration_sqlite(hub_root, durable=False) as conn:
+        conn.execute(
+            """
+            UPDATE orch_thread_targets
+               SET status_updated_at = ?,
+                   updated_at = ?
+             WHERE thread_target_id = ?
+            """,
+            (ts, ts, idleish["managed_thread_id"]),
+        )
+        conn.execute(
+            """
+            UPDATE orch_thread_targets
+               SET runtime_status = 'failed',
+                   status_reason = 'test',
+                   status_updated_at = ?,
+                   updated_at = ?,
+                   status_terminal = 0
+             WHERE thread_target_id = ?
+            """,
+            (ts, ts, failedish["managed_thread_id"]),
+        )
+        conn.commit()
+
+    report = build_pma_hygiene_report(
+        hub_root,
+        categories=["threads"],
+        generated_at=_iso(now + timedelta(hours=2)),
+        stale_threshold_seconds=60,
+    )
+    needs_confirmation = [
+        item
+        for item in report["groups"]["needs-confirmation"]
+        if isinstance(item, dict)
+        and item.get("candidate_id") == f"threads:worktree:{worktree.id}"
+    ]
+    assert len(needs_confirmation) == 1
+    assert (
+        "not all stale threads"
+        in str(needs_confirmation[0].get("reason") or "").lower()
+    )
 
 
 def test_build_pma_hygiene_report_marks_clean_stale_worktree_safe(

--- a/tests/core/test_pma_hygiene.py
+++ b/tests/core/test_pma_hygiene.py
@@ -449,6 +449,127 @@ def test_build_pma_hygiene_report_marks_clean_stale_worktree_safe(
     assert safe_items[0]["target"]["archive_requested"] is True
 
 
+def test_build_pma_hygiene_report_respects_cleanup_require_archive_false(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    supervisor = _build_supervisor(hub_root)
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg.setdefault("pma", {})["cleanup_require_archive"] = False
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/no-archive-policy",
+        start_point="HEAD",
+    )
+    PmaThreadStore(hub_root).create_thread(
+        "codex",
+        worktree.path,
+        repo_id=worktree.id,
+        name="stale-thread",
+    )
+
+    now = datetime.now(timezone.utc)
+    report = build_pma_hygiene_report(
+        hub_root,
+        categories=["threads"],
+        generated_at=_iso(now + timedelta(hours=2)),
+        stale_threshold_seconds=60,
+    )
+    safe_items = [item for item in report["groups"]["safe"] if isinstance(item, dict)]
+    assert {item["candidate_id"] for item in safe_items} == {
+        f"threads:worktree:{worktree.id}"
+    }
+    assert safe_items[0]["target"]["archive_requested"] is False
+
+
+def test_build_pma_hygiene_report_includes_chat_bound_stale_worktree_as_protected(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    supervisor = _build_supervisor(hub_root)
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/chat-bound-worktree",
+        start_point="HEAD",
+    )
+    PmaThreadStore(hub_root).create_thread(
+        "codex",
+        worktree.path,
+        repo_id=worktree.id,
+        name="stale-chat-bound",
+    )
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.pma_hygiene.repo_has_active_non_pma_chat_binding",
+        lambda **kwargs: True,
+    )
+
+    now = datetime.now(timezone.utc)
+    report = build_pma_hygiene_report(
+        hub_root,
+        categories=["threads"],
+        generated_at=_iso(now + timedelta(hours=2)),
+        stale_threshold_seconds=60,
+    )
+    protected = [
+        item
+        for item in report["groups"]["protected"]
+        if isinstance(item, dict)
+        and item.get("candidate_id") == f"threads:worktree:{worktree.id}"
+    ]
+    assert len(protected) == 1
+    assert "Chat-bound worktree" in str(protected[0].get("reason") or "")
+
+
+def test_apply_pma_hygiene_report_purge_worktree_fails_on_error_status_payload(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    report = {
+        "groups": {
+            "safe": [
+                {
+                    "candidate_id": "threads:worktree:wt-1",
+                    "group": "safe",
+                    "category": "threads",
+                    "label": "wt-1",
+                    "action": "purge_worktree",
+                    "reason": "test",
+                    "target": {
+                        "worktree_repo_id": "wt-1",
+                        "archive_requested": False,
+                    },
+                }
+            ],
+            "protected": [],
+            "needs-confirmation": [],
+        }
+    }
+
+    def _fake_cleanup(_repo_id: str, _archive: bool) -> dict[str, object]:
+        return {"status": "error", "message": "cleanup refused"}
+
+    apply_result = apply_pma_hygiene_report(
+        hub_root, report, cleanup_worktree=_fake_cleanup
+    )
+    assert apply_result["applied"] == 0
+    assert apply_result["failed"] == 1
+    assert apply_result["results"][0]["status"] == "failed"
+    assert apply_result["results"][0]["error"] == "cleanup refused"
+
+
 def test_build_pma_hygiene_report_marks_dirty_stale_worktree_needs_confirmation(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -4,6 +4,8 @@ import json
 import shutil
 import sqlite3
 import subprocess
+import sys
+import tempfile
 import types
 from pathlib import Path
 from typing import Optional
@@ -3139,6 +3141,60 @@ def test_cleanup_worktree_removes_leftover_car_state_directory(
     supervisor.cleanup_worktree(worktree_repo_id=worktree.id, archive=False)
 
     assert not worktree.path.exists()
+
+
+def test_cleanup_worktree_removes_leftover_car_state_via_cwd_safe_subprocess(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hub_root = tmp_path / "hub"
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg["pma"]["cleanup_require_archive"] = False
+    write_test_config(hub_root / CONFIG_FILENAME, cfg)
+
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+    worktree = supervisor.create_worktree(
+        base_repo_id="base",
+        branch="feature/leftover-car-state-subprocess",
+        start_point="HEAD",
+    )
+
+    def _leave_only_car_state(**kwargs) -> None:
+        worktree_path = kwargs["worktree_path"]
+        for child in worktree_path.iterdir():
+            if child.name == ".codex-autorunner":
+                continue
+            if child.is_dir():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+
+    subprocess_cwds: list[str | None] = []
+    original_subprocess_run = wtm_module.subprocess.run
+
+    def _record_subprocess_run(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("args")
+        if isinstance(cmd, list) and cmd[:2] == [sys.executable, "-c"]:
+            subprocess_cwds.append(kwargs.get("cwd"))
+        return original_subprocess_run(*args, **kwargs)
+
+    monkeypatch.setattr(
+        supervisor._worktree_manager,
+        "_remove_worktree_git_refs",
+        _leave_only_car_state,
+    )
+    monkeypatch.setattr(wtm_module.subprocess, "run", _record_subprocess_run)
+
+    supervisor.cleanup_worktree(worktree_repo_id=worktree.id, archive=False)
+
+    assert not worktree.path.exists()
+    assert subprocess_cwds == [tempfile.gettempdir()]
 
 
 def test_cleanup_worktree_refreshes_topology_listing(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- classify stale worktree-backed PMA thread hygiene candidates as safe or needs-confirmation at the worktree level
- route safe hygiene apply operations through the canonical worktree cleanup lifecycle instead of thread-only archiving
- harden leftover worktree directory removal with a CWD-safe subprocess and stop cleanup before manifest removal if disk verification fails

## Why
`car pma hygiene --apply --category threads` previously stopped at archiving the managed thread record. It did not purge the hub manifest entry, git worktree metadata, or leftover on-disk CAR state, which left ghost worktrees behind and pushed operators toward unsafe manual `rm -rf` cleanup.

## Validation
- full `core` validation lane from the commit hook
- `.venv/bin/python -m ruff check src/codex_autorunner/core/hub_worktree_manager.py src/codex_autorunner/core/pma_hygiene.py src/codex_autorunner/surfaces/cli/pma_cli.py tests/core/test_pma_hygiene.py tests/test_hub_supervisor.py`
- `.venv/bin/pytest -q tests/test_hub_single_owner_invariants.py -k 'archive_required_but_not_requested'`
- `.venv/bin/pytest -q tests/core/test_pma_hygiene.py tests/test_hub_supervisor.py -k 'pma_hygiene or leftover_car_state or stale_worktree'`

Closes #1642