### PR TITLE
[codex] Recover PMA wake-up lanes after hub restart

### DIFF
--- a/src/codex_autorunner/core/pma_queue.py
+++ b/src/codex_autorunner/core/pma_queue.py
@@ -288,15 +288,25 @@ class PmaQueue:
         known = self._ensure_lane_known_ids(lane_id)
         for item in items:
             known.add(item.item_id)
-        pending = [item for item in items if item.state == QueueItemState.PENDING]
-        if not pending:
+        replayable: list[PmaQueueItem] = []
+        for item in items:
+            if item.state == QueueItemState.PENDING:
+                replayable.append(item)
+                continue
+            if item.state != QueueItemState.RUNNING:
+                continue
+            item.state = QueueItemState.PENDING
+            item.started_at = None
+            await self._update_in_file(item)
+            replayable.append(item)
+        if not replayable:
             return 0
 
         queue = self._ensure_lane_queue(lane_id)
-        for item in pending:
+        for item in replayable:
             await queue.put(item)
         self._ensure_lane_event(lane_id).set()
-        return len(pending)
+        return len(replayable)
 
     async def wait_for_lane_item(
         self,

--- a/src/codex_autorunner/surfaces/web/app.py
+++ b/src/codex_autorunner/surfaces/web/app.py
@@ -35,6 +35,8 @@ from ...core.orchestration.execution_history_maintenance import (
     resolve_execution_history_maintenance_policy,
     run_execution_history_housekeeping_once,
 )
+from ...core.pma_domain.constants import DEFAULT_PMA_LANE_ID
+from ...core.pma_queue import PmaQueue, QueueItemState
 from ...housekeeping import reap_managed_docker_containers, run_housekeeping_once
 from .app_builders import create_app, create_repo_app
 from .app_factory import CacheStaticFiles, resolve_allowed_hosts, resolve_auth_token
@@ -75,6 +77,34 @@ _DEFAULT_HUB_FLOW_SWEEP_INTERVAL_SECONDS = float(
 
 class _IdlePrunable(Protocol):
     async def prune_idle(self) -> None: ...
+
+
+async def _start_replayable_pma_lane_workers(
+    app: FastAPI,
+    starter: object,
+) -> list[str]:
+    if not callable(starter):
+        return []
+
+    queue = PmaQueue(Path(app.state.config.root))
+    lanes = [DEFAULT_PMA_LANE_ID]
+    seen = {DEFAULT_PMA_LANE_ID}
+    for lane_id in await queue.get_all_lanes():
+        if lane_id in seen:
+            continue
+        items = await queue.list_items(lane_id)
+        if any(
+            item.state in {QueueItemState.PENDING, QueueItemState.RUNNING}
+            for item in items
+        ):
+            lanes.append(lane_id)
+            seen.add(lane_id)
+
+    started: list[str] = []
+    for lane_id in lanes:
+        await starter(app, lane_id)
+        started.append(lane_id)
+    return started
 
 
 def _resolve_hub_flow_sweep_interval_seconds(
@@ -317,12 +347,16 @@ def create_hub_app(
                     if starter is not None:
                         t_phase = time.monotonic()
                         try:
-                            await starter(app, "pma:default")
+                            started_lanes = await _start_replayable_pma_lane_workers(
+                                app,
+                                starter,
+                            )
                         except (
                             RuntimeError,
                             TypeError,
                             AttributeError,
                             OSError,
+                            sqlite3.Error,
                         ) as exc:  # intentional: best-effort startup
                             safe_log(
                                 log,
@@ -332,7 +366,8 @@ def create_hub_app(
                             )
                         else:
                             log.info(
-                                "hub.deferred_startup.phase done=pma_lane_worker elapsed_ms=%.2f",
+                                "hub.deferred_startup.phase done=pma_lane_worker lanes=%s elapsed_ms=%.2f",
+                                ",".join(started_lanes) if started_lanes else "-",
                                 (time.monotonic() - t_phase) * 1000,
                             )
                 log.info(

--- a/tests/core/test_pma_queue_cross_process.py
+++ b/tests/core/test_pma_queue_cross_process.py
@@ -95,6 +95,33 @@ async def test_refresh_does_not_duplicate_items(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
+async def test_replay_pending_recovers_running_item_after_restart(
+    tmp_path: Path,
+) -> None:
+    lane_id = "discord:channel-1"
+    producer_queue = PmaQueue(tmp_path)
+
+    item, _ = producer_queue.enqueue_sync(
+        lane_id,
+        "running-key-1",
+        {"message": "hello"},
+    )
+    item.state = QueueItemState.RUNNING
+    item.started_at = "2026-04-27T14:10:00Z"
+    await producer_queue._update_in_file(item)
+
+    recovered_queue = PmaQueue(tmp_path)
+    replayed = await recovered_queue.replay_pending(lane_id)
+    assert replayed == 1
+
+    recovered = await recovered_queue.dequeue(lane_id)
+    assert recovered is not None
+    assert recovered.item_id == item.item_id
+    assert recovered.state == QueueItemState.RUNNING
+    assert recovered.started_at is not None
+
+
+@pytest.mark.anyio
 async def test_enqueue_sync_idempotency_dedupe(tmp_path: Path) -> None:
     lane_id = "pma:default"
     queue = PmaQueue(tmp_path)

--- a/tests/test_hub_issue_1266.py
+++ b/tests/test_hub_issue_1266.py
@@ -27,10 +27,12 @@ from codex_autorunner.core.orchestration import (
     legacy_backfill_gate as legacy_backfill_gate_module,
 )
 from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
+from codex_autorunner.core.pma_queue import PmaQueue
 from codex_autorunner.server import create_hub_app
 from codex_autorunner.surfaces.web import app as web_app_module
 from codex_autorunner.surfaces.web import app_state as web_app_state_module
 from tests.conftest import write_test_config
+from tests.pma_support import _enable_pma
 from tests.test_hub_app_context import _stub_opencode_supervisor
 
 _APP_PY = Path(web_app_module.__file__).resolve()
@@ -392,6 +394,37 @@ def test_health_reports_deferred_startup_complete_after_lifespan(
         body = response.json()
         assert body["hub_startup_phase"] == HUB_STARTUP_STARTED
         assert body["hub_deferred_startup_complete"] is True
+
+
+def test_deferred_startup_recovers_non_default_pma_lanes(
+    hub_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_opencode_supervisor(monkeypatch)
+    _enable_pma(hub_env.hub_root)
+
+    queue = PmaQueue(hub_env.hub_root)
+    queue.enqueue_sync(
+        "discord:channel-1",
+        "wake-up-1646",
+        {"message": "resume wake-up delivery"},
+    )
+
+    app = create_hub_app(hub_env.hub_root)
+    started_lanes: list[str] = []
+    started = threading.Event()
+
+    async def _record_start(_app: object, lane_id: str) -> None:
+        started_lanes.append(lane_id)
+        if lane_id == "discord:channel-1":
+            started.set()
+
+    app.state.pma_lane_worker_start = _record_start
+
+    with TestClient(app):
+        assert started.wait(timeout=10.0), "startup should recover queued PMA lanes"
+
+    assert "pma:default" in started_lanes
+    assert "discord:channel-1" in started_lanes
 
 
 def test_control_plane_error_codes_map_to_distinct_http_statuses() -> None:


### PR DESCRIPTION
## Summary
- recover PMA wake-up lane workers for every lane that still has replayable queue work at hub startup, not just `pma:default`
- treat PMA queue items left in `RUNNING` state after a restart as replayable so wake-ups are not stranded after a hub/control-plane interruption
- add regression coverage for both the queue recovery path and deferred startup lane recovery

## Root Cause
Terminal follow-up subscriptions can resolve to non-default PMA lanes such as `discord:<channel>`. When the hub went unavailable after a wake-up had been drained into one of those lanes, startup only restarted `pma:default`, so the persisted wake-up could remain stranded with no worker. If the interruption happened after dequeue, the queue item could also be left in `RUNNING` and never replayed.

## Validation
- `.venv/bin/pytest -q tests/core/test_pma_queue_cross_process.py::test_replay_pending_recovers_running_item_after_restart tests/test_hub_issue_1266.py::test_deferred_startup_recovers_non_default_pma_lanes tests/core/test_lifecycle_event_processing.py::test_flow_completion_subscription_can_trigger_next_lane`
- full commit-hook validation passed, including repo lint/type checks, full `pytest`, static asset build, JS tests, and chat-surface lab checks

Closes #1646