### PR TITLE
fix: suppress discord duplicate ingress during delivery

### DIFF
--- a/src/codex_autorunner/core/orchestration/__init__.py
+++ b/src/codex_autorunner/core/orchestration/__init__.py
@@ -14,6 +14,12 @@ from .catalog import (
     map_agent_capabilities,
     merge_agent_capabilities,
 )
+from .chat_operation_duplicates import (
+    ChatOperationDuplicateAction,
+    ChatOperationDuplicateDecision,
+    chat_operation_is_terminal_duplicate,
+    plan_chat_operation_duplicate,
+)
 from .chat_operation_ledger import (
     ChatOperationRegistration,
     SQLiteChatOperationLedger,
@@ -186,6 +192,8 @@ __all__ = [
     "Binding",
     "CHAT_OPERATION_ALLOWED_TRANSITIONS",
     "CHAT_OPERATION_TERMINAL_STATES",
+    "ChatOperationDuplicateAction",
+    "ChatOperationDuplicateDecision",
     "ChatOperationRecoveryAction",
     "ChatOperationRecoveryDecision",
     "ChatOperationRegistration",
@@ -291,6 +299,7 @@ __all__ = [
     "build_ticket_flow_orchestration_service",
     "build_ticket_flow_target",
     "build_ticket_flow_target_wrapper",
+    "chat_operation_is_terminal_duplicate",
     "current_orchestration_schema_version",
     "classify_run_event_family",
     "compact_completed_execution_history",
@@ -310,6 +319,7 @@ __all__ = [
     "map_agent_capabilities",
     "merge_agent_capabilities",
     "normalize_managed_thread_delivery_intent",
+    "plan_chat_operation_duplicate",
     "plan_chat_operation_recovery",
     "plan_managed_thread_delivery_recovery",
     "record_from_intent",

--- a/src/codex_autorunner/core/orchestration/chat_operation_duplicates.py
+++ b/src/codex_autorunner/core/orchestration/chat_operation_duplicates.py
@@ -1,0 +1,121 @@
+"""Domain-owned duplicate-ingress policy for shared chat operations.
+
+This module decides how adapters should treat a second ingress event when a
+durable chat operation already exists. The goal is to keep duplicate handling
+aligned with the shared chat-operation state machine rather than letting each
+adapter guess whether an in-flight operation should restart, stay suppressed, or
+be treated as a terminal duplicate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Optional
+
+from .chat_operation_state import (
+    CHAT_OPERATION_TERMINAL_STATES,
+    ChatOperationSnapshot,
+    ChatOperationState,
+)
+
+
+class ChatOperationDuplicateAction(str, Enum):
+    """Authoritative duplicate-ingress actions for one chat operation."""
+
+    ACCEPT_FRESH = "accept_fresh"
+    REJECT_TERMINAL = "reject_terminal"
+    SUPPRESS_IN_FLIGHT = "suppress_in_flight"
+    SUPPRESS_PENDING_DELIVERY = "suppress_pending_delivery"
+
+
+@dataclass(frozen=True)
+class ChatOperationDuplicateDecision:
+    action: ChatOperationDuplicateAction
+    reason: str
+    previous_state: Optional[ChatOperationState]
+    delivery_pending: bool
+    rationale: Mapping[str, Any] = field(default_factory=dict)
+
+
+def chat_operation_is_terminal_duplicate(snapshot: ChatOperationSnapshot) -> bool:
+    """Return whether a snapshot represents a duplicate that should be rejected."""
+
+    if snapshot.terminal_outcome in {"abandoned", "expired"}:
+        return True
+    return snapshot.state in CHAT_OPERATION_TERMINAL_STATES
+
+
+def plan_chat_operation_duplicate(
+    snapshot: Optional[ChatOperationSnapshot],
+    *,
+    operation_already_registered: bool = False,
+    delivery_pending: bool = False,
+) -> ChatOperationDuplicateDecision:
+    """Plan how ingress should handle an existing chat operation.
+
+    Adapters may provide a transport-local ``delivery_pending`` hint when the
+    delivery cursor or ledger indicates final delivery is still outstanding even
+    if the shared snapshot is missing or stale.
+    """
+
+    if delivery_pending:
+        return ChatOperationDuplicateDecision(
+            action=ChatOperationDuplicateAction.SUPPRESS_PENDING_DELIVERY,
+            reason="delivery_pending_duplicate_suppressed",
+            previous_state=snapshot.state if snapshot is not None else None,
+            delivery_pending=True,
+            rationale={
+                "delivery_state": (
+                    snapshot.delivery_state if snapshot is not None else None
+                ),
+            },
+        )
+
+    if snapshot is None:
+        if operation_already_registered:
+            return ChatOperationDuplicateDecision(
+                action=ChatOperationDuplicateAction.SUPPRESS_IN_FLIGHT,
+                reason="existing_operation_duplicate_suppressed",
+                previous_state=None,
+                delivery_pending=False,
+            )
+        return ChatOperationDuplicateDecision(
+            action=ChatOperationDuplicateAction.ACCEPT_FRESH,
+            reason="no_existing_snapshot",
+            previous_state=None,
+            delivery_pending=False,
+        )
+
+    if chat_operation_is_terminal_duplicate(snapshot):
+        return ChatOperationDuplicateDecision(
+            action=ChatOperationDuplicateAction.REJECT_TERMINAL,
+            reason="terminal_duplicate_rejected",
+            previous_state=snapshot.state,
+            delivery_pending=False,
+            rationale={"terminal_outcome": snapshot.terminal_outcome},
+        )
+
+    if snapshot.state == ChatOperationState.DELIVERING:
+        return ChatOperationDuplicateDecision(
+            action=ChatOperationDuplicateAction.SUPPRESS_PENDING_DELIVERY,
+            reason="delivering_duplicate_suppressed",
+            previous_state=snapshot.state,
+            delivery_pending=False,
+            rationale={"delivery_state": snapshot.delivery_state},
+        )
+
+    return ChatOperationDuplicateDecision(
+        action=ChatOperationDuplicateAction.SUPPRESS_IN_FLIGHT,
+        reason="non_terminal_duplicate_suppressed",
+        previous_state=snapshot.state,
+        delivery_pending=False,
+    )
+
+
+__all__ = [
+    "ChatOperationDuplicateAction",
+    "ChatOperationDuplicateDecision",
+    "chat_operation_is_terminal_duplicate",
+    "plan_chat_operation_duplicate",
+]

--- a/src/codex_autorunner/core/orchestration/chat_operation_duplicates.py
+++ b/src/codex_autorunner/core/orchestration/chat_operation_duplicates.py
@@ -105,6 +105,18 @@ def plan_chat_operation_duplicate(
             rationale={"delivery_state": snapshot.delivery_state},
         )
 
+    if snapshot.state == ChatOperationState.RECEIVED:
+        # RECEIVED is the earliest durable row (often before transport ACK/ledger
+        # persistence completes). A redelivered event must be allowed to proceed so
+        # a failed or skipped first attempt can run ACK/registration again; only
+        # true in-flight *past* received is suppressed for higher states.
+        return ChatOperationDuplicateDecision(
+            action=ChatOperationDuplicateAction.ACCEPT_FRESH,
+            reason="received_allows_ingress_replay",
+            previous_state=snapshot.state,
+            delivery_pending=False,
+        )
+
     return ChatOperationDuplicateDecision(
         action=ChatOperationDuplicateAction.SUPPRESS_IN_FLIGHT,
         reason="non_terminal_duplicate_suppressed",

--- a/src/codex_autorunner/integrations/discord/interaction_scheduler.py
+++ b/src/codex_autorunner/integrations/discord/interaction_scheduler.py
@@ -73,9 +73,29 @@ async def schedule_ingressed_interaction(
             ctx, now=dispatch_started_at, envelope=envelope
         ),
     )
-    await service._register_chat_operation_received(
+    registration = await service._register_chat_operation_received(
         ctx, conversation_id=envelope.conversation_id
     )
+    if registration is not None and not registration.inserted:
+        duplicate_suppressed = await service._suppress_registered_duplicate_interaction(
+            interaction_id=ctx.interaction_id,
+            snapshot=registration.snapshot,
+        )
+        if duplicate_suppressed:
+            log_event(
+                service._logger,
+                logging.INFO,
+                "discord.interaction.rejected",
+                rejection_reason="duplicate_interaction",
+                **service._interaction_telemetry_fields(
+                    ctx, now=dispatch_started_at, envelope=envelope
+                ),
+            )
+            ctx.timing = replace(
+                ctx.timing,
+                ingress_finished_at=time.monotonic(),
+            )
+            return ScheduleResult(submitted=False)
     acked = await service._acknowledge_runtime_envelope(envelope, stage="dispatch")
     if not acked and service._dispatch_ack_failure_confirms_expiry(ctx, envelope):
         log_event(

--- a/src/codex_autorunner/integrations/discord/response_helpers.py
+++ b/src/codex_autorunner/integrations/discord/response_helpers.py
@@ -147,6 +147,14 @@ class DiscordResponder:
             "respond_modal": "modal",
         }.get(operation)
 
+    @staticmethod
+    def _operation_uses_delivery_cursor(operation: str) -> bool:
+        return operation not in {
+            "defer_ephemeral",
+            "defer_public",
+            "defer_component_update",
+        }
+
     async def _record_delivery_attempt(
         self,
         interaction_id: str,
@@ -157,6 +165,8 @@ class DiscordResponder:
         session: Optional[DiscordInteractionSession] = None,
     ) -> None:
         if self._record_delivery_cursor is None:
+            return
+        if not self._operation_uses_delivery_cursor(operation):
             return
         if state == "completed":
             await self._clear_delivery_attempt(interaction_id)

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -80,11 +80,14 @@ from ...core.managed_thread_identity import (
 )
 from ...core.orchestration import (
     ORCHESTRATION_SCHEMA_VERSION,
+    ChatOperationDuplicateAction,
+    ChatOperationRegistration,
     ChatOperationRecoveryAction,
     ChatOperationSnapshot,
     ChatOperationState,
     SQLiteChatOperationLedger,
     build_ticket_flow_orchestration_service,
+    plan_chat_operation_duplicate,
     plan_chat_operation_recovery,
 )
 from ...core.orchestration.managed_thread_delivery_ledger import (
@@ -5043,17 +5046,47 @@ class DiscordBotService:
         async with self._chat_operation_write_guard(operation_id):
             return await asyncio.to_thread(store.get_operation, operation_id)
 
-    def _chat_operation_terminal_duplicate(
-        self, snapshot: ChatOperationSnapshot
-    ) -> bool:
-        if snapshot.terminal_outcome in {"abandoned", "expired"}:
-            return True
-        return snapshot.state in {
-            ChatOperationState.COMPLETED,
-            ChatOperationState.INTERRUPTED,
-            ChatOperationState.FAILED,
-            ChatOperationState.CANCELLED,
-        }
+    async def _maybe_reject_duplicate_interaction(
+        self,
+        *,
+        interaction_id: str,
+        snapshot: Optional[ChatOperationSnapshot],
+        operation_already_registered: bool,
+        has_pending_delivery: bool,
+        scheduler_state: Optional[str],
+        execution_status: Optional[str],
+        release_reservation: bool,
+    ) -> Optional[bool]:
+        decision = plan_chat_operation_duplicate(
+            snapshot,
+            operation_already_registered=operation_already_registered,
+            delivery_pending=has_pending_delivery,
+        )
+        if decision.action == ChatOperationDuplicateAction.ACCEPT_FRESH:
+            return None
+        if release_reservation:
+            await self._release_interaction_ingress(interaction_id)
+        event_name = (
+            "discord.interaction.duplicate_terminal_rejected"
+            if decision.action == ChatOperationDuplicateAction.REJECT_TERMINAL
+            else (
+                "discord.interaction.duplicate_delivery_pending_suppressed"
+                if decision.action
+                == ChatOperationDuplicateAction.SUPPRESS_PENDING_DELIVERY
+                else "discord.interaction.duplicate_in_flight_suppressed"
+            )
+        )
+        log_event(
+            self._logger,
+            logging.INFO,
+            event_name,
+            interaction_id=interaction_id,
+            scheduler_state=scheduler_state,
+            execution_status=execution_status,
+            shared_state=snapshot.state.value if snapshot is not None else None,
+            reason=decision.reason,
+        )
+        return True
 
     def _discord_chat_operation_state_for_scheduler(
         self, scheduler_state: str
@@ -5089,7 +5122,7 @@ class DiscordBotService:
         ctx: IngressContext,
         *,
         conversation_id: Optional[str] = None,
-    ) -> Optional[ChatOperationSnapshot]:
+    ) -> Optional[ChatOperationRegistration]:
         store = self._chat_operation_store_or_none()
         if store is None:
             return None
@@ -5097,7 +5130,7 @@ class DiscordBotService:
         interaction_id = ctx.interaction_id
         metadata = self._interaction_ledger_metadata(ctx)
 
-        def _register_sync() -> Optional[ChatOperationSnapshot]:
+        def _register_sync() -> Optional[ChatOperationRegistration]:
             registration = store.register_operation(
                 operation_id=interaction_id,
                 surface_kind="discord",
@@ -5111,17 +5144,39 @@ class DiscordBotService:
                 ack_requested_at=now_iso(),
             )
             if registration.inserted:
-                return registration.snapshot
-            return store.patch_operation(
+                return registration
+            updated = store.patch_operation(
                 interaction_id,
                 conversation_id=(
                     conversation_id or registration.snapshot.conversation_id
                 ),
                 metadata_updates=metadata,
             )
+            return ChatOperationRegistration(
+                snapshot=updated or registration.snapshot,
+                inserted=False,
+            )
 
         async with self._chat_operation_write_guard(interaction_id):
             return await asyncio.to_thread(_register_sync)
+
+    async def _suppress_registered_duplicate_interaction(
+        self,
+        *,
+        interaction_id: str,
+        snapshot: ChatOperationSnapshot,
+    ) -> bool:
+        has_pending_delivery = snapshot.delivery_state in {"pending", "failed"}
+        duplicate_rejected = await self._maybe_reject_duplicate_interaction(
+            interaction_id=interaction_id,
+            snapshot=snapshot,
+            operation_already_registered=True,
+            has_pending_delivery=has_pending_delivery,
+            scheduler_state=None,
+            execution_status=None,
+            release_reservation=False,
+        )
+        return bool(duplicate_rejected)
 
     async def _patch_chat_operation(
         self,
@@ -5877,13 +5932,26 @@ class DiscordBotService:
 
         has_pending_delivery = bool(
             record is not None
-            and isinstance(record.delivery_cursor_json, dict)
-            and str(record.delivery_cursor_json.get("state") or "").strip()
-            in {"pending", "failed"}
+            and (
+                (
+                    isinstance(record.delivery_cursor_json, dict)
+                    and str(record.delivery_cursor_json.get("state") or "").strip()
+                    in {"pending", "failed"}
+                )
+                or record.scheduler_state in {"delivery_pending", "delivery_replaying"}
+            )
         )
-        if snapshot is not None and self._chat_operation_terminal_duplicate(snapshot):
-            await self._release_interaction_ingress(ctx.interaction_id)
-            return True
+        duplicate_rejected = await self._maybe_reject_duplicate_interaction(
+            interaction_id=ctx.interaction_id,
+            snapshot=snapshot,
+            operation_already_registered=(snapshot is not None or record is not None),
+            has_pending_delivery=has_pending_delivery,
+            scheduler_state=(record.scheduler_state if record is not None else None),
+            execution_status=(record.execution_status if record is not None else None),
+            release_reservation=True,
+        )
+        if duplicate_rejected is not None:
+            return duplicate_rejected
         if record is not None and record.scheduler_state in {
             "completed",
             "delivery_expired",
@@ -5936,12 +6004,24 @@ class DiscordBotService:
         record = registration.record
         snapshot = await self._chat_operation_get(ctx.interaction_id)
         has_pending_delivery = bool(
-            isinstance(record.delivery_cursor_json, dict)
-            and str(record.delivery_cursor_json.get("state") or "").strip()
-            in {"pending", "failed"}
+            (
+                isinstance(record.delivery_cursor_json, dict)
+                and str(record.delivery_cursor_json.get("state") or "").strip()
+                in {"pending", "failed"}
+            )
+            or record.scheduler_state in {"delivery_pending", "delivery_replaying"}
         )
-        if snapshot is not None and self._chat_operation_terminal_duplicate(snapshot):
-            return True
+        duplicate_rejected = await self._maybe_reject_duplicate_interaction(
+            interaction_id=ctx.interaction_id,
+            snapshot=snapshot,
+            operation_already_registered=True,
+            has_pending_delivery=has_pending_delivery,
+            scheduler_state=record.scheduler_state,
+            execution_status=record.execution_status,
+            release_reservation=False,
+        )
+        if duplicate_rejected is not None:
+            return duplicate_rejected
         if record.scheduler_state in {"completed", "delivery_expired", "abandoned"}:
             return True
         if (

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -81,8 +81,8 @@ from ...core.managed_thread_identity import (
 from ...core.orchestration import (
     ORCHESTRATION_SCHEMA_VERSION,
     ChatOperationDuplicateAction,
-    ChatOperationRegistration,
     ChatOperationRecoveryAction,
+    ChatOperationRegistration,
     ChatOperationSnapshot,
     ChatOperationState,
     SQLiteChatOperationLedger,
@@ -5941,7 +5941,7 @@ class DiscordBotService:
                 or record.scheduler_state in {"delivery_pending", "delivery_replaying"}
             )
         )
-        await self._maybe_reject_duplicate_interaction(
+        rejected = await self._maybe_reject_duplicate_interaction(
             interaction_id=ctx.interaction_id,
             snapshot=snapshot,
             operation_already_registered=True,
@@ -5950,6 +5950,9 @@ class DiscordBotService:
             execution_status=(record.execution_status if record is not None else None),
             release_reservation=True,
         )
+        if rejected is None:
+            await self._release_interaction_ingress(ctx.interaction_id)
+            return False
         return True
 
     async def _release_interaction_ingress(self, interaction_id: str) -> None:
@@ -5985,7 +5988,7 @@ class DiscordBotService:
             )
             or record.scheduler_state in {"delivery_pending", "delivery_replaying"}
         )
-        await self._maybe_reject_duplicate_interaction(
+        rejected = await self._maybe_reject_duplicate_interaction(
             interaction_id=ctx.interaction_id,
             snapshot=snapshot,
             operation_already_registered=True,
@@ -5994,7 +5997,7 @@ class DiscordBotService:
             execution_status=record.execution_status,
             release_reservation=False,
         )
-        return True
+        return rejected is not None
 
     async def _begin_interaction_execution(self, ctx: IngressContext) -> bool:
         claimed = await self._store.claim_interaction_execution(ctx.interaction_id)

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -5941,42 +5941,16 @@ class DiscordBotService:
                 or record.scheduler_state in {"delivery_pending", "delivery_replaying"}
             )
         )
-        duplicate_rejected = await self._maybe_reject_duplicate_interaction(
+        await self._maybe_reject_duplicate_interaction(
             interaction_id=ctx.interaction_id,
             snapshot=snapshot,
-            operation_already_registered=(snapshot is not None or record is not None),
+            operation_already_registered=True,
             has_pending_delivery=has_pending_delivery,
             scheduler_state=(record.scheduler_state if record is not None else None),
             execution_status=(record.execution_status if record is not None else None),
             release_reservation=True,
         )
-        if duplicate_rejected is not None:
-            return duplicate_rejected
-        if record is not None and record.scheduler_state in {
-            "completed",
-            "delivery_expired",
-            "abandoned",
-        }:
-            await self._release_interaction_ingress(ctx.interaction_id)
-            return True
-        if (
-            record is not None
-            and record.execution_status
-            in {"completed", "failed", "timeout", "cancelled"}
-            and not has_pending_delivery
-        ):
-            await self._release_interaction_ingress(ctx.interaction_id)
-            return True
-        log_event(
-            self._logger,
-            logging.INFO,
-            "discord.interaction.duplicate_resuming",
-            interaction_id=ctx.interaction_id,
-            scheduler_state=(record.scheduler_state if record is not None else None),
-            execution_status=(record.execution_status if record is not None else None),
-            shared_state=snapshot.state.value if snapshot is not None else None,
-        )
-        return False
+        return True
 
     async def _release_interaction_ingress(self, interaction_id: str) -> None:
         reservations = getattr(self, "_ingress_pre_ack_reservations", None)
@@ -6011,7 +5985,7 @@ class DiscordBotService:
             )
             or record.scheduler_state in {"delivery_pending", "delivery_replaying"}
         )
-        duplicate_rejected = await self._maybe_reject_duplicate_interaction(
+        await self._maybe_reject_duplicate_interaction(
             interaction_id=ctx.interaction_id,
             snapshot=snapshot,
             operation_already_registered=True,
@@ -6020,25 +5994,7 @@ class DiscordBotService:
             execution_status=record.execution_status,
             release_reservation=False,
         )
-        if duplicate_rejected is not None:
-            return duplicate_rejected
-        if record.scheduler_state in {"completed", "delivery_expired", "abandoned"}:
-            return True
-        if (
-            record.execution_status in {"completed", "failed", "timeout", "cancelled"}
-            and not has_pending_delivery
-        ):
-            return True
-        log_event(
-            self._logger,
-            logging.INFO,
-            "discord.interaction.duplicate_resuming",
-            interaction_id=ctx.interaction_id,
-            scheduler_state=record.scheduler_state,
-            execution_status=record.execution_status,
-            shared_state=snapshot.state.value if snapshot is not None else None,
-        )
-        return False
+        return True
 
     async def _begin_interaction_execution(self, ctx: IngressContext) -> bool:
         claimed = await self._store.claim_interaction_execution(ctx.interaction_id)

--- a/tests/chat_surface_integration/test_hermes_pma_ux_regressions.py
+++ b/tests/chat_surface_integration/test_hermes_pma_ux_regressions.py
@@ -497,18 +497,14 @@ async def test_discord_duplicate_interactions_are_deduped(
             text for text in response_texts if "workspace:" in text.lower()
         ]
         assert len(status_messages) == 1
-        duplicate_resumes = [
+        duplicate_suppressed = [
             record
             for record in rest.log_records
-            if record.get("event") == "discord.interaction.duplicate_resuming"
+            if record.get("event")
+            == "discord.interaction.duplicate_in_flight_suppressed"
             and record.get("interaction_id") == "inter-dup-1"
         ]
-        assert duplicate_resumes
-        assert any(
-            record.get("event") == "discord.interaction.ack.reused"
-            and record.get("interaction_id") == "inter-dup-1"
-            for record in rest.log_records
-        )
+        assert duplicate_suppressed
         assert any(
             event.get("kind") == "duplicate_interaction_injected"
             for event in rest.surface_timeline

--- a/tests/chat_surface_lab/scenarios/duplicate_delivery.json
+++ b/tests/chat_surface_lab/scenarios/duplicate_delivery.json
@@ -55,7 +55,7 @@
         "discord"
       ],
       "params": {
-        "event_name": "discord.interaction.duplicate_resuming",
+        "event_name": "discord.interaction.duplicate_in_flight_suppressed",
         "field": "interaction_id",
         "value": "inter-dup-1"
       }
@@ -66,9 +66,9 @@
         "discord"
       ],
       "params": {
-        "event_name": "discord.interaction.ack.reused",
-        "field": "interaction_id",
-        "value": "inter-dup-1"
+        "event_name": "discord.interaction.rejected",
+        "field": "rejection_reason",
+        "value": "duplicate_interaction"
       }
     },
     {

--- a/tests/core/orchestration/test_chat_operation_duplicates.py
+++ b/tests/core/orchestration/test_chat_operation_duplicates.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from codex_autorunner.core.orchestration.chat_operation_duplicates import (
+    ChatOperationDuplicateAction,
+    chat_operation_is_terminal_duplicate,
+    plan_chat_operation_duplicate,
+)
+from codex_autorunner.core.orchestration.chat_operation_state import (
+    ChatOperationSnapshot,
+    ChatOperationState,
+)
+
+
+def _snap(
+    *,
+    state: ChatOperationState = ChatOperationState.RECEIVED,
+    delivery_state: str | None = None,
+    terminal_outcome: str | None = None,
+) -> ChatOperationSnapshot:
+    return ChatOperationSnapshot(
+        operation_id="dup-op-1",
+        surface_kind="discord",
+        surface_operation_key="interaction-dup-1",
+        state=state,
+        delivery_state=delivery_state,
+        terminal_outcome=terminal_outcome,
+        created_at="2026-04-15T11:00:00Z",
+        updated_at="2026-04-15T11:05:00Z",
+    )
+
+
+def test_duplicate_plan_accepts_missing_snapshot() -> None:
+    decision = plan_chat_operation_duplicate(None)
+    assert decision.action is ChatOperationDuplicateAction.ACCEPT_FRESH
+    assert decision.reason == "no_existing_snapshot"
+
+
+def test_duplicate_plan_rejects_terminal_snapshot() -> None:
+    decision = plan_chat_operation_duplicate(
+        _snap(
+            state=ChatOperationState.COMPLETED,
+            terminal_outcome="completed",
+        )
+    )
+    assert decision.action is ChatOperationDuplicateAction.REJECT_TERMINAL
+    assert decision.reason == "terminal_duplicate_rejected"
+
+
+def test_duplicate_plan_suppresses_delivery_pending_hint_without_snapshot() -> None:
+    decision = plan_chat_operation_duplicate(None, delivery_pending=True)
+    assert decision.action is ChatOperationDuplicateAction.SUPPRESS_PENDING_DELIVERY
+    assert decision.reason == "delivery_pending_duplicate_suppressed"
+    assert decision.previous_state is None
+
+
+def test_duplicate_plan_suppresses_delivering_snapshot() -> None:
+    decision = plan_chat_operation_duplicate(
+        _snap(
+            state=ChatOperationState.DELIVERING,
+            delivery_state="pending",
+        )
+    )
+    assert decision.action is ChatOperationDuplicateAction.SUPPRESS_PENDING_DELIVERY
+    assert decision.reason == "delivering_duplicate_suppressed"
+
+
+def test_duplicate_plan_suppresses_non_terminal_non_delivery_state() -> None:
+    decision = plan_chat_operation_duplicate(
+        _snap(state=ChatOperationState.ACKNOWLEDGED)
+    )
+    assert decision.action is ChatOperationDuplicateAction.SUPPRESS_IN_FLIGHT
+    assert decision.reason == "non_terminal_duplicate_suppressed"
+
+
+def test_duplicate_plan_suppresses_existing_record_without_snapshot() -> None:
+    decision = plan_chat_operation_duplicate(
+        None,
+        operation_already_registered=True,
+    )
+    assert decision.action is ChatOperationDuplicateAction.SUPPRESS_IN_FLIGHT
+    assert decision.reason == "existing_operation_duplicate_suppressed"
+
+
+def test_terminal_duplicate_helper_accepts_abandoned_terminal_outcome() -> None:
+    assert (
+        chat_operation_is_terminal_duplicate(
+            _snap(
+                state=ChatOperationState.RECEIVED,
+                terminal_outcome="abandoned",
+            )
+        )
+        is True
+    )

--- a/tests/core/orchestration/test_chat_operation_duplicates.py
+++ b/tests/core/orchestration/test_chat_operation_duplicates.py
@@ -72,6 +72,13 @@ def test_duplicate_plan_suppresses_non_terminal_non_delivery_state() -> None:
     assert decision.reason == "non_terminal_duplicate_suppressed"
 
 
+def test_duplicate_plan_accepts_received_for_replay() -> None:
+    """RECEIVED may exist before full ACK/ledger; redelivery must be able to continue."""
+    decision = plan_chat_operation_duplicate(_snap(state=ChatOperationState.RECEIVED))
+    assert decision.action is ChatOperationDuplicateAction.ACCEPT_FRESH
+    assert decision.reason == "received_allows_ingress_replay"
+
+
 def test_duplicate_plan_suppresses_existing_record_without_snapshot() -> None:
     decision = plan_chat_operation_duplicate(
         None,

--- a/tests/integrations/discord/test_interaction_runtime_chaos.py
+++ b/tests/integrations/discord/test_interaction_runtime_chaos.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from codex_autorunner.core.orchestration import (
+    ChatOperationState,
     SQLiteChatOperationLedger,
     initialize_orchestration_sqlite,
 )
@@ -648,6 +649,76 @@ async def test_chaos_callback_failure_before_defer_does_not_persist_ack(
 
 
 @pytest.mark.anyio
+async def test_defer_ack_does_not_project_delivery_pending_before_ack(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    harness = _ChaosHarness(tmp_path)
+    await harness.initialize()
+    try:
+        service = _build_recovery_service(
+            store=harness.store,
+            rest=harness.rest,
+            operation_store=harness.operation_store,
+        )
+        ctx = _make_ctx(
+            interaction_id="defer-ordering-1",
+            interaction_token="token-defer-ordering-1",
+        )
+        payload = _slash_payload(
+            interaction_id=ctx.interaction_id,
+            interaction_token=ctx.interaction_token,
+        )
+        await harness.store.register_interaction(
+            interaction_id=ctx.interaction_id,
+            interaction_token=ctx.interaction_token,
+            interaction_kind=ctx.kind.value,
+            channel_id=ctx.channel_id,
+            guild_id=ctx.guild_id,
+            user_id=ctx.user_id,
+            metadata_json=service._interaction_ledger_metadata(ctx),
+        )
+        envelope = RuntimeInteractionEnvelope(
+            context=ctx,
+            conversation_id="conversation:discord:chan-1:guild-1",
+            resource_keys=("conversation:discord:chan-1:guild-1",),
+            dispatch_ack_policy="defer_ephemeral",
+        )
+        await service._persist_runtime_interaction(
+            envelope,
+            payload,
+            scheduler_state="dispatch_ack_pending",
+        )
+
+        with caplog.at_level(logging.INFO, logger=service._logger.name):
+            deferred = await service._responder.defer(
+                interaction_id=ctx.interaction_id,
+                interaction_token=ctx.interaction_token,
+                ephemeral=True,
+            )
+
+        assert deferred is True
+
+        record = await harness.store.get_interaction(ctx.interaction_id)
+        assert record is not None
+        assert record.ack_mode == "defer_ephemeral"
+        assert record.delivery_cursor_json is None
+
+        snapshot = await service._chat_operation_get(ctx.interaction_id)
+        assert snapshot is not None
+        assert snapshot.state == ChatOperationState.ACKNOWLEDGED
+        assert snapshot.delivery_cursor is None
+
+        events = _logged_events(caplog, service._logger.name)
+        assert not any(
+            event["event"] == "discord.chat_operation.invalid_transition_rejected"
+            for event in events
+        )
+    finally:
+        await harness.close()
+
+
+@pytest.mark.anyio
 async def test_chaos_followup_failure_after_defer_recovers_after_restart(
     tmp_path: Path,
 ) -> None:
@@ -1170,6 +1241,165 @@ async def test_duplicate_completed_interaction_is_rejected_without_rerun(
         assert duplicate.rejection_reason == "duplicate_interaction"
         service._handle_car_command.assert_not_awaited()
         assert harness.rest.interaction_responses == []
+    finally:
+        await harness.close()
+
+
+@pytest.mark.anyio
+async def test_duplicate_delivery_pending_interaction_is_suppressed_without_rerun(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    harness = _ChaosHarness(tmp_path)
+    await harness.initialize()
+    try:
+        service = _build_recovery_service(
+            store=harness.store,
+            rest=harness.rest,
+            operation_store=harness.operation_store,
+        )
+        ctx = _make_ctx(
+            interaction_id="recover-dup-delivery-1",
+            interaction_token="token-recover-dup-delivery-1",
+        )
+        payload = _slash_payload(
+            interaction_id="recover-dup-delivery-1",
+            interaction_token="token-recover-dup-delivery-1",
+        )
+        await harness.store.register_interaction(
+            interaction_id=ctx.interaction_id,
+            interaction_token=ctx.interaction_token,
+            interaction_kind=ctx.kind.value,
+            channel_id=ctx.channel_id,
+            guild_id=ctx.guild_id,
+            user_id=ctx.user_id,
+            metadata_json=service._interaction_ledger_metadata(ctx),
+        )
+        envelope = RuntimeInteractionEnvelope(
+            context=ctx,
+            conversation_id="conversation:discord:chan-1:guild-1",
+            resource_keys=("conversation:discord:chan-1:guild-1",),
+            dispatch_ack_policy="defer_ephemeral",
+        )
+        await service._persist_runtime_interaction(
+            envelope,
+            payload,
+            scheduler_state="delivery_pending",
+        )
+        await harness.store.mark_interaction_acknowledged(
+            ctx.interaction_id,
+            ack_mode="defer_ephemeral",
+        )
+        await harness.store.mark_interaction_execution(
+            ctx.interaction_id,
+            execution_status="completed",
+        )
+        await harness.store.update_interaction_delivery_cursor(
+            ctx.interaction_id,
+            delivery_cursor_json={
+                "state": "pending",
+                "operation": "send_followup",
+                "payload": {
+                    "content": "Recovered final message.",
+                    "ephemeral": True,
+                },
+            },
+            scheduler_state="delivery_pending",
+        )
+        harness.set_operation_delivery_pending(
+            ctx.interaction_id,
+            cursor={
+                "state": "pending",
+                "operation": "send_followup",
+                "payload": {
+                    "content": "Recovered final message.",
+                    "ephemeral": True,
+                },
+            },
+        )
+
+        ingress = InteractionIngress(service, logger=service._logger)
+        with caplog.at_level(logging.INFO, logger=service._logger.name):
+            duplicate = await ingress.process_raw_payload(payload)
+
+        assert duplicate.accepted is False
+        assert duplicate.rejection_reason == "duplicate_interaction"
+        service._handle_car_command.assert_not_awaited()
+        assert harness.rest.interaction_responses == []
+        assert harness.rest.followup_messages == []
+
+        events = _logged_events(caplog, service._logger.name)
+        assert any(
+            event["event"]
+            == "discord.interaction.duplicate_delivery_pending_suppressed"
+            for event in events
+        )
+        assert not any(
+            event["event"] == "discord.chat_operation.invalid_transition_rejected"
+            for event in events
+        )
+    finally:
+        await harness.close()
+
+
+@pytest.mark.anyio
+async def test_duplicate_non_terminal_interaction_is_suppressed_before_ack_reuse(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    harness = _ChaosHarness(tmp_path)
+    await harness.initialize()
+    try:
+        service = _build_recovery_service(
+            store=harness.store,
+            rest=harness.rest,
+            operation_store=harness.operation_store,
+        )
+        ctx = _make_ctx(
+            interaction_id="recover-dup-in-flight-1",
+            interaction_token="token-recover-dup-in-flight-1",
+        )
+        payload = _slash_payload(
+            interaction_id="recover-dup-in-flight-1",
+            interaction_token="token-recover-dup-in-flight-1",
+        )
+        await harness.store.register_interaction(
+            interaction_id=ctx.interaction_id,
+            interaction_token=ctx.interaction_token,
+            interaction_kind=ctx.kind.value,
+            channel_id=ctx.channel_id,
+            guild_id=ctx.guild_id,
+            user_id=ctx.user_id,
+            metadata_json=service._interaction_ledger_metadata(ctx),
+        )
+        envelope = RuntimeInteractionEnvelope(
+            context=ctx,
+            conversation_id="conversation:discord:chan-1:guild-1",
+            resource_keys=("conversation:discord:chan-1:guild-1",),
+            dispatch_ack_policy="defer_ephemeral",
+        )
+        await service._persist_runtime_interaction(
+            envelope,
+            payload,
+            scheduler_state="scheduled",
+        )
+
+        ingress = InteractionIngress(service, logger=service._logger)
+        with caplog.at_level(logging.INFO, logger=service._logger.name):
+            duplicate = await ingress.process_raw_payload(payload)
+
+        assert duplicate.accepted is False
+        assert duplicate.rejection_reason == "duplicate_interaction"
+        service._handle_car_command.assert_not_awaited()
+        assert harness.rest.interaction_responses == []
+        assert harness.rest.followup_messages == []
+
+        events = _logged_events(caplog, service._logger.name)
+        assert any(
+            event["event"] == "discord.interaction.duplicate_in_flight_suppressed"
+            for event in events
+        )
+        assert not any(
+            event["event"] == "discord.interaction.ack.reused" for event in events
+        )
     finally:
         await harness.close()
 


### PR DESCRIPTION
## Summary
- add a domain duplicate-ingress planner so Discord ingress suppression follows shared chat-operation state instead of adapter-local guesses
- suppress duplicate Discord interactions before they re-ack or requeue an operation that is already in flight or pending delivery
- stop persisting delivery cursors for defer ACK operations so the shared state machine stays in `ACKNOWLEDGED` until real delivery begins
- update chat-surface expectations and add regressions for duplicate suppression and defer ordering

Closes #1631.

## Testing
- repo aggregate validation hook on commit, including repo-wide mypy, full pytest (`7945 passed`), frontend build/tests, chat-surface deterministic checks, and latency budget suite
- `./.venv/bin/pytest -q tests/core/orchestration/test_chat_operation_duplicates.py tests/integrations/discord/test_interaction_runtime_chaos.py -k 'duplicate_ or defer_ack_does_not_project_delivery_pending_before_ack'`
- `./.venv/bin/pytest -q tests/chat_surface_lab/test_latency_budgets.py tests/chat_surface_lab/test_seeded_exploration.py tests/chat_surface_lab/test_scenario_runner.py -k 'duplicate_delivery or replay_preserved_failure_seed or latency_budget_suite'`
- `./.venv/bin/pytest -q tests/integrations/discord/test_reliability.py -k 'deferred_interaction_recovers_after_simulated_restart or expired_ack'`
