### PR TITLE
Fix zombie running state after managed turn finalization failure

### DIFF
--- a/src/codex_autorunner/core/orchestration/chat_operation_duplicates.py
+++ b/src/codex_autorunner/core/orchestration/chat_operation_duplicates.py
@@ -73,18 +73,20 @@ def plan_chat_operation_duplicate(
         )
 
     if snapshot is None:
-        if operation_already_registered:
-            return ChatOperationDuplicateDecision(
-                action=ChatOperationDuplicateAction.SUPPRESS_IN_FLIGHT,
-                reason="existing_operation_duplicate_suppressed",
-                previous_state=None,
-                delivery_pending=False,
-            )
+        # Transport-local ledger rows can exist without a shared chat-operation
+        # snapshot (ordering gaps, partial persistence, or tests). Those must not
+        # suppress a different interaction_id, and redelivery for the same id
+        # still needs a snapshot-backed duplicate decision once the row exists.
         return ChatOperationDuplicateDecision(
             action=ChatOperationDuplicateAction.ACCEPT_FRESH,
-            reason="no_existing_snapshot",
+            reason=(
+                "ledger_without_shared_snapshot"
+                if operation_already_registered
+                else "no_existing_snapshot"
+            ),
             previous_state=None,
             delivery_pending=False,
+            rationale={"operation_already_registered": operation_already_registered},
         )
 
     if chat_operation_is_terminal_duplicate(snapshot):

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -1148,6 +1148,7 @@ class ManagedThreadTurnCoordinator:
             ManagedThreadExecutionHooks | ManagedThreadCoordinatorHooks
         ] = None,
         runtime_event_state: Optional[RuntimeThreadRunEventState] = None,
+        record_finalization_failure: bool = True,
     ) -> ManagedThreadFinalizationResult:
         resolved_hooks = _coerce_execution_hooks(hooks)
         turn_preview = self.turn_preview
@@ -1187,6 +1188,17 @@ class ManagedThreadTurnCoordinator:
             )
             return finalized
         except BaseException as exc:
+            if record_finalization_failure and isinstance(
+                exc, (asyncio.CancelledError, Exception)
+            ):
+                _record_managed_thread_finalization_failure(
+                    orchestration_service=self.orchestration_service,
+                    started=started,
+                    surface=self.surface,
+                    errors=self.errors,
+                    logger=self.logger,
+                    exc=exc,
+                )
             await _invoke_execution_error_hook(
                 resolved_hooks.on_execution_error,
                 started,
@@ -1217,6 +1229,7 @@ class ManagedThreadTurnCoordinator:
                 hooks=_queue_worker_progress_execution_hooks(
                     resolved_hooks.execution_hooks
                 ),
+                record_finalization_failure=False,
             ),
             durable_delivery=resolved_hooks.durable_delivery,
             run_with_indicator=resolved_hooks.run_with_indicator,
@@ -1338,6 +1351,97 @@ def _resolve_repo_raw_config_for_workspace(
         if isinstance(resolved_raw_config, dict)
         else normalized_raw_config
     )
+
+
+def _managed_thread_finalization_failure_detail(
+    started: RuntimeThreadExecution,
+    errors: ManagedThreadErrorMessages,
+    exc: BaseException,
+) -> str:
+    metadata = getattr(started.request, "metadata", {})
+    configured = ""
+    if isinstance(metadata, Mapping):
+        configured = str(metadata.get("execution_error_message") or "").strip()
+    if configured:
+        return configured
+    detail = str(exc).strip()
+    if detail:
+        return detail
+    return errors.public_execution_error
+
+
+def _record_managed_thread_finalization_failure(
+    *,
+    orchestration_service: Any,
+    started: RuntimeThreadExecution,
+    surface: ManagedThreadSurfaceInfo,
+    errors: ManagedThreadErrorMessages,
+    logger: logging.Logger,
+    exc: BaseException,
+) -> None:
+    managed_thread_id = started.thread.thread_target_id
+    managed_turn_id = started.execution.execution_id
+    detail = _managed_thread_finalization_failure_detail(started, errors, exc)
+    try:
+        get_execution = getattr(orchestration_service, "get_execution", None)
+        if callable(get_execution):
+            current = get_execution(managed_thread_id, managed_turn_id)
+            current_status = str(getattr(current, "status", "") or "").strip()
+            if current is not None and current_status != "running":
+                return
+        orchestration_service.record_execution_result(
+            managed_thread_id,
+            managed_turn_id,
+            status="error",
+            assistant_text="",
+            error=detail,
+            backend_turn_id=getattr(started.execution, "backend_id", None),
+            transcript_turn_id=None,
+        )
+    except asyncio.CancelledError:
+        log_event(
+            logger,
+            logging.WARNING,
+            "chat.managed_thread.finalization_failure_status_record_cancelled",
+            **_managed_thread_trace_fields(
+                managed_thread_id=managed_thread_id,
+                managed_turn_id=managed_turn_id,
+                backend_thread_id=getattr(started.thread, "backend_thread_id", None),
+                backend_turn_id=getattr(started.execution, "backend_id", None),
+                surface=surface,
+            ),
+            detail=detail,
+        )
+    except Exception as record_exc:
+        log_event(
+            logger,
+            logging.WARNING,
+            "chat.managed_thread.finalization_failure_status_record_failed",
+            **_managed_thread_trace_fields(
+                managed_thread_id=managed_thread_id,
+                managed_turn_id=managed_turn_id,
+                backend_thread_id=getattr(started.thread, "backend_thread_id", None),
+                backend_turn_id=getattr(started.execution, "backend_id", None),
+                surface=surface,
+            ),
+            detail=detail,
+            exc=record_exc,
+        )
+    else:
+        log_event(
+            logger,
+            logging.WARNING,
+            "chat.managed_thread.finalization_failure_status_recorded",
+            **_managed_thread_trace_fields(
+                managed_thread_id=managed_thread_id,
+                managed_turn_id=managed_turn_id,
+                backend_thread_id=getattr(started.thread, "backend_thread_id", None),
+                backend_turn_id=getattr(started.execution, "backend_id", None),
+                surface=surface,
+            ),
+            detail=detail,
+            error_type=type(exc).__name__,
+        )
 
 
 async def _persist_execution_timeline_via_hub(

--- a/tests/core/orchestration/test_chat_operation_duplicates.py
+++ b/tests/core/orchestration/test_chat_operation_duplicates.py
@@ -79,13 +79,13 @@ def test_duplicate_plan_accepts_received_for_replay() -> None:
     assert decision.reason == "received_allows_ingress_replay"
 
 
-def test_duplicate_plan_suppresses_existing_record_without_snapshot() -> None:
+def test_duplicate_plan_accepts_fresh_when_registered_without_shared_snapshot() -> None:
     decision = plan_chat_operation_duplicate(
         None,
         operation_already_registered=True,
     )
-    assert decision.action is ChatOperationDuplicateAction.SUPPRESS_IN_FLIGHT
-    assert decision.reason == "existing_operation_duplicate_suppressed"
+    assert decision.action is ChatOperationDuplicateAction.ACCEPT_FRESH
+    assert decision.reason == "ledger_without_shared_snapshot"
 
 
 def test_terminal_duplicate_helper_accepts_abandoned_terminal_outcome() -> None:

--- a/tests/integrations/chat/test_managed_thread_turns.py
+++ b/tests/integrations/chat/test_managed_thread_turns.py
@@ -249,6 +249,69 @@ async def test_managed_thread_turn_coordinator_runs_lifecycle_hooks(
 
 
 @pytest.mark.anyio
+async def test_managed_thread_turn_coordinator_records_error_when_finalization_is_cancelled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = _build_started_execution(tmp_path)
+    recorded: list[dict[str, Any]] = []
+
+    async def _cancelled_finalize(**kwargs: Any) -> None:
+        _ = kwargs
+        raise asyncio.CancelledError()
+
+    class _Service:
+        def get_execution(
+            self, managed_thread_id: str, managed_turn_id: str
+        ) -> SimpleNamespace:
+            _ = managed_thread_id, managed_turn_id
+            return SimpleNamespace(status="running")
+
+        def record_execution_result(self, *args: Any, **kwargs: Any) -> SimpleNamespace:
+            recorded.append({"args": args, "kwargs": kwargs})
+            return SimpleNamespace(status="error", error=kwargs["error"])
+
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "finalize_managed_thread_execution",
+        _cancelled_finalize,
+    )
+    coordinator = managed_thread_turns_module.ManagedThreadTurnCoordinator(
+        orchestration_service=_Service(),
+        state_root=tmp_path,
+        surface=managed_thread_turns_module.ManagedThreadSurfaceInfo(
+            log_label="Test",
+            surface_kind="test",
+            surface_key="surface-1",
+        ),
+        errors=managed_thread_turns_module.ManagedThreadErrorMessages(
+            public_execution_error="public finalization failure",
+            timeout_error="timeout",
+            interrupted_error="interrupted",
+            timeout_seconds=30,
+        ),
+        logger=logging.getLogger("test"),
+        turn_preview="preview",
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await coordinator.run_started_execution(started)
+
+    assert recorded == [
+        {
+            "args": ("thread-1", "exec-1"),
+            "kwargs": {
+                "status": "error",
+                "assistant_text": "",
+                "error": "public finalization failure",
+                "backend_turn_id": None,
+                "transcript_turn_id": None,
+            },
+        }
+    ]
+
+
+@pytest.mark.anyio
 async def test_managed_thread_turn_coordinator_uses_preview_builder_per_execution(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- record managed-thread finalization exceptions as orchestration error results so running executions become terminal
- keep queue-worker failure handling single-owner to avoid duplicate failure records
- add regression coverage for cancellation during finalization

Closes #1654.

## Validation
- .venv/bin/python -m black src/codex_autorunner/integrations/chat/managed_thread_turns.py tests/integrations/chat/test_managed_thread_turns.py
- .venv/bin/python -m ruff check src/codex_autorunner/integrations/chat/managed_thread_turns.py tests/integrations/chat/test_managed_thread_turns.py
- .venv/bin/python -m pytest -q tests/integrations/chat/test_managed_thread_turns.py -q
- commit hook chat-apps lane: mypy, 7948 pytest tests, chat-surface lab, latency budgets