### PR TITLE
Seed bound progress for SCM wakeups

### DIFF
--- a/src/codex_autorunner/core/chat_bindings.py
+++ b/src/codex_autorunner/core/chat_bindings.py
@@ -586,6 +586,63 @@ def active_chat_binding_metadata_by_thread(
     return metadata_by_thread
 
 
+def orchestration_surface_targets_for_thread(
+    *, hub_root: Path, thread_target_id: str
+) -> tuple[tuple[str, str], ...]:
+    """Return (surface_kind, surface_key) pairs for all active orchestration bindings.
+
+    ``active_chat_binding_metadata_by_thread`` exposes a single preferred binding; this
+    includes every non-disabled row so multi-surface threads fan out (e.g. Discord + Telegram).
+    """
+    normalized_thread = _normalize_scope(thread_target_id)
+    if normalized_thread is None:
+        return ()
+    try:
+        with open_orchestration_sqlite(hub_root, durable=False, migrate=False) as conn:
+            rows = conn.execute(
+                """
+                SELECT surface_kind, surface_key, updated_at
+                  FROM orch_bindings
+                 WHERE disabled_at IS NULL
+                   AND target_kind = 'thread'
+                   AND target_id = ?
+                   AND surface_kind IN ('discord', 'telegram')
+                   AND TRIM(COALESCE(surface_key, '')) != ''
+                """,
+                (normalized_thread,),
+            ).fetchall()
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            return ()
+        raise RuntimeError(
+            f"Failed reading orchestration chat bindings for thread {thread_target_id!r}: {exc}"
+        ) from exc
+
+    ordered = sorted(
+        rows,
+        key=lambda row: (
+            _parse_iso_timestamp_float(row["updated_at"]),
+            1 if str(row["surface_kind"] or "").strip() == "telegram" else 0,
+            str(row["surface_key"] or "").strip(),
+        ),
+    )
+    out: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for row in ordered:
+        sk = _normalize_scope(row["surface_kind"])
+        skey = _normalize_scope(row["surface_key"])
+        if sk is None or skey is None:
+            continue
+        if sk not in {"discord", "telegram"}:
+            continue
+        pair = (sk, skey)
+        if pair in seen:
+            continue
+        seen.add(pair)
+        out.append(pair)
+    return tuple(out)
+
+
 def _orchestration_binding_timestamps_by_workspace(
     *,
     hub_root: Path,
@@ -843,23 +900,6 @@ def preferred_non_pma_chat_notification_sources_by_workspace(
     return preferred_by_workspace
 
 
-__all__ = [
-    "active_chat_binding_counts",
-    "active_chat_binding_counts_by_source",
-    "active_chat_binding_metadata_by_thread",
-    "preferred_non_pma_chat_notification_source_for_workspace",
-    "preferred_non_pma_chat_notification_sources_by_workspace",
-    "repo_has_active_chat_binding",
-    "repo_has_active_non_pma_chat_binding",
-    "resolve_chat_state_path",
-    "resolve_repo_id_by_workspace_path",
-    "resolve_bound_repo_id",
-    "normalize_workspace_path",
-    "resolve_discord_state_path",
-    "resolve_telegram_state_path",
-]
-
-
 def resolve_chat_state_path(
     *,
     hub_root: Path,
@@ -915,3 +955,21 @@ def resolve_discord_state_path(hub_root: Path, raw_config: Mapping[str, Any]) ->
 
 def resolve_telegram_state_path(hub_root: Path, raw_config: Mapping[str, Any]) -> Path:
     return _resolve_telegram_state_path(hub_root, raw_config)
+
+
+__all__ = [
+    "active_chat_binding_counts",
+    "active_chat_binding_counts_by_source",
+    "active_chat_binding_metadata_by_thread",
+    "orchestration_surface_targets_for_thread",
+    "preferred_non_pma_chat_notification_source_for_workspace",
+    "preferred_non_pma_chat_notification_sources_by_workspace",
+    "repo_has_active_chat_binding",
+    "repo_has_active_non_pma_chat_binding",
+    "resolve_chat_state_path",
+    "resolve_repo_id_by_workspace_path",
+    "resolve_bound_repo_id",
+    "normalize_workspace_path",
+    "resolve_discord_state_path",
+    "resolve_telegram_state_path",
+]

--- a/src/codex_autorunner/core/pma_chat_delivery.py
+++ b/src/codex_autorunner/core/pma_chat_delivery.py
@@ -393,6 +393,33 @@ async def notify_preferred_bound_chat_for_workspace(
     )
 
 
+async def start_bound_chat_live_progress_for_thread(
+    *,
+    hub_root: Path,
+    raw_config: Mapping[str, Any],
+    managed_thread_id: str,
+    managed_turn_id: str,
+    agent: str,
+    model: Optional[str],
+    workspace_root: Optional[Path] = None,
+    repo_id: Optional[str] = None,
+) -> dict[str, Any]:
+    from ..pma_chat_delivery_runtime import (
+        start_bound_chat_live_progress_for_thread as runtime_start,
+    )
+
+    return await runtime_start(
+        hub_root=hub_root,
+        raw_config=raw_config,
+        managed_thread_id=managed_thread_id,
+        managed_turn_id=managed_turn_id,
+        agent=agent,
+        model=model,
+        workspace_root=workspace_root,
+        repo_id=repo_id,
+    )
+
+
 async def notify_primary_pma_chat_for_repo(
     *,
     hub_root: Path,
@@ -424,4 +451,5 @@ __all__ = [
     "deliver_pma_notification",
     "notify_preferred_bound_chat_for_workspace",
     "notify_primary_pma_chat_for_repo",
+    "start_bound_chat_live_progress_for_thread",
 ]

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -7,7 +7,7 @@ import threading
 from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Callable, Coroutine, Optional
+from typing import Any, Callable, Coroutine, Optional, cast
 
 from ..manifest import ManifestError, load_manifest
 from .config import load_hub_config
@@ -16,6 +16,7 @@ from .pma_chat_delivery import (
     deliver_pma_notification,
     notify_preferred_bound_chat_for_workspace,
     notify_primary_pma_chat_for_repo,
+    start_bound_chat_live_progress_for_thread,
 )
 from .pma_thread_store import ManagedThreadNotActiveError, PmaThreadStore
 from .pr_bindings import PrBinding, PrBindingStore
@@ -305,6 +306,90 @@ def _resolve_notify_message(
         "Waiting for managed turn start confirmation",
         retry_after_seconds=_MANAGED_TURN_START_CONFIRMATION_RETRY_SECONDS,
     )
+
+
+def _confirmed_managed_turn_for_notify(
+    *,
+    payload: dict[str, Any],
+    journal: PublishJournalStore,
+    thread_store: PmaThreadStore,
+) -> Optional[tuple[str, str, dict[str, Any]]]:
+    dependency = _normalize_mapping(payload.get("managed_turn_dependency"))
+    if (
+        _normalize_optional_text(dependency.get("dependency_kind"))
+        != "enqueue_managed_turn_started"
+    ):
+        return None
+    dependency_operation_id = _normalize_optional_text(dependency.get("operation_id"))
+    if dependency_operation_id is None:
+        return None
+    enqueue_operation = journal.get_operation(dependency_operation_id)
+    if enqueue_operation is None or enqueue_operation.state != "succeeded":
+        return None
+    enqueue_response = _normalize_mapping(enqueue_operation.response)
+    thread_target_id = _normalize_optional_text(
+        enqueue_response.get("thread_target_id")
+    ) or _normalize_optional_text(dependency.get("thread_target_id"))
+    managed_turn_id = _normalize_optional_text(enqueue_response.get("managed_turn_id"))
+    if thread_target_id is None or managed_turn_id is None:
+        return None
+    turn = thread_store.get_turn(thread_target_id, managed_turn_id)
+    if turn is None:
+        return None
+    metadata = _normalize_mapping(turn.get("metadata"))
+    if _normalize_optional_text(metadata.get(_RUNTIME_STARTED_AT_KEY)) is None:
+        return None
+    return thread_target_id, managed_turn_id, turn
+
+
+def _maybe_start_bound_live_progress_for_notify(
+    *,
+    hub_root: Path,
+    payload: dict[str, Any],
+    journal: PublishJournalStore,
+    thread_store: PmaThreadStore,
+    run_coroutine: Callable[[Coroutine[Any, Any, Any]], Any],
+    workspace_root: Optional[Path],
+    repo_id: Optional[str],
+) -> Optional[dict[str, Any]]:
+    confirmed = _confirmed_managed_turn_for_notify(
+        payload=payload,
+        journal=journal,
+        thread_store=thread_store,
+    )
+    if confirmed is None:
+        return None
+    thread_target_id, managed_turn_id, turn = confirmed
+    try:
+        thread = thread_store.get_thread(thread_target_id) or {}
+        raw_config = load_hub_config(hub_root).raw
+        return cast(
+            dict[str, Any],
+            run_coroutine(
+                start_bound_chat_live_progress_for_thread(
+                    hub_root=hub_root,
+                    raw_config=raw_config if isinstance(raw_config, Mapping) else {},
+                    managed_thread_id=thread_target_id,
+                    managed_turn_id=managed_turn_id,
+                    agent=(
+                        _normalize_optional_text(thread.get("agent_id"))
+                        or _normalize_optional_text(thread.get("agent"))
+                        or "agent"
+                    ),
+                    model=_normalize_optional_text(turn.get("model")),
+                    workspace_root=workspace_root,
+                    repo_id=repo_id,
+                )
+            ),
+        )
+    except Exception:
+        _LOGGER.exception(
+            "Failed to seed bound chat live progress for managed turn "
+            "thread_target_id=%s managed_turn_id=%s",
+            thread_target_id,
+            managed_turn_id,
+        )
+        return None
 
 
 def _merge_into_existing_queued_scm_turn(
@@ -954,6 +1039,15 @@ def build_notify_chat_executor(
             prefix="publish-chat",
         )
         repo_id, workspace_root = _resolve_thread_context(store, payload=payload)
+        progress_start = _maybe_start_bound_live_progress_for_notify(
+            hub_root=hub_root,
+            payload=payload,
+            journal=journal,
+            thread_store=store,
+            run_coroutine=coroutine_runner,
+            workspace_root=workspace_root,
+            repo_id=repo_id,
+        )
 
         if delivery == "none":
             outcome = {"route": "none", "targets": 0, "published": 0}
@@ -999,7 +1093,7 @@ def build_notify_chat_executor(
 
         targets = _coerce_int((outcome or {}).get("targets", 0))
         published = _coerce_int((outcome or {}).get("published", 0))
-        result = {
+        result: dict[str, Any] = {
             "delivery": delivery,
             "repo_id": repo_id,
             "targets": targets,
@@ -1010,6 +1104,8 @@ def build_notify_chat_executor(
             result["route"] = route
         if correlation_id is not None:
             result["correlation_id"] = correlation_id
+        if progress_start is not None:
+            result["progress_start"] = progress_start
         return result
 
     return executor

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -208,12 +208,15 @@ def _resolve_notify_message(
     payload: dict[str, Any],
     journal: PublishJournalStore,
     thread_store: PmaThreadStore,
-) -> str:
+) -> tuple[str, Optional[tuple[str, str, dict[str, Any]]]]:
     dependency = _normalize_mapping(payload.get("managed_turn_dependency"))
     if not dependency:
-        return _require_text(
-            payload.get("message") or payload.get("body") or payload.get("text"),
-            field_name="notify_chat message",
+        return (
+            _require_text(
+                payload.get("message") or payload.get("body") or payload.get("text"),
+                field_name="notify_chat message",
+            ),
+            None,
         )
 
     if (
@@ -242,7 +245,7 @@ def _resolve_notify_message(
     failure_message = _normalize_optional_text(dependency.get("failure_message"))
     if enqueue_operation.state != "succeeded":
         if failure_message is not None:
-            return failure_message
+            return failure_message, None
         raise TerminalPublishError(
             "notify_chat dependency enqueue_managed_turn did not succeed"
         )
@@ -254,7 +257,7 @@ def _resolve_notify_message(
     managed_turn_id = _normalize_optional_text(enqueue_response.get("managed_turn_id"))
     if thread_target_id is None or managed_turn_id is None:
         if failure_message is not None:
-            return failure_message
+            return failure_message, None
         raise TerminalPublishError(
             "notify_chat dependency is missing managed-turn identifiers"
         )
@@ -268,7 +271,7 @@ def _resolve_notify_message(
         )
         if datetime.now(timezone.utc) >= deadline:
             if failure_message is not None:
-                return failure_message
+                return failure_message, None
             raise TerminalPublishError(
                 "Managed turn record never became visible before timeout"
             )
@@ -280,13 +283,16 @@ def _resolve_notify_message(
     metadata = _normalize_mapping(turn.get("metadata"))
     runtime_started_at = _normalize_optional_text(metadata.get(_RUNTIME_STARTED_AT_KEY))
     if runtime_started_at is not None:
-        return _require_text(
-            payload.get("message") or payload.get("body") or payload.get("text"),
-            field_name="notify_chat message",
+        return (
+            _require_text(
+                payload.get("message") or payload.get("body") or payload.get("text"),
+                field_name="notify_chat message",
+            ),
+            (thread_target_id, managed_turn_id, turn),
         )
     if turn_status in {"error", "interrupted", "ok"}:
         if failure_message is not None:
-            return failure_message
+            return failure_message, None
         raise TerminalPublishError(
             f"Managed turn reached terminal status '{turn_status}' before start confirmation"
         )
@@ -298,7 +304,7 @@ def _resolve_notify_message(
     )
     if datetime.now(timezone.utc) >= deadline:
         if failure_message is not None:
-            return failure_message
+            return failure_message, None
         raise TerminalPublishError(
             "Managed turn did not reach a confirmed running state before timeout"
         )
@@ -308,55 +314,15 @@ def _resolve_notify_message(
     )
 
 
-def _confirmed_managed_turn_for_notify(
-    *,
-    payload: dict[str, Any],
-    journal: PublishJournalStore,
-    thread_store: PmaThreadStore,
-) -> Optional[tuple[str, str, dict[str, Any]]]:
-    dependency = _normalize_mapping(payload.get("managed_turn_dependency"))
-    if (
-        _normalize_optional_text(dependency.get("dependency_kind"))
-        != "enqueue_managed_turn_started"
-    ):
-        return None
-    dependency_operation_id = _normalize_optional_text(dependency.get("operation_id"))
-    if dependency_operation_id is None:
-        return None
-    enqueue_operation = journal.get_operation(dependency_operation_id)
-    if enqueue_operation is None or enqueue_operation.state != "succeeded":
-        return None
-    enqueue_response = _normalize_mapping(enqueue_operation.response)
-    thread_target_id = _normalize_optional_text(
-        enqueue_response.get("thread_target_id")
-    ) or _normalize_optional_text(dependency.get("thread_target_id"))
-    managed_turn_id = _normalize_optional_text(enqueue_response.get("managed_turn_id"))
-    if thread_target_id is None or managed_turn_id is None:
-        return None
-    turn = thread_store.get_turn(thread_target_id, managed_turn_id)
-    if turn is None:
-        return None
-    metadata = _normalize_mapping(turn.get("metadata"))
-    if _normalize_optional_text(metadata.get(_RUNTIME_STARTED_AT_KEY)) is None:
-        return None
-    return thread_target_id, managed_turn_id, turn
-
-
 def _maybe_start_bound_live_progress_for_notify(
     *,
     hub_root: Path,
-    payload: dict[str, Any],
-    journal: PublishJournalStore,
     thread_store: PmaThreadStore,
     run_coroutine: Callable[[Coroutine[Any, Any, Any]], Any],
     workspace_root: Optional[Path],
     repo_id: Optional[str],
+    confirmed: Optional[tuple[str, str, dict[str, Any]]],
 ) -> Optional[dict[str, Any]]:
-    confirmed = _confirmed_managed_turn_for_notify(
-        payload=payload,
-        journal=journal,
-        thread_store=thread_store,
-    )
     if confirmed is None:
         return None
     thread_target_id, managed_turn_id, turn = confirmed
@@ -1014,14 +980,13 @@ def build_notify_chat_executor(
                     )
                     if resolved_thread_id is not None:
                         payload["thread_target_id"] = resolved_thread_id
-        message = _normalize_optional_text(
-            _resolve_notify_message(
-                operation=operation,
-                payload=payload,
-                journal=journal,
-                thread_store=store,
-            )
+        message, confirmed_managed_turn = _resolve_notify_message(
+            operation=operation,
+            payload=payload,
+            journal=journal,
+            thread_store=store,
         )
+        message = _normalize_optional_text(message)
         if message is None:
             raise TerminalPublishError("Publish payload is missing notify_chat message")
 
@@ -1041,12 +1006,11 @@ def build_notify_chat_executor(
         repo_id, workspace_root = _resolve_thread_context(store, payload=payload)
         progress_start = _maybe_start_bound_live_progress_for_notify(
             hub_root=hub_root,
-            payload=payload,
-            journal=journal,
             thread_store=store,
             run_coroutine=coroutine_runner,
             workspace_root=workspace_root,
             repo_id=repo_id,
+            confirmed=confirmed_managed_turn,
         )
 
         if delivery == "none":

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -980,13 +980,13 @@ def build_notify_chat_executor(
                     )
                     if resolved_thread_id is not None:
                         payload["thread_target_id"] = resolved_thread_id
-        message, confirmed_managed_turn = _resolve_notify_message(
+        raw_message, confirmed_managed_turn = _resolve_notify_message(
             operation=operation,
             payload=payload,
             journal=journal,
             thread_store=store,
         )
-        message = _normalize_optional_text(message)
+        message = _normalize_optional_text(raw_message)
         if message is None:
             raise TerminalPublishError("Publish payload is missing notify_chat message")
 
@@ -1004,13 +1004,16 @@ def build_notify_chat_executor(
             prefix="publish-chat",
         )
         repo_id, workspace_root = _resolve_thread_context(store, payload=payload)
+        # Do not enqueue bound live-progress when notify is muted (none) or when only
+        # primary_pma is selected (invalid/missing repo_id would still have skipped chat).
+        should_seed_bound_progress = delivery not in {"none", "primary_pma"}
         progress_start = _maybe_start_bound_live_progress_for_notify(
             hub_root=hub_root,
             thread_store=store,
             run_coroutine=coroutine_runner,
             workspace_root=workspace_root,
             repo_id=repo_id,
-            confirmed=confirmed_managed_turn,
+            confirmed=(confirmed_managed_turn if should_seed_bound_progress else None),
         )
 
         if delivery == "none":

--- a/src/codex_autorunner/pma_chat_delivery_runtime.py
+++ b/src/codex_autorunner/pma_chat_delivery_runtime.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Any, Mapping, Optional
 
 from .core.chat_bindings import (
-    active_chat_binding_metadata_by_thread,
     normalize_workspace_path,
+    orchestration_surface_targets_for_thread,
     preferred_non_pma_chat_notification_source_for_workspace,
     resolve_bound_repo_id,
     resolve_discord_state_path,
@@ -75,14 +75,10 @@ async def _resolve_bound_progress_targets(
         seen.add(pair)
         targets.append(pair)
 
-    binding = active_chat_binding_metadata_by_thread(hub_root=hub_root).get(
-        managed_thread_id
-    )
-    if isinstance(binding, Mapping):
-        surface_kind = _normalize_optional_text(binding.get("binding_kind"))
-        surface_key = _normalize_optional_text(binding.get("binding_id"))
-        if surface_kind is not None and surface_key is not None:
-            _append_target(surface_kind, surface_key)
+    for sk, skey in orchestration_surface_targets_for_thread(
+        hub_root=hub_root, thread_target_id=managed_thread_id
+    ):
+        _append_target(sk, skey)
 
     if workspace_root is None:
         return tuple(targets)

--- a/src/codex_autorunner/pma_chat_delivery_runtime.py
+++ b/src/codex_autorunner/pma_chat_delivery_runtime.py
@@ -3,10 +3,23 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional
 
+from .core.chat_bindings import (
+    active_chat_binding_metadata_by_thread,
+    normalize_workspace_path,
+    preferred_non_pma_chat_notification_source_for_workspace,
+    resolve_bound_repo_id,
+    resolve_discord_state_path,
+    resolve_repo_id_by_workspace_path,
+    resolve_telegram_state_path,
+)
 from .core.pma_chat_delivery import PmaChatDeliveryIntent
 from .core.pma_notification_store import PmaNotificationStore
+from .core.text_utils import _normalize_optional_text
+from .integrations.chat.bound_live_progress import (
+    build_bound_chat_live_progress_session,
+)
 from .integrations.chat.pma_delivery import (
     PmaChatDeliveryAdapter,
     PmaChatDeliveryAdapterResult,
@@ -19,6 +32,175 @@ _DEFAULT_PMA_CHAT_DELIVERY_ADAPTERS: dict[str, PmaChatDeliveryAdapter] = {
     "discord": DiscordPmaChatDeliveryAdapter(),
     "telegram": TelegramPmaChatDeliveryAdapter(),
 }
+
+
+def _ordered_surface_kinds_for_bound_progress(
+    *,
+    hub_root: Path,
+    raw_config: Mapping[str, Any],
+    workspace_root: Path,
+) -> tuple[str, ...]:
+    preferred_source = preferred_non_pma_chat_notification_source_for_workspace(
+        hub_root=hub_root,
+        raw_config=raw_config,
+        workspace_root=workspace_root,
+    )
+    if preferred_source in {"discord", "telegram"}:
+        ordered_sources = [preferred_source]
+        ordered_sources.extend(
+            source for source in ("discord", "telegram") if source != preferred_source
+        )
+        return tuple(ordered_sources)
+    return ("discord", "telegram")
+
+
+async def _resolve_bound_progress_targets(
+    *,
+    hub_root: Path,
+    raw_config: Mapping[str, Any],
+    managed_thread_id: str,
+    workspace_root: Optional[Path],
+    repo_id: Optional[str],
+) -> tuple[tuple[str, str], ...]:
+    normalized_repo_id = _normalize_optional_text(repo_id)
+    targets: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+
+    def _append_target(surface_kind: str, surface_key: str) -> None:
+        if surface_kind not in {"discord", "telegram"} or not surface_key:
+            return
+        pair = (surface_kind, surface_key)
+        if pair in seen:
+            return
+        seen.add(pair)
+        targets.append(pair)
+
+    binding = active_chat_binding_metadata_by_thread(hub_root=hub_root).get(
+        managed_thread_id
+    )
+    if isinstance(binding, Mapping):
+        surface_kind = _normalize_optional_text(binding.get("binding_kind"))
+        surface_key = _normalize_optional_text(binding.get("binding_id"))
+        if surface_kind is not None and surface_key is not None:
+            _append_target(surface_kind, surface_key)
+
+    if workspace_root is None:
+        return tuple(targets)
+
+    repo_id_by_workspace = resolve_repo_id_by_workspace_path(hub_root, raw_config)
+    for surface_kind in _ordered_surface_kinds_for_bound_progress(
+        hub_root=hub_root,
+        raw_config=raw_config,
+        workspace_root=workspace_root,
+    ):
+        if surface_kind == "discord":
+            from .integrations.discord.state import DiscordStateStore
+
+            discord_store = DiscordStateStore(
+                resolve_discord_state_path(hub_root, raw_config)
+            )
+            try:
+                for legacy_binding in await discord_store.list_bindings():
+                    if bool(legacy_binding.get("pma_enabled")):
+                        continue
+                    if normalize_workspace_path(
+                        legacy_binding.get("workspace_path")
+                    ) != normalize_workspace_path(workspace_root):
+                        continue
+                    binding_repo_id = resolve_bound_repo_id(
+                        repo_id=legacy_binding.get("repo_id"),
+                        repo_id_by_workspace=repo_id_by_workspace,
+                        workspace_values=(legacy_binding.get("workspace_path"),),
+                    )
+                    if normalized_repo_id and binding_repo_id not in {
+                        None,
+                        normalized_repo_id,
+                    }:
+                        continue
+                    channel_id = _normalize_optional_text(
+                        legacy_binding.get("channel_id")
+                    )
+                    if channel_id is not None:
+                        _append_target("discord", channel_id)
+            finally:
+                await discord_store.close()
+        elif surface_kind == "telegram":
+            from .integrations.telegram.state import TelegramStateStore, parse_topic_key
+
+            telegram_store = TelegramStateStore(
+                resolve_telegram_state_path(hub_root, raw_config)
+            )
+            try:
+                for surface_key, topic in sorted(
+                    (await telegram_store.list_topics()).items()
+                ):
+                    if bool(getattr(topic, "pma_enabled", False)):
+                        continue
+                    try:
+                        chat_id, thread_id, scope = parse_topic_key(surface_key)
+                    except ValueError:
+                        continue
+                    base_key = f"{chat_id}:{thread_id or 'root'}"
+                    if scope != await telegram_store.get_topic_scope(base_key):
+                        continue
+                    if normalize_workspace_path(
+                        getattr(topic, "workspace_path", None)
+                    ) != normalize_workspace_path(workspace_root):
+                        continue
+                    binding_repo_id = resolve_bound_repo_id(
+                        repo_id=getattr(topic, "repo_id", None),
+                        repo_id_by_workspace=repo_id_by_workspace,
+                        workspace_values=(getattr(topic, "workspace_path", None),),
+                    )
+                    if normalized_repo_id and binding_repo_id not in {
+                        None,
+                        normalized_repo_id,
+                    }:
+                        continue
+                    _append_target("telegram", surface_key)
+            finally:
+                await telegram_store.close()
+
+    return tuple(targets)
+
+
+async def start_bound_chat_live_progress_for_thread(
+    *,
+    hub_root: Path,
+    raw_config: Mapping[str, Any],
+    managed_thread_id: str,
+    managed_turn_id: str,
+    agent: str,
+    model: Optional[str],
+    workspace_root: Optional[Path] = None,
+    repo_id: Optional[str] = None,
+) -> dict[str, Any]:
+    targets = await _resolve_bound_progress_targets(
+        hub_root=hub_root,
+        raw_config=raw_config,
+        managed_thread_id=managed_thread_id,
+        workspace_root=workspace_root,
+        repo_id=repo_id,
+    )
+    if not targets:
+        return {"targets": 0, "published": 0}
+    session = build_bound_chat_live_progress_session(
+        hub_root=hub_root,
+        raw_config=raw_config,
+        managed_thread_id=managed_thread_id,
+        managed_turn_id=managed_turn_id,
+        agent=agent,
+        model=model,
+        surface_targets=targets,
+    )
+    try:
+        published = await session.start()
+    finally:
+        await session.close()
+    return {
+        "targets": len(session.surface_targets),
+        "published": 1 if published else 0,
+    }
 
 
 def _record_notification_deliveries(
@@ -83,4 +265,7 @@ async def dispatch_pma_chat_delivery_intent(
     return last_result.to_dict()
 
 
-__all__ = ["dispatch_pma_chat_delivery_intent"]
+__all__ = [
+    "dispatch_pma_chat_delivery_intent",
+    "start_bound_chat_live_progress_for_thread",
+]

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -375,9 +375,10 @@ def _write_manifest(hub_root: Path, *, repo_rel: str, repo_id: str = "repo-1") -
 
 
 class _SimpleOutboxRecord:
-    __slots__ = ("channel_id", "payload_json")
+    __slots__ = ("record_id", "channel_id", "payload_json")
 
-    def __init__(self, channel_id: str, payload_json: str) -> None:
+    def __init__(self, record_id: str, channel_id: str, payload_json: str) -> None:
+        self.record_id = record_id
         self.channel_id = channel_id
         self.payload_json = json.loads(payload_json)
 
@@ -388,9 +389,9 @@ def _read_outbox_records(db_path: Path) -> list[_SimpleOutboxRecord]:
     conn = sqlite3.connect(db_path)
     try:
         rows = conn.execute(
-            "SELECT channel_id, payload_json FROM outbox ORDER BY created_at ASC"
+            "SELECT record_id, channel_id, payload_json FROM outbox ORDER BY created_at ASC"
         ).fetchall()
-        return [_SimpleOutboxRecord(row[0], row[1]) for row in rows]
+        return [_SimpleOutboxRecord(row[0], row[1], row[2]) for row in rows]
     finally:
         conn.close()
 
@@ -1700,6 +1701,8 @@ def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
     assert confirmed[0].response["route"] == "bound"
     assert confirmed[0].response["targets"] == 1
     assert confirmed[0].response["published"] == 1
+    assert confirmed[0].response["progress_start"]["targets"] == 1
+    assert confirmed[0].response["progress_start"]["published"] == 1
     assert reaction_calls == [("acme", "widgets", str(hub_root), 2844, "eyes")]
 
     turns = _thread_store.list_turns(thread["managed_thread_id"], limit=10)
@@ -1714,6 +1717,12 @@ def test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat(
         in str(record.payload_json.get("content", "")).lower()
         and "working on the latest review feedback now"
         in str(record.payload_json.get("content", "")).lower()
+        for record in outbox
+    )
+    assert any(
+        record.channel_id == "repo-discord"
+        and record.record_id.startswith("managed-thread-progress:discord:")
+        and "working · agent codex" in str(record.payload_json.get("content", ""))
         for record in outbox
     )
 


### PR DESCRIPTION
## Summary
- seed deterministic bound live-progress records once SCM-managed turns confirm runtime start
- resolve both orchestration and legacy Discord/Telegram bindings through the PMA delivery runtime boundary
- cover GitHub polling wakeup path with progress outbox assertions

## Tests
- .venv/bin/python -m pytest tests/integrations/github/test_polling.py::test_process_due_watches_reacts_then_wakes_thread_and_notifies_bound_chat tests/core/test_publish_executor.py tests/core/test_pma_chat_delivery.py tests/core/test_scm_automation_service.py -q
- commit hook aggregate lane: black, ruff, import boundaries, repo-wide mypy, full pytest, frontend build/tests, chat-surface lab latency checks