### PR TITLE
[codex] Show app identity in ticket flow status

### DIFF
--- a/src/codex_autorunner/core/flows/ux_helpers.py
+++ b/src/codex_autorunner/core/flows/ux_helpers.py
@@ -277,6 +277,19 @@ def _flow_status_current_step(record: FlowRunRecord) -> Optional[str]:
     return extract_current_step(record)
 
 
+def format_ticket_flow_app_label(app_payload: Any) -> Optional[str]:
+    if not isinstance(app_payload, Mapping):
+        return None
+    app_id = app_payload.get("id")
+    if not isinstance(app_id, str) or not app_id.strip():
+        return None
+    label = app_id.strip()
+    version = app_payload.get("version")
+    if isinstance(version, str) and version.strip():
+        label = f"{label} v{version.strip()}"
+    return label
+
+
 def format_ticket_flow_status_lines(
     record: FlowRunRecord,
     snapshot: Mapping[str, Any],
@@ -322,6 +335,9 @@ def format_ticket_flow_status_lines(
             f"Current ticket: {current_ticket or '-'}",
         ]
     )
+    app_label = format_ticket_flow_app_label(snapshot.get("app"))
+    if app_label:
+        lines.append(f"App: {app_label}")
 
     freshness_summary = summarize_flow_freshness(snapshot.get("freshness"))
     if freshness_summary:
@@ -358,6 +374,7 @@ __all__ = [
     "bootstrap_check",
     "build_flow_status_snapshot",
     "ensure_worker",
+    "format_ticket_flow_app_label",
     "format_ticket_flow_status_lines",
     "format_issue_as_markdown",
     "issue_md_has_content",

--- a/src/codex_autorunner/core/ticket_flow_operator.py
+++ b/src/codex_autorunner/core/ticket_flow_operator.py
@@ -32,6 +32,7 @@ from .flows.worker_process import (
 from .flows.workspace_root import resolve_ticket_flow_workspace_root
 from .freshness import resolve_stale_threshold_seconds
 from .state_roots import resolve_repo_flows_db_path
+from .text_utils import _normalize_optional_text
 from .ticket_flow_projection import (
     build_canonical_state_v1,
     collect_ticket_flow_census,
@@ -928,13 +929,6 @@ def _canonical_flow_status_state(
         )
     except (AttributeError, KeyError, OSError, RuntimeError, TypeError, ValueError):
         return None
-
-
-def _normalize_optional_text(value: Any) -> Optional[str]:
-    if not isinstance(value, str):
-        return None
-    value = value.strip()
-    return value or None
 
 
 def _resolve_ticket_path(repo_root: Path, ticket_ref: str) -> Optional[Path]:

--- a/src/codex_autorunner/core/ticket_flow_operator.py
+++ b/src/codex_autorunner/core/ticket_flow_operator.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Literal, Mapping, Optional, Sequence, TypedDict
 
 from ..tickets.files import list_ticket_paths, read_ticket, safe_relpath, ticket_is_done
+from ..tickets.frontmatter import parse_markdown_frontmatter
 from ..tickets.models import Dispatch
 from ..tickets.outbox import parse_dispatch, resolve_outbox_paths
 from ..tickets.replies import resolve_reply_paths
@@ -929,6 +930,59 @@ def _canonical_flow_status_state(
         return None
 
 
+def _normalize_optional_text(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _resolve_ticket_path(repo_root: Path, ticket_ref: str) -> Optional[Path]:
+    candidate = Path(ticket_ref)
+    candidates: list[Path]
+    if candidate.is_absolute():
+        candidates = [candidate]
+    else:
+        candidates = [
+            repo_root / candidate,
+            repo_root / ".codex-autorunner" / "tickets" / candidate,
+        ]
+    for path in candidates:
+        try:
+            if path.is_file():
+                return path
+        except OSError:
+            continue
+    return None
+
+
+def _read_ticket_flow_app_metadata(
+    repo_root: Path, ticket_ref: Optional[str]
+) -> Optional[dict[str, str]]:
+    if not ticket_ref:
+        return None
+    ticket_path = _resolve_ticket_path(repo_root, ticket_ref)
+    if ticket_path is None:
+        return None
+    try:
+        data, _body = parse_markdown_frontmatter(
+            ticket_path.read_text(encoding="utf-8")
+        )
+    except OSError:
+        return None
+    app_id = _normalize_optional_text(data.get("app"))
+    if app_id is None:
+        return None
+    metadata = {"id": app_id}
+    app_version = _normalize_optional_text(data.get("app_version"))
+    if app_version is not None:
+        metadata["version"] = app_version
+    app_source = _normalize_optional_text(data.get("app_source"))
+    if app_source is not None:
+        metadata["source"] = app_source
+    return metadata
+
+
 def build_ticket_flow_status_snapshot(
     repo_root: Path,
     record: FlowRunRecord,
@@ -946,6 +1000,7 @@ def build_ticket_flow_status_snapshot(
                 current_ticket = None
 
     effective_ticket = current_ticket or _derive_effective_current_ticket(record, store)
+    app_metadata = _read_ticket_flow_app_metadata(repo_root, effective_ticket)
     updated_state: Optional[dict[str, Any]] = None
     if effective_ticket and not current_ticket and isinstance(state, dict):
         ticket_engine = state.get("ticket_engine")
@@ -960,6 +1015,7 @@ def build_ticket_flow_status_snapshot(
             "last_event_at": None,
             "worker_health": None,
             "effective_current_ticket": effective_ticket,
+            "app": app_metadata,
             "ticket_progress": None,
             "state": updated_state,
             "canonical_state_v1": None,
@@ -984,6 +1040,7 @@ def build_ticket_flow_status_snapshot(
         "last_event_at": last_event_at,
         "worker_health": health,
         "effective_current_ticket": effective_ticket,
+        "app": app_metadata,
         "ticket_progress": ticket_progress(repo_root),
         "state": updated_state,
         "canonical_state_v1": canonical_state,

--- a/src/codex_autorunner/surfaces/cli/commands/flow.py
+++ b/src/codex_autorunner/surfaces/cli/commands/flow.py
@@ -31,7 +31,10 @@ from ....core.flows.models import (
     format_flow_duration,
 )
 from ....core.flows.telemetry_export import export_all_runs
-from ....core.flows.ux_helpers import build_flow_status_snapshot
+from ....core.flows.ux_helpers import (
+    build_flow_status_snapshot,
+    format_ticket_flow_app_label,
+)
 from ....core.flows.worker_process import (
     register_worker_metadata,
     write_worker_crash_info,
@@ -199,6 +202,7 @@ def register_flow_commands(
             "last_event_seq": snapshot.get("last_event_seq"),
             "last_event_at": snapshot.get("last_event_at"),
             "current_ticket": effective_ticket,
+            "app": snapshot.get("app"),
             "ticket_progress": snapshot.get("ticket_progress"),
             "reason_summary": normalized_reason_summary,
             "reason": normalized_reason,
@@ -232,6 +236,9 @@ def register_flow_commands(
         step = payload.get("current_step")
         ticket = payload.get("current_ticket") or "n/a"
         typer.echo(f"step={step} ticket={ticket}")
+        app_label = format_ticket_flow_app_label(payload.get("app"))
+        if app_label:
+            typer.echo(f"app={app_label}")
         typer.echo(
             f"created={payload.get('created_at')} started={payload.get('started_at')} "
             f"finished={payload.get('finished_at')}"

--- a/tests/core/test_flow_ux_helpers.py
+++ b/tests/core/test_flow_ux_helpers.py
@@ -174,3 +174,62 @@ def test_select_ticket_flow_run_record_authoritative_matches_existing_policy() -
 
     assert result is not None
     assert result.id == "paused-run"
+
+
+def test_flow_status_snapshot_includes_current_ticket_app_metadata(
+    tmp_path: Path,
+) -> None:
+    ticket_dir = tmp_path / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True, exist_ok=True)
+    (ticket_dir / "TICKET-001.md").write_text(
+        "---\n"
+        'ticket_id: "tkt_appstatus001"\n'
+        "agent: codex\n"
+        "done: false\n"
+        "app: local.my-workflow\n"
+        "app_version: 1.2.3\n"
+        "app_source: local:apps/my-workflow@main\n"
+        "---\n\n"
+        "App ticket\n",
+        encoding="utf-8",
+    )
+    record = FlowRunRecord(
+        id="app-run",
+        flow_type="ticket_flow",
+        status=FlowRunStatus.RUNNING,
+        created_at="2026-01-01T00:00:00Z",
+        state={"ticket_engine": {"current_ticket": "TICKET-001.md"}},
+    )
+
+    snapshot = ux_helpers.build_flow_status_snapshot(
+        tmp_path, record, store=None, lite=True
+    )
+
+    assert snapshot["app"] == {
+        "id": "local.my-workflow",
+        "version": "1.2.3",
+        "source": "local:apps/my-workflow@main",
+    }
+
+
+def test_flow_status_lines_include_app_only_when_present() -> None:
+    record = _run("app-run", FlowRunStatus.RUNNING)
+    base_snapshot = {
+        "worker_health": None,
+        "last_event_seq": None,
+        "last_event_at": None,
+        "effective_current_ticket": "TICKET-001.md",
+        "ticket_progress": None,
+    }
+
+    lines = ux_helpers.format_ticket_flow_status_lines(
+        record,
+        {
+            **base_snapshot,
+            "app": {"id": "local.my-workflow", "version": "1.2.3"},
+        },
+    )
+    no_app_lines = ux_helpers.format_ticket_flow_status_lines(record, base_snapshot)
+
+    assert "App: local.my-workflow v1.2.3" in lines
+    assert all(not line.startswith("App:") for line in no_app_lines)

--- a/tests/test_cli_ticket_flow_status.py
+++ b/tests/test_cli_ticket_flow_status.py
@@ -13,11 +13,26 @@ from codex_autorunner.core.flows.store import FlowStore
 runner = CliRunner()
 
 
-def _setup_paused_run(repo_root: Path, run_id: str) -> None:
+def _setup_paused_run(
+    repo_root: Path, run_id: str, *, app_ticket: bool = False
+) -> None:
     ticket_dir = repo_root / ".codex-autorunner" / "tickets"
     ticket_dir.mkdir(parents=True, exist_ok=True)
+    app_frontmatter = (
+        'app: "local.my-workflow"\n'
+        'app_version: "1.2.3"\n'
+        'app_source: "local:apps/my-workflow@main"\n'
+        if app_ticket
+        else ""
+    )
     (ticket_dir / "TICKET-001.md").write_text(
-        '---\nticket_id: "tkt_status001"\nagent: user\ndone: false\n---\n\nStatus ticket\n',
+        "---\n"
+        'ticket_id: "tkt_status001"\n'
+        "agent: user\n"
+        "done: false\n"
+        f"{app_frontmatter}"
+        "---\n\n"
+        "Status ticket\n",
         encoding="utf-8",
     )
 
@@ -35,6 +50,7 @@ def _setup_paused_run(repo_root: Path, run_id: str) -> None:
             state={
                 "reason_summary": "Paused for user input.",
                 "ticket_engine": {
+                    "current_ticket": ".codex-autorunner/tickets/TICKET-001.md",
                     "reason": (
                         "Paused for user input. Mark ticket as done when ready: "
                         ".codex-autorunner/tickets/TICKET-001.md"
@@ -103,3 +119,57 @@ def test_ticket_flow_status_includes_pause_reason_in_json_output(
     assert payload["reason"].startswith(
         "Paused for user input. Mark ticket as done when ready:"
     )
+
+
+def test_ticket_flow_status_includes_app_in_human_output(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".git").mkdir()
+    seed_hub_files(tmp_path, force=True)
+    seed_repo_files(repo_root, git_required=False)
+
+    run_id = "56565656-5656-5656-5656-565656565656"
+    _setup_paused_run(repo_root, run_id, app_ticket=True)
+
+    result = runner.invoke(
+        app, ["ticket-flow", "status", "--repo", str(repo_root), "--run-id", run_id]
+    )
+
+    assert result.exit_code == 0
+    assert "app=local.my-workflow v1.2.3" in result.stdout
+
+
+def test_ticket_flow_status_includes_app_in_json_output(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".git").mkdir()
+    seed_hub_files(tmp_path, force=True)
+    seed_repo_files(repo_root, git_required=False)
+
+    run_id = "78787878-7878-7878-7878-787878787878"
+    _setup_paused_run(repo_root, run_id, app_ticket=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "ticket-flow",
+            "status",
+            "--repo",
+            str(repo_root),
+            "--run-id",
+            run_id,
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["app"] == {
+        "id": "local.my-workflow",
+        "version": "1.2.3",
+        "source": "local:apps/my-workflow@main",
+    }


### PR DESCRIPTION
## Summary
- resolve app metadata from the effective current ticket frontmatter in the ticket-flow status snapshot
- include app metadata in `car ticket-flow status --json` and an app line in CLI text output
- render the same app label through the shared Discord/Telegram status formatter

## Validation
- `.venv/bin/python -m pytest -q tests/core/test_flow_ux_helpers.py tests/test_cli_ticket_flow_status.py tests/test_telegram_flow_status.py::test_flow_status_includes_effective_current_ticket tests/integrations/discord/test_flow_handlers.py::test_flow_status_and_runs_render_expected_output`
- `.venv/bin/python -m ruff check src/codex_autorunner/core/ticket_flow_operator.py src/codex_autorunner/core/flows/ux_helpers.py src/codex_autorunner/surfaces/cli/commands/flow.py tests/core/test_flow_ux_helpers.py tests/test_cli_ticket_flow_status.py`
- commit hook core lane: Black, Ruff, import/contract checks, repo-wide mypy, and 8,099 pytest tests

Closes #1657