### PR TITLE
Surface active tool activity in flow status

### DIFF
--- a/src/codex_autorunner/core/flows/ux_helpers.py
+++ b/src/codex_autorunner/core/flows/ux_helpers.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Protocol
 
 from ...tickets.files import list_ticket_paths
+from ..freshness import normalize_iso_datetime
 from ..ticket_flow_operator import TicketFlowRunSelection
 from ..ticket_flow_operator import (
     build_ticket_flow_status_snapshot as _build_ticket_flow_status_snapshot,
@@ -227,6 +228,58 @@ def _format_age_compact(age_seconds: Any) -> Optional[str]:
     return f"{age_seconds // 86400}d ago"
 
 
+def _format_duration_compact(seconds: Any) -> Optional[str]:
+    if not isinstance(seconds, int) or seconds < 0:
+        return None
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    return f"{seconds // 3600}h {(seconds % 3600) // 60}m"
+
+
+def _shorten_command(command: str, *, max_chars: int = 96) -> str:
+    text = " ".join(command.split())
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 1].rstrip() + "..."
+
+
+def _format_active_tool_line(active_tool: Any, freshness: Any) -> Optional[str]:
+    if not isinstance(active_tool, Mapping):
+        return None
+    command = active_tool.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return None
+    details: list[str] = []
+    elapsed = _format_duration_compact(active_tool.get("elapsed_seconds"))
+    if elapsed:
+        details.append(f"running {elapsed}")
+
+    output_updated_at = active_tool.get("output_updated_at")
+    last_activity_at = active_tool.get("last_activity_at")
+    freshness_basis = (
+        freshness.get("basis_at") if isinstance(freshness, Mapping) else None
+    )
+    if isinstance(output_updated_at, str) and output_updated_at.strip():
+        age_seconds = (
+            freshness.get("age_seconds") if isinstance(freshness, Mapping) else None
+        )
+        output_at = normalize_iso_datetime(output_updated_at)
+        basis_at = normalize_iso_datetime(freshness_basis)
+        age = (
+            _format_age_compact(age_seconds)
+            if output_at is not None and output_at == basis_at
+            else None
+        )
+        details.append(f"output updated {age or output_updated_at}")
+    elif isinstance(last_activity_at, str) and last_activity_at.strip():
+        details.append(f"observed active {last_activity_at}")
+
+    suffix = f" ({', '.join(details)})" if details else ""
+    return f"Active tool: {_shorten_command(command)}{suffix}"
+
+
 def _freshness_basis_label(value: Any) -> Optional[str]:
     if not isinstance(value, str):
         return None
@@ -241,6 +294,7 @@ def _freshness_basis_label(value: Any) -> Optional[str]:
         "latest_run_created_at": "run created",
         "ticket_ingested_at": "ticket ingest",
         "snapshot_generated_at": "snapshot time",
+        "effective_last_activity_at": "activity",
     }
     return labels.get(basis, basis.replace("_", " "))
 
@@ -340,6 +394,11 @@ def format_ticket_flow_status_lines(
         lines.append(f"App: {app_label}")
 
     freshness_summary = summarize_flow_freshness(snapshot.get("freshness"))
+    active_tool_line = _format_active_tool_line(
+        snapshot.get("active_tool"), snapshot.get("freshness")
+    )
+    if active_tool_line:
+        lines.append(active_tool_line)
     if freshness_summary:
         lines.append(f"Freshness: {freshness_summary}")
 

--- a/src/codex_autorunner/core/flows/ux_helpers.py
+++ b/src/codex_autorunner/core/flows/ux_helpers.py
@@ -242,7 +242,7 @@ def _shorten_command(command: str, *, max_chars: int = 96) -> str:
     text = " ".join(command.split())
     if len(text) <= max_chars:
         return text
-    return text[: max_chars - 1].rstrip() + "..."
+    return text[: max_chars - 3].rstrip() + "..."
 
 
 def _format_active_tool_line(active_tool: Any, freshness: Any) -> Optional[str]:

--- a/src/codex_autorunner/core/flows/worker_process.py
+++ b/src/codex_autorunner/core/flows/worker_process.py
@@ -384,14 +384,18 @@ def _read_process_group_rows(pgid: int) -> list[dict[str, Any]]:
 
 
 def detect_active_tool(
-    repo_root: Path, run_id: str, worker_pid: int
+    repo_root: Path,
+    run_id: str,
+    worker_pid: int,
+    *,
+    artifacts_root: Optional[Path] = None,
 ) -> Optional[FlowActiveTool]:
     """Infer active tool work from descendants in the flow worker's process group."""
 
     pgid = _process_group_for_pid(worker_pid)
     if pgid is None or pgid != worker_pid:
         return None
-    artifacts_dir = _worker_artifacts_dir(repo_root, run_id)
+    artifacts_dir = _worker_artifacts_dir(repo_root, run_id, artifacts_root)
     rows = [
         row
         for row in _read_process_group_rows(pgid)
@@ -599,7 +603,9 @@ def check_worker_health(
             cmdline=cmd,
             artifact_path=metadata_path,
             message="worker running (cmdline unknown)",
-            active_tool=detect_active_tool(repo_root, run_id, pid),
+            active_tool=detect_active_tool(
+                repo_root, run_id, pid, artifacts_root=artifacts_root
+            ),
         )
 
     if not _cmdline_matches(expected_cmd, actual_cmd):
@@ -617,7 +623,9 @@ def check_worker_health(
         cmdline=actual_cmd,
         artifact_path=metadata_path,
         message="worker running",
-        active_tool=detect_active_tool(repo_root, run_id, pid),
+        active_tool=detect_active_tool(
+            repo_root, run_id, pid, artifacts_root=artifacts_root
+        ),
     )
 
 

--- a/src/codex_autorunner/core/flows/worker_process.py
+++ b/src/codex_autorunner/core/flows/worker_process.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO, Any, Literal, Optional, Tuple
 
@@ -22,6 +23,28 @@ _WORKER_CRASH_FILENAME = "crash.json"
 _MAX_TAIL_BYTES = 32_768
 
 
+@dataclass(frozen=True)
+class FlowActiveTool:
+    pid: int
+    ppid: Optional[int]
+    pgid: Optional[int]
+    command: str
+    elapsed_seconds: Optional[int]
+    last_activity_at: Optional[str]
+    output_updated_at: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pid": self.pid,
+            "ppid": self.ppid,
+            "pgid": self.pgid,
+            "command": self.command,
+            "elapsed_seconds": self.elapsed_seconds,
+            "last_activity_at": self.last_activity_at,
+            "output_updated_at": self.output_updated_at,
+        }
+
+
 @dataclass
 class FlowWorkerHealth:
     status: Literal["absent", "alive", "dead", "invalid", "mismatch"]
@@ -34,6 +57,7 @@ class FlowWorkerHealth:
     crash_path: Optional[Path] = None
     crash_info: Optional[dict[str, Any]] = None
     shutdown_intent: bool = False
+    active_tool: Optional[FlowActiveTool] = None
 
     @property
     def is_alive(self) -> bool:
@@ -281,6 +305,126 @@ def _read_process_cmdline(pid: int) -> list[str] | None:
     return None
 
 
+def _iso_from_epoch(value: float) -> str:
+    return datetime.fromtimestamp(value, timezone.utc).isoformat()
+
+
+def _process_group_for_pid(pid: int) -> Optional[int]:
+    if os.name == "nt" or not hasattr(os, "getpgid"):
+        return None
+    try:
+        return os.getpgid(pid)
+    except OSError:
+        return None
+
+
+def _latest_log_activity_at(artifacts_dir: Path) -> Optional[str]:
+    mtimes: list[float] = []
+    for name in ("worker.out.log", "worker.err.log"):
+        try:
+            path = artifacts_dir / name
+            if path.exists() and path.is_file():
+                mtimes.append(path.stat().st_mtime)
+        except OSError:
+            continue
+    if not mtimes:
+        return None
+    return _iso_from_epoch(max(mtimes))
+
+
+def _read_process_group_rows(pgid: int) -> list[dict[str, Any]]:
+    if pgid <= 0:
+        return []
+    try:
+        out = subprocess.check_output(
+            ["ps", "-ww", "-g", str(pgid), "-o", "pid=,ppid=,pgid=,etimes=,command="],
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.SubprocessError, OSError, ValueError):
+        try:
+            out = subprocess.check_output(
+                ["ps", "-ww", "-g", str(pgid), "-o", "pid=,ppid=,pgid=,command="],
+                stderr=subprocess.DEVNULL,
+            )
+        except (subprocess.SubprocessError, OSError, ValueError):
+            return []
+        has_elapsed = False
+    else:
+        has_elapsed = True
+
+    rows: list[dict[str, Any]] = []
+    for raw_line in out.decode(errors="replace").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split(maxsplit=4 if has_elapsed else 3)
+        expected_parts = 5 if has_elapsed else 4
+        if len(parts) < expected_parts:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+            row_pgid = int(parts[2])
+            elapsed = int(parts[3]) if has_elapsed else None
+        except ValueError:
+            continue
+        command = parts[4] if has_elapsed else parts[3]
+        if row_pgid != pgid or not command.strip():
+            continue
+        rows.append(
+            {
+                "pid": pid,
+                "ppid": ppid,
+                "pgid": row_pgid,
+                "elapsed_seconds": elapsed,
+                "command": command.strip(),
+            }
+        )
+    return rows
+
+
+def detect_active_tool(
+    repo_root: Path, run_id: str, worker_pid: int
+) -> Optional[FlowActiveTool]:
+    """Infer active tool work from descendants in the flow worker's process group."""
+
+    pgid = _process_group_for_pid(worker_pid)
+    if pgid is None or pgid != worker_pid:
+        return None
+    artifacts_dir = _worker_artifacts_dir(repo_root, run_id)
+    rows = [
+        row
+        for row in _read_process_group_rows(pgid)
+        if row.get("pid") != worker_pid and row.get("pid") != os.getpid()
+    ]
+    if not rows:
+        return None
+
+    direct_children = [row for row in rows if row.get("ppid") == worker_pid]
+    candidates = direct_children or rows
+
+    def _elapsed_sort_key(row: dict[str, Any]) -> int:
+        elapsed = row.get("elapsed_seconds")
+        return elapsed if isinstance(elapsed, int) else 2**31
+
+    selected = min(
+        candidates,
+        key=_elapsed_sort_key,
+    )
+    elapsed = selected.get("elapsed_seconds")
+    observed_at = datetime.now(timezone.utc).isoformat()
+    output_updated_at = _latest_log_activity_at(artifacts_dir)
+    return FlowActiveTool(
+        pid=selected["pid"],
+        ppid=selected.get("ppid"),
+        pgid=selected.get("pgid"),
+        command=selected["command"],
+        elapsed_seconds=elapsed if isinstance(elapsed, int) else None,
+        last_activity_at=output_updated_at or observed_at,
+        output_updated_at=output_updated_at,
+    )
+
+
 def _normalize_executable_token(token: str) -> str:
     resolved = resolve_executable(token)
     candidate = resolved or token
@@ -455,6 +599,7 @@ def check_worker_health(
             cmdline=cmd,
             artifact_path=metadata_path,
             message="worker running (cmdline unknown)",
+            active_tool=detect_active_tool(repo_root, run_id, pid),
         )
 
     if not _cmdline_matches(expected_cmd, actual_cmd):
@@ -472,6 +617,7 @@ def check_worker_health(
         cmdline=actual_cmd,
         artifact_path=metadata_path,
         message="worker running",
+        active_tool=detect_active_tool(repo_root, run_id, pid),
     )
 
 

--- a/src/codex_autorunner/core/ticket_flow_operator.py
+++ b/src/codex_autorunner/core/ticket_flow_operator.py
@@ -30,7 +30,11 @@ from .flows.worker_process import (
     spawn_flow_worker,
 )
 from .flows.workspace_root import resolve_ticket_flow_workspace_root
-from .freshness import resolve_stale_threshold_seconds
+from .freshness import (
+    build_freshness_payload,
+    normalize_iso_datetime,
+    resolve_stale_threshold_seconds,
+)
 from .state_roots import resolve_repo_flows_db_path
 from .text_utils import _normalize_optional_text
 from .ticket_flow_projection import (
@@ -977,6 +981,45 @@ def _read_ticket_flow_app_metadata(
     return metadata
 
 
+def _effective_last_activity_at(
+    *,
+    last_event_at: Optional[str],
+    freshness: Any,
+    active_tool: Optional[Mapping[str, Any]],
+) -> Optional[str]:
+    candidates = [
+        normalize_iso_datetime(last_event_at),
+        normalize_iso_datetime(
+            freshness.get("basis_at") if isinstance(freshness, Mapping) else None
+        ),
+        normalize_iso_datetime(
+            active_tool.get("last_activity_at")
+            if isinstance(active_tool, Mapping)
+            else None
+        ),
+    ]
+    normalized = [candidate for candidate in candidates if candidate is not None]
+    if not normalized:
+        return None
+    return max(normalized)
+
+
+def _effective_freshness(
+    *, freshness: Any, effective_last_activity_at: Optional[str]
+) -> Any:
+    if not isinstance(freshness, Mapping) or effective_last_activity_at is None:
+        return freshness
+    generated_at = freshness.get("generated_at")
+    threshold = freshness.get("stale_threshold_seconds")
+    return build_freshness_payload(
+        generated_at=generated_at if isinstance(generated_at, str) else None,
+        stale_threshold_seconds=threshold,
+        candidates=[
+            ("effective_last_activity_at", effective_last_activity_at),
+        ],
+    )
+
+
 def build_ticket_flow_status_snapshot(
     repo_root: Path,
     record: FlowRunRecord,
@@ -1029,16 +1072,34 @@ def build_ticket_flow_status_snapshot(
     freshness = (
         canonical_state.get("freshness") if isinstance(canonical_state, dict) else None
     )
+    active_tool = getattr(health, "active_tool", None)
+    active_tool_payload = (
+        active_tool.to_dict()
+        if active_tool is not None and hasattr(active_tool, "to_dict")
+        else None
+    )
+    effective_last_activity_at = _effective_last_activity_at(
+        last_event_at=last_event_at,
+        freshness=freshness,
+        active_tool=active_tool_payload,
+    )
+    effective_freshness = _effective_freshness(
+        freshness=freshness,
+        effective_last_activity_at=effective_last_activity_at,
+    )
     return {
         "last_event_seq": last_event_seq,
         "last_event_at": last_event_at,
         "worker_health": health,
+        "agent_status": "busy" if active_tool_payload else None,
+        "active_tool": active_tool_payload,
+        "effective_last_activity_at": effective_last_activity_at,
         "effective_current_ticket": effective_ticket,
         "app": app_metadata,
         "ticket_progress": ticket_progress(repo_root),
         "state": updated_state,
         "canonical_state_v1": canonical_state,
-        "freshness": freshness,
+        "freshness": effective_freshness,
     }
 
 

--- a/src/codex_autorunner/surfaces/cli/commands/flow.py
+++ b/src/codex_autorunner/surfaces/cli/commands/flow.py
@@ -201,6 +201,14 @@ def register_flow_commands(
             "duration_seconds": flow_run_duration_seconds(record),
             "last_event_seq": snapshot.get("last_event_seq"),
             "last_event_at": snapshot.get("last_event_at"),
+            "effective_last_activity_at": snapshot.get("effective_last_activity_at"),
+            "agent": (
+                {"status": snapshot.get("agent_status")}
+                if snapshot.get("agent_status")
+                else None
+            ),
+            "active_tool": snapshot.get("active_tool"),
+            "freshness": snapshot.get("freshness"),
             "current_ticket": effective_ticket,
             "app": snapshot.get("app"),
             "ticket_progress": snapshot.get("ticket_progress"),
@@ -216,6 +224,7 @@ def register_flow_commands(
                     "message": health.message,
                     "exit_code": getattr(health, "exit_code", None),
                     "stderr_tail": getattr(health, "stderr_tail", None),
+                    "active_tool": snapshot.get("active_tool"),
                 }
                 if health
                 else None
@@ -249,6 +258,22 @@ def register_flow_commands(
         typer.echo(
             f"last_event={payload.get('last_event_at')} seq={payload.get('last_event_seq')}"
         )
+        effective_last_activity_at = payload.get("effective_last_activity_at")
+        if effective_last_activity_at:
+            typer.echo(f"effective_last_activity={effective_last_activity_at}")
+        active_tool = payload.get("active_tool")
+        if isinstance(active_tool, dict):
+            command = active_tool.get("command")
+            if isinstance(command, str) and command.strip():
+                detail_parts = []
+                elapsed = active_tool.get("elapsed_seconds")
+                if isinstance(elapsed, int):
+                    detail_parts.append(f"running={format_flow_duration(elapsed)}")
+                output_updated_at = active_tool.get("output_updated_at")
+                if isinstance(output_updated_at, str) and output_updated_at.strip():
+                    detail_parts.append(f"output_updated={output_updated_at.strip()}")
+                suffix = f" {' '.join(detail_parts)}" if detail_parts else ""
+                typer.echo(f"active_tool: {command.strip()}{suffix}")
         status = payload.get("status") or ""
         reason_summary = payload.get("reason_summary")
         if isinstance(reason_summary, str) and reason_summary.strip():

--- a/src/codex_autorunner/surfaces/web/routes/flows.py
+++ b/src/codex_autorunner/surfaces/web/routes/flows.py
@@ -502,9 +502,11 @@ class FlowWorkerHealthResponse(BaseModel):
     message: Optional[str] = None
     exit_code: Optional[int] = None
     stderr_tail: Optional[str] = None
+    active_tool: Optional[Dict[str, Any]] = None
 
     @classmethod
     def from_health(cls, health: FlowWorkerHealth) -> "FlowWorkerHealthResponse":
+        active_tool = getattr(health, "active_tool", None)
         return cls(
             status=health.status,
             pid=health.pid,
@@ -512,6 +514,7 @@ class FlowWorkerHealthResponse(BaseModel):
             message=health.message,
             exit_code=getattr(health, "exit_code", None),
             stderr_tail=getattr(health, "stderr_tail", None),
+            active_tool=active_tool.to_dict() if active_tool is not None else None,
         )
 
 
@@ -530,6 +533,10 @@ class FlowStatusResponse(BaseModel):
     ticket_progress: Optional[Dict[str, int]] = None
     last_event_seq: Optional[int] = None
     last_event_at: Optional[str] = None
+    effective_last_activity_at: Optional[str] = None
+    agent: Optional[Dict[str, Any]] = None
+    active_tool: Optional[Dict[str, Any]] = None
+    freshness: Optional[Dict[str, Any]] = None
     worker_health: Optional[FlowWorkerHealthResponse] = None
 
     @classmethod
@@ -540,6 +547,10 @@ class FlowStatusResponse(BaseModel):
         last_event_seq: Optional[int] = None,
         last_event_at: Optional[str] = None,
         worker_health: Optional[FlowWorkerHealth] = None,
+        effective_last_activity_at: Optional[str] = None,
+        agent_status: Optional[str] = None,
+        active_tool: Optional[dict[str, Any]] = None,
+        freshness: Optional[dict[str, Any]] = None,
     ) -> "FlowStatusResponse":
         state = record.state or {}
         state_outcome = _validate_run_state(record.state)
@@ -564,6 +575,10 @@ class FlowStatusResponse(BaseModel):
             reason_summary=reason_summary,
             last_event_seq=last_event_seq,
             last_event_at=last_event_at,
+            effective_last_activity_at=effective_last_activity_at,
+            agent={"status": agent_status} if agent_status else None,
+            active_tool=active_tool,
+            freshness=freshness,
             worker_health=(
                 FlowWorkerHealthResponse.from_health(worker_health)
                 if worker_health
@@ -639,6 +654,10 @@ def _build_flow_status_response(
         last_event_seq=snapshot["last_event_seq"],
         last_event_at=snapshot["last_event_at"],
         worker_health=snapshot["worker_health"],
+        effective_last_activity_at=snapshot.get("effective_last_activity_at"),
+        agent_status=snapshot.get("agent_status"),
+        active_tool=snapshot.get("active_tool"),
+        freshness=snapshot.get("freshness"),
     )
     resp.ticket_progress = snapshot.get("ticket_progress")
     if lite:

--- a/tests/core/test_flow_ux_helpers.py
+++ b/tests/core/test_flow_ux_helpers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
+from codex_autorunner.core import ticket_flow_operator
 from codex_autorunner.core.flows import ux_helpers
 from codex_autorunner.core.flows.models import FlowRunRecord, FlowRunStatus
 from codex_autorunner.core.flows.worker_process import FlowWorkerHealth
@@ -233,3 +234,79 @@ def test_flow_status_lines_include_app_only_when_present() -> None:
 
     assert "App: local.my-workflow v1.2.3" in lines
     assert all(not line.startswith("App:") for line in no_app_lines)
+
+
+def test_flow_status_lines_include_active_tool() -> None:
+    record = _run("tool-run", FlowRunStatus.RUNNING)
+    lines = ux_helpers.format_ticket_flow_status_lines(
+        record,
+        {
+            "worker_health": None,
+            "last_event_seq": 7,
+            "last_event_at": "2026-03-11T00:00:00Z",
+            "effective_current_ticket": "TICKET-001.md",
+            "ticket_progress": None,
+            "active_tool": {
+                "command": ".venv/bin/python -m pytest -q",
+                "elapsed_seconds": 245,
+                "last_activity_at": "2026-03-11T01:00:00+00:00",
+                "output_updated_at": "2026-03-11T01:00:00+00:00",
+            },
+            "freshness": {
+                "status": "fresh",
+                "recency_basis": "effective_last_activity_at",
+                "basis_at": "2026-03-11T01:00:00+00:00",
+                "age_seconds": 20,
+            },
+        },
+    )
+
+    assert (
+        "Active tool: .venv/bin/python -m pytest -q (running 4m, output updated 20s ago)"
+        in lines
+    )
+    assert "Freshness: fresh · activity 20s ago" in lines
+
+
+def test_flow_status_snapshot_uses_active_tool_as_effective_activity(
+    monkeypatch, tmp_path: Path
+) -> None:
+    record = _run("tool-run", FlowRunStatus.RUNNING)
+    health = FlowWorkerHealth(
+        status="alive",
+        pid=4242,
+        cmdline=["worker"],
+        artifact_path=tmp_path / ".codex-autorunner" / "flows" / "tool-run",
+    )
+    health.active_tool = SimpleNamespace(
+        to_dict=lambda: {
+            "command": ".venv/bin/python -m pytest -q",
+            "elapsed_seconds": 245,
+            "last_activity_at": "2026-03-11T01:00:00+00:00",
+            "output_updated_at": "2026-03-11T01:00:00+00:00",
+        }
+    )
+    monkeypatch.setattr(
+        ticket_flow_operator, "check_worker_health", lambda *_args, **_kwargs: health
+    )
+    monkeypatch.setattr(
+        ticket_flow_operator,
+        "_canonical_flow_status_state",
+        lambda *_args, **_kwargs: {
+            "freshness": {
+                "generated_at": "2026-03-11T01:00:20+00:00",
+                "stale_threshold_seconds": 1800,
+                "basis_at": "2026-03-11T00:00:00+00:00",
+                "status": "stale",
+            }
+        },
+    )
+
+    snapshot = ticket_flow_operator.build_ticket_flow_status_snapshot(
+        tmp_path, record, store=None
+    )
+
+    assert snapshot["agent_status"] == "busy"
+    assert snapshot["active_tool"]["command"] == ".venv/bin/python -m pytest -q"
+    assert snapshot["effective_last_activity_at"] == "2026-03-11T01:00:00+00:00"
+    assert snapshot["freshness"]["status"] == "fresh"

--- a/tests/flows/test_worker_process.py
+++ b/tests/flows/test_worker_process.py
@@ -118,6 +118,44 @@ def test_read_process_cmdline_falls_back_without_wide_flag(monkeypatch) -> None:
     assert seen[1] == ["ps", "-p", "456", "-o", "command="]
 
 
+def test_detect_active_tool_uses_worker_process_group(
+    monkeypatch, tmp_path: Path
+) -> None:
+    run_id = "3022db08-82b8-40dd-8cfa-d04eb0fcded2"
+    artifacts_dir = worker_process._worker_artifacts_dir(tmp_path, run_id)
+    out_log = artifacts_dir / "worker.out.log"
+    out_log.write_text("pytest output\n", encoding="utf-8")
+    monkeypatch.setattr(worker_process, "_process_group_for_pid", lambda _pid: 4242)
+    monkeypatch.setattr(
+        worker_process,
+        "_read_process_group_rows",
+        lambda _pgid: [
+            {
+                "pid": 4242,
+                "ppid": 1,
+                "pgid": 4242,
+                "elapsed_seconds": 120,
+                "command": "python -m codex_autorunner flow worker",
+            },
+            {
+                "pid": 4300,
+                "ppid": 4242,
+                "pgid": 4242,
+                "elapsed_seconds": 65,
+                "command": ".venv/bin/python -m pytest -q",
+            },
+        ],
+    )
+
+    active_tool = worker_process.detect_active_tool(tmp_path, run_id, 4242)
+
+    assert active_tool is not None
+    assert active_tool.pid == 4300
+    assert active_tool.command == ".venv/bin/python -m pytest -q"
+    assert active_tool.elapsed_seconds == 65
+    assert active_tool.last_activity_at is not None
+
+
 def test_spawn_flow_worker_closes_streams_when_popen_fails(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/flows/test_worker_process.py
+++ b/tests/flows/test_worker_process.py
@@ -156,6 +156,49 @@ def test_detect_active_tool_uses_worker_process_group(
     assert active_tool.last_activity_at is not None
 
 
+def test_detect_active_tool_respects_artifacts_root(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Log-based activity must use the same artifacts root as worker health checks."""
+    run_id = "3022db08-82b8-40dd-8cfa-d04eb0fcded2"
+    custom_root = tmp_path / "custom-flow-artifacts"
+    artifacts_dir = worker_process._worker_artifacts_dir(
+        tmp_path, run_id, artifacts_root=custom_root
+    )
+    (artifacts_dir / "worker.out.log").write_text("custom root logs\n", encoding="utf-8")
+
+    monkeypatch.setattr(worker_process, "_process_group_for_pid", lambda _pid: 4242)
+    monkeypatch.setattr(
+        worker_process,
+        "_read_process_group_rows",
+        lambda _pgid: [
+            {
+                "pid": 4242,
+                "ppid": 1,
+                "pgid": 4242,
+                "elapsed_seconds": 10,
+                "command": "python -m codex_autorunner flow worker",
+            },
+            {
+                "pid": 4300,
+                "ppid": 4242,
+                "pgid": 4242,
+                "elapsed_seconds": 5,
+                "command": "tool",
+            },
+        ],
+    )
+
+    active_tool = worker_process.detect_active_tool(
+        tmp_path, run_id, 4242, artifacts_root=custom_root
+    )
+
+    assert active_tool is not None
+    assert active_tool.output_updated_at is not None
+    default_dir = tmp_path / ".codex-autorunner" / "flows" / worker_process._normalized_run_id(run_id)
+    assert not default_dir.exists()
+
+
 def test_spawn_flow_worker_closes_streams_when_popen_fails(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/flows/test_worker_process.py
+++ b/tests/flows/test_worker_process.py
@@ -165,7 +165,9 @@ def test_detect_active_tool_respects_artifacts_root(
     artifacts_dir = worker_process._worker_artifacts_dir(
         tmp_path, run_id, artifacts_root=custom_root
     )
-    (artifacts_dir / "worker.out.log").write_text("custom root logs\n", encoding="utf-8")
+    (artifacts_dir / "worker.out.log").write_text(
+        "custom root logs\n", encoding="utf-8"
+    )
 
     monkeypatch.setattr(worker_process, "_process_group_for_pid", lambda _pid: 4242)
     monkeypatch.setattr(
@@ -195,7 +197,12 @@ def test_detect_active_tool_respects_artifacts_root(
 
     assert active_tool is not None
     assert active_tool.output_updated_at is not None
-    default_dir = tmp_path / ".codex-autorunner" / "flows" / worker_process._normalized_run_id(run_id)
+    default_dir = (
+        tmp_path
+        / ".codex-autorunner"
+        / "flows"
+        / worker_process._normalized_run_id(run_id)
+    )
     assert not default_dir.exists()
 
 


### PR DESCRIPTION
## Summary
- infer active child/tool processes from the ticket-flow worker process group
- include active_tool, agent.status, effective_last_activity_at, and freshness in status payloads
- render compact active-tool lines in CLI and Discord/Telegram flow status output

## Validation
- .venv/bin/python -m pytest tests/flows/test_worker_process.py tests/core/test_flow_ux_helpers.py tests/test_telegram_flow_status.py::test_flow_status_includes_freshness_summary -q
- .venv/bin/python -m ruff check src/codex_autorunner/core/flows/worker_process.py src/codex_autorunner/core/ticket_flow_operator.py src/codex_autorunner/core/flows/ux_helpers.py src/codex_autorunner/surfaces/cli/commands/flow.py src/codex_autorunner/surfaces/web/routes/flows.py tests/flows/test_worker_process.py tests/core/test_flow_ux_helpers.py
- .venv/bin/python -m mypy src/codex_autorunner/core/flows/worker_process.py src/codex_autorunner/core/ticket_flow_operator.py src/codex_autorunner/core/flows/ux_helpers.py src/codex_autorunner/surfaces/cli/commands/flow.py src/codex_autorunner/surfaces/web/routes/flows.py
- git commit hook aggregate lane: full repo mypy, 8102 pytest tests, frontend build/tests, chat-surface lab checks

Closes #1660