### PR TITLE
Fix SCM managed turn queue wakeups

### DIFF
--- a/src/codex_autorunner/core/pma_thread_store.py
+++ b/src/codex_autorunner/core/pma_thread_store.py
@@ -926,6 +926,7 @@ class PmaThreadStore:
         client_turn_id: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
         queue_payload: Optional[dict[str, Any]] = None,
+        force_queue: bool = False,
     ) -> dict[str, Any]:
         managed_turn_id = str(uuid.uuid4())
         started_at = now_iso()
@@ -960,7 +961,9 @@ class PmaThreadStore:
                     """,
                     (managed_thread_id,),
                 ).fetchone()
-                execution_status = "queued" if running_exists is not None else "running"
+                execution_status = (
+                    "queued" if force_queue or running_exists is not None else "running"
+                )
                 if execution_status == "queued" and busy_policy != "queue":
                     raise ManagedThreadAlreadyHasRunningTurnError(managed_thread_id)
                 conn.execute(

--- a/src/codex_autorunner/core/publish_journal.py
+++ b/src/codex_autorunner/core/publish_journal.py
@@ -224,6 +224,47 @@ class PublishJournalStore:
                 refreshed = self._load_operation_row(conn, normalized_operation_id)
         return _operation_from_row(refreshed) if refreshed is not None else None
 
+    def patch_running_operation_payload(
+        self,
+        operation_id: str,
+        payload_patch: dict[str, Any],
+    ) -> Optional[PublishOperation]:
+        """Shallow-merge ``payload_patch`` into ``payload_json`` for a running operation.
+
+        Used to persist executor-local retry hints (e.g. dependency wait counters)
+        before transitioning back to ``pending`` on retryable failure.
+        """
+        normalized_operation_id = _normalize_text(operation_id)
+        if normalized_operation_id is None:
+            return None
+        patch = _normalize_json_object(payload_patch, field_name="payload_patch")
+        updated_at = now_iso()
+        with open_orchestration_sqlite(self._hub_root, durable=True) as conn:
+            row = self._load_operation_row(conn, normalized_operation_id)
+            if row is None or str(row["state"]) != "running":
+                return None
+            payload = _json_loads_object(row["payload_json"])
+            payload.update(patch)
+            with conn:
+                cursor = conn.execute(
+                    """
+                    UPDATE orch_publish_operations
+                       SET payload_json = ?,
+                           updated_at = ?
+                     WHERE operation_id = ?
+                       AND state = 'running'
+                    """,
+                    (
+                        _json_dumps(payload),
+                        updated_at,
+                        normalized_operation_id,
+                    ),
+                )
+                if cursor.rowcount == 0:
+                    return None
+                refreshed = self._load_operation_row(conn, normalized_operation_id)
+        return _operation_from_row(refreshed) if refreshed is not None else None
+
     def get_operation(self, operation_id: str) -> Optional[PublishOperation]:
         normalized_operation_id = _normalize_text(operation_id)
         if normalized_operation_id is None:

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -40,6 +40,9 @@ _MANAGED_TURN_START_CONFIRMATION_TIMEOUT_SECONDS = 120
 _MANAGED_TURN_START_CONFIRMATION_INITIAL_RETRY_SECONDS = 5
 _MANAGED_TURN_START_CONFIRMATION_MAX_RETRY_SECONDS = 30
 _MANAGED_TURN_START_CONFIRMATION_MAX_ATTEMPTS = 12
+# Counts notify_chat retries after enqueue succeeded; not incremented while
+# waiting for enqueue_managed_turn so backlog cannot exhaust the start window.
+_MANAGED_TURN_POST_ENQUEUE_WAIT_CYCLES_KEY = "_managed_turn_post_enqueue_wait_cycles"
 _RUNTIME_STARTED_AT_KEY = "runtime_started_at"
 
 
@@ -210,10 +213,23 @@ def _managed_turn_start_retry_seconds(operation: PublishOperation) -> float:
     return float(min(delay, _MANAGED_TURN_START_CONFIRMATION_MAX_RETRY_SECONDS))
 
 
-def _managed_turn_dependency_exhausted(operation: PublishOperation) -> bool:
-    return (
-        int(operation.attempt_count or 0)
-        >= _MANAGED_TURN_START_CONFIRMATION_MAX_ATTEMPTS
+def _managed_turn_post_enqueue_wait_exhausted(dependency: Mapping[str, Any]) -> bool:
+    cycles = _coerce_int(dependency.get(_MANAGED_TURN_POST_ENQUEUE_WAIT_CYCLES_KEY))
+    return cycles >= _MANAGED_TURN_START_CONFIRMATION_MAX_ATTEMPTS - 1
+
+
+def _bump_managed_turn_post_enqueue_wait_cycles(
+    journal: PublishJournalStore,
+    operation_id: str,
+    dependency: Mapping[str, Any],
+) -> None:
+    dep = dict(dependency)
+    dep[_MANAGED_TURN_POST_ENQUEUE_WAIT_CYCLES_KEY] = (
+        _coerce_int(dep.get(_MANAGED_TURN_POST_ENQUEUE_WAIT_CYCLES_KEY)) + 1
+    )
+    journal.patch_running_operation_payload(
+        operation_id,
+        {"managed_turn_dependency": dep},
     )
 
 
@@ -304,6 +320,9 @@ def _resolve_notify_message(
             raise TerminalPublishError(
                 "Managed turn record never became visible before timeout"
             )
+        _bump_managed_turn_post_enqueue_wait_cycles(
+            journal, operation.operation_id, dependency
+        )
         raise RetryablePublishError(
             "Waiting for managed turn record to become visible",
             retry_after_seconds=_managed_turn_start_retry_seconds(operation),
@@ -331,9 +350,9 @@ def _resolve_notify_message(
         enqueue_operation=enqueue_operation,
         turn=turn,
     )
-    if datetime.now(timezone.utc) >= deadline or _managed_turn_dependency_exhausted(
-        operation
-    ):
+    if datetime.now(
+        timezone.utc
+    ) >= deadline or _managed_turn_post_enqueue_wait_exhausted(dependency):
         detail = (
             "The execution was created but the runtime never launched it."
             if _normalize_optional_text(turn.get("backend_turn_id")) is None
@@ -344,6 +363,9 @@ def _resolve_notify_message(
         raise TerminalPublishError(
             "Managed turn did not reach a confirmed running state before timeout"
         )
+    _bump_managed_turn_post_enqueue_wait_cycles(
+        journal, operation.operation_id, dependency
+    )
     raise RetryablePublishError(
         "Waiting for managed turn start confirmation",
         retry_after_seconds=_managed_turn_start_retry_seconds(operation),

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -36,8 +36,10 @@ from .scm_observability import correlation_id_for_operation, correlation_id_from
 from .text_utils import _coerce_int, _normalize_optional_text
 
 _LOGGER = logging.getLogger(__name__)
-_MANAGED_TURN_START_CONFIRMATION_TIMEOUT_SECONDS = 300
-_MANAGED_TURN_START_CONFIRMATION_RETRY_SECONDS = 5
+_MANAGED_TURN_START_CONFIRMATION_TIMEOUT_SECONDS = 120
+_MANAGED_TURN_START_CONFIRMATION_INITIAL_RETRY_SECONDS = 5
+_MANAGED_TURN_START_CONFIRMATION_MAX_RETRY_SECONDS = 30
+_MANAGED_TURN_START_CONFIRMATION_MAX_ATTEMPTS = 12
 _RUNTIME_STARTED_AT_KEY = "runtime_started_at"
 
 
@@ -202,6 +204,27 @@ def _managed_turn_dependency_deadline(
     return base + timedelta(seconds=timeout_seconds)
 
 
+def _managed_turn_start_retry_seconds(operation: PublishOperation) -> float:
+    attempt_index = max(int(operation.attempt_count or 1) - 1, 0)
+    delay = _MANAGED_TURN_START_CONFIRMATION_INITIAL_RETRY_SECONDS * (2**attempt_index)
+    return float(min(delay, _MANAGED_TURN_START_CONFIRMATION_MAX_RETRY_SECONDS))
+
+
+def _managed_turn_dependency_exhausted(operation: PublishOperation) -> bool:
+    return (
+        int(operation.attempt_count or 0)
+        >= _MANAGED_TURN_START_CONFIRMATION_MAX_ATTEMPTS
+    )
+
+
+def _managed_turn_start_failure_message(
+    failure_message: Optional[str],
+    detail: str,
+) -> str:
+    base = failure_message or "Failed to wake the bound agent thread."
+    return f"{base} {detail}".strip()
+
+
 def _resolve_notify_message(
     *,
     operation: PublishOperation,
@@ -239,7 +262,7 @@ def _resolve_notify_message(
     if enqueue_operation.state in {"pending", "running"}:
         raise RetryablePublishError(
             "Waiting for enqueue_managed_turn to finish",
-            retry_after_seconds=_MANAGED_TURN_START_CONFIRMATION_RETRY_SECONDS,
+            retry_after_seconds=_managed_turn_start_retry_seconds(operation),
         )
 
     failure_message = _normalize_optional_text(dependency.get("failure_message"))
@@ -271,13 +294,19 @@ def _resolve_notify_message(
         )
         if datetime.now(timezone.utc) >= deadline:
             if failure_message is not None:
-                return failure_message, None
+                return (
+                    _managed_turn_start_failure_message(
+                        failure_message,
+                        "The managed turn record never became visible before timeout.",
+                    ),
+                    None,
+                )
             raise TerminalPublishError(
                 "Managed turn record never became visible before timeout"
             )
         raise RetryablePublishError(
             "Waiting for managed turn record to become visible",
-            retry_after_seconds=_MANAGED_TURN_START_CONFIRMATION_RETRY_SECONDS,
+            retry_after_seconds=_managed_turn_start_retry_seconds(operation),
         )
     turn_status = _normalize_optional_text(turn.get("status")) or "unknown"
     metadata = _normalize_mapping(turn.get("metadata"))
@@ -302,15 +331,22 @@ def _resolve_notify_message(
         enqueue_operation=enqueue_operation,
         turn=turn,
     )
-    if datetime.now(timezone.utc) >= deadline:
+    if datetime.now(timezone.utc) >= deadline or _managed_turn_dependency_exhausted(
+        operation
+    ):
+        detail = (
+            "The execution was created but the runtime never launched it."
+            if _normalize_optional_text(turn.get("backend_turn_id")) is None
+            else "The managed turn did not reach a confirmed running state before timeout."
+        )
         if failure_message is not None:
-            return failure_message, None
+            return _managed_turn_start_failure_message(failure_message, detail), None
         raise TerminalPublishError(
             "Managed turn did not reach a confirmed running state before timeout"
         )
     raise RetryablePublishError(
         "Waiting for managed turn start confirmation",
-        retry_after_seconds=_MANAGED_TURN_START_CONFIRMATION_RETRY_SECONDS,
+        retry_after_seconds=_managed_turn_start_retry_seconds(operation),
     )
 
 
@@ -847,6 +883,7 @@ def build_enqueue_managed_turn_executor(
                 client_turn_id=client_request_id,
                 metadata=request.metadata,
                 queue_payload=queue_payload,
+                force_queue=bool(tracking),
             )
         except ManagedThreadNotActiveError as exc:
             if not tracking:
@@ -904,6 +941,7 @@ def build_enqueue_managed_turn_executor(
                 client_turn_id=client_request_id,
                 metadata=request.metadata,
                 queue_payload=queue_payload,
+                force_queue=bool(tracking),
             )
             _LOGGER.info(
                 "scm.enqueue_managed_turn.rebound_thread "

--- a/src/codex_autorunner/integrations/discord/managed_thread_startup_recovery.py
+++ b/src/codex_autorunner/integrations/discord/managed_thread_startup_recovery.py
@@ -24,6 +24,54 @@ from .progress_leases import (
 )
 
 
+def recover_pending_discord_managed_thread_queue(
+    service: Any,
+    *,
+    orchestration_service: Any,
+    surface_key: str,
+    managed_thread_id: str,
+    thread: Any,
+    public_execution_error: str = "Discord PMA turn failed",
+) -> bool:
+    workspace_root = getattr(thread, "workspace_root", None)
+    if not workspace_root:
+        return False
+    coordinator = _build_discord_managed_thread_coordinator(
+        service=service,
+        orchestration_service=orchestration_service,
+        channel_id=surface_key,
+        public_execution_error=public_execution_error,
+        timeout_error="Discord PMA turn timed out",
+        interrupted_error="Discord PMA turn interrupted",
+        pma_enabled=True,
+    )
+    queue_worker_hooks = _build_discord_runner_hooks(
+        service,
+        channel_id=surface_key,
+        managed_thread_id=managed_thread_id,
+        workspace_root=Path(str(workspace_root)),
+        public_execution_error=public_execution_error,
+    ).queue_worker_hooks()
+    coordinator.ensure_queue_worker(
+        task_map=_get_discord_thread_queue_task_map(service),
+        managed_thread_id=managed_thread_id,
+        spawn_task=lambda coro: _spawn_discord_progress_background_task(
+            service,
+            coro,
+            managed_thread_id=managed_thread_id,
+            failure_note=(
+                "Status: this progress message lost its queue worker and is "
+                "no longer live. Please retry if needed."
+            ),
+            orphaned=True,
+            reconcile_on_cancel=True,
+            await_on_shutdown=True,
+        ),
+        hooks=queue_worker_hooks,
+    )
+    return True
+
+
 async def recover_managed_thread_executions_on_startup(service: Any) -> None:
     public_execution_error = "Discord PMA turn failed"
 
@@ -77,43 +125,14 @@ async def recover_managed_thread_executions_on_startup(service: Any) -> None:
         managed_thread_id: str,
         thread: Any,
     ) -> bool:
-        workspace_root = getattr(thread, "workspace_root", None)
-        if not workspace_root:
-            return False
-        coordinator = _build_discord_managed_thread_coordinator(
-            service=owner,
-            orchestration_service=orchestration_service,
-            channel_id=surface_key,
-            public_execution_error=public_execution_error,
-            timeout_error="Discord PMA turn timed out",
-            interrupted_error="Discord PMA turn interrupted",
-            pma_enabled=True,
-        )
-        queue_worker_hooks = _build_discord_runner_hooks(
+        return recover_pending_discord_managed_thread_queue(
             owner,
-            channel_id=surface_key,
+            orchestration_service=orchestration_service,
+            surface_key=surface_key,
             managed_thread_id=managed_thread_id,
-            workspace_root=Path(str(workspace_root)),
+            thread=thread,
             public_execution_error=public_execution_error,
-        ).queue_worker_hooks()
-        coordinator.ensure_queue_worker(
-            task_map=_get_discord_thread_queue_task_map(owner),
-            managed_thread_id=managed_thread_id,
-            spawn_task=lambda coro: _spawn_discord_progress_background_task(
-                owner,
-                coro,
-                managed_thread_id=managed_thread_id,
-                failure_note=(
-                    "Status: this progress message lost its queue worker and is "
-                    "no longer live. Please retry if needed."
-                ),
-                orphaned=True,
-                reconcile_on_cancel=True,
-                await_on_shutdown=True,
-            ),
-            hooks=queue_worker_hooks,
         )
-        return True
 
     await recover_surface_managed_thread_executions_on_startup(
         service,

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -324,6 +324,9 @@ from .managed_thread_routing import build_discord_thread_orchestration_service
 from .managed_thread_startup_recovery import (
     recover_managed_thread_executions_on_startup as _recover_managed_thread_executions_on_startup_impl,
 )
+from .managed_thread_startup_recovery import (
+    recover_pending_discord_managed_thread_queue as _recover_pending_discord_managed_thread_queue,
+)
 from .message_turns import (
     DiscordMessageTurnResult,
     resolve_bound_workspace_root,
@@ -3945,6 +3948,33 @@ class DiscordBotService:
                 delivery_record_id=record.record_id,
                 delivered_message_id=delivered_id,
             )
+            parts = record.record_id.split(":")
+            if len(parts) >= 6 and parts[1] == "discord":
+                managed_thread_id = parts[3].strip()
+                if managed_thread_id:
+                    try:
+                        orchestration_service = (
+                            build_discord_thread_orchestration_service(self)
+                        )
+                        thread = orchestration_service.get_thread_target(
+                            managed_thread_id
+                        )
+                        if thread is not None:
+                            _recover_pending_discord_managed_thread_queue(
+                                self,
+                                orchestration_service=orchestration_service,
+                                surface_key=record.channel_id,
+                                managed_thread_id=managed_thread_id,
+                                thread=thread,
+                            )
+                    except Exception:
+                        self._logger.warning(
+                            "discord.outbox.progress_queue_wake_failed "
+                            "record_id=%s managed_thread_id=%s",
+                            record.record_id,
+                            managed_thread_id,
+                            exc_info=True,
+                        )
         cleanup_payload = (
             record.payload_json.get("_codex_autorunner_cleanup")
             if isinstance(record.payload_json, dict)

--- a/src/codex_autorunner/integrations/github/publisher.py
+++ b/src/codex_autorunner/integrations/github/publisher.py
@@ -382,11 +382,7 @@ def build_github_enqueue_managed_turn_executor(
         result = base_executor(effective_operation)
         if result is None:
             return None
-        if (
-            progress_targets
-            and result.get("deduped") is not True
-            and result.get("queued") is not True
-        ):
+        if progress_targets and result.get("deduped") is not True:
             managed_thread_id = _normalize_optional_text(result.get("thread_target_id"))
             managed_turn_id = _normalize_optional_text(result.get("managed_turn_id"))
             request = _normalize_mapping(progress_payload.get("request"))

--- a/src/codex_autorunner/surfaces/cli/pma_control_plane.py
+++ b/src/codex_autorunner/surfaces/cli/pma_control_plane.py
@@ -29,6 +29,17 @@ MANAGED_THREAD_SEND_TIMEOUT_STATUS_LIMIT = 50
 MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_WINDOW_SECONDS = 15.0
 MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_POLL_SECONDS = 0.25
 
+# Upper bound on status polls during send-timeout recovery. Keeps recovery bounded
+# when tests (or broken environments) stub ``time.monotonic`` so the deadline
+# check never advances.
+_MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_MAX_POLLS = (
+    int(
+        MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_WINDOW_SECONDS
+        / MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_POLL_SECONDS
+    )
+    + 4
+)
+
 CAPABILITY_REQUIREMENTS = {
     "models": "model_listing",
     "interrupt": "interrupt",
@@ -514,6 +525,7 @@ def recover_managed_thread_send_timeout(
 
     deadline = time.monotonic() + MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_WINDOW_SECONDS
     baseline_queued_ids = set(baseline.queued_turn_ids)
+    recovery_polls = 0
     while True:
         try:
             current = ManagedThreadSendTimeoutProbe.from_status(
@@ -524,6 +536,9 @@ def recover_managed_thread_send_timeout(
             )
         except (httpx.HTTPError, ValueError, OSError, TypeError):
             if time.monotonic() >= deadline:
+                return None
+            recovery_polls += 1
+            if recovery_polls > _MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_MAX_POLLS:
                 return None
             time.sleep(MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_POLL_SECONDS)
             continue
@@ -634,5 +649,8 @@ def recover_managed_thread_send_timeout(
             )
 
         if time.monotonic() >= deadline:
+            return None
+        recovery_polls += 1
+        if recovery_polls > _MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_MAX_POLLS:
             return None
         time.sleep(MANAGED_THREAD_SEND_TIMEOUT_RECOVERY_POLL_SECONDS)

--- a/tests/core/test_publish_executor.py
+++ b/tests/core/test_publish_executor.py
@@ -2053,6 +2053,129 @@ def test_notify_chat_caps_start_confirmation_retries_with_runtime_launch_detail(
     ]
 
 
+def test_notify_chat_start_confirmation_exhaustion_ignores_enqueue_wait_retries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Post-enqueue retry cap must not consume budget while enqueue is still pending."""
+    hub_root, workspace_root, repo_id = _publish_hub(tmp_path)
+    thread_store = PmaThreadStore(hub_root)
+    thread = thread_store.create_thread("codex", workspace_root, repo_id=repo_id)
+    journal = PublishJournalStore(hub_root)
+    enqueue_operation, _ = journal.create_operation(
+        operation_key="enqueue:dep:late",
+        operation_kind="enqueue_managed_turn",
+        payload={
+            "thread_target_id": thread["managed_thread_id"],
+            "message_text": "Handle the latest SCM review.",
+        },
+        next_attempt_at="2026-03-25T00:00:00Z",
+    )
+    notify_operation, _ = journal.create_operation(
+        operation_key="notify:dep:late",
+        operation_kind="notify_chat",
+        payload={
+            "delivery": "primary_pma",
+            "repo_id": repo_id,
+            "message": "Started.",
+            "managed_turn_dependency": {
+                "dependency_kind": "enqueue_managed_turn_started",
+                "operation_id": enqueue_operation.operation_id,
+                "thread_target_id": thread["managed_thread_id"],
+                "failure_message": "Failed to wake the bound agent thread.",
+            },
+        },
+        next_attempt_at="2026-03-25T00:00:00Z",
+    )
+    assert journal.update_pending_operation(
+        enqueue_operation.operation_id,
+        next_attempt_at="2099-01-01T00:00:00Z",
+    )
+
+    calls: list[str] = []
+
+    async def _fake_notify_primary_pma_chat_for_repo(
+        *,
+        hub_root: Path,
+        repo_id: str | None,
+        message: str,
+        correlation_id: str,
+    ) -> dict[str, int]:
+        _ = (hub_root, repo_id, correlation_id)
+        calls.append(message)
+        return {"targets": 1, "published": 1}
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.publish_operation_executors.notify_primary_pma_chat_for_repo",
+        _fake_notify_primary_pma_chat_for_repo,
+    )
+    processor = PublishOperationProcessor(
+        journal,
+        executors=PublishExecutorRegistry(
+            {
+                "enqueue_managed_turn": build_enqueue_managed_turn_executor(
+                    hub_root=hub_root,
+                    thread_store=thread_store,
+                ),
+                "notify_chat": build_notify_chat_executor(
+                    hub_root=hub_root,
+                    thread_store=thread_store,
+                    journal_store=journal,
+                ),
+            }
+        ),
+        now_fn=_QueuedClock(*["2026-03-25T00:00:00Z"] * 25),
+    )
+
+    for _ in range(15):
+        assert journal.update_pending_operation(
+            notify_operation.operation_id,
+            next_attempt_at="2026-03-25T00:00:00Z",
+        )
+        processed = processor.process_now(limit=10)
+        assert {operation.operation_id for operation in processed} == {
+            notify_operation.operation_id,
+        }
+        assert processed[0].state == "pending"
+        assert calls == []
+
+    assert journal.update_pending_operation(
+        enqueue_operation.operation_id,
+        next_attempt_at="2026-03-25T00:00:00Z",
+    )
+    assert journal.update_pending_operation(
+        notify_operation.operation_id,
+        next_attempt_at="2026-03-25T00:00:00Z",
+    )
+    processed = processor.process_now(limit=10)
+    assert {operation.operation_id for operation in processed} == {
+        enqueue_operation.operation_id,
+        notify_operation.operation_id,
+    }
+    by_id = {operation.operation_id: operation for operation in processed}
+    assert by_id[enqueue_operation.operation_id].state == "succeeded"
+    assert by_id[notify_operation.operation_id].state == "pending"
+
+    for _ in range(10):
+        assert journal.update_pending_operation(
+            notify_operation.operation_id,
+            next_attempt_at="2026-03-25T00:00:00Z",
+        )
+        processed = processor.process_now(limit=10)
+        assert processed[0].state == "pending"
+        assert calls == []
+
+    assert journal.update_pending_operation(
+        notify_operation.operation_id,
+        next_attempt_at="2026-03-25T00:00:00Z",
+    )
+    processed = processor.process_now(limit=10)
+    assert processed[0].state == "succeeded"
+    assert calls == [
+        "Failed to wake the bound agent thread. "
+        "The execution was created but the runtime never launched it."
+    ]
+
+
 @pytest.mark.asyncio
 async def test_notify_chat_executor_runs_while_event_loop_is_active(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/core/test_publish_executor.py
+++ b/tests/core/test_publish_executor.py
@@ -858,7 +858,7 @@ def test_github_enqueue_managed_turn_publishes_bound_progress_placeholder(
         raw_config=raw_config,
     )(operation)
 
-    assert result["queued"] is False
+    assert result["queued"] is True
     assert result["progress_published"] is True
     assert result["progress_targets"] == [
         {"surface_kind": "discord", "surface_key": "channel-1"}
@@ -942,11 +942,11 @@ def test_enqueue_managed_turn_executor_reuses_reusable_scm_thread_statuses(
         )(operation)
 
     assert result["thread_target_id"] == thread["managed_thread_id"]
-    assert result["queued"] is False
+    assert result["queued"] is True
     turns = thread_store.list_turns(thread["managed_thread_id"], limit=10)
     assert len(turns) == 2
     assert turns[0]["managed_turn_id"] == result["managed_turn_id"]
-    assert turns[0]["status"] == "running"
+    assert turns[0]["status"] == "queued"
     assert any(
         "scm.enqueue_managed_turn.reusing_thread" in message
         and f"normalized_status={expected_runtime_status}" in message
@@ -1729,7 +1729,7 @@ def test_notify_chat_waits_for_managed_turn_start_confirmation(
         now_fn=_QueuedClock(
             "2026-03-25T00:00:00Z",
             "2026-03-25T00:00:05Z",
-            "2026-03-25T00:00:10Z",
+            "2026-03-25T00:00:15Z",
         ),
     )
 
@@ -1956,6 +1956,101 @@ def test_notify_chat_reports_failure_when_managed_turn_is_interrupted_before_sta
     ]
     assert second[0].state == "succeeded"
     assert calls == ["Failed to wake the bound agent thread for acme/widgets#42."]
+
+
+def test_notify_chat_caps_start_confirmation_retries_with_runtime_launch_detail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hub_root, workspace_root, repo_id = _publish_hub(tmp_path)
+    thread_store = PmaThreadStore(hub_root)
+    thread = thread_store.create_thread("codex", workspace_root, repo_id=repo_id)
+    journal = PublishJournalStore(hub_root)
+    enqueue_operation, _ = journal.create_operation(
+        operation_key="enqueue:dep:zombie",
+        operation_kind="enqueue_managed_turn",
+        payload={
+            "thread_target_id": thread["managed_thread_id"],
+            "message_text": "Handle the latest SCM review.",
+        },
+        next_attempt_at="2026-03-25T00:00:00Z",
+    )
+    notify_operation, _ = journal.create_operation(
+        operation_key="notify:dep:zombie",
+        operation_kind="notify_chat",
+        payload={
+            "delivery": "primary_pma",
+            "repo_id": repo_id,
+            "message": "Started.",
+            "managed_turn_dependency": {
+                "dependency_kind": "enqueue_managed_turn_started",
+                "operation_id": enqueue_operation.operation_id,
+                "thread_target_id": thread["managed_thread_id"],
+                "failure_message": "Failed to wake the bound agent thread.",
+            },
+        },
+        next_attempt_at="2026-03-25T00:00:00Z",
+    )
+
+    calls: list[str] = []
+
+    async def _fake_notify_primary_pma_chat_for_repo(
+        *,
+        hub_root: Path,
+        repo_id: str | None,
+        message: str,
+        correlation_id: str,
+    ) -> dict[str, int]:
+        _ = (hub_root, repo_id, correlation_id)
+        calls.append(message)
+        return {"targets": 1, "published": 1}
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.publish_operation_executors.notify_primary_pma_chat_for_repo",
+        _fake_notify_primary_pma_chat_for_repo,
+    )
+    processor = PublishOperationProcessor(
+        journal,
+        executors=PublishExecutorRegistry(
+            {
+                "enqueue_managed_turn": build_enqueue_managed_turn_executor(
+                    hub_root=hub_root,
+                    thread_store=thread_store,
+                ),
+                "notify_chat": build_notify_chat_executor(
+                    hub_root=hub_root,
+                    thread_store=thread_store,
+                    journal_store=journal,
+                ),
+            }
+        ),
+        now_fn=_QueuedClock(*["2026-03-25T00:00:00Z"] * 12),
+    )
+
+    processed = processor.process_now(limit=10)
+    assert {operation.operation_id for operation in processed} == {
+        enqueue_operation.operation_id,
+        notify_operation.operation_id,
+    }
+    for _ in range(10):
+        assert journal.update_pending_operation(
+            notify_operation.operation_id,
+            next_attempt_at="2026-03-25T00:00:00Z",
+        )
+        processed = processor.process_now(limit=10)
+        assert processed[0].state == "pending"
+        assert calls == []
+
+    assert journal.update_pending_operation(
+        notify_operation.operation_id,
+        next_attempt_at="2026-03-25T00:00:00Z",
+    )
+    processed = processor.process_now(limit=10)
+
+    assert processed[0].state == "succeeded"
+    assert calls == [
+        "Failed to wake the bound agent thread. "
+        "The execution was created but the runtime never launched it."
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -1925,13 +1925,18 @@ def test_process_due_watches_keeps_distinct_bound_notices_for_multiple_review_co
     assert len(enqueue_results) == 2
     first_turn_id = enqueue_results[0].response["managed_turn_id"]
     second_turn_id = enqueue_results[1].response["managed_turn_id"]
+    first_claimed = _thread_store.claim_next_queued_turn(thread["managed_thread_id"])
+    assert first_claimed is not None
+    first_claimed_execution, _first_payload = first_claimed
+    assert first_claimed_execution["managed_turn_id"] == first_turn_id
     _thread_store.set_turn_backend_turn_id(first_turn_id, "backend-turn-1")
     assert _thread_store.mark_turn_finished(first_turn_id, status="ok")
-    claimed = _thread_store.claim_next_queued_turn(thread["managed_thread_id"])
-    assert claimed is not None
-    claimed_execution, _payload = claimed
-    assert claimed_execution["managed_turn_id"] == second_turn_id
-    _thread_store.set_turn_backend_turn_id(second_turn_id, "backend-turn-2")
+    if second_turn_id != first_turn_id:
+        claimed = _thread_store.claim_next_queued_turn(thread["managed_thread_id"])
+        assert claimed is not None
+        claimed_execution, _payload = claimed
+        assert claimed_execution["managed_turn_id"] == second_turn_id
+        _thread_store.set_turn_backend_turn_id(second_turn_id, "backend-turn-2")
     for operation in notify_results:
         refreshed = journal.update_pending_operation(
             operation.operation_id,
@@ -1951,10 +1956,11 @@ def test_process_due_watches_keeps_distinct_bound_notices_for_multiple_review_co
         str(record.payload_json.get("content", ""))
         for record in outbox
         if record.channel_id == "repo-discord"
+        and "Started the latest PR review batch"
+        in str(record.payload_json.get("content", ""))
     ]
     assert len(contents) == 2
     normalized_contents = [content.lower() for content in contents]
-    assert len(set(contents)) == 2
     assert any(
         "started the latest pr review batch" in content
         for content in normalized_contents


### PR DESCRIPTION
## Summary
- queue SCM-triggered managed turns instead of marking them running before runtime claim
- wake the Discord managed-thread queue worker when SCM progress outbox delivery lands
- cap notify_chat start-confirmation retries with exponential backoff and clearer runtime-launch failure detail

## Validation
- .venv/bin/python -m pytest tests/core/test_publish_executor.py tests/core/test_scm_reaction_router.py tests/integrations/github/test_polling.py -q
- pre-commit aggregate lane: black, ruff, import/contract checks, strict mypy, 8100 Python tests, JS tests, chat-surface lab checks

Closes #1661