### PR TITLE
test: parallelize fast validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ VENV_PIP := $(VENV)/bin/pip
 # Prefer venv python if it exists
 PYTHON := $(shell if [ -x $(VENV_PYTHON) ]; then echo $(VENV_PYTHON); else echo python3; fi)
 PYTHON_ABS := $(abspath $(PYTHON))
+PYTEST_FAST_WORKERS ?= 4
 
 export PATH := $(CURDIR)/$(VENV)/bin:$(PATH)
 HOST ?= 127.0.0.1
@@ -85,7 +86,7 @@ hooks:
 test: test-fast
 
 test-fast:
-	$(PYTHON) -m pytest -m "not integration and not slow"
+	$(PYTHON) -m pytest -m "not integration and not slow" -n $(PYTEST_FAST_WORKERS)
 
 test-full:
 	$(PYTHON) -m pytest -m "not integration"

--- a/docs/reports/autooptimize-test-speed-2026-04-29.md
+++ b/docs/reports/autooptimize-test-speed-2026-04-29.md
@@ -1,0 +1,84 @@
+# AutoOptimize Test Speed Run - 2026-04-29
+
+This report captures the stopped AutoOptimize run from branch
+`autooptimize-test-speed-5`.
+
+Run id: `77586ac2-e5a8-4b04-804f-ca0dfb07a0f2`
+
+AutoOptimize app run id: `autooptimize-146b5e7b24bb`
+
+## Result
+
+The run found large theoretical speedups from pytest-xdist, but no full-suite
+configuration was mergeable because each full-suite xdist variant introduced
+failures beyond the existing baseline failures. The safe change in this PR is
+to apply parallel execution only to the fast local make target:
+
+```bash
+make test-fast
+```
+
+The optimized target passed locally with `8105 passed in 111.74s`.
+
+## Chart
+
+![AutoOptimize test speed chart](autooptimize-test-speed-2026-04-29.svg)
+
+## Iteration Stats
+
+| Step | Hypothesis | Time | Delta vs baseline | Guard | Decision |
+| --- | --- | ---: | ---: | --- | --- |
+| Baseline | Serial `pytest -q -m "not integration"` | 746.25s | 0.0% | 23 pre-existing failures | baseline |
+| Iteration 1 | Global xdist `-n auto` | 279.05s | 62.6% faster | fail, about 10 new failures | pivot |
+| Iteration 2 | Global xdist with `--dist loadfile` | 251.12s | 66.4% faster | fail, about 7 new failures | pivot |
+| Iteration 3 | Limited global xdist `-n 2` | 560.47s | 24.9% faster | fail, about 6 new failures | discard |
+| Iteration 4 | `-n 3 --dist loadfile` plus serialized non-unit grouping | 386.17s | 48.3% faster | fail, about 3 new failures | discard |
+
+## What Was Kept
+
+The mergeable conclusion is narrower than the fastest experiment:
+
+- Keep xdist out of global `pyproject.toml` defaults for now.
+- Use xdist with a conservative four-worker default for the fast,
+  non-integration, non-slow local target.
+- Keep the worker count configurable through `PYTEST_FAST_WORKERS` for
+  `make test-fast` and `CODEX_FAST_TEST_WORKERS` for `scripts/check.sh`.
+- Preserve serial behavior for the broader `test-full` and integration targets.
+
+## Validation
+
+- `make test-fast`: passed, `8105 passed in 111.74s`.
+- A 10-worker `-n auto` run passed once in 63.06s but was rejected after a
+  later local timeout in
+  `tests/integrations/chat/test_hermes_official_completion.py::test_telegram_pma_turn_completes_for_official_hermes_prompt[asyncio]`.
+- A more aggressive `--dist loadfile` fast-target variant was rejected after a
+  local timeout in
+  `tests/integrations/discord/test_dispatch_validation.py::test_dispatch_deferred_slash_commands_ack_before_prior_handler_finishes[asyncio]`.
+- Serial comparison command, `/usr/bin/time -p .venv/bin/python -m pytest -m
+  "not integration and not slow"`, timed out one test after `8094` passes and
+  `188.51s` wall time. That reinforced the decision to keep only the passing
+  parallel fast target in this PR.
+
+## Why The Run Took So Long
+
+The eight-hour runtime came from the campaign design and the agent's measurement
+strategy, not from one single hung process.
+
+- The baseline ticket ran multiple full-suite measurements before recording
+  state. The recorded baseline alone took 746.25 seconds.
+- Each iteration repeatedly ran expensive full-suite pytest commands to compare
+  xdist modes and diagnose the new failures they introduced.
+- Full-suite xdist attempts did not fail fast. They typically had to run most of
+  the suite before exposing the final failure count.
+- The agent reran variants such as `-n auto`, `--dist loadfile`, `-n 2`, `-n 3`,
+  and grouping experiments instead of using a fixed per-iteration time budget.
+- Flow status looked stale during long pytest tool calls because CAR did not
+  surface child process activity as flow freshness.
+- AutoOptimize created extra follow-up tickets even though the five-iteration
+  queue had already been pre-created, adding queue noise.
+
+Follow-up tracking:
+
+- Flow status child activity: https://github.com/Git-on-my-level/codex-autorunner/issues/1660
+- App metadata in flow status: https://github.com/Git-on-my-level/codex-autorunner/issues/1657
+- Blessed/third-party app distribution: https://github.com/Git-on-my-level/codex-autorunner/issues/1658

--- a/docs/reports/autooptimize-test-speed-2026-04-29.svg
+++ b/docs/reports/autooptimize-test-speed-2026-04-29.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540" role="img" aria-label="AutoOptimize test speed chart">
+  <rect width="960" height="540" fill="#f8fafc"/>
+  <rect x="24" y="24" width="912" height="492" rx="10" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="48" y="70" font-family="Arial, sans-serif" font-size="24" font-weight="700" fill="#0f172a">AutoOptimize Test Speed Run</text>
+  <text x="48" y="100" font-family="Arial, sans-serif" font-size="14" fill="#475569">Metric: pytest wall time in seconds. Lower is better. Full-suite xdist was fast but not mergeable due to new failures.</text>
+
+  <g font-family="Arial, sans-serif" font-size="13" fill="#334155">
+    <text x="640" y="70">Baseline: 746.25s</text>
+    <text x="640" y="94">Best observed: 251.12s</text>
+    <text x="640" y="118">Best passing: none beyond baseline</text>
+    <text x="640" y="142">Recorded iterations: 4 of 5</text>
+  </g>
+
+  <g transform="translate(90 160)">
+    <line x1="0" y1="0" x2="0" y2="280" stroke="#94a3b8"/>
+    <line x1="0" y1="280" x2="780" y2="280" stroke="#94a3b8"/>
+    <g stroke="#e2e8f0">
+      <line x1="0" y1="0" x2="780" y2="0"/>
+      <line x1="0" y1="70" x2="780" y2="70"/>
+      <line x1="0" y1="140" x2="780" y2="140"/>
+      <line x1="0" y1="210" x2="780" y2="210"/>
+    </g>
+    <g font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">
+      <text x="-10" y="4">800s</text>
+      <text x="-10" y="74">600s</text>
+      <text x="-10" y="144">400s</text>
+      <text x="-10" y="214">200s</text>
+      <text x="-10" y="284">0s</text>
+    </g>
+
+    <polyline fill="none" stroke="#0f766e" stroke-width="3" points="0,18.8 195,182.3 390,192.1 585,83.8 780,144.8"/>
+
+    <g font-family="Arial, sans-serif" font-size="12" text-anchor="middle">
+      <circle cx="0" cy="18.8" r="6" fill="#0f172a"/>
+      <text x="0" y="305" fill="#334155">B</text>
+      <text x="0" y="5" fill="#0f172a">746.25</text>
+
+      <polygon points="195,175.3 202,182.3 195,189.3 188,182.3" fill="#d97706"/>
+      <text x="195" y="305" fill="#334155">I1</text>
+      <text x="195" y="169" fill="#92400e">279.05</text>
+
+      <polygon points="390,185.1 397,192.1 390,199.1 383,192.1" fill="#d97706"/>
+      <text x="390" y="305" fill="#334155">I2</text>
+      <text x="390" y="179" fill="#92400e">251.12</text>
+
+      <rect x="579" y="77.8" width="12" height="12" fill="#dc2626"/>
+      <text x="585" y="305" fill="#334155">I3</text>
+      <text x="585" y="70" fill="#991b1b">560.47</text>
+
+      <rect x="774" y="138.8" width="12" height="12" fill="#dc2626"/>
+      <text x="780" y="305" fill="#334155">I4</text>
+      <text x="780" y="132" fill="#991b1b">386.17</text>
+    </g>
+  </g>
+
+  <g font-family="Arial, sans-serif" font-size="13" fill="#475569">
+    <circle cx="96" cy="492" r="5" fill="#0f172a"/>
+    <text x="108" y="496">baseline</text>
+    <polygon points="196,487 202,493 196,499 190,493" fill="#d97706"/>
+    <text x="212" y="496">pivot after failed guard</text>
+    <rect x="390" y="487" width="10" height="10" fill="#dc2626"/>
+    <text x="408" y="496">discard after failed guard</text>
+  </g>
+</svg>

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -93,6 +93,7 @@ need_cmd make
 # unless the caller opts in with CODEX_FAST_TEST_ENFORCE_BUDGET=1.
 FAST_TEST_MARKERS='not integration and not slow'
 FAST_TEST_ENFORCE_BUDGET="${CODEX_FAST_TEST_ENFORCE_BUDGET:-0}"
+FAST_TEST_WORKERS="${CODEX_FAST_TEST_WORKERS:-4}"
 
 # --- Lane detection (if not explicitly set) ----------------------------------
 if [[ -z "$LANE" ]]; then
@@ -209,7 +210,7 @@ if [[ "$RUN_CORE" == true ]]; then
         rm -f "$FAST_TEST_JUNIT" "${FAST_TEST_SELECTED:-}"
       }
       trap cleanup_fast_test_artifacts EXIT
-      "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" -n auto -o junit_duration_report=call --junitxml "$FAST_TEST_JUNIT"
+      "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" -n "$FAST_TEST_WORKERS" -o junit_duration_report=call --junitxml "$FAST_TEST_JUNIT"
       FAST_TEST_REPORT_ARGS=(
         "$FAST_TEST_JUNIT"
         --repo-root "$REPO_ROOT"
@@ -238,7 +239,7 @@ if [[ "$RUN_CORE" == true ]]; then
           rm -f "$FAST_TEST_JUNIT" "${FAST_TEST_SELECTED:-}"
         }
         trap cleanup_fast_test_artifacts EXIT
-        "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" -n auto -o junit_duration_report=call --junitxml "$FAST_TEST_JUNIT"
+        "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" -n "$FAST_TEST_WORKERS" -o junit_duration_report=call --junitxml "$FAST_TEST_JUNIT"
         FAST_TEST_REPORT_ARGS=(
           "$FAST_TEST_JUNIT"
           --repo-root "$REPO_ROOT"
@@ -257,7 +258,7 @@ if [[ "$RUN_CORE" == true ]]; then
         echo "Enforcing fast-test budget (CODEX_FAST_TEST_ENFORCE_BUDGET=1)."
         "$PYTHON_BIN" scripts/report_fast_test_budget.py "${FAST_TEST_REPORT_ARGS[@]}"
       else
-        "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" -n auto
+        "$PYTHON_BIN" -m pytest -m "$FAST_TEST_MARKERS" -n "$FAST_TEST_WORKERS"
       fi
   fi
 


### PR DESCRIPTION
## Summary

- stop the long AutoOptimize campaign after four completed iterations and preserve the stats/report
- parallelize the fast pytest lane with a conservative four-worker default in `make test-fast` and `scripts/check.sh`
- keep full-suite/global pytest behavior serial because every full-suite xdist variant introduced new failures

## AutoOptimize Results

Run id: `77586ac2-e5a8-4b04-804f-ca0dfb07a0f2`

App run id: `autooptimize-146b5e7b24bb`

![AutoOptimize test speed chart](docs/reports/autooptimize-test-speed-2026-04-29.svg)

Detailed report: `docs/reports/autooptimize-test-speed-2026-04-29.md`

| Step | Hypothesis | Time | Delta vs baseline | Guard | Decision |
| --- | --- | ---: | ---: | --- | --- |
| Baseline | Serial `pytest -q -m "not integration"` | 746.25s | 0.0% | 23 pre-existing failures | baseline |
| Iteration 1 | Global xdist `-n auto` | 279.05s | 62.6% faster | fail, about 10 new failures | pivot |
| Iteration 2 | Global xdist with `--dist loadfile` | 251.12s | 66.4% faster | fail, about 7 new failures | pivot |
| Iteration 3 | Limited global xdist `-n 2` | 560.47s | 24.9% faster | fail, about 6 new failures | discard |
| Iteration 4 | `-n 3 --dist loadfile` plus serialized non-unit grouping | 386.17s | 48.3% faster | fail, about 3 new failures | discard |

## Runtime Root Cause

The eight-hour duration came from the campaign design rather than one hung process: baseline alone took 746.25s, each iteration reran expensive full-suite pytest variants, full-suite xdist failures surfaced only near the end of each run, and the agent kept diagnosing variants without a fixed per-iteration time budget. The status UI also looked stale because child process activity does not yet bump flow freshness; that is tracked in #1660.

## Validation

- `make test-fast`: `8105 passed in 111.74s`
- pre-commit aggregate hook: passed, including `scripts/check.sh` fast pytest with 4 workers, mypy, frontend build/tests, and chat-surface lab

## Follow-ups

- #1660: surface child activity in flow status
- #1657: show app metadata in flow status
- #1658: decide blessed/third-party app distribution model
