### PR TITLE
[codex] Fix Codex app-server command isolation

### DIFF
--- a/docs/ops/env-and-defaults.md
+++ b/docs/ops/env-and-defaults.md
@@ -61,8 +61,9 @@ When `usage.global_cache_root` is omitted from config, CAR defaults it to match 
 
 | Env var | Purpose | Default / config key |
 | --- | --- | --- |
-| `CAR_APP_SERVER_COMMAND` | Override the command used to launch the app-server subprocess. Checked first; takes precedence over per-integration env vars and config. | Falls back to `("codex", "app-server")`. |
-| `CAR_TELEGRAM_APP_SERVER_COMMAND` | Legacy per-Telegram override for the app-server command. Honored as a fallback when `CAR_APP_SERVER_COMMAND` is unset. | Configurable via `telegram_bot.app_server_command_env`. |
+| `CAR_CODEX_APP_SERVER_COMMAND` | Override the command used to launch Codex app-server subprocesses for Codex-backed runtimes such as ticket-flow. Checked before `CAR_APP_SERVER_COMMAND` and config. | Falls back to `("codex", "app-server")`. |
+| `CAR_APP_SERVER_COMMAND` | Legacy generic override for Codex app-server subprocesses. Checked after `CAR_CODEX_APP_SERVER_COMMAND` and before config. | Falls back to `("codex", "app-server")`. |
+| `CAR_TELEGRAM_APP_SERVER_COMMAND` | Legacy per-Telegram override for the Telegram app-server command. Ignored by non-Telegram runtimes, including ticket-flow. | Configurable via `telegram_bot.app_server_command_env`. |
 | `CAR_OPENCODE_COMMAND` | Override the OpenCode binary command path for the Telegram integration. | Overrides `telegram_bot.opencode_command`. |
 | `CODEX_BIN` | Explicit path to the Codex CLI binary (protocol schema generation). | Falls back to PATH resolution of `codex`. |
 | `OPENCODE_BIN` | Explicit path to the OpenCode binary (protocol schema generation). | Falls back to PATH resolution of `opencode`. |
@@ -72,9 +73,10 @@ When `usage.global_cache_root` is omitted from config, CAR defaults it to match 
 Env overrides that take precedence over config:
 
 - `CAR_OPENCODE_COMMAND` overrides `telegram_bot.opencode_command`
-- `CAR_APP_SERVER_COMMAND` overrides `telegram_bot.app_server_command` (checked first)
-- `CAR_TELEGRAM_APP_SERVER_COMMAND` is still honored as a fallback when the global env is unset
-  - The preferred env var name is configurable via `telegram_bot.app_server_command_env` (default `CAR_APP_SERVER_COMMAND`).
+- `CAR_CODEX_APP_SERVER_COMMAND` overrides `app_server.command` for Codex-backed runtimes (checked first)
+- `CAR_APP_SERVER_COMMAND` is still honored as a generic fallback when `CAR_CODEX_APP_SERVER_COMMAND` is unset
+- `CAR_TELEGRAM_APP_SERVER_COMMAND` is only honored by Telegram-specific config/runtime paths
+  - The preferred Telegram env var name is configurable via `telegram_bot.app_server_command_env` (default `CAR_APP_SERVER_COMMAND`).
 
 Telegram auth envs (names configurable via `telegram_bot.*_env`):
 

--- a/src/codex_autorunner/core/app_server_command.py
+++ b/src/codex_autorunner/core/app_server_command.py
@@ -1,9 +1,24 @@
 from __future__ import annotations
 
+import dataclasses
 import shlex
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 
 DEFAULT_APP_SERVER_COMMAND: tuple[str, str] = ("codex", "app-server")
+CODEX_APP_SERVER_COMMAND_ENV = "CAR_CODEX_APP_SERVER_COMMAND"
+LEGACY_APP_SERVER_COMMAND_ENV = "CAR_APP_SERVER_COMMAND"
+TELEGRAM_APP_SERVER_COMMAND_ENV = "CAR_TELEGRAM_APP_SERVER_COMMAND"
+DEFAULT_CODEX_APP_SERVER_COMMAND_ENVS: tuple[str, str] = (
+    CODEX_APP_SERVER_COMMAND_ENV,
+    LEGACY_APP_SERVER_COMMAND_ENV,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class ResolvedAppServerCommand:
+    command: list[str]
+    source: str
+    ignored_env: tuple[str, ...] = ()
 
 
 def parse_command(raw: Any) -> list[str]:
@@ -34,8 +49,49 @@ def resolve_app_server_command(
     return [str(part) for part in fallback]
 
 
+def resolve_app_server_command_with_source(
+    configured_command: Any,
+    *,
+    env: Mapping[str, str] | None = None,
+    env_names: Sequence[str] = DEFAULT_CODEX_APP_SERVER_COMMAND_ENVS,
+    ignored_env_names: Sequence[str] = (TELEGRAM_APP_SERVER_COMMAND_ENV,),
+    fallback: Sequence[str] = DEFAULT_APP_SERVER_COMMAND,
+    fallback_source: str = "default",
+) -> ResolvedAppServerCommand:
+    source_env = env or {}
+    ignored = tuple(
+        name for name in ignored_env_names if str(source_env.get(name) or "").strip()
+    )
+    for name in env_names:
+        command = parse_command(source_env.get(name))
+        if command:
+            return ResolvedAppServerCommand(
+                command=command,
+                source=f"env:{name}",
+                ignored_env=ignored,
+            )
+    configured = parse_command(configured_command)
+    if configured:
+        return ResolvedAppServerCommand(
+            command=configured,
+            source="config",
+            ignored_env=ignored,
+        )
+    return ResolvedAppServerCommand(
+        command=[str(part) for part in fallback],
+        source=fallback_source,
+        ignored_env=ignored,
+    )
+
+
 __all__ = [
     "DEFAULT_APP_SERVER_COMMAND",
+    "CODEX_APP_SERVER_COMMAND_ENV",
+    "LEGACY_APP_SERVER_COMMAND_ENV",
+    "TELEGRAM_APP_SERVER_COMMAND_ENV",
+    "DEFAULT_CODEX_APP_SERVER_COMMAND_ENVS",
+    "ResolvedAppServerCommand",
     "parse_command",
     "resolve_app_server_command",
+    "resolve_app_server_command_with_source",
 ]

--- a/src/codex_autorunner/core/config_parsers.py
+++ b/src/codex_autorunner/core/config_parsers.py
@@ -17,7 +17,7 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
-from .app_server_command import resolve_app_server_command
+from .app_server_command import resolve_app_server_command_with_source
 from .config_contract import APP_SERVER_OUTPUT_POLICIES, ConfigError
 from .config_field_schema import (
     APP_SERVER_CLIENT_FIELD_SCHEMAS,
@@ -540,16 +540,21 @@ def _parse_app_server_config(
     defaults = defaults if isinstance(defaults, dict) else {}
     raw_command = cfg.get("command", dataclasses.MISSING)
     if raw_command is dataclasses.MISSING:
-        command = resolve_app_server_command(
+        resolved_command = resolve_app_server_command_with_source(
             default_from_mapping(
                 defaults, "command", APP_SERVER_FIELD_SCHEMAS["command"]
-            )
+            ),
+            env=os.environ,
+            fallback_source="default",
         )
     else:
-        command = resolve_app_server_command(
+        resolved_command = resolve_app_server_command_with_source(
             raw_command,
+            env=os.environ,
             fallback=(),
+            fallback_source="empty-config",
         )
+    command = resolved_command.command
     state_root = cast(
         Path,
         parse_schema_field(
@@ -710,6 +715,8 @@ def _parse_app_server_config(
     prompts = _parse_app_server_prompts_config(cfg.get("prompts"), prompt_defaults)
     return AppServerConfig(
         command=command,
+        command_source=resolved_command.source,
+        ignored_command_env=resolved_command.ignored_env,
         state_root=state_root,
         auto_restart=auto_restart,
         max_handles=max_handles,

--- a/src/codex_autorunner/core/config_types.py
+++ b/src/codex_autorunner/core/config_types.py
@@ -87,6 +87,8 @@ class AppServerOutputConfig:
 @dataclasses.dataclass
 class AppServerConfig:
     command: List[str]
+    command_source: str
+    ignored_command_env: tuple[str, ...]
     state_root: Path
     auto_restart: Optional[bool]
     max_handles: Optional[int]

--- a/src/codex_autorunner/core/ticket_flow_operator.py
+++ b/src/codex_autorunner/core/ticket_flow_operator.py
@@ -292,11 +292,15 @@ def _codex_runtime_preflight_details(
     version_command = _codex_version_command(app_cmd)
     if version_command:
         try:
-            output = subprocess.check_output(
+            raw_output = subprocess.check_output(
                 version_command,
                 stderr=subprocess.STDOUT,
-                text=True,
                 timeout=_CODEX_VERSION_TIMEOUT_SECONDS,
+            )
+            output = (
+                raw_output.decode("utf-8", errors="replace")
+                if isinstance(raw_output, bytes)
+                else str(raw_output)
             )
             version = " ".join(output.split())
             details.append(f"version: {version or 'no output'}")

--- a/src/codex_autorunner/core/ticket_flow_operator.py
+++ b/src/codex_autorunner/core/ticket_flow_operator.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shlex
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, Mapping, Optional, Sequence, TypedDict
@@ -47,6 +49,7 @@ from .utils import resolve_executable
 logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_TEXT_CHARS = 800
+_CODEX_VERSION_TIMEOUT_SECONDS = 5.0
 TicketFlowRunSelection = Literal["active", "authoritative", "non_terminal", "paused"]
 
 
@@ -257,6 +260,54 @@ def _trim_extra(extra: Any, limit: Optional[int]) -> Any:
         "note": "extra omitted due to size",
         "preview": _truncate(raw, limit),
     }
+
+
+def _codex_version_command(app_server_command: Sequence[str]) -> list[str]:
+    command = [str(part) for part in app_server_command if str(part).strip()]
+    try:
+        app_server_index = command.index("app-server")
+    except ValueError:
+        app_server_index = 1 if len(command) > 1 else len(command)
+    return command[:app_server_index] + ["--version"]
+
+
+def _codex_runtime_preflight_details(config: Any, app_cmd: Sequence[str]) -> list[str]:
+    details = [f"command: {shlex.join([str(part) for part in app_cmd])}"]
+    source = getattr(getattr(config, "app_server", None), "command_source", None)
+    if source:
+        details.append(f"source: {source}")
+    model = getattr(config, "codex_model", None)
+    if model:
+        details.append(f"model: {model}")
+    app_binary = app_cmd[0] if app_cmd else None
+    resolved = resolve_executable(app_binary) if app_binary else None
+    if resolved:
+        details.append(f"executable: {resolved}")
+    elif app_binary:
+        details.append(f"executable: not found ({app_binary})")
+    version_command = _codex_version_command(app_cmd)
+    if version_command:
+        try:
+            output = subprocess.check_output(
+                version_command,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=_CODEX_VERSION_TIMEOUT_SECONDS,
+            )
+            version = " ".join(output.split())
+            details.append(f"version: {version or 'no output'}")
+        except (OSError, subprocess.SubprocessError) as exc:
+            details.append(f"version: unavailable ({type(exc).__name__}: {exc})")
+    ignored_env = getattr(
+        getattr(config, "app_server", None), "ignored_command_env", ()
+    )
+    if ignored_env:
+        details.append(
+            "ignored surface env: " + ", ".join(str(name) for name in ignored_env)
+        )
+    elif os.environ.get("CAR_TELEGRAM_APP_SERVER_COMMAND"):
+        details.append("ignored surface env: CAR_TELEGRAM_APP_SERVER_COMMAND")
+    return details
 
 
 def _dispatch_dict(
@@ -737,9 +788,11 @@ def ticket_flow_preflight(repo_root: Path, *, config: Any = None) -> PreflightRe
     agents = sorted({doc.frontmatter.agent for doc in ticket_docs})
     agent_errors: list[str] = []
     agent_warnings: list[str] = []
+    codex_details: list[str] = []
 
     if "codex" in agents:
         app_cmd = getattr(getattr(config, "app_server", None), "command", None) or []
+        codex_details = _codex_runtime_preflight_details(config, app_cmd)
         app_binary = app_cmd[0] if app_cmd else None
         resolved = resolve_executable(app_binary) if app_binary else None
         if config is not None and not resolved:
@@ -777,7 +830,7 @@ def ticket_flow_preflight(repo_root: Path, *, config: Any = None) -> PreflightRe
                 check_id="agents",
                 status="error",
                 message="Agent backend validation failed.",
-                details=agent_errors,
+                details=agent_errors + codex_details,
             )
         )
     elif agent_warnings:
@@ -786,7 +839,7 @@ def ticket_flow_preflight(repo_root: Path, *, config: Any = None) -> PreflightRe
                 check_id="agents",
                 status="warning",
                 message="Some agents could not be verified automatically.",
-                details=agent_warnings,
+                details=agent_warnings + codex_details,
             )
         )
     else:
@@ -795,6 +848,7 @@ def ticket_flow_preflight(repo_root: Path, *, config: Any = None) -> PreflightRe
                 check_id="agents",
                 status="ok",
                 message="All referenced agents appear available.",
+                details=codex_details,
             )
         )
 

--- a/src/codex_autorunner/core/ticket_flow_operator.py
+++ b/src/codex_autorunner/core/ticket_flow_operator.py
@@ -264,6 +264,8 @@ def _trim_extra(extra: Any, limit: Optional[int]) -> Any:
 
 def _codex_version_command(app_server_command: Sequence[str]) -> list[str]:
     command = [str(part) for part in app_server_command if str(part).strip()]
+    if not command:
+        return []
     try:
         app_server_index = command.index("app-server")
     except ValueError:
@@ -271,7 +273,9 @@ def _codex_version_command(app_server_command: Sequence[str]) -> list[str]:
     return command[:app_server_index] + ["--version"]
 
 
-def _codex_runtime_preflight_details(config: Any, app_cmd: Sequence[str]) -> list[str]:
+def _codex_runtime_preflight_details(
+    config: Any, app_cmd: Sequence[str]
+) -> tuple[list[str], Optional[str]]:
     details = [f"command: {shlex.join([str(part) for part in app_cmd])}"]
     source = getattr(getattr(config, "app_server", None), "command_source", None)
     if source:
@@ -307,7 +311,7 @@ def _codex_runtime_preflight_details(config: Any, app_cmd: Sequence[str]) -> lis
         )
     elif os.environ.get("CAR_TELEGRAM_APP_SERVER_COMMAND"):
         details.append("ignored surface env: CAR_TELEGRAM_APP_SERVER_COMMAND")
-    return details
+    return details, resolved
 
 
 def _dispatch_dict(
@@ -792,9 +796,7 @@ def ticket_flow_preflight(repo_root: Path, *, config: Any = None) -> PreflightRe
 
     if "codex" in agents:
         app_cmd = getattr(getattr(config, "app_server", None), "command", None) or []
-        codex_details = _codex_runtime_preflight_details(config, app_cmd)
-        app_binary = app_cmd[0] if app_cmd else None
-        resolved = resolve_executable(app_binary) if app_binary else None
+        codex_details, resolved = _codex_runtime_preflight_details(config, app_cmd)
         if config is not None and not resolved:
             agent_errors.append("codex: app_server command not available in PATH.")
 

--- a/src/codex_autorunner/integrations/agents/wiring.py
+++ b/src/codex_autorunner/integrations/agents/wiring.py
@@ -318,6 +318,19 @@ class AgentBackendFactory:
             raise ValueError("app_server.command is required for codex backend")
 
         supervisor_command = list(self._config.app_server.command)
+        ignored_env = getattr(self._config.app_server, "ignored_command_env", ())
+        if ignored_env:
+            self._logger.warning(
+                "Ignoring surface-specific app-server command env for Codex runtime: %s",
+                ", ".join(str(name) for name in ignored_env),
+            )
+        self._logger.info(
+            "Codex app-server command selected",
+            extra={
+                "command": supervisor_command,
+                "source": getattr(self._config.app_server, "command_source", "config"),
+            },
+        )
         state_root = self._config.app_server.state_root
         if isinstance(self._destination, DockerDestination):
             wrapped = wrap_command_for_destination(

--- a/src/codex_autorunner/integrations/telegram/config.py
+++ b/src/codex_autorunner/integrations/telegram/config.py
@@ -11,7 +11,7 @@ from typing import Any, Iterable, Optional
 from ...core.app_server_command import (
     DEFAULT_APP_SERVER_COMMAND as CORE_DEFAULT_APP_SERVER_COMMAND,
 )
-from ...core.app_server_command import resolve_app_server_command
+from ...core.app_server_command import resolve_app_server_command_with_source
 from ..chat.approval_modes import resolve_approval_mode_policies
 from ..chat.collaboration_policy import (
     CollaborationPolicy,
@@ -596,10 +596,18 @@ class TelegramBotConfig:
                 "(.sqlite3). Update your config to .codex-autorunner/telegram_state.sqlite3"
             )
 
-        app_server_command = resolve_app_server_command(
-            cfg.get("app_server_command"),
-            fallback=DEFAULT_APP_SERVER_COMMAND,
+        app_server_command_env = (
+            str(cfg.get("app_server_command_env", "CAR_APP_SERVER_COMMAND")).strip()
+            or "CAR_APP_SERVER_COMMAND"
         )
+        telegram_env_names = (app_server_command_env, "CAR_TELEGRAM_APP_SERVER_COMMAND")
+        app_server_command = resolve_app_server_command_with_source(
+            cfg.get("app_server_command"),
+            env=env,
+            env_names=telegram_env_names,
+            ignored_env_names=(),
+            fallback=DEFAULT_APP_SERVER_COMMAND,
+        ).command
 
         app_server_raw_value = cfg.get("app_server")
         app_server_raw: dict[str, Any] = (

--- a/tests/core/test_ticket_flow_operator.py
+++ b/tests/core/test_ticket_flow_operator.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 
+from codex_autorunner.core import ticket_flow_operator as operator_module
 from codex_autorunner.core.flows.models import FlowRunStatus
 from codex_autorunner.core.flows.store import FlowStore
 from codex_autorunner.core.ticket_flow_operator import (
@@ -106,6 +107,34 @@ def test_ticket_flow_operator_preflight_reports_codex_runtime_details(
     assert "source: config" in agents.details
     assert "model: gpt-5.5" in agents.details
     assert "ignored surface env: CAR_TELEGRAM_APP_SERVER_COMMAND" in agents.details
+
+
+def test_codex_version_command_skips_empty_command() -> None:
+    assert operator_module._codex_version_command([]) == []
+
+
+def test_codex_runtime_preflight_decodes_non_utf8_version_output(
+    monkeypatch,
+) -> None:
+    def fake_check_output(*args, **kwargs):
+        return b"codex \xff\n"
+
+    monkeypatch.setattr(operator_module.subprocess, "check_output", fake_check_output)
+    config = SimpleNamespace(
+        codex_model="gpt-5.5",
+        app_server=SimpleNamespace(
+            command=["echo", "app-server"],
+            command_source="config",
+            ignored_command_env=(),
+        ),
+    )
+
+    details, resolved = operator_module._codex_runtime_preflight_details(
+        config, ["echo", "app-server"]
+    )
+
+    assert resolved is not None
+    assert any(detail.startswith("version: codex") for detail in details)
 
 
 def test_ticket_flow_operator_latest_dispatch_prefers_handoff_and_turn_summary(

--- a/tests/core/test_ticket_flow_operator.py
+++ b/tests/core/test_ticket_flow_operator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 from codex_autorunner.core.flows.models import FlowRunStatus
 from codex_autorunner.core.flows.store import FlowStore
@@ -80,6 +81,31 @@ def test_ticket_flow_operator_preflight_reports_no_tickets(tmp_path: Path) -> No
     report = ticket_flow_preflight(tmp_path, config=None)
     failing = {check.check_id for check in report.checks if check.status == "error"}
     assert "tickets_present" in failing
+
+
+def test_ticket_flow_operator_preflight_reports_codex_runtime_details(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = Path(tmp_path)
+    _write_ticket(repo_root, "TICKET-001.md")
+    monkeypatch.setenv("CAR_TELEGRAM_APP_SERVER_COMMAND", "/stale/codex app-server")
+    config = SimpleNamespace(
+        codex_model="gpt-5.5",
+        app_server=SimpleNamespace(
+            command=["echo", "app-server"],
+            command_source="config",
+            ignored_command_env=("CAR_TELEGRAM_APP_SERVER_COMMAND",),
+        ),
+    )
+
+    report = ticket_flow_preflight(repo_root, config=config)
+    agents = next(check for check in report.checks if check.check_id == "agents")
+
+    assert agents.status == "ok"
+    assert "command: echo app-server" in agents.details
+    assert "source: config" in agents.details
+    assert "model: gpt-5.5" in agents.details
+    assert "ignored surface env: CAR_TELEGRAM_APP_SERVER_COMMAND" in agents.details
 
 
 def test_ticket_flow_operator_latest_dispatch_prefers_handoff_and_turn_summary(

--- a/tests/test_app_server_command.py
+++ b/tests/test_app_server_command.py
@@ -2,6 +2,7 @@ from codex_autorunner.core.app_server_command import (
     DEFAULT_APP_SERVER_COMMAND,
     parse_command,
     resolve_app_server_command,
+    resolve_app_server_command_with_source,
 )
 
 
@@ -16,6 +17,31 @@ def test_resolve_app_server_command_uses_config_before_default() -> None:
 def test_resolve_app_server_command_ignores_invalid_config_string() -> None:
     command = resolve_app_server_command('"unterminated', fallback=())
     assert command == []
+
+
+def test_resolve_app_server_command_with_source_prefers_codex_env() -> None:
+    resolved = resolve_app_server_command_with_source(
+        ["config-codex", "app-server"],
+        env={
+            "CAR_CODEX_APP_SERVER_COMMAND": "/opt/homebrew/bin/codex app-server",
+            "CAR_TELEGRAM_APP_SERVER_COMMAND": "/old/node/codex app-server",
+        },
+    )
+
+    assert resolved.command == ["/opt/homebrew/bin/codex", "app-server"]
+    assert resolved.source == "env:CAR_CODEX_APP_SERVER_COMMAND"
+    assert resolved.ignored_env == ("CAR_TELEGRAM_APP_SERVER_COMMAND",)
+
+
+def test_resolve_app_server_command_with_source_ignores_telegram_env() -> None:
+    resolved = resolve_app_server_command_with_source(
+        ["config-codex", "app-server"],
+        env={"CAR_TELEGRAM_APP_SERVER_COMMAND": "/old/node/codex app-server"},
+    )
+
+    assert resolved.command == ["config-codex", "app-server"]
+    assert resolved.source == "config"
+    assert resolved.ignored_env == ("CAR_TELEGRAM_APP_SERVER_COMMAND",)
 
 
 class TestParseCommandEdgeCases:

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -1052,8 +1052,10 @@ def test_load_repo_config_fails_when_manifest_yaml_is_invalid(tmp_path: Path) ->
 
 
 def test_load_repo_config_preserves_explicit_empty_app_server_command(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.delenv("CAR_CODEX_APP_SERVER_COMMAND", raising=False)
+    monkeypatch.delenv("CAR_APP_SERVER_COMMAND", raising=False)
     hub_root = tmp_path / "hub"
     hub_root.mkdir()
     write_test_config(hub_root / CONFIG_FILENAME, {"mode": "hub"})
@@ -1067,6 +1069,51 @@ def test_load_repo_config_preserves_explicit_empty_app_server_command(
     config = load_repo_config(repo_root, hub_path=hub_root)
 
     assert config.app_server.command == []
+
+
+def test_load_repo_config_uses_codex_app_server_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CAR_CODEX_APP_SERVER_COMMAND", "/opt/codex app-server")
+    monkeypatch.setenv(
+        "CAR_TELEGRAM_APP_SERVER_COMMAND", "/stale/telegram/codex app-server"
+    )
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    write_test_config(hub_root / CONFIG_FILENAME, {"mode": "hub"})
+    repo_root = hub_root / "repo"
+    repo_root.mkdir()
+
+    config = load_repo_config(repo_root, hub_path=hub_root)
+
+    assert config.app_server.command == ["/opt/codex", "app-server"]
+    assert config.app_server.command_source == "env:CAR_CODEX_APP_SERVER_COMMAND"
+    assert config.app_server.ignored_command_env == ("CAR_TELEGRAM_APP_SERVER_COMMAND",)
+
+
+def test_load_repo_config_ignores_telegram_app_server_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("CAR_CODEX_APP_SERVER_COMMAND", raising=False)
+    monkeypatch.delenv("CAR_APP_SERVER_COMMAND", raising=False)
+    monkeypatch.setenv(
+        "CAR_TELEGRAM_APP_SERVER_COMMAND", "/stale/telegram/codex app-server"
+    )
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    write_test_config(hub_root / CONFIG_FILENAME, {"mode": "hub"})
+    repo_root = hub_root / "repo"
+    repo_root.mkdir()
+    write_test_config(
+        repo_root / REPO_OVERRIDE_FILENAME,
+        {"app_server": {"command": ["/cfg/codex", "app-server"]}},
+    )
+
+    config = load_repo_config(repo_root, hub_path=hub_root)
+
+    assert config.app_server.command == ["/cfg/codex", "app-server"]
+    assert config.app_server.command_source == "config"
+    assert config.app_server.ignored_command_env == ("CAR_TELEGRAM_APP_SERVER_COMMAND",)
 
 
 def test_load_hub_config_raises_when_no_config_in_git_repo(

--- a/tests/test_telegram_bot_config.py
+++ b/tests/test_telegram_bot_config.py
@@ -52,6 +52,25 @@ def test_telegram_bot_config_uses_configured_app_server_command(
     assert cfg.app_server_command == ["config-codex", "app-server"]
 
 
+def test_telegram_bot_config_honors_telegram_app_server_env(
+    tmp_path: Path,
+) -> None:
+    raw = {
+        "enabled": True,
+        "bot_token_env": "TEST_BOT_TOKEN",
+        "chat_id_env": "TEST_CHAT_ID",
+        "allowed_user_ids": [123],
+        "app_server_command": ["config-codex", "app-server"],
+    }
+    env = {
+        "TEST_BOT_TOKEN": "token",
+        "TEST_CHAT_ID": "-100",
+        "CAR_TELEGRAM_APP_SERVER_COMMAND": "/telegram/codex app-server",
+    }
+    cfg = TelegramBotConfig.from_raw(raw, root=tmp_path, env=env)
+    assert cfg.app_server_command == ["/telegram/codex", "app-server"]
+
+
 def test_telegram_bot_config_uses_explicit_opencode_lifecycle_settings(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add generic Codex app-server command env resolution with source tracking (`CAR_CODEX_APP_SERVER_COMMAND`, then legacy `CAR_APP_SERVER_COMMAND`)
- ignore and report `CAR_TELEGRAM_APP_SERVER_COMMAND` in non-Telegram Codex runtimes, including ticket-flow
- add ticket-flow preflight details for selected command, source, model, executable, version, and ignored surface env
- keep Telegram-specific command env support on the Telegram config path

## Validation
- `.venv/bin/python -m pytest -q tests/test_app_server_command.py tests/test_config_resolution.py tests/test_telegram_bot_config.py tests/core/test_ticket_flow_operator.py tests/flows/ticket_flow/test_runtime_helpers.py`
- commit hook aggregate lane: Black, Ruff, import boundaries, mypy, full pytest (`8104 passed`), frontend build/tests, chat-surface lab checks

Closes #1669