### PR TITLE
[codex] Harden audited security boundaries

### DIFF
--- a/docs/AGENT_SETUP_DISCORD_GUIDE.md
+++ b/docs/AGENT_SETUP_DISCORD_GUIDE.md
@@ -179,7 +179,7 @@ discord_bot:
     guild_ids:
       - "123456789012345678"
   shell:
-    enabled: true
+    enabled: false
     timeout_ms: 120000
     max_output_chars: 3800
   dispatch:
@@ -399,7 +399,7 @@ Notes:
 - Plain-text turns now require both collaboration-policy approval and an active execution target (`/car bind ...` or `/pma on`).
 - `plain_text_trigger: mentions` uses Discord bot mentions such as `<@bot-id>` and is the recommended trigger for shared channels.
 - Unbound but allowlisted channels stay quiet for ordinary conversation instead of replying with repeated "not bound" notices.
-- `!<cmd>` runs a local non-interactive shell command in the bound workspace when `discord_bot.shell.enabled` is `true`.
+- `!<cmd>` runs a local non-interactive shell command in the bound workspace only when `discord_bot.shell.enabled` is explicitly set to `true`.
 
 ### PMA Commands
 

--- a/src/codex_autorunner/core/apps/apply.py
+++ b/src/codex_autorunner/core/apps/apply.py
@@ -23,6 +23,7 @@ from .install import (
     get_installed_app,
     install_app,
 )
+from .refs import parse_app_ref
 
 
 class AppApplyError(Exception):
@@ -59,6 +60,11 @@ def apply_app_entrypoint(
         hub_config=hub_config,
         hub_root=hub_root,
     )
+    if not installed_app.lock.trusted:
+        raise AppApplyError(
+            f"Installed app {installed_app.app_id} is untrusted; "
+            "trust the source app repo before applying ticket templates"
+        )
     manifest = installed_app.manifest
     if template_name is None and manifest.entrypoint is None:
         raise AppApplyError(
@@ -152,6 +158,24 @@ def _resolve_app_install(
     if hub_config is None or hub_root is None:
         raise AppApplyError(
             "Applying an app source ref requires hub configuration context."
+        )
+    try:
+        parsed = parse_app_ref(app_ref_or_id)
+    except ValueError as exc:
+        raise AppApplyError(str(exc)) from exc
+    repo = next(
+        (
+            candidate
+            for candidate in hub_config.apps.repos
+            if candidate.id == parsed.repo_id
+        ),
+        None,
+    )
+    if repo is None:
+        raise AppApplyError(f"App repo not configured: {parsed.repo_id}")
+    if not repo.trusted:
+        raise AppApplyError(
+            f"App repo {repo.id} is untrusted; trust it before applying ticket templates"
         )
 
     try:

--- a/src/codex_autorunner/core/apps/install.py
+++ b/src/codex_autorunner/core/apps/install.py
@@ -109,6 +109,10 @@ class AppLock:
         if not installed_at.strip():
             raise AppInstallError("invalid app lock: installed_at must not be empty")
 
+        trusted_raw = payload.get("trusted", False)
+        if not isinstance(trusted_raw, bool):
+            raise AppInstallError("invalid app lock: trusted must be boolean")
+
         return AppLock(
             id=app_id,
             version=version,
@@ -119,7 +123,7 @@ class AppLock:
             commit_sha=commit_sha,
             manifest_sha=manifest_sha,
             bundle_sha=bundle_sha,
-            trusted=bool(payload.get("trusted", False)),
+            trusted=trusted_raw,
             installed_at=installed_at,
         )
 

--- a/src/codex_autorunner/core/config_layering.py
+++ b/src/codex_autorunner/core/config_layering.py
@@ -209,7 +209,7 @@ def _default_discord_bot_section() -> Dict[str, Any]:
         "intents": 33281,
         "max_message_length": 2000,
         "shell": {
-            "enabled": True,
+            "enabled": False,
             "timeout_ms": 120000,
             "max_output_chars": 3800,
         },

--- a/src/codex_autorunner/core/config_parsers.py
+++ b/src/codex_autorunner/core/config_parsers.py
@@ -14,6 +14,7 @@ Ownership contract (TICKET-1040):
 
 import dataclasses
 import os
+import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
@@ -72,8 +73,19 @@ from .report_retention import (
     DEFAULT_REPORT_MAX_TOTAL_BYTES,
 )
 
+_SAFE_REPO_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _APP_SERVER_OUTPUT_POLICIES = set(APP_SERVER_OUTPUT_POLICIES)
 SHARED_CONFIG_PARSER_FIELD_PATHS = _SHARED_CONFIG_PARSER_FIELD_PATHS
+
+
+def _validate_safe_repo_id(repo_id: str, *, field: str) -> str:
+    normalized = repo_id.strip()
+    if not _SAFE_REPO_ID_RE.fullmatch(normalized):
+        raise ConfigError(
+            f"{field} must be a safe path segment containing only letters, "
+            "numbers, '.', '_', or '-'"
+        )
+    return normalized
 
 
 def _parse_optional_int(value: Any) -> Optional[int]:
@@ -1164,7 +1176,7 @@ def _parse_templates_config(
         repo_id = repo.get("id")
         if not isinstance(repo_id, str) or not repo_id.strip():
             raise ConfigError(f"templates.repos[{idx}].id must be a non-empty string")
-        repo_id = repo_id.strip()
+        repo_id = _validate_safe_repo_id(repo_id, field=f"templates.repos[{idx}].id")
         if repo_id in seen_ids:
             raise ConfigError(f"templates.repos[{idx}].id must be unique")
         seen_ids.add(repo_id)
@@ -1213,7 +1225,7 @@ def _parse_apps_config(
         repo_id = repo.get("id")
         if not isinstance(repo_id, str) or not repo_id.strip():
             raise ConfigError(f"apps.repos[{idx}].id must be a non-empty string")
-        repo_id = repo_id.strip()
+        repo_id = _validate_safe_repo_id(repo_id, field=f"apps.repos[{idx}].id")
         if repo_id in seen_ids:
             raise ConfigError(f"apps.repos[{idx}].id must be unique")
         seen_ids.add(repo_id)

--- a/src/codex_autorunner/core/filebox.py
+++ b/src/codex_autorunner/core/filebox.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import errno
+import os
+import stat
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, List
+from typing import Any, BinaryIO, Dict, Iterable, List
 
 
 @dataclass(frozen=True)
@@ -41,6 +44,7 @@ def outbox_sent_dir(repo_root: Path) -> Path:
 
 
 def ensure_structure(repo_root: Path) -> None:
+    _ensure_filebox_ancestors(repo_root)
     for path in (
         inbox_dir(repo_root),
         outbox_dir(repo_root),
@@ -77,15 +81,15 @@ def _gather_files(entries: Iterable[tuple[str, Path]], box: str) -> List[FileBox
         try:
             for path in folder.iterdir():
                 try:
-                    if path.is_symlink() or not path.is_file():
+                    stat_result = path.lstat()
+                    if not _is_single_regular_file(stat_result):
                         continue
-                    stat = path.stat()
                     collected.append(
                         FileBoxEntry(
                             name=path.name,
                             box=box,
-                            size=stat.st_size if stat else None,
-                            modified_at=_format_mtime(stat.st_mtime) if stat else None,
+                            size=stat_result.st_size,
+                            modified_at=_format_mtime(stat_result.st_mtime),
                             source=source,
                             path=path,
                         )
@@ -122,10 +126,44 @@ def _box_dir(repo_root: Path, box: str) -> Path:
     raise ValueError("Invalid filebox")
 
 
+def _ensure_filebox_ancestors(repo_root: Path) -> None:
+    root_path = Path(repo_root)
+    if root_path.is_symlink():
+        raise ValueError(f"FileBox path must not be a symlink: {root_path}")
+    control_root = Path(repo_root) / ".codex-autorunner"
+    root = filebox_root(repo_root)
+    for path in (control_root, root):
+        if path.is_symlink():
+            raise ValueError(f"FileBox path must not be a symlink: {path}")
+
+
+def _open_box_dir(repo_root: Path, box: str) -> tuple[int, Path]:
+    _ensure_filebox_ancestors(repo_root)
+    target_dir = _box_dir(repo_root, box)
+    if target_dir.is_symlink():
+        raise ValueError("Invalid filebox")
+    target_dir.mkdir(parents=True, exist_ok=True)
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        dir_fd = os.open(target_dir, flags)
+    except OSError as exc:
+        if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+            raise ValueError("Invalid filebox") from exc
+        raise
+    return dir_fd, target_dir.resolve()
+
+
+def _is_single_regular_file(stat_result: os.stat_result) -> bool:
+    return stat.S_ISREG(stat_result.st_mode) and stat_result.st_nlink == 1
+
+
 def _target_path(repo_root: Path, box: str, filename: str) -> Path:
     """Return a resolved path within the FileBox, rejecting traversal attempts."""
 
     safe_name = sanitize_filename(filename)
+    _ensure_filebox_ancestors(repo_root)
     target_dir = _box_dir(repo_root, box)
     if target_dir.is_symlink():
         raise ValueError("Invalid filebox")
@@ -145,6 +183,7 @@ def _target_path(repo_root: Path, box: str, filename: str) -> Path:
 
 def _unresolved_target_path(repo_root: Path, box: str, filename: str) -> Path:
     safe_name = sanitize_filename(filename)
+    _ensure_filebox_ancestors(repo_root)
     target_dir = _box_dir(repo_root, box)
     if target_dir.is_symlink():
         raise ValueError("Invalid filebox")
@@ -152,51 +191,166 @@ def _unresolved_target_path(repo_root: Path, box: str, filename: str) -> Path:
     return target_dir.resolve() / safe_name
 
 
-def save_file(repo_root: Path, box: str, filename: str, data: bytes) -> Path:
-    if box not in BOXES:
-        raise ValueError("Invalid box")
-    ensure_structure(repo_root)
-    unresolved = _unresolved_target_path(repo_root, box, filename)
-    if unresolved.is_symlink():
-        raise ValueError("Invalid filename")
-    path = _target_path(repo_root, box, filename)
-    path.write_bytes(data)
-    return path
+def _existing_regular_entry(repo_root: Path, box: str, filename: str) -> Path | None:
+    safe_name = sanitize_filename(filename)
+    _ensure_filebox_ancestors(repo_root)
+    target_dir = _box_dir(repo_root, box)
+    if target_dir.is_symlink():
+        raise ValueError("Invalid filebox")
+    target_dir.mkdir(parents=True, exist_ok=True)
+    root = target_dir.resolve()
+    try:
+        for candidate in root.iterdir():
+            try:
+                if candidate.name != safe_name:
+                    continue
+                file_stat = candidate.lstat()
+                if not _is_single_regular_file(file_stat):
+                    return None
+                if candidate.parent != root:
+                    return None
+                return candidate
+            except OSError:
+                return None
+    except OSError:
+        return None
+    return None
 
 
-def resolve_file(repo_root: Path, box: str, filename: str) -> FileBoxEntry | None:
-    if box not in BOXES:
-        return None
-    unresolved = _unresolved_target_path(repo_root, box, filename)
-    if unresolved.is_symlink():
-        return None
-    path = _target_path(repo_root, box, filename)
-    if not path.exists() or not path.is_file():
-        return None
-    stat = path.stat()
+def _entry_from_stat(path: Path, box: str, stat_result: os.stat_result) -> FileBoxEntry:
     return FileBoxEntry(
         name=path.name,
         box=box,
-        size=stat.st_size,
-        modified_at=_format_mtime(stat.st_mtime),
+        size=stat_result.st_size,
+        modified_at=_format_mtime(stat_result.st_mtime),
         source="filebox",
         path=path,
     )
 
 
+def _read_all(fd: int) -> bytes:
+    chunks: list[bytes] = []
+    while True:
+        chunk = os.read(fd, 1024 * 1024)
+        if not chunk:
+            return b"".join(chunks)
+        chunks.append(chunk)
+
+
+def read_file(
+    repo_root: Path, box: str, filename: str
+) -> tuple[FileBoxEntry, bytes] | None:
+    if box not in BOXES:
+        return None
+    safe_name = sanitize_filename(filename)
+    dir_fd, root = _open_box_dir(repo_root, box)
+    file_fd: int | None = None
+    try:
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            file_fd = os.open(safe_name, flags, dir_fd=dir_fd)
+        except OSError as exc:
+            if exc.errno in {errno.ENOENT, errno.ELOOP, errno.ENOTDIR}:
+                return None
+            raise
+        file_stat = os.fstat(file_fd)
+        if not _is_single_regular_file(file_stat):
+            return None
+        entry = _entry_from_stat(root / safe_name, box, file_stat)
+        return entry, _read_all(file_fd)
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        os.close(dir_fd)
+
+
+def open_file(
+    repo_root: Path, box: str, filename: str
+) -> tuple[FileBoxEntry, BinaryIO] | None:
+    if box not in BOXES:
+        return None
+    safe_name = sanitize_filename(filename)
+    dir_fd, root = _open_box_dir(repo_root, box)
+    file_fd: int | None = None
+    try:
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            file_fd = os.open(safe_name, flags, dir_fd=dir_fd)
+        except OSError as exc:
+            if exc.errno in {errno.ENOENT, errno.ELOOP, errno.ENOTDIR}:
+                return None
+            raise
+        file_stat = os.fstat(file_fd)
+        if not _is_single_regular_file(file_stat):
+            return None
+        entry = _entry_from_stat(root / safe_name, box, file_stat)
+        handle = os.fdopen(file_fd, "rb")
+        file_fd = None
+        return entry, handle
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        os.close(dir_fd)
+
+
+def save_file(repo_root: Path, box: str, filename: str, data: bytes) -> Path:
+    if box not in BOXES:
+        raise ValueError("Invalid box")
+    ensure_structure(repo_root)
+    safe_name = sanitize_filename(filename)
+    dir_fd, root = _open_box_dir(repo_root, box)
+    file_fd: int | None = None
+    try:
+        flags = os.O_WRONLY | os.O_CREAT
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            file_fd = os.open(safe_name, flags, 0o666, dir_fd=dir_fd)
+        except OSError as exc:
+            if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+                raise ValueError("Invalid filename") from exc
+            raise
+        file_stat = os.fstat(file_fd)
+        if not _is_single_regular_file(file_stat):
+            raise ValueError("Invalid filename")
+        os.ftruncate(file_fd, 0)
+        view = memoryview(data)
+        while view:
+            written = os.write(file_fd, view)
+            view = view[written:]
+        return root / safe_name
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        os.close(dir_fd)
+
+
+def resolve_file(repo_root: Path, box: str, filename: str) -> FileBoxEntry | None:
+    if box not in BOXES:
+        return None
+    path = _existing_regular_entry(repo_root, box, filename)
+    if path is None:
+        return None
+    stat_result = path.lstat()
+    return _entry_from_stat(path, box, stat_result)
+
+
 def delete_file(repo_root: Path, box: str, filename: str) -> bool:
     if box not in BOXES:
         return False
-    unresolved = _unresolved_target_path(repo_root, box, filename)
-    if unresolved.is_symlink():
-        return False
-    path = _target_path(repo_root, box, filename)
-    if not path.exists() or not path.is_file():
+    path = _existing_regular_entry(repo_root, box, filename)
+    if path is None:
         return False
     try:
         path.unlink()
-    except OSError:
+    except FileNotFoundError:
         return False
+    except OSError:
+        raise
     return True
 
 
@@ -207,7 +361,8 @@ def list_regular_files(folder: Path) -> List[Path]:
     try:
         for path in folder.iterdir():
             try:
-                if not path.is_symlink() and path.is_file():
+                stat_result = path.lstat()
+                if _is_single_regular_file(stat_result):
                     files.append(path)
             except OSError:
                 continue
@@ -230,7 +385,8 @@ def delete_regular_files(folder: Path) -> int:
     try:
         for path in folder.iterdir():
             try:
-                if not path.is_symlink() and path.is_file():
+                stat_result = path.lstat()
+                if _is_single_regular_file(stat_result):
                     path.unlink()
                     deleted += 1
             except OSError:
@@ -250,9 +406,11 @@ __all__ = [
     "inbox_dir",
     "list_regular_files",
     "list_filebox",
+    "open_file",
     "outbox_dir",
     "outbox_pending_dir",
     "outbox_sent_dir",
+    "read_file",
     "resolve_file",
     "sanitize_filename",
     "save_file",

--- a/src/codex_autorunner/core/filebox.py
+++ b/src/codex_autorunner/core/filebox.py
@@ -47,6 +47,8 @@ def ensure_structure(repo_root: Path) -> None:
         outbox_pending_dir(repo_root),
         outbox_sent_dir(repo_root),
     ):
+        if path.is_symlink():
+            raise ValueError(f"FileBox path must not be a symlink: {path}")
         path.mkdir(parents=True, exist_ok=True)
 
 
@@ -70,12 +72,12 @@ def sanitize_filename(name: str) -> str:
 def _gather_files(entries: Iterable[tuple[str, Path]], box: str) -> List[FileBoxEntry]:
     collected: List[FileBoxEntry] = []
     for source, folder in entries:
-        if not folder.exists():
+        if folder.is_symlink() or not folder.exists():
             continue
         try:
             for path in folder.iterdir():
                 try:
-                    if not path.is_file():
+                    if path.is_symlink() or not path.is_file():
                         continue
                     stat = path.stat()
                     collected.append(
@@ -125,6 +127,8 @@ def _target_path(repo_root: Path, box: str, filename: str) -> Path:
 
     safe_name = sanitize_filename(filename)
     target_dir = _box_dir(repo_root, box)
+    if target_dir.is_symlink():
+        raise ValueError("Invalid filebox")
     target_dir.mkdir(parents=True, exist_ok=True)
 
     root = target_dir.resolve()
@@ -139,10 +143,22 @@ def _target_path(repo_root: Path, box: str, filename: str) -> Path:
     return candidate
 
 
+def _unresolved_target_path(repo_root: Path, box: str, filename: str) -> Path:
+    safe_name = sanitize_filename(filename)
+    target_dir = _box_dir(repo_root, box)
+    if target_dir.is_symlink():
+        raise ValueError("Invalid filebox")
+    target_dir.mkdir(parents=True, exist_ok=True)
+    return target_dir.resolve() / safe_name
+
+
 def save_file(repo_root: Path, box: str, filename: str, data: bytes) -> Path:
     if box not in BOXES:
         raise ValueError("Invalid box")
     ensure_structure(repo_root)
+    unresolved = _unresolved_target_path(repo_root, box, filename)
+    if unresolved.is_symlink():
+        raise ValueError("Invalid filename")
     path = _target_path(repo_root, box, filename)
     path.write_bytes(data)
     return path
@@ -150,6 +166,9 @@ def save_file(repo_root: Path, box: str, filename: str, data: bytes) -> Path:
 
 def resolve_file(repo_root: Path, box: str, filename: str) -> FileBoxEntry | None:
     if box not in BOXES:
+        return None
+    unresolved = _unresolved_target_path(repo_root, box, filename)
+    if unresolved.is_symlink():
         return None
     path = _target_path(repo_root, box, filename)
     if not path.exists() or not path.is_file():
@@ -168,6 +187,9 @@ def resolve_file(repo_root: Path, box: str, filename: str) -> FileBoxEntry | Non
 def delete_file(repo_root: Path, box: str, filename: str) -> bool:
     if box not in BOXES:
         return False
+    unresolved = _unresolved_target_path(repo_root, box, filename)
+    if unresolved.is_symlink():
+        return False
     path = _target_path(repo_root, box, filename)
     if not path.exists() or not path.is_file():
         return False
@@ -179,13 +201,13 @@ def delete_file(repo_root: Path, box: str, filename: str) -> bool:
 
 
 def list_regular_files(folder: Path) -> List[Path]:
-    if not folder.exists():
+    if folder.is_symlink() or not folder.exists():
         return []
     files: List[Path] = []
     try:
         for path in folder.iterdir():
             try:
-                if path.is_file():
+                if not path.is_symlink() and path.is_file():
                     files.append(path)
             except OSError:
                 continue
@@ -202,13 +224,13 @@ def list_regular_files(folder: Path) -> List[Path]:
 
 
 def delete_regular_files(folder: Path) -> int:
-    if not folder.exists():
+    if folder.is_symlink() or not folder.exists():
         return 0
     deleted = 0
     try:
         for path in folder.iterdir():
             try:
-                if path.is_file():
+                if not path.is_symlink() and path.is_file():
                     path.unlink()
                     deleted += 1
             except OSError:

--- a/src/codex_autorunner/core/filebox.py
+++ b/src/codex_autorunner/core/filebox.py
@@ -159,38 +159,6 @@ def _is_single_regular_file(stat_result: os.stat_result) -> bool:
     return stat.S_ISREG(stat_result.st_mode) and stat_result.st_nlink == 1
 
 
-def _target_path(repo_root: Path, box: str, filename: str) -> Path:
-    """Return a resolved path within the FileBox, rejecting traversal attempts."""
-
-    safe_name = sanitize_filename(filename)
-    _ensure_filebox_ancestors(repo_root)
-    target_dir = _box_dir(repo_root, box)
-    if target_dir.is_symlink():
-        raise ValueError("Invalid filebox")
-    target_dir.mkdir(parents=True, exist_ok=True)
-
-    root = target_dir.resolve()
-    candidate = (root / safe_name).resolve()
-    try:
-        candidate.relative_to(root)
-    except ValueError as exc:
-        raise ValueError("Invalid filename") from exc
-    if candidate.parent != root:
-        # Disallow sneaky path tricks that resolve inside nested folders.
-        raise ValueError("Invalid filename")
-    return candidate
-
-
-def _unresolved_target_path(repo_root: Path, box: str, filename: str) -> Path:
-    safe_name = sanitize_filename(filename)
-    _ensure_filebox_ancestors(repo_root)
-    target_dir = _box_dir(repo_root, box)
-    if target_dir.is_symlink():
-        raise ValueError("Invalid filebox")
-    target_dir.mkdir(parents=True, exist_ok=True)
-    return target_dir.resolve() / safe_name
-
-
 def _existing_regular_entry(repo_root: Path, box: str, filename: str) -> Path | None:
     safe_name = sanitize_filename(filename)
     _ensure_filebox_ancestors(repo_root)

--- a/src/codex_autorunner/core/filebox_lifecycle.py
+++ b/src/codex_autorunner/core/filebox_lifecycle.py
@@ -21,6 +21,8 @@ def ensure_lifecycle_structure(repo_root: Path) -> None:
         consumed_dir(repo_root),
         dismissed_dir(repo_root),
     ):
+        if path.is_symlink():
+            raise ValueError(f"FileBox lifecycle path must not be a symlink: {path}")
         path.mkdir(parents=True, exist_ok=True)
 
 
@@ -80,7 +82,7 @@ def _lifecycle_dir(repo_root: Path, box: str) -> Path:
 
 
 def _list_box_entries(folder: Path, *, box: str) -> list[FileBoxEntry]:
-    if not folder.exists():
+    if folder.is_symlink() or not folder.exists():
         return []
     entries: list[FileBoxEntry] = []
     try:
@@ -89,7 +91,7 @@ def _list_box_entries(folder: Path, *, box: str) -> list[FileBoxEntry]:
         return []
     for path in iterator:
         try:
-            if not path.is_file():
+            if path.is_symlink() or not path.is_file():
                 continue
             entries.append(_build_entry(path, box=box))
         except OSError:
@@ -102,7 +104,11 @@ def _find_archived_sources(repo_root: Path, filename: str) -> list[Path]:
     for box in LIFECYCLE_BOXES:
         candidate = _resolve_child_path(_lifecycle_dir(repo_root, box), filename)
         try:
-            if candidate.exists() and candidate.is_file():
+            if (
+                not candidate.is_symlink()
+                and candidate.exists()
+                and candidate.is_file()
+            ):
                 sources.append(candidate)
         except OSError:
             continue
@@ -145,10 +151,15 @@ def _build_entry(path: Path, *, box: str) -> FileBoxEntry:
 
 def _resolve_child_path(root: Path, filename: str, *, create_dir: bool = False) -> Path:
     safe_name = sanitize_filename(filename)
+    if root.is_symlink():
+        raise ValueError("Invalid filebox")
     if create_dir:
         root.mkdir(parents=True, exist_ok=True)
     resolved_root = root.resolve()
-    candidate = (resolved_root / safe_name).resolve()
+    candidate = resolved_root / safe_name
+    if candidate.is_symlink():
+        raise ValueError("Invalid filename")
+    candidate = candidate.resolve()
     try:
         candidate.relative_to(resolved_root)
     except ValueError as exc:

--- a/src/codex_autorunner/core/orchestration/cold_trace_store.py
+++ b/src/codex_autorunner/core/orchestration/cold_trace_store.py
@@ -8,6 +8,7 @@ import zlib
 from pathlib import Path
 from typing import Any, Iterator, Optional, cast
 
+from ..redaction import redact_jsonable
 from ..state_roots import resolve_hub_traces_root
 from ..text_utils import _json_dumps
 from ..time_utils import now_iso
@@ -81,6 +82,7 @@ class ColdTraceWriter:
         self._event_count: int = 0
         self._byte_count: int = 0
         self._includes_families: set[str] = set()
+        self._redactions_applied: set[str] = set()
         self._started_at: Optional[str] = None
         self._finished_at: Optional[str] = None
         self._manifest: Optional[ExecutionTraceManifest] = None
@@ -142,11 +144,14 @@ class ColdTraceWriter:
         if self._disabled or self._file is None:
             raise RuntimeError("ColdTraceWriter is not open")
         self._seq += 1
+        redacted_payload, redacted = redact_jsonable(payload)
+        if redacted:
+            self._redactions_applied.add("secret-patterns")
         envelope = _build_trace_envelope(
             seq=self._seq,
             event_family=event_family,
             event_type=event_type,
-            payload=payload,
+            payload=cast(dict[str, Any], redacted_payload),
         )
         data = _serialize_envelope(envelope)
         self._file.write(data)
@@ -188,7 +193,7 @@ class ColdTraceWriter:
                 tuple[ExecutionHistoryEventFamily, ...],
                 tuple(sorted(self._includes_families)),
             ),
-            redactions_applied=(),
+            redactions_applied=tuple(sorted(self._redactions_applied)),
         )
         self._manifest = manifest
         _persist_manifest(self._hub_root, manifest)

--- a/src/codex_autorunner/core/orchestration/migrations.py
+++ b/src/codex_autorunner/core/orchestration/migrations.py
@@ -9,7 +9,7 @@ from ..sqlite_utils import table_columns, table_exists
 from ..time_utils import now_iso
 from .models import OrchestrationTableDefinition
 
-ORCHESTRATION_SCHEMA_VERSION = 26
+ORCHESTRATION_SCHEMA_VERSION = 27
 
 
 @dataclass(frozen=True)
@@ -1358,6 +1358,51 @@ def _apply_v26(conn: sqlite3.Connection) -> None:
     )
 
 
+def _apply_v27(conn: sqlite3.Connection) -> None:
+    if not table_exists(conn, "orch_queue_items"):
+        return
+    conn.execute(
+        """
+        UPDATE orch_queue_items
+           SET state = 'deduped',
+               dedupe_reason = COALESCE(
+                   dedupe_reason,
+                   'duplicate_of_' || (
+                       SELECT keep.queue_item_id
+                         FROM orch_queue_items AS keep
+                        WHERE keep.lane_id = orch_queue_items.lane_id
+                          AND keep.source_kind = orch_queue_items.source_kind
+                          AND keep.idempotency_key = orch_queue_items.idempotency_key
+                          AND keep.state IN ('pending', 'running')
+                        ORDER BY keep.rowid ASC
+                        LIMIT 1
+                   )
+               ),
+               updated_at = COALESCE(updated_at, created_at)
+         WHERE state IN ('pending', 'running')
+           AND idempotency_key IS NOT NULL
+           AND idempotency_key != ''
+           AND rowid NOT IN (
+               SELECT MIN(rowid)
+                 FROM orch_queue_items
+                WHERE state IN ('pending', 'running')
+                  AND idempotency_key IS NOT NULL
+                  AND idempotency_key != ''
+                GROUP BY lane_id, source_kind, idempotency_key
+           )
+        """
+    )
+    conn.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_orch_queue_items_active_idempotency
+            ON orch_queue_items(lane_id, source_kind, idempotency_key)
+         WHERE state IN ('pending', 'running')
+           AND idempotency_key IS NOT NULL
+           AND idempotency_key != ''
+        """
+    )
+
+
 _MIGRATIONS = (
     _MigrationStep(1, "create_core_orchestration_schema", _apply_v1),
     _MigrationStep(2, "add_binding_and_flow_projection_scaffolding", _apply_v2),
@@ -1397,6 +1442,7 @@ _MIGRATIONS = (
     _MigrationStep(24, "add_thread_identity_bindings", _apply_v24),
     _MigrationStep(25, "extend_publish_dedupe_index_for_effect_applied", _apply_v25),
     _MigrationStep(26, "add_operation_flags", _apply_v26),
+    _MigrationStep(27, "enforce_active_queue_item_idempotency", _apply_v27),
 )
 
 

--- a/src/codex_autorunner/core/pma_queue.py
+++ b/src/codex_autorunner/core/pma_queue.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import sqlite3
 import uuid
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -466,46 +467,80 @@ class PmaQueue:
     def _append_to_file_sync(self, item: PmaQueueItem) -> None:
         with open_orchestration_sqlite(self._hub_root, durable=True) as conn:
             with conn:
-                conn.execute(
-                    """
-                    INSERT INTO orch_queue_items (
-                        queue_item_id,
-                        lane_id,
-                        source_kind,
-                        source_key,
-                        dedupe_key,
-                        state,
-                        visible_at,
-                        claimed_at,
-                        completed_at,
-                        payload_json,
-                        created_at,
-                        updated_at,
-                        idempotency_key,
-                        error_text,
-                        dedupe_reason,
-                        result_json
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(queue_item_id) DO UPDATE SET
-                        lane_id = excluded.lane_id,
-                        source_kind = excluded.source_kind,
-                        source_key = excluded.source_key,
-                        dedupe_key = excluded.dedupe_key,
-                        state = excluded.state,
-                        visible_at = excluded.visible_at,
-                        claimed_at = excluded.claimed_at,
-                        completed_at = excluded.completed_at,
-                        payload_json = excluded.payload_json,
-                        created_at = excluded.created_at,
-                        updated_at = excluded.updated_at,
-                        idempotency_key = excluded.idempotency_key,
-                        error_text = excluded.error_text,
-                        dedupe_reason = excluded.dedupe_reason,
-                        result_json = excluded.result_json
-                    """,
-                    self._item_db_tuple(item),
-                )
+                try:
+                    self._insert_or_update_item(conn, item)
+                except sqlite3.IntegrityError:
+                    existing = self._find_active_item_by_idempotency_key_conn(
+                        conn, item.lane_id, item.idempotency_key
+                    )
+                    if existing is None:
+                        self._insert_or_update_item(conn, item)
+                        return
+                    item.state = QueueItemState.DEDUPED
+                    item.dedupe_reason = f"duplicate_of_{existing.item_id}"
+                    self._insert_or_update_item(conn, item)
         self._sync_lane_mirror_sync(item.lane_id)
+
+    def _insert_or_update_item(
+        self, conn: sqlite3.Connection, item: PmaQueueItem
+    ) -> None:
+        conn.execute(
+            """
+            INSERT INTO orch_queue_items (
+                queue_item_id,
+                lane_id,
+                source_kind,
+                source_key,
+                dedupe_key,
+                state,
+                visible_at,
+                claimed_at,
+                completed_at,
+                payload_json,
+                created_at,
+                updated_at,
+                idempotency_key,
+                error_text,
+                dedupe_reason,
+                result_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(queue_item_id) DO UPDATE SET
+                lane_id = excluded.lane_id,
+                source_kind = excluded.source_kind,
+                source_key = excluded.source_key,
+                dedupe_key = excluded.dedupe_key,
+                state = excluded.state,
+                visible_at = excluded.visible_at,
+                claimed_at = excluded.claimed_at,
+                completed_at = excluded.completed_at,
+                payload_json = excluded.payload_json,
+                created_at = excluded.created_at,
+                updated_at = excluded.updated_at,
+                idempotency_key = excluded.idempotency_key,
+                error_text = excluded.error_text,
+                dedupe_reason = excluded.dedupe_reason,
+                result_json = excluded.result_json
+            """,
+            self._item_db_tuple(item),
+        )
+
+    def _find_active_item_by_idempotency_key_conn(
+        self, conn: sqlite3.Connection, lane_id: str, idempotency_key: str
+    ) -> Optional[PmaQueueItem]:
+        row = conn.execute(
+            """
+            SELECT *
+              FROM orch_queue_items
+             WHERE lane_id = ?
+               AND source_kind = ?
+               AND idempotency_key = ?
+               AND state IN ('pending', 'running')
+             ORDER BY rowid ASC
+             LIMIT 1
+            """,
+            (lane_id, PMA_LANE_SOURCE_KIND, idempotency_key),
+        ).fetchone()
+        return self._row_to_item(row) if row is not None else None
 
     def _update_in_file_sync(self, item: PmaQueueItem) -> None:
         with open_orchestration_sqlite(self._hub_root, durable=True) as conn:

--- a/src/codex_autorunner/core/pma_queue.py
+++ b/src/codex_autorunner/core/pma_queue.py
@@ -475,10 +475,10 @@ class PmaQueue:
                     )
                     if existing is None:
                         self._insert_or_update_item(conn, item)
-                        return
-                    item.state = QueueItemState.DEDUPED
-                    item.dedupe_reason = f"duplicate_of_{existing.item_id}"
-                    self._insert_or_update_item(conn, item)
+                    else:
+                        item.state = QueueItemState.DEDUPED
+                        item.dedupe_reason = f"duplicate_of_{existing.item_id}"
+                        self._insert_or_update_item(conn, item)
         self._sync_lane_mirror_sync(item.lane_id)
 
     def _insert_or_update_item(

--- a/src/codex_autorunner/core/pma_transcripts.py
+++ b/src/codex_autorunner/core/pma_transcripts.py
@@ -12,6 +12,7 @@ from .orchestration.transcript_mirror import (
     TranscriptMirrorStore,
     build_plain_text_transcript,
 )
+from .redaction import redact_jsonable, redact_text
 from .time_utils import now_iso
 from .utils import atomic_write
 
@@ -100,18 +101,37 @@ class PmaTranscriptStore:
         if resolved_user_text:
             payload["user_text_chars"] = len(resolved_user_text)
 
+        redacted_user_text = (
+            redact_text(resolved_user_text) if resolved_user_text is not None else None
+        )
+        redacted_assistant_text = redact_text(assistant_text or "")
+        redacted_payload, metadata_redacted = redact_jsonable(payload)
+        payload = dict(redacted_payload)
+        existing_redactions = payload.get("redactions_applied") or []
+        if not isinstance(existing_redactions, list):
+            existing_redactions = []
+        redactions_applied = {str(item) for item in existing_redactions}
+        if (
+            metadata_redacted
+            or redacted_user_text != resolved_user_text
+            or redacted_assistant_text != (assistant_text or "")
+        ):
+            redactions_applied.add("secret-patterns")
+        if redactions_applied:
+            payload["redactions_applied"] = sorted(redactions_applied)
+
         self._dir.mkdir(parents=True, exist_ok=True)
         transcript_content = build_plain_text_transcript(
-            user_text=resolved_user_text or "",
-            assistant_text=assistant_text or "",
+            user_text=redacted_user_text or "",
+            assistant_text=redacted_assistant_text,
         )
         atomic_write(md_path, transcript_content + "\n")
         atomic_write(json_path, json.dumps(payload, indent=2) + "\n")
         self._mirror_store.write_mirror(
             turn_id=turn_id,
             metadata=payload,
-            user_text=resolved_user_text,
-            assistant_text=assistant_text,
+            user_text=redacted_user_text,
+            assistant_text=redacted_assistant_text,
         )
 
         return PmaTranscriptPointer(

--- a/src/codex_autorunner/core/redaction.py
+++ b/src/codex_autorunner/core/redaction.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 _REDACTIONS: List[Tuple[re.Pattern[str], str]] = [
     # OpenAI-like keys.
@@ -23,3 +23,36 @@ def redact_text(text: str) -> str:
     for pattern, replacement in _REDACTIONS:
         redacted = pattern.sub(replacement, redacted)
     return redacted
+
+
+def redact_jsonable(value: Any) -> tuple[Any, bool]:
+    """Redact known secret patterns in JSON-like values."""
+
+    if isinstance(value, str):
+        redacted = redact_text(value)
+        return redacted, redacted != value
+    if isinstance(value, list):
+        changed = False
+        items = []
+        for item in value:
+            redacted_item, item_changed = redact_jsonable(item)
+            changed = changed or item_changed
+            items.append(redacted_item)
+        return items, changed
+    if isinstance(value, tuple):
+        changed = False
+        items = []
+        for item in value:
+            redacted_item, item_changed = redact_jsonable(item)
+            changed = changed or item_changed
+            items.append(redacted_item)
+        return tuple(items), changed
+    if isinstance(value, dict):
+        changed = False
+        redacted_dict = {}
+        for key, item in value.items():
+            redacted_item, item_changed = redact_jsonable(item)
+            changed = changed or item_changed
+            redacted_dict[key] = redacted_item
+        return redacted_dict, changed
+    return value, False

--- a/src/codex_autorunner/integrations/discord/config.py
+++ b/src/codex_autorunner/integrations/discord/config.py
@@ -50,7 +50,7 @@ class DiscordCommandRegistration:
 
 @dataclass(frozen=True)
 class DiscordBotShellConfig:
-    enabled: bool = True
+    enabled: bool = False
     timeout_ms: int = DEFAULT_SHELL_TIMEOUT_MS
     max_output_chars: int = DEFAULT_SHELL_MAX_OUTPUT_CHARS
 
@@ -167,7 +167,7 @@ class DiscordBotConfig:
         shell_cfg = shell_raw if isinstance(shell_raw, dict) else {}
         shell_enabled = _parse_bool_or_default(
             shell_cfg.get("enabled"),
-            default=True,
+            default=False,
             key="discord_bot.shell.enabled",
         )
         shell_timeout_ms = _parse_positive_int_or_default(

--- a/src/codex_autorunner/surfaces/web/middleware.py
+++ b/src/codex_autorunner/surfaces/web/middleware.py
@@ -200,7 +200,14 @@ class AuthTokenMiddleware:
             return None
         return value.split(" ", 1)[1].strip() or None
 
+    def _allows_query_token(self, scope) -> bool:
+        # Query-string bearer tokens are intentionally limited to WebSocket
+        # migration compatibility. HTTP callers must use Authorization headers.
+        return bool(scope.get("type") == "websocket")
+
     def _extract_query_token(self, scope) -> str | None:
+        if not self._allows_query_token(scope):
+            return None
         query_string = scope.get("query_string") or b""
         if not query_string:
             return None

--- a/src/codex_autorunner/surfaces/web/routes/filebox.py
+++ b/src/codex_autorunner/surfaces/web/routes/filebox.py
@@ -20,6 +20,8 @@ from ....core.hub import HubSupervisor
 from ....core.utils import find_repo_root
 
 logger = logging.getLogger(__name__)
+DEFAULT_FILEBOX_MAX_UPLOAD_BYTES = 10_000_000
+UPLOAD_CHUNK_BYTES = 1024 * 1024
 
 
 def _serialize_entry(entry: FileBoxEntry, *, request: Request) -> dict[str, Any]:
@@ -63,21 +65,55 @@ async def _upload_files_to_box(
 ) -> dict[str, Any]:
     ensure_structure(repo_root)
     form = await request.form()
-    saved = []
+    max_upload_bytes = _resolve_max_upload_bytes(request)
+    pending: list[tuple[str, bytes]] = []
     for filename, file in form.items():
         if not isinstance(file, UploadFile):
             continue
         try:
-            data = await file.read()
+            data = await _read_upload_limited(file, max_upload_bytes=max_upload_bytes)
         except OSError as exc:
             logger.warning("Failed to read upload: %s", exc)
             continue
+        except ValueError as exc:
+            raise HTTPException(status_code=413, detail=str(exc)) from exc
+        pending.append((file.filename or filename, data))
+
+    saved = []
+    for filename, data in pending:
         try:
             path = save_file(repo_root, box, filename, data)
             saved.append(path.name)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"status": "ok", "saved": saved}
+
+
+def _resolve_max_upload_bytes(request: Request) -> int:
+    config = getattr(request.app.state, "config", None)
+    pma_config = getattr(config, "pma", None)
+    raw = getattr(pma_config, "max_upload_bytes", None)
+    if raw is None:
+        return DEFAULT_FILEBOX_MAX_UPLOAD_BYTES
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        value = DEFAULT_FILEBOX_MAX_UPLOAD_BYTES
+    return value if value > 0 else DEFAULT_FILEBOX_MAX_UPLOAD_BYTES
+
+
+async def _read_upload_limited(file: UploadFile, *, max_upload_bytes: int) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = await file.read(UPLOAD_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_upload_bytes:
+            raise ValueError(f"File too large (max {max_upload_bytes} bytes)")
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def build_filebox_routes() -> APIRouter:

--- a/src/codex_autorunner/surfaces/web/routes/filebox.py
+++ b/src/codex_autorunner/surfaces/web/routes/filebox.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import logging
+import mimetypes
+from datetime import datetime
+from email.utils import format_datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, BinaryIO, Iterator, Optional
+from urllib.parse import quote
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import FileResponse
+from fastapi.responses import StreamingResponse
 from starlette.datastructures import UploadFile
 
 from ....core.filebox import (
@@ -13,8 +17,12 @@ from ....core.filebox import (
     FileBoxEntry,
     ensure_structure,
     list_filebox,
-    resolve_file,
+    open_file,
+    sanitize_filename,
     save_file,
+)
+from ....core.filebox import (
+    delete_file as delete_filebox_file,
 )
 from ....core.hub import HubSupervisor
 from ....core.utils import find_repo_root
@@ -60,6 +68,37 @@ def _resolve_repo_root(request: Request) -> Path:
     return find_repo_root()
 
 
+def _stream_file(handle: BinaryIO) -> Iterator[bytes]:
+    try:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        handle.close()
+
+
+def _file_download_response(entry: FileBoxEntry, handle: BinaryIO) -> StreamingResponse:
+    encoded = quote(entry.name, safe="")
+    content_type = mimetypes.guess_type(entry.name)[0] or "application/octet-stream"
+    headers = {"Content-Disposition": f"attachment; filename*=UTF-8''{encoded}"}
+    if entry.size is not None:
+        headers["Content-Length"] = str(entry.size)
+    if entry.modified_at:
+        try:
+            modified = datetime.fromisoformat(entry.modified_at)
+            headers["Last-Modified"] = format_datetime(modified, usegmt=True)
+            headers["ETag"] = f'W/"{entry.size or 0}-{int(modified.timestamp())}"'
+        except ValueError:
+            pass
+    return StreamingResponse(
+        _stream_file(handle),
+        media_type=content_type,
+        headers=headers,
+    )
+
+
 async def _upload_files_to_box(
     *, repo_root: Path, box: str, request: Request
 ) -> dict[str, Any]:
@@ -71,13 +110,18 @@ async def _upload_files_to_box(
         if not isinstance(file, UploadFile):
             continue
         try:
+            sanitize_filename(filename)
+            effective_filename = sanitize_filename(file.filename or filename)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        try:
             data = await _read_upload_limited(file, max_upload_bytes=max_upload_bytes)
         except OSError as exc:
             logger.warning("Failed to read upload: %s", exc)
             continue
         except ValueError as exc:
             raise HTTPException(status_code=413, detail=str(exc)) from exc
-        pending.append((file.filename or filename, data))
+        pending.append((effective_filename, data))
 
     saved = []
     for filename, data in pending:
@@ -147,27 +191,27 @@ def build_filebox_routes() -> APIRouter:
         if box not in BOXES:
             raise HTTPException(status_code=400, detail="Invalid box")
         repo_root = _resolve_repo_root(request)
-        entry = resolve_file(repo_root, box, filename)
-        if entry is None:
+        result = open_file(repo_root, box, filename)
+        if result is None:
             raise HTTPException(status_code=404, detail="File not found")
-        return FileResponse(entry.path, filename=entry.name)
+        entry, handle = result
+        return _file_download_response(entry, handle)
 
     @router.delete("/filebox/{box}/{filename}")
     def delete_file_entry(box: str, filename: str, request: Request) -> dict[str, Any]:
         if box not in BOXES:
             raise HTTPException(status_code=400, detail="Invalid box")
         repo_root = _resolve_repo_root(request)
-        entry = resolve_file(repo_root, box, filename)
-        if entry is None:
-            raise HTTPException(status_code=404, detail="File not found")
         try:
-            entry.path.unlink()
-        except FileNotFoundError:
-            raise HTTPException(status_code=404, detail="File not found") from None
+            removed = delete_filebox_file(repo_root, box, filename)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         except OSError as exc:
             raise HTTPException(
                 status_code=500, detail="Failed to delete file"
             ) from exc
+        if not removed:
+            raise HTTPException(status_code=404, detail="File not found") from None
         return {"status": "ok"}
 
     return router
@@ -239,10 +283,11 @@ def build_hub_filebox_routes() -> APIRouter:
         if box not in BOXES:
             raise HTTPException(status_code=400, detail="Invalid box")
         repo_root = _resolve_hub_repo_root(request, repo_id)
-        entry = resolve_file(repo_root, box, filename)
-        if entry is None:
+        result = open_file(repo_root, box, filename)
+        if result is None:
             raise HTTPException(status_code=404, detail="File not found")
-        return FileResponse(entry.path, filename=entry.name)
+        entry, handle = result
+        return _file_download_response(entry, handle)
 
     @router.delete("/{repo_id}/{box}/{filename}")
     def hub_delete(
@@ -251,17 +296,16 @@ def build_hub_filebox_routes() -> APIRouter:
         if box not in BOXES:
             raise HTTPException(status_code=400, detail="Invalid box")
         repo_root = _resolve_hub_repo_root(request, repo_id)
-        entry = resolve_file(repo_root, box, filename)
-        if entry is None:
-            raise HTTPException(status_code=404, detail="File not found")
         try:
-            entry.path.unlink()
-        except FileNotFoundError:
-            raise HTTPException(status_code=404, detail="File not found") from None
+            removed = delete_filebox_file(repo_root, box, filename)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         except OSError as exc:
             raise HTTPException(
                 status_code=500, detail="Failed to delete file"
             ) from exc
+        if not removed:
+            raise HTTPException(status_code=404, detail="File not found") from None
         return {"status": "ok"}
 
     return router

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/history_files_docs.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/history_files_docs.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import mimetypes
 from datetime import datetime, timezone
+from email.utils import format_datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, BinaryIO, Iterator, Optional
+from urllib.parse import quote
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import FileResponse
+from fastapi.responses import StreamingResponse
 from starlette.datastructures import UploadFile
 
 from .....bootstrap import (
@@ -42,6 +45,39 @@ logger = logging.getLogger(__name__)
 PMA_CONTEXT_SNAPSHOT_MAX_BYTES = 200_000
 PMA_CONTEXT_LOG_SOFT_LIMIT_BYTES = 5_000_000
 PMA_BULK_DELETE_SAMPLE_LIMIT = 10
+
+
+def _stream_file(handle: BinaryIO) -> Iterator[bytes]:
+    try:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        handle.close()
+
+
+def _file_download_response(
+    entry: filebox.FileBoxEntry, handle: BinaryIO
+) -> StreamingResponse:
+    encoded = quote(entry.name, safe="")
+    content_type = mimetypes.guess_type(entry.name)[0] or "application/octet-stream"
+    headers = {"Content-Disposition": f"attachment; filename*=UTF-8''{encoded}"}
+    if entry.size is not None:
+        headers["Content-Length"] = str(entry.size)
+    if entry.modified_at:
+        try:
+            modified = datetime.fromisoformat(entry.modified_at)
+            headers["Last-Modified"] = format_datetime(modified, usegmt=True)
+            headers["ETag"] = f'W/"{entry.size or 0}-{int(modified.timestamp())}"'
+        except ValueError:
+            pass
+    return StreamingResponse(
+        _stream_file(handle),
+        media_type=content_type,
+        headers=headers,
+    )
 
 
 def build_history_files_docs_router(
@@ -277,13 +313,14 @@ def build_history_files_docs_router(
         context = get_pma_request_context(request)
         hub_root = context.hub_root
         try:
-            entry = filebox.resolve_file(hub_root, box, filename)
+            result = filebox.open_file(hub_root, box, filename)
         except ValueError as exc:
             logger.warning("Invalid filename in PMA download: %s (%s)", filename, exc)
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        if entry is None:
+        if result is None:
             logger.warning("File not found in PMA download: %s", filename)
             raise HTTPException(status_code=404, detail="File not found")
+        entry, handle = result
         _get_safety_checker(request).record_action(
             action_type=PmaActionType.FILE_DOWNLOADED,
             details={
@@ -292,7 +329,7 @@ def build_history_files_docs_router(
                 "size": entry.size,
             },
         )
-        return FileResponse(entry.path, filename=entry.name)
+        return _file_download_response(entry, handle)
 
     @router.delete("/files/{box}/{filename}")
     async def delete_pma_file(box: str, filename: str, request: Request):
@@ -309,7 +346,12 @@ def build_history_files_docs_router(
                 if entry is None:
                     logger.warning("File not found in PMA delete: %s", filename)
                     raise HTTPException(status_code=404, detail="File not found")
-                await asyncio.to_thread(entry.path.unlink)
+                removed = await asyncio.to_thread(
+                    filebox.delete_file, hub_root, box, filename
+                )
+                if not removed:
+                    logger.warning("File not found in PMA delete: %s", filename)
+                    raise HTTPException(status_code=404, detail="File not found")
         except ValueError as exc:
             logger.warning("Invalid filename in PMA delete: %s (%s)", filename, exc)
             raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/tests/core/apps/test_apply.py
+++ b/tests/core/apps/test_apply.py
@@ -34,7 +34,9 @@ def _commit_repo(repo_path: Path, message: str) -> str:
     return (run_git(["rev-parse", "HEAD"], repo_path, check=True).stdout or "").strip()
 
 
-def _configure_apps_repo(hub_root: Path, app_repo: Path) -> None:
+def _configure_apps_repo(
+    hub_root: Path, app_repo: Path, *, trusted: bool = True
+) -> None:
     config_path = hub_root / CONFIG_FILENAME
     raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
     raw["apps"] = {
@@ -43,7 +45,7 @@ def _configure_apps_repo(hub_root: Path, app_repo: Path) -> None:
             {
                 "id": "local",
                 "url": str(app_repo),
-                "trusted": True,
+                "trusted": trusted,
                 "default_ref": "main",
             }
         ],
@@ -134,6 +136,22 @@ def _setup_apply_env(tmp_path: Path) -> tuple[Path, Path, Path]:
     return hub_root, repo_root, app_repo
 
 
+def _setup_untrusted_apply_env(tmp_path: Path) -> tuple[Path, Path, Path]:
+    from codex_autorunner.bootstrap import seed_hub_files, seed_repo_files
+
+    hub_root = tmp_path / "hub"
+    seed_hub_files(hub_root, force=True)
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True, exist_ok=True)
+    seed_repo_files(repo_root, git_required=False)
+    app_repo = tmp_path / "app_repo"
+    _init_repo(app_repo)
+    _configure_apps_repo(hub_root, app_repo, trusted=False)
+    _write_valid_app(app_repo)
+    _commit_repo(app_repo, "add untrusted app")
+    return hub_root, repo_root, app_repo
+
+
 def test_apply_installed_app_by_id_creates_ticket_and_persists_inputs(
     tmp_path: Path,
 ) -> None:
@@ -186,6 +204,36 @@ def test_apply_source_ref_installs_implicitly(tmp_path: Path) -> None:
     assert installed is not None
     assert result.ticket_path.exists()
     assert result.source_ref == "local:apps/hello@main"
+
+
+def test_apply_refuses_untrusted_app_template(tmp_path: Path) -> None:
+    hub_root, repo_root, _app_repo = _setup_untrusted_apply_env(tmp_path)
+    hub_config = load_hub_config(hub_root)
+    install_result = install_app(hub_config, hub_root, repo_root, "local:apps/hello")
+    assert install_result.app.lock.trusted is False
+
+    with pytest.raises(AppApplyError, match="is untrusted"):
+        apply_app_entrypoint(
+            repo_root,
+            "local.hello",
+            app_inputs={"goal": "blocked"},
+        )
+
+
+def test_apply_refuses_untrusted_source_ref_before_install(tmp_path: Path) -> None:
+    hub_root, repo_root, _app_repo = _setup_untrusted_apply_env(tmp_path)
+    hub_config = load_hub_config(hub_root)
+
+    with pytest.raises(AppApplyError, match="repo local is untrusted"):
+        apply_app_entrypoint(
+            repo_root,
+            "local:apps/hello",
+            hub_config=hub_config,
+            hub_root=hub_root,
+            app_inputs={"goal": "blocked"},
+        )
+
+    assert get_installed_app(repo_root, "local.hello") is None
 
 
 def test_apply_injects_provenance_frontmatter(tmp_path: Path) -> None:

--- a/tests/core/apps/test_apps_config.py
+++ b/tests/core/apps/test_apps_config.py
@@ -11,7 +11,10 @@ from codex_autorunner.core.config import (
     load_hub_config,
     load_repo_config,
 )
-from codex_autorunner.core.config_parsers import _parse_apps_config
+from codex_autorunner.core.config_parsers import (
+    _parse_apps_config,
+    _parse_templates_config,
+)
 
 
 def test_parse_apps_config_valid() -> None:
@@ -68,11 +71,29 @@ def test_parse_apps_config_rejects_duplicate_repo_ids() -> None:
             {"repos": [{"id": "", "url": "https://example.com/apps.git"}]},
             r"apps\.repos\[0\]\.id must be a non-empty string",
         ),
+        (
+            {"repos": [{"id": "../escape", "url": "https://example.com/apps.git"}]},
+            r"apps\.repos\[0\]\.id must be a safe path segment",
+        ),
     ],
 )
 def test_parse_apps_config_rejects_invalid_repo_values(cfg, pattern: str) -> None:
     with pytest.raises(ConfigError, match=pattern):
         _parse_apps_config(cfg, {})
+
+
+def test_parse_templates_config_rejects_path_segment_repo_id() -> None:
+    with pytest.raises(
+        ConfigError, match=r"templates\.repos\[0\]\.id must be a safe path segment"
+    ):
+        _parse_templates_config(
+            {
+                "repos": [
+                    {"id": "nested/id", "url": "https://example.com/templates.git"}
+                ]
+            },
+            {},
+        )
 
 
 def test_default_loaded_config_exposes_apps_shape(tmp_path: Path) -> None:

--- a/tests/core/apps/test_install.py
+++ b/tests/core/apps/test_install.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -142,6 +143,23 @@ def test_lock_contents_and_lookup(tmp_path: Path) -> None:
     assert installed is not None
     assert installed.lock == lock
     assert installed.bundle_verified is True
+
+
+def test_load_app_lock_rejects_non_boolean_trusted(tmp_path: Path) -> None:
+    hub_root, repo_root, app_repo = _setup_install_env(tmp_path)
+    _write_valid_app(app_repo)
+    _commit_repo(app_repo, "add hello app")
+    hub_config = load_hub_config(hub_root)
+    result = install_app(hub_config, hub_root, repo_root, "local:apps/hello")
+
+    payload = json.loads(result.app.paths.lock_path.read_text(encoding="utf-8"))
+    payload["trusted"] = "false"
+    result.app.paths.lock_path.write_text(
+        json.dumps(payload, indent=2) + "\n", encoding="utf-8"
+    )
+
+    with pytest.raises(AppInstallError, match="trusted must be boolean"):
+        load_app_lock(result.app.paths.lock_path)
 
 
 def test_compute_bundle_sha_is_deterministic(tmp_path: Path) -> None:

--- a/tests/core/orchestration/test_cold_trace_store.py
+++ b/tests/core/orchestration/test_cold_trace_store.py
@@ -109,6 +109,22 @@ class TestColdTraceWriter:
         assert event["event_family"] == "tool_call"
         assert event["payload"]["tool_name"] == "read"
 
+    def test_append_redacts_secret_payloads(self, hub_root: Path) -> None:
+        _init_orchestration_db(hub_root)
+        secret = "sk-" + ("b" * 24)
+        with ColdTraceWriter(hub_root=hub_root, execution_id="exec-redact") as writer:
+            writer.append(
+                event_family="tool_call",
+                event_type="ToolCall",
+                payload={"tool_input": {"cmd": f"echo {secret}"}},
+            )
+            manifest = writer.finalize()
+
+        assert manifest.redactions_applied == ("secret-patterns",)
+        events = ColdTraceReader.read_events(hub_root, manifest)
+        assert secret not in json.dumps(events)
+        assert "sk-[REDACTED]" in json.dumps(events)
+
     def test_trace_id_is_stable(self, hub_root: Path) -> None:
         _init_orchestration_db(hub_root)
         with ColdTraceWriter(

--- a/tests/core/test_pma_queue_cross_process.py
+++ b/tests/core/test_pma_queue_cross_process.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 from pathlib import Path
 
 import pytest
 
+from codex_autorunner.core.orchestration.migrations import _apply_v27
 from codex_autorunner.core.pma_lane_worker import PmaLaneWorker
 from codex_autorunner.core.pma_queue import PmaQueue, QueueItemState
 from tests.support.waits import wait_for_async_event, wait_for_async_predicate
@@ -142,6 +144,98 @@ async def test_enqueue_sync_idempotency_dedupe(tmp_path: Path) -> None:
     states = [item.state for item in items]
     assert states.count(QueueItemState.PENDING) == 1
     assert states.count(QueueItemState.DEDUPED) == 1
+
+
+@pytest.mark.anyio
+async def test_enqueue_sync_dedupes_after_sqlite_idempotency_conflict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    lane_id = "pma:default"
+    queue = PmaQueue(tmp_path)
+    original_insert = queue._insert_or_update_item
+
+    item, reason = queue.enqueue_sync(lane_id, "race-key", {"message": "a"})
+    assert reason is None
+    calls = 0
+
+    def _raise_once_then_allow(conn, candidate):
+        nonlocal calls
+        if candidate.item_id != item.item_id and calls == 0:
+            calls += 1
+            conn.execute(
+                """
+                UPDATE orch_queue_items
+                   SET state = 'completed'
+                 WHERE queue_item_id = ?
+                """,
+                (item.item_id,),
+            )
+            raise sqlite3.IntegrityError("simulated active idempotency conflict")
+        return original_insert(conn, candidate)
+
+    monkeypatch.setattr(queue, "_insert_or_update_item", _raise_once_then_allow)
+    monkeypatch.setattr(queue, "_find_by_idempotency_key_sync", lambda *_args: None)
+
+    deduped, reason = queue.enqueue_sync(lane_id, "race-key", {"message": "b"})
+    assert reason is None
+    assert deduped.state == QueueItemState.PENDING
+    assert deduped.dedupe_reason is None
+
+    items = await queue.list_items(lane_id)
+    assert [queued.state for queued in items].count(QueueItemState.COMPLETED) == 1
+    assert [queued.state for queued in items].count(QueueItemState.PENDING) == 1
+
+
+def test_v27_migration_dedupes_existing_active_queue_rows() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE orch_queue_items (
+            queue_item_id TEXT PRIMARY KEY,
+            lane_id TEXT NOT NULL,
+            source_kind TEXT NOT NULL,
+            source_key TEXT,
+            dedupe_key TEXT,
+            state TEXT NOT NULL,
+            visible_at TEXT,
+            claimed_at TEXT,
+            completed_at TEXT,
+            payload_json TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            idempotency_key TEXT,
+            error_text TEXT,
+            dedupe_reason TEXT,
+            result_json TEXT NOT NULL DEFAULT '{}'
+        )
+        """
+    )
+    conn.executemany(
+        """
+        INSERT INTO orch_queue_items (
+            queue_item_id, lane_id, source_kind, state, created_at, updated_at,
+            idempotency_key
+        ) VALUES (?, 'pma:default', 'pma_lane', 'pending', 't', 't', 'same')
+        """,
+        [("first",), ("second",)],
+    )
+
+    _apply_v27(conn)
+
+    rows = conn.execute(
+        "SELECT queue_item_id, state, dedupe_reason FROM orch_queue_items ORDER BY rowid"
+    ).fetchall()
+    assert rows[0] == ("first", "pending", None)
+    assert rows[1] == ("second", "deduped", "duplicate_of_first")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO orch_queue_items (
+                queue_item_id, lane_id, source_kind, state, created_at, updated_at,
+                idempotency_key
+            ) VALUES ('third', 'pma:default', 'pma_lane', 'running', 't', 't', 'same')
+            """
+        )
 
 
 @pytest.mark.anyio

--- a/tests/fixtures/default_hub_config.v2.json
+++ b/tests/fixtures/default_hub_config.v2.json
@@ -97,7 +97,7 @@
       "voice": true
     },
     "shell": {
-      "enabled": true,
+      "enabled": false,
       "max_output_chars": 3800,
       "timeout_ms": 120000
     },

--- a/tests/fixtures/default_repo_config.v2.json
+++ b/tests/fixtures/default_repo_config.v2.json
@@ -118,7 +118,7 @@
       "voice": true
     },
     "shell": {
-      "enabled": true,
+      "enabled": false,
       "max_output_chars": 3800,
       "timeout_ms": 120000
     },

--- a/tests/integrations/discord/test_config.py
+++ b/tests/integrations/discord/test_config.py
@@ -125,7 +125,7 @@ def test_discord_bot_config_migrates_legacy_intents_to_default(
 
 def test_discord_bot_config_shell_defaults(tmp_path) -> None:
     cfg = DiscordBotConfig.from_raw(root=tmp_path, raw={"enabled": False})
-    assert cfg.shell.enabled is True
+    assert cfg.shell.enabled is False
     assert cfg.shell.timeout_ms == 120000
     assert cfg.shell.max_output_chars == 3800
 

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -69,3 +69,17 @@ def test_auth_middleware_extracts_ws_protocol_b64_token() -> None:
         ]
     )
     assert middleware._extract_ws_protocol_token(scope) == raw
+
+
+def test_auth_middleware_rejects_query_token_for_http_routes() -> None:
+    middleware = AuthTokenMiddleware(lambda *_: None, token="token")
+    scope = _scope("/api/repo/health")
+    scope["query_string"] = b"token=secret"
+    assert middleware._extract_query_token(scope) is None
+
+
+def test_auth_middleware_keeps_query_token_for_legacy_websockets() -> None:
+    middleware = AuthTokenMiddleware(lambda *_: None, token="token")
+    scope = _ws_scope()
+    scope["query_string"] = b"token=secret"
+    assert middleware._extract_query_token(scope) == "secret"

--- a/tests/test_filebox.py
+++ b/tests/test_filebox.py
@@ -43,6 +43,17 @@ def test_save_resolve_and_delete(tmp_path: Path) -> None:
     assert entry is not None
     assert entry.source == "filebox"
     assert entry.path.read_bytes() == b"hello"
+    loaded = filebox.read_file(repo, "inbox", "note.md")
+    assert loaded is not None
+    loaded_entry, loaded_data = loaded
+    assert loaded_entry.name == "note.md"
+    assert loaded_data == b"hello"
+    opened = filebox.open_file(repo, "inbox", "note.md")
+    assert opened is not None
+    opened_entry, opened_handle = opened
+    with opened_handle:
+        assert opened_entry.name == "note.md"
+        assert opened_handle.read() == b"hello"
 
     removed = filebox.delete_file(repo, "inbox", "note.md")
     assert removed
@@ -60,12 +71,43 @@ def test_resolve_ignores_symlinked_filebox_entries(tmp_path: Path) -> None:
     assert filebox.list_filebox(repo)["inbox"] == []
 
 
+def test_filebox_ignores_hardlinked_entries(tmp_path: Path) -> None:
+    repo = tmp_path
+    outside = _write(tmp_path / "outside", "secret.txt", b"secret")
+    inbox = filebox.inbox_dir(repo)
+    inbox.mkdir(parents=True, exist_ok=True)
+    try:
+        os.link(outside, inbox / "hardlink.txt")
+    except OSError as exc:
+        pytest.skip(f"hard links unavailable: {exc}")
+
+    assert filebox.resolve_file(repo, "inbox", "hardlink.txt") is None
+    assert filebox.read_file(repo, "inbox", "hardlink.txt") is None
+    assert filebox.open_file(repo, "inbox", "hardlink.txt") is None
+    assert filebox.list_filebox(repo)["inbox"] == []
+
+
 def test_save_rejects_symlinked_filebox_target(tmp_path: Path) -> None:
     repo = tmp_path
     target = _write(tmp_path / "outside", "secret.txt", b"secret")
     inbox = filebox.inbox_dir(repo)
     inbox.mkdir(parents=True, exist_ok=True)
     (inbox / "note.md").symlink_to(target)
+
+    with pytest.raises(ValueError):
+        filebox.save_file(repo, "inbox", "note.md", b"replacement")
+    assert target.read_bytes() == b"secret"
+
+
+def test_save_rejects_hardlinked_filebox_target(tmp_path: Path) -> None:
+    repo = tmp_path
+    target = _write(tmp_path / "outside", "secret.txt", b"secret")
+    inbox = filebox.inbox_dir(repo)
+    inbox.mkdir(parents=True, exist_ok=True)
+    try:
+        os.link(target, inbox / "note.md")
+    except OSError as exc:
+        pytest.skip(f"hard links unavailable: {exc}")
 
     with pytest.raises(ValueError):
         filebox.save_file(repo, "inbox", "note.md", b"replacement")
@@ -83,6 +125,42 @@ def test_save_rejects_symlinked_filebox_box_dir(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="must not be a symlink"):
         filebox.save_file(repo, "inbox", "note.md", b"secret")
     assert not (outside / "note.md").exists()
+
+
+def test_save_rejects_symlinked_filebox_root(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside-filebox"
+    outside.mkdir()
+    root = filebox.filebox_root(repo)
+    root.parent.mkdir(parents=True, exist_ok=True)
+    root.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        filebox.save_file(repo, "inbox", "note.md", b"secret")
+    assert not (outside / "inbox" / "note.md").exists()
+
+
+def test_save_rejects_symlinked_repo_root(tmp_path: Path) -> None:
+    real_repo = tmp_path / "real-repo"
+    real_repo.mkdir()
+    repo = tmp_path / "repo-link"
+    repo.symlink_to(real_repo, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        filebox.save_file(repo, "inbox", "note.md", b"secret")
+    assert not (filebox.inbox_dir(real_repo) / "note.md").exists()
+
+
+def test_list_filebox_rejects_symlinked_control_root(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside-control"
+    outside.mkdir()
+    control_root = repo / ".codex-autorunner"
+    control_root.parent.mkdir(parents=True, exist_ok=True)
+    control_root.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        filebox.list_filebox(repo)
 
 
 def test_consume_inbox_file_moves_file_out_of_active_inbox(tmp_path: Path) -> None:

--- a/tests/test_filebox.py
+++ b/tests/test_filebox.py
@@ -1,9 +1,16 @@
 import os
+from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+from starlette.datastructures import UploadFile
 
 from codex_autorunner.core import filebox, filebox_lifecycle
+from codex_autorunner.surfaces.web.routes.filebox import (
+    _read_upload_limited,
+    _upload_files_to_box,
+)
 
 
 def _write(dir_path: Path, name: str, content: bytes = b"x") -> Path:
@@ -40,6 +47,42 @@ def test_save_resolve_and_delete(tmp_path: Path) -> None:
     removed = filebox.delete_file(repo, "inbox", "note.md")
     assert removed
     assert filebox.resolve_file(repo, "inbox", "note.md") is None
+
+
+def test_resolve_ignores_symlinked_filebox_entries(tmp_path: Path) -> None:
+    repo = tmp_path
+    outside = _write(tmp_path / "outside", "secret.txt", b"secret")
+    inbox = filebox.inbox_dir(repo)
+    inbox.mkdir(parents=True, exist_ok=True)
+    (inbox / "link.txt").symlink_to(outside)
+
+    assert filebox.resolve_file(repo, "inbox", "link.txt") is None
+    assert filebox.list_filebox(repo)["inbox"] == []
+
+
+def test_save_rejects_symlinked_filebox_target(tmp_path: Path) -> None:
+    repo = tmp_path
+    target = _write(tmp_path / "outside", "secret.txt", b"secret")
+    inbox = filebox.inbox_dir(repo)
+    inbox.mkdir(parents=True, exist_ok=True)
+    (inbox / "note.md").symlink_to(target)
+
+    with pytest.raises(ValueError):
+        filebox.save_file(repo, "inbox", "note.md", b"replacement")
+    assert target.read_bytes() == b"secret"
+
+
+def test_save_rejects_symlinked_filebox_box_dir(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside-inbox"
+    outside.mkdir()
+    inbox = filebox.inbox_dir(repo)
+    inbox.parent.mkdir(parents=True, exist_ok=True)
+    inbox.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        filebox.save_file(repo, "inbox", "note.md", b"secret")
+    assert not (outside / "note.md").exists()
 
 
 def test_consume_inbox_file_moves_file_out_of_active_inbox(tmp_path: Path) -> None:
@@ -120,6 +163,27 @@ def test_list_regular_files_sorts_newest_first(tmp_path: Path) -> None:
     ]
 
 
+def test_list_regular_files_skips_symlinked_files(tmp_path: Path) -> None:
+    folder = tmp_path / "files"
+    real = _write(folder, "real.txt", b"real")
+    outside = _write(tmp_path / "outside", "secret.txt", b"secret")
+    (folder / "link.txt").symlink_to(outside)
+
+    assert filebox.list_regular_files(folder) == [real]
+
+
+def test_lifecycle_rejects_symlinked_archive_entries(tmp_path: Path) -> None:
+    repo = tmp_path
+    filebox.save_file(repo, "inbox", "note.md", b"hello")
+    consumed = filebox_lifecycle.consumed_dir(repo)
+    consumed.mkdir(parents=True, exist_ok=True)
+    link = consumed / "note.md"
+    link.symlink_to(filebox.inbox_dir(repo) / "note.md")
+
+    with pytest.raises(ValueError, match="Invalid filename"):
+        filebox_lifecycle.consume_inbox_file(repo, "note.md")
+
+
 def test_delete_regular_files_only_removes_regular_files(tmp_path: Path) -> None:
     folder = tmp_path / "files"
     first = _write(folder, "first.txt", b"1")
@@ -141,6 +205,51 @@ def test_delete_ignores_legacy_duplicates(tmp_path: Path) -> None:
     removed = filebox.delete_file(repo, "inbox", "shared.txt")
     assert not removed
     assert (repo / ".codex-autorunner" / "pma" / "inbox" / "shared.txt").exists()
+
+
+class _ChunkedUpload:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+
+    async def read(self, _size: int) -> bytes:
+        if not self._chunks:
+            return b""
+        return self._chunks.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_upload_reader_enforces_max_bytes() -> None:
+    upload = _ChunkedUpload([b"abc", b"def"])
+
+    with pytest.raises(ValueError, match="File too large"):
+        await _read_upload_limited(upload, max_upload_bytes=5)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_filebox_upload_limit_failure_does_not_partially_save(
+    tmp_path: Path,
+) -> None:
+    class _Request:
+        app = SimpleNamespace(
+            state=SimpleNamespace(
+                config=SimpleNamespace(pma=SimpleNamespace(max_upload_bytes=3))
+            )
+        )
+
+        async def form(self):
+            return {
+                "small": UploadFile(filename="small.txt", file=BytesIO(b"ok")),
+                "large": UploadFile(filename="large.txt", file=BytesIO(b"too-big")),
+            }
+
+    with pytest.raises(Exception, match="File too large"):
+        await _upload_files_to_box(
+            repo_root=tmp_path,
+            box="inbox",
+            request=_Request(),  # type: ignore[arg-type]
+        )
+
+    assert filebox.list_filebox(tmp_path)["inbox"] == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pma_managed_threads_messages.py
+++ b/tests/test_pma_managed_threads_messages.py
@@ -152,6 +152,21 @@ def test_send_message_persists_turns_and_reuses_backend_thread(hub_env) -> None:
     assert transcript["content"].strip() == "assistant-output-1"
 
 
+def test_pma_transcript_store_redacts_known_secret_patterns(hub_env) -> None:
+    secret = "sk-" + ("a" * 24)
+    pointer = PmaTranscriptStore(hub_env.hub_root).write_transcript(
+        turn_id="turn-redaction",
+        metadata={"user_prompt": f"use {secret}"},
+        assistant_text=f"echo {secret}",
+    )
+
+    transcript = PmaTranscriptStore(hub_env.hub_root).read_transcript(pointer.turn_id)
+    assert transcript is not None
+    assert secret not in transcript["content"]
+    assert "sk-[REDACTED]" in transcript["content"]
+    assert transcript["metadata"]["redactions_applied"] == ["secret-patterns"]
+
+
 def test_send_message_resolves_alias_backed_hermes_profile_runtime(
     hub_env, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

Hardens the security findings that were actionable with small, local changes:

- rejects HTTP `?token=` bearer auth outside legacy WebSocket migration paths
- makes Discord `!<cmd>` shell passthrough opt-in by default and updates config snapshots/docs
- rejects symlinked FileBox entries, symlinked FileBox box/archive directories, and over-limit multipart uploads without partial saves
- requires app/template repo IDs to be safe cache path segments
- blocks untrusted app template apply before source-ref install/fetch side effects, and validates app lock `trusted` as a boolean
- redacts known secret patterns before PMA transcript and cold trace persistence, and records redaction metadata
- adds a SQLite partial unique index for active PMA queue idempotency and handles enqueue races with dedupe/retry behavior

## Assessment

Treated as valid and addressed here: query-token auth breadth, Discord shell default, FileBox symlink serving/upload limits, app-template trust boundary, repo-id cache path traversal, PMA transcript/cold-trace secret retention, and PMA queue idempotency.

Not addressed in this PR because they need broader design work: hub control-plane credential separation, Docker destination fail-closed/container ownership validation, and cross-surface ticket mutation serialization.

## Validation

Commit hook aggregate lane passed:

- black
- ruff
- import boundary and contract checks
- repo-wide mypy over `src/codex_autorunner`
- full Python pytest: 8118 passed
- frontend build and JS tests
- chat-surface lab deterministic checks and latency budget suite

Additional focused checks before commit covered auth middleware, FileBox, Discord config, app apply/install, cold traces, PMA transcript redaction, queue migration/idempotency, SQLite migrations, and config snapshots.
