### PR TITLE
fix: keep car CLI wrapper synced to hub venv after updates (fixes #1674)

### DIFF
--- a/scripts/install-car-cli-wrapper.sh
+++ b/scripts/install-car-cli-wrapper.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install the user-facing `car` command as a dispatcher to the active CAR hub venv.
+#
+# Overrides:
+#   CURRENT_VENV_LINK  Symlink to the active hub venv
+#                      (default: ~/.local/pipx/venvs/codex-autorunner.current)
+#   LOCAL_BIN          Directory that should contain the `car` wrapper
+#                      (default: ~/.local/bin)
+
+CURRENT_VENV_LINK="${CURRENT_VENV_LINK:-$HOME/.local/pipx/venvs/codex-autorunner.current}"
+LOCAL_BIN="${LOCAL_BIN:-$HOME/.local/bin}"
+CAR_WRAPPER_PATH="${CAR_WRAPPER_PATH:-$LOCAL_BIN/car}"
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+mkdir -p "$(dirname "${CAR_WRAPPER_PATH}")"
+
+cat > "${CAR_WRAPPER_PATH}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installed hub venv python: ${CURRENT_VENV_LINK}/bin/python
+current_venv_link="\${CAR_CURRENT_VENV_LINK:-${CURRENT_VENV_LINK}}"
+python_bin="\${current_venv_link}/bin/python"
+
+if [[ ! -L "\${current_venv_link}" ]]; then
+  echo "car: active codex-autorunner venv symlink is missing: \${current_venv_link}" >&2
+  echo "car: run the hub refresh script to recreate it, or set CAR_CURRENT_VENV_LINK." >&2
+  exit 127
+fi
+
+if [[ ! -x "\${python_bin}" ]]; then
+  echo "car: active codex-autorunner Python is missing or not executable: \${python_bin}" >&2
+  echo "car: current symlink target: \$(readlink "\${current_venv_link}" 2>/dev/null || echo unknown)" >&2
+  exit 127
+fi
+
+exec "\${python_bin}" -m codex_autorunner.cli "\$@"
+EOF
+
+chmod 0755 "${CAR_WRAPPER_PATH}"
+
+if ! grep -Fq "${CURRENT_VENV_LINK}/bin/python" "${CAR_WRAPPER_PATH}"; then
+  fail "car wrapper verification failed: ${CAR_WRAPPER_PATH} does not dispatch through ${CURRENT_VENV_LINK}/bin/python"
+fi
+
+echo "Installed car wrapper at ${CAR_WRAPPER_PATH} -> ${CURRENT_VENV_LINK}/bin/python"

--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -46,7 +46,7 @@ set -euo pipefail
 #                          SIGKILL (default: 10). Hub/chat can hold DB handles briefly; 5s was tight.
 #   KEEP_OLD_VENVS         how many old next-* venvs to keep (default: 3)
 #   NVM_BIN                Node bin path to prepend (default: ~/.nvm/versions/node/v22.12.0/bin)
-#   LOCAL_BIN              Local bin path to prepend (default: ~/.local/bin)
+#   LOCAL_BIN              Local bin path for the `car` wrapper and PATH bootstrap (default: ~/.local/bin)
 #   PY39_BIN               Python bin path to prepend (default: auto-detected from active Python)
 #   OPENCODE_BIN           OpenCode bin path to prepend (default: ~/.opencode/bin)
 
@@ -639,7 +639,7 @@ if [[ ! -d "${PIPX_VENV}" ]]; then
   fi
 fi
 
-for cmd in git launchctl curl pipx; do
+for cmd in git launchctl curl; do
   if ! command -v "${cmd}" >/dev/null 2>&1; then
     fail "Missing required command: ${cmd}."
   fi
@@ -1970,13 +1970,11 @@ if [[ "${health_ok}" == "true" ]]; then
   if [[ -n "${discord_health_reason}" ]]; then
     status_msg+=" ${discord_health_reason}"
   fi
-  echo "Updating global car CLI..."
-  if ! pipx install --force "${PACKAGE_INSTALL_SPEC}"; then
+  echo "Updating global car CLI wrapper..."
+  if ! CURRENT_VENV_LINK="${CURRENT_VENV_LINK}" LOCAL_BIN="${LOCAL_BIN}" \
+    bash "${PACKAGE_SRC}/scripts/install-car-cli-wrapper.sh"; then
     _warn_post_cutover \
-      "Global pipx install failed after cutover; keeping the healthy staged venv active and skipping rollback."
-  elif ! _ensure_playwright_chromium "${PIPX_VENV}/bin/python"; then
-    _warn_post_cutover \
-      "Playwright Chromium install for the global pipx venv failed after cutover; the staged service venv remains active."
+      "Global car CLI wrapper update failed after cutover; keeping the healthy staged venv active and skipping rollback."
   fi
   ensure_login_shell_path "${LOCAL_BIN}"
 else

--- a/tests/test_install_car_cli_wrapper_script.py
+++ b/tests/test_install_car_cli_wrapper_script.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_install_car_cli_wrapper_dispatches_to_current_venv(tmp_path: Path) -> None:
+    script_path = Path("scripts/install-car-cli-wrapper.sh").resolve()
+    current_link = tmp_path / "pipx" / "venvs" / "codex-autorunner.current"
+    current_target = tmp_path / "pipx" / "venvs" / "codex-autorunner.next-test"
+    bin_dir = current_target / "bin"
+    local_bin = tmp_path / "bin"
+    log_path = tmp_path / "python-args.txt"
+
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "python").write_text(
+        "#!/usr/bin/env bash\n" f"printf '%s\\n' \"$@\" > {log_path}\n",
+        encoding="utf-8",
+    )
+    (bin_dir / "python").chmod(0o755)
+    current_link.parent.mkdir(parents=True, exist_ok=True)
+    current_link.symlink_to(current_target)
+
+    result = subprocess.run(
+        [str(script_path)],
+        env={
+            **os.environ,
+            "CURRENT_VENV_LINK": str(current_link),
+            "LOCAL_BIN": str(local_bin),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    car_wrapper = local_bin / "car"
+    assert car_wrapper.exists()
+    assert os.access(car_wrapper, os.X_OK)
+    assert f"{current_link}/bin/python" in car_wrapper.read_text(encoding="utf-8")
+
+    run_result = subprocess.run(
+        [str(car_wrapper), "--version"],
+        env={**os.environ, "PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert run_result.returncode == 0, run_result.stderr
+    assert log_path.read_text(encoding="utf-8").splitlines() == [
+        "-m",
+        "codex_autorunner.cli",
+        "--version",
+    ]
+
+
+def test_car_cli_wrapper_reports_missing_current_symlink(tmp_path: Path) -> None:
+    script_path = Path("scripts/install-car-cli-wrapper.sh").resolve()
+    current_link = tmp_path / "pipx" / "venvs" / "codex-autorunner.current"
+    local_bin = tmp_path / "bin"
+
+    result = subprocess.run(
+        [str(script_path)],
+        env={
+            **os.environ,
+            "CURRENT_VENV_LINK": str(current_link),
+            "LOCAL_BIN": str(local_bin),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    run_result = subprocess.run(
+        [str(local_bin / "car"), "--version"],
+        env={**os.environ, "PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert run_result.returncode == 127
+    assert f"active codex-autorunner venv symlink is missing: {current_link}" in (
+        run_result.stderr
+    )
+    assert "run the hub refresh script" in run_result.stderr


### PR DESCRIPTION
Closes #1674.

## Summary
- add a portable `scripts/install-car-cli-wrapper.sh` that installs `~/.local/bin/car` as a runtime dispatcher to `${CURRENT_VENV_LINK}/bin/python`
- update the macOS safe-refresh cutover path to rewrite and verify the `car` wrapper after the new `.current` venv is live
- cover wrapper dispatch and missing `.current` fallback behavior with tests

## Acceptance checklist
- [x] After a hub update, the update flow rewrites `~/.local/bin/car` and verifies it dispatches through the configured `.current` venv Python
- [x] `car --version` runs via `${CURRENT_VENV_LINK}/bin/python -m codex_autorunner.cli`, so it reports the package version from the same venv as the hub
- [x] No manual post-update step is needed; the macOS refresh script installs the wrapper after successful health checks
- [x] If `.current` is missing, the wrapper exits with a clear error message pointing at the missing symlink

Note: the generated wrapper keeps a portable bash shebang so it can print the missing-`.current` fallback message; the verified current Python path is recorded in the wrapper body and used for the final `exec`.

## Verification
- `bash -n scripts/install-car-cli-wrapper.sh`
- `bash -n scripts/safe-refresh-local-mac-hub.sh`
- `.venv/bin/python -m pytest -q tests/test_install_car_cli_wrapper_script.py tests/test_safe_refresh_local_mac_hub_script.py`
- commit hook aggregate lane: Black, Ruff, import-boundary checks, command-hint validation, mypy, `pytest` (8103 passed), frontend build/JS tests, chat-surface lab checks
