### PR TITLE
fix: chat operation state machine transitions + dedup (fixes #1675)

### DIFF
--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -5346,13 +5346,14 @@ class DiscordBotService:
             interaction_id,
             visible_delivery=visible_delivery,
         )
-        await self._patch_chat_operation(
-            interaction_id,
-            state=state,
-            ack_completed_at=now_iso(),
-            first_visible_feedback_at=(now_iso() if visible_delivery else None),
-            anchor_ref=original_response_message_id,
-        )
+        if state is not None:
+            await self._patch_chat_operation(
+                interaction_id,
+                state=state,
+                ack_completed_at=now_iso(),
+                first_visible_feedback_at=(now_iso() if visible_delivery else None),
+                anchor_ref=original_response_message_id,
+            )
 
     async def _record_interaction_delivery(
         self,

--- a/src/codex_autorunner/integrations/discord/service.py
+++ b/src/codex_autorunner/integrations/discord/service.py
@@ -907,6 +907,7 @@ class DiscordBotService:
         self._ingress = InteractionIngress(self, logger=self._logger)
         self._ingress_pre_ack_reservations: set[str] = set()
         self._ingress_pre_ack_reservations_lock = asyncio.Lock()
+        self._recent_interaction_ingress: dict[str, float] = {}
         self._chat_operation_write_lock_guard = asyncio.Lock()
         self._chat_operation_write_locks: dict[str, asyncio.Lock] = {}
         self._command_runner = _CommandRunner(
@@ -5208,16 +5209,27 @@ class DiscordBotService:
                 )
             except ValueError as exc:
                 current = store.get_operation(interaction_id)
+                current_state = current.state if current is not None else None
+                requested_state = (
+                    state if isinstance(state, ChatOperationState) else None
+                )
                 log_event(
                     self._logger,
-                    logging.ERROR,
+                    (
+                        logging.WARNING
+                        if self._is_known_chat_operation_transition_race(
+                            current_state,
+                            requested_state,
+                        )
+                        else logging.ERROR
+                    ),
                     "discord.chat_operation.invalid_transition_rejected",
                     interaction_id=interaction_id,
                     current_state=(
-                        current.state.value if current is not None else None
+                        current_state.value if current_state is not None else None
                     ),
                     requested_state=(
-                        state.value if isinstance(state, ChatOperationState) else None
+                        requested_state.value if requested_state is not None else None
                     ),
                     error=str(exc),
                 )
@@ -5225,6 +5237,18 @@ class DiscordBotService:
 
         async with self._chat_operation_write_guard(interaction_id):
             return await asyncio.to_thread(_patch_sync)
+
+    @staticmethod
+    def _is_known_chat_operation_transition_race(
+        current_state: Optional[ChatOperationState],
+        requested_state: Optional[ChatOperationState],
+    ) -> bool:
+        if current_state in {ChatOperationState.RUNNING, ChatOperationState.QUEUED}:
+            return requested_state == ChatOperationState.ACKNOWLEDGED
+        return (
+            current_state == ChatOperationState.COMPLETED
+            and requested_state == ChatOperationState.DELIVERING
+        )
 
     async def _patch_chat_operation_recovery(
         self,
@@ -5242,6 +5266,69 @@ class DiscordBotService:
             **changes,
         )
 
+    @staticmethod
+    def _is_interrupt_component_custom_id(custom_id: Optional[str]) -> bool:
+        normalized = str(custom_id or "").strip()
+        if not normalized:
+            return False
+        return normalized == "cancel_turn" or normalized.startswith(
+            (
+                "cancel_turn:",
+                "queue_interrupt_send:",
+                "queued_turn_interrupt_send",
+                "qis:",
+            )
+        )
+
+    async def _interaction_custom_id(self, interaction_id: str) -> Optional[str]:
+        record = await self._store.get_interaction(interaction_id)
+        envelope = record.envelope_json if record is not None else None
+        if isinstance(envelope, Mapping):
+            custom_id = envelope.get("custom_id")
+            if isinstance(custom_id, str) and custom_id.strip():
+                return custom_id.strip()
+        metadata = record.metadata_json if record is not None else None
+        if isinstance(metadata, Mapping):
+            custom_id = metadata.get("custom_id")
+            if isinstance(custom_id, str) and custom_id.strip():
+                return custom_id.strip()
+        return None
+
+    async def _chat_operation_ack_state_for_interaction(
+        self,
+        interaction_id: str,
+        *,
+        visible_delivery: bool,
+    ) -> Optional[ChatOperationState]:
+        default_state = (
+            ChatOperationState.VISIBLE
+            if visible_delivery
+            else ChatOperationState.ACKNOWLEDGED
+        )
+        custom_id = await self._interaction_custom_id(interaction_id)
+        if not self._is_interrupt_component_custom_id(custom_id):
+            return default_state
+        snapshot = await self._chat_operation_get(interaction_id)
+        if snapshot is None:
+            return ChatOperationState.INTERRUPTING
+        if snapshot.state in {
+            ChatOperationState.QUEUED,
+            ChatOperationState.RUNNING,
+            ChatOperationState.INTERRUPTING,
+        }:
+            return ChatOperationState.INTERRUPTING
+        if snapshot.state == ChatOperationState.DELIVERING:
+            log_event(
+                self._logger,
+                logging.INFO,
+                "discord.chat_operation.interrupt_ack_noop",
+                interaction_id=interaction_id,
+                current_state=snapshot.state.value,
+                custom_id=custom_id,
+            )
+            return None
+        return default_state
+
     async def _record_interaction_ack(
         self,
         interaction_id: str,
@@ -5255,13 +5342,13 @@ class DiscordBotService:
             original_response_message_id=original_response_message_id,
         )
         visible_delivery = ack_mode in {"immediate_message", "component_update"}
+        state = await self._chat_operation_ack_state_for_interaction(
+            interaction_id,
+            visible_delivery=visible_delivery,
+        )
         await self._patch_chat_operation(
             interaction_id,
-            state=(
-                ChatOperationState.VISIBLE
-                if visible_delivery
-                else ChatOperationState.ACKNOWLEDGED
-            ),
+            state=state,
             ack_completed_at=now_iso(),
             first_visible_feedback_at=(now_iso() if visible_delivery else None),
             anchor_ref=original_response_message_id,
@@ -5305,6 +5392,18 @@ class DiscordBotService:
             state = ChatOperationState.DELIVERING
             delivery_state = "failed"
             terminal_outcome = "delivery_failed"
+        if state == ChatOperationState.DELIVERING:
+            snapshot = await self._chat_operation_get(interaction_id)
+            if snapshot is not None and snapshot.state == ChatOperationState.COMPLETED:
+                log_event(
+                    self._logger,
+                    logging.INFO,
+                    "discord.chat_operation.delivery_already_finalized",
+                    interaction_id=interaction_id,
+                    current_state=snapshot.state.value,
+                    delivery_status=delivery_status,
+                )
+                return
         await self._patch_chat_operation(
             interaction_id,
             state=state,
@@ -5319,6 +5418,22 @@ class DiscordBotService:
         interaction_id: str,
         cursor: Optional[dict[str, Any]],
     ) -> None:
+        snapshot = await self._chat_operation_get(interaction_id)
+        if (
+            isinstance(cursor, dict)
+            and str(cursor.get("state") or "").strip() in {"pending", "failed"}
+            and snapshot is not None
+            and snapshot.state == ChatOperationState.COMPLETED
+        ):
+            log_event(
+                self._logger,
+                logging.INFO,
+                "discord.chat_operation.delivery_already_finalized",
+                interaction_id=interaction_id,
+                current_state=snapshot.state.value,
+                delivery_cursor_state=str(cursor.get("state") or "").strip(),
+            )
+            return
         scheduler_state = None
         if isinstance(cursor, dict):
             state = str(cursor.get("state") or "").strip()
@@ -5921,11 +6036,42 @@ class DiscordBotService:
         if not isinstance(reservations, set):
             reservations = set()
             self._ingress_pre_ack_reservations = reservations
+        recent_ingress = getattr(self, "_recent_interaction_ingress", None)
+        if not isinstance(recent_ingress, dict):
+            recent_ingress = {}
+            self._recent_interaction_ingress = recent_ingress
         reservation_lock = getattr(self, "_ingress_pre_ack_reservations_lock", None)
         if reservation_lock is None:
             reservation_lock = asyncio.Lock()
             self._ingress_pre_ack_reservations_lock = reservation_lock
+        now = time.monotonic()
         async with reservation_lock:
+            expired_before = now - 2.0
+            for interaction_id, seen_at in list(recent_ingress.items()):
+                if seen_at < expired_before:
+                    recent_ingress.pop(interaction_id, None)
+            previous_seen_at = recent_ingress.get(ctx.interaction_id)
+            if previous_seen_at is not None and now - previous_seen_at <= 2.0:
+                age_ms = round((now - previous_seen_at) * 1000, 1)
+                log_event(
+                    self._logger,
+                    logging.INFO,
+                    "discord.interaction.rapid_duplicate_suppressed",
+                    interaction_id=ctx.interaction_id,
+                    duplicate_window_seconds=2.0,
+                    age_ms=age_ms,
+                )
+                log_event(
+                    self._logger,
+                    logging.INFO,
+                    "discord.interaction.duplicate_in_flight_suppressed",
+                    interaction_id=ctx.interaction_id,
+                    reason="rapid_duplicate_suppressed",
+                    duplicate_window_seconds=2.0,
+                    age_ms=age_ms,
+                )
+                return True
+            recent_ingress[ctx.interaction_id] = now
             if ctx.interaction_id in reservations:
                 return True
             reservations.add(ctx.interaction_id)

--- a/tests/integrations/discord/test_interaction_runtime_chaos.py
+++ b/tests/integrations/discord/test_interaction_runtime_chaos.py
@@ -719,6 +719,185 @@ async def test_defer_ack_does_not_project_delivery_pending_before_ack(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    "current_state",
+    (ChatOperationState.QUEUED, ChatOperationState.RUNNING),
+)
+async def test_interrupt_component_ack_projects_interrupting_from_active_state(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    current_state: ChatOperationState,
+) -> None:
+    harness = _ChaosHarness(tmp_path)
+    await harness.initialize()
+    try:
+        service = _build_recovery_service(
+            store=harness.store,
+            rest=harness.rest,
+            operation_store=harness.operation_store,
+        )
+        interaction_id = f"interrupt-{current_state.value}-1"
+        await harness.store.register_interaction(
+            interaction_id=interaction_id,
+            interaction_token=f"token-{interaction_id}",
+            interaction_kind=InteractionKind.COMPONENT.value,
+            channel_id="chan-1",
+            guild_id="guild-1",
+            user_id="user-1",
+            metadata_json={"custom_id": "cancel_turn:thread-1:turn-1"},
+        )
+        harness.operation_store.register_operation(
+            operation_id=interaction_id,
+            surface_kind="discord",
+            surface_operation_key=interaction_id,
+            state=current_state,
+        )
+
+        with caplog.at_level(logging.INFO, logger=service._logger.name):
+            await service._record_interaction_ack(
+                interaction_id,
+                f"token-{interaction_id}",
+                "ack_deferred_component_update",
+                None,
+            )
+
+        snapshot = harness.operation_store.get_operation(interaction_id)
+        assert snapshot is not None
+        assert snapshot.state == ChatOperationState.INTERRUPTING
+        events = _logged_events(caplog, service._logger.name)
+        assert not any(
+            event["event"] == "discord.chat_operation.invalid_transition_rejected"
+            for event in events
+        )
+    finally:
+        await harness.close()
+
+
+@pytest.mark.anyio
+async def test_delivery_cursor_pending_is_idempotent_after_completion(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    harness = _ChaosHarness(tmp_path)
+    await harness.initialize()
+    try:
+        service = _build_recovery_service(
+            store=harness.store,
+            rest=harness.rest,
+            operation_store=harness.operation_store,
+        )
+        await harness.store.register_interaction(
+            interaction_id="delivery-completed-1",
+            interaction_token="token-delivery-completed-1",
+            interaction_kind=InteractionKind.SLASH_COMMAND.value,
+            channel_id="chan-1",
+            guild_id="guild-1",
+            user_id="user-1",
+            metadata_json={"command_path": ["car", "status"]},
+        )
+        harness.operation_store.register_operation(
+            operation_id="delivery-completed-1",
+            surface_kind="discord",
+            surface_operation_key="delivery-completed-1",
+            state=ChatOperationState.COMPLETED,
+        )
+
+        with caplog.at_level(logging.INFO, logger=service._logger.name):
+            await service._record_interaction_delivery_cursor(
+                "delivery-completed-1",
+                {
+                    "state": "pending",
+                    "operation": "send_followup",
+                    "payload": {"content": "late delivery"},
+                },
+            )
+
+        snapshot = harness.operation_store.get_operation("delivery-completed-1")
+        assert snapshot is not None
+        assert snapshot.state == ChatOperationState.COMPLETED
+        record = await harness.store.get_interaction("delivery-completed-1")
+        assert record is not None
+        assert record.delivery_cursor_json is None
+        events = _logged_events(caplog, service._logger.name)
+        assert any(
+            event["event"] == "discord.chat_operation.delivery_already_finalized"
+            for event in events
+        )
+    finally:
+        await harness.close()
+
+
+@pytest.mark.anyio
+async def test_rapid_same_interaction_id_is_debounced(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    harness = _ChaosHarness(tmp_path)
+    await harness.initialize()
+    try:
+        service = _build_recovery_service(
+            store=harness.store,
+            rest=harness.rest,
+            operation_store=harness.operation_store,
+        )
+        ctx = _make_ctx(interaction_id="rapid-dup-1")
+
+        first = await service._check_interaction_ingress_duplicate(ctx)
+        with caplog.at_level(logging.INFO, logger=service._logger.name):
+            second = await service._check_interaction_ingress_duplicate(ctx)
+
+        assert first is False
+        assert second is True
+        events = _logged_events(caplog, service._logger.name)
+        assert any(
+            event["event"] == "discord.interaction.rapid_duplicate_suppressed"
+            for event in events
+        )
+    finally:
+        await harness.close()
+
+
+@pytest.mark.anyio
+async def test_known_transition_race_is_logged_at_warning(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    harness = _ChaosHarness(tmp_path)
+    await harness.initialize()
+    try:
+        service = _build_recovery_service(
+            store=harness.store,
+            rest=harness.rest,
+            operation_store=harness.operation_store,
+        )
+        harness.operation_store.register_operation(
+            operation_id="completed-delivering-race-1",
+            surface_kind="discord",
+            surface_operation_key="completed-delivering-race-1",
+            state=ChatOperationState.COMPLETED,
+        )
+
+        with caplog.at_level(logging.WARNING, logger=service._logger.name):
+            updated = await service._patch_chat_operation(
+                "completed-delivering-race-1",
+                state=ChatOperationState.DELIVERING,
+            )
+
+        assert updated is None
+        records = [
+            record
+            for record in caplog.records
+            if record.name == service._logger.name
+            and "discord.chat_operation.invalid_transition_rejected"
+            in record.getMessage()
+        ]
+        assert records
+        assert records[-1].levelno == logging.WARNING
+    finally:
+        await harness.close()
+
+
+@pytest.mark.anyio
 async def test_chaos_followup_failure_after_defer_recovers_after_restart(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes #1675.
Related: #1631.

## Summary
- Route interrupt component ACK projection from queued/running operations to `interrupting` instead of retrying `acknowledged`.
- Make late delivery cursor/failure updates no-op once the chat operation is already completed.
- Add a 2s same-interaction ingress debounce while preserving existing duplicate-in-flight telemetry.
- Downgrade known benign invalid transition races to warning-level logs.

## Acceptance Criteria
- [x] Interrupt button on running/queued turns requests a valid state transition.
- [x] Delivery finalization is idempotent and safe to call multiple times.
- [x] Same `interaction_id` within a 2s window is deduplicated.
- [x] `invalid_transition_rejected` should drop to only genuine errors.
- [x] Non-critical rejections log at WARNING level.

## Validation
- `PATH=/Users/dazheng/car-workspace/codex-autorunner/.venv/bin:$PATH git commit -m "fix: chat operation transition races"` pre-commit lane passed:
  - black, ruff, import boundaries, contracts, mypy
  - pytest: 8101 passed
  - chat-surface lab: 21 passed
  - latency budget suite: PASS
- `PYTHONPATH=src /Users/dazheng/car-workspace/codex-autorunner/.venv/bin/python -m pytest tests/core/orchestration/test_chat_operation_duplicates.py tests/core/orchestration/test_chat_operation_ledger.py tests/integrations/discord/test_interaction_runtime_chaos.py` passed: 74 passed.
