### PR TITLE
[codex] Quiet stale GitHub CI wakes

### DIFF
--- a/src/codex_autorunner/core/scm_automation_service.py
+++ b/src/codex_autorunner/core/scm_automation_service.py
@@ -388,6 +388,39 @@ def _ci_failed_head_sha_from_payload(
     return _normalize_text(bundle.get("ci_head_sha"))
 
 
+def _ci_head_already_has_reaction(
+    reaction_state_store: ScmReactionStateTracker,
+    *,
+    binding_id: str,
+    head_sha: str,
+    fingerprint: str,
+) -> bool:
+    list_reaction_states = getattr(reaction_state_store, "list_reaction_states", None)
+    if not callable(list_reaction_states):
+        return False
+    try:
+        states = list_reaction_states(
+            binding_id=binding_id,
+            reaction_kind="ci_failed",
+            limit=200,
+        )
+    except Exception:
+        _LOGGER.debug(
+            "Unable to list SCM reaction state for CI head suppression",
+            exc_info=True,
+        )
+        return False
+    for state in states:
+        if _normalize_text(getattr(state, "fingerprint", None)) == fingerprint:
+            continue
+        metadata = getattr(state, "metadata", None)
+        if not isinstance(metadata, Mapping):
+            continue
+        if _normalize_text(metadata.get("ci_head_sha")) == head_sha:
+            return True
+    return False
+
+
 def _merged_feedback_publish_payload(
     base_payload: Mapping[str, Any],
     incoming_payload: Mapping[str, Any],
@@ -989,8 +1022,6 @@ class ScmAutomationService:
                 ),
                 tracking=tracking,
             )
-            if tracking:
-                payload["scm_reaction"] = tracking
             operation: PublishOperation
             deduped = False
             if (
@@ -999,6 +1030,18 @@ class ScmAutomationService:
                 and intent.operation_kind == "enqueue_managed_turn"
             ):
                 head_sha = _ci_failed_head_sha_from_payload(payload)
+                if tracking and head_sha is not None:
+                    tracking["ci_head_sha"] = head_sha
+                    payload["scm_reaction"] = tracking
+            else:
+                head_sha = None
+            if tracking and "scm_reaction" not in payload:
+                payload["scm_reaction"] = tracking
+            if (
+                binding is not None
+                and intent.reaction_kind == "ci_failed"
+                and intent.operation_kind == "enqueue_managed_turn"
+            ):
                 if head_sha is not None:
                     existing_ci_batch = self._find_pending_ci_failed_batch_operation(
                         binding=binding,
@@ -1022,6 +1065,28 @@ class ScmAutomationService:
                         )
                         deduped = True
                     else:
+                        if (
+                            binding_id is not None
+                            and fingerprint is not None
+                            and rsk is not None
+                            and _ci_head_already_has_reaction(
+                                self._reaction_state_store,
+                                binding_id=binding_id,
+                                head_sha=head_sha,
+                                fingerprint=fingerprint,
+                            )
+                        ):
+                            self._reaction_state_store.mark_reaction_suppressed(
+                                binding_id=binding_id,
+                                reaction_kind=rsk,
+                                fingerprint=fingerprint,
+                                event_id=intent.event_id or event.event_id,
+                                metadata={
+                                    **tracking,
+                                    "suppression_reason": "ci_head_already_queued",
+                                },
+                            )
+                            continue
                         next_attempt_at = self._ci_failed_enqueue_next_attempt_at(
                             event=event,
                             bundle=extract_feedback_bundle(payload) or {},

--- a/src/codex_autorunner/core/scm_reaction_state.py
+++ b/src/codex_autorunner/core/scm_reaction_state.py
@@ -798,28 +798,62 @@ class ScmReactionStateStore:
                 fingerprint=normalized_fingerprint,
             )
             if row is None:
-                raise RuntimeError("reaction state row missing before suppression")
-            merged_metadata = self._merge_metadata(row, metadata_object)
-            conn.execute(
-                """
-                UPDATE orch_reaction_state
-                   SET last_event_id = COALESCE(?, last_event_id),
-                       updated_at = ?,
-                       attempt_count = attempt_count + 1,
-                       metadata_json = ?
-                 WHERE binding_id = ?
-                   AND reaction_kind = ?
-                   AND fingerprint = ?
-                """,
-                (
-                    normalized_event_id,
-                    timestamp,
-                    _json_dumps(merged_metadata),
-                    normalized_binding_id,
-                    normalized_reaction_kind,
-                    normalized_fingerprint,
-                ),
-            )
+                conn.execute(
+                    """
+                    INSERT INTO orch_reaction_state (
+                        binding_id,
+                        reaction_kind,
+                        fingerprint,
+                        state,
+                        first_event_id,
+                        last_event_id,
+                        last_operation_key,
+                        created_at,
+                        updated_at,
+                        first_emitted_at,
+                        last_emitted_at,
+                        last_delivery_failed_at,
+                        escalated_at,
+                        resolved_at,
+                        attempt_count,
+                        delivery_failure_count,
+                        last_error_text,
+                        metadata_json
+                    ) VALUES (?, ?, ?, 'suppressed', ?, ?, NULL, ?, ?, NULL, NULL, NULL, NULL, NULL, 1, 0, NULL, ?)
+                    """,
+                    (
+                        normalized_binding_id,
+                        normalized_reaction_kind,
+                        normalized_fingerprint,
+                        normalized_event_id,
+                        normalized_event_id,
+                        timestamp,
+                        timestamp,
+                        _json_dumps(metadata_object),
+                    ),
+                )
+            else:
+                merged_metadata = self._merge_metadata(row, metadata_object)
+                conn.execute(
+                    """
+                    UPDATE orch_reaction_state
+                       SET last_event_id = COALESCE(?, last_event_id),
+                           updated_at = ?,
+                           attempt_count = attempt_count + 1,
+                           metadata_json = ?
+                     WHERE binding_id = ?
+                       AND reaction_kind = ?
+                       AND fingerprint = ?
+                    """,
+                    (
+                        normalized_event_id,
+                        timestamp,
+                        _json_dumps(merged_metadata),
+                        normalized_binding_id,
+                        normalized_reaction_kind,
+                        normalized_fingerprint,
+                    ),
+                )
             refreshed = self._load_reaction_state_row(
                 conn,
                 binding_id=normalized_binding_id,

--- a/src/codex_autorunner/integrations/github/polling_events.py
+++ b/src/codex_autorunner/integrations/github/polling_events.py
@@ -21,6 +21,7 @@ def emit_new_conditions(
 ) -> int:
     from ...core.text_utils import _normalize_text
 
+    current_head_sha = _normalize_text(snapshot.get("head_sha"))
     previous_reviews = snapshot_map(previous_snapshot, "changes_requested_reviews")
     current_reviews = snapshot_map(snapshot, "changes_requested_reviews")
     previous_checks = snapshot_map(previous_snapshot, "failed_checks")
@@ -81,6 +82,13 @@ def emit_new_conditions(
 
     for key, payload in current_checks.items():
         if key in previous_checks:
+            continue
+        check_head_sha = _normalize_text(payload.get("head_sha"))
+        if (
+            current_head_sha is not None
+            and check_head_sha is not None
+            and check_head_sha != current_head_sha
+        ):
             continue
         event = event_store.record_event(
             event_id=f"github:poll:check:{watch.watch_id}:{uuid.uuid4().hex[:12]}",

--- a/src/codex_autorunner/integrations/github/polling_snapshot.py
+++ b/src/codex_autorunner/integrations/github/polling_snapshot.py
@@ -246,7 +246,7 @@ def build_snapshot(
             "status": status,
             "conclusion": conclusion,
             "details_url": _normalize_text(check.get("details_url")),
-            "head_sha": head_sha,
+            "head_sha": _normalize_text(check.get("head_sha")) or head_sha,
         }
         failed_checks[_check_key(payload)] = {
             key: value for key, value in payload.items() if value is not None

--- a/src/codex_autorunner/integrations/github/service.py
+++ b/src/codex_autorunner/integrations/github/service.py
@@ -876,6 +876,9 @@ class GitHubService:
     def pr_checks(
         self, *, number: int, cwd: Optional[Path] = None
     ) -> list[dict[str, Any]]:
+        graphql_checks = self._pr_checks_from_graphql(number=number, cwd=cwd)
+        if graphql_checks is not None:
+            return graphql_checks
         proc = self._gh(
             ["pr", "view", str(number), "--json", "statusCheckRollup"],
             cwd=cwd or self.repo_root,
@@ -902,6 +905,12 @@ class GitHubService:
             status = entry.get("status") or entry.get("state")
             conclusion = entry.get("conclusion") or entry.get("result")
             details_url = entry.get("detailsUrl") or entry.get("targetUrl")
+            head_sha = (
+                entry.get("headSha")
+                or entry.get("head_sha")
+                or entry.get("commitOid")
+                or entry.get("commit_oid")
+            )
             if name or status or conclusion:
                 checks.append(
                     {
@@ -909,9 +918,148 @@ class GitHubService:
                         "status": status,
                         "conclusion": conclusion,
                         "details_url": details_url,
+                        "head_sha": head_sha,
                     }
                 )
         return checks
+
+    def _pr_checks_from_graphql(
+        self, *, number: int, cwd: Optional[Path] = None
+    ) -> Optional[list[dict[str, Any]]]:
+        try:
+            repo = self.repo_info()
+        except GitHubError:
+            return None
+        if "/" not in repo.name_with_owner:
+            return None
+        owner, repo_name = repo.name_with_owner.split("/", 1)
+        query = """
+        query($owner: String!, $name: String!, $number: Int!) {
+          repository(owner: $owner, name: $name) {
+            pullRequest(number: $number) {
+              commits(last: 1) {
+                nodes {
+                  commit {
+                    oid
+                    statusCheckRollup {
+                      contexts(first: 100) {
+                        nodes {
+                          __typename
+                          ... on CheckRun {
+                            name
+                            status
+                            conclusion
+                            detailsUrl
+                            checkSuite {
+                              commit {
+                                oid
+                              }
+                            }
+                          }
+                          ... on StatusContext {
+                            context
+                            state
+                            targetUrl
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+        proc = self._gh(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"owner={owner}",
+                "-f",
+                f"name={repo_name}",
+                "-F",
+                f"number={int(number)}",
+                "-f",
+                f"query={query}",
+            ],
+            cwd=cwd or self.repo_root,
+            check=False,
+            timeout_seconds=30,
+        )
+        if proc.returncode != 0:
+            return None
+        try:
+            payload = json.loads(proc.stdout or "{}")
+        except json.JSONDecodeError:
+            return None
+        pull_request = (
+            ((payload.get("data") or {}).get("repository") or {}).get("pullRequest")
+            if isinstance(payload, dict)
+            else None
+        )
+        if not isinstance(pull_request, dict):
+            return None
+        commits = pull_request.get("commits")
+        nodes = commits.get("nodes") if isinstance(commits, dict) else None
+        if not isinstance(nodes, list) or not nodes:
+            return None
+        commit = nodes[-1].get("commit") if isinstance(nodes[-1], dict) else None
+        if not isinstance(commit, dict):
+            return None
+        commit_oid = _normalize_optional_text(commit.get("oid"))
+        rollup = commit.get("statusCheckRollup")
+        contexts_container = (
+            rollup.get("contexts") if isinstance(rollup, dict) else None
+        )
+        contexts = (
+            contexts_container.get("nodes")
+            if isinstance(contexts_container, dict)
+            else None
+        )
+        if not isinstance(contexts, list):
+            return []
+        checks: list[dict[str, Any]] = []
+        for entry in contexts:
+            if not isinstance(entry, dict):
+                continue
+            typename = _normalize_optional_text(entry.get("__typename"))
+            if typename == "CheckRun":
+                check_suite = entry.get("checkSuite")
+                check_commit = (
+                    check_suite.get("commit") if isinstance(check_suite, dict) else None
+                )
+                check_head_sha = (
+                    _normalize_optional_text(check_commit.get("oid"))
+                    if isinstance(check_commit, dict)
+                    else None
+                )
+                checks.append(
+                    {
+                        "name": entry.get("name"),
+                        "status": entry.get("status"),
+                        "conclusion": entry.get("conclusion"),
+                        "details_url": entry.get("detailsUrl"),
+                        "head_sha": check_head_sha or commit_oid,
+                    }
+                )
+                continue
+            if typename == "StatusContext":
+                checks.append(
+                    {
+                        "name": entry.get("context"),
+                        "status": entry.get("state"),
+                        "conclusion": entry.get("state"),
+                        "details_url": entry.get("targetUrl"),
+                        "head_sha": commit_oid,
+                    }
+                )
+        return [
+            check
+            for check in checks
+            if check.get("name") or check.get("status") or check.get("conclusion")
+        ]
 
     def issue_meta(
         self, *, owner: str, repo: str, number: int, cwd: Optional[Path] = None

--- a/tests/core/test_scm_automation_service.py
+++ b/tests/core/test_scm_automation_service.py
@@ -1171,6 +1171,64 @@ def test_ingest_event_batches_ci_failures_for_same_head_and_refreshes_timer(
     )
 
 
+def test_ingest_event_suppresses_late_ci_failure_for_already_handled_head(
+    tmp_path: Path,
+) -> None:
+    first = _ci_failed_event(event_id="github:check-1", head_sha="abc123")
+    second = ScmEvent(
+        **{
+            **first.to_dict(),
+            "event_id": "github:check-2",
+            "payload": {
+                **first.payload,
+                "name": "aggregate",
+            },
+        }
+    )
+    binding = _binding()
+    journal = _JournalFake()
+    state_store = ScmReactionStateStore(tmp_path)
+    service = ScmAutomationService(
+        tmp_path,
+        event_store=_EventStoreFake(first, second),
+        binding_resolver=_BindingResolverFake(binding),
+        reaction_router=route_scm_reactions,
+        reaction_state_store=state_store,
+        journal=journal,
+        publish_processor=_ProcessorFake(processed=[]),
+    )
+
+    first_result = service.ingest_event(first.event_id)
+    first_operation = first_result.publish_operations[0]
+    journal.operations_by_key[first_operation.operation_key] = PublishOperation(
+        **{
+            **first_operation.to_dict(),
+            "state": "succeeded",
+        }
+    )
+
+    second_result = service.ingest_event(second.event_id)
+
+    assert second_result.publish_operations == ()
+    assert journal.create_calls == [
+        (first_operation.operation_key, "enqueue_managed_turn")
+    ]
+    second_fingerprint = state_store.compute_reaction_fingerprint(
+        second,
+        binding=binding,
+        intent=second_result.reaction_intents[0],
+    )
+    suppressed = state_store.get_reaction_state(
+        binding_id=binding.binding_id,
+        reaction_kind="ci_failed",
+        fingerprint=second_fingerprint,
+    )
+    assert suppressed is not None
+    assert suppressed.state == "suppressed"
+    assert suppressed.metadata["ci_head_sha"] == "abc123"
+    assert suppressed.metadata["suppression_reason"] == "ci_head_already_queued"
+
+
 def test_ingest_event_ci_failure_batch_refresh_honors_max_window(
     tmp_path: Path,
 ) -> None:

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -28,6 +28,7 @@ from codex_autorunner.integrations.github.polling import (
     GitHubPollingConfig,
     GitHubScmPollingService,
 )
+from codex_autorunner.integrations.github.polling_events import emit_new_conditions
 
 pytestmark = pytest.mark.integration
 from codex_autorunner.integrations.github.publisher import (
@@ -1343,6 +1344,61 @@ def test_process_due_watches_emits_only_new_review_and_check_transitions(
         "pull_request_review",
         "check_run",
     }
+
+
+def test_emit_new_conditions_skips_failed_checks_from_stale_head(
+    tmp_path: Path,
+) -> None:
+    binding = PrBindingStore(tmp_path).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        pr_number=17,
+        pr_state="open",
+        head_branch="feature/scm-polling",
+        base_branch="main",
+    )
+    watch = ScmPollingWatchStore(tmp_path).upsert_watch(
+        provider="github",
+        binding_id=binding.binding_id,
+        repo_slug=binding.repo_slug,
+        pr_number=binding.pr_number,
+        workspace_root=str((tmp_path / "repo").resolve()),
+        poll_interval_seconds=90,
+        next_poll_at="2026-03-30T00:00:00Z",
+        expires_at="2099-03-30T01:00:00Z",
+        reaction_config={"enabled": True},
+        snapshot={"head_sha": "oldsha"},
+    )
+    event_store = ScmEventStore(tmp_path)
+    _AutomationServiceFake.ingested_events = []
+    _AutomationServiceFake.process_calls = 0
+
+    emitted = emit_new_conditions(
+        event_store=event_store,
+        watch=watch,
+        binding=binding,
+        previous_snapshot={"head_sha": "oldsha", "failed_checks": {}},
+        snapshot={
+            "head_sha": "newsha",
+            "failed_checks": {
+                "oldsha:unit-tests:failure:https://example.invalid/checks/1": {
+                    "action": "completed",
+                    "name": "unit-tests",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "head_sha": "oldsha",
+                    "details_url": "https://example.invalid/checks/1",
+                }
+            },
+        },
+        automation_service_factory=lambda: _AutomationServiceFake(tmp_path),
+        now_iso_fn=lambda: "2026-03-30T00:00:00Z",
+    )
+
+    assert emitted == 0
+    assert _AutomationServiceFake.ingested_events == []
+    assert _AutomationServiceFake.process_calls == 0
+    assert event_store.list_events(limit=10) == []
 
 
 def test_process_due_watches_emits_new_pr_comment_and_inline_review_comment(

--- a/tests/test_github_service_pr_discovery.py
+++ b/tests/test_github_service_pr_discovery.py
@@ -156,6 +156,98 @@ def test_pr_reviews_preserves_numeric_review_ids(
     ]
 
 
+def test_pr_checks_reads_per_check_head_sha_from_graphql(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = GitHubService(tmp_path, raw_config={})
+    monkeypatch.setattr(
+        service,
+        "repo_info",
+        lambda: RepoInfo(
+            name_with_owner="acme/widgets",
+            url="https://github.com/acme/widgets",
+            default_branch="main",
+        ),
+    )
+
+    def _fake_gh(
+        args: list[str], *, cwd=None, check=True, timeout_seconds=None
+    ):  # type: ignore[no-untyped-def]
+        assert args[:2] == ["api", "graphql"]
+        _ = cwd, check, timeout_seconds
+        return type(
+            "Proc",
+            (),
+            {
+                "returncode": 0,
+                "stdout": json.dumps(
+                    {
+                        "data": {
+                            "repository": {
+                                "pullRequest": {
+                                    "commits": {
+                                        "nodes": [
+                                            {
+                                                "commit": {
+                                                    "oid": "current-sha",
+                                                    "statusCheckRollup": {
+                                                        "contexts": {
+                                                            "nodes": [
+                                                                {
+                                                                    "__typename": "CheckRun",
+                                                                    "name": "unit",
+                                                                    "status": "COMPLETED",
+                                                                    "conclusion": "FAILURE",
+                                                                    "detailsUrl": "https://example.invalid/check",
+                                                                    "checkSuite": {
+                                                                        "commit": {
+                                                                            "oid": "check-sha"
+                                                                        }
+                                                                    },
+                                                                },
+                                                                {
+                                                                    "__typename": "StatusContext",
+                                                                    "context": "legacy/status",
+                                                                    "state": "SUCCESS",
+                                                                    "targetUrl": "https://example.invalid/status",
+                                                                },
+                                                            ]
+                                                        }
+                                                    },
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ),
+            },
+        )()
+
+    monkeypatch.setattr(service, "_gh", _fake_gh)
+
+    checks = service.pr_checks(number=17)
+
+    assert checks == [
+        {
+            "name": "unit",
+            "status": "COMPLETED",
+            "conclusion": "FAILURE",
+            "details_url": "https://example.invalid/check",
+            "head_sha": "check-sha",
+        },
+        {
+            "name": "legacy/status",
+            "status": "SUCCESS",
+            "conclusion": "SUCCESS",
+            "details_url": "https://example.invalid/status",
+            "head_sha": "current-sha",
+        },
+    ]
+
+
 def test_sync_pr_does_not_append_duplicate_close_keyword(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Suppress GitHub polling check-run events when a failed check belongs to an older head SHA than the current PR snapshot.
- Track CI head SHAs in SCM reaction metadata and suppress later same-head CI wakeups once there is no pending batch left to merge into.
- Allow suppression-only reaction-state rows so ignored SCM conditions are still durable and observable.

## Why

GitHub PR wakeups could enqueue agent turns for stale or already-handled CI failures. This keeps Discord visible progress for active batches while avoiding extra agent turns for old PR heads or repeated same-head CI noise.

## Validation

- `.venv/bin/python -m pytest tests/core/test_scm_automation_service.py tests/integrations/github/test_polling.py -q` (66 passed)
- `git diff --check`
- Commit hook aggregate lane passed: black, ruff, import boundaries, contract checks, strict mypy, full pytest (8102 passed), frontend build/tests, and chat-surface lab latency checks.