### PR TITLE
[codex] Fix Telegram polling backoff and lazy app-server startup

### DIFF
--- a/src/codex_autorunner/integrations/chat/service.py
+++ b/src/codex_autorunner/integrations/chat/service.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 from typing import Any, Awaitable, Callable, Optional
 
+from ...core.exceptions import TransientError
 from ...core.logging_utils import log_event
 from ...core.managed_processes import reap_managed_processes
 from .adapter import ChatAdapter
@@ -19,6 +20,32 @@ from .dispatcher import ChatDispatcher
 from .models import ChatEvent
 from .state_store import ChatStateStore
 from .transport import ChatTransport
+
+_POLL_FAILURE_BACKOFF_INITIAL_SECONDS = 1.0
+_POLL_FAILURE_BACKOFF_MAX_SECONDS = 60.0
+
+
+class _PollFailureBackoff:
+    def __init__(
+        self,
+        *,
+        initial_seconds: float = _POLL_FAILURE_BACKOFF_INITIAL_SECONDS,
+        max_seconds: float = _POLL_FAILURE_BACKOFF_MAX_SECONDS,
+    ) -> None:
+        self._initial_seconds = max(initial_seconds, 0.0)
+        self._max_seconds = max(max_seconds, self._initial_seconds)
+        self._current_seconds = self._initial_seconds
+
+    def next_delay(self) -> float:
+        delay = self._current_seconds
+        if self._current_seconds <= 0:
+            self._current_seconds = self._initial_seconds
+        else:
+            self._current_seconds = min(self._current_seconds * 2.0, self._max_seconds)
+        return delay
+
+    def reset(self) -> None:
+        self._current_seconds = self._initial_seconds
 
 
 class ChatBotServiceCore:
@@ -115,6 +142,11 @@ class ChatBotServiceCore:
                         name="prime_poller_offset",
                         action=owner._prime_poller_offset,
                     ),
+                    ChatBootstrapStep(
+                        name="prune_stale_workspace_bindings",
+                        action=owner._prune_stale_workspace_bindings,
+                        required=False,
+                    ),
                 ),
             )
             owner._outbox_task = asyncio.create_task(owner._outbox_manager.run_loop())
@@ -131,7 +163,6 @@ class ChatBotServiceCore:
                     owner.TICKET_FLOW_WATCH_INTERVAL_SECONDS
                 )
             )
-            owner._spawn_task(owner._prewarm_workspace_clients())
             if getattr(owner, "_delivery_worker", None) is not None:
                 owner._delivery_worker_task = asyncio.create_task(
                     owner._delivery_worker.run_loop()
@@ -175,27 +206,32 @@ class ChatBotServiceCore:
                     f"{self._platform}.compact.notify_failed",
                     exc=exc,
                 )
+            poll_failure_backoff = _PollFailureBackoff()
             while True:
                 updates = []
                 try:
                     updates = await owner._poller.poll(
                         timeout=owner._config.poll_timeout_seconds
                     )
+                    poll_failure_backoff.reset()
                     if owner._poller.offset is not None:
                         await owner._record_poll_offset(updates)
                 except (
+                    TransientError,
                     RuntimeError,
                     ConnectionError,
                     OSError,
                     ValueError,
-                ) as exc:  # transient poll failure, retry immediately
+                ) as exc:
+                    delay_seconds = poll_failure_backoff.next_delay()
                     log_event(
                         owner._logger,
                         logging.WARNING,
                         f"{self._platform}.poll.failed",
                         exc=exc,
+                        delay_seconds=delay_seconds,
                     )
-                    await asyncio.sleep(1.0)
+                    await asyncio.sleep(delay_seconds)
                     continue
                 for update in updates:
                     owner._spawn_task(owner._dispatch_update(update))

--- a/src/codex_autorunner/integrations/telegram/adapter.py
+++ b/src/codex_autorunner/integrations/telegram/adapter.py
@@ -1200,7 +1200,7 @@ class TelegramBotClient:
             payload["offset"] = offset
         if allowed_updates:
             payload["allowed_updates"] = list(allowed_updates)
-        result = await self._request("getUpdates", payload)
+        result = await self._request_once_payload("getUpdates", payload)
         if not isinstance(result, list):
             return []
         return [item for item in result if isinstance(item, dict)]
@@ -1590,12 +1590,25 @@ class TelegramBotClient:
         return result if isinstance(result, dict) else {}
 
     async def _request(self, method: str, payload: dict[str, Any]) -> Any:
+        return await self._request_with_retry(
+            method,
+            self._build_json_sender(method, payload),
+        )
+
+    async def _request_once_payload(self, method: str, payload: dict[str, Any]) -> Any:
+        return await self._request_once(
+            method, self._build_json_sender(method, payload)
+        )
+
+    def _build_json_sender(
+        self, method: str, payload: dict[str, Any]
+    ) -> Callable[[], Awaitable[httpx.Response]]:
         url = f"{self._base_url}/bot{self._bot_token}/{method}"
 
         async def send() -> httpx.Response:
             return await self._client.post(url, json=payload)
 
-        return await self._request_with_retry(method, send)
+        return send
 
     async def _request_multipart(
         self, method: str, data: dict[str, Any], files: dict[str, Any]
@@ -1609,6 +1622,11 @@ class TelegramBotClient:
 
     @retry_transient(max_attempts=5, base_wait=1.0, max_wait=60.0)
     async def _request_with_retry(
+        self, method: str, send: Callable[[], Awaitable[httpx.Response]]
+    ) -> Any:
+        return await self._request_once(method, send)
+
+    async def _request_once(
         self, method: str, send: Callable[[], Awaitable[httpx.Response]]
     ) -> Any:
         async with self._resilience_guard(method):

--- a/src/codex_autorunner/integrations/telegram/service.py
+++ b/src/codex_autorunner/integrations/telegram/service.py
@@ -818,6 +818,12 @@ class TelegramBotService(
             prune_reason="prewarm",
         )
 
+    async def _prune_stale_workspace_bindings(self) -> None:
+        await self._workspace_roots_from_state(
+            state_failed_event="telegram.workspace_binding.startup_prune_failed",
+            prune_reason="startup",
+        )
+
     async def _workspace_roots_from_state(
         self,
         *,

--- a/tests/test_lifecycle_events.py
+++ b/tests/test_lifecycle_events.py
@@ -19,6 +19,7 @@ from codex_autorunner.core.lifecycle_events import (
     LifecycleEventStore,
     LifecycleEventType,
 )
+from codex_autorunner.core.orchestration.sqlite import initialize_orchestration_sqlite
 
 
 def test_lifecycle_event_store_load_save():
@@ -259,6 +260,7 @@ def test_non_duplicate_events_still_append():
 def test_terminal_duplicate_dedupes_under_concurrent_writers() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
+        initialize_orchestration_sqlite(tmp_path)
         store = LifecycleEventStore(tmp_path)
         start_barrier = threading.Barrier(8)
         _max_attempts = 20

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -713,6 +713,27 @@ async def test_request_retries_on_rate_limit(monkeypatch: pytest.MonkeyPatch) ->
 
 
 @pytest.mark.anyio
+async def test_get_updates_leaves_transport_backoff_to_poll_loop() -> None:
+    calls = {"count": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        raise httpx.ConnectError("simulated connect failure", request=request)
+
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.AsyncClient(transport=transport)
+    bot = TelegramBotClient("test-token", client=http_client)
+
+    try:
+        with pytest.raises(TelegramAPIError, match="Telegram request failed"):
+            await bot.get_updates(timeout=1)
+    finally:
+        await bot.close()
+
+    assert calls["count"] == 1
+
+
+@pytest.mark.anyio
 async def test_rate_limit_scope_does_not_block_other_methods(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_telegram_filebox_housekeeping.py
+++ b/tests/test_telegram_filebox_housekeeping.py
@@ -169,6 +169,36 @@ async def test_housekeeping_roots_prune_missing_workspace_bindings(
 
 
 @pytest.mark.anyio
+async def test_startup_prune_clears_missing_workspace_bindings_without_spawning(
+    tmp_path: Path,
+) -> None:
+    service = TelegramBotService(_config(tmp_path), hub_root=tmp_path)
+    live_workspace = tmp_path / "startup-live"
+    live_workspace.mkdir()
+    missing_workspace = tmp_path / "startup-missing"
+    missing_key = topic_key(123, 14)
+
+    async def _unexpected_get_client(_workspace_root: Path) -> object:
+        raise AssertionError("startup prune must not start app-server clients")
+
+    service._app_server_supervisor = SimpleNamespace(get_client=_unexpected_get_client)
+
+    try:
+        await service._store.bind_topic(topic_key(123, 15), str(live_workspace))
+        await service._store.bind_topic(missing_key, str(missing_workspace))
+
+        await service._prune_stale_workspace_bindings()
+        stale_record = await service._store.get_topic(missing_key)
+    finally:
+        await service._bot.close()
+        await service._store.close()
+
+    assert stale_record is not None
+    assert stale_record.workspace_path is None
+    assert stale_record.workspace_id is None
+
+
+@pytest.mark.anyio
 async def test_prewarm_skips_missing_workspaces_without_spawning(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_telegram_service_startup_reaper.py
+++ b/tests/test_telegram_service_startup_reaper.py
@@ -45,10 +45,14 @@ class _StateStoreStub:
 
 
 class _PollerStub:
-    def __init__(self) -> None:
+    def __init__(self, errors: list[BaseException] | None = None) -> None:
         self.offset = None
+        self._errors = errors or [KeyboardInterrupt("stop after startup")]
 
     async def poll(self, *, timeout: int) -> list[object]:
+        _ = timeout
+        if self._errors:
+            raise self._errors.pop(0)
         raise KeyboardInterrupt("stop after startup")
 
 
@@ -85,6 +89,8 @@ class _OwnerStub:
         self._spawned_tasks: set[asyncio.Task[object]] = set()
         self._hub_client = None
         self._poller = _PollerStub()
+        self.prewarm_called = False
+        self.prune_called = False
 
     def _acquire_instance_lock(self) -> None:
         return None
@@ -111,6 +117,11 @@ class _OwnerStub:
         await asyncio.Event().wait()
 
     async def _prewarm_workspace_clients(self) -> None:
+        self.prewarm_called = True
+        return None
+
+    async def _prune_stale_workspace_bindings(self) -> None:
+        self.prune_called = True
         return None
 
     async def _maybe_send_update_status_notice(self) -> None:
@@ -154,3 +165,46 @@ async def test_telegram_service_startup_reaps_managed_processes(
         await core.run()
 
     assert called_roots == [tmp_path]
+    assert owner.prewarm_called is False
+    assert owner.prune_called is True
+
+
+@pytest.mark.anyio
+async def test_telegram_poll_failures_use_persistent_backoff(
+    tmp_path: Path, monkeypatch
+) -> None:
+    sleep_delays: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(
+        "codex_autorunner.integrations.chat.service.asyncio.sleep",
+        _fake_sleep,
+    )
+
+    owner = _OwnerStub(tmp_path)
+    owner._poller = _PollerStub(
+        [
+            RuntimeError("poll failed 1"),
+            RuntimeError("poll failed 2"),
+            RuntimeError("poll failed 3"),
+            KeyboardInterrupt("stop after backoff"),
+        ]
+    )
+    core = ChatBotServiceCore(
+        owner=owner,
+        runtime_services=_RuntimeServicesStub(),
+        state_store=_StateStoreStub(),
+        reap_managed_processes_fn=lambda _root: SimpleNamespace(
+            killed=0,
+            signaled=0,
+            removed=0,
+            skipped=0,
+        ),
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="stop after backoff"):
+        await core.run()
+
+    assert sleep_delays == [1.0, 2.0, 4.0]


### PR DESCRIPTION
## Summary
- stop Telegram startup from prewarming app-server clients for every persisted workspace binding
- make Telegram getUpdates perform a single request attempt so the poll loop owns transport backoff
- add persistent poll-loop backoff for transient polling failures, resetting only after a successful poll

Fixes #1684

## Validation
- `.venv/bin/python -m pytest tests/test_telegram_adapter.py tests/test_telegram_service_startup_reaper.py -q`
- commit hook chat-apps lane: black, ruff, import boundaries, contracts, mypy, 8040 pytest tests, chat-surface lab deterministic checks, latency budgets

## Notes
- Discord already lazy-starts app-server clients through per-workspace supervisors when a workspace client is first requested, so no Discord prewarm path needed removal.
- One broad pre-commit rerun that included `tests/test_telegram_filebox_housekeeping.py::test_prewarm_skips_missing_workspaces_without_spawning` passed test assertions but hit a teardown cleanup timeout from `lsof`; a prior run of the same 80-test slice passed before formatting, and the commit hook full lane passed afterward.