### PR TITLE
[codex] fix idle CPU soak orphan cleanup

### DIFF
--- a/scripts/idle_cpu_soak.py
+++ b/scripts/idle_cpu_soak.py
@@ -298,6 +298,9 @@ def _collect_service_pids(
                         queue.extend(pp_to_pid.get(p, []))
         except ProcessLookupError:
             service_pids.append(proc.pid)
+        # proc.pid is the watchdog wrapper, not the service; omit it from idle
+        # resource measurement (see _start_service / start_new_session).
+        service_pids = [p for p in service_pids if p != proc.pid]
         pids.extend(service_pids)
     return list(set(pids))
 

--- a/scripts/idle_cpu_soak.py
+++ b/scripts/idle_cpu_soak.py
@@ -16,6 +16,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import atexit
 import json
 import logging
 import os
@@ -36,6 +37,48 @@ import yaml
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = _SCRIPT_DIR.parent
 _PROFILES_PATH = _SCRIPT_DIR / "idle_cpu_profiles.yml"
+_PROCESS_KIND = "idle_cpu_soak"
+_SERVICE_WATCHDOG_CODE = r"""
+import os
+import signal
+import subprocess
+import sys
+import time
+
+owner_pid = int(sys.argv[1])
+service_cmd = sys.argv[2:]
+child = subprocess.Popen(service_cmd)
+stopping = False
+
+
+def stop(signum, _frame):
+    global stopping
+    if stopping:
+        return
+    stopping = True
+    if child.poll() is None:
+        child.terminate()
+        try:
+            child.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            child.kill()
+            child.wait(timeout=2)
+    raise SystemExit(128 + signum)
+
+
+for candidate in ("SIGTERM", "SIGINT", "SIGHUP"):
+    sig = getattr(signal, candidate, None)
+    if sig is not None:
+        signal.signal(sig, stop)
+
+while True:
+    returncode = child.poll()
+    if returncode is not None:
+        raise SystemExit(returncode)
+    if os.getppid() != owner_pid:
+        stop(signal.SIGTERM, None)
+    time.sleep(0.5)
+"""
 
 sys.path.insert(0, str(_REPO_ROOT / "src"))
 
@@ -50,6 +93,11 @@ from codex_autorunner.core.diagnostics.cpu_sampler import (
 )  # noqa: E402
 from codex_autorunner.core.diagnostics.process_snapshot import (  # noqa: E402
     ProcessCategory,
+)
+from codex_autorunner.core.managed_processes.registry import (  # noqa: E402
+    ProcessRecord,
+    delete_process_record,
+    write_process_record,
 )
 from codex_autorunner.core.utils import atomic_write  # noqa: E402
 
@@ -266,23 +314,80 @@ def _start_service(
     env["CAR_HUB_ROOT"] = str(hub_root)
     env["CAR_DEV_INCLUDE_ROOT_REPO"] = "1"
     logger.info("starting service: %s (%s)", svc["alias"], " ".join(cmd))
+    watchdog_cmd = [
+        sys.executable,
+        "-c",
+        _SERVICE_WATCHDOG_CODE,
+        str(os.getpid()),
+        *cmd,
+    ]
     proc = subprocess.Popen(
-        cmd,
+        watchdog_cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=env,
-        preexec_fn=os.setsid,
+        start_new_session=True,
     )
     return proc
 
 
+def _service_record_key(proc: subprocess.Popen) -> str:
+    return str(proc.pid)
+
+
+def _write_service_record(
+    proc: subprocess.Popen,
+    svc: dict[str, Any],
+    profile_name: str,
+    hub_root: Path,
+    base_url: str,
+    logger: logging.Logger,
+) -> None:
+    pgid: int | None = None
+    try:
+        pgid = os.getpgid(proc.pid)
+    except ProcessLookupError:
+        pass
+    record = ProcessRecord(
+        kind=_PROCESS_KIND,
+        workspace_id=None,
+        pid=proc.pid,
+        pgid=pgid,
+        base_url=base_url,
+        command=list(svc["command"]),
+        owner_pid=os.getpid(),
+        started_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        metadata={
+            "alias": svc.get("alias", ""),
+            "hub_root": str(hub_root),
+            "profile": profile_name,
+        },
+    )
+    write_process_record(_REPO_ROOT, record)
+    logger.debug(
+        "registered soak service process pid=%d pgid=%s kind=%s",
+        proc.pid,
+        pgid,
+        _PROCESS_KIND,
+    )
+
+
+def _delete_service_record(proc: subprocess.Popen, logger: logging.Logger) -> None:
+    try:
+        delete_process_record(_REPO_ROOT, _PROCESS_KIND, _service_record_key(proc))
+    except ValueError as exc:
+        logger.warning("failed to delete soak service process record: %s", exc)
+
+
 def _stop_service(proc: subprocess.Popen, logger: logging.Logger) -> None:
     if proc.poll() is not None:
+        _delete_service_record(proc, logger)
         return
     logger.info("stopping service pid=%d", proc.pid)
     try:
         os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
     except ProcessLookupError:
+        _delete_service_record(proc, logger)
         return
     try:
         proc.wait(timeout=5)
@@ -295,6 +400,12 @@ def _stop_service(proc: subprocess.Popen, logger: logging.Logger) -> None:
             proc.wait(timeout=2)
         except subprocess.TimeoutExpired:
             pass
+    _delete_service_record(proc, logger)
+
+
+def _stop_services(procs: list[subprocess.Popen], logger: logging.Logger) -> None:
+    for proc in procs:
+        _stop_service(proc, logger)
 
 
 def _collect_environment() -> dict[str, Any]:
@@ -443,19 +554,47 @@ def run_soak(
 
         services = _parse_services(profile, port)
         procs: list[subprocess.Popen] = []
+        cleanup_done = False
+
+        def cleanup_services() -> None:
+            nonlocal cleanup_done
+            if cleanup_done:
+                return
+            cleanup_done = True
+            _stop_services(procs, logger)
+
+        def handle_shutdown_signal(signum: int, _frame: object) -> None:
+            logger.warning("received signal %s; stopping soak services", signum)
+            cleanup_services()
+            raise SystemExit(128 + signum)
+
+        shutdown_signals = [signal.SIGTERM, signal.SIGINT]
+        if hasattr(signal, "SIGHUP"):
+            shutdown_signals.append(signal.SIGHUP)
+        previous_handlers = {
+            sig: signal.getsignal(sig)
+            for sig in shutdown_signals
+            if signal.getsignal(sig) is not None
+        }
 
         try:
+            for sig in previous_handlers:
+                signal.signal(sig, handle_shutdown_signal)
+            atexit.register(cleanup_services)
+
             for svc in services:
                 proc = _start_service(svc, hub_root, logger)
                 procs.append(proc)
                 svc["pid"] = proc.pid
+                _write_service_record(
+                    proc, svc, profile_name, hub_root, base_url, logger
+                )
 
             health_ok = _wait_for_health(
                 base_url, probe_config, timeout=60.0, logger=logger
             )
             if not health_ok:
-                for proc in procs:
-                    _stop_service(proc, logger)
+                cleanup_services()
                 raise RuntimeError(
                     f"Service(s) failed to become healthy at {base_url}/health"
                 )
@@ -487,8 +626,13 @@ def run_soak(
                     time.sleep(remaining)
 
         finally:
-            for proc in procs:
-                _stop_service(proc, logger)
+            cleanup_services()
+            try:
+                atexit.unregister(cleanup_services)
+            except ValueError:
+                pass
+            for sig, previous in previous_handlers.items():
+                signal.signal(sig, previous)
 
         finished_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 

--- a/src/codex_autorunner/core/pytest_temp_cleanup.py
+++ b/src/codex_autorunner/core/pytest_temp_cleanup.py
@@ -17,6 +17,7 @@ _TEMP_ENV_KEYS = ("TMPDIR", "TMP", "TEMP")
 _CAR_TEMP_DIR_PREFIXES = (
     "car-cached-",
     "car-hub-profile-",
+    "idle-cpu-soak-",
     "car-nocache-",
     "car-patch-",
 )

--- a/tests/core/test_pytest_temp_cleanup.py
+++ b/tests/core/test_pytest_temp_cleanup.py
@@ -97,14 +97,16 @@ def test_discover_repo_temp_paths_finds_car_dirs_and_repo_workspaces(
     repo_root.mkdir()
     temp_base = tmp_path / "tmp"
     car_profile = temp_base / "car-hub-profile-20260414"
+    idle_soak = temp_base / "idle-cpu-soak-abc123"
     workspace = temp_base / "tmp.NmYoDUn4Sd"
     (car_profile / "Profile").mkdir(parents=True)
+    (idle_soak / "hub").mkdir(parents=True)
     (workspace / "repo" / ".git").mkdir(parents=True)
     (workspace / "flows.db").write_text("sqlite", encoding="utf-8")
 
     paths = discover_repo_temp_paths(repo_root, temp_base=temp_base)
 
-    assert paths == (car_profile, workspace)
+    assert paths == (car_profile, idle_soak, workspace)
 
 
 def test_cleanup_repo_managed_temp_paths_combines_pytest_and_generic_temp_roots(

--- a/tests/unit/test_idle_cpu_soak.py
+++ b/tests/unit/test_idle_cpu_soak.py
@@ -227,6 +227,29 @@ class TestIdleCpuSoakProcessManagement:
         ]
         assert seen["cmd"][-2:] == ["--path", str(tmp_path / "hub")]
 
+    def test_collect_service_pids_excludes_watchdog_pid(self, monkeypatch):
+        """Session scan includes the watchdog; measurement must omit its RSS/CPU."""
+
+        class FakeProc:
+            pid = 1000
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd == ["ps", "-A", "-o", "pid=", "-o", "sid="]:
+                # Watchdog is session leader (sid == watchdog pid); child shares sid.
+                return subprocess.CompletedProcess(cmd, 0, "1000 1000\n1001 1000\n", "")
+            return subprocess.CompletedProcess(cmd, 1, "", "")
+
+        monkeypatch.setattr(soak_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(soak_module.os, "getsid", lambda _pid: 1000)
+
+        pids = soak_module._collect_service_pids(  # noqa: SLF001
+            [FakeProc()], logging.getLogger("test")
+        )
+        assert sorted(pids) == [1001]
+
     def test_write_and_delete_service_record(self, monkeypatch, tmp_path: Path):
         class FakeProc:
             pid = 5151

--- a/tests/unit/test_idle_cpu_soak.py
+++ b/tests/unit/test_idle_cpu_soak.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +14,9 @@ import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SOAK_SCRIPT = _REPO_ROOT / "scripts" / "idle_cpu_soak.py"
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+import idle_cpu_soak as soak_module  # noqa: E402
 
 
 class TestIdleCpuSoakArtifactSchema:
@@ -176,6 +182,123 @@ class TestIdleCpuSoakProfileParsing:
             assert name in profiles
             assert "services" in profiles[name]
             assert "hard_budget" in profiles[name]
+
+
+class TestIdleCpuSoakProcessManagement:
+    def _assert_pid_gone(self, pid: int) -> None:
+        for _ in range(50):
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return
+            time.sleep(0.1)
+        raise AssertionError(f"process {pid} still running")
+
+    def test_start_service_uses_new_session(self, monkeypatch, tmp_path: Path):
+        seen: dict[str, Any] = {}
+
+        class FakePopen:
+            pid = 4242
+
+            def __init__(self, cmd, **kwargs):
+                seen["cmd"] = cmd
+                seen.update(kwargs)
+
+        monkeypatch.setattr(soak_module.subprocess, "Popen", FakePopen)
+        monkeypatch.setattr(soak_module.os, "getpid", lambda: 3131)
+
+        proc = soak_module._start_service(  # noqa: SLF001
+            {
+                "alias": "hub",
+                "command": ["python", "-m", "codex_autorunner.cli", "hub", "serve"],
+            },
+            tmp_path / "hub",
+            logging.getLogger("test_idle_cpu_soak"),
+        )
+
+        assert proc.pid == 4242
+        assert seen["start_new_session"] is True
+        assert "preexec_fn" not in seen
+        assert seen["cmd"][:4] == [
+            sys.executable,
+            "-c",
+            soak_module._SERVICE_WATCHDOG_CODE,  # noqa: SLF001
+            "3131",
+        ]
+        assert seen["cmd"][-2:] == ["--path", str(tmp_path / "hub")]
+
+    def test_write_and_delete_service_record(self, monkeypatch, tmp_path: Path):
+        class FakeProc:
+            pid = 5151
+
+            def poll(self):
+                return 0
+
+        monkeypatch.setattr(soak_module, "_REPO_ROOT", tmp_path)
+        monkeypatch.setattr(soak_module.os, "getpgid", lambda _pid: 6161)
+        monkeypatch.setattr(soak_module.os, "getpid", lambda: 7171)
+
+        proc = FakeProc()
+        logger = logging.getLogger("test_idle_cpu_soak")
+        soak_module._write_service_record(  # noqa: SLF001
+            proc,
+            {
+                "alias": "hub",
+                "command": ["python", "-m", "codex_autorunner.cli", "hub", "serve"],
+            },
+            "hub_only",
+            tmp_path / "idle-cpu-soak-abcd" / "hub",
+            "http://127.0.0.1:12345",
+            logger,
+        )
+
+        record = (
+            tmp_path / ".codex-autorunner" / "processes" / "idle_cpu_soak" / "5151.json"
+        )
+        assert record.exists()
+        payload = json.loads(record.read_text(encoding="utf-8"))
+        assert payload["pid"] == 5151
+        assert payload["pgid"] == 6161
+        assert payload["owner_pid"] == 7171
+        assert payload["metadata"]["profile"] == "hub_only"
+
+        soak_module._stop_service(proc, logger)  # noqa: SLF001
+
+        assert record.exists() is False
+
+    def test_service_watchdog_exits_when_harness_parent_exits(self, tmp_path: Path):
+        helper = f"""
+import logging
+import pathlib
+import sys
+
+sys.path.insert(0, {str(_REPO_ROOT / "scripts")!r})
+import idle_cpu_soak as soak
+
+proc = soak._start_service(
+    {{
+        "alias": "sleeper",
+        "command": [
+            sys.executable,
+            "-c",
+            "import time; time.sleep(300)",
+        ],
+    }},
+    pathlib.Path({str(tmp_path / "hub")!r}),
+    logging.getLogger("test_idle_cpu_soak.helper"),
+)
+print(proc.pid, flush=True)
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", helper],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+        wrapper_pid = int(result.stdout.strip().splitlines()[-1])
+
+        self._assert_pid_gone(wrapper_pid)
 
 
 class TestIdleCpuSoakSignoffLogic:


### PR DESCRIPTION
## Summary
- wrap idle CPU soak services in a watchdog process that exits when the harness parent disappears
- register soak service process groups in the managed process registry for reaper-based recovery
- include idle-cpu-soak temp roots in CAR managed temp cleanup discovery
- add focused tests for new-session launch, registry cleanup, watchdog parent-death behavior, and temp discovery

Fixes #1683.

## Validation
- .venv/bin/python -m ruff check scripts/idle_cpu_soak.py tests/unit/test_idle_cpu_soak.py tests/core/test_pytest_temp_cleanup.py src/codex_autorunner/core/pytest_temp_cleanup.py
- .venv/bin/python -m pytest tests/unit/test_idle_cpu_soak.py -q -m 'not integration'\n- .venv/bin/python -m pytest tests/core/test_pytest_temp_cleanup.py -q\n- pre-commit aggregate lane: 8041 Python tests passed, 210 JS tests passed, 21 chat-surface lab tests passed, latency budget suite passed\n\n## Notes\n- Verified no idle-cpu-soak hub/service processes or idle_cpu_soak process records remained after tests.