### PR TITLE
fix(#1689): track processed comment_ids to prevent duplicate SCM wake-ups

### DIFF
--- a/src/codex_autorunner/integrations/github/polling_events.py
+++ b/src/codex_autorunner/integrations/github/polling_events.py
@@ -1,12 +1,122 @@
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import Any, Callable, Mapping
 
 from ...core.pr_bindings import PrBinding
+from ...core.publish_journal import PublishOperation
 from ...core.scm_events import ScmEventStore
 from ...core.scm_polling_watches import ScmPollingWatch
+from ...core.text_utils import _mapping, _normalize_text
 from .polling_snapshot import _comment_timestamp, snapshot_map
+
+_LOGGER = logging.getLogger(__name__)
+_PROCESSED_REVIEW_COMMENTS_KEY = "processed_review_comment_ids"
+_MAX_PROCESSED_REVIEW_COMMENTS_PER_SCOPE = 500
+
+
+def _processed_review_comment_scope(binding: PrBinding) -> str:
+    return _normalize_text(binding.thread_target_id) or "unbound"
+
+
+def _processed_review_comments(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    processed = snapshot.get(_PROCESSED_REVIEW_COMMENTS_KEY)
+    return dict(processed) if isinstance(processed, Mapping) else {}
+
+
+def _processed_review_comments_for_scope(
+    snapshot: Mapping[str, Any],
+    *,
+    binding: PrBinding,
+) -> dict[str, str]:
+    scoped = _processed_review_comments(snapshot)
+    scope = _processed_review_comment_scope(binding)
+    values = scoped.get(scope)
+    if not isinstance(values, Mapping):
+        return {}
+    normalized: dict[str, str] = {}
+    for key, value in values.items():
+        comment_id = _normalize_text(key)
+        processed_at = _normalize_text(value)
+        if comment_id is not None and processed_at is not None:
+            normalized[comment_id] = processed_at
+    return normalized
+
+
+def _inherit_processed_review_comments(
+    *,
+    previous_snapshot: Mapping[str, Any],
+    snapshot: dict[str, Any],
+) -> None:
+    processed = _processed_review_comments(previous_snapshot)
+    if processed:
+        snapshot[_PROCESSED_REVIEW_COMMENTS_KEY] = processed
+
+
+def _review_comment_was_processed(
+    payload: Mapping[str, Any],
+    *,
+    processed: Mapping[str, str],
+) -> bool:
+    comment_id = _normalize_text(payload.get("comment_id"))
+    if comment_id is None:
+        return False
+    processed_at = _normalize_text(processed.get(comment_id))
+    if processed_at is None:
+        return False
+    updated_at = _comment_timestamp(payload)
+    if updated_at is None:
+        return True
+    return updated_at <= processed_at
+
+
+def _mark_review_comment_processed(
+    snapshot: dict[str, Any],
+    payload: Mapping[str, Any],
+    *,
+    binding: PrBinding,
+) -> None:
+    comment_id = _normalize_text(payload.get("comment_id"))
+    if comment_id is None:
+        return
+    processed_at = _comment_timestamp(payload) or _normalize_text(
+        payload.get("created_at")
+    )
+    if processed_at is None:
+        return
+    scoped = _processed_review_comments(snapshot)
+    scope = _processed_review_comment_scope(binding)
+    existing_scope_values = scoped.get(scope)
+    scope_values = (
+        dict(existing_scope_values)
+        if isinstance(existing_scope_values, Mapping)
+        else {}
+    )
+    scope_values[comment_id] = processed_at
+    if len(scope_values) > _MAX_PROCESSED_REVIEW_COMMENTS_PER_SCOPE:
+        scope_values = dict(
+            sorted(scope_values.items(), key=lambda item: item[1], reverse=True)[
+                :_MAX_PROCESSED_REVIEW_COMMENTS_PER_SCOPE
+            ]
+        )
+    scoped[scope] = scope_values
+    snapshot[_PROCESSED_REVIEW_COMMENTS_KEY] = scoped
+
+
+def _ingest_created_enqueue(result: Any) -> bool:
+    operations = getattr(result, "publish_operations", None)
+    if operations is None:
+        return True
+    for operation in operations:
+        if (
+            isinstance(operation, PublishOperation)
+            and operation.operation_kind == "enqueue_managed_turn"
+        ):
+            return True
+        if getattr(operation, "operation_kind", None) == "enqueue_managed_turn":
+            return True
+    return False
 
 
 def emit_new_conditions(
@@ -19,8 +129,11 @@ def emit_new_conditions(
     automation_service_factory: Callable[[], Any],
     now_iso_fn: Any,
 ) -> int:
-    from ...core.text_utils import _normalize_text
-
+    snapshot = snapshot if isinstance(snapshot, dict) else dict(snapshot)
+    _inherit_processed_review_comments(
+        previous_snapshot=previous_snapshot,
+        snapshot=snapshot,
+    )
     current_head_sha = _normalize_text(snapshot.get("head_sha"))
     previous_reviews = snapshot_map(previous_snapshot, "changes_requested_reviews")
     current_reviews = snapshot_map(snapshot, "changes_requested_reviews")
@@ -32,6 +145,10 @@ def emit_new_conditions(
         previous_snapshot, "review_thread_comments"
     )
     current_review_thread_comments = snapshot_map(snapshot, "review_thread_comments")
+    processed_review_comments = _processed_review_comments_for_scope(
+        snapshot,
+        binding=binding,
+    )
 
     has_new = False
     for key in current_reviews:
@@ -53,6 +170,10 @@ def emit_new_conditions(
             if (
                 not bool(payload.get("thread_resolved"))
                 and key not in previous_review_thread_comments
+                and not _review_comment_was_processed(
+                    _mapping(payload),
+                    processed=processed_review_comments,
+                )
             ):
                 has_new = True
                 break
@@ -130,6 +251,19 @@ def emit_new_conditions(
             continue
         if key in previous_review_thread_comments:
             continue
+        payload_mapping = _mapping(payload)
+        if _review_comment_was_processed(
+            payload_mapping,
+            processed=processed_review_comments,
+        ):
+            _LOGGER.info(
+                "Suppressed duplicate SCM polling review comment event "
+                "watch_id=%s thread_target_id=%s comment_id=%s",
+                watch.watch_id,
+                binding.thread_target_id,
+                _normalize_text(payload_mapping.get("comment_id")),
+            )
+            continue
         event = event_store.record_event(
             event_id=(
                 f"github:poll:review-comment:{watch.watch_id}:{uuid.uuid4().hex[:12]}"
@@ -142,9 +276,19 @@ def emit_new_conditions(
             repo_id=binding.repo_id or watch.repo_id,
             pr_number=watch.pr_number,
             correlation_id=f"scm-poll:{watch.watch_id}",
-            payload=dict(payload),
+            payload=dict(payload_mapping),
         )
-        automation_service.ingest_event(event)
+        ingest_result = automation_service.ingest_event(event)
+        if _ingest_created_enqueue(ingest_result):
+            _mark_review_comment_processed(
+                snapshot,
+                payload_mapping,
+                binding=binding,
+            )
+            processed_review_comments = _processed_review_comments_for_scope(
+                snapshot,
+                binding=binding,
+            )
         emitted += 1
 
     if emitted:

--- a/tests/integrations/github/test_polling.py
+++ b/tests/integrations/github/test_polling.py
@@ -15,7 +15,7 @@ from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
 from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.pma_thread_store import PmaThreadStore
 from codex_autorunner.core.pr_binding_runtime import upsert_pr_binding
-from codex_autorunner.core.pr_bindings import PrBindingStore
+from codex_autorunner.core.pr_bindings import PrBinding, PrBindingStore
 from codex_autorunner.core.publish_executor import PublishOperationProcessor
 from codex_autorunner.core.publish_journal import PublishJournalStore
 from codex_autorunner.core.publish_operation_executors import (
@@ -24,7 +24,10 @@ from codex_autorunner.core.publish_operation_executors import (
 )
 from codex_autorunner.core.scm_automation_service import ScmAutomationService
 from codex_autorunner.core.scm_events import ScmEventStore
-from codex_autorunner.core.scm_polling_watches import ScmPollingWatchStore
+from codex_autorunner.core.scm_polling_watches import (
+    ScmPollingWatch,
+    ScmPollingWatchStore,
+)
 from codex_autorunner.integrations.github.polling import (
     GitHubPollingConfig,
     GitHubScmPollingService,
@@ -398,6 +401,89 @@ def _read_outbox_records(db_path: Path) -> list[_SimpleOutboxRecord]:
         conn.close()
 
 
+def _polling_watch_for_binding(
+    tmp_path: Path,
+    binding,
+    *,
+    snapshot: dict[str, object] | None = None,
+):
+    return ScmPollingWatch(
+        watch_id="watch-1",
+        provider="github",
+        binding_id=binding.binding_id,
+        repo_slug=binding.repo_slug,
+        repo_id=binding.repo_id,
+        pr_number=binding.pr_number,
+        workspace_root=str((tmp_path / "repo").resolve()),
+        thread_target_id=binding.thread_target_id,
+        poll_interval_seconds=90,
+        state="active",
+        started_at="2026-03-30T00:00:00Z",
+        updated_at="2026-03-30T00:00:00Z",
+        next_poll_at="2026-03-30T00:00:00Z",
+        expires_at="2099-03-30T01:00:00Z",
+        last_polled_at=None,
+        last_error_text=None,
+        reaction_config={"enabled": True},
+        snapshot=snapshot or {},
+    )
+
+
+def _review_comment_payload(
+    comment_id: str,
+    *,
+    body: str = "Please address this inline comment.",
+    updated_at: str = "2026-03-30T00:04:00Z",
+) -> dict[str, object]:
+    return {
+        "action": "created",
+        "comment_id": comment_id,
+        "author_login": "reviewer",
+        "author_type": "User",
+        "issue_author_login": "pr-author",
+        "body": body,
+        "path": "src/codex_autorunner/integrations/github/polling.py",
+        "line": 196,
+        "updated_at": updated_at,
+    }
+
+
+def _emit_review_comment_snapshot(
+    tmp_path: Path,
+    *,
+    watch,
+    binding,
+    previous_snapshot: dict[str, object],
+    snapshot: dict[str, object],
+) -> int:
+    return emit_new_conditions(
+        event_store=ScmEventStore(tmp_path),
+        watch=watch,
+        binding=binding,
+        previous_snapshot=previous_snapshot,
+        snapshot=snapshot,
+        automation_service_factory=lambda: _AutomationServiceFake(tmp_path),
+        now_iso_fn=lambda: "2026-03-30T00:05:00Z",
+    )
+
+
+def _polling_test_binding(*, thread_target_id: str | None = "thread-123") -> PrBinding:
+    return PrBinding(
+        binding_id="binding-1",
+        provider="github",
+        repo_slug="acme/widgets",
+        repo_id="repo-1",
+        pr_number=17,
+        pr_state="open",
+        head_branch="feature/scm-polling",
+        base_branch="main",
+        thread_target_id=thread_target_id,
+        created_at="2026-03-29T00:00:00Z",
+        updated_at="2026-03-30T00:00:00Z",
+        closed_at=None,
+    )
+
+
 def _polling_config(
     *,
     profile: str | None = None,
@@ -448,6 +534,132 @@ def test_polling_config_defaults_to_30_minute_post_open_boost() -> None:
     assert config.discovery_include_manifest_repos is False
     assert config.discovery_terminal_thread_lookback_minutes == 24 * 60
     assert config.no_activity_tier == "cold"
+
+
+def test_emit_new_conditions_dedupes_review_comments_by_processed_comment_id(
+    tmp_path: Path,
+) -> None:
+    binding = _polling_test_binding()
+    watch = _polling_watch_for_binding(tmp_path, binding)
+    _AutomationServiceFake.ingested_events = []
+    _AutomationServiceFake.process_calls = 0
+
+    first_snapshot: dict[str, object] = {
+        "review_thread_comments": {"poll-a": _review_comment_payload("2844")}
+    }
+    first_emitted = _emit_review_comment_snapshot(
+        tmp_path,
+        watch=watch,
+        binding=binding,
+        previous_snapshot={"review_thread_comments": {}},
+        snapshot=first_snapshot,
+    )
+    second_snapshot: dict[str, object] = {
+        "review_thread_comments": {"poll-b": _review_comment_payload("2844")}
+    }
+    second_emitted = _emit_review_comment_snapshot(
+        tmp_path,
+        watch=watch,
+        binding=binding,
+        previous_snapshot=first_snapshot,
+        snapshot=second_snapshot,
+    )
+
+    assert first_emitted == 1
+    assert second_emitted == 0
+    assert [
+        (event_type, payload["comment_id"])
+        for event_type, payload, _config in _AutomationServiceFake.ingested_events
+    ] == [("pull_request_review_comment", "2844")]
+
+
+def test_emit_new_conditions_dispatches_only_new_comment_in_mixed_poll(
+    tmp_path: Path,
+) -> None:
+    binding = _polling_test_binding()
+    watch = _polling_watch_for_binding(tmp_path, binding)
+    _AutomationServiceFake.ingested_events = []
+    first_snapshot: dict[str, object] = {
+        "review_thread_comments": {"poll-a": _review_comment_payload("2844")}
+    }
+    assert (
+        _emit_review_comment_snapshot(
+            tmp_path,
+            watch=watch,
+            binding=binding,
+            previous_snapshot={"review_thread_comments": {}},
+            snapshot=first_snapshot,
+        )
+        == 1
+    )
+
+    second_snapshot: dict[str, object] = {
+        "review_thread_comments": {
+            "poll-b": _review_comment_payload("2844"),
+            "poll-c": _review_comment_payload("2845", body="New review feedback."),
+        }
+    }
+    assert (
+        _emit_review_comment_snapshot(
+            tmp_path,
+            watch=watch,
+            binding=binding,
+            previous_snapshot=first_snapshot,
+            snapshot=second_snapshot,
+        )
+        == 1
+    )
+
+    assert [
+        payload["comment_id"]
+        for _event_type, payload, _config in _AutomationServiceFake.ingested_events
+    ] == ["2844", "2845"]
+
+
+def test_emit_new_conditions_redelivers_edited_review_comment(
+    tmp_path: Path,
+) -> None:
+    binding = _polling_test_binding()
+    watch = _polling_watch_for_binding(tmp_path, binding)
+    _AutomationServiceFake.ingested_events = []
+    first_snapshot: dict[str, object] = {
+        "review_thread_comments": {"poll-a": _review_comment_payload("2844")}
+    }
+    assert (
+        _emit_review_comment_snapshot(
+            tmp_path,
+            watch=watch,
+            binding=binding,
+            previous_snapshot={"review_thread_comments": {}},
+            snapshot=first_snapshot,
+        )
+        == 1
+    )
+
+    second_snapshot: dict[str, object] = {
+        "review_thread_comments": {
+            "poll-b": _review_comment_payload(
+                "2844",
+                body="Edited review feedback.",
+                updated_at="2026-03-30T00:06:00Z",
+            )
+        }
+    }
+    assert (
+        _emit_review_comment_snapshot(
+            tmp_path,
+            watch=watch,
+            binding=binding,
+            previous_snapshot=first_snapshot,
+            snapshot=second_snapshot,
+        )
+        == 1
+    )
+
+    assert [
+        payload["body"]
+        for _event_type, payload, _config in _AutomationServiceFake.ingested_events
+    ] == ["Please address this inline comment.", "Edited review feedback."]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1689