### PR TITLE
fix: show actual model name instead of 'default' in chat responses

### DIFF
--- a/src/codex_autorunner/integrations/chat/agents.py
+++ b/src/codex_autorunner/integrations/chat/agents.py
@@ -9,7 +9,7 @@ from typing import Any, Literal, Optional, Tuple
 DEFAULT_CHAT_AGENT = "codex"
 DEFAULT_CHAT_AGENT_MODELS = MappingProxyType(
     {
-        "codex": "gpt-5.4",
+        "codex": "gpt-5.5",
         "opencode": "zai-coding-plan/glm-5.1",
     }
 )

--- a/src/codex_autorunner/integrations/chat/bound_live_progress.py
+++ b/src/codex_autorunner/integrations/chat/bound_live_progress.py
@@ -26,6 +26,7 @@ from ..telegram.adapter import TelegramBotClient
 from ..telegram.outbox import _outbox_key as telegram_outbox_key
 from ..telegram.state import OutboxRecord as TelegramOutboxRecord
 from ..telegram.state import TelegramStateStore, parse_topic_key
+from .agents import DEFAULT_CHAT_AGENT_MODELS
 from .managed_thread_progress_projector import ManagedThreadProgressProjector
 from .managed_thread_turns import (
     ManagedThreadExecutionHooks,
@@ -994,7 +995,7 @@ def build_bound_chat_live_progress_session(
     tracker = TurnProgressTracker(
         started_at=time.monotonic(),
         agent=agent,
-        model=model or "default",
+        model=model or DEFAULT_CHAT_AGENT_MODELS.get(agent, "default"),
         label="working",
         max_actions=25,
         max_output_chars=max_length,

--- a/src/codex_autorunner/integrations/discord/message_turns.py
+++ b/src/codex_autorunner/integrations/discord/message_turns.py
@@ -78,6 +78,7 @@ from ...integrations.chat.models import ChatMessageEvent
 from ...integrations.chat.runtime_thread_errors import (
     sanitize_runtime_thread_error,
 )
+from ..chat.agents import DEFAULT_CHAT_AGENT_MODELS
 from ..chat.bound_chat_execution_metadata import merge_bound_chat_execution_metadata
 from ..chat.managed_thread_progress_projector import (
     ManagedThreadProgressProjector,
@@ -1805,7 +1806,7 @@ async def _run_discord_orchestrated_turn_for_message(
     tracker = TurnProgressTracker(
         started_at=time.monotonic(),
         agent=agent,
-        model=model_override or "default",
+        model=model_override or DEFAULT_CHAT_AGENT_MODELS.get(agent, "default"),
         label="working",
         max_actions=max_actions,
         max_output_chars=max_progress_len,

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace_resume.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace_resume.py
@@ -1066,6 +1066,7 @@ class WorkspaceResumeMixin:
             workspace_path=updated_record.workspace_path,
             model=updated_record.model,
             effort=updated_record.effort,
+            agent=updated_record.agent,
         )
         await self._finalize_selection(key, callback, message)
 
@@ -1302,5 +1303,6 @@ class WorkspaceResumeMixin:
             workspace_path=updated_record.workspace_path if updated_record else None,
             model=updated_record.model if updated_record else None,
             effort=updated_record.effort if updated_record else None,
+            agent=updated_record.agent if updated_record else None,
         )
         await self._finalize_selection(key, callback, message)

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace_session_commands.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace_session_commands.py
@@ -13,6 +13,7 @@ from .....core.pma_context import clear_pma_prompt_state_sessions
 from .....core.state import now_iso
 from .....core.utils import canonicalize_path
 from ....app_server.client import CodexAppServerError
+from ....chat.agents import DEFAULT_CHAT_AGENT_MODELS
 from ....chat.constants import APP_SERVER_UNAVAILABLE_MESSAGE, TOPIC_NOT_BOUND_MESSAGE
 from ....chat.newt_support import (
     NewtSetupCommandsError,
@@ -648,7 +649,8 @@ class WorkspaceSessionCommandsMixin:
                         headline=f"Started new thread `{thread_id}`.",
                         workspace_path=record.workspace_path,
                         actor_label=self._effective_agent_label(record),
-                        model=record.model or "default",
+                        model=record.model
+                        or DEFAULT_CHAT_AGENT_MODELS.get(agent, "default"),
                         effort=effort_label,
                     ),
                 ]
@@ -970,7 +972,7 @@ class WorkspaceSessionCommandsMixin:
                 headline=f"Started new thread `{thread_id}`.",
                 workspace_path=str(workspace_root),
                 actor_label=self._effective_agent_label(record),
-                model=record.model or "default",
+                model=record.model or DEFAULT_CHAT_AGENT_MODELS.get(agent, "default"),
                 effort=effort_label,
             ),
         ]

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/workspace_status.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/workspace_status.py
@@ -7,6 +7,7 @@ from .....core.flows import FlowStore
 from .....core.flows.models import FlowRunStatus
 from .....core.state_roots import resolve_repo_flows_db_path
 from .....manifest import load_manifest
+from ....chat.agents import DEFAULT_CHAT_AGENT_MODELS
 from ....chat.status_diagnostics import (
     StatusBlockContext,
     build_process_monitor_lines_for_root,
@@ -101,7 +102,8 @@ class WorkspaceStatusMixin:
                         if self._agent_supports_resume(agent)
                         else "unsupported"
                     ),
-                    model=record.model or "default",
+                    model=record.model
+                    or DEFAULT_CHAT_AGENT_MODELS.get(agent, "default"),
                     effort=effort_label,
                     approval_mode=record.approval_mode,
                     approval_policy=approval_policy or "default",

--- a/src/codex_autorunner/integrations/telegram/notifications.py
+++ b/src/codex_autorunner/integrations/telegram/notifications.py
@@ -12,6 +12,7 @@ from ...core.ports.run_event import (
 )
 from ...core.state import now_iso
 from ...core.text_delta_coalescer import TextDeltaCoalescer
+from ..chat.agents import DEFAULT_CHAT_AGENT_MODELS
 from ..chat.managed_thread_progress import progress_item_id_for_log_line
 from ..chat.managed_thread_progress_projector import (
     ManagedThreadProgressProjector,
@@ -518,7 +519,7 @@ class TelegramNotificationHandlers:
         tracker = TurnProgressTracker(
             started_at=time.monotonic(),
             agent=agent,
-            model=model or "default",
+            model=model or DEFAULT_CHAT_AGENT_MODELS.get(agent, "default"),
             label=label,
             max_actions=self._config.progress_stream.max_actions,
             max_output_chars=self._config.progress_stream.max_output_chars,

--- a/src/codex_autorunner/integrations/telegram/preview_utils.py
+++ b/src/codex_autorunner/integrations/telegram/preview_utils.py
@@ -463,13 +463,20 @@ def _format_resume_summary(
     workspace_path: Optional[str] = None,
     model: Optional[str] = None,
     effort: Optional[str] = None,
+    agent: Optional[str] = None,
 ) -> str:
+    from ..chat.agents import DEFAULT_CHAT_AGENT_MODELS
+
     user_preview, assistant_preview = _extract_thread_resume_parts(entry)
     return "\n".join(
         build_resumed_thread_lines(
             thread_id=thread_id,
             workspace_path=workspace_path,
-            model="default" if model is None else model,
+            model=(
+                model or DEFAULT_CHAT_AGENT_MODELS.get(agent, "default")
+                if model is None
+                else model
+            ),
             effort="default" if effort is None else effort,
             user_preview=user_preview,
             assistant_preview=assistant_preview,

--- a/src/codex_autorunner/integrations/telegram/preview_utils.py
+++ b/src/codex_autorunner/integrations/telegram/preview_utils.py
@@ -472,11 +472,7 @@ def _format_resume_summary(
         build_resumed_thread_lines(
             thread_id=thread_id,
             workspace_path=workspace_path,
-            model=(
-                model or DEFAULT_CHAT_AGENT_MODELS.get(agent, "default")
-                if model is None
-                else model
-            ),
+            model=model or DEFAULT_CHAT_AGENT_MODELS.get(agent, "default"),
             effort="default" if effort is None else effort,
             user_preview=user_preview,
             assistant_preview=assistant_preview,

--- a/tests/test_telegram_status_rate_limits.py
+++ b/tests/test_telegram_status_rate_limits.py
@@ -128,7 +128,7 @@ async def test_status_opencode_skips_rate_limits() -> None:
     assert "Active thread: none" in text
     assert "Agent: opencode" in text
     assert "Resume: supported" in text
-    assert "Model: default" in text
+    assert "Model: zai-coding-plan/glm-5.1" in text
     assert "Channel is bound." not in text
     assert "/car flow status" not in text
     assert "Limits:" not in handler._sent_messages[-1]
@@ -153,7 +153,7 @@ async def test_status_codex_includes_rate_limits() -> None:
     assert "Active thread: none" in text
     assert "Agent: codex" in text
     assert "Resume: supported" in text
-    assert "Model: default" in text
+    assert "Model: gpt-5.5" in text
     assert "Approval mode: yolo" in text
     assert "Sandbox policy: default" in text
     assert "Limits:" in text


### PR DESCRIPTION
## Summary

When `/new` or `newt` is used on Discord/Telegram, the model field displayed **"Model: default"** instead of the actual resolved model name. This PR resolves the model through `DEFAULT_CHAT_AGENT_MODELS` so users see e.g. **"Model: gpt-5.5"** for codex and **"Model: zai-coding-plan/glm-5.1"** for opencode.

Also bumps the default codex model from `gpt-5.4` → `gpt-5.5`.

## Changes

| File | Change |
|------|--------|
| `integrations/chat/agents.py` | Bump codex default: `gpt-5.4` → `gpt-5.5` |
| `integrations/discord/message_turns.py` | Resolve model via `DEFAULT_CHAT_AGENT_MODELS` in TurnProgressTracker |
| `integrations/chat/bound_live_progress.py` | Same resolution for bound live progress tracker |
| `integrations/telegram/handlers/commands/workspace_session_commands.py` | Resolve model in `/new` and `newt` responses (2 call sites) |
| `integrations/telegram/preview_utils.py` | Accept `agent` param, resolve model in resume summary |
| `integrations/telegram/handlers/commands/workspace_resume.py` | Pass `agent` to resume summary formatter |
| `integrations/telegram/handlers/commands/workspace_status.py` | Resolve model in status display |
| `integrations/telegram/notifications.py` | Resolve model in Telegram progress tracker |
| `tests/test_telegram_status_rate_limits.py` | Update assertions to expect actual model names |

## Validation

- ✅ `black` formatting passes
- ✅ `ruff` linting passes
- ✅ `mypy` type checking passes (798 source files, 0 issues)
- ✅ All hub interface contracts valid
- ✅ 275+ targeted tests pass (test_session/test_model/test_default/test_chat_agent/test_progress/test_preview/test_resume/test_status/test_new)
- ✅ Full test suite: 8103 items collected, all pre-commit static checks green

Co-Authored-By: Hermes <hermes@localhost>