### PR TITLE
[codex] Consolidate managed chat state reducers

### DIFF
--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -158,8 +158,11 @@ class _PromptState:
     def __post_init__(self) -> None:
         self._assistant_text = AssistantOutputState(stream_text=self.final_output)
 
-    def note_output_delta(self, text: str) -> None:
-        self._assistant_text.note_stream_snapshot(text)
+    def note_output_delta(self, text: str, *, merge_snapshot: bool = False) -> None:
+        if merge_snapshot:
+            self._assistant_text.note_stream_snapshot(text)
+        else:
+            self._assistant_text.note_stream_delta(text)
         self.final_output = self._assistant_text.text
 
     def note_assistant_message(self, text: str) -> None:
@@ -1124,7 +1127,10 @@ class ACPClient:
         self._note_prompt_trace_event(state, event)
         state.events.append(event)
         if isinstance(event, ACPOutputDeltaEvent):
-            state.note_output_delta(event.delta)
+            state.note_output_delta(
+                event.delta,
+                merge_snapshot=event.method == "session/update",
+            )
         elif isinstance(event, ACPMessageEvent) and event.message:
             state.note_assistant_message(event.message)
         await state.queue.put(event)

--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -32,7 +32,7 @@ from ...core.acp_lifecycle import (
     should_map_missing_turn_id as _should_map_missing_turn_id,
 )
 from ...core.logging_utils import log_event
-from ...core.orchestration.stream_text_merge import AssistantTextAccumulator
+from ...core.orchestration.stream_text_merge import AssistantOutputState
 from ...core.text_utils import _normalize_optional_text
 from .errors import (
     ACPError,
@@ -136,22 +136,22 @@ class _PromptState:
     last_session_update_part_types: tuple[str, ...] = ()
     last_session_update_text_length: Optional[int] = None
     last_session_update_at: Optional[float] = None
-    _assistant_text: AssistantTextAccumulator = field(
-        default_factory=AssistantTextAccumulator,
+    _assistant_text: AssistantOutputState = field(
+        default_factory=AssistantOutputState,
         init=False,
         repr=False,
     )
 
     def __post_init__(self) -> None:
-        self._assistant_text = AssistantTextAccumulator(stream_text=self.final_output)
+        self._assistant_text = AssistantOutputState(stream_text=self.final_output)
 
     def note_output_delta(self, text: str) -> None:
-        self._assistant_text.merge_snapshot(text)
+        self._assistant_text.note_stream_snapshot(text)
         self.final_output = self._assistant_text.text
 
     def note_assistant_message(self, text: str) -> None:
         if isinstance(text, str) and text:
-            self._assistant_text.replace_final(text)
+            self._assistant_text.note_final_message(text)
             self.final_output = self._assistant_text.text
 
 

--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -35,9 +35,6 @@ from ...core.acp_lifecycle import (
     session_update_content_summary as _session_update_content_summary,
 )
 from ...core.acp_lifecycle import (
-    should_map_missing_turn_id as _shared_should_map_missing_turn_id,
-)
-from ...core.acp_lifecycle import (
     should_register_server_turn_alias as _should_register_server_turn_alias,
 )
 from ...core.logging_utils import log_event
@@ -113,10 +110,6 @@ _ACP_STDOUT_NOISE_PREFIXES = (
 )
 _ACP_STDOUT_BRACKETED_STATUS_RE = re.compile(r"^\[[^\]\s]{1,32}\]\s+(?![\[{])\S")
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
-
-
-def _should_map_missing_turn_id(method: str, params: dict[str, Any]) -> bool:
-    return _shared_should_map_missing_turn_id(method, params)
 
 
 @dataclass(frozen=True)

--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -11,6 +11,9 @@ from pathlib import Path
 from typing import Any, AsyncIterator, Awaitable, Callable, Optional, Sequence
 
 from ...core.acp_lifecycle import (
+    active_turn_matches as _active_turn_matches,
+)
+from ...core.acp_lifecycle import (
     classify_prompt_response_status as _classify_prompt_response_status,
 )
 from ...core.acp_lifecycle import (
@@ -26,10 +29,16 @@ from ...core.acp_lifecycle import (
     prompt_terminal_method_for_status as _prompt_terminal_method_for_status,
 )
 from ...core.acp_lifecycle import (
+    resolve_active_turn_for_missing_id as _resolve_active_turn_for_missing_id,
+)
+from ...core.acp_lifecycle import (
     session_update_content_summary as _session_update_content_summary,
 )
 from ...core.acp_lifecycle import (
-    should_map_missing_turn_id as _should_map_missing_turn_id,
+    should_map_missing_turn_id as _shared_should_map_missing_turn_id,
+)
+from ...core.acp_lifecycle import (
+    should_register_server_turn_alias as _should_register_server_turn_alias,
 )
 from ...core.logging_utils import log_event
 from ...core.orchestration.stream_text_merge import AssistantOutputState
@@ -104,6 +113,10 @@ _ACP_STDOUT_NOISE_PREFIXES = (
 )
 _ACP_STDOUT_BRACKETED_STATUS_RE = re.compile(r"^\[[^\]\s]{1,32}\]\s+(?![\[{])\S")
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _should_map_missing_turn_id(method: str, params: dict[str, Any]) -> bool:
+    return _shared_should_map_missing_turn_id(method, params)
 
 
 @dataclass(frozen=True)
@@ -925,9 +938,23 @@ class ACPClient:
         state: _PromptState,
         alias_turn_id: Optional[str],
     ) -> None:
-        normalized_alias = _normalize_optional_text(alias_turn_id)
-        if not normalized_alias or normalized_alias == state.turn_id:
+        decision = _should_register_server_turn_alias(
+            local_turn_id=state.turn_id,
+            alias_turn_id=alias_turn_id,
+            state_closed=state.closed,
+        )
+        if not decision.allowed:
+            if decision.reason == "state_closed":
+                self._log_trace_event(
+                    "acp.prompt.turn_alias_rejected",
+                    session_id=state.session_id,
+                    turn_id=state.turn_id,
+                    aliased_turn_id=decision.turn_id,
+                    reason=decision.reason,
+                    **self._prompt_trace_fields(state),
+                )
             return
+        normalized_alias = decision.turn_id or ""
         existing = self._prompts.get(normalized_alias)
         if existing is not None and existing is not state:
             raise ACPProtocolError(
@@ -962,9 +989,28 @@ class ACPClient:
             return None
         active_state = self._prompts.get(active_turn_id)
         if active_state is None or active_state.closed:
+            self._log_trace_event(
+                "acp.prompt.active_turn_mismatch",
+                session_id=session_id,
+                event_turn_id=event.turn_id,
+                active_turn_id=active_turn_id,
+                event_method=event.method,
+                event_kind=event.kind,
+                reason="active_turn_closed_or_missing",
+            )
             return None
         request_task = active_state.request_task
         if request_task is None or request_task.done():
+            self._log_trace_event(
+                "acp.prompt.active_turn_mismatch",
+                session_id=session_id,
+                event_turn_id=event.turn_id,
+                active_turn_id=active_turn_id,
+                event_method=event.method,
+                event_kind=event.kind,
+                reason="active_turn_request_not_inflight",
+                **self._prompt_trace_fields(active_state),
+            )
             return None
         await self._register_prompt_turn_alias(active_state, event.turn_id)
         self._log_trace_event(
@@ -1013,7 +1059,11 @@ class ACPClient:
         resolved_completion_source = completion_source or "terminal_event"
         state.closed = True
         state.completion_source = resolved_completion_source
-        if self._session_active_turns.get(state.session_id) == state.turn_id:
+        if _active_turn_matches(
+            active_turns=self._session_active_turns,
+            session_id=state.session_id,
+            turn_id=state.turn_id,
+        ):
             self._session_active_turns.pop(state.session_id, None)
         self._log_trace_event(
             "acp.prompt.terminal_recorded",
@@ -1223,7 +1273,12 @@ class ACPClient:
                     **self._prompt_trace_fields(state),
                 )
                 return
-            self._session_active_turns.pop(state.session_id, None)
+            if _active_turn_matches(
+                active_turns=self._session_active_turns,
+                session_id=state.session_id,
+                turn_id=state.turn_id,
+            ):
+                self._session_active_turns.pop(state.session_id, None)
             self._log_trace_event(
                 "acp.prompt.request_failed",
                 session_id=state.session_id,
@@ -1245,7 +1300,6 @@ class ACPClient:
             "turnId",
             "turn_id",
         )
-        await self._register_prompt_turn_alias(state, response_turn_id)
         response_status = _classify_prompt_response_status(result_payload)
         response_method = _prompt_terminal_method_for_status(response_status)
         self._log_trace_event(
@@ -1262,6 +1316,7 @@ class ACPClient:
             **self._prompt_trace_fields(state),
         )
         if state.closed:
+            await self._register_prompt_turn_alias(state, response_turn_id)
             self._log_trace_event(
                 "acp.prompt.request_reconciled",
                 session_id=state.session_id,
@@ -1277,6 +1332,7 @@ class ACPClient:
                 **self._prompt_trace_fields(state),
             )
             return
+        await self._register_prompt_turn_alias(state, response_turn_id)
         terminal_event = normalize_notification(
             {
                 "method": response_method,
@@ -1309,16 +1365,39 @@ class ACPClient:
         )
         if not session_id:
             return message
-        if not _should_map_missing_turn_id(method or "", params):
+        decision = _resolve_active_turn_for_missing_id(
+            session_id=session_id,
+            method=method or "",
+            params=params,
+            active_turns=self._session_active_turns,
+            is_turn_open=self._is_prompt_turn_open,
+        )
+        if not decision.allowed or not decision.turn_id:
+            if decision.reason not in {"fallback_not_allowed", "no_active_turn"}:
+                self._log_trace_event(
+                    "acp.prompt.missing_turn_id_fallback_rejected",
+                    session_id=session_id,
+                    method=method,
+                    candidate_turn_id=decision.turn_id,
+                    reason=decision.reason,
+                )
             return message
-        turn_id = self._session_active_turns.get(session_id)
-        if not turn_id:
-            return message
+        turn_id = decision.turn_id
+        self._log_trace_event(
+            "acp.prompt.missing_turn_id_fallback",
+            session_id=session_id,
+            turn_id=turn_id,
+            method=method,
+        )
         enriched = dict(message)
         enriched_params = dict(params)
         enriched_params["turnId"] = turn_id
         enriched["params"] = enriched_params
         return enriched
+
+    def _is_prompt_turn_open(self, turn_id: str) -> bool:
+        state = self._prompts.get(turn_id)
+        return state is not None and not state.closed
 
     def _track_background_task(self, task: asyncio.Task[Any]) -> None:
         self._background_tasks.add(task)

--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -32,7 +32,7 @@ from ...core.acp_lifecycle import (
     should_map_missing_turn_id as _should_map_missing_turn_id,
 )
 from ...core.logging_utils import log_event
-from ...core.orchestration.stream_text_merge import merge_assistant_stream_text
+from ...core.orchestration.stream_text_merge import AssistantTextAccumulator
 from ...core.text_utils import _normalize_optional_text
 from .errors import (
     ACPError,
@@ -136,6 +136,23 @@ class _PromptState:
     last_session_update_part_types: tuple[str, ...] = ()
     last_session_update_text_length: Optional[int] = None
     last_session_update_at: Optional[float] = None
+    _assistant_text: AssistantTextAccumulator = field(
+        default_factory=AssistantTextAccumulator,
+        init=False,
+        repr=False,
+    )
+
+    def __post_init__(self) -> None:
+        self._assistant_text = AssistantTextAccumulator(stream_text=self.final_output)
+
+    def note_output_delta(self, text: str) -> None:
+        self._assistant_text.merge_snapshot(text)
+        self.final_output = self._assistant_text.text
+
+    def note_assistant_message(self, text: str) -> None:
+        if isinstance(text, str) and text:
+            self._assistant_text.replace_final(text)
+            self.final_output = self._assistant_text.text
 
 
 def _text_excerpt(value: Any, *, limit: int = 120) -> Optional[str]:
@@ -1057,12 +1074,9 @@ class ACPClient:
         self._note_prompt_trace_event(state, event)
         state.events.append(event)
         if isinstance(event, ACPOutputDeltaEvent):
-            state.final_output = merge_assistant_stream_text(
-                state.final_output,
-                event.delta,
-            )
+            state.note_output_delta(event.delta)
         elif isinstance(event, ACPMessageEvent) and event.message:
-            state.final_output = event.message
+            state.note_assistant_message(event.message)
         await state.queue.put(event)
         if not isinstance(event, ACPTurnTerminalEvent):
             return
@@ -1080,7 +1094,7 @@ class ACPClient:
         self._note_prompt_trace_event(state, event)
         state.events.append(event)
         if event.final_output:
-            state.final_output = event.final_output
+            state.note_assistant_message(event.final_output)
         await state.queue.put(event)
         await self._finalize_prompt_with_event(
             state,

--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -32,6 +32,7 @@ from ...core.acp_lifecycle import (
     should_map_missing_turn_id as _should_map_missing_turn_id,
 )
 from ...core.logging_utils import log_event
+from ...core.orchestration.stream_text_merge import merge_assistant_stream_text
 from ...core.text_utils import _normalize_optional_text
 from .errors import (
     ACPError,
@@ -1056,7 +1057,10 @@ class ACPClient:
         self._note_prompt_trace_event(state, event)
         state.events.append(event)
         if isinstance(event, ACPOutputDeltaEvent):
-            state.final_output += event.delta
+            state.final_output = merge_assistant_stream_text(
+                state.final_output,
+                event.delta,
+            )
         elif isinstance(event, ACPMessageEvent) and event.message:
             state.final_output = event.message
         await state.queue.put(event)

--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -10,6 +10,9 @@ from pathlib import Path
 from typing import Any, AsyncIterator, Awaitable, Callable, Mapping, Optional, Sequence
 
 from ...core.acp_lifecycle import (
+    active_turn_matches as _active_turn_matches,
+)
+from ...core.acp_lifecycle import (
     should_close_turn_buffer as _should_close_acp_turn_buffer,
 )
 from ...core.config import HubConfig, RepoConfig
@@ -114,6 +117,7 @@ class _HermesTurnState:
     last_event_method: Optional[str] = None
     last_session_update_kind: Optional[str] = None
     last_progress_at: Optional[str] = None
+    closed: bool = False
 
 
 class HermesSupervisor:
@@ -508,6 +512,14 @@ class HermesSupervisor:
             raise
         await self._sync_prompt_snapshot_into_event_buffer(workspace_root, state)
         await state.event_buffer.close()
+        async with self._lock:
+            state.closed = True
+            if _active_turn_matches(
+                active_turns=self._session_turns,
+                session_id=(workspace, session_id),
+                turn_id=resolved_turn_id,
+            ):
+                self._session_turns.pop((workspace, session_id), None)
         errors = [result.error_message] if result.error_message else []
         raw_events = state.event_buffer.snapshot()
         log_event(
@@ -626,8 +638,17 @@ class HermesSupervisor:
         workspace = _workspace_key(workspace_root)
         async with self._lock:
             tracked_turn_id = self._session_turns.get((workspace, session_id))
-        if tracked_turn_id:
-            return tracked_turn_id
+            tracked_state = (
+                self._turn_states.get((workspace, tracked_turn_id))
+                if tracked_turn_id
+                else None
+            )
+            if (
+                tracked_turn_id is not None
+                and tracked_state is not None
+                and not tracked_state.closed
+            ):
+                return tracked_turn_id
         raise HermesSupervisorError(
             f"No active Hermes turn tracked for session '{session_id}'"
         )

--- a/src/codex_autorunner/core/acp_lifecycle.py
+++ b/src/codex_autorunner/core/acp_lifecycle.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Literal, Mapping, Optional
+from typing import Any, Callable, Literal, Mapping, Optional
 
 from .text_utils import _normalize_optional_text
 
@@ -359,6 +359,64 @@ def should_close_turn_buffer(method: str, params: Mapping[str, Any]) -> bool:
     if runtime_terminal_status_for_lifecycle(method, params) is None:
         return False
     return method not in _IDLE_TERMINAL_METHODS
+
+
+@dataclass(frozen=True)
+class ActiveTurnIdentityDecision:
+    allowed: bool
+    turn_id: Optional[str] = None
+    reason: str = ""
+
+
+def resolve_active_turn_for_missing_id(
+    *,
+    session_id: str,
+    method: str,
+    params: Mapping[str, Any],
+    active_turns: Mapping[str, str],
+    is_turn_open: Callable[[str], bool],
+) -> ActiveTurnIdentityDecision:
+    if not should_map_missing_turn_id(method, params):
+        return ActiveTurnIdentityDecision(False, reason="fallback_not_allowed")
+    active_turn_id = _normalize_optional_text(active_turns.get(session_id))
+    if not active_turn_id:
+        return ActiveTurnIdentityDecision(False, reason="no_active_turn")
+    if not is_turn_open(active_turn_id):
+        return ActiveTurnIdentityDecision(
+            False,
+            turn_id=active_turn_id,
+            reason="active_turn_closed",
+        )
+    return ActiveTurnIdentityDecision(True, turn_id=active_turn_id, reason="active")
+
+
+def should_register_server_turn_alias(
+    *,
+    local_turn_id: str,
+    alias_turn_id: Optional[str],
+    state_closed: bool,
+) -> ActiveTurnIdentityDecision:
+    normalized_alias = _normalize_optional_text(alias_turn_id)
+    if not normalized_alias:
+        return ActiveTurnIdentityDecision(False, reason="missing_alias")
+    if normalized_alias == local_turn_id:
+        return ActiveTurnIdentityDecision(False, reason="same_turn")
+    if state_closed:
+        return ActiveTurnIdentityDecision(
+            False,
+            turn_id=normalized_alias,
+            reason="state_closed",
+        )
+    return ActiveTurnIdentityDecision(True, turn_id=normalized_alias, reason="open")
+
+
+def active_turn_matches(
+    *,
+    active_turns: Mapping[Any, str],
+    session_id: Any,
+    turn_id: str,
+) -> bool:
+    return _normalize_optional_text(active_turns.get(session_id)) == turn_id
 
 
 @dataclass(frozen=True)

--- a/src/codex_autorunner/core/orchestration/runtime_state_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_state_events.py
@@ -1,0 +1,245 @@
+"""Semantic runtime state events consumed by orchestration reducers.
+
+Adapters and runtime decoders normalize protocol-specific ACP, OpenCode, and
+transport payloads into these events. Reducers should apply these semantic
+events and preserve raw payloads only for observability.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Optional, Union
+
+from ..acp_lifecycle import (
+    analyze_acp_lifecycle_message,
+    extract_message_phase,
+)
+from ..acp_lifecycle import (
+    extract_error_message as _extract_error_message,
+)
+from ..acp_lifecycle import (
+    extract_message_text as _extract_message_text,
+)
+from ..acp_lifecycle import (
+    extract_output_delta as _extract_output_delta,
+)
+from .codex_item_normalizers import (
+    extract_agent_message_text as _shared_extract_agent_message_text,
+)
+from .codex_item_normalizers import (
+    extract_codex_usage,
+    is_commentary_agent_message,
+)
+
+RuntimeStateEventStatus = Literal["ok", "error", "interrupted"]
+
+
+@dataclass(frozen=True)
+class AssistantDelta:
+    text: str
+    source: str
+    message_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class AssistantMessage:
+    text: str
+    source: str
+    message_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class TerminalSignal:
+    status: RuntimeStateEventStatus
+    source: str
+    error: Optional[str] = None
+    final_text: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class TransportReturned:
+    status: str
+    assistant_text: str
+    errors: tuple[str, ...]
+    raw_events: tuple[Any, ...]
+
+
+@dataclass(frozen=True)
+class FailureSignal:
+    error: str
+    source: str
+
+
+@dataclass(frozen=True)
+class TokenUsage:
+    usage: dict[str, Any]
+    source: str
+
+
+@dataclass(frozen=True)
+class ProgressSignal:
+    kind: str
+    message: str
+    source: str
+
+
+RuntimeStateEvent = Union[
+    AssistantDelta,
+    AssistantMessage,
+    TerminalSignal,
+    TransportReturned,
+    FailureSignal,
+    TokenUsage,
+    ProgressSignal,
+]
+
+
+def normalize_runtime_state_events(raw_event: Any) -> list[RuntimeStateEvent]:
+    """Map protocol-specific runtime payloads into reducer-owned state events.
+
+    Adapters and protocol decoders own wire shape handling. Runtime state reducers
+    should consume the semantic events from this module and retain raw payloads
+    only for observability and trace storage.
+    """
+
+    if not isinstance(raw_event, dict):
+        return []
+    message = raw_event.get("message")
+    payload = message if isinstance(message, dict) else raw_event
+    method = str(payload.get("method") or "").strip()
+    params = payload.get("params")
+    if not isinstance(params, dict):
+        params = payload if isinstance(payload, dict) else {}
+    if not method:
+        return []
+
+    events: list[RuntimeStateEvent] = []
+    usage = extract_codex_usage(params)
+    if usage:
+        events.append(TokenUsage(usage=dict(usage), source=method))
+
+    assistant_message_text = None
+    assistant_stream_text = None
+    failure_message = None
+    terminal_status: Optional[RuntimeStateEventStatus] = None
+    method_lower = method.lower()
+    lifecycle = analyze_acp_lifecycle_message(payload)
+
+    if method in {"message.completed", "message.updated"}:
+        role = _extract_message_role(params)
+        if (
+            role != "user"
+            and str(params.get("phase") or "").strip().lower() != "commentary"
+        ):
+            assistant_message_text = _extract_message_text(params)
+    elif method in {"prompt/message", "turn/message"}:
+        if lifecycle.message_phase != "commentary":
+            assistant_message_text = lifecycle.assistant_text
+    elif lifecycle.runtime_terminal_status is not None:
+        terminal_status = lifecycle.runtime_terminal_status
+        assistant_message_text = lifecycle.assistant_text or None
+        if terminal_status in {"error", "interrupted"}:
+            failure_message = lifecycle.error_message or _extract_error_message(
+                params,
+                default="",
+            )
+    elif method in {"turn/failed", "turn/error", "error"}:
+        failure_message = _extract_error_message(params)
+        terminal_status = "error"
+    elif method == "item/completed":
+        item = params.get("item")
+        if (
+            isinstance(item, dict)
+            and str(item.get("type") or "").strip() == "agentMessage"
+            and not is_commentary_agent_message(item)
+        ):
+            assistant_message_text = _shared_extract_agent_message_text(item) or None
+
+    if (
+        assistant_message_text is None
+        and (
+            method
+            in {
+                "prompt/output",
+                "prompt/delta",
+                "prompt/progress",
+                "turn/progress",
+                "item/agentMessage/delta",
+                "message.delta",
+                "turn/streamDelta",
+            }
+            or "outputdelta" in method_lower
+        )
+        and extract_message_phase(params) != "commentary"
+    ):
+        assistant_stream_text = _extract_output_delta(params)
+    if assistant_stream_text is None and method == "session/update":
+        update = params.get("update")
+        if isinstance(update, dict):
+            update_kind = str(lifecycle.session_update_kind or "").strip()
+            if (
+                update_kind == "agent_message_chunk"
+                and lifecycle.message_phase != "commentary"
+            ):
+                assistant_stream_text = _extract_output_delta(update)
+
+    if assistant_stream_text:
+        events.append(AssistantDelta(text=assistant_stream_text, source=method))
+    if assistant_message_text:
+        events.append(AssistantMessage(text=assistant_message_text, source=method))
+    if failure_message:
+        events.append(FailureSignal(error=failure_message, source=method))
+    if terminal_status is not None:
+        events.append(
+            TerminalSignal(
+                status=terminal_status,
+                source=method,
+                error=failure_message or None,
+                final_text=assistant_message_text or None,
+            )
+        )
+    if events:
+        events.append(
+            ProgressSignal(kind="runtime_method", message=method, source=method)
+        )
+    return events
+
+
+def normalize_transport_returned(result: Any) -> TransportReturned:
+    return TransportReturned(
+        status=str(getattr(result, "status", "") or "").strip().lower(),
+        assistant_text=str(getattr(result, "assistant_text", "") or ""),
+        errors=tuple(
+            str(error or "").strip()
+            for error in (getattr(result, "errors", ()) or ())
+            if str(error or "").strip()
+        ),
+        raw_events=tuple(getattr(result, "raw_events", ()) or ()),
+    )
+
+
+def _extract_message_role(params: dict[str, Any]) -> str:
+    role = params.get("role")
+    if isinstance(role, str):
+        return role.strip().lower()
+    message = params.get("message")
+    if isinstance(message, dict):
+        role = message.get("role")
+        if isinstance(role, str):
+            return role.strip().lower()
+    return ""
+
+
+__all__ = [
+    "AssistantDelta",
+    "AssistantMessage",
+    "FailureSignal",
+    "ProgressSignal",
+    "RuntimeStateEvent",
+    "RuntimeStateEventStatus",
+    "TerminalSignal",
+    "TokenUsage",
+    "TransportReturned",
+    "normalize_runtime_state_events",
+    "normalize_transport_returned",
+]

--- a/src/codex_autorunner/core/orchestration/runtime_state_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_state_events.py
@@ -114,7 +114,10 @@ def normalize_runtime_state_events(raw_event: Any) -> list[RuntimeStateEvent]:
         return []
 
     events: list[RuntimeStateEvent] = []
+    lifecycle = analyze_acp_lifecycle_message(payload)
     usage = extract_codex_usage(params)
+    if not usage and lifecycle.usage:
+        usage = dict(lifecycle.usage)
     if usage:
         events.append(TokenUsage(usage=dict(usage), source=method))
 
@@ -123,8 +126,6 @@ def normalize_runtime_state_events(raw_event: Any) -> list[RuntimeStateEvent]:
     failure_message = None
     terminal_status: Optional[RuntimeStateEventStatus] = None
     method_lower = method.lower()
-    lifecycle = analyze_acp_lifecycle_message(payload)
-
     if method in {"message.completed", "message.updated"}:
         role = _extract_message_role(params)
         if (

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -285,6 +285,12 @@ def runtime_trace_fields(
     }
 
 
+def terminal_evidence_trace_fields(
+    outcome: RuntimeThreadOutcome,
+) -> dict[str, Any]:
+    return dict(outcome.terminal_evidence)
+
+
 def completion_source_from_outcome(
     outcome: RuntimeThreadOutcome,
     *,
@@ -724,6 +730,7 @@ __all__ = [
     "note_run_event_state",
     "normalize_runtime_progress_event",
     "runtime_trace_fields",
+    "terminal_evidence_trace_fields",
     "completion_source_from_outcome",
     "DECODE_FAILURE_REASON_MALFORMED_JSON",
     "DECODE_FAILURE_REASON_REGISTRY_MISS",

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -34,7 +34,7 @@ from .runtime_thread_decoders import (
     build_default_decoder_registry,
 )
 from .runtime_threads import RUNTIME_THREAD_TIMEOUT_ERROR, RuntimeThreadOutcome
-from .stream_text_merge import AssistantTextAccumulator
+from .stream_text_merge import AssistantOutputState, AssistantTextAccumulator
 
 _logger = logging.getLogger(__name__)
 
@@ -56,19 +56,32 @@ DIRECT_RUN_EVENT_TYPES = (
     Started,
 )
 
+RawTimelineEvent = Any
+TimelineEvent = RunEvent
+RawTimelineHistory = list[RawTimelineEvent]
+TimelineHistory = list[TimelineEvent]
+
 
 @dataclass
 class RuntimeEventDriver:
-    """Canonical reducer for raw runtime payloads into normalized run events."""
+    """Keeps append-only timeline history separate from reduced assistant output."""
 
     state: RuntimeThreadRunEventState = field(
         default_factory=lambda: RuntimeThreadRunEventState()
     )
-    raw_events: list[Any] = field(default_factory=list)
-    run_events: list[RunEvent] = field(default_factory=list)
-    assistant_parts: list[str] = field(default_factory=list)
+    raw_events: RawTimelineHistory = field(default_factory=list)
+    run_events: TimelineHistory = field(default_factory=list)
+    assistant_output: AssistantOutputState = field(default_factory=AssistantOutputState)
+    timeline_assistant_chunks: list[str] = field(default_factory=list)
     log_lines: list[str] = field(default_factory=list)
     token_usage: Optional[dict[str, Any]] = None
+
+    def __post_init__(self) -> None:
+        if not self.assistant_output.text and self.state.best_assistant_text():
+            self.assistant_output = AssistantOutputState(
+                stream_text=self.state.assistant_stream_text,
+                final_text=self.state.assistant_message_text,
+            )
 
     async def consume_raw_event(
         self,
@@ -108,10 +121,13 @@ class RuntimeEventDriver:
         self._record_run_events([event])
 
     def best_assistant_text(self) -> str:
-        assistant_text = self.state.best_assistant_text()
-        if isinstance(assistant_text, str) and assistant_text.strip():
-            return assistant_text
-        return "".join(self.assistant_parts).strip()
+        return self.assistant_output.text
+
+    @property
+    def assistant_parts(self) -> list[str]:
+        """Append-only assistant output timeline chunks, not final output state."""
+
+        return self.timeline_assistant_chunks
 
     def merged_raw_events(self, raw_events: Iterable[Any]) -> list[Any]:
         return merge_runtime_thread_raw_events(
@@ -129,11 +145,17 @@ class RuntimeEventDriver:
                     RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
                     RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
                 }:
-                    self.assistant_parts.append(event.content)
+                    self.timeline_assistant_chunks.append(event.content)
+                    if event.delta_type == RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM:
+                        self.assistant_output.note_stream_snapshot(event.content)
+                    else:
+                        self.assistant_output.note_final_message(event.content)
                     continue
                 if event.delta_type == RUN_EVENT_DELTA_TYPE_LOG_LINE:
                     self.log_lines.append(event.content)
                     continue
+            if isinstance(event, Completed) and isinstance(event.final_message, str):
+                self.assistant_output.note_final_message(event.final_message)
             if isinstance(event, TokenUsage) and isinstance(event.usage, dict):
                 self.token_usage = dict(event.usage)
 
@@ -337,25 +359,25 @@ class RuntimeThreadRunEventState:
     opencode_part_types: dict[str, str] = field(default_factory=dict)
     opencode_tool_status: dict[str, str] = field(default_factory=dict)
     opencode_patch_hashes: set[str] = field(default_factory=set)
-    _assistant_text: AssistantTextAccumulator = field(
-        default_factory=AssistantTextAccumulator,
+    _assistant_text: AssistantOutputState = field(
+        default_factory=AssistantOutputState,
         init=False,
         repr=False,
     )
 
     def __post_init__(self) -> None:
-        self._assistant_text = AssistantTextAccumulator(
+        self._assistant_text = AssistantOutputState(
             stream_text=self.assistant_stream_text,
             final_text=self.assistant_message_text,
         )
 
     def note_stream_text(self, text: str) -> None:
-        self._assistant_text.merge_snapshot(text)
+        self._assistant_text.note_stream_snapshot(text)
         self.assistant_stream_text = self._assistant_text.stream_text
 
     def note_message_text(self, text: str) -> None:
         if isinstance(text, str) and text.strip():
-            self._assistant_text.replace_final(text)
+            self._assistant_text.note_final_message(text)
             self.assistant_message_text = self._assistant_text.final_text
 
     def best_assistant_text(self) -> str:
@@ -715,6 +737,10 @@ def _load_json_object(raw: str) -> dict[str, Any]:
 __all__ = [
     "RuntimeEventDriver",
     "RuntimeThreadRunEventState",
+    "RawTimelineEvent",
+    "RawTimelineHistory",
+    "TimelineEvent",
+    "TimelineHistory",
     "decode_runtime_raw_messages",
     "merge_runtime_thread_raw_events",
     "normalize_runtime_thread_message",

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -34,7 +34,7 @@ from .runtime_thread_decoders import (
     build_default_decoder_registry,
 )
 from .runtime_threads import RUNTIME_THREAD_TIMEOUT_ERROR, RuntimeThreadOutcome
-from .stream_text_merge import merge_assistant_stream_text
+from .stream_text_merge import AssistantTextAccumulator
 
 _logger = logging.getLogger(__name__)
 
@@ -308,6 +308,12 @@ def merge_runtime_thread_raw_events(
     return merge_runtime_raw_events(streamed_raw_events, result_raw_events)
 
 
+def _merge_pending_stream_text(current: str, incoming: str) -> str:
+    accumulator = AssistantTextAccumulator(stream_text=current)
+    accumulator.merge_snapshot(incoming)
+    return accumulator.stream_text
+
+
 @dataclass
 class RuntimeThreadRunEventState:
     reasoning_buffers: dict[str, str] = field(default_factory=dict)
@@ -325,22 +331,29 @@ class RuntimeThreadRunEventState:
     opencode_part_types: dict[str, str] = field(default_factory=dict)
     opencode_tool_status: dict[str, str] = field(default_factory=dict)
     opencode_patch_hashes: set[str] = field(default_factory=set)
+    _assistant_text: AssistantTextAccumulator = field(
+        default_factory=AssistantTextAccumulator,
+        init=False,
+        repr=False,
+    )
+
+    def __post_init__(self) -> None:
+        self._assistant_text = AssistantTextAccumulator(
+            stream_text=self.assistant_stream_text,
+            final_text=self.assistant_message_text,
+        )
 
     def note_stream_text(self, text: str) -> None:
-        if isinstance(text, str) and text:
-            self.assistant_stream_text = merge_assistant_stream_text(
-                self.assistant_stream_text,
-                text,
-            )
+        self._assistant_text.merge_snapshot(text)
+        self.assistant_stream_text = self._assistant_text.stream_text
 
     def note_message_text(self, text: str) -> None:
         if isinstance(text, str) and text.strip():
-            self.assistant_message_text = text
+            self._assistant_text.replace_final(text)
+            self.assistant_message_text = self._assistant_text.final_text
 
     def best_assistant_text(self) -> str:
-        if self.assistant_message_text.strip():
-            return self.assistant_message_text
-        return self.assistant_stream_text
+        return self._assistant_text.text
 
     def note_runtime_progress(
         self,
@@ -413,7 +426,7 @@ class RuntimeThreadRunEventState:
                         delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
                     )
                 ]
-            self.pending_stream_no_id = merge_assistant_stream_text(
+            self.pending_stream_no_id = _merge_pending_stream_text(
                 self.pending_stream_no_id,
                 text,
             )
@@ -430,7 +443,7 @@ class RuntimeThreadRunEventState:
                     delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
                 )
             ]
-        self.pending_stream_by_message[message_id] = merge_assistant_stream_text(
+        self.pending_stream_by_message[message_id] = _merge_pending_stream_text(
             self.pending_stream_by_message.get(message_id, ""),
             text,
         )

--- a/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
+++ b/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
@@ -30,7 +30,7 @@ from .codex_item_normalizers import (
     merge_runtime_raw_events as _merge_runtime_raw_events,
 )
 from .execution_history import ExecutionCheckpoint, ExecutionCheckpointSignal
-from .stream_text_merge import merge_assistant_stream_text
+from .stream_text_merge import AssistantTextAccumulator
 
 RuntimeThreadOutcomeStatus = Literal["ok", "error", "interrupted"]
 RuntimeThreadCompletionSource = Literal[
@@ -108,9 +108,26 @@ class RuntimeTurnTerminalStateMachine:
         repr=False,
     )
     _terminal_signal_event: asyncio.Event = field(init=False, repr=False)
+    _assistant_text: AssistantTextAccumulator = field(
+        default_factory=AssistantTextAccumulator,
+        init=False,
+        repr=False,
+    )
 
     def __post_init__(self) -> None:
         self._terminal_signal_event = asyncio.Event()
+        self._assistant_text = AssistantTextAccumulator(
+            stream_text=self.last_assistant_text,
+        )
+
+    def _note_assistant_stream_text(self, text: str) -> None:
+        self._assistant_text.merge_snapshot(text)
+        self.last_assistant_text = self._assistant_text.text
+
+    def _note_assistant_message_text(self, text: str) -> None:
+        if isinstance(text, str) and text.strip():
+            self._assistant_text.replace_final(text)
+            self.last_assistant_text = self._assistant_text.text
 
     def terminal_signal_waiter(self) -> asyncio.Event:
         return self._terminal_signal_event
@@ -126,12 +143,9 @@ class RuntimeTurnTerminalStateMachine:
         if inspection.runtime_method:
             self.last_runtime_method = inspection.runtime_method
         if inspection.assistant_stream_text:
-            self.last_assistant_text = merge_assistant_stream_text(
-                self.last_assistant_text,
-                inspection.assistant_stream_text,
-            )
+            self._note_assistant_stream_text(inspection.assistant_stream_text)
         if inspection.assistant_message_text:
-            self.last_assistant_text = inspection.assistant_message_text
+            self._note_assistant_message_text(inspection.assistant_message_text)
         if inspection.failure_message:
             self.failure_cause = inspection.failure_message
         if inspection.token_usage:
@@ -155,7 +169,7 @@ class RuntimeTurnTerminalStateMachine:
         )
         assistant_text = str(getattr(result, "assistant_text", "") or "")
         if assistant_text.strip():
-            self.last_assistant_text = assistant_text
+            self._note_assistant_message_text(assistant_text)
         merged_raw_events = _merge_runtime_raw_events(
             self.raw_events,
             list(getattr(result, "raw_events", ()) or ()),
@@ -166,12 +180,9 @@ class RuntimeTurnTerminalStateMachine:
             for raw_event in new_events:
                 inspection = _inspect_raw_event(raw_event, timestamp=event_timestamp)
                 if inspection.assistant_stream_text:
-                    self.last_assistant_text = merge_assistant_stream_text(
-                        self.last_assistant_text,
-                        inspection.assistant_stream_text,
-                    )
+                    self._note_assistant_stream_text(inspection.assistant_stream_text)
                 if inspection.assistant_message_text:
-                    self.last_assistant_text = inspection.assistant_message_text
+                    self._note_assistant_message_text(inspection.assistant_message_text)
                 if inspection.failure_message:
                     self.failure_cause = inspection.failure_message
                 if inspection.token_usage:

--- a/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
+++ b/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
@@ -5,31 +5,23 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Literal, Optional
 
-from ..acp_lifecycle import (
-    analyze_acp_lifecycle_message,
-    extract_message_phase,
-)
-from ..acp_lifecycle import (
-    extract_error_message as _extract_error_message,
-)
-from ..acp_lifecycle import (
-    extract_message_text as _extract_message_text,
-)
-from ..acp_lifecycle import (
-    extract_output_delta as _extract_output_delta,
-)
 from ..time_utils import now_iso
-from .codex_item_normalizers import (
-    extract_agent_message_text as _shared_extract_agent_message_text,
-)
-from .codex_item_normalizers import (
-    extract_codex_usage,
-    is_commentary_agent_message,
-)
 from .codex_item_normalizers import (
     merge_runtime_raw_events as _merge_runtime_raw_events,
 )
 from .execution_history import ExecutionCheckpoint, ExecutionCheckpointSignal
+from .runtime_state_events import (
+    AssistantDelta,
+    AssistantMessage,
+    FailureSignal,
+    ProgressSignal,
+    RuntimeStateEvent,
+    TerminalSignal,
+    TokenUsage,
+    TransportReturned,
+    normalize_runtime_state_events,
+    normalize_transport_returned,
+)
 from .stream_text_merge import AssistantTextAccumulator
 
 RuntimeThreadOutcomeStatus = Literal["ok", "error", "interrupted"]
@@ -73,16 +65,6 @@ class RuntimeThreadOutcome:
     transport_request_return_timestamp: Optional[str] = None
     last_progress_timestamp: Optional[str] = None
     failure_cause: Optional[str] = None
-
-
-@dataclass
-class _RawEventInspection:
-    assistant_message_text: Optional[str] = None
-    assistant_stream_text: Optional[str] = None
-    failure_message: Optional[str] = None
-    terminal_signal: Optional[RuntimeThreadTerminalSignal] = None
-    token_usage: Optional[dict[str, Any]] = None
-    runtime_method: Optional[str] = None
 
 
 @dataclass
@@ -139,19 +121,52 @@ class RuntimeTurnTerminalStateMachine:
         self.raw_events.append(raw_event)
         self.last_progress_timestamp = event_timestamp
         self.last_progress_monotonic = time.monotonic()
-        inspection = _inspect_raw_event(raw_event, timestamp=event_timestamp)
-        if inspection.runtime_method:
-            self.last_runtime_method = inspection.runtime_method
-        if inspection.assistant_stream_text:
-            self._note_assistant_stream_text(inspection.assistant_stream_text)
-        if inspection.assistant_message_text:
-            self._note_assistant_message_text(inspection.assistant_message_text)
-        if inspection.failure_message:
-            self.failure_cause = inspection.failure_message
-        if inspection.token_usage:
-            self.token_usage = dict(inspection.token_usage)
-        if inspection.terminal_signal is not None:
-            self._note_terminal_signal(inspection.terminal_signal)
+        for event in normalize_runtime_state_events(raw_event):
+            self.note_state_event(event, timestamp=event_timestamp)
+
+    def note_state_event(
+        self,
+        event: RuntimeStateEvent,
+        *,
+        timestamp: Optional[str] = None,
+    ) -> None:
+        event_timestamp = timestamp or now_iso()
+        if isinstance(event, AssistantDelta):
+            self._note_assistant_stream_text(event.text)
+            return
+        if isinstance(event, AssistantMessage):
+            self._note_assistant_message_text(event.text)
+            return
+        if isinstance(event, TerminalSignal):
+            if event.final_text:
+                self._note_assistant_message_text(event.final_text)
+            if event.error:
+                self.failure_cause = event.error
+            self._note_terminal_signal(
+                RuntimeThreadTerminalSignal(
+                    source=event.source,
+                    status=event.status,
+                    timestamp=event_timestamp,
+                )
+            )
+            return
+        if isinstance(event, TransportReturned):
+            self.transport_request_return_timestamp = event_timestamp
+            self.transport_status = event.status
+            self.transport_errors = event.errors
+            if event.assistant_text.strip():
+                self._note_assistant_message_text(event.assistant_text)
+            if self.transport_errors and not self.failure_cause:
+                self.failure_cause = self.transport_errors[0]
+            return
+        if isinstance(event, FailureSignal):
+            self.failure_cause = event.error
+            return
+        if isinstance(event, TokenUsage):
+            self.token_usage = dict(event.usage)
+            return
+        if isinstance(event, ProgressSignal) and event.kind == "runtime_method":
+            self.last_runtime_method = event.message
 
     def note_transport_result(
         self,
@@ -160,37 +175,18 @@ class RuntimeTurnTerminalStateMachine:
         timestamp: Optional[str] = None,
     ) -> None:
         event_timestamp = timestamp or now_iso()
-        self.transport_request_return_timestamp = event_timestamp
-        self.transport_status = str(getattr(result, "status", "") or "").strip().lower()
-        self.transport_errors = tuple(
-            str(error or "").strip()
-            for error in (getattr(result, "errors", ()) or ())
-            if str(error or "").strip()
-        )
-        assistant_text = str(getattr(result, "assistant_text", "") or "")
-        if assistant_text.strip():
-            self._note_assistant_message_text(assistant_text)
+        transport_event = normalize_transport_returned(result)
+        self.note_state_event(transport_event, timestamp=event_timestamp)
         merged_raw_events = _merge_runtime_raw_events(
             self.raw_events,
-            list(getattr(result, "raw_events", ()) or ()),
+            list(transport_event.raw_events),
         )
         if len(merged_raw_events) > len(self.raw_events):
             new_events = merged_raw_events[len(self.raw_events) :]
             self.raw_events = merged_raw_events
             for raw_event in new_events:
-                inspection = _inspect_raw_event(raw_event, timestamp=event_timestamp)
-                if inspection.assistant_stream_text:
-                    self._note_assistant_stream_text(inspection.assistant_stream_text)
-                if inspection.assistant_message_text:
-                    self._note_assistant_message_text(inspection.assistant_message_text)
-                if inspection.failure_message:
-                    self.failure_cause = inspection.failure_message
-                if inspection.token_usage:
-                    self.token_usage = dict(inspection.token_usage)
-                if inspection.terminal_signal is not None:
-                    self._note_terminal_signal(inspection.terminal_signal)
-        if self.transport_errors and not self.failure_cause:
-            self.failure_cause = self.transport_errors[0]
+                for event in normalize_runtime_state_events(raw_event):
+                    self.note_state_event(event, timestamp=event_timestamp)
 
     def build_missing_backend_ids_outcome(self, error: str) -> RuntimeThreadOutcome:
         return RuntimeThreadOutcome(
@@ -444,110 +440,6 @@ class RuntimeTurnTerminalStateMachine:
         )
 
 
-def _inspect_raw_event(
-    raw_event: Any,
-    *,
-    timestamp: str,
-) -> _RawEventInspection:
-    if not isinstance(raw_event, dict):
-        return _RawEventInspection()
-    message = raw_event.get("message")
-    payload = message if isinstance(message, dict) else raw_event
-    method = str(payload.get("method") or "").strip()
-    params = payload.get("params")
-    if not isinstance(params, dict):
-        params = payload if isinstance(payload, dict) else {}
-    if not method:
-        return _RawEventInspection()
-
-    assistant_message_text = None
-    assistant_stream_text = None
-    failure_message = None
-    terminal_signal = None
-    token_usage = _extract_usage(params)
-    method_lower = method.lower()
-    lifecycle = analyze_acp_lifecycle_message(payload)
-
-    if method in {"message.completed", "message.updated"}:
-        role = _extract_message_role(params)
-        if (
-            role != "user"
-            and str(params.get("phase") or "").strip().lower() != "commentary"
-        ):
-            assistant_message_text = _extract_message_text(params)
-    elif method in {"prompt/message", "turn/message"}:
-        if lifecycle.message_phase != "commentary":
-            assistant_message_text = lifecycle.assistant_text
-    elif lifecycle.runtime_terminal_status is not None:
-        assistant_message_text = lifecycle.assistant_text or None
-        terminal_signal = RuntimeThreadTerminalSignal(
-            source=method,
-            status=lifecycle.runtime_terminal_status,
-            timestamp=timestamp,
-        )
-        if lifecycle.runtime_terminal_status in {"error", "interrupted"}:
-            failure_message = lifecycle.error_message or _extract_error_message(
-                params,
-                default="",
-            )
-    elif method in {"turn/failed", "turn/error", "error"}:
-        failure_message = _extract_error_message(params)
-        terminal_signal = RuntimeThreadTerminalSignal(
-            source=method,
-            status="error",
-            timestamp=timestamp,
-        )
-    elif method == "item/completed":
-        item = params.get("item")
-        if (
-            isinstance(item, dict)
-            and str(item.get("type") or "").strip() == "agentMessage"
-            and not is_commentary_agent_message(item)
-        ):
-            assistant_message_text = _shared_extract_agent_message_text(item) or None
-
-    if (
-        assistant_message_text is None
-        and (
-            method
-            in {
-                "prompt/output",
-                "prompt/delta",
-                "prompt/progress",
-                "turn/progress",
-                "item/agentMessage/delta",
-                "message.delta",
-                "turn/streamDelta",
-            }
-            or "outputdelta" in method_lower
-        )
-        and extract_message_phase(params) != "commentary"
-    ):
-        assistant_stream_text = _extract_output_delta(params)
-    if assistant_stream_text is None and method == "session/update":
-        update = params.get("update")
-        if isinstance(update, dict):
-            update_kind = str(lifecycle.session_update_kind or "").strip()
-            if (
-                update_kind == "agent_message_chunk"
-                and lifecycle.message_phase != "commentary"
-            ):
-                assistant_stream_text = _extract_output_delta(update)
-
-    return _RawEventInspection(
-        assistant_message_text=assistant_message_text,
-        assistant_stream_text=assistant_stream_text,
-        failure_message=failure_message,
-        terminal_signal=terminal_signal,
-        token_usage=token_usage,
-        runtime_method=method,
-    )
-
-
-def _extract_usage(params: dict[str, Any]) -> Optional[dict[str, Any]]:
-    return extract_codex_usage(params)
-
-
 def _checkpoint_preview(value: str, limit: int = 240) -> str:
     text = str(value or "")
     if len(text) <= limit:
@@ -555,18 +447,6 @@ def _checkpoint_preview(value: str, limit: int = 240) -> str:
     if limit <= 3:
         return text[:limit]
     return text[: limit - 3] + "..."
-
-
-def _extract_message_role(params: dict[str, Any]) -> str:
-    role = params.get("role")
-    if isinstance(role, str):
-        return role.strip().lower()
-    message = params.get("message")
-    if isinstance(message, dict):
-        role = message.get("role")
-        if isinstance(role, str):
-            return role.strip().lower()
-    return ""
 
 
 __all__ = [

--- a/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
+++ b/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
@@ -22,7 +22,7 @@ from .runtime_state_events import (
     normalize_runtime_state_events,
     normalize_transport_returned,
 )
-from .stream_text_merge import AssistantTextAccumulator
+from .stream_text_merge import AssistantOutputState
 
 RuntimeThreadOutcomeStatus = Literal["ok", "error", "interrupted"]
 RuntimeThreadCompletionSource = Literal[
@@ -322,25 +322,25 @@ class RuntimeTurnTerminalStateMachine:
         repr=False,
     )
     _terminal_signal_event: asyncio.Event = field(init=False, repr=False)
-    _assistant_text: AssistantTextAccumulator = field(
-        default_factory=AssistantTextAccumulator,
+    _assistant_text: AssistantOutputState = field(
+        default_factory=AssistantOutputState,
         init=False,
         repr=False,
     )
 
     def __post_init__(self) -> None:
         self._terminal_signal_event = asyncio.Event()
-        self._assistant_text = AssistantTextAccumulator(
+        self._assistant_text = AssistantOutputState(
             stream_text=self.last_assistant_text,
         )
 
     def _note_assistant_stream_text(self, text: str) -> None:
-        self._assistant_text.merge_snapshot(text)
+        self._assistant_text.note_stream_snapshot(text)
         self.last_assistant_text = self._assistant_text.text
 
     def _note_assistant_message_text(self, text: str) -> None:
         if isinstance(text, str) and text.strip():
-            self._assistant_text.replace_final(text)
+            self._assistant_text.note_final_message(text)
             self.last_assistant_text = self._assistant_text.text
 
     def terminal_signal_waiter(self) -> asyncio.Event:

--- a/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
+++ b/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
@@ -51,6 +51,64 @@ class RuntimeThreadTerminalSignal:
 
 
 @dataclass(frozen=True)
+class TerminalEvidence:
+    """Inputs to the terminal-outcome precedence reducer.
+
+    Precedence table:
+    - Explicit timeout wins and never delivers partial assistant text.
+    - Explicit interrupt wins unless a successful transport return is already
+      durably recorded for this turn.
+    - Failed transport with no successful terminal evidence is an error.
+    - Successful terminal evidence plus assistant text can recover
+      transport-layer failures.
+    - Idle/status terminal evidence is a terminal signal only; it can release
+      already observed assistant text, but cannot synthesize assistant text.
+    """
+
+    transport_status: str
+    transport_errors: tuple[str, ...]
+    transport_returned: bool
+    assistant_text: str
+    failure_cause: Optional[str]
+    terminal_signals: tuple[RuntimeThreadTerminalSignal, ...]
+    explicit_interrupt: bool = False
+    explicit_timeout: bool = False
+    transport_exception: Optional[str] = None
+    execution_error_message: str = ""
+
+
+@dataclass(frozen=True)
+class TerminalEvidenceDecision:
+    status: RuntimeThreadOutcomeStatus
+    assistant_text: str
+    error: Optional[str]
+    completion_source: RuntimeThreadCompletionSource
+    reason: str
+
+    def evidence_fields(self, evidence: TerminalEvidence) -> dict[str, Any]:
+        latest_terminal = _latest_terminal_signal(evidence.terminal_signals)
+        return {
+            "terminal_evidence_reason": self.reason,
+            "terminal_evidence_transport_status": evidence.transport_status or None,
+            "terminal_evidence_transport_returned": evidence.transport_returned,
+            "terminal_evidence_transport_error_count": len(evidence.transport_errors),
+            "terminal_evidence_terminal_signal_count": len(evidence.terminal_signals),
+            "terminal_evidence_latest_terminal_source": (
+                latest_terminal.source if latest_terminal is not None else None
+            ),
+            "terminal_evidence_latest_terminal_status": (
+                latest_terminal.status if latest_terminal is not None else None
+            ),
+            "terminal_evidence_assistant_chars": len(evidence.assistant_text),
+            "terminal_evidence_explicit_interrupt": evidence.explicit_interrupt,
+            "terminal_evidence_explicit_timeout": evidence.explicit_timeout,
+            "terminal_evidence_transport_exception": (
+                bool(evidence.transport_exception)
+            ),
+        }
+
+
+@dataclass(frozen=True)
 class RuntimeThreadOutcome:
     """Collected outcome of one runtime-thread execution before persistence."""
 
@@ -65,6 +123,180 @@ class RuntimeThreadOutcome:
     transport_request_return_timestamp: Optional[str] = None
     last_progress_timestamp: Optional[str] = None
     failure_cause: Optional[str] = None
+    terminal_evidence: dict[str, Any] = field(default_factory=dict)
+
+
+def reduce_terminal_evidence(evidence: TerminalEvidence) -> TerminalEvidenceDecision:
+    """Resolve terminal evidence into one user-visible outcome.
+
+    This is the only policy function that decides precedence between streamed
+    terminal signals, prompt/request return status, explicit interrupt records,
+    timeout/stall probes, and transport exceptions.
+    """
+
+    status = evidence.transport_status
+    assistant_text = evidence.assistant_text
+    detail = (
+        next(iter(evidence.transport_errors), "")
+        or evidence.transport_exception
+        or evidence.failure_cause
+        or None
+    )
+    successful_transport = status in _SUCCESSFUL_COMPLETION_STATUSES
+    interrupted_transport = status in _INTERRUPTED_COMPLETION_STATUSES
+    failed_transport = (
+        bool(status) and not successful_transport and not interrupted_transport
+    )
+    successful_terminal = _saw_successful_terminal_signal(evidence.terminal_signals)
+    latest_terminal = _latest_terminal_signal(evidence.terminal_signals)
+    has_assistant_text = bool(assistant_text.strip())
+
+    if evidence.explicit_timeout:
+        return TerminalEvidenceDecision(
+            status="error",
+            assistant_text="",
+            error=detail or evidence.execution_error_message,
+            completion_source="timeout",
+            reason="explicit_timeout",
+        )
+
+    if evidence.explicit_interrupt and not successful_transport:
+        return TerminalEvidenceDecision(
+            status="interrupted",
+            assistant_text="",
+            error=detail or _DEFAULT_INTERRUPTED_ERROR,
+            completion_source="interrupt",
+            reason="explicit_interrupt",
+        )
+
+    if evidence.transport_exception:
+        if successful_terminal and has_assistant_text:
+            return TerminalEvidenceDecision(
+                status="ok",
+                assistant_text=assistant_text,
+                error=None,
+                completion_source="reconciled_failure",
+                reason="terminal_success_recovered_transport_exception",
+            )
+        return TerminalEvidenceDecision(
+            status="error",
+            assistant_text="",
+            error=detail or evidence.execution_error_message,
+            completion_source="transport_error",
+            reason="transport_exception_without_terminal_success",
+        )
+
+    if not evidence.transport_returned:
+        if latest_terminal is not None and latest_terminal.status == "ok":
+            return TerminalEvidenceDecision(
+                status="ok",
+                assistant_text=assistant_text,
+                error=None,
+                completion_source="stream_terminal_event",
+                reason="stream_terminal_success",
+            )
+        if latest_terminal is not None and latest_terminal.status == "interrupted":
+            return TerminalEvidenceDecision(
+                status="interrupted",
+                assistant_text="",
+                error=detail or _DEFAULT_INTERRUPTED_ERROR,
+                completion_source="stream_terminal_event",
+                reason="stream_terminal_interrupted",
+            )
+        return TerminalEvidenceDecision(
+            status="error",
+            assistant_text="",
+            error=detail or evidence.execution_error_message,
+            completion_source="stream_terminal_event",
+            reason="stream_terminal_error",
+        )
+
+    if evidence.transport_errors:
+        if interrupted_transport:
+            return TerminalEvidenceDecision(
+                status="interrupted",
+                assistant_text="",
+                error=detail or _DEFAULT_INTERRUPTED_ERROR,
+                completion_source="prompt_return",
+                reason="transport_interrupted",
+            )
+        if successful_terminal and has_assistant_text:
+            return TerminalEvidenceDecision(
+                status="ok",
+                assistant_text=assistant_text,
+                error=None if successful_transport else detail or None,
+                completion_source=(
+                    "reconciled_failure"
+                    if not successful_transport
+                    else "prompt_return"
+                ),
+                reason=(
+                    "terminal_success_recovered_failed_transport"
+                    if not successful_transport
+                    else "successful_transport_with_terminal_success"
+                ),
+            )
+        if failed_transport:
+            return TerminalEvidenceDecision(
+                status="error",
+                assistant_text="",
+                error=detail or evidence.execution_error_message,
+                completion_source="prompt_return",
+                reason="failed_transport_without_terminal_success",
+            )
+        if has_assistant_text:
+            return TerminalEvidenceDecision(
+                status="ok",
+                assistant_text=assistant_text,
+                error=detail or None,
+                completion_source="prompt_return",
+                reason="successful_transport_with_assistant_text",
+            )
+        return TerminalEvidenceDecision(
+            status="error",
+            assistant_text="",
+            error=detail or evidence.execution_error_message,
+            completion_source="prompt_return",
+            reason="transport_errors_without_assistant_text",
+        )
+
+    if interrupted_transport:
+        return TerminalEvidenceDecision(
+            status="interrupted",
+            assistant_text="",
+            error=evidence.failure_cause,
+            completion_source="interrupt",
+            reason="transport_interrupted",
+        )
+    if failed_transport:
+        return TerminalEvidenceDecision(
+            status="error",
+            assistant_text="",
+            error=detail or evidence.execution_error_message,
+            completion_source="prompt_return",
+            reason="failed_transport",
+        )
+    return TerminalEvidenceDecision(
+        status="ok",
+        assistant_text=assistant_text,
+        error=None,
+        completion_source="prompt_return",
+        reason="successful_transport",
+    )
+
+
+def _saw_successful_terminal_signal(
+    signals: tuple[RuntimeThreadTerminalSignal, ...],
+) -> bool:
+    return any(signal.status == "ok" for signal in signals)
+
+
+def _latest_terminal_signal(
+    signals: tuple[RuntimeThreadTerminalSignal, ...],
+) -> Optional[RuntimeThreadTerminalSignal]:
+    if not signals:
+        return None
+    return signals[-1]
 
 
 @dataclass
@@ -213,11 +445,11 @@ class RuntimeTurnTerminalStateMachine:
                 timestamp=timestamp,
             )
         )
-        return self._build_outcome(
-            status="error",
-            assistant_text="",
-            error=error,
-            completion_source="timeout",
+        return self._build_outcome_from_evidence(
+            self._terminal_evidence(
+                explicit_timeout=True,
+                execution_error_message=error,
+            )
         )
 
     def build_interrupted_outcome(self, error: str) -> RuntimeThreadOutcome:
@@ -230,11 +462,11 @@ class RuntimeTurnTerminalStateMachine:
                 timestamp=timestamp,
             )
         )
-        return self._build_outcome(
-            status="interrupted",
-            assistant_text="",
-            error=error,
-            completion_source="interrupt",
+        return self._build_outcome_from_evidence(
+            self._terminal_evidence(
+                explicit_interrupt=True,
+                execution_error_message=error,
+            )
         )
 
     def build_transport_exception_outcome(
@@ -242,122 +474,56 @@ class RuntimeTurnTerminalStateMachine:
         error: str,
     ) -> RuntimeThreadOutcome:
         self.failure_cause = error
-        if self._saw_successful_terminal_signal() and self.last_assistant_text.strip():
-            return self._build_outcome(
-                status="ok",
-                assistant_text=self.last_assistant_text,
-                error=None,
-                completion_source="reconciled_failure",
+        return self._build_outcome_from_evidence(
+            self._terminal_evidence(
+                transport_exception=error,
+                execution_error_message=error,
             )
-        return self._build_outcome(
-            status="error",
-            assistant_text="",
-            error=error,
-            completion_source="transport_error",
         )
 
     def build_outcome(self, execution_error_message: str) -> RuntimeThreadOutcome:
-        status = self.transport_status or ""
-        assistant_text = self.last_assistant_text
-        detail = next(iter(self.transport_errors), "") or self.failure_cause or None
-        successful_transport = status in _SUCCESSFUL_COMPLETION_STATUSES
-        interrupted_transport = status in _INTERRUPTED_COMPLETION_STATUSES
-        failed_transport = (
-            bool(status) and not successful_transport and not interrupted_transport
+        return self._build_outcome_from_evidence(
+            self._terminal_evidence(execution_error_message=execution_error_message)
         )
-        successful_terminal = self._saw_successful_terminal_signal()
-        latest_terminal = self._latest_terminal_signal()
 
-        if self.transport_request_return_timestamp is None:
-            if latest_terminal is not None and latest_terminal.status == "ok":
-                return self._build_outcome(
-                    status="ok",
-                    assistant_text=assistant_text,
-                    error=None,
-                    completion_source="stream_terminal_event",
-                )
-            if latest_terminal is not None and latest_terminal.status == "interrupted":
-                return self._build_outcome(
-                    status="interrupted",
-                    assistant_text="",
-                    error=detail or _DEFAULT_INTERRUPTED_ERROR,
-                    completion_source="stream_terminal_event",
-                )
-            return self._build_outcome(
-                status="error",
-                assistant_text="",
-                error=detail or execution_error_message,
-                completion_source="stream_terminal_event",
-            )
+    def _terminal_evidence(
+        self,
+        *,
+        explicit_interrupt: bool = False,
+        explicit_timeout: bool = False,
+        transport_exception: Optional[str] = None,
+        execution_error_message: str = "",
+    ) -> TerminalEvidence:
+        return TerminalEvidence(
+            transport_status=self.transport_status or "",
+            transport_errors=tuple(self.transport_errors),
+            transport_returned=self.transport_request_return_timestamp is not None,
+            assistant_text=self.last_assistant_text,
+            failure_cause=self.failure_cause,
+            terminal_signals=tuple(self.terminal_signals),
+            explicit_interrupt=explicit_interrupt,
+            explicit_timeout=explicit_timeout,
+            transport_exception=transport_exception,
+            execution_error_message=execution_error_message,
+        )
 
-        if self.transport_errors:
-            if interrupted_transport:
-                return self._build_outcome(
-                    status="interrupted",
-                    assistant_text="",
-                    error=detail or _DEFAULT_INTERRUPTED_ERROR,
-                    completion_source="prompt_return",
-                )
-            if successful_terminal and assistant_text.strip():
-                return self._build_outcome(
-                    status="ok",
-                    assistant_text=assistant_text,
-                    error=None if successful_transport else detail or None,
-                    completion_source=(
-                        "reconciled_failure"
-                        if not successful_transport
-                        else "prompt_return"
-                    ),
-                )
-            if failed_transport:
-                return self._build_outcome(
-                    status="error",
-                    assistant_text="",
-                    error=detail or execution_error_message,
-                    completion_source="prompt_return",
-                )
-            if assistant_text.strip():
-                return self._build_outcome(
-                    status="ok",
-                    assistant_text=assistant_text,
-                    error=detail or None,
-                    completion_source="prompt_return",
-                )
-            return self._build_outcome(
-                status="error",
-                assistant_text="",
-                error=detail or execution_error_message,
-                completion_source="prompt_return",
-            )
-
-        if interrupted_transport:
-            return self._build_outcome(
-                status="interrupted",
-                assistant_text="",
-                error=self.failure_cause,
-                completion_source="interrupt",
-            )
-        if failed_transport:
-            return self._build_outcome(
-                status="error",
-                assistant_text="",
-                error=detail or execution_error_message,
-                completion_source="prompt_return",
-            )
+    def _build_outcome_from_evidence(
+        self, evidence: TerminalEvidence
+    ) -> RuntimeThreadOutcome:
+        decision = reduce_terminal_evidence(evidence)
         return self._build_outcome(
-            status="ok",
-            assistant_text=assistant_text,
-            error=None,
-            completion_source="prompt_return",
+            status=decision.status,
+            assistant_text=decision.assistant_text,
+            error=decision.error,
+            completion_source=decision.completion_source,
+            terminal_evidence=decision.evidence_fields(evidence),
         )
 
     def _saw_successful_terminal_signal(self) -> bool:
-        return any(signal.status == "ok" for signal in self.terminal_signals)
+        return _saw_successful_terminal_signal(tuple(self.terminal_signals))
 
     def _latest_terminal_signal(self) -> Optional[RuntimeThreadTerminalSignal]:
-        if not self.terminal_signals:
-            return None
-        return self.terminal_signals[-1]
+        return _latest_terminal_signal(tuple(self.terminal_signals))
 
     def _note_terminal_signal(self, signal: RuntimeThreadTerminalSignal) -> None:
         key = (signal.source, signal.status)
@@ -374,6 +540,7 @@ class RuntimeTurnTerminalStateMachine:
         assistant_text: str,
         error: Optional[str],
         completion_source: RuntimeThreadCompletionSource,
+        terminal_evidence: Optional[dict[str, Any]] = None,
     ) -> RuntimeThreadOutcome:
         return RuntimeThreadOutcome(
             status=status,
@@ -387,6 +554,7 @@ class RuntimeTurnTerminalStateMachine:
             transport_request_return_timestamp=self.transport_request_return_timestamp,
             last_progress_timestamp=self.last_progress_timestamp,
             failure_cause=self.failure_cause,
+            terminal_evidence=dict(terminal_evidence or {}),
         )
 
     def build_checkpoint(
@@ -456,4 +624,7 @@ __all__ = [
     "RuntimeThreadOutcomeStatus",
     "RuntimeThreadTerminalSignal",
     "RuntimeTurnTerminalStateMachine",
+    "TerminalEvidence",
+    "TerminalEvidenceDecision",
+    "reduce_terminal_evidence",
 ]

--- a/src/codex_autorunner/core/orchestration/stream_text_merge.py
+++ b/src/codex_autorunner/core/orchestration/stream_text_merge.py
@@ -50,3 +50,17 @@ class AssistantTextAccumulator:
         if self.final_text.strip():
             return self.final_text
         return self.stream_text
+
+
+@dataclass
+class AssistantOutputState(AssistantTextAccumulator):
+    """Reduced assistant output state, distinct from append-only timelines."""
+
+    def note_stream_delta(self, text: str) -> str:
+        return self.append_delta(text)
+
+    def note_stream_snapshot(self, text: str) -> str:
+        return self.merge_snapshot(text)
+
+    def note_final_message(self, text: str) -> str:
+        return self.replace_final(text)

--- a/src/codex_autorunner/core/orchestration/stream_text_merge.py
+++ b/src/codex_autorunner/core/orchestration/stream_text_merge.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 
 def merge_assistant_stream_text(current: str, incoming: str) -> str:
     """Merge overlapping streamed assistant chunks without duplicating prefixes."""
@@ -16,3 +18,35 @@ def merge_assistant_stream_text(current: str, incoming: str) -> str:
         if current[-overlap:] == incoming[:overlap]:
             return f"{current}{incoming[overlap:]}"
     return f"{current}{incoming}"
+
+
+@dataclass
+class AssistantTextAccumulator:
+    """Shared assistant text reducer for stream and terminal message text."""
+
+    stream_text: str = ""
+    final_text: str = ""
+
+    def append_delta(self, text: str) -> str:
+        """Record a strict append-only stream delta."""
+        if isinstance(text, str) and text:
+            self.stream_text = f"{self.stream_text}{text}"
+        return self.text
+
+    def merge_snapshot(self, text: str) -> str:
+        """Record a stream chunk that may be cumulative or overlap prior chunks."""
+        if isinstance(text, str) and text:
+            self.stream_text = merge_assistant_stream_text(self.stream_text, text)
+        return self.text
+
+    def replace_final(self, text: str) -> str:
+        """Record the canonical terminal assistant message."""
+        if isinstance(text, str):
+            self.final_text = text
+        return self.text
+
+    @property
+    def text(self) -> str:
+        if self.final_text.strip():
+            return self.final_text
+        return self.stream_text

--- a/src/codex_autorunner/integrations/app_server/transport.py
+++ b/src/codex_autorunner/integrations/app_server/transport.py
@@ -79,7 +79,7 @@ class AppServerReadBuffer:
                 truncated=True,
             )
             return
-        await self._on_payload_line(self._buffer)
+        await self._on_payload_line(bytes(self._buffer))
 
     async def _collect_chunk(self, chunk: bytes, *, initializing: bool) -> None:
         self._buffer.extend(chunk)
@@ -145,7 +145,7 @@ class AppServerReadBuffer:
             newline_index = self._buffer.find(b"\n")
             if newline_index == -1:
                 return
-            line = self._buffer[:newline_index]
+            line = bytes(self._buffer[:newline_index])
             del self._buffer[: newline_index + 1]
             await self._on_payload_line(line)
 

--- a/src/codex_autorunner/integrations/chat/managed_thread_delivery_support.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_delivery_support.py
@@ -14,9 +14,12 @@ from ...core.orchestration import (
 @dataclass(frozen=True)
 class ManagedThreadDeliveryCleanupContext:
     delivery_id: str
+    idempotency_key: str
     managed_thread_id: str
     managed_turn_id: str
     final_status: str
+    assistant_text: str
+    error_text: Optional[str] = None
     transport_target: Mapping[str, Any] = field(default_factory=dict)
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
@@ -24,10 +27,18 @@ class ManagedThreadDeliveryCleanupContext:
     def from_record(cls, record: Any) -> "ManagedThreadDeliveryCleanupContext":
         return cls(
             delivery_id=str(getattr(record, "delivery_id", "") or ""),
+            idempotency_key=str(getattr(record, "idempotency_key", "") or ""),
             managed_thread_id=str(getattr(record, "managed_thread_id", "") or ""),
             managed_turn_id=str(getattr(record, "managed_turn_id", "") or ""),
-            final_status=str(
-                getattr(getattr(record, "envelope", None), "final_status", "") or ""
+            final_status=_normalize_terminal_status(
+                getattr(getattr(record, "envelope", None), "final_status", "")
+            ),
+            assistant_text=str(
+                getattr(getattr(record, "envelope", None), "assistant_text", "") or ""
+            ),
+            error_text=(
+                str(getattr(getattr(record, "envelope", None), "error_text", "") or "")
+                or None
             ),
             transport_target=dict(
                 getattr(getattr(record, "target", None), "transport_target", {}) or {}
@@ -52,6 +63,24 @@ ManagedThreadDeliveryCleanupFn = Callable[
 ]
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def managed_thread_terminal_delivery_send_key(
+    record: Any,
+    *,
+    suffix: Optional[str] = None,
+) -> str:
+    """Return the shared transport idempotency key for one terminal send."""
+
+    base = str(getattr(record, "idempotency_key", "") or "").strip()
+    if not base:
+        base = str(getattr(record, "delivery_id", "") or "").strip()
+    if not base:
+        managed_thread_id = str(getattr(record, "managed_thread_id", "") or "").strip()
+        managed_turn_id = str(getattr(record, "managed_turn_id", "") or "").strip()
+        base = f"managed-delivery:{managed_thread_id}:{managed_turn_id}"
+    normalized_suffix = str(suffix or "").strip()
+    return f"{base}:{normalized_suffix}" if normalized_suffix else base
 
 
 async def deliver_managed_thread_terminal_record(
@@ -110,10 +139,20 @@ async def deliver_managed_thread_terminal_record(
     )
 
 
+def _normalize_terminal_status(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized == "ok":
+        return "ok"
+    if normalized == "interrupted":
+        return "interrupted"
+    return "error"
+
+
 __all__ = [
     "ManagedThreadDeliveryCleanupContext",
     "ManagedThreadDeliveryCleanupFn",
     "ManagedThreadDeliverySendFn",
     "ManagedThreadDeliverySendResult",
     "deliver_managed_thread_terminal_record",
+    "managed_thread_terminal_delivery_send_key",
 ]

--- a/src/codex_autorunner/integrations/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/integrations/chat/managed_thread_turns.py
@@ -75,6 +75,7 @@ from ...core.orchestration.runtime_thread_events import (
     raw_event_method,
     recover_post_completion_outcome,
     runtime_trace_fields,
+    terminal_evidence_trace_fields,
     terminal_run_event_from_outcome,
 )
 from ...core.orchestration.runtime_threads import (
@@ -2674,6 +2675,7 @@ async def finalize_managed_thread_execution(
             ),
             original_error=outcome.error,
             **runtime_trace_fields(event_state),
+            **terminal_evidence_trace_fields(outcome),
         )
         timeline_events.append(
             make_chat_execution_journal_notice(
@@ -2982,6 +2984,7 @@ async def finalize_managed_thread_execution(
             fresh_backend_session_started=fresh_backend_session_started,
             fresh_backend_session_reason=fresh_backend_session_reason,
             **runtime_trace_fields(event_state),
+            **terminal_evidence_trace_fields(outcome),
         )
         # Hub control-plane: thread activity record (best-effort, ok outcomes only).
         await _best_effort_hub_call(
@@ -3068,6 +3071,7 @@ async def finalize_managed_thread_execution(
             fresh_backend_session_started=fresh_backend_session_started,
             fresh_backend_session_reason=fresh_backend_session_reason,
             **runtime_trace_fields(event_state),
+            **terminal_evidence_trace_fields(outcome),
         )
         return ManagedThreadFinalizationResult(
             status="interrupted",
@@ -3149,6 +3153,7 @@ async def finalize_managed_thread_execution(
         fresh_backend_session_started=fresh_backend_session_started,
         fresh_backend_session_reason=fresh_backend_session_reason,
         **runtime_trace_fields(event_state),
+        **terminal_evidence_trace_fields(outcome),
     )
     return ManagedThreadFinalizationResult(
         status="error",

--- a/src/codex_autorunner/integrations/discord/managed_thread_delivery.py
+++ b/src/codex_autorunner/integrations/discord/managed_thread_delivery.py
@@ -21,6 +21,7 @@ from ..chat.managed_thread_delivery_support import (
     ManagedThreadDeliveryCleanupContext,
     ManagedThreadDeliverySendResult,
     deliver_managed_thread_terminal_record,
+    managed_thread_terminal_delivery_send_key,
 )
 from .constants import DISCORD_MAX_MESSAGE_LENGTH
 from .progress_leases import cleanup_discord_terminal_progress_leases
@@ -64,14 +65,15 @@ async def deliver_discord_managed_thread_record(
         )
         if not chunks:
             chunks = [formatted]
-        base_record_id = (
-            f"{base_record_label}:{record.managed_thread_id}:{record.managed_turn_id}"
-        )
         for chunk_index, chunk in enumerate(chunks, start=1):
             record_id = (
-                f"{base_record_id}:chunk:{chunk_index}"
+                managed_thread_terminal_delivery_send_key(
+                    record, suffix=f"{base_record_label}:chunk:{chunk_index}"
+                )
                 if len(chunks) > 1
-                else base_record_id
+                else managed_thread_terminal_delivery_send_key(
+                    record, suffix=base_record_label
+                )
             )
             delivered = await service._send_channel_message_safe(
                 target_channel_id,
@@ -97,7 +99,9 @@ async def deliver_discord_managed_thread_record(
                 )
             },
             record_id=(
-                f"{error_record_label}:{record.managed_thread_id}:{record.managed_turn_id}"
+                managed_thread_terminal_delivery_send_key(
+                    record, suffix=error_record_label
+                )
             ),
         )
         if not delivered:
@@ -188,14 +192,15 @@ def build_discord_managed_thread_durable_delivery_hooks(
         )
         if not chunks:
             chunks = [formatted]
-        base_record_id = (
-            f"discord-queued:{record.managed_thread_id}:{record.managed_turn_id}"
-        )
         for chunk_index, chunk in enumerate(chunks, start=1):
             record_id = (
-                f"{base_record_id}:chunk:{chunk_index}"
+                managed_thread_terminal_delivery_send_key(
+                    record, suffix=f"discord-queued:chunk:{chunk_index}"
+                )
                 if len(chunks) > 1
-                else base_record_id
+                else managed_thread_terminal_delivery_send_key(
+                    record, suffix="discord-queued"
+                )
             )
             delivered = await service._send_channel_message_safe(
                 target_channel_id,
@@ -223,7 +228,9 @@ def build_discord_managed_thread_durable_delivery_hooks(
                 )
             },
             record_id=(
-                f"discord-queued-error:{record.managed_thread_id}:{record.managed_turn_id}"
+                managed_thread_terminal_delivery_send_key(
+                    record, suffix="discord-queued-error"
+                )
             ),
         )
         if not delivered:

--- a/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/integrations/telegram/handlers/commands/execution.py
@@ -93,6 +93,7 @@ from .....integrations.chat.execution_event_journal import (
 from .....integrations.chat.managed_thread_delivery_support import (
     ManagedThreadDeliveryCleanupContext,
     ManagedThreadDeliverySendResult,
+    managed_thread_terminal_delivery_send_key,
 )
 from .....integrations.chat.managed_thread_direct_delivery import (
     record_managed_thread_direct_delivery,
@@ -845,12 +846,28 @@ def _build_telegram_success_delivery(
         transport_target = dict(record.target.transport_target or {})
         target_chat_id = int(transport_target.get("chat_id") or chat_id)
         target_thread_id = transport_target.get("thread_id", thread_id)
-        await handlers._send_message(
-            target_chat_id,
-            render_managed_thread_delivery_record_text(record),
-            thread_id=target_thread_id,
-            reply_to=None,
-        )
+        text = render_managed_thread_delivery_record_text(record)
+        send_with_outbox = getattr(handlers, "_send_message_with_outbox", None)
+        if callable(send_with_outbox):
+            delivered = await _send_telegram_terminal_message_with_outbox(
+                send_with_outbox,
+                target_chat_id,
+                text,
+                thread_id=target_thread_id,
+                record=record,
+                status="ok",
+            )
+            if not delivered:
+                return ManagedThreadDeliverySendResult(
+                    error="telegram_terminal_send_deferred"
+                )
+        else:
+            await handlers._send_message(
+                target_chat_id,
+                text,
+                thread_id=target_thread_id,
+                reply_to=None,
+            )
         return ManagedThreadDeliverySendResult()
 
     return _send_success
@@ -870,15 +887,70 @@ def _build_telegram_failure_delivery(
         transport_target = dict(record.target.transport_target or {})
         target_chat_id = int(transport_target.get("chat_id") or chat_id)
         target_thread_id = transport_target.get("thread_id", thread_id)
-        await handlers._send_message(
-            target_chat_id,
-            f"Turn failed: {record.envelope.error_text or public_execution_error}",
-            thread_id=target_thread_id,
-            reply_to=None,
-        )
+        text = f"Turn failed: {record.envelope.error_text or public_execution_error}"
+        send_with_outbox = getattr(handlers, "_send_message_with_outbox", None)
+        if callable(send_with_outbox):
+            delivered = await _send_telegram_terminal_message_with_outbox(
+                send_with_outbox,
+                target_chat_id,
+                text,
+                thread_id=target_thread_id,
+                record=record,
+                status="error",
+            )
+            if not delivered:
+                return ManagedThreadDeliverySendResult(
+                    error="telegram_terminal_error_send_deferred"
+                )
+        else:
+            await handlers._send_message(
+                target_chat_id,
+                text,
+                thread_id=target_thread_id,
+                reply_to=None,
+            )
         return ManagedThreadDeliverySendResult()
 
     return _send_failure
+
+
+async def _send_telegram_terminal_message_with_outbox(
+    send_with_outbox: Any,
+    chat_id: int,
+    text: str,
+    *,
+    thread_id: Optional[int],
+    record: Any,
+    status: str,
+) -> bool:
+    record_key = managed_thread_terminal_delivery_send_key(
+        record, suffix=f"telegram:{status}"
+    )
+    try:
+        return await send_with_outbox(
+            chat_id,
+            text,
+            thread_id=thread_id,
+            reply_to=None,
+            record_id=record_key,
+            outbox_key=record.idempotency_key,
+            delivery_metadata={
+                "managed_thread_delivery_id": record.delivery_id,
+                "managed_thread_delivery_idempotency_key": record.idempotency_key,
+                "managed_thread_id": record.managed_thread_id,
+                "managed_turn_id": record.managed_turn_id,
+                "terminal_status": status,
+            },
+        )
+    except TypeError as exc:
+        if "record_id" not in str(exc) and "outbox_key" not in str(exc):
+            raise
+        return await send_with_outbox(
+            chat_id,
+            text,
+            thread_id=thread_id,
+            reply_to=None,
+        )
 
 
 def _build_telegram_delivery_cleanup(handlers: Any, *, topic_key: str) -> Any:

--- a/src/codex_autorunner/integrations/telegram/service.py
+++ b/src/codex_autorunner/integrations/telegram/service.py
@@ -83,6 +83,7 @@ from ..chat.managed_thread_delivery_support import (
     ManagedThreadDeliveryCleanupContext,
     ManagedThreadDeliverySendResult,
     deliver_managed_thread_terminal_record,
+    managed_thread_terminal_delivery_send_key,
 )
 from ..chat.managed_thread_delivery_worker import (
     ManagedThreadDeliveryWorker,
@@ -560,25 +561,84 @@ class TelegramBotService(
                 async def _send_success(
                     _context: ManagedThreadDeliveryCleanupContext,
                 ) -> ManagedThreadDeliverySendResult:
-                    await service._send_message(
-                        target_chat_id,
-                        render_managed_thread_delivery_record_text(record),
-                        thread_id=target_thread_id,
-                        reply_to=None,
+                    text = render_managed_thread_delivery_record_text(record)
+                    send_with_outbox = getattr(
+                        service, "_send_message_with_outbox", None
                     )
+                    if callable(send_with_outbox):
+                        delivered = await send_with_outbox(
+                            target_chat_id,
+                            text,
+                            thread_id=target_thread_id,
+                            reply_to=None,
+                            record_id=managed_thread_terminal_delivery_send_key(
+                                record, suffix="telegram:ok"
+                            ),
+                            outbox_key=record.idempotency_key,
+                            delivery_metadata={
+                                "managed_thread_delivery_id": record.delivery_id,
+                                "managed_thread_delivery_idempotency_key": (
+                                    record.idempotency_key
+                                ),
+                                "managed_thread_id": record.managed_thread_id,
+                                "managed_turn_id": record.managed_turn_id,
+                                "terminal_status": "ok",
+                            },
+                        )
+                        if not delivered:
+                            return ManagedThreadDeliverySendResult(
+                                error="telegram_terminal_send_deferred"
+                            )
+                    else:
+                        await service._send_message(
+                            target_chat_id,
+                            text,
+                            thread_id=target_thread_id,
+                            reply_to=None,
+                        )
                     return ManagedThreadDeliverySendResult()
 
                 async def _send_failure(
                     _context: ManagedThreadDeliveryCleanupContext,
                 ) -> ManagedThreadDeliverySendResult:
-                    await service._send_message(
-                        target_chat_id,
-                        (
-                            f"Turn failed: {record.envelope.error_text or 'execution error'}"
-                        ),
-                        thread_id=target_thread_id,
-                        reply_to=None,
+                    text = (
+                        f"Turn failed: "
+                        f"{record.envelope.error_text or 'execution error'}"
                     )
+                    send_with_outbox = getattr(
+                        service, "_send_message_with_outbox", None
+                    )
+                    if callable(send_with_outbox):
+                        delivered = await send_with_outbox(
+                            target_chat_id,
+                            text,
+                            thread_id=target_thread_id,
+                            reply_to=None,
+                            record_id=managed_thread_terminal_delivery_send_key(
+                                record, suffix="telegram:error"
+                            ),
+                            outbox_key=record.idempotency_key,
+                            delivery_metadata={
+                                "managed_thread_delivery_id": record.delivery_id,
+                                "managed_thread_delivery_idempotency_key": (
+                                    record.idempotency_key
+                                ),
+                                "managed_thread_id": record.managed_thread_id,
+                                "managed_turn_id": record.managed_turn_id,
+                                "terminal_status": "error",
+                            },
+                        )
+                        if not delivered:
+                            return ManagedThreadDeliverySendResult(
+                                error="telegram_terminal_error_send_deferred"
+                            )
+                    else:
+                        await service._send_message(
+                            target_chat_id,
+                            text,
+                            thread_id=target_thread_id,
+                            reply_to=None,
+                        )
                     return ManagedThreadDeliverySendResult()
 
                 async def _cleanup(

--- a/src/codex_autorunner/integrations/telegram/transport.py
+++ b/src/codex_autorunner/integrations/telegram/transport.py
@@ -89,6 +89,9 @@ class TelegramMessageTransport:
         placeholder_id: Optional[int] = None,
         delete_placeholder_on_delivery: bool = True,
         overflow_mode_override: Optional[str] = None,
+        record_id: Optional[str] = None,
+        outbox_key: Optional[str] = None,
+        delivery_metadata: Optional[dict[str, Any]] = None,
     ) -> bool:
         operation: Optional[str] = None
         operation_id = self._current_chat_operation_id()
@@ -104,7 +107,11 @@ class TelegramMessageTransport:
                 delivery_state="pending",
             )
         record = OutboxRecord(
-            record_id=secrets.token_hex(8),
+            record_id=(
+                str(record_id).strip()
+                if isinstance(record_id, str) and record_id.strip()
+                else secrets.token_hex(8)
+            ),
             chat_id=chat_id,
             thread_id=thread_id,
             reply_to_message_id=reply_to,
@@ -113,7 +120,15 @@ class TelegramMessageTransport:
             created_at=now_iso(),
             operation=operation,
             operation_id=operation_id,
+            outbox_key=(
+                str(outbox_key).strip()
+                if isinstance(outbox_key, str) and outbox_key.strip()
+                else None
+            ),
             overflow_mode_override=overflow_mode_override,
+            delivery_metadata=(
+                dict(delivery_metadata) if isinstance(delivery_metadata, dict) else None
+            ),
         )
         return await self._outbox_manager.send_message_with_outbox(record)
 

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime_execution.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime_execution.py
@@ -415,6 +415,8 @@ async def execute_harness_turn(
     timeline_events, timeline_state = await timeline_from_raw_events(merged_raw_events)
 
     assistant_text = str(getattr(turn_result, "assistant_text", "") or "").strip()
+    if not assistant_text:
+        assistant_text = str(timeline_state.best_assistant_text() or "").strip()
 
     status = str(getattr(turn_result, "status", "") or "").strip().lower()
     errors = tuple(getattr(turn_result, "errors", ()) or ())

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime_execution.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime_execution.py
@@ -415,8 +415,6 @@ async def execute_harness_turn(
     timeline_events, timeline_state = await timeline_from_raw_events(merged_raw_events)
 
     assistant_text = str(getattr(turn_result, "assistant_text", "") or "").strip()
-    if not assistant_text:
-        assistant_text = timeline_state.best_assistant_text().strip()
 
     status = str(getattr(turn_result, "status", "") or "").strip().lower()
     errors = tuple(getattr(turn_result, "errors", ()) or ())

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 from tests.acp_lifecycle_corpus import load_acp_lifecycle_corpus
+from tests.runtime_lifecycle_sequences import load_runtime_lifecycle_sequences
 
 from codex_autorunner.agents.acp import (
     ACPClient,
@@ -111,6 +112,29 @@ async def test_client_maps_shared_lifecycle_fixtures_without_turn_id(
 
     expected_turn_id = "turn-2" if expected["uses_turn_id_fallback"] else None
     assert mapped.get("params", {}).get("turnId") == expected_turn_id
+
+
+@pytest.mark.asyncio
+async def test_client_turn_id_mapping_references_runtime_sequence_corpus() -> None:
+    client = ACPClient(fixture_command("official"))
+    client._ensure_prompt_state("session-1", "turn-current")
+    client._session_active_turns["session-1"] = "turn-current"
+
+    mapped_cases = [
+        case
+        for case in load_runtime_lifecycle_sequences()
+        if dict(case.get("expected") or {}).get("mapped_turn_id")
+    ]
+    assert mapped_cases
+
+    for case in mapped_cases:
+        expected_turn_id = str(dict(case["expected"])["mapped_turn_id"])
+        for action_obj in case["actions"]:
+            action = dict(action_obj)
+            if action.get("kind") != "raw_event":
+                continue
+            mapped = client._message_with_mapped_turn_id(dict(action["raw"]))
+            assert mapped.get("params", {}).get("turnId") == expected_turn_id
 
 
 @pytest.mark.asyncio

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -30,8 +30,6 @@ from codex_autorunner.agents.acp.protocol import (
 )
 from codex_autorunner.core.acp_lifecycle import (
     _IDLE_TERMINAL_METHODS,
-    _SESSION_TURN_ID_FALLBACK_METHODS,
-    _TERMINAL_METHODS,
 )
 from codex_autorunner.core.acp_lifecycle import (
     classify_prompt_response_status as _classify_prompt_response_status,
@@ -41,9 +39,6 @@ from codex_autorunner.core.acp_lifecycle import (
 )
 from codex_autorunner.core.acp_lifecycle import (
     prompt_terminal_method_for_status as _prompt_terminal_method_for_status,
-)
-from codex_autorunner.core.acp_lifecycle import (
-    should_map_missing_turn_id as _shared_should_map_missing_turn_id,
 )
 
 FIXTURE_PATH = Path(__file__).resolve().parents[2] / "fixtures" / "fake_acp_server.py"
@@ -1003,34 +998,6 @@ def test_extract_session_capabilities_from_various_payloads() -> None:
 
 
 class TestClientLifecycleDelegation:
-    def test_client_imports_shared_turn_id_fallback(self) -> None:
-        from codex_autorunner.agents.acp.client import (
-            _should_map_missing_turn_id,
-        )
-
-        for method in _SESSION_TURN_ID_FALLBACK_METHODS:
-            assert _should_map_missing_turn_id(method, {})
-
-    def test_client_fallback_matches_shared_lifecycle(self) -> None:
-        from codex_autorunner.agents.acp.client import (
-            _should_map_missing_turn_id,
-        )
-
-        for method in _TERMINAL_METHODS:
-            assert _should_map_missing_turn_id(
-                method, {}
-            ) == _shared_should_map_missing_turn_id(method, {})
-
-        for method in (
-            "prompt/started",
-            "turn/started",
-            "permission/requested",
-            "token/usage",
-        ):
-            assert _should_map_missing_turn_id(
-                method, {}
-            ) == _shared_should_map_missing_turn_id(method, {})
-
     def test_client_idle_terminal_not_mapped_without_active_turn(self) -> None:
         client = ACPClient(fixture_command("official"))
         for method in _IDLE_TERMINAL_METHODS:

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -276,6 +276,31 @@ async def test_client_official_prompt_hang_tracks_last_session_update_state(
 
 
 @pytest.mark.asyncio
+async def test_client_merges_cumulative_stream_chunks_without_duplication(
+    tmp_path: Path,
+) -> None:
+    client = ACPClient(
+        fixture_command("official_cumulative_stream_chunks"),
+        cwd=tmp_path,
+    )
+    try:
+        created = await client.create_session(cwd=str(tmp_path))
+        handle = await client.start_prompt(created.session_id, "Reply with exactly OK.")
+
+        result = await asyncio.wait_for(handle.wait(), timeout=0.4)
+
+        assert result.status == "completed"
+        assert result.final_output == "fixture reply"
+        assert [
+            getattr(event, "delta", None)
+            for event in handle.snapshot_events()
+            if event.kind == "output_delta"
+        ] == ["fixture", "fixture reply"]
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
 async def test_client_can_recover_official_prompt_hang_with_synthetic_completion(
     tmp_path: Path,
 ) -> None:

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -16,6 +16,7 @@ from codex_autorunner.agents.acp import (
     ACPMissingSessionError,
     ACPPermissionRequestEvent,
 )
+from codex_autorunner.agents.acp.client import _PromptState
 from codex_autorunner.agents.acp.errors import (
     ACPProcessCrashedError,
     ACPProtocolError,
@@ -47,6 +48,26 @@ pytestmark = pytest.mark.slow
 
 def fixture_command(scenario: str) -> list[str]:
     return [sys.executable, "-u", str(FIXTURE_PATH), "--scenario", scenario]
+
+
+def test_prompt_state_strict_deltas_append_without_overlap_merge() -> None:
+    state = _PromptState(session_id="session-1", turn_id="turn-1")
+
+    state.note_output_delta("Hel")
+    state.note_output_delta("lo")
+    state.note_output_delta("ha")
+    state.note_output_delta("ha")
+
+    assert state.final_output == "Hellohaha"
+
+
+def test_prompt_state_session_update_snapshots_merge_without_duplication() -> None:
+    state = _PromptState(session_id="session-1", turn_id="turn-1")
+
+    state.note_output_delta("fixture", merge_snapshot=True)
+    state.note_output_delta("fixture reply", merge_snapshot=True)
+
+    assert state.final_output == "fixture reply"
 
 
 @pytest.mark.parametrize(("method"), ("session/update", "session/request_permission"))

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -54,10 +54,12 @@ def fixture_command(scenario: str) -> list[str]:
 
 
 @pytest.mark.parametrize(("method"), ("session/update", "session/request_permission"))
-def test_client_maps_session_scoped_official_events_without_turn_id(
+@pytest.mark.asyncio
+async def test_client_maps_session_scoped_official_events_without_turn_id(
     method: str,
 ) -> None:
     client = ACPClient(fixture_command("official"))
+    client._ensure_prompt_state("session-1", "turn-2")
     client._session_active_turns["session-1"] = "turn-2"
 
     message = client._message_with_mapped_turn_id(
@@ -73,15 +75,34 @@ def test_client_maps_session_scoped_official_events_without_turn_id(
     assert message["params"]["turnId"] == "turn-2"
 
 
+@pytest.mark.asyncio
+async def test_client_does_not_map_missing_turn_id_to_closed_active_turn() -> None:
+    client = ACPClient(fixture_command("official"))
+    state = client._ensure_prompt_state("session-1", "turn-closed")
+    state.closed = True
+    client._session_active_turns["session-1"] = "turn-closed"
+
+    message = client._message_with_mapped_turn_id(
+        {
+            "method": "session.status",
+            "params": {"sessionId": "session-1", "status": {"type": "idle"}},
+        }
+    )
+
+    assert message.get("params", {}).get("turnId") is None
+
+
 @pytest.mark.parametrize(
     ("case"),
     load_acp_lifecycle_corpus(),
     ids=[case["name"] for case in load_acp_lifecycle_corpus()],
 )
-def test_client_maps_shared_lifecycle_fixtures_without_turn_id(
+@pytest.mark.asyncio
+async def test_client_maps_shared_lifecycle_fixtures_without_turn_id(
     case: dict[str, object],
 ) -> None:
     client = ACPClient(fixture_command("official"))
+    client._ensure_prompt_state("session-1", "turn-2")
     client._session_active_turns["session-1"] = "turn-2"
     message = dict(case["raw"])  # type: ignore[index]
     expected = dict(case["expected"])  # type: ignore[index]
@@ -120,6 +141,34 @@ async def test_client_infers_server_turn_alias_from_inflight_prompt_event() -> N
         request_task.cancel()
         with suppress(asyncio.CancelledError):
             await request_task
+
+
+@pytest.mark.asyncio
+async def test_client_rejects_server_turn_alias_for_closed_prompt() -> None:
+    client = ACPClient(fixture_command("official"))
+    state = client._ensure_prompt_state("session-1", "turn-1")
+    state.closed = True
+
+    await client._register_prompt_turn_alias(state, "server-turn-1")
+
+    assert "server-turn-1" not in client._prompts
+
+
+@pytest.mark.asyncio
+async def test_client_late_request_failure_cannot_clear_newer_active_turn() -> None:
+    client = ACPClient(fixture_command("official"))
+    old_state = client._ensure_prompt_state("session-1", "turn-old")
+    client._ensure_prompt_state("session-1", "turn-new")
+    client._session_active_turns["session-1"] = "turn-new"
+
+    async def fail_request(_method: str, _params: dict[str, object]) -> object:
+        raise ACPProtocolError("late failure")
+
+    client.request = fail_request  # type: ignore[method-assign]
+
+    await client._run_official_prompt_request(old_state, prompt="old")
+
+    assert client._session_active_turns["session-1"] == "turn-new"
 
 
 @pytest.mark.asyncio
@@ -436,6 +485,34 @@ async def test_client_official_session_status_idle_can_complete_before_request_r
             "session/update",
             "session/update",
             "session.status",
+        ]
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_client_idle_without_output_does_not_replay_previous_turn_text(
+    tmp_path: Path,
+) -> None:
+    client = ACPClient(
+        fixture_command("official_second_prompt_idle_without_output"),
+        cwd=tmp_path,
+    )
+    try:
+        created = await client.create_session(cwd=str(tmp_path))
+        first = await client.start_prompt(created.session_id, "first")
+        first_result = await asyncio.wait_for(first.wait(), timeout=1.0)
+
+        second = await client.start_prompt(created.session_id, "second")
+        second_result = await asyncio.wait_for(second.wait(), timeout=1.0)
+
+        assert first_result.final_output == "fixture reply"
+        assert second_result.status == "completed"
+        assert second_result.final_output == ""
+        assert [event.kind for event in second.snapshot_events()] == [
+            "turn_started",
+            "progress",
+            "turn_terminal",
         ]
     finally:
         await client.close()
@@ -943,11 +1020,13 @@ class TestClientLifecycleDelegation:
         load_acp_lifecycle_corpus(),
         ids=[case["name"] for case in load_acp_lifecycle_corpus()],
     )
-    def test_client_turn_id_mapping_consistent_with_shared_lifecycle(
+    @pytest.mark.asyncio
+    async def test_client_turn_id_mapping_consistent_with_shared_lifecycle(
         self,
         case: dict[str, object],
     ) -> None:
         client = ACPClient(fixture_command("official"))
+        client._ensure_prompt_state("session-1", "turn-active")
         client._session_active_turns["session-1"] = "turn-active"
         raw = dict(case["raw"])
         expected = dict(case["expected"])

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
-from tests.acp_lifecycle_corpus import load_acp_lifecycle_corpus
+import copy
 
+import pytest
+from tests.acp_lifecycle_corpus import load_acp_lifecycle_corpus
+from tests.runtime_lifecycle_sequences import (
+    load_runtime_lifecycle_sequences,
+    runtime_lifecycle_sequence_ids,
+)
+
+from codex_autorunner.agents.types import TerminalTurnResult
 from codex_autorunner.core.orchestration.runtime_thread_events import (
     DECODE_FAILURE_REASON_EMPTY_METHOD,
     DECODE_FAILURE_REASON_REGISTRY_MISS,
@@ -22,6 +30,12 @@ from codex_autorunner.core.orchestration.runtime_thread_events import (
     terminal_run_event_from_outcome,
 )
 from codex_autorunner.core.orchestration.runtime_threads import RuntimeThreadOutcome
+from codex_autorunner.core.orchestration.runtime_turn_terminal_state import (
+    RuntimeThreadOutcome as TerminalStateOutcome,
+)
+from codex_autorunner.core.orchestration.runtime_turn_terminal_state import (
+    RuntimeTurnTerminalStateMachine,
+)
 from codex_autorunner.core.ports.run_event import (
     RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
     ApprovalRequested,
@@ -34,6 +48,16 @@ from codex_autorunner.core.ports.run_event import (
     ToolResult,
 )
 from codex_autorunner.core.sse import format_sse
+
+
+def _terminal_source(outcome: TerminalStateOutcome) -> str:
+    if outcome.terminal_signals:
+        return outcome.terminal_signals[-1].source
+    return outcome.completion_source
+
+
+def _delivery_allowed(outcome: TerminalStateOutcome) -> bool:
+    return outcome.status == "ok" and bool(outcome.assistant_text.strip())
 
 
 async def test_runtime_event_driver_keeps_timeline_chunks_and_reduced_output_separate() -> (
@@ -60,6 +84,87 @@ async def test_runtime_event_driver_keeps_timeline_chunks_and_reduced_output_sep
     assert driver.assistant_parts == ["Hel", "Hello"]
     assert "".join(driver.assistant_parts) == "HelHello"
     assert driver.best_assistant_text() == "Hello"
+
+
+@pytest.mark.parametrize(
+    ("case"),
+    load_runtime_lifecycle_sequences(),
+    ids=runtime_lifecycle_sequence_ids(),
+)
+async def test_runtime_lifecycle_sequence_corpus_reduces_final_state_and_timeline(
+    case: dict[str, object],
+) -> None:
+    driver = RuntimeEventDriver()
+    terminal_state = RuntimeTurnTerminalStateMachine(
+        backend_thread_id="thread-1",
+        backend_turn_id="turn-current",
+    )
+    outcome: TerminalStateOutcome | None = None
+
+    for action_obj in case["actions"]:  # type: ignore[index]
+        action = dict(action_obj)  # type: ignore[arg-type]
+        kind = action["kind"]
+        if kind == "raw_event":
+            raw_event = copy.deepcopy(action["raw"])
+            await driver.consume_raw_event(raw_event)
+            terminal_state.note_raw_event(raw_event)
+            continue
+        if kind == "transport_return":
+            terminal_state.note_transport_result(
+                TerminalTurnResult(
+                    status=str(action.get("status") or ""),
+                    assistant_text=str(action.get("assistant_text") or ""),
+                    errors=[
+                        str(error)
+                        for error in (action.get("errors") or [])
+                        if str(error).strip()
+                    ],
+                    raw_events=[
+                        copy.deepcopy(raw)
+                        for raw in (action.get("raw_events") or [])
+                        if isinstance(raw, dict)
+                    ],
+                )
+            )
+            continue
+        if kind == "timeout":
+            outcome = terminal_state.build_timeout_outcome(
+                str(action.get("error") or "Runtime thread timed out")
+            )
+            continue
+        if kind == "transport_exception":
+            outcome = terminal_state.build_transport_exception_outcome(
+                str(action.get("error") or "Runtime transport failed")
+            )
+            continue
+        raise AssertionError(f"Unknown lifecycle sequence action: {kind}")
+
+    if outcome is None:
+        outcome = terminal_state.build_outcome("Runtime thread failed")
+
+    expected = dict(case["expected"])  # type: ignore[index]
+    commentary = [
+        event.message
+        for event in driver.run_events
+        if isinstance(event, RunNotice) and event.kind == "commentary"
+    ]
+
+    assert outcome.status == expected["status"]
+    assert outcome.assistant_text == expected["assistant_text"]
+    assert _terminal_source(outcome) == expected["terminal_source"]
+    assert outcome.completion_source == expected["completion_source"]
+    assert terminal_state.token_usage == expected["token_usage"]
+    assert driver.token_usage == expected["token_usage"]
+    assert _delivery_allowed(outcome) is expected["delivery_allowed"]
+    assert driver.best_assistant_text() == expected["assistant_text"] or (
+        expected["status"] == "error"
+        and driver.best_assistant_text() in {"", "partial output"}
+    )
+    assert driver.assistant_parts == expected["assistant_timeline"]
+    assert [type(event).__name__ for event in driver.run_events] == expected[
+        "run_event_types"
+    ]
+    assert commentary == expected["commentary"]
 
 
 async def test_normalize_runtime_thread_raw_event_shared_lifecycle_corpus() -> None:

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -6,6 +6,7 @@ from codex_autorunner.core.orchestration.runtime_thread_events import (
     DECODE_FAILURE_REASON_EMPTY_METHOD,
     DECODE_FAILURE_REASON_REGISTRY_MISS,
     DECODE_FAILURE_REASON_UNSUPPORTED_SHAPE,
+    RuntimeEventDriver,
     RuntimeThreadRunEventState,
     completion_source_from_outcome,
     decode_runtime_raw_messages,
@@ -22,6 +23,7 @@ from codex_autorunner.core.orchestration.runtime_thread_events import (
 )
 from codex_autorunner.core.orchestration.runtime_threads import RuntimeThreadOutcome
 from codex_autorunner.core.ports.run_event import (
+    RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
     ApprovalRequested,
     Completed,
     Failed,
@@ -32,6 +34,32 @@ from codex_autorunner.core.ports.run_event import (
     ToolResult,
 )
 from codex_autorunner.core.sse import format_sse
+
+
+async def test_runtime_event_driver_keeps_timeline_chunks_and_reduced_output_separate() -> (
+    None
+):
+    driver = RuntimeEventDriver()
+
+    first_chunk = OutputDelta(
+        timestamp="2026-05-07T00:00:00Z",
+        content="Hel",
+        delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
+    )
+    cumulative_chunk = OutputDelta(
+        timestamp="2026-05-07T00:00:01Z",
+        content="Hello",
+        delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
+    )
+
+    await driver.consume_raw_event(first_chunk)
+    await driver.consume_raw_event(cumulative_chunk)
+
+    assert driver.raw_events == [first_chunk, cumulative_chunk]
+    assert driver.run_events == [first_chunk, cumulative_chunk]
+    assert driver.assistant_parts == ["Hel", "Hello"]
+    assert "".join(driver.assistant_parts) == "HelHello"
+    assert driver.best_assistant_text() == "Hello"
 
 
 async def test_normalize_runtime_thread_raw_event_shared_lifecycle_corpus() -> None:

--- a/tests/core/orchestration/test_runtime_turn_terminal_state.py
+++ b/tests/core/orchestration/test_runtime_turn_terminal_state.py
@@ -4,6 +4,14 @@ from types import SimpleNamespace
 
 from tests.acp_lifecycle_corpus import load_acp_lifecycle_corpus
 
+from codex_autorunner.core.orchestration.runtime_state_events import (
+    AssistantDelta,
+    AssistantMessage,
+    FailureSignal,
+    TerminalSignal,
+    TokenUsage,
+    normalize_runtime_state_events,
+)
 from codex_autorunner.core.orchestration.runtime_turn_terminal_state import (
     RuntimeTurnTerminalStateMachine,
 )
@@ -171,3 +179,50 @@ def test_runtime_turn_terminal_state_machine_ignores_prompt_output_commentary_fo
     )
 
     assert state.last_assistant_text == ""
+
+
+def test_runtime_turn_terminal_state_machine_reduces_semantic_events() -> None:
+    state = RuntimeTurnTerminalStateMachine(
+        backend_thread_id="thread-1",
+        backend_turn_id="turn-1",
+    )
+
+    state.note_state_event(AssistantDelta(text="hel", source="semantic"))
+    state.note_state_event(AssistantDelta(text="hello", source="semantic"))
+    state.note_state_event(
+        AssistantMessage(text="hello final", source="semantic", message_id="msg-1")
+    )
+    state.note_state_event(
+        TokenUsage(usage={"input": 3, "output": 5}, source="semantic")
+    )
+    state.note_state_event(FailureSignal(error="late warning", source="semantic"))
+    state.note_state_event(
+        TerminalSignal(status="ok", source="semantic", final_text="hello final")
+    )
+
+    assert state.last_assistant_text == "hello final"
+    assert state.token_usage == {"input": 3, "output": 5}
+    assert state.failure_cause == "late warning"
+    assert len(state.terminal_signals) == 1
+    assert state.terminal_signals[0].source == "semantic"
+    assert state.terminal_signals[0].status == "ok"
+
+
+def test_unknown_raw_event_remains_observable_without_terminal_mutation() -> None:
+    state = RuntimeTurnTerminalStateMachine(
+        backend_thread_id="thread-1",
+        backend_turn_id="turn-1",
+    )
+    raw = {"method": "vendor/unknown", "params": {"text": "ignore me"}}
+
+    assert normalize_runtime_state_events(raw) == []
+
+    state.note_raw_event(raw, timestamp="2026-01-01T00:00:00Z")
+
+    assert state.raw_events == [raw]
+    assert state.last_progress_timestamp == "2026-01-01T00:00:00Z"
+    assert state.last_runtime_method is None
+    assert state.last_assistant_text == ""
+    assert state.failure_cause is None
+    assert state.token_usage is None
+    assert state.terminal_signals == []

--- a/tests/core/orchestration/test_runtime_turn_terminal_state.py
+++ b/tests/core/orchestration/test_runtime_turn_terminal_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Literal, Optional, cast
 
 from tests.acp_lifecycle_corpus import load_acp_lifecycle_corpus
 
@@ -13,8 +14,132 @@ from codex_autorunner.core.orchestration.runtime_state_events import (
     normalize_runtime_state_events,
 )
 from codex_autorunner.core.orchestration.runtime_turn_terminal_state import (
+    RuntimeThreadTerminalSignal,
     RuntimeTurnTerminalStateMachine,
+    TerminalEvidence,
+    reduce_terminal_evidence,
 )
+
+
+def _terminal_signal(
+    status: str,
+    *,
+    source: str = "turn/completed",
+) -> RuntimeThreadTerminalSignal:
+    return RuntimeThreadTerminalSignal(
+        source=source,
+        status=cast(Literal["ok", "error", "interrupted"], status),
+        timestamp="2026-01-01T00:00:00Z",
+    )
+
+
+def _evidence(**overrides: object) -> TerminalEvidence:
+    values: dict[str, object] = {
+        "transport_status": "",
+        "transport_errors": (),
+        "transport_returned": False,
+        "assistant_text": "",
+        "failure_cause": None,
+        "terminal_signals": (),
+        "execution_error_message": "Managed thread execution failed",
+    }
+    values.update(overrides)
+    return TerminalEvidence(
+        transport_status=cast(str, values["transport_status"]),
+        transport_errors=cast(tuple[str, ...], values["transport_errors"]),
+        transport_returned=cast(bool, values["transport_returned"]),
+        assistant_text=cast(str, values["assistant_text"]),
+        failure_cause=cast(Optional[str], values["failure_cause"]),
+        terminal_signals=cast(
+            tuple[RuntimeThreadTerminalSignal, ...], values["terminal_signals"]
+        ),
+        explicit_interrupt=cast(bool, values.get("explicit_interrupt", False)),
+        explicit_timeout=cast(bool, values.get("explicit_timeout", False)),
+        transport_exception=cast(Optional[str], values.get("transport_exception")),
+        execution_error_message=cast(str, values["execution_error_message"]),
+    )
+
+
+def test_terminal_evidence_precedence_combinations() -> None:
+    cases = [
+        (
+            "timeout drops partial text",
+            _evidence(
+                explicit_timeout=True,
+                assistant_text="partial",
+                failure_cause="Runtime thread timed out",
+            ),
+            ("error", "", "Runtime thread timed out", "timeout"),
+        ),
+        (
+            "interrupt beats streamed success",
+            _evidence(
+                explicit_interrupt=True,
+                assistant_text="done",
+                terminal_signals=(_terminal_signal("ok"),),
+                failure_cause="Runtime thread interrupted",
+            ),
+            ("interrupted", "", "Runtime thread interrupted", "interrupt"),
+        ),
+        (
+            "durable transport success beats later interrupt request",
+            _evidence(
+                explicit_interrupt=True,
+                transport_returned=True,
+                transport_status="ok",
+                assistant_text="done",
+            ),
+            ("ok", "done", None, "prompt_return"),
+        ),
+        (
+            "failed transport without terminal success is error",
+            _evidence(
+                transport_returned=True,
+                transport_status="failed",
+                transport_errors=("permission denied",),
+                assistant_text="partial",
+            ),
+            ("error", "", "permission denied", "prompt_return"),
+        ),
+        (
+            "terminal success and text recover failed transport",
+            _evidence(
+                transport_returned=True,
+                transport_status="failed",
+                transport_errors=("connection reset",),
+                assistant_text="final answer",
+                terminal_signals=(_terminal_signal("ok"),),
+            ),
+            ("ok", "final answer", "connection reset", "reconciled_failure"),
+        ),
+        (
+            "transport exception recovers from terminal success and text",
+            _evidence(
+                transport_exception="socket closed",
+                assistant_text="final answer",
+                terminal_signals=(_terminal_signal("ok"),),
+            ),
+            ("ok", "final answer", None, "reconciled_failure"),
+        ),
+        (
+            "idle status alone cannot synthesize assistant text",
+            _evidence(
+                terminal_signals=(_terminal_signal("ok", source="session.status"),),
+            ),
+            ("ok", "", None, "stream_terminal_event"),
+        ),
+    ]
+
+    for label, evidence, expected in cases:
+        decision = reduce_terminal_evidence(evidence)
+
+        assert (
+            decision.status,
+            decision.assistant_text,
+            decision.error,
+            decision.completion_source,
+        ) == expected, label
+        assert decision.evidence_fields(evidence)["terminal_evidence_reason"]
 
 
 def test_runtime_turn_terminal_state_machine_shared_lifecycle_corpus() -> None:

--- a/tests/core/orchestration/test_stream_text_merge.py
+++ b/tests/core/orchestration/test_stream_text_merge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from codex_autorunner.core.orchestration.stream_text_merge import (
+    AssistantTextAccumulator,
     merge_assistant_stream_text,
 )
 
@@ -23,3 +24,42 @@ def test_merge_assistant_stream_text_appends_only_non_overlapping_suffix() -> No
 
 def test_merge_assistant_stream_text_concatenates_when_no_overlap() -> None:
     assert merge_assistant_stream_text("alpha", "beta") == "alphabeta"
+
+
+def test_assistant_text_accumulator_records_strict_deltas() -> None:
+    accumulator = AssistantTextAccumulator()
+
+    accumulator.append_delta("hello")
+    accumulator.append_delta(" world")
+
+    assert accumulator.text == "hello world"
+
+
+def test_assistant_text_accumulator_records_cumulative_snapshots() -> None:
+    accumulator = AssistantTextAccumulator()
+
+    accumulator.merge_snapshot("hello")
+    accumulator.merge_snapshot("hello world")
+
+    assert accumulator.text == "hello world"
+
+
+def test_assistant_text_accumulator_replaces_stream_with_terminal_message() -> None:
+    accumulator = AssistantTextAccumulator()
+
+    accumulator.merge_snapshot("draft answer")
+    accumulator.replace_final("final canonical answer")
+
+    assert accumulator.text == "final canonical answer"
+    assert accumulator.stream_text == "draft answer"
+
+
+def test_assistant_text_accumulator_empty_and_duplicate_chunks_are_stable() -> None:
+    accumulator = AssistantTextAccumulator()
+
+    accumulator.merge_snapshot("")
+    accumulator.merge_snapshot("hello")
+    accumulator.merge_snapshot("hello")
+    accumulator.append_delta("")
+
+    assert accumulator.text == "hello"

--- a/tests/fixtures/fake_acp_server.py
+++ b/tests/fixtures/fake_acp_server.py
@@ -332,6 +332,8 @@ class FakeACPServer:
         if self._scenario == "official_second_prompt_hang_with_persisted_completion":
             # Match persisted session-store text so streaming chunks and recovery agree.
             reply_content = {"type": "text", "text": "identical fixture output"}
+        if self._scenario == "official_cumulative_stream_chunks":
+            reply_content = {"type": "text", "text": "fixture"}
         if self._scenario == "official_content_parts":
             thought_content = [
                 {"type": "text", "text": "thinking"},
@@ -450,6 +452,19 @@ class FakeACPServer:
                 },
             }
         )
+        if self._scenario == "official_cumulative_stream_chunks":
+            self.send(
+                {
+                    "method": "session/update",
+                    "params": {
+                        "sessionId": session_id,
+                        "update": {
+                            "sessionUpdate": "agent_message_chunk",
+                            "content": {"type": "text", "text": "fixture reply"},
+                        },
+                    },
+                }
+            )
         if self._scenario == "official_token_usage":
             self.send(
                 {

--- a/tests/fixtures/fake_acp_server.py
+++ b/tests/fixtures/fake_acp_server.py
@@ -436,6 +436,20 @@ class FakeACPServer:
                 {"stopReason": "cancelled", "userMessageId": turn_id},
             )
             return
+        if self._scenario == "official_second_prompt_idle_without_output":
+            prompt_count = self._official_prompt_counts.get(session_id, 0) + 1
+            self._official_prompt_counts[session_id] = prompt_count
+            if prompt_count >= 2:
+                self.send(
+                    {
+                        "method": "session.status",
+                        "params": {
+                            "sessionId": session_id,
+                            "status": {"type": "idle"},
+                        },
+                    }
+                )
+                return
         # Keep official fixture pacing short so queue-visible / interrupt lab
         # scenarios exercise orchestration behavior instead of burning most of
         # the latency budget inside fixture sleeps under xdist load.

--- a/tests/fixtures/runtime_lifecycle_sequences.json
+++ b/tests/fixtures/runtime_lifecycle_sequences.json
@@ -1,0 +1,627 @@
+[
+  {
+    "name": "strict_deltas",
+    "actions": [
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session/update",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": "Hel"
+            }
+          }
+        }
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session/update",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": "lo"
+            }
+          }
+        }
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "token/usage",
+          "params": {
+            "usage": {
+              "inputTokens": 12,
+              "outputTokens": 5,
+              "totalTokens": 17
+            }
+          }
+        }
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "prompt/completed",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "status": "completed",
+            "finalOutput": "Hello"
+          }
+        }
+      },
+      {
+        "kind": "transport_return",
+        "status": "ok",
+        "assistant_text": "Hello",
+        "errors": []
+      }
+    ],
+    "expected": {
+      "status": "ok",
+      "assistant_text": "Hello",
+      "terminal_source": "prompt/completed",
+      "completion_source": "prompt_return",
+      "token_usage": {
+        "inputTokens": 12,
+        "outputTokens": 5,
+        "totalTokens": 17
+      },
+      "delivery_allowed": true,
+      "assistant_timeline": [
+        "Hel",
+        "lo",
+        "Hello"
+      ],
+      "run_event_types": [
+        "OutputDelta",
+        "OutputDelta",
+        "TokenUsage",
+        "OutputDelta"
+      ],
+      "commentary": []
+    }
+  },
+  {
+    "name": "cumulative_chunks",
+    "actions": [
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session/update",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": "Hel"
+            }
+          }
+        }
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session/update",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": "Hello"
+            }
+          }
+        }
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session.status",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "status": {
+              "type": "idle"
+            }
+          }
+        }
+      },
+      {
+        "kind": "transport_return",
+        "status": "ok",
+        "assistant_text": "Hello",
+        "errors": []
+      }
+    ],
+    "expected": {
+      "status": "ok",
+      "assistant_text": "Hello",
+      "terminal_source": "session.status",
+      "completion_source": "prompt_return",
+      "token_usage": null,
+      "delivery_allowed": true,
+      "assistant_timeline": [
+        "Hel",
+        "Hello"
+      ],
+      "run_event_types": [
+        "OutputDelta",
+        "OutputDelta"
+      ],
+      "commentary": []
+    }
+  },
+  {
+    "name": "duplicate_chunks",
+    "actions": [
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session/update",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": "Hello"
+            }
+          }
+        }
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session/update",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": "Hello"
+            }
+          }
+        }
+      },
+      {
+        "kind": "transport_return",
+        "status": "ok",
+        "assistant_text": "Hello",
+        "errors": []
+      }
+    ],
+    "expected": {
+      "status": "ok",
+      "assistant_text": "Hello",
+      "terminal_source": "prompt_return",
+      "completion_source": "prompt_return",
+      "token_usage": null,
+      "delivery_allowed": true,
+      "assistant_timeline": [
+        "Hello",
+        "Hello"
+      ],
+      "run_event_types": [
+        "OutputDelta",
+        "OutputDelta"
+      ],
+      "commentary": []
+    }
+  },
+  {
+    "name": "terminal_before_request_return",
+    "actions": [
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session/update",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": "fixture"
+            }
+          }
+        }
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "prompt/completed",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "status": "completed",
+            "finalOutput": "fixture reply"
+          }
+        }
+      },
+      {
+        "kind": "transport_return",
+        "status": "ok",
+        "assistant_text": "fixture reply",
+        "errors": []
+      }
+    ],
+    "expected": {
+      "status": "ok",
+      "assistant_text": "fixture reply",
+      "terminal_source": "prompt/completed",
+      "completion_source": "prompt_return",
+      "token_usage": null,
+      "delivery_allowed": true,
+      "assistant_timeline": [
+        "fixture",
+        "fixture reply"
+      ],
+      "run_event_types": [
+        "OutputDelta",
+        "OutputDelta"
+      ],
+      "commentary": []
+    }
+  },
+  {
+    "name": "request_return_before_terminal",
+    "actions": [
+      {
+        "kind": "transport_return",
+        "status": "ok",
+        "assistant_text": "fixture reply",
+        "errors": []
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "prompt/completed",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "status": "completed",
+            "finalOutput": "fixture reply"
+          }
+        }
+      }
+    ],
+    "expected": {
+      "status": "ok",
+      "assistant_text": "fixture reply",
+      "terminal_source": "prompt/completed",
+      "completion_source": "prompt_return",
+      "token_usage": null,
+      "delivery_allowed": true,
+      "assistant_timeline": [
+        "fixture reply"
+      ],
+      "run_event_types": [
+        "OutputDelta"
+      ],
+      "commentary": []
+    }
+  },
+  {
+    "name": "idle_before_request_return",
+    "actions": [
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session/update",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": "idle reply"
+            }
+          }
+        }
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session.status",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "status": {
+              "type": "idle"
+            }
+          }
+        }
+      }
+    ],
+    "expected": {
+      "status": "ok",
+      "assistant_text": "idle reply",
+      "terminal_source": "session.status",
+      "completion_source": "stream_terminal_event",
+      "token_usage": null,
+      "delivery_allowed": true,
+      "assistant_timeline": [
+        "idle reply"
+      ],
+      "run_event_types": [
+        "OutputDelta"
+      ],
+      "commentary": []
+    }
+  },
+  {
+    "name": "missing_turn_id_mapped_to_active_turn",
+    "actions": [
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session/update",
+          "params": {
+            "sessionId": "session-1",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": "mapped reply"
+            }
+          }
+        }
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "prompt/completed",
+          "params": {
+            "sessionId": "session-1",
+            "status": "completed",
+            "finalOutput": "mapped reply"
+          }
+        }
+      }
+    ],
+    "expected": {
+      "status": "ok",
+      "assistant_text": "mapped reply",
+      "terminal_source": "prompt/completed",
+      "completion_source": "stream_terminal_event",
+      "token_usage": null,
+      "delivery_allowed": true,
+      "assistant_timeline": [
+        "mapped reply",
+        "mapped reply"
+      ],
+      "run_event_types": [
+        "OutputDelta",
+        "OutputDelta"
+      ],
+      "commentary": [],
+      "mapped_turn_id": "turn-current"
+    }
+  },
+  {
+    "name": "previous_turn_and_current_turn_identical_final_text",
+    "actions": [
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "prompt/completed",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-previous",
+            "status": "completed",
+            "finalOutput": "same final"
+          }
+        }
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session/update",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": "same"
+            }
+          }
+        }
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "prompt/completed",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "status": "completed",
+            "finalOutput": "same final"
+          }
+        }
+      }
+    ],
+    "expected": {
+      "status": "ok",
+      "assistant_text": "same final",
+      "terminal_source": "prompt/completed",
+      "completion_source": "stream_terminal_event",
+      "token_usage": null,
+      "delivery_allowed": true,
+      "assistant_timeline": [
+        "same final",
+        "same",
+        "same final"
+      ],
+      "run_event_types": [
+        "OutputDelta",
+        "OutputDelta",
+        "OutputDelta"
+      ],
+      "commentary": []
+    }
+  },
+  {
+    "name": "commentary_mixed_with_final_text",
+    "actions": [
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session/update",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "phase": "commentary",
+              "alreadyStreamed": true,
+              "content": "draft plan"
+            }
+          }
+        }
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session/update",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": "final"
+            }
+          }
+        }
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "prompt/completed",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "status": "completed",
+            "finalOutput": "final answer"
+          }
+        }
+      }
+    ],
+    "expected": {
+      "status": "ok",
+      "assistant_text": "final answer",
+      "terminal_source": "prompt/completed",
+      "completion_source": "stream_terminal_event",
+      "token_usage": null,
+      "delivery_allowed": true,
+      "assistant_timeline": [
+        "final",
+        "final answer"
+      ],
+      "run_event_types": [
+        "RunNotice",
+        "OutputDelta",
+        "OutputDelta"
+      ],
+      "commentary": [
+        "draft plan"
+      ]
+    }
+  },
+  {
+    "name": "failed_transport_after_successful_terminal_event",
+    "actions": [
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "prompt/completed",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "status": "completed",
+            "finalOutput": "done despite transport"
+          }
+        }
+      },
+      {
+        "kind": "transport_return",
+        "status": "failed",
+        "assistant_text": "",
+        "errors": [
+          "transport disconnected after completion"
+        ]
+      }
+    ],
+    "expected": {
+      "status": "ok",
+      "assistant_text": "done despite transport",
+      "terminal_source": "prompt/completed",
+      "completion_source": "reconciled_failure",
+      "token_usage": null,
+      "delivery_allowed": true,
+      "assistant_timeline": [
+        "done despite transport"
+      ],
+      "run_event_types": [
+        "OutputDelta"
+      ],
+      "commentary": []
+    }
+  },
+  {
+    "name": "timeout_with_partial_output",
+    "actions": [
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session/update",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": "partial output"
+            }
+          }
+        }
+      },
+      {
+        "kind": "raw_event",
+        "raw": {
+          "method": "session/update",
+          "params": {
+            "sessionId": "session-1",
+            "turnId": "turn-current",
+            "update": {
+              "sessionUpdate": "usage_update",
+              "usage": {
+                "totalTokens": 11
+              }
+            }
+          }
+        }
+      },
+      {
+        "kind": "timeout",
+        "error": "Runtime thread timed out"
+      }
+    ],
+    "expected": {
+      "status": "error",
+      "assistant_text": "",
+      "terminal_source": "timeout",
+      "completion_source": "timeout",
+      "token_usage": {
+        "totalTokens": 11
+      },
+      "delivery_allowed": false,
+      "assistant_timeline": [
+        "partial output"
+      ],
+      "run_event_types": [
+        "OutputDelta",
+        "TokenUsage"
+      ],
+      "commentary": []
+    }
+  }
+]

--- a/tests/integrations/discord/test_discord_managed_thread_delivery_adapter.py
+++ b/tests/integrations/discord/test_discord_managed_thread_delivery_adapter.py
@@ -364,7 +364,9 @@ async def test_discord_adapter_safe_send_false_leaves_record_replayable(
     assert record is not None
     assert record.state is ManagedThreadDeliveryState.RETRY_SCHEDULED
     assert record.next_attempt_at is not None
-    assert record.last_error == "discord_send_deferred:discord-queued:thread-1:turn-1"
+    assert record.last_error == (
+        f"discord_send_deferred:{record.idempotency_key}:discord-queued"
+    )
     assert service.sent_messages == []
 
 
@@ -583,6 +585,32 @@ async def test_discord_adapter_delivered_record_is_terminal(
     engine = delivery.engine
     re_claim = engine.claim_delivery(record.delivery_id)
     assert re_claim is None
+
+
+@pytest.mark.anyio
+async def test_discord_second_handoff_after_delivered_does_not_resend(
+    tmp_path: Path,
+) -> None:
+    service = _DiscordServiceStub(state_root=tmp_path)
+    delivery = _build_hooks(tmp_path, service=service)
+    finalized = _finalized_ok()
+
+    first = await handoff_managed_thread_final_delivery(
+        finalized,
+        delivery=delivery,
+        logger=logging.getLogger("test"),
+    )
+    second = await handoff_managed_thread_final_delivery(
+        finalized,
+        delivery=delivery,
+        logger=logging.getLogger("test"),
+    )
+
+    assert first is not None
+    assert second is not None
+    assert first.delivery_id == second.delivery_id
+    assert second.state is ManagedThreadDeliveryState.DELIVERED
+    assert len(service.sent_messages) == 1
 
 
 @pytest.mark.anyio

--- a/tests/integrations/telegram/test_telegram_managed_thread_delivery_adapter.py
+++ b/tests/integrations/telegram/test_telegram_managed_thread_delivery_adapter.py
@@ -64,6 +64,7 @@ class _TelegramHandlersStub:
         self._logger = logging.getLogger("test.telegram.adapter")
         self.sent_messages: list[dict[str, Any]] = []
         self.flushed_outbox: list[dict[str, Any]] = []
+        self.outbox_messages: list[dict[str, Any]] = []
 
     async def _send_message(
         self,
@@ -83,6 +84,36 @@ class _TelegramHandlersStub:
                 "reply_to": reply_to,
             }
         )
+
+    async def _send_message_with_outbox(
+        self,
+        chat_id: int,
+        text: str,
+        *,
+        thread_id: Optional[int],
+        reply_to: Optional[int],
+        record_id: Optional[str] = None,
+        outbox_key: Optional[str] = None,
+        delivery_metadata: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        self.outbox_messages.append(
+            {
+                "chat_id": chat_id,
+                "text": text,
+                "thread_id": thread_id,
+                "reply_to": reply_to,
+                "record_id": record_id,
+                "outbox_key": outbox_key,
+                "delivery_metadata": dict(delivery_metadata or {}),
+            }
+        )
+        await self._send_message(
+            chat_id,
+            text,
+            thread_id=thread_id,
+            reply_to=reply_to,
+        )
+        return True
 
     async def _flush_outbox_files(
         self,
@@ -381,6 +412,34 @@ async def test_telegram_adapter_delivered_record_is_terminal(
     engine = delivery.engine
     re_claim = engine.claim_delivery(record.delivery_id)
     assert re_claim is None
+
+
+@pytest.mark.anyio
+async def test_telegram_second_handoff_after_delivered_does_not_resend(
+    tmp_path: Path,
+) -> None:
+    handlers = _TelegramHandlersStub(state_root=tmp_path)
+    delivery = _build_hooks(tmp_path, handlers=handlers)
+    finalized = _finalized_ok()
+
+    first = await handoff_managed_thread_final_delivery(
+        finalized,
+        delivery=delivery,
+        logger=logging.getLogger("test"),
+    )
+    second = await handoff_managed_thread_final_delivery(
+        finalized,
+        delivery=delivery,
+        logger=logging.getLogger("test"),
+    )
+
+    assert first is not None
+    assert second is not None
+    assert first.delivery_id == second.delivery_id
+    assert second.state is ManagedThreadDeliveryState.DELIVERED
+    assert len(handlers.sent_messages) == 1
+    assert len(handlers.outbox_messages) == 1
+    assert handlers.outbox_messages[0]["outbox_key"] == first.idempotency_key
 
 
 @pytest.mark.anyio

--- a/tests/runtime_lifecycle_sequences.py
+++ b/tests/runtime_lifecycle_sequences.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+_CORPUS_PATH = (
+    Path(__file__).resolve().parent / "fixtures" / "runtime_lifecycle_sequences.json"
+)
+
+
+@lru_cache(maxsize=1)
+def load_runtime_lifecycle_sequences() -> list[dict[str, Any]]:
+    loaded = json.loads(_CORPUS_PATH.read_text(encoding="utf-8"))
+    if not isinstance(loaded, list):
+        raise TypeError("Runtime lifecycle sequence corpus must be a JSON array")
+    return [dict(item) for item in loaded]
+
+
+def runtime_lifecycle_sequence_ids() -> list[str]:
+    return [str(case["name"]) for case in load_runtime_lifecycle_sequences()]

--- a/tests/surfaces/web/routes/pma_routes/test_chat_runtime_execution_fresh_base_prompt.py
+++ b/tests/surfaces/web/routes/pma_routes/test_chat_runtime_execution_fresh_base_prompt.py
@@ -107,6 +107,71 @@ async def test_fresh_conversation_uses_rebuild_prompt_for_base_prompt_injection(
     assert prompts_seen == ["DELTA_PROMPT\n\nCORE PMA FROM PROMPT_MD\n\n"]
 
 
+@pytest.mark.asyncio
+async def test_execute_harness_turn_recovers_empty_result_from_streamed_timeline(
+    tmp_path: Path,
+) -> None:
+    event_stream_started = asyncio.Event()
+    wait_can_finish = asyncio.Event()
+
+    class Harness:
+        def supports(self, capability: str) -> bool:
+            return capability in {
+                "durable_threads",
+                "message_turns",
+                "event_streaming",
+            }
+
+        async def ensure_ready(self, _repo_root: Path) -> None:
+            return None
+
+        async def new_conversation(self, _repo_root: Path, title: str = ""):
+            _ = title
+            return SimpleNamespace(id="fresh-conv")
+
+        async def start_turn(
+            self, _repo_root: Path, conversation_id: str, prompt: str, *args, **kwargs
+        ):
+            _ = prompt, args, kwargs
+            return _HarnessTurnStub(conversation_id, "turn-fresh")
+
+        async def stream_events(
+            self, _repo_root: Path, conversation_id: str, turn_id: str
+        ):
+            _ = conversation_id, turn_id
+            yield {
+                "message": {
+                    "method": "item/agentMessage/delta",
+                    "params": {"delta": "streamed fallback"},
+                }
+            }
+            event_stream_started.set()
+            await wait_can_finish.wait()
+
+        async def wait_for_turn(
+            self, _repo_root: Path, conversation_id: str, turn_id: str, timeout=None
+        ):
+            _ = conversation_id, turn_id, timeout
+            await event_stream_started.wait()
+            wait_can_finish.set()
+            return SimpleNamespace(
+                status="ok",
+                assistant_text="",
+                raw_events=[],
+                errors=[],
+            )
+
+    result = await execute_harness_turn(
+        Harness(),
+        tmp_path,
+        "DELTA_PROMPT",
+        asyncio.Event(),
+    )
+
+    assert result["status"] == "ok"
+    assert result["message"] == "streamed fallback"
+
+
 def test_resolve_pma_session_key_isolates_automation_from_interactive_pma() -> None:
     interactive = resolve_pma_session_key(
         "hermes",


### PR DESCRIPTION
## Summary

Consolidates managed chat state handling around explicit assistant-output, runtime-state-event, terminal-evidence, active-turn identity, and final-delivery contracts. This includes the original ACP cumulative stream-output fix and the broader cleanup roadmap implementation.

## What changed

- Added shared assistant text accumulation helpers that distinguish strict deltas from cumulative snapshots.
- Added semantic runtime state events before terminal-state reduction.
- Refactored terminal evidence reconciliation with explicit precedence for success, error, interrupt, timeout, and recovery cases.
- Separated append-only timeline history from reduced final assistant output.
- Hardened ACP/Hermes active-turn identity, missing-turn-id fallback, and idle recovery behavior.
- Added a multi-event runtime lifecycle sequence corpus for reducer regression coverage.
- Consolidated managed-thread final delivery contracts across Discord and Telegram adapters.

## Review feedback addressed

- Preserves strict ACP delta accumulation while still deduplicating cumulative `agent_message_chunk` snapshots.

## Validation

- `make typecheck-strict`
- `.venv/bin/python -m pytest tests/core/orchestration/test_stream_text_merge.py tests/core/orchestration/test_runtime_thread_events.py tests/core/orchestration/test_runtime_turn_terminal_state.py tests/agents/acp/test_client.py tests/integrations/discord/test_discord_managed_thread_delivery_adapter.py tests/integrations/telegram/test_telegram_managed_thread_delivery_adapter.py`

The PR is ready for review.