### PR TITLE
[codex] Add PMA PR spawn mode

### DIFF
--- a/src/codex_autorunner/bootstrap.py
+++ b/src/codex_autorunner/bootstrap.py
@@ -292,6 +292,12 @@ You are an **abstraction layer, not an executor**. Coordinate tickets and flows 
 
 - Managed threads are the default for straightforward work in one repo: exploratory work, reviews, bug fixes, focused refactors, and single-feature PRs that fit in one clear prompt.
 - Reuse an existing relevant managed thread before spawning a new one.
+- For work that should open a PR, use PR mode instead of a reused thread:
+  `car pma thread spawn --agent codex --repo <base_or_worktree_repo_id> --pr --name <label> --path <hub_root>`.
+  PR mode resolves hub worktrees back to their upstream/base repo, creates a
+  fresh hub-owned worktree from `origin/<default-branch>` (or `--pr-base-ref`),
+  runs configured worktree setup commands, and fails instead of falling back to
+  the original workspace when isolation cannot be provisioned.
 - Do not launch runtime CLIs directly (`codex`, `opencode`, `zeroclaw`, etc.) for PMA-managed work when a managed thread fits; use `car pma thread spawn` and `car pma thread send` so CAR can track lifecycle and progress.
 - Do not write ticket files as scaffolding for managed-thread work.
 - Use ticket flows for larger structured work: cross-repo changes, 3+ planned tickets, explicit acceptance criteria tracking, or work that benefits from pause/resume/review handoffs.
@@ -300,6 +306,7 @@ You are an **abstraction layer, not an executor**. Coordinate tickets and flows 
   intended hub config instead of relying on the current working directory.
 - CLI primitives:
   - `car pma thread spawn --agent codex --repo <repo_id> --name <label> --path <hub_root>`
+  - `car pma thread spawn --agent codex --repo <repo_id> --pr --name <label> --path <hub_root>`
   - `car pma thread send --id <managed_thread_id> --message "..." --path <hub_root>`
   - `car pma thread send --id <managed_thread_id> --message-file prompt.md --path <hub_root>`
   - `car pma thread send --id <managed_thread_id> --message "..." --watch --path <hub_root>` only when you intentionally want synchronous foreground babysitting
@@ -449,6 +456,10 @@ Canonical worktree creation:
 - CLI (from hub root):
   `car hub worktree create <base_repo_id> <branch> [--start-point <ref>]`
   (defaults to `origin/<default-branch>` when `--start-point` is omitted)
+- PMA PR work:
+  `car pma thread spawn --agent codex --repo <base_or_worktree_repo_id> --pr --path <hub_root>`
+  creates a fresh PR-isolated worktree from the upstream/base repo and runs the
+  base repo's configured worktree setup commands.
 
 Registering a manually-created worktree:
 - If you used `git worktree add`, run:

--- a/src/codex_autorunner/integrations/app_server/transport.py
+++ b/src/codex_autorunner/integrations/app_server/transport.py
@@ -79,7 +79,7 @@ class AppServerReadBuffer:
                 truncated=True,
             )
             return
-        await self._on_payload_line(self._buffer)
+        await self._on_payload_line(bytes(self._buffer))
 
     async def _collect_chunk(self, chunk: bytes, *, initializing: bool) -> None:
         self._buffer.extend(chunk)
@@ -145,7 +145,7 @@ class AppServerReadBuffer:
             newline_index = self._buffer.find(b"\n")
             if newline_index == -1:
                 return
-            line = self._buffer[:newline_index]
+            line = bytes(self._buffer[:newline_index])
             del self._buffer[: newline_index + 1]
             await self._on_payload_line(line)
 

--- a/src/codex_autorunner/surfaces/cli/pma_thread_commands.py
+++ b/src/codex_autorunner/surfaces/cli/pma_thread_commands.py
@@ -822,6 +822,19 @@ def pma_thread_spawn(
         None, "--workspace-root", help="Absolute or hub-relative workspace path"
     ),
     name: Optional[str] = typer.Option(None, "--name", help="Optional thread label"),
+    pr_mode: bool = typer.Option(
+        False,
+        "--pr/--no-pr",
+        help=(
+            "Spawn a PR-oriented thread in a fresh hub worktree from the repo "
+            "upstream/default branch"
+        ),
+    ),
+    pr_base_ref: Optional[str] = typer.Option(
+        None,
+        "--pr-base-ref",
+        help="Optional git ref for PR worktree creation (default: origin/<default-branch>)",
+    ),
     context_profile: Optional[str] = typer.Option(
         None,
         "--context-profile",
@@ -885,6 +898,12 @@ def pma_thread_spawn(
             err=True,
         )
         raise typer.Exit(code=1) from None
+    if pr_mode and normalized_resource_kind != "repo":
+        typer.echo("--pr requires --repo or --resource-kind repo", err=True)
+        raise typer.Exit(code=1) from None
+    if pr_base_ref is not None and not pr_mode:
+        typer.echo("--pr-base-ref requires --pr", err=True)
+        raise typer.Exit(code=1) from None
     normalized_context_profile = normalize_car_context_profile(context_profile)
     if context_profile is not None and normalized_context_profile is None:
         typer.echo(
@@ -920,21 +939,26 @@ def pma_thread_spawn(
             raise typer.BadParameter(
                 "--no-terminal-followup cannot be combined with --notify-on terminal"
             )
+        request_payload = {
+            "agent": normalized_agent,
+            "resource_kind": normalized_resource_kind,
+            "resource_id": normalized_resource_id,
+            "workspace_root": normalized_workspace_root,
+            "name": name,
+            "context_profile": normalized_context_profile,
+            "notify_on": normalized_notify_on,
+            "terminal_followup": terminal_followup,
+            "notify_lane": notify_lane,
+            "notify_once": notify_once,
+        }
+        if pr_mode:
+            request_payload["pr_mode"] = True
+        if pr_base_ref is not None:
+            request_payload["pr_base_ref"] = pr_base_ref
         data = _request_json(
             "POST",
             _build_pma_url(config, "/threads"),
-            {
-                "agent": normalized_agent,
-                "resource_kind": normalized_resource_kind,
-                "resource_id": normalized_resource_id,
-                "workspace_root": normalized_workspace_root,
-                "name": name,
-                "context_profile": normalized_context_profile,
-                "notify_on": normalized_notify_on,
-                "terminal_followup": terminal_followup,
-                "notify_lane": notify_lane,
-                "notify_once": notify_once,
-            },
+            request_payload,
             token_env=config.server_auth_token_env,
         )
     except httpx.HTTPError as exc:

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
@@ -43,6 +43,8 @@ class ManagedThreadCreateResolution:
     requested_profile: Optional[str]
     metadata: dict[str, Any]
     followup_policy: ManagedThreadFollowupPolicy
+    pr_mode: bool = False
+    pr_base_ref: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -108,6 +110,31 @@ def _resolve_repo_snapshot(request: Request, repo_id: str) -> Any:
             continue
         return snapshot
     raise HTTPException(status_code=404, detail=f"Repo not found: {repo_id}")
+
+
+def _resolve_pr_upstream_repo_id(request: Request, repo_id: str) -> str:
+    snapshot = _resolve_repo_snapshot(request, repo_id)
+    kind = normalize_optional_text(getattr(snapshot, "kind", None))
+    if kind == "base":
+        return repo_id
+    if kind == "worktree":
+        base_repo_id = normalize_optional_text(getattr(snapshot, "worktree_of", None))
+        if base_repo_id is None:
+            raise HTTPException(
+                status_code=400,
+                detail="PR mode requires a worktree with worktree_of metadata",
+            )
+        base_snapshot = _resolve_repo_snapshot(request, base_repo_id)
+        if normalize_optional_text(getattr(base_snapshot, "kind", None)) != "base":
+            raise HTTPException(
+                status_code=400,
+                detail=f"PR upstream repo is not a base repo: {base_repo_id}",
+            )
+        return base_repo_id
+    raise HTTPException(
+        status_code=400,
+        detail="PR mode requires a base repo or hub-managed worktree repo",
+    )
 
 
 def _slugify_worktree_branch_component(value: Any) -> str:
@@ -504,6 +531,7 @@ def resolve_managed_thread_create_resolution(
         resource_id=payload.resource_id,
     )
     workspace_root = normalize_optional_text(payload.workspace_root)
+    pr_base_ref = normalize_optional_text(payload.pr_base_ref)
     followup_policy = resolve_managed_thread_followup_policy(
         payload,
         # Terminal follow-up defaults now apply when the thread is used, not at
@@ -517,11 +545,24 @@ def resolve_managed_thread_create_resolution(
             status_code=400,
             detail="Exactly one of resource owner or workspace_root is required",
         )
+    if pr_base_ref is not None and not payload.pr_mode:
+        raise HTTPException(
+            status_code=400,
+            detail="pr_base_ref requires PR mode",
+        )
+    if payload.pr_mode and resource_kind != "repo":
+        raise HTTPException(
+            status_code=400,
+            detail="PR mode requires a repo resource owner",
+        )
 
     resolved_runtime: Optional[str] = None
     if owner_present:
         assert resource_kind is not None
         assert resource_id is not None
+        if payload.pr_mode:
+            resource_id = _resolve_pr_upstream_repo_id(request, resource_id)
+            resolved_repo_id = resource_id
         resolved_workspace, resolved_repo_id, resolved_runtime = (
             _resolve_workspace_from_resource_owner(
                 request,
@@ -589,6 +630,10 @@ def resolve_managed_thread_create_resolution(
         "context_profile": context_profile,
         "approval_mode": approval_mode,
     }
+    if payload.pr_mode:
+        metadata["pr_mode"] = True
+        if pr_base_ref is not None:
+            metadata["pr_base_ref"] = pr_base_ref
     if requested_profile is not None:
         metadata["agent_profile"] = requested_profile
 
@@ -601,6 +646,8 @@ def resolve_managed_thread_create_resolution(
         requested_profile=requested_profile,
         metadata=metadata,
         followup_policy=followup_policy,
+        pr_mode=bool(payload.pr_mode),
+        pr_base_ref=pr_base_ref,
     )
 
 
@@ -617,13 +664,22 @@ def provision_managed_thread_workspace(
     context = get_pma_request_context(request)
     supervisor = context.hub_supervisor
     if supervisor is None:
+        if resolution.pr_mode:
+            raise HTTPException(status_code=500, detail="Hub supervisor unavailable")
         return fallback
 
     try:
         snapshot = _resolve_repo_snapshot(request, resolution.repo_id)
     except HTTPException:
+        if resolution.pr_mode:
+            raise
         return fallback
     if normalize_optional_text(getattr(snapshot, "kind", None)) != "base":
+        if resolution.pr_mode:
+            raise HTTPException(
+                status_code=400,
+                detail="PR mode requires a base repo",
+            )
         return fallback
 
     branch_name = _build_managed_thread_worktree_branch_name(
@@ -635,14 +691,25 @@ def provision_managed_thread_workspace(
         created = supervisor.create_worktree(
             base_repo_id=resolution.repo_id,
             branch=branch_name,
+            start_point=resolution.pr_base_ref,
         )
-    except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+    except (AttributeError, OSError, RuntimeError, TypeError, ValueError) as exc:
+        if resolution.pr_mode:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Unable to provision PR worktree: {exc}",
+            ) from exc
         return fallback
 
     worktree_path = getattr(created, "path", None)
     if isinstance(worktree_path, str):
         worktree_path = Path(worktree_path)
     if not isinstance(worktree_path, Path):
+        if resolution.pr_mode:
+            raise HTTPException(
+                status_code=409,
+                detail="Unable to provision PR worktree: missing worktree path",
+            )
         return fallback
     return ManagedThreadWorkspaceProvision(
         workspace_root=worktree_path.absolute(),

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
@@ -562,7 +562,6 @@ def resolve_managed_thread_create_resolution(
         assert resource_id is not None
         if payload.pr_mode:
             resource_id = _resolve_pr_upstream_repo_id(request, resource_id)
-            resolved_repo_id = resource_id
         resolved_workspace, resolved_repo_id, resolved_runtime = (
             _resolve_workspace_from_resource_owner(
                 request,

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -312,6 +312,16 @@ class PmaManagedThreadCreateRequest(Payload):
     )
     workspace_root: Optional[str] = None
     name: Optional[str] = None
+    pr_mode: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("pr_mode", "prMode", "pr_intent", "prIntent"),
+    )
+    pr_base_ref: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "pr_base_ref", "prBaseRef", "base_ref", "baseRef"
+        ),
+    )
     notify_on: Optional[Literal["terminal"]] = Field(
         default=None, validation_alias=AliasChoices("notify_on", "notifyOn")
     )

--- a/tests/test_pma_managed_threads_routes.py
+++ b/tests/test_pma_managed_threads_routes.py
@@ -165,6 +165,106 @@ def test_create_managed_thread_with_repo_owner_prefers_fresh_worktree(
     assert stored["workspace_root"] == str(fresh_worktree_root.resolve())
 
 
+def test_create_pr_managed_thread_with_worktree_owner_uses_base_repo(
+    hub_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codex_autorunner.core.config import load_hub_config
+    from codex_autorunner.manifest import load_manifest, save_manifest
+
+    hub_config = load_hub_config(hub_env.hub_root)
+    manifest = load_manifest(hub_config.manifest_path, hub_env.hub_root)
+    worktree_root = hub_env.hub_root / "worktrees" / "repo--existing"
+    worktree_root.mkdir(parents=True, exist_ok=True)
+    manifest.ensure_repo(
+        hub_env.hub_root,
+        worktree_root,
+        repo_id="repo--existing",
+        kind="worktree",
+        worktree_of=hub_env.repo_id,
+        branch="feature/existing",
+    )
+    save_manifest(hub_config.manifest_path, manifest, hub_env.hub_root)
+
+    app = create_hub_app(hub_env.hub_root)
+    fresh_worktree_root = hub_env.hub_root / "worktrees" / "repo--pma-pr"
+    fresh_worktree_root.mkdir(parents=True, exist_ok=True)
+    observed: dict[str, object] = {}
+
+    def _fake_create_worktree(
+        *, base_repo_id: str, branch: str, force: bool = False, start_point=None
+    ):
+        observed["base_repo_id"] = base_repo_id
+        observed["branch"] = branch
+        observed["force"] = force
+        observed["start_point"] = start_point
+        return SimpleNamespace(
+            id="repo--pma-pr",
+            path=fresh_worktree_root,
+            branch=branch,
+            kind="worktree",
+        )
+
+    monkeypatch.setattr(
+        app.state.hub_supervisor, "create_worktree", _fake_create_worktree
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                "resource_kind": "repo",
+                "resource_id": "repo--existing",
+                "name": "PR thread",
+                "pr_mode": True,
+                "pr_base_ref": "origin/main",
+            },
+        )
+
+    assert resp.status_code == 200
+    thread = resp.json()["thread"]
+    assert observed["base_repo_id"] == hub_env.repo_id
+    assert observed["start_point"] == "origin/main"
+    assert str(observed["branch"]).startswith(f"pma/{hub_env.repo_id}/")
+    assert thread["repo_id"] == hub_env.repo_id
+    assert thread["resource_kind"] == "repo"
+    assert thread["resource_id"] == hub_env.repo_id
+    assert thread["workspace_root"] == str(fresh_worktree_root.resolve())
+
+    store = PmaThreadStore(hub_env.hub_root)
+    stored = store.get_thread(thread["managed_thread_id"])
+    assert stored is not None
+    assert stored["metadata"]["pr_mode"] is True
+    assert stored["metadata"]["pr_base_ref"] == "origin/main"
+
+
+def test_create_pr_managed_thread_fails_when_worktree_provisioning_fails(
+    hub_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    def _fake_create_worktree(**_kwargs: object):
+        raise ValueError("origin fetch failed")
+
+    monkeypatch.setattr(
+        app.state.hub_supervisor, "create_worktree", _fake_create_worktree
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                **_repo_owner(hub_env),
+                "name": "PR thread",
+                "pr_mode": True,
+            },
+        )
+
+    assert resp.status_code == 409
+    assert "Unable to provision PR worktree" in resp.json()["detail"]
+
+
 def test_create_managed_thread_failure_cleanup_worktree_uses_archive(
     hub_env, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add PMA managed-thread PR mode with API/CLI flags for fresh PR worktree provisioning
- resolve worktree repo owners back to their base/upstream repo in PR mode and fail closed if isolation cannot be created
- update generated PMA guidance to prefer PR mode for work that will open pull requests

## Validation
- .venv/bin/python -m pytest tests/test_pma_managed_threads_routes.py -q
- .venv/bin/python -m pytest tests/surfaces/cli/test_pma_thread_commands.py::test_pma_cli_thread_control_commands_use_orchestration_routes tests/surfaces/cli/test_pma_thread_commands.py::test_pma_cli_thread_spawn_defaults_agent_for_agent_workspace -q
- .venv/bin/python -m ruff check src/codex_autorunner/surfaces/web/schemas.py src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py src/codex_autorunner/surfaces/cli/pma_thread_commands.py tests/test_pma_managed_threads_routes.py
- .venv/bin/python -m mypy src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py src/codex_autorunner/surfaces/cli/pma_thread_commands.py

## Note
The normal commit hook reached full pytest and failed on tests/unit/test_idle_cpu_soak.py::TestIdleCpuSoakProcessManagement::test_service_watchdog_exits_when_harness_parent_exits timing out while starting its helper process. That test is unrelated to the touched PMA/CLI paths and reproduced when run directly.