### PR TITLE
[codex] Handle missing repo root when listing flow runs

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/flow_routes/run_list_cache.py
+++ b/src/codex_autorunner/surfaces/web/routes/flow_routes/run_list_cache.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 from fastapi import Request
 from fastapi.encoders import jsonable_encoder
 
+from .....core.utils import RepoNotFoundError
+
 if TYPE_CHECKING:
     from . import FlowRouteDependencies
 
@@ -141,7 +143,10 @@ def list_flow_runs_payload(
     flow_target_id: Optional[str],
     reconcile: bool,
 ) -> list[dict[str, Any]]:
-    repo_root = deps.find_repo_root()
+    try:
+        repo_root = deps.find_repo_root()
+    except RepoNotFoundError:
+        return []
     if repo_root is None:
         return []
     cache_key = (str(repo_root.resolve()), flow_type or "", flow_target_id or "")

--- a/tests/routes/test_flow_status_history_routes_extracted.py
+++ b/tests/routes/test_flow_status_history_routes_extracted.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from codex_autorunner.core.orchestration.models import FlowRunTarget
+from codex_autorunner.core.utils import RepoNotFoundError
 from codex_autorunner.surfaces.web.routes.flow_routes.dependencies import (
     FlowRouteDependencies,
 )
@@ -188,6 +189,32 @@ def test_extracted_status_history_routes_support_reconcile_requests(
         "logger": True,
     }
     assert store.close_calls == 1
+
+
+def test_extracted_list_runs_returns_empty_when_no_repo_root() -> None:
+    deps = FlowRouteDependencies(
+        find_repo_root=lambda: (_ for _ in ()).throw(RepoNotFoundError("no repo")),
+        build_flow_orchestration_service=lambda *_args, **_kwargs: None,
+        require_flow_store=lambda _repo_root: None,
+        safe_list_flow_runs=lambda *args, **kwargs: [],
+        build_flow_status_response=lambda *args, **kwargs: {},
+        get_flow_record=lambda _repo_root, _run_id: None,
+        get_flow_controller=lambda *args, **kwargs: None,
+        start_flow_worker=lambda *args, **kwargs: None,
+        recover_flow_store_if_possible=lambda *args, **kwargs: None,
+        bootstrap_check=lambda *args, **kwargs: None,
+        seed_issue=lambda *args, **kwargs: {},
+    )
+
+    router, _ = build_status_history_routes(deps)
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.get("/api/flows/runs?flow_type=ticket_flow")
+
+    assert response.status_code == 200
+    assert response.json() == []
 
 
 def test_extracted_status_history_routes_use_orchestration_service_for_status(


### PR DESCRIPTION
## Summary

Fixes the repos page partial failure where the active-runs panel showed `Active runs unavailable` with `Internal Server Error` at hub scope.

## Root Cause

The repos page calls the hub-scoped `/api/flows/runs?flow_type=ticket_flow` endpoint. When the hub root is not itself a Git checkout, `find_repo_root()` raises `RepoNotFoundError`. The list-runs helper only handled a `None` repo root, so the exception escaped as a 500.

## Changes

- Treat `RepoNotFoundError` as an empty flow-run list in the flow-run list helper.
- Add a regression test covering the no-repo-root case for `/api/flows/runs`.

## Validation

- `.venv/bin/python -m pytest tests/routes/test_flow_status_history_routes_extracted.py tests/test_base_path_static.py -q`
- Commit hook web-ui lane passed, including black, ruff, import boundary checks, hub interface contracts, command hint checks, mypy, full pytest (`8525 passed`), Web Hub lint/build/tests, and SPA shell/static asset checks.

Note: the first commit attempt hit a transient Hypothesis health check in an unrelated memory contract test; rerunning that exact seeded test passed, and the full hook passed on retry.