### PR TITLE
[codex] Refactor ticket flow prompt construction

### DIFF
--- a/src/codex_autorunner/tickets/runner_prompt.py
+++ b/src/codex_autorunner/tickets/runner_prompt.py
@@ -151,5 +151,7 @@ def build_prompt(
     )
     model = reduce_ticket_flow_prompt_to_budget(model, max_bytes=prompt_max_bytes)
     prompt = render_ticket_flow_prompt(model)
+    if len(prompt.encode("utf-8")) > prompt_max_bytes:
+        prompt = _truncate_text_by_bytes(prompt, prompt_max_bytes)
     validate_ticket_flow_prompt(prompt, max_bytes=prompt_max_bytes)
     return prompt

--- a/src/codex_autorunner/tickets/runner_prompt.py
+++ b/src/codex_autorunner/tickets/runner_prompt.py
@@ -8,17 +8,19 @@ from ..core.apps.prompt_hints import build_installed_apps_prompt_hint
 from . import runner_prompt_support as _support
 from .files import safe_relpath
 from .runner_prompt_support import (
-    MAIN_SECTION_ORDER,
+    FULL_TICKET_FLOW_INSTRUCTIONS,
+    TicketFlowPromptModel,
+    TicketFlowPromptSections,
     build_checkpoint_block,
     build_commit_block,
     build_lint_block,
     build_loop_guard_block,
     build_previous_ticket_block,
     build_ticket_block,
-    build_ticket_first_fallback_prompt,
     build_workspace_block,
-    prompt_has_ticket_control_plane,
-    render_full_prompt,
+    reduce_ticket_flow_prompt_to_budget,
+    render_ticket_flow_prompt,
+    validate_ticket_flow_prompt,
 )
 
 _logger = logging.getLogger(__name__)
@@ -61,6 +63,56 @@ def _build_apps_hint(workspace_root: Path) -> str:
         return ""
 
 
+def _build_prompt_model(
+    *,
+    ticket_path: Path,
+    workspace_root: Path,
+    last_agent_output: Optional[str],
+    last_checkpoint_error: Optional[str],
+    commit_required: bool,
+    commit_attempt: int,
+    commit_max_attempts: int,
+    outbox_paths: Any,
+    lint_errors: Optional[list[str]],
+    reply_context: Optional[str],
+    requested_context: Optional[str],
+    previous_ticket_content: Optional[str],
+    prior_no_change_turns: int,
+    prompt_max_bytes: int,
+) -> TicketFlowPromptModel:
+    rel_ticket = safe_relpath(ticket_path, workspace_root)
+    prev_block = last_agent_output or ""
+    if prev_block:
+        cap = max(prompt_max_bytes - _PREVIOUS_OUTPUT_HEADROOM_BYTES, 1)
+        if len(prev_block.encode("utf-8")) > cap:
+            prev_block = _truncate_text_by_bytes(prev_block, cap)
+    return TicketFlowPromptModel(
+        instructions=FULL_TICKET_FLOW_INSTRUCTIONS,
+        include_optional_sections=True,
+        rel_ticket=rel_ticket,
+        rel_dispatch_dir=safe_relpath(outbox_paths.dispatch_dir, workspace_root),
+        rel_dispatch_path=safe_relpath(outbox_paths.dispatch_path, workspace_root),
+        car_hud=_build_car_hud(),
+        apps_hint=_build_apps_hint(workspace_root),
+        checkpoint_block=build_checkpoint_block(last_checkpoint_error),
+        commit_block=build_commit_block(
+            commit_required=commit_required,
+            commit_attempt=commit_attempt,
+            commit_max_attempts=commit_max_attempts,
+        ),
+        lint_block=build_lint_block(lint_errors),
+        loop_guard_block=build_loop_guard_block(prior_no_change_turns),
+        sections=TicketFlowPromptSections(
+            prev_block=prev_block,
+            prev_ticket_block=build_previous_ticket_block(previous_ticket_content),
+            reply_block=reply_context or "",
+            requested_context_block=requested_context or "",
+            workspace_block=build_workspace_block(workspace_root),
+            ticket_block=build_ticket_block(ticket_path, rel_ticket),
+        ),
+    )
+
+
 def build_prompt(
     *,
     ticket_path: Path,
@@ -80,64 +132,24 @@ def build_prompt(
     prompt_max_bytes: int = 5 * 1024 * 1024,
 ) -> str:
     """Build the full prompt for an agent turn."""
-    rel_ticket = safe_relpath(ticket_path, workspace_root)
-    rel_dispatch_dir = safe_relpath(outbox_paths.dispatch_dir, workspace_root)
-    rel_dispatch_path = safe_relpath(outbox_paths.dispatch_path, workspace_root)
-    checkpoint_block = build_checkpoint_block(last_checkpoint_error)
-    apps_hint = _build_apps_hint(workspace_root)
-    commit_block = build_commit_block(
+    _ = ticket_doc
+    model = _build_prompt_model(
+        ticket_path=ticket_path,
+        workspace_root=workspace_root,
+        last_agent_output=last_agent_output,
+        last_checkpoint_error=last_checkpoint_error,
         commit_required=commit_required,
         commit_attempt=commit_attempt,
         commit_max_attempts=commit_max_attempts,
+        outbox_paths=outbox_paths,
+        lint_errors=lint_errors,
+        reply_context=reply_context,
+        requested_context=requested_context,
+        previous_ticket_content=previous_ticket_content,
+        prior_no_change_turns=prior_no_change_turns,
+        prompt_max_bytes=prompt_max_bytes,
     )
-    lint_block = build_lint_block(lint_errors)
-    loop_guard_block = build_loop_guard_block(prior_no_change_turns)
-    ticket_block = build_ticket_block(ticket_path, rel_ticket)
-    prev_block = last_agent_output or ""
-    if prev_block:
-        cap = max(prompt_max_bytes - _PREVIOUS_OUTPUT_HEADROOM_BYTES, 1)
-        if len(prev_block.encode("utf-8")) > cap:
-            prev_block = _truncate_text_by_bytes(prev_block, cap)
-    sections = {
-        "prev_block": prev_block,
-        "prev_ticket_block": build_previous_ticket_block(previous_ticket_content),
-        "workspace_block": build_workspace_block(workspace_root),
-        "reply_block": reply_context or "",
-        "requested_context_block": requested_context or "",
-        "ticket_block": ticket_block,
-    }
-    prompt = _shrink_prompt(
-        max_bytes=prompt_max_bytes,
-        render=lambda: render_full_prompt(
-            rel_ticket=rel_ticket,
-            rel_dispatch_dir=rel_dispatch_dir,
-            rel_dispatch_path=rel_dispatch_path,
-            car_hud=_build_car_hud(),
-            apps_hint=apps_hint,
-            checkpoint_block=checkpoint_block,
-            commit_block=commit_block,
-            lint_block=lint_block,
-            loop_guard_block=loop_guard_block,
-            sections=sections,
-        ),
-        sections=sections,
-        order=MAIN_SECTION_ORDER,
-    )
-    if not prompt_has_ticket_control_plane(prompt, ticket_doc):
-        cap = max(prompt_max_bytes - _PREVIOUS_OUTPUT_HEADROOM_BYTES, 1)
-        fallback_prev = sections["prev_block"]
-        raw_prev = last_agent_output if isinstance(last_agent_output, str) else ""
-        if raw_prev and len(raw_prev.encode("utf-8")) > cap:
-            fallback_prev = _truncate_text_by_bytes(raw_prev, cap)
-        prompt = build_ticket_first_fallback_prompt(
-            max_bytes=prompt_max_bytes,
-            rel_ticket=rel_ticket,
-            rel_dispatch_path=rel_dispatch_path,
-            prev_block=fallback_prev,
-            checkpoint_block=checkpoint_block,
-            commit_block=commit_block,
-            lint_block=lint_block,
-            loop_guard_block=loop_guard_block,
-            ticket_block=ticket_block,
-        )
+    model = reduce_ticket_flow_prompt_to_budget(model, max_bytes=prompt_max_bytes)
+    prompt = render_ticket_flow_prompt(model)
+    validate_ticket_flow_prompt(prompt, max_bytes=prompt_max_bytes)
     return prompt

--- a/src/codex_autorunner/tickets/runner_prompt.py
+++ b/src/codex_autorunner/tickets/runner_prompt.py
@@ -151,7 +151,5 @@ def build_prompt(
     )
     model = reduce_ticket_flow_prompt_to_budget(model, max_bytes=prompt_max_bytes)
     prompt = render_ticket_flow_prompt(model)
-    if len(prompt.encode("utf-8")) > prompt_max_bytes:
-        prompt = _truncate_text_by_bytes(prompt, prompt_max_bytes)
     validate_ticket_flow_prompt(prompt, max_bytes=prompt_max_bytes)
     return prompt

--- a/src/codex_autorunner/tickets/runner_prompt_support.py
+++ b/src/codex_autorunner/tickets/runner_prompt_support.py
@@ -600,35 +600,3 @@ def validate_ticket_flow_prompt(prompt: str, *, max_bytes: int) -> None:
         raise ValueError(
             "ticket-flow prompt missing required marker(s): " + ", ".join(missing)
         )
-
-
-def render_full_prompt(
-    *,
-    rel_ticket: str,
-    rel_dispatch_dir: str,
-    rel_dispatch_path: str,
-    car_hud: str,
-    apps_hint: str,
-    checkpoint_block: str,
-    commit_block: str,
-    lint_block: str,
-    loop_guard_block: str,
-    sections: dict[str, str],
-) -> str:
-    """Compatibility wrapper for older tests and callers."""
-    return render_ticket_flow_prompt(
-        TicketFlowPromptModel(
-            instructions=FULL_TICKET_FLOW_INSTRUCTIONS,
-            include_optional_sections=True,
-            rel_ticket=rel_ticket,
-            rel_dispatch_dir=rel_dispatch_dir,
-            rel_dispatch_path=rel_dispatch_path,
-            car_hud=car_hud,
-            apps_hint=apps_hint,
-            checkpoint_block=checkpoint_block,
-            commit_block=commit_block,
-            lint_block=lint_block,
-            loop_guard_block=loop_guard_block,
-            sections=TicketFlowPromptSections.from_dict(sections),
-        )
-    )

--- a/src/codex_autorunner/tickets/runner_prompt_support.py
+++ b/src/codex_autorunner/tickets/runner_prompt_support.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Callable
 
 from ..contextspace.paths import contextspace_doc_path
 from .files import safe_relpath
@@ -12,22 +13,175 @@ _logger = logging.getLogger(__name__)
 WORKSPACE_DOC_MAX_CHARS = 4000
 PREVIOUS_TICKET_MAX_BYTES = 16384
 TRUNCATION_MARKER = "\n\n[... TRUNCATED ...]\n\n"
-MAIN_SECTION_ORDER = [
-    "prev_block",
-    "prev_ticket_block",
-    "reply_block",
-    "requested_context_block",
-    "workspace_block",
-    "ticket_block",
-]
-FALLBACK_SECTION_ORDER = [
-    "prev_block",
-    "checkpoint_block",
-    "commit_block",
-    "lint_block",
-    "loop_guard_block",
-    "ticket_block",
-]
+FULL_TICKET_FLOW_INSTRUCTIONS = (
+    "You are running inside Codex Autorunner (CAR) in a ticket-based workflow.\n\n"
+    "Your job in this turn:\n"
+    "- Read the current ticket file.\n"
+    "- Make the required repo changes.\n"
+    "- Update the ticket file to reflect progress.\n"
+    "- Set `done: true` in the ticket YAML frontmatter only when the ticket is truly complete.\n\n"
+    "CAR orientation (80/20):\n"
+    "- `.codex-autorunner/tickets/` is the queue that drives the flow (files named `TICKET-###*.md`, processed in numeric order).\n"
+    "- `.codex-autorunner/contextspace/` holds durable context shared across ticket turns (especially `active_context.md` and `spec.md`).\n"
+    "- `.codex-autorunner/ABOUT_CAR.md` is the repo-local briefing (what CAR auto-generates + helper scripts) if you need operational details.\n\n"
+    "Communicating with the user (optional):\n"
+    "- To send a message or request input, write to the dispatch directory:\n"
+    "  1) write any attachments to the dispatch directory\n"
+    "  2) write `DISPATCH.md` last\n"
+    "- `DISPATCH.md` YAML supports `mode: notify|pause`.\n"
+    "  - `pause` waits for user input; `notify` continues without waiting.\n"
+    "  - Example:\n"
+    "    ---\n"
+    "    mode: pause\n"
+    "    ---\n"
+    "    Need clarification on X before proceeding.\n"
+    '- You do not need a "final" dispatch when you finish; the runner will archive your turn output automatically. Dispatch only if you want something to stand out or you need user input.\n\n'
+    "If blocked:\n"
+    "- Dispatch with `mode: pause` rather than guessing.\n\n"
+    "Creating follow-up tickets (optional):\n"
+    "- New tickets live under `.codex-autorunner/tickets/` and follow the `TICKET-###*.md` naming pattern.\n"
+    "- If present, `.codex-autorunner/bin/ticket_tool.py` can create/insert/move tickets; `.codex-autorunner/bin/lint_tickets.py` is the canonical ticket linter and `ticket_tool.py lint` is only a compatibility wrapper (see `.codex-autorunner/ABOUT_CAR.md`).\n"
+    "Using ticket templates (optional):\n"
+    "- If you need a standard ticket pattern, prefer: `car templates fetch <repo_id>:<path>[@<ref>]`\n"
+    "  - Trusted repos skip scanning; untrusted repos are scanned (cached by blob SHA).\n\n"
+    "Workspace docs:\n"
+    "- You may update or add context under `.codex-autorunner/contextspace/` so future ticket turns have durable context.\n"
+    '- Prefer referencing these docs instead of creating duplicate "shadow" docs elsewhere.\n\n'
+    "Repo hygiene:\n"
+    "- Do not add new `.codex-autorunner/` artifacts to git unless they are already tracked."
+)
+COMPACT_TICKET_FLOW_INSTRUCTIONS = (
+    "CAR ticket flow: read ticket, change repo, update ticket, set "
+    "`done: true` only when complete. If blocked, write DISPATCH.md "
+    "`mode: pause`."
+)
+REQUIRED_PROMPT_MARKERS = (
+    "<CAR_TICKET_FLOW_PROMPT>",
+    "</CAR_TICKET_FLOW_PROMPT>",
+    "<CAR_TICKET_FLOW_INSTRUCTIONS>",
+    "</CAR_TICKET_FLOW_INSTRUCTIONS>",
+    "<CAR_RUNTIME_PATHS>",
+    "</CAR_RUNTIME_PATHS>",
+    "<CAR_CURRENT_TICKET_FILE>",
+    "</CAR_CURRENT_TICKET_FILE>",
+    "<TICKET_MARKDOWN>",
+    "</TICKET_MARKDOWN>",
+)
+
+
+@dataclass(frozen=True)
+class PromptSectionPolicy:
+    key: str
+    required: bool = False
+    preserve_ticket_structure: bool = False
+
+
+SECTION_REDUCTION_POLICY = (
+    PromptSectionPolicy("prev_block"),
+    PromptSectionPolicy("prev_ticket_block"),
+    PromptSectionPolicy("reply_block"),
+    PromptSectionPolicy("requested_context_block"),
+    PromptSectionPolicy("workspace_block"),
+    PromptSectionPolicy("ticket_block", required=True, preserve_ticket_structure=True),
+)
+MAIN_SECTION_ORDER = [policy.key for policy in SECTION_REDUCTION_POLICY]
+
+
+@dataclass(frozen=True)
+class TicketFlowPromptSections:
+    prev_block: str
+    prev_ticket_block: str
+    reply_block: str
+    requested_context_block: str
+    workspace_block: str
+    ticket_block: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "prev_block": self.prev_block,
+            "prev_ticket_block": self.prev_ticket_block,
+            "reply_block": self.reply_block,
+            "requested_context_block": self.requested_context_block,
+            "workspace_block": self.workspace_block,
+            "ticket_block": self.ticket_block,
+        }
+
+    @classmethod
+    def from_dict(cls, values: dict[str, str]) -> TicketFlowPromptSections:
+        return cls(
+            prev_block=values.get("prev_block", ""),
+            prev_ticket_block=values.get("prev_ticket_block", ""),
+            reply_block=values.get("reply_block", ""),
+            requested_context_block=values.get("requested_context_block", ""),
+            workspace_block=values.get("workspace_block", ""),
+            ticket_block=values.get("ticket_block", ""),
+        )
+
+
+@dataclass(frozen=True)
+class TicketFlowPromptModel:
+    instructions: str
+    include_optional_sections: bool
+    rel_ticket: str
+    rel_dispatch_dir: str
+    rel_dispatch_path: str
+    car_hud: str
+    apps_hint: str
+    checkpoint_block: str
+    commit_block: str
+    lint_block: str
+    loop_guard_block: str
+    sections: TicketFlowPromptSections
+
+    def with_sections(
+        self, sections: TicketFlowPromptSections
+    ) -> TicketFlowPromptModel:
+        return TicketFlowPromptModel(
+            instructions=self.instructions,
+            include_optional_sections=self.include_optional_sections,
+            rel_ticket=self.rel_ticket,
+            rel_dispatch_dir=self.rel_dispatch_dir,
+            rel_dispatch_path=self.rel_dispatch_path,
+            car_hud=self.car_hud,
+            apps_hint=self.apps_hint,
+            checkpoint_block=self.checkpoint_block,
+            commit_block=self.commit_block,
+            lint_block=self.lint_block,
+            loop_guard_block=self.loop_guard_block,
+            sections=sections,
+        )
+
+    def with_instructions(self, instructions: str) -> TicketFlowPromptModel:
+        return TicketFlowPromptModel(
+            instructions=instructions,
+            include_optional_sections=self.include_optional_sections,
+            rel_ticket=self.rel_ticket,
+            rel_dispatch_dir=self.rel_dispatch_dir,
+            rel_dispatch_path=self.rel_dispatch_path,
+            car_hud=self.car_hud,
+            apps_hint=self.apps_hint,
+            checkpoint_block=self.checkpoint_block,
+            commit_block=self.commit_block,
+            lint_block=self.lint_block,
+            loop_guard_block=self.loop_guard_block,
+            sections=self.sections,
+        )
+
+    def without_optional_static_blocks(self) -> TicketFlowPromptModel:
+        return TicketFlowPromptModel(
+            instructions=self.instructions,
+            include_optional_sections=False,
+            rel_ticket=self.rel_ticket,
+            rel_dispatch_dir=self.rel_dispatch_dir,
+            rel_dispatch_path=self.rel_dispatch_path,
+            car_hud="",
+            apps_hint="",
+            checkpoint_block=self.checkpoint_block,
+            commit_block=self.commit_block,
+            lint_block=self.lint_block,
+            loop_guard_block=self.loop_guard_block,
+            sections=self.sections,
+        )
 
 
 def truncate_text_by_bytes(text: str, max_bytes: int) -> str:
@@ -69,15 +223,56 @@ def preserve_ticket_structure(ticket_block: str, max_bytes: int) -> str:
     preserve_end = second_marker_idx + len(marker)
     preserved_part = ticket_block[:preserve_end]
     preserved_bytes = len(preserved_part.encode("utf-8"))
+    suffix_start = ticket_block.find("\n</TICKET_MARKDOWN>", preserve_end)
+    suffix = ticket_block[suffix_start:] if suffix_start != -1 else ""
+    suffix_bytes = len(suffix.encode("utf-8"))
     marker_bytes = len(TRUNCATION_MARKER.encode("utf-8"))
-    remaining_bytes = max(max_bytes - preserved_bytes, 0)
+    remaining_bytes = max(max_bytes - preserved_bytes - suffix_bytes, 0)
 
     if remaining_bytes > 0:
-        body = ticket_block[preserve_end:]
+        body = (
+            ticket_block[preserve_end:suffix_start]
+            if suffix_start != -1
+            else ticket_block[preserve_end:]
+        )
         body_budget = max(remaining_bytes - marker_bytes, 0)
-        return preserved_part + truncate_text_by_bytes(body, body_budget)
+        return preserved_part + truncate_text_by_bytes(body, body_budget) + suffix
 
     return truncate_text_by_bytes(ticket_block, max_bytes)
+
+
+def _minimum_ticket_section_bytes(ticket_block: str) -> int:
+    marker = "\n---\n"
+    ticket_md_idx = ticket_block.find("<TICKET_MARKDOWN>")
+    if ticket_md_idx == -1:
+        return 1
+    first_marker_idx = ticket_block.find(marker, ticket_md_idx)
+    if first_marker_idx == -1:
+        return 1
+    second_marker_idx = ticket_block.find(marker, first_marker_idx + 1)
+    if second_marker_idx == -1:
+        return 1
+    preserve_end = second_marker_idx + len(marker)
+    suffix_start = ticket_block.find("\n</TICKET_MARKDOWN>", preserve_end)
+    suffix = ticket_block[suffix_start:] if suffix_start != -1 else ""
+    minimum = (ticket_block[:preserve_end] + TRUNCATION_MARKER + suffix).encode("utf-8")
+    return len(minimum)
+
+
+def _minimum_section_bytes(key: str, value: str) -> int:
+    if key == "ticket_block":
+        return _minimum_ticket_section_bytes(value)
+    return 1
+
+
+def _truncate_section(key: str, value: str, max_bytes: int) -> str:
+    policy = next(
+        (candidate for candidate in SECTION_REDUCTION_POLICY if candidate.key == key),
+        PromptSectionPolicy(key),
+    )
+    if policy.preserve_ticket_structure:
+        return preserve_ticket_structure(value, max_bytes)
+    return truncate_text_by_bytes(value, max_bytes)
 
 
 def shrink_prompt(
@@ -106,11 +301,7 @@ def shrink_prompt(
             new_limit = max(new_limit - marker_bytes, 0)
         if new_limit == 0 and value_bytes > 0:
             new_limit = min(value_bytes, marker_bytes + 1)
-        sections[key] = (
-            preserve_ticket_structure(value, new_limit)
-            if key == "ticket_block"
-            else truncate_text_by_bytes(value, new_limit)
-        )
+        sections[key] = _truncate_section(key, value, new_limit)
         prompt = render()
 
     # Never tail-truncate the assembled prompt: the ticket shell places
@@ -129,11 +320,7 @@ def shrink_prompt(
                 sections[key] = ""
             else:
                 new_limit = max(value_bytes // 2, 1)
-                sections[key] = (
-                    preserve_ticket_structure(value, new_limit)
-                    if key == "ticket_block"
-                    else truncate_text_by_bytes(value, new_limit)
-                )
+                sections[key] = _truncate_section(key, value, new_limit)
             prompt = render()
             progressed = True
             break
@@ -285,6 +472,136 @@ def _apps_hint_block(apps_hint: str) -> str:
     return f"<CAR_INSTALLED_APPS>\n{apps_hint}\n</CAR_INSTALLED_APPS>"
 
 
+def render_ticket_flow_prompt(model: TicketFlowPromptModel) -> str:
+    """Render the canonical ticket-flow prompt contract."""
+    sections = model.sections
+    optional_sections = ""
+    if model.include_optional_sections:
+        optional_sections = (
+            "<CAR_REQUESTED_CONTEXT>\n"
+            f"{sections.requested_context_block}\n"
+            "</CAR_REQUESTED_CONTEXT>\n\n"
+            "<CAR_WORKSPACE_DOCS>\n"
+            f"{sections.workspace_block}\n"
+            "</CAR_WORKSPACE_DOCS>\n\n"
+            "<CAR_HUMAN_REPLIES>\n"
+            f"{sections.reply_block}\n"
+            "</CAR_HUMAN_REPLIES>\n\n"
+            "<CAR_PREVIOUS_TICKET_REFERENCE>\n"
+            f"{sections.prev_ticket_block}\n"
+            "</CAR_PREVIOUS_TICKET_REFERENCE>\n\n"
+        )
+    previous_agent_output = ""
+    if model.include_optional_sections:
+        previous_agent_output = (
+            "\n\n<CAR_PREVIOUS_AGENT_OUTPUT>\n"
+            f"{sections.prev_block}\n"
+            "</CAR_PREVIOUS_AGENT_OUTPUT>"
+        )
+    return (
+        "<CAR_TICKET_FLOW_PROMPT>\n\n"
+        "<CAR_TICKET_FLOW_INSTRUCTIONS>\n"
+        f"{model.instructions}\n"
+        "</CAR_TICKET_FLOW_INSTRUCTIONS>\n\n"
+        "<CAR_RUNTIME_PATHS>\n"
+        f"Current ticket file: {model.rel_ticket}\n"
+        f"Dispatch directory: {model.rel_dispatch_dir}\n"
+        f"DISPATCH.md path: {model.rel_dispatch_path}\n"
+        "</CAR_RUNTIME_PATHS>\n\n"
+        "<CAR_HUD>\n"
+        f"{model.car_hud}\n"
+        "</CAR_HUD>\n\n"
+        f"{_apps_hint_block(model.apps_hint)}\n\n"
+        f"{model.checkpoint_block}\n\n"
+        f"{model.commit_block}\n\n"
+        f"{model.lint_block}\n\n"
+        f"{model.loop_guard_block}\n\n"
+        f"{optional_sections}"
+        f"{sections.ticket_block}\n\n"
+        f"{previous_agent_output}\n\n"
+        "</CAR_TICKET_FLOW_PROMPT>"
+    )
+
+
+def reduce_ticket_flow_prompt_to_budget(
+    model: TicketFlowPromptModel, *, max_bytes: int
+) -> TicketFlowPromptModel:
+    """Shrink optional prompt sections without changing the prompt contract."""
+    if len(render_ticket_flow_prompt(model).encode("utf-8")) > max_bytes:
+        model = model.with_instructions(COMPACT_TICKET_FLOW_INSTRUCTIONS)
+        model = model.without_optional_static_blocks()
+    sections = model.sections.as_dict()
+
+    def current_model() -> TicketFlowPromptModel:
+        return model.with_sections(TicketFlowPromptSections.from_dict(sections))
+
+    def current_prompt() -> str:
+        return render_ticket_flow_prompt(current_model())
+
+    prompt = current_prompt()
+    if len(prompt.encode("utf-8")) <= max_bytes:
+        return model
+
+    marker_bytes = len(TRUNCATION_MARKER.encode("utf-8"))
+    for policy in SECTION_REDUCTION_POLICY:
+        key = policy.key
+        value = sections.get(key, "")
+        if not value:
+            continue
+        prompt = current_prompt()
+        if len(prompt.encode("utf-8")) <= max_bytes:
+            break
+        overflow = len(prompt.encode("utf-8")) - max_bytes
+        value_bytes = len(value.encode("utf-8"))
+        new_limit = max(value_bytes - overflow, 0)
+        if 0 < new_limit < value_bytes:
+            new_limit = max(new_limit - marker_bytes, 0)
+        if new_limit == 0 and value_bytes > 0 and policy.required:
+            new_limit = min(value_bytes, marker_bytes + 1)
+        if policy.required:
+            new_limit = max(new_limit, _minimum_section_bytes(key, value))
+        sections[key] = _truncate_section(key, value, new_limit)
+
+    while len(current_prompt().encode("utf-8")) > max_bytes:
+        progressed = False
+        for policy in SECTION_REDUCTION_POLICY:
+            key = policy.key
+            value = sections.get(key, "")
+            if not value:
+                continue
+            if not policy.required:
+                sections[key] = ""
+            else:
+                value_bytes = len(value.encode("utf-8"))
+                minimum_bytes = _minimum_section_bytes(key, value)
+                if value_bytes <= minimum_bytes:
+                    continue
+                else:
+                    sections[key] = _truncate_section(
+                        key, value, max(value_bytes // 2, minimum_bytes)
+                    )
+            progressed = True
+            break
+        if not progressed:
+            break
+
+    return current_model()
+
+
+def validate_ticket_flow_prompt(prompt: str, *, max_bytes: int) -> None:
+    """Assert the rendered prompt preserves the ticket-flow prompt contract."""
+    prompt_bytes = len(prompt.encode("utf-8"))
+    if prompt_bytes > max_bytes:
+        raise ValueError(
+            f"ticket-flow prompt exceeds budget: {prompt_bytes} > {max_bytes}"
+        )
+    missing = [marker for marker in REQUIRED_PROMPT_MARKERS if marker not in prompt]
+    if missing:
+        raise ValueError(
+            "ticket-flow prompt missing required marker(s): " + ", ".join(missing)
+        )
+
+
 def render_full_prompt(
     *,
     rel_ticket: str,
@@ -298,145 +615,20 @@ def render_full_prompt(
     loop_guard_block: str,
     sections: dict[str, str],
 ) -> str:
-    return (
-        "<CAR_TICKET_FLOW_PROMPT>\n\n"
-        "<CAR_TICKET_FLOW_INSTRUCTIONS>\n"
-        "You are running inside Codex Autorunner (CAR) in a ticket-based workflow.\n\n"
-        "Your job in this turn:\n"
-        "- Read the current ticket file.\n"
-        "- Make the required repo changes.\n"
-        "- Update the ticket file to reflect progress.\n"
-        "- Set `done: true` in the ticket YAML frontmatter only when the ticket is truly complete.\n\n"
-        "CAR orientation (80/20):\n"
-        "- `.codex-autorunner/tickets/` is the queue that drives the flow (files named `TICKET-###*.md`, processed in numeric order).\n"
-        "- `.codex-autorunner/contextspace/` holds durable context shared across ticket turns (especially `active_context.md` and `spec.md`).\n"
-        "- `.codex-autorunner/ABOUT_CAR.md` is the repo-local briefing (what CAR auto-generates + helper scripts) if you need operational details.\n\n"
-        "Communicating with the user (optional):\n"
-        "- To send a message or request input, write to the dispatch directory:\n"
-        "  1) write any attachments to the dispatch directory\n"
-        "  2) write `DISPATCH.md` last\n"
-        "- `DISPATCH.md` YAML supports `mode: notify|pause`.\n"
-        "  - `pause` waits for user input; `notify` continues without waiting.\n"
-        "  - Example:\n"
-        "    ---\n"
-        "    mode: pause\n"
-        "    ---\n"
-        "    Need clarification on X before proceeding.\n"
-        '- You do not need a "final" dispatch when you finish; the runner will archive your turn output automatically. Dispatch only if you want something to stand out or you need user input.\n\n'
-        "If blocked:\n"
-        "- Dispatch with `mode: pause` rather than guessing.\n\n"
-        "Creating follow-up tickets (optional):\n"
-        "- New tickets live under `.codex-autorunner/tickets/` and follow the `TICKET-###*.md` naming pattern.\n"
-        "- If present, `.codex-autorunner/bin/ticket_tool.py` can create/insert/move tickets; `.codex-autorunner/bin/lint_tickets.py` is the canonical ticket linter and `ticket_tool.py lint` is only a compatibility wrapper (see `.codex-autorunner/ABOUT_CAR.md`).\n"
-        "Using ticket templates (optional):\n"
-        "- If you need a standard ticket pattern, prefer: `car templates fetch <repo_id>:<path>[@<ref>]`\n"
-        "  - Trusted repos skip scanning; untrusted repos are scanned (cached by blob SHA).\n\n"
-        "Workspace docs:\n"
-        "- You may update or add context under `.codex-autorunner/contextspace/` so future ticket turns have durable context.\n"
-        '- Prefer referencing these docs instead of creating duplicate "shadow" docs elsewhere.\n\n'
-        "Repo hygiene:\n"
-        "- Do not add new `.codex-autorunner/` artifacts to git unless they are already tracked.\n"
-        "</CAR_TICKET_FLOW_INSTRUCTIONS>\n\n"
-        "<CAR_RUNTIME_PATHS>\n"
-        f"Current ticket file: {rel_ticket}\n"
-        f"Dispatch directory: {rel_dispatch_dir}\n"
-        f"DISPATCH.md path: {rel_dispatch_path}\n"
-        "</CAR_RUNTIME_PATHS>\n\n"
-        "<CAR_HUD>\n"
-        f"{car_hud}\n"
-        "</CAR_HUD>\n\n"
-        f"{_apps_hint_block(apps_hint)}\n\n"
-        f"{checkpoint_block}\n\n"
-        f"{commit_block}\n\n"
-        f"{lint_block}\n\n"
-        f"{loop_guard_block}\n\n"
-        "<CAR_REQUESTED_CONTEXT>\n"
-        f"{sections['requested_context_block']}\n"
-        "</CAR_REQUESTED_CONTEXT>\n\n"
-        "<CAR_WORKSPACE_DOCS>\n"
-        f"{sections['workspace_block']}\n"
-        "</CAR_WORKSPACE_DOCS>\n\n"
-        "<CAR_HUMAN_REPLIES>\n"
-        f"{sections['reply_block']}\n"
-        "</CAR_HUMAN_REPLIES>\n\n"
-        "<CAR_PREVIOUS_TICKET_REFERENCE>\n"
-        f"{sections['prev_ticket_block']}\n"
-        "</CAR_PREVIOUS_TICKET_REFERENCE>\n\n"
-        f"{sections['ticket_block']}\n\n"
-        "<CAR_PREVIOUS_AGENT_OUTPUT>\n"
-        f"{sections['prev_block']}\n"
-        "</CAR_PREVIOUS_AGENT_OUTPUT>\n\n"
-        "</CAR_TICKET_FLOW_PROMPT>"
-    )
-
-
-def build_ticket_first_fallback_prompt(
-    *,
-    max_bytes: int,
-    rel_ticket: str,
-    rel_dispatch_path: str,
-    prev_block: str,
-    checkpoint_block: str,
-    commit_block: str,
-    lint_block: str,
-    loop_guard_block: str,
-    ticket_block: str,
-) -> str:
-    sections = {
-        "prev_block": prev_block,
-        "checkpoint_block": checkpoint_block,
-        "commit_block": commit_block,
-        "lint_block": lint_block,
-        "loop_guard_block": loop_guard_block,
-        "ticket_block": ticket_block,
-    }
-
-    def render() -> str:
-        parts = [
-            "<CAR_TICKET_FLOW_PROMPT>",
-            (
-                "<CAR_TICKET_FLOW_INSTRUCTIONS>\n"
-                "Ticket-first fallback prompt: treat the current ticket file below as the control plane.\n"
-                "Make the required repo changes, update the ticket, and only set `done: true` when the ticket is truly complete.\n"
-                "</CAR_TICKET_FLOW_INSTRUCTIONS>"
-            ),
-            (
-                "<CAR_RUNTIME_PATHS>\n"
-                f"Current ticket file: {rel_ticket}\n"
-                f"DISPATCH.md path: {rel_dispatch_path}\n"
-                "</CAR_RUNTIME_PATHS>"
-            ),
-        ]
-        for key in FALLBACK_SECTION_ORDER:
-            value = sections[key]
-            if value:
-                parts.append(value)
-        parts.append("</CAR_TICKET_FLOW_PROMPT>")
-        return "\n\n".join(parts)
-
-    prompt = shrink_prompt(
-        max_bytes=max_bytes,
-        render=render,
-        sections=sections,
-        order=FALLBACK_SECTION_ORDER,
-    )
-    if (
-        len(prompt.encode("utf-8")) <= max_bytes
-        and "<CAR_CURRENT_TICKET_FILE>" in prompt
-        and "<TICKET_MARKDOWN>" in prompt
-    ):
-        return prompt
-
-    return preserve_ticket_structure(ticket_block, max_bytes)
-
-
-def prompt_has_ticket_control_plane(prompt: str, ticket_doc: Any) -> bool:
-    required_ticket_lines = (
-        f"agent: {ticket_doc.frontmatter.agent}",
-        f"done: {str(bool(ticket_doc.frontmatter.done)).lower()}",
-    )
-    return (
-        "<CAR_CURRENT_TICKET_FILE>" in prompt
-        and "<TICKET_MARKDOWN>" in prompt
-        and all(line in prompt for line in required_ticket_lines)
+    """Compatibility wrapper for older tests and callers."""
+    return render_ticket_flow_prompt(
+        TicketFlowPromptModel(
+            instructions=FULL_TICKET_FLOW_INSTRUCTIONS,
+            include_optional_sections=True,
+            rel_ticket=rel_ticket,
+            rel_dispatch_dir=rel_dispatch_dir,
+            rel_dispatch_path=rel_dispatch_path,
+            car_hud=car_hud,
+            apps_hint=apps_hint,
+            checkpoint_block=checkpoint_block,
+            commit_block=commit_block,
+            lint_block=lint_block,
+            loop_guard_block=loop_guard_block,
+            sections=TicketFlowPromptSections.from_dict(sections),
+        )
     )

--- a/src/codex_autorunner/tickets/runner_prompt_support.py
+++ b/src/codex_autorunner/tickets/runner_prompt_support.py
@@ -235,7 +235,6 @@ def preserve_ticket_structure(ticket_block: str, max_bytes: int) -> str:
     suffix_start = ticket_block.find("\n</TICKET_MARKDOWN>", preserve_end)
     suffix = ticket_block[suffix_start:] if suffix_start != -1 else ""
     suffix_bytes = len(suffix.encode("utf-8"))
-    marker_bytes = len(TRUNCATION_MARKER.encode("utf-8"))
     remaining_bytes = max(max_bytes - preserved_bytes - suffix_bytes, 0)
 
     if remaining_bytes > 0:
@@ -244,8 +243,7 @@ def preserve_ticket_structure(ticket_block: str, max_bytes: int) -> str:
             if suffix_start != -1
             else ticket_block[preserve_end:]
         )
-        body_budget = max(remaining_bytes - marker_bytes, 0)
-        return preserved_part + truncate_text_by_bytes(body, body_budget) + suffix
+        return preserved_part + truncate_text_by_bytes(body, remaining_bytes) + suffix
 
     return truncate_text_by_bytes(ticket_block, max_bytes)
 
@@ -536,9 +534,6 @@ def reduce_ticket_flow_prompt_to_budget(
     model: TicketFlowPromptModel, *, max_bytes: int
 ) -> TicketFlowPromptModel:
     """Shrink optional prompt sections without changing the prompt contract."""
-    if len(render_ticket_flow_prompt(model).encode("utf-8")) > max_bytes:
-        model = model.with_instructions(COMPACT_TICKET_FLOW_INSTRUCTIONS)
-        model = model.without_optional_static_blocks()
     work_model = model
     sections = work_model.sections.as_dict()
 
@@ -548,36 +543,8 @@ def reduce_ticket_flow_prompt_to_budget(
     def current_prompt() -> str:
         return render_ticket_flow_prompt(current_model())
 
-    prompt = current_prompt()
-    if len(prompt.encode("utf-8")) <= max_bytes:
-        return current_model()
-
-    marker_bytes = len(TRUNCATION_MARKER.encode("utf-8"))
-    for policy in SECTION_REDUCTION_POLICY:
-        key = policy.key
-        if not _section_key_affects_render_size(
-            key, include_optional_sections=work_model.include_optional_sections
-        ):
-            continue
-        value = sections.get(key, "")
-        if not value:
-            continue
-        prompt = current_prompt()
-        if len(prompt.encode("utf-8")) <= max_bytes:
-            break
-        overflow = len(prompt.encode("utf-8")) - max_bytes
-        value_bytes = len(value.encode("utf-8"))
-        new_limit = max(value_bytes - overflow, 0)
-        if 0 < new_limit < value_bytes:
-            new_limit = max(new_limit - marker_bytes, 0)
-        if new_limit == 0 and value_bytes > 0 and policy.required:
-            new_limit = min(value_bytes, marker_bytes + 1)
-        if policy.required:
-            new_limit = max(new_limit, _minimum_section_bytes(key, value))
-        sections[key] = _truncate_section(key, value, new_limit)
-
-    while len(current_prompt().encode("utf-8")) > max_bytes:
-        progressed = False
+    def shrink_rendered_sections() -> None:
+        marker_bytes = len(TRUNCATION_MARKER.encode("utf-8"))
         for policy in SECTION_REDUCTION_POLICY:
             key = policy.key
             if not _section_key_affects_render_size(
@@ -587,49 +554,69 @@ def reduce_ticket_flow_prompt_to_budget(
             value = sections.get(key, "")
             if not value:
                 continue
-            if not policy.required:
-                sections[key] = ""
-            else:
-                value_bytes = len(value.encode("utf-8"))
-                minimum_bytes = _minimum_section_bytes(key, value)
-                if value_bytes <= minimum_bytes:
+            prompt = current_prompt()
+            if len(prompt.encode("utf-8")) <= max_bytes:
+                break
+            overflow = len(prompt.encode("utf-8")) - max_bytes
+            value_bytes = len(value.encode("utf-8"))
+            new_limit = max(value_bytes - overflow, 0)
+            if 0 < new_limit < value_bytes:
+                new_limit = max(new_limit - marker_bytes, 0)
+            if new_limit == 0 and value_bytes > 0 and policy.required:
+                new_limit = min(value_bytes, marker_bytes + 1)
+            if policy.required:
+                new_limit = max(new_limit, _minimum_section_bytes(key, value))
+            sections[key] = _truncate_section(key, value, new_limit)
+
+        while len(current_prompt().encode("utf-8")) > max_bytes:
+            progressed = False
+            for policy in SECTION_REDUCTION_POLICY:
+                key = policy.key
+                if not _section_key_affects_render_size(
+                    key, include_optional_sections=work_model.include_optional_sections
+                ):
                     continue
+                value = sections.get(key, "")
+                if not value:
+                    continue
+                if not policy.required:
+                    sections[key] = ""
                 else:
-                    sections[key] = _truncate_section(
-                        key, value, max(value_bytes // 2, minimum_bytes)
-                    )
-            progressed = True
-            break
-        if not progressed:
-            break
+                    value_bytes = len(value.encode("utf-8"))
+                    minimum_bytes = _minimum_section_bytes(key, value)
+                    if value_bytes <= minimum_bytes:
+                        continue
+                    else:
+                        sections[key] = _truncate_section(
+                            key, value, max(value_bytes // 2, minimum_bytes)
+                        )
+                progressed = True
+                break
+            if not progressed:
+                break
+
+    if len(current_prompt().encode("utf-8")) <= max_bytes:
+        return current_model()
+
+    shrink_rendered_sections()
+    if len(current_prompt().encode("utf-8")) <= max_bytes:
+        return current_model()
+
+    work_model = work_model.with_instructions(COMPACT_TICKET_FLOW_INSTRUCTIONS)
+    work_model = work_model.without_optional_static_blocks()
+    shrink_rendered_sections()
 
     while len(current_prompt().encode("utf-8")) > max_bytes:
-        progressed = False
         if work_model.checkpoint_block:
             work_model = replace(work_model, checkpoint_block="")
-            progressed = True
         elif work_model.commit_block:
             work_model = replace(work_model, commit_block="")
-            progressed = True
         elif work_model.lint_block:
             work_model = replace(work_model, lint_block="")
-            progressed = True
         elif work_model.loop_guard_block:
             work_model = replace(work_model, loop_guard_block="")
-            progressed = True
-        if progressed:
-            continue
-        tb = sections.get("ticket_block", "")
-        if not tb:
+        else:
             break
-        prompt_len = len(current_prompt().encode("utf-8"))
-        overflow = prompt_len - max_bytes
-        tb_bytes = len(tb.encode("utf-8"))
-        new_limit = max(tb_bytes - overflow - marker_bytes, 1)
-        new_tb = truncate_text_by_bytes(tb, new_limit)
-        if new_tb == tb:
-            break
-        sections["ticket_block"] = new_tb
 
     return current_model()
 

--- a/src/codex_autorunner/tickets/runner_prompt_support.py
+++ b/src/codex_autorunner/tickets/runner_prompt_support.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Callable
 
@@ -85,6 +85,15 @@ SECTION_REDUCTION_POLICY = (
     PromptSectionPolicy("ticket_block", required=True, preserve_ticket_structure=True),
 )
 MAIN_SECTION_ORDER = [policy.key for policy in SECTION_REDUCTION_POLICY]
+
+
+def _section_key_affects_render_size(
+    key: str, *, include_optional_sections: bool
+) -> bool:
+    """Return whether mutating this section key can change rendered prompt size."""
+    if include_optional_sections:
+        return True
+    return key == "ticket_block"
 
 
 @dataclass(frozen=True)
@@ -530,21 +539,26 @@ def reduce_ticket_flow_prompt_to_budget(
     if len(render_ticket_flow_prompt(model).encode("utf-8")) > max_bytes:
         model = model.with_instructions(COMPACT_TICKET_FLOW_INSTRUCTIONS)
         model = model.without_optional_static_blocks()
-    sections = model.sections.as_dict()
+    work_model = model
+    sections = work_model.sections.as_dict()
 
     def current_model() -> TicketFlowPromptModel:
-        return model.with_sections(TicketFlowPromptSections.from_dict(sections))
+        return work_model.with_sections(TicketFlowPromptSections.from_dict(sections))
 
     def current_prompt() -> str:
         return render_ticket_flow_prompt(current_model())
 
     prompt = current_prompt()
     if len(prompt.encode("utf-8")) <= max_bytes:
-        return model
+        return current_model()
 
     marker_bytes = len(TRUNCATION_MARKER.encode("utf-8"))
     for policy in SECTION_REDUCTION_POLICY:
         key = policy.key
+        if not _section_key_affects_render_size(
+            key, include_optional_sections=work_model.include_optional_sections
+        ):
+            continue
         value = sections.get(key, "")
         if not value:
             continue
@@ -566,6 +580,10 @@ def reduce_ticket_flow_prompt_to_budget(
         progressed = False
         for policy in SECTION_REDUCTION_POLICY:
             key = policy.key
+            if not _section_key_affects_render_size(
+                key, include_optional_sections=work_model.include_optional_sections
+            ):
+                continue
             value = sections.get(key, "")
             if not value:
                 continue
@@ -584,6 +602,34 @@ def reduce_ticket_flow_prompt_to_budget(
             break
         if not progressed:
             break
+
+    while len(current_prompt().encode("utf-8")) > max_bytes:
+        progressed = False
+        if work_model.checkpoint_block:
+            work_model = replace(work_model, checkpoint_block="")
+            progressed = True
+        elif work_model.commit_block:
+            work_model = replace(work_model, commit_block="")
+            progressed = True
+        elif work_model.lint_block:
+            work_model = replace(work_model, lint_block="")
+            progressed = True
+        elif work_model.loop_guard_block:
+            work_model = replace(work_model, loop_guard_block="")
+            progressed = True
+        if progressed:
+            continue
+        tb = sections.get("ticket_block", "")
+        if not tb:
+            break
+        prompt_len = len(current_prompt().encode("utf-8"))
+        overflow = prompt_len - max_bytes
+        tb_bytes = len(tb.encode("utf-8"))
+        new_limit = max(tb_bytes - overflow - marker_bytes, 1)
+        new_tb = truncate_text_by_bytes(tb, new_limit)
+        if new_tb == tb:
+            break
+        sections["ticket_block"] = new_tb
 
     return current_model()
 

--- a/tests/tickets/test_prompt_budgeting.py
+++ b/tests/tickets/test_prompt_budgeting.py
@@ -13,6 +13,7 @@ from codex_autorunner.tickets.runner_prompt import (
     _shrink_prompt,
     _truncate_text_by_bytes,
 )
+from codex_autorunner.tickets.runner_prompt_support import REQUIRED_PROMPT_MARKERS
 
 
 def _write_ticket(
@@ -180,6 +181,8 @@ async def test_oversize_ticket_body_is_truncated(tmp_path: Path) -> None:
         # Prompt should be truncated to fit budget
         assert len(req.prompt.encode("utf-8")) <= 1024
         assert "[... TRUNCATED ...]" in req.prompt
+        for marker in REQUIRED_PROMPT_MARKERS:
+            assert marker in req.prompt
         return AgentTurnResult(
             agent_id=req.agent_id,
             conversation_id="conv",
@@ -243,147 +246,8 @@ class TestPreserveTicketStructure:
         assert "[... TRUNCATED" in result
 
 
-class TestPromptHasTicketControlPlane:
-    def test_detects_valid_prompt(self) -> None:
-        from codex_autorunner.tickets.models import TicketDoc, TicketFrontmatter
-        from codex_autorunner.tickets.runner_prompt_support import (
-            prompt_has_ticket_control_plane,
-        )
-
-        fm = TicketFrontmatter(ticket_id="t1", agent="codex", done=False)
-        doc = TicketDoc(path=Path("t.md"), index=1, frontmatter=fm, body="")
-        prompt = (
-            "<CAR_CURRENT_TICKET_FILE>\n"
-            "<TICKET_MARKDOWN>\n"
-            "agent: codex\n"
-            "done: false\n"
-            "</TICKET_MARKDOWN>\n"
-            "</CAR_CURRENT_TICKET_FILE>"
-        )
-        assert prompt_has_ticket_control_plane(prompt, doc) is True
-
-    def test_rejects_prompt_missing_ticket_file_tag(self) -> None:
-        from codex_autorunner.tickets.models import TicketDoc, TicketFrontmatter
-        from codex_autorunner.tickets.runner_prompt_support import (
-            prompt_has_ticket_control_plane,
-        )
-
-        fm = TicketFrontmatter(ticket_id="t1", agent="codex", done=False)
-        doc = TicketDoc(path=Path("t.md"), index=1, frontmatter=fm, body="")
-        assert prompt_has_ticket_control_plane("no tags here", doc) is False
-
-    def test_rejects_prompt_missing_agent_line(self) -> None:
-        from codex_autorunner.tickets.models import TicketDoc, TicketFrontmatter
-        from codex_autorunner.tickets.runner_prompt_support import (
-            prompt_has_ticket_control_plane,
-        )
-
-        fm = TicketFrontmatter(ticket_id="t1", agent="codex", done=False)
-        doc = TicketDoc(path=Path("t.md"), index=1, frontmatter=fm, body="")
-        prompt = (
-            "<CAR_CURRENT_TICKET_FILE>\n"
-            "<TICKET_MARKDOWN>\n"
-            "done: false\n"
-            "</TICKET_MARKDOWN>\n"
-            "</CAR_CURRENT_TICKET_FILE>"
-        )
-        assert prompt_has_ticket_control_plane(prompt, doc) is False
-
-    def test_rejects_prompt_missing_done_line(self) -> None:
-        from codex_autorunner.tickets.models import TicketDoc, TicketFrontmatter
-        from codex_autorunner.tickets.runner_prompt_support import (
-            prompt_has_ticket_control_plane,
-        )
-
-        fm = TicketFrontmatter(ticket_id="t1", agent="codex", done=True)
-        doc = TicketDoc(path=Path("t.md"), index=1, frontmatter=fm, body="")
-        prompt = (
-            "<CAR_CURRENT_TICKET_FILE>\n"
-            "<TICKET_MARKDOWN>\n"
-            "agent: codex\n"
-            "</TICKET_MARKDOWN>\n"
-            "</CAR_CURRENT_TICKET_FILE>"
-        )
-        assert prompt_has_ticket_control_plane(prompt, doc) is False
-
-
-class TestBuildTicketFirstFallbackPrompt:
-    def test_fallback_contains_ticket_shell(self, tmp_path: Path) -> None:
-        from codex_autorunner.tickets.runner_prompt_support import (
-            build_ticket_first_fallback_prompt,
-        )
-
-        ticket_block = (
-            "<CAR_CURRENT_TICKET_FILE>\n"
-            "PATH: tickets/TICKET-001.md\n"
-            "<TICKET_MARKDOWN>\n"
-            "---\n"
-            "agent: codex\n"
-            "done: false\n"
-            "title: Test\n"
-            "---\n\n"
-            "Do the thing\n"
-            "</TICKET_MARKDOWN>\n"
-            "</CAR_CURRENT_TICKET_FILE>"
-        )
-
-        result = build_ticket_first_fallback_prompt(
-            max_bytes=50000,
-            rel_ticket="tickets/TICKET-001.md",
-            rel_dispatch_path="dispatch/DISPATCH.md",
-            prev_block="",
-            checkpoint_block="",
-            commit_block="",
-            lint_block="",
-            loop_guard_block="",
-            ticket_block=ticket_block,
-        )
-
-        assert "<CAR_TICKET_FLOW_PROMPT>" in result
-        assert "<CAR_TICKET_FLOW_INSTRUCTIONS>" in result
-        assert "<CAR_CURRENT_TICKET_FILE>" in result
-        assert "<TICKET_MARKDOWN>" in result
-        assert "agent: codex" in result
-        assert "done: false" in result
-
-    def test_fallback_preserves_ticket_when_over_budget(self, tmp_path: Path) -> None:
-        from codex_autorunner.tickets.runner_prompt_support import (
-            build_ticket_first_fallback_prompt,
-        )
-
-        ticket_block = (
-            "<CAR_CURRENT_TICKET_FILE>\n"
-            "PATH: tickets/TICKET-001.md\n"
-            "<TICKET_MARKDOWN>\n"
-            "---\n"
-            "agent: codex\n"
-            "done: false\n"
-            "title: Test\n"
-            "---\n\n"
-            "Do the thing\n"
-            "</TICKET_MARKDOWN>\n"
-            "</CAR_CURRENT_TICKET_FILE>"
-        )
-
-        small_budget = 200
-        result = build_ticket_first_fallback_prompt(
-            max_bytes=small_budget,
-            rel_ticket="tickets/TICKET-001.md",
-            rel_dispatch_path="dispatch/DISPATCH.md",
-            prev_block="x" * 50000,
-            checkpoint_block="",
-            commit_block="",
-            lint_block="",
-            loop_guard_block="",
-            ticket_block=ticket_block,
-        )
-
-        assert len(result.encode("utf-8")) <= small_budget
-        assert "agent: codex" in result or "[... TRUNCATED" in result
-
-
 @pytest.mark.asyncio
-async def test_aggressive_shrink_triggers_fallback_prompt(tmp_path: Path) -> None:
+async def test_aggressive_shrink_uses_full_prompt_path(tmp_path: Path) -> None:
     workspace_root = tmp_path
     ticket_dir = workspace_root / ".codex-autorunner" / "tickets"
     ticket_dir.mkdir(parents=True, exist_ok=True)
@@ -401,8 +265,9 @@ async def test_aggressive_shrink_triggers_fallback_prompt(tmp_path: Path) -> Non
 
     def handler(req: AgentTurnRequest) -> AgentTurnResult:
         assert len(req.prompt.encode("utf-8")) <= 800
-        if "<CAR_TICKET_FLOW_PROMPT>" in req.prompt:
-            assert "<TICKET_MARKDOWN>" in req.prompt or "[... TRUNCATED" in req.prompt
+        assert "Ticket-first fallback prompt" not in req.prompt
+        for marker in REQUIRED_PROMPT_MARKERS:
+            assert marker in req.prompt
         return AgentTurnResult(
             agent_id=req.agent_id,
             conversation_id="conv",
@@ -504,111 +369,3 @@ async def test_ticket_frontmatter_preserved_on_truncation(tmp_path: Path) -> Non
 
     result = await runner.step({})
     assert result.status == "continue"
-
-
-class TestTicketFirstFallbackPromptContract:
-    def test_fallback_contains_required_control_plane_tags(
-        self, tmp_path: Path
-    ) -> None:
-        from codex_autorunner.tickets.runner_prompt_support import (
-            build_ticket_first_fallback_prompt,
-        )
-
-        ticket_block = (
-            "<CAR_CURRENT_TICKET_FILE>\n"
-            "PATH: tickets/TICKET-001.md\n"
-            "<TICKET_MARKDOWN>\n"
-            "---\n"
-            "agent: codex\n"
-            "done: false\n"
-            "title: Test\n"
-            "---\n\nDo the thing\n"
-            "</TICKET_MARKDOWN>\n"
-            "</CAR_CURRENT_TICKET_FILE>"
-        )
-
-        result = build_ticket_first_fallback_prompt(
-            max_bytes=50000,
-            rel_ticket="tickets/TICKET-001.md",
-            rel_dispatch_path="dispatch/DISPATCH.md",
-            prev_block="",
-            checkpoint_block="",
-            commit_block="",
-            lint_block="",
-            loop_guard_block="",
-            ticket_block=ticket_block,
-        )
-
-        assert "<CAR_TICKET_FLOW_PROMPT>" in result
-        assert "<CAR_TICKET_FLOW_INSTRUCTIONS>" in result
-        assert "<CAR_CURRENT_TICKET_FILE>" in result
-        assert "agent: codex" in result
-        assert "done: false" in result
-
-    def test_fallback_drops_nonessential_blocks_under_budget(
-        self, tmp_path: Path
-    ) -> None:
-        from codex_autorunner.tickets.runner_prompt_support import (
-            build_ticket_first_fallback_prompt,
-        )
-
-        ticket_block = (
-            "<CAR_CURRENT_TICKET_FILE>\n"
-            "PATH: tickets/TICKET-001.md\n"
-            "<TICKET_MARKDOWN>\n"
-            "---\n"
-            "agent: codex\n"
-            "done: false\n"
-            "---\n\nBody\n"
-            "</TICKET_MARKDOWN>\n"
-            "</CAR_CURRENT_TICKET_FILE>"
-        )
-
-        result = build_ticket_first_fallback_prompt(
-            max_bytes=500,
-            rel_ticket="tickets/TICKET-001.md",
-            rel_dispatch_path="dispatch/DISPATCH.md",
-            prev_block="x" * 50000,
-            checkpoint_block="y" * 50000,
-            commit_block="z" * 50000,
-            lint_block="w" * 50000,
-            loop_guard_block="v" * 50000,
-            ticket_block=ticket_block,
-        )
-
-        assert len(result.encode("utf-8")) <= 500
-        assert "agent: codex" in result or "[... TRUNCATED" in result
-
-    def test_fallback_preserves_ticket_under_severe_budget(
-        self, tmp_path: Path
-    ) -> None:
-        from codex_autorunner.tickets.runner_prompt_support import (
-            build_ticket_first_fallback_prompt,
-        )
-
-        ticket_block = (
-            "<CAR_CURRENT_TICKET_FILE>\n"
-            "PATH: tickets/TICKET-001.md\n"
-            "<TICKET_MARKDOWN>\n"
-            "---\n"
-            "agent: codex\n"
-            "done: false\n"
-            "---\n\nBody\n"
-            "</TICKET_MARKDOWN>\n"
-            "</CAR_CURRENT_TICKET_FILE>"
-        )
-
-        result = build_ticket_first_fallback_prompt(
-            max_bytes=1000,
-            rel_ticket="tickets/TICKET-001.md",
-            rel_dispatch_path="dispatch/DISPATCH.md",
-            prev_block="x" * 50000,
-            checkpoint_block="",
-            commit_block="",
-            lint_block="",
-            loop_guard_block="",
-            ticket_block=ticket_block,
-        )
-
-        assert "<CAR_TICKET_FLOW_PROMPT>" in result
-        assert len(result.encode("utf-8")) <= 1000

--- a/tests/tickets/test_ticket_prompt_boundaries.py
+++ b/tests/tickets/test_ticket_prompt_boundaries.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from codex_autorunner.tickets.files import read_ticket
 from codex_autorunner.tickets.models import TicketRunConfig
 from codex_autorunner.tickets.runner_prompt import (
@@ -11,6 +13,7 @@ from codex_autorunner.tickets.runner_prompt import (
     CAR_HUD_MAX_LINES,
     build_prompt,
 )
+from codex_autorunner.tickets.runner_prompt_support import REQUIRED_PROMPT_MARKERS
 
 
 def _make_outbox(workspace_root: Path) -> MagicMock:
@@ -100,6 +103,45 @@ def test_ticket_flow_prompt_boundaries(tmp_path: Path) -> None:
     section = prompt[start:end]
     path_marker = "PATH: .codex-autorunner/tickets/TICKET-001.md"
     assert path_marker in section
+
+
+@pytest.mark.parametrize(
+    ("agent_line", "expected_agent"),
+    [
+        ("agent: codex", "agent: codex"),
+        ('agent: "codex"', 'agent: "codex"'),
+        ("agent: opencode", "agent: opencode"),
+    ],
+)
+def test_ticket_flow_prompt_shape_is_not_agent_specific(
+    tmp_path: Path, agent_line: str, expected_agent: str
+) -> None:
+    workspace_root = tmp_path
+    ticket_dir = workspace_root / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True, exist_ok=True)
+    ticket_path = ticket_dir / "TICKET-001.md"
+    ticket_path.write_text(
+        f"---\n{agent_line}\ndone: false\n---\nGoal: Test agent prompt shape\n",
+        encoding="utf-8",
+    )
+
+    ticket_doc, errors = read_ticket(ticket_path)
+    assert errors == []
+    prompt = build_prompt(
+        ticket_path=ticket_path,
+        workspace_root=workspace_root,
+        ticket_doc=ticket_doc,
+        last_agent_output=None,
+        outbox_paths=_make_outbox(workspace_root),
+        lint_errors=None,
+    )
+
+    assert "<CAR_HUD>" in prompt
+    assert "<CAR_REQUESTED_CONTEXT>" in prompt
+    assert expected_agent in prompt
+    for marker in REQUIRED_PROMPT_MARKERS:
+        assert marker in prompt
+    assert "Ticket-first fallback prompt" not in prompt
 
 
 def test_prompt_no_apps_installed_omits_apps_section(tmp_path: Path) -> None:

--- a/tests/tickets/test_ticket_prompt_boundaries.py
+++ b/tests/tickets/test_ticket_prompt_boundaries.py
@@ -192,3 +192,81 @@ def test_prompt_with_installed_apps_includes_hint(tmp_path: Path) -> None:
     assert "</CAR_INSTALLED_APPS>" in prompt
     assert "test.app v1.2.3" in prompt
     assert "car apps run test.app run -- ..." in prompt
+
+
+def test_prompt_budget_trims_previous_output_before_compacting(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path
+    ticket_dir = workspace_root / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True, exist_ok=True)
+    ticket_path = ticket_dir / "TICKET-001.md"
+    ticket_path.write_text(
+        "---\nagent: codex\ndone: false\n---\nGoal: Preserve replies\n",
+        encoding="utf-8",
+    )
+    ticket_doc, errors = read_ticket(ticket_path)
+    assert errors == []
+    base_prompt = build_prompt(
+        ticket_path=ticket_path,
+        workspace_root=workspace_root,
+        ticket_doc=ticket_doc,
+        last_agent_output=None,
+        outbox_paths=_make_outbox(workspace_root),
+        lint_errors=None,
+        reply_context="KEEP_REPLY",
+        requested_context="KEEP_REQUESTED_CONTEXT",
+    )
+    budget = len(base_prompt.encode("utf-8")) + 100
+
+    prompt = build_prompt(
+        ticket_path=ticket_path,
+        workspace_root=workspace_root,
+        ticket_doc=ticket_doc,
+        last_agent_output="z" * 500_000,
+        outbox_paths=_make_outbox(workspace_root),
+        lint_errors=None,
+        reply_context="KEEP_REPLY",
+        requested_context="KEEP_REQUESTED_CONTEXT",
+        prompt_max_bytes=budget,
+    )
+
+    assert len(prompt.encode("utf-8")) <= budget
+    assert "KEEP_REPLY" in prompt
+    assert "KEEP_REQUESTED_CONTEXT" in prompt
+    assert "<CAR_HUMAN_REPLIES>" in prompt
+    assert "[... TRUNCATED ...]" in prompt
+
+
+def test_prompt_budget_can_drop_static_warnings_without_crashing(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path
+    ticket_dir = workspace_root / ".codex-autorunner" / "tickets"
+    ticket_dir.mkdir(parents=True, exist_ok=True)
+    ticket_path = ticket_dir / "TICKET-001.md"
+    ticket_path.write_text(
+        "---\nagent: codex\ndone: false\n---\nGoal: Tight static warnings\n",
+        encoding="utf-8",
+    )
+    ticket_doc, errors = read_ticket(ticket_path)
+    assert errors == []
+
+    prompt = build_prompt(
+        ticket_path=ticket_path,
+        workspace_root=workspace_root,
+        ticket_doc=ticket_doc,
+        last_agent_output="z" * 500_000,
+        last_checkpoint_error="checkpoint failed: " + ("x" * 20_000),
+        commit_required=True,
+        commit_attempt=1,
+        commit_max_attempts=2,
+        outbox_paths=_make_outbox(workspace_root),
+        lint_errors=["bad frontmatter: " + ("y" * 20_000)],
+        prior_no_change_turns=3,
+        prompt_max_bytes=1200,
+    )
+
+    assert len(prompt.encode("utf-8")) <= 1200
+    for marker in REQUIRED_PROMPT_MARKERS:
+        assert marker in prompt


### PR DESCRIPTION
## Summary

Refactors ticket-flow prompt construction into a single canonical prompt pipeline:

- builds a typed `TicketFlowPromptModel` and `TicketFlowPromptSections` before rendering
- renders through one ticket-flow prompt contract instead of switching to a semantic fallback prompt
- applies deterministic budget reduction through section policies, preserving the current ticket block and required markers
- validates rendered prompts against required structural markers and byte budget
- adds regression coverage for quoted/non-codex agents and severe budget prompts

## Root Cause

The old prompt path used a raw string guard for `agent` and `done` to decide whether the full prompt survived shrinking. Valid YAML such as `agent: "codex"` failed that guard and triggered the compact `Ticket-first fallback prompt` path on normal ticket turns.

## Validation

- `.venv/bin/python -m pytest -q tests/tickets/test_ticket_prompt_boundaries.py tests/tickets/test_prompt_budgeting.py tests/tickets/test_runner_invariants.py` -> 65 passed
- `.venv/bin/python -m ruff check src/codex_autorunner/tickets/runner_prompt.py src/codex_autorunner/tickets/runner_prompt_support.py tests/tickets/test_prompt_budgeting.py tests/tickets/test_ticket_prompt_boundaries.py` -> passed
- `git diff --check` -> clean
- Commit hook aggregate lane -> passed, including 8518 backend tests, mypy, frontend lint/build/tests, SPA shell check, and chat-surface lab checks