### PR TITLE
[codex] Fix short cumulative Hermes PMA replies

### DIFF
--- a/src/codex_autorunner/adapters/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_turns.py
@@ -784,8 +784,6 @@ def trim_cumulative_assistant_text(
     previous = str(previous_assistant_text or "")
     if not current.strip() or not previous.strip():
         return current
-    if len(_normalized_non_whitespace(previous)) < 80:
-        return current
     if current == previous:
         return current
     if current.startswith(previous):

--- a/src/codex_autorunner/adapters/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_turns.py
@@ -739,10 +739,6 @@ def managed_thread_session_metadata(
     )
 
 
-def _normalized_non_whitespace(value: str) -> str:
-    return "".join(ch for ch in value if not ch.isspace())
-
-
 def _whitespace_insensitive_prefix_end(value: str, prefix: str) -> Optional[int]:
     value_index = 0
     prefix_index = 0

--- a/src/codex_autorunner/adapters/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_turns.py
@@ -3034,6 +3034,9 @@ async def finalize_managed_thread_execution(
         outcome = recovered_outcome
 
     if outcome.status == "ok":
+        assistant_text_for_normalization = (
+            outcome.assistant_text or event_state.best_assistant_text()
+        )
         prior_assistant_candidates = await _prior_assistant_text_candidates(
             orchestration_service,
             hub_client=resolved_hub_client,
@@ -3044,10 +3047,13 @@ async def finalize_managed_thread_execution(
             normalized_assistant_text,
             matched_prior_assistant_text,
         ) = trim_cumulative_assistant_text_from_candidates(
-            outcome.assistant_text,
+            assistant_text_for_normalization,
             prior_assistant_candidates,
         )
-        if normalized_assistant_text != outcome.assistant_text:
+        terminal_evidence_updates: dict[str, Any] = {}
+        if not outcome.assistant_text and assistant_text_for_normalization:
+            terminal_evidence_updates["assistant_text_from_event_state"] = True
+        if normalized_assistant_text != assistant_text_for_normalization:
             log_event(
                 logger,
                 logging.WARNING,
@@ -3060,18 +3066,20 @@ async def finalize_managed_thread_execution(
                     or started.execution.backend_id,
                     surface=surface,
                 ),
-                original_assistant_chars=len(outcome.assistant_text),
+                original_assistant_chars=len(assistant_text_for_normalization),
                 previous_assistant_chars=len(matched_prior_assistant_text),
                 trimmed_assistant_chars=len(normalized_assistant_text),
                 prior_assistant_candidate_count=len(prior_assistant_candidates),
                 **runtime_trace_fields(event_state),
                 **terminal_evidence_trace_fields(outcome),
             )
+            terminal_evidence_updates["assistant_text_trimmed_from_cumulative"] = True
+        if normalized_assistant_text != outcome.assistant_text:
             outcome = replace(
                 outcome,
                 assistant_text=normalized_assistant_text,
                 terminal_evidence=dict(outcome.terminal_evidence)
-                | {"assistant_text_trimmed_from_cumulative": True},
+                | terminal_evidence_updates,
             )
 
     terminal_event = terminal_run_event_from_outcome(outcome, event_state)

--- a/tests/adapters/chat/test_managed_thread_turns.py
+++ b/tests/adapters/chat/test_managed_thread_turns.py
@@ -1989,6 +1989,114 @@ async def test_finalize_managed_thread_execution_trims_cumulative_terminal_outpu
 
 
 @pytest.mark.anyio
+async def test_finalize_managed_thread_execution_trims_cumulative_streamed_terminal_output_when_outcome_is_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    previous_answer = (
+        "Earlier Hermes PMA answer with enough detail to resemble a real "
+        "multi-paragraph Discord response. " * 40
+    )
+    new_answer = "Fresh answer for only the current turn."
+    cumulative_answer = previous_answer + "\n\n" + new_answer
+    recorded_results: list[dict[str, Any]] = []
+    fake_hub_client = _FakeHubPersistenceClient()
+    started = _started_execution_with_backend_ids(tmp_path)
+
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "harness_supports_event_streaming",
+        lambda _harness: True,
+    )
+
+    async def _progress_stream(*args: Any, **kwargs: Any):
+        _ = args, kwargs
+        yield {
+            "message": {
+                "method": "prompt/completed",
+                "params": {
+                    "status": "completed",
+                    "finalOutput": cumulative_answer,
+                },
+            }
+        }
+
+    async def _empty_successful_outcome(
+        *args: Any, **kwargs: Any
+    ) -> RuntimeThreadOutcome:
+        _ = args, kwargs
+        return RuntimeThreadOutcome(
+            status="ok",
+            assistant_text="",
+            error=None,
+            backend_thread_id="session-1",
+            backend_turn_id="turn-1",
+        )
+
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "harness_progress_event_stream",
+        _progress_stream,
+    )
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "await_runtime_thread_outcome",
+        _empty_successful_outcome,
+    )
+
+    orchestration_service = SimpleNamespace(
+        get_thread_target=lambda managed_thread_id: SimpleNamespace(
+            backend_thread_id="session-1",
+            repo_id="repo-1",
+            resource_kind="repo",
+            resource_id="repo-1",
+            agent_id="hermes",
+            workspace_root=str(tmp_path),
+        ),
+        get_thread_runtime_binding=lambda managed_thread_id: SimpleNamespace(
+            backend_thread_id="session-1"
+        ),
+        get_previous_completed_execution=lambda managed_thread_id, *, exclude_execution_id=None: ExecutionRecord(
+            execution_id="previous-exec",
+            target_id=managed_thread_id,
+            target_kind="thread",
+            status="ok",
+            output_text=previous_answer,
+        ),
+        record_execution_result=lambda *args, **kwargs: (
+            recorded_results.append(dict(kwargs))
+            or SimpleNamespace(status="ok", error=None)
+        ),
+    )
+
+    result = await managed_thread_turns_module.finalize_managed_thread_execution(
+        orchestration_service=orchestration_service,
+        started=started,
+        state_root=tmp_path,
+        hub_client=fake_hub_client,
+        raw_config={},
+        surface=managed_thread_turns_module.ManagedThreadSurfaceInfo(
+            log_label="Discord",
+            surface_kind="discord",
+            surface_key="discord:chan-1",
+        ),
+        errors=managed_thread_turns_module.ManagedThreadErrorMessages(
+            public_execution_error="Discord PMA execution failed",
+            timeout_error="Discord PMA turn timed out",
+            interrupted_error="Discord PMA turn interrupted",
+            timeout_seconds=5,
+        ),
+        logger=logging.getLogger("test.managed_thread.trim_streamed_cumulative"),
+        turn_preview="hello",
+    )
+
+    assert result.assistant_text == new_answer
+    assert recorded_results[-1]["assistant_text"] == new_answer
+    assert fake_hub_client.transcript_requests[-1].assistant_text == new_answer
+    assert result.token_usage is None
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     (
         "surface_kind",

--- a/tests/adapters/chat/test_managed_thread_turns.py
+++ b/tests/adapters/chat/test_managed_thread_turns.py
@@ -143,6 +143,13 @@ def test_trim_cumulative_assistant_text_removes_exact_prior_prefix() -> None:
     )
 
 
+def test_trim_cumulative_assistant_text_removes_short_prior_prefix() -> None:
+    assert (
+        managed_thread_turns_module.trim_cumulative_assistant_text("ABCZYX", "ABC")
+        == "ZYX"
+    )
+
+
 def test_trim_cumulative_assistant_text_handles_collapsed_whitespace_prefix() -> None:
     previous = (
         "CLI is outdated. Let me upgrade it first.\n\n"
@@ -1729,11 +1736,13 @@ class _FakeTranscriptStore:
 
 
 class _FakeHubPersistenceClient:
-    def __init__(self) -> None:
+    def __init__(self, transcript_history: list[dict[str, Any]] | None = None) -> None:
         self.timeline_requests: list[Any] = []
         self.trace_requests: list[Any] = []
         self.transcript_requests: list[Any] = []
         self.activity_requests: list[Any] = []
+        self.transcript_history_requests: list[Any] = []
+        self.transcript_history = list(transcript_history or [])
 
     async def persist_execution_timeline(self, request: Any) -> Any:
         self.timeline_requests.append(request)
@@ -1752,6 +1761,10 @@ class _FakeHubPersistenceClient:
     async def write_transcript(self, request: Any) -> Any:
         self.transcript_requests.append(request)
         return SimpleNamespace(turn_id=request.turn_id)
+
+    async def get_transcript_history(self, request: Any) -> Any:
+        self.transcript_history_requests.append(request)
+        return SimpleNamespace(entries=list(self.transcript_history))
 
     async def record_thread_activity(self, request: Any) -> None:
         self.activity_requests.append(request)
@@ -1973,6 +1986,130 @@ async def test_finalize_managed_thread_execution_trims_cumulative_terminal_outpu
     assert result.assistant_text == new_answer
     assert recorded_results[-1]["assistant_text"] == new_answer
     assert fake_hub_client.transcript_requests[-1].assistant_text == new_answer
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    (
+        "surface_kind",
+        "log_label",
+        "surface_key",
+        "public_error",
+        "timeout_error",
+        "interrupted_error",
+    ),
+    [
+        (
+            "discord",
+            "Discord",
+            "discord:chan-1",
+            "Discord PMA execution failed",
+            "Discord PMA turn timed out",
+            "Discord PMA turn interrupted",
+        ),
+        (
+            "telegram",
+            "Telegram",
+            "telegram:-1001:101",
+            "Telegram PMA execution failed",
+            "Telegram PMA turn timed out",
+            "Telegram PMA turn interrupted",
+        ),
+    ],
+)
+async def test_finalize_managed_thread_execution_trims_short_cumulative_history_for_chat_surfaces(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    surface_kind: str,
+    log_label: str,
+    surface_key: str,
+    public_error: str,
+    timeout_error: str,
+    interrupted_error: str,
+) -> None:
+    recorded_results: list[dict[str, Any]] = []
+    fake_hub_client = _FakeHubPersistenceClient(
+        transcript_history=[
+            {
+                "managed_turn_id": "previous-2",
+                "content": "User:\nsecond\n\nAssistant:\nABCZYX",
+            },
+            {
+                "managed_turn_id": "previous-1",
+                "content": "User:\nfirst\n\nAssistant:\nABC",
+            },
+        ]
+    )
+    started = _started_execution_with_backend_ids(tmp_path)
+
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "harness_supports_event_streaming",
+        lambda _harness: False,
+    )
+
+    async def _successful_outcome(*args: Any, **kwargs: Any) -> RuntimeThreadOutcome:
+        _ = args, kwargs
+        return RuntimeThreadOutcome(
+            status="ok",
+            assistant_text="ABCZYX123",
+            error=None,
+            backend_thread_id="session-1",
+            backend_turn_id="turn-1",
+        )
+
+    monkeypatch.setattr(
+        managed_thread_turns_module,
+        "await_runtime_thread_outcome",
+        _successful_outcome,
+    )
+
+    orchestration_service = SimpleNamespace(
+        get_thread_target=lambda managed_thread_id: SimpleNamespace(
+            backend_thread_id="session-1",
+            repo_id="repo-1",
+            resource_kind="repo",
+            resource_id="repo-1",
+            agent_id="hermes",
+            workspace_root=str(tmp_path),
+        ),
+        get_thread_runtime_binding=lambda managed_thread_id: SimpleNamespace(
+            backend_thread_id="session-1"
+        ),
+        get_previous_completed_execution=(
+            lambda managed_thread_id, *, exclude_execution_id=None: None
+        ),
+        record_execution_result=lambda *args, **kwargs: (
+            recorded_results.append(dict(kwargs))
+            or SimpleNamespace(status="ok", error=None)
+        ),
+    )
+
+    result = await managed_thread_turns_module.finalize_managed_thread_execution(
+        orchestration_service=orchestration_service,
+        started=started,
+        state_root=tmp_path,
+        hub_client=fake_hub_client,
+        raw_config={},
+        surface=managed_thread_turns_module.ManagedThreadSurfaceInfo(
+            log_label=log_label,
+            surface_kind=surface_kind,
+            surface_key=surface_key,
+        ),
+        errors=managed_thread_turns_module.ManagedThreadErrorMessages(
+            public_execution_error=public_error,
+            timeout_error=timeout_error,
+            interrupted_error=interrupted_error,
+            timeout_seconds=5,
+        ),
+        logger=logging.getLogger(f"test.managed_thread.{surface_kind}.short_trim"),
+        turn_preview="hello",
+    )
+
+    assert result.assistant_text == "123"
+    assert recorded_results[-1]["assistant_text"] == "123"
+    assert fake_hub_client.transcript_requests[-1].assistant_text == "123"
+    assert fake_hub_client.transcript_history_requests[-1].limit == 0
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- normalize cumulative Hermes PMA replies in the shared managed-thread finalizer before transcript persistence, execution result recording, and Discord/Telegram delivery
- trim both runtime-outcome assistant text and streamed/event-state terminal text, including long `prompt/completed.finalOutput` payloads when the runtime outcome is empty
- keep the short-prefix regression too, but the main production fix is the streamed terminal fallback path
- cover Discord and Telegram through the shared PMA finalization path to prove this is state-machine behavior, not a Discord formatter issue

## Root Cause
Hermes ACP can emit a completed terminal output that contains the whole assistant session transcript. The finalizer already attempted to trim cumulative output from `outcome.assistant_text`, but later fell back to `event_state.best_assistant_text()` when the runtime outcome had no assistant text. Long cumulative streamed terminal output therefore bypassed trimming entirely and was persisted/delivered as the final turn.

## Validation
- .venv/bin/python -m pytest tests/adapters/chat/test_managed_thread_turns.py -k "trim_cumulative or streamed_terminal_output or short_cumulative_history"
- .venv/bin/python -m pytest tests/adapters/chat/test_managed_thread_turns.py tests/adapters/chat/test_managed_turn_runner.py tests/adapters/chat/test_orchestration_guardrails.py
- pre-commit chat-apps lane: black, ruff, import boundaries, contract drift, command hints, mypy, 8526 pytest tests, chat-surface lab deterministic checks, chat latency budgets
