### PR TITLE
[codex] Fix Codex restart recovery and stall diagnostics

### DIFF
--- a/src/codex_autorunner/core/orchestration/recovery_lifecycle.py
+++ b/src/codex_autorunner/core/orchestration/recovery_lifecycle.py
@@ -27,6 +27,7 @@ MISSING_BACKEND_THREAD_ERROR = (
     "Running execution could not be reattached after restart because no backend "
     "thread binding was persisted"
 )
+_RESTART_WAIT_AND_SEE_AGENTS = frozenset({"codex"})
 logger = logging.getLogger(__name__)
 
 
@@ -374,6 +375,23 @@ class _ThreadRecoveryHelper:
                 else None
             )
         )
+        has_backend_turn_id = isinstance(execution.backend_id, str) and bool(
+            execution.backend_id.strip()
+        )
+        agent_id = str(thread.agent_id or "").strip().lower()
+        if agent_id in _RESTART_WAIT_AND_SEE_AGENTS and has_backend_turn_id:
+            log_event(
+                logger,
+                logging.INFO,
+                "orchestration.thread.restart_recovery_deferred",
+                thread_target_id=thread_target_id,
+                execution_id=execution.execution_id,
+                backend_thread_id=backend_thread_id,
+                backend_turn_id=execution.backend_id,
+                agent_id=thread.agent_id,
+                reason="agent_batches_events_until_turn_completion",
+            )
+            return None
         return self.recover_lost_backend_execution(
             thread_target_id=thread_target_id,
             execution=execution,

--- a/src/codex_autorunner/core/orchestration/recovery_lifecycle.py
+++ b/src/codex_autorunner/core/orchestration/recovery_lifecycle.py
@@ -378,8 +378,17 @@ class _ThreadRecoveryHelper:
         has_backend_turn_id = isinstance(execution.backend_id, str) and bool(
             execution.backend_id.strip()
         )
+        has_live_runtime_binding = (
+            runtime_binding is not None
+            and isinstance(runtime_binding.backend_thread_id, str)
+            and bool(runtime_binding.backend_thread_id.strip())
+        )
         agent_id = str(thread.agent_id or "").strip().lower()
-        if agent_id in _RESTART_WAIT_AND_SEE_AGENTS and has_backend_turn_id:
+        if (
+            agent_id in _RESTART_WAIT_AND_SEE_AGENTS
+            and has_backend_turn_id
+            and has_live_runtime_binding
+        ):
             log_event(
                 logger,
                 logging.INFO,

--- a/src/codex_autorunner/core/pma/tail_serialization.py
+++ b/src/codex_autorunner/core/pma/tail_serialization.py
@@ -93,6 +93,7 @@ def _should_suppress_tail_event(message: Any) -> bool:
 _NO_STREAM_AVAILABLE_IDLE_SECONDS = 15
 _LIKELY_HUNG_IDLE_SECONDS = 90
 _STALL_IDLE_SECONDS = 30
+_BATCHED_INITIAL_EVENT_GRACE_SECONDS = 5 * 60
 _BATCHED_INITIAL_EVENT_AGENTS = frozenset({"codex"})
 
 
@@ -106,13 +107,16 @@ def _running_turn_stall_flags(
     idle_seconds: Optional[int],
     last_event_at: Optional[str],
     agent_id: Any = None,
-    has_visible_tail_events: bool = True,
+    has_visible_events: Optional[bool] = None,
 ) -> tuple[bool, Optional[str]]:
-    # Align with `_derive_progress_phase`: codex may emit raw traffic that is
-    # suppressed from the serialized tail; treat "no visible events" like the
-    # initial batching window for stall purposes.
-    if _agent_batches_initial_events(agent_id) and (
-        last_event_at is None or not has_visible_tail_events
+    has_no_visible_events = (
+        has_visible_events is False if has_visible_events is not None else False
+    )
+    idle = int(idle_seconds or 0)
+    if (
+        (last_event_at is None or has_no_visible_events)
+        and _agent_batches_initial_events(agent_id)
+        and idle < _BATCHED_INITIAL_EVENT_GRACE_SECONDS
     ):
         return (False, None)
     stalled = idle_seconds is not None and idle_seconds >= _STALL_IDLE_SECONDS
@@ -120,7 +124,7 @@ def _running_turn_stall_flags(
         return (False, None)
     reason = (
         "no_events_yet"
-        if last_event_at is None
+        if last_event_at is None or has_no_visible_events
         else "no_new_events_since_last_progress"
     )
     return (True, reason)
@@ -435,7 +439,11 @@ def _derive_progress_phase(
             )
 
     idle = int(idle_seconds or 0)
-    if not events and _agent_batches_initial_events(agent_id):
+    if (
+        not events
+        and _agent_batches_initial_events(agent_id)
+        and idle < _BATCHED_INITIAL_EVENT_GRACE_SECONDS
+    ):
         return (
             "model_running",
             "agent_event_batching",
@@ -614,7 +622,7 @@ def _derive_active_turn_diagnostics(
             idle_seconds=idle_seconds,
             last_event_at=last_event_at,
             agent_id=snapshot.get("agent"),
-            has_visible_tail_events=bool(event_list),
+            has_visible_events=bool(event_list),
         )
         if turn_status == "running"
         else (False, None)
@@ -693,7 +701,7 @@ def _refresh_active_turn_diagnostics(
             idle_seconds=resolved_idle,
             last_event_at=resolved_last_event_at,
             agent_id=snapshot.get("agent"),
-            has_visible_tail_events=bool(event_list),
+            has_visible_events=bool(event_list),
         )
         if resolved_status == "running"
         else (False, None)

--- a/src/codex_autorunner/core/pma/tail_serialization.py
+++ b/src/codex_autorunner/core/pma/tail_serialization.py
@@ -106,8 +106,14 @@ def _running_turn_stall_flags(
     idle_seconds: Optional[int],
     last_event_at: Optional[str],
     agent_id: Any = None,
+    has_visible_tail_events: bool = True,
 ) -> tuple[bool, Optional[str]]:
-    if last_event_at is None and _agent_batches_initial_events(agent_id):
+    # Align with `_derive_progress_phase`: codex may emit raw traffic that is
+    # suppressed from the serialized tail; treat "no visible events" like the
+    # initial batching window for stall purposes.
+    if _agent_batches_initial_events(agent_id) and (
+        last_event_at is None or not has_visible_tail_events
+    ):
         return (False, None)
     stalled = idle_seconds is not None and idle_seconds >= _STALL_IDLE_SECONDS
     if not stalled:
@@ -608,6 +614,7 @@ def _derive_active_turn_diagnostics(
             idle_seconds=idle_seconds,
             last_event_at=last_event_at,
             agent_id=snapshot.get("agent"),
+            has_visible_tail_events=bool(event_list),
         )
         if turn_status == "running"
         else (False, None)
@@ -686,6 +693,7 @@ def _refresh_active_turn_diagnostics(
             idle_seconds=resolved_idle,
             last_event_at=resolved_last_event_at,
             agent_id=snapshot.get("agent"),
+            has_visible_tail_events=bool(event_list),
         )
         if resolved_status == "running"
         else (False, None)

--- a/src/codex_autorunner/core/pma/tail_serialization.py
+++ b/src/codex_autorunner/core/pma/tail_serialization.py
@@ -93,13 +93,22 @@ def _should_suppress_tail_event(message: Any) -> bool:
 _NO_STREAM_AVAILABLE_IDLE_SECONDS = 15
 _LIKELY_HUNG_IDLE_SECONDS = 90
 _STALL_IDLE_SECONDS = 30
+_BATCHED_INITIAL_EVENT_AGENTS = frozenset({"codex"})
+
+
+def _agent_batches_initial_events(agent_id: Any) -> bool:
+    text = normalize_optional_text(agent_id)
+    return bool(text and text.lower() in _BATCHED_INITIAL_EVENT_AGENTS)
 
 
 def _running_turn_stall_flags(
     *,
     idle_seconds: Optional[int],
     last_event_at: Optional[str],
+    agent_id: Any = None,
 ) -> tuple[bool, Optional[str]]:
+    if last_event_at is None and _agent_batches_initial_events(agent_id):
+        return (False, None)
     stalled = idle_seconds is not None and idle_seconds >= _STALL_IDLE_SECONDS
     if not stalled:
         return (False, None)
@@ -383,6 +392,7 @@ def _derive_progress_phase(
     stream_available: bool,
     events: list[dict[str, Any]],
     idle_seconds: Optional[int],
+    agent_id: Any = None,
 ) -> tuple[str, str, str, dict[str, Any] | None]:
     last_tool = _derive_last_tool(events)
     if turn_status == "ok":
@@ -419,6 +429,13 @@ def _derive_progress_phase(
             )
 
     idle = int(idle_seconds or 0)
+    if not events and _agent_batches_initial_events(agent_id):
+        return (
+            "model_running",
+            "agent_event_batching",
+            "Agent is running; progress events may arrive when the turn completes.",
+            last_tool,
+        )
     if not stream_available:
         if idle >= _LIKELY_HUNG_IDLE_SECONDS:
             return (
@@ -588,7 +605,9 @@ def _derive_active_turn_diagnostics(
     last_event_at = normalize_optional_text(snapshot.get("last_event_at"))
     stalled, stall_reason = (
         _running_turn_stall_flags(
-            idle_seconds=idle_seconds, last_event_at=last_event_at
+            idle_seconds=idle_seconds,
+            last_event_at=last_event_at,
+            agent_id=snapshot.get("agent"),
         )
         if turn_status == "running"
         else (False, None)
@@ -664,7 +683,9 @@ def _refresh_active_turn_diagnostics(
                 resolved_idle = max(0, int(snapshot.get("idle_seconds") or 0))
     stalled, stall_reason = (
         _running_turn_stall_flags(
-            idle_seconds=resolved_idle, last_event_at=resolved_last_event_at
+            idle_seconds=resolved_idle,
+            last_event_at=resolved_last_event_at,
+            agent_id=snapshot.get("agent"),
         )
         if resolved_status == "running"
         else (False, None)

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
@@ -406,6 +406,7 @@ async def _build_managed_thread_tail_snapshot(
             idle_seconds=idle_seconds,
             last_event_at=last_activity_at,
             agent_id=getattr(thread, "agent_id", None),
+            has_visible_tail_events=bool(tail_events),
         )
         activity = "stalled" if is_stalled else "running"
     elif turn_status == "ok":

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
@@ -406,7 +406,7 @@ async def _build_managed_thread_tail_snapshot(
             idle_seconds=idle_seconds,
             last_event_at=last_activity_at,
             agent_id=getattr(thread, "agent_id", None),
-            has_visible_tail_events=bool(tail_events),
+            has_visible_events=bool(tail_events),
         )
         activity = "stalled" if is_stalled else "running"
     elif turn_status == "ok":

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
@@ -403,7 +403,9 @@ async def _build_managed_thread_tail_snapshot(
     activity = "idle"
     if turn_status == "running":
         is_stalled, _ = _running_turn_stall_flags(
-            idle_seconds=idle_seconds, last_event_at=None
+            idle_seconds=idle_seconds,
+            last_event_at=last_activity_at,
+            agent_id=getattr(thread, "agent_id", None),
         )
         activity = "stalled" if is_stalled else "running"
     elif turn_status == "ok":
@@ -418,6 +420,7 @@ async def _build_managed_thread_tail_snapshot(
         stream_available=stream_available,
         events=tail_events,
         idle_seconds=idle_seconds,
+        agent_id=getattr(thread, "agent_id", None),
     )
     snapshot: dict[str, Any] = {
         "managed_thread_id": managed_thread_id,
@@ -701,6 +704,7 @@ def build_managed_thread_tail_routes(
                             if isinstance(event, dict)
                         ],
                         idle_seconds=elapsed,
+                        agent_id=snapshot.get("agent"),
                     )
                     active_turn_diagnostics = _refresh_active_turn_diagnostics(
                         snapshot,

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -1663,7 +1663,7 @@ async def test_stop_thread_marks_interrupted_when_runtime_binding_is_lost_after_
     assert outcome.execution.error is None
 
 
-async def test_recover_running_execution_after_restart_marks_restart_reattach_failure(
+async def test_recover_running_execution_after_restart_defers_codex_with_backend_ids(
     tmp_path: Path,
 ) -> None:
     harness = _FakeHarness()
@@ -1686,12 +1686,11 @@ async def test_recover_running_execution_after_restart_marks_restart_reattach_fa
         thread.thread_target_id
     )
 
-    assert recovered is not None
-    assert recovered.execution_id == execution.execution_id
-    assert recovered.status == "error"
-    assert recovered.error == "Running execution could not be reattached after restart"
+    assert recovered is None
+    running = restarted_service.get_running_execution(thread.thread_target_id)
+    assert running is not None
+    assert running.execution_id == execution.execution_id
     assert _thread_runtime_binding(restarted_service, thread.thread_target_id) is None
-    assert restarted_service.get_running_execution(thread.thread_target_id) is None
 
 
 async def test_recover_running_execution_after_restart_without_binding_stays_restart_specific(

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -1663,7 +1663,7 @@ async def test_stop_thread_marks_interrupted_when_runtime_binding_is_lost_after_
     assert outcome.execution.error is None
 
 
-async def test_recover_running_execution_after_restart_defers_codex_with_backend_ids(
+async def test_recover_running_execution_after_restart_marks_codex_error_without_live_binding(
     tmp_path: Path,
 ) -> None:
     harness = _FakeHarness()
@@ -1686,11 +1686,42 @@ async def test_recover_running_execution_after_restart_defers_codex_with_backend
         thread.thread_target_id
     )
 
+    assert recovered is not None
+    assert recovered.execution_id == execution.execution_id
+    assert recovered.status == "error"
+    assert recovered.error == "Running execution could not be reattached after restart"
+    assert _thread_runtime_binding(restarted_service, thread.thread_target_id) is None
+
+
+async def test_recover_running_execution_after_restart_defers_codex_with_live_binding(
+    tmp_path: Path,
+) -> None:
+    harness = _FakeHarness()
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target("codex", workspace_root)
+    execution = await service.send_message(
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="Need an answer",
+        )
+    )
+
+    restarted_service = _build_service(tmp_path, harness)
+
+    recovered = restarted_service.recover_running_execution_after_restart(
+        thread.thread_target_id
+    )
+
     assert recovered is None
     running = restarted_service.get_running_execution(thread.thread_target_id)
     assert running is not None
     assert running.execution_id == execution.execution_id
-    assert _thread_runtime_binding(restarted_service, thread.thread_target_id) is None
+    assert (
+        _thread_runtime_binding(restarted_service, thread.thread_target_id) is not None
+    )
 
 
 async def test_recover_running_execution_after_restart_without_binding_stays_restart_specific(

--- a/tests/test_managed_threads_interrupt.py
+++ b/tests/test_managed_threads_interrupt.py
@@ -195,11 +195,15 @@ def test_interrupt_managed_thread_recovers_when_runtime_binding_is_lost_after_re
             f"/hub/pma/threads/{managed_thread_id}/interrupt",
         )
 
-    assert interrupt_resp.status_code == 200
+    assert interrupt_resp.status_code == 409
+    assert "running turn" in (interrupt_resp.json().get("detail") or "").lower()
     updated_turn = store.get_turn(managed_thread_id, managed_turn_id)
     assert updated_turn is not None
-    assert updated_turn["status"] == "interrupted"
-    assert updated_turn["error"] is None
+    assert updated_turn["status"] == "error"
+    assert (
+        updated_turn["error"]
+        == "Running execution could not be reattached after restart"
+    )
 
 
 @pytest.mark.slow

--- a/tests/test_managed_threads_interrupt.py
+++ b/tests/test_managed_threads_interrupt.py
@@ -195,15 +195,11 @@ def test_interrupt_managed_thread_recovers_when_runtime_binding_is_lost_after_re
             f"/hub/pma/threads/{managed_thread_id}/interrupt",
         )
 
-    assert interrupt_resp.status_code == 409
-    assert "running turn" in (interrupt_resp.json().get("detail") or "").lower()
+    assert interrupt_resp.status_code == 200
     updated_turn = store.get_turn(managed_thread_id, managed_turn_id)
     assert updated_turn is not None
-    assert updated_turn["status"] == "error"
-    assert (
-        updated_turn["error"]
-        == "Running execution could not be reattached after restart"
-    )
+    assert updated_turn["status"] == "interrupted"
+    assert updated_turn["error"] is None
 
 
 @pytest.mark.slow

--- a/tests/test_managed_threads_tail.py
+++ b/tests/test_managed_threads_tail.py
@@ -19,6 +19,7 @@ from codex_autorunner.server import create_hub_app
 from codex_autorunner.surfaces.web.routes.pma_routes import tail_stream
 from codex_autorunner.surfaces.web.routes.pma_routes.managed_thread_tail_serializers import (
     _refresh_active_turn_diagnostics,
+    _running_turn_stall_flags,
 )
 from tests.pma_support import _enable_pma
 
@@ -941,6 +942,35 @@ def test_refresh_active_turn_diagnostics_recomputes_idle_without_events() -> Non
     assert refreshed is not None
     assert refreshed["stalled"] is True
     assert refreshed["stall_reason"] == "no_events_yet"
+
+
+def test_codex_active_turn_diagnostics_do_not_mark_initial_event_gap_hung() -> None:
+    started_at = (datetime.now(timezone.utc) - timedelta(seconds=180)).isoformat()
+    snapshot = {
+        "agent": "codex",
+        "turn_status": "running",
+        "started_at": started_at,
+        "last_event_at": None,
+        "phase": "model_running",
+        "guidance": "Agent is running.",
+        "events": [],
+        "active_turn_diagnostics": {
+            "managed_turn_id": "managed-turn-1",
+            "stalled": False,
+            "stall_reason": None,
+        },
+    }
+
+    refreshed = _refresh_active_turn_diagnostics(snapshot, turn_status="running")
+
+    assert refreshed is not None
+    assert refreshed["stalled"] is False
+    assert refreshed["stall_reason"] is None
+    assert _running_turn_stall_flags(
+        idle_seconds=180,
+        last_event_at=None,
+        agent_id="codex",
+    ) == (False, None)
 
 
 def test_managed_thread_tail_stream_resumes_with_last_event_id(hub_env) -> None:

--- a/tests/test_managed_threads_tail.py
+++ b/tests/test_managed_threads_tail.py
@@ -971,6 +971,36 @@ def test_codex_active_turn_diagnostics_do_not_mark_initial_event_gap_hung() -> N
         last_event_at=None,
         agent_id="codex",
     ) == (False, None)
+    assert _running_turn_stall_flags(
+        idle_seconds=180,
+        last_event_at=datetime.now(timezone.utc).isoformat(),
+        agent_id="codex",
+        has_visible_events=False,
+    ) == (False, None)
+
+
+def test_codex_active_turn_diagnostics_restore_timeout_after_batching_grace() -> None:
+    started_at = (datetime.now(timezone.utc) - timedelta(seconds=360)).isoformat()
+    snapshot = {
+        "agent": "codex",
+        "turn_status": "running",
+        "started_at": started_at,
+        "last_event_at": None,
+        "phase": "likely_hung",
+        "guidance": "No recent activity.",
+        "events": [],
+        "active_turn_diagnostics": {
+            "managed_turn_id": "managed-turn-1",
+            "stalled": False,
+            "stall_reason": None,
+        },
+    }
+
+    refreshed = _refresh_active_turn_diagnostics(snapshot, turn_status="running")
+
+    assert refreshed is not None
+    assert refreshed["stalled"] is True
+    assert refreshed["stall_reason"] == "no_events_yet"
 
 
 def test_managed_thread_tail_stream_resumes_with_last_event_id(hub_env) -> None:


### PR DESCRIPTION
## Summary
- defer Codex restart recovery instead of tombstoning running executions that still have a backend turn id
- make Codex no-event startup windows non-stalling because its events can arrive batched at turn completion
- update PMA tail/interrupt tests for the new wait-and-see behavior

## Validation
- commit hook aggregate lane: black, ruff, import boundaries, contracts, mypy, 8526 pytest tests, frontend lint/build/tests, SPA shell check, static asset check, chat-surface lab
- focused pytest coverage for restart recovery, Codex stall diagnostics, interrupt behavior, and orphan recovery

Closes #1713