### PR TITLE
[codex] fix cumulative Hermes PMA final output

### DIFF
--- a/src/codex_autorunner/adapters/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_turns.py
@@ -829,6 +829,71 @@ def _previous_completed_assistant_text(
     return str(getattr(previous, "output_text", "") or "")
 
 
+def _record_assistant_text(record: Any) -> str:
+    if isinstance(record, Mapping):
+        return str(record.get("output_text") or record.get("assistant_text") or "")
+    return str(
+        getattr(record, "output_text", None)
+        or getattr(record, "assistant_text", None)
+        or ""
+    )
+
+
+def _record_status(record: Any) -> str:
+    if isinstance(record, Mapping):
+        return str(record.get("status") or "")
+    return str(getattr(record, "status", "") or "")
+
+
+def _record_turn_id(record: Any) -> str:
+    if isinstance(record, Mapping):
+        return str(record.get("execution_id") or record.get("managed_turn_id") or "")
+    return str(
+        getattr(record, "execution_id", None)
+        or getattr(record, "managed_turn_id", None)
+        or ""
+    )
+
+
+def _prior_completed_assistant_text_prefix(
+    orchestration_service: Any,
+    *,
+    managed_thread_id: str,
+    managed_turn_id: str,
+) -> str:
+    owners = (
+        orchestration_service,
+        getattr(orchestration_service, "thread_store", None),
+        getattr(orchestration_service, "_store", None),
+    )
+    for owner in owners:
+        lister = getattr(owner, "list_turns", None)
+        if not callable(lister):
+            continue
+        try:
+            turns = lister(managed_thread_id, limit=50)
+        except (RuntimeError, TypeError, ValueError, AttributeError, OSError):
+            continue
+        if not isinstance(turns, (list, tuple)):
+            continue
+        prefix = ""
+        for record in reversed(turns):
+            if _record_turn_id(record).strip() == managed_turn_id:
+                continue
+            if _record_status(record).strip() != "ok":
+                continue
+            assistant_text = _record_assistant_text(record)
+            if not assistant_text.strip():
+                continue
+            if _assistant_text_extends_prefix(assistant_text, prefix):
+                prefix = assistant_text
+            else:
+                prefix += assistant_text
+        if prefix.strip():
+            return prefix
+    return ""
+
+
 def _assistant_text_from_transcript_content(content: str) -> str:
     text = str(content or "").strip()
     marker = "\n\nAssistant:\n"
@@ -925,6 +990,13 @@ async def _prior_assistant_text_candidates(
     )
     if transcript_text:
         candidates.append(transcript_text)
+    prior_prefix = _prior_completed_assistant_text_prefix(
+        orchestration_service,
+        managed_thread_id=managed_thread_id,
+        managed_turn_id=managed_turn_id,
+    )
+    if prior_prefix and prior_prefix not in candidates:
+        candidates.append(prior_prefix)
     previous_text = _previous_completed_assistant_text(
         orchestration_service,
         managed_thread_id=managed_thread_id,

--- a/tests/adapters/chat/test_managed_thread_turns.py
+++ b/tests/adapters/chat/test_managed_thread_turns.py
@@ -201,6 +201,45 @@ def test_trim_cumulative_assistant_text_from_candidates_uses_full_transcript_pre
     assert matched == first + second
 
 
+def test_prior_completed_assistant_text_prefix_reconstructs_trimmed_history() -> None:
+    service = SimpleNamespace(
+        thread_store=SimpleNamespace(
+            list_turns=lambda _thread_id, *, limit: [
+                {
+                    "execution_id": "turn-current",
+                    "status": "running",
+                    "assistant_text": "",
+                },
+                {
+                    "execution_id": "turn-2",
+                    "status": "ok",
+                    "assistant_text": "second answer",
+                },
+                {
+                    "execution_id": "turn-1",
+                    "status": "ok",
+                    "assistant_text": "first answer",
+                },
+            ]
+        )
+    )
+
+    prefix = managed_thread_turns_module._prior_completed_assistant_text_prefix(
+        service,
+        managed_thread_id="thread-1",
+        managed_turn_id="turn-current",
+    )
+
+    assert prefix == "first answersecond answer"
+    assert (
+        managed_thread_turns_module.trim_cumulative_assistant_text(
+            "first answersecond answerthird answer",
+            prefix,
+        )
+        == "third answer"
+    )
+
+
 def test_build_assistant_transcript_prefix_collapses_legacy_cumulative_rows() -> None:
     first = "First assistant answer " * 5
     second = "Second assistant answer " * 5


### PR DESCRIPTION
## Summary
- reconstruct the full prior assistant-output prefix before trimming Hermes cumulative PMA final output
- request actual transcript history entries instead of an empty history window
- add regressions for trimmed prior history and transcript-history request coverage

## Root cause
Hermes can return final output as the whole assistant transcript for the session. CAR already trimmed cumulative output, but one fallback only compared the new output against the immediately previous persisted assistant text. After turn 2 was trimmed and persisted as only its own reply, turn 3 could arrive as A+B+C and no longer matched the previous B prefix. The transcript fallback also requested `limit=0`, so it could be unavailable as a full-prefix candidate.

## Validation
- Real local Hermes Discord PMA integration: three-turn repro showed terminal evidence growing 23 -> 46 -> 71 chars, while finalized assistant text stayed per-turn 23 -> 23 -> 25 chars with `assistant_text_trimmed_from_cumulative=true` on turns 2 and 3.
- `.venv/bin/python -m pytest tests/adapters/chat/test_managed_thread_turns.py -k "cumulative or transcript or prior_completed" -q`
- `.venv/bin/python -m pytest tests/adapters/chat/test_managed_thread_turns.py tests/chat_surface_integration/test_hermes_pma_surfaces.py tests/chat_surface_integration/test_hermes_pma_official_timeout.py -q`
- Commit hook chat-apps lane: black, ruff, import checks, mypy, repo-wide pytest (`8528 passed`), chat-surface lab deterministic checks, latency budget check.