### PR TITLE
[codex] Handle sudo password prompt ACP stdout noise

### DIFF
--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -91,6 +91,7 @@ _PERMISSION_NOTIFICATION_METHODS = (
 )
 _ACP_PROTOCOL_VERSION = 1
 _ACP_STDOUT_NOISE_PREFIXES = (
+    "Password (hidden):",
     "┊",
     "╎",
     "│",

--- a/tests/fixtures/fake_acp_server.py
+++ b/tests/fixtures/fake_acp_server.py
@@ -143,6 +143,7 @@ class FakeACPServer:
         )
         if prompt == "stdout noise":
             _write_raw_stdout(self._lock, "\n")
+            _write_raw_stdout(self._lock, "  Password (hidden): \n")
             _write_raw_stdout(
                 self._lock,
                 "  ┊ 💻 $ curl -fsS http://127.0.0.1:4517/car/hub... 0.3s\n",
@@ -357,6 +358,7 @@ class FakeACPServer:
         )
         if prompt == "stdout noise":
             _write_raw_stdout(self._lock, "\n")
+            _write_raw_stdout(self._lock, "  Password (hidden): \n")
             _write_raw_stdout(
                 self._lock,
                 "  ┊ 💻 $ curl -fsS http://127.0.0.1:4517/car/hub... 0.3s\n",


### PR DESCRIPTION
## Summary
- classify the known `Password (hidden):` sudo prompt line as ignorable ACP stdout noise
- extend the fake ACP fixture so the existing stdout-noise regression test covers the prompt in both legacy and official prompt paths

## Root cause
Hermes emitted a terminal sudo password prompt on stdout during ACP execution. CAR treats ACP stdout as JSON-RPC framing, so that line caused `ACPProtocolError: ACP subprocess emitted invalid JSON`.

## Validation
- `.venv/bin/python -m pytest tests/agents/acp/test_client.py -k stdout`
- pre-commit aggregate lane: black, ruff, import boundaries, mypy, `8528 passed`, web lint/build/test, chat-surface lab, latency budget suite
