### PR TITLE
[codex] Fix Hermes inherited profile launch

### DIFF
--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -1016,6 +1016,19 @@ def _resolve_hermes_launch(
     )
     configured_name = basename(configured_binary) if configured_binary else ""
     if (
+        normalized_agent_id == HERMES_RUNTIME_ID
+        and normalized_profile is not None
+        and configured_binary
+    ):
+        base_binary = _configured_hermes_binary(config, agent_id=HERMES_RUNTIME_ID)
+        if base_binary and configured_binary == base_binary:
+            return [
+                configured_binary,
+                "-p",
+                normalized_profile,
+                HERMES_ACP_COMMAND,
+            ], configured_binary
+    if (
         normalized_agent_id != HERMES_RUNTIME_ID
         and normalized_profile is None
         and configured_name == normalized_agent_id

--- a/tests/agents/hermes/test_hermes_supervisor.py
+++ b/tests/agents/hermes/test_hermes_supervisor.py
@@ -62,6 +62,14 @@ class _HermesCustomAliasConfig:
         raise AssertionError(f"unexpected agent_id: {agent_id}")
 
 
+class _HermesAliasOnlyConfig:
+    def agent_binary(self, agent_id: str, *, profile: str | None = None) -> str:
+        assert profile is None
+        if agent_id == "hermes-special":
+            return "/opt/hermes/special-launcher"
+        raise KeyError(agent_id)
+
+
 class _HermesProfileBinaryConfig:
     def __init__(self, profile_binary: str) -> None:
         self._profile_binary = profile_binary
@@ -70,6 +78,13 @@ class _HermesProfileBinaryConfig:
         if agent_id == "hermes" and profile == "m4-pma":
             return self._profile_binary
         if agent_id == "hermes":
+            return "hermes"
+        raise AssertionError(f"unexpected agent_id={agent_id!r} profile={profile!r}")
+
+
+class _HermesInheritedProfileBinaryConfig:
+    def agent_binary(self, agent_id: str, *, profile: str | None = None) -> str:
+        if agent_id == "hermes" and profile in {None, "pma"}:
             return "hermes"
         raise AssertionError(f"unexpected agent_id={agent_id!r} profile={profile!r}")
 
@@ -354,6 +369,63 @@ def test_build_hermes_supervisor_preserves_custom_alias_binary(
     assert supervisor is not None
     assert observed["command"] == [
         "/opt/hermes/special-launcher",
+        "acp",
+    ]
+
+
+def test_build_hermes_supervisor_preserves_alias_binary_without_base_hermes_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+
+    class _FakeHermesSupervisor:
+        def __init__(self, command, **kwargs):  # type: ignore[no-untyped-def]
+            observed["command"] = list(command)
+            observed["kwargs"] = dict(kwargs)
+
+    monkeypatch.setattr(
+        "codex_autorunner.agents.hermes.supervisor.HermesSupervisor",
+        _FakeHermesSupervisor,
+    )
+
+    supervisor = build_hermes_supervisor_from_config(
+        _HermesAliasOnlyConfig(),
+        agent_id="hermes-special",
+    )
+
+    assert supervisor is not None
+    assert observed["command"] == [
+        "/opt/hermes/special-launcher",
+        "acp",
+    ]
+
+
+def test_build_hermes_supervisor_uses_hermes_profile_when_profile_inherits_base_binary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+
+    class _FakeHermesSupervisor:
+        def __init__(self, command, **kwargs):  # type: ignore[no-untyped-def]
+            observed["command"] = list(command)
+            observed["kwargs"] = dict(kwargs)
+
+    monkeypatch.setattr(
+        "codex_autorunner.agents.hermes.supervisor.HermesSupervisor",
+        _FakeHermesSupervisor,
+    )
+
+    supervisor = build_hermes_supervisor_from_config(
+        _HermesInheritedProfileBinaryConfig(),
+        agent_id="hermes",
+        profile="pma",
+    )
+
+    assert supervisor is not None
+    assert observed["command"] == [
+        "hermes",
+        "-p",
+        "pma",
         "acp",
     ]
 

--- a/tests/pma_support/core.py
+++ b/tests/pma_support/core.py
@@ -2196,6 +2196,87 @@ def test_pma_chat_hermes_profile_uses_profile_scoped_registry_binding(
     assert observed["start_turn"][1] == "hermes-session-m4"
 
 
+def test_pma_chat_hermes_inherited_binary_profile_launches_named_hermes_profile(
+    hub_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = json.loads(json.dumps(DEFAULT_HUB_CONFIG))
+    cfg.setdefault("pma", {})
+    cfg["pma"]["enabled"] = True
+    cfg["pma"]["default_agent"] = "hermes"
+    cfg["pma"]["profile"] = "pma"
+    cfg.setdefault("agents", {})
+    cfg["agents"]["hermes"] = {
+        "binary": "hermes",
+        "default_profile": "pma",
+        "profiles": {"pma": {"display_name": "PMA"}},
+    }
+    write_test_config(hub_env.hub_root / CONFIG_FILENAME, cfg)
+    observed: dict[str, Any] = {}
+
+    class _FakeHermesSupervisor:
+        def __init__(self, command, **_kwargs):  # type: ignore[no-untyped-def]
+            observed["command"] = list(command)
+
+        async def ensure_ready(self, workspace_root: Path) -> None:
+            _ = workspace_root
+
+        async def create_session(
+            self, workspace_root: Path, title: Optional[str] = None
+        ):
+            _ = workspace_root, title
+            return type("Session", (), {"session_id": "hermes-pma-session"})()
+
+        async def resume_session(self, workspace_root: Path, conversation_id: str):
+            _ = workspace_root
+            return type("Session", (), {"session_id": conversation_id})()
+
+        async def start_turn(
+            self,
+            workspace_root: Path,
+            conversation_id: str,
+            prompt: str,
+            model: Optional[str] = None,
+            approval_mode: Optional[str] = None,
+        ) -> str:
+            _ = workspace_root, conversation_id, prompt, model, approval_mode
+            return "hermes-pma-turn"
+
+        async def wait_for_turn(self, *_args: Any, **_kwargs: Any):
+            return type(
+                "Result",
+                (),
+                {
+                    "status": "completed",
+                    "assistant_text": "hermes pma reply",
+                    "raw_events": [],
+                    "errors": [],
+                },
+            )()
+
+        async def interrupt_turn(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+        async def stream_turn_events(self, *_args: Any, **_kwargs: Any):
+            if False:
+                yield {}
+
+    monkeypatch.setattr(
+        "codex_autorunner.agents.hermes.supervisor.HermesSupervisor",
+        _FakeHermesSupervisor,
+    )
+
+    app = create_hub_app(hub_env.hub_root)
+    client = TestClient(app)
+    resp = client.post(
+        "/hub/pma/chat",
+        json={"message": "hello inherited pma profile", "agent": "hermes"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "hermes pma reply"
+    assert observed["command"] == ["hermes", "-p", "pma", "acp"]
+
+
 def test_pma_chat_codex_ignores_global_profile_default_when_agent_has_no_profiles(
     hub_env,
 ) -> None:


### PR DESCRIPTION
## Summary

Fix Hermes supervisor launch resolution for canonical profiles that inherit the base Hermes binary.

Previously, a config like `agents.hermes.profiles.pma` without a profile-specific `binary` resolved to `hermes acp`. That starts Hermes' default profile, so web PMA could use the wrong provider/model configuration and fail with calls such as `/v4/responses`. The fixed behavior launches `hermes -p pma acp` when the profile inherits the base binary, while preserving explicit profile wrapper binaries such as `hermes-m4-pma acp` and legacy alias behavior.

## Root Cause

Web PMA can select `pma.profile` as the effective Hermes profile. Once that profile reached `build_hermes_supervisor_from_config`, canonical profiles that inherited `agents.hermes.binary` lost the profile name during launch. Discord worked when it used a profile-specific alias/wrapper path, so it avoided the default-profile launch.

## Validation

- Reproduced the web-surface shape with a new regression: `agent=hermes`, `profile=pma`, profile inherits `binary: hermes`, and the web PMA chat route now launches `['hermes', '-p', 'pma', 'acp']`.
- `.venv/bin/python -m pytest -q tests/agents/hermes/test_hermes_supervisor.py -k "profile or alias"`
- `.venv/bin/python -m pytest -q tests/adapters/discord/test_runtime_resolution_logging.py`
- `.venv/bin/python -m pytest -q tests/pma_support/core.py -k "inherited_binary_profile or pma_chat_hermes_profile_uses_profile_scoped_registry_binding"`
- `.venv/bin/python -m pytest -q tests/test_managed_threads_messages.py -k "alias_backed_hermes_profile_runtime"`
- `.venv/bin/python -m pytest -q tests/agents/hermes/test_hermes_supervisor.py tests/adapters/chat/test_agents.py tests/adapters/discord/test_runtime_resolution_logging.py`
- `.venv/bin/python -m pytest -q tests/pma_support/core.py -k "pma_agents_endpoint or hermes_profile or inherited_binary_profile"`
- `.venv/bin/python -m pytest -q tests/test_managed_threads_messages.py tests/test_managed_threads_routes.py -k "hermes_profile or alias_backed_hermes_profile_runtime or profile"`
- `.venv/bin/python -m ruff check src/codex_autorunner/agents/hermes/supervisor.py tests/agents/hermes/test_hermes_supervisor.py tests/pma_support/core.py`
- Commit hook aggregate lane: black, ruff, import boundaries, contract checks, mypy, 8529 pytest tests, Web Hub lint/build/tests, SPA shell check, chat-surface lab, and latency budget suite all passed.