### PR TITLE
[codex] Fix orphan followups and OpenCode staggered output

### DIFF
--- a/src/codex_autorunner/agents/opencode/run_prompt.py
+++ b/src/codex_autorunner/agents/opencode/run_prompt.py
@@ -262,19 +262,25 @@ async def _run_turn(
         )
         collector_kwargs["stall_timeout_seconds"] = stall_timeout
         collector_kwargs["first_event_timeout_seconds"] = first_event_timeout
-    output_task = asyncio.create_task(
-        collect_opencode_output(
-            client,
-            session_id=session_id,
-            workspace_path=config.workspace_root,
-            model_payload=model_payload,
-            permission_policy=permission_policy,
-            should_stop=should_stop,
-            ready_event=ready_event,
-            logger=logger,
-            **collector_kwargs,
+
+    def _start_output_task(
+        *, ready: Optional[asyncio.Event]
+    ) -> asyncio.Task[OpenCodeTurnOutput]:
+        return asyncio.create_task(
+            collect_opencode_output(
+                client,
+                session_id=session_id,
+                workspace_path=config.workspace_root,
+                model_payload=model_payload,
+                permission_policy=permission_policy,
+                should_stop=should_stop,
+                ready_event=ready,
+                logger=logger,
+                **collector_kwargs,
+            )
         )
-    )
+
+    output_task = _start_output_task(ready=ready_event)
     with contextlib.suppress(asyncio.TimeoutError):
         await asyncio.wait_for(ready_event.wait(), timeout=2.0)
     prompt_task = asyncio.create_task(
@@ -288,7 +294,16 @@ async def _run_turn(
     timeout_task = asyncio.create_task(asyncio.sleep(config.timeout_seconds))
     grace_seconds = max(0, config.interrupt_grace_seconds or 0)
 
+    async def _await_prompt_completion() -> None:
+        try:
+            await prompt_task
+        except (RuntimeError, OSError, ConnectionError, ValueError) as exc:
+            if logger is not None:
+                logger.error(f"OpenCode prompt failed: {exc}")
+            raise RuntimeError(f"OpenCode prompt failed: {exc}") from exc
+
     try:
+        restarted_after_empty_stream = False
         tasks: set[asyncio.Task[Any]] = {output_task, prompt_task, timeout_task}
         if stop_task is not None:
             tasks.add(stop_task)
@@ -300,6 +315,20 @@ async def _run_turn(
 
             if output_task in done:
                 output_result = await output_task
+                if (
+                    not restarted_after_empty_stream
+                    and output_result is not None
+                    and not output_result.text
+                    and output_result.error is None
+                ):
+                    await _await_prompt_completion()
+                    restarted_after_empty_stream = True
+                    output_result = None
+                    output_task = _start_output_task(ready=None)
+                    tasks = {output_task, timeout_task}
+                    if stop_task is not None:
+                        tasks.add(stop_task)
+                    continue
                 if should_stop is not None and should_stop():
                     stopped = True
                 break
@@ -332,14 +361,12 @@ async def _run_turn(
 
             if prompt_task in done:
                 try:
-                    await prompt_task
-                except (RuntimeError, OSError, ConnectionError, ValueError) as exc:
-                    if logger is not None:
-                        logger.error(f"OpenCode prompt failed: {exc}")
+                    await _await_prompt_completion()
+                except RuntimeError:
                     output_task.cancel()
                     with contextlib.suppress(asyncio.CancelledError):
                         await output_task
-                    raise RuntimeError(f"OpenCode prompt failed: {exc}") from exc
+                    raise
                 tasks.discard(prompt_task)
                 tasks = pending
     finally:

--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -286,7 +286,18 @@ async def collect_opencode_output_from_events(
                 else:
                     event = await _stream_iter.__anext__()
             except StopAsyncIteration:
-                break
+                decision = await lifecycle.on_stream_end(now=time.monotonic())
+                if (
+                    decision.should_flush_if_pending
+                    and not assembler.has_text
+                    and assembler.has_pending_text
+                ):
+                    assembler.flush_pending()
+                if decision.error is not None:
+                    assembler.error = decision.error
+                if decision.action == LifecycleAction.BREAK:
+                    break
+                continue
             except asyncio.TimeoutError:
                 now = time.monotonic()
                 decision = await lifecycle.on_timeout_error(now=now)

--- a/src/codex_autorunner/agents/opencode/stream_lifecycle.py
+++ b/src/codex_autorunner/agents/opencode/stream_lifecycle.py
@@ -184,6 +184,15 @@ class StreamLifecycleController:
 
         return await self._handle_stall_recovery(now=now)
 
+    async def on_stream_end(self, *, now: float) -> LifecycleDecision:
+        status_type = await self._poll_session_status_warn()
+        if status_is_idle(status_type):
+            return LifecycleDecision(
+                action=LifecycleAction.BREAK,
+                should_flush_if_pending=True,
+            )
+        return await self._handle_stall_recovery(now=now)
+
     async def on_irrelevant_event(self, *, now: float) -> LifecycleDecision:
         if (
             not self._received_any_event

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
@@ -121,6 +121,8 @@ class ManagedThreadAutomationClient:
     ) -> Optional[dict[str, Any]]:
         runtime_state = self._get_runtime_state() if self._get_runtime_state else None
         origin = resolve_runtime_pma_origin(runtime_state)
+        if not required and origin is None:
+            return None
         try:
             store = await get_automation_store(
                 self._request,

--- a/tests/surfaces/web/test_pma_common_service.py
+++ b/tests/surfaces/web/test_pma_common_service.py
@@ -296,6 +296,32 @@ async def test_managed_thread_automation_client_downgrades_optional_missing_thre
 
 
 @pytest.mark.asyncio
+async def test_managed_thread_automation_client_skips_optional_without_pma_origin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+    client = ManagedThreadAutomationClient(request, lambda: None)
+
+    async def _unexpected_get_store(*_args, **_kwargs):
+        raise AssertionError("optional terminal follow-up without PMA origin is inert")
+
+    monkeypatch.setattr(
+        "codex_autorunner.surfaces.web.services.pma.managed_thread_followup.get_automation_store",
+        _unexpected_get_store,
+    )
+
+    created = await client.create_terminal_followup(
+        managed_thread_id="thread-1",
+        lane_id=None,
+        notify_once=True,
+        idempotency_key="managed-thread-notify:thread-1",
+        required=False,
+    )
+
+    assert created is None
+
+
+@pytest.mark.asyncio
 async def test_managed_thread_automation_client_forwards_origin_thread_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -364,26 +390,16 @@ async def test_managed_thread_automation_client_ignores_stale_last_result_origin
         },
     )
     client = ManagedThreadAutomationClient(request, lambda: runtime_state)
-    captured: dict[str, object] = {}
 
-    async def _fake_get_store(_request, _runtime_state, *, required):
-        assert required is False
-        return object()
-
-    async def _fake_create(_store, _method_names, payload):
-        captured.update(payload)
-        return {"subscription": {"subscription_id": "sub-1"}}
+    async def _unexpected_get_store(*_args, **_kwargs):
+        raise AssertionError("stale last-result origin must not create follow-up")
 
     monkeypatch.setattr(
         "codex_autorunner.surfaces.web.services.pma.managed_thread_followup.get_automation_store",
-        _fake_get_store,
-    )
-    monkeypatch.setattr(
-        "codex_autorunner.surfaces.web.services.pma.managed_thread_followup.call_store_create_with_payload",
-        _fake_create,
+        _unexpected_get_store,
     )
 
-    await client.create_terminal_followup(
+    created = await client.create_terminal_followup(
         managed_thread_id="thread-1",
         lane_id=None,
         notify_once=True,
@@ -391,6 +407,4 @@ async def test_managed_thread_automation_client_ignores_stale_last_result_origin
         required=False,
     )
 
-    assert "origin_thread_id" not in captured
-    assert "origin_lane_id" not in captured
-    assert "pma_origin" not in captured["metadata"]
+    assert created is None

--- a/tests/test_managed_threads_messages.py
+++ b/tests/test_managed_threads_messages.py
@@ -1194,7 +1194,9 @@ def test_send_message_notify_on_terminal_auto_subscribes_once(hub_env) -> None:
     assert all_subs[0].get("match_count") == 1
 
 
-def test_send_message_defaults_to_terminal_followup_subscription(hub_env) -> None:
+def test_send_message_default_terminal_followup_without_origin_is_inert(
+    hub_env,
+) -> None:
     _enable_pma(hub_env.hub_root)
     app = create_hub_app(hub_env.hub_root)
     install_fake_supervisor(app)
@@ -1217,10 +1219,7 @@ def test_send_message_defaults_to_terminal_followup_subscription(hub_env) -> Non
         payload = message_resp.json()
         assert payload["status"] == "ok"
         assert payload["send_state"] == "accepted"
-        notification = payload.get("notification") or {}
-        subscription = notification.get("subscription") or {}
-        assert notification.get("mode") == "terminal"
-        assert subscription.get("thread_id") == managed_thread_id
+        assert "notification" not in payload
 
     automation_store = app.state.hub_supervisor.get_pma_automation_store()
     active_subs = automation_store.list_subscriptions(thread_id=managed_thread_id)
@@ -1228,9 +1227,7 @@ def test_send_message_defaults_to_terminal_followup_subscription(hub_env) -> Non
     all_subs = automation_store.list_subscriptions(
         include_inactive=True, thread_id=managed_thread_id
     )
-    assert all_subs
-    assert all_subs[0].get("state") == "cancelled"
-    assert all_subs[0].get("match_count") == 1
+    assert all_subs == []
 
 
 @pytest.mark.anyio

--- a/tests/test_opencode_run_prompt.py
+++ b/tests/test_opencode_run_prompt.py
@@ -98,6 +98,51 @@ async def test_run_opencode_prompt_disposes_temporary_session_after_completion(
 
 
 @pytest.mark.anyio
+async def test_run_opencode_prompt_restarts_after_empty_pre_prompt_stream(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from codex_autorunner.agents.opencode import run_prompt as run_prompt_module
+
+    client = _ClientStub("session-late-output")
+    supervisor = _SupervisorStub(client)
+    collect_calls = 0
+
+    async def _fake_collect(*_args: Any, **_kwargs: Any) -> OpenCodeTurnOutput:
+        nonlocal collect_calls
+        collect_calls += 1
+        ready_event = _kwargs.get("ready_event")
+        if ready_event is not None:
+            ready_event.set()
+        if collect_calls == 1:
+            return OpenCodeTurnOutput(text="")
+        return OpenCodeTurnOutput(text="final answer")
+
+    async def _fake_missing_env(*_args: Any, **_kwargs: Any) -> list[str]:
+        return []
+
+    monkeypatch.setattr(run_prompt_module, "collect_opencode_output", _fake_collect)
+    monkeypatch.setattr(run_prompt_module, "opencode_missing_env", _fake_missing_env)
+
+    result = await run_opencode_prompt(
+        supervisor,  # type: ignore[arg-type]
+        OpenCodeRunConfig(
+            agent="opencode",
+            model=None,
+            reasoning=None,
+            prompt="hello",
+            workspace_root=str(tmp_path),
+            timeout_seconds=5,
+        ),
+    )
+
+    assert result.output_text == "final answer"
+    assert collect_calls == 2
+    assert client.dispose_calls == ["session-late-output"]
+    assert supervisor.started == [tmp_path]
+    assert supervisor.finished == [tmp_path]
+
+
+@pytest.mark.anyio
 async def test_run_opencode_prompt_disposes_session_when_env_check_fails(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -1169,6 +1169,52 @@ async def test_collect_output_bounds_stall_reconnect_loop_if_session_missing(
 
 
 @pytest.mark.anyio
+async def test_collect_output_reconnects_when_stream_ends_while_session_busy(
+    monkeypatch,
+) -> None:
+    stream_calls = 0
+    statuses: list[dict[str, object]] = []
+
+    async def _status_fetcher():
+        statuses.append({"status": {"type": "busy"}})
+        return {"status": {"type": "busy"}}
+
+    async def _event_stream():
+        nonlocal stream_calls
+        stream_calls += 1
+        if stream_calls == 1:
+            for event in ():
+                yield event
+            return
+        yield SSEEvent(
+            event="message.part.updated",
+            data='{"sessionID":"s1","properties":{"delta":{"text":"Recovered"},'
+            '"part":{"type":"text","text":"Recovered"}}}',
+        )
+        yield SSEEvent(event="session.idle", data='{"sessionID":"s1"}')
+
+    monkeypatch.setattr(
+        opencode_stream_lifecycle,
+        "_OPENCODE_STREAM_RECONNECT_BACKOFF_SECONDS",
+        (0.0,),
+    )
+
+    output = await collect_opencode_output_from_events(
+        None,
+        session_id="s1",
+        event_stream_factory=lambda: _event_stream(),
+        session_fetcher=_status_fetcher,
+        stall_timeout_seconds=1.0,
+        first_event_timeout_seconds=1.0,
+    )
+
+    assert output.text == "Recovered"
+    assert output.error is None
+    assert stream_calls == 2
+    assert statuses
+
+
+@pytest.mark.anyio
 async def test_collect_output_waits_if_session_busy(monkeypatch) -> None:
     statuses: list[dict[str, object]] = []
     progress_events: list[dict[str, object]] = []


### PR DESCRIPTION
## Summary
- Make optional/default managed-thread terminal followups inert when there is no live PMA origin to wake.
- Keep explicit terminal notifications working for `notify_on`, `notifyLane`, and `terminalFollowup` callers.
- Prevent OpenCode managed turns from finalizing on an empty pre-prompt stream result, then surfacing the previous assistant response on the next user message.
- Reconnect OpenCode output collection when the SSE stream ends while the session is still busy.
- Add regressions for both the orphan followup archive path and the staggered OpenCode output path.

## Root Cause
There were two related failures behind the observed behavior.

First, a normal web/worktree send created an optional terminal-followup subscription on `pma:default` even when no PMA turn had requested a wake-up. When the OpenCode thread completed, that subscription woke hub PMA with a generic `managed_thread_completed` task. PMA then archived the just-completed worktree thread, making the active web chat read-only.

Second, OpenCode's event stream can connect and close before the prompt has actually produced output. CAR treated that empty stream result as a completed managed turn, while the OpenCode prompt kept running in the backend session. The assistant output then remained in the OpenCode session and could be picked up on the next user message, making responses appear one turn late/staggered.

## Validation
- `.venv/bin/python -m pytest tests/test_opencode_run_prompt.py tests/test_opencode_runtime.py -q`
- `.venv/bin/python -m pytest tests/test_opencode_run_prompt.py tests/test_opencode_runtime.py tests/surfaces/web/test_pma_common_service.py tests/test_managed_threads_messages.py -q`
- Commit hook aggregate lane: black, ruff, import-boundary checks, mypy, full pytest, web lint/build/test, SPA shell, chat-surface lab deterministic checks, and chat latency budgets
