### PR TITLE
[codex] fix hermes pma tail profile streaming

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
@@ -124,14 +124,41 @@ def resolve_resume_after(
     return parsed
 
 
-def _managed_thread_harness(service: Any, agent_id: str) -> Any:
+def _managed_thread_harness(
+    service: Any, agent_id: str, profile: Optional[str] = None
+) -> Any:
     factory = getattr(service, "harness_factory", None)
     if not callable(factory):
         return None
     try:
+        if profile:
+            try:
+                return factory(agent_id, profile)
+            except TypeError as exc:
+                if "positional argument" not in str(exc):
+                    raise
+                return factory(agent_id)
         return factory(agent_id)
     except Exception:  # intentional: dynamic harness factory - exception types unknown
         return None
+
+
+def _managed_thread_agent_profile(thread: Any) -> Optional[str]:
+    profile = normalize_optional_text(getattr(thread, "agent_profile", None))
+    if profile:
+        return profile
+    metadata = getattr(thread, "metadata", None)
+    if isinstance(metadata, dict):
+        return normalize_optional_text(metadata.get("agent_profile"))
+    return None
+
+
+def _managed_thread_harness_for_thread(service: Any, thread: Any) -> Any:
+    agent_id = str(getattr(thread, "agent_id", "") or "")
+    profile = _managed_thread_agent_profile(thread)
+    if profile:
+        return _managed_thread_harness(service, agent_id, profile)
+    return _managed_thread_harness(service, agent_id)
 
 
 def _load_managed_thread_tail_store_state(
@@ -313,7 +340,7 @@ async def _build_managed_thread_tail_snapshot(
     backend_thread_id = normalize_optional_text(thread.backend_thread_id)
     backend_turn_id = normalize_optional_text(turn.backend_id)
     if harness is None:
-        harness = _managed_thread_harness(service, str(thread.agent_id or ""))
+        harness = _managed_thread_harness_for_thread(service, thread)
     has_backend_binding = bool(backend_thread_id) and bool(backend_turn_id)
     stream_available = bool(
         harness is not None
@@ -564,9 +591,7 @@ def build_managed_thread_tail_routes(
         )
         harness = None
         if thread_target is not None:
-            harness = _managed_thread_harness(
-                service, str(thread_target.agent_id or "")
-            )
+            harness = _managed_thread_harness_for_thread(service, thread_target)
         snapshot = await _build_managed_thread_tail_snapshot(
             request=request,
             service=service,

--- a/tests/surfaces/web/routes/pma_routes/test_tail_stream_characterization.py
+++ b/tests/surfaces/web/routes/pma_routes/test_tail_stream_characterization.py
@@ -406,6 +406,140 @@ class TestTailSnapshotEnumContracts:
         if payload["turn_status"] is not None:
             assert payload["phase"] in valid_phases
 
+    async def test_tail_snapshot_resolves_profiled_thread_harness(
+        self, monkeypatch, hub_env
+    ) -> None:
+        calls: list[tuple[str, str | None]] = []
+
+        class Harness:
+            def supports(self, capability: str) -> bool:
+                return capability == "event_streaming"
+
+            async def list_progress_events(
+                self,
+                _backend_thread_id: str,
+                _backend_turn_id: str,
+                **_kwargs,
+            ) -> list[dict[str, object]]:
+                return []
+
+        class Service:
+            def harness_factory(self, agent_id: str, profile: str | None = None):
+                calls.append((agent_id, profile))
+                return Harness()
+
+        monkeypatch.setattr(
+            tail_stream,
+            "get_pma_request_context",
+            lambda _request: SimpleNamespace(
+                hub_root=hub_env.hub_root,
+                thread_store=lambda: object(),
+            ),
+        )
+        monkeypatch.setattr(
+            tail_stream,
+            "_load_managed_thread_tail_store_state",
+            lambda **_kwargs: (
+                SimpleNamespace(
+                    agent_id="hermes",
+                    agent_profile="m4-pma",
+                    backend_thread_id="hermes-session-1",
+                    status="running",
+                    lifecycle_status="active",
+                    metadata={"agent_profile": "m4-pma"},
+                ),
+                SimpleNamespace(
+                    execution_id="managed-turn-1",
+                    status="running",
+                    started_at="2026-05-10T17:00:00+00:00",
+                    finished_at=None,
+                    backend_id="turn-1",
+                ),
+                [],
+                None,
+            ),
+        )
+
+        payload = await tail_stream._build_managed_thread_tail_snapshot(
+            request=object(),
+            service=Service(),
+            managed_thread_id="thread-1",
+            limit=50,
+            level="info",
+            since_ms=None,
+            resume_after=0,
+        )
+
+        assert calls == [("hermes", "m4-pma")]
+        assert payload["stream_available"] is True
+
+    async def test_tail_snapshot_falls_back_for_legacy_harness_factory(
+        self, monkeypatch, hub_env
+    ) -> None:
+        calls: list[str] = []
+
+        class Harness:
+            def supports(self, capability: str) -> bool:
+                return capability == "event_streaming"
+
+            async def list_progress_events(
+                self,
+                _backend_thread_id: str,
+                _backend_turn_id: str,
+                **_kwargs,
+            ) -> list[dict[str, object]]:
+                return []
+
+        class Service:
+            def harness_factory(self, agent_id: str):
+                calls.append(agent_id)
+                return Harness()
+
+        monkeypatch.setattr(
+            tail_stream,
+            "get_pma_request_context",
+            lambda _request: SimpleNamespace(
+                hub_root=hub_env.hub_root,
+                thread_store=lambda: object(),
+            ),
+        )
+        monkeypatch.setattr(
+            tail_stream,
+            "_load_managed_thread_tail_store_state",
+            lambda **_kwargs: (
+                SimpleNamespace(
+                    agent_id="hermes",
+                    agent_profile="m4-pma",
+                    backend_thread_id="hermes-session-1",
+                    status="running",
+                    lifecycle_status="active",
+                    metadata={"agent_profile": "m4-pma"},
+                ),
+                SimpleNamespace(
+                    execution_id="managed-turn-1",
+                    status="running",
+                    started_at="2026-05-10T17:00:00+00:00",
+                    finished_at=None,
+                    backend_id="turn-1",
+                ),
+                [],
+                None,
+            ),
+        )
+
+        payload = await tail_stream._build_managed_thread_tail_snapshot(
+            request=object(),
+            service=Service(),
+            managed_thread_id="thread-1",
+            limit=50,
+            level="info",
+            since_ms=None,
+            resume_after=0,
+        )
+
+        assert calls == ["hermes"]
+        assert payload["stream_available"] is True
+
     async def test_tail_snapshot_captures_token_usage_from_runtime_fallback(
         self, monkeypatch, hub_env
     ) -> None:


### PR DESCRIPTION
## Summary
- Resolve managed-thread tail harnesses with the thread's `agent_profile` so profiled Hermes PMA chats attach to the same live supervisor used for execution.
- Add a regression test proving profiled Hermes tail snapshots call `harness_factory("hermes", "m4-pma")`.

## Root Cause
Web PMA deferred execution preserved the Hermes profile when starting the turn, but `/tail/events` rebuilt the live harness with only `agent_id="hermes"`. For `m4-pma` chats this selected a different Hermes supervisor, so the SSE stream crashed with `Unknown Hermes turn 'turn-1'` and the browser fell back to polling.

## Validation
- Reproduced locally against real Hermes `m4-pma`: `/tail/events` closed after one state frame with `HermesSupervisorError: Unknown Hermes turn 'turn-1'`.
- Re-ran locally against real Hermes after the fix: `/tail/events` stayed connected through backend binding handoff and emitted live `tail`/`timeline` frames at 9.5s.
- `.venv/bin/python -m pytest -q tests/surfaces/web/routes/pma_routes/test_tail_stream_characterization.py tests/test_managed_threads_tail.py`
- `.venv/bin/python -m pytest -q tests/agents/hermes/test_hermes_supervisor.py tests/agents/hermes/test_hermes_supervisor_official_prompt_hang.py`
- Commit hook web-ui lane: black, ruff, import/contract checks, mypy, 8536 pytest tests, web lint/build/test, SPA shell check.