### PR TITLE
[codex] Fix chat channel name mapping

### DIFF
--- a/src/codex_autorunner/adapters/discord/service.py
+++ b/src/codex_autorunner/adapters/discord/service.py
@@ -4066,6 +4066,9 @@ class DiscordBotService(DiscordInteractionResponseMixin):
 
     async def _on_dispatch(self, event_type: str, payload: dict[str, Any]) -> None:
         if event_type == "INTERACTION_CREATE":
+            self._spawn_task(
+                self._record_channel_directory_seen_from_message_payload(payload)
+            )
             await self._handle_interaction_create(payload)
             return
         if event_type == "MESSAGE_CREATE":

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/channel_source_readers.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/channel_source_readers.py
@@ -297,10 +297,16 @@ def read_discord_bindings(
                 row["agent_profile"] if "agent_profile" in columns else None,
                 context=context,
             )
+            guild_id = row["guild_id"] if "guild_id" in columns else None
             binding = {
                 "platform": "discord",
                 "chat_id": channel_id.strip(),
                 "surface_key": channel_id.strip(),
+                "guild_id": (
+                    guild_id.strip()
+                    if isinstance(guild_id, str) and guild_id.strip()
+                    else None
+                ),
                 "workspace_path": wp,
                 "repo_id": repo_id,
                 "resource_kind": (
@@ -323,10 +329,16 @@ def read_discord_bindings(
                 "agent": agent,
                 "agent_profile": agent_profile,
                 "active_thread_id": None,
+                "updated_at": (
+                    row["updated_at"]
+                    if "updated_at" in columns
+                    and isinstance(row["updated_at"], str)
+                    and row["updated_at"].strip()
+                    else None
+                ),
             }
             primary_key = f"discord:{binding['chat_id']}"
             bindings.setdefault(primary_key, binding)
-            guild_id = row["guild_id"] if "guild_id" in columns else None
             if isinstance(guild_id, str) and guild_id.strip():
                 bindings.setdefault(
                     f"discord:{binding['chat_id']}:{guild_id.strip()}",
@@ -508,6 +520,13 @@ def read_telegram_bindings(
                     "agent": agent,
                     "agent_profile": agent_profile,
                     "active_thread_id": active_thread_id,
+                    "updated_at": (
+                        row["updated_at"]
+                        if "updated_at" in columns
+                        and isinstance(row["updated_at"], str)
+                        and row["updated_at"].strip()
+                        else None
+                    ),
                 },
             )
     except (sqlite3.Error, OSError, ValueError, TypeError, KeyError) as exc:

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/channels.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/channels.py
@@ -266,18 +266,25 @@ class HubChannelService:
             entry["thread_id"] = thread_id
         return entry
 
+    def _binding_merge_identity(self, entry: dict[str, Any]) -> Optional[str]:
+        platform = str(entry.get("platform") or "").strip().lower()
+        chat_id = str(entry.get("chat_id") or "").strip()
+        if platform == "discord" and chat_id:
+            return f"discord:{chat_id}"
+        return channel_entry_key(entry)
+
     def _merge_binding_entries(
         self,
         entries: list[dict[str, Any]],
         *binding_sources: dict[str, dict[str, Any]],
     ) -> list[dict[str, Any]]:
         merged = list(entries)
-        seen = {
-            key
+        seen_identities = {
+            identity
             for entry in merged
-            if isinstance((key := channel_entry_key(entry)), str)
+            if isinstance((identity := self._binding_merge_identity(entry)), str)
         }
-        synthesized_seen: set[str] = set()
+        synthesized_seen_identities: set[str] = set()
         for bindings in binding_sources:
             for binding in bindings.values():
                 if not isinstance(binding, dict):
@@ -285,12 +292,15 @@ class HubChannelService:
                 entry = self._binding_directory_entry(binding)
                 if entry is None:
                     continue
-                key = channel_entry_key(entry)
-                if not isinstance(key, str):
+                identity = self._binding_merge_identity(entry)
+                if not isinstance(identity, str):
                     continue
-                if key in seen or key in synthesized_seen:
+                if (
+                    identity in seen_identities
+                    or identity in synthesized_seen_identities
+                ):
                     continue
-                synthesized_seen.add(key)
+                synthesized_seen_identities.add(identity)
                 merged.append(entry)
         return merged
 

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/channels.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/channels.py
@@ -29,6 +29,8 @@ from .....core.managed_thread_identity import (
     pma_base_key,
     pma_topic_scoped_key,
 )
+from .....core.managed_thread_store import default_managed_threads_db_path
+from .....core.orchestration.sqlite import resolve_orchestration_sqlite_path
 from .....core.pma_context import (
     get_latest_ticket_flow_run_state_with_record,
 )
@@ -59,6 +61,7 @@ _CHANNEL_DIR_CACHE_TTL_SECONDS = 60.0
 @dataclass(frozen=True)
 class _ChannelDirectoryCacheEntry:
     expires_at: float
+    source_token: tuple[tuple[str, int, int], ...]
     rows: list[dict[str, Any]]
 
 
@@ -218,6 +221,78 @@ class HubChannelService:
         if not isinstance(workspace_path, str) or not workspace_path.strip():
             return None
         return file_chat_discord_key(agent, channel_id, workspace_path)
+
+    def _binding_directory_entry(
+        self, binding: dict[str, Any]
+    ) -> Optional[dict[str, Any]]:
+        platform = str(binding.get("platform") or "").strip().lower()
+        if platform not in {"discord", "telegram"}:
+            return None
+        chat_id = binding.get("chat_id")
+        if not isinstance(chat_id, str) or not chat_id.strip():
+            return None
+        chat_id = chat_id.strip()
+        thread_id = binding.get("thread_id")
+        if not isinstance(thread_id, str) or not thread_id.strip():
+            thread_id = None
+        else:
+            thread_id = thread_id.strip()
+
+        meta: dict[str, Any] = {}
+        if platform == "discord":
+            guild_id = binding.get("guild_id")
+            if isinstance(guild_id, str) and guild_id.strip():
+                meta["guild_id"] = guild_id.strip()
+            display = (
+                f"guild:{meta['guild_id']} / #{chat_id}"
+                if "guild_id" in meta
+                else f"discord:{chat_id}"
+            )
+        else:
+            display = (
+                f"telegram:{chat_id}:{thread_id}"
+                if thread_id
+                else f"telegram:{chat_id}"
+            )
+
+        entry: dict[str, Any] = {
+            "platform": platform,
+            "chat_id": chat_id,
+            "display": display,
+            "seen_at": binding.get("updated_at") or "",
+            "meta": meta,
+        }
+        if thread_id is not None:
+            entry["thread_id"] = thread_id
+        return entry
+
+    def _merge_binding_entries(
+        self,
+        entries: list[dict[str, Any]],
+        *binding_sources: dict[str, dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        merged = list(entries)
+        seen = {
+            key
+            for entry in merged
+            if isinstance((key := channel_entry_key(entry)), str)
+        }
+        synthesized_seen: set[str] = set()
+        for bindings in binding_sources:
+            for binding in bindings.values():
+                if not isinstance(binding, dict):
+                    continue
+                entry = self._binding_directory_entry(binding)
+                if entry is None:
+                    continue
+                key = channel_entry_key(entry)
+                if not isinstance(key, str):
+                    continue
+                if key in seen or key in synthesized_seen:
+                    continue
+                synthesized_seen.add(key)
+                merged.append(entry)
+        return merged
 
     def _registry_thread_id(
         self,
@@ -406,6 +481,11 @@ class HubChannelService:
             telegram_thread_bindings_task,
             managed_threads_task,
             return_exceptions=False,
+        )
+        entries = self._merge_binding_entries(
+            entries,
+            discord_bindings,
+            telegram_bindings,
         )
         run_cache: dict[str, dict[str, Any]] = {}
         usage_cache: dict[str, dict[str, dict[str, Any]]] = {}
@@ -711,15 +791,39 @@ class HubChannelService:
     async def _list_cached_channel_rows(self) -> list[dict[str, Any]]:
         now = time.monotonic()
         cached = self._channel_dir_cache
-        if cached is not None and cached.expires_at > now:
+        source_token = self._cache_source_token()
+        if (
+            cached is not None
+            and cached.expires_at > now
+            and cached.source_token == source_token
+        ):
             return copy.deepcopy(cached.rows)
 
         rows = await self._build_channel_rows()
         self._channel_dir_cache = _ChannelDirectoryCacheEntry(
             expires_at=time.monotonic() + _CHANNEL_DIR_CACHE_TTL_SECONDS,
+            source_token=source_token,
             rows=copy.deepcopy(rows),
         )
         return rows
+
+    def _cache_source_token(self) -> tuple[tuple[str, int, int], ...]:
+        paths = [
+            ChannelDirectoryStore(self._context.config.root).path,
+            state_db_path(self._context, "discord_bot", DISCORD_STATE_FILE_DEFAULT),
+            state_db_path(self._context, "telegram_bot", TELEGRAM_STATE_FILE_DEFAULT),
+            resolve_orchestration_sqlite_path(self._context.config.root),
+            default_managed_threads_db_path(self._context.config.root),
+        ]
+        token: list[tuple[str, int, int]] = []
+        for path in paths:
+            try:
+                stat = path.stat()
+            except OSError:
+                token.append((str(path), 0, 0))
+                continue
+            token.append((str(path), stat.st_mtime_ns, stat.st_size))
+        return tuple(token)
 
 
 def build_hub_channel_router(context: HubAppContext) -> APIRouter:

--- a/tests/adapters/discord/test_channel_directory_ingest.py
+++ b/tests/adapters/discord/test_channel_directory_ingest.py
@@ -118,6 +118,37 @@ async def test_message_create_records_channel_directory_with_names(
 
 
 @pytest.mark.anyio
+async def test_interaction_payload_records_channel_directory_with_channel_object(
+    tmp_path: Path,
+) -> None:
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=_FakeRest(),
+        gateway_client=_FakeGateway(),
+    )
+
+    await service._record_channel_directory_seen_from_message_payload(
+        {
+            "id": "interaction-1",
+            "channel_id": "channel-1",
+            "guild_id": "guild-1",
+            "channel": {"id": "channel-1", "name": "pma"},
+            "data": {"name": "pma"},
+            "member": {"user": {"id": "user-1"}},
+        },
+    )
+
+    entries = ChannelDirectoryStore(tmp_path).list_entries(limit=None)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["platform"] == "discord"
+    assert entry["chat_id"] == "channel-1"
+    assert entry["display"] == "guild:guild-1 / #pma"
+    assert entry["meta"] == {"guild_id": "guild-1"}
+
+
+@pytest.mark.anyio
 async def test_message_create_records_channel_directory_with_id_fallbacks(
     tmp_path: Path,
 ) -> None:

--- a/tests/surfaces/web/test_hub_channel_directory_routes.py
+++ b/tests/surfaces/web/test_hub_channel_directory_routes.py
@@ -84,6 +84,26 @@ def test_hub_channel_directory_route_lists_and_filters(tmp_path: Path) -> None:
     assert "limit must be <= 1000" in bad_limit_high.json()["detail"]
 
 
+def test_hub_channel_directory_route_cache_invalidates_when_directory_changes(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    create_test_hub_supervisor(hub_root)
+    store = ChannelDirectoryStore(hub_root)
+    store.record_seen("discord", "chan-first", None, "CAR / #first", {})
+
+    client = TestClient(create_hub_app(hub_root))
+    first_rows = client.get("/hub/chat/channels").json()["entries"]
+    assert {row["key"] for row in first_rows} == {"discord:chan-first"}
+
+    store.record_seen("discord", "chan-second", None, "CAR / #second", {})
+    second_rows = client.get("/hub/chat/channels").json()["entries"]
+    assert {row["key"] for row in second_rows} == {
+        "discord:chan-first",
+        "discord:chan-second",
+    }
+
+
 def test_hub_channel_directory_route_enriches_entries_best_effort(
     tmp_path: Path,
 ) -> None:
@@ -364,6 +384,61 @@ def test_hub_channel_directory_route_enriches_entries_best_effort(
     assert telegram_clean["provenance"]["source"] == "telegram"
     assert telegram_clean["channel_status"] == "clean"
     assert telegram_clean["status_label"] == "clean"
+
+
+def test_hub_channel_directory_route_includes_binding_rows_without_directory_entries(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    supervisor = create_test_hub_supervisor(hub_root)
+    repo = supervisor.create_repo("work")
+    init_git_repo(repo.path)
+
+    write_discord_binding_rows(
+        hub_root / ".codex-autorunner" / "discord_state.sqlite3",
+        rows=[
+            {
+                "channel_id": "chan-bound",
+                "guild_id": "guild-1",
+                "workspace_path": str(repo.path),
+                "repo_id": None,
+                "pma_enabled": 0,
+                "agent": "codex",
+                "updated_at": "2026-01-01T00:00:01Z",
+            }
+        ],
+    )
+    write_telegram_topic_rows(
+        hub_root / ".codex-autorunner" / "telegram_state.sqlite3",
+        topics=[
+            {
+                "topic_key": telegram_topic_key(-1001, 77),
+                "chat_id": -1001,
+                "thread_id": 77,
+                "scope": None,
+                "workspace_path": str(repo.path),
+                "repo_id": None,
+                "active_thread_id": "telegram-thread",
+                "payload_json": {"agent": "codex"},
+                "updated_at": "2026-01-01T00:00:02Z",
+            }
+        ],
+        scopes=[],
+    )
+
+    client = TestClient(create_hub_app(hub_root))
+    rows = client.get("/hub/chat/channels", params={"limit": 20}).json()["entries"]
+    by_key = {row["key"]: row for row in rows}
+
+    assert "discord:chan-bound" in by_key
+    assert by_key["discord:chan-bound"]["display"] == "guild:guild-1 / #chan-bound"
+    assert by_key["discord:chan-bound"]["repo_id"] == "work"
+    assert by_key["discord:chan-bound"]["workspace_path"] == str(repo.path)
+
+    assert "telegram:-1001:77" in by_key
+    assert by_key["telegram:-1001:77"]["display"] == "telegram:-1001:77"
+    assert by_key["telegram:-1001:77"]["active_thread_id"] == "telegram-thread"
+    assert by_key["telegram:-1001:77"]["repo_id"] == "work"
 
 
 def test_hub_channel_directory_route_uses_managed_thread_id_for_pma_usage(

--- a/tests/surfaces/web/test_hub_channel_directory_routes.py
+++ b/tests/surfaces/web/test_hub_channel_directory_routes.py
@@ -441,6 +441,50 @@ def test_hub_channel_directory_route_includes_binding_rows_without_directory_ent
     assert by_key["telegram:-1001:77"]["repo_id"] == "work"
 
 
+def test_hub_channel_directory_route_deduplicates_legacy_discord_guild_keys(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    supervisor = create_test_hub_supervisor(hub_root)
+    repo = supervisor.create_repo("work")
+
+    ChannelDirectoryStore(hub_root).record_seen(
+        "discord",
+        "chan-legacy",
+        "guild-1",
+        "CAR / #legacy",
+        {"guild_id": "guild-1"},
+    )
+    write_discord_binding_rows(
+        hub_root / ".codex-autorunner" / "discord_state.sqlite3",
+        rows=[
+            {
+                "channel_id": "chan-legacy",
+                "guild_id": "guild-1",
+                "workspace_path": str(repo.path),
+                "repo_id": "work",
+                "pma_enabled": 0,
+                "agent": "codex",
+                "updated_at": "2026-01-01T00:00:01Z",
+            }
+        ],
+    )
+
+    client = TestClient(create_hub_app(hub_root))
+    rows = client.get("/hub/chat/channels", params={"limit": 20}).json()["entries"]
+    matching_rows = [
+        row
+        for row in rows
+        if row.get("entry", {}).get("platform") == "discord"
+        and row.get("entry", {}).get("chat_id") == "chan-legacy"
+    ]
+
+    assert len(matching_rows) == 1
+    assert matching_rows[0]["key"] == "discord:chan-legacy:guild-1"
+    assert matching_rows[0]["repo_id"] == "work"
+    assert matching_rows[0]["display"] == "CAR / #legacy"
+
+
 def test_hub_channel_directory_route_uses_managed_thread_id_for_pma_usage(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes unreliable Telegram and Discord chat name mapping in the Web Hub chat list.

Root cause: `/hub/chat/channels` treated `.codex-autorunner/chat/channel_directory.json` as the seed set of chats and only used Discord/Telegram binding databases for enrichment. That meant bound channels/topics without a recent directory record were invisible or fell back to raw IDs. Discord also only recorded directory metadata from `MESSAGE_CREATE`, so slash-command-only usage often never populated human-readable names. The route cache then kept stale rows for up to 60 seconds even after the backing files changed.

## Changes

- Synthesize hub chat rows from durable Discord channel bindings and Telegram topic bindings when no directory entry exists yet.
- Preserve binding update timestamps and Discord guild IDs for those synthesized rows.
- Record Discord `INTERACTION_CREATE` payloads into the channel directory in the background, matching existing message ingress behavior without slowing command handling.
- Make the hub channel row cache validate source file mtimes/sizes for the directory, transport state DBs, orchestration DB, and managed-thread DB.
- Add regression coverage for binding-only rows, cache invalidation, and Discord interaction metadata ingest.

## Validation

- `git commit` aggregate lane passed:
  - black
  - ruff
  - import boundary checks
  - hub interface contracts
  - destination/keyword/context hint checks
  - strict mypy over `src/codex_autorunner`
  - `pytest`: 8537 passed
  - Web Hub lint/build/tests: 473 frontend tests passed
  - chat-surface lab checks and latency budgets passed
- Focused suite: `23 passed` for hub channel directory and Discord/Telegram directory ingest tests.