### PR TITLE
[codex] Fix web PMA attachment prompts

### DIFF
--- a/src/codex_autorunner/core/pma/message_options.py
+++ b/src/codex_autorunner/core/pma/message_options.py
@@ -70,19 +70,23 @@ def resolve_managed_thread_message_options(
 ) -> ManagedThreadMessageOptions:
     busy_policy = normalize_busy_policy(input.busy_policy)
     message = str(input.message or "")
-    if not message.strip():
+    attachments = normalize_managed_thread_attachments(input.attachments)
+    if not message.strip() and not attachments:
         raise ValueError("message is required")
     max_text_chars = int(input.defaults.get("max_text_chars", 0) or 0)
     validate_max_text_chars(message, max_text_chars)
 
-    attachments = normalize_managed_thread_attachments(input.attachments)
     attachment_context = build_managed_thread_attachment_execution_context(
         attachments,
         hub_root=input.hub_root,
     )
     execution_message = message
     if attachment_context is not None:
-        execution_message = f"{message}\n\n{attachment_context.prompt_text}"
+        execution_message = (
+            f"{message}\n\n{attachment_context.prompt_text}"
+            if message.strip()
+            else attachment_context.prompt_text
+        )
     model = _normalize_optional_text(input.model) or input.defaults.get("model")
     reasoning = _normalize_optional_text(input.reasoning) or input.defaults.get(
         "reasoning"

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -29,6 +29,7 @@ from .....adapters.chat.managed_thread_turns import (
     ManagedThreadSurfaceInfo,
     ManagedThreadTurnCoordinator,
     build_managed_thread_delivery_intent,
+    build_managed_thread_input_items,
 )
 from .....adapters.github.managed_thread_pr_binding import (
     self_claim_and_arm_pr_binding,
@@ -904,7 +905,10 @@ def build_managed_thread_runtime_routes(
                 reasoning=options.reasoning,
                 approval_mode=options.approval_policy,
                 context_profile=options.context_profile,
-                input_items=options.execution_input_items,
+                input_items=build_managed_thread_input_items(
+                    options.execution_prompt,
+                    options.execution_input_items,
+                ),
                 metadata=merge_bound_chat_execution_metadata(
                     {
                         "runtime_prompt": options.execution_prompt,

--- a/tests/test_managed_threads_messages.py
+++ b/tests/test_managed_threads_messages.py
@@ -221,7 +221,8 @@ def test_send_message_round_trips_structured_attachments(hub_env) -> None:
     assert f"  Saved to: {inbox_file}" in runtime_prompt
     assert "  URL: /hub/pma/files/inbox/screen.png" in runtime_prompt
     assert fake_supervisor.client.turn_start_calls[0]["turn_kwargs"]["input_items"] == [
-        {"type": "localImage", "path": str(inbox_file)}
+        {"type": "text", "text": runtime_prompt},
+        {"type": "localImage", "path": str(inbox_file)},
     ]
     assert turns[0]["attachments"] == [
         {
@@ -250,6 +251,58 @@ def test_send_message_round_trips_structured_attachments(hub_env) -> None:
             "url": "https://example.test/preview",
             "metadata": {"kind": "link"},
         },
+    ]
+
+
+def test_send_message_accepts_attachment_only_turn(hub_env) -> None:
+    _enable_pma(
+        hub_env.hub_root,
+        reactive_enabled=False,
+        managed_thread_terminal_followup_default=False,
+    )
+    app = create_hub_app(hub_env.hub_root)
+
+    fake_client = FakeClient(sequential=True)
+    fake_supervisor = FakeSupervisor(fake_client)
+    inbox_file = (
+        hub_env.hub_root / ".codex-autorunner" / "filebox" / "inbox" / "screen.png"
+    )
+    inbox_file.parent.mkdir(parents=True, exist_ok=True)
+    inbox_file.write_bytes(b"png")
+
+    attachments = [
+        {
+            "id": "att-1",
+            "kind": "image",
+            "title": "screen.png",
+            "url": "/hub/pma/files/inbox/screen.png",
+            "uploadedName": "screen.png",
+        }
+    ]
+
+    with TestClient(app) as client:
+        app.state.app_server_supervisor = fake_supervisor
+        app.state.app_server_events = object()
+        create_resp = client.post(
+            "/hub/pma/threads",
+            json={"agent": "codex", **_repo_owner(hub_env)},
+        )
+        assert create_resp.status_code == 200
+        managed_thread_id = create_resp.json()["thread"]["managed_thread_id"]
+
+        send_resp = client.post(
+            f"/hub/pma/threads/{managed_thread_id}/messages",
+            json={"message": "", "attachments": attachments},
+        )
+
+    assert send_resp.status_code == 200
+    runtime_prompt = str(fake_supervisor.client.turn_start_calls[0]["prompt"])
+    assert "<user_message>\nPMA File Inbox:" in runtime_prompt
+    assert "- screen.png" in runtime_prompt
+    assert f"  Saved to: {inbox_file}" in runtime_prompt
+    assert fake_supervisor.client.turn_start_calls[0]["turn_kwargs"]["input_items"] == [
+        {"type": "text", "text": runtime_prompt},
+        {"type": "localImage", "path": str(inbox_file)},
     ]
 
 


### PR DESCRIPTION
## Summary

Fixes web PMA managed-thread sends with attachments so the runtime receives both the user prompt and native image inputs.

## Root Cause

The web PMA runtime passed attachment-derived `localImage` items directly into orchestration. Codex treats `input_items` as the multimodal turn body, so when native items were present without a text item, the agent could see the image while missing the typed user message. Discord and Telegram already route their native items through the shared managed-thread input item builder, which inserts the runtime prompt as the first text item.

## Changes

- Route web PMA `input_items` through `build_managed_thread_input_items()` so the runtime prompt is included beside uploaded images.
- Allow attachment-only PMA turns by accepting empty `message` text when valid attachments are present.
- Add regression coverage for both prompt-plus-image sends and attachment-only sends.

## Validation

- Commit hook aggregate lane passed:
  - black
  - ruff
  - import boundary checks
  - hub interface contract checks
  - destination and keyword contract checks
  - injected context and command hint checks
  - mypy over `src/codex_autorunner`
  - pytest: 8586 passed
  - web lint/build/test: 481 frontend tests passed
  - SPA shell and web static asset checks
  - chat-surface lab checks: 21 passed plus latency budget suite PASS
- Focused checks also passed before commit:
  - `.venv/bin/python -m pytest tests/test_managed_threads_messages.py -q`
  - `.venv/bin/python -m pytest tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime_payloads.py -q`