### PR TITLE
[codex] Improve web-core validation ergonomics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,9 @@ jobs:
             web-ui)
               [[ "${run_web_ui}" == "true" && "${web_ui_result}" == "success" ]] || exit 1
               ;;
+            web-core-contract)
+              [[ "${run_web_ui}" == "true" && "${web_ui_result}" == "success" ]] || exit 1
+              ;;
             chat-apps)
               [[ "${run_chat_apps}" == "true" && "${chat_apps_result}" == "success" ]] || exit 1
               ;;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,9 @@ Thanks for helping improve codex-autorunner.
 The pre-commit hook and CI use lane-based validation to avoid running unnecessary checks:
 - `core`: Backend/logic changes only (no frontend build or JS tests)
 - `web-ui`: Frontend/UI changes (includes core + frontend build + JS lint + JS tests)
+- `web-core-contract`: Scoped core + Web surface contract changes (same checks as `web-ui`, without chat-app validation)
 - `chat-apps`: Chat integration changes (Discord/Telegram adapters and tests)
-- `aggregate`: Full validation (all of the above; used for multi-lane or shared-risk diffs)
+- `aggregate`: Full validation (all of the above; used for broad multi-lane or shared-risk diffs)
 
 Lane is auto-detected from changed files. Force a specific lane with `./scripts/check.sh --lane <lane>`.
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ PIPX_ROOT ?= $(HOME)/.local/pipx
 PIPX_VENV ?= $(PIPX_ROOT)/venvs/codex-autorunner
 PIPX_PYTHON ?= $(PIPX_VENV)/bin/python
 
-.PHONY: install dev hooks build web-build test test-fast test-full test-chat-platform-contract test-chat-surface-lab test-managed-thread-cutover check check-full check-extended preflight-hub-startup format serve serve-hub serve-onboarding web-ui-screens launchd-hub deadcode-baseline venv venv-dev setup npm-install car-artifacts agent-compatibility-check agent-compatibility-refresh protocol-schemas-check protocol-schemas-refresh typecheck-strict perf-idle-cpu perf-chat-latency-budgets perf-chat-seeded-exploration
+.PHONY: install dev hooks build web-build test test-fast test-full test-chat-platform-contract test-chat-surface-lab test-managed-thread-cutover check check-full check-web-core-contract check-extended preflight-hub-startup format serve serve-hub serve-onboarding web-ui-screens launchd-hub deadcode-baseline venv venv-dev setup npm-install car-artifacts agent-compatibility-check agent-compatibility-refresh protocol-schemas-check protocol-schemas-refresh typecheck-strict perf-idle-cpu perf-chat-latency-budgets perf-chat-seeded-exploration
 
 build: web-build
 
@@ -142,6 +142,9 @@ check:
 
 check-full:
 	./scripts/check.sh --full
+
+check-web-core-contract:
+	./scripts/check.sh --lane web-core-contract
 
 check-extended: check-full
 	$(MAKE) test-chat-platform-contract PYTHON="$(PYTHON)"

--- a/docs/ops/running-in-a-vm.md
+++ b/docs/ops/running-in-a-vm.md
@@ -9,7 +9,7 @@ Notes for running codex-autorunner inside containerized or cloud-provisioned VMs
 |---------|-----------|-------|
 | Web Hub (dev: FastAPI reload + Vite HMR) | `make serve` — hub on **4173**, Web UI on **5173** (`WEB_DEV_PORT`) | Open the printed **Vite** URL; `CAR_DEV_INCLUDE_ROOT_REPO=1` is set by the script |
 | Python tests | `make test` or `.venv/bin/python -m pytest -m "not integration"` | Serial by default; use `-n auto` for xdist parallelism |
-| Lane-aware checks | `./scripts/check.sh` (auto-detect) or `./scripts/check.sh --lane <lane>` | Lanes: `core`, `web-ui`, `chat-apps`, `aggregate` (full) |
+| Lane-aware checks | `./scripts/check.sh` (auto-detect) or `./scripts/check.sh --lane <lane>` | Lanes: `core`, `web-ui`, `web-core-contract`, `chat-apps`, `aggregate` (full) |
 | Full validation | `./scripts/check.sh --full` or `make check-full` | Runs all lanes plus extended checks |
 | Linting | `black --check src tests`, `ruff check src tests`, `make typecheck-strict` | Individual linters for targeted runs |
 | Web Hub build | `pnpm run build` or `make build` | Builds the default Svelte UI in `src/codex_autorunner/web_frontend/` → `src/codex_autorunner/web_static/`; always rebuild after Web UI changes |
@@ -22,7 +22,7 @@ Notes for running codex-autorunner inside containerized or cloud-provisioned VMs
 - **Process termination tests**: A few tests in `tests/test_opencode_supervisor_process_management.py` and `tests/test_process_termination.py` may fail in containerized environments due to PID namespace / signal handling constraints. These are environment-specific, not code bugs.
 - **Text delta coalescer**: `tests/unit/test_text_delta_coalescer.py::test_multibyte_unicode_newline` may occasionally error in containerized VMs. This is environment-specific.
 - **Test suite is large**: ~6300+ tests. Run via `make test` (serial, `-m "not integration"`) or in parallel with `-n auto` (used by `scripts/check.sh`).
-- **Lane-based validation**: `scripts/check.sh` auto-detects the appropriate lane from staged files. Backend-only changes run the `core` lane (no frontend build); UI changes run `web-ui`; chat integration changes run `chat-apps`. Multi-lane or shared-risk diffs fall back to `aggregate` (full checks). Force full checks with `--full`.
+- **Lane-based validation**: `scripts/check.sh` auto-detects the appropriate lane from staged files. Backend-only changes run the `core` lane (no frontend build); UI changes run `web-ui`; scoped core + Web surface contract changes run `web-core-contract`; chat integration changes run `chat-apps`. Broad multi-lane or shared-risk diffs fall back to `aggregate` (full checks). Force full checks with `--full`.
 - **Tests are hermetic**: Tests use isolated temp directories (via fixtures and `tmp_path`). A guard script (`scripts/check_test_tmp_usage.py`) runs as part of the standard check flow and blocks new non-hermetic `/tmp` writable patterns in tests. Known read-only exceptions are allowlisted in `scripts/test_tmp_usage_allowlist.json`.
 - **No external services required**: SQLite is embedded (stdlib); no Postgres/Redis/Docker needed for core dev workflows.
 - **Pre-commit subset**: The pre-commit hook (`scripts/check.sh`) runs `pytest -m "not integration and not slow"` with lane-aware scoping. Use the same marker set when iterating locally to match pre-commit behavior.

--- a/docs/ops/validation-and-testing.md
+++ b/docs/ops/validation-and-testing.md
@@ -12,6 +12,7 @@ Validation is split into lanes so that small, scoped changes don't trigger the f
 |------|-------|-------------|
 | `core` | Backend/logic | Python lint, typecheck, core pytest, dead-code check |
 | `web-ui` | Frontend/UI | Core checks + Web frontend lint, `pnpm run build`, Web frontend tests, `web_static` drift check |
+| `web-core-contract` | Web/API contract changes | Same local checks as `web-ui`; selected for scoped core + Web surface diffs so chat-surface lab work stays out of the first feedback loop |
 | `chat-apps` | Chat integrations | Core checks + deterministic chat-surface lab suite (`make test-chat-surface-lab`) |
 | `aggregate` | Full validation | All lane checks combined |
 
@@ -20,7 +21,8 @@ Validation is split into lanes so that small, scoped changes don't trigger the f
 Changed files are classified by path prefixes and globs defined in `src/codex_autorunner/core/validation_lanes.py`.
 
 - Single-lane diffs route to that lane.
-- Multi-lane diffs, shared-risk files (e.g. `pyproject.toml`, `Makefile`, `scripts/`), or unknown paths route to `aggregate`.
+- Scoped core + Web diffs route to `web-core-contract`.
+- Other multi-lane diffs, shared-risk files (e.g. `pyproject.toml`, `Makefile`, `scripts/`), or unknown paths route to `aggregate`.
 
 ### Local Usage
 
@@ -31,6 +33,7 @@ Changed files are classified by path prefixes and globs defined in `src/codex_au
 # Force a specific lane
 ./scripts/check.sh --lane core
 ./scripts/check.sh --lane web-ui
+./scripts/check.sh --lane web-core-contract
 ./scripts/check.sh --lane chat-apps
 
 # Run the chat-surface lab directly
@@ -39,6 +42,21 @@ make test-chat-surface-lab
 # Force full validation (all lanes)
 ./scripts/check.sh --full
 ```
+
+When staged Web frontend source changes require committed generated assets,
+`scripts/check.sh` runs `scripts/check_web_static_preflight.py` before the
+expensive Web lane. If `src/codex_autorunner/web_static/` is missing from the
+staged diff, refresh it with:
+
+```bash
+pnpm run build
+git add src/codex_autorunner/web_static/
+```
+
+The Web lane also compares `svelte-check` warnings against
+`scripts/svelte_warning_baseline.json`. Known warnings are reported as baseline
+matches; warnings outside the baseline fail the lane so new frontend diagnostics
+are not hidden by existing debt.
 
 The chat-surface lab command is deterministic and does not require live
 Telegram/Discord credentials. It writes budget artifacts to:
@@ -54,6 +72,9 @@ CI (`.github/workflows/ci.yml`) uses the same classifier via `scripts/select_ci_
 1. The `route` job computes changed files and emits `lane`, `run_core`, `run_web_ui`, `run_chat_apps`, `run_aggregate` outputs.
 2. Exactly one lane job runs; others are skipped.
 3. The `check` job asserts the routing contract: exactly one lane selected, it succeeded, and all others were skipped.
+
+`web-core-contract` selects the existing `web-ui` job because that job already
+executes core + Web checks without chat-app validation.
 
 ## Hermetic Test Guarantees
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -6,7 +6,7 @@
 #   ./scripts/check.sh --full           # force full safety suite (all checks)
 #   ./scripts/check.sh --lane <lane>    # run checks for a specific lane
 #
-# Lanes: core, web-ui, chat-apps, aggregate (= full).
+# Lanes: core, web-ui, web-core-contract, chat-apps, aggregate (= full).
 # When no flag is given, staged files are classified via the shared lane
 # classifier (scripts/select_validation_lane.py).
 
@@ -33,7 +33,7 @@ while [[ $# -gt 0 ]]; do
     --lane)
       LANE="${2:-}"
       if [[ -z "$LANE" ]]; then
-        echo "--lane requires an argument (core|web-ui|chat-apps|aggregate)" >&2
+        echo "--lane requires an argument (core|web-ui|web-core-contract|chat-apps|aggregate)" >&2
         exit 1
       fi
       shift 2
@@ -94,10 +94,10 @@ need_cmd make
 FAST_TEST_MARKERS='not integration and not slow'
 FAST_TEST_ENFORCE_BUDGET="${CODEX_FAST_TEST_ENFORCE_BUDGET:-0}"
 FAST_TEST_WORKERS="${CODEX_FAST_TEST_WORKERS:-4}"
+STAGED_FILES="$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)"
 
 # --- Lane detection (if not explicitly set) ----------------------------------
 if [[ -z "$LANE" ]]; then
-  STAGED_FILES="$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)"
   if [[ -n "$STAGED_FILES" ]]; then
     SELECTION_TEXT="$(printf '%s\n' "$STAGED_FILES" | "$PYTHON_BIN" scripts/select_validation_lane.py)"
     LANE="$(
@@ -135,6 +135,11 @@ case "$LANE" in
     RUN_WEB_UI=true
     RUN_CHAT_APPS=false
     ;;
+  web-core-contract)
+    RUN_CORE=true
+    RUN_WEB_UI=true
+    RUN_CHAT_APPS=false
+    ;;
   chat-apps)
     RUN_CORE=true
     RUN_WEB_UI=false
@@ -162,6 +167,11 @@ if [[ "${CODEX_CHECK_REQUIRE_NODE:-0}" != "1" ]] && [[ "$LANE" == "aggregate" ]]
     RUN_WEB_UI=false
     RUN_CHAT_APPS=false
   fi
+fi
+
+if [[ "$RUN_WEB_UI" == true && -n "$STAGED_FILES" ]]; then
+  echo "Checking Web static asset preflight..."
+  printf '%s\n' "$STAGED_FILES" | "$PYTHON_BIN" scripts/check_web_static_preflight.py
 fi
 
 # --- Always-on guardrails (non-negotiable safety checks) ---------------------
@@ -284,7 +294,10 @@ if [[ "$RUN_WEB_UI" == true ]]; then
   need_cmd pnpm
 
   echo "Linting Web Hub frontend..."
-  pnpm web:lint
+  WEB_LINT_OUTPUT="$(mktemp)"
+  pnpm web:lint 2>&1 | tee "$WEB_LINT_OUTPUT"
+  "$PYTHON_BIN" scripts/check_svelte_warning_baseline.py "$WEB_LINT_OUTPUT"
+  rm -f "$WEB_LINT_OUTPUT"
 
   echo "Build Web Hub static assets (pnpm run build)..."
   pnpm run build

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -94,7 +94,7 @@ need_cmd make
 FAST_TEST_MARKERS='not integration and not slow'
 FAST_TEST_ENFORCE_BUDGET="${CODEX_FAST_TEST_ENFORCE_BUDGET:-0}"
 FAST_TEST_WORKERS="${CODEX_FAST_TEST_WORKERS:-4}"
-STAGED_FILES="$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)"
+STAGED_FILES="$(git diff --cached --name-only --diff-filter=ACMRD 2>/dev/null || true)"
 
 # --- Lane detection (if not explicitly set) ----------------------------------
 if [[ -z "$LANE" ]]; then

--- a/scripts/check_svelte_warning_baseline.py
+++ b/scripts/check_svelte_warning_baseline.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Compare svelte-check warnings against the committed warning baseline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BASELINE = REPO_ROOT / "scripts" / "svelte_warning_baseline.json"
+LOCATION_RE = re.compile(r"^(?P<path>.+\.svelte):\d+:\d+$")
+
+
+@dataclass(frozen=True, order=True)
+class SvelteWarning:
+    path: str
+    message: str
+
+
+def parse_svelte_warnings(
+    output: str, *, repo_root: Path = REPO_ROOT
+) -> tuple[SvelteWarning, ...]:
+    warnings: list[SvelteWarning] = []
+    current_path: str | None = None
+
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        location_match = LOCATION_RE.match(line)
+        if location_match:
+            current_path = _repo_relative_path(
+                Path(location_match.group("path")), repo_root
+            )
+            continue
+        if current_path and line.startswith("Warn: "):
+            warnings.append(
+                SvelteWarning(path=current_path, message=line.removeprefix("Warn: "))
+            )
+            current_path = None
+
+    return tuple(sorted(warnings))
+
+
+def load_warning_baseline(path: Path) -> tuple[SvelteWarning, ...]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return tuple(
+        sorted(
+            SvelteWarning(path=str(item["path"]), message=str(item["message"]))
+            for item in payload.get("warnings", [])
+        )
+    )
+
+
+def _repo_relative_path(path: Path, repo_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fail when svelte-check emits warnings outside the baseline."
+    )
+    parser.add_argument("output", help="Path to captured svelte-check output.")
+    parser.add_argument(
+        "--baseline",
+        default=str(DEFAULT_BASELINE),
+        help="Path to the JSON warning baseline.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(tuple(sys.argv[1:] if argv is None else argv))
+    current = set(parse_svelte_warnings(Path(args.output).read_text(encoding="utf-8")))
+    baseline = set(load_warning_baseline(Path(args.baseline)))
+
+    new_warnings = sorted(current - baseline)
+    stale_warnings = sorted(baseline - current)
+
+    if new_warnings:
+        print(
+            "New Svelte warnings found outside scripts/svelte_warning_baseline.json:",
+            file=sys.stderr,
+        )
+        for warning in new_warnings:
+            print(f"  - {warning.path}: {warning.message}", file=sys.stderr)
+        return 1
+
+    if stale_warnings:
+        print(
+            "Svelte warning baseline has stale entries; consider removing:",
+            file=sys.stderr,
+        )
+        for warning in stale_warnings:
+            print(f"  - {warning.path}: {warning.message}", file=sys.stderr)
+
+    print(f"Svelte warning baseline matched ({len(current)} warning(s)).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_web_static_preflight.py
+++ b/scripts/check_web_static_preflight.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Fail early when staged Web source changes are missing generated assets."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import PurePosixPath
+from typing import Sequence
+
+WEB_FRONTEND_SOURCE_PREFIX = "src/codex_autorunner/web_frontend/src"
+WEB_STATIC_PREFIX = "src/codex_autorunner/web_static"
+WEB_BUILD_CONFIG_PATHS = frozenset(
+    {
+        "src/codex_autorunner/web_frontend/package.json",
+        "src/codex_autorunner/web_frontend/svelte.config.js",
+        "src/codex_autorunner/web_frontend/vite.config.ts",
+    }
+)
+WEB_SOURCE_TEST_SUFFIXES = (
+    ".test.js",
+    ".test.ts",
+    ".test.svelte",
+    ".spec.js",
+    ".spec.ts",
+    ".spec.svelte",
+)
+
+
+def normalize_path(raw_path: str) -> str:
+    path = str(raw_path).strip().replace("\\", "/")
+    if not path:
+        return ""
+    normalized = PurePosixPath(path).as_posix()
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return "" if normalized == "." else normalized
+
+
+def needs_web_static_refresh(path: str) -> bool:
+    if path in WEB_BUILD_CONFIG_PATHS:
+        return True
+    if not _matches_prefix(path, WEB_FRONTEND_SOURCE_PREFIX):
+        return False
+    return not path.endswith(WEB_SOURCE_TEST_SUFFIXES)
+
+
+def includes_web_static(path: str) -> bool:
+    return _matches_prefix(path, WEB_STATIC_PREFIX)
+
+
+def missing_static_for_paths(paths: Sequence[str]) -> tuple[str, ...]:
+    normalized_paths = tuple(
+        sorted({path for path in map(normalize_path, paths) if path})
+    )
+    if any(includes_web_static(path) for path in normalized_paths):
+        return ()
+    return tuple(path for path in normalized_paths if needs_web_static_refresh(path))
+
+
+def _matches_prefix(path: str, prefix: str) -> bool:
+    return path == prefix or path.startswith(f"{prefix}/")
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check staged Web source paths for missing committed web_static output."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Changed paths. If omitted, newline-delimited paths are read from stdin.",
+    )
+    return parser.parse_args(argv)
+
+
+def _read_paths(args: argparse.Namespace) -> tuple[str, ...]:
+    if args.paths:
+        return tuple(args.paths)
+    return tuple(line.strip() for line in sys.stdin.read().splitlines() if line.strip())
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(tuple(sys.argv[1:] if argv is None else argv))
+    missing_paths = missing_static_for_paths(_read_paths(args))
+    if not missing_paths:
+        return 0
+
+    print(
+        "Web frontend source changes are staged without generated web_static output.",
+        file=sys.stderr,
+    )
+    print(
+        "Run 'pnpm run build' and stage src/codex_autorunner/web_static/.",
+        file=sys.stderr,
+    )
+    print("Source paths requiring generated assets:", file=sys.stderr)
+    for path in missing_paths:
+        print(f"  - {path}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_web_static_preflight.py
+++ b/scripts/check_web_static_preflight.py
@@ -4,9 +4,34 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import sys
-from pathlib import PurePosixPath
+from pathlib import Path
 from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_VALIDATION_LANES_PATH = (
+    REPO_ROOT / "src" / "codex_autorunner" / "core" / "validation_lanes.py"
+)
+
+
+def _load_validation_lanes_module():
+    spec = importlib.util.spec_from_file_location(
+        "_car_validation_lanes", _VALIDATION_LANES_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(
+            f"Unable to load validation lanes from {_VALIDATION_LANES_PATH}"
+        )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_VALIDATION_LANES = _load_validation_lanes_module()
+normalize_path = _VALIDATION_LANES.normalize_changed_path
+_matches_prefix = _VALIDATION_LANES._matches_prefix
 
 WEB_FRONTEND_SOURCE_PREFIX = "src/codex_autorunner/web_frontend/src"
 WEB_STATIC_PREFIX = "src/codex_autorunner/web_static"
@@ -25,16 +50,6 @@ WEB_SOURCE_TEST_SUFFIXES = (
     ".spec.ts",
     ".spec.svelte",
 )
-
-
-def normalize_path(raw_path: str) -> str:
-    path = str(raw_path).strip().replace("\\", "/")
-    if not path:
-        return ""
-    normalized = PurePosixPath(path).as_posix()
-    while normalized.startswith("./"):
-        normalized = normalized[2:]
-    return "" if normalized == "." else normalized
 
 
 def needs_web_static_refresh(path: str) -> bool:
@@ -56,10 +71,6 @@ def missing_static_for_paths(paths: Sequence[str]) -> tuple[str, ...]:
     if any(includes_web_static(path) for path in normalized_paths):
         return ()
     return tuple(path for path in normalized_paths if needs_web_static_refresh(path))
-
-
-def _matches_prefix(path: str, prefix: str) -> bool:
-    return path == prefix or path.startswith(f"{prefix}/")
 
 
 def _parse_args(argv: Sequence[str]) -> argparse.Namespace:

--- a/scripts/check_web_static_preflight.py
+++ b/scripts/check_web_static_preflight.py
@@ -30,8 +30,8 @@ def _load_validation_lanes_module():
 
 
 _VALIDATION_LANES = _load_validation_lanes_module()
-normalize_path = _VALIDATION_LANES.normalize_changed_path
-_matches_prefix = _VALIDATION_LANES._matches_prefix
+normalize_changed_path = _VALIDATION_LANES.normalize_changed_path
+matches_prefix = _VALIDATION_LANES._matches_prefix
 
 WEB_FRONTEND_SOURCE_PREFIX = "src/codex_autorunner/web_frontend/src"
 WEB_STATIC_PREFIX = "src/codex_autorunner/web_static"
@@ -55,18 +55,18 @@ WEB_SOURCE_TEST_SUFFIXES = (
 def needs_web_static_refresh(path: str) -> bool:
     if path in WEB_BUILD_CONFIG_PATHS:
         return True
-    if not _matches_prefix(path, WEB_FRONTEND_SOURCE_PREFIX):
+    if not matches_prefix(path, WEB_FRONTEND_SOURCE_PREFIX):
         return False
     return not path.endswith(WEB_SOURCE_TEST_SUFFIXES)
 
 
 def includes_web_static(path: str) -> bool:
-    return _matches_prefix(path, WEB_STATIC_PREFIX)
+    return matches_prefix(path, WEB_STATIC_PREFIX)
 
 
 def missing_static_for_paths(paths: Sequence[str]) -> tuple[str, ...]:
     normalized_paths = tuple(
-        sorted({path for path in map(normalize_path, paths) if path})
+        sorted({path for path in map(normalize_changed_path, paths) if path})
     )
     if any(includes_web_static(path) for path in normalized_paths):
         return ()

--- a/scripts/select_ci_validation_jobs.py
+++ b/scripts/select_ci_validation_jobs.py
@@ -96,7 +96,7 @@ def _to_ci_payload(selection_payload: dict[str, object]) -> dict[str, object]:
     payload.update(
         {
             "run_core": lane == "core",
-            "run_web_ui": lane == "web-ui",
+            "run_web_ui": lane in {"web-ui", "web-core-contract"},
             "run_chat_apps": lane == "chat-apps",
             "run_aggregate": lane == "aggregate",
         }

--- a/scripts/select_validation_lane.py
+++ b/scripts/select_validation_lane.py
@@ -40,7 +40,7 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Map changed files to one validation lane: "
-            "core, web-ui, chat-apps, or aggregate."
+            "core, web-ui, web-core-contract, chat-apps, or aggregate."
         )
     )
     parser.add_argument(

--- a/scripts/svelte_warning_baseline.json
+++ b/scripts/svelte_warning_baseline.json
@@ -1,0 +1,24 @@
+{
+  "warnings": [
+    {
+      "path": "src/codex_autorunner/web_frontend/src/lib/components/PageHero.svelte",
+      "message": "Also define the standard property 'line-clamp' for compatibility (css)"
+    },
+    {
+      "path": "src/codex_autorunner/web_frontend/src/lib/components/TicketViews.svelte",
+      "message": "Unused CSS selector \".ticket-flow-timeline > li\""
+    },
+    {
+      "path": "src/codex_autorunner/web_frontend/src/lib/components/ScopedNewTicketPage.svelte",
+      "message": "`<h1>` element should contain text"
+    },
+    {
+      "path": "src/codex_autorunner/web_frontend/src/lib/components/ScopedNewTicketPage.svelte",
+      "message": "Avoid using autofocus"
+    },
+    {
+      "path": "src/codex_autorunner/web_frontend/src/lib/components/ScopedNewTicketPage.svelte",
+      "message": "Unused CSS selector \".ticket-hero-num\""
+    }
+  ]
+}

--- a/src/codex_autorunner/core/validation_lanes.py
+++ b/src/codex_autorunner/core/validation_lanes.py
@@ -5,7 +5,9 @@ from fnmatch import fnmatch
 from pathlib import PurePosixPath
 from typing import Iterable, Literal, Sequence
 
-ValidationLane = Literal["core", "web-ui", "chat-apps", "aggregate"]
+ValidationLane = Literal[
+    "core", "web-ui", "web-core-contract", "chat-apps", "aggregate"
+]
 ScopedValidationLane = Literal["core", "web-ui", "chat-apps"]
 
 _SCOPED_LANES: tuple[ScopedValidationLane, ...] = ("core", "web-ui", "chat-apps")
@@ -152,6 +154,9 @@ def classify_changed_files(paths: Iterable[str]) -> ValidationLaneSelection:
     elif unknown_paths:
         selected_lane = "aggregate"
         reason = "unknown-path"
+    elif lanes_touched == ("core", "web-ui"):
+        selected_lane = "web-core-contract"
+        reason = "web-core-contract-diff"
     elif len(lanes_touched) > 1:
         selected_lane = "aggregate"
         reason = "multi-lane-diff"

--- a/tests/core/test_validation_lanes.py
+++ b/tests/core/test_validation_lanes.py
@@ -93,7 +93,7 @@ def test_unknown_paths_force_aggregate() -> None:
     assert selection.unknown_paths == ("README.md",)
 
 
-def test_multi_lane_diff_forces_aggregate() -> None:
+def test_core_web_diff_routes_to_web_core_contract() -> None:
     selection = classify_changed_files(
         [
             "src/codex_autorunner/core/update_targets.py",
@@ -101,13 +101,27 @@ def test_multi_lane_diff_forces_aggregate() -> None:
         ]
     )
 
-    assert selection.lane == "aggregate"
-    assert selection.reason == "multi-lane-diff"
+    assert selection.lane == "web-core-contract"
+    assert selection.reason == "web-core-contract-diff"
     assert selection.lanes_touched == ("core", "web-ui")
     assert selection.lane_paths == (
         ("core", ("src/codex_autorunner/core/update_targets.py",)),
         ("web-ui", ("src/codex_autorunner/web_frontend/src/routes/+page.svelte",)),
     )
+
+
+def test_multi_lane_diff_with_chat_forces_aggregate() -> None:
+    selection = classify_changed_files(
+        [
+            "src/codex_autorunner/core/update_targets.py",
+            "src/codex_autorunner/web_frontend/src/routes/+page.svelte",
+            "tests/test_telegram_flow_status.py",
+        ]
+    )
+
+    assert selection.lane == "aggregate"
+    assert selection.reason == "multi-lane-diff"
+    assert selection.lanes_touched == ("core", "web-ui", "chat-apps")
 
 
 def test_classification_is_deterministic_for_same_input_set() -> None:

--- a/tests/test_select_ci_validation_jobs_script.py
+++ b/tests/test_select_ci_validation_jobs_script.py
@@ -77,6 +77,31 @@ def test_select_ci_validation_jobs_script_writes_github_outputs(tmp_path: Path) 
     }
 
 
+def test_select_ci_validation_jobs_routes_web_core_contract_to_web_ui_job() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_script_path()),
+            "--format",
+            "json",
+            "src/codex_autorunner/core/update_targets.py",
+            "src/codex_autorunner/web_frontend/src/routes/+page.svelte",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["lane"] == "web-core-contract"
+    assert payload["reason"] == "web-core-contract-diff"
+    assert payload["run_core"] is False
+    assert payload["run_web_ui"] is True
+    assert payload["run_chat_apps"] is False
+    assert payload["run_aggregate"] is False
+
+
 def test_select_ci_validation_jobs_script_runs_without_site_packages() -> None:
     result = subprocess.run(
         [

--- a/tests/test_svelte_warning_baseline_script.py
+++ b/tests/test_svelte_warning_baseline_script.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_svelte_warning_baseline import SvelteWarning, parse_svelte_warnings
+
+
+def _script_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "scripts"
+        / "check_svelte_warning_baseline.py"
+    )
+
+
+def test_parse_svelte_warnings_uses_repo_relative_paths() -> None:
+    repo_root = Path("/repo")
+    output = """
+/repo/src/codex_autorunner/web_frontend/src/lib/components/PageHero.svelte:101:7
+Warn: Also define the standard property 'line-clamp' for compatibility (css)
+      display: -webkit-box;
+"""
+
+    assert parse_svelte_warnings(output, repo_root=repo_root) == (
+        SvelteWarning(
+            path="src/codex_autorunner/web_frontend/src/lib/components/PageHero.svelte",
+            message="Also define the standard property 'line-clamp' for compatibility (css)",
+        ),
+    )
+
+
+def test_warning_baseline_script_fails_on_new_warning(tmp_path: Path) -> None:
+    output_path = tmp_path / "svelte-output.txt"
+    output_path.write_text(
+        """
+/repo/src/codex_autorunner/web_frontend/src/lib/components/NewThing.svelte:12:3
+Warn: New frontend warning (svelte)
+""",
+        encoding="utf-8",
+    )
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps({"warnings": []}), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_script_path()),
+            str(output_path),
+            "--baseline",
+            str(baseline_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "New Svelte warnings found" in result.stderr
+    assert "New frontend warning" in result.stderr
+
+
+def test_warning_baseline_script_accepts_known_warning(tmp_path: Path) -> None:
+    output_path = tmp_path / "svelte-output.txt"
+    output_path.write_text(
+        """
+/repo/src/codex_autorunner/web_frontend/src/lib/components/PageHero.svelte:101:7
+Warn: Also define the standard property 'line-clamp' for compatibility (css)
+""",
+        encoding="utf-8",
+    )
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "warnings": [
+                    {
+                        "path": "/repo/src/codex_autorunner/web_frontend/src/lib/components/PageHero.svelte",
+                        "message": "Also define the standard property 'line-clamp' for compatibility (css)",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_script_path()),
+            str(output_path),
+            "--baseline",
+            str(baseline_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0

--- a/tests/test_web_static_preflight_script.py
+++ b/tests/test_web_static_preflight_script.py
@@ -15,10 +15,30 @@ def _script_path() -> Path:
     )
 
 
+def test_check_script_feeds_deletions_and_renames_to_preflight() -> None:
+    check_script = (
+        Path(__file__).resolve().parents[1] / "scripts" / "check.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "--diff-filter=ACMRD" in check_script
+
+
 def test_missing_static_for_web_source_change() -> None:
     assert missing_static_for_paths(
         ["src/codex_autorunner/web_frontend/src/routes/+page.svelte"]
     ) == ("src/codex_autorunner/web_frontend/src/routes/+page.svelte",)
+
+
+def test_missing_static_normalizes_changed_paths_with_shared_lane_helper() -> None:
+    assert missing_static_for_paths(
+        [".\\src\\codex_autorunner\\web_frontend\\src\\routes\\+page.svelte"]
+    ) == ("src/codex_autorunner/web_frontend/src/routes/+page.svelte",)
+
+
+def test_missing_static_for_deleted_web_source_path() -> None:
+    assert missing_static_for_paths(
+        ["src/codex_autorunner/web_frontend/src/routes/old/+page.svelte"]
+    ) == ("src/codex_autorunner/web_frontend/src/routes/old/+page.svelte",)
 
 
 def test_static_output_satisfies_web_source_change() -> None:

--- a/tests/test_web_static_preflight_script.py
+++ b/tests/test_web_static_preflight_script.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_web_static_preflight import missing_static_for_paths
+
+
+def _script_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "scripts"
+        / "check_web_static_preflight.py"
+    )
+
+
+def test_missing_static_for_web_source_change() -> None:
+    assert missing_static_for_paths(
+        ["src/codex_autorunner/web_frontend/src/routes/+page.svelte"]
+    ) == ("src/codex_autorunner/web_frontend/src/routes/+page.svelte",)
+
+
+def test_static_output_satisfies_web_source_change() -> None:
+    assert (
+        missing_static_for_paths(
+            [
+                "src/codex_autorunner/web_frontend/src/routes/+page.svelte",
+                "src/codex_autorunner/web_static/_app/immutable/chunks/app.js",
+            ]
+        )
+        == ()
+    )
+
+
+def test_web_frontend_tests_do_not_require_static_refresh() -> None:
+    assert (
+        missing_static_for_paths(
+            ["src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts"]
+        )
+        == ()
+    )
+
+
+def test_preflight_script_fails_with_actionable_message() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_script_path()),
+            "src/codex_autorunner/web_frontend/src/routes/+page.svelte",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "pnpm run build" in result.stderr
+    assert "src/codex_autorunner/web_static/" in result.stderr


### PR DESCRIPTION
## Summary

Fixes #1741.

This makes the validation architecture model the actual dependency shape for web/core work:

- Adds a first-class `web-core-contract` lane for scoped core + Web surface diffs, routed to the existing `web-ui` job because that job already runs core + Web checks without chat-app validation.
- Adds an early staged-diff `web_static` preflight so Web source changes without generated assets fail before the expensive lane starts.
- Adds a Svelte warning baseline check around `pnpm web:lint` so existing frontend warnings are separated from new warning regressions.
- Documents the fast validation path and adds `make check-web-core-contract`.

## Root cause

The previous lane classifier treated any core + Web diff as generic multi-lane risk, which collapsed small web/core contract changes into `aggregate`. That made chat-surface lab, full Web checks, and generated-asset freshness all show up as one late feedback loop. The Web lane also had two hidden surface invariants: committed `web_static` drift was only checked after build/tests, and known Svelte warnings were printed inline with new diagnostics.

## Validation

- `python -m pytest -q tests/core/test_validation_lanes.py tests/test_select_validation_lane_script.py tests/test_select_ci_validation_jobs_script.py tests/test_web_static_preflight_script.py tests/test_svelte_warning_baseline_script.py`
- `pnpm web:lint` captured through `scripts/check_svelte_warning_baseline.py`
- `scripts/check_web_static_preflight.py` failure path manually verified
- Commit hook `./scripts/check.sh` auto-detected `aggregate` for this shared-risk PR and passed: 8599 Python tests, Web lint/build/tests/static drift, SPA shell check, and chat-surface lab

## Notes

The first aggregate commit attempt hit an unrelated transient Hypothesis `HealthCheck.too_slow` in `tests/contracts/memory/test_memory_store_contract.py::TestMemoryWriteReadInvariant::test_save_load_preserves_content`. The specific test passed on immediate rerun, and the full aggregate hook passed on retry.
