### PR TITLE
[codex] Resume Discord threads after restart

### DIFF
--- a/src/codex_autorunner/adapters/chat/managed_thread_startup_recovery.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_startup_recovery.py
@@ -31,6 +31,7 @@ BuildRecoveryExecutionHooks = Callable[
     Optional[ManagedThreadExecutionHooks],
 ]
 RecoverPendingQueue = Callable[[Any, Any, str, str, Any], object]
+ReattachRunningExecution = Callable[[Any, Any, str, str, Any, Any], object]
 _PENDING_QUEUE_SCAN_LIMIT = 10_000
 
 
@@ -187,6 +188,7 @@ async def recover_managed_thread_executions_on_startup(
     build_orchestration_service: BuildOrchestrationService,
     build_durable_delivery: BuildDurableDelivery,
     build_execution_hooks: Optional[BuildRecoveryExecutionHooks] = None,
+    reattach_running_execution: Optional[ReattachRunningExecution] = None,
     recover_pending_queue: Optional[RecoverPendingQueue] = None,
     public_execution_error: str,
     failure_event_name: str,
@@ -227,6 +229,20 @@ async def recover_managed_thread_executions_on_startup(
                 )
             )
             if recovered_execution is None:
+                if reattach_running_execution is not None:
+                    reattached = reattach_running_execution(
+                        service,
+                        orchestration_service,
+                        surface_key,
+                        managed_thread_id,
+                        thread,
+                        execution,
+                    )
+                    if asyncio.iscoroutine(reattached):
+                        reattached = await reattached
+                    if reattached:
+                        recovered += 1
+                        continue
                 recovered_execution = (
                     orchestration_service.recover_running_execution_after_restart(
                         managed_thread_id

--- a/src/codex_autorunner/adapters/discord/managed_thread_startup_recovery.py
+++ b/src/codex_autorunner/adapters/discord/managed_thread_startup_recovery.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 
@@ -10,7 +11,13 @@ from ...adapters.chat.bound_live_progress import (
 from ...adapters.chat.managed_thread_startup_recovery import (
     recover_managed_thread_executions_on_startup as recover_surface_managed_thread_executions_on_startup,
 )
-from ...adapters.chat.managed_thread_turns import ManagedThreadExecutionHooks
+from ...adapters.chat.managed_thread_turns import (
+    ManagedThreadExecutionHooks,
+    handoff_managed_thread_final_delivery,
+)
+from ...core.orchestration.models import MessageRequest
+from ...core.orchestration.runtime_thread_events import RuntimeThreadRunEventState
+from ...core.orchestration.runtime_threads import RuntimeThreadExecution
 from .managed_thread_delivery import build_discord_managed_thread_durable_delivery_hooks
 from .managed_thread_routing import (
     _build_discord_managed_thread_coordinator,
@@ -69,6 +76,153 @@ def recover_pending_discord_managed_thread_queue(
         ),
         hooks=queue_worker_hooks,
     )
+    return True
+
+
+def _running_execution_request(
+    *,
+    managed_thread_id: str,
+    thread: Any,
+    execution: Any,
+    raw_turn: Any,
+) -> MessageRequest:
+    metadata = getattr(execution, "metadata", None)
+    prompt = ""
+    kind = getattr(execution, "request_kind", None)
+    model = None
+    reasoning = None
+    if isinstance(raw_turn, dict):
+        prompt = str(raw_turn.get("prompt") or raw_turn.get("prompt_text") or "")
+        kind = raw_turn.get("request_kind") or kind
+        model = raw_turn.get("model") or raw_turn.get("model_id")
+        reasoning = raw_turn.get("reasoning") or raw_turn.get("reasoning_level")
+        raw_metadata = raw_turn.get("metadata")
+        if isinstance(raw_metadata, dict):
+            metadata = raw_metadata
+    if not prompt:
+        prompt = str(getattr(thread, "last_message_preview", "") or "")
+    return MessageRequest(
+        target_id=managed_thread_id,
+        target_kind="thread",
+        message_text=prompt,
+        kind="review" if str(kind or "").strip().lower() == "review" else "message",
+        busy_policy="queue",
+        agent_profile=getattr(thread, "agent_profile", None),
+        model=str(model).strip() or None if model is not None else None,
+        reasoning=str(reasoning).strip() or None if reasoning is not None else None,
+        approval_mode=getattr(thread, "approval_mode", None),
+        metadata=dict(metadata) if isinstance(metadata, dict) else {},
+    )
+
+
+def reattach_running_discord_managed_thread_execution(
+    service: Any,
+    *,
+    orchestration_service: Any,
+    surface_key: str,
+    managed_thread_id: str,
+    thread: Any,
+    execution: Any,
+    public_execution_error: str = "Discord PMA turn failed",
+) -> bool:
+    workspace_root_raw = getattr(thread, "workspace_root", None)
+    backend_thread_id = str(getattr(thread, "backend_thread_id", "") or "").strip()
+    backend_turn_id = str(getattr(execution, "backend_id", "") or "").strip()
+    if not workspace_root_raw or not backend_thread_id or not backend_turn_id:
+        return False
+    harness_for_thread = getattr(orchestration_service, "_harness_for_thread", None)
+    if not callable(harness_for_thread):
+        return False
+    workspace_root = Path(str(workspace_root_raw))
+    raw_turn = None
+    thread_store = getattr(orchestration_service, "thread_store", None)
+    get_running_turn = getattr(thread_store, "get_running_turn", None)
+    if callable(get_running_turn):
+        raw_turn = get_running_turn(managed_thread_id)
+    request = _running_execution_request(
+        managed_thread_id=managed_thread_id,
+        thread=thread,
+        execution=execution,
+        raw_turn=raw_turn,
+    )
+    started = RuntimeThreadExecution(
+        service=orchestration_service,
+        harness=harness_for_thread(thread),
+        thread=thread,
+        execution=execution,
+        workspace_root=workspace_root,
+        request=request,
+    )
+    coordinator = _build_discord_managed_thread_coordinator(
+        service=service,
+        orchestration_service=orchestration_service,
+        channel_id=surface_key,
+        public_execution_error=public_execution_error,
+        timeout_error="Discord PMA turn timed out",
+        interrupted_error="Discord PMA turn interrupted",
+        pma_enabled=True,
+    )
+    runner_hooks = _build_discord_runner_hooks(
+        service,
+        channel_id=surface_key,
+        managed_thread_id=managed_thread_id,
+        workspace_root=workspace_root,
+        public_execution_error=public_execution_error,
+    ).queue_worker_hooks()
+    task_map = _get_discord_thread_queue_task_map(service)
+    existing = task_map.get(managed_thread_id)
+    if existing is not None and not existing.done():
+        return True
+
+    async def _reattach_and_deliver() -> None:
+        try:
+            finalized = await coordinator.run_started_execution(
+                started,
+                hooks=runner_hooks.execution_hooks,
+                runtime_event_state=RuntimeThreadRunEventState(),
+                record_finalization_failure=True,
+            )
+            await handoff_managed_thread_final_delivery(
+                finalized,
+                delivery=runner_hooks.durable_delivery,
+                logger=service._logger,
+            )
+        finally:
+            if task_map.get(managed_thread_id) is asyncio.current_task():
+                task_map.pop(managed_thread_id, None)
+            coordinator.ensure_queue_worker(
+                task_map=task_map,
+                managed_thread_id=managed_thread_id,
+                spawn_task=lambda coro: _spawn_discord_progress_background_task(
+                    service,
+                    coro,
+                    managed_thread_id=managed_thread_id,
+                    failure_note=(
+                        "Status: this progress message lost its queue worker and is "
+                        "no longer live. Please retry if needed."
+                    ),
+                    orphaned=True,
+                    reconcile_on_cancel=True,
+                    await_on_shutdown=True,
+                ),
+                hooks=runner_hooks,
+            )
+
+    task = _spawn_discord_progress_background_task(
+        service,
+        _reattach_and_deliver(),
+        managed_thread_id=managed_thread_id,
+        execution_id=str(getattr(execution, "execution_id", "") or "").strip() or None,
+        channel_id=surface_key,
+        failure_note=(
+            "Status: this recovered Discord worker failed and is no longer live. "
+            "Please retry if needed."
+        ),
+        orphaned=True,
+        reconcile_on_cancel=True,
+        await_on_shutdown=True,
+    )
+    task_map[managed_thread_id] = task
     return True
 
 
@@ -134,6 +288,24 @@ async def recover_managed_thread_executions_on_startup(service: Any) -> None:
             public_execution_error=public_execution_error,
         )
 
+    def _reattach_running_execution(
+        owner: Any,
+        orchestration_service: Any,
+        surface_key: str,
+        managed_thread_id: str,
+        thread: Any,
+        execution: Any,
+    ) -> bool:
+        return reattach_running_discord_managed_thread_execution(
+            owner,
+            orchestration_service=orchestration_service,
+            surface_key=surface_key,
+            managed_thread_id=managed_thread_id,
+            thread=thread,
+            execution=execution,
+            public_execution_error=public_execution_error,
+        )
+
     await recover_surface_managed_thread_executions_on_startup(
         service,
         surface_kind="discord",
@@ -150,6 +322,7 @@ async def recover_managed_thread_executions_on_startup(service: Any) -> None:
             )
         ),
         build_execution_hooks=_build_execution_hooks,
+        reattach_running_execution=_reattach_running_execution,
         recover_pending_queue=_recover_pending_queue,
         public_execution_error=public_execution_error,
         failure_event_name="discord.turn.startup_execution_recovery_failed",

--- a/src/codex_autorunner/adapters/discord/managed_thread_startup_recovery.py
+++ b/src/codex_autorunner/adapters/discord/managed_thread_startup_recovery.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +31,79 @@ from .progress_leases import (
     _spawn_discord_progress_background_task,
     cleanup_discord_terminal_progress_leases,
 )
+
+
+def _build_discord_startup_recovery_execution_hooks(
+    owner: Any,
+    *,
+    surface_key: str,
+    managed_thread_id: str,
+) -> ManagedThreadExecutionHooks:
+    hub_root, raw_config = resolve_bound_chat_queue_progress_context(
+        owner,
+        fallback_root=Path(owner._config.root),
+    )
+
+    async def _cleanup_interrupted_progress(
+        _started: Any,
+        finalized: Any,
+    ) -> None:
+        status = str(getattr(finalized, "status", "") or "").strip().lower()
+        managed_turn_id = str(getattr(finalized, "managed_turn_id", "") or "").strip()
+        if status != "interrupted" or not managed_turn_id:
+            return
+        await cleanup_discord_terminal_progress_leases(
+            owner,
+            managed_thread_id=managed_thread_id,
+            execution_id=managed_turn_id,
+            channel_id=surface_key,
+            note="Status: this turn was interrupted.",
+            record_prefix=(
+                "discord:startup-recovery-interrupted-progress-cleanup:"
+                f"{managed_thread_id}:{managed_turn_id}"
+            ),
+        )
+
+    return build_bound_chat_queue_execution_controller(
+        hub_root=hub_root,
+        raw_config=raw_config,
+        managed_thread_id=managed_thread_id,
+        surface_targets=(("discord", surface_key),),
+        base_hooks=ManagedThreadExecutionHooks(
+            on_execution_finalized=_cleanup_interrupted_progress
+        ),
+    ).hooks
+
+
+async def _invoke_discord_finalization_hook(
+    hook: Any,
+    started: Any,
+    finalized: Any,
+) -> None:
+    if hook is None:
+        return
+    result = hook(started, finalized)
+    if inspect.isawaitable(result):
+        await result
+
+
+def _compose_discord_reattach_execution_hooks(
+    base_hooks: ManagedThreadExecutionHooks,
+    startup_hooks: ManagedThreadExecutionHooks,
+) -> ManagedThreadExecutionHooks:
+    async def _on_execution_finalized(started: Any, finalized: Any) -> None:
+        await _invoke_discord_finalization_hook(
+            base_hooks.on_execution_finalized,
+            started,
+            finalized,
+        )
+        await _invoke_discord_finalization_hook(
+            startup_hooks.on_execution_finalized,
+            started,
+            finalized,
+        )
+
+    return replace(base_hooks, on_execution_finalized=_on_execution_finalized)
 
 
 def recover_pending_discord_managed_thread_queue(
@@ -169,6 +244,14 @@ def reattach_running_discord_managed_thread_execution(
         workspace_root=workspace_root,
         public_execution_error=public_execution_error,
     ).queue_worker_hooks()
+    execution_hooks = _compose_discord_reattach_execution_hooks(
+        runner_hooks.execution_hooks,
+        _build_discord_startup_recovery_execution_hooks(
+            service,
+            surface_key=surface_key,
+            managed_thread_id=managed_thread_id,
+        ),
+    )
     task_map = _get_discord_thread_queue_task_map(service)
     existing = task_map.get(managed_thread_id)
     if existing is not None and not existing.done():
@@ -178,7 +261,7 @@ def reattach_running_discord_managed_thread_execution(
         try:
             finalized = await coordinator.run_started_execution(
                 started,
-                hooks=runner_hooks.execution_hooks,
+                hooks=execution_hooks,
                 runtime_event_state=RuntimeThreadRunEventState(),
                 record_finalization_failure=True,
             )
@@ -235,42 +318,11 @@ async def recover_managed_thread_executions_on_startup(service: Any) -> None:
         managed_thread_id: str,
         _thread: Any,
     ) -> Any:
-        hub_root, raw_config = resolve_bound_chat_queue_progress_context(
+        return _build_discord_startup_recovery_execution_hooks(
             owner,
-            fallback_root=Path(owner._config.root),
-        )
-
-        async def _cleanup_interrupted_progress(
-            _started: Any,
-            finalized: Any,
-        ) -> None:
-            status = str(getattr(finalized, "status", "") or "").strip().lower()
-            managed_turn_id = str(
-                getattr(finalized, "managed_turn_id", "") or ""
-            ).strip()
-            if status != "interrupted" or not managed_turn_id:
-                return
-            await cleanup_discord_terminal_progress_leases(
-                owner,
-                managed_thread_id=managed_thread_id,
-                execution_id=managed_turn_id,
-                channel_id=surface_key,
-                note="Status: this turn was interrupted.",
-                record_prefix=(
-                    "discord:startup-recovery-interrupted-progress-cleanup:"
-                    f"{managed_thread_id}:{managed_turn_id}"
-                ),
-            )
-
-        return build_bound_chat_queue_execution_controller(
-            hub_root=hub_root,
-            raw_config=raw_config,
+            surface_key=surface_key,
             managed_thread_id=managed_thread_id,
-            surface_targets=(("discord", surface_key),),
-            base_hooks=ManagedThreadExecutionHooks(
-                on_execution_finalized=_cleanup_interrupted_progress
-            ),
-        ).hooks
+        )
 
     def _recover_pending_queue(
         owner: Any,

--- a/src/codex_autorunner/adapters/discord/progress_leases.py
+++ b/src/codex_autorunner/adapters/discord/progress_leases.py
@@ -346,10 +346,6 @@ def _resolve_discord_progress_reconcile_note(
         return "Status: this turn already failed."
     if resolved_status == "queued":
         return "Status: this turn is queued and no longer has an active cancel surface."
-    if resolved_status == "running":
-        running_execution_id = _execution_field(running_execution, "execution_id")
-        if running_execution_id == referenced_execution_id:
-            return None
     return "Status: this turn is no longer active."
 
 

--- a/src/codex_autorunner/adapters/discord/progress_leases.py
+++ b/src/codex_autorunner/adapters/discord/progress_leases.py
@@ -328,10 +328,12 @@ def _resolve_discord_progress_reconcile_note(
         return (
             "Status: this progress message no longer maps to an active managed thread."
         )
-    if orphaned:
-        return _orphaned_progress_note(startup=startup)
     if referenced_execution_id is None:
         return "Status: this turn failed before execution started."
+    if _execution_field(running_execution, "execution_id") == referenced_execution_id:
+        return None
+    if orphaned:
+        return _orphaned_progress_note(startup=startup)
     latest_execution_id = _execution_field(latest_execution, "execution_id")
     if latest_execution_id and latest_execution_id != referenced_execution_id:
         return "Status: this progress message belongs to an older turn. A newer turn is active."

--- a/src/codex_autorunner/adapters/discord/service.py
+++ b/src/codex_autorunner/adapters/discord/service.py
@@ -964,12 +964,12 @@ class DiscordBotService(DiscordInteractionResponseMixin):
             raise SystemExit(1)
         self._reap_managed_processes(stage="startup")
         await self._store.initialize()
-        await _reconcile_progress_leases_on_startup_impl(self)
         await self._resume_interaction_recovery()
         _validate_command_sync_config_impl(self)
         self._outbox.start()
         outbox_task = asyncio.create_task(self._outbox.run_loop())
         await _recover_managed_thread_executions_on_startup_impl(self)
+        await _reconcile_progress_leases_on_startup_impl(self)
         self._opencode_prune_task = asyncio.create_task(
             _run_opencode_prune_loop_impl(self)
         )

--- a/src/codex_autorunner/adapters/discord/service.py
+++ b/src/codex_autorunner/adapters/discord/service.py
@@ -4042,6 +4042,10 @@ class DiscordBotService(DiscordInteractionResponseMixin):
         self, coro: Awaitable[None], *, await_on_shutdown: bool = False
     ) -> asyncio.Task[Any]:
         task = cast(asyncio.Task[Any], asyncio.ensure_future(coro))
+        if not isinstance(getattr(self, "_background_tasks", None), set):
+            self._background_tasks = set()
+        if not isinstance(getattr(self, "_background_shutdown_wait_tasks", None), set):
+            self._background_shutdown_wait_tasks = set()
         self._background_tasks.add(task)
         if await_on_shutdown:
             self._background_shutdown_wait_tasks.add(task)

--- a/tests/adapters/chat/test_managed_thread_startup_recovery.py
+++ b/tests/adapters/chat/test_managed_thread_startup_recovery.py
@@ -150,6 +150,79 @@ async def test_startup_recovery_selects_owned_binding_among_same_surface_binding
 
 
 @pytest.mark.anyio
+async def test_startup_recovery_reattaches_running_turn_before_marking_lost() -> None:
+    reattached: list[tuple[str, str, str]] = []
+    marked_lost: list[str] = []
+
+    class FakeThreadStore:
+        def list_thread_ids_with_running_executions(self, limit=None):
+            _ = limit
+            return ["thread-1"]
+
+        def get_running_turn(self, managed_thread_id: str):
+            assert managed_thread_id == "thread-1"
+            return {"client_turn_id": "discord:channel-1:run-1"}
+
+    class FakeOrchestrationService:
+        thread_store = FakeThreadStore()
+
+        def get_thread_target(self, managed_thread_id: str):
+            assert managed_thread_id == "thread-1"
+            return SimpleNamespace(
+                backend_thread_id="backend-thread-1",
+                agent_id="codex",
+                workspace_root="/workspace/thread-1",
+            )
+
+        def get_running_execution(self, managed_thread_id: str):
+            assert managed_thread_id == "thread-1"
+            return SimpleNamespace(
+                execution_id="turn-1",
+                backend_id="backend-turn-1",
+            )
+
+        def list_bindings(self, **kwargs: object):
+            assert kwargs["surface_kind"] == "discord"
+            return [SimpleNamespace(surface_key="channel-1")]
+
+        async def recover_running_execution_from_harness(
+            self,
+            managed_thread_id: str,
+            *,
+            default_error: str,
+        ):
+            assert managed_thread_id == "thread-1"
+            assert default_error == "Discord PMA turn failed"
+            return None
+
+        def recover_running_execution_after_restart(self, managed_thread_id: str):
+            marked_lost.append(managed_thread_id)
+            return SimpleNamespace(
+                status="error",
+                output_text="",
+                error="lost",
+                execution_id="turn-1",
+            )
+
+    await recovery_module.recover_managed_thread_executions_on_startup(
+        SimpleNamespace(_logger=logging.getLogger("test.startup_recovery.reattach")),
+        surface_kind="discord",
+        build_orchestration_service=lambda _service: FakeOrchestrationService(),
+        build_durable_delivery=lambda *_args: object(),
+        reattach_running_execution=lambda _service, _orch, surface_key, thread_id, _thread, execution: reattached.append(
+            (surface_key, thread_id, execution.execution_id)
+        )
+        or True,
+        public_execution_error="Discord PMA turn failed",
+        failure_event_name="discord.turn.startup_execution_recovery_failed",
+        finished_event_name="discord.turn.startup_execution_recovery_finished",
+    )
+
+    assert reattached == [("channel-1", "thread-1", "turn-1")]
+    assert marked_lost == []
+
+
+@pytest.mark.anyio
 async def test_startup_recovery_runs_execution_hooks_for_recovered_running_turn(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/adapters/discord/test_message_turns_transient_progress.py
+++ b/tests/adapters/discord/test_message_turns_transient_progress.py
@@ -342,6 +342,67 @@ async def test_reconcile_progress_lease_retries_when_retire_edit_fails(
 
 
 @pytest.mark.anyio
+async def test_startup_reconcile_keeps_lease_for_still_running_execution(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = support.DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_turn_progress_lease(
+        lease_id="lease-1",
+        managed_thread_id="thread-1",
+        execution_id="exec-1",
+        channel_id="channel-1",
+        message_id="msg-1",
+        state="active",
+        progress_label="running",
+    )
+    fake_orchestration_service = SimpleNamespace(
+        get_thread_target=lambda _thread_id: SimpleNamespace(
+            thread_target_id="thread-1"
+        ),
+        get_latest_execution=lambda _thread_id: SimpleNamespace(
+            execution_id="exec-1",
+            status="running",
+        ),
+        get_running_execution=lambda _thread_id: SimpleNamespace(
+            execution_id="exec-1",
+            status="running",
+        ),
+        get_execution=lambda _thread_id, _execution_id: SimpleNamespace(
+            execution_id="exec-1",
+            status="running",
+        ),
+    )
+    monkeypatch.setattr(
+        discord_managed_thread_routing_module,
+        "build_discord_thread_orchestration_service",
+        lambda _service: fake_orchestration_service,
+    )
+    service = SimpleNamespace(
+        _store=store,
+        _rest=support._FakeRest(),
+        _config=support._config(tmp_path),
+        _logger=logging.getLogger("test"),
+    )
+
+    try:
+        reconciled = await support.discord_progress_leases_module.reconcile_discord_turn_progress_leases(
+            service,
+            lease_id="lease-1",
+            orphaned=True,
+            startup=True,
+        )
+
+        assert reconciled == 0
+        retained = await store.get_turn_progress_lease(lease_id="lease-1")
+        assert retained is not None
+        assert retained.state == "active"
+        assert service._rest.edited_channel_messages == []
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
 async def test_deliver_result_reconciles_stale_sibling_progress_leases(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/adapters/discord/test_service_startup.py
+++ b/tests/adapters/discord/test_service_startup.py
@@ -267,6 +267,154 @@ async def test_startup_recovery_cleans_interrupted_progress_leases(
 
 
 @pytest.mark.anyio
+async def test_reattach_running_execution_cleans_interrupted_progress_leases(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    cleanup_calls: list[dict[str, object]] = []
+    base_finalized: list[str] = []
+    handoffs: list[object] = []
+    ensured_workers: list[str] = []
+    spawned_tasks: list[asyncio.Task[object]] = []
+
+    async def _fake_cleanup_discord_terminal_progress_leases(
+        owner: object,
+        *,
+        managed_thread_id: str,
+        execution_id: str | None,
+        channel_id: str,
+        note: str,
+        record_prefix: str,
+    ) -> int:
+        cleanup_calls.append(
+            {
+                "owner": owner,
+                "managed_thread_id": managed_thread_id,
+                "execution_id": execution_id,
+                "channel_id": channel_id,
+                "note": note,
+                "record_prefix": record_prefix,
+            }
+        )
+        return 1
+
+    async def _base_on_execution_finalized(_started: object, finalized: object) -> None:
+        base_finalized.append(str(finalized.managed_turn_id))
+
+    class FakeCoordinator:
+        async def run_started_execution(
+            self,
+            started: object,
+            *,
+            hooks: object,
+            runtime_event_state: object,
+            record_finalization_failure: bool,
+        ) -> object:
+            _ = runtime_event_state
+            assert record_finalization_failure is True
+            finalized = SimpleNamespace(
+                status="interrupted",
+                managed_turn_id="turn-1",
+                managed_thread_id="thread-1",
+                assistant_text="",
+                error="Discord PMA turn interrupted",
+                backend_thread_id="backend-thread-1",
+            )
+            await hooks.on_execution_finalized(started, finalized)
+            return finalized
+
+        def ensure_queue_worker(self, **kwargs: object) -> None:
+            ensured_workers.append(str(kwargs["managed_thread_id"]))
+
+    def _fake_runner_hooks(*_args: object, **_kwargs: object) -> object:
+        return SimpleNamespace(
+            queue_worker_hooks=lambda: SimpleNamespace(
+                durable_delivery=object(),
+                execution_hooks=discord_startup_recovery_module.ManagedThreadExecutionHooks(
+                    on_execution_finalized=_base_on_execution_finalized
+                ),
+            )
+        )
+
+    async def _fake_handoff(finalized: object, **_kwargs: object) -> None:
+        handoffs.append(finalized)
+
+    monkeypatch.setattr(
+        discord_startup_recovery_module,
+        "cleanup_discord_terminal_progress_leases",
+        _fake_cleanup_discord_terminal_progress_leases,
+    )
+    monkeypatch.setattr(
+        discord_startup_recovery_module,
+        "_build_discord_managed_thread_coordinator",
+        lambda **_kwargs: FakeCoordinator(),
+    )
+    monkeypatch.setattr(
+        discord_startup_recovery_module,
+        "_build_discord_runner_hooks",
+        _fake_runner_hooks,
+    )
+    monkeypatch.setattr(
+        discord_startup_recovery_module,
+        "handoff_managed_thread_final_delivery",
+        _fake_handoff,
+    )
+    monkeypatch.setattr(
+        discord_startup_recovery_module,
+        "_spawn_discord_progress_background_task",
+        lambda _service, coro, **_kwargs: spawned_tasks.append(
+            asyncio.create_task(coro)
+        )
+        or spawned_tasks[-1],
+    )
+
+    service = SimpleNamespace(
+        _config=SimpleNamespace(root=tmp_path),
+        _logger=logging.getLogger("test.discord.startup.reattach_interrupted"),
+    )
+    orchestration_service = SimpleNamespace(
+        thread_store=SimpleNamespace(get_running_turn=lambda _thread_id: {}),
+        _harness_for_thread=lambda _thread: object(),
+    )
+
+    reattached = discord_startup_recovery_module.reattach_running_discord_managed_thread_execution(
+        service,
+        orchestration_service=orchestration_service,
+        surface_key="channel-1",
+        managed_thread_id="thread-1",
+        thread=SimpleNamespace(
+            workspace_root=tmp_path,
+            backend_thread_id="backend-thread-1",
+        ),
+        execution=SimpleNamespace(
+            execution_id="turn-1",
+            backend_id="backend-turn-1",
+        ),
+    )
+
+    assert reattached is True
+    assert len(spawned_tasks) == 1
+    await spawned_tasks[0]
+
+    assert base_finalized == ["turn-1"]
+    assert len(handoffs) == 1
+    assert ensured_workers == ["thread-1"]
+    assert cleanup_calls == [
+        {
+            "owner": service,
+            "managed_thread_id": "thread-1",
+            "execution_id": "turn-1",
+            "channel_id": "channel-1",
+            "note": "Status: this turn was interrupted.",
+            "record_prefix": (
+                "discord:startup-recovery-interrupted-progress-cleanup:"
+                "thread-1:turn-1"
+            ),
+        }
+    ]
+
+
+@pytest.mark.anyio
 async def test_service_exposes_app_server_event_buffer_context(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes Discord managed-thread restart recovery so agents can resume previous backend turns instead of appearing to start fresh after a process restart.

## Root Cause

Discord startup reconciled persisted live progress leases before managed-thread recovery had a chance to reattach workers. At the same time, Codex-backed running turns deliberately deferred lost-backend recovery, but no replacement Discord worker was spawned to await and deliver the existing backend turn.

## Changes

- Add a shared startup recovery hook for reattaching still-running executions before marking them lost.
- Add Discord reattachment for running backend turns using the persisted managed thread, backend conversation id, backend turn id, and durable delivery hooks.
- Preserve live progress leases when their referenced execution is still the active running turn.
- Run Discord managed-thread recovery before orphan progress reconciliation.
- Add regression coverage for both the shared reattach path and Discord progress lease preservation.

## Validation

- `ruff check` on changed files
- `pytest tests/adapters/chat/test_managed_thread_startup_recovery.py tests/adapters/discord/test_service_startup.py tests/adapters/discord/test_message_turns_transient_progress.py -q`
- Commit hook chat-apps lane: black, ruff, import boundaries, hub interface contracts, mypy, full pytest (`8673 passed`), chat-surface lab tests (`21 passed`), and chat surface latency budgets (`PASS`)