### PR TITLE
[codex] Recover ticket flow workers after signal loss

### DIFF
--- a/src/codex_autorunner/core/flows/reconciler.py
+++ b/src/codex_autorunner/core/flows/reconciler.py
@@ -268,13 +268,26 @@ def _restart_backoff_ready(record: FlowRunRecord, backoff_seconds: float) -> boo
 
 
 def _restart_policy_observation(
-    repo_root: Path, record: FlowRunRecord
+    repo_root: Path, record: FlowRunRecord, health: Optional[Any] = None
 ) -> RestartPolicyObservation:
     enabled, max_attempts, backoff_seconds = _load_restart_config(repo_root)
+    worker_exit_origin = getattr(health, "exit_origin", None)
+    worker_exit_kind = getattr(health, "exit_kind", None)
+    recoverable_shutdown = worker_exit_origin in {
+        "worker_signal",
+        "worker_watchdog",
+    } or worker_exit_kind in {
+        "external_signal",
+        "max_wall_time",
+        "opencode_stream_stalled_timeout",
+    }
     if (
         record.flow_type != "ticket_flow"
-        or record.stop_requested
-        or record.status != FlowRunStatus.RUNNING
+        or (record.stop_requested and not recoverable_shutdown)
+        or (
+            record.status != FlowRunStatus.RUNNING
+            and not (record.status == FlowRunStatus.STOPPING and recoverable_shutdown)
+        )
     ):
         enabled = False
     return RestartPolicyObservation(
@@ -543,7 +556,7 @@ def reconcile_flow_run(
 
             now = now_iso()
             commit_barrier = _commit_barrier_observation(repo_root, record)
-            restart_policy = _restart_policy_observation(repo_root, record)
+            restart_policy = _restart_policy_observation(repo_root, record, health)
             decision = supervise_reconcile_flow(
                 record,
                 health,
@@ -604,6 +617,7 @@ def reconcile_flow_run(
                         failure_reason=f"spawn_failed: {exc}",
                     )
                 else:
+                    store.set_stop_requested(record.id, False)
                     updated = store.update_flow_run_status(
                         run_id=record.id,
                         status=FlowRunStatus.RUNNING,

--- a/src/codex_autorunner/core/flows/reconciler.py
+++ b/src/codex_autorunner/core/flows/reconciler.py
@@ -37,6 +37,7 @@ from .supervisor import (
     RestartPolicyObservation,
     SupervisorEffectKind,
     supervise_reconcile_flow,
+    worker_observation_from_health,
 )
 from .worker_process import (
     FlowWorkerHealth,
@@ -271,16 +272,9 @@ def _restart_policy_observation(
     repo_root: Path, record: FlowRunRecord, health: Optional[Any] = None
 ) -> RestartPolicyObservation:
     enabled, max_attempts, backoff_seconds = _load_restart_config(repo_root)
-    worker_exit_origin = getattr(health, "exit_origin", None)
-    worker_exit_kind = getattr(health, "exit_kind", None)
-    recoverable_shutdown = worker_exit_origin in {
-        "worker_signal",
-        "worker_watchdog",
-    } or worker_exit_kind in {
-        "external_signal",
-        "max_wall_time",
-        "opencode_stream_stalled_timeout",
-    }
+    recoverable_shutdown = worker_observation_from_health(
+        health
+    ).exit.recoverable_shutdown
     if (
         record.flow_type != "ticket_flow"
         or (record.stop_requested and not recoverable_shutdown)

--- a/src/codex_autorunner/core/flows/supervisor.py
+++ b/src/codex_autorunner/core/flows/supervisor.py
@@ -75,14 +75,19 @@ class WorkerExitObservation:
 
     @property
     def recoverable_shutdown(self) -> bool:
-        return self.exit_origin in {
-            "worker_signal",
-            "worker_watchdog",
-        } or self.exit_kind in {
-            "external_signal",
+        if self.exit_origin == "worker_watchdog":
+            return True
+        if self.exit_kind in {
             "max_wall_time",
             "opencode_stream_stalled_timeout",
-        }
+        }:
+            return True
+        # SIGTERM from the parent uses the same handler as an external signal, but
+        # cooperative shutdown records shutdown_intent=True in worker.exit.json.
+        # Only treat signal loss as recoverable when that cooperative bit is absent.
+        if self.exit_origin == "worker_signal" and self.exit_kind == "external_signal":
+            return not self.shutdown_intent
+        return False
 
 
 @dataclass(frozen=True)

--- a/src/codex_autorunner/core/flows/supervisor.py
+++ b/src/codex_autorunner/core/flows/supervisor.py
@@ -73,6 +73,17 @@ class WorkerExitObservation:
     def stale_reaper_exit(self) -> bool:
         return self.exit_origin == "stale_reaper" or self.exit_kind == "reaped_stale"
 
+    @property
+    def recoverable_shutdown(self) -> bool:
+        return self.exit_origin in {
+            "worker_signal",
+            "worker_watchdog",
+        } or self.exit_kind in {
+            "external_signal",
+            "max_wall_time",
+            "opencode_stream_stalled_timeout",
+        }
+
 
 @dataclass(frozen=True)
 class WorkerObservation:
@@ -240,7 +251,12 @@ def supervise_flow_recovery(
             return FlowSupervisorDecision(intents, effects, note="engine-completed")
 
         if worker.is_deadish:
-            if worker.exit.shutdown_intent and not worker.exit.stale_reaper_exit:
+            if (
+                record.stop_requested
+                and worker.exit.shutdown_intent
+                and not worker.exit.stale_reaper_exit
+                and not worker.exit.recoverable_shutdown
+            ):
                 effects.append(
                     SupervisorEffectIntent(
                         SupervisorEffectKind.UPDATE_RUN_STATE,
@@ -302,6 +318,11 @@ def supervise_flow_recovery(
                 _append_worker_dead_decision(observation, intents, effects)
                 return FlowSupervisorDecision(
                     intents, effects, note="stale-worker-reaped"
+                )
+            if worker.exit.recoverable_shutdown:
+                _append_worker_dead_decision(observation, intents, effects)
+                return FlowSupervisorDecision(
+                    intents, effects, note="recoverable-worker-shutdown"
                 )
             effects.append(
                 SupervisorEffectIntent(
@@ -365,6 +386,7 @@ def worker_observation_from_health(health: Any) -> WorkerObservation:
         artifact_path=getattr(health, "artifact_path", None),
         exit=WorkerExitObservation(
             exit_code=getattr(health, "exit_code", None),
+            signal=getattr(health, "signal", None),
             shutdown_intent=bool(getattr(health, "shutdown_intent", False)),
             exit_origin=getattr(health, "exit_origin", None),
             exit_kind=getattr(health, "exit_kind", None),
@@ -515,6 +537,12 @@ def _worker_dead_error_message(worker: WorkerObservation) -> str:
         error_msg += f", reason: {worker.message}"
     if worker.exit.reap_reason:
         error_msg += f", reap_reason={worker.exit.reap_reason}"
+    if worker.exit.signal:
+        error_msg += f", signal={worker.exit.signal}"
+    if worker.exit.exit_origin:
+        error_msg += f", exit_origin={worker.exit.exit_origin}"
+    if worker.exit.exit_kind:
+        error_msg += f", exit_kind={worker.exit.exit_kind}"
     if isinstance(worker.exit.exit_code, int):
         error_msg += f", exit_code={worker.exit.exit_code}"
     error_msg += ")"

--- a/src/codex_autorunner/core/flows/worker_process.py
+++ b/src/codex_autorunner/core/flows/worker_process.py
@@ -57,6 +57,7 @@ class FlowWorkerHealth:
     crash_path: Optional[Path] = None
     crash_info: Optional[dict[str, Any]] = None
     shutdown_intent: bool = False
+    signal: Optional[str] = None
     exit_origin: Optional[str] = None
     exit_kind: Optional[str] = None
     reap_reason: Optional[str] = None
@@ -142,6 +143,7 @@ def write_worker_exit_info(
     *,
     returncode: Optional[int],
     shutdown_intent: bool = False,
+    signal: Optional[str] = None,
     exit_origin: Optional[str] = None,
     exit_kind: Optional[str] = None,
     reap_reason: Optional[str] = None,
@@ -153,10 +155,9 @@ def write_worker_exit_info(
     Parameters
     ----------
     shutdown_intent : bool
-        When True, indicates the worker received a signal (SIGTERM/SIGINT) and
-        intended to shut down gracefully. This is used by the transition logic
-        to distinguish between unexpected worker death (FAILED) and intentional
-        shutdown (STOPPED).
+        When True, indicates the worker intentionally started shutdown cleanup.
+        Transition policy also considers exit provenance fields; a raw signal or
+        watchdog shutdown can still be classified as recoverable worker loss.
     """
     import time
 
@@ -195,6 +196,8 @@ def write_worker_exit_info(
         data["exit_origin"] = exit_origin
     if exit_kind:
         data["exit_kind"] = exit_kind
+    if signal:
+        data["signal"] = signal
     if reap_reason:
         data["reap_reason"] = reap_reason
     try:
@@ -568,6 +571,7 @@ def check_worker_health(
         shutdown_intent = False
         exit_origin = None
         exit_kind = None
+        signal = None
         reap_reason = None
         crash_path = _worker_crash_path(artifacts_dir)
         if exit_path.exists():
@@ -592,6 +596,9 @@ def check_worker_health(
                         raw_kind = exit_data.get("exit_kind")
                         if isinstance(raw_kind, str) and raw_kind.strip():
                             exit_kind = raw_kind.strip()
+                        raw_signal = exit_data.get("signal")
+                        if isinstance(raw_signal, str) and raw_signal.strip():
+                            signal = raw_signal.strip()
                         raw_reap_reason = exit_data.get("reap_reason")
                         if isinstance(raw_reap_reason, str) and raw_reap_reason.strip():
                             reap_reason = raw_reap_reason.strip()
@@ -625,6 +632,7 @@ def check_worker_health(
             crash_path=crash_path if crash_path.exists() else None,
             crash_info=crash_info if isinstance(crash_info, dict) else None,
             shutdown_intent=shutdown_intent,
+            signal=signal,
             exit_origin=exit_origin,
             exit_kind=exit_kind,
             reap_reason=reap_reason,

--- a/src/codex_autorunner/surfaces/cli/commands/flow.py
+++ b/src/codex_autorunner/surfaces/cli/commands/flow.py
@@ -397,6 +397,9 @@ def register_flow_commands(
         shutdown_event = threading.Event()
         watchdog_reason: dict[str, Optional[str]] = {"value": None}
         watchdog_app_server_floor_seq: dict[str, Optional[int]] = {"value": None}
+        shutdown_signal: dict[str, Optional[str]] = {"value": None}
+        shutdown_exit_origin: dict[str, Optional[str]] = {"value": None}
+        shutdown_exit_kind: dict[str, Optional[str]] = {"value": None}
 
         def _write_exit_info(*, shutdown_intent: bool = False) -> None:
             try:
@@ -405,6 +408,9 @@ def register_flow_commands(
                     worker_run_id,
                     returncode=exit_code_holder[0] or None,
                     shutdown_intent=shutdown_intent,
+                    signal=shutdown_signal["value"],
+                    exit_origin=shutdown_exit_origin["value"],
+                    exit_kind=shutdown_exit_kind["value"],
                     artifacts_root=_artifacts_root,
                 )
             except OSError:
@@ -412,6 +418,16 @@ def register_flow_commands(
 
         def _signal_handler(signum: int, _frame) -> None:
             exit_code_holder[0] = -signum
+            signal_enum = getattr(signal, "Signals", None)
+            if signal_enum is not None:
+                try:
+                    shutdown_signal["value"] = signal_enum(signum).name
+                except ValueError:
+                    shutdown_signal["value"] = f"signal-{signum}"
+            else:
+                shutdown_signal["value"] = f"signal-{signum}"
+            shutdown_exit_origin["value"] = "worker_signal"
+            shutdown_exit_kind["value"] = "external_signal"
             shutdown_event.set()
 
         def _resolve_worker_max_wall_seconds() -> float:
@@ -457,6 +473,8 @@ def register_flow_commands(
                 if method == _OPENCODE_STALL_TIMEOUT_METHOD:
                     watchdog_reason["value"] = method
                     exit_code_holder[0] = 1
+                    shutdown_exit_origin["value"] = "worker_watchdog"
+                    shutdown_exit_kind["value"] = "opencode_stream_stalled_timeout"
                     write_worker_crash_info(
                         _repo_root,
                         worker_run_id,
@@ -472,6 +490,9 @@ def register_flow_commands(
                     continue
                 watchdog_reason["value"] = "max_wall_time"
                 exit_code_holder[0] = -signal.SIGTERM
+                shutdown_signal["value"] = "SIGTERM"
+                shutdown_exit_origin["value"] = "worker_watchdog"
+                shutdown_exit_kind["value"] = "max_wall_time"
                 write_worker_crash_info(
                     _repo_root,
                     worker_run_id,

--- a/tests/core/flows/test_flow_supervisor.py
+++ b/tests/core/flows/test_flow_supervisor.py
@@ -107,7 +107,7 @@ def test_policy_treats_signal_shutdown_as_recoverable_crash() -> None:
             worker=_worker(
                 WorkerHealthStatus.DEAD,
                 pid=123,
-                shutdown_intent=True,
+                shutdown_intent=False,
                 signal="SIGTERM",
                 exit_origin="worker_signal",
                 exit_kind="external_signal",
@@ -126,6 +126,33 @@ def test_policy_treats_signal_shutdown_as_recoverable_crash() -> None:
     assert trigger is not None
     assert trigger.kind == TriggerKind.RECONCILE_WORKER_DEAD
     assert "exit_kind=external_signal" in (trigger.error_message or "")
+
+
+def test_policy_treats_cooperative_sigterm_as_intentional_stop_not_recoverable() -> (
+    None
+):
+    decision = supervise_flow_recovery(
+        FlowSupervisorObservation(
+            run=_run(status=FlowRunStatus.STOPPING, stop_requested=True),
+            worker=_worker(
+                WorkerHealthStatus.DEAD,
+                pid=123,
+                shutdown_intent=True,
+                signal="SIGTERM",
+                exit_origin="worker_signal",
+                exit_kind="external_signal",
+                exit_code=-15,
+            ),
+            restart=RestartPolicyObservation(enabled=True, attempts=0, max_attempts=2),
+        )
+    )
+
+    assert _intent_kinds(decision) == []
+    assert decision.note == "worker-stopped"
+    assert SupervisorEffectKind.UPDATE_RUN_STATE in _effect_kinds(decision)
+    trigger = decision.first_lifecycle_trigger()
+    assert trigger is not None
+    assert trigger.kind == TriggerKind.RECONCILE_STOPPING_FINALIZE
 
 
 def test_policy_classifies_stale_reaped_worker_active_run() -> None:

--- a/tests/core/flows/test_flow_supervisor.py
+++ b/tests/core/flows/test_flow_supervisor.py
@@ -41,6 +41,8 @@ def _worker(
     status: WorkerHealthStatus,
     *,
     pid: Optional[int] = None,
+    shutdown_intent: bool = False,
+    signal: Optional[str] = None,
     exit_origin: Optional[str] = None,
     exit_kind: Optional[str] = None,
     reap_reason: Optional[str] = None,
@@ -50,6 +52,8 @@ def _worker(
         status=status,
         pid=pid,
         exit=WorkerExitObservation(
+            shutdown_intent=shutdown_intent,
+            signal=signal,
             exit_origin=exit_origin,
             exit_kind=exit_kind,
             reap_reason=reap_reason,
@@ -94,6 +98,34 @@ def test_policy_classifies_dead_worker_active_run_as_crash() -> None:
     assert trigger is not None
     assert trigger.kind == TriggerKind.RECONCILE_WORKER_DEAD
     assert "pid=123" in (trigger.error_message or "")
+
+
+def test_policy_treats_signal_shutdown_as_recoverable_crash() -> None:
+    decision = supervise_flow_recovery(
+        FlowSupervisorObservation(
+            run=_run(status=FlowRunStatus.STOPPING, stop_requested=True),
+            worker=_worker(
+                WorkerHealthStatus.DEAD,
+                pid=123,
+                shutdown_intent=True,
+                signal="SIGTERM",
+                exit_origin="worker_signal",
+                exit_kind="external_signal",
+                exit_code=-15,
+            ),
+            restart=RestartPolicyObservation(enabled=True, attempts=0, max_attempts=2),
+        )
+    )
+
+    assert _intent_kinds(decision) == [
+        RecoveryIntentKind.WORKER_CRASH,
+        RecoveryIntentKind.RESTART_ATTEMPTED,
+    ]
+    assert SupervisorEffectKind.SPAWN_WORKER in _effect_kinds(decision)
+    trigger = decision.first_lifecycle_trigger()
+    assert trigger is not None
+    assert trigger.kind == TriggerKind.RECONCILE_WORKER_DEAD
+    assert "exit_kind=external_signal" in (trigger.error_message or "")
 
 
 def test_policy_classifies_stale_reaped_worker_active_run() -> None:

--- a/tests/flows/test_flow_reconcile.py
+++ b/tests/flows/test_flow_reconcile.py
@@ -478,3 +478,68 @@ def test_user_stop_requested_dead_worker_is_not_auto_restarted(
     assert updated is True
     assert locked is False
     assert spawned == []
+
+
+def test_signal_stopped_worker_is_auto_restarted(monkeypatch, tmp_path: Path) -> None:
+    db = tmp_path / "flows.db"
+    store = FlowStore(db)
+    store.initialize()
+    run_id = str(uuid.uuid4())
+    record = store.create_flow_run(
+        run_id=run_id,
+        flow_type="ticket_flow",
+        input_data={},
+        state={"ticket_engine": {"status": "running"}},
+        current_step="ticket_turn",
+    )
+    store.update_flow_run_status(
+        run_id=record.id,
+        status=FlowRunStatus.STOPPING,
+        state=record.state,
+    )
+    store.set_stop_requested(record.id, True)
+    artifact_dir = tmp_path / ".codex-autorunner" / "flows" / run_id
+    artifact_dir.mkdir(parents=True)
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.check_worker_health",
+        lambda repo_root, run_id: SimpleNamespace(
+            is_alive=False,
+            status="dead",
+            pid=12345,
+            message="worker PID not running",
+            artifact_path=artifact_dir / "worker.json",
+            shutdown_intent=True,
+            signal="SIGTERM",
+            exit_origin="worker_signal",
+            exit_kind="external_signal",
+            exit_code=-15,
+        ),
+    )
+    spawned: list[str] = []
+
+    def fake_spawn(repo_root: Path, run_id: str):
+        spawned.append(run_id)
+        return (
+            SimpleNamespace(pid=999),
+            SimpleNamespace(close=lambda: None),
+            SimpleNamespace(close=lambda: None),
+        )
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.spawn_flow_worker",
+        fake_spawn,
+    )
+
+    current_record = store.get_flow_run(record.id)
+    assert current_record is not None
+    recovered, updated, locked = reconcile_flow_run(tmp_path, current_record, store)
+
+    assert recovered.status == FlowRunStatus.RUNNING
+    assert recovered.stop_requested is False
+    assert recovered.error_message is None
+    assert updated is True
+    assert locked is False
+    assert spawned == [run_id]
+    restart = recovered.state["recovery"]["restart"]
+    assert restart["count"] == 1
+    assert restart["last_reason"] == "recoverable-worker-shutdown"

--- a/tests/flows/test_flow_reconcile.py
+++ b/tests/flows/test_flow_reconcile.py
@@ -508,7 +508,7 @@ def test_signal_stopped_worker_is_auto_restarted(monkeypatch, tmp_path: Path) ->
             pid=12345,
             message="worker PID not running",
             artifact_path=artifact_dir / "worker.json",
-            shutdown_intent=True,
+            shutdown_intent=False,
             signal="SIGTERM",
             exit_origin="worker_signal",
             exit_kind="external_signal",

--- a/tests/flows/test_lifecycle_reducer.py
+++ b/tests/flows/test_lifecycle_reducer.py
@@ -743,11 +743,11 @@ class TestResolveReconcileTrigger:
         assert trigger.kind == TriggerKind.RECONCILE_WORKER_DEAD
         assert "Worker died" in (trigger.error_message or "")
 
-    def test_running_dead_shutdown_intent(self):
+    def test_running_dead_shutdown_intent_without_stop_request_is_worker_dead(self):
         rec = _rec(FlowRunStatus.RUNNING, {"ticket_engine": {"status": "running"}})
         trigger = _resolve_reconcile_trigger(rec, _health(False, shutdown_intent=True))
         assert trigger is not None
-        assert trigger.kind == TriggerKind.RECONCILE_WORKER_SHUTDOWN
+        assert trigger.kind == TriggerKind.RECONCILE_WORKER_DEAD
 
     def test_running_dead_stale_reaper_shutdown_intent_is_recovery_failure(self):
         rec = _rec(FlowRunStatus.RUNNING, {"ticket_engine": {"status": "running"}})

--- a/tests/flows/test_transition_table.py
+++ b/tests/flows/test_transition_table.py
@@ -134,9 +134,9 @@ def test_shutdown_intent_without_stop_request_transitions_to_failed():
     assert dec.finished_at == _NOW
 
 
-def test_signal_shutdown_transitions_to_failed_not_stopped():
+def test_signal_shutdown_without_cooperative_intent_transitions_to_failed():
     state = {"ticket_engine": {"status": "running"}}
-    health = _health_with_shutdown(alive=False, shutdown_intent=True)
+    health = _health_with_shutdown(alive=False, shutdown_intent=False)
     health.exit_origin = "worker_signal"
     health.exit_kind = "external_signal"
     health.signal = "SIGTERM"
@@ -146,6 +146,19 @@ def test_signal_shutdown_transitions_to_failed_not_stopped():
     assert dec.status == FlowRunStatus.FAILED
     assert dec.note == "worker-dead"
     assert "exit_kind=external_signal" in (dec.error_message or "")
+
+
+def test_cooperative_sigterm_in_stopping_finalizes_to_stopped():
+    state = {"ticket_engine": {"status": "running"}}
+    health = _health_with_shutdown(alive=False, shutdown_intent=True)
+    health.exit_origin = "worker_signal"
+    health.exit_kind = "external_signal"
+    health.signal = "SIGTERM"
+
+    dec = _apply(_rec(FlowRunStatus.STOPPING, state), health)
+
+    assert dec.status == FlowRunStatus.STOPPED
+    assert dec.note == "worker-dead"
 
 
 def test_stale_reaper_shutdown_intent_transitions_to_failed_not_stopped():

--- a/tests/flows/test_transition_table.py
+++ b/tests/flows/test_transition_table.py
@@ -123,15 +123,29 @@ def _health_with_shutdown(alive: bool, shutdown_intent: bool) -> SimpleNamespace
     )
 
 
-def test_shutdown_intent_transitions_to_stopped_not_failed():
+def test_shutdown_intent_without_stop_request_transitions_to_failed():
     state = {"ticket_engine": {"status": "running"}}
     dec = _apply(
         _rec(FlowRunStatus.RUNNING, state),
         _health_with_shutdown(alive=False, shutdown_intent=True),
     )
-    assert dec.status == FlowRunStatus.STOPPED
-    assert dec.note == "worker-shutdown-intent"
+    assert dec.status == FlowRunStatus.FAILED
+    assert dec.note == "worker-dead"
     assert dec.finished_at == _NOW
+
+
+def test_signal_shutdown_transitions_to_failed_not_stopped():
+    state = {"ticket_engine": {"status": "running"}}
+    health = _health_with_shutdown(alive=False, shutdown_intent=True)
+    health.exit_origin = "worker_signal"
+    health.exit_kind = "external_signal"
+    health.signal = "SIGTERM"
+
+    dec = _apply(_rec(FlowRunStatus.STOPPING, state), health)
+
+    assert dec.status == FlowRunStatus.FAILED
+    assert dec.note == "worker-dead"
+    assert "exit_kind=external_signal" in (dec.error_message or "")
 
 
 def test_stale_reaper_shutdown_intent_transitions_to_failed_not_stopped():

--- a/tests/flows/test_worker_crash.py
+++ b/tests/flows/test_worker_crash.py
@@ -163,6 +163,9 @@ def test_write_worker_exit_info_with_shutdown_intent(tmp_path: Path) -> None:
         run_id,
         returncode=-15,
         shutdown_intent=True,
+        signal="SIGTERM",
+        exit_origin="worker_signal",
+        exit_kind="external_signal",
     )
 
     exit_path = artifacts_dir / "worker.exit.json"
@@ -170,6 +173,9 @@ def test_write_worker_exit_info_with_shutdown_intent(tmp_path: Path) -> None:
     payload = json.loads(exit_path.read_text(encoding="utf-8"))
     assert payload["returncode"] == -15
     assert payload["shutdown_intent"] is True
+    assert payload["signal"] == "SIGTERM"
+    assert payload["exit_origin"] == "worker_signal"
+    assert payload["exit_kind"] == "external_signal"
 
 
 def test_write_worker_exit_info_without_shutdown_intent(tmp_path: Path) -> None:
@@ -234,6 +240,7 @@ def test_check_worker_health_reads_shutdown_intent(monkeypatch, tmp_path: Path) 
     assert health.status == "dead"
     assert health.shutdown_intent is True
     assert health.exit_code == -15
+    assert health.signal is None
 
 
 def test_write_worker_exit_info_preserves_existing_shutdown_intent(


### PR DESCRIPTION
## Summary

- record worker exit provenance for raw signals and watchdog-triggered shutdowns
- classify signal/watchdog shutdowns as recoverable worker loss instead of intentional stops
- allow the reconciler to restart recoverable STOPPING ticket-flow workers and clear stale stop requests
- add regression coverage for signal-loss recovery and updated shutdown classification

## Root cause

A worker that received a signal during an active app-server turn wrote `shutdown_intent: true`, moved the flow through STOPPING, and was later reconciled as a normal stopped run. That collapsed external signal loss into the same path as an operator-requested stop.

## Validation

- `./scripts/check.sh`
- `.venv/bin/python -m pytest tests/flows tests/core/flows/test_flow_supervisor.py tests/core/flows/test_reconciler_idle.py tests/core/flows/test_reconciler_issue1745_recovery.py`
- `.venv/bin/python -m pytest tests/test_flow_worker_graceful_shutdown.py::test_flow_worker_sigterm_closes_agent_pool_and_controller tests/flows/test_flow_reconcile.py::test_signal_stopped_worker_is_auto_restarted tests/core/flows/test_flow_supervisor.py::test_policy_treats_signal_shutdown_as_recoverable_crash`