### PR TITLE
Add bootstrap browser auth for remote hubs

### DIFF
--- a/docs/ops/systemd.md
+++ b/docs/ops/systemd.md
@@ -7,8 +7,9 @@ user and system service guidance plus templates for hub and Telegram.
 
 - CAR installed and `car` on disk (use an absolute path from `which car`).
 - Hub workspace initialized: `car init --mode hub --path ~/car-workspace`.
-- If binding to a non-loopback host, set `server.auth_token_env` and
-  `server.allowed_hosts` (see `docs/web/security.md`).
+- If binding to a non-loopback host, set `server.allowed_hosts`. Keep
+  `server.auth_token_env` for CLI/API automation; browser access can be claimed
+  with `.codex-autorunner/bootstrap-token` (see `docs/web/security.md`).
 
 ## Environment file
 
@@ -36,6 +37,10 @@ server:
 
 If you set `server.base_path`, also set `CAR_BASE_PATH=/car` in the env file
 and update your health check URLs to include the prefix.
+
+For first browser login on a remote host, read the token from
+`~/car-workspace/.codex-autorunner/bootstrap-token` after the hub starts and
+open `https://host/auth/bootstrap#token=...`.
 
 Set Linux updater defaults in `codex-autorunner.yml` (or `.codex-autorunner/config.yml`)
 so `/system/update` and Telegram `/update` use systemd:

--- a/docs/web/security.md
+++ b/docs/web/security.md
@@ -10,38 +10,48 @@ interface and how to secure it.
 - The UI/API can run code and modify files in bound workspaces.
 - There is no built-in multi-user auth or per-endpoint role separation.
 
-## Authentication token
+## Bootstrap browser auth
 
-CAR supports a bearer token enforced by middleware when configured:
+Remote hub deployments can use a one-time bootstrap token to create a browser
+session without putting a bearer token in browser storage:
+
+- On remote boot, CAR writes a high-entropy token to
+  `.codex-autorunner/bootstrap-token` with `0600` permissions.
+- Open `https://host/auth/bootstrap#token=YOUR_BOOTSTRAP_TOKEN`.
+- The browser posts the fragment token to `/auth/bootstrap/claim`; URL fragments
+  are not sent in HTTP requests.
+- A successful claim deletes the bootstrap token and sets an HttpOnly Secure
+  `car_session` cookie with `SameSite=Lax`.
+- Because the session cookie is `Secure`, expose remote browser deployments over
+  HTTPS, including when a reverse proxy terminates TLS in front of CAR.
+
+To recover or rotate browser access, remove the old session file
+`.codex-autorunner/browser-sessions.json`, remove any stale
+`.codex-autorunner/bootstrap-token`, and restart the hub. CAR will write a fresh
+bootstrap token on the next authenticated or remote boot.
+
+## API bearer token
+
+CAR also supports a bearer token enforced by middleware when configured:
 
 - Set `server.auth_token_env` in `.codex-autorunner/config.yml`.
 - Export the token in the environment before starting the server.
-- All non-public endpoints require `Authorization: Bearer <token>`.
+- API and CLI requests can use `Authorization: Bearer <token>`.
 - WebSockets accept the token via `Sec-WebSocket-Protocol: car-token-b64.<base64url(token)>`.
   The legacy `?token=...` query string is still accepted for backward compatibility.
-
-When `server.auth_token_env` is set, the web UI can be accessed by visiting:
-
-```
-http://host:port/?token=YOUR_TOKEN
-```
-
-The UI stores the token in `sessionStorage` and removes it from the URL.
 
 ## Public endpoints
 
 The following endpoints remain public so health checks and static assets work:
 
 - `/` (UI shell)
-- `/pma`, `/dashboard`, `/repos`, `/worktrees`, `/tickets`, `/contextspace/*`,
-  and `/settings` (Web Hub shell)
+- `/auth/bootstrap` and `/auth/bootstrap/claim`
 - `/_app/*`
-- `/static/*` (Web Hub assets)
 - `/health`
 - `/cat/*`
 
-All API endpoints, hub endpoints, and repo endpoints require the auth token
-once configured.
+All API endpoints, hub endpoints, repo endpoints, and deep-linked UI routes
+require a valid browser session or bearer token once auth is enabled.
 
 ## Localhost hardening (Host/Origin checks)
 
@@ -65,7 +75,8 @@ Config:
 ## Recommendations
 
 - Prefer local-only access (`127.0.0.1`) or a private network like Tailscale.
-- If exposing the server beyond localhost, always set `server.auth_token_env`.
+- If exposing the server beyond localhost, use bootstrap browser auth and keep
+  `server.auth_token_env` available for automation.
 - Use a reverse proxy with additional auth (basic auth, SSO) if you must put it
   on the public internet.
 - Avoid placing the web UI behind a publicly accessible hostname without

--- a/src/codex_autorunner/surfaces/cli/commands/hub.py
+++ b/src/codex_autorunner/surfaces/cli/commands/hub.py
@@ -973,7 +973,7 @@ def register_hub_commands(
         )
         bind_host = host or config.server_host
         bind_port = port or config.server_port
-        enforce_bind_auth(bind_host, config.server_auth_token_env)
+        enforce_bind_auth(bind_host, config.server_auth_token_env, config.root)
         typer.echo(
             f"Serving hub on http://{bind_host}:{bind_port}{normalized_base or ''}"
         )

--- a/src/codex_autorunner/surfaces/cli/commands/root.py
+++ b/src/codex_autorunner/surfaces/cli/commands/root.py
@@ -41,6 +41,7 @@ from ....core.usage import (
 from ....core.utils import RepoNotFoundError, default_editor, find_repo_root
 from ....manifest import load_manifest
 from ...web.app import create_hub_app
+from ...web.services.browser_auth import ensure_bootstrap_token
 from ..hub_path_option import hub_root_path_option
 from .utils import request_json
 
@@ -157,13 +158,18 @@ def _resolve_auth_token(env_name: str) -> Optional[str]:
     return value or None
 
 
-def _enforce_bind_auth(host: str, token_env: str) -> None:
+def _enforce_bind_auth(
+    host: str, token_env: str, hub_root: Optional[Path] = None
+) -> None:
     if is_loopback_host(host):
         return
     if _resolve_auth_token(token_env):
         return
+    if hub_root is not None:
+        ensure_bootstrap_token(hub_root)
+        return
     _raise_exit(
-        "Refusing to bind to a non-loopback host without server.auth_token_env set."
+        "Refusing to bind to a non-loopback host without server.auth_token_env or bootstrap auth."
     )
 
 
@@ -724,12 +730,17 @@ def register_root_commands(app: typer.Typer) -> None:
             if base_path is not None
             else config.server_base_path
         )
-        _enforce_bind_auth(bind_host, config.server_auth_token_env)
+        _enforce_bind_auth(bind_host, config.server_auth_token_env, config.root)
         typer.echo(
             f"Serving hub on http://{bind_host}:{bind_port}{normalized_base or ''}"
         )
         uvicorn.run(
-            create_hub_app(config.root, base_path=normalized_base),
+            create_hub_app(
+                config.root,
+                base_path=normalized_base,
+                endpoint_host=bind_host,
+                endpoint_port=bind_port,
+            ),
             host=bind_host,
             port=bind_port,
             root_path="",

--- a/src/codex_autorunner/surfaces/cli/commands/utils.py
+++ b/src/codex_autorunner/surfaces/cli/commands/utils.py
@@ -35,6 +35,7 @@ from ....tickets.files import list_ticket_paths, read_ticket, safe_relpath
 from ....tickets.frontmatter import render_markdown_frontmatter
 from ....tickets.ingest_state import INGEST_STATE_FILENAME
 from ....tickets.lint import lint_ticket_directory, parse_ticket_index
+from ...web.services.browser_auth import ensure_bootstrap_token
 
 if TYPE_CHECKING:
     from ....core.hub import HubSupervisor
@@ -85,13 +86,18 @@ def is_loopback_host(host: str) -> bool:
         return False
 
 
-def enforce_bind_auth(host: str, token_env: str) -> None:
+def enforce_bind_auth(
+    host: str, token_env: str, hub_root: Optional[Path] = None
+) -> None:
     if is_loopback_host(host):
         return
     if resolve_auth_token(token_env):
         return
+    if hub_root is not None:
+        ensure_bootstrap_token(hub_root)
+        return
     raise_exit(
-        "Refusing to bind to a non-loopback host without server.auth_token_env set."
+        "Refusing to bind to a non-loopback host without server.auth_token_env or bootstrap auth."
     )
 
 

--- a/src/codex_autorunner/surfaces/web/app.py
+++ b/src/codex_autorunner/surfaces/web/app.py
@@ -14,6 +14,7 @@ from starlette.middleware.gzip import GZipMiddleware
 from starlette.types import ASGIApp
 
 from ...core.config import parse_flow_retention_config
+from ...core.config_validation import is_loopback_host
 from ...core.diagnostics import (
     DEFAULT_PROCESS_MONITOR_CADENCE_SECONDS,
     DEFAULT_PROCESS_MONITOR_WINDOW_SECONDS,
@@ -59,6 +60,7 @@ from .middleware import (
     RequestIdMiddleware,
     SecurityHeadersMiddleware,
 )
+from .routes.auth import build_auth_routes
 from .routes.chat_events import build_hub_chat_event_routes
 from .routes.contextspace import build_contextspace_routes
 from .routes.feedback_reports import build_feedback_report_routes
@@ -79,6 +81,7 @@ from .routes.scm_webhooks import build_scm_webhook_routes
 from .routes.settings import build_settings_routes
 from .routes.system import build_system_routes
 from .routes.voice import build_voice_routes
+from .services.browser_auth import SESSION_COOKIE_NAME, BrowserAuthStore
 from .services.pma import create_pma_application_container
 from .static_assets import (
     render_web_index_html,
@@ -213,6 +216,15 @@ def create_hub_app(
     web_static_dir, web_static_context = resolve_web_static_dir()
     app.state.web_static_dir = web_static_dir
     app.state.web_static_assets_context = web_static_context
+    bind_host = endpoint_host or context.config.server_host
+    remote_bind = not is_loopback_host(bind_host)
+    auth_token = resolve_auth_token(context.config.server_auth_token_env)
+    browser_auth_store: Optional[BrowserAuthStore] = None
+    if auth_token or remote_bind:
+        browser_auth_store = BrowserAuthStore(context.config.root)
+        browser_auth_store.ensure_bootstrap_token()
+        app.state.browser_auth_store = browser_auth_store
+        app.include_router(build_auth_routes(browser_auth_store))
     web_app_assets_dir = web_static_dir / "_app"
     if web_app_assets_dir.exists():
         app.mount(
@@ -1030,11 +1042,20 @@ def create_hub_app(
         context.config.server_host, context.config.server_allowed_hosts
     )
     allowed_origins = context.config.server_allowed_origins
-    auth_token = resolve_auth_token(context.config.server_auth_token_env)
     app.state.auth_token = auth_token
     asgi_app: ASGIApp = app
-    if auth_token:
-        asgi_app = AuthTokenMiddleware(asgi_app, auth_token, context.base_path)
+    if auth_token or browser_auth_store is not None:
+        asgi_app = AuthTokenMiddleware(
+            asgi_app,
+            auth_token,
+            context.base_path,
+            session_cookie_name=SESSION_COOKIE_NAME,
+            session_validator=(
+                browser_auth_store.validate_session_token
+                if browser_auth_store is not None
+                else None
+            ),
+        )
     if context.base_path:
         asgi_app = BasePathRouterMiddleware(asgi_app, context.base_path)
     asgi_app = HostOriginMiddleware(asgi_app, allowed_hosts, allowed_origins)

--- a/src/codex_autorunner/surfaces/web/middleware.py
+++ b/src/codex_autorunner/surfaces/web/middleware.py
@@ -6,6 +6,8 @@ import hmac
 import logging
 import time
 import uuid
+from http.cookies import SimpleCookie
+from typing import Callable, Optional
 from urllib.parse import parse_qs, urlparse
 
 from fastapi.responses import RedirectResponse, Response
@@ -44,6 +46,7 @@ class BasePathRouterMiddleware:
                 "/contextspace",
                 "/settings",
                 "/health",
+                "/auth",
                 "/cat",
             )
         )
@@ -149,11 +152,21 @@ class BasePathRouterMiddleware:
 class AuthTokenMiddleware:
     """Middleware that enforces an auth token on all non-public endpoints."""
 
-    def __init__(self, app, token: str, base_path: str = ""):
+    def __init__(
+        self,
+        app,
+        token: Optional[str] = None,
+        base_path: str = "",
+        *,
+        session_cookie_name: str = "car_session",
+        session_validator: Optional[Callable[[Optional[str]], bool]] = None,
+    ):
         self.app = app
         self.token = token
         self.base_path = normalize_base_path(base_path)
-        self.public_prefixes = ("/_app", "/health", "/cat")
+        self.session_cookie_name = session_cookie_name
+        self.session_validator = session_validator
+        self.public_prefixes = ("/_app", "/health", "/auth/bootstrap", "/cat")
 
     def __getattr__(self, name):
         return getattr(self.app, name)
@@ -212,6 +225,25 @@ class AuthTokenMiddleware:
         if not value.lower().startswith("bearer "):
             return None
         return value.split(" ", 1)[1].strip() or None
+
+    def _extract_session_cookie(self, scope) -> Optional[str]:
+        headers = {k.lower(): v for k, v in (scope.get("headers") or [])}
+        raw = headers.get(b"cookie")
+        if not raw:
+            return None
+        try:
+            value = raw.decode("latin-1")
+        except UnicodeDecodeError:
+            return None
+        cookie = SimpleCookie()
+        try:
+            cookie.load(value)
+        except Exception:
+            return None
+        morsel = cookie.get(self.session_cookie_name)
+        if morsel is None:
+            return None
+        return morsel.value.strip() or None
 
     def _allows_query_token(self, scope) -> bool:
         # Query-string bearer tokens are intentionally limited to WebSocket
@@ -284,12 +316,22 @@ class AuthTokenMiddleware:
                 token = self._extract_ws_protocol_token(scope)
             token = token or self._extract_query_token(scope)
 
-        if not token or not hmac.compare_digest(token, self.token):
+        if token and self.token and hmac.compare_digest(token, self.token):
+            return await self.app(scope, receive, send)
+
+        if self.session_validator is not None:
+            session_token = self._extract_session_cookie(scope)
+            if self.session_validator(session_token):
+                return await self.app(scope, receive, send)
+
+        if not token or not self.token:
             if scope.get("type") == "websocket":
                 return await self._reject_ws(scope, receive, send)
             return await self._reject_http(scope, receive, send)
 
-        return await self.app(scope, receive, send)
+        if scope.get("type") == "websocket":
+            return await self._reject_ws(scope, receive, send)
+        return await self._reject_http(scope, receive, send)
 
 
 class HostOriginMiddleware:

--- a/src/codex_autorunner/surfaces/web/routes/auth.py
+++ b/src/codex_autorunner/surfaces/web/routes/auth.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from pydantic import BaseModel
+
+from ..services.browser_auth import (
+    SESSION_COOKIE_NAME,
+    BrowserAuthStore,
+)
+
+
+class BootstrapClaimRequest(BaseModel):
+    token: str
+
+
+def _bootstrap_html() -> str:
+    return r"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CAR Bootstrap</title>
+    <style>
+      body {
+        background: #0a0c12;
+        color: #f3f7fb;
+        font: 16px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+      }
+      main {
+        width: min(32rem, calc(100vw - 2rem));
+      }
+      h1 {
+        font-size: 1.5rem;
+        font-weight: 650;
+        margin: 0 0 0.75rem;
+      }
+      p {
+        color: #b7c3d2;
+        line-height: 1.5;
+        margin: 0.5rem 0;
+      }
+      code {
+        color: #6cf5d8;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>CAR Bootstrap</h1>
+      <p id="status">Claiming browser session...</p>
+      <p id="detail"></p>
+    </main>
+    <script>
+      (async function () {
+        var status = document.getElementById('status');
+        var detail = document.getElementById('detail');
+        var params = new URLSearchParams((window.location.hash || '').replace(/^#/, ''));
+        var token = params.get('token') || '';
+        if (!token) {
+          status.textContent = 'Missing bootstrap token.';
+          detail.innerHTML = 'Open this page as <code>/auth/bootstrap#token=...</code>.';
+          return;
+        }
+        window.history.replaceState(null, document.title, window.location.pathname + window.location.search);
+        try {
+          var response = await fetch(window.location.pathname.replace(/\/$/, '') + '/claim', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json', accept: 'application/json' },
+            body: JSON.stringify({ token: token })
+          });
+          if (!response.ok) throw new Error('Bootstrap claim failed.');
+          window.location.replace(window.location.pathname.replace(/\/auth\/bootstrap\/?$/, '/') || '/');
+        } catch (error) {
+          status.textContent = 'Bootstrap claim failed.';
+          detail.textContent = error && error.message ? error.message : 'Request failed.';
+        }
+      })();
+    </script>
+  </body>
+</html>
+"""
+
+
+def build_auth_routes(store: BrowserAuthStore) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/auth/bootstrap", include_in_schema=False)
+    def bootstrap_page() -> HTMLResponse:
+        return HTMLResponse(
+            _bootstrap_html(),
+            headers={
+                "Cache-Control": "no-store",
+                "Content-Security-Policy": (
+                    "default-src 'self'; base-uri 'none'; frame-ancestors 'none'; "
+                    "style-src 'unsafe-inline'; script-src 'unsafe-inline'"
+                ),
+            },
+        )
+
+    @router.post("/auth/bootstrap/claim", include_in_schema=False)
+    def claim_bootstrap(
+        payload: BootstrapClaimRequest, request: Request
+    ) -> JSONResponse:
+        claim = store.claim_bootstrap_token(payload.token)
+        if claim is None:
+            raise HTTPException(status_code=401, detail="Invalid bootstrap token")
+        response = JSONResponse({"ok": True})
+        response.set_cookie(
+            SESSION_COOKIE_NAME,
+            claim.session_token,
+            max_age=claim.max_age_seconds,
+            httponly=True,
+            secure=True,
+            samesite="lax",
+            path=request.scope.get("root_path") or "/",
+        )
+        return response
+
+    return router

--- a/src/codex_autorunner/surfaces/web/services/browser_auth.py
+++ b/src/codex_autorunner/surfaces/web/services/browser_auth.py
@@ -6,9 +6,10 @@ import json
 import os
 import secrets
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 BOOTSTRAP_TOKEN_RELATIVE_PATH = Path(".codex-autorunner/bootstrap-token")
 SESSION_STORE_RELATIVE_PATH = Path(".codex-autorunner/browser-sessions.json")
@@ -58,10 +59,11 @@ class BootstrapClaim:
 
 
 class BrowserAuthStore:
-    def __init__(self, root: Path):
+    def __init__(self, root: Path, now: Callable[[], float] = time.time):
         self.root = root
         self.bootstrap_token_path = root / BOOTSTRAP_TOKEN_RELATIVE_PATH
         self.session_store_path = root / SESSION_STORE_RELATIVE_PATH
+        self._now = now
         self._lock = threading.Lock()
 
     def ensure_bootstrap_token(self) -> tuple[Path, str]:
@@ -99,14 +101,36 @@ class BrowserAuthStore:
         token_hash = _sha256(token.strip())
         if not token_hash:
             return False
-        data = self._read_store()
-        sessions = data.get("sessions")
-        if not isinstance(sessions, list):
-            return False
-        return any(
-            isinstance(entry, str) and hmac.compare_digest(entry, token_hash)
-            for entry in sessions
-        )
+        with self._lock:
+            data = self._read_store()
+            sessions = data.get("sessions")
+            if not isinstance(sessions, list):
+                return False
+            now = self._now()
+            valid = False
+            active_sessions = []
+            changed = False
+            for entry in sessions:
+                if not isinstance(entry, dict):
+                    changed = True
+                    continue
+                stored_hash = entry.get("token_hash")
+                expires_at = entry.get("expires_at")
+                if not isinstance(stored_hash, str) or not isinstance(
+                    expires_at, (int, float)
+                ):
+                    changed = True
+                    continue
+                if expires_at <= now:
+                    changed = True
+                    continue
+                active_sessions.append(entry)
+                if hmac.compare_digest(stored_hash, token_hash):
+                    valid = True
+            if changed:
+                data["sessions"] = active_sessions
+                self._write_store(data)
+            return valid
 
     def _add_session(self, token: str) -> None:
         data = self._read_store()
@@ -114,9 +138,28 @@ class BrowserAuthStore:
         if not isinstance(sessions, list):
             sessions = []
         token_hash = _sha256(token)
-        if token_hash not in sessions:
-            sessions.append(token_hash)
-        data["sessions"] = sessions
+        now = self._now()
+        active_sessions = []
+        for entry in sessions:
+            if not isinstance(entry, dict):
+                continue
+            stored_hash = entry.get("token_hash")
+            expires_at = entry.get("expires_at")
+            if not isinstance(stored_hash, str) or not isinstance(
+                expires_at, (int, float)
+            ):
+                continue
+            if expires_at <= now or stored_hash == token_hash:
+                continue
+            active_sessions.append(entry)
+        active_sessions.append(
+            {
+                "token_hash": token_hash,
+                "issued_at": now,
+                "expires_at": now + SESSION_MAX_AGE_SECONDS,
+            }
+        )
+        data["sessions"] = active_sessions
         self._write_store(data)
 
     def _read_store(self) -> dict[str, Any]:

--- a/src/codex_autorunner/surfaces/web/services/browser_auth.py
+++ b/src/codex_autorunner/surfaces/web/services/browser_auth.py
@@ -69,12 +69,6 @@ class BrowserAuthStore:
     def ensure_bootstrap_token(self) -> tuple[Path, str]:
         return ensure_bootstrap_token(self.root)
 
-    def has_bootstrap_token(self) -> bool:
-        try:
-            return bool(self.bootstrap_token_path.read_text(encoding="utf-8").strip())
-        except FileNotFoundError:
-            return False
-
     def claim_bootstrap_token(self, token: str) -> Optional[BootstrapClaim]:
         candidate = token.strip()
         if not candidate:

--- a/src/codex_autorunner/surfaces/web/services/browser_auth.py
+++ b/src/codex_autorunner/surfaces/web/services/browser_auth.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+BOOTSTRAP_TOKEN_RELATIVE_PATH = Path(".codex-autorunner/bootstrap-token")
+SESSION_STORE_RELATIVE_PATH = Path(".codex-autorunner/browser-sessions.json")
+SESSION_COOKIE_NAME = "car_session"
+SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _write_private_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+    finally:
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+
+
+def ensure_bootstrap_token(root: Path) -> tuple[Path, str]:
+    path = root / BOOTSTRAP_TOKEN_RELATIVE_PATH
+    try:
+        existing = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        existing = ""
+    if existing:
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+        return path, existing
+    token = secrets.token_urlsafe(48)
+    _write_private_text(path, f"{token}\n")
+    return path, token
+
+
+@dataclass(frozen=True)
+class BootstrapClaim:
+    session_token: str
+    max_age_seconds: int = SESSION_MAX_AGE_SECONDS
+
+
+class BrowserAuthStore:
+    def __init__(self, root: Path):
+        self.root = root
+        self.bootstrap_token_path = root / BOOTSTRAP_TOKEN_RELATIVE_PATH
+        self.session_store_path = root / SESSION_STORE_RELATIVE_PATH
+        self._lock = threading.Lock()
+
+    def ensure_bootstrap_token(self) -> tuple[Path, str]:
+        return ensure_bootstrap_token(self.root)
+
+    def has_bootstrap_token(self) -> bool:
+        try:
+            return bool(self.bootstrap_token_path.read_text(encoding="utf-8").strip())
+        except FileNotFoundError:
+            return False
+
+    def claim_bootstrap_token(self, token: str) -> Optional[BootstrapClaim]:
+        candidate = token.strip()
+        if not candidate:
+            return None
+        with self._lock:
+            try:
+                expected = self.bootstrap_token_path.read_text(encoding="utf-8").strip()
+            except FileNotFoundError:
+                return None
+            if not expected or not hmac.compare_digest(candidate, expected):
+                return None
+
+            session_token = secrets.token_urlsafe(48)
+            self._add_session(session_token)
+            try:
+                self.bootstrap_token_path.unlink()
+            except FileNotFoundError:
+                pass
+            return BootstrapClaim(session_token=session_token)
+
+    def validate_session_token(self, token: Optional[str]) -> bool:
+        if not token:
+            return False
+        token_hash = _sha256(token.strip())
+        if not token_hash:
+            return False
+        data = self._read_store()
+        sessions = data.get("sessions")
+        if not isinstance(sessions, list):
+            return False
+        return any(
+            isinstance(entry, str) and hmac.compare_digest(entry, token_hash)
+            for entry in sessions
+        )
+
+    def _add_session(self, token: str) -> None:
+        data = self._read_store()
+        sessions = data.get("sessions")
+        if not isinstance(sessions, list):
+            sessions = []
+        token_hash = _sha256(token)
+        if token_hash not in sessions:
+            sessions.append(token_hash)
+        data["sessions"] = sessions
+        self._write_store(data)
+
+    def _read_store(self) -> dict[str, Any]:
+        try:
+            data = json.loads(self.session_store_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return {"sessions": []}
+        return data if isinstance(data, dict) else {"sessions": []}
+
+    def _write_store(self, data: dict[str, Any]) -> None:
+        text = json.dumps(data, sort_keys=True, indent=2)
+        _write_private_text(self.session_store_path, f"{text}\n")

--- a/tests/surfaces/web/test_bootstrap_auth_routes.py
+++ b/tests/surfaces/web/test_bootstrap_auth_routes.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from codex_autorunner.bootstrap import seed_hub_files
+from codex_autorunner.server import create_hub_app
+from codex_autorunner.surfaces.web.services.browser_auth import (
+    BOOTSTRAP_TOKEN_RELATIVE_PATH,
+    SESSION_COOKIE_NAME,
+)
+
+
+def _read_bootstrap_token(hub_root: Path) -> str:
+    return (
+        (hub_root / BOOTSTRAP_TOKEN_RELATIVE_PATH).read_text(encoding="utf-8").strip()
+    )
+
+
+def test_remote_hub_bootstrap_claim_creates_http_only_session(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    seed_hub_files(hub_root, force=True)
+    client = TestClient(create_hub_app(hub_root, endpoint_host="0.0.0.0"))
+
+    assert client.get("/health").status_code == 200
+    assert client.get("/hub/repos").status_code == 401
+
+    page = client.get("/auth/bootstrap")
+    assert page.status_code == 200
+    assert "/auth/bootstrap#token=..." in page.text
+
+    token = _read_bootstrap_token(hub_root)
+    claim = client.post("/auth/bootstrap/claim", json={"token": token})
+
+    assert claim.status_code == 200
+    cookie = claim.headers["set-cookie"]
+    assert f"{SESSION_COOKIE_NAME}=" in cookie
+    assert "HttpOnly" in cookie
+    assert "Secure" in cookie
+    assert "SameSite=lax" in cookie
+    assert not (hub_root / BOOTSTRAP_TOKEN_RELATIVE_PATH).exists()
+    session_token = cookie.split(f"{SESSION_COOKIE_NAME}=", 1)[1].split(";", 1)[0]
+    assert (
+        client.get(
+            "/hub/repos", headers={"Cookie": f"{SESSION_COOKIE_NAME}={session_token}"}
+        ).status_code
+        == 200
+    )
+
+
+def test_bootstrap_token_is_single_use(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    seed_hub_files(hub_root, force=True)
+    client = TestClient(create_hub_app(hub_root, endpoint_host="0.0.0.0"))
+    token = _read_bootstrap_token(hub_root)
+
+    first = client.post("/auth/bootstrap/claim", json={"token": token})
+    second = client.post("/auth/bootstrap/claim", json={"token": token})
+
+    assert first.status_code == 200
+    assert second.status_code == 401
+
+
+def test_bearer_token_auth_still_works_with_bootstrap_routes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    hub_root = tmp_path / "hub"
+    seed_hub_files(hub_root, force=True)
+    config_path = hub_root / ".codex-autorunner/config.yml"
+    text = config_path.read_text(encoding="utf-8")
+    config_path.write_text(f"{text}\nserver:\n  auth_token_env: CAR_TEST_TOKEN\n")
+    monkeypatch.setenv("CAR_TEST_TOKEN", "api-secret")
+    client = TestClient(create_hub_app(hub_root, endpoint_host="0.0.0.0"))
+
+    denied = client.get("/hub/repos")
+    allowed = client.get("/hub/repos", headers={"Authorization": "Bearer api-secret"})
+
+    assert denied.status_code == 401
+    assert allowed.status_code == 200
+    assert (hub_root / BOOTSTRAP_TOKEN_RELATIVE_PATH).exists()

--- a/tests/surfaces/web/test_bootstrap_auth_routes.py
+++ b/tests/surfaces/web/test_bootstrap_auth_routes.py
@@ -9,6 +9,8 @@ from codex_autorunner.server import create_hub_app
 from codex_autorunner.surfaces.web.services.browser_auth import (
     BOOTSTRAP_TOKEN_RELATIVE_PATH,
     SESSION_COOKIE_NAME,
+    SESSION_MAX_AGE_SECONDS,
+    BrowserAuthStore,
 )
 
 
@@ -79,3 +81,23 @@ def test_bearer_token_auth_still_works_with_bootstrap_routes(
     assert denied.status_code == 401
     assert allowed.status_code == 200
     assert (hub_root / BOOTSTRAP_TOKEN_RELATIVE_PATH).exists()
+
+
+def test_browser_session_validation_enforces_server_side_expiry(
+    tmp_path: Path,
+) -> None:
+    now = 1_000.0
+    store = BrowserAuthStore(tmp_path, now=lambda: now)
+    _, bootstrap_token = store.ensure_bootstrap_token()
+
+    claim = store.claim_bootstrap_token(bootstrap_token)
+    assert claim is not None
+    token = claim.session_token
+
+    assert store.validate_session_token(token) is True
+
+    now += SESSION_MAX_AGE_SECONDS + 1
+
+    assert store.validate_session_token(token) is False
+    data = store._read_store()
+    assert data["sessions"] == []

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -83,3 +83,15 @@ def test_auth_middleware_keeps_query_token_for_legacy_websockets() -> None:
     scope = _ws_scope()
     scope["query_string"] = b"token=secret"
     assert middleware._extract_query_token(scope) == "secret"
+
+
+def test_auth_middleware_accepts_browser_session_cookie() -> None:
+    middleware = AuthTokenMiddleware(
+        lambda *_: None,
+        token=None,
+        session_validator=lambda token: token == "session-secret",
+    )
+    scope = _scope("/hub/repos")
+    scope["headers"] = [(b"cookie", b"car_session=session-secret")]
+    assert middleware._extract_session_cookie(scope) == "session-secret"
+    assert middleware.session_validator(middleware._extract_session_cookie(scope))


### PR DESCRIPTION
Closes #1764

## Summary
- add a hub-local bootstrap token and browser session store under .codex-autorunner
- add /auth/bootstrap and /auth/bootstrap/claim to exchange a URL-fragment token for an HttpOnly Secure car_session cookie
- allow auth middleware to accept browser session cookies while preserving Authorization: Bearer and websocket token support
- allow non-loopback hub serve to proceed via bootstrap auth and document remote/systemd recovery steps

## Validation
- pre-commit aggregate lane completed: 8687 pytest passed, mypy strict passed, ruff passed, web lint/build/test passed, chat-surface lab passed
- focused: .venv/bin/python -m pytest -q tests/test_auth_middleware.py tests/surfaces/web/test_bootstrap_auth_routes.py tests/surfaces/web/test_web_static_routes.py tests/surfaces/web/test_web_spa_shell_contract.py tests/core/test_config_validation.py tests/test_config_default_snapshots.py