### PR TITLE
Fix remote bootstrap origin handling

### DIFF
--- a/docs/ops/systemd.md
+++ b/docs/ops/systemd.md
@@ -7,9 +7,11 @@ user and system service guidance plus templates for hub and Telegram.
 
 - CAR installed and `car` on disk (use an absolute path from `which car`).
 - Hub workspace initialized: `car init --mode hub --path ~/car-workspace`.
-- If binding to a non-loopback host, set `server.allowed_hosts`. Keep
-  `server.auth_token_env` for CLI/API automation; browser access can be claimed
-  with `.codex-autorunner/bootstrap-token` (see `docs/web/security.md`).
+- If binding to a non-loopback host, set `server.allowed_hosts`. When exposing
+  CAR through a public HTTPS reverse proxy, also set `server.allowed_origins`
+  to the public origin for normal browser API/WebSocket requests. Keep
+  `server.auth_token_env` for CLI/API automation; first browser access can be
+  claimed with `.codex-autorunner/bootstrap-token` (see `docs/web/security.md`).
 
 ## Environment file
 
@@ -32,6 +34,10 @@ Set the auth token env in `.codex-autorunner/config.yml`:
 ```yaml
 server:
   auth_token_env: CAR_AUTH_TOKEN
+  allowed_hosts:
+    - your-public-host.example
+  allowed_origins:
+    - https://your-public-host.example
   # base_path: /car
 ```
 

--- a/docs/web/security.md
+++ b/docs/web/security.md
@@ -20,6 +20,9 @@ session without putting a bearer token in browser storage:
 - Open `https://host/auth/bootstrap#token=YOUR_BOOTSTRAP_TOKEN`.
 - The browser posts the fragment token to `/auth/bootstrap/claim`; URL fragments
   are not sent in HTTP requests.
+- The bootstrap claim endpoint accepts the browser `Origin` from an HTTPS
+  reverse proxy so first login does not require pre-populating
+  `server.allowed_origins`; Host header validation still applies.
 - A successful claim deletes the bootstrap token and sets an HttpOnly Secure
   `car_session` cookie with `SameSite=Lax`.
 - Because the session cookie is `Secure`, expose remote browser deployments over
@@ -71,6 +74,8 @@ Config:
 - `server.allowed_hosts`: explicit host allowlist. Required when binding to a
   non-loopback host.
 - `server.allowed_origins`: extra allowed origins (scheme + host + port).
+  Configure this for normal browser API/WebSocket use when CAR is exposed
+  through a public reverse proxy.
 
 ## Recommendations
 

--- a/src/codex_autorunner/surfaces/web/app.py
+++ b/src/codex_autorunner/surfaces/web/app.py
@@ -1058,7 +1058,12 @@ def create_hub_app(
         )
     if context.base_path:
         asgi_app = BasePathRouterMiddleware(asgi_app, context.base_path)
-    asgi_app = HostOriginMiddleware(asgi_app, allowed_hosts, allowed_origins)
+    asgi_app = HostOriginMiddleware(
+        asgi_app,
+        allowed_hosts,
+        allowed_origins,
+        base_path=context.base_path,
+    )
     asgi_app = RequestIdMiddleware(asgi_app)
     asgi_app = SecurityHeadersMiddleware(asgi_app)
 

--- a/src/codex_autorunner/surfaces/web/app_builders.py
+++ b/src/codex_autorunner/surfaces/web/app_builders.py
@@ -390,6 +390,7 @@ def _add_shared_repo_middlewares(
         HostOriginMiddleware,
         allowed_hosts=allowed_hosts,
         allowed_origins=allowed_origins,
+        base_path=context.base_path if include_base_path_router else "",
     )
     app.add_middleware(RequestIdMiddleware)
     app.add_middleware(SecurityHeadersMiddleware)

--- a/src/codex_autorunner/surfaces/web/middleware.py
+++ b/src/codex_autorunner/surfaces/web/middleware.py
@@ -341,7 +341,7 @@ class HostOriginMiddleware:
         {"/auth/bootstrap/claim", "/auth/bootstrap/claim/"}
     )
 
-    def __init__(self, app, allowed_hosts, allowed_origins):
+    def __init__(self, app, allowed_hosts, allowed_origins, base_path: str = ""):
         self.app = app
         self.allowed_hosts = [
             entry.strip().lower()
@@ -357,6 +357,7 @@ class HostOriginMiddleware:
             )
             if entry is not None
         }
+        self.base_path = base_path.rstrip("/")
 
     def __getattr__(self, name):
         return getattr(self.app, name)
@@ -450,6 +451,8 @@ class HostOriginMiddleware:
         candidates = [path]
         if root_path and path.startswith(root_path):
             candidates.append(path[len(root_path) :] or "/")
+        if self.base_path and path.startswith(f"{self.base_path}/"):
+            candidates.append(path[len(self.base_path) :] or "/")
         return any(candidate in self._BOOTSTRAP_CLAIM_PATHS for candidate in candidates)
 
     async def _reject_http(self, scope, receive, send, status: int, body: str) -> None:

--- a/src/codex_autorunner/surfaces/web/middleware.py
+++ b/src/codex_autorunner/surfaces/web/middleware.py
@@ -337,6 +337,10 @@ class AuthTokenMiddleware:
 class HostOriginMiddleware:
     """Validate Host and Origin headers for localhost hardening."""
 
+    _BOOTSTRAP_CLAIM_PATHS = frozenset(
+        {"/auth/bootstrap/claim", "/auth/bootstrap/claim/"}
+    )
+
     def __init__(self, app, allowed_hosts, allowed_origins):
         self.app = app
         self.allowed_hosts = [
@@ -440,6 +444,14 @@ class HostOriginMiddleware:
         request_origin = self._request_origin(scheme, host)
         return request_origin == normalized
 
+    def _is_bootstrap_claim_path(self, scope) -> bool:
+        path = scope.get("path") or ""
+        root_path = scope.get("root_path") or ""
+        candidates = [path]
+        if root_path and path.startswith(root_path):
+            candidates.append(path[len(root_path) :] or "/")
+        return any(candidate in self._BOOTSTRAP_CLAIM_PATHS for candidate in candidates)
+
     async def _reject_http(self, scope, receive, send, status: int, body: str) -> None:
         response = Response(content=body, status_code=status)
         await response(scope, receive, send)
@@ -481,7 +493,11 @@ class HostOriginMiddleware:
         method = (scope.get("method") or "GET").upper()
         if method in {"POST", "PUT", "PATCH", "DELETE"} and origin:
             if not self._origin_allowed(origin, scheme, host):
-                return await self._reject_http(scope, receive, send, 403, "Forbidden")
+                if method == "POST" and self._is_bootstrap_claim_path(scope):
+                    return await self.app(scope, receive, send)
+                return await self._reject_http(
+                    scope, receive, send, 403, "Origin not allowed"
+                )
 
         return await self.app(scope, receive, send)
 

--- a/src/codex_autorunner/surfaces/web/routes/auth.py
+++ b/src/codex_autorunner/surfaces/web/routes/auth.py
@@ -73,7 +73,20 @@ def _bootstrap_html() -> str:
             headers: { 'content-type': 'application/json', accept: 'application/json' },
             body: JSON.stringify({ token: token })
           });
-          if (!response.ok) throw new Error('Bootstrap claim failed.');
+          if (!response.ok) {
+            var errorText = 'Bootstrap claim failed.';
+            try {
+              var contentType = response.headers.get('content-type') || '';
+              if (contentType.indexOf('application/json') !== -1) {
+                var payload = await response.json();
+                errorText = payload && payload.detail ? payload.detail : errorText;
+              } else {
+                var text = await response.text();
+                errorText = text || errorText;
+              }
+            } catch (parseError) {}
+            throw new Error(errorText);
+          }
           window.location.replace(window.location.pathname.replace(/\/auth\/bootstrap\/?$/, '/') || '/');
         } catch (error) {
           status.textContent = 'Bootstrap claim failed.';

--- a/tests/surfaces/web/test_bootstrap_auth_routes.py
+++ b/tests/surfaces/web/test_bootstrap_auth_routes.py
@@ -64,6 +64,33 @@ def test_bootstrap_token_is_single_use(tmp_path: Path) -> None:
     assert second.status_code == 401
 
 
+def test_remote_hub_bootstrap_claim_reaches_token_validation_from_proxy_origin(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    seed_hub_files(hub_root, force=True)
+    config_path = hub_root / ".codex-autorunner/config.yml"
+    text = config_path.read_text(encoding="utf-8")
+    config_path.write_text(
+        f'{text}\nserver:\n  auth_token_env: CAR_TEST_TOKEN\n  allowed_hosts:\n    - "*"\n',
+        encoding="utf-8",
+    )
+    client = TestClient(create_hub_app(hub_root, endpoint_host="0.0.0.0"))
+
+    claim = client.post(
+        "/auth/bootstrap/claim",
+        json={"token": "deliberately-wrong"},
+        headers={
+            "host": "4173-glad-arch-jvr2.pad.dev",
+            "origin": "https://4173-glad-arch-jvr2.pad.dev",
+        },
+    )
+
+    assert claim.status_code == 401
+    assert claim.json() == {"detail": "Invalid bootstrap token"}
+    assert (hub_root / BOOTSTRAP_TOKEN_RELATIVE_PATH).exists()
+
+
 def test_bearer_token_auth_still_works_with_bootstrap_routes(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/surfaces/web/test_bootstrap_auth_routes.py
+++ b/tests/surfaces/web/test_bootstrap_auth_routes.py
@@ -91,6 +91,35 @@ def test_remote_hub_bootstrap_claim_reaches_token_validation_from_proxy_origin(
     assert (hub_root / BOOTSTRAP_TOKEN_RELATIVE_PATH).exists()
 
 
+def test_base_path_remote_hub_bootstrap_claim_reaches_token_validation_from_proxy_origin(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    seed_hub_files(hub_root, force=True)
+    config_path = hub_root / ".codex-autorunner/config.yml"
+    text = config_path.read_text(encoding="utf-8")
+    config_path.write_text(
+        f'{text}\nserver:\n  auth_token_env: CAR_TEST_TOKEN\n  allowed_hosts:\n    - "*"\n',
+        encoding="utf-8",
+    )
+    client = TestClient(
+        create_hub_app(hub_root, base_path="/car", endpoint_host="0.0.0.0")
+    )
+
+    claim = client.post(
+        "/car/auth/bootstrap/claim",
+        json={"token": "deliberately-wrong"},
+        headers={
+            "host": "4173-glad-arch-jvr2.pad.dev",
+            "origin": "https://4173-glad-arch-jvr2.pad.dev",
+        },
+    )
+
+    assert claim.status_code == 401
+    assert claim.json() == {"detail": "Invalid bootstrap token"}
+    assert (hub_root / BOOTSTRAP_TOKEN_RELATIVE_PATH).exists()
+
+
 def test_bearer_token_auth_still_works_with_bootstrap_routes(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_origin_middleware.py
+++ b/tests/test_origin_middleware.py
@@ -70,6 +70,64 @@ def test_origin_allows_bootstrap_claim_from_public_proxy_origin():
     assert messages[0]["status"] == 200
 
 
+def test_origin_allows_base_path_bootstrap_claim_from_public_proxy_origin():
+    called = False
+
+    async def dummy_app(scope, receive, send):
+        nonlocal called
+        called = True
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok", "more_body": False})
+
+    middleware = HostOriginMiddleware(dummy_app, ["*"], [], base_path="/car")
+    scope = {
+        "type": "http",
+        "path": "/car/auth/bootstrap/claim",
+        "root_path": "",
+        "headers": [
+            (b"host", b"4173-glad-arch-jvr2.pad.dev"),
+            (b"origin", b"https://4173-glad-arch-jvr2.pad.dev"),
+        ],
+        "method": "POST",
+        "scheme": "http",
+        "http_version": "1.1",
+        "query_string": b"",
+    }
+
+    messages = anyio.run(_http_call, middleware, scope)
+    assert called is True
+    assert messages[0]["status"] == 200
+
+
+def test_origin_rejects_prefixed_bootstrap_claim_without_configured_base_path():
+    called = False
+
+    async def dummy_app(scope, receive, send):
+        nonlocal called
+        called = True
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok", "more_body": False})
+
+    middleware = HostOriginMiddleware(dummy_app, ["*"], [])
+    scope = {
+        "type": "http",
+        "path": "/car/auth/bootstrap/claim",
+        "root_path": "",
+        "headers": [
+            (b"host", b"4173-glad-arch-jvr2.pad.dev"),
+            (b"origin", b"https://4173-glad-arch-jvr2.pad.dev"),
+        ],
+        "method": "POST",
+        "scheme": "http",
+        "http_version": "1.1",
+        "query_string": b"",
+    }
+
+    messages = anyio.run(_http_call, middleware, scope)
+    assert called is False
+    assert messages[0]["status"] == 403
+
+
 def test_origin_allows_no_origin_post():
     called = False
 

--- a/tests/test_origin_middleware.py
+++ b/tests/test_origin_middleware.py
@@ -38,6 +38,36 @@ def test_origin_rejects_mismatched_post():
 
     messages = anyio.run(_http_call, middleware, scope)
     assert messages[0]["status"] == 403
+    assert messages[1]["body"] == b"Origin not allowed"
+
+
+def test_origin_allows_bootstrap_claim_from_public_proxy_origin():
+    called = False
+
+    async def dummy_app(scope, receive, send):
+        nonlocal called
+        called = True
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok", "more_body": False})
+
+    middleware = HostOriginMiddleware(dummy_app, ["*"], [])
+    scope = {
+        "type": "http",
+        "path": "/auth/bootstrap/claim",
+        "root_path": "",
+        "headers": [
+            (b"host", b"4173-glad-arch-jvr2.pad.dev"),
+            (b"origin", b"https://4173-glad-arch-jvr2.pad.dev"),
+        ],
+        "method": "POST",
+        "scheme": "http",
+        "http_version": "1.1",
+        "query_string": b"",
+    }
+
+    messages = anyio.run(_http_call, middleware, scope)
+    assert called is True
+    assert messages[0]["status"] == 200
 
 
 def test_origin_allows_no_origin_post():


### PR DESCRIPTION
## Summary
- allow only `/auth/bootstrap/claim` to reach token validation when a public proxy Origin differs from the internal Host origin
- return clearer Origin rejection text and surface bootstrap failure details in the browser page
- document remote `allowed_hosts` / `allowed_origins` setup and add Pad-style regression coverage

Fixes #1766

## Validation
- `.venv/bin/python -m pytest tests/test_origin_middleware.py tests/surfaces/web/test_bootstrap_auth_routes.py`
- aggregate commit validation lane: black, ruff, import boundaries, contracts, command hints, mypy, full pytest (8720 passed), Web UI lab fast check, web lint/build/test (617 passed)
