### PR TITLE
[codex] Type managed turn assistant output

### DIFF
--- a/src/codex_autorunner/adapters/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_turns.py
@@ -87,6 +87,10 @@ from ...core.orchestration.runtime_threads import (
     begin_next_queued_runtime_thread_execution,
     begin_runtime_thread_execution,
 )
+from ...core.orchestration.turn_assistant_output import (
+    TurnAssistantOutput,
+    TurnAssistantOutputOwnership,
+)
 from ...core.orchestration.turn_output_reducer import (
     assistant_text_extends_prefix,
     build_assistant_transcript_prefix,
@@ -151,6 +155,38 @@ class ManagedThreadFinalizationResult:
     token_usage: Optional[dict[str, Any]] = None
     session_notice: Optional[str] = None
     fresh_backend_session_reason: Optional[str] = None
+    assistant_output: Optional[TurnAssistantOutput] = None
+
+    def __post_init__(self) -> None:
+        assistant_output = self.assistant_output
+        if assistant_output is None:
+            ownership: TurnAssistantOutputOwnership = (
+                "current_turn"
+                if self.status == "ok" and self.assistant_text
+                else "empty"
+            )
+            assistant_output = TurnAssistantOutput(
+                managed_thread_id=self.managed_thread_id,
+                managed_turn_id=self.managed_turn_id,
+                backend_thread_id=self.backend_thread_id,
+                backend_turn_id=None,
+                text=str(self.assistant_text or "") if self.status == "ok" else "",
+                ownership=ownership,
+                source="none",
+                provenance={"compatibility_source": "managed_thread_finalization"},
+            )
+        object.__setattr__(
+            self,
+            "assistant_output",
+            assistant_output,
+        )
+        object.__setattr__(self, "assistant_text", assistant_output.text)
+
+    @property
+    def turn_assistant_text(self) -> str:
+        if self.assistant_output is None:
+            return ""
+        return self.assistant_output.text
 
 
 FinalizeQueuedExecution = Callable[
@@ -904,7 +940,7 @@ def render_managed_thread_response_text(
     *,
     no_response_fallback: str = "(No response text returned.)",
 ) -> str:
-    assistant_text = str(finalized.assistant_text or "").strip()
+    assistant_text = finalized.turn_assistant_text.strip()
     session_notice = str(finalized.session_notice or "").strip()
     return _render_managed_thread_delivery_text(
         assistant_text=assistant_text,
@@ -979,7 +1015,7 @@ def build_managed_thread_delivery_intent(
     envelope = ManagedThreadDeliveryEnvelope(
         envelope_version="managed_thread_delivery.v1",
         final_status=finalized.status,
-        assistant_text=str(finalized.assistant_text or ""),
+        assistant_text=finalized.turn_assistant_text,
         session_notice=_normalized_optional_text(finalized.session_notice),
         error_text=_normalized_optional_text(finalized.error),
         backend_thread_id=_normalized_optional_text(finalized.backend_thread_id),
@@ -3014,10 +3050,13 @@ async def finalize_managed_thread_execution(
             prior_assistant_texts=prior_assistant_candidates,
         )
         terminal_evidence_updates: dict[str, Any] = {}
-        if turn_output.source in {"event_final", "event_stream"}:
+        if turn_output.provenance.get("candidate_source") in {
+            "event_final",
+            "event_stream",
+        }:
             terminal_evidence_updates["assistant_text_from_event_state"] = True
         terminal_evidence_updates.update(turn_output.evidence)
-        if turn_output.scope == "cumulative_transcript_trimmed":
+        if turn_output.ownership == "trimmed_from_cumulative":
             log_event(
                 logger,
                 logging.WARNING,
@@ -3030,8 +3069,9 @@ async def finalize_managed_thread_execution(
                     or started.execution.backend_id,
                     surface=surface,
                 ),
-                original_assistant_chars=len(
-                    outcome.assistant_text or event_state.best_assistant_text()
+                original_assistant_chars=max(
+                    len(outcome.assistant_text),
+                    len(event_state.best_assistant_text()),
                 ),
                 previous_assistant_chars=len(turn_output.matched_prior_text),
                 trimmed_assistant_chars=len(turn_output.text),
@@ -3040,7 +3080,7 @@ async def finalize_managed_thread_execution(
                 **terminal_evidence_trace_fields(outcome),
             )
             terminal_evidence_updates["assistant_text_trimmed_from_cumulative"] = True
-        elif turn_output.scope == "stale_prior_output":
+        elif turn_output.ownership == "rejected_stale_prior":
             log_event(
                 logger,
                 logging.ERROR,
@@ -3063,6 +3103,7 @@ async def finalize_managed_thread_execution(
             outcome = replace(
                 outcome,
                 assistant_text=turn_output.text,
+                assistant_output=turn_output,
                 terminal_evidence=dict(outcome.terminal_evidence)
                 | terminal_evidence_updates,
             )
@@ -3103,13 +3144,9 @@ async def finalize_managed_thread_execution(
     )
 
     resolved_assistant_text = (
-        outcome.assistant_text
-        if outcome.status == "ok"
-        else (
-            (outcome.assistant_text or event_state.best_assistant_text())
-            if outcome.status == "interrupted"
-            else ""
-        )
+        outcome.assistant_output.text
+        if outcome.status == "ok" and outcome.assistant_output is not None
+        else outcome.assistant_text if outcome.status == "ok" else ""
     )
     finalized_state = _resolve_thread_state(
         orchestration_service,
@@ -3393,6 +3430,7 @@ async def finalize_managed_thread_execution(
             token_usage=event_state.token_usage,
             session_notice=session_notice,
             fresh_backend_session_reason=fresh_backend_session_reason,
+            assistant_output=outcome.assistant_output,
         )
 
     if outcome.status == "interrupted":

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -560,12 +560,11 @@ def terminal_run_event_from_outcome(
     state: RuntimeThreadRunEventState,
 ) -> Completed | Failed:
     if outcome.status == "ok":
-        final_message = outcome.assistant_text
-        # Once managed-thread finalization has reduced provider output into a
-        # turn-owned envelope, that envelope is authoritative. Falling back to
-        # the runtime state's best text here can resurrect stale cumulative
-        # transcript output that the reducer already rejected.
-        if not final_message and "turn_output_scope" not in outcome.terminal_evidence:
+        if outcome.assistant_output is not None:
+            final_message = outcome.assistant_output.text
+        else:
+            final_message = outcome.assistant_text
+        if not final_message and outcome.assistant_output is None:
             final_message = state.best_assistant_text()
         return Completed(
             timestamp=now_iso(),
@@ -605,7 +604,9 @@ def recover_post_completion_outcome(
 
     if outcome.status not in {"error", "interrupted"} or not state.completed_seen:
         return outcome
-    assistant_text = outcome.assistant_text or state.best_assistant_text()
+    assistant_text = outcome.assistant_text
+    if not assistant_text:
+        assistant_text = state.best_assistant_text()
     if not isinstance(assistant_text, str) or not assistant_text.strip():
         return outcome
     return RuntimeThreadOutcome(

--- a/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
+++ b/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
@@ -23,6 +23,7 @@ from .runtime_state_events import (
     normalize_transport_returned,
 )
 from .stream_text_merge import AssistantOutputState
+from .turn_assistant_output import TurnAssistantOutput
 
 RuntimeThreadOutcomeStatus = Literal["ok", "error", "interrupted"]
 RuntimeThreadCompletionSource = Literal[
@@ -124,6 +125,7 @@ class RuntimeThreadOutcome:
     last_progress_timestamp: Optional[str] = None
     failure_cause: Optional[str] = None
     terminal_evidence: dict[str, Any] = field(default_factory=dict)
+    assistant_output: Optional[TurnAssistantOutput] = None
 
 
 def reduce_terminal_evidence(evidence: TerminalEvidence) -> TerminalEvidenceDecision:

--- a/src/codex_autorunner/core/orchestration/turn_assistant_output.py
+++ b/src/codex_autorunner/core/orchestration/turn_assistant_output.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+TurnAssistantOutputOwnership = Literal[
+    "current_turn",
+    "current_turn_stream",
+    "trimmed_from_cumulative",
+    "rejected_stale_prior",
+    "empty",
+]
+
+TurnAssistantOutputSource = Literal[
+    "adapter_final",
+    "adapter_stream",
+    "runtime_final",
+    "runtime_stream",
+    "reducer",
+    "none",
+]
+
+
+@dataclass(frozen=True)
+class TurnAssistantOutput:
+    """Turn-owned assistant output consumed after runtime finalization."""
+
+    managed_thread_id: str
+    managed_turn_id: str
+    backend_thread_id: str | None
+    backend_turn_id: str | None
+    text: str
+    ownership: TurnAssistantOutputOwnership
+    source: TurnAssistantOutputSource
+    provenance: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def matched_prior_text(self) -> str:
+        return str(self.provenance.get("matched_prior_text") or "")
+
+    @property
+    def evidence(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "turn_output_ownership": self.ownership,
+            "turn_output_source": self.source,
+        }
+        if self.matched_prior_text:
+            data["turn_output_prior_chars"] = len(self.matched_prior_text)
+        if self.provenance:
+            data["turn_output_provenance"] = dict(self.provenance)
+        return data
+
+
+__all__ = [
+    "TurnAssistantOutput",
+    "TurnAssistantOutputOwnership",
+    "TurnAssistantOutputSource",
+]

--- a/src/codex_autorunner/core/orchestration/turn_assistant_output.py
+++ b/src/codex_autorunner/core/orchestration/turn_assistant_output.py
@@ -47,7 +47,10 @@ class TurnAssistantOutput:
         if self.matched_prior_text:
             data["turn_output_prior_chars"] = len(self.matched_prior_text)
         if self.provenance:
-            data["turn_output_provenance"] = dict(self.provenance)
+            prov = dict(self.provenance)
+            prov.pop("matched_prior_text", None)
+            if prov:
+                data["turn_output_provenance"] = prov
         return data
 
 

--- a/src/codex_autorunner/core/orchestration/turn_output_reducer.py
+++ b/src/codex_autorunner/core/orchestration/turn_output_reducer.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any, Literal, Mapping, Sequence
 
 from .runtime_thread_events import RuntimeThreadRunEventState
 from .runtime_threads import RuntimeThreadOutcome
+from .turn_assistant_output import (
+    TurnAssistantOutput,
+    TurnAssistantOutputOwnership,
+    TurnAssistantOutputSource,
+)
 
 TurnOutputScope = Literal[
     "current_turn_final",
@@ -15,35 +19,57 @@ TurnOutputScope = Literal[
 ]
 
 
-@dataclass(frozen=True)
-class TurnOutputEnvelope:
-    """Turn-owned assistant output after provider/runtime transcript normalization.
+def _output_source(source: str) -> TurnAssistantOutputSource:
+    if source == "event_stream":
+        return "runtime_stream"
+    if source == "event_final":
+        return "runtime_final"
+    if source in {"outcome", "prior_guard"}:
+        return "reducer"
+    return "none"
 
-    Runtime adapters may expose provider payloads that are cumulative at the
-    backend-thread level. Core finalization must persist only text owned by the
-    active managed turn. This envelope is the explicit boundary: downstream
-    timeline, transcript, and delivery code consumes ``text`` and ``scope``
-    rather than reinterpreting thread-level "latest assistant" state.
-    """
 
-    managed_thread_id: str
-    managed_turn_id: str
-    backend_thread_id: str | None
-    backend_turn_id: str | None
-    text: str
-    scope: TurnOutputScope
-    source: str
-    matched_prior_text: str = ""
+def _scope_ownership(scope: TurnOutputScope) -> TurnAssistantOutputOwnership:
+    if scope == "current_turn_stream":
+        return "current_turn_stream"
+    if scope == "cumulative_transcript_trimmed":
+        return "trimmed_from_cumulative"
+    if scope == "stale_prior_output":
+        return "rejected_stale_prior"
+    if scope == "empty":
+        return "empty"
+    return "current_turn"
 
-    @property
-    def evidence(self) -> dict[str, Any]:
-        data: dict[str, Any] = {
-            "turn_output_scope": self.scope,
-            "turn_output_source": self.source,
-        }
-        if self.matched_prior_text:
-            data["turn_output_prior_chars"] = len(self.matched_prior_text)
-        return data
+
+def _turn_output(
+    *,
+    managed_thread_id: str,
+    managed_turn_id: str,
+    backend_thread_id: str | None,
+    backend_turn_id: str | None,
+    text: str,
+    scope: TurnOutputScope,
+    source: str,
+    matched_prior_text: str = "",
+    candidate_source: str | None = None,
+) -> TurnAssistantOutput:
+    provenance: dict[str, Any] = {
+        "reducer_scope": scope,
+    }
+    if candidate_source:
+        provenance["candidate_source"] = candidate_source
+    if matched_prior_text:
+        provenance["matched_prior_text"] = matched_prior_text
+    return TurnAssistantOutput(
+        managed_thread_id=managed_thread_id,
+        managed_turn_id=managed_turn_id,
+        backend_thread_id=backend_thread_id,
+        backend_turn_id=backend_turn_id,
+        text=text,
+        ownership=_scope_ownership(scope),
+        source=_output_source(source),
+        provenance=provenance,
+    )
 
 
 def _whitespace_insensitive_prefix_end(value: str, prefix: str) -> int | None:
@@ -156,11 +182,11 @@ def reduce_turn_output(
     outcome: RuntimeThreadOutcome,
     event_state: RuntimeThreadRunEventState,
     prior_assistant_texts: Sequence[str],
-) -> TurnOutputEnvelope:
+) -> TurnAssistantOutput:
     """Return the only assistant text downstream code may persist for this turn."""
 
     if outcome.status != "ok":
-        return TurnOutputEnvelope(
+        return _turn_output(
             managed_thread_id=managed_thread_id,
             managed_turn_id=managed_turn_id,
             backend_thread_id=backend_thread_id,
@@ -168,6 +194,7 @@ def reduce_turn_output(
             text="",
             scope="empty",
             source="non_ok_outcome",
+            candidate_source="outcome",
         )
 
     candidates = [
@@ -188,7 +215,7 @@ def reduce_turn_output(
             continue
         if source == "event_stream" and scope == "current_turn_final":
             scope = "current_turn_stream"
-        return TurnOutputEnvelope(
+        return _turn_output(
             managed_thread_id=managed_thread_id,
             managed_turn_id=managed_turn_id,
             backend_thread_id=backend_thread_id,
@@ -197,9 +224,10 @@ def reduce_turn_output(
             scope=scope,
             source=source,
             matched_prior_text=matched_prior,
+            candidate_source=source,
         )
 
-    return TurnOutputEnvelope(
+    return _turn_output(
         managed_thread_id=managed_thread_id,
         managed_turn_id=managed_turn_id,
         backend_thread_id=backend_thread_id,
@@ -208,6 +236,7 @@ def reduce_turn_output(
         scope="stale_prior_output" if stale_match else "empty",
         source="prior_guard" if stale_match else "no_output",
         matched_prior_text=stale_match,
+        candidate_source="prior_guard" if stale_match else None,
     )
 
 
@@ -240,7 +269,6 @@ def assistant_text_from_transcript_content(content: str) -> str:
 
 
 __all__ = [
-    "TurnOutputEnvelope",
     "TurnOutputScope",
     "assistant_text_extends_prefix",
     "assistant_text_from_transcript_content",

--- a/tests/adapters/chat/test_managed_thread_turns.py
+++ b/tests/adapters/chat/test_managed_thread_turns.py
@@ -2346,6 +2346,10 @@ async def test_finalize_managed_thread_execution_rejects_exact_prior_assistant_t
     )
 
     assert result.assistant_text == ""
+    assert result.assistant_output is not None
+    assert result.assistant_output.text == ""
+    assert result.assistant_output.ownership == "rejected_stale_prior"
+    assert result.assistant_output.source == "reducer"
     assert "chat.managed_thread.stale_prior_assistant_output_rejected" in caplog.text
     assert recorded_results[-1]["assistant_text"] == ""
     assert fake_hub_client.transcript_requests[-1].assistant_text == ""

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -36,6 +36,9 @@ from codex_autorunner.core.orchestration.runtime_turn_terminal_state import (
 from codex_autorunner.core.orchestration.runtime_turn_terminal_state import (
     RuntimeTurnTerminalStateMachine,
 )
+from codex_autorunner.core.orchestration.turn_assistant_output import (
+    TurnAssistantOutput,
+)
 from codex_autorunner.core.ports.run_event import (
     RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
     ApprovalRequested,
@@ -870,7 +873,16 @@ async def test_terminal_run_event_from_outcome_respects_turn_output_envelope() -
             error=None,
             backend_thread_id="thread-1",
             backend_turn_id="turn-2",
-            terminal_evidence={"turn_output_scope": "stale_prior_output"},
+            assistant_output=TurnAssistantOutput(
+                managed_thread_id="managed-thread-1",
+                managed_turn_id="turn-2",
+                backend_thread_id="thread-1",
+                backend_turn_id="turn-2",
+                text="",
+                ownership="rejected_stale_prior",
+                source="reducer",
+                provenance={"matched_prior_text": "stale prior output"},
+            ),
         ),
         state,
     )

--- a/tests/core/orchestration/test_turn_output_reducer.py
+++ b/tests/core/orchestration/test_turn_output_reducer.py
@@ -31,8 +31,9 @@ def test_reduce_turn_output_trims_cumulative_transcript_prefix() -> None:
     )
 
     assert envelope.text == "second answer"
-    assert envelope.scope == "cumulative_transcript_trimmed"
-    assert envelope.source == "outcome"
+    assert envelope.ownership == "trimmed_from_cumulative"
+    assert envelope.source == "reducer"
+    assert envelope.provenance["candidate_source"] == "outcome"
 
 
 def test_reduce_turn_output_rejects_exact_prior_output_as_stale() -> None:
@@ -49,8 +50,9 @@ def test_reduce_turn_output_rejects_exact_prior_output_as_stale() -> None:
     )
 
     assert envelope.text == ""
-    assert envelope.scope == "stale_prior_output"
-    assert envelope.source == "prior_guard"
+    assert envelope.ownership == "rejected_stale_prior"
+    assert envelope.source == "reducer"
+    assert envelope.provenance["candidate_source"] == "prior_guard"
 
 
 def test_reduce_turn_output_uses_stream_text_when_terminal_text_is_stale() -> None:
@@ -68,5 +70,6 @@ def test_reduce_turn_output_uses_stream_text_when_terminal_text_is_stale() -> No
     )
 
     assert envelope.text == "second answer"
-    assert envelope.scope == "current_turn_stream"
-    assert envelope.source == "event_stream"
+    assert envelope.ownership == "current_turn_stream"
+    assert envelope.source == "runtime_stream"
+    assert envelope.provenance["candidate_source"] == "event_stream"

--- a/tests/core/orchestration/test_turn_output_reducer.py
+++ b/tests/core/orchestration/test_turn_output_reducer.py
@@ -55,6 +55,29 @@ def test_reduce_turn_output_rejects_exact_prior_output_as_stale() -> None:
     assert envelope.provenance["candidate_source"] == "prior_guard"
 
 
+def test_turn_output_evidence_does_not_include_matched_prior_text() -> None:
+    state = RuntimeThreadRunEventState()
+    prior_text = "first answer"
+
+    envelope = reduce_turn_output(
+        managed_thread_id="thread-1",
+        managed_turn_id="turn-2",
+        backend_thread_id="session-1",
+        backend_turn_id="turn-2",
+        outcome=_outcome(prior_text),
+        event_state=state,
+        prior_assistant_texts=[prior_text],
+    )
+
+    assert envelope.matched_prior_text == prior_text
+    assert envelope.evidence["turn_output_prior_chars"] == len(prior_text)
+    assert envelope.evidence["turn_output_provenance"]["candidate_source"] == (
+        "prior_guard"
+    )
+    assert "matched_prior_text" not in envelope.evidence["turn_output_provenance"]
+    assert prior_text not in str(envelope.evidence)
+
+
 def test_reduce_turn_output_uses_stream_text_when_terminal_text_is_stale() -> None:
     state = RuntimeThreadRunEventState()
     state.note_stream_text("second answer")


### PR DESCRIPTION
## Summary

- Introduce `TurnAssistantOutput` as the typed turn-owned assistant output contract.
- Attach the typed output to `RuntimeThreadOutcome` after managed-thread reduction.
- Make terminal completion events, managed-thread rendering, transcript/result persistence, and durable delivery consume the typed output text when present.
- Remove the old `TurnOutputEnvelope`/`.scope` compatibility layer and the `turn_output_scope` magic evidence guard.
- Normalize `ManagedThreadFinalizationResult.assistant_text` from `assistant_output.text` so legacy string projections cannot diverge internally.

## Validation

- Commit hook aggregate lane passed.
- `mypy src/codex_autorunner` passed.
- Full Python suite passed: 8718 passed.
- Web UI lab fast check passed: 25 scenarios.
- Web Hub lint/build/tests passed: 63 files / 617 tests.

Fixes #1773