### PR TITLE
Add resolved chat binding CLI views

### DIFF
--- a/src/codex_autorunner/adapters/chat/surface_resolver.py
+++ b/src/codex_autorunner/adapters/chat/surface_resolver.py
@@ -59,6 +59,11 @@ def _normalize_text(value: Any) -> Optional[str]:
     return text or None
 
 
+def is_discord_channel_key(value: Any) -> bool:
+    normalized = _normalize_text(value)
+    return normalized is not None and normalized.isdigit()
+
+
 def _token_env(raw_config: Mapping[str, Any], section_name: str, default: str) -> str:
     section = raw_config.get(section_name)
     if isinstance(section, Mapping):
@@ -113,7 +118,7 @@ class DiscordSurfaceResolver:
 
     async def resolve(self, key: str) -> Optional[SurfaceInfo]:
         channel_id = _normalize_text(key)
-        if channel_id is None:
+        if channel_id is None or not is_discord_channel_key(channel_id):
             return None
         if channel_id in self._channel_cache:
             return self._channel_cache[channel_id]
@@ -352,6 +357,7 @@ __all__ = [
     "TelegramSurfaceResolver",
     "build_surface_resolvers",
     "close_surface_resolvers",
+    "is_discord_channel_key",
     "resolve_surface_bindings",
     "resolve_surface_key",
     "surface_info_display",

--- a/src/codex_autorunner/adapters/chat/surface_resolver.py
+++ b/src/codex_autorunner/adapters/chat/surface_resolver.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Protocol, Sequence
+
+from ..discord.config import DEFAULT_BOT_TOKEN_ENV as DEFAULT_DISCORD_BOT_TOKEN_ENV
+from ..discord.rest import DiscordRestClient
+from ..telegram.client import TelegramBotClient
+
+DEFAULT_TELEGRAM_BOT_TOKEN_ENV = "CAR_TELEGRAM_BOT_TOKEN"
+
+_DISCORD_CHANNEL_TYPES = {
+    0: "text",
+    1: "dm",
+    2: "voice",
+    3: "group_dm",
+    4: "category",
+    5: "announcement",
+    10: "announcement_thread",
+    11: "public_thread",
+    12: "private_thread",
+    13: "stage_voice",
+    14: "directory",
+    15: "forum",
+    16: "media",
+}
+
+
+@dataclass(frozen=True)
+class SurfaceInfo:
+    channel_id: str
+    name: str
+    surface_type: str
+    parent_name: Optional[str] = None
+    parent_id: Optional[str] = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "channel_id": self.channel_id,
+            "name": self.name,
+            "surface_type": self.surface_type,
+            "parent_name": self.parent_name,
+            "parent_id": self.parent_id,
+            "raw": self.raw,
+        }
+
+
+class SurfaceResolver(Protocol):
+    async def resolve(self, key: str) -> Optional[SurfaceInfo]: ...
+
+
+def _normalize_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _token_env(raw_config: Mapping[str, Any], section_name: str, default: str) -> str:
+    section = raw_config.get(section_name)
+    if isinstance(section, Mapping):
+        configured = _normalize_text(section.get("bot_token_env"))
+        if configured:
+            return configured
+    return default
+
+
+class DiscordSurfaceResolver:
+    def __init__(
+        self,
+        *,
+        bot_token: Optional[str],
+        concurrency: int = 5,
+        rest_client_factory: Any = None,
+    ) -> None:
+        self._bot_token = _normalize_text(bot_token)
+        self._semaphore = asyncio.Semaphore(max(1, int(concurrency)))
+        self._rest_client_factory = rest_client_factory or DiscordRestClient
+        self._channel_cache: dict[str, Optional[SurfaceInfo]] = {}
+        self._guild_cache: dict[str, Optional[dict[str, Any]]] = {}
+        self._rest_context: Any = None
+        self._rest: Any = None
+        self._rest_failed = False
+
+    async def _client(self) -> Any:
+        if not self._bot_token or self._rest_failed:
+            return None
+        if self._rest is not None:
+            return self._rest
+        try:
+            self._rest_context = self._rest_client_factory(bot_token=self._bot_token)
+            self._rest = await self._rest_context.__aenter__()
+        except Exception:
+            self._rest_failed = True
+            self._rest_context = None
+            self._rest = None
+        return self._rest
+
+    async def close(self) -> None:
+        if self._rest_context is not None:
+            await self._rest_context.__aexit__(None, None, None)
+        self._rest_context = None
+        self._rest = None
+
+    async def __aenter__(self) -> "DiscordSurfaceResolver":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.close()
+
+    async def resolve(self, key: str) -> Optional[SurfaceInfo]:
+        channel_id = _normalize_text(key)
+        if channel_id is None:
+            return None
+        if channel_id in self._channel_cache:
+            return self._channel_cache[channel_id]
+        client = await self._client()
+        if client is None:
+            self._channel_cache[channel_id] = None
+            return None
+        async with self._semaphore:
+            try:
+                channel_payload = await client.get_channel(channel_id=channel_id)
+            except Exception:
+                self._channel_cache[channel_id] = None
+                return None
+        guild_id = _normalize_text(channel_payload.get("guild_id"))
+        guild_payload: Optional[dict[str, Any]] = None
+        if guild_id:
+            guild_payload = await self._resolve_guild(guild_id)
+        info = _discord_surface_info(
+            channel_id=channel_id,
+            channel_payload=channel_payload,
+            guild_payload=guild_payload,
+        )
+        self._channel_cache[channel_id] = info
+        return info
+
+    async def _resolve_guild(self, guild_id: str) -> Optional[dict[str, Any]]:
+        if guild_id in self._guild_cache:
+            return self._guild_cache[guild_id]
+        client = await self._client()
+        if client is None:
+            self._guild_cache[guild_id] = None
+            return None
+        async with self._semaphore:
+            try:
+                raw_guild_payload = await client.get_guild(guild_id=guild_id)
+                guild_payload = (
+                    dict(raw_guild_payload)
+                    if isinstance(raw_guild_payload, Mapping)
+                    else None
+                )
+            except Exception:
+                guild_payload = None
+        self._guild_cache[guild_id] = guild_payload
+        return guild_payload
+
+
+def _discord_surface_info(
+    *,
+    channel_id: str,
+    channel_payload: Mapping[str, Any],
+    guild_payload: Optional[Mapping[str, Any]],
+) -> SurfaceInfo:
+    channel_type = channel_payload.get("type")
+    surface_type = (
+        _DISCORD_CHANNEL_TYPES.get(channel_type, str(channel_type))
+        if isinstance(channel_type, int)
+        else "unknown"
+    )
+    if channel_type == 1:
+        name = "(DM)"
+    else:
+        raw_name = _normalize_text(channel_payload.get("name"))
+        if raw_name and not raw_name.startswith("#"):
+            name = f"#{raw_name}"
+        else:
+            name = raw_name or "(unavailable)"
+    parent_name = None
+    if isinstance(guild_payload, Mapping):
+        parent_name = _normalize_text(guild_payload.get("name"))
+    return SurfaceInfo(
+        channel_id=channel_id,
+        name=name,
+        surface_type=surface_type,
+        parent_name=parent_name,
+        parent_id=_normalize_text(channel_payload.get("guild_id")),
+        raw={
+            "channel": dict(channel_payload),
+            "guild": (
+                dict(guild_payload) if isinstance(guild_payload, Mapping) else None
+            ),
+        },
+    )
+
+
+class TelegramSurfaceResolver:
+    def __init__(
+        self,
+        *,
+        bot_token: Optional[str],
+        client_factory: Any = None,
+    ) -> None:
+        self._bot_token = _normalize_text(bot_token)
+        self._client_factory = client_factory or TelegramBotClient
+        self._cache: dict[str, Optional[SurfaceInfo]] = {}
+
+    async def resolve(self, key: str) -> Optional[SurfaceInfo]:
+        surface_key = _normalize_text(key)
+        if surface_key is None:
+            return None
+        if surface_key in self._cache:
+            return self._cache[surface_key]
+        chat_id = _telegram_chat_id_from_key(surface_key)
+        if chat_id is None or not self._bot_token:
+            self._cache[surface_key] = None
+            return None
+        try:
+            async with self._client_factory(self._bot_token) as client:
+                payload = await client.get_chat(chat_id=chat_id)
+        except Exception:
+            self._cache[surface_key] = None
+            return None
+        info = _telegram_surface_info(surface_key=surface_key, payload=payload)
+        self._cache[surface_key] = info
+        return info
+
+
+def _telegram_chat_id_from_key(surface_key: str) -> Optional[str]:
+    head = surface_key.split(":", 1)[0].strip()
+    return head or None
+
+
+def _telegram_surface_info(
+    *, surface_key: str, payload: Mapping[str, Any]
+) -> SurfaceInfo:
+    title = _normalize_text(payload.get("title"))
+    username = _normalize_text(payload.get("username"))
+    first_name = _normalize_text(payload.get("first_name"))
+    last_name = _normalize_text(payload.get("last_name"))
+    full_name = " ".join(
+        part for part in (first_name, last_name) if isinstance(part, str) and part
+    ).strip()
+    if title:
+        name = title
+    elif username:
+        name = f"@{username}"
+    elif full_name:
+        name = full_name
+    else:
+        name = "(unavailable)"
+    return SurfaceInfo(
+        channel_id=surface_key,
+        name=name,
+        surface_type=_normalize_text(payload.get("type")) or "unknown",
+        parent_name=None,
+        parent_id=None,
+        raw=dict(payload),
+    )
+
+
+def build_surface_resolvers(
+    raw_config: Mapping[str, Any],
+) -> dict[str, SurfaceResolver]:
+    discord_token_env = _token_env(
+        raw_config, "discord_bot", DEFAULT_DISCORD_BOT_TOKEN_ENV
+    )
+    telegram_token_env = _token_env(
+        raw_config, "telegram_bot", DEFAULT_TELEGRAM_BOT_TOKEN_ENV
+    )
+    return {
+        "discord": DiscordSurfaceResolver(bot_token=os.environ.get(discord_token_env)),
+        "telegram": TelegramSurfaceResolver(
+            bot_token=os.environ.get(telegram_token_env)
+        ),
+    }
+
+
+async def close_surface_resolvers(resolvers: Mapping[str, SurfaceResolver]) -> None:
+    for resolver in resolvers.values():
+        close = getattr(resolver, "close", None)
+        if callable(close):
+            await close()
+
+
+async def resolve_surface_key(
+    resolvers: Mapping[str, SurfaceResolver],
+    *,
+    surface_kind: Any,
+    surface_key: Any,
+) -> Optional[SurfaceInfo]:
+    kind = _normalize_text(surface_kind)
+    key = _normalize_text(surface_key)
+    if kind is None or key is None:
+        return None
+    resolver = resolvers.get(kind)
+    if resolver is None:
+        return None
+    try:
+        return await resolver.resolve(key)
+    except Exception:
+        return None
+
+
+async def resolve_surface_bindings(
+    bindings: Sequence[Mapping[str, Any]],
+    resolvers: Mapping[str, SurfaceResolver],
+) -> dict[tuple[str, str], Optional[SurfaceInfo]]:
+    keys = sorted(
+        {
+            (surface_kind, surface_key)
+            for binding in bindings
+            for surface_kind, surface_key in [
+                (
+                    _normalize_text(binding.get("surface_kind")),
+                    _normalize_text(binding.get("surface_key")),
+                )
+            ]
+            if surface_kind is not None and surface_key is not None
+        }
+    )
+
+    async def resolve_one(surface_kind: str, surface_key: str) -> None:
+        results[(surface_kind, surface_key)] = await resolve_surface_key(
+            resolvers,
+            surface_kind=surface_kind,
+            surface_key=surface_key,
+        )
+
+    results: dict[tuple[str, str], Optional[SurfaceInfo]] = {}
+    await asyncio.gather(*(resolve_one(kind, key) for kind, key in keys))
+    return results
+
+
+def surface_info_display(info: Optional[SurfaceInfo]) -> str:
+    if info is None:
+        return "(unavailable)"
+    if info.parent_name:
+        return f"{info.parent_name} / {info.name}"
+    return info.name
+
+
+__all__ = [
+    "DEFAULT_TELEGRAM_BOT_TOKEN_ENV",
+    "DiscordSurfaceResolver",
+    "SurfaceInfo",
+    "SurfaceResolver",
+    "TelegramSurfaceResolver",
+    "build_surface_resolvers",
+    "close_surface_resolvers",
+    "resolve_surface_bindings",
+    "resolve_surface_key",
+    "surface_info_display",
+]

--- a/src/codex_autorunner/adapters/discord/cli_channels.py
+++ b/src/codex_autorunner/adapters/discord/cli_channels.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from ...core.orchestration.sqlite import open_orchestration_sqlite
+from ...core.sqlite_utils import table_columns
+from ..chat.surface_resolver import (
+    DiscordSurfaceResolver,
+    SurfaceInfo,
+    build_surface_resolvers,
+    close_surface_resolvers,
+    resolve_surface_key,
+)
+
+_UNAVAILABLE = "(unavailable)"
+_DM_GUILD_SORT = "\uffff"
+
+
+@dataclass(frozen=True)
+class DiscordChannelBinding:
+    channel_id: str
+    binding_id: Optional[str]
+    thread_target_id: Optional[str]
+    agent_id: Optional[str]
+    repo_id: Optional[str]
+    resource_kind: Optional[str]
+    resource_id: Optional[str]
+    workspace_root: Optional[str]
+    display_name: Optional[str]
+    lifecycle_status: Optional[str]
+    runtime_status: Optional[str]
+    disabled_at: Optional[str]
+    updated_at: Optional[str]
+
+
+@dataclass(frozen=True)
+class DiscordChannelRow:
+    channel_id: str
+    name: str
+    type: str
+    guild_id: Optional[str]
+    guild: str
+    bound_thread: str
+    available: bool
+    error: Optional[str]
+    bindings: tuple[DiscordChannelBinding, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "channel_id": self.channel_id,
+            "name": self.name,
+            "type": self.type,
+            "guild_id": self.guild_id,
+            "guild": None if self.guild == "-" else self.guild,
+            "bound_thread": self.bound_thread or None,
+            "available": self.available,
+            "error": self.error,
+            "bindings": [
+                {
+                    "binding_id": binding.binding_id,
+                    "thread_target_id": binding.thread_target_id,
+                    "agent_id": binding.agent_id,
+                    "repo_id": binding.repo_id,
+                    "resource_kind": binding.resource_kind,
+                    "resource_id": binding.resource_id,
+                    "workspace_root": binding.workspace_root,
+                    "display_name": binding.display_name,
+                    "lifecycle_status": binding.lifecycle_status,
+                    "runtime_status": binding.runtime_status,
+                    "disabled_at": binding.disabled_at,
+                    "updated_at": binding.updated_at,
+                }
+                for binding in self.bindings
+            ],
+        }
+
+
+def _normalize_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _select_expr(columns: set[str], alias: str, column: str) -> str:
+    if column in columns:
+        return f"{alias}.{column}"
+    return f"NULL AS {column}"
+
+
+def list_discord_channel_bindings(hub_root: Path) -> list[DiscordChannelBinding]:
+    with open_orchestration_sqlite(hub_root, durable=False, migrate=False) as conn:
+        binding_columns = table_columns(conn, "orch_bindings")
+        thread_columns = table_columns(conn, "orch_thread_targets")
+        if not binding_columns:
+            return []
+        rows = conn.execute(
+            f"""
+            SELECT
+                b.binding_id,
+                b.surface_key AS channel_id,
+                b.target_id AS thread_target_id,
+                COALESCE(b.agent_id, t.agent_id) AS agent_id,
+                COALESCE(b.repo_id, t.repo_id) AS repo_id,
+                {_select_expr(binding_columns, 'b', 'resource_kind')},
+                {_select_expr(binding_columns, 'b', 'resource_id')},
+                {_select_expr(thread_columns, 't', 'workspace_root')},
+                {_select_expr(thread_columns, 't', 'display_name')},
+                {_select_expr(thread_columns, 't', 'lifecycle_status')},
+                {_select_expr(thread_columns, 't', 'runtime_status')},
+                b.disabled_at,
+                b.updated_at
+              FROM orch_bindings AS b
+         LEFT JOIN orch_thread_targets AS t
+                ON t.thread_target_id = b.target_id
+             WHERE b.surface_kind = 'discord'
+          ORDER BY b.updated_at DESC, b.created_at DESC
+            """
+        ).fetchall()
+    bindings: list[DiscordChannelBinding] = []
+    for row in rows:
+        channel_id = _normalize_text(row["channel_id"])
+        if channel_id is None:
+            continue
+        bindings.append(
+            DiscordChannelBinding(
+                channel_id=channel_id,
+                binding_id=_normalize_text(row["binding_id"]),
+                thread_target_id=_normalize_text(row["thread_target_id"]),
+                agent_id=_normalize_text(row["agent_id"]),
+                repo_id=_normalize_text(row["repo_id"]),
+                resource_kind=_normalize_text(row["resource_kind"]),
+                resource_id=_normalize_text(row["resource_id"]),
+                workspace_root=_normalize_text(row["workspace_root"]),
+                display_name=_normalize_text(row["display_name"]),
+                lifecycle_status=_normalize_text(row["lifecycle_status"]),
+                runtime_status=_normalize_text(row["runtime_status"]),
+                disabled_at=_normalize_text(row["disabled_at"]),
+                updated_at=_normalize_text(row["updated_at"]),
+            )
+        )
+    return bindings
+
+
+def _binding_owner(binding: DiscordChannelBinding) -> str:
+    if binding.repo_id:
+        return binding.repo_id
+    if binding.resource_kind and binding.resource_id:
+        return binding.resource_id
+    if binding.workspace_root:
+        return Path(binding.workspace_root).name or binding.workspace_root
+    return "hub"
+
+
+def _is_active_binding(binding: DiscordChannelBinding) -> bool:
+    return binding.disabled_at is None and binding.lifecycle_status != "archived"
+
+
+def _bound_thread_label(bindings: tuple[DiscordChannelBinding, ...]) -> str:
+    active = [binding for binding in bindings if _is_active_binding(binding)]
+    if not active:
+        return ""
+    binding = active[0]
+    thread_id = binding.thread_target_id or ""
+    agent = binding.agent_id or "unknown"
+    return f"{thread_id[:8]} ({agent}/{_binding_owner(binding)})"
+
+
+def _group_bindings(
+    bindings: list[DiscordChannelBinding],
+) -> dict[str, tuple[DiscordChannelBinding, ...]]:
+    grouped: dict[str, list[DiscordChannelBinding]] = {}
+    for binding in bindings:
+        grouped.setdefault(binding.channel_id, []).append(binding)
+    return {
+        channel_id: tuple(channel_bindings)
+        for channel_id, channel_bindings in grouped.items()
+    }
+
+
+async def build_discord_channel_rows(
+    *,
+    hub_root: Path,
+    raw_config: Mapping[str, Any],
+    bound_only: bool = False,
+    guild_id: Optional[str] = None,
+) -> list[DiscordChannelRow]:
+    try:
+        bindings = list_discord_channel_bindings(hub_root)
+    except sqlite3.Error:
+        bindings = []
+
+    grouped = _group_bindings(bindings)
+    channel_ids = sorted(grouped)
+    resolvers = build_surface_resolvers(raw_config)
+    resolver = resolvers.get("discord")
+    try:
+        resolved = await _resolve_discord_infos(
+            channel_ids=channel_ids,
+            resolver=resolver if isinstance(resolver, DiscordSurfaceResolver) else None,
+        )
+    finally:
+        await close_surface_resolvers(resolvers)
+
+    rows: list[DiscordChannelRow] = []
+    for channel_id in channel_ids:
+        channel_bindings = grouped[channel_id]
+        if bound_only and not any(
+            _is_active_binding(binding) for binding in channel_bindings
+        ):
+            continue
+        info = resolved.get(channel_id)
+        payload_guild_id = info.parent_id if info is not None else None
+        if guild_id and payload_guild_id != guild_id:
+            continue
+        rows.append(
+            DiscordChannelRow(
+                channel_id=channel_id,
+                name=info.name if info is not None else _UNAVAILABLE,
+                type=info.surface_type if info is not None else "-",
+                guild_id=payload_guild_id,
+                guild=info.parent_name or "-" if info is not None else _UNAVAILABLE,
+                bound_thread=_bound_thread_label(channel_bindings),
+                available=info is not None,
+                error=None if info is not None else "not resolved",
+                bindings=channel_bindings,
+            )
+        )
+
+    return sorted(rows, key=_channel_sort_key)
+
+
+async def _resolve_discord_infos(
+    *,
+    channel_ids: list[str],
+    resolver: Optional[DiscordSurfaceResolver],
+) -> dict[str, Optional[SurfaceInfo]]:
+    if resolver is None:
+        return {channel_id: None for channel_id in channel_ids}
+
+    async def resolve_one(channel_id: str) -> None:
+        resolved[channel_id] = await resolve_surface_key(
+            {"discord": resolver},
+            surface_kind="discord",
+            surface_key=channel_id,
+        )
+
+    resolved: dict[str, Optional[SurfaceInfo]] = {}
+    await asyncio.gather(*(resolve_one(channel_id) for channel_id in channel_ids))
+    return resolved
+
+
+def _channel_sort_key(row: DiscordChannelRow) -> tuple[str, str, str]:
+    guild = _DM_GUILD_SORT if row.type == "dm" else row.guild.lower()
+    return (guild, row.name.lower(), row.channel_id)
+
+
+def rows_to_json(rows: list[DiscordChannelRow]) -> str:
+    return json.dumps([row.to_dict() for row in rows], indent=2, sort_keys=False)
+
+
+def rows_to_table(rows: list[DiscordChannelRow]) -> str:
+    if not rows:
+        return "No Discord channels found"
+    headers = ("CHANNEL ID", "NAME", "TYPE", "GUILD", "BOUND THREAD")
+    body = [
+        (
+            row.channel_id,
+            row.name,
+            row.type,
+            row.guild,
+            row.bound_thread or "-",
+        )
+        for row in rows
+    ]
+    widths = [
+        max(len(headers[index]), *(len(item[index]) for item in body))
+        for index in range(len(headers))
+    ]
+    lines = [
+        "  ".join(header.ljust(widths[index]) for index, header in enumerate(headers))
+    ]
+    lines.extend(
+        "  ".join(value.ljust(widths[index]) for index, value in enumerate(item))
+        for item in body
+    )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "DiscordChannelBinding",
+    "DiscordChannelRow",
+    "build_discord_channel_rows",
+    "list_discord_channel_bindings",
+    "rows_to_json",
+    "rows_to_table",
+]

--- a/src/codex_autorunner/adapters/discord/cli_channels.py
+++ b/src/codex_autorunner/adapters/discord/cli_channels.py
@@ -14,6 +14,7 @@ from ..chat.surface_resolver import (
     SurfaceInfo,
     build_surface_resolvers,
     close_surface_resolvers,
+    is_discord_channel_key,
     resolve_surface_key,
 )
 
@@ -125,7 +126,7 @@ def list_discord_channel_bindings(hub_root: Path) -> list[DiscordChannelBinding]
     bindings: list[DiscordChannelBinding] = []
     for row in rows:
         channel_id = _normalize_text(row["channel_id"])
-        if channel_id is None:
+        if channel_id is None or not is_discord_channel_key(channel_id):
             continue
         bindings.append(
             DiscordChannelBinding(

--- a/src/codex_autorunner/adapters/telegram/cli_chats.py
+++ b/src/codex_autorunner/adapters/telegram/cli_chats.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from ...core.orchestration.sqlite import open_orchestration_sqlite
+from ...core.sqlite_utils import table_columns
+from ..chat.surface_resolver import (
+    SurfaceInfo,
+    build_surface_resolvers,
+    close_surface_resolvers,
+    resolve_surface_key,
+)
+
+_UNAVAILABLE = "(unavailable)"
+
+
+@dataclass(frozen=True)
+class TelegramChatBinding:
+    chat_key: str
+    binding_id: Optional[str]
+    thread_target_id: Optional[str]
+    agent_id: Optional[str]
+    repo_id: Optional[str]
+    resource_kind: Optional[str]
+    resource_id: Optional[str]
+    workspace_root: Optional[str]
+    lifecycle_status: Optional[str]
+    disabled_at: Optional[str]
+
+
+@dataclass(frozen=True)
+class TelegramChatRow:
+    chat_key: str
+    name: str
+    type: str
+    bound_thread: str
+    available: bool
+    error: Optional[str]
+    bindings: tuple[TelegramChatBinding, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "chat_key": self.chat_key,
+            "name": self.name,
+            "type": self.type,
+            "bound_thread": self.bound_thread or None,
+            "available": self.available,
+            "error": self.error,
+            "bindings": [
+                {
+                    "binding_id": binding.binding_id,
+                    "thread_target_id": binding.thread_target_id,
+                    "agent_id": binding.agent_id,
+                    "repo_id": binding.repo_id,
+                    "resource_kind": binding.resource_kind,
+                    "resource_id": binding.resource_id,
+                    "workspace_root": binding.workspace_root,
+                    "lifecycle_status": binding.lifecycle_status,
+                    "disabled_at": binding.disabled_at,
+                }
+                for binding in self.bindings
+            ],
+        }
+
+
+def _normalize_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _select_expr(columns: set[str], alias: str, column: str) -> str:
+    if column in columns:
+        return f"{alias}.{column}"
+    return f"NULL AS {column}"
+
+
+def list_telegram_chat_bindings(hub_root: Path) -> list[TelegramChatBinding]:
+    with open_orchestration_sqlite(hub_root, durable=False, migrate=False) as conn:
+        binding_columns = table_columns(conn, "orch_bindings")
+        thread_columns = table_columns(conn, "orch_thread_targets")
+        if not binding_columns:
+            return []
+        rows = conn.execute(
+            f"""
+            SELECT
+                b.binding_id,
+                b.surface_key AS chat_key,
+                b.target_id AS thread_target_id,
+                COALESCE(b.agent_id, t.agent_id) AS agent_id,
+                COALESCE(b.repo_id, t.repo_id) AS repo_id,
+                {_select_expr(binding_columns, 'b', 'resource_kind')},
+                {_select_expr(binding_columns, 'b', 'resource_id')},
+                {_select_expr(thread_columns, 't', 'workspace_root')},
+                {_select_expr(thread_columns, 't', 'lifecycle_status')},
+                b.disabled_at
+              FROM orch_bindings AS b
+         LEFT JOIN orch_thread_targets AS t
+                ON t.thread_target_id = b.target_id
+             WHERE b.surface_kind = 'telegram'
+          ORDER BY b.updated_at DESC, b.created_at DESC
+            """
+        ).fetchall()
+    bindings: list[TelegramChatBinding] = []
+    for row in rows:
+        chat_key = _normalize_text(row["chat_key"])
+        if chat_key is None:
+            continue
+        bindings.append(
+            TelegramChatBinding(
+                chat_key=chat_key,
+                binding_id=_normalize_text(row["binding_id"]),
+                thread_target_id=_normalize_text(row["thread_target_id"]),
+                agent_id=_normalize_text(row["agent_id"]),
+                repo_id=_normalize_text(row["repo_id"]),
+                resource_kind=_normalize_text(row["resource_kind"]),
+                resource_id=_normalize_text(row["resource_id"]),
+                workspace_root=_normalize_text(row["workspace_root"]),
+                lifecycle_status=_normalize_text(row["lifecycle_status"]),
+                disabled_at=_normalize_text(row["disabled_at"]),
+            )
+        )
+    return bindings
+
+
+async def build_telegram_chat_rows(
+    *,
+    hub_root: Path,
+    raw_config: Mapping[str, Any],
+    bound_only: bool = False,
+) -> list[TelegramChatRow]:
+    try:
+        bindings = list_telegram_chat_bindings(hub_root)
+    except sqlite3.Error:
+        bindings = []
+    grouped = _group_bindings(bindings)
+    chat_keys = sorted(grouped)
+    resolvers = build_surface_resolvers(raw_config)
+    try:
+        resolved = await _resolve_telegram_infos(
+            chat_keys=chat_keys, resolvers=resolvers
+        )
+    finally:
+        await close_surface_resolvers(resolvers)
+    rows: list[TelegramChatRow] = []
+    for chat_key in chat_keys:
+        chat_bindings = grouped[chat_key]
+        if bound_only and not any(
+            _is_active_binding(binding) for binding in chat_bindings
+        ):
+            continue
+        info = resolved.get(chat_key)
+        rows.append(
+            TelegramChatRow(
+                chat_key=chat_key,
+                name=info.name if info is not None else _UNAVAILABLE,
+                type=info.surface_type if info is not None else "-",
+                bound_thread=_bound_thread_label(chat_bindings),
+                available=info is not None,
+                error=None if info is not None else "not resolved",
+                bindings=chat_bindings,
+            )
+        )
+    return sorted(rows, key=lambda row: (row.name.lower(), row.chat_key))
+
+
+async def _resolve_telegram_infos(
+    *,
+    chat_keys: list[str],
+    resolvers: Mapping[str, Any],
+) -> dict[str, Optional[SurfaceInfo]]:
+    async def resolve_one(chat_key: str) -> None:
+        resolved[chat_key] = await resolve_surface_key(
+            resolvers,
+            surface_kind="telegram",
+            surface_key=chat_key,
+        )
+
+    resolved: dict[str, Optional[SurfaceInfo]] = {}
+    await asyncio.gather(*(resolve_one(chat_key) for chat_key in chat_keys))
+    return resolved
+
+
+def _group_bindings(
+    bindings: list[TelegramChatBinding],
+) -> dict[str, tuple[TelegramChatBinding, ...]]:
+    grouped: dict[str, list[TelegramChatBinding]] = {}
+    for binding in bindings:
+        grouped.setdefault(binding.chat_key, []).append(binding)
+    return {chat_key: tuple(items) for chat_key, items in grouped.items()}
+
+
+def _binding_owner(binding: TelegramChatBinding) -> str:
+    if binding.repo_id:
+        return binding.repo_id
+    if binding.resource_kind and binding.resource_id:
+        return binding.resource_id
+    if binding.workspace_root:
+        return Path(binding.workspace_root).name or binding.workspace_root
+    return "hub"
+
+
+def _is_active_binding(binding: TelegramChatBinding) -> bool:
+    return binding.disabled_at is None and binding.lifecycle_status != "archived"
+
+
+def _bound_thread_label(bindings: tuple[TelegramChatBinding, ...]) -> str:
+    active = [binding for binding in bindings if _is_active_binding(binding)]
+    if not active:
+        return ""
+    binding = active[0]
+    thread_id = binding.thread_target_id or ""
+    agent = binding.agent_id or "unknown"
+    return f"{thread_id[:8]} ({agent}/{_binding_owner(binding)})"
+
+
+def rows_to_json(rows: list[TelegramChatRow]) -> str:
+    return json.dumps([row.to_dict() for row in rows], indent=2, sort_keys=False)
+
+
+def rows_to_table(rows: list[TelegramChatRow]) -> str:
+    if not rows:
+        return "No Telegram chats found"
+    headers = ("CHAT KEY", "NAME", "TYPE", "BOUND THREAD")
+    body = [
+        (
+            row.chat_key,
+            row.name,
+            row.type,
+            row.bound_thread or "-",
+        )
+        for row in rows
+    ]
+    widths = [
+        max(len(headers[index]), *(len(item[index]) for item in body))
+        for index in range(len(headers))
+    ]
+    lines = [
+        "  ".join(header.ljust(widths[index]) for index, header in enumerate(headers))
+    ]
+    lines.extend(
+        "  ".join(value.ljust(widths[index]) for index, value in enumerate(item))
+        for item in body
+    )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "TelegramChatBinding",
+    "TelegramChatRow",
+    "build_telegram_chat_rows",
+    "list_telegram_chat_bindings",
+    "rows_to_json",
+    "rows_to_table",
+]

--- a/src/codex_autorunner/surfaces/cli/commands/discord.py
+++ b/src/codex_autorunner/surfaces/cli/commands/discord.py
@@ -11,6 +11,11 @@ from typing import Any, Awaitable, Callable, Optional
 
 import typer
 
+from ....adapters.discord.cli_channels import (
+    build_discord_channel_rows,
+    rows_to_json,
+    rows_to_table,
+)
 from ....adapters.discord.command_registry import sync_commands
 from ....adapters.discord.commands import build_application_commands
 from ....adapters.discord.config import DiscordBotConfig, DiscordBotConfigError
@@ -288,6 +293,43 @@ def register_discord_commands(
         """Run Discord health checks (placeholder; not implemented)."""
         _require_discord_feature(require_optional_feature)
         raise NotImplementedError("Discord health check is not implemented yet.")
+
+    @app.command("channels")
+    def discord_channels(
+        path: Optional[Path] = typer.Option(
+            None, "--path", help="Repo or hub root path"
+        ),
+        json_output: bool = typer.Option(False, "--json", help="Emit JSON output"),
+        bound_only: bool = typer.Option(
+            False,
+            "--bound-only",
+            help="Only show channels with active thread bindings",
+        ),
+        guild_id: Optional[str] = typer.Option(
+            None, "--guild", help="Filter by Discord guild ID"
+        ),
+    ) -> None:
+        """List Discord channels known through PMA bindings."""
+        _require_discord_feature(require_optional_feature)
+        try:
+            config = load_hub_config(path or Path.cwd())
+        except ConfigError as exc:
+            raise_exit(str(exc), cause=exc)
+
+        normalized_guild_id = (
+            str(guild_id).strip() if isinstance(guild_id, str) else None
+        )
+        if normalized_guild_id == "":
+            normalized_guild_id = None
+        rows = asyncio.run(
+            build_discord_channel_rows(
+                hub_root=config.root,
+                raw_config=config.raw if isinstance(config.raw, dict) else {},
+                bound_only=bound_only,
+                guild_id=normalized_guild_id,
+            )
+        )
+        typer.echo(rows_to_json(rows) if json_output else rows_to_table(rows))
 
     @app.command("trace")
     def discord_trace(

--- a/src/codex_autorunner/surfaces/cli/commands/telegram.py
+++ b/src/codex_autorunner/surfaces/cli/commands/telegram.py
@@ -9,6 +9,15 @@ from typing import Any, Callable, Optional
 
 import typer
 
+from ....adapters.telegram.cli_chats import (
+    build_telegram_chat_rows,
+)
+from ....adapters.telegram.cli_chats import (
+    rows_to_json as telegram_chat_rows_to_json,
+)
+from ....adapters.telegram.cli_chats import (
+    rows_to_table as telegram_chat_rows_to_table,
+)
 from ....adapters.telegram.client import TelegramAPIError, TelegramBotClient
 from ....adapters.telegram.service import (
     TelegramBotConfig,
@@ -319,6 +328,41 @@ def register_telegram_commands(
             asyncio.run(_run())
         except TelegramAPIError as exc:
             raise_exit(f"Telegram health check failed: {exc}", cause=exc)
+
+    @telegram_app.command("chats")
+    def telegram_chats(
+        path: Optional[Path] = typer.Option(
+            None, "--path", help="Repo or hub root path"
+        ),
+        json_output: bool = typer.Option(False, "--json", help="Emit JSON output"),
+        bound_only: bool = typer.Option(
+            False,
+            "--bound-only",
+            help="Only show chats with active thread bindings",
+        ),
+    ) -> None:
+        """List Telegram chats known through PMA bindings."""
+        require_optional_feature(
+            feature="telegram",
+            deps=[("httpx", "httpx")],
+            extra="telegram",
+        )
+        try:
+            config = load_hub_config(path or Path.cwd())
+        except ConfigError as exc:
+            raise_exit(str(exc), cause=exc)
+        rows = asyncio.run(
+            build_telegram_chat_rows(
+                hub_root=config.root,
+                raw_config=config.raw if isinstance(config.raw, dict) else {},
+                bound_only=bound_only,
+            )
+        )
+        typer.echo(
+            telegram_chat_rows_to_json(rows)
+            if json_output
+            else telegram_chat_rows_to_table(rows)
+        )
 
     @telegram_app.command("state-check")
     def telegram_state_check(

--- a/src/codex_autorunner/surfaces/cli/pma_binding_commands.py
+++ b/src/codex_autorunner/surfaces/cli/pma_binding_commands.py
@@ -1,11 +1,19 @@
 """PMA binding CLI commands (non-thread binding queries)."""
 
+import asyncio
 from pathlib import Path
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 import httpx
 import typer
 
+from ...adapters.chat.surface_resolver import (
+    SurfaceInfo,
+    build_surface_resolvers,
+    close_surface_resolvers,
+    resolve_surface_bindings,
+    surface_info_display,
+)
 from ...core.config import load_hub_config
 from .hub_control_plane_client import (
     build_hub_control_plane_url,
@@ -40,6 +48,11 @@ def pma_binding_list(
         False, "--include-disabled", help="Include disabled bindings"
     ),
     limit: int = typer.Option(200, "--limit", min=1, help="Maximum rows to return"),
+    resolve: bool = typer.Option(
+        False,
+        "--resolve",
+        help="Resolve surface keys to human-readable channel/chat names",
+    ),
     output_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
     path: Optional[Path] = hub_root_path_option(),
 ):
@@ -79,11 +92,30 @@ def pma_binding_list(
     except (ValueError, OSError) as exc:  # intentional: top-level error handler
         exit_with_error(f"Error: {exc}", cause=None)
 
+    bindings = data.get("bindings", []) if isinstance(data, dict) else []
+    resolved: dict[tuple[str, str], Optional[SurfaceInfo]] = {}
+    if resolve and isinstance(bindings, list):
+        resolved = asyncio.run(
+            _resolve_bindings_for_cli(
+                bindings=bindings,
+                raw_config=config.raw if isinstance(config.raw, dict) else {},
+            )
+        )
+        if output_json and isinstance(data, dict):
+            data = dict(data)
+            data["bindings"] = [
+                (
+                    _binding_with_resolved_surface(binding, resolved)
+                    if isinstance(binding, dict)
+                    else binding
+                )
+                for binding in bindings
+            ]
+
     if output_json:
         echo_json(data)
         return
 
-    bindings = data.get("bindings", []) if isinstance(data, dict) else []
     if not isinstance(bindings, list) or not bindings:
         typer.echo("No bindings found")
         return
@@ -97,6 +129,7 @@ def pma_binding_list(
                     str(binding.get("binding_id") or "")[:12],
                     f"surface={binding.get('surface_kind') or ''}",
                     f"key={binding.get('surface_key') or ''}",
+                    _resolved_binding_label(binding, resolved) if resolve else "",
                     f"thread={binding.get('thread_target_id') or ''}"[:20],
                     f"agent={binding.get('agent_id') or ''}",
                     format_resource_owner_label(binding),
@@ -104,6 +137,51 @@ def pma_binding_list(
             ).strip()
             + disabled
         )
+
+
+async def _resolve_bindings_for_cli(
+    *,
+    bindings: list[Any],
+    raw_config: Mapping[str, Any],
+) -> dict[tuple[str, str], Optional[SurfaceInfo]]:
+    mapping_bindings = [binding for binding in bindings if isinstance(binding, Mapping)]
+    resolvers = build_surface_resolvers(raw_config)
+    try:
+        return await resolve_surface_bindings(mapping_bindings, resolvers)
+    finally:
+        await close_surface_resolvers(resolvers)
+
+
+def _binding_surface_lookup_key(
+    binding: Mapping[str, Any],
+) -> Optional[tuple[str, str]]:
+    surface_kind = binding.get("surface_kind")
+    surface_key = binding.get("surface_key")
+    if not isinstance(surface_kind, str) or not surface_kind.strip():
+        return None
+    if not isinstance(surface_key, str) or not surface_key.strip():
+        return None
+    return (surface_kind.strip(), surface_key.strip())
+
+
+def _resolved_binding_label(
+    binding: Mapping[str, Any],
+    resolved: Mapping[tuple[str, str], Optional[SurfaceInfo]],
+) -> str:
+    lookup_key = _binding_surface_lookup_key(binding)
+    info = resolved.get(lookup_key) if lookup_key is not None else None
+    return f"name={surface_info_display(info)}"
+
+
+def _binding_with_resolved_surface(
+    binding: dict[str, Any],
+    resolved: Mapping[tuple[str, str], Optional[SurfaceInfo]],
+) -> dict[str, Any]:
+    enriched = dict(binding)
+    lookup_key = _binding_surface_lookup_key(binding)
+    info = resolved.get(lookup_key) if lookup_key is not None else None
+    enriched["surface_resolved"] = info.to_dict() if info is not None else None
+    return enriched
 
 
 def pma_binding_active(

--- a/tests/routes/test_agents_routes.py
+++ b/tests/routes/test_agents_routes.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from codex_autorunner.adapters.chat.agents import ChatAgentProfileOption
 from codex_autorunner.agents.types import ModelCatalog, ModelSpec
+from codex_autorunner.surfaces.web.routes import agents as agents_routes
 from codex_autorunner.surfaces.web.routes.agents import build_agents_routes
 from codex_autorunner.surfaces.web.routes.agents_helpers import (
     normalize_path_agent_id,
@@ -222,9 +223,13 @@ def test_list_agents_includes_expected_capabilities() -> None:
 def test_list_agents_fallback_does_not_advertise_unavailable_capabilities(
     monkeypatch,
 ) -> None:
+    monkeypatch.setattr(agents_routes, "get_available_agents", lambda _state: {})
     monkeypatch.setattr(
-        "codex_autorunner.surfaces.web.routes.agents.get_available_agents",
-        lambda _state: {},
+        agents_routes,
+        "get_agent_descriptor",
+        lambda agent_id, _state=None: (
+            SimpleNamespace(id="codex", name="Codex") if agent_id == "codex" else None
+        ),
     )
     client = _build_client(with_supervisors=True)
 

--- a/tests/surfaces/cli/test_telegram_cli_registered.py
+++ b/tests/surfaces/cli/test_telegram_cli_registered.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from codex_autorunner.cli import app
+
+
+def test_telegram_cli_chats_registered() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["telegram", "--help"])
+    assert result.exit_code == 0
+    assert "chats" in result.stdout

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -675,8 +675,14 @@ _SIDE_PROCESS_BOUNDARY_ALLOWLIST: dict[str, list[str]] = {
         "build_ticket_flow_orchestration_service -- ALLOWED: ticket flow uses per-workspace orchestration SQLite",
         "seed_repo_files -- ALLOWED: bootstrap seeding runs during startup before hub handshake completes",
     ],
+    "adapters/discord/cli_channels.py": [
+        "open_orchestration_sqlite -- ALLOWED: CLI-only diagnostic reads hub binding rows",
+    ],
     "adapters/telegram/service.py": [
         "AppServerThreadRegistry -- ALLOWED: protocol-local PMA thread ID mapping for topic routing",
+    ],
+    "adapters/telegram/cli_chats.py": [
+        "open_orchestration_sqlite -- ALLOWED: CLI-only diagnostic reads hub binding rows",
     ],
     "adapters/telegram/handlers/commands/execution.py": [
         "AppServerThreadRegistry -- ALLOWED: protocol-local PMA thread ID mapping for topic routing",

--- a/tests/test_cli_discord_channels.py
+++ b/tests/test_cli_discord_channels.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+from codex_autorunner.cli import app
+from codex_autorunner.core.orchestration.sqlite import (
+    initialize_orchestration_sqlite,
+    open_orchestration_sqlite,
+)
+
+runner = CliRunner()
+
+
+class _FakeDiscordRestClient:
+    channels: dict[str, dict[str, Any]] = {}
+    guilds: dict[str, dict[str, Any]] = {}
+
+    def __init__(self, *, bot_token: str) -> None:
+        self.bot_token = bot_token
+
+    async def __aenter__(self) -> "_FakeDiscordRestClient":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def get_channel(self, *, channel_id: str) -> dict[str, Any]:
+        payload = self.channels.get(channel_id)
+        if payload is None:
+            raise RuntimeError("missing channel")
+        return dict(payload)
+
+    async def get_guild(self, *, guild_id: str) -> dict[str, Any]:
+        return dict(self.guilds.get(guild_id, {}))
+
+
+def _insert_discord_binding(
+    hub_root: Path,
+    *,
+    channel_id: str,
+    thread_id: str,
+    agent: str = "codex",
+    repo_id: str = "repo",
+    lifecycle_status: str = "idle",
+    disabled_at: str | None = None,
+) -> None:
+    initialize_orchestration_sqlite(hub_root, durable=False)
+    with open_orchestration_sqlite(hub_root, durable=False) as conn:
+        conn.execute(
+            """
+            INSERT INTO orch_thread_targets (
+                thread_target_id,
+                agent_id,
+                repo_id,
+                resource_kind,
+                resource_id,
+                workspace_root,
+                display_name,
+                lifecycle_status,
+                runtime_status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, 'repo', ?, ?, ?, ?, 'idle', ?, ?)
+            """,
+            (
+                thread_id,
+                agent,
+                repo_id,
+                repo_id,
+                str(hub_root / "worktrees" / repo_id),
+                repo_id,
+                lifecycle_status,
+                "2026-05-14T00:00:00Z",
+                "2026-05-14T00:00:00Z",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO orch_bindings (
+                binding_id,
+                surface_kind,
+                surface_key,
+                target_kind,
+                target_id,
+                agent_id,
+                repo_id,
+                resource_kind,
+                resource_id,
+                mode,
+                created_at,
+                updated_at,
+                disabled_at
+            )
+            VALUES (?, 'discord', ?, 'thread', ?, ?, ?, 'repo', ?, 'bound', ?, ?, ?)
+            """,
+            (
+                f"binding-{channel_id}",
+                channel_id,
+                thread_id,
+                agent,
+                repo_id,
+                repo_id,
+                "2026-05-14T00:00:00Z",
+                "2026-05-14T00:00:00Z",
+                disabled_at,
+            ),
+        )
+
+
+def test_discord_channels_help_registered() -> None:
+    result = runner.invoke(app, ["discord", "--help"])
+    assert result.exit_code == 0
+    assert "channels" in result.stdout
+
+
+def test_discord_channels_outputs_resolved_table(hub_env, monkeypatch) -> None:
+    _insert_discord_binding(
+        hub_env.hub_root,
+        channel_id="1495134681929355404",
+        thread_id="21ee4260-0000-0000-0000-000000000000",
+        agent="codex",
+        repo_id="agent-nexus-saas",
+    )
+    _FakeDiscordRestClient.channels = {
+        "1495134681929355404": {
+            "id": "1495134681929355404",
+            "name": "anx-saas",
+            "type": 0,
+            "guild_id": "guild-1",
+        }
+    }
+    _FakeDiscordRestClient.guilds = {
+        "guild-1": {"id": "guild-1", "name": "David's Server"}
+    }
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.chat.surface_resolver.DiscordRestClient",
+        _FakeDiscordRestClient,
+    )
+    monkeypatch.setenv("CAR_DISCORD_BOT_TOKEN", "token")
+
+    result = runner.invoke(
+        app, ["discord", "channels", "--path", str(hub_env.hub_root)]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "CHANNEL ID" in result.output
+    assert "#anx-saas" in result.output
+    assert "text" in result.output
+    assert "David's Server" in result.output
+    assert "21ee4260 (codex/agent-nexus-saas)" in result.output
+
+
+def test_discord_channels_json_and_bound_only_filters(hub_env, monkeypatch) -> None:
+    _insert_discord_binding(
+        hub_env.hub_root,
+        channel_id="1495134681929355404",
+        thread_id="21ee4260-0000-0000-0000-000000000000",
+    )
+    _insert_discord_binding(
+        hub_env.hub_root,
+        channel_id="1488827014600331415",
+        thread_id="1a2a98a4-0000-0000-0000-000000000000",
+        lifecycle_status="archived",
+        disabled_at="2026-05-14T00:01:00Z",
+    )
+    _FakeDiscordRestClient.channels = {
+        "1495134681929355404": {
+            "id": "1495134681929355404",
+            "name": "discord-2",
+            "type": 0,
+            "guild_id": "guild-1",
+        },
+        "1488827014600331415": {
+            "id": "1488827014600331415",
+            "type": 1,
+        },
+    }
+    _FakeDiscordRestClient.guilds = {
+        "guild-1": {"id": "guild-1", "name": "David's Server"}
+    }
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.chat.surface_resolver.DiscordRestClient",
+        _FakeDiscordRestClient,
+    )
+    monkeypatch.setenv("CAR_DISCORD_BOT_TOKEN", "token")
+
+    result = runner.invoke(
+        app,
+        [
+            "discord",
+            "channels",
+            "--json",
+            "--bound-only",
+            "--guild",
+            "guild-1",
+            "--path",
+            str(hub_env.hub_root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert [row["channel_id"] for row in payload] == ["1495134681929355404"]
+    assert payload[0]["guild"] == "David's Server"
+    assert payload[0]["type"] == "text"
+
+
+def test_discord_channels_degrades_when_token_missing(hub_env, monkeypatch) -> None:
+    _insert_discord_binding(
+        hub_env.hub_root,
+        channel_id="1495134681929355404",
+        thread_id="21ee4260-0000-0000-0000-000000000000",
+    )
+    monkeypatch.delenv("CAR_DISCORD_BOT_TOKEN", raising=False)
+
+    result = runner.invoke(
+        app, ["discord", "channels", "--path", str(hub_env.hub_root)]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "1495134681929355404" in result.output
+    assert "(unavailable)" in result.output

--- a/tests/test_cli_discord_channels.py
+++ b/tests/test_cli_discord_channels.py
@@ -18,6 +18,7 @@ runner = CliRunner()
 class _FakeDiscordRestClient:
     channels: dict[str, dict[str, Any]] = {}
     guilds: dict[str, dict[str, Any]] = {}
+    channel_calls: list[str] = []
 
     def __init__(self, *, bot_token: str) -> None:
         self.bot_token = bot_token
@@ -29,6 +30,7 @@ class _FakeDiscordRestClient:
         return None
 
     async def get_channel(self, *, channel_id: str) -> dict[str, Any]:
+        self.channel_calls.append(channel_id)
         payload = self.channels.get(channel_id)
         if payload is None:
             raise RuntimeError("missing channel")
@@ -137,6 +139,7 @@ def test_discord_channels_outputs_resolved_table(hub_env, monkeypatch) -> None:
     _FakeDiscordRestClient.guilds = {
         "guild-1": {"id": "guild-1", "name": "David's Server"}
     }
+    _FakeDiscordRestClient.channel_calls = []
     monkeypatch.setattr(
         "codex_autorunner.adapters.chat.surface_resolver.DiscordRestClient",
         _FakeDiscordRestClient,
@@ -183,6 +186,7 @@ def test_discord_channels_json_and_bound_only_filters(hub_env, monkeypatch) -> N
     _FakeDiscordRestClient.guilds = {
         "guild-1": {"id": "guild-1", "name": "David's Server"}
     }
+    _FakeDiscordRestClient.channel_calls = []
     monkeypatch.setattr(
         "codex_autorunner.adapters.chat.surface_resolver.DiscordRestClient",
         _FakeDiscordRestClient,
@@ -208,6 +212,46 @@ def test_discord_channels_json_and_bound_only_filters(hub_env, monkeypatch) -> N
     assert [row["channel_id"] for row in payload] == ["1495134681929355404"]
     assert payload[0]["guild"] == "David's Server"
     assert payload[0]["type"] == "text"
+
+
+def test_discord_channels_excludes_notification_bindings(hub_env, monkeypatch) -> None:
+    _insert_discord_binding(
+        hub_env.hub_root,
+        channel_id="1495134681929355404",
+        thread_id="21ee4260-0000-0000-0000-000000000000",
+    )
+    _insert_discord_binding(
+        hub_env.hub_root,
+        channel_id="notification:notif-123",
+        thread_id="1a2a98a4-0000-0000-0000-000000000000",
+    )
+    _FakeDiscordRestClient.channels = {
+        "1495134681929355404": {
+            "id": "1495134681929355404",
+            "name": "discord-2",
+            "type": 0,
+            "guild_id": "guild-1",
+        },
+    }
+    _FakeDiscordRestClient.guilds = {
+        "guild-1": {"id": "guild-1", "name": "David's Server"}
+    }
+    _FakeDiscordRestClient.channel_calls = []
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.chat.surface_resolver.DiscordRestClient",
+        _FakeDiscordRestClient,
+    )
+    monkeypatch.setenv("CAR_DISCORD_BOT_TOKEN", "token")
+
+    result = runner.invoke(
+        app, ["discord", "channels", "--json", "--path", str(hub_env.hub_root)]
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert [row["channel_id"] for row in payload] == ["1495134681929355404"]
+    assert "notification:notif-123" not in result.output
+    assert _FakeDiscordRestClient.channel_calls == ["1495134681929355404"]
 
 
 def test_discord_channels_degrades_when_token_missing(hub_env, monkeypatch) -> None:

--- a/tests/test_surface_resolver.py
+++ b/tests/test_surface_resolver.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+
+from codex_autorunner.adapters.chat.surface_resolver import (
+    SurfaceInfo,
+    resolve_surface_bindings,
+)
+
+
+class _FakeResolver:
+    def __init__(self, *, prefix: str) -> None:
+        self.prefix = prefix
+        self.calls: list[str] = []
+
+    async def resolve(self, key: str) -> Optional[SurfaceInfo]:
+        self.calls.append(key)
+        return SurfaceInfo(
+            channel_id=key,
+            name=f"{self.prefix}-{key}",
+            surface_type="text",
+            raw={"key": key},
+        )
+
+
+@pytest.mark.asyncio
+async def test_surface_resolver_dispatches_by_surface_and_deduplicates() -> None:
+    discord = _FakeResolver(prefix="discord")
+    telegram = _FakeResolver(prefix="telegram")
+
+    resolved = await resolve_surface_bindings(
+        [
+            {"surface_kind": "discord", "surface_key": "123"},
+            {"surface_kind": "telegram", "surface_key": "-100:root"},
+            {"surface_kind": "discord", "surface_key": "123"},
+            {"surface_kind": "unknown", "surface_key": "ignored"},
+        ],
+        {"discord": discord, "telegram": telegram},
+    )
+
+    assert discord.calls == ["123"]
+    assert telegram.calls == ["-100:root"]
+    assert resolved[("discord", "123")].name == "discord-123"
+    assert resolved[("telegram", "-100:root")].name == "telegram--100:root"
+    assert resolved[("unknown", "ignored")] is None

--- a/tests/test_surface_resolver.py
+++ b/tests/test_surface_resolver.py
@@ -5,6 +5,7 @@ from typing import Optional
 import pytest
 
 from codex_autorunner.adapters.chat.surface_resolver import (
+    DiscordSurfaceResolver,
     SurfaceInfo,
     resolve_surface_bindings,
 )
@@ -45,3 +46,10 @@ async def test_surface_resolver_dispatches_by_surface_and_deduplicates() -> None
     assert resolved[("discord", "123")].name == "discord-123"
     assert resolved[("telegram", "-100:root")].name == "telegram--100:root"
     assert resolved[("unknown", "ignored")] is None
+
+
+@pytest.mark.asyncio
+async def test_discord_resolver_ignores_non_channel_keys() -> None:
+    resolver = DiscordSurfaceResolver(bot_token="token")
+
+    assert await resolver.resolve("notification:notif-123") is None


### PR DESCRIPTION
## Summary
- add a shared surface resolver protocol for Discord and Telegram binding keys
- add `car pma binding list --resolve` as the primary surface-agnostic operator view
- keep `car discord channels` as a convenience wrapper backed by the shared Discord resolver
- add `car telegram chats` using the existing Telegram `get_chat` client

## Verification
- `.venv/bin/python -m pytest -q tests/test_cli_discord_channels.py tests/test_surface_resolver.py tests/surfaces/cli/test_discord_cli_registered.py tests/surfaces/cli/test_telegram_cli_registered.py tests/test_architecture_boundaries.py::test_side_process_shared_state_imports_are_allowlisted`
- `.venv/bin/python -m codex_autorunner.cli pma binding list --resolve --path /Users/dazheng/car-workspace --limit 5`
- `.venv/bin/python -m codex_autorunner.cli pma binding list --resolve --json --path /Users/dazheng/car-workspace --limit 3 | .venv/bin/python -m json.tool >/tmp/car-pma-binding-resolve.jsoncheck`
- `.venv/bin/python -m codex_autorunner.cli discord channels --path /Users/dazheng/car-workspace`
- `.venv/bin/python -m codex_autorunner.cli discord channels --json --path /Users/dazheng/car-workspace | .venv/bin/python -m json.tool >/tmp/car-discord-channels-refactor.jsoncheck`
- `.venv/bin/python -m codex_autorunner.cli telegram chats --path /Users/dazheng/car-workspace --bound-only`
- amend commit hook aggregate lane: pytest `8780 passed`, mypy, ruff, black, web lint/build/tests