### PR TITLE
[codex] Stabilize chat surface test lanes

### DIFF
--- a/tests/adapters/discord/test_channel_directory_ingest.py
+++ b/tests/adapters/discord/test_channel_directory_ingest.py
@@ -335,10 +335,13 @@ async def test_message_create_dispatch_does_not_wait_for_channel_directory_looku
         "author": {"id": "user-1", "bot": False},
     }
 
-    await asyncio.wait_for(service._on_dispatch("MESSAGE_CREATE", dict(payload)), 0.1)
-    await asyncio.wait_for(lookup_started.wait(), 0.1)
+    await asyncio.wait_for(service._on_dispatch("MESSAGE_CREATE", dict(payload)), 1.0)
+    await asyncio.wait_for(lookup_started.wait(), 1.0)
 
     assert submitted_message_ids == ["m-hot-path"]
 
     release_lookup.set()
-    await asyncio.sleep(0)
+    if service._background_tasks:
+        await asyncio.wait_for(
+            asyncio.gather(*list(service._background_tasks)), timeout=1.0
+        )

--- a/tests/adapters/discord/test_dispatch_validation.py
+++ b/tests/adapters/discord/test_dispatch_validation.py
@@ -61,6 +61,14 @@ class _InitialResponseFailingRest(_FakeRest):
         raise DiscordAPIError("simulated initial response failure")
 
 
+async def _wait_for_condition(condition: Any, *, timeout: float = 1.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not condition():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError("condition was not met before timeout")
+        await asyncio.sleep(0.01)
+
+
 def _config(
     root: Path,
     *,
@@ -248,6 +256,10 @@ async def test_service_continues_when_sync_request_fails(tmp_path: Path) -> None
 
     try:
         await service.run_forever()
+        await _wait_for_condition(
+            lambda: len(rest.interaction_responses) == 1
+            and len(rest.followup_messages) == 1
+        )
         assert len(rest.interaction_responses) == 1
         payload = rest.interaction_responses[0]["payload"]
         assert payload["type"] == 5
@@ -764,6 +776,7 @@ async def test_malformed_interaction_payload_returns_ephemeral_response(
 
 
 @pytest.mark.anyio
+@pytest.mark.slow
 async def test_dispatch_deferred_slash_commands_ack_before_prior_handler_finishes(
     tmp_path: Path,
 ) -> None:
@@ -835,7 +848,7 @@ async def test_dispatch_deferred_slash_commands_ack_before_prior_handler_finishe
         assert started == ["inter-1"]
 
         release_first.set()
-        await asyncio.wait_for(task, timeout=1.0)
+        await asyncio.wait_for(task, timeout=3.0)
         assert started == ["inter-1", "inter-2"]
     finally:
         release_first.set()

--- a/tests/adapters/discord/test_service_routing.py
+++ b/tests/adapters/discord/test_service_routing.py
@@ -5952,7 +5952,7 @@ async def test_dispatch_deferred_slash_commands_ack_before_prior_handler_finishe
         assert started == ["inter-1"]
 
         release_first.set()
-        await asyncio.wait_for(task, timeout=1.0)
+        await asyncio.wait_for(task, timeout=3.0)
         assert started == ["inter-1", "inter-2"]
     finally:
         release_first.set()

--- a/tests/chat_surface_lab/scenario_runner.py
+++ b/tests/chat_surface_lab/scenario_runner.py
@@ -388,7 +388,7 @@ class ChatSurfaceScenarioRunner:
                 if task.done():
                     continue
                 task.cancel()
-                with contextlib.suppress(Exception):
+                with contextlib.suppress(asyncio.CancelledError, Exception):
                     await task
             if context.surface == SurfaceKind.WEB_PMA:
                 assert isinstance(context.harness, WebPmaSurfaceSimulator)

--- a/tests/chat_surface_lab/test_scenario_runner.py
+++ b/tests/chat_surface_lab/test_scenario_runner.py
@@ -12,6 +12,8 @@ from tests.chat_surface_lab.scenario_runner import (
     load_scenario_by_id,
 )
 
+pytestmark = pytest.mark.slow
+
 
 @pytest.mark.anyio
 async def test_runner_executes_first_visible_feedback_and_emits_artifacts(

--- a/tests/chat_surface_lab/test_web_responsiveness_budgets.py
+++ b/tests/chat_surface_lab/test_web_responsiveness_budgets.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from tests.chat_surface_lab.web_responsiveness_budgets import (
     run_web_responsiveness_budget_smoke,
 )
+
+pytestmark = pytest.mark.slow
 
 
 def test_web_responsiveness_budget_smoke_writes_actionable_diagnostics(


### PR DESCRIPTION
## Summary

- Move chat-surface lab timing/performance tests out of the fast lane by marking them slow.
- Harden Discord timing tests by waiting for observable completion instead of asserting immediately after async shutdown paths.
- Make scenario-runner cleanup preserve the original failure instead of masking it with task cancellation.

## Root Cause

Discord/chat-surface tests were mixing fast-lane execution with wall-clock scenario harnesses and short async shutdown deadlines. Under pre-commit and CI load, those timing assumptions could observe transient state or mask the underlying failure.

## Validation

- Full local pre-commit aggregate lane passed during commit.
- Pytest fast lane: 8754 passed, 10 warnings.
- Web UI lab, lint, build, frontend tests, and SPA shell checks passed.
- Targeted reliability checks passed before commit, including the Discord/chat-surface xdist slice.
