### PR TITLE
[codex] Compact PMA transcript activity

### DIFF
--- a/src/codex_autorunner/core/orchestration/__init__.py
+++ b/src/codex_autorunner/core/orchestration/__init__.py
@@ -37,9 +37,9 @@ from .chat_operation_state import (
     ChatOperationState,
 )
 from .chat_surface_emitters import (
+    chat_surface_key,
     emit_binding_event,
     emit_chat_surface_event,
-    pma_surface_key,
 )
 from .chat_surface_events import (
     CHAT_SURFACE_EVENT_TYPES,
@@ -295,7 +295,7 @@ __all__ = [
     "plan_chat_operation_duplicate",
     "plan_chat_operation_recovery",
     "plan_managed_thread_delivery_recovery",
-    "pma_surface_key",
+    "chat_surface_key",
     "record_from_intent",
     "resolve_execution_history_maintenance_policy",
     "resolve_orchestration_sqlite_path",

--- a/src/codex_autorunner/core/orchestration/chat_surface_emitters.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_emitters.py
@@ -149,7 +149,7 @@ def emit_binding_event(
     )
 
 
-def pma_surface_key(managed_thread_id: Any) -> Optional[str]:
+def chat_surface_key(managed_thread_id: Any) -> Optional[str]:
     normalized = _normalize_optional_text(managed_thread_id)
     return normalized
 
@@ -169,5 +169,5 @@ def _hub_operation_from_chat_surface_event(event_type: str) -> str:
 __all__ = [
     "emit_binding_event",
     "emit_chat_surface_event",
-    "pma_surface_key",
+    "chat_surface_key",
 ]

--- a/src/codex_autorunner/surfaces/web/app.py
+++ b/src/codex_autorunner/surfaces/web/app.py
@@ -61,7 +61,7 @@ from .middleware import (
     SecurityHeadersMiddleware,
 )
 from .routes.auth import build_auth_routes
-from .routes.chat_events import build_hub_chat_event_routes
+from .routes.chat_events import build_chat_surface_event_routes
 from .routes.contextspace import build_contextspace_routes
 from .routes.feedback_reports import build_feedback_report_routes
 from .routes.filebox import build_hub_filebox_routes
@@ -257,7 +257,7 @@ def create_hub_app(
     app.include_router(build_hub_filebox_routes())
     app.include_router(build_hub_control_plane_routes())
     app.include_router(build_hub_state_routes(context))
-    app.include_router(build_hub_chat_event_routes(context))
+    app.include_router(build_chat_surface_event_routes(context))
     app.include_router(build_hub_chat_read_model_router(context))
 
     app.state.hub_started = False

--- a/src/codex_autorunner/surfaces/web/routes/chat_events.py
+++ b/src/codex_autorunner/surfaces/web/routes/chat_events.py
@@ -27,7 +27,7 @@ def _sse_frame(event: str, payload: dict[str, Any], *, event_id: Optional[str]) 
     )
 
 
-def build_hub_chat_event_routes(context: HubAppContext) -> APIRouter:
+def build_chat_surface_event_routes(context: HubAppContext) -> APIRouter:
     router = APIRouter(prefix="/hub/chat", tags=["chat"])
 
     @router.get("/events")
@@ -216,4 +216,4 @@ def build_hub_chat_event_routes(context: HubAppContext) -> APIRouter:
     return router
 
 
-__all__ = ["build_hub_chat_event_routes"]
+__all__ = ["build_chat_surface_event_routes"]

--- a/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
@@ -62,7 +62,7 @@ SNAPSHOT_CHAT_INDEX_ROUTE = "/hub/read-models/chats"
 def build_hub_chat_read_model_router(context: HubAppContext) -> APIRouter:
     router = APIRouter()
 
-    service = HubChatReadModelService(context.config.root)
+    service = ChatReadModelService(context.config.root)
 
     @router.get(SNAPSHOT_CHAT_INDEX_ROUTE)
     def chat_read_model_index(
@@ -111,7 +111,7 @@ def build_hub_chat_read_model_router(context: HubAppContext) -> APIRouter:
     return router
 
 
-class HubChatReadModelService:
+class ChatReadModelService:
     """Thin read-model façade over ChatSurfaceReadService."""
 
     def __init__(self, hub_root):

--- a/src/codex_autorunner/web_frontend/src/lib/actions/repoWorktreeActions.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/actions/repoWorktreeActions.ts
@@ -1,4 +1,4 @@
-import { pmaApi, type JsonRecord } from '$lib/api/client';
+import { webApi, type JsonRecord } from '$lib/api/client';
 import {
   confirmDialog,
   confirmDialogTyped
@@ -61,7 +61,7 @@ export async function confirmAndCleanupWorktree(target: CleanupWorktreeTarget): 
     if (!ok) return null;
   }
 
-  const result = await pmaApi.hub.cleanupWorktree({
+  const result = await webApi.hub.cleanupWorktree({
     worktreeRepoId: target.id,
     archive: true,
     force: requiresTypedConfirmation,
@@ -97,7 +97,7 @@ export async function confirmAndArchiveState(target: ArchiveStateTarget): Promis
   });
   if (!ok) return null;
 
-  const result = await pmaApi.hub.archiveState({
+  const result = await webApi.hub.archiveState({
     kind: target.kind,
     id: target.id,
     archiveNote: null
@@ -130,7 +130,7 @@ export async function submitCreateRepo(input: CreateRepoInput): Promise<ActionNo
   if (!repoId && !gitUrl) {
     return { tone: 'warning', message: 'Provide a repo name or a git URL.' };
   }
-  const result = await pmaApi.hub.createRepo({ repoId, gitUrl });
+  const result = await webApi.hub.createRepo({ repoId, gitUrl });
   if (!result.ok) return { tone: 'danger', message: result.error.message };
   await invalidateReadModelTags([readModelEntityTags.repoWorktreeIndex]);
   const label = stringValue(result.data.repo_id) ?? repoId ?? gitUrl ?? 'repo';
@@ -153,7 +153,7 @@ export async function submitCreateWorktree(input: CreateWorktreeInput): Promise<
   if (!branch) {
     return { tone: 'warning', message: 'Branch name is required.' };
   }
-  const result = await pmaApi.hub.createWorktree({
+  const result = await webApi.hub.createWorktree({
     baseRepoId: input.baseRepoId,
     branch
     // startPoint omitted on purpose — backend defaults to origin/<default-branch>
@@ -187,7 +187,7 @@ export type SetWorktreeSetupInput = {
 
 export async function submitSetWorktreeSetup(input: SetWorktreeSetupInput): Promise<ActionNotice> {
   const cleaned = input.commands.map((cmd) => cmd.trim()).filter((cmd) => cmd.length > 0);
-  const result = await pmaApi.hub.setWorktreeSetup(input.repoId, cleaned);
+  const result = await webApi.hub.setWorktreeSetup(input.repoId, cleaned);
   if (!result.ok) return { tone: 'danger', message: result.error.message };
   await invalidateReadModelTags([
     readModelEntityTags.repoWorktreeIndex,

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { PmaApiClient, dataOr, normalizeApiError, partialPageIssue } from './client';
+import { WebApiClient, dataOr, normalizeApiError, partialPageIssue } from './client';
 
 describe('API client error handling', () => {
   it('normalizes HTTP JSON errors into displayable errors', async () => {
@@ -10,7 +10,7 @@ describe('API client error handling', () => {
         headers: { 'content-type': 'application/json' }
       })
     ) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.getJson('/hub/repos/missing');
 
@@ -33,7 +33,7 @@ describe('API client error handling', () => {
         headers: { 'content-type': 'text/html' }
       })
     ) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.getJson('/hub/pma/threads');
 
@@ -45,7 +45,7 @@ describe('API client error handling', () => {
 
   it('truncates long text error responses before display', async () => {
     const fetcher = vi.fn(async () => new Response('x'.repeat(260), { status: 500 })) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.getJson('/hub/pma/threads');
 
@@ -73,7 +73,7 @@ describe('API client error handling', () => {
         threads: [{ thread_target_id: 'thread-1', display_name: 'PMA room', status: 'running' }]
       })
     ) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.pma.listChats();
 
@@ -102,7 +102,7 @@ describe('API client error handling', () => {
         ]
       })
     ) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.pma.listChats();
 
@@ -123,7 +123,7 @@ describe('API client error handling', () => {
       }
       return Response.json({ status: 'ok' });
     }) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     await client.pma.interruptThread('thread-1');
     await client.pma.resumeThread('thread-1');
@@ -145,7 +145,7 @@ describe('API client error handling', () => {
       if (url === '/hub/state') return Response.json({ title: 'Dispatch Desk' });
       return Response.json({ status: 'ok' });
     }) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const state = await client.hub.getState();
     await client.hub.updateState({ title: 'Dispatch Desk' });
@@ -162,7 +162,7 @@ describe('API client error handling', () => {
         threads: []
       })
     ) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher, '/car');
+    const client = new WebApiClient(fetcher, '/car');
 
     const result = await client.pma.listChats();
 
@@ -196,7 +196,7 @@ describe('API client error handling', () => {
       }
       return new Response('unexpected request', { status: 500 });
     }) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.ticketFlow.listTickets({ worktree: 'wt-1' });
 
@@ -224,7 +224,7 @@ describe('API client error handling', () => {
       }
       return new Response('unexpected request', { status: 500 });
     }) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     await client.ticketFlow.listTickets({ repo: 'repo with spaces/and%symbols' });
     await client.ticketFlow.listTickets({ worktree: 'wt with spaces/and%symbols' });
@@ -267,7 +267,7 @@ describe('API client error handling', () => {
       }
       return new Response('unexpected request', { status: 500 });
     }) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.ticketFlow.listTickets();
 
@@ -291,7 +291,7 @@ describe('API client error handling', () => {
       }
       return new Response('unexpected request', { status: 500 });
     }) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const repoRuns = await client.ticketFlow.listRuns({ repo: 'repo-1' });
     const worktreeRuns = await client.ticketFlow.listRuns({ worktree: 'wt-1' });
@@ -313,7 +313,7 @@ describe('API client error handling', () => {
       }
       return new Response('unexpected request', { status: 500 });
     }) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const created = await client.ticketFlow.createTicket({ title: 'Created', body: '## Goal\nShip it.' }, { repo: 'repo-1' });
     const reordered = await client.ticketFlow.reorderTicket(3, 1, false, { repo: 'repo-1' });
@@ -334,7 +334,7 @@ describe('API client error handling', () => {
 
   it('does not double-prefix already based request paths', async () => {
     const fetcher = vi.fn(async () => Response.json({ ok: true })) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher, '/car');
+    const client = new WebApiClient(fetcher, '/car');
 
     const result = await client.getJson('/car/hub/messages');
 
@@ -370,7 +370,7 @@ describe('API client error handling', () => {
         ]
       })
     ) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.pma.diagnostics.getTimeline('thread-1');
 
@@ -460,7 +460,7 @@ describe('API client error handling', () => {
         ]
       })
     ) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.pma.diagnostics.getTimeline('thread-1');
 
@@ -492,7 +492,7 @@ describe('API client error handling', () => {
         items: []
       })
     ) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     await client.pma.diagnostics.getTimeline('thread-1', { limit: 25 });
 
@@ -525,7 +525,7 @@ describe('API client error handling', () => {
         status: null
       })
     ) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.pma.getTranscript('thread-1', { limit: 25 });
 
@@ -548,7 +548,7 @@ describe('API client error handling', () => {
         status: 'running'
       })
     ) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.pma.diagnostics.getTail('thread-1');
 
@@ -565,7 +565,7 @@ describe('API client error handling', () => {
 
   it('uploads PMA inbox files with multipart form data', async () => {
     const fetcher = vi.fn(async () => Response.json({ status: 'ok', saved: ['screen.png'] })) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.pma.uploadInboxFile(new File(['png'], 'screen.png', { type: 'image/png' }));
 
@@ -587,7 +587,7 @@ describe('API client error handling', () => {
         decisions: '- Decision'
       })
     ) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.contextspace.listDocuments('repo-1');
 
@@ -620,7 +620,7 @@ describe('API client error handling', () => {
       }
       return Response.json({ name: 'active_context.md', content: 'Current PMA work' });
     }) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.pma.listDocsWithContent();
 
@@ -640,7 +640,7 @@ describe('API client error handling', () => {
 
   it('updates PMA docs through the hub docs endpoint', async () => {
     const fetcher = vi.fn(async () => Response.json({ name: 'AGENTS.md', status: 'ok' })) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.pma.updateDoc('AGENTS.md', '# Updated guidance');
 
@@ -685,7 +685,7 @@ describe('API client error handling', () => {
         decisions: '- Decision'
       })
     ) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await client.contextspace.updateDocument('repo-1', 'active_context', '# Updated');
 

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.ts
@@ -29,7 +29,7 @@ import {
   type TicketSummary,
   type WorktreeSummary
 } from '$lib/viewModels/domain';
-import { mapPmaTranscriptSnapshot, type PmaTranscriptSnapshot } from '$lib/viewModels/pmaChat';
+import { mapChatTranscriptSnapshot, type ChatTranscriptSnapshot } from '$lib/viewModels/pmaChat';
 import { runtimeBasePath, withRuntimeBasePath } from '$lib/runtime/basePath';
 
 export type ApiErrorKind = 'http' | 'network' | 'parse' | 'aborted';
@@ -209,7 +209,7 @@ function readableErrorText(text: string, status: number): string {
   return text.length > 220 ? `${text.slice(0, 217)}...` : text;
 }
 
-export class PmaApiClient {
+export class WebApiClient {
   constructor(
     private readonly fetcher: typeof fetch = fetch,
     private readonly basePath = runtimeBasePath()
@@ -319,10 +319,10 @@ export class PmaApiClient {
         (payload) => mapPmaChatSummary(asRecord(payload.thread ?? payload))
       ),
     // Chat rendering uses transcript projections; timeline and tail are diagnostics-only.
-    getTranscript: async (chatId: string, request: PmaTimelineRequest = {}): Promise<ApiResult<PmaTranscriptSnapshot>> => {
+    getTranscript: async (chatId: string, request: PmaTimelineRequest = {}): Promise<ApiResult<ChatTranscriptSnapshot>> => {
       const params = new URLSearchParams({ limit: String(request.limit ?? 200) });
       return mapResult(await this.getJson<JsonRecord>(`/hub/pma/threads/${encodeURIComponent(chatId)}/transcript?${params.toString()}`), (payload) =>
-        mapPmaTranscriptSnapshot(payload, mapPmaRunProgress)
+        mapChatTranscriptSnapshot(payload, mapPmaRunProgress)
       );
     },
     diagnostics: {
@@ -924,4 +924,4 @@ function isStandardPmaDoc(name: string): boolean {
   );
 }
 
-export const pmaApi = new PmaApiClient();
+export const webApi = new WebApiClient();

--- a/src/codex_autorunner/web_frontend/src/lib/api/streaming.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/streaming.test.ts
@@ -2,14 +2,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   normalizeChatSurfaceStreamEvent,
   normalizePmaChatStreamEvent,
-  normalizePmaTranscriptStreamEvent,
+  normalizeChatTranscriptStreamEvent,
   openFlowRunEventSource,
   openChatSurfaceEventSource,
   openPmaChatEventSource,
-  openPmaTranscriptEventSource,
+  openChatTranscriptEventSource,
   parseJsonSseFrame,
   parseSseFrame,
-  shouldUsePmaTranscriptStream
+  shouldUseChatTranscriptStream
 } from './streaming';
 
 class FakeEventSource extends EventTarget {
@@ -64,7 +64,7 @@ describe('SSE helpers', () => {
   it('parses JSON data and normalizes PMA transcript events', () => {
     const parsed = parseJsonSseFrame('id: 9\nevent: transcript.patch\ndata: {"status":{"phase":"testing"}}\n\n');
     expect(parsed).not.toBeNull();
-    const normalized = normalizePmaTranscriptStreamEvent(parsed!);
+    const normalized = normalizeChatTranscriptStreamEvent(parsed!);
 
     expect(normalized).toEqual({
       kind: 'transcript_patch',
@@ -77,7 +77,7 @@ describe('SSE helpers', () => {
     const parsed = parseJsonSseFrame('id: 7\nevent: transcript.append\ndata: {"rows":[{"id":"turn:1:intermediate:0001","kind":"intermediate"}]}\n\n');
     expect(parsed).not.toBeNull();
 
-    expect(normalizePmaTranscriptStreamEvent(parsed!)).toEqual({
+    expect(normalizeChatTranscriptStreamEvent(parsed!)).toEqual({
       kind: 'transcript_append',
       lastEventId: '7',
       payload: { rows: [{ id: 'turn:1:intermediate:0001', kind: 'intermediate' }] }
@@ -119,7 +119,7 @@ describe('SSE helpers', () => {
     });
     vi.stubGlobal('EventSource', eventSource);
 
-    const subscription = openPmaTranscriptEventSource('thread/1', { onEvent: vi.fn() }, '/car');
+    const subscription = openChatTranscriptEventSource('thread/1', { onEvent: vi.fn() }, '/car');
 
     expect(eventSource).toHaveBeenCalledWith('/car/hub/pma/threads/thread%2F1/transcript/events', {
       withCredentials: undefined
@@ -136,7 +136,7 @@ describe('SSE helpers', () => {
     vi.stubGlobal('EventSource', FakeEventSource);
     const events: unknown[] = [];
 
-    const subscription = openPmaTranscriptEventSource('thread/1', { onEvent: (event) => events.push(event) }, '/car');
+    const subscription = openChatTranscriptEventSource('thread/1', { onEvent: (event) => events.push(event) }, '/car');
     expect(FakeEventSource.instances[0].url).toBe('/car/hub/pma/threads/thread%2F1/transcript/events');
 
     FakeEventSource.instances[0].emit('transcript.append', { rows: [{ id: 'item-1', turn_id: 'turn-1' }] }, '8');
@@ -159,7 +159,7 @@ describe('SSE helpers', () => {
   it('opens PMA transcript streams from a provided progress cursor', () => {
     vi.stubGlobal('EventSource', FakeEventSource);
 
-    const subscription = openPmaTranscriptEventSource(
+    const subscription = openChatTranscriptEventSource(
       'thread/1',
       {
         onEvent: vi.fn(),
@@ -176,20 +176,20 @@ describe('SSE helpers', () => {
   });
 
   it('does not open PMA transcript streams for terminal snapshots with no queued follow-up', () => {
-    expect(shouldUsePmaTranscriptStream({ status: 'completed' }, { status: 'completed', queueDepth: 0 }, 0)).toBe(false);
+    expect(shouldUseChatTranscriptStream({ status: 'completed' }, { status: 'completed', queueDepth: 0 }, 0)).toBe(false);
   });
 
   it('keeps PMA transcript streams useful for live and queued turns', () => {
-    expect(shouldUsePmaTranscriptStream({ status: 'completed' }, { status: 'running', queueDepth: 0 }, 0)).toBe(true);
-    expect(shouldUsePmaTranscriptStream({ status: 'completed' }, { status: 'completed', queueDepth: 0 }, 1)).toBe(true);
-    expect(shouldUsePmaTranscriptStream({ status: 'waiting' }, null, 0)).toBe(true);
+    expect(shouldUseChatTranscriptStream({ status: 'completed' }, { status: 'running', queueDepth: 0 }, 0)).toBe(true);
+    expect(shouldUseChatTranscriptStream({ status: 'completed' }, { status: 'completed', queueDepth: 0 }, 1)).toBe(true);
+    expect(shouldUseChatTranscriptStream({ status: 'waiting' }, null, 0)).toBe(true);
   });
 
   it('resets PMA transcript stream cursors when the managed turn changes', () => {
     vi.useFakeTimers();
     vi.stubGlobal('EventSource', FakeEventSource);
 
-    const subscription = openPmaTranscriptEventSource('thread/1', { onEvent: vi.fn() }, '/car');
+    const subscription = openChatTranscriptEventSource('thread/1', { onEvent: vi.fn() }, '/car');
     FakeEventSource.instances[0].emit('transcript.append', { rows: [{ id: 'old-item', turn_id: 'turn-1' }] }, '8');
     FakeEventSource.instances[0].emit('transcript.patch', { status: { managed_turn_id: 'turn-2', phase: 'booting' } });
     FakeEventSource.instances[0].fail();

--- a/src/codex_autorunner/web_frontend/src/lib/api/streaming.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/streaming.ts
@@ -7,7 +7,7 @@ export type SseEvent<T = unknown> = {
   retry: number | null;
 };
 
-export type PmaTranscriptStreamEvent =
+export type ChatTranscriptStreamEvent =
   | { kind: 'transcript_snapshot'; payload: Record<string, unknown>; lastEventId: string | null }
   | { kind: 'transcript_append'; payload: Record<string, unknown>; lastEventId: string | null }
   | { kind: 'transcript_patch'; payload: Record<string, unknown>; lastEventId: string | null }
@@ -32,7 +32,7 @@ export type FlowRunStreamEvent = {
 };
 
 export type TranscriptStreamOptions = {
-  onEvent: (event: PmaTranscriptStreamEvent) => void;
+  onEvent: (event: ChatTranscriptStreamEvent) => void;
   onError?: (error: Event) => void;
   onStatus?: (status: 'connecting' | 'connected' | 'interrupted' | 'closed') => void;
   sinceEventId?: string | number | null;
@@ -40,7 +40,7 @@ export type TranscriptStreamOptions = {
   withCredentials?: boolean;
 };
 
-export type PmaTranscriptStreamUseState = {
+export type ChatTranscriptStreamUseState = {
   status?: string | null;
   queueDepth?: number | null;
 };
@@ -91,7 +91,7 @@ export function parseJsonSseFrame(frame: string): SseEvent<unknown> | null {
   }
 }
 
-export function normalizePmaTranscriptStreamEvent(event: SseEvent<unknown>): PmaTranscriptStreamEvent {
+export function normalizeChatTranscriptStreamEvent(event: SseEvent<unknown>): ChatTranscriptStreamEvent {
   const payload = asRecord(event.data);
   if (event.event === 'transcript.snapshot') return { kind: 'transcript_snapshot', payload, lastEventId: event.id };
   if (event.event === 'transcript.append') return { kind: 'transcript_append', payload, lastEventId: event.id };
@@ -116,7 +116,7 @@ export function normalizeChatSurfaceStreamEvent(event: SseEvent<unknown>): ChatS
   return { kind: 'message', payload: event.data, lastEventId: event.id };
 }
 
-export function openPmaTranscriptEventSource(
+export function openChatTranscriptEventSource(
   managedThreadId: string,
   options: TranscriptStreamOptions,
   basePath = runtimeBasePath()
@@ -130,7 +130,7 @@ export function openPmaTranscriptEventSource(
   let lastManagedTurnId: string | null = optionalString(options.sinceManagedTurnId);
   const handle = (message: MessageEvent) => {
     attempt = 0;
-    const event = normalizePmaTranscriptStreamEvent({
+    const event = normalizeChatTranscriptStreamEvent({
       id: message.lastEventId || null,
       event: message.type || 'message',
       data: parseJson(message.data),
@@ -186,13 +186,13 @@ export function openPmaTranscriptEventSource(
   };
 }
 
-export function shouldUsePmaTranscriptStream(
-  chat: PmaTranscriptStreamUseState | null | undefined,
-  progress: PmaTranscriptStreamUseState | null | undefined,
+export function shouldUseChatTranscriptStream(
+  chat: ChatTranscriptStreamUseState | null | undefined,
+  progress: ChatTranscriptStreamUseState | null | undefined,
   queuedTurns = 0
 ): boolean {
   if (queuedTurns > 0 || (progress?.queueDepth ?? 0) > 0) return true;
-  return isActivePmaTranscriptStatus(progress?.status) || isActivePmaTranscriptStatus(chat?.status);
+  return isActiveChatTranscriptStatus(progress?.status) || isActiveChatTranscriptStatus(chat?.status);
 }
 
 export function openPmaChatEventSource(
@@ -353,7 +353,7 @@ function optionalString(value: unknown): string | null {
   return null;
 }
 
-function isActivePmaTranscriptStatus(status: unknown): boolean {
+function isActiveChatTranscriptStatus(status: unknown): boolean {
   return status === 'running' || status === 'waiting' || status === 'blocked';
 }
 

--- a/src/codex_autorunner/web_frontend/src/lib/application/pmaChatCommands.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/pmaChatCommands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { PmaApiClient } from '$lib/api/client';
+import { WebApiClient } from '$lib/api/client';
 import { localPmaChatScopeOption } from '$lib/viewModels/pmaChat';
 import {
   executePmaChatCommandPlan,
@@ -104,7 +104,7 @@ describe('PMA chat command execution', () => {
       }
       return Response.json({ thread: { thread_target_id: 'unexpected' } });
     }) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await executePmaChatCommandPlan(client, planSendExistingChat('thread-1', 'Continue'));
 
@@ -121,7 +121,7 @@ describe('PMA chat command execution', () => {
     const fetcher = vi.fn(async () =>
       Response.json({ thread: { thread_target_id: 'thread-new', display_name: 'New chat' } })
     ) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     await executePmaChatCommandPlan(client, planStartChat(localPmaChatScopeOption(), 'codex'));
     await executePmaChatCommandPlan(client, planForkChat('thread-1', { name: 'Forked chat' }));
@@ -140,7 +140,7 @@ describe('PMA chat command execution', () => {
     const fetcher = vi.fn(async () =>
       Response.json({ managed_thread_id: 'thread-new', managed_turn_id: 'turn-1', delivered_message: 'Hello' })
     ) as unknown as typeof fetch;
-    const client = new PmaApiClient(fetcher);
+    const client = new WebApiClient(fetcher);
 
     const result = await executePmaChatCommandPlan(
       client,

--- a/src/codex_autorunner/web_frontend/src/lib/application/pmaChatCommands.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/pmaChatCommands.ts
@@ -1,4 +1,4 @@
-import type { ApiResult, PmaApiClient } from '$lib/api/client';
+import type { ApiResult, WebApiClient } from '$lib/api/client';
 import type { PmaChatMessage, PmaChatSummary } from '$lib/viewModels/domain';
 import {
   buildManagedThreadCreatePayload,
@@ -54,7 +54,7 @@ export type ExistingPmaChatMessageOptions = {
 };
 
 type PmaCommandClient = {
-  pma: Pick<PmaApiClient['pma'], 'createChat' | 'startChatWithMessage' | 'sendMessage' | 'forkThread'>;
+  pma: Pick<WebApiClient['pma'], 'createChat' | 'startChatWithMessage' | 'sendMessage' | 'forkThread'>;
 };
 
 function requireThreadId(threadId: string): string {

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
@@ -2,7 +2,7 @@
   import SurfaceArtifactCard from '$lib/components/SurfaceArtifactCard.svelte';
   import { withRuntimeBasePath as href } from '$lib/runtime/basePath';
   import { renderMarkdownToHtml } from '$lib/viewModels/contextspace';
-  import { formatCompactMessageDateTime, type PmaCard, type PmaToolCallCard } from '$lib/viewModels/pmaChat';
+  import { compactPmaTranscriptCards, formatCompactMessageDateTime, type PmaCard, type PmaToolCallCard } from '$lib/viewModels/pmaChat';
   import type { SurfaceArtifact } from '$lib/viewModels/domain';
 
   let {
@@ -110,26 +110,7 @@
     return tool.title;
   }
 
-  function foldConsecutiveToolGroups(input: PmaCard[]): PmaCard[] {
-    const out: PmaCard[] = [];
-    for (const card of input) {
-      const prev = out[out.length - 1];
-      if (
-        card.kind === 'tool_group' &&
-        prev &&
-        prev.kind === 'tool_group' &&
-        prev.turnId === card.turnId &&
-        prev.turnId !== null
-      ) {
-        out[out.length - 1] = { ...prev, tools: [...prev.tools, ...card.tools] };
-        continue;
-      }
-      out.push(card);
-    }
-    return out;
-  }
-
-  const displayCards = $derived(foldConsecutiveToolGroups(cards));
+  const displayCards = $derived(compactPmaTranscriptCards(cards));
 </script>
 
 {#each displayCards as card (card.id)}

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
@@ -2,14 +2,14 @@
   import SurfaceArtifactCard from '$lib/components/SurfaceArtifactCard.svelte';
   import { withRuntimeBasePath as href } from '$lib/runtime/basePath';
   import { renderMarkdownToHtml } from '$lib/viewModels/contextspace';
-  import { compactPmaTranscriptCards, formatCompactMessageDateTime, type PmaCard, type PmaToolCallCard } from '$lib/viewModels/pmaChat';
+  import { compactChatTranscriptCards, formatCompactMessageDateTime, type ChatTranscriptCard, type ChatToolCallCard } from '$lib/viewModels/pmaChat';
   import type { SurfaceArtifact } from '$lib/viewModels/domain';
 
   let {
     cards,
     assistantLabel = 'Assistant',
     streamingMessageId = null,
-  }: { cards: PmaCard[]; assistantLabel?: string; streamingMessageId?: string | null } = $props();
+  }: { cards: ChatTranscriptCard[]; assistantLabel?: string; streamingMessageId?: string | null } = $props();
 
   const userToggled = $state<Record<string, boolean>>({});
 
@@ -27,21 +27,21 @@
     return null;
   }
 
-  function isThinkingTrace(card: Extract<PmaCard, { kind: 'intermediate' }>): boolean {
+  function isThinkingTrace(card: Extract<ChatTranscriptCard, { kind: 'intermediate' }>): boolean {
     return card.title.trim().toLowerCase() === 'thinking';
   }
 
-  function isCommentaryTrace(card: Extract<PmaCard, { kind: 'intermediate' }>): boolean {
+  function isCommentaryTrace(card: Extract<ChatTranscriptCard, { kind: 'intermediate' }>): boolean {
     return card.title.trim().toLowerCase() === 'commentary';
   }
 
-  function traceKindLabel(card: Extract<PmaCard, { kind: 'intermediate' }>): string {
+  function traceKindLabel(card: Extract<ChatTranscriptCard, { kind: 'intermediate' }>): string {
     const title = card.title.trim();
     if (!title) return 'Update';
     return title.charAt(0).toUpperCase() + title.slice(1);
   }
 
-  function traceSummaryLabel(card: Extract<PmaCard, { kind: 'intermediate' }>): string {
+  function traceSummaryLabel(card: Extract<ChatTranscriptCard, { kind: 'intermediate' }>): string {
     const detail = card.detail?.split('·', 1)[0]?.trim();
     if (detail) return detail;
     const text = card.text.trim().replace(/\s+/g, ' ');
@@ -49,7 +49,7 @@
     return traceKindLabel(card);
   }
 
-  function thinkingTraceLabel(card: Extract<PmaCard, { kind: 'intermediate' }>): string {
+  function thinkingTraceLabel(card: Extract<ChatTranscriptCard, { kind: 'intermediate' }>): string {
     const detail = card.detail;
     if (detail) {
       const trimmed = detail.trim();
@@ -88,11 +88,11 @@
     return 'Reasoning trace';
   }
 
-  function isToolGroupRunning(tools: PmaToolCallCard[]): boolean {
+  function isToolGroupRunning(tools: ChatToolCallCard[]): boolean {
     return tools.length > 0 && tools[0].state === 'started';
   }
 
-  function toolGroupOpen(card: Extract<PmaCard, { kind: 'tool_group' }>): boolean {
+  function toolGroupOpen(card: Extract<ChatTranscriptCard, { kind: 'tool_group' }>): boolean {
     const userPref = userToggled[card.id];
     if (typeof userPref === 'boolean') return userPref;
     return isToolGroupRunning(card.tools);
@@ -103,14 +103,14 @@
     userToggled[cardId] = el.open;
   }
 
-  function toolHeadlineText(tool: PmaToolCallCard | undefined): string {
+  function toolHeadlineText(tool: ChatToolCallCard | undefined): string {
     if (!tool) return 'Tool call';
     const summary = tool.summary?.trim();
     if (summary) return summary;
     return tool.title;
   }
 
-  const displayCards = $derived(compactPmaTranscriptCards(cards));
+  const displayCards = $derived(compactChatTranscriptCards(cards));
 </script>
 
 {#each displayCards as card (card.id)}

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
@@ -1,7 +1,7 @@
 import { render } from 'svelte/server';
 import { describe, expect, it } from 'vitest';
 import ChatTranscriptCards from './ChatTranscriptCards.svelte';
-import type { PmaCard } from '$lib/viewModels/pmaChat';
+import type { ChatTranscriptCard } from '$lib/viewModels/pmaChat';
 
 const baseTrace = {
   turnId: 'turn-1',
@@ -13,7 +13,7 @@ const baseTrace = {
 
 describe('ChatTranscriptCards', () => {
   it('collapses thinking traces while keeping commentary visible', () => {
-    const cards: PmaCard[] = [
+    const cards: ChatTranscriptCard[] = [
       {
         ...baseTrace,
         kind: 'intermediate',
@@ -45,7 +45,7 @@ describe('ChatTranscriptCards', () => {
   });
 
   it('collapses non-commentary progress traces instead of rendering them as chat bubbles', () => {
-    const cards: PmaCard[] = [
+    const cards: ChatTranscriptCard[] = [
       {
         ...baseTrace,
         kind: 'intermediate',
@@ -75,7 +75,7 @@ describe('ChatTranscriptCards', () => {
   });
 
   it('renders richer progress labels when the model supplies them', () => {
-    const cards: PmaCard[] = [
+    const cards: ChatTranscriptCard[] = [
       {
         ...baseTrace,
         kind: 'intermediate',
@@ -92,7 +92,7 @@ describe('ChatTranscriptCards', () => {
   });
 
   it('collapses thinking traces inside worked summaries', () => {
-    const cards: PmaCard[] = [
+    const cards: ChatTranscriptCard[] = [
       {
         kind: 'turn_summary',
         id: 'summary-1',
@@ -133,7 +133,7 @@ describe('ChatTranscriptCards', () => {
   });
 
   it('renders compact timestamps on user and assistant message bubbles', () => {
-    const cards: PmaCard[] = [
+    const cards: ChatTranscriptCard[] = [
       {
         kind: 'message',
         id: 'u1',

--- a/src/codex_autorunner/web_frontend/src/lib/components/CurrentTicketChatStream.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/CurrentTicketChatStream.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
-  import { openPmaTranscriptEventSource, type StreamSubscription } from '$lib/api/streaming';
+  import { openChatTranscriptEventSource, type StreamSubscription } from '$lib/api/streaming';
   import { withRuntimeBasePath as href } from '$lib/runtime/basePath';
 
   let {
@@ -39,7 +39,7 @@
   onDestroy(() => teardown());
 
   function connect(id: string): void {
-    subscription = openPmaTranscriptEventSource(id, {
+    subscription = openChatTranscriptEventSource(id, {
       onEvent: (event) => {
         if (activeChatId !== id) return;
         streamState = 'connected';

--- a/src/codex_autorunner/web_frontend/src/lib/components/MemoryRail.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/MemoryRail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import MemoryView from '$lib/components/MemoryView.svelte';
-  import { pmaApi, type ApiError } from '$lib/api/client';
+  import { webApi, type ApiError } from '$lib/api/client';
   import { buildMemoryViewModel, type MemoryViewModel } from '$lib/viewModels/memory';
   import type { ScopeRef } from '$lib/viewModels/scope';
 
@@ -30,7 +30,7 @@
   async function loadMemory(): Promise<void> {
     loading = true;
     error = null;
-    const docs = await pmaApi.pma.listDocsWithContent();
+    const docs = await webApi.pma.listDocsWithContent();
     if (!docs.ok) {
       error = docs.error;
       vm = null;
@@ -42,7 +42,7 @@
   }
 
   async function saveDoc(docId: string, content: string): Promise<boolean> {
-    const result = await pmaApi.pma.updateDoc(docId, content);
+    const result = await webApi.pma.updateDoc(docId, content);
     if (!result.ok) {
       error = result.error;
       return false;

--- a/src/codex_autorunner/web_frontend/src/lib/components/ScopedContextspacePage.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ScopedContextspacePage.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import ContextspaceView from '$lib/components/ContextspaceView.svelte';
-  import { pmaApi, type ApiError } from '$lib/api/client';
+  import { webApi, type ApiError } from '$lib/api/client';
   import { buildContextspaceViewModel, type ContextspaceViewModel } from '$lib/viewModels/contextspace';
   import { mapRepoSummary, mapWorktreeSummary, type RepoSummary, type WorktreeSummary } from '$lib/viewModels/domain';
   import type { ScopeRef } from '$lib/viewModels/scope';
@@ -31,7 +31,7 @@
   }
 
   async function loadInventory(): Promise<void> {
-    const topology = await pmaApi.readModels.repoWorktreeTopology('all', 200);
+    const topology = await webApi.readModels.repoWorktreeTopology('all', 200);
     repoList = topology.ok
       ? topology.data.repos.map((repo) =>
           mapRepoSummary({
@@ -62,7 +62,7 @@
     error = null;
     await loadInventory();
     const id = await resolveWorkspaceId();
-    const docs = await pmaApi.contextspace.listDocuments(id);
+    const docs = await webApi.contextspace.listDocuments(id);
     if (!docs.ok) {
       error = docs.error;
       vm = null;
@@ -75,7 +75,7 @@
 
   async function saveDoc(docId: string, content: string): Promise<boolean> {
     if (!vm) return false;
-    const result = await pmaApi.contextspace.updateDocument(vm.workspaceId, docId, content);
+    const result = await webApi.contextspace.updateDocument(vm.workspaceId, docId, content);
     if (!result.ok) {
       error = result.error;
       return false;

--- a/src/codex_autorunner/web_frontend/src/lib/components/ScopedNewTicketPage.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ScopedNewTicketPage.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { onMount, tick } from 'svelte';
-  import { pmaApi } from '$lib/api/client';
+  import { webApi } from '$lib/api/client';
   import AutoDismissNotice from '$lib/components/AutoDismissNotice.svelte';
   import { invalidateReadModelTags, readModelEntityTags } from '$lib/data';
   import { createScopedTicket, type ScopedTicketQueueConfig } from '$lib/viewModels/scopedTicketQueue';
@@ -31,7 +31,7 @@
     if (!trimmed || submitting) return;
     submitting = true;
     apiError = null;
-    const result = await createScopedTicket(pmaApi, queueConfig, { title: trimmed, body });
+    const result = await createScopedTicket(webApi, queueConfig, { title: trimmed, body });
     submitting = false;
     if (!result.ok) {
       apiError = result.status;

--- a/src/codex_autorunner/web_frontend/src/lib/components/VoiceComposerButton.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/VoiceComposerButton.svelte
@@ -11,7 +11,7 @@
 
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
-  import { pmaApi } from '$lib/api/client';
+  import { webApi } from '$lib/api/client';
 
   let {
     disabled = false,
@@ -65,7 +65,7 @@
   });
 
   async function loadConfig(): Promise<void> {
-    const result = await pmaApi.voice.getConfig();
+    const result = await webApi.voice.getConfig();
     if (result.ok) {
       config = result.data as VoiceConfigPayload;
     } else {
@@ -179,7 +179,7 @@
       return;
     }
     const filename = `voice.${extensionFor(recorderMime)}`;
-    const result = await pmaApi.voice.transcribe(blob, filename);
+    const result = await webApi.voice.transcribe(blob, filename);
     sending = false;
     if (!result.ok) {
       onError?.(result.error.message || 'Voice transcription failed');

--- a/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ApiResult, JsonRecord, PmaApiClient } from '$lib/api/client';
+import type { ApiResult, JsonRecord, WebApiClient } from '$lib/api/client';
 import {
   READ_MODEL_CONTRACT_VERSION,
   type ChatIndexRow,
@@ -219,7 +219,7 @@ describe('chat index session', () => {
   });
 });
 
-function mockApi(): PmaApiClient {
+function mockApi(): WebApiClient {
   return {
     getJson: vi.fn(async (path: string): Promise<ApiResult<JsonRecord>> => {
       if (path.includes('filter=archived')) {
@@ -236,7 +236,7 @@ function mockApi(): PmaApiClient {
       }
       return ok({ rows: [] });
     })
-  } as unknown as PmaApiClient;
+  } as unknown as WebApiClient;
 }
 
 function ok<T>(data: T): ApiResult<T> {

--- a/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.ts
@@ -1,5 +1,5 @@
 import { writable, type Readable } from 'svelte/store';
-import { pmaApi, type ApiError, type JsonRecord, type PmaApiClient } from '$lib/api/client';
+import { webApi, type ApiError, type JsonRecord, type WebApiClient } from '$lib/api/client';
 import {
   mapReadModelContract,
   type ChatIndexRow,
@@ -40,7 +40,7 @@ export type ChatIndexSession = {
 };
 
 type ChatIndexSessionDeps = {
-  api?: PmaApiClient;
+  api?: WebApiClient;
   store?: ReadModelEntityStore;
   openStream?: (options: ChatSurfaceStreamOptions) => StreamSubscription;
 };
@@ -57,7 +57,7 @@ function mergeUniqueChatIndexRows(primary: ChatIndexRow[], secondary: ChatIndexR
 }
 
 export function createChatIndexSession(deps: ChatIndexSessionDeps = {}): ChatIndexSession {
-  const api = deps.api ?? pmaApi;
+  const api = deps.api ?? webApi;
   const store = deps.store ?? readModelEntityStore;
   const openStream = deps.openStream ?? openChatSurfaceEventSource;
   const state = writable<ChatIndexSessionState>({ status: 'idle', error: null });

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelClients.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelClients.ts
@@ -1,4 +1,4 @@
-import { mapResult, pmaApi, type ApiResult, type PmaApiClient } from '$lib/api/client';
+import { mapResult, webApi, type ApiResult, type WebApiClient } from '$lib/api/client';
 import type { TicketSummary } from '$lib/viewModels/domain';
 import {
   mapReadModelContract,
@@ -30,7 +30,7 @@ export type ReadModelSnapshotClient = {
   ticketIndex(owner?: { repo?: string; worktree?: string }): Promise<ApiResult<TicketSummary[]>>;
 };
 
-export function createReadModelSnapshotClient(api: PmaApiClient = pmaApi): ReadModelSnapshotClient {
+export function createReadModelSnapshotClient(api: WebApiClient = webApi): ReadModelSnapshotClient {
   return {
     chatIndex: async (request = {}) => {
       const params = new URLSearchParams({

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -10,7 +10,7 @@ import {
   type ProjectionCursor
 } from '$lib/api/readModelContracts';
 import { type PmaRunProgress, type SurfaceArtifact } from '$lib/viewModels/domain';
-import type { PmaCard } from '$lib/viewModels/pmaChat';
+import type { ChatTranscriptCard } from '$lib/viewModels/pmaChat';
 import {
   PMA_LIVE_PROGRESS_EVENT_LIMIT,
   ReadModelEntityStore,
@@ -215,7 +215,7 @@ describe('read model entity store', () => {
 
   it('replaces and upserts backend-owned PMA transcript cards independently of timeline state', () => {
     const store = new ReadModelEntityStore();
-    const first: PmaCard = {
+    const first: ChatTranscriptCard = {
       kind: 'message',
       id: 'turn:1:user',
       turnId: '1',
@@ -232,7 +232,7 @@ describe('read model entity store', () => {
         raw: {}
       }
     };
-    const second: PmaCard = {
+    const second: ChatTranscriptCard = {
       ...first,
       id: 'turn:1:assistant',
       orderKey: '002',
@@ -244,11 +244,11 @@ describe('read model entity store', () => {
       }
     };
 
-    store.replacePmaTranscript('chat-1', [first]);
-    store.upsertPmaTranscriptCards('chat-1', [second]);
+    store.replaceChatTranscript('chat-1', [first]);
+    store.upsertChatTranscriptCards('chat-1', [second]);
 
-    expect(store.snapshot().pmaTranscripts['chat-1'].order).toEqual(['turn:1:user', 'turn:1:assistant']);
-    expect(store.snapshot().pmaTranscripts['chat-1'].cardsById['turn:1:assistant']).toMatchObject({
+    expect(store.snapshot().chatTranscripts['chat-1'].order).toEqual(['turn:1:user', 'turn:1:assistant']);
+    expect(store.snapshot().chatTranscripts['chat-1'].cardsById['turn:1:assistant']).toMatchObject({
       kind: 'message',
       message: { role: 'assistant', text: 'hi' }
     });
@@ -256,7 +256,7 @@ describe('read model entity store', () => {
 
   it('orders backend-owned PMA transcript cards by backend order key across turns', () => {
     const store = new ReadModelEntityStore();
-    const userOne: PmaCard = {
+    const userOne: ChatTranscriptCard = {
       kind: 'message',
       id: 'turn:1:user',
       turnId: '1',
@@ -273,13 +273,13 @@ describe('read model entity store', () => {
         raw: {}
       }
     };
-    const assistantOne: PmaCard = {
+    const assistantOne: ChatTranscriptCard = {
       ...userOne,
       id: 'turn:1:assistant',
       orderKey: '00000002|assistant',
       message: { ...userOne.message, id: 'turn:1:assistant', role: 'assistant', text: 'first reply' }
     };
-    const userTwo: PmaCard = {
+    const userTwo: ChatTranscriptCard = {
       ...userOne,
       id: 'turn:2:user',
       turnId: '2',
@@ -287,9 +287,9 @@ describe('read model entity store', () => {
       message: { ...userOne.message, id: 'turn:2:user', text: 'second' }
     };
 
-    store.replacePmaTranscript('chat-1', [userTwo, assistantOne, userOne]);
+    store.replaceChatTranscript('chat-1', [userTwo, assistantOne, userOne]);
 
-    expect(store.snapshot().pmaTranscripts['chat-1'].order).toEqual([
+    expect(store.snapshot().chatTranscripts['chat-1'].order).toEqual([
       'turn:1:user',
       'turn:1:assistant',
       'turn:2:user'
@@ -298,7 +298,7 @@ describe('read model entity store', () => {
 
   it('keeps an optimistic user transcript row before live progress that arrives first', () => {
     const store = new ReadModelEntityStore();
-    const optimistic: PmaCard = {
+    const optimistic: ChatTranscriptCard = {
       kind: 'message',
       id: 'optimistic:user:1',
       turnId: null,
@@ -315,7 +315,7 @@ describe('read model entity store', () => {
         raw: { optimistic: true }
       }
     };
-    const progress: PmaCard = {
+    const progress: ChatTranscriptCard = {
       kind: 'intermediate',
       id: 'turn:1:intermediate:0001',
       title: 'Chat Execution Journal',
@@ -327,7 +327,7 @@ describe('read model entity store', () => {
       orderKey: '00000001|2026-05-11T12:00:01.000Z|turn:1:intermediate:0001',
       timestamp: '2026-05-11T12:00:01.000Z'
     };
-    const canonicalUser: PmaCard = {
+    const canonicalUser: ChatTranscriptCard = {
       ...optimistic,
       id: 'turn:1:user',
       turnId: '1',
@@ -339,19 +339,19 @@ describe('read model entity store', () => {
       }
     };
 
-    store.upsertPmaTranscriptCards('chat-1', [progress]);
-    store.upsertPmaTranscriptCards('chat-1', [optimistic]);
+    store.upsertChatTranscriptCards('chat-1', [progress]);
+    store.upsertChatTranscriptCards('chat-1', [optimistic]);
 
-    expect(store.snapshot().pmaTranscripts['chat-1'].order).toEqual(['optimistic:user:1', 'turn:1:intermediate:0001']);
+    expect(store.snapshot().chatTranscripts['chat-1'].order).toEqual(['optimistic:user:1', 'turn:1:intermediate:0001']);
 
-    store.replacePmaTranscript('chat-1', [progress, canonicalUser]);
+    store.replaceChatTranscript('chat-1', [progress, canonicalUser]);
 
-    expect(store.snapshot().pmaTranscripts['chat-1'].order).toEqual(['turn:1:user', 'turn:1:intermediate:0001']);
+    expect(store.snapshot().chatTranscripts['chat-1'].order).toEqual(['turn:1:user', 'turn:1:intermediate:0001']);
   });
 
   it('keeps live progress below the same-turn user when event sequence ties', () => {
     const store = new ReadModelEntityStore();
-    const user: PmaCard = {
+    const user: ChatTranscriptCard = {
       kind: 'message',
       id: 'turn:1:user',
       turnId: '1',
@@ -368,7 +368,7 @@ describe('read model entity store', () => {
         raw: {}
       }
     };
-    const progress: PmaCard = {
+    const progress: ChatTranscriptCard = {
       kind: 'intermediate',
       id: 'turn:1:intermediate:0001',
       title: 'Chat Execution Journal',
@@ -381,14 +381,14 @@ describe('read model entity store', () => {
       timestamp: '2026-05-11T12:00:00.000Z'
     };
 
-    store.replacePmaTranscript('chat-1', [progress, user]);
+    store.replaceChatTranscript('chat-1', [progress, user]);
 
-    expect(store.snapshot().pmaTranscripts['chat-1'].order).toEqual(['turn:1:user', 'turn:1:intermediate:0001']);
+    expect(store.snapshot().chatTranscripts['chat-1'].order).toEqual(['turn:1:user', 'turn:1:intermediate:0001']);
   });
 
   it('orders later live progress after an earlier assistant despite low live event sequence', () => {
     const store = new ReadModelEntityStore();
-    const firstUser: PmaCard = {
+    const firstUser: ChatTranscriptCard = {
       kind: 'message',
       id: 'turn:1:user',
       turnId: '1',
@@ -405,7 +405,7 @@ describe('read model entity store', () => {
         raw: {}
       }
     };
-    const firstAssistant: PmaCard = {
+    const firstAssistant: ChatTranscriptCard = {
       ...firstUser,
       id: 'turn:1:assistant',
       orderKey: '00000003|2026-05-11T12:00:08.000Z|turn:1:assistant',
@@ -418,7 +418,7 @@ describe('read model entity store', () => {
         createdAt: '2026-05-11T12:00:08.000Z'
       }
     };
-    const secondProgress: PmaCard = {
+    const secondProgress: ChatTranscriptCard = {
       kind: 'intermediate',
       id: 'turn:2:intermediate:0001',
       title: 'Chat Execution Journal',
@@ -431,9 +431,9 @@ describe('read model entity store', () => {
       timestamp: '2026-05-11T12:00:27.000Z'
     };
 
-    store.replacePmaTranscript('chat-1', [secondProgress, firstAssistant, firstUser]);
+    store.replaceChatTranscript('chat-1', [secondProgress, firstAssistant, firstUser]);
 
-    expect(store.snapshot().pmaTranscripts['chat-1'].order).toEqual([
+    expect(store.snapshot().chatTranscripts['chat-1'].order).toEqual([
       'turn:1:user',
       'turn:1:assistant',
       'turn:2:intermediate:0001'

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -29,7 +29,7 @@ import {
   type SurfaceArtifact,
   type TicketSummary
 } from '$lib/viewModels/domain';
-import type { PmaCard } from '$lib/viewModels/pmaChat';
+import type { ChatTranscriptCard } from '$lib/viewModels/pmaChat';
 
 export type EntityKind =
   | 'chat'
@@ -84,7 +84,7 @@ export type ReadModelEntityState = {
   chatCounters: ChatIndexCounters;
   chatDetails: Record<string, ChatDetailProjection>;
   timelines: Record<string, TimelineProjection>;
-  pmaTranscripts: Record<string, { cardsById: Record<string, PmaCard>; order: string[] }>;
+  chatTranscripts: Record<string, { cardsById: Record<string, ChatTranscriptCard>; order: string[] }>;
   pmaProgress: Record<string, PmaRunProgress>;
   pmaQueues: Record<string, PmaQueuedTurn[]>;
   pmaArtifacts: Record<string, SurfaceArtifact[]>;
@@ -146,7 +146,7 @@ export function createInitialReadModelState(): ReadModelEntityState {
     chatCounters: emptyChatCounters,
     chatDetails: {},
     timelines: {},
-    pmaTranscripts: {},
+    chatTranscripts: {},
     pmaProgress: {},
     pmaQueues: {},
     pmaArtifacts: {},
@@ -365,37 +365,37 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     return 'applied';
   }
 
-  replacePmaTranscript(chatId: string, cards: PmaCard[]): void {
-    const orderedCards = orderPmaTranscriptCards(cards);
+  replaceChatTranscript(chatId: string, cards: ChatTranscriptCard[]): void {
+    const orderedCards = orderChatTranscriptCards(cards);
     const next = cloneState(this.state);
-    next.pmaTranscripts[chatId] = {
-      cardsById: keyed(orderedCards, pmaCardEntityId),
-      order: orderedCards.map(pmaCardEntityId)
+    next.chatTranscripts[chatId] = {
+      cardsById: keyed(orderedCards, chatTranscriptCardEntityId),
+      order: orderedCards.map(chatTranscriptCardEntityId)
     };
     bump(next, 'timeline', chatId);
     this.commit(next);
   }
 
-  upsertPmaTranscriptCards(chatId: string, cards: PmaCard[]): void {
+  upsertChatTranscriptCards(chatId: string, cards: ChatTranscriptCard[]): void {
     if (!cards.length) return;
     const next = cloneState(this.state);
-    const transcript = next.pmaTranscripts[chatId] ?? { cardsById: {}, order: [] };
+    const transcript = next.chatTranscripts[chatId] ?? { cardsById: {}, order: [] };
     for (const card of cards) {
-      const id = pmaCardEntityId(card);
+      const id = chatTranscriptCardEntityId(card);
       transcript.cardsById[id] = card;
       if (!transcript.order.includes(id)) transcript.order.push(id);
     }
-    transcript.order = orderPmaTranscriptCards(transcript.order.map((id) => transcript.cardsById[id]).filter(Boolean)).map(pmaCardEntityId);
-    next.pmaTranscripts[chatId] = transcript;
+    transcript.order = orderChatTranscriptCards(transcript.order.map((id) => transcript.cardsById[id]).filter(Boolean)).map(chatTranscriptCardEntityId);
+    next.chatTranscripts[chatId] = transcript;
     bump(next, 'timeline', chatId);
     this.commit(next);
   }
 
-  removeOptimisticPmaTranscriptCards(chatId: string): void {
-    const transcript = this.state.pmaTranscripts[chatId];
+  removeOptimisticChatTranscriptCards(chatId: string): void {
+    const transcript = this.state.chatTranscripts[chatId];
     if (!transcript || !transcript.order.some((id) => id.startsWith('optimistic:'))) return;
     const next = cloneState(this.state);
-    const target = next.pmaTranscripts[chatId];
+    const target = next.chatTranscripts[chatId];
     for (const id of target.order) {
       if (id.startsWith('optimistic:')) delete target.cardsById[id];
     }
@@ -747,7 +747,7 @@ function cloneState(state: ReadModelEntityState): ReadModelEntityState {
     chatCounters: { ...state.chatCounters },
     chatDetails: cloneRecord(state.chatDetails),
     timelines: cloneRecord(state.timelines),
-    pmaTranscripts: cloneRecord(state.pmaTranscripts),
+    chatTranscripts: cloneRecord(state.chatTranscripts),
     pmaProgress: { ...state.pmaProgress },
     pmaQueues: cloneRecord(state.pmaQueues),
     pmaArtifacts: cloneRecord(state.pmaArtifacts),
@@ -805,15 +805,15 @@ function uniqueChatIndexRows(rows: ChatIndexRow[]): ChatIndexRow[] {
   return order.map((chatId) => byChatId.get(chatId)).filter((row): row is ChatIndexRow => Boolean(row));
 }
 
-function pmaCardEntityId(card: PmaCard): string {
+function chatTranscriptCardEntityId(card: ChatTranscriptCard): string {
   return card.id;
 }
 
-function orderPmaTranscriptCards(cards: PmaCard[]): PmaCard[] {
-  return [...cards].sort(comparePmaTranscriptCards);
+function orderChatTranscriptCards(cards: ChatTranscriptCard[]): ChatTranscriptCard[] {
+  return [...cards].sort(compareChatTranscriptCards);
 }
 
-function comparePmaTranscriptCards(left: PmaCard, right: PmaCard): number {
+function compareChatTranscriptCards(left: ChatTranscriptCard, right: ChatTranscriptCard): number {
   const leftTimestamp = transcriptCardTimestamp(left) ?? '';
   const rightTimestamp = transcriptCardTimestamp(right) ?? '';
   if (leftTimestamp && rightTimestamp && leftTimestamp !== rightTimestamp) return leftTimestamp.localeCompare(rightTimestamp);
@@ -826,24 +826,24 @@ function comparePmaTranscriptCards(left: PmaCard, right: PmaCard): number {
   if (byKey !== 0) return byKey;
   const byRole = transcriptCardRoleRank(left).localeCompare(transcriptCardRoleRank(right));
   if (byRole !== 0) return byRole;
-  return pmaCardEntityId(left).localeCompare(pmaCardEntityId(right));
+  return chatTranscriptCardEntityId(left).localeCompare(chatTranscriptCardEntityId(right));
 }
 
-function transcriptCardOrderKey(card: PmaCard): string {
+function transcriptCardOrderKey(card: ChatTranscriptCard): string {
   if ('orderKey' in card && typeof card.orderKey === 'string') return card.orderKey.trim();
   return '';
 }
 
-function transcriptCardRoleRank(card: PmaCard): string {
+function transcriptCardRoleRank(card: ChatTranscriptCard): string {
   if (card.kind === 'message') return card.message.role === 'user' ? '0' : '2';
   return '1';
 }
 
-function transcriptCardTurnId(card: PmaCard): string | null {
+function transcriptCardTurnId(card: ChatTranscriptCard): string | null {
   return 'turnId' in card ? card.turnId : null;
 }
 
-function transcriptCardTimestamp(card: PmaCard): string | null {
+function transcriptCardTimestamp(card: ChatTranscriptCard): string | null {
   if ('timestamp' in card && card.timestamp) return card.timestamp;
   if (card.kind === 'message') return card.message.createdAt;
   return null;

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
@@ -21,7 +21,7 @@ import {
 } from '$lib/viewModels/domain';
 import { normalizeManagedThreadChatKind } from '$lib/viewModels/managedThreadChatKind';
 import type { PmaQueuedTurn } from '$lib/api/client';
-import type { PmaCard } from '$lib/viewModels/pmaChat';
+import type { ChatTranscriptCard } from '$lib/viewModels/pmaChat';
 import type { ReadModelEntityState } from './readModelStore';
 
 type JsonRecord = Record<string, unknown>;
@@ -144,9 +144,9 @@ export function selectPmaChats(state: ReadModelEntityState): PmaChatSummary[] {
   return state.chatOrder.map((id) => state.chats[id]).filter(Boolean).map(chatIndexRowToPmaChatSummary);
 }
 
-export function selectPmaTranscript(state: ReadModelEntityState, chatId: string | null): PmaCard[] {
+export function selectChatTranscript(state: ReadModelEntityState, chatId: string | null): ChatTranscriptCard[] {
   if (!chatId) return [];
-  const transcript = state.pmaTranscripts[chatId];
+  const transcript = state.chatTranscripts[chatId];
   return transcript ? transcript.order.map((id) => transcript.cardsById[id]).filter(Boolean) : [];
 }
 

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -1571,6 +1571,35 @@ describe('PMA chat view helpers', () => {
     });
   });
 
+  it('keeps numeric token-like progress updates out of thinking summaries', () => {
+    const cards = compactPmaTranscriptCards([
+      {
+        ...baseArtifactCardTrace('progress-10', '10%', ['301']),
+        turnId: 'progress-turn',
+        orderKey: '001'
+      },
+      {
+        ...baseArtifactCardTrace('progress-20', '20%', ['302']),
+        turnId: 'progress-turn',
+        orderKey: '002'
+      }
+    ]);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      kind: 'turn_summary',
+      title: '2 progress updates'
+    });
+    const summary = cards[0];
+    if (summary.kind !== 'turn_summary') throw new Error('expected turn summary');
+    expect(summary.cards[0]).toMatchObject({
+      kind: 'intermediate',
+      title: 'Progress',
+      text: '10% 20%',
+      eventIds: ['301', '302']
+    });
+  });
+
   it('merges streamed activity events without dropping older transcript activity', () => {
     const merged = mergePmaActivityEvents(
       [

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -12,6 +12,7 @@ import {
   buildPmaLiveActivity,
   buildPmaStatusBar,
   chooseActiveChatId,
+  compactPmaTranscriptCards,
   composeMessageWithAttachments,
   countTicketRunGroups,
   filterPmaChats,
@@ -119,6 +120,21 @@ const baseProgress: PmaRunProgress = {
   ],
   raw: {}
 };
+
+function baseArtifactCardTrace(id: string, text: string, eventIds: string[]) {
+  return {
+    kind: 'intermediate' as const,
+    id,
+    title: text,
+    text,
+    eventIds,
+    progressSourceIds: [],
+    detail: null,
+    turnId: 'one',
+    orderKey: id,
+    timestamp: '2026-05-04T00:00:01Z'
+  };
+}
 
 describe('PMA chat view helpers', () => {
   it('collapses ticket-flow chats sharing a worktree into one run group, even without ticket ids', () => {
@@ -1467,6 +1483,92 @@ describe('PMA chat view helpers', () => {
     expect(toolCard.tools[0].eventIds).toContain('evt-51');
     expect(toolCard.tools[0].eventIds).toContain('evt-52');
     expect(toolCard.tools[0].eventIds).toContain('evt-53');
+  });
+
+  it('compacts dense transcript activity into expandable turn summaries', () => {
+    const cards = compactPmaTranscriptCards([
+      {
+        kind: 'message',
+        id: 'turn:one:user',
+        turnId: 'one',
+        orderKey: '001',
+        timestamp: '2026-05-04T00:00:00Z',
+        message: {
+          id: 'turn:one:user',
+          chatId: 'chat-1',
+          role: 'user',
+          text: 'Investigate',
+          createdAt: '2026-05-04T00:00:00Z',
+          status: null,
+          artifacts: [],
+          raw: {}
+        }
+      },
+      {
+        ...baseArtifactCardTrace('need', 'Need', ['197']),
+        orderKey: '002'
+      },
+      {
+        ...baseArtifactCardTrace('to', 'to', ['198']),
+        orderKey: '003'
+      },
+      {
+        kind: 'tool_group',
+        id: 'tool-1',
+        turnId: 'one',
+        orderKey: '004',
+        timestamp: '2026-05-04T00:00:03Z',
+        tools: [
+          {
+            id: 'tool-1',
+            title: 'rg',
+            summary: 'Search files',
+            detail: null,
+            state: 'completed',
+            eventIds: ['199']
+          }
+        ]
+      },
+      {
+        kind: 'tool_group',
+        id: 'tool-2',
+        turnId: 'one',
+        orderKey: '005',
+        timestamp: '2026-05-04T00:00:04Z',
+        tools: [
+          {
+            id: 'tool-2',
+            title: 'pytest',
+            summary: 'Run tests',
+            detail: null,
+            state: 'completed',
+            eventIds: ['200']
+          }
+        ]
+      }
+    ]);
+
+    expect(cards).toHaveLength(2);
+    expect(cards[1]).toMatchObject({
+      kind: 'turn_summary',
+      title: '2 tool calls, 2 thinking updates'
+    });
+    const summary = cards[1];
+    if (summary.kind !== 'turn_summary') throw new Error('expected turn summary');
+    expect(summary.cards).toHaveLength(2);
+    expect(summary.cards[0]).toMatchObject({
+      kind: 'intermediate',
+      title: 'Thinking',
+      text: 'Need to',
+      eventIds: ['197', '198']
+    });
+    expect(summary.cards[1]).toMatchObject({
+      kind: 'tool_group',
+      tools: [
+        { title: 'rg', eventIds: ['199'] },
+        { title: 'pytest', eventIds: ['200'] }
+      ]
+    });
   });
 
   it('merges streamed activity events without dropping older transcript activity', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -1600,6 +1600,28 @@ describe('PMA chat view helpers', () => {
     });
   });
 
+  it('keeps compact transcript ids stable as streaming activity grows', () => {
+    const first = compactPmaTranscriptCards([
+      baseArtifactCardTrace('thinking-1', 'Need', ['401']),
+      baseArtifactCardTrace('thinking-2', 'to', ['402'])
+    ]);
+    const second = compactPmaTranscriptCards([
+      baseArtifactCardTrace('thinking-1', 'Need', ['401']),
+      baseArtifactCardTrace('thinking-2', 'to', ['402']),
+      baseArtifactCardTrace('thinking-3', 'check', ['403'])
+    ]);
+
+    expect(first[0]).toMatchObject({ kind: 'turn_summary', id: 'turn:one:activity:thinking-1' });
+    expect(second[0]).toMatchObject({ kind: 'turn_summary', id: 'turn:one:activity:thinking-1' });
+    const firstSummary = first[0];
+    const secondSummary = second[0];
+    if (firstSummary.kind !== 'turn_summary' || secondSummary.kind !== 'turn_summary') {
+      throw new Error('expected turn summaries');
+    }
+    expect(firstSummary.cards[0]).toMatchObject({ id: 'thinking-1', text: 'Need to' });
+    expect(secondSummary.cards[0]).toMatchObject({ id: 'thinking-1', text: 'Need to check' });
+  });
+
   it('merges streamed activity events without dropping older transcript activity', () => {
     const merged = mergePmaActivityEvents(
       [

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -7,22 +7,22 @@ import {
   buildManagedThreadMessagePayload,
   agentCapabilityAllowed,
   buildPmaChatScopeOptions,
-  buildPmaCards,
-  buildPmaActivityCards,
+  buildChatTranscriptCards,
+  buildChatActivityCards,
   buildPmaLiveActivity,
   buildPmaStatusBar,
   chooseActiveChatId,
-  compactPmaTranscriptCards,
+  compactChatTranscriptCards,
   composeMessageWithAttachments,
   countTicketRunGroups,
   filterPmaChats,
-  filterPmaChatEntries,
+  filterChatEntries,
   filterArtifactsForActiveChat,
   formatRelativeTime,
   formatCompactMessageDateTime,
   isPrimaryProgressArtifact,
-  mergePmaActivityEvents,
-  mapPmaTranscriptSnapshot,
+  mergeChatActivityEvents,
+  mapChatTranscriptSnapshot,
   mapChatSurfaceSnapshotToPmaChats,
   mapChatSurfaceEventToPmaChatSummary,
   modelReasoningOptions,
@@ -30,11 +30,11 @@ import {
   pmaChatKind,
   pmaChatKindLabel,
   pmaChatHeaderScopeLine,
-  pmaChatMessengerSurface,
+  chatMessengerSurface,
   pmaChatScopeLabelFromChat,
   pmaChatScopeTagView,
-  pmaChatSurfaceFilterOptions,
-  pmaChatSurfaceFilterToken,
+  chatSurfaceFilterOptions,
+  chatSurfaceFilterToken,
   progressPercent,
   reconcileChatSurfaceEvent,
   reconcileChatSurfaceSnapshot,
@@ -42,7 +42,7 @@ import {
   sortChatsUnreadFirst,
   sortChatsWaitingFirst,
   summarizeFilterCounts,
-  buildPmaChatListEntries
+  buildChatListEntries
 } from './pmaChat';
 import { resolvePmaChatSelectorsForActiveChat } from './modelPickers';
 
@@ -143,7 +143,7 @@ describe('PMA chat view helpers', () => {
       { ...baseChat, id: 'tf-2', ticketId: null, isTicketFlow: true, worktreeId: 'wt-A', repoId: 'repo-1' },
       { ...baseChat, id: 'tf-3', ticketId: null, isTicketFlow: true, worktreeId: 'wt-A', repoId: 'repo-1' }
     ];
-    const entries = buildPmaChatListEntries(chats, { groupRuns: true });
+    const entries = buildChatListEntries(chats, { groupRuns: true });
     expect(entries).toHaveLength(1);
     expect(entries[0].kind).toBe('group');
     if (entries[0].kind === 'group') {
@@ -157,7 +157,7 @@ describe('PMA chat view helpers', () => {
       { ...baseChat, id: 'tf-2', status: 'idle', ticketId: 'TICKET-002', ticketDone: true },
       { ...baseChat, id: 'tf-3', status: 'running', ticketId: 'TICKET-003', ticketDone: false }
     ];
-    const entries = buildPmaChatListEntries(chats, { groupRuns: true });
+    const entries = buildChatListEntries(chats, { groupRuns: true });
     expect(entries).toHaveLength(1);
     expect(entries[0].kind).toBe('group');
     if (entries[0].kind === 'group') {
@@ -183,8 +183,8 @@ describe('PMA chat view helpers', () => {
     const chats = [standalone, runA, runB, runOther];
     expect(countTicketRunGroups(chats)).toBe(2);
     expect(filterPmaChats(chats, 'ticket_runs', '', {}).map((c) => c.id).sort()).toEqual(['r-a', 'r-b', 'r-c']);
-    const entries = buildPmaChatListEntries(chats, { groupRuns: true });
-    const filtered = filterPmaChatEntries(entries, 'ticket_runs', '', {});
+    const entries = buildChatListEntries(chats, { groupRuns: true });
+    const filtered = filterChatEntries(entries, 'ticket_runs', '', {});
     expect(filtered).toHaveLength(2);
     expect(filtered.every((e) => e.kind === 'group')).toBe(true);
   });
@@ -196,7 +196,7 @@ describe('PMA chat view helpers', () => {
       { ...baseChat, id: 'run-b-ticket-1', runId: 'run-b', isTicketFlow: true, worktreeId: 'wt-1', repoId: 'repo-1' }
     ];
 
-    const entries = buildPmaChatListEntries(chats, { groupRuns: true });
+    const entries = buildChatListEntries(chats, { groupRuns: true });
 
     expect(entries).toHaveLength(2);
     expect(entries.map((entry) => entry.kind === 'group' ? entry.group.key : '').sort()).toEqual([
@@ -212,7 +212,7 @@ describe('PMA chat view helpers', () => {
       { ...baseChat, id: 'run-2-a', runId: 'run-2', ticketId: 'TICKET-003', worktreeId: 'wt-1' }
     ];
 
-    const entries = buildPmaChatListEntries(chats, { groupRuns: true });
+    const entries = buildChatListEntries(chats, { groupRuns: true });
 
     expect(entries).toHaveLength(2);
     expect(entries.filter((entry) => entry.kind === 'group').map((entry) => entry.group.key).sort()).toEqual([
@@ -222,7 +222,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('merges overlapping live assistant progress without duplicating snapshots', () => {
-    const cards = buildPmaActivityCards([
+    const cards = buildChatActivityCards([
       {
         ...baseArtifact,
         id: 'progress-1',
@@ -313,9 +313,9 @@ describe('PMA chat view helpers', () => {
       raw: { lifecycle: 'archived' }
     };
     const chats: PmaChatSummary[] = [active, archivedViaRaw];
-    const entries = buildPmaChatListEntries(chats, { groupRuns: true });
+    const entries = buildChatListEntries(chats, { groupRuns: true });
     expect(entries).toHaveLength(1);
-    const filtered = filterPmaChatEntries(entries, 'all', '', {});
+    const filtered = filterChatEntries(entries, 'all', '', {});
     expect(filtered).toHaveLength(1);
     if (filtered[0].kind !== 'group') throw new Error('expected group row');
     expect(filtered[0].group.chats.map((c) => c.id)).toEqual(['tf-active']);
@@ -324,7 +324,7 @@ describe('PMA chat view helpers', () => {
 
   it('detects messenger surface from API fields and title prefix', () => {
     expect(
-      pmaChatMessengerSurface({
+      chatMessengerSurface({
         ...baseChat,
         title: 'discord:123',
         raw: {}
@@ -332,7 +332,7 @@ describe('PMA chat view helpers', () => {
     ).toEqual({ slug: 'discord', label: 'Discord', badgeClass: 'surface-discord' });
 
     expect(
-      pmaChatMessengerSurface({
+      chatMessengerSurface({
         ...baseChat,
         title: 'General',
         raw: { surface_kind: 'discord', surface_key: 'ch-1' }
@@ -340,7 +340,7 @@ describe('PMA chat view helpers', () => {
     ).toEqual({ slug: 'discord', label: 'Discord', badgeClass: 'surface-discord' });
 
     expect(
-      pmaChatMessengerSurface({
+      chatMessengerSurface({
         ...baseChat,
         title: 'side thread',
         raw: { managed_thread_id: 't1', surface_urn: 'managed_thread:t1' }
@@ -722,21 +722,21 @@ describe('PMA chat view helpers', () => {
     const discordChat = { ...baseChat, id: 'd1', title: 'discord:999', raw: {} };
     const hubChat = { ...baseChat, id: 'h1', title: 'Chat · repo', raw: {} };
     const list = [discordChat, hubChat];
-    expect(filterPmaChats(list, pmaChatSurfaceFilterToken('discord'), '')).toEqual([discordChat]);
-    expect(pmaChatSurfaceFilterOptions(list)).toEqual([{ slug: 'discord', label: 'Discord', count: 1 }]);
+    expect(filterPmaChats(list, chatSurfaceFilterToken('discord'), '')).toEqual([discordChat]);
+    expect(chatSurfaceFilterOptions(list)).toEqual([{ slug: 'discord', label: 'Discord', count: 1 }]);
   });
 
   it('gives notification chats their own surface filter instead of generic other when identifiable', () => {
     const notificationChat = { ...baseChat, id: 'n1', title: 'Notification run_finished', raw: { surface_kind: 'other' } };
     const list = [notificationChat, { ...baseChat, id: 'h1', title: 'Chat', raw: {} }];
 
-    expect(pmaChatMessengerSurface(notificationChat)).toEqual({
+    expect(chatMessengerSurface(notificationChat)).toEqual({
       slug: 'notifications',
       label: 'Notifications',
       badgeClass: 'surface-notifications'
     });
-    expect(pmaChatSurfaceFilterOptions(list)).toEqual([{ slug: 'notifications', label: 'Notifications', count: 1 }]);
-    expect(filterPmaChats(list, pmaChatSurfaceFilterToken('notifications'), '')).toEqual([notificationChat]);
+    expect(chatSurfaceFilterOptions(list)).toEqual([{ slug: 'notifications', label: 'Notifications', count: 1 }]);
+    expect(filterPmaChats(list, chatSurfaceFilterToken('notifications'), '')).toEqual([notificationChat]);
   });
 
   it('sorts waiting chats ahead of others then by recent updates', () => {
@@ -766,7 +766,7 @@ describe('PMA chat view helpers', () => {
       'read-new',
       'read-old'
     ]);
-    expect(buildPmaChatListEntries(chats, { groupRuns: false, lastSeen }).map((entry) => entry.kind === 'chat' ? entry.chat.id : '')).toEqual([
+    expect(buildChatListEntries(chats, { groupRuns: false, lastSeen }).map((entry) => entry.kind === 'chat' ? entry.chat.id : '')).toEqual([
       'unread-new',
       'unread-old',
       'read-new',
@@ -794,7 +794,7 @@ describe('PMA chat view helpers', () => {
       'backend-read'
     ]);
 
-    const entries = buildPmaChatListEntries(chats, { groupRuns: true, lastSeen });
+    const entries = buildChatListEntries(chats, { groupRuns: true, lastSeen });
     expect(entries).toHaveLength(1);
     expect(entries[0].kind).toBe('group');
     if (entries[0].kind === 'group') {
@@ -869,7 +869,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('builds active chat cards for durable transcript content and scoped artifacts', () => {
-    const cards = buildPmaCards(
+    const cards = buildChatTranscriptCards(
       [
         timelineItem('turn:one:assistant', 'assistant_message', {
           text: 'Created a PMA ticket and started the run.',
@@ -907,7 +907,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('maps backend-owned PMA transcript snapshots into renderable cards and status', () => {
-    const snapshot = mapPmaTranscriptSnapshot(
+    const snapshot = mapChatTranscriptSnapshot(
       {
         rows: [
           {
@@ -986,7 +986,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('prefers specific progress labels over generic progress/update fallbacks', () => {
-    const activityCards = buildPmaActivityCards([
+    const activityCards = buildChatActivityCards([
       {
         ...baseArtifact,
         id: 'progress-1',
@@ -1014,7 +1014,7 @@ describe('PMA chat view helpers', () => {
       text: 'Starting pytest'
     });
 
-    const transcriptCards = buildPmaCards(
+    const transcriptCards = buildChatTranscriptCards(
       [
         timelineItem(
           'turn:one:intermediate:21',
@@ -1054,7 +1054,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('falls back to phase metadata when the progress text is generic', () => {
-    const activityCards = buildPmaActivityCards([
+    const activityCards = buildChatActivityCards([
       {
         ...baseArtifact,
         id: 'progress-2',
@@ -1125,7 +1125,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('skips empty message cards and suppresses debug-only lifecycle events from the transcript', () => {
-    const cards = buildPmaCards(
+    const cards = buildChatTranscriptCards(
       [
         timelineItem('turn:empty:user', 'user_message', { text: '' }),
         timelineItem('turn:empty:status:running', 'status', { status: 'running' })
@@ -1139,7 +1139,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('keeps low-level PMA events out of primary transcript cards while preserving final responses', () => {
-    const cards = buildPmaCards(
+    const cards = buildChatTranscriptCards(
       [
         timelineItem('turn:final:assistant', 'assistant_message', {
           text: 'Done. The PMA smoke fixtures are now covered.'
@@ -1158,7 +1158,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('persists intermediate output and groups tool calls between user and final assistant messages', () => {
-    const cards = buildPmaCards(
+    const cards = buildChatTranscriptCards(
       [
         timelineItem('turn:one:user', 'user_message', { text: 'Create tickets' }, '001'),
         {
@@ -1196,7 +1196,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('treats Hermes tool_call progress items as tool cards', () => {
-    const cards = buildPmaActivityCards([
+    const cards = buildChatActivityCards([
       {
         ...baseArtifact,
         id: 'hermes-tool-1',
@@ -1223,7 +1223,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('does not merge live progress notices across tool activity', () => {
-    const cards = buildPmaActivityCards(
+    const cards = buildChatActivityCards(
       [
         {
           ...baseArtifact,
@@ -1280,7 +1280,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('does not merge live progress notices across tool activity', () => {
-    const cards = buildPmaActivityCards(
+    const cards = buildChatActivityCards(
       [
         {
           ...baseArtifact,
@@ -1338,7 +1338,7 @@ describe('PMA chat view helpers', () => {
 
   it('drops decode-failure lifecycle noise from canonical and live activity cards', () => {
     expect(
-      buildPmaCards(
+      buildChatTranscriptCards(
         [
           timelineItem('turn:one:intermediate:1', 'intermediate', {
             intermediate_kind: 'decode_failure',
@@ -1350,7 +1350,7 @@ describe('PMA chat view helpers', () => {
       )
     ).toEqual([]);
     expect(
-      buildPmaActivityCards([
+      buildChatActivityCards([
         {
           ...baseArtifact,
           id: 'decode-1',
@@ -1364,7 +1364,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('drops persisted assistant answer deltas, log lines, and internal journal notices from visible trace cards', () => {
-    const cards = buildPmaCards(
+    const cards = buildChatTranscriptCards(
       [
         timelineItem('turn:one:intermediate:journal', 'intermediate', {
           intermediate_kind: 'chat_execution_journal',
@@ -1403,7 +1403,7 @@ describe('PMA chat view helpers', () => {
     expect(cards).toHaveLength(1);
     expect(cards[0]).toMatchObject({ kind: 'intermediate', text: 'Reading files' });
     expect(
-      buildPmaActivityCards([
+      buildChatActivityCards([
         {
           ...baseArtifact,
           id: 'journal-1',
@@ -1425,7 +1425,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('renders compaction lifecycle timeline items as visible dividers', () => {
-    const cards = buildPmaCards(
+    const cards = buildChatTranscriptCards(
       [
         timelineItem('action:1:compact', 'lifecycle', {
           lifecycle_kind: 'chat_compacted',
@@ -1447,7 +1447,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('preserves grouped tool provenance across all contributing events', () => {
-    const cards = buildPmaCards(
+    const cards = buildChatTranscriptCards(
       [
         timelineItem('turn:one:user', 'user_message', { text: 'Refactor' }, '001'),
         {
@@ -1486,7 +1486,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('compacts dense transcript activity into expandable turn summaries', () => {
-    const cards = compactPmaTranscriptCards([
+    const cards = compactChatTranscriptCards([
       {
         kind: 'message',
         id: 'turn:one:user',
@@ -1572,7 +1572,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('keeps numeric token-like progress updates out of thinking summaries', () => {
-    const cards = compactPmaTranscriptCards([
+    const cards = compactChatTranscriptCards([
       {
         ...baseArtifactCardTrace('progress-10', '10%', ['301']),
         turnId: 'progress-turn',
@@ -1601,11 +1601,11 @@ describe('PMA chat view helpers', () => {
   });
 
   it('keeps compact transcript ids stable as streaming activity grows', () => {
-    const first = compactPmaTranscriptCards([
+    const first = compactChatTranscriptCards([
       baseArtifactCardTrace('thinking-1', 'Need', ['401']),
       baseArtifactCardTrace('thinking-2', 'to', ['402'])
     ]);
-    const second = compactPmaTranscriptCards([
+    const second = compactChatTranscriptCards([
       baseArtifactCardTrace('thinking-1', 'Need', ['401']),
       baseArtifactCardTrace('thinking-2', 'to', ['402']),
       baseArtifactCardTrace('thinking-3', 'check', ['403'])
@@ -1623,7 +1623,7 @@ describe('PMA chat view helpers', () => {
   });
 
   it('merges streamed activity events without dropping older transcript activity', () => {
-    const merged = mergePmaActivityEvents(
+    const merged = mergeChatActivityEvents(
       [
         {
           ...baseArtifact,

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -998,7 +998,6 @@ function foldAdjacentToolGroups(cards: PmaCard[]): PmaCard[] {
     ) {
       out[out.length - 1] = {
         ...prev,
-        id: `${prev.id}..${card.id}`,
         tools: [...prev.tools, ...card.tools],
         orderKey: prev.orderKey || card.orderKey,
         timestamp: prev.timestamp ?? card.timestamp
@@ -1021,7 +1020,6 @@ function mergeIntermediateDeltas(cards: PmaCard[]): PmaCard[] {
     ) {
       out[out.length - 1] = {
         ...prev,
-        id: `${prev.id}..${card.id}`,
         title: mergedIntermediateTitle(prev, card),
         text: mergeIntermediateText(prev.text, card.text),
         eventIds: uniqueStrings([...prev.eventIds, ...card.eventIds]),
@@ -1067,7 +1065,7 @@ function compactActivityRun(cards: PmaActivitySummaryCard[]): PmaCard[] {
   const turnId = activitySummaryTurnId(cards[0]);
   return [{
     kind: 'turn_summary',
-    id: `turn:${turnId ?? cards[0].id}:activity:${cards[0].id}:${cards.at(-1)?.id ?? cards[0].id}`,
+    id: `turn:${turnId ?? cards[0].id}:activity:${cards[0].id}`,
     title: activitySummaryTitle(cards),
     cards,
     turnId,

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -1122,6 +1122,10 @@ function shouldAppendIntermediateDelta(
   if (isCommentaryTraceCard(left) || isCommentaryTraceCard(right)) return false;
   if (isTerminalTraceCard(left) || isTerminalTraceCard(right)) return false;
   if (isThinkingTraceTitle(left.title) && isThinkingTraceTitle(right.title)) return true;
+  if (isThinkingTraceTitle(left.title) && isTokenLikeIntermediate(right) && !isTokenLikeProgressIntermediate(right)) return true;
+  if (isThinkingTraceTitle(right.title) && isTokenLikeIntermediate(left) && !isTokenLikeProgressIntermediate(left)) return true;
+  if (isProgressTraceTitle(left.title) && isTokenLikeProgressIntermediate(right)) return true;
+  if (isProgressTraceTitle(right.title) && isTokenLikeProgressIntermediate(left)) return true;
   if (traceLabelText(left.title).toLowerCase() === traceLabelText(right.title).toLowerCase()) return true;
   return isTokenLikeIntermediate(left) && isTokenLikeIntermediate(right);
 }
@@ -1155,6 +1159,10 @@ function uniqueStrings(values: string[]): string[] {
 
 function isThinkingTraceTitle(title: string): boolean {
   return traceLabelText(title).toLowerCase() === 'thinking';
+}
+
+function isProgressTraceTitle(title: string): boolean {
+  return traceLabelText(title).toLowerCase() === 'progress';
 }
 
 function isTokenLikeProgressIntermediate(card: Extract<PmaCard, { kind: 'intermediate' }>): boolean {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -1142,6 +1142,7 @@ function mergedIntermediateTitle(
   right: Extract<PmaCard, { kind: 'intermediate' }>
 ): string {
   if (isThinkingTraceTitle(left.title) || isThinkingTraceTitle(right.title)) return 'Thinking';
+  if (isTokenLikeProgressIntermediate(left) && isTokenLikeProgressIntermediate(right)) return 'Progress';
   if (isTokenLikeIntermediate(left) && isTokenLikeIntermediate(right)) return 'Thinking';
   return left.title || right.title || 'Update';
 }
@@ -1156,6 +1157,13 @@ function uniqueStrings(values: string[]): string[] {
 
 function isThinkingTraceTitle(title: string): boolean {
   return traceLabelText(title).toLowerCase() === 'thinking';
+}
+
+function isTokenLikeProgressIntermediate(card: Extract<PmaCard, { kind: 'intermediate' }>): boolean {
+  if (!isTokenLikeIntermediate(card)) return false;
+  const text = card.text.trim();
+  const title = card.title.trim();
+  return /(?:\d|%)/.test(text) || /(?:\d|%)/.test(title);
 }
 
 function mapPmaTranscriptRow(raw: Record<string, unknown>): PmaCard | null {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -217,6 +217,8 @@ export type PmaTranscriptSnapshot = {
   raw: Record<string, unknown>;
 };
 
+type PmaActivitySummaryCard = Extract<PmaCard, { kind: 'intermediate' | 'tool_group' | 'approval' }>;
+
 type CanonicalProgressItem = {
   item_id?: string;
   kind?: string;
@@ -978,6 +980,182 @@ export function mapPmaTranscriptSnapshot(
 
 export function mapPmaTranscriptRows(rawRows: unknown): PmaCard[] {
   return asRecordArray(rawRows).map(mapPmaTranscriptRow).filter((row): row is PmaCard => row !== null);
+}
+
+export function compactPmaTranscriptCards(cards: PmaCard[]): PmaCard[] {
+  return summarizeTurnActivity(mergeIntermediateDeltas(foldAdjacentToolGroups(cards)));
+}
+
+function foldAdjacentToolGroups(cards: PmaCard[]): PmaCard[] {
+  const out: PmaCard[] = [];
+  for (const card of cards) {
+    const prev = out[out.length - 1];
+    if (
+      card.kind === 'tool_group' &&
+      prev?.kind === 'tool_group' &&
+      prev.turnId === card.turnId &&
+      prev.turnId !== null
+    ) {
+      out[out.length - 1] = {
+        ...prev,
+        id: `${prev.id}..${card.id}`,
+        tools: [...prev.tools, ...card.tools],
+        orderKey: prev.orderKey || card.orderKey,
+        timestamp: prev.timestamp ?? card.timestamp
+      };
+      continue;
+    }
+    out.push(card);
+  }
+  return out;
+}
+
+function mergeIntermediateDeltas(cards: PmaCard[]): PmaCard[] {
+  const out: PmaCard[] = [];
+  for (const card of cards) {
+    const prev = out[out.length - 1];
+    if (
+      card.kind === 'intermediate' &&
+      prev?.kind === 'intermediate' &&
+      shouldAppendIntermediateDelta(prev, card)
+    ) {
+      out[out.length - 1] = {
+        ...prev,
+        id: `${prev.id}..${card.id}`,
+        title: mergedIntermediateTitle(prev, card),
+        text: mergeIntermediateText(prev.text, card.text),
+        eventIds: uniqueStrings([...prev.eventIds, ...card.eventIds]),
+        progressSourceIds: uniqueStrings([...prev.progressSourceIds, ...card.progressSourceIds]),
+        detail: mergedTraceDetail(mergedIntermediateTitle(prev, card), [...prev.eventIds, ...card.eventIds]),
+        orderKey: prev.orderKey || card.orderKey,
+        timestamp: prev.timestamp ?? card.timestamp
+      };
+      continue;
+    }
+    out.push(card);
+  }
+  return out;
+}
+
+function summarizeTurnActivity(cards: PmaCard[]): PmaCard[] {
+  const out: PmaCard[] = [];
+  let pending: PmaActivitySummaryCard[] = [];
+
+  const flush = () => {
+    if (!pending.length) return;
+    out.push(...compactActivityRun(pending));
+    pending = [];
+  };
+
+  for (const card of cards) {
+    if (isSummaryActivityCard(card)) {
+      const currentTurn = activitySummaryTurnId(card);
+      const pendingTurn = pending.length ? activitySummaryTurnId(pending[0]) : currentTurn;
+      if (pending.length && currentTurn !== pendingTurn) flush();
+      pending.push(card);
+      continue;
+    }
+    flush();
+    out.push(card);
+  }
+  flush();
+  return out;
+}
+
+function compactActivityRun(cards: PmaActivitySummaryCard[]): PmaCard[] {
+  if (cards.length === 1 && !activityCardNeedsSummary(cards[0])) return cards;
+  const turnId = activitySummaryTurnId(cards[0]);
+  return [{
+    kind: 'turn_summary',
+    id: `turn:${turnId ?? cards[0].id}:activity:${cards[0].id}:${cards.at(-1)?.id ?? cards[0].id}`,
+    title: activitySummaryTitle(cards),
+    cards,
+    turnId,
+    orderKey: cards[0].orderKey,
+    timestamp: cards[0].timestamp
+  }];
+}
+
+function activitySummaryTitle(cards: PmaActivitySummaryCard[]): string {
+  let toolCalls = 0;
+  let thinkingUpdates = 0;
+  let progressUpdates = 0;
+  let approvals = 0;
+  for (const card of cards) {
+    if (card.kind === 'tool_group') {
+      toolCalls += card.tools.length;
+    } else if (card.kind === 'approval') {
+      approvals += 1;
+    } else if (card.kind === 'intermediate') {
+      const count = Math.max(1, uniqueStrings([...card.eventIds, ...card.progressSourceIds]).length);
+      if (isThinkingTraceTitle(card.title)) thinkingUpdates += count;
+      else progressUpdates += count;
+    }
+  }
+  const parts: string[] = [];
+  if (toolCalls) parts.push(`${toolCalls} tool ${toolCalls === 1 ? 'call' : 'calls'}`);
+  if (thinkingUpdates) parts.push(`${thinkingUpdates} thinking ${thinkingUpdates === 1 ? 'update' : 'updates'}`);
+  if (progressUpdates) parts.push(`${progressUpdates} progress ${progressUpdates === 1 ? 'update' : 'updates'}`);
+  if (approvals) parts.push(`${approvals} approval ${approvals === 1 ? 'request' : 'requests'}`);
+  return parts.length ? parts.join(', ') : 'Activity details';
+}
+
+function activityCardNeedsSummary(card: PmaActivitySummaryCard): boolean {
+  if (card.kind === 'tool_group') return card.tools.length > 1;
+  if (card.kind === 'intermediate') return uniqueStrings([...card.eventIds, ...card.progressSourceIds]).length > 1;
+  return false;
+}
+
+function isSummaryActivityCard(card: PmaCard): card is PmaActivitySummaryCard {
+  if (card.kind === 'tool_group' || card.kind === 'approval') return true;
+  if (card.kind !== 'intermediate') return false;
+  return !isCommentaryTraceCard(card);
+}
+
+function activitySummaryTurnId(card: PmaActivitySummaryCard): string | null {
+  return card.turnId;
+}
+
+function shouldAppendIntermediateDelta(
+  left: Extract<PmaCard, { kind: 'intermediate' }>,
+  right: Extract<PmaCard, { kind: 'intermediate' }>
+): boolean {
+  if (left.turnId !== right.turnId) return false;
+  if (isCommentaryTraceCard(left) || isCommentaryTraceCard(right)) return false;
+  if (isTerminalTraceCard(left) || isTerminalTraceCard(right)) return false;
+  if (isThinkingTraceTitle(left.title) && isThinkingTraceTitle(right.title)) return true;
+  if (traceLabelText(left.title).toLowerCase() === traceLabelText(right.title).toLowerCase()) return true;
+  return isTokenLikeIntermediate(left) && isTokenLikeIntermediate(right);
+}
+
+function isTokenLikeIntermediate(card: Extract<PmaCard, { kind: 'intermediate' }>): boolean {
+  const text = card.text.trim();
+  const title = card.title.trim();
+  if (!text || text.length > 32 || /\n/.test(text)) return false;
+  if (/[.!?]$/.test(text)) return false;
+  if (title && title.length <= 32 && text.toLowerCase() === title.toLowerCase()) return true;
+  return text.split(/\s+/).length <= 3 && !isSpecificTraceSummary(text);
+}
+
+function mergedIntermediateTitle(
+  left: Extract<PmaCard, { kind: 'intermediate' }>,
+  right: Extract<PmaCard, { kind: 'intermediate' }>
+): string {
+  if (isThinkingTraceTitle(left.title) || isThinkingTraceTitle(right.title)) return 'Thinking';
+  if (isTokenLikeIntermediate(left) && isTokenLikeIntermediate(right)) return 'Thinking';
+  return left.title || right.title || 'Update';
+}
+
+function mergedTraceDetail(title: string, eventIds: string[]): string | null {
+  return traceDetailSummary(title, uniqueStrings(eventIds));
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function isThinkingTraceTitle(title: string): boolean {
+  return traceLabelText(title).toLowerCase() === 'thinking';
 }
 
 function mapPmaTranscriptRow(raw: Record<string, unknown>): PmaCard | null {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -13,18 +13,18 @@ import { surfaceRefFromThreadRaw } from './thread';
 import { isChatUnread } from './unread';
 
 /** Status chips (All / Waiting / …) on the chat list. */
-export type PmaChatStatusFilter = 'all' | 'active' | 'waiting' | 'unread' | 'archived';
+export type ChatStatusFilter = 'all' | 'active' | 'waiting' | 'unread' | 'archived';
 
 /** Full list filter: status chips, grouped ticket runs, or `surface:<slug>` messenger filters. */
-export type PmaChatFilter = PmaChatStatusFilter | 'ticket_runs' | `surface:${string}`;
+export type ChatFilter = ChatStatusFilter | 'ticket_runs' | `surface:${string}`;
 
 /** Token for the chats sidebar filter that lists only ticket-flow run groups (collapsed headers). */
-export const PMA_CHAT_TICKET_RUNS_FILTER = 'ticket_runs' as const satisfies PmaChatFilter;
+export const CHAT_TICKET_RUNS_FILTER = 'ticket_runs' as const satisfies ChatFilter;
 
 /** Synthetic list selection id for pinned PMA Memory in the chats sidebar. */
-export const PMA_MEMORY_LIST_ID = '__memory__';
+export const CHAT_MEMORY_LIST_ID = '__memory__';
 
-export const PMA_CHAT_FILTER_ORDER: PmaChatStatusFilter[] = ['all', 'waiting', 'active', 'unread', 'archived'];
+export const CHAT_FILTER_ORDER: ChatStatusFilter[] = ['all', 'waiting', 'active', 'unread', 'archived'];
 
 const INTERNAL_MESSENGER_SURFACE_KINDS = new Set([
   'managed_thread',
@@ -74,7 +74,7 @@ function messengerBadgeClass(slug: string): string {
 }
 
 /** Badge + filter slug for chats bound to an external messenger surface (Discord, Telegram, …). */
-export function pmaChatMessengerSurface(
+export function chatMessengerSurface(
   chat: PmaChatSummary | null
 ): { slug: string; label: string; badgeClass: string } | null {
   if (!chat) return null;
@@ -105,21 +105,21 @@ export function pmaChatMessengerSurface(
   return null;
 }
 
-export function pmaChatSurfaceFilterToken(slug: string): PmaChatFilter {
+export function chatSurfaceFilterToken(slug: string): ChatFilter {
   return `surface:${slug}`;
 }
 
-export function isPmaChatSurfaceFilter(filter: PmaChatFilter): filter is `surface:${string}` {
+export function isChatSurfaceFilter(filter: ChatFilter): filter is `surface:${string}` {
   return filter.startsWith('surface:');
 }
 
-export function pmaChatSurfaceFilterOptions(
+export function chatSurfaceFilterOptions(
   chats: PmaChatSummary[]
 ): { slug: string; label: string; count: number }[] {
   const counts = new Map<string, { label: string; count: number }>();
   for (const chat of chats) {
     if (isPmaChatArchived(chat)) continue;
-    const surf = pmaChatMessengerSurface(chat);
+    const surf = chatMessengerSurface(chat);
     if (!surf) continue;
     const prev = counts.get(surf.slug);
     if (prev) prev.count += 1;
@@ -179,7 +179,7 @@ export type ArtifactCardView = {
   detailLabel: string;
 };
 
-export type PmaCard =
+export type ChatTranscriptCard =
   | { kind: 'message'; id: string; message: PmaChatMessage; turnId: string | null; orderKey: string; timestamp: string | null }
   | {
       kind: 'intermediate';
@@ -194,14 +194,14 @@ export type PmaCard =
       orderKey: string;
       timestamp: string | null;
     }
-  | { kind: 'tool_group'; id: string; tools: PmaToolCallCard[]; turnId: string | null; orderKey: string; timestamp: string | null }
-  | { kind: 'turn_summary'; id: string; title: string; cards: PmaCard[]; turnId: string | null; orderKey: string; timestamp: string | null }
+  | { kind: 'tool_group'; id: string; tools: ChatToolCallCard[]; turnId: string | null; orderKey: string; timestamp: string | null }
+  | { kind: 'turn_summary'; id: string; title: string; cards: ChatTranscriptCard[]; turnId: string | null; orderKey: string; timestamp: string | null }
   | { kind: 'approval'; id: string; title: string; summary: string; detail: string | null; turnId: string | null; orderKey: string; timestamp: string | null }
   | { kind: 'lifecycle'; id: string; title: string; text: string; detail: string | null; turnId: string | null; orderKey: string; timestamp: string | null }
   | { kind: 'ticket'; id: string; title: string; summary: string | null; ticketId: string }
   | { kind: 'artifact'; id: string; artifact: SurfaceArtifact };
 
-export type PmaToolCallCard = {
+export type ChatToolCallCard = {
   id: string;
   title: string;
   summary: string | null;
@@ -211,13 +211,13 @@ export type PmaToolCallCard = {
   source?: SurfaceArtifact;
 };
 
-export type PmaTranscriptSnapshot = {
-  rows: PmaCard[];
+export type ChatTranscriptSnapshot = {
+  rows: ChatTranscriptCard[];
   status: PmaRunProgress | null;
   raw: Record<string, unknown>;
 };
 
-type PmaActivitySummaryCard = Extract<PmaCard, { kind: 'intermediate' | 'tool_group' | 'approval' }>;
+type ChatActivitySummaryCard = Extract<ChatTranscriptCard, { kind: 'intermediate' | 'tool_group' | 'approval' }>;
 
 type CanonicalProgressItem = {
   item_id?: string;
@@ -570,7 +570,7 @@ export function isPmaChatArchived(chat: PmaChatSummary): boolean {
 
 export function filterPmaChats(
   chats: PmaChatSummary[],
-  filter: PmaChatFilter,
+  filter: ChatFilter,
   query: string,
   lastSeen: Record<string, string> = {}
 ): PmaChatSummary[] {
@@ -580,11 +580,11 @@ export function filterPmaChats(
       const archived = isPmaChatArchived(chat);
       if (filter === 'archived') return archived;
       if (archived) return false;
-      if (isPmaChatSurfaceFilter(filter)) {
+      if (isChatSurfaceFilter(filter)) {
         const slug = filter.slice('surface:'.length);
-        return pmaChatMessengerSurface(chat)?.slug === slug;
+        return chatMessengerSurface(chat)?.slug === slug;
       }
-      if (filter === 'ticket_runs') return pmaChatRunGroupKey(chat) !== null;
+      if (filter === 'ticket_runs') return chatRunGroupKey(chat) !== null;
       if (filter === 'active') return activeStatuses.includes(chat.status);
       if (filter === 'waiting') return waitingStatuses.includes(chat.status);
       if (filter === 'unread') {
@@ -594,7 +594,7 @@ export function filterPmaChats(
     })
     .filter((chat) => {
       if (!needle) return true;
-      const surfaceLabel = pmaChatMessengerSurface(chat)?.label;
+      const surfaceLabel = chatMessengerSurface(chat)?.label;
       return [
         chat.title,
         chat.repoId,
@@ -647,7 +647,7 @@ export function sortChatsWaitingFirst(chats: PmaChatSummary[]): PmaChatSummary[]
 export function summarizeFilterCounts(
   chats: PmaChatSummary[],
   lastSeen: Record<string, string> = {}
-): Record<PmaChatStatusFilter, number> {
+): Record<ChatStatusFilter, number> {
   const activeChats = chats.filter((chat) => !isPmaChatArchived(chat));
   return {
     all: activeChats.length,
@@ -663,7 +663,7 @@ export function summarizeFilterCounts(
  * worktree (or repo, for repo-scoped flows) belong to the same operator-visible
  * run; they collapse into a single row on chat lists.
  */
-export type PmaChatRunGroup = {
+export type ChatRunGroup = {
   key: string;
   scopeKind: 'worktree' | 'repo';
   scopeId: string;
@@ -680,11 +680,11 @@ export type PmaChatRunGroup = {
   updatedAt: string | null;
 };
 
-export type PmaChatListEntry =
-  | { kind: 'group'; group: PmaChatRunGroup }
+export type ChatListEntry =
+  | { kind: 'group'; group: ChatRunGroup }
   | { kind: 'chat'; chat: PmaChatSummary };
 
-export function pmaChatRunGroupKey(chat: PmaChatSummary): string | null {
+export function chatRunGroupKey(chat: PmaChatSummary): string | null {
   if (!chat.isTicketFlow && !chat.ticketId) return null;
   const runSuffix = chat.runId ? `:run:${chat.runId}` : '';
   if (chat.worktreeId) return `worktree:${chat.worktreeId}${runSuffix}`;
@@ -697,7 +697,7 @@ export function countTicketRunGroups(chats: PmaChatSummary[]): number {
   const keys = new Set<string>();
   for (const chat of chats) {
     if (isPmaChatArchived(chat)) continue;
-    const key = pmaChatRunGroupKey(chat);
+    const key = chatRunGroupKey(chat);
     if (key) keys.add(key);
   }
   return keys.size;
@@ -707,7 +707,7 @@ function isUnread(chat: PmaChatSummary, lastSeen: Record<string, string>): boole
   return isChatUnread(chat, lastSeen);
 }
 
-function rollupGroupStatus(group: PmaChatRunGroup): WorkStatus {
+function rollupGroupStatus(group: ChatRunGroup): WorkStatus {
   if (group.waitingCount > 0) return 'waiting';
   if (group.activeCount > 0) return 'running';
   if (group.failedCount > 0) return 'failed';
@@ -720,7 +720,7 @@ function chatCountsDoneForRun(chat: PmaChatSummary): boolean {
   return chat.ticketDone === true || chat.status === 'done';
 }
 
-export function buildPmaChatListEntries(
+export function buildChatListEntries(
   chats: PmaChatSummary[],
   options: {
     lastSeen?: Record<string, string>;
@@ -728,16 +728,16 @@ export function buildPmaChatListEntries(
     worktreeLabel?: (worktreeId: string) => string | null;
     groupRuns?: boolean;
   } = {}
-): PmaChatListEntry[] {
+): ChatListEntry[] {
   const lastSeen = options.lastSeen ?? {};
   if (options.groupRuns === false) {
-    return sortChatsUnreadFirst(chats, lastSeen).map((chat) => ({ kind: 'chat', chat }) as PmaChatListEntry);
+    return sortChatsUnreadFirst(chats, lastSeen).map((chat) => ({ kind: 'chat', chat }) as ChatListEntry);
   }
-  const groups = new Map<string, PmaChatRunGroup>();
+  const groups = new Map<string, ChatRunGroup>();
   const standalone: PmaChatSummary[] = [];
 
   for (const chat of chats) {
-    const key = pmaChatRunGroupKey(chat);
+    const key = chatRunGroupKey(chat);
     if (!key) {
       standalone.push(chat);
       continue;
@@ -787,7 +787,7 @@ export function buildPmaChatListEntries(
     group.status = rollupGroupStatus(group);
   }
 
-  type Sortable = { entry: PmaChatListEntry; unreadRank: number; statusRank: number; sort: string; id: string };
+  type Sortable = { entry: ChatListEntry; unreadRank: number; statusRank: number; sort: string; id: string };
   const sortables: Sortable[] = [];
   for (const group of groups.values()) {
     sortables.push({
@@ -818,13 +818,13 @@ export function buildPmaChatListEntries(
 }
 
 /** Filter entries against a single PMA chat filter while preserving group structure. */
-export function filterPmaChatEntries(
-  entries: PmaChatListEntry[],
-  filter: PmaChatFilter,
+export function filterChatEntries(
+  entries: ChatListEntry[],
+  filter: ChatFilter,
   search: string,
   lastSeen: Record<string, string> = {}
-): PmaChatListEntry[] {
-  const out: PmaChatListEntry[] = [];
+): ChatListEntry[] {
+  const out: ChatListEntry[] = [];
   for (const entry of entries) {
     if (entry.kind === 'chat') {
       const filtered = filterPmaChats([entry.chat], filter, search, lastSeen);
@@ -838,7 +838,7 @@ export function filterPmaChatEntries(
       continue;
     }
     // Rebuild a slimmer group containing only matched chats so counts stay honest.
-    const trimmed: PmaChatRunGroup = {
+    const trimmed: ChatRunGroup = {
       ...entry.group,
       chats: matchedChats,
       totalCount: matchedChats.length,
@@ -879,17 +879,17 @@ export function chooseActiveChatId(
   return null;
 }
 
-export function buildPmaCards(
+export function buildChatTranscriptCards(
   timeline: PmaTimelineItem[],
   chat: PmaChatSummary | null,
   artifacts: SurfaceArtifact[]
-): PmaCard[] {
+): ChatTranscriptCard[] {
   const normalizedTimeline = suppressDuplicateTimelineDeliveries(timeline);
   const messageAttachmentKeys = collectMessageAttachmentKeys(normalizedTimeline);
   const timelineCards = normalizedTimeline
     .flatMap(timelineItemToCard)
     .filter((card) => !isMessageAttachmentArtifactCard(card, messageAttachmentKeys));
-  const cards: PmaCard[] = [...timelineCards];
+  const cards: ChatTranscriptCard[] = [...timelineCards];
 
   if (chat?.ticketId) {
     cards.push({
@@ -927,7 +927,7 @@ function canonicalTimelineIdentityKey(item: PmaTimelineItem): string {
   return item.identity.timelineItemId;
 }
 
-function isMessageAttachmentArtifactCard(card: PmaCard, messageAttachmentKeys: Set<string>): boolean {
+function isMessageAttachmentArtifactCard(card: ChatTranscriptCard, messageAttachmentKeys: Set<string>): boolean {
   if (card.kind !== 'artifact') return false;
   return artifactKeysFor(card.artifact).some((key) => messageAttachmentKeys.has(key));
 }
@@ -965,12 +965,12 @@ function artifactKeysFor(artifact: SurfaceArtifact): string[] {
   return [...keys];
 }
 
-export function mapPmaTranscriptSnapshot(
+export function mapChatTranscriptSnapshot(
   raw: Record<string, unknown>,
   mapProgress: (raw: Record<string, unknown>) => PmaRunProgress
-): PmaTranscriptSnapshot {
+): ChatTranscriptSnapshot {
   return {
-    rows: asRecordArray(raw.rows).map(mapPmaTranscriptRow).filter((row): row is PmaCard => row !== null),
+    rows: asRecordArray(raw.rows).map(mapChatTranscriptRow).filter((row): row is ChatTranscriptCard => row !== null),
     status: raw.status && typeof raw.status === 'object' && !Array.isArray(raw.status)
       ? mapProgress(raw.status as Record<string, unknown>)
       : null,
@@ -978,16 +978,16 @@ export function mapPmaTranscriptSnapshot(
   };
 }
 
-export function mapPmaTranscriptRows(rawRows: unknown): PmaCard[] {
-  return asRecordArray(rawRows).map(mapPmaTranscriptRow).filter((row): row is PmaCard => row !== null);
+export function mapChatTranscriptRows(rawRows: unknown): ChatTranscriptCard[] {
+  return asRecordArray(rawRows).map(mapChatTranscriptRow).filter((row): row is ChatTranscriptCard => row !== null);
 }
 
-export function compactPmaTranscriptCards(cards: PmaCard[]): PmaCard[] {
+export function compactChatTranscriptCards(cards: ChatTranscriptCard[]): ChatTranscriptCard[] {
   return summarizeTurnActivity(mergeIntermediateDeltas(foldAdjacentToolGroups(cards)));
 }
 
-function foldAdjacentToolGroups(cards: PmaCard[]): PmaCard[] {
-  const out: PmaCard[] = [];
+function foldAdjacentToolGroups(cards: ChatTranscriptCard[]): ChatTranscriptCard[] {
+  const out: ChatTranscriptCard[] = [];
   for (const card of cards) {
     const prev = out[out.length - 1];
     if (
@@ -1009,8 +1009,8 @@ function foldAdjacentToolGroups(cards: PmaCard[]): PmaCard[] {
   return out;
 }
 
-function mergeIntermediateDeltas(cards: PmaCard[]): PmaCard[] {
-  const out: PmaCard[] = [];
+function mergeIntermediateDeltas(cards: ChatTranscriptCard[]): ChatTranscriptCard[] {
+  const out: ChatTranscriptCard[] = [];
   for (const card of cards) {
     const prev = out[out.length - 1];
     if (
@@ -1035,9 +1035,9 @@ function mergeIntermediateDeltas(cards: PmaCard[]): PmaCard[] {
   return out;
 }
 
-function summarizeTurnActivity(cards: PmaCard[]): PmaCard[] {
-  const out: PmaCard[] = [];
-  let pending: PmaActivitySummaryCard[] = [];
+function summarizeTurnActivity(cards: ChatTranscriptCard[]): ChatTranscriptCard[] {
+  const out: ChatTranscriptCard[] = [];
+  let pending: ChatActivitySummaryCard[] = [];
 
   const flush = () => {
     if (!pending.length) return;
@@ -1060,7 +1060,7 @@ function summarizeTurnActivity(cards: PmaCard[]): PmaCard[] {
   return out;
 }
 
-function compactActivityRun(cards: PmaActivitySummaryCard[]): PmaCard[] {
+function compactActivityRun(cards: ChatActivitySummaryCard[]): ChatTranscriptCard[] {
   if (cards.length === 1 && !activityCardNeedsSummary(cards[0])) return cards;
   const turnId = activitySummaryTurnId(cards[0]);
   return [{
@@ -1074,7 +1074,7 @@ function compactActivityRun(cards: PmaActivitySummaryCard[]): PmaCard[] {
   }];
 }
 
-function activitySummaryTitle(cards: PmaActivitySummaryCard[]): string {
+function activitySummaryTitle(cards: ChatActivitySummaryCard[]): string {
   let toolCalls = 0;
   let thinkingUpdates = 0;
   let progressUpdates = 0;
@@ -1098,25 +1098,25 @@ function activitySummaryTitle(cards: PmaActivitySummaryCard[]): string {
   return parts.length ? parts.join(', ') : 'Activity details';
 }
 
-function activityCardNeedsSummary(card: PmaActivitySummaryCard): boolean {
+function activityCardNeedsSummary(card: ChatActivitySummaryCard): boolean {
   if (card.kind === 'tool_group') return card.tools.length > 1;
   if (card.kind === 'intermediate') return uniqueStrings([...card.eventIds, ...card.progressSourceIds]).length > 1;
   return false;
 }
 
-function isSummaryActivityCard(card: PmaCard): card is PmaActivitySummaryCard {
+function isSummaryActivityCard(card: ChatTranscriptCard): card is ChatActivitySummaryCard {
   if (card.kind === 'tool_group' || card.kind === 'approval') return true;
   if (card.kind !== 'intermediate') return false;
   return !isCommentaryTraceCard(card);
 }
 
-function activitySummaryTurnId(card: PmaActivitySummaryCard): string | null {
+function activitySummaryTurnId(card: ChatActivitySummaryCard): string | null {
   return card.turnId;
 }
 
 function shouldAppendIntermediateDelta(
-  left: Extract<PmaCard, { kind: 'intermediate' }>,
-  right: Extract<PmaCard, { kind: 'intermediate' }>
+  left: Extract<ChatTranscriptCard, { kind: 'intermediate' }>,
+  right: Extract<ChatTranscriptCard, { kind: 'intermediate' }>
 ): boolean {
   if (left.turnId !== right.turnId) return false;
   if (isCommentaryTraceCard(left) || isCommentaryTraceCard(right)) return false;
@@ -1130,7 +1130,7 @@ function shouldAppendIntermediateDelta(
   return isTokenLikeIntermediate(left) && isTokenLikeIntermediate(right);
 }
 
-function isTokenLikeIntermediate(card: Extract<PmaCard, { kind: 'intermediate' }>): boolean {
+function isTokenLikeIntermediate(card: Extract<ChatTranscriptCard, { kind: 'intermediate' }>): boolean {
   const text = card.text.trim();
   const title = card.title.trim();
   if (!text || text.length > 32 || /\n/.test(text)) return false;
@@ -1140,8 +1140,8 @@ function isTokenLikeIntermediate(card: Extract<PmaCard, { kind: 'intermediate' }
 }
 
 function mergedIntermediateTitle(
-  left: Extract<PmaCard, { kind: 'intermediate' }>,
-  right: Extract<PmaCard, { kind: 'intermediate' }>
+  left: Extract<ChatTranscriptCard, { kind: 'intermediate' }>,
+  right: Extract<ChatTranscriptCard, { kind: 'intermediate' }>
 ): string {
   if (isThinkingTraceTitle(left.title) || isThinkingTraceTitle(right.title)) return 'Thinking';
   if (isTokenLikeProgressIntermediate(left) && isTokenLikeProgressIntermediate(right)) return 'Progress';
@@ -1165,14 +1165,14 @@ function isProgressTraceTitle(title: string): boolean {
   return traceLabelText(title).toLowerCase() === 'progress';
 }
 
-function isTokenLikeProgressIntermediate(card: Extract<PmaCard, { kind: 'intermediate' }>): boolean {
+function isTokenLikeProgressIntermediate(card: Extract<ChatTranscriptCard, { kind: 'intermediate' }>): boolean {
   if (!isTokenLikeIntermediate(card)) return false;
   const text = card.text.trim();
   const title = card.title.trim();
   return /(?:\d|%)/.test(text) || /(?:\d|%)/.test(title);
 }
 
-function mapPmaTranscriptRow(raw: Record<string, unknown>): PmaCard | null {
+function mapChatTranscriptRow(raw: Record<string, unknown>): ChatTranscriptCard | null {
   const kind = stringValue(raw.kind);
   const id = stringValue(raw.id);
   if (!kind || !id) return null;
@@ -1259,7 +1259,7 @@ function mapPmaTranscriptRow(raw: Record<string, unknown>): PmaCard | null {
   return null;
 }
 
-function mapTranscriptToolCard(raw: Record<string, unknown>): PmaToolCallCard {
+function mapTranscriptToolCard(raw: Record<string, unknown>): ChatToolCallCard {
   const state = stringValue(raw.state);
   return {
     id: stringValue(raw.id) || 'tool',
@@ -1283,7 +1283,7 @@ function mapTranscriptArtifact(raw: Record<string, unknown>): SurfaceArtifact {
   };
 }
 
-export function mergePmaActivityEvents(
+export function mergeChatActivityEvents(
   existing: SurfaceArtifact[],
   incoming: SurfaceArtifact[],
   limit = 160
@@ -1305,12 +1305,12 @@ export function mergePmaActivityEvents(
   return ordered.slice(-limit);
 }
 
-export function buildPmaActivityCards(
+export function buildChatActivityCards(
   events: SurfaceArtifact[],
   options: { fallbackTurnId?: string | null } = {}
-): PmaCard[] {
-  const cards: PmaCard[] = [];
-  let toolGroup: PmaToolCallCard[] = [];
+): ChatTranscriptCard[] {
+  const cards: ChatTranscriptCard[] = [];
+  let toolGroup: ChatToolCallCard[] = [];
   const fallbackTurnId = options.fallbackTurnId ?? null;
 
   const flushToolGroup = () => {
@@ -1372,10 +1372,10 @@ export function buildPmaActivityCards(
 }
 
 function findMergeableIntermediate(
-  cards: PmaCard[],
+  cards: ChatTranscriptCard[],
   event: SurfaceArtifact,
   fallbackTurnId: string | null
-): Extract<PmaCard, { kind: 'intermediate' }> | null {
+): Extract<ChatTranscriptCard, { kind: 'intermediate' }> | null {
   if (isCommentaryTraceEvent(event)) {
     return null;
   }
@@ -1615,7 +1615,7 @@ function intermediateTitle(event: SurfaceArtifact): string {
 }
 
 function shouldMergeIntermediate(
-  card: Extract<PmaCard, { kind: 'intermediate' }>,
+  card: Extract<ChatTranscriptCard, { kind: 'intermediate' }>,
   event: SurfaceArtifact,
   fallbackTurnId: string | null = null
 ): boolean {
@@ -1658,7 +1658,7 @@ function toolDisplayTitle(event: SurfaceArtifact): string {
   return stringValue(item?.tool_name) || stringValue(item?.title) || event.summary || event.title || 'Tool call';
 }
 
-function toolState(event: SurfaceArtifact): PmaToolCallCard['state'] {
+function toolState(event: SurfaceArtifact): ChatToolCallCard['state'] {
   const rawState = stringValue(canonicalProgressItem(event)?.state).toLowerCase();
   if (rawState === 'started' || rawState === 'completed' || rawState === 'failed') return rawState;
   return 'unknown';
@@ -1729,7 +1729,7 @@ function isHiddenLifecycleActivity(event: SurfaceArtifact): boolean {
   return title === 'chat execution journal' || title === 'compaction summary';
 }
 
-function timelineItemToCard(item: PmaTimelineItem): PmaCard[] {
+function timelineItemToCard(item: PmaTimelineItem): ChatTranscriptCard[] {
   if (item.kind === 'user_message' || item.kind === 'assistant_message') {
     const text = stringValue(item.payload.text);
     if (!text.trim()) return [];
@@ -1815,11 +1815,11 @@ function timelineItemToCard(item: PmaTimelineItem): PmaCard[] {
   return [];
 }
 
-function toolCardFromTimeline(item: PmaTimelineItem): PmaToolCallCard {
+function toolCardFromTimeline(item: PmaTimelineItem): ChatToolCallCard {
   const result = asRecord(item.payload.result);
   const call = asRecord(item.payload.call);
   const rawState = stringValue(result.status ?? item.raw.status ?? item.status).toLowerCase();
-  const state: PmaToolCallCard['state'] =
+  const state: ChatToolCallCard['state'] =
     rawState.includes('fail') || rawState === 'error'
       ? 'failed'
       : result && Object.keys(result).length > 0
@@ -1887,13 +1887,13 @@ function mapTimelineArtifact(raw: Record<string, unknown>): SurfaceArtifact {
   };
 }
 
-function isCommentaryTraceCard(card: PmaCard): boolean {
+function isCommentaryTraceCard(card: ChatTranscriptCard): boolean {
   if (card.kind !== 'intermediate') return false;
   const title = card.title.trim().toLowerCase();
   return title === 'commentary';
 }
 
-function isTerminalTraceCard(card: PmaCard): boolean {
+function isTerminalTraceCard(card: ChatTranscriptCard): boolean {
   if (card.kind !== 'intermediate') return false;
   const title = card.title.trim().toLowerCase();
   return title === 'run failed' || title === 'turn failed' || title === 'interrupted';

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/webUiScenarioHarness.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/webUiScenarioHarness.test.ts
@@ -15,7 +15,7 @@ import {
   type TicketSummary,
   type WorktreeSummary
 } from './domain';
-import { buildPmaChatListEntries } from './pmaChat';
+import { buildChatListEntries } from './pmaChat';
 import {
   buildRepoWorktreeDetailViewModel,
   buildRepoWorktreeIndexViewModel,
@@ -274,7 +274,7 @@ describe('fixture-backed Web UI scenario harness', () => {
 
   it('normalizes unknown statuses and missing optional fields for chat lists', () => {
     const source = mapped(chatListDetail());
-    const entries = buildPmaChatListEntries(source.chats);
+    const entries = buildChatListEntries(source.chats);
 
     expect(source.chats.find((chat) => chat.id === 'chat-unknown-status')?.status).toBe('idle');
     expect(entries.length).toBeGreaterThan(0);

--- a/src/codex_autorunner/web_frontend/src/routes/+layout.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/+layout.svelte
@@ -4,7 +4,7 @@
   import { breadcrumbsForPath } from '$lib/breadcrumbs';
   import { primaryNav, isActiveRoute } from '$lib/navigation';
   import { stripRuntimeBasePath, withRuntimeBasePath as href } from '$lib/runtime/basePath';
-  import { pmaApi } from '$lib/api/client';
+  import { webApi } from '$lib/api/client';
   import { chatIndexSession } from '$lib/data';
   import { Palette, createPaletteStore, scopeSource } from '$lib/palette';
   import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
@@ -64,7 +64,7 @@
   const hubGlyph = $derived((hubTitle.trim().charAt(0) || 'W').toUpperCase());
 
   async function loadHubState(): Promise<void> {
-    const result = await pmaApi.hub.getState();
+    const result = await webApi.hub.getState();
     if (!result.ok) return;
     hubTitle = result.data.title;
     titleDraft = result.data.title;
@@ -77,7 +77,7 @@
       return;
     }
     titleSaving = true;
-    const result = await pmaApi.hub.updateState({ title: next });
+    const result = await webApi.hub.updateState({ title: next });
     titleSaving = false;
     if (!result.ok) {
       titleDraft = hubTitle;

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -11,7 +11,7 @@
   import VoiceComposerButton from '$lib/components/VoiceComposerButton.svelte';
   import ContentSkeleton from '$lib/components/ContentSkeleton.svelte';
   import { confirmDialog } from '$lib/components/confirmDialog';
-  import { pmaApi, type ApiError, type JsonRecord, type PmaQueuedTurn } from '$lib/api/client';
+  import { webApi, type ApiError, type JsonRecord, type PmaQueuedTurn } from '$lib/api/client';
   import {
     pmaChatSummaryToChatIndexRow,
     chatIndexSession,
@@ -24,7 +24,7 @@
     selectPmaChats,
     selectPmaProgress,
     selectPmaQueue,
-    selectPmaTranscript,
+    selectChatTranscript,
     selectWorktreeSummaries,
     selectReadMarkers
   } from '$lib/data';
@@ -36,7 +36,7 @@
     planStartAndSendChat
   } from '$lib/application/pmaChatCommands';
   import { withRuntimeBasePath as href } from '$lib/runtime/basePath';
-  import { openPmaTranscriptEventSource, shouldUsePmaTranscriptStream, type StreamSubscription } from '$lib/api/streaming';
+  import { openChatTranscriptEventSource, shouldUseChatTranscriptStream, type StreamSubscription } from '$lib/api/streaming';
   import {
     repoContextspaceRoute,
     repoRoute,
@@ -52,7 +52,7 @@
     SurfaceArtifact
   } from '$lib/viewModels/domain';
   import {
-    buildPmaChatListEntries,
+    buildChatListEntries,
     buildPmaChatScopeOptions,
     buildPmaLiveActivity,
     buildManagedThreadMessagePayload,
@@ -60,33 +60,33 @@
     chooseActiveChatId,
     composeMessageWithAttachments,
     countTicketRunGroups,
-    filterPmaChatEntries,
+    filterChatEntries,
     formatBytes,
     formatRelativeTime,
     isPmaChatArchived,
     localPmaChatScopeOption,
-    PMA_CHAT_FILTER_ORDER,
-    PMA_CHAT_TICKET_RUNS_FILTER,
+    CHAT_FILTER_ORDER,
+    CHAT_TICKET_RUNS_FILTER,
     pmaChatKind,
     pmaChatKindLabel,
     pmaChatBindingKey,
     pmaChatHeaderScopeLine,
-    pmaChatMessengerSurface,
+    chatMessengerSurface,
     pmaChatScopeTagView,
-    pmaChatSurfaceFilterOptions,
-    pmaChatSurfaceFilterToken,
+    chatSurfaceFilterOptions,
+    chatSurfaceFilterToken,
     progressPercent,
-    mapPmaTranscriptRows,
+    mapChatTranscriptRows,
     removePendingAttachment,
     statusLabel,
     summarizeFilterCounts,
     type DocumentFileIntentPayload,
     type PendingAttachment,
-    type PmaCard,
-    type PmaChatFilter,
-    type PmaChatStatusFilter,
-    type PmaChatListEntry,
-    type PmaChatRunGroup,
+    type ChatTranscriptCard,
+    type ChatFilter,
+    type ChatStatusFilter,
+    type ChatListEntry,
+    type ChatRunGroup,
     type PmaChatScopeOption
   } from '$lib/viewModels/pmaChat';
   import {
@@ -137,7 +137,7 @@
   let localDraftChat = $state<PmaChatSummary | null>(null);
   const persistedChats = $derived<PmaChatSummary[]>(selectPmaChats(readModelState));
   const chats = $derived<PmaChatSummary[]>(localDraftChat ? [localDraftChat, ...persistedChats] : persistedChats);
-  const transcriptCards = $derived<PmaCard[]>(selectPmaTranscript(readModelState, activeChatId));
+  const transcriptCards = $derived<ChatTranscriptCard[]>(selectChatTranscript(readModelState, activeChatId));
   const progress = $derived<PmaRunProgress | null>(selectPmaProgress(readModelState, activeChatId));
   const artifacts = $derived<SurfaceArtifact[]>(selectPmaArtifacts(readModelState, activeChatId));
   const queuedTurns = $derived<PmaQueuedTurn[]>(selectPmaQueue(readModelState, activeChatId));
@@ -156,7 +156,7 @@
   let selectedProfile = $state('');
   let selectedScopeId = $state('local');
   let newChatKind = $state<'pma' | 'agent'>('pma');
-  let filter = $state<PmaChatFilter>('all');
+  let filter = $state<ChatFilter>('all');
   let detailMode = $state<'list' | 'detail'>('list');
   let search = $state('');
   let draft = $state('');
@@ -305,16 +305,16 @@
   let expandedRunGroups = $state<Record<string, boolean>>({});
   let pinnedChatIds = $state<Record<string, true>>({});
   const chatListEntries = $derived(
-    buildPmaChatListEntries(chats, {
+    buildChatListEntries(chats, {
       lastSeen: lastSeenMap,
       repoLabel: repoLabelForRepoId,
       worktreeLabel: (wid) => worktreeScopeOption(wid)?.label ?? null,
       groupRuns: true
     })
   );
-  const filteredEntries = $derived(sortEntriesForPins(filterPmaChatEntries(chatListEntries, filter, search, lastSeenMap), pinnedChatIds));
+  const filteredEntries = $derived(sortEntriesForPins(filterChatEntries(chatListEntries, filter, search, lastSeenMap), pinnedChatIds));
   const filterCounts = $derived(summarizeFilterCounts(chats, lastSeenMap));
-  const surfaceFilterChips = $derived(pmaChatSurfaceFilterOptions(chats));
+  const surfaceFilterChips = $derived(chatSurfaceFilterOptions(chats));
   const ticketRunGroupCount = $derived(countTicketRunGroups(chats));
   const activeChatCount = $derived(chats.filter((chat) => !isPmaChatArchived(chat)).length);
   const hasUsableChatIndex = $derived(Boolean(readModelState.chatIndexCursor || readModelState.chatOrder.length > 0));
@@ -322,14 +322,14 @@
   const visibleChatError = $derived(chatError ?? (!hasUsableChatIndex ? initialChatIndexError : null));
   const showChatListSkeleton = $derived(loadingChats && !hasUsableChatIndex && !visibleChatError);
 
-  function isGroupExpanded(group: PmaChatRunGroup): boolean {
+  function isGroupExpanded(group: ChatRunGroup): boolean {
     if (group.key in expandedRunGroups) return expandedRunGroups[group.key];
     // Default collapsed; expand only when the active chat lives inside this group.
     if (activeChatId && group.chats.some((chat) => chat.id === activeChatId)) return true;
     return false;
   }
 
-  function toggleGroup(group: PmaChatRunGroup): void {
+  function toggleGroup(group: ChatRunGroup): void {
     expandedRunGroups = { ...expandedRunGroups, [group.key]: !isGroupExpanded(group) };
   }
 
@@ -364,7 +364,7 @@
   }
 
   /** VirtualList keys must change when pin state or pin-driven order changes, or keyed {#each} reuses stale row DOM. */
-  function chatListVirtualKey(entry: PmaChatListEntry): string {
+  function chatListVirtualKey(entry: ChatListEntry): string {
     if (entry.kind === 'group') {
       const pinOrder = entry.group.chats
         .map((c) => `${c.id}:${pinnedChatIds[c.id] ? 1 : 0}`)
@@ -378,7 +378,7 @@
     return `${chat.id}:${pinnedChatIds[chat.id] ? 1 : 0}`;
   }
 
-  function sortEntriesForPins(entries: PmaChatListEntry[], pinned: Record<string, true>): PmaChatListEntry[] {
+  function sortEntriesForPins(entries: ChatListEntry[], pinned: Record<string, true>): ChatListEntry[] {
     const decorated = entries.map((entry) => {
       if (entry.kind === 'chat') {
         return { entry, pinned: pinned[entry.chat.id] === true, sort: entry.chat.updatedAt ?? '', id: entry.chat.id };
@@ -405,7 +405,7 @@
     return decorated.map((item) => item.entry);
   }
 
-  function markGroupRead(group: PmaChatRunGroup): void {
+  function markGroupRead(group: ChatRunGroup): void {
     let next = lastSeenMap;
     const now = new Date().toISOString();
     for (const chat of group.chats) {
@@ -422,11 +422,11 @@
     saveLastSeenMap(next);
   }
 
-  function groupBadgeClass(group: PmaChatRunGroup): string {
+  function groupBadgeClass(group: ChatRunGroup): string {
     return `chat-run-status-pill ${group.status}`;
   }
 
-  function groupSummaryParts(group: PmaChatRunGroup): string[] {
+  function groupSummaryParts(group: ChatRunGroup): string[] {
     const parts: string[] = [];
     if (group.waitingCount > 0) parts.push(`${group.waitingCount} waiting`);
     if (group.activeCount > 0) parts.push(`${group.activeCount} active`);
@@ -436,8 +436,8 @@
   }
   const displayedProgress = $derived(progressWithLiveElapsed(progress, clockNowMs));
   const liveActivity = $derived(buildPmaLiveActivity(displayedProgress));
-  const activeCards = $derived<PmaCard[]>(transcriptCards);
-  const lastAssistantMessageCard = $derived.by<PmaCard | null>(() => {
+  const activeCards = $derived<ChatTranscriptCard[]>(transcriptCards);
+  const lastAssistantMessageCard = $derived.by<ChatTranscriptCard | null>(() => {
     for (let i = activeCards.length - 1; i >= 0; i -= 1) {
       const card = activeCards[i];
       if (card.kind === 'message' && card.message.role === 'assistant') {
@@ -499,7 +499,7 @@
     const text = (card.message.text ?? '').trim();
     return text.length > 120 ? text.slice(text.length - 120) : text;
   });
-  const activeMessengerSurface = $derived(pmaChatMessengerSurface(activeChat));
+  const activeMessengerSurface = $derived(chatMessengerSurface(activeChat));
   const activeRepoIngress = $derived(repoIngressForChat(activeChat));
   const createChatLabel = $derived(
     creating ? 'Creating...' : newChatKind === 'agent' && canStartCodingAgentChat ? '+ Coding agent' : '+ Chat'
@@ -567,7 +567,7 @@
     return null;
   }
 
-  function filterChipLabel(key: PmaChatStatusFilter): string {
+  function filterChipLabel(key: ChatStatusFilter): string {
     return key === 'all' ? 'All' : key.charAt(0).toUpperCase() + key.slice(1);
   }
 
@@ -614,10 +614,10 @@
     loadingChats = !hasChatIndexProjection(readModelEntityStore.snapshot());
     if (!loadingChats) activateRequestedChatFromCurrentRows();
     void loadInitialSupportingData(
-      pmaApi.pma.listFiles(),
-      pmaApi.pma.listAgents(),
-      pmaApi.readModels.repoWorktreeTopology('all', 200),
-      pmaApi.readModels.repoWorktreeRuntime('all', 200)
+      webApi.pma.listFiles(),
+      webApi.pma.listAgents(),
+      webApi.readModels.repoWorktreeTopology('all', 200),
+      webApi.readModels.repoWorktreeRuntime('all', 200)
     );
     activeClockInterval = window.setInterval(() => {
       if (progress?.status === 'running') clockNowMs = Date.now();
@@ -722,10 +722,10 @@
   }
 
   async function loadInitialSupportingData(
-    artifactPromise: ReturnType<typeof pmaApi.pma.listFiles>,
-    agentPromise: ReturnType<typeof pmaApi.pma.listAgents>,
-    topologyPromise: ReturnType<typeof pmaApi.readModels.repoWorktreeTopology>,
-    runtimePromise: ReturnType<typeof pmaApi.readModels.repoWorktreeRuntime>
+    artifactPromise: ReturnType<typeof webApi.pma.listFiles>,
+    agentPromise: ReturnType<typeof webApi.pma.listAgents>,
+    topologyPromise: ReturnType<typeof webApi.readModels.repoWorktreeTopology>,
+    runtimePromise: ReturnType<typeof webApi.readModels.repoWorktreeRuntime>
   ): Promise<void> {
     const [artifactResult, agentResult, topologyResult, runtimeResult] = await Promise.all([
       artifactPromise,
@@ -826,7 +826,7 @@
     selectedModel = '';
     selectedReasoning = '';
 
-    const result = await pmaApi.pma.listAgentModels(agentId);
+    const result = await webApi.pma.listAgentModels(agentId);
     if (seq !== loadModelsSeq) return;
 
     if (!result.ok) {
@@ -972,7 +972,7 @@
     composeError = null;
     const reconciliationId = `archive:${chatId}:${Date.now()}`;
     readModelEntityStore.optimisticArchiveChat(chatId, reconciliationId);
-    const result = await pmaApi.pma.archiveThread(chatId);
+    const result = await webApi.pma.archiveThread(chatId);
     if (result.ok) {
       await invalidateChatMutation(chatId);
       upsertPmaChats([result.data]);
@@ -1000,7 +1000,7 @@
     if (!ok) return;
     archiving = true;
     composeError = null;
-    const result = await pmaApi.pma.archiveThreads(targets);
+    const result = await webApi.pma.archiveThreads(targets);
     if (result.ok) {
       await invalidateReadModelTags([
         readModelEntityTags.chatIndex,
@@ -1039,19 +1039,19 @@
       activeError = null;
     }
     let missingThreadError: ApiError | null = null;
-    const transcriptTask = pmaApi.pma.getTranscript(chatId, { limit: PMA_TRANSCRIPT_LIMIT }).then((messageResult) => {
+    const transcriptTask = webApi.pma.getTranscript(chatId, { limit: PMA_TRANSCRIPT_LIMIT }).then((messageResult) => {
       if (activeChatId !== chatId || refreshSeq !== activeRefreshSeq) return;
       if (messageResult.ok) {
-        replacePmaTranscriptPreservingPendingOptimistic(chatId, messageResult.data.rows);
+        replaceChatTranscriptPreservingPendingOptimistic(chatId, messageResult.data.rows);
         if (messageResult.data.status) updateProgress(messageResult.data.status);
       } else if (isMissingManagedThreadError(messageResult.error)) {
         missingThreadError = messageResult.error;
-        readModelEntityStore.replacePmaTranscript(chatId, []);
+        readModelEntityStore.replaceChatTranscript(chatId, []);
       } else if (!options.quiet) {
         activeError = messageResult.error;
       }
     });
-    const queueTask = pmaApi.pma.getQueue(chatId).then((queueResult) => {
+    const queueTask = webApi.pma.getQueue(chatId).then((queueResult) => {
       if (activeChatId !== chatId || refreshSeq !== activeRefreshSeq) return;
       if (queueResult.ok) {
         readModelEntityStore.setPmaQueue(chatId, queueResult.data.queuedTurns);
@@ -1077,7 +1077,7 @@
     closeStream();
     const seedProgress = currentProgress(chatId);
     const seedChat = chats.find((chat) => chat.id === chatId) ?? null;
-    if (!shouldUsePmaTranscriptStream(seedChat, seedProgress, currentQueueDepth(chatId))) {
+    if (!shouldUseChatTranscriptStream(seedChat, seedProgress, currentQueueDepth(chatId))) {
       streamState = 'idle';
       streamError = null;
       return;
@@ -1085,7 +1085,7 @@
     streamState = 'connecting';
     streamError = null;
     refreshedTerminalTurnId = null;
-    streamSubscription = openPmaTranscriptEventSource(chatId, {
+    streamSubscription = openChatTranscriptEventSource(chatId, {
       sinceEventId: seedProgress?.lastEventId,
       sinceManagedTurnId: seedProgress?.id,
       onStatus: (status) => {
@@ -1101,15 +1101,15 @@
         if (activeChatId !== chatId) return;
         streamState = 'connected';
         if (event.kind === 'transcript_snapshot') {
-          const rows = mapPmaTranscriptRows(event.payload.rows);
-          replacePmaTranscriptPreservingPendingOptimistic(chatId, rows);
+          const rows = mapChatTranscriptRows(event.payload.rows);
+          replaceChatTranscriptPreservingPendingOptimistic(chatId, rows);
           const status = event.payload.status;
           if (status && typeof status === 'object' && !Array.isArray(status)) updateProgress(mapPmaRunProgress(status as JsonRecord));
           return;
         }
         if (event.kind === 'transcript_append') {
-          const rows = mapPmaTranscriptRows(event.payload.rows);
-          readModelEntityStore.upsertPmaTranscriptCards(chatId, rows);
+          const rows = mapChatTranscriptRows(event.payload.rows);
+          readModelEntityStore.upsertChatTranscriptCards(chatId, rows);
           return;
         }
         if (event.kind === 'transcript_patch') {
@@ -1148,7 +1148,7 @@
     if (activeChatId !== chatId || streamSubscription) return;
     const seedProgress = currentProgress(chatId);
     const seedChat = chats.find((chat) => chat.id === chatId) ?? null;
-    if (shouldUsePmaTranscriptStream(seedChat, seedProgress, currentQueueDepth(chatId))) connectStream(chatId);
+    if (shouldUseChatTranscriptStream(seedChat, seedProgress, currentQueueDepth(chatId))) connectStream(chatId);
   }
 
   function scheduleActiveRefresh(chatId: string, delayMs = 600): void {
@@ -1219,7 +1219,7 @@
   function hasCachedDetail(chatId: string): boolean {
     const state = readModelEntityStore.snapshot();
     return Boolean(
-      state.pmaTranscripts[chatId]?.order.length ||
+      state.chatTranscripts[chatId]?.order.length ||
       state.pmaProgress[chatId] ||
       state.pmaQueues[chatId]?.length ||
       state.timelines[chatId]?.order.length ||
@@ -1227,21 +1227,21 @@
     );
   }
 
-  function replacePmaTranscriptPreservingPendingOptimistic(chatId: string, rows: PmaCard[]): void {
-    const transcript = readModelEntityStore.snapshot().pmaTranscripts[chatId];
+  function replaceChatTranscriptPreservingPendingOptimistic(chatId: string, rows: ChatTranscriptCard[]): void {
+    const transcript = readModelEntityStore.snapshot().chatTranscripts[chatId];
     if (!transcript) {
-      readModelEntityStore.replacePmaTranscript(chatId, rows);
+      readModelEntityStore.replaceChatTranscript(chatId, rows);
       return;
     }
     const retainedOptimistic = transcript.order
       .filter((id) => id.startsWith('optimistic:'))
       .map((id) => transcript.cardsById[id])
-      .filter((card): card is PmaCard => Boolean(card))
+      .filter((card): card is ChatTranscriptCard => Boolean(card))
       .filter((card) => !transcriptRowsConfirmOptimistic(rows, card));
-    readModelEntityStore.replacePmaTranscript(chatId, [...rows, ...retainedOptimistic]);
+    readModelEntityStore.replaceChatTranscript(chatId, [...rows, ...retainedOptimistic]);
   }
 
-  function transcriptRowsConfirmOptimistic(rows: PmaCard[], optimistic: PmaCard): boolean {
+  function transcriptRowsConfirmOptimistic(rows: ChatTranscriptCard[], optimistic: ChatTranscriptCard): boolean {
     if (optimistic.kind !== 'message' || optimistic.message.role !== 'user') return true;
     const optimisticCorrelationId = transcriptCardCorrelationId(optimistic);
     if (!optimisticCorrelationId) return false;
@@ -1252,7 +1252,7 @@
     });
   }
 
-  function transcriptCardCorrelationId(card: PmaCard): string | null {
+  function transcriptCardCorrelationId(card: ChatTranscriptCard): string | null {
     if (card.kind !== 'message') return null;
     const raw = card.message.raw;
     const direct = raw.correlation_id ?? raw.client_turn_id;
@@ -1527,7 +1527,7 @@
     const optimisticChatId = activeChatId;
     const optimisticId = `optimistic:user:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`;
     const optimisticTimestamp = new Date().toISOString();
-    const optimisticPlaceholder: PmaCard = {
+    const optimisticPlaceholder: ChatTranscriptCard = {
       kind: 'message',
       id: optimisticId,
       turnId: null,
@@ -1570,7 +1570,7 @@
       },
       optimisticId
     );
-    readModelEntityStore.upsertPmaTranscriptCards(optimisticChatId, [optimisticPlaceholder]);
+    readModelEntityStore.upsertChatTranscriptCards(optimisticChatId, [optimisticPlaceholder]);
     draft = '';
     pendingAttachments = [];
     const composerVersionAtClear = composerEditVersion;
@@ -1579,7 +1579,7 @@
 
     const moveOptimisticToCommittedChat = (committedChatId: string) => {
       if (committedChatId === optimisticChatId) return;
-      readModelEntityStore.upsertPmaTranscriptCards(committedChatId, [
+      readModelEntityStore.upsertChatTranscriptCards(committedChatId, [
         {
           ...optimisticPlaceholder,
           message: {
@@ -1588,10 +1588,10 @@
           }
         }
       ]);
-      readModelEntityStore.removeOptimisticPmaTranscriptCards(optimisticChatId);
+      readModelEntityStore.removeOptimisticChatTranscriptCards(optimisticChatId);
     };
     const transcriptHasBackendUserRow = (chatId: string) => {
-      const transcript = readModelEntityStore.snapshot().pmaTranscripts[chatId];
+      const transcript = readModelEntityStore.snapshot().chatTranscripts[chatId];
       if (!transcript) return false;
       return transcript.order.some((id) => {
         if (id.startsWith('optimistic:')) return false;
@@ -1602,7 +1602,7 @@
     };
     const removeOptimistic = (chatId = optimisticChatId, options: { requireBackendRow?: boolean } = {}) => {
       if (options.requireBackendRow && !transcriptHasBackendUserRow(chatId)) return false;
-      readModelEntityStore.removeOptimisticPmaTranscriptCards(chatId);
+      readModelEntityStore.removeOptimisticChatTranscriptCards(chatId);
       return true;
     };
     const restoreDraft = () => {
@@ -1665,7 +1665,7 @@
               profile: profileForSend,
               clientTurnId: optimisticId
             });
-    const result = await executePmaChatCommandPlan(pmaApi, commandPlan);
+    const result = await executePmaChatCommandPlan(webApi, commandPlan);
     if (result.ok) {
       const committedChatId = targetIsDraft ? result.data.chatId : targetChatId;
       if (!committedChatId) {
@@ -1720,7 +1720,7 @@
       if (!ok) return;
     }
     composeError = null;
-    const result = await pmaApi.pma.cancelQueuedTurn(activeChatId, turn.managedTurnId);
+    const result = await webApi.pma.cancelQueuedTurn(activeChatId, turn.managedTurnId);
     if (result.ok) {
       readModelEntityStore.setPmaQueue(
         activeChatId,
@@ -1736,7 +1736,7 @@
     if (!activeChatId || !turn.prompt.trim()) return;
     const chatId = activeChatId;
     composeError = null;
-    const cancelResult = await pmaApi.pma.cancelQueuedTurn(chatId, turn.managedTurnId);
+    const cancelResult = await webApi.pma.cancelQueuedTurn(chatId, turn.managedTurnId);
     if (!cancelResult.ok) {
       composeError = cancelResult.error;
       return;
@@ -1748,7 +1748,7 @@
     const profileForSend =
       activeChat?.agentProfile?.trim() || selectedProfile?.trim() || '';
     const result = await executePmaChatCommandPlan(
-      pmaApi,
+      webApi,
       planInterruptExistingChat(chatId, turn.prompt, {
         model: turn.model ?? selectedModel,
         attachments: turn.attachments as DocumentFileIntentPayload[],
@@ -1771,7 +1771,7 @@
     }
     sending = true;
     showCommandNotice('Generating compact summary...');
-    const summaryResult = await pmaApi.pma.sendMessage(
+    const summaryResult = await webApi.pma.sendMessage(
       chatId,
       {
         ...buildManagedThreadMessagePayload(
@@ -1800,7 +1800,7 @@
       await refreshActive(chatId, { quiet: true });
       return;
     }
-    const compactResult = await pmaApi.pma.compactThread(chatId, summary);
+    const compactResult = await webApi.pma.compactThread(chatId, summary);
     if (!compactResult.ok) {
       composeError = compactResult.error;
       sending = false;
@@ -1956,7 +1956,7 @@
       return true;
     }
     if (spec.id === 'files') {
-      const result = await pmaApi.pma.listFiles();
+      const result = await webApi.pma.listFiles();
       if (!result.ok) composeError = result.error;
       else {
         readModelEntityStore.setPmaArtifacts(activeChatId ?? '__global__', result.data);
@@ -1966,7 +1966,7 @@
       return true;
     }
     if (spec.id === 'interrupt') {
-      const result = await pmaApi.pma.interruptThread(activeChatId);
+      const result = await webApi.pma.interruptThread(activeChatId);
       if (!result.ok) composeError = result.error;
       else {
         showCommandNotice('Interrupt requested.');
@@ -1976,7 +1976,7 @@
       return true;
     }
     if (spec.id === 'resume') {
-      const result = await pmaApi.pma.resumeThread(activeChatId);
+      const result = await webApi.pma.resumeThread(activeChatId);
       if (!result.ok) composeError = result.error;
       else {
         await invalidateChatMutation(activeChatId);
@@ -1992,7 +1992,7 @@
         await autoCompactActiveThread(activeChatId);
         return true;
       }
-      const result = await pmaApi.pma.compactThread(activeChatId, args);
+      const result = await webApi.pma.compactThread(activeChatId, args);
       if (!result.ok) composeError = result.error;
       else {
         await invalidateChatMutation(activeChatId);
@@ -2020,7 +2020,7 @@
       return true;
     }
     if (spec.id === 'clearqueue') {
-      const result = await pmaApi.pma.clearQueue(activeChatId);
+      const result = await webApi.pma.clearQueue(activeChatId);
       if (!result.ok) composeError = result.error;
       else {
         readModelEntityStore.setPmaQueue(activeChatId, []);
@@ -2126,7 +2126,7 @@
         uploaded.push(attachment);
         continue;
       }
-      const result = await pmaApi.pma.uploadInboxFile(file);
+      const result = await webApi.pma.uploadInboxFile(file);
       if (!result.ok || !result.data[0]) {
         composeError = result.ok
           ? { kind: 'parse', status: null, code: 'upload_missing_file', message: 'Upload did not return a file name.' }
@@ -2173,7 +2173,7 @@
         rootClass="chat-filter-chips-row"
         ariaLabel="Chat filters"
         items={[
-          ...PMA_CHAT_FILTER_ORDER.filter(
+          ...CHAT_FILTER_ORDER.filter(
             (item) => item !== 'unread' || filterCounts.unread > 0 || filter === 'unread'
           ).map((item) => ({
             key: `status:${item}`,
@@ -2182,24 +2182,24 @@
             active: filter === item,
             onSelect: () => (filter = item)
           })),
-          ...(ticketRunGroupCount > 0 || filter === PMA_CHAT_TICKET_RUNS_FILTER
+          ...(ticketRunGroupCount > 0 || filter === CHAT_TICKET_RUNS_FILTER
             ? [
                 {
                   key: 'ticket-runs',
                   label: 'Ticket Runs',
                   count: ticketRunGroupCount,
-                  active: filter === PMA_CHAT_TICKET_RUNS_FILTER,
-                  onSelect: () => (filter = PMA_CHAT_TICKET_RUNS_FILTER)
+                  active: filter === CHAT_TICKET_RUNS_FILTER,
+                  onSelect: () => (filter = CHAT_TICKET_RUNS_FILTER)
                 }
               ]
             : []),
           ...surfaceFilterChips
-            .filter((surf) => surf.count > 0 || filter === pmaChatSurfaceFilterToken(surf.slug))
+            .filter((surf) => surf.count > 0 || filter === chatSurfaceFilterToken(surf.slug))
             // Suppress the surface chip when it is the only surface available and its
             // count duplicates the All count — the chip would communicate nothing new
             // and forces the filter row onto a second line.
             .filter((surf, _idx, arr) => {
-              if (filter === pmaChatSurfaceFilterToken(surf.slug)) return true;
+              if (filter === chatSurfaceFilterToken(surf.slug)) return true;
               if (arr.length !== 1) return true;
               return surf.count !== filterCounts.all;
             })
@@ -2207,8 +2207,8 @@
               key: `surface:${surf.slug}`,
               label: surf.label,
               count: surf.count,
-              active: filter === pmaChatSurfaceFilterToken(surf.slug),
-              onSelect: () => (filter = pmaChatSurfaceFilterToken(surf.slug))
+              active: filter === chatSurfaceFilterToken(surf.slug),
+              onSelect: () => (filter = chatSurfaceFilterToken(surf.slug))
             }))
         ]}
       />
@@ -2240,7 +2240,7 @@
         repoLabel: repoLabelForRepoId,
         worktreeLabel: (wid) => worktreeScopeOption(wid)?.label ?? null
       })}
-      {@const messengerSurface = pmaChatMessengerSurface(chat)}
+      {@const messengerSurface = chatMessengerSurface(chat)}
       {@const listScopeAccent = chatListScopeAccentLabel(chat, scopeTags)}
       {@const listScopeAccentHex = listScopeAccent ? repoAccent(listScopeAccent) : null}
       {@const listAgentLabel = agentDisplayForChat(agents, chat)}

--- a/src/codex_autorunner/web_frontend/src/routes/repos/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/+page.svelte
@@ -7,7 +7,7 @@
   import NewWorktreeDialog from '$lib/components/NewWorktreeDialog.svelte';
   import RepoSettingsDialog, { type RepoSettingsTarget } from '$lib/components/RepoSettingsDialog.svelte';
   import { confirmAndArchiveState, confirmAndCleanupWorktree, type ActionNotice } from '$lib/actions/repoWorktreeActions';
-  import { pmaApi, type ApiError, type PartialPageIssue } from '$lib/api/client';
+  import { webApi, type ApiError, type PartialPageIssue } from '$lib/api/client';
   import { ensureRepoWorktreeIndexLoaded, invalidateReadModelTags, readModelEntityStore, readModelEntityTags, selectRepoSummaries, selectWorktreeSummaries } from '$lib/data';
   import {
     buildRepoWorktreeIndexViewModel,
@@ -77,7 +77,7 @@
   }
 
   async function handleRepoPin(target: { id: string; pinned: boolean }): Promise<void> {
-    const result = await pmaApi.hub.setRepoPinned(target.id, target.pinned);
+    const result = await webApi.hub.setRepoPinned(target.id, target.pinned);
     if (!result.ok) {
       notice = { tone: 'danger', message: result.error.message };
       return;

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/+page.svelte
@@ -4,7 +4,7 @@
   import AutoDismissNotice from '$lib/components/AutoDismissNotice.svelte';
   import RepoWorktreeViews from '$lib/components/RepoWorktreeViews.svelte';
   import { confirmAndArchiveState, confirmAndCleanupWorktree, type ActionNotice } from '$lib/actions/repoWorktreeActions';
-  import { pmaApi, type ApiError, type JsonRecord, type PartialPageIssue } from '$lib/api/client';
+  import { webApi, type ApiError, type JsonRecord, type PartialPageIssue } from '$lib/api/client';
   import { ensureRepoDetailLoaded, invalidateReadModelTags, readModelEntityStore, readModelEntityTags } from '$lib/data';
   import {
     mapContextspaceDocument,
@@ -105,7 +105,7 @@
     if (syncRepoBusy) return;
     syncRepoBusy = true;
     try {
-      const result = await pmaApi.hub.syncRepoMain(repoId);
+      const result = await webApi.hub.syncRepoMain(repoId);
       if (!result.ok) {
         notice = { tone: 'danger', message: result.error.message };
         return;

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/tickets/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/tickets/+page.svelte
@@ -3,7 +3,7 @@
   import { onDestroy, onMount } from 'svelte';
   import TicketViews from '$lib/components/TicketViews.svelte';
   import { confirmDialog } from '$lib/components/confirmDialog';
-  import { dataOr, partialPageIssue, pmaApi, type ApiError, type PartialPageIssue } from '$lib/api/client';
+  import { dataOr, partialPageIssue, webApi, type ApiError, type PartialPageIssue } from '$lib/api/client';
   import {
     invalidateReadModelTags,
     pmaChatSummaryToChatIndexRow,
@@ -61,7 +61,7 @@
     error = null;
     sectionIssues = [];
     const owner = scopedTicketQueueOwner(queueConfig);
-    const snapshot = await pmaApi.readModels.repoDetail(repoId);
+    const snapshot = await webApi.readModels.repoDetail(repoId);
     if (!snapshot.ok) {
       error = snapshot.error;
       loading = false;
@@ -76,7 +76,7 @@
     readModelEntityStore.upsertChatIndexRows(chats.map(pmaChatSummaryToChatIndexRow));
     selectedFilter = 'all';
     loading = false;
-    const manifest = await loadScopedActionManifest(pmaApi, queueConfig);
+    const manifest = await loadScopedActionManifest(webApi, queueConfig);
     actionManifest = dataOr(manifest, null);
     sectionIssues = [
       !manifest.ok ? partialPageIssue('action_manifest', 'Action manifest unavailable', manifest.error) : null
@@ -86,7 +86,7 @@
   }
 
   async function reorderTicket(sourceRouteId: string, destinationRouteId: string, placeAfter: boolean): Promise<boolean> {
-    const result = await reorderScopedTicket(pmaApi, queueConfig, sourceRouteId, destinationRouteId, placeAfter);
+    const result = await reorderScopedTicket(webApi, queueConfig, sourceRouteId, destinationRouteId, placeAfter);
     actionStatus = result.status;
     if (result.ok) {
       await invalidateReadModelTags([
@@ -103,7 +103,7 @@
     const action = list?.queueActions.find((candidate) => candidate.action === command) ?? null;
     actionStatus = scopedTicketActionStatus(command, queueConfig);
     const result = await runScopedTicketQueueCommand(
-      pmaApi,
+      webApi,
       queueConfig,
       command,
       runId,

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/tickets/[ticketId]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/tickets/[ticketId]/+page.svelte
@@ -3,7 +3,7 @@
   import { page } from '$app/state';
   import { onDestroy, onMount } from 'svelte';
   import TicketViews from '$lib/components/TicketViews.svelte';
-  import { pmaApi, type ApiError, type JsonRecord, type PartialPageIssue } from '$lib/api/client';
+  import { webApi, type ApiError, type JsonRecord, type PartialPageIssue } from '$lib/api/client';
   import { openFlowRunEventSource, type StreamSubscription } from '$lib/api/streaming';
   import {
     invalidateReadModelTags,
@@ -70,7 +70,7 @@
   });
 
   async function loadPickerSupport(): Promise<void> {
-    const result = await pmaApi.pma.listAgents();
+    const result = await webApi.pma.listAgents();
     if (!result.ok) return;
     agents = result.data.agents;
     const entries = await Promise.all(
@@ -78,7 +78,7 @@
         .filter((agent) => agentCanListModels(agent))
         .map(async (agent) => {
           const id = agentId(agent);
-          const models = await pmaApi.pma.listAgentModels(id);
+          const models = await webApi.pma.listAgentModels(id);
           return [id, models.ok ? models.data : null] as const;
         })
     );
@@ -131,7 +131,7 @@
         }
       }
     }
-    const snapshot = await pmaApi.readModels.ticketDetail(routeTicketId, { kind: 'repo', id: ownerId });
+    const snapshot = await webApi.readModels.ticketDetail(routeTicketId, { kind: 'repo', id: ownerId });
     if (!isCurrentRequest()) return;
     if (!snapshot.ok) {
       error = snapshot.error;
@@ -231,7 +231,7 @@
       command === 'resume' && currentRunId
         ? `/repos/${encodeURIComponent(repoId)}/api/flows/${encodeURIComponent(currentRunId)}/resume`
         : `/repos/${encodeURIComponent(repoId)}/api/flows/ticket_flow/bootstrap`;
-    const result = await pmaApi.requestJson(path, { method: 'POST', body: command === 'bootstrap' ? { once: false } : undefined });
+    const result = await webApi.requestJson(path, { method: 'POST', body: command === 'bootstrap' ? { once: false } : undefined });
     actionStatus = result.ok ? 'Ticket flow command accepted.' : result.error.message;
     await loadTicketDetail(false);
   }
@@ -244,7 +244,7 @@
       return false;
     }
     saveStatus = 'Saving ticket...';
-    const result = await pmaApi.ticketFlow.updateTicket(ticketNumber, buildTicketUpdateContent(detail, payload), { repo: repoId });
+    const result = await webApi.ticketFlow.updateTicket(ticketNumber, buildTicketUpdateContent(detail, payload), { repo: repoId });
     saveStatus = result.ok ? 'Ticket saved.' : result.error.message;
     if (result.ok) {
       await invalidateReadModelTags([
@@ -259,12 +259,12 @@
 
   async function repairWithPma(ticket: TicketDetailViewModel): Promise<void> {
     actionStatus = 'Creating PMA repair chat...';
-    const createResult = await pmaApi.pma.createChat(buildTicketRepairChatCreatePayload(ticket));
+    const createResult = await webApi.pma.createChat(buildTicketRepairChatCreatePayload(ticket));
     if (!createResult.ok) {
       actionStatus = createResult.error.message;
       return;
     }
-    const sendResult = await pmaApi.pma.sendMessage(createResult.data.id, buildManagedThreadMessagePayload(buildTicketRepairPrompt(ticket), '', false));
+    const sendResult = await webApi.pma.sendMessage(createResult.data.id, buildManagedThreadMessagePayload(buildTicketRepairPrompt(ticket), '', false));
     if (!sendResult.ok) {
       actionStatus = sendResult.error.message;
       return;

--- a/src/codex_autorunner/web_frontend/src/routes/settings/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/settings/+page.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import { onMount } from 'svelte';
   import { page } from '$app/state';
-  import { pmaApi, type ApiError, type JsonRecord } from '$lib/api/client';
+  import { webApi, type ApiError, type JsonRecord } from '$lib/api/client';
   import MemoryRail from '$lib/components/MemoryRail.svelte';
   import { withRuntimeBasePath as href } from '$lib/runtime/basePath';
   import SettingsView from '$lib/components/SettingsView.svelte';
@@ -47,9 +47,9 @@
     error = null;
     saveError = null;
     const [session, agents, voice] = await Promise.all([
-      pmaApi.settings.getSession(),
-      pmaApi.pma.listAgents(),
-      pmaApi.voice.getConfig()
+      webApi.settings.getSession(),
+      webApi.pma.listAgents(),
+      webApi.voice.getConfig()
     ]);
 
     if (!session.ok && !agents.ok && !voice.ok) {
@@ -64,7 +64,7 @@
       agentRows.map(async (agent) => {
         if (!agentCanListModels(agent)) return;
         const id = agentId(agent);
-        const result = await pmaApi.pma.listAgentModels(id);
+        const result = await webApi.pma.listAgentModels(id);
         modelCatalogs[id] = result.ok ? result.data : null;
       })
     );
@@ -88,7 +88,7 @@
     if (!view || saving) return;
     saving = true;
     saveError = null;
-    const result = await pmaApi.settings.updateSession(buildSessionUpdatePayload(view.session));
+    const result = await webApi.settings.updateSession(buildSessionUpdatePayload(view.session));
     if (!result.ok) {
       saveError = result.error;
       saving = false;

--- a/src/codex_autorunner/web_frontend/src/routes/tickets/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/tickets/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import TicketViews from '$lib/components/TicketViews.svelte';
-  import { pmaApi, type ApiError } from '$lib/api/client';
+  import { webApi, type ApiError } from '$lib/api/client';
   import { readModelEntityStore } from '$lib/data';
   import { buildTicketListViewModel, type TicketFilter, type TicketListViewModel } from '$lib/viewModels/ticket';
   import { mapTicketSummary } from '$lib/viewModels/domain';
@@ -33,7 +33,7 @@
       }
     }
 
-    const result = await pmaApi.ticketFlow.listTickets();
+    const result = await webApi.ticketFlow.listTickets();
     if (!result.ok) {
       error = result.error;
       list = null;

--- a/src/codex_autorunner/web_frontend/src/routes/tickets/[ticketId]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/tickets/[ticketId]/+page.svelte
@@ -3,7 +3,7 @@
   import { page } from '$app/state';
   import { onMount } from 'svelte';
   import TicketViews from '$lib/components/TicketViews.svelte';
-  import { pmaApi, type ApiError } from '$lib/api/client';
+  import { webApi, type ApiError } from '$lib/api/client';
   import { readModelEntityStore } from '$lib/data';
   import {
     buildTicketDetailViewModel,
@@ -49,7 +49,7 @@
       }
     }
 
-    const result = await pmaApi.ticketFlow.listTickets();
+    const result = await webApi.ticketFlow.listTickets();
     if (!result.ok) {
       error = result.error;
       detail = null;

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/+page.svelte
@@ -5,7 +5,7 @@
   import AutoDismissNotice from '$lib/components/AutoDismissNotice.svelte';
   import RepoWorktreeViews from '$lib/components/RepoWorktreeViews.svelte';
   import { confirmAndArchiveState, confirmAndCleanupWorktree, type ActionNotice } from '$lib/actions/repoWorktreeActions';
-  import { pmaApi, type ApiError, type JsonRecord, type PartialPageIssue } from '$lib/api/client';
+  import { webApi, type ApiError, type JsonRecord, type PartialPageIssue } from '$lib/api/client';
   import { mapContextspaceDocument, mapPmaChatSummary, mapPmaRunProgress, mapSurfaceArtifact, mapTicketSummary, mapWorktreeSummary } from '$lib/viewModels/domain';
   import { stripRuntimeBasePath, withRuntimeBasePath as href } from '$lib/runtime/basePath';
   import {
@@ -119,7 +119,7 @@
     }
     syncRepoBusy = true;
     try {
-      const result = await pmaApi.hub.syncRepoMain(repoId);
+      const result = await webApi.hub.syncRepoMain(repoId);
       if (!result.ok) {
         notice = { tone: 'danger', message: result.error.message };
         return;

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/tickets/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/tickets/+page.svelte
@@ -4,7 +4,7 @@
   import { onDestroy, onMount } from 'svelte';
   import TicketViews from '$lib/components/TicketViews.svelte';
   import { confirmDialog } from '$lib/components/confirmDialog';
-  import { dataOr, partialPageIssue, pmaApi, type ApiError, type PartialPageIssue } from '$lib/api/client';
+  import { dataOr, partialPageIssue, webApi, type ApiError, type PartialPageIssue } from '$lib/api/client';
   import {
     invalidateReadModelTags,
     pmaChatSummaryToChatIndexRow,
@@ -67,7 +67,7 @@
     if (showLoading) loading = true;
     error = null;
     sectionIssues = [];
-    const detail = await pmaApi.readModels.worktreeDetail(worktreeId);
+    const detail = await webApi.readModels.worktreeDetail(worktreeId);
     if (!detail.ok) {
       error = detail.error;
       loading = false;
@@ -90,7 +90,7 @@
     readModelEntityStore.upsertChatIndexRows(chats.map(pmaChatSummaryToChatIndexRow));
     selectedFilter = 'all';
     loading = false;
-    const manifest = await loadScopedActionManifest(pmaApi, queueConfig);
+    const manifest = await loadScopedActionManifest(webApi, queueConfig);
     actionManifest = dataOr(manifest, null);
     sectionIssues = [
       !manifest.ok ? partialPageIssue('action_manifest', 'Action manifest unavailable', manifest.error) : null
@@ -100,7 +100,7 @@
   }
 
   async function reorderTicket(sourceRouteId: string, destinationRouteId: string, placeAfter: boolean): Promise<boolean> {
-    const result = await reorderScopedTicket(pmaApi, queueConfig, sourceRouteId, destinationRouteId, placeAfter);
+    const result = await reorderScopedTicket(webApi, queueConfig, sourceRouteId, destinationRouteId, placeAfter);
     actionStatus = result.status;
     if (result.ok) {
       await invalidateReadModelTags([
@@ -117,7 +117,7 @@
     const action = list?.queueActions.find((candidate) => candidate.action === command) ?? null;
     actionStatus = scopedTicketActionStatus(command, queueConfig);
     const result = await runScopedTicketQueueCommand(
-      pmaApi,
+      webApi,
       queueConfig,
       command,
       runId,

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/tickets/[ticketId]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/tickets/[ticketId]/+page.svelte
@@ -3,7 +3,7 @@
   import { page } from '$app/state';
   import { onDestroy, onMount } from 'svelte';
   import TicketViews from '$lib/components/TicketViews.svelte';
-  import { pmaApi, type ApiError, type JsonRecord, type PartialPageIssue } from '$lib/api/client';
+  import { webApi, type ApiError, type JsonRecord, type PartialPageIssue } from '$lib/api/client';
   import { openFlowRunEventSource, type StreamSubscription } from '$lib/api/streaming';
   import {
     invalidateReadModelTags,
@@ -71,7 +71,7 @@
   });
 
   async function loadPickerSupport(): Promise<void> {
-    const result = await pmaApi.pma.listAgents();
+    const result = await webApi.pma.listAgents();
     if (!result.ok) return;
     agents = result.data.agents;
     const entries = await Promise.all(
@@ -79,7 +79,7 @@
         .filter((agent) => agentCanListModels(agent))
         .map(async (agent) => {
           const id = agentId(agent);
-          const models = await pmaApi.pma.listAgentModels(id);
+          const models = await webApi.pma.listAgentModels(id);
           return [id, models.ok ? models.data : null] as const;
         })
     );
@@ -132,7 +132,7 @@
         }
       }
     }
-    const snapshot = await pmaApi.readModels.ticketDetail(routeTicketId, { kind: 'worktree', id: ownerId });
+    const snapshot = await webApi.readModels.ticketDetail(routeTicketId, { kind: 'worktree', id: ownerId });
     if (!isCurrentRequest()) return;
     if (!snapshot.ok) {
       error = snapshot.error;
@@ -241,7 +241,7 @@
       command === 'resume' && currentRunId
         ? `/repos/${encodeURIComponent(worktreeId)}/api/flows/${encodeURIComponent(currentRunId)}/resume`
         : `/repos/${encodeURIComponent(worktreeId)}/api/flows/ticket_flow/bootstrap`;
-    const result = await pmaApi.requestJson(path, { method: 'POST', body: command === 'bootstrap' ? { once: false } : undefined });
+    const result = await webApi.requestJson(path, { method: 'POST', body: command === 'bootstrap' ? { once: false } : undefined });
     actionStatus = result.ok ? 'Ticket flow command accepted.' : result.error.message;
     await loadTicketDetail(false);
   }
@@ -254,7 +254,7 @@
       return false;
     }
     saveStatus = 'Saving ticket...';
-    const result = await pmaApi.ticketFlow.updateTicket(ticketNumber, buildTicketUpdateContent(detail, payload), { worktree: worktreeId });
+    const result = await webApi.ticketFlow.updateTicket(ticketNumber, buildTicketUpdateContent(detail, payload), { worktree: worktreeId });
     saveStatus = result.ok ? 'Ticket saved.' : result.error.message;
     if (result.ok) {
       await invalidateReadModelTags([
@@ -269,12 +269,12 @@
 
   async function repairWithPma(ticket: TicketDetailViewModel): Promise<void> {
     actionStatus = 'Creating PMA repair chat...';
-    const createResult = await pmaApi.pma.createChat(buildTicketRepairChatCreatePayload(ticket));
+    const createResult = await webApi.pma.createChat(buildTicketRepairChatCreatePayload(ticket));
     if (!createResult.ok) {
       actionStatus = createResult.error.message;
       return;
     }
-    const sendResult = await pmaApi.pma.sendMessage(createResult.data.id, buildManagedThreadMessagePayload(buildTicketRepairPrompt(ticket), '', false));
+    const sendResult = await webApi.pma.sendMessage(createResult.data.id, buildManagedThreadMessagePayload(buildTicketRepairPrompt(ticket), '', false));
     if (!sendResult.ok) {
       actionStatus = sendResult.error.message;
       return;


### PR DESCRIPTION
## Summary
- add a shared PMA transcript compaction helper that appends token-like progress deltas and groups dense turn activity into expandable summaries
- keep detailed introspection by nesting thinking, progress, tool, and approval rows inside the existing turn summary details UI
- update transcript rendering to consume the compact presentation model instead of rendering every Hermes/OpenCode/Codex progress row flat

## Validation
- pnpm web:lint
- pnpm web:test -- ChatTranscriptCards pmaChat
- pnpm run build
- git diff --check
- pre-commit web-ui lane: full pytest, web-ui lab, web lint, web build, full web tests, SPA shell check
