### PR TITLE
[codex] Fix web chat store cloning hotspot

### DIFF
--- a/scripts/profile_web_page_view_models.py
+++ b/scripts/profile_web_page_view_models.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Run manual Web page/view-model profiling scenarios.
+
+This is intentionally opt-in and excluded from default test/CI lanes. It
+targets expensive client-side page assembly work for large hubs.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROFILE_TEST = "src/lib/viewModels/pageViewModels.profile.test.ts"
+
+
+def main() -> int:
+    env = os.environ.copy()
+    env["RUN_WEB_PAGE_PROFILE"] = "1"
+    cmd = [
+        "pnpm",
+        "--filter",
+        "@codex-autorunner/web-hub",
+        "exec",
+        "vitest",
+        "run",
+        PROFILE_TEST,
+        "--reporter=verbose",
+    ]
+    return subprocess.call(cmd, cwd=REPO_ROOT, env=env)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/profile_web_read_model_store.py
+++ b/scripts/profile_web_read_model_store.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Run the manual Web read-model store profiling suite.
+
+This intentionally stays out of default test and CI lanes. It exercises large
+cached chat/transcript states so agents can isolate browser-side store update
+costs without needing a live hub.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROFILE_TEST = "src/lib/data/readModelStore.profile.test.ts"
+
+
+def main() -> int:
+    env = os.environ.copy()
+    env["RUN_WEB_STORE_PROFILE"] = "1"
+    cmd = [
+        "pnpm",
+        "--filter",
+        "@codex-autorunner/web-hub",
+        "exec",
+        "vitest",
+        "run",
+        PROFILE_TEST,
+        "--reporter=verbose",
+    ]
+    return subprocess.call(cmd, cwd=REPO_ROOT, env=env)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.profile.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.profile.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import type { PmaRunProgress, SurfaceArtifact } from '$lib/viewModels/domain';
+import type { PmaCard } from '$lib/viewModels/pmaChat';
+import { ReadModelEntityStore, type ReadModelEntityState } from './readModelStore';
+
+const runProfile = process.env.RUN_WEB_STORE_PROFILE === '1';
+const describeProfile = runProfile ? describe : describe.skip;
+const now = '2026-05-15T12:00:00Z';
+
+describeProfile('manual read model store profile', () => {
+  it('measures active-chat update cost with many cached transcripts', () => {
+    const store = new ReadModelEntityStore();
+    const chatCount = numberFromEnv('WEB_STORE_PROFILE_CHATS', 160);
+    const cardsPerChat = numberFromEnv('WEB_STORE_PROFILE_CARDS_PER_CHAT', 120);
+    const iterations = numberFromEnv('WEB_STORE_PROFILE_ITERATIONS', 80);
+
+    for (let chatIndex = 0; chatIndex < chatCount; chatIndex += 1) {
+      store.replacePmaTranscript(`chat-${chatIndex}`, cardsForChat(`chat-${chatIndex}`, cardsPerChat));
+    }
+
+    const legacySamples: number[] = [];
+    const seededState = store.snapshot();
+    for (let i = 0; i < iterations; i += 1) {
+      const start = performance.now();
+      legacyDeepCloneState(seededState);
+      legacySamples.push(performance.now() - start);
+    }
+
+    const samples: number[] = [];
+    for (let i = 0; i < iterations; i += 1) {
+      const start = performance.now();
+      store.setPmaProgress('chat-0', progress(i));
+      samples.push(performance.now() - start);
+    }
+
+    samples.sort((left, right) => left - right);
+    legacySamples.sort((left, right) => left - right);
+    const p50 = percentile(samples, 0.5);
+    const p95 = percentile(samples, 0.95);
+    const legacyP95 = percentile(legacySamples, 0.95);
+    const payload = {
+      chatCount,
+      cardsPerChat,
+      iterations,
+      transcriptCards: chatCount * cardsPerChat,
+      p50Ms: round(p50),
+      p95Ms: round(p95),
+      maxMs: round(samples[samples.length - 1] ?? 0),
+      legacyDeepCloneP95Ms: round(legacyP95),
+      p95Improvement: legacyP95 > 0 ? round(legacyP95 / Math.max(p95, 0.001)) : null
+    };
+    console.info(`WEB_STORE_PROFILE ${JSON.stringify(payload)}`);
+    expect(p95).toBeLessThan(8);
+  }, 30_000);
+});
+
+function numberFromEnv(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function legacyDeepCloneState(state: ReadModelEntityState): ReadModelEntityState {
+  return {
+    ...state,
+    cursors: { ...state.cursors },
+    chats: { ...state.chats },
+    chatOrder: [...state.chatOrder],
+    chatGroups: { ...state.chatGroups },
+    chatGroupOrder: [...state.chatGroupOrder],
+    chatCounters: { ...state.chatCounters },
+    chatDetails: legacyCloneRecord(state.chatDetails),
+    timelines: legacyCloneRecord(state.timelines),
+    pmaTranscripts: legacyCloneRecord(state.pmaTranscripts),
+    pmaProgress: { ...state.pmaProgress },
+    pmaQueues: legacyCloneRecord(state.pmaQueues),
+    pmaArtifacts: legacyCloneRecord(state.pmaArtifacts),
+    readMarkers: { ...state.readMarkers },
+    artifacts: { ...state.artifacts },
+    repos: { ...state.repos },
+    repoOrder: [...state.repoOrder],
+    worktrees: { ...state.worktrees },
+    worktreeOrder: [...state.worktreeOrder],
+    runtime: { ...state.runtime },
+    tickets: { ...state.tickets },
+    ticketSummaries: { ...state.ticketSummaries },
+    ticketOrderByOwner: legacyCloneRecord(state.ticketOrderByOwner),
+    ticketSiblings: legacyCloneRecord(state.ticketSiblings),
+    runs: { ...state.runs },
+    pmaRuns: { ...state.pmaRuns },
+    pmaRunOrderByOwner: legacyCloneRecord(state.pmaRunOrderByOwner),
+    repoDetails: legacyCloneRecord(state.repoDetails),
+    worktreeDetails: legacyCloneRecord(state.worktreeDetails),
+    agents: { ...state.agents },
+    models: { ...state.models },
+    optimistic: { ...state.optimistic },
+    versions: {
+      chat: { ...state.versions.chat },
+      chatGroup: { ...state.versions.chatGroup },
+      timeline: { ...state.versions.timeline },
+      repo: { ...state.versions.repo },
+      worktree: { ...state.versions.worktree },
+      ticket: { ...state.versions.ticket },
+      run: { ...state.versions.run },
+      artifact: { ...state.versions.artifact },
+      agent: { ...state.versions.agent },
+      model: { ...state.versions.model }
+    }
+  };
+}
+
+function legacyCloneRecord<T>(record: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(Object.entries(record).map(([key, value]) => [key, structuredClone(value)]));
+}
+
+function percentile(samples: number[], p: number): number {
+  if (!samples.length) return 0;
+  const index = Math.min(samples.length - 1, Math.max(0, Math.ceil(samples.length * p) - 1));
+  return samples[index] ?? 0;
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function cardsForChat(chatId: string, count: number): PmaCard[] {
+  const cards: PmaCard[] = [];
+  for (let index = 0; index < count; index += 1) {
+    cards.push({
+      kind: 'message',
+      id: `${chatId}:turn:${index}:assistant`,
+      turnId: `${index}`,
+      orderKey: String(index).padStart(8, '0'),
+      timestamp: now,
+      message: {
+        id: `${chatId}:message:${index}`,
+        chatId,
+        role: 'assistant',
+        text: `Synthetic transcript row ${index} `.repeat(20),
+        createdAt: now,
+        status: null,
+        artifacts: [],
+        raw: {}
+      }
+    });
+  }
+  return cards;
+}
+
+function progress(index: number): PmaRunProgress {
+  const events: SurfaceArtifact[] = [];
+  for (let i = 0; i < 8; i += 1) {
+    events.push({
+      id: `event-${index}-${i}`,
+      kind: 'progress',
+      title: `Event ${i}`,
+      summary: null,
+      url: null,
+      createdAt: now,
+      raw: {}
+    });
+  }
+  return {
+    id: `turn-${index}`,
+    chatId: 'chat-0',
+    status: 'running',
+    workStatus: 'running',
+    operatorStatus: null,
+    streamShouldClose: false,
+    streamCloseReason: null,
+    terminal: false,
+    phase: null,
+    guidance: null,
+    queueDepth: 0,
+    elapsedSeconds: index,
+    startedAt: now,
+    idleSeconds: null,
+    lastEventId: index,
+    lastEventAt: now,
+    progressPercent: null,
+    events,
+    raw: {}
+  };
+}

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -254,6 +254,59 @@ describe('read model entity store', () => {
     });
   });
 
+  it('does not clone untouched cached transcripts when progress updates', () => {
+    const store = new ReadModelEntityStore();
+    const active = pmaMessageCard('chat-1', 'turn:1:user', 'hello');
+    const inactive = pmaMessageCard('chat-2', 'turn:2:user', 'cached transcript');
+    store.replacePmaTranscript('chat-1', [active]);
+    store.replacePmaTranscript('chat-2', [inactive]);
+    const inactiveBefore = store.snapshot().pmaTranscripts['chat-2'];
+
+    store.setPmaProgress('chat-1', progress('chat-1', 1));
+
+    expect(store.snapshot().pmaTranscripts['chat-2']).toBe(inactiveBefore);
+  });
+
+  it('does not clone untouched cached details when another detail patches', () => {
+    const store = new ReadModelEntityStore();
+    store.applyChatDetailSnapshot(detailSnapshot('chat-1'));
+    store.applyChatDetailSnapshot(detailSnapshot('chat-2'));
+    const detailBefore = store.snapshot().chatDetails['chat-2'];
+    const timelineBefore = store.snapshot().timelines['chat-2'];
+
+    store.applyChatDetailPatchEvent({
+      envelope: {
+        contractVersion: READ_MODEL_CONTRACT_VERSION,
+        eventType: 'chat.detail.patch',
+        cursor: cursor(2),
+        entityKind: 'chat',
+        entityId: 'chat-1',
+        operation: 'patch',
+        generatedAt: now
+      },
+      patch: {
+        thread: null,
+        appendedTimeline: [
+          {
+            itemId: 'item-2',
+            kind: 'assistant_message',
+            role: 'assistant',
+            createdAt: now,
+            text: 'hi',
+            artifactIds: []
+          }
+        ],
+        patchedTimeline: [],
+        removedTimelineIds: [],
+        queue: null,
+        artifacts: []
+      }
+    });
+
+    expect(store.snapshot().chatDetails['chat-2']).toBe(detailBefore);
+    expect(store.snapshot().timelines['chat-2']).toBe(timelineBefore);
+  });
+
   it('orders backend-owned PMA transcript cards by backend order key across turns', () => {
     const store = new ReadModelEntityStore();
     const userOne: PmaCard = {
@@ -596,6 +649,50 @@ describe('read model entity store', () => {
     expect(retained[0].id).toBe('visible-5');
   });
 });
+
+function pmaMessageCard(chatId: string, id: string, text: string): PmaCard {
+  return {
+    kind: 'message',
+    id,
+    turnId: id,
+    orderKey: id,
+    timestamp: now,
+    message: {
+      id,
+      chatId,
+      role: 'user',
+      text,
+      createdAt: now,
+      status: null,
+      artifacts: [],
+      raw: {}
+    }
+  };
+}
+
+function progress(chatId: string, sequence: number): PmaRunProgress {
+  return {
+    id: `turn-${sequence}`,
+    chatId,
+    status: 'running',
+    workStatus: 'running',
+    operatorStatus: null,
+    streamShouldClose: false,
+    streamCloseReason: null,
+    terminal: false,
+    phase: null,
+    guidance: null,
+    queueDepth: 0,
+    elapsedSeconds: sequence,
+    startedAt: now,
+    idleSeconds: null,
+    lastEventId: sequence,
+    lastEventAt: now,
+    progressPercent: null,
+    events: [],
+    raw: {}
+  };
+}
 
 function progressArtifact(id: string, progressItem: Record<string, unknown>): SurfaceArtifact {
   return {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -402,6 +402,7 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
       if (id.startsWith('optimistic:')) delete target.cardsById[id];
     }
     target.order = target.order.filter((id) => !id.startsWith('optimistic:'));
+    next.pmaTranscripts[chatId] = target;
     bump(next, 'timeline', chatId);
     this.commit(next);
   }

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -329,12 +329,14 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     }
     if (!isNewer(this.state.cursors[cursorKey], event.envelope.cursor)) return 'ignored';
     const next = cloneState(this.state);
-    const existingTimeline = next.timelines[chatId] ?? {
-      chatId,
-      itemsById: {},
-      order: [],
-      windowLimit: 50
-    };
+    const existingTimeline = cloneTimelineProjection(
+      next.timelines[chatId] ?? {
+        chatId,
+        itemsById: {},
+        order: [],
+        windowLimit: 50
+      }
+    );
     for (const item of [...event.patch.appendedTimeline, ...event.patch.patchedTimeline]) {
       existingTimeline.itemsById[item.itemId] = item;
       if (!existingTimeline.order.includes(item.itemId)) existingTimeline.order.push(item.itemId);
@@ -344,7 +346,7 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
       existingTimeline.order = existingTimeline.order.filter((itemId) => itemId !== id);
     }
     next.timelines[chatId] = existingTimeline;
-    const detail = next.chatDetails[chatId] ?? { thread: null, queue: null, artifactIds: [] };
+    const detail = cloneChatDetailProjection(next.chatDetails[chatId] ?? { thread: null, queue: null, artifactIds: [] });
     if (event.patch.thread) {
       detail.thread = event.patch.thread;
       upsertChatThread(next, event.patch.thread);
@@ -379,7 +381,7 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
   upsertPmaTranscriptCards(chatId: string, cards: PmaCard[]): void {
     if (!cards.length) return;
     const next = cloneState(this.state);
-    const transcript = next.pmaTranscripts[chatId] ?? { cardsById: {}, order: [] };
+    const transcript = clonePmaTranscript(next.pmaTranscripts[chatId] ?? { cardsById: {}, order: [] });
     for (const card of cards) {
       const id = pmaCardEntityId(card);
       transcript.cardsById[id] = card;
@@ -395,7 +397,7 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     const transcript = this.state.pmaTranscripts[chatId];
     if (!transcript || !transcript.order.some((id) => id.startsWith('optimistic:'))) return;
     const next = cloneState(this.state);
-    const target = next.pmaTranscripts[chatId];
+    const target = clonePmaTranscript(next.pmaTranscripts[chatId]);
     for (const id of target.order) {
       if (id.startsWith('optimistic:')) delete target.cardsById[id];
     }
@@ -598,7 +600,7 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
 
   optimisticSend(chatId: string, item: ChatTimelineItem, reconciliationId: string): void {
     const next = cloneState(this.state);
-    const timeline = next.timelines[chatId] ?? { chatId, itemsById: {}, order: [], windowLimit: 50 };
+    const timeline = cloneTimelineProjection(next.timelines[chatId] ?? { chatId, itemsById: {}, order: [], windowLimit: 50 });
     timeline.itemsById[item.itemId] = item;
     if (!timeline.order.includes(item.itemId)) timeline.order.push(item.itemId);
     next.timelines[chatId] = timeline;
@@ -618,13 +620,14 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
   reconcileOptimisticTimelineItem(chatId: string, reconciliationId: string, backendItem: ChatTimelineItem): void {
     const next = cloneState(this.state);
     const mutation = next.optimistic[reconciliationId];
-    const timeline = next.timelines[chatId];
+    const timeline = next.timelines[chatId] ? cloneTimelineProjection(next.timelines[chatId]) : undefined;
     const optimisticItemId = (mutation?.previousValue as { itemId?: string } | undefined)?.itemId;
     if (timeline && optimisticItemId) {
       delete timeline.itemsById[optimisticItemId];
       timeline.itemsById[backendItem.itemId] = backendItem;
       timeline.order = timeline.order.map((id) => (id === optimisticItemId ? backendItem.itemId : id));
       if (!timeline.order.includes(backendItem.itemId)) timeline.order.push(backendItem.itemId);
+      next.timelines[chatId] = timeline;
     }
     if (mutation) next.optimistic[reconciliationId] = { ...mutation, status: 'reconciled' };
     bump(next, 'timeline', chatId);
@@ -638,10 +641,11 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
       const chatId = mutation.entityId;
       const itemId = (mutation.previousValue as { itemId?: string } | undefined)?.itemId;
       const next = cloneState(this.state);
-      const timeline = next.timelines[chatId];
+      const timeline = next.timelines[chatId] ? cloneTimelineProjection(next.timelines[chatId]) : undefined;
       if (timeline && itemId) {
         delete timeline.itemsById[itemId];
         timeline.order = timeline.order.filter((id) => id !== itemId);
+        next.timelines[chatId] = timeline;
       }
       next.optimistic[reconciliationId] = { ...mutation, status: 'failed' };
       bump(next, 'timeline', chatId);
@@ -681,10 +685,11 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     }
     if (mutation.kind === 'send' && mutation.entityKind === 'timeline') {
       const itemId = (mutation.previousValue as { itemId?: string } | undefined)?.itemId;
-      const timeline = next.timelines[mutation.entityId];
+      const timeline = next.timelines[mutation.entityId] ? cloneTimelineProjection(next.timelines[mutation.entityId]) : undefined;
       if (timeline && itemId) {
         delete timeline.itemsById[itemId];
         timeline.order = timeline.order.filter((id) => id !== itemId);
+        next.timelines[mutation.entityId] = timeline;
         bump(next, 'timeline', mutation.entityId);
       }
     }
@@ -745,12 +750,12 @@ function cloneState(state: ReadModelEntityState): ReadModelEntityState {
     chatGroups: { ...state.chatGroups },
     chatGroupOrder: [...state.chatGroupOrder],
     chatCounters: { ...state.chatCounters },
-    chatDetails: cloneRecord(state.chatDetails),
-    timelines: cloneRecord(state.timelines),
-    pmaTranscripts: cloneRecord(state.pmaTranscripts),
+    chatDetails: { ...state.chatDetails },
+    timelines: { ...state.timelines },
+    pmaTranscripts: { ...state.pmaTranscripts },
     pmaProgress: { ...state.pmaProgress },
-    pmaQueues: cloneRecord(state.pmaQueues),
-    pmaArtifacts: cloneRecord(state.pmaArtifacts),
+    pmaQueues: { ...state.pmaQueues },
+    pmaArtifacts: { ...state.pmaArtifacts },
     readMarkers: { ...state.readMarkers },
     artifacts: { ...state.artifacts },
     repos: { ...state.repos },
@@ -760,13 +765,13 @@ function cloneState(state: ReadModelEntityState): ReadModelEntityState {
     runtime: { ...state.runtime },
     tickets: { ...state.tickets },
     ticketSummaries: { ...state.ticketSummaries },
-    ticketOrderByOwner: cloneRecord(state.ticketOrderByOwner),
-    ticketSiblings: cloneRecord(state.ticketSiblings),
+    ticketOrderByOwner: { ...state.ticketOrderByOwner },
+    ticketSiblings: { ...state.ticketSiblings },
     runs: { ...state.runs },
     pmaRuns: { ...state.pmaRuns },
-    pmaRunOrderByOwner: cloneRecord(state.pmaRunOrderByOwner),
-    repoDetails: cloneRecord(state.repoDetails),
-    worktreeDetails: cloneRecord(state.worktreeDetails),
+    pmaRunOrderByOwner: { ...state.pmaRunOrderByOwner },
+    repoDetails: { ...state.repoDetails },
+    worktreeDetails: { ...state.worktreeDetails },
     agents: { ...state.agents },
     models: { ...state.models },
     optimistic: { ...state.optimistic },
@@ -785,8 +790,28 @@ function cloneState(state: ReadModelEntityState): ReadModelEntityState {
   };
 }
 
-function cloneRecord<T>(record: Record<string, T>): Record<string, T> {
-  return Object.fromEntries(Object.entries(record).map(([key, value]) => [key, structuredClone(value)]));
+function cloneChatDetailProjection(detail: ChatDetailProjection): ChatDetailProjection {
+  return {
+    thread: detail.thread,
+    queue: detail.queue,
+    artifactIds: [...detail.artifactIds]
+  };
+}
+
+function cloneTimelineProjection(timeline: TimelineProjection): TimelineProjection {
+  return {
+    chatId: timeline.chatId,
+    itemsById: { ...timeline.itemsById },
+    order: [...timeline.order],
+    windowLimit: timeline.windowLimit
+  };
+}
+
+function clonePmaTranscript(transcript: { cardsById: Record<string, PmaCard>; order: string[] }): { cardsById: Record<string, PmaCard>; order: string[] } {
+  return {
+    cardsById: { ...transcript.cardsById },
+    order: [...transcript.order]
+  };
 }
 
 function keyed<T>(items: T[], key: (item: T) => string): Record<string, T> {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pageViewModels.profile.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pageViewModels.profile.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest';
+import type { PmaChatSummary, PmaRunProgress, RepoSummary, TicketSummary, WorktreeSummary } from './domain';
+import { buildRepoWorktreeDetailViewModel, buildRepoWorktreeIndexViewModel } from './repoWorktree';
+import { buildSettingsViewModel } from './settings';
+import { buildTicketListViewModel } from './ticket';
+
+const runProfile = process.env.RUN_WEB_PAGE_PROFILE === '1';
+const describeProfile = runProfile ? describe : describe.skip;
+const now = '2026-05-15T12:00:00Z';
+
+describeProfile('manual page view-model profile', () => {
+  it('measures large hub page assembly costs', () => {
+    const source = syntheticHubSource({
+      repoCount: numberFromEnv('WEB_PAGE_PROFILE_REPOS', 90),
+      worktreesPerRepo: numberFromEnv('WEB_PAGE_PROFILE_WORKTREES_PER_REPO', 5),
+      ticketsPerWorkspace: numberFromEnv('WEB_PAGE_PROFILE_TICKETS_PER_WORKSPACE', 5),
+      chatsPerWorkspace: numberFromEnv('WEB_PAGE_PROFILE_CHATS_PER_WORKSPACE', 3),
+      runsPerWorkspace: numberFromEnv('WEB_PAGE_PROFILE_RUNS_PER_WORKSPACE', 2)
+    });
+    const owner = { kind: 'repo' as const, id: 'repo-10' };
+    const settingsInput = syntheticSettingsInput(
+      numberFromEnv('WEB_PAGE_PROFILE_AGENTS', 40),
+      numberFromEnv('WEB_PAGE_PROFILE_MODELS_PER_AGENT', 250)
+    );
+
+    const repoIndex = measure(() => buildRepoWorktreeIndexViewModel(source));
+    const repoDetail = measure(() => buildRepoWorktreeDetailViewModel(source, 'repo', owner.id));
+    const ticketList = measure(() => buildTicketListViewModel(source, owner));
+    const globalTicketList = measure(() => buildTicketListViewModel({
+      tickets: source.tickets,
+      runs: [],
+      chats: [],
+      artifacts: []
+    }));
+    const settings = measure(() => buildSettingsViewModel(settingsInput));
+
+    const payload = {
+      repos: source.repos.length,
+      worktrees: source.worktrees.length,
+      tickets: source.tickets.length,
+      chats: source.chats.length,
+      runs: source.runs.length,
+      agents: settingsInput.agents?.length ?? 0,
+      modelsPerAgent: settingsInput.modelCatalogs?.agent_0?.length ?? 0,
+      repoIndexMs: round(repoIndex.durationMs),
+      repoIndexRows: repoIndex.value.rows.length,
+      repoDetailMs: round(repoDetail.durationMs),
+      repoDetailTickets: repoDetail.value.ticketOverview.total,
+      ticketListMs: round(ticketList.durationMs),
+      ticketRows: ticketList.value.rows.length,
+      globalTicketListMs: round(globalTicketList.durationMs),
+      globalTicketRows: globalTicketList.value.rows.length,
+      settingsMs: round(settings.durationMs),
+      settingsAgents: settings.value.agents.length
+    };
+    console.info(`WEB_PAGE_PROFILE ${JSON.stringify(payload)}`);
+    expect(repoIndex.durationMs).toBeLessThan(80);
+    expect(repoDetail.durationMs).toBeLessThan(30);
+    expect(ticketList.durationMs).toBeLessThan(30);
+    expect(globalTicketList.durationMs).toBeLessThan(80);
+    expect(settings.durationMs).toBeLessThan(30);
+  }, 30_000);
+});
+
+function measure<T>(fn: () => T): { value: T; durationMs: number } {
+  const start = performance.now();
+  const value = fn();
+  return { value, durationMs: performance.now() - start };
+}
+
+function numberFromEnv(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function syntheticHubSource(config: {
+  repoCount: number;
+  worktreesPerRepo: number;
+  ticketsPerWorkspace: number;
+  chatsPerWorkspace: number;
+  runsPerWorkspace: number;
+}) {
+  const repos: RepoSummary[] = [];
+  const worktrees: WorktreeSummary[] = [];
+  const tickets: TicketSummary[] = [];
+  const chats: PmaChatSummary[] = [];
+  const runs: PmaRunProgress[] = [];
+  for (let repoIndex = 0; repoIndex < config.repoCount; repoIndex += 1) {
+    const repoId = `repo-${repoIndex}`;
+    repos.push(repo(repoId, repoIndex));
+    addWorkspaceRows('repo', repoId, repoId, null, config, tickets, chats, runs);
+    for (let worktreeIndex = 0; worktreeIndex < config.worktreesPerRepo; worktreeIndex += 1) {
+      const worktreeId = `${repoId}-worktree-${worktreeIndex}`;
+      worktrees.push(worktree(worktreeId, repoId, worktreeIndex));
+      addWorkspaceRows('worktree', worktreeId, repoId, worktreeId, config, tickets, chats, runs);
+    }
+  }
+  return { repos, worktrees, tickets, runs, chats, artifacts: [], ticketsListLoaded: true };
+}
+
+function addWorkspaceRows(
+  kind: 'repo' | 'worktree',
+  id: string,
+  repoId: string,
+  worktreeId: string | null,
+  config: { ticketsPerWorkspace: number; chatsPerWorkspace: number; runsPerWorkspace: number },
+  tickets: TicketSummary[],
+  chats: PmaChatSummary[],
+  runs: PmaRunProgress[]
+): void {
+  for (let ticketIndex = 0; ticketIndex < config.ticketsPerWorkspace; ticketIndex += 1) {
+    const ticketId = `${id}-ticket-${ticketIndex}`;
+    const runId = `${id}-run-${ticketIndex % Math.max(1, config.runsPerWorkspace)}`;
+    const chatId = `${id}-chat-${ticketIndex % Math.max(1, config.chatsPerWorkspace)}`;
+    tickets.push(ticket(ticketId, kind, id, repoId, worktreeId, runId, chatId, ticketIndex));
+  }
+  for (let chatIndex = 0; chatIndex < config.chatsPerWorkspace; chatIndex += 1) {
+    chats.push(chat(`${id}-chat-${chatIndex}`, kind, id, repoId, worktreeId, chatIndex));
+  }
+  for (let runIndex = 0; runIndex < config.runsPerWorkspace; runIndex += 1) {
+    runs.push(run(`${id}-run-${runIndex}`, kind, id, repoId, worktreeId, `${id}-chat-${runIndex % Math.max(1, config.chatsPerWorkspace)}`, runIndex));
+  }
+}
+
+function repo(id: string, index: number): RepoSummary {
+  return {
+    id,
+    name: id,
+    path: `/repos/${id}`,
+    status: index % 7 === 0 ? 'running' : 'idle',
+    activeRuns: index % 7 === 0 ? 1 : 0,
+    openTickets: 0,
+    worktreeCount: 0,
+    lastActivityAt: now,
+    defaultBranch: 'main',
+    gitStatus: null,
+    raw: { has_car_state: true, is_pinned: index % 13 === 0 }
+  };
+}
+
+function worktree(id: string, repoId: string, index: number): WorktreeSummary {
+  return {
+    id,
+    name: id,
+    path: `/repos/${repoId}/worktrees/${id}`,
+    repoId,
+    branch: `branch-${index}`,
+    status: index % 5 === 0 ? 'running' : 'idle',
+    activeRuns: index % 5 === 0 ? 1 : 0,
+    openTickets: 0,
+    lastActivityAt: now,
+    gitStatus: null,
+    raw: { has_car_state: true }
+  };
+}
+
+function ticket(
+  id: string,
+  kind: 'repo' | 'worktree',
+  workspaceId: string,
+  repoId: string,
+  worktreeId: string | null,
+  runId: string,
+  chatKey: string,
+  index: number
+): TicketSummary {
+  return {
+    id,
+    number: index + 1,
+    title: `Ticket ${id}`,
+    status: index % 6 === 0 ? 'waiting' : index % 8 === 0 ? 'failed' : 'idle',
+    workspaceKind: kind,
+    workspaceId,
+    workspacePath: `/workspace/${workspaceId}`,
+    repoId,
+    worktreeId,
+    path: `.codex-autorunner/tickets/TICKET-${String(index + 1).padStart(3, '0')}.md`,
+    ticketPath: null,
+    agentId: 'codex',
+    chatKey,
+    runId,
+    updatedAt: now,
+    durationSeconds: index * 10,
+    diffStats: null,
+    errors: [],
+    raw: {
+      body: `---\nagent: codex\nmodel: gpt-5.5\n---\n\n## Goal\n${id}`,
+      frontmatter: { agent: 'codex', model: 'gpt-5.5' },
+      repo_id: repoId,
+      ...(worktreeId ? { worktree_id: worktreeId } : {}),
+      resource_kind: kind,
+      resource_id: workspaceId
+    }
+  };
+}
+
+function chat(
+  id: string,
+  kind: 'repo' | 'worktree',
+  workspaceId: string,
+  repoId: string,
+  worktreeId: string | null,
+  index: number
+): PmaChatSummary {
+  return {
+    id,
+    title: `Chat ${id}`,
+    lifecycleStatus: 'active',
+    status: index % 5 === 0 ? 'waiting' : index % 7 === 0 ? 'failed' : 'idle',
+    agentId: 'codex',
+    agentProfile: null,
+    model: 'gpt-5.5',
+    repoId: kind === 'repo' ? workspaceId : repoId,
+    worktreeId,
+    ticketId: `${workspaceId}-ticket-${index}`,
+    runId: `${workspaceId}-run-${index}`,
+    isTicketFlow: true,
+    progressPercent: null,
+    updatedAt: now,
+    raw: { resource_kind: kind, resource_id: workspaceId }
+  };
+}
+
+function run(
+  id: string,
+  kind: 'repo' | 'worktree',
+  workspaceId: string,
+  repoId: string,
+  worktreeId: string | null,
+  chatId: string,
+  index: number
+): PmaRunProgress {
+  return {
+    id,
+    chatId,
+    status: index % 3 === 0 ? 'running' : 'idle',
+    workStatus: index % 3 === 0 ? 'running' : 'idle',
+    operatorStatus: null,
+    terminal: false,
+    streamShouldClose: false,
+    streamCloseReason: null,
+    phase: null,
+    guidance: null,
+    queueDepth: 0,
+    elapsedSeconds: index,
+    startedAt: now,
+    idleSeconds: null,
+    lastEventId: index,
+    lastEventAt: now,
+    progressPercent: null,
+    events: [],
+    raw: {
+      resource_kind: kind,
+      resource_id: workspaceId,
+      repo_id: repoId,
+      ...(worktreeId ? { worktree_id: worktreeId } : {})
+    }
+  };
+}
+
+function syntheticSettingsInput(agentCount: number, modelsPerAgent: number) {
+  const agents = Array.from({ length: agentCount }, (_, index) => ({
+    id: `agent_${index}`,
+    name: `Agent ${index}`,
+    capabilities: ['list_models'],
+    capability_projection: { actions: { list_models: { allowed: true } } }
+  }));
+  const modelCatalogs = Object.fromEntries(
+    agents.map((agent) => [
+      agent.id,
+      Array.from({ length: modelsPerAgent }, (_, modelIndex) => ({
+        id: `${agent.id}-model-${modelIndex}`,
+        display_name: `Model ${modelIndex}`
+      }))
+    ])
+  );
+  return {
+    session: {
+      autorunner_model_overrides: {},
+      autorunner_effort_override: '',
+      runner_stop_after_runs: null
+    },
+    agents,
+    modelCatalogs,
+    voiceConfig: { enabled: false, provider: 'local_whisper' }
+  };
+}

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.test.ts
@@ -367,7 +367,7 @@ describe('repo/worktree view models', () => {
     expect(vm.childWorktrees[0]).toMatchObject({
       href: '/repos/repo-1/worktrees/worktree-1',
       currentTicketId: null,
-      openTickets: 0,
+      openTickets: 1,
       activeRuns: 1
     });
   });

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.ts
@@ -305,28 +305,31 @@ export function buildRepoWorktreeIndexViewModel(
   source: RepoWorktreeSourceData,
   kind: 'all' | RepoWorktreeKind = 'all'
 ): RepoWorktreeIndexViewModel {
+  const lookup = buildRepoWorktreeLookup(source);
   const ticketIndexMetricsAvailable = source.ticketsListLoaded !== false;
   const repoIds = new Set(source.repos.map((repo) => repo.id));
   const orphanWorktrees = source.worktrees.filter((worktree) => !worktree.repoId || !repoIds.has(worktree.repoId));
   const rows =
     kind === 'worktree'
       ? source.worktrees
-          .map((worktree) => enrichIndexRowSignals(worktreeToIndexRow(worktree, source), source))
+          .map((worktree) => enrichIndexRowSignals(worktreeToIndexRow(worktree, source, lookup), source, lookup))
           .sort(bySignalsThenActiveThenRecent)
       : [
           ...source.repos.map((repo) =>
             enrichIndexRowSignals(
               repoToIndexRow(
                 repo,
-                source.worktrees.filter((worktree) => worktree.repoId === repo.id),
-                source
+                lookup.worktreesByRepo.get(repo.id) ?? [],
+                source,
+                lookup
               ),
-              source
+              source,
+              lookup
             )
           ),
           ...(kind === 'all'
             ? orphanWorktrees.map((worktree) =>
-                enrichIndexRowSignals(worktreeToIndexRow(worktree, source), source)
+                enrichIndexRowSignals(worktreeToIndexRow(worktree, source, lookup), source, lookup)
               )
             : [])
         ].sort(bySignalsThenActiveThenRecent);
@@ -352,6 +355,7 @@ export function buildRepoWorktreeDetailViewModel(
   kind: RepoWorktreeKind,
   id: string
 ): RepoWorktreeDetailViewModel {
+  const lookup = buildRepoWorktreeLookup(source);
   const resource =
     kind === 'repo'
       ? source.repos.find((repo) => repo.id === id) ?? null
@@ -360,19 +364,19 @@ export function buildRepoWorktreeDetailViewModel(
   const title = resource?.name ?? id;
   const branch = kind === 'repo' ? (resource as RepoSummary | null)?.defaultBranch ?? null : (resource as WorktreeSummary | null)?.branch ?? null;
   const path = resource?.path ?? null;
-  const childWorktreeSummaries = kind === 'repo' ? source.worktrees.filter((worktree) => worktree.repoId === id) : [];
+  const childWorktreeSummaries = kind === 'repo' ? lookup.worktreesByRepo.get(id) ?? [] : [];
   const baseRepo =
     kind === 'worktree'
       ? source.repos.find((repo) => repo.id === (resource as WorktreeSummary | null)?.repoId) ?? null
       : null;
   const parentRepoId = kind === 'worktree' ? (resource as WorktreeSummary | null)?.repoId ?? null : null;
-  const primaryRuns = source.runs.filter((run) => runMatchesResource(run, kind, id));
-  const primaryChats = source.chats.filter((chat) => chatMatchesResource(chat, kind, id));
+  const primaryRuns = lookup.runsByResource.get(resourceKey(kind, id)) ?? [];
+  const primaryChats = lookup.chatsByResource.get(resourceKey(kind, id)) ?? [];
   const runCards = mergeRunCards(primaryRuns, primaryChats, kind, id, parentRepoId);
   const activeRunCards = runCards.filter((run) => ['running', 'waiting', 'blocked'].includes(run.status));
   const visibleRuns = activeRunCards.length ? activeRunCards : runCards.slice(0, 1);
   const currentTicketIds = new Set(visibleRuns.map((run) => run.ticketId).filter((ticketId): ticketId is string => Boolean(ticketId)));
-  const scopedTickets = ticketsForResource(source.tickets, kind, id);
+  const scopedTickets = ticketsForResource(source.tickets, kind, id, lookup);
   const flowStatus = buildTicketFlowStatusViewModel(scopedTickets, primaryRuns, { kind, id });
   const activeCurrentTicketId = isActiveTicketFlowStatus(flowStatus.status) ? flowStatus.currentTicketId : null;
   const currentTickets = ticketsForIds(scopedTickets, currentTicketIds, activeCurrentTicketId);
@@ -416,7 +420,7 @@ export function buildRepoWorktreeDetailViewModel(
     ticketIndexHref: scopedTicketHref(kind, id, parentRepoId),
     ticketIndexLabel: kind === 'repo' ? 'Repo tickets' : 'Worktree tickets',
     ticketOverview,
-    childWorktrees: childWorktreeSummaries.map((worktree) => worktreeToNavChildRow(worktree, baseRepo?.name ?? null)),
+    childWorktrees: childWorktreeSummaries.map((worktree) => worktreeToNavChildRow(worktree, baseRepo?.name ?? null, source, lookup)),
     baseRepoLabel: baseRepo?.name ?? (kind === 'worktree' ? (resource as WorktreeSummary | null)?.repoId ?? null : null),
     baseRepoHref: kind === 'worktree' && (resource as WorktreeSummary | null)?.repoId ? repoRoute((resource as WorktreeSummary).repoId as string) : null,
     hasActiveRun: activeRunCards.length > 0,
@@ -513,12 +517,98 @@ function ticketIndexRollup(scoped: TicketSummary[]): { open: number; total: numb
   return { open, total, done };
 }
 
-function repoToIndexRow(repo: RepoSummary, worktrees: WorktreeSummary[], source: RepoWorktreeSourceData): RepoWorktreeIndexRow {
+type RepoWorktreeLookup = {
+  worktreesByRepo: Map<string, WorktreeSummary[]>;
+  ticketsByResource: Map<string, TicketSummary[]>;
+  chatsByResource: Map<string, PmaChatSummary[]>;
+  runsByResource: Map<string, PmaRunProgress[]>;
+};
+
+function buildRepoWorktreeLookup(source: RepoWorktreeSourceData): RepoWorktreeLookup {
+  const worktreesByRepo = new Map<string, WorktreeSummary[]>();
+  for (const worktree of source.worktrees) {
+    if (worktree.repoId) appendResource(worktreesByRepo, worktree.repoId, worktree);
+  }
+  const ticketsByResource = new Map<string, TicketSummary[]>();
+  for (const ticket of source.tickets) {
+    for (const key of ticketResourceKeys(ticket)) appendResource(ticketsByResource, key, ticket);
+  }
+  const chatsByResource = new Map<string, PmaChatSummary[]>();
+  for (const chat of source.chats) {
+    if (chat.worktreeId) appendResource(chatsByResource, resourceKey('worktree', chat.worktreeId), chat);
+    else if (chat.repoId) appendResource(chatsByResource, resourceKey('repo', chat.repoId), chat);
+  }
+  const runsByResource = new Map<string, PmaRunProgress[]>();
+  for (const run of source.runs) {
+    for (const key of runResourceKeys(run)) appendResource(runsByResource, key, run);
+  }
+  return { worktreesByRepo, ticketsByResource, chatsByResource, runsByResource };
+}
+
+function appendResource<T>(map: Map<string, T[]>, key: string, value: T): void {
+  const existing = map.get(key);
+  if (existing) existing.push(value);
+  else map.set(key, [value]);
+}
+
+function resourceKey(kind: RepoWorktreeKind, id: string): string {
+  return `${kind}:${id}`;
+}
+
+function ticketResourceKeys(ticket: TicketSummary): Set<string> {
+  const keys = new Set<string>();
+  if (ticket.workspaceKind === 'worktree' && ticket.workspaceId) keys.add(resourceKey('worktree', ticket.workspaceId));
+  else if (ticket.workspaceKind === 'repo' && ticket.workspaceId) keys.add(resourceKey('repo', ticket.workspaceId));
+  if (ticket.worktreeId) keys.add(resourceKey('worktree', ticket.worktreeId));
+  else if (ticket.repoId) keys.add(resourceKey('repo', ticket.repoId));
+  const raw = ticket.raw;
+  const frontmatter = asRecord(raw.frontmatter);
+  const rawResourceKind = stringFromRaw(raw, ['resource_kind']);
+  const frontmatterResourceKind = stringFromRaw(frontmatter, ['resource_kind']);
+  const rawResourceId = stringFromRaw(raw, ['resource_id']);
+  const frontmatterResourceId = stringFromRaw(frontmatter, ['resource_id']);
+  const worktreeId =
+    stringFromRaw(raw, ['worktree_id', 'worktree_repo_id']) ??
+    stringFromRaw(frontmatter, ['worktree_id', 'worktree_repo_id']);
+  const repoId =
+    stringFromRaw(raw, ['repo_id', 'base_repo_id']) ??
+    stringFromRaw(frontmatter, ['repo_id', 'base_repo_id']);
+  if (worktreeId) keys.add(resourceKey('worktree', worktreeId));
+  else if (repoId) keys.add(resourceKey('repo', repoId));
+  if (rawResourceKind === 'worktree' && rawResourceId) keys.add(resourceKey('worktree', rawResourceId));
+  if (frontmatterResourceKind === 'worktree' && frontmatterResourceId) keys.add(resourceKey('worktree', frontmatterResourceId));
+  if (rawResourceKind === 'repo' && rawResourceId) keys.add(resourceKey('repo', rawResourceId));
+  if (frontmatterResourceKind === 'repo' && frontmatterResourceId) keys.add(resourceKey('repo', frontmatterResourceId));
+  return keys;
+}
+
+function runResourceKeys(run: PmaRunProgress): Set<string> {
+  const keys = new Set<string>();
+  const state = asRecord(run.raw.state);
+  const ticketEngine = asRecord(state.ticket_engine);
+  const resourceKind = stringFromRaw(run.raw, ['resource_kind']) ?? stringFromRaw(state, ['resource_kind']) ?? stringFromRaw(ticketEngine, ['resource_kind']);
+  const resourceId = stringFromRaw(run.raw, ['resource_id']) ?? stringFromRaw(state, ['resource_id']) ?? stringFromRaw(ticketEngine, ['resource_id']);
+  const worktreeId =
+    stringFromRaw(run.raw, ['worktree_id', 'worktree_repo_id']) ??
+    stringFromRaw(state, ['worktree_id', 'worktree_repo_id']) ??
+    stringFromRaw(ticketEngine, ['worktree_id', 'worktree_repo_id']);
+  const repoId =
+    stringFromRaw(run.raw, ['repo_id']) ??
+    stringFromRaw(state, ['repo_id']) ??
+    stringFromRaw(ticketEngine, ['repo_id']);
+  if (worktreeId) keys.add(resourceKey('worktree', worktreeId));
+  else if (repoId) keys.add(resourceKey('repo', repoId));
+  if (resourceKind === 'worktree' && resourceId) keys.add(resourceKey('worktree', resourceId));
+  if (resourceKind === 'repo' && resourceId && !worktreeId) keys.add(resourceKey('repo', resourceId));
+  return keys;
+}
+
+function repoToIndexRow(repo: RepoSummary, worktrees: WorktreeSummary[], source: RepoWorktreeSourceData, lookup: RepoWorktreeLookup): RepoWorktreeIndexRow {
   const listLoaded = hubTicketListLoaded(source);
   const childWorktrees = worktrees
-    .map((worktree) => worktreeToNavChildRow(worktree, repo.name, source))
+    .map((worktree) => worktreeToNavChildRow(worktree, repo.name, source, lookup))
     .sort(byChildActiveThenLabel);
-  const repoScoped = ticketsForResource(source.tickets, 'repo', repo.id);
+  const repoScoped = ticketsForResource(source.tickets, 'repo', repo.id, lookup);
   const rollup = listLoaded ? ticketIndexRollup(repoScoped) : { open: 0, total: 0, done: 0 };
   let dirtyWorktrees = 0;
   let inUseWorktrees = 0;
@@ -527,7 +617,7 @@ function repoToIndexRow(repo: RepoSummary, worktrees: WorktreeSummary[], source:
     if (dirty) dirtyWorktrees += 1;
     let inUse = dirty || (worktree.activeRuns ?? 0) > 0 || worktree.status === 'running';
     if (!inUse) {
-      const sig = scopedSignals(source, 'worktree', worktree.id);
+      const sig = scopedSignals(source, 'worktree', worktree.id, [], lookup);
       inUse = sig.active > 0 || sig.waiting > 0 || sig.failed > 0;
     }
     if (inUse) inUseWorktrees += 1;
@@ -571,17 +661,18 @@ function repoToIndexRow(repo: RepoSummary, worktrees: WorktreeSummary[], source:
 function worktreeToNavChildRow(
   worktree: WorktreeSummary,
   repoName: string | null = null,
-  source: RepoWorktreeSourceData | null = null
+  source: RepoWorktreeSourceData | null = null,
+  lookup: RepoWorktreeLookup | null = source ? buildRepoWorktreeLookup(source) : null
 ): RepoWorktreeChildRow {
   const listLoaded = source ? hubTicketListLoaded(source) : false;
-  const scoped = source ? ticketsForResource(source.tickets, 'worktree', worktree.id) : [];
+  const scoped = source ? ticketsForResource(source.tickets, 'worktree', worktree.id, lookup ?? undefined) : [];
   const rollup = listLoaded ? ticketIndexRollup(scoped) : { open: 0, total: 0, done: 0 };
-  const primaryRuns = source ? source.runs.filter((run) => runMatchesResource(run, 'worktree', worktree.id)) : [];
-  const primaryChats = source ? source.chats.filter((chat) => chatMatchesResource(chat, 'worktree', worktree.id)) : [];
+  const primaryRuns = lookup?.runsByResource.get(resourceKey('worktree', worktree.id)) ?? (source ? source.runs.filter((run) => runMatchesResource(run, 'worktree', worktree.id)) : []);
+  const primaryChats = lookup?.chatsByResource.get(resourceKey('worktree', worktree.id)) ?? (source ? source.chats.filter((chat) => chatMatchesResource(chat, 'worktree', worktree.id)) : []);
   const currentRun =
     mergeRunCards(primaryRuns, primaryChats, 'worktree', worktree.id, worktree.repoId)
       .find((run) => run.status === 'running' || run.status === 'waiting' || run.status === 'blocked') ?? null;
-  const signals = source ? scopedSignals(source, 'worktree', worktree.id) : { waiting: 0, failed: 0, active: 0 };
+  const signals = source ? scopedSignals(source, 'worktree', worktree.id, [], lookup ?? undefined) : { waiting: 0, failed: 0, active: 0 };
   return {
     id: worktree.id,
     label: shortenWorktreeLabel(worktree.name, repoName),
@@ -609,9 +700,9 @@ function worktreeToNavChildRow(
   };
 }
 
-function worktreeToIndexRow(worktree: WorktreeSummary, source: RepoWorktreeSourceData): RepoWorktreeIndexRow {
+function worktreeToIndexRow(worktree: WorktreeSummary, source: RepoWorktreeSourceData, lookup: RepoWorktreeLookup): RepoWorktreeIndexRow {
   const listLoaded = hubTicketListLoaded(source);
-  const scoped = ticketsForResource(source.tickets, 'worktree', worktree.id);
+  const scoped = ticketsForResource(source.tickets, 'worktree', worktree.id, lookup);
   const rollup = listLoaded ? ticketIndexRollup(scoped) : { open: 0, total: 0, done: 0 };
   return {
     id: worktree.id,
@@ -968,7 +1059,9 @@ function ticketsForIds(tickets: TicketSummary[], ids: Set<string>, currentTicket
     .map((ticket) => ticketToRow(ticket, currentTicketId));
 }
 
-function ticketsForResource(tickets: TicketSummary[], kind: RepoWorktreeKind, id: string): TicketSummary[] {
+function ticketsForResource(tickets: TicketSummary[], kind: RepoWorktreeKind, id: string, lookup?: RepoWorktreeLookup | null): TicketSummary[] {
+  const indexed = lookup?.ticketsByResource.get(resourceKey(kind, id));
+  if (indexed) return indexed;
   return tickets.filter((ticket) => ticketMatchesResource(ticket, kind, id));
 }
 
@@ -1116,8 +1209,8 @@ function bySignalsThenActiveThenRecent(left: RepoWorktreeIndexRow, right: RepoWo
   return byActiveThenRecent(left, right);
 }
 
-function enrichIndexRowSignals(row: RepoWorktreeIndexRow, source: RepoWorktreeSourceData): RepoWorktreeIndexRow {
-  const signals = scopedSignals(source, row.kind, row.id, row.childWorktrees.map((child) => child.id));
+function enrichIndexRowSignals(row: RepoWorktreeIndexRow, source: RepoWorktreeSourceData, lookup?: RepoWorktreeLookup): RepoWorktreeIndexRow {
+  const signals = scopedSignals(source, row.kind, row.id, row.childWorktrees.map((child) => child.id), lookup);
   return {
     ...row,
     signalWaiting: signals.waiting,
@@ -1130,14 +1223,17 @@ function scopedSignals(
   source: RepoWorktreeSourceData,
   kind: RepoWorktreeKind,
   id: string,
-  childIds: string[] = []
+  childIds: string[] = [],
+  lookup?: RepoWorktreeLookup | null
 ): { waiting: number; failed: number; active: number } {
-  const scopedChats = source.chats.filter((chat) =>
+  const key = resourceKey(kind, id);
+  const scopedChats = lookup?.chatsByResource.get(key) ?? source.chats.filter((chat) =>
     kind === 'repo'
       ? Boolean(chat.repoId === id && !chat.worktreeId)
       : chat.worktreeId === id
   );
-  const scopedRuns = source.runs.filter((run) =>
+  const indexedRuns = lookup?.runsByResource.get(key);
+  const scopedRuns = indexedRuns ?? source.runs.filter((run) =>
     kind === 'repo'
       ? runMatchesResource(run, 'repo', id) &&
         !childIds.some((wid) => runMatchesResource(run, 'worktree', wid))

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/ticket.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/ticket.ts
@@ -256,13 +256,15 @@ export function buildTicketListViewModel(
   owner: TicketOwnerScope = null,
   actionManifest: SurfaceActionManifest | null = null
 ): TicketListViewModel {
-  const rows = source.tickets.map((ticket) => ticketToListRow(ticket, source)).sort(owner ? byTicketNumberThenTitle : bySignalThenRecent);
+  const scopedSource = owner ? scopeTicketSource(source, owner) : source;
+  const lookup = buildTicketLookup(scopedSource);
+  const rows = scopedSource.tickets.map((ticket) => ticketToListRow(ticket, scopedSource, lookup)).sort(owner ? byTicketNumberThenTitle : bySignalThenRecent);
   const ownerLabel = owner?.label || owner?.id;
-  const queueRun = owner ? findQueueRun(source.runs, owner) ?? findQueueRunFromRows(rows) : null;
-  const flowStatus = buildTicketFlowStatusViewModel(source.tickets, source.runs, owner);
+  const queueRun = owner ? findQueueRun(scopedSource.runs, owner) ?? findQueueRunFromRows(rows) : null;
+  const flowStatus = buildTicketFlowStatusViewModel(scopedSource.tickets, scopedSource.runs, owner);
   const activeCurrentTicketId = isTicketFlowActuallyWorking(flowStatus.status) ? flowStatus.currentTicketId : null;
   const rowsWithCurrent = rows.map((row) => ({ ...row, isCurrent: row.id === activeCurrentTicketId || row.routeId === activeCurrentTicketId }));
-  const currentChatId = pickCurrentChatId(source.chats, flowStatus.currentTicketId);
+  const currentChatId = pickCurrentChatId(scopedSource.chats, flowStatus.currentTicketId);
   return {
     title: owner ? `${ownerLabel} tickets` : 'Tickets',
     eyebrow: owner ? `${owner.kind === 'repo' ? 'Repo' : 'Worktree'} ticket queue` : 'All-ticket projection',
@@ -285,6 +287,27 @@ export function buildTicketListViewModel(
     currentChatId,
     rows: rowsWithCurrent
   };
+}
+
+function scopeTicketSource(source: TicketSourceData, owner: Exclude<TicketOwnerScope, null>): TicketSourceData {
+  return {
+    tickets: source.tickets.filter((ticket) => ticketMatchesOwner(ticket, owner)),
+    runs: source.runs.filter((run) => runMatchesOwner(run, owner)),
+    chats: source.chats.filter((chat) => chatMatchesOwner(chat, owner)),
+    artifacts: source.artifacts,
+    timeline: source.timeline
+  };
+}
+
+function ticketMatchesOwner(ticket: TicketSummary, owner: Exclude<TicketOwnerScope, null>): boolean {
+  const scope = workspaceScope(ticket);
+  return scope.kind === owner.kind && scope.id === owner.id;
+}
+
+function chatMatchesOwner(chat: PmaChatSummary, owner: Exclude<TicketOwnerScope, null>): boolean {
+  return owner.kind === 'repo'
+    ? chat.repoId === owner.id && !chat.worktreeId
+    : chat.worktreeId === owner.id;
 }
 
 function pickCurrentChatId(chats: PmaChatSummary[], currentTicketId: string | null): string | null {
@@ -425,8 +448,9 @@ export function buildTicketDetailViewModel(
   source: TicketSourceData,
   now = new Date()
 ): TicketDetailViewModel {
-  const run = findTicketRun(detail, source.runs);
-  const allLinkedChats = findTicketChats(detail, source.chats, run);
+  const lookup = buildTicketLookup(source);
+  const run = findTicketRun(detail, source.runs, lookup);
+  const allLinkedChats = findTicketChats(detail, source.chats, run, lookup);
   const chat = allLinkedChats[0] ?? null;
   const runArtifacts = [...detail.artifacts, ...source.artifacts, ...(run?.events ?? [])];
   const sections = parseTicketContract(detail.body);
@@ -437,7 +461,7 @@ export function buildTicketDetailViewModel(
   const debugHref = run ? `/api/flows/${encodeURIComponent(run.id)}/dispatch_history` : null;
   const chatHref = chat ? `/chats?chat=${encodeURIComponent(chat.id)}` : detail.chatKey ? `/chats?chat=${encodeURIComponent(detail.chatKey)}` : null;
   const linkedChatId = chat?.id ?? null;
-  const sourceTickets = source.tickets.map((ticket) => ticketToListRow(ticket, source)).sort(byTicketNumberThenTitle);
+  const sourceTickets = source.tickets.map((ticket) => ticketToListRow(ticket, source, lookup)).sort(byTicketNumberThenTitle);
   const routeId = routeIdForTicket(detail);
   const selectedIndex = sourceTickets.findIndex((row) => row.routeId === routeId || row.id === detail.id);
   const frontmatter = asRecord(detail.raw.frontmatter);
@@ -661,14 +685,57 @@ export function rowRelativeTime(row: { updatedAt?: string | null; createdAt?: st
   return formatRelativeTime(row.updatedAt ?? row.createdAt ?? null, now);
 }
 
-function ticketToListRow(ticket: TicketSummary, source: TicketSourceData): TicketListRow {
-  const run = findTicketRun(ticket, source.runs);
-  const chat = findTicketChat(ticket, source.chats, run);
+type TicketLookup = {
+  ticketAliasesById: Map<string, Set<string>>;
+  runsByAlias: Map<string, PmaRunProgress[]>;
+  runOrder: Map<string, number>;
+  chatsByAlias: Map<string, PmaChatSummary[]>;
+  chatById: Map<string, PmaChatSummary>;
+};
+
+function buildTicketLookup(source: TicketSourceData): TicketLookup {
+  const ticketAliasesById = new Map(source.tickets.map((ticket) => [ticket.id, ticketAliases(ticket)]));
+  const runsByAlias = new Map<string, PmaRunProgress[]>();
+  const runOrder = new Map<string, number>();
+  source.runs.forEach((run, index) => {
+    runOrder.set(run.id, index);
+    for (const alias of ticketAliasesFromRun(run)) appendMapList(runsByAlias, alias, run);
+  });
+  const chatsByAlias = new Map<string, PmaChatSummary[]>();
+  const chatById = new Map<string, PmaChatSummary>();
+  for (const chat of source.chats) {
+    chatById.set(chat.id, chat);
+    for (const alias of ticketAliasesFromChat(chat)) appendMapList(chatsByAlias, alias, chat);
+  }
+  return { ticketAliasesById, runsByAlias, runOrder, chatsByAlias, chatById };
+}
+
+function appendMapList<T>(map: Map<string, T[]>, key: string, value: T): void {
+  const existing = map.get(key);
+  if (existing) existing.push(value);
+  else map.set(key, [value]);
+}
+
+function ticketAliasesFromChat(chat: PmaChatSummary): Set<string> {
+  const aliases = new Set<string>();
+  for (const value of [
+    chat.ticketId,
+    stringFromRaw(chat.raw, ['chat_key', 'ticket_path', 'current_ticket'])
+  ]) {
+    if (typeof value === 'string' && value.length > 0) aliases.add(normalizeAlias(value));
+  }
+  return aliases;
+}
+
+function ticketToListRow(ticket: TicketSummary, source: TicketSourceData, lookup: TicketLookup = buildTicketLookup(source)): TicketListRow {
+  const run = findTicketRun(ticket, source.runs, lookup);
+  const chat = findTicketChat(ticket, source.chats, run, lookup);
   const status = run?.status ?? ticket.status;
   const scope = workspaceScope(ticket);
   const modelFromTicket = ticketModelRawFromSummary(ticket).trim();
   const modelFromChat = chat?.model?.trim() ?? '';
   const modelResolved = modelFromTicket || modelFromChat;
+  const ownerHref = ownerTicketListHrefFromScope(scope);
   return {
     id: ticket.id,
     routeId: routeIdForTicket(ticket),
@@ -677,8 +744,8 @@ function ticketToListRow(ticket: TicketSummary, source: TicketSourceData): Ticke
     repoLabel: scope.label,
     workspaceKind: scope.kind,
     workspaceId: scope.id,
-    workspaceHref: workspaceHref(ticket),
-    ownerTicketHref: scopedTicketHref(ticket),
+    workspaceHref: workspaceHrefFromScope(scope),
+    ownerTicketHref: scopedTicketHrefFromBase(ownerHref, ticket),
     pathLabel: ticket.path,
     agentLabel: ticket.agentId ?? chat?.agentId ?? 'Unassigned',
     modelLabel: modelResolved ? modelResolved : null,
@@ -690,7 +757,7 @@ function ticketToListRow(ticket: TicketSummary, source: TicketSourceData): Ticke
     currentRunId: run?.id ?? null,
     updatedAt: ticket.updatedAt ?? run?.lastEventAt ?? chat?.updatedAt ?? null,
     chatHref: chat ? `/chats?chat=${encodeURIComponent(chat.id)}` : ticket.chatKey ? `/chats?chat=${encodeURIComponent(ticket.chatKey)}` : null,
-    href: scopedTicketHref(ticket) ?? '/chats',
+    href: scopedTicketHrefFromBase(ownerHref, ticket) ?? '/chats',
     needsAttention: ticket.errors.length > 0 || ['waiting', 'failed', 'blocked', 'invalid'].includes(status),
     isCurrent: false
   };
@@ -1003,16 +1070,36 @@ function linkedChatToVm(chat: PmaChatSummary): TicketLinkedChat {
   };
 }
 
-function findTicketRun(ticket: TicketSummary, runs: PmaRunProgress[]): PmaRunProgress | null {
+function findTicketRun(ticket: TicketSummary, runs: PmaRunProgress[], lookup: TicketLookup | null = null): PmaRunProgress | null {
+  if (lookup) {
+    const candidates = new Map<string, PmaRunProgress>();
+    for (const alias of lookup.ticketAliasesById.get(ticket.id) ?? ticketAliases(ticket)) {
+      for (const run of lookup.runsByAlias.get(alias) ?? []) candidates.set(run.id, run);
+    }
+    if (candidates.size > 0) {
+      return [...candidates.values()].sort((a, b) => (lookup.runOrder.get(a.id) ?? 0) - (lookup.runOrder.get(b.id) ?? 0))[0] ?? null;
+    }
+  }
   const aliases = ticketAliases(ticket);
   return runs.find((run) => aliasesOverlap(aliases, ticketAliasesFromRun(run))) ?? null;
 }
 
-function findTicketChat(ticket: TicketSummary, chats: PmaChatSummary[], run: PmaRunProgress | null): PmaChatSummary | null {
-  return findTicketChats(ticket, chats, run)[0] ?? null;
+function findTicketChat(ticket: TicketSummary, chats: PmaChatSummary[], run: PmaRunProgress | null, lookup: TicketLookup | null = null): PmaChatSummary | null {
+  return findTicketChats(ticket, chats, run, lookup)[0] ?? null;
 }
 
-function findTicketChats(ticket: TicketSummary, chats: PmaChatSummary[], run: PmaRunProgress | null): PmaChatSummary[] {
+function findTicketChats(ticket: TicketSummary, chats: PmaChatSummary[], run: PmaRunProgress | null, lookup: TicketLookup | null = null): PmaChatSummary[] {
+  if (lookup) {
+    const matchedById = new Map<string, PmaChatSummary>();
+    if (run?.chatId) {
+      const runChat = lookup.chatById.get(run.chatId);
+      if (runChat) matchedById.set(runChat.id, runChat);
+    }
+    for (const alias of lookup.ticketAliasesById.get(ticket.id) ?? ticketAliases(ticket)) {
+      for (const chat of lookup.chatsByAlias.get(alias) ?? []) matchedById.set(chat.id, chat);
+    }
+    if (matchedById.size > 0) return orderTicketChats([...matchedById.values()], run);
+  }
   const aliases = ticketAliases(ticket);
   const matched = chats.filter((chat) => {
     if (run?.chatId && chat.id === run.chatId) return true;
@@ -1021,8 +1108,12 @@ function findTicketChats(ticket: TicketSummary, chats: PmaChatSummary[], run: Pm
       .map(normalizeAlias);
     return chatAliases.some((alias) => aliases.has(alias));
   });
+  return orderTicketChats(matched, run);
+}
+
+function orderTicketChats(chats: PmaChatSummary[], run: PmaRunProgress | null): PmaChatSummary[] {
   // Active run's chat first, then by recency, with the active chat retained as the canonical primary.
-  return matched.sort((a, b) => {
+  return chats.sort((a, b) => {
     const aRun = run?.chatId === a.id ? 0 : 1;
     const bRun = run?.chatId === b.id ? 0 : 1;
     if (aRun !== bRun) return aRun - bRun;
@@ -1113,6 +1204,10 @@ function workspaceScope(ticket: TicketSummary): {
 
 function workspaceHref(ticket: TicketSummary): string | null {
   const scope = workspaceScope(ticket);
+  return workspaceHrefFromScope(scope);
+}
+
+function workspaceHrefFromScope(scope: ReturnType<typeof workspaceScope>): string | null {
   if (scope.kind === 'repo' && scope.id) return repoRoute(scope.id);
   if (scope.kind === 'worktree' && scope.id) return worktreeRoute(scope.id, scope.parentRepoId);
   return null;
@@ -1120,13 +1215,20 @@ function workspaceHref(ticket: TicketSummary): string | null {
 
 function ownerTicketListHref(ticket: TicketSummary): string | null {
   const scope = workspaceScope(ticket);
+  return ownerTicketListHrefFromScope(scope);
+}
+
+function ownerTicketListHrefFromScope(scope: ReturnType<typeof workspaceScope>): string | null {
   if (scope.kind === 'repo' && scope.id) return repoTicketRoute(scope.id);
   if (scope.kind === 'worktree' && scope.id) return worktreeTicketRoute(scope.id, scope.parentRepoId);
   return null;
 }
 
 function scopedTicketHref(ticket: TicketSummary): string | null {
-  const base = ownerTicketListHref(ticket);
+  return scopedTicketHrefFromBase(ownerTicketListHref(ticket), ticket);
+}
+
+function scopedTicketHrefFromBase(base: string | null, ticket: TicketSummary): string | null {
   return base ? `${base}/${encodeURIComponent(routeIdForTicket(ticket))}` : null;
 }
 

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/ticketFlowStatus.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/ticketFlowStatus.ts
@@ -32,7 +32,8 @@ export function buildTicketFlowStatusViewModel(
   const activeRun = selectPrimaryRun(scopedRuns);
   const recentRun = activeRun ?? mostRecentRun(scopedRuns);
   const run = activeRun ?? recentRun;
-  const currentTicket = run ? findTicketForRun(scopedTickets, run) : scopedTickets.find((ticket) => ticket.status !== 'done') ?? null;
+  const ticketLookup = run ? buildTicketAliasLookup(scopedTickets) : null;
+  const currentTicket = run ? findTicketForRun(scopedTickets, run, ticketLookup) : scopedTickets.find((ticket) => ticket.status !== 'done') ?? null;
   const doneCount = scopedTickets.filter((ticket) => ticket.status === 'done').length;
   const totalCount = scopedTickets.length;
   const status = activeRun?.status ?? currentTicket?.status ?? (doneCount > 0 && doneCount === totalCount ? 'done' : 'idle');
@@ -174,8 +175,28 @@ function dateFromRaw(raw: Record<string, unknown> | undefined, keys: string[]): 
   return null;
 }
 
-function findTicketForRun(tickets: TicketSummary[], run: PmaRunProgress): TicketSummary | null {
+type TicketAliasLookup = Map<string, TicketSummary[]>;
+
+function buildTicketAliasLookup(tickets: TicketSummary[]): TicketAliasLookup {
+  const lookup = new Map<string, TicketSummary[]>();
+  for (const ticket of tickets) {
+    for (const alias of ticketAliases(ticket)) {
+      const existing = lookup.get(alias);
+      if (existing) existing.push(ticket);
+      else lookup.set(alias, [ticket]);
+    }
+  }
+  return lookup;
+}
+
+function findTicketForRun(tickets: TicketSummary[], run: PmaRunProgress, lookup: TicketAliasLookup | null = null): TicketSummary | null {
   const runAliases = ticketAliasesFromRun(run);
+  if (lookup) {
+    for (const alias of runAliases) {
+      const matches = lookup.get(alias);
+      if (matches?.length) return matches[0] ?? null;
+    }
+  }
   return tickets.find((ticket) => aliasesOverlap(ticketAliases(ticket), runAliases)) ?? null;
 }
 

--- a/src/codex_autorunner/web_frontend/src/routes/settings/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/settings/+page.svelte
@@ -21,6 +21,9 @@
   let saveError = $state<ApiError | null>(null);
   let saving = $state(false);
   let memoryOpen = $state(false);
+  let settingsLoadSeq = 0;
+  let settingsSessionRaw = $state<JsonRecord | null>(null);
+  let settingsVoiceRaw = $state<JsonRecord | null>(null);
   const hubScope = { kind: 'hub' as const };
   type SetupPromptKind = 'telegram' | 'discord' | 'notifications' | 'github' | 'voice';
 
@@ -43,6 +46,7 @@
   });
 
   async function loadSettings(): Promise<void> {
+    const loadSeq = ++settingsLoadSeq;
     loading = true;
     error = null;
     saveError = null;
@@ -59,24 +63,39 @@
     }
 
     const agentRows = agents.ok ? agents.data.agents : [];
-    const modelCatalogs: Record<string, JsonRecord[] | null> = {};
-    await Promise.all(
-      agentRows.map(async (agent) => {
-        if (!agentCanListModels(agent)) return;
-        const id = agentId(agent);
-        const result = await pmaApi.pma.listAgentModels(id);
-        modelCatalogs[id] = result.ok ? result.data : null;
-      })
-    );
-
+    settingsSessionRaw = session.ok ? session.data : null;
+    settingsVoiceRaw = voice.ok ? voice.data : null;
     view = buildSettingsViewModel({
-      session: session.ok ? session.data : null,
+      session: settingsSessionRaw,
       agents: agentRows,
-      modelCatalogs,
-      voiceConfig: voice.ok ? voice.data : null
+      modelCatalogs: {},
+      voiceConfig: settingsVoiceRaw
     });
     sessionBaselineEpoch += 1;
     loading = false;
+    void loadModelCatalogs(agentRows, loadSeq);
+  }
+
+  async function loadModelCatalogs(agentRows: JsonRecord[], loadSeq: number): Promise<void> {
+    const catalogEntries = await Promise.all(
+      agentRows.map(async (agent) => {
+        if (!agentCanListModels(agent)) return null;
+        const id = agentId(agent);
+        const result = await pmaApi.pma.listAgentModels(id);
+        return [id, result.ok ? result.data : null] as const;
+      })
+    );
+    if (loadSeq !== settingsLoadSeq || !view) return;
+    const currentSession = view.session;
+    const modelCatalogs = Object.fromEntries(
+      catalogEntries.filter((entry): entry is readonly [string, JsonRecord[] | null] => entry !== null)
+    );
+    view = buildSettingsViewModel({
+      session: buildSessionUpdatePayload(currentSession),
+      agents: agentRows,
+      modelCatalogs,
+      voiceConfig: settingsVoiceRaw
+    });
   }
 
   function updateSession(session: SettingsSessionState): void {


### PR DESCRIPTION
## Summary
- Fix the Web Hub read-model store cloning hotspot by preserving cached chat detail/transcript object identity unless that specific chat is updated.
- Add opt-in manual profilers for cached chat-store updates and large page/view-model assembly.
- Optimize repo list, repo details, scoped ticket list, global ticket list, and ticket flow lookup paths by replacing repeated full-array scans with per-build indexes.
- Make the settings page render from session/agent/voice data first, then load large per-agent model catalogs asynchronously without blocking first paint.

## Root Cause
The original chat lag came from deep-cloning every cached transcript/detail on each store update, so each live progress update got slower as users visited more large chats. Additional page-load profiling found the same shape in repo and ticket pages: repo/worktree and ticket view models repeatedly scanned all tickets, runs, and chats for each rendered row. On hubs with many repos, worktrees, tickets, chats, and runs, scoped pages could accidentally do thousands of redundant comparisons per load. Settings was different: local view-model assembly was cheap, but first render was blocked on all agent model catalog network requests.

## Profiling Evidence
Manual profilers are opt-in and excluded from default test/CI lanes:
- `python3 scripts/profile_web_read_model_store.py`
- `python3 scripts/profile_web_page_view_models.py`

Latest local profile runs:
- chat store, 160 cached chats x 120 cards, 80 active updates: fixed p95 0.026 ms vs legacy deep-clone p95 314.311 ms, about 12050x p95 improvement.
- page/view-model synthetic hub, 90 repos, 450 worktrees, 2700 tickets, 1620 chats, 1080 runs, 40 agents x 250 models: repo index 39.446 ms, repo detail 7.467 ms, scoped ticket list 6.726 ms, global ticket list 54.564 ms, settings view-model 1.37 ms.

## Validation
- `pnpm web:lint`
- `pnpm web:test`
- `python3 scripts/profile_web_read_model_store.py && python3 scripts/profile_web_page_view_models.py`
- commit hook aggregate lane: guardrails passed, mypy passed, `8856 passed`, Web UI lab fast check passed, Web Hub build passed, Web frontend tests passed
