### PR TITLE
[codex] Harden standalone updater rollback

### DIFF
--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -85,14 +85,18 @@ HEALTH_CHECK_DISCORD="${HEALTH_CHECK_DISCORD:-auto}"
 WAIT_HUB_HEALTH_BEFORE_CHAT_RELOAD="${WAIT_HUB_HEALTH_BEFORE_CHAT_RELOAD:-true}"
 LAUNCHD_STOP_WAIT_SECONDS="${LAUNCHD_STOP_WAIT_SECONDS:-10}"
 KEEP_OLD_VENVS="${KEEP_OLD_VENVS:-3}"
+UPDATE_SNAPSHOT_ROOT="${UPDATE_SNAPSHOT_ROOT:-}"
 NVM_BIN="${NVM_BIN:-$HOME/.nvm/versions/node/v22.12.0/bin}"
 LOCAL_BIN="${LOCAL_BIN:-$HOME/.local/bin}"
 PY39_BIN="${PY39_BIN:-$HOME/Library/Python/$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')/bin}"
 OPENCODE_BIN="${OPENCODE_BIN:-$HOME/.opencode/bin}"
 
 current_target=""
+db_snapshot_dir=""
+update_run_id=""
 swap_completed=false
 rollback_completed=false
+rollback_restore_failed=false
 cutover_committed=false
 post_cutover_warnings=()
 hub_health_verified_after_reload=false
@@ -101,17 +105,50 @@ TELEGRAM_HEALTH_WAIT_TIMED_OUT=false
 DISCORD_HEALTH_WAIT_TIMED_OUT=false
 
 write_status() {
-  local status message
+  local status message phase error_type exit_code
   status="$1"
   message="$2"
+  phase="${3:-}"
+  error_type="${4:-}"
+  exit_code="${5:-}"
   if [[ -z "${UPDATE_STATUS_PATH}" || ! -x "${HELPER_PYTHON}" ]]; then
     return 0
   fi
-  "${HELPER_PYTHON}" - <<PY
-import json, pathlib, time
-path = pathlib.Path("${UPDATE_STATUS_PATH}")
+  UPDATE_STATUS_PATH_VALUE="${UPDATE_STATUS_PATH}" \
+  UPDATE_STATUS_VALUE="${status}" \
+  UPDATE_STATUS_MESSAGE="${message}" \
+  UPDATE_STATUS_PHASE="${phase}" \
+  UPDATE_STATUS_ERROR_TYPE="${error_type}" \
+  UPDATE_STATUS_EXIT_CODE="${exit_code}" \
+  UPDATE_RUN_ID_VALUE="${update_run_id}" \
+  "${HELPER_PYTHON}" - <<'PY'
+import json
+import os
+import pathlib
+import time
+
+path = pathlib.Path(os.environ["UPDATE_STATUS_PATH_VALUE"])
 path.parent.mkdir(parents=True, exist_ok=True)
-payload = {"status": "${status}", "message": "${message}", "at": time.time()}
+payload = {
+    "status": os.environ["UPDATE_STATUS_VALUE"],
+    "message": os.environ["UPDATE_STATUS_MESSAGE"],
+    "at": time.time(),
+}
+phase = os.environ.get("UPDATE_STATUS_PHASE") or ""
+if phase:
+    payload["phase"] = phase
+error_type = os.environ.get("UPDATE_STATUS_ERROR_TYPE") or ""
+if error_type:
+    payload["error_type"] = error_type
+exit_code = os.environ.get("UPDATE_STATUS_EXIT_CODE") or ""
+if exit_code:
+    try:
+        payload["exit_code"] = int(exit_code)
+    except ValueError:
+        payload["exit_code"] = exit_code
+run_id = os.environ.get("UPDATE_RUN_ID_VALUE") or ""
+if run_id:
+    payload["update_run_id"] = run_id
 try:
     existing = json.loads(path.read_text(encoding="utf-8"))
 except Exception:
@@ -134,7 +171,7 @@ PY
 fail() {
   local message="$1"
   echo "${message}" >&2
-  write_status "error" "${message}"
+  write_status "error" "${message}" "${2:-failed}" "${3:-script_error}"
   exit 1
 }
 
@@ -678,20 +715,38 @@ if [[ -z "${current_target}" ]]; then
 fi
 
 ts="$(date +%Y%m%d-%H%M%S)"
+update_run_id="${ts}-$$"
 next_venv="${PIPX_ROOT}/venvs/codex-autorunner.next-${ts}"
 wheel_dir="${next_venv}.wheelhouse"
+if [[ -z "${UPDATE_SNAPSHOT_ROOT}" ]]; then
+  if [[ -n "${UPDATE_STATUS_PATH}" ]]; then
+    UPDATE_SNAPSHOT_ROOT="$(dirname "${UPDATE_STATUS_PATH}")/update_snapshots"
+  else
+    UPDATE_SNAPSHOT_ROOT="${PIPX_ROOT}/venvs/codex-autorunner.update-snapshots"
+  fi
+fi
 
 echo "Creating staged venv at ${next_venv} (python: ${PIPX_PYTHON})..."
+write_status "running" "Creating staged venv at ${next_venv}." "venv_create_start"
 "${PIPX_PYTHON}" -m venv "${next_venv}"
 "${next_venv}/bin/python" -m pip -q install --upgrade pip
+write_status "running" "Created staged venv at ${next_venv}." "venv_create_done"
 
 echo "Preparing staged wheel for ${PACKAGE_INSTALL_SPEC}..."
+write_status "running" "Building staged wheel." "wheel_build_start"
 wheel_path="$(_build_package_wheel "${next_venv}/bin/python" "${wheel_dir}")"
+write_status "running" "Built staged wheel." "wheel_build_done"
+write_status "running" "Installing staged wheel into candidate venv." "pip_install_start"
 _install_package_from_wheel "${next_venv}/bin/python" "${wheel_path}"
+write_status "running" "Installed staged wheel into candidate venv." "pip_install_done"
 _ensure_playwright_chromium "${next_venv}/bin/python"
 rm -rf "${wheel_dir}"
 
 echo "Smoke-checking staged venv imports..."
+write_status "running" "Validating staged venv." "candidate_validation_start"
+if [[ ! -x "${next_venv}/bin/codex-autorunner" ]]; then
+  fail "Staged venv is missing codex-autorunner console script." "candidate_validation_failed" "candidate_invalid"
+fi
 "${next_venv}/bin/python" - <<'PY'
 import importlib.util
 
@@ -743,6 +798,7 @@ if spec is None or spec.origin is None:
 py_compile.compile(spec.origin, doraise=True)
 print("telegram service ok")
 PY
+write_status "running" "Validated staged venv." "candidate_validation_done"
 
 domain="gui/$(id -u)/${LABEL}"
 
@@ -1893,10 +1949,34 @@ _rollback() {
   fi
   rollback_completed=true
   echo "${message}" >&2
-  ln -sfn "${current_target}" "${CURRENT_VENV_LINK}"
+  write_status "running" "${message}" "rollback_start"
   hub_health_verified_after_reload=false
   if [[ "${should_reload_hub}" == "true" ]]; then
     _stop_service || true
+  fi
+  if [[ "${should_reload_telegram}" == "true" && -f "${TELEGRAM_PLIST_PATH}" ]]; then
+    launchctl unload -w "${TELEGRAM_PLIST_PATH}" >/dev/null 2>&1 || true
+  fi
+  if [[ "${should_reload_discord}" == "true" && -f "${DISCORD_PLIST_PATH}" ]]; then
+    launchctl unload -w "${DISCORD_PLIST_PATH}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${db_snapshot_dir}" ]]; then
+    echo "Restoring orchestration DB snapshot from ${db_snapshot_dir}..." >&2
+    if "${next_venv}/bin/python" -m codex_autorunner.core.update_transaction \
+      restore-db \
+      --snapshot-dir "${db_snapshot_dir}" >/dev/null; then
+      write_status "running" "Restored orchestration DB snapshot." "db_restore_done"
+    else
+      rollback_restore_failed=true
+      write_status "error" \
+        "Update failed; orchestration DB snapshot restore failed. Keeping candidate venv active to avoid schema rollback mismatch." \
+        "db_restore_failed" \
+        "db_restore_failed"
+      return 1
+    fi
+  fi
+  ln -sfn "${current_target}" "${CURRENT_VENV_LINK}"
+  if [[ "${should_reload_hub}" == "true" ]]; then
     _start_service || true
   fi
   if [[ "${should_reload_telegram}" == "true" ]]; then
@@ -1916,11 +1996,37 @@ _on_exit() {
   if [[ "${swap_completed}" != "true" || "${rollback_completed}" == "true" || "${cutover_committed}" == "true" ]]; then
     return 0
   fi
-  _rollback "Update failed; rolling back to ${current_target}..."
-  write_status "rollback" "Update failed; rollback attempted."
+  if ! _rollback "Update failed; rolling back to ${current_target}..."; then
+    return 0
+  fi
+  write_status "rollback" "Update failed; rollback attempted." "rollback_attempted"
 }
 
 trap '_on_exit $?' EXIT
+
+if [[ -z "${HUB_ROOT}" ]]; then
+  fail "Unable to determine HUB_ROOT from ${PLIST_PATH}."
+fi
+
+echo "Snapshotting orchestration DB before cutover..."
+write_status "running" "Snapshotting orchestration DB before cutover." "db_snapshot_start"
+snapshot_payload="$(
+  "${next_venv}/bin/python" -m codex_autorunner.core.update_transaction \
+    snapshot-db \
+    --hub-root "${HUB_ROOT}" \
+    --snapshot-root "${UPDATE_SNAPSHOT_ROOT}" \
+    --run-id "${update_run_id}"
+)"
+db_snapshot_dir="$(
+  SNAPSHOT_PAYLOAD="${snapshot_payload}" "${HELPER_PYTHON}" - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["SNAPSHOT_PAYLOAD"])
+print(payload.get("snapshot_dir", ""))
+PY
+)"
+write_status "running" "Snapshot orchestration DB before cutover." "db_snapshot_done"
 
 echo "Switching ${PREV_VENV_LINK} -> ${current_target}"
 ln -sfn "${current_target}" "${PREV_VENV_LINK}"
@@ -1929,19 +2035,19 @@ echo "Switching ${CURRENT_VENV_LINK} -> ${next_venv}"
 ln -sfn "${next_venv}" "${CURRENT_VENV_LINK}"
 swap_completed=true
 
-if [[ -z "${HUB_ROOT}" ]]; then
-  fail "Unable to determine HUB_ROOT from ${PLIST_PATH}."
-fi
-
 echo "Refreshing hub-managed repo artifacts under ${HUB_ROOT}..."
+write_status "running" "Refreshing hub-managed repo artifacts." "managed_repo_refresh_start"
 HUB_ROOT="${HUB_ROOT}" HELPER_PYTHON="${CURRENT_VENV_LINK}/bin/python" \
   bash "${PACKAGE_SRC}/scripts/update-hub-managed-repos.sh"
+write_status "running" "Refreshed hub-managed repo artifacts." "managed_repo_refresh_done"
 
 if [[ "${should_reload_hub}" == "true" ]]; then
   echo "Restarting launchd service ${LABEL}..."
+  write_status "running" "Restarting hub service." "service_restart_start"
   _ensure_plist_uses_current_venv
   _stop_service
   _start_service
+  write_status "running" "Restarted hub service." "service_restart_done"
 fi
 
 hub_warm_ok=true
@@ -2000,7 +2106,10 @@ if [[ "${health_ok}" == "true" ]]; then
   fi
   ensure_login_shell_path "${LOCAL_BIN}"
 else
-  _rollback "Health check failed; rolling back to ${current_target}..."
+  if ! _rollback "Health check failed; rolling back to ${current_target}..."; then
+    echo "Rollback aborted because orchestration DB restore failed." >&2
+    exit 2
+  fi
   rollback_hub_ok=true
   rollback_telegram_ok=true
   rollback_discord_ok=true

--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -1972,6 +1972,16 @@ _rollback() {
         "Update failed; orchestration DB snapshot restore failed. Keeping candidate venv active to avoid schema rollback mismatch." \
         "db_restore_failed" \
         "db_restore_failed"
+      # Symlink still points at next_venv; restart what we stopped above.
+      if [[ "${should_reload_hub}" == "true" ]]; then
+        _start_service || true
+      fi
+      if [[ "${should_reload_telegram}" == "true" ]]; then
+        _reload_telegram || true
+      fi
+      if [[ "${should_reload_discord}" == "true" ]]; then
+        _reload_discord || true
+      fi
       return 1
     fi
   fi

--- a/src/codex_autorunner/adapters/chat/update_notifier.py
+++ b/src/codex_autorunner/adapters/chat/update_notifier.py
@@ -117,6 +117,12 @@ def format_update_status_message(status: Optional[dict[str, Any]]) -> str:
     target = status.get("update_target")
     if isinstance(target, str) and target.strip():
         lines.append(f"Target: {get_update_target_label(target)}")
+    phase = status.get("phase")
+    if isinstance(phase, str) and phase.strip():
+        lines.append(f"Phase: {phase.strip()}")
+    error_type = status.get("error_type")
+    if isinstance(error_type, str) and error_type.strip():
+        lines.append(f"Error: {error_type.strip()}")
     if message:
         lines.append(f"Message: {message}")
     if rendered_time:

--- a/src/codex_autorunner/core/update.py
+++ b/src/codex_autorunner/core/update.py
@@ -820,6 +820,7 @@ def _system_update_worker(
         _write_update_status(
             "running",
             "Update started.",
+            phase="worker_start",
             repo_url=repo_url,
             update_dir=str(update_dir),
             repo_ref=repo_ref,
@@ -962,6 +963,8 @@ def _system_update_worker(
                 _write_update_status(
                     "error",
                     "Update failed; check hub logs for details.",
+                    phase="refresh_script_failed",
+                    error_type="refresh_script_failed",
                     exit_code=returncode,
                 )
             return
@@ -969,13 +972,18 @@ def _system_update_worker(
         existing = _read_update_status()
         if not existing or existing.get("status") not in ("rollback", "error"):
             _write_update_status(
-                "ok", "Update completed successfully.", update_target=update_target
+                "ok",
+                "Update completed successfully.",
+                phase="completed",
+                update_target=update_target,
             )
     except Exception:  # intentional: top-level error handler
         logger.exception("System update failed")
         _write_update_status(
             "error",
             "Update crashed; see hub logs for details.",
+            phase="worker_crashed",
+            error_type="worker_crashed",
         )
     finally:
         if lock_acquired:
@@ -1010,6 +1018,7 @@ def _spawn_update_process(
     _write_update_status(
         "running",
         "Update spawned.",
+        phase="spawned",
         repo_url=repo_url,
         update_dir=str(update_dir),
         repo_ref=repo_ref,

--- a/src/codex_autorunner/core/update_transaction.py
+++ b/src/codex_autorunner/core/update_transaction.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sqlite3
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+from .orchestration.migrations import ORCHESTRATION_SCHEMA_VERSION
+from .orchestration.sqlite import resolve_orchestration_sqlite_path
+
+_PRESERVED_STATUS_KEYS = (
+    "notify_chat_id",
+    "notify_thread_id",
+    "notify_reply_to",
+    "notify_platform",
+    "notify_context",
+    "notify_sent_at",
+)
+
+_ORCHESTRATION_DB_SUFFIXES = ("", "-wal", "-shm")
+_SNAPSHOT_METADATA = "snapshot.json"
+
+
+@dataclass(frozen=True)
+class OrchestrationSchemaInfo:
+    db_path: str
+    db_exists: bool
+    current_schema: int
+    supported_schema: int
+    snapshot_recommended: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class OrchestrationDbSnapshot:
+    snapshot_dir: str
+    hub_root: str
+    db_path: str
+    db_existed: bool
+    copied_files: tuple[str, ...]
+    current_schema: int
+    supported_schema: int
+    created_at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def write_update_status_projection(
+    path: Path,
+    *,
+    status: str,
+    message: str,
+    phase: str | None = None,
+    error_type: str | None = None,
+    exit_code: int | None = None,
+    run_id: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "status": status,
+        "message": message,
+        "at": time.time(),
+    }
+    if phase:
+        payload["phase"] = phase
+    if error_type:
+        payload["error_type"] = error_type
+    if exit_code is not None:
+        payload["exit_code"] = exit_code
+    if run_id:
+        payload["update_run_id"] = run_id
+    if extra:
+        payload.update(extra)
+
+    existing = _read_json(path) if path.exists() else None
+    if isinstance(existing, dict):
+        for key in _PRESERVED_STATUS_KEYS:
+            if key not in payload and key in existing:
+                payload[key] = existing[key]
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return payload
+
+
+def read_orchestration_schema_info(hub_root: Path) -> OrchestrationSchemaInfo:
+    db_path = resolve_orchestration_sqlite_path(hub_root)
+    current_schema = 0
+    db_exists = db_path.exists()
+    if db_exists:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='orch_schema_migrations'"
+            ).fetchone()
+            if row is not None:
+                version_row = conn.execute(
+                    "SELECT COALESCE(MAX(version), 0) FROM orch_schema_migrations"
+                ).fetchone()
+                if version_row is not None:
+                    current_schema = int(version_row[0] or 0)
+        finally:
+            conn.close()
+
+    return OrchestrationSchemaInfo(
+        db_path=str(db_path),
+        db_exists=db_exists,
+        current_schema=current_schema,
+        supported_schema=ORCHESTRATION_SCHEMA_VERSION,
+        snapshot_recommended=db_exists
+        and current_schema < ORCHESTRATION_SCHEMA_VERSION,
+    )
+
+
+def snapshot_orchestration_db(
+    hub_root: Path,
+    *,
+    snapshot_root: Path,
+    run_id: str,
+) -> OrchestrationDbSnapshot:
+    info = read_orchestration_schema_info(hub_root)
+    snapshot_dir = snapshot_root / run_id / "orchestration"
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+    db_path = Path(info.db_path)
+    copied: list[str] = []
+    if db_path.exists():
+        target = snapshot_dir / db_path.name
+        source_conn = sqlite3.connect(str(db_path))
+        target_conn = sqlite3.connect(str(target))
+        try:
+            source_conn.backup(target_conn)
+        finally:
+            target_conn.close()
+            source_conn.close()
+        copied.append(db_path.name)
+
+    snapshot = OrchestrationDbSnapshot(
+        snapshot_dir=str(snapshot_dir),
+        hub_root=str(hub_root),
+        db_path=str(db_path),
+        db_existed=info.db_exists,
+        copied_files=tuple(copied),
+        current_schema=info.current_schema,
+        supported_schema=info.supported_schema,
+        created_at=time.time(),
+    )
+    (snapshot_dir / _SNAPSHOT_METADATA).write_text(
+        json.dumps(snapshot.to_dict(), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return snapshot
+
+
+def restore_orchestration_db_snapshot(snapshot_dir: Path) -> OrchestrationDbSnapshot:
+    metadata_path = snapshot_dir / _SNAPSHOT_METADATA
+    metadata = _read_json(metadata_path)
+    if metadata is None:
+        raise RuntimeError(
+            f"Missing orchestration DB snapshot metadata: {metadata_path}"
+        )
+
+    try:
+        snapshot = OrchestrationDbSnapshot(
+            snapshot_dir=str(snapshot_dir),
+            hub_root=str(metadata["hub_root"]),
+            db_path=str(metadata["db_path"]),
+            db_existed=bool(metadata["db_existed"]),
+            copied_files=tuple(str(item) for item in metadata.get("copied_files", ())),
+            current_schema=int(metadata.get("current_schema") or 0),
+            supported_schema=int(metadata.get("supported_schema") or 0),
+            created_at=float(metadata.get("created_at") or 0.0),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError(
+            f"Invalid orchestration DB snapshot metadata: {metadata_path}"
+        ) from exc
+
+    db_path = Path(snapshot.db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    for suffix in _ORCHESTRATION_DB_SUFFIXES:
+        target = Path(f"{db_path}{suffix}")
+        source = snapshot_dir / target.name
+        if source.exists():
+            shutil.copy2(source, target)
+        elif target.exists():
+            target.unlink()
+
+    if not snapshot.db_existed:
+        for suffix in _ORCHESTRATION_DB_SUFFIXES:
+            target = Path(f"{db_path}{suffix}")
+            if target.exists():
+                target.unlink()
+
+    return snapshot
+
+
+def _json_arg(raw: str | None) -> dict[str, Any] | None:
+    if not raw:
+        return None
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise argparse.ArgumentTypeError("--extra-json must be a JSON object")
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Update transaction helper for status and state snapshots."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    status = sub.add_parser("status", help="Write update status projection.")
+    status.add_argument("--path", required=True)
+    status.add_argument("--status", required=True)
+    status.add_argument("--message", required=True)
+    status.add_argument("--phase")
+    status.add_argument("--error-type")
+    status.add_argument("--exit-code", type=int)
+    status.add_argument("--run-id")
+    status.add_argument("--extra-json")
+
+    schema = sub.add_parser("schema-info", help="Read orchestration schema info.")
+    schema.add_argument("--hub-root", required=True)
+
+    snapshot = sub.add_parser("snapshot-db", help="Snapshot orchestration DB files.")
+    snapshot.add_argument("--hub-root", required=True)
+    snapshot.add_argument("--snapshot-root", required=True)
+    snapshot.add_argument("--run-id", required=True)
+
+    restore = sub.add_parser("restore-db", help="Restore an orchestration DB snapshot.")
+    restore.add_argument("--snapshot-dir", required=True)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.command == "status":
+        payload = write_update_status_projection(
+            Path(args.path),
+            status=args.status,
+            message=args.message,
+            phase=args.phase,
+            error_type=args.error_type,
+            exit_code=args.exit_code,
+            run_id=args.run_id,
+            extra=_json_arg(args.extra_json),
+        )
+        print(json.dumps(payload, sort_keys=True))
+        return 0
+
+    if args.command == "schema-info":
+        info = read_orchestration_schema_info(Path(args.hub_root))
+        print(json.dumps(info.to_dict(), sort_keys=True))
+        return 0
+
+    if args.command == "snapshot-db":
+        snapshot = snapshot_orchestration_db(
+            Path(args.hub_root),
+            snapshot_root=Path(args.snapshot_root),
+            run_id=args.run_id,
+        )
+        print(json.dumps(snapshot.to_dict(), sort_keys=True))
+        return 0
+
+    if args.command == "restore-db":
+        snapshot = restore_orchestration_db_snapshot(Path(args.snapshot_dir))
+        print(json.dumps(snapshot.to_dict(), sort_keys=True))
+        return 0
+
+    parser.error(f"Unsupported command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_system_update_worker.py
+++ b/tests/test_system_update_worker.py
@@ -355,6 +355,7 @@ def test_spawn_update_process_writes_status(tmp_path: Path, monkeypatch) -> None
     status_path = system._update_status_path()
     payload = json.loads(status_path.read_text(encoding="utf-8"))
     assert payload["status"] == "running"
+    assert payload["phase"] == "spawned"
     assert payload["notify_platform"] == "discord"
     assert payload["notify_context"] == {"chat_id": "channel-1"}
     assert "log_path" in payload

--- a/tests/test_update_transaction.py
+++ b/tests/test_update_transaction.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from codex_autorunner.core.orchestration.migrations import (
+    ORCHESTRATION_SCHEMA_VERSION,
+)
+from codex_autorunner.core.orchestration.sqlite import (
+    resolve_orchestration_sqlite_path,
+)
+from codex_autorunner.core.update_transaction import (
+    read_orchestration_schema_info,
+    restore_orchestration_db_snapshot,
+    snapshot_orchestration_db,
+    write_update_status_projection,
+)
+
+
+def test_write_update_status_projection_records_phase_and_preserves_notify(
+    tmp_path: Path,
+) -> None:
+    status_path = tmp_path / "update_status.json"
+    status_path.write_text(
+        json.dumps(
+            {
+                "status": "running",
+                "message": "old",
+                "notify_platform": "discord",
+                "notify_context": {"chat_id": "channel-1"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = write_update_status_projection(
+        status_path,
+        status="error",
+        message="pip install failed",
+        phase="pip_install_start",
+        error_type="command_failed",
+        exit_code=124,
+        run_id="run-1",
+    )
+
+    assert payload["status"] == "error"
+    assert payload["phase"] == "pip_install_start"
+    assert payload["error_type"] == "command_failed"
+    assert payload["exit_code"] == 124
+    assert payload["update_run_id"] == "run-1"
+    assert payload["notify_platform"] == "discord"
+    assert payload["notify_context"] == {"chat_id": "channel-1"}
+    assert json.loads(status_path.read_text(encoding="utf-8")) == payload
+
+
+def test_orchestration_db_snapshot_restore_roundtrip(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    db_path = resolve_orchestration_sqlite_path(hub_root)
+    db_path.parent.mkdir(parents=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE orch_schema_migrations (version INTEGER)")
+        conn.execute("INSERT INTO orch_schema_migrations(version) VALUES (31)")
+        conn.execute("CREATE TABLE marker (value TEXT)")
+        conn.execute("INSERT INTO marker(value) VALUES ('before')")
+
+    info = read_orchestration_schema_info(hub_root)
+    assert info.db_exists is True
+    assert info.current_schema == 31
+    assert info.supported_schema == ORCHESTRATION_SCHEMA_VERSION
+
+    snapshot = snapshot_orchestration_db(
+        hub_root,
+        snapshot_root=tmp_path / "snapshots",
+        run_id="run-1",
+    )
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE marker SET value = 'after'")
+        conn.execute("INSERT INTO orch_schema_migrations(version) VALUES (32)")
+
+    restored = restore_orchestration_db_snapshot(Path(snapshot.snapshot_dir))
+
+    assert restored.db_path == str(db_path)
+    with sqlite3.connect(db_path) as conn:
+        value = conn.execute("SELECT value FROM marker").fetchone()[0]
+        version = conn.execute(
+            "SELECT MAX(version) FROM orch_schema_migrations"
+        ).fetchone()[0]
+    assert value == "before"
+    assert version == 31
+
+
+def test_orchestration_db_snapshot_restore_removes_new_db_when_absent(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    db_path = resolve_orchestration_sqlite_path(hub_root)
+
+    snapshot = snapshot_orchestration_db(
+        hub_root,
+        snapshot_root=tmp_path / "snapshots",
+        run_id="run-absent",
+    )
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE marker (value TEXT)")
+
+    restore_orchestration_db_snapshot(Path(snapshot.snapshot_dir))
+
+    assert not db_path.exists()


### PR DESCRIPTION
## Summary
- add a small update transaction helper for phase-aware status projection and orchestration DB snapshot/restore
- gate macOS standalone cutover on staged venv validation, including console script presence and import smoke checks
- snapshot orchestration.sqlite3 with SQLite backup before switching the current venv, and restore it before relinking old code during rollback
- surface update phase/error fields in chat update status messages

Fixes #1806

## Validation
- commit hook aggregate lane passed: guardrails, ruff, black check, import boundaries, mypy, pytest fast suite, Web UI lab/lint/build/tests, SPA shell checks
- make test-fast: 8859 passed, 10 warnings
- focused updater/status tests: 63 passed, 1 warning
