### PR TITLE
Preserve explicit progress labels

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -1600,6 +1600,37 @@ describe('PMA chat view helpers', () => {
     });
   });
 
+  it('preserves explicit non-thinking labels when merging token-like updates', () => {
+    const cards = compactChatTranscriptCards([
+      {
+        ...baseArtifactCardTrace('status-queued', 'queued', ['311']),
+        title: 'Status',
+        turnId: 'status-turn',
+        orderKey: '001'
+      },
+      {
+        ...baseArtifactCardTrace('status-running', 'running', ['312']),
+        title: 'Status',
+        turnId: 'status-turn',
+        orderKey: '002'
+      }
+    ]);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      kind: 'turn_summary',
+      title: '2 progress updates'
+    });
+    const summary = cards[0];
+    if (summary.kind !== 'turn_summary') throw new Error('expected turn summary');
+    expect(summary.cards[0]).toMatchObject({
+      kind: 'intermediate',
+      title: 'Status',
+      text: 'queued running',
+      eventIds: ['311', '312']
+    });
+  });
+
   it('keeps compact transcript ids stable as streaming activity grows', () => {
     const first = compactChatTranscriptCards([
       baseArtifactCardTrace('thinking-1', 'Need', ['401']),

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -1143,8 +1143,11 @@ function mergedIntermediateTitle(
   left: Extract<ChatTranscriptCard, { kind: 'intermediate' }>,
   right: Extract<ChatTranscriptCard, { kind: 'intermediate' }>
 ): string {
+  const leftLabel = traceLabelText(left.title);
+  const rightLabel = traceLabelText(right.title);
   if (isThinkingTraceTitle(left.title) || isThinkingTraceTitle(right.title)) return 'Thinking';
   if (isTokenLikeProgressIntermediate(left) && isTokenLikeProgressIntermediate(right)) return 'Progress';
+  if (leftLabel && leftLabel.toLowerCase() === rightLabel.toLowerCase()) return left.title || right.title;
   if (isTokenLikeIntermediate(left) && isTokenLikeIntermediate(right)) return 'Thinking';
   return left.title || right.title || 'Update';
 }


### PR DESCRIPTION
Follow-up to #1807 after it merged while the latest review thread was still open.\n\nThis tightens transcript compaction so token-like updates with an explicit non-thinking label preserve that label when merged. Numeric/percent progress still stays Progress, and raw word-token deltas can still compact as Thinking.\n\nValidation:\n- pnpm web:test -- pmaChat ChatTranscriptCards\n- git diff --check\n- pnpm web:lint\n- pnpm web:test\n- commit hook web-ui lane with CODEX_FAST_TEST_WORKERS=4: guardrails, mypy, pytest 8856 passed, Web UI lab, web lint, web build, web tests 627 passed, SPA shell check