### PR TITLE
[codex] Fix chat index projection state

### DIFF
--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -270,6 +270,7 @@ class ChatSurfaceReadService:
             parent_group_id=parent_group_id,
         )
         rows = sorted(rows, key=_chat_index_sort_key)
+        counters = _chat_index_counters(rows)
         total_count = len(rows)
         bounded_offset = max(0, int(offset or 0))
         bounded_limit = _bounded_limit(limit, MAX_CHAT_INDEX_LIMIT)
@@ -316,6 +317,7 @@ class ChatSurfaceReadService:
             },
             "rows": window,
             "groups": groups if group_by == "ticket_run" else [],
+            "counters": counters,
         }
         _log_read_model_metric(
             "snapshot_query_latency",
@@ -805,6 +807,9 @@ class ChatSurfaceReadService:
                     "agent_id": _normalize_text(row["agent_id"]),
                     "agent_profile": _normalize_text(metadata.get("agent_profile")),
                     "chat_kind": chat_kind,
+                    "flow_type": _normalize_text(metadata.get("flow_type")),
+                    "run_id": _normalize_text(metadata.get("run_id")),
+                    "ticket_id": _normalize_text(metadata.get("ticket_id")),
                     "backend_thread_id": _normalize_text(
                         _row_get(row, "backend_thread_id")
                     ),
@@ -1137,6 +1142,9 @@ def _chat_index_rows_from_surfaces(
                 "unread": bool(metadata_map.get("unread")),
                 "unread_count": int(metadata_map.get("unread_count") or 0),
                 "cleanup_protected": bool(metadata_map.get("cleanup_protected")),
+                "flow_type": metadata_map.get("flow_type"),
+                "ticket_id": metadata_map.get("ticket_id"),
+                "run_id": metadata_map.get("run_id"),
             }
             by_thread[managed_thread_id] = row
         row["surfaces"].append(base_surface)
@@ -1176,8 +1184,11 @@ def _chat_index_rows_from_surfaces(
                 "agent_id",
                 "agent_profile",
                 "chat_kind",
+                "flow_type",
                 "model",
                 "active_turn_id",
+                "ticket_id",
+                "run_id",
             ):
                 if metadata_map.get(key) is not None:
                     row["agent" if key == "agent_id" else key] = metadata_map.get(key)
@@ -1421,10 +1432,12 @@ def _filter_chat_index_rows(
             row.get("surface_kinds") or []
         ):
             continue
-        lifecycle = str(row.get("lifecycle") or "")
         if normalized_view == "waiting" and int(row.get("queue_depth") or 0) <= 0:
             continue
-        if normalized_view == "active" and lifecycle != "running":
+        if (
+            normalized_view == "active"
+            and _chat_index_effective_status(row) != "running"
+        ):
             continue
         if normalized_view == "unread" and not row.get("unread"):
             continue
@@ -1471,6 +1484,41 @@ def _chat_index_sort_key(row: Mapping[str, Any]) -> tuple[int, float, str]:
     )
 
 
+def _chat_index_effective_status(row: Mapping[str, Any]) -> str:
+    lifecycle = _normalize_kind(row.get("lifecycle"))
+    lifecycle_status = _normalize_kind(row.get("lifecycle_status"))
+    runtime = _status_to_lifecycle(
+        row.get("runtime_status") or row.get("target_runtime_status")
+    )
+    if (
+        lifecycle_status == "archived"
+        or lifecycle == "archived"
+        or runtime == "archived"
+    ):
+        return "archived"
+    if int(row.get("queue_depth") or 0) > 0:
+        return "waiting"
+    if runtime == "idle":
+        return "idle"
+    if runtime == "failed":
+        return "failed"
+    if runtime == "running" or lifecycle == "running":
+        return "running"
+    return "idle"
+
+
+def _chat_index_counters(rows: list[dict[str, Any]]) -> dict[str, int]:
+    return {
+        "total": len(rows),
+        "waiting": sum(1 for row in rows if int(row.get("queue_depth") or 0) > 0),
+        "running": sum(
+            1 for row in rows if _chat_index_effective_status(row) == "running"
+        ),
+        "unread": sum(int(row.get("unread_count") or 0) for row in rows),
+        "archived": sum(1 for row in rows if row.get("lifecycle_status") == "archived"),
+    }
+
+
 def _chat_index_sort_key_parts(row: Mapping[str, Any]) -> dict[str, Any]:
     key = _chat_index_sort_key(row)
     last_activity_desc: Any = key[1]
@@ -1484,6 +1532,12 @@ def _chat_index_sort_key_parts(row: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _chat_ticket_group_id(row: Mapping[str, Any]) -> Optional[str]:
+    ticket_id = _normalize_text(row.get("ticket_id") or row.get("current_ticket_id"))
+    if ticket_id is not None:
+        return f"ticket:{ticket_id}"
+    run_id = _normalize_text(row.get("run_id"))
+    if run_id is not None:
+        return f"run:{run_id}"
     kind = _normalize_kind(row.get("resource_kind"))
     identifier = _normalize_text(row.get("resource_id"))
     if kind in {"ticket", "ticket_run", "run"} and identifier is not None:
@@ -1514,7 +1568,9 @@ def _ticket_run_groups(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     1 for child in children if int(child.get("queue_depth") or 0) > 0
                 ),
                 "running_count": sum(
-                    1 for child in children if child.get("lifecycle") == "running"
+                    1
+                    for child in children
+                    if _chat_index_effective_status(child) == "running"
                 ),
                 "unread_count": sum(1 for child in children if child.get("unread")),
                 "updated_at": latest,
@@ -1796,7 +1852,9 @@ def _chat_index_patch_counters(
     return {
         "total": int((snapshot.get("window") or {}).get("total_count") or 0),
         "waiting": sum(1 for row in rows if int(row.get("queue_depth") or 0) > 0),
-        "running": sum(1 for row in rows if row.get("lifecycle") == "running"),
+        "running": sum(
+            1 for row in rows if _chat_index_effective_status(row) == "running"
+        ),
         "unread": sum(int(row.get("unread_count") or 0) for row in rows),
         "archived": sum(1 for row in rows if row.get("lifecycle_status") == "archived"),
     }
@@ -2133,11 +2191,18 @@ def _pma_thread_from_surface(surface: Mapping[str, Any]) -> dict[str, Any]:
     projected_runtime_status = (
         lifecycle if lifecycle in {"idle", "queued", "running", "failed"} else None
     )
+    metadata_runtime_status = _normalize_text(metadata.get("runtime_status"))
+    terminal_runtime_status = (
+        metadata_runtime_status
+        if _normalize_kind(metadata_runtime_status) in _TERMINAL_SUCCESS_STATUSES
+        else None
+    )
     runtime_status = (
         (lifecycle if lifecycle_status == "archived" else None)
+        or terminal_runtime_status
         or projected_runtime_status
         or _normalize_text(metadata.get("latest_execution_status"))
-        or _normalize_text(metadata.get("runtime_status"))
+        or metadata_runtime_status
         or lifecycle
         or ""
     )

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -30,7 +30,14 @@ DEFAULT_CHAT_TIMELINE_LIMIT = 50
 MAX_CHAT_TIMELINE_LIMIT = 200
 MAX_CHAT_TIMELINE_PAGE_SOURCE_LIMIT = 1000
 
-_TERMINAL_SUCCESS_STATUSES = {"completed", "succeeded", "success", "delivered"}
+_TERMINAL_SUCCESS_STATUSES = {
+    "completed",
+    "complete",
+    "ok",
+    "succeeded",
+    "success",
+    "delivered",
+}
 _TERMINAL_FAILED_STATUSES = {"failed", "error", "cancelled", "canceled", "timeout"}
 _RUNNING_STATUSES = {"running", "in_progress", "started", "claimed", "delivering"}
 _QUEUED_STATUSES = {"queued", "pending"}

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -1856,6 +1856,15 @@ def _chat_id_for_event(event: ChatSurfaceEvent) -> str:
 def _chat_index_patch_counters(
     snapshot: Mapping[str, Any], rows: list[Mapping[str, Any]]
 ) -> dict[str, int]:
+    counters = snapshot.get("counters")
+    if isinstance(counters, Mapping):
+        return {
+            "total": max(0, int(counters.get("total") or 0)),
+            "waiting": max(0, int(counters.get("waiting") or 0)),
+            "running": max(0, int(counters.get("running") or 0)),
+            "unread": max(0, int(counters.get("unread") or 0)),
+            "archived": max(0, int(counters.get("archived") or 0)),
+        }
     return {
         "total": int((snapshot.get("window") or {}).get("total_count") or 0),
         "waiting": sum(1 for row in rows if int(row.get("queue_depth") or 0) > 0),

--- a/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
@@ -254,7 +254,7 @@ class ChatReadModelService:
         returned_len = len(hub_rows)
         win_limit = max(1, _int_fallback(hub_window.get("limit"), limit))
         proj_cursor = projection_cursor_chat_index(self._surface.latest_cursor())
-        counters = counters_from_contract_rows(rows, total)
+        counters = counters_from_hub_payload(payload.get("counters"), rows, total)
 
         return ChatIndexSnapshot(
             cursor=proj_cursor,
@@ -591,6 +591,15 @@ def _chat_surface_status_from_row(row: Mapping[str, Any]) -> ChatSurfaceStatus:
     queue_depth = _int_fallback(row.get("queue_depth"), 0)
     if queue_depth > 0:
         return "waiting"
+    if runtime_l in {
+        "completed",
+        "complete",
+        "ok",
+        "succeeded",
+        "success",
+        "delivered",
+    }:
+        return "idle"
     if lifecycle == "running" or runtime_l == "running":
         return "running"
     if runtime_l in {"failed", "error", "blocked", "invalid"}:
@@ -707,7 +716,9 @@ def hub_chat_row_to_chat_index_row(raw: Mapping[str, Any]) -> ChatIndexRow:
 def hub_group_dict_to_contract(raw: Mapping[str, Any]) -> ChatIndexGroup:
     group_id = str(raw.get("group_id") or raw.get("row_id") or "").strip()
     kind: Literal["ticket_run", "surface", "repo", "worktree"] = (
-        "ticket_run" if group_id.startswith(("ticket:", "run:")) else "surface"
+        "ticket_run"
+        if group_id.startswith(("ticket:", "run:", "ticket-run:"))
+        else "surface"
     )
     label = str(raw.get("title") or group_id)
     child_count = max(0, _int_fallback(raw.get("child_count"), 0))
@@ -731,6 +742,20 @@ def counters_from_contract_rows(
         unread=sum(r.unread_count for r in rows),
         archived=sum(1 for r in rows if r.status == "archived"),
     )
+
+
+def counters_from_hub_payload(
+    raw: Any, rows: list[ChatIndexRow], total: int
+) -> ChatIndexCounters:
+    if isinstance(raw, Mapping):
+        return ChatIndexCounters(
+            total=max(0, _int_fallback(raw.get("total"), total)),
+            waiting=max(0, _int_fallback(raw.get("waiting"), 0)),
+            running=max(0, _int_fallback(raw.get("running"), 0)),
+            unread=max(0, _int_fallback(raw.get("unread"), 0)),
+            archived=max(0, _int_fallback(raw.get("archived"), 0)),
+        )
+    return counters_from_contract_rows(rows, total)
 
 
 def projection_cursor_chat_index(sequence: Union[int, str]) -> ProjectionCursor:

--- a/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
@@ -600,10 +600,10 @@ def _chat_surface_status_from_row(row: Mapping[str, Any]) -> ChatSurfaceStatus:
         "delivered",
     }:
         return "idle"
-    if lifecycle == "running" or runtime_l == "running":
-        return "running"
     if runtime_l in {"failed", "error", "blocked", "invalid"}:
         return "failed"
+    if lifecycle == "running" or runtime_l == "running":
+        return "running"
     return "idle"
 
 

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/loadChatRoute.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/loadChatRoute.ts
@@ -13,6 +13,7 @@ export type ChatRouteLoadData = {
 };
 
 const CHAT_DETAIL_TIMELINE_LIMIT = 50;
+const CHAT_INDEX_WINDOW_LIMIT = 200;
 
 /** Testable helper; must not live in `+page.ts` (SvelteKit allows only reserved route exports there). */
 export async function loadChatRoute(options: {
@@ -21,11 +22,14 @@ export async function loadChatRoute(options: {
   loaderOptions?: ReadModelLoaderOptions;
 }): Promise<ChatRouteLoadData> {
   const chatId = options.chatId?.trim() || null;
-  const chatIndexPromise = ensureChatIndexLoaded({}, {
-    ...options.loaderOptions,
-    depends: options.depends,
-    refresh: true
-  });
+  const chatIndexPromise = ensureChatIndexLoaded(
+    { limit: CHAT_INDEX_WINDOW_LIMIT },
+    {
+      ...options.loaderOptions,
+      depends: options.depends,
+      refresh: true
+    }
+  );
   if (!chatId) return { chatId: null, chatIndex: await chatIndexPromise, activeDetail: null };
 
   const activeDetailPromise = ensureChatDetailLoaded(chatId, {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/load.test.ts
@@ -29,6 +29,7 @@ describe('/chats route load', () => {
     });
     expect(depends).toHaveBeenCalledWith('entity:chat:index');
     expect(client.chatIndex).toHaveBeenCalledTimes(1);
+    expect(client.chatIndex).toHaveBeenCalledWith({ limit: 200 });
   });
 
   it('registers the chat index and active chat entity dependencies', async () => {

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -413,6 +413,39 @@ def test_pma_compat_snapshot_keeps_completed_runtime_over_stale_running_event(
     assert thread["status"] == "completed"
 
 
+def test_chat_index_treats_ok_runtime_as_terminal_over_stale_running_event(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(
+        hub_root,
+        thread_id="thread-ok-stale-running",
+        runtime_status="ok",
+    )
+    SQLiteChatSurfaceEventJournal(hub_root, durable=False).append_event(
+        idempotency_key="ok-stale-running",
+        event_type="execution.progress",
+        surface_kind="pma",
+        surface_key="thread-ok-stale-running",
+        managed_thread_id="thread-ok-stale-running",
+        repo_id="repo-1",
+        status="running",
+        occurred_at="2026-05-11T00:00:10Z",
+    )
+
+    active = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(
+        view="active",
+        limit=20,
+    )
+    pma_snapshot = ChatSurfaceReadService(hub_root, durable=False).pma_compat_snapshot()
+    by_thread_id = {
+        thread["managed_thread_id"]: thread for thread in pma_snapshot["threads"]
+    }
+
+    assert active["rows"] == []
+    assert by_thread_id["thread-ok-stale-running"]["runtime_status"] == "ok"
+
+
 def test_chat_index_carries_ticket_flow_metadata_for_grouping(
     tmp_path: Path,
 ) -> None:

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -382,6 +382,99 @@ def test_chat_surface_read_model_keeps_queued_execution_when_runtime_completed(
     assert surface["metadata"]["active_turn_id"] == f"{thread_id}-turn-b"
 
 
+def test_pma_compat_snapshot_keeps_completed_runtime_over_stale_running_event(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(
+        hub_root,
+        thread_id="thread-completed-stale-running",
+        runtime_status="completed",
+    )
+    SQLiteChatSurfaceEventJournal(hub_root, durable=False).append_event(
+        idempotency_key="completed-stale-running",
+        event_type="execution.progress",
+        surface_kind="pma",
+        surface_key="thread-completed-stale-running",
+        managed_thread_id="thread-completed-stale-running",
+        repo_id="repo-1",
+        status="running",
+        occurred_at="2026-05-11T00:00:10Z",
+    )
+
+    snapshot = ChatSurfaceReadService(hub_root, durable=False).pma_compat_snapshot()
+    by_thread_id = {
+        thread["managed_thread_id"]: thread for thread in snapshot["threads"]
+    }
+
+    thread = by_thread_id["thread-completed-stale-running"]
+    assert thread["runtime_status"] == "completed"
+    assert thread["normalized_status"] == "completed"
+    assert thread["status"] == "completed"
+
+
+def test_chat_index_carries_ticket_flow_metadata_for_grouping(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(
+        hub_root,
+        thread_id="thread-ticket-flow",
+        repo_id="repo-1",
+        resource_kind="worktree",
+        resource_id="repo-1--ticket-flow",
+        runtime_status="completed",
+        metadata={
+            "flow_type": "ticket_flow",
+            "thread_kind": "ticket_flow",
+            "ticket_id": "TICKET-015",
+            "run_id": "run-015",
+        },
+    )
+    SQLiteChatSurfaceEventJournal(hub_root, durable=False).append_event(
+        idempotency_key="stale-running-progress",
+        event_type="execution.progress",
+        surface_kind="pma",
+        surface_key="thread-ticket-flow",
+        managed_thread_id="thread-ticket-flow",
+        repo_id="repo-1",
+        resource_kind="worktree",
+        resource_id="repo-1--ticket-flow",
+        status="running",
+        occurred_at="2026-05-11T00:00:10Z",
+    )
+
+    index = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(
+        view="all",
+        limit=20,
+    )
+
+    row = next(
+        item
+        for item in index["rows"]
+        if item["managed_thread_id"] == "thread-ticket-flow"
+    )
+    assert row["ticket_id"] == "TICKET-015"
+    assert row["run_id"] == "run-015"
+    assert row["group_id"] == "ticket:TICKET-015"
+
+    grouped = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(
+        view="ticket_run",
+        group_by="ticket_run",
+        limit=20,
+    )
+
+    assert grouped["rows"][0]["row_type"] == "group"
+    assert grouped["rows"][0]["group_id"] == "ticket:TICKET-015"
+
+    active = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(
+        view="active",
+        group_by="ticket_run",
+        limit=20,
+    )
+    assert active["rows"] == []
+
+
 def test_chat_index_sorts_by_conversation_activity_not_metadata_hydration(
     tmp_path: Path,
 ) -> None:

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -267,6 +267,68 @@ def test_chat_index_contract_uses_terminal_thread_status_and_ticket_flow_metadat
     assert all(item.chat_id != thread_id for item in active_snapshot.rows)
 
 
+def test_chat_index_contract_prioritizes_failed_runtime_over_running_lifecycle(
+    hub_env,
+) -> None:
+    thread_id = "thread-failed-stale-running"
+    with open_orchestration_sqlite(
+        hub_env.hub_root, durable=True, migrate=True
+    ) as conn:
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO orch_thread_targets (
+                    thread_target_id,
+                    agent_id,
+                    repo_id,
+                    resource_kind,
+                    resource_id,
+                    display_name,
+                    lifecycle_status,
+                    runtime_status,
+                    metadata_json,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    thread_id,
+                    "codex",
+                    "repo",
+                    "worktree",
+                    "repo--discord-4",
+                    "failed flow",
+                    "active",
+                    "failed",
+                    "{}",
+                    "2026-05-15T11:57:27Z",
+                    "2026-05-15T12:08:56Z",
+                ),
+            )
+    SQLiteChatSurfaceEventJournal(hub_env.hub_root, durable=True).append_event(
+        idempotency_key="failed-stale-running",
+        event_type="execution.progress",
+        surface_kind="pma",
+        surface_key=thread_id,
+        managed_thread_id=thread_id,
+        repo_id="repo",
+        resource_kind="worktree",
+        resource_id="repo--discord-4",
+        status="running",
+        occurred_at="2026-05-15T12:08:56Z",
+    )
+
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    response = client.get(
+        "/hub/read-models/chats", params={"filter": "all", "limit": 20}
+    )
+
+    assert response.status_code == 200
+    snapshot = load_read_model_contract(ChatIndexSnapshot, response.json())
+    row = next(item for item in snapshot.rows if item.chat_id == thread_id)
+    assert row.status == "failed"
+
+
 def test_chat_detail_snapshot_contains_timeline_queue_and_cursor(hub_env) -> None:
     store = ManagedThreadStore(hub_env.hub_root, durable=True)
     thread = store.create_thread(
@@ -534,6 +596,36 @@ def test_hub_read_models_chats_patch_stream_replays_typed_events(hub_env) -> Non
     assert patches[0]["envelope"]["eventType"] == "chat.index.patch"
     assert patches[0]["patch"]["rows"][0]["chatId"] == "thread-0001"
     assert patches[0]["patch"]["order"]
+
+
+def test_hub_read_models_chats_patch_counters_cover_full_filtered_set(
+    hub_env,
+) -> None:
+    _seed_thread_rows(hub_env.hub_root, 30)
+    event = (
+        SQLiteChatSurfaceEventJournal(hub_env.hub_root, durable=True)
+        .append_event(
+            idempotency_key="index-patch-windowed-counters",
+            event_type="delivery.status_changed",
+            surface_kind="pma",
+            surface_key="thread-0029",
+            managed_thread_id="thread-0029",
+            repo_id="repo",
+            status="delivered",
+        )
+        .event
+    )
+
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    response = client.get(
+        "/hub/read-models/chats/patches",
+        params={"cursor": str(event.cursor - 1), "once": "true", "window_limit": 1},
+    )
+
+    assert response.status_code == 200
+    patches = _event_payloads(response.text, "chat.index.patch")
+    assert patches[0]["patch"]["counters"]["total"] == 29
+    assert patches[0]["patch"]["counters"]["running"] == 1
 
 
 def test_hub_read_models_chats_patch_stream_repairs_future_cursor(hub_env) -> None:

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -18,6 +18,9 @@ from codex_autorunner.surfaces.web.read_model_contracts import (
     ChatIndexSnapshot,
     load_read_model_contract,
 )
+from codex_autorunner.surfaces.web.routes.hub_chat_read_models import (
+    hub_group_dict_to_contract,
+)
 
 
 def _seed_thread_rows(hub_root: Path, count: int) -> None:
@@ -146,6 +149,122 @@ def test_chat_index_snapshot_filters_groups_and_bounds_large_windows(hub_env) ->
     assert children["window"]["returned"] == 5
     assert children["window"]["has_more"] is True
     assert {row["group_id"] for row in children["rows"]} == {"ticket:TICKET-900"}
+
+
+def test_chat_index_group_contract_accepts_legacy_ticket_run_prefix() -> None:
+    group = hub_group_dict_to_contract(
+        {
+            "group_id": "ticket-run:run-1",
+            "title": "Legacy ticket run",
+            "child_count": 3,
+        }
+    )
+
+    assert group.kind == "ticket_run"
+    assert group.group_id == "ticket-run:run-1"
+
+
+def test_chat_index_contract_uses_terminal_thread_status_and_ticket_flow_metadata(
+    hub_env,
+) -> None:
+    thread_id = "thread-ticket-flow-complete"
+    with open_orchestration_sqlite(
+        hub_env.hub_root, durable=True, migrate=True
+    ) as conn:
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO orch_thread_targets (
+                    thread_target_id,
+                    agent_id,
+                    repo_id,
+                    resource_kind,
+                    resource_id,
+                    display_name,
+                    lifecycle_status,
+                    runtime_status,
+                    metadata_json,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    thread_id,
+                    "codex",
+                    "repo",
+                    "worktree",
+                    "repo--discord-4",
+                    "ticket-flow:codex",
+                    "active",
+                    "completed",
+                    json.dumps(
+                        {
+                            "flow_type": "ticket_flow",
+                            "thread_kind": "ticket_flow",
+                            "ticket_id": "TICKET-015",
+                            "run_id": "run-015",
+                        }
+                    ),
+                    "2026-05-15T11:57:27Z",
+                    "2026-05-15T12:08:56Z",
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO orch_thread_executions (
+                    execution_id,
+                    thread_target_id,
+                    request_kind,
+                    status,
+                    created_at,
+                    started_at,
+                    finished_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "turn-ticket-flow-complete",
+                    thread_id,
+                    "message",
+                    "ok",
+                    "2026-05-15T12:03:18Z",
+                    "2026-05-15T12:03:18Z",
+                    "2026-05-15T12:08:56Z",
+                ),
+            )
+    SQLiteChatSurfaceEventJournal(hub_env.hub_root, durable=True).append_event(
+        idempotency_key="stale-running-progress",
+        event_type="execution.progress",
+        surface_kind="pma",
+        surface_key=thread_id,
+        managed_thread_id=thread_id,
+        repo_id="repo",
+        resource_kind="worktree",
+        resource_id="repo--discord-4",
+        status="running",
+        occurred_at="2026-05-15T12:08:56Z",
+    )
+
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    response = client.get(
+        "/hub/read-models/chats", params={"filter": "all", "limit": 20}
+    )
+
+    assert response.status_code == 200
+    snapshot = load_read_model_contract(ChatIndexSnapshot, response.json())
+    row = next(item for item in snapshot.rows if item.chat_id == thread_id)
+    assert row.status == "idle"
+    assert row.ticket_id == "TICKET-015"
+    assert row.run_id == "run-015"
+    assert row.group_id == "ticket:TICKET-015"
+
+    active_response = client.get(
+        "/hub/read-models/chats", params={"filter": "active", "limit": 20}
+    )
+    assert active_response.status_code == 200
+    active_snapshot = load_read_model_contract(
+        ChatIndexSnapshot, active_response.json()
+    )
+    assert all(item.chat_id != thread_id for item in active_snapshot.rows)
 
 
 def test_chat_detail_snapshot_contains_timeline_queue_and_cursor(hub_env) -> None:
@@ -289,6 +408,21 @@ def test_hub_read_models_chats_returns_web_contract_snapshot(hub_env) -> None:
     snapshot = load_read_model_contract(ChatIndexSnapshot, body)
     assert snapshot.rows[0].chat_id.startswith("thread-")
     assert len(snapshot.rows) == 10
+
+
+def test_hub_read_models_chats_counters_cover_full_filtered_set(hub_env) -> None:
+    _seed_thread_rows(hub_env.hub_root, 30)
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    response = client.get(
+        "/hub/read-models/chats", params={"filter": "all", "limit": 1}
+    )
+
+    assert response.status_code == 200
+    snapshot = load_read_model_contract(ChatIndexSnapshot, response.json())
+    assert len(snapshot.rows) == 1
+    assert snapshot.counters.total == 29
+    assert snapshot.counters.running == 1
+    assert snapshot.rows[0].status != "running"
 
 
 def test_hub_read_models_chats_contract_active_filter_matches_index_window(


### PR DESCRIPTION
## Summary
- Carry ticket-flow `ticket_id` / `run_id` metadata through the chat-index projection so ticket-flow rows get stable `ticket:` / `run:` group ids again.
- Normalize effective chat status from terminal runtime state before stale `running` lifecycle events, including PMA compatibility output, active filters, group counters, patch counters, and web contract rows.
- Keep route-load chat-index refreshes on the same 200-row window as the live session so navigation cannot replace a fuller list with the smaller default snapshot.
- Emit full-filter counters from the core chat-index snapshot and serialize legacy `ticket-run:` groups as `ticket_run`.

## Root cause
The live machine had terminal orchestration rows whose chat-surface lifecycle was still `running`. The old projection let the later/stale lifecycle win in several places, so completed ticket flows stayed in Active and showed as running. The same projection path also dropped PMA ticket-flow metadata before grouping, leaving the frontend without the fields it uses to rebuild ticket-flow toggles. Separately, `/chats` route-load refreshes requested the default 50-row snapshot while the live session expects 200, and the store replaces the list from each snapshot.

## Tests
- `.venv/bin/python -m pytest tests/core/orchestration/test_chat_surface_read_model.py tests/surfaces/web/test_hub_chat_read_model_routes.py -q`
- `pnpm --filter @codex-autorunner/web-hub test -- src/routes/chats/load.test.ts`
- `pnpm --filter @codex-autorunner/web-hub lint`
- `.venv/bin/python -m ruff check ...`
- `.venv/bin/python -m black --check ...`
- `git diff --check`
- Commit hook `web-core-contract`: guardrails, repo-wide mypy, `8871 passed`, web UI lab, web lint/build/tests `633 passed | 2 skipped`

## Notes
- `python3 .codex-autorunner/bin/lint_tickets.py` was attempted, but this worktree has no `.codex-autorunner/tickets` files, so it exits with `No tickets found`.
- I did not restart the local hub; deployment should use the repo’s safe refresh path.
