### PR TITLE
[codex] Fix updater staged wheel path capture

### DIFF
--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -621,7 +621,7 @@ _build_package_wheel() {
   rm -rf "${wheel_dir}"
   mkdir -p "${wheel_dir}"
 
-  _build_web_static_assets
+  _build_web_static_assets >&2
 
   echo "Building codex-autorunner wheel from ${PACKAGE_SRC} into ${wheel_dir}..." >&2
   "${python_bin}" -m pip -q wheel --no-deps --no-cache-dir --wheel-dir "${wheel_dir}" "${PACKAGE_SRC}" >&2
@@ -677,6 +677,9 @@ _install_package_from_wheel() {
   local python_bin wheel_path wheel_uri install_spec
   python_bin="$1"
   wheel_path="$2"
+  if [[ -z "${wheel_path}" || "${wheel_path}" == *$'\n'* || "${wheel_path}" != *.whl || ! -f "${wheel_path}" ]]; then
+    fail "Invalid staged wheel path for pip install: ${wheel_path:0:200}"
+  fi
   wheel_uri="$(_path_to_file_uri "${wheel_path}")"
   install_spec="codex-autorunner${PACKAGE_EXTRAS} @ ${wheel_uri}"
 

--- a/tests/test_safe_refresh_local_mac_hub_script.py
+++ b/tests/test_safe_refresh_local_mac_hub_script.py
@@ -30,3 +30,14 @@ def test_safe_refresh_local_mac_hub_script_runs_past_parse_stage(
     assert result.returncode == 1
     assert "LaunchAgent plist not found" in output
     assert "syntax error near unexpected token" not in output
+
+
+def test_safe_refresh_local_mac_hub_script_keeps_build_logs_out_of_wheel_path() -> None:
+    script = Path("scripts/safe-refresh-local-mac-hub.sh").read_text(encoding="utf-8")
+
+    assert "_build_web_static_assets >&2" in script
+    assert 'wheel_path="$(_build_package_wheel ' in script
+    assert "\"${wheel_path}\" == *$'\\n'*" in script
+    assert '"${wheel_path}" != *.whl' in script
+    assert '! -f "${wheel_path}"' in script
+    assert "Invalid staged wheel path for pip install" in script


### PR DESCRIPTION
## Summary
- route Web Hub static build output to stderr so `_build_package_wheel` command substitution captures only the wheel path
- validate the staged wheel argument before constructing the pip install file URI
- add a regression test covering the stdout capture and install guard

## Validation
- `.venv/bin/python -m pytest tests/test_safe_refresh_local_mac_hub_script.py`
- `bash -n scripts/safe-refresh-local-mac-hub.sh`
- commit hook aggregate lane: guardrails, ruff, mypy, repo-wide pytest, web lint/build/tests

Closes #1814
