### PR TITLE
[codex] Stabilize chat index read model

### DIFF
--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -267,28 +267,21 @@ class ChatSurfaceReadService:
         """
 
         started_at = time.perf_counter()
-        surfaces = self._projected_surfaces(limit=None)
-        rows = _chat_index_rows_from_surfaces(surfaces)
-        rows = _filter_chat_index_rows(
-            rows,
+        projection = self._query_chat_index_projection(
             view=view,
             query=query,
             surface_kind=surface_kind,
+            group_by=group_by,
             parent_group_id=parent_group_id,
+            offset=offset,
+            limit=limit,
         )
-        rows = sorted(rows, key=_chat_index_sort_key)
-        counters = _chat_index_counters(rows)
-        total_count = len(rows)
-        bounded_offset = max(0, int(offset or 0))
-        bounded_limit = _bounded_limit(limit, MAX_CHAT_INDEX_LIMIT)
-
-        groups = _ticket_run_groups(rows) if group_by == "ticket_run" else []
-        if group_by == "ticket_run" and parent_group_id is None:
-            group_rows = _filter_chat_index_groups(groups, view=view, query=query)
-            total_count = len(group_rows)
-            window = group_rows[bounded_offset : bounded_offset + bounded_limit]
-        else:
-            window = rows[bounded_offset : bounded_offset + bounded_limit]
+        window = projection["window"]
+        groups = projection["groups"]
+        counters = projection["counters"]
+        total_count = int(projection["total_count"])
+        bounded_offset = int(projection["offset"])
+        bounded_limit = int(projection["limit"])
 
         cursor = self.latest_cursor()
         payload = {
@@ -637,6 +630,239 @@ class ChatSurfaceReadService:
 
     def latest_cursor(self) -> int:
         return self._journal.latest_cursor()
+
+    def rebuild_chat_index_projection(self) -> None:
+        source_signature = self._chat_index_source_signature()
+        surfaces = self._projected_surfaces(limit=None)
+        rows = sorted(
+            _chat_index_rows_from_surfaces(surfaces), key=_chat_index_sort_key
+        )
+        rebuilt_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        with open_orchestration_sqlite(
+            self._hub_root, durable=self._durable, migrate=True
+        ) as conn:
+            with conn:
+                conn.execute("DELETE FROM orch_chat_index_projection")
+                conn.executemany(
+                    """
+                    INSERT INTO orch_chat_index_projection (
+                        row_id,
+                        chat_id,
+                        managed_thread_id,
+                        surface_kinds_json,
+                        surface_kind_list,
+                        lifecycle_status,
+                        runtime_status,
+                        effective_status,
+                        queue_depth,
+                        unread_count,
+                        unread,
+                        last_activity_at,
+                        updated_at,
+                        created_at,
+                        repo_id,
+                        worktree_id,
+                        resource_kind,
+                        resource_id,
+                        ticket_id,
+                        run_id,
+                        group_id,
+                        search_text,
+                        sort_unread_priority,
+                        sort_last_activity_desc,
+                        row_json,
+                        source_signature,
+                        rebuilt_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    [
+                        _chat_index_projection_params(
+                            row,
+                            source_signature=source_signature,
+                            rebuilt_at=rebuilt_at,
+                        )
+                        for row in rows
+                    ],
+                )
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO orch_chat_index_projection_meta (
+                        key,
+                        value,
+                        updated_at
+                    ) VALUES ('source_signature', ?, ?)
+                    """,
+                    (source_signature, rebuilt_at),
+                )
+
+    def _ensure_chat_index_projection_current(self) -> None:
+        source_signature = self._chat_index_source_signature()
+        with open_orchestration_sqlite(
+            self._hub_root, durable=self._durable, migrate=True
+        ) as conn:
+            if not _table_exists(
+                conn, "orch_chat_index_projection"
+            ) or not _table_exists(conn, "orch_chat_index_projection_meta"):
+                needs_rebuild = True
+            else:
+                row = conn.execute(
+                    """
+                    SELECT value
+                      FROM orch_chat_index_projection_meta
+                     WHERE key = 'source_signature'
+                    """
+                ).fetchone()
+                needs_rebuild = row is None or row["value"] != source_signature
+        if needs_rebuild:
+            self.rebuild_chat_index_projection()
+
+    def _chat_index_source_signature(self) -> str:
+        with open_orchestration_sqlite(
+            self._hub_root, durable=self._durable, migrate=True
+        ) as conn:
+            table_updated_exprs = {
+                "orch_thread_targets": "MAX(COALESCE(updated_at, created_at))",
+                "orch_thread_executions": "MAX(COALESCE(finished_at, started_at, created_at))",
+                "orch_bindings": "MAX(COALESCE(updated_at, created_at))",
+                "orch_managed_thread_deliveries": "MAX(COALESCE(updated_at, delivered_at, created_at))",
+                "orch_notification_conversations": "MAX(COALESCE(updated_at, created_at))",
+                "orch_chat_surface_events": "MAX(COALESCE(created_at, occurred_at, event_id))",
+            }
+            facts: dict[str, Any] = {}
+            for table, updated_expr in table_updated_exprs.items():
+                if not _table_exists(conn, table):
+                    facts[table] = None
+                    continue
+                row = conn.execute(
+                    f"SELECT COUNT(*) AS count, {updated_expr} AS max_updated FROM {table}"
+                ).fetchone()
+                facts[table] = {
+                    "count": int(row["count"] or 0),
+                    "max_updated": row["max_updated"],
+                }
+        directory_path = (
+            self._hub_root / ".codex-autorunner" / "chat" / "channel_directory.json"
+        )
+        try:
+            stat = directory_path.stat()
+            facts["channel_directory"] = {
+                "mtime_ns": stat.st_mtime_ns,
+                "size": stat.st_size,
+            }
+        except OSError:
+            facts["channel_directory"] = None
+        basis = json.dumps(facts, sort_keys=True, separators=(",", ":"), default=str)
+        return hashlib.sha256(basis.encode("utf-8")).hexdigest()
+
+    def _query_chat_index_projection(
+        self,
+        *,
+        view: str,
+        query: Optional[str],
+        surface_kind: Optional[str],
+        group_by: Optional[str],
+        parent_group_id: Optional[str],
+        offset: int,
+        limit: int,
+    ) -> dict[str, Any]:
+        self._ensure_chat_index_projection_current()
+        bounded_offset = max(0, int(offset or 0))
+        bounded_limit = _bounded_limit(limit, MAX_CHAT_INDEX_LIMIT)
+        where_sql, params = _chat_index_projection_where(
+            view=view,
+            query=query,
+            surface_kind=surface_kind,
+            parent_group_id=parent_group_id,
+        )
+        with open_orchestration_sqlite(
+            self._hub_root, durable=self._durable, migrate=True
+        ) as conn:
+            counters_row = conn.execute(
+                f"""
+                SELECT COUNT(*) AS total,
+                       COALESCE(SUM(CASE WHEN queue_depth > 0 THEN 1 ELSE 0 END), 0) AS waiting,
+                       COALESCE(SUM(CASE WHEN effective_status = 'running' THEN 1 ELSE 0 END), 0) AS running,
+                       COALESCE(SUM(unread_count), 0) AS unread,
+                       COALESCE(SUM(CASE WHEN lifecycle_status = 'archived' THEN 1 ELSE 0 END), 0) AS archived
+                  FROM orch_chat_index_projection
+                 WHERE {where_sql}
+                """,
+                params,
+            ).fetchone()
+            counters = {
+                "total": int(counters_row["total"] or 0),
+                "waiting": int(counters_row["waiting"] or 0),
+                "running": int(counters_row["running"] or 0),
+                "unread": int(counters_row["unread"] or 0),
+                "archived": int(counters_row["archived"] or 0),
+            }
+            if group_by == "ticket_run" and parent_group_id is None:
+                all_rows = [
+                    _chat_index_row_from_projection(row)
+                    for row in conn.execute(
+                        f"""
+                        SELECT row_json
+                          FROM orch_chat_index_projection
+                         WHERE {where_sql}
+                         ORDER BY sort_unread_priority DESC,
+                                  sort_last_activity_desc ASC,
+                                  row_id ASC
+                        """,
+                        params,
+                    ).fetchall()
+                ]
+                groups = _filter_chat_index_groups(
+                    _ticket_run_groups(all_rows),
+                    view=view,
+                    query=query,
+                )
+                window_rows = groups[bounded_offset : bounded_offset + bounded_limit]
+                total_count = len(groups)
+            else:
+                total_count = counters["total"]
+                page_params = [*params, bounded_limit, bounded_offset]
+                window_rows = [
+                    _chat_index_row_from_projection(row)
+                    for row in conn.execute(
+                        f"""
+                        SELECT row_json
+                          FROM orch_chat_index_projection
+                         WHERE {where_sql}
+                         ORDER BY sort_unread_priority DESC,
+                                  sort_last_activity_desc ASC,
+                                  row_id ASC
+                         LIMIT ? OFFSET ?
+                        """,
+                        page_params,
+                    ).fetchall()
+                ]
+                if group_by == "ticket_run":
+                    all_rows = [
+                        _chat_index_row_from_projection(row)
+                        for row in conn.execute(
+                            f"""
+                            SELECT row_json
+                              FROM orch_chat_index_projection
+                             WHERE {where_sql}
+                             ORDER BY sort_unread_priority DESC,
+                                      sort_last_activity_desc ASC,
+                                      row_id ASC
+                            """,
+                            params,
+                        ).fetchall()
+                    ]
+                    groups = _ticket_run_groups(all_rows)
+                else:
+                    groups = []
+        return {
+            "offset": bounded_offset,
+            "limit": bounded_limit,
+            "rows": window_rows,
+            "groups": groups,
+            "counters": counters,
+            "total_count": total_count,
+            "window": window_rows,
+        }
 
     def _projected_surfaces(self, *, limit: Optional[int]) -> list[dict[str, Any]]:
         projections: dict[tuple[str, str], ChatSurfaceProjection] = {}
@@ -1524,6 +1750,103 @@ def _chat_index_counters(rows: list[dict[str, Any]]) -> dict[str, int]:
         "unread": sum(int(row.get("unread_count") or 0) for row in rows),
         "archived": sum(1 for row in rows if row.get("lifecycle_status") == "archived"),
     }
+
+
+def _chat_index_projection_params(
+    row: Mapping[str, Any],
+    *,
+    source_signature: str,
+    rebuilt_at: str,
+) -> tuple[Any, ...]:
+    surface_kinds = sorted(str(kind) for kind in row.get("surface_kinds") or [])
+    raw_sort_key = row.get("sort_key")
+    sort_key: Mapping[str, Any] = (
+        raw_sort_key if isinstance(raw_sort_key, Mapping) else {}
+    )
+    last_activity_desc = sort_key.get("last_activity_desc")
+    if last_activity_desc is not None:
+        last_activity_desc = float(last_activity_desc)
+    return (
+        str(row.get("row_id") or row.get("chat_id")),
+        str(row.get("chat_id") or row.get("row_id")),
+        _normalize_text(row.get("managed_thread_id")),
+        json.dumps(surface_kinds, sort_keys=True, separators=(",", ":")),
+        "|" + "|".join(surface_kinds) + "|" if surface_kinds else "",
+        _normalize_text(row.get("lifecycle_status")),
+        _normalize_text(row.get("runtime_status")),
+        _chat_index_effective_status(row),
+        int(row.get("queue_depth") or 0),
+        int(row.get("unread_count") or 0),
+        1 if row.get("unread") else 0,
+        _normalize_text(row.get("last_activity_at")),
+        _normalize_text(row.get("updated_at")),
+        _normalize_text(row.get("created_at")),
+        _normalize_text(row.get("repo_id")),
+        _normalize_text(row.get("worktree_id")),
+        _normalize_text(row.get("resource_kind")),
+        _normalize_text(row.get("resource_id")),
+        _normalize_text(row.get("ticket_id")),
+        _normalize_text(row.get("run_id")),
+        _normalize_text(row.get("group_id")),
+        str(row.get("search_text") or ""),
+        int(sort_key.get("unread_priority") or 0),
+        last_activity_desc,
+        json.dumps(dict(row), sort_keys=True, separators=(",", ":"), default=str),
+        source_signature,
+        rebuilt_at,
+    )
+
+
+def _chat_index_row_from_projection(row: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        parsed = json.loads(str(row["row_json"]))
+    except (KeyError, TypeError, json.JSONDecodeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _chat_index_projection_where(
+    *,
+    view: str,
+    query: Optional[str],
+    surface_kind: Optional[str],
+    parent_group_id: Optional[str],
+) -> tuple[str, list[Any]]:
+    normalized_view = (view or "all").strip().lower()
+    normalized_query = _normalize_text(query)
+    normalized_query = normalized_query.lower() if normalized_query else None
+    normalized_surface = _normalize_kind(surface_kind)
+    clauses = ["1 = 1"]
+    params: list[Any] = []
+    if parent_group_id is not None:
+        clauses.append("group_id = ?")
+        params.append(parent_group_id)
+    if normalized_view != "external":
+        clauses.append("managed_thread_id IS NOT NULL")
+    if normalized_surface is not None:
+        clauses.append("surface_kind_list LIKE ?")
+        params.append(f"%|{normalized_surface}|%")
+    if normalized_view == "waiting":
+        clauses.append("queue_depth > 0")
+    elif normalized_view == "active":
+        clauses.append("effective_status = 'running'")
+    elif normalized_view == "unread":
+        clauses.append("unread != 0")
+    elif normalized_view == "archived":
+        clauses.append("lifecycle_status = 'archived'")
+    elif normalized_view == "external":
+        clauses.append("surface_kind_list != ''")
+        clauses.append("surface_kind_list != '|pma|'")
+    elif normalized_view == "ticket_run":
+        clauses.append("group_id IS NOT NULL")
+    elif normalized_view != "all":
+        clauses.append("0 = 1")
+    if normalized_view != "archived":
+        clauses.append("(lifecycle_status IS NULL OR lifecycle_status != 'archived')")
+    if normalized_query is not None:
+        clauses.append("search_text LIKE ?")
+        params.append(f"%{normalized_query}%")
+    return " AND ".join(clauses), params
 
 
 def _chat_index_sort_key_parts(row: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -774,20 +774,41 @@ class ChatSurfaceReadService:
             surface_kind=surface_kind,
             parent_group_id=parent_group_id,
         )
-        with open_orchestration_sqlite(
-            self._hub_root, durable=self._durable, migrate=True
-        ) as conn:
-            counters_row = conn.execute(
-                f"""
+        normalized_view = (view or "all").strip().lower()
+        if normalized_view == "all":
+            where_counters_sql, counters_params = _chat_index_projection_where(
+                view=view,
+                query=query,
+                surface_kind=surface_kind,
+                parent_group_id=parent_group_id,
+                include_archived_rows=True,
+            )
+            counters_sql = f"""
+                SELECT COALESCE(SUM(CASE WHEN (lifecycle_status IS NULL OR lifecycle_status != 'archived') THEN 1 ELSE 0 END), 0) AS total,
+                       COALESCE(SUM(CASE WHEN (lifecycle_status IS NULL OR lifecycle_status != 'archived') AND queue_depth > 0 THEN 1 ELSE 0 END), 0) AS waiting,
+                       COALESCE(SUM(CASE WHEN (lifecycle_status IS NULL OR lifecycle_status != 'archived') AND effective_status = 'running' THEN 1 ELSE 0 END), 0) AS running,
+                       COALESCE(SUM(CASE WHEN (lifecycle_status IS NULL OR lifecycle_status != 'archived') THEN unread_count ELSE 0 END), 0) AS unread,
+                       COALESCE(SUM(CASE WHEN lifecycle_status = 'archived' THEN 1 ELSE 0 END), 0) AS archived
+                  FROM orch_chat_index_projection
+                 WHERE {where_counters_sql}
+                """
+        else:
+            where_counters_sql, counters_params = where_sql, params
+            counters_sql = f"""
                 SELECT COUNT(*) AS total,
                        COALESCE(SUM(CASE WHEN queue_depth > 0 THEN 1 ELSE 0 END), 0) AS waiting,
                        COALESCE(SUM(CASE WHEN effective_status = 'running' THEN 1 ELSE 0 END), 0) AS running,
                        COALESCE(SUM(unread_count), 0) AS unread,
                        COALESCE(SUM(CASE WHEN lifecycle_status = 'archived' THEN 1 ELSE 0 END), 0) AS archived
                   FROM orch_chat_index_projection
-                 WHERE {where_sql}
-                """,
-                params,
+                 WHERE {where_counters_sql}
+                """
+        with open_orchestration_sqlite(
+            self._hub_root, durable=self._durable, migrate=True
+        ) as conn:
+            counters_row = conn.execute(
+                counters_sql,
+                counters_params,
             ).fetchone()
             counters = {
                 "total": int(counters_row["total"] or 0),
@@ -1811,6 +1832,7 @@ def _chat_index_projection_where(
     query: Optional[str],
     surface_kind: Optional[str],
     parent_group_id: Optional[str],
+    include_archived_rows: bool = False,
 ) -> tuple[str, list[Any]]:
     normalized_view = (view or "all").strip().lower()
     normalized_query = _normalize_text(query)
@@ -1841,7 +1863,9 @@ def _chat_index_projection_where(
         clauses.append("group_id IS NOT NULL")
     elif normalized_view != "all":
         clauses.append("0 = 1")
-    if normalized_view != "archived":
+    if normalized_view != "archived" and not (
+        include_archived_rows and normalized_view == "all"
+    ):
         clauses.append("(lifecycle_status IS NULL OR lifecycle_status != 'archived')")
     if normalized_query is not None:
         clauses.append("search_text LIKE ?")

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -1664,63 +1664,6 @@ def _chat_row_search_text(row: Mapping[str, Any]) -> str:
     return " ".join(str(value).lower() for value in values if value)
 
 
-def _filter_chat_index_rows(
-    rows: list[dict[str, Any]],
-    *,
-    view: str,
-    query: Optional[str],
-    surface_kind: Optional[str],
-    parent_group_id: Optional[str],
-) -> list[dict[str, Any]]:
-    normalized_view = (view or "all").strip().lower()
-    normalized_query = _normalize_text(query)
-    normalized_query = normalized_query.lower() if normalized_query else None
-    normalized_surface = _normalize_kind(surface_kind)
-    filtered: list[dict[str, Any]] = []
-    for row in rows:
-        if parent_group_id is not None and row.get("group_id") != parent_group_id:
-            continue
-        if normalized_view != "external" and row.get("managed_thread_id") is None:
-            continue
-        if normalized_surface is not None and normalized_surface not in set(
-            row.get("surface_kinds") or []
-        ):
-            continue
-        if normalized_view == "waiting" and int(row.get("queue_depth") or 0) <= 0:
-            continue
-        if (
-            normalized_view == "active"
-            and _chat_index_effective_status(row) != "running"
-        ):
-            continue
-        if normalized_view == "unread" and not row.get("unread"):
-            continue
-        if normalized_view == "archived" and row.get("lifecycle_status") != "archived":
-            continue
-        if normalized_view == "external" and set(row.get("surface_kinds") or []) <= {
-            "pma"
-        }:
-            continue
-        if normalized_view == "ticket_run" and row.get("group_id") is None:
-            continue
-        if normalized_view not in {
-            "all",
-            "waiting",
-            "active",
-            "unread",
-            "archived",
-            "external",
-            "ticket_run",
-        }:
-            continue
-        if normalized_view != "archived" and row.get("lifecycle_status") == "archived":
-            continue
-        if normalized_query is not None and normalized_query not in row["search_text"]:
-            continue
-        filtered.append(row)
-    return filtered
-
-
 def _chat_index_sort_key(row: Mapping[str, Any]) -> tuple[int, float, str]:
     priority = 1 if row.get("unread") else 0
     raw = str(
@@ -1759,18 +1702,6 @@ def _chat_index_effective_status(row: Mapping[str, Any]) -> str:
     if runtime == "running" or lifecycle == "running":
         return "running"
     return "idle"
-
-
-def _chat_index_counters(rows: list[dict[str, Any]]) -> dict[str, int]:
-    return {
-        "total": len(rows),
-        "waiting": sum(1 for row in rows if int(row.get("queue_depth") or 0) > 0),
-        "running": sum(
-            1 for row in rows if _chat_index_effective_status(row) == "running"
-        ),
-        "unread": sum(int(row.get("unread_count") or 0) for row in rows),
-        "archived": sum(1 for row in rows if row.get("lifecycle_status") == "archived"),
-    }
 
 
 def _chat_index_projection_params(

--- a/src/codex_autorunner/core/orchestration/migrations.py
+++ b/src/codex_autorunner/core/orchestration/migrations.py
@@ -9,7 +9,7 @@ from ..sqlite_utils import table_columns, table_exists
 from ..time_utils import now_iso
 from .models import OrchestrationTableDefinition
 
-ORCHESTRATION_SCHEMA_VERSION = 32
+ORCHESTRATION_SCHEMA_VERSION = 33
 
 
 @dataclass(frozen=True)
@@ -1692,6 +1692,87 @@ def _apply_v32(conn: sqlite3.Connection) -> None:
     )
 
 
+def _apply_v33(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS orch_chat_index_projection (
+            row_id TEXT PRIMARY KEY,
+            chat_id TEXT NOT NULL,
+            managed_thread_id TEXT,
+            surface_kinds_json TEXT NOT NULL DEFAULT '[]',
+            surface_kind_list TEXT NOT NULL DEFAULT '',
+            lifecycle_status TEXT,
+            runtime_status TEXT,
+            effective_status TEXT NOT NULL DEFAULT 'idle',
+            queue_depth INTEGER NOT NULL DEFAULT 0,
+            unread_count INTEGER NOT NULL DEFAULT 0,
+            unread INTEGER NOT NULL DEFAULT 0,
+            last_activity_at TEXT,
+            updated_at TEXT,
+            created_at TEXT,
+            repo_id TEXT,
+            worktree_id TEXT,
+            resource_kind TEXT,
+            resource_id TEXT,
+            ticket_id TEXT,
+            run_id TEXT,
+            group_id TEXT,
+            search_text TEXT NOT NULL DEFAULT '',
+            sort_unread_priority INTEGER NOT NULL DEFAULT 0,
+            sort_last_activity_desc REAL,
+            row_json TEXT NOT NULL,
+            source_signature TEXT NOT NULL,
+            rebuilt_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS orch_chat_index_projection_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_orch_chat_index_projection_status
+            ON orch_chat_index_projection(lifecycle_status, effective_status)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_orch_chat_index_projection_surface
+            ON orch_chat_index_projection(surface_kind_list)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_orch_chat_index_projection_group
+            ON orch_chat_index_projection(group_id)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_orch_chat_index_projection_activity
+            ON orch_chat_index_projection(sort_unread_priority DESC, sort_last_activity_desc ASC, row_id ASC)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_orch_chat_index_projection_owner
+            ON orch_chat_index_projection(repo_id, worktree_id, ticket_id, run_id)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_orch_chat_index_projection_search
+            ON orch_chat_index_projection(search_text)
+        """
+    )
+
+
 _MIGRATIONS = (
     _MigrationStep(1, "create_core_orchestration_schema", _apply_v1),
     _MigrationStep(2, "add_binding_and_flow_projection_scaffolding", _apply_v2),
@@ -1748,6 +1829,11 @@ _MIGRATIONS = (
         32,
         "add_managed_thread_post_terminal_side_effects",
         _apply_v32,
+    ),
+    _MigrationStep(
+        33,
+        "add_chat_index_projection",
+        _apply_v33,
     ),
 )
 
@@ -1857,6 +1943,16 @@ _TABLE_DEFINITIONS = (
         name="orch_managed_thread_side_effects",
         role="authoritative",
         description="Durable post-terminal managed-thread side-effect intents for retryable transcript, timeline, cold-trace, activity, PR-binding, and cleanup work.",
+    ),
+    OrchestrationTableDefinition(
+        name="orch_chat_index_projection",
+        role="projection",
+        description="Materialized chat index rows for indexed filtering, sorting, grouping, and windowed web read-model snapshots.",
+    ),
+    OrchestrationTableDefinition(
+        name="orch_chat_index_projection_meta",
+        role="projection",
+        description="Metadata for chat index projection rebuild freshness and source signatures.",
     ),
     OrchestrationTableDefinition(
         name="orch_thread_identity_bindings",

--- a/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.test.ts
@@ -100,7 +100,8 @@ describe('chat index session', () => {
     expect(client.chatIndex).toHaveBeenCalledTimes(1);
     expect(client.chatIndex).toHaveBeenNthCalledWith(1, { filter: 'all', limit: 200 });
     expect(streamFactory).toHaveBeenCalledWith(expect.objectContaining({
-      path: '/hub/read-models/chats/patches?filter=all&window_limit=200',
+      key: 'chat.index.entity',
+      path: '/hub/read-models/chats/patches',
       eventTypes: ['chat.index.patch', 'projection.cursor_gap']
     }));
     expect(selectPmaChats(store.snapshot()).map((chat) => chat.id)).toEqual(['chat-active']);
@@ -169,6 +170,23 @@ describe('chat index session', () => {
     expect(Object.keys(store.snapshot().chats).sort()).toEqual(['chat-active', 'chat-archived']);
     expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual(['chat-active']);
     expect(selectChatIndexWindowView(store.snapshot(), { filter: 'archived', limit: 200 }).rows.map((row) => row.chatId)).toEqual(['chat-archived']);
+  });
+
+  it('keeps the chat-index entity stream stable across filter refreshes', async () => {
+    const store = new ReadModelEntityStore();
+    const client = mockClient();
+    const streamFactory = mockStreamFactory();
+    const session = createChatIndexSession({ client, store, streamFactory });
+
+    session.start();
+    await session.refresh({ filter: 'all', limit: 200 });
+    await session.refresh({ filter: 'archived', limit: 200 });
+
+    expect(streamFactory).toHaveBeenCalledTimes(1);
+    expect(streamFactory).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      key: 'chat.index.entity',
+      path: '/hub/read-models/chats/patches'
+    }));
   });
 });
 

--- a/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.test.ts
@@ -7,7 +7,7 @@ import {
   type ChatIndexSnapshot,
   type ProjectionCursor
 } from '$lib/api/readModelContracts';
-import { ReadModelEntityStore } from './readModelStore';
+import { ReadModelEntityStore, selectChatIndexWindowView } from './readModelStore';
 import { selectPmaChats } from './readModelViewModels';
 import { createChatIndexSession } from './chatIndexSession';
 import type { ReadModelSnapshotClient } from './readModelClients';
@@ -166,6 +166,9 @@ describe('chat index session', () => {
     expect(client.chatIndex).toHaveBeenNthCalledWith(1, { filter: 'all', limit: 200 });
     expect(client.chatIndex).toHaveBeenNthCalledWith(2, { filter: 'archived', limit: 200 });
     expect(store.snapshot().chatOrder).toEqual(['chat-archived']);
+    expect(Object.keys(store.snapshot().chats).sort()).toEqual(['chat-active', 'chat-archived']);
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual(['chat-active']);
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'archived', limit: 200 }).rows.map((row) => row.chatId)).toEqual(['chat-archived']);
   });
 });
 

--- a/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.ts
@@ -89,7 +89,7 @@ export function createChatIndexSession(deps: ChatIndexSessionDeps = {}): ChatInd
       inFlightRequest = { ...currentRequest };
       const result = await client.chatIndex(inFlightRequest);
       if (!result.ok) throw result.error;
-      store.applyChatIndexSnapshot(result.data);
+      store.applyChatIndexSnapshot(result.data, inFlightRequest);
     } while (refreshAgain || !sameChatIndexRequest(inFlightRequest, currentRequest));
   }
 
@@ -107,7 +107,7 @@ export function createChatIndexSession(deps: ChatIndexSessionDeps = {}): ChatInd
       eventTypes: ['chat.index.patch', 'projection.cursor_gap'],
       parse: parseChatIndexPatchEvent,
       onEvent: (event) => {
-        const result = store.applyChatIndexPatchEvent(event);
+        const result = store.applyChatIndexPatchEvent(event, currentRequest);
         if (result === 'repair_required') {
           stream?.resetCursor();
           void refresh();

--- a/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.ts
@@ -70,7 +70,7 @@ export function createChatIndexSession(deps: ChatIndexSessionDeps = {}): ChatInd
     refreshPromise = refreshChatListUntilSettled()
       .then(() => {
         state.set({ status: started ? 'connected' : 'idle', error: null });
-        if (started) openStream();
+        if (started && !stream) openStream();
       })
       .catch((error: ApiError) => {
         state.set({ status: 'interrupted', error });
@@ -94,20 +94,14 @@ export function createChatIndexSession(deps: ChatIndexSessionDeps = {}): ChatInd
   }
 
   function openStream(): void {
-    stream?.close();
-    const params = new URLSearchParams({
-      filter: currentRequest.filter ?? 'all',
-      window_limit: String(currentRequest.limit ?? 200)
-    });
-    if (currentRequest.query) params.set('search', currentRequest.query);
-    if (currentRequest.surfaceKind) params.set('surface_kind', currentRequest.surfaceKind);
+    if (stream) return;
     stream = streamFactory({
-      key: `chat.index.${params.toString()}`,
-      path: `/hub/read-models/chats/patches?${params.toString()}`,
+      key: 'chat.index.entity',
+      path: '/hub/read-models/chats/patches',
       eventTypes: ['chat.index.patch', 'projection.cursor_gap'],
       parse: parseChatIndexPatchEvent,
       onEvent: (event) => {
-        const result = store.applyChatIndexPatchEvent(event, currentRequest);
+        const result = store.applyChatIndexPatchEvent(event);
         if (result === 'repair_required') {
           stream?.resetCursor();
           void refresh();

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.ts
@@ -67,7 +67,7 @@ export async function ensureChatIndexLoaded(
   const client = options.client ?? readModelSnapshotClient;
   const result = await client.chatIndex(request);
   if (!result.ok) return { status: 'error', tags, error: result.error };
-  store.applyChatIndexSnapshot(result.data);
+  store.applyChatIndexSnapshot(result.data, request);
   return { status: 'fetched', tags };
 }
 

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -591,6 +591,48 @@ describe('read model entity store', () => {
     expect(selectChatIndexWindowView(store.snapshot(), { filter: 'waiting', limit: 200 }).rows).toEqual([]);
   });
 
+  it('applies entity chat-index patches once and marks affected cached windows stale', () => {
+    const store = new ReadModelEntityStore();
+    store.applyChatIndexSnapshot({
+      cursor: cursor(1),
+      rows: [chat('chat-active', 'running'), chat('chat-waiting', 'waiting')],
+      groups: [],
+      counters: { total: 2, waiting: 1, running: 1, unread: 0, archived: 0 },
+      filter: 'all',
+      query: null,
+      window: { limit: 200, totalIsExact: true, totalEstimate: 2 }
+    }, { filter: 'all', limit: 200 });
+    store.applyChatIndexSnapshot({
+      cursor: cursor(1),
+      rows: [chat('chat-active', 'running')],
+      groups: [],
+      counters: { total: 1, waiting: 0, running: 1, unread: 0, archived: 0 },
+      filter: 'active',
+      query: null,
+      window: { limit: 200, totalIsExact: true, totalEstimate: 1 }
+    }, { filter: 'active', limit: 200 });
+
+    const archived = chat('chat-active', 'archived');
+    expect(store.applyChatIndexPatchEvent({
+      ...chatPatch(2, archived),
+      patch: {
+        ...chatPatch(2, archived).patch,
+        order: ['chat-active', 'chat-waiting'],
+        counters: { total: 2, waiting: 1, running: 0, unread: 0, archived: 1 }
+      }
+    })).toBe('applied');
+
+    const activeWindow = selectChatIndexWindowView(store.snapshot(), { filter: 'active', limit: 200 });
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual([
+      'chat-active',
+      'chat-waiting'
+    ]);
+    expect(activeWindow.rows.map((row) => row.chatId)).toEqual([]);
+    expect(activeWindow.window?.status).toBe('interrupted');
+    expect(activeWindow.window?.refreshing).toBe(true);
+    expect(store.snapshot().cursors['chat.index'].sequence).toBe(2);
+  });
+
   it('preserves chat kind when detail snapshots omit the durable field', () => {
     const store = new ReadModelEntityStore();
     const row = chat('chat-1');

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -16,6 +16,7 @@ import {
   ReadModelEntityStore,
   selectChatDetailView,
   selectChatIndexView,
+  selectChatIndexWindowView,
   selectorFingerprint
 } from './readModelStore';
 
@@ -529,6 +530,65 @@ describe('read model entity store', () => {
     expect(view.rows.map((row) => row.chatId)).toEqual(['chat-1', 'chat-2']);
     expect(view.rows[0].title).toBe('Latest title');
     expect(view.rows[0].status).toBe('running');
+  });
+
+  it('keeps filtered chat index windows separate from cached chat entities', () => {
+    const store = new ReadModelEntityStore();
+    store.applyChatIndexSnapshot({
+      cursor: cursor(1),
+      rows: [chat('chat-active', 'running'), chat('chat-waiting', 'waiting')],
+      groups: [],
+      counters: { total: 2, waiting: 1, running: 1, unread: 0, archived: 1 },
+      filter: 'all',
+      query: null,
+      window: { limit: 200, totalIsExact: true, totalEstimate: 2 }
+    }, { filter: 'all', limit: 200 });
+
+    store.applyChatIndexSnapshot({
+      cursor: cursor(2),
+      rows: [chat('chat-archived', 'archived')],
+      groups: [],
+      counters: { total: 1, waiting: 0, running: 0, unread: 0, archived: 1 },
+      filter: 'archived',
+      query: null,
+      window: { limit: 200, totalIsExact: true, totalEstimate: 1 }
+    }, { filter: 'archived', limit: 200 });
+
+    expect(Object.keys(store.snapshot().chats).sort()).toEqual(['chat-active', 'chat-archived', 'chat-waiting']);
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual([
+      'chat-active',
+      'chat-waiting'
+    ]);
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'archived', limit: 200 }).rows.map((row) => row.chatId)).toEqual([
+      'chat-archived'
+    ]);
+    expect(store.snapshot().chatCounters).toEqual({ total: 2, waiting: 1, running: 1, unread: 0, archived: 1 });
+  });
+
+  it('returns cached chat index windows immediately by canonical request', () => {
+    const store = new ReadModelEntityStore();
+    store.applyChatIndexSnapshot({
+      cursor: cursor(1),
+      rows: [chat('chat-active', 'running')],
+      groups: [],
+      counters: { total: 1, waiting: 0, running: 1, unread: 0, archived: 0 },
+      filter: 'all',
+      query: null,
+      window: { limit: 200, totalIsExact: true, totalEstimate: 1 }
+    }, { filter: 'all', limit: 200 });
+    store.applyChatIndexSnapshot({
+      cursor: cursor(2),
+      rows: [chat('chat-archived', 'archived')],
+      groups: [],
+      counters: { total: 1, waiting: 0, running: 0, unread: 0, archived: 1 },
+      filter: 'archived',
+      query: null,
+      window: { limit: 200, totalIsExact: true, totalEstimate: 1 }
+    }, { filter: 'archived', limit: 200 });
+
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual(['chat-active']);
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'archived', limit: 200 }).rows.map((row) => row.chatId)).toEqual(['chat-archived']);
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'waiting', limit: 200 }).rows).toEqual([]);
   });
 
   it('preserves chat kind when detail snapshots omit the durable field', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -6,8 +6,10 @@ import type {
   ChatDetailSnapshot,
   ChatIndexCounters,
   ChatIndexGroup,
+  ChatIndexSnapshot,
   ChatIndexPatchEvent,
   ChatIndexRow,
+  PageWindow,
   ChatQueueSummary,
   ChatThreadProjection,
   ChatTimelineItem,
@@ -74,6 +76,33 @@ export type RepoWorktreeRuntimeEntity = RuntimeProjection & {
 
 export type EntityVersions = Record<EntityKind, Record<string, number>>;
 
+export type ChatIndexWindowRequest = {
+  filter?: ChatIndexSnapshot['filter'];
+  query?: string | null;
+  surfaceKind?: string | null;
+  limit?: number;
+};
+
+export type ChatIndexWindowStatus = 'idle' | 'loading' | 'ready' | 'interrupted';
+
+export type ChatIndexWindow = {
+  key: string;
+  request: Required<Pick<ChatIndexWindowRequest, 'filter'>> & {
+    query: string | null;
+    surfaceKind: string | null;
+    limit: number;
+  };
+  rowIds: string[];
+  groupIds: string[];
+  counters: ChatIndexCounters;
+  cursor: ProjectionCursor | null;
+  window: PageWindow | null;
+  status: ChatIndexWindowStatus;
+  refreshing: boolean;
+  lastLoadedAt: string | null;
+  error: string | null;
+};
+
 export type ReadModelEntityState = {
   cursors: Record<string, ProjectionCursor>;
   chatIndexCursor: ProjectionCursor | null;
@@ -82,6 +111,7 @@ export type ReadModelEntityState = {
   chatGroups: Record<string, ChatIndexGroup>;
   chatGroupOrder: string[];
   chatCounters: ChatIndexCounters;
+  chatWindows: Record<string, ChatIndexWindow>;
   chatDetails: Record<string, ChatDetailProjection>;
   timelines: Record<string, TimelineProjection>;
   chatTranscripts: Record<string, { cardsById: Record<string, ChatTranscriptCard>; order: string[] }>;
@@ -144,6 +174,7 @@ export function createInitialReadModelState(): ReadModelEntityState {
     chatGroups: {},
     chatGroupOrder: [],
     chatCounters: emptyChatCounters,
+    chatWindows: {},
     chatDetails: {},
     timelines: {},
     chatTranscripts: {},
@@ -204,19 +235,41 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     rows: ChatIndexRow[];
     groups: ChatIndexGroup[];
     counters: ChatIndexCounters;
-  }): void {
+    filter?: ChatIndexSnapshot['filter'];
+    query?: string | null;
+    window?: PageWindow;
+  }, request: ChatIndexWindowRequest = {}): void {
     const rows = uniqueChatIndexRows(snapshot.rows);
     const next = cloneState(this.state);
-    for (const id of Object.keys(next.chats)) bump(next, 'chat', id);
-    for (const id of Object.keys(next.chatGroups)) bump(next, 'chatGroup', id);
-    next.chats = keyed(rows, (row) => row.chatId);
+    const windowRequest = normalizeChatIndexWindowRequest({
+      filter: request.filter ?? snapshot.filter,
+      query: request.query ?? snapshot.query,
+      surfaceKind: request.surfaceKind,
+      limit: request.limit ?? snapshot.window?.limit
+    });
+    const windowKey = canonicalChatIndexWindowKey(windowRequest);
+    for (const row of rows) next.chats[row.chatId] = row;
+    for (const group of snapshot.groups) next.chatGroups[group.groupId] = group;
     next.chatOrder = rows.map((row) => row.chatId);
-    next.chatGroups = keyed(snapshot.groups, (group) => group.groupId);
     next.chatGroupOrder = snapshot.groups.map((group) => group.groupId);
-    next.chatCounters = snapshot.counters;
+    if (isDefaultChatIndexWindow(windowRequest)) next.chatCounters = snapshot.counters;
     next.chatIndexCursor = snapshot.cursor;
+    next.chatWindows[windowKey] = {
+      key: windowKey,
+      request: windowRequest,
+      rowIds: rows.map((row) => row.chatId),
+      groupIds: snapshot.groups.map((group) => group.groupId),
+      counters: snapshot.counters,
+      cursor: snapshot.cursor,
+      window: snapshot.window ?? null,
+      status: 'ready',
+      refreshing: false,
+      lastLoadedAt: new Date().toISOString(),
+      error: null
+    };
     next.repairRequired = false;
     rememberCursor(next, 'chat.index', snapshot.cursor);
+    rememberCursor(next, `chat.index.window:${windowKey}`, snapshot.cursor);
     for (const detail of Object.values(next.chatDetails)) {
       if (detail.thread) seedDetailBackedChatRow(next, detail.thread);
     }
@@ -239,43 +292,74 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
       if (!next.chatOrder.includes(row.chatId)) next.chatOrder.push(row.chatId);
       bump(next, 'chat', row.chatId);
     }
-    next.chatCounters = countersFromRows(next.chatOrder.map((id) => next.chats[id]).filter(Boolean));
+    const orderedRows = next.chatOrder.map((id) => next.chats[id]).filter(Boolean);
+    next.chatCounters = countersFromRows(orderedRows);
+    const windowRequest = normalizeChatIndexWindowRequest({ filter: 'all', limit: 200 });
+    const windowKey = canonicalChatIndexWindowKey(windowRequest);
+    next.chatWindows[windowKey] = {
+      key: windowKey,
+      request: windowRequest,
+      rowIds: orderedRows.map((row) => row.chatId),
+      groupIds: [],
+      counters: next.chatCounters,
+      cursor: next.chatIndexCursor,
+      window: null,
+      status: 'ready',
+      refreshing: false,
+      lastLoadedAt: new Date().toISOString(),
+      error: null
+    };
     this.commit(next);
   }
 
-  applyChatIndexPatchEvent(event: ChatIndexPatchEvent): 'applied' | 'ignored' | 'repair_required' {
+  applyChatIndexPatchEvent(event: ChatIndexPatchEvent, request: ChatIndexWindowRequest = {}): 'applied' | 'ignored' | 'repair_required' {
     if (isRepairEvent(event.envelope.eventType, event.envelope.operation)) {
       this.markRepairRequired(event.envelope.cursor);
       return 'repair_required';
     }
-    if (!isNewer(this.state.cursors['chat.index'], event.envelope.cursor)) return 'ignored';
+    const windowRequest = normalizeChatIndexWindowRequest(request);
+    const windowKey = canonicalChatIndexWindowKey(windowRequest);
+    const cursorKey = `chat.index.window:${windowKey}`;
+    if (!isNewer(this.state.cursors[cursorKey] ?? this.state.cursors['chat.index'], event.envelope.cursor)) return 'ignored';
     const next = cloneState(this.state);
+    const existingWindow = cloneChatIndexWindow(next.chatWindows[windowKey] ?? emptyChatIndexWindow(windowRequest));
     for (const row of event.patch.rows) {
       next.chats[row.chatId] = row;
       if (!next.chatOrder.includes(row.chatId)) next.chatOrder.push(row.chatId);
+      if (!existingWindow.rowIds.includes(row.chatId)) existingWindow.rowIds.push(row.chatId);
       bump(next, 'chat', row.chatId);
     }
     for (const id of event.patch.removedRowIds) {
-      delete next.chats[id];
       next.chatOrder = next.chatOrder.filter((rowId) => rowId !== id);
+      existingWindow.rowIds = existingWindow.rowIds.filter((rowId) => rowId !== id);
       bump(next, 'chat', id);
     }
     for (const group of event.patch.groups) {
       next.chatGroups[group.groupId] = group;
       if (!next.chatGroupOrder.includes(group.groupId)) next.chatGroupOrder.push(group.groupId);
+      if (!existingWindow.groupIds.includes(group.groupId)) existingWindow.groupIds.push(group.groupId);
       bump(next, 'chatGroup', group.groupId);
     }
     for (const id of event.patch.removedGroupIds) {
-      delete next.chatGroups[id];
       next.chatGroupOrder = next.chatGroupOrder.filter((groupId) => groupId !== id);
+      existingWindow.groupIds = existingWindow.groupIds.filter((groupId) => groupId !== id);
       bump(next, 'chatGroup', id);
     }
     if (event.patch.order) {
       next.chatOrder = event.patch.order.filter((id) => Boolean(next.chats[id]));
+      existingWindow.rowIds = event.patch.order.filter((id) => Boolean(next.chats[id]));
     }
-    if (event.patch.counters) next.chatCounters = event.patch.counters;
+    if (event.patch.counters && isDefaultChatIndexWindow(windowRequest)) next.chatCounters = event.patch.counters;
+    if (event.patch.counters) existingWindow.counters = event.patch.counters;
+    existingWindow.cursor = event.envelope.cursor;
+    existingWindow.status = 'ready';
+    existingWindow.refreshing = false;
+    existingWindow.lastLoadedAt = new Date().toISOString();
+    existingWindow.error = null;
+    next.chatWindows[windowKey] = existingWindow;
     next.chatIndexCursor = event.envelope.cursor;
     rememberCursor(next, 'chat.index', event.envelope.cursor);
+    rememberCursor(next, cursorKey, event.envelope.cursor);
     this.commit(next);
     return 'applied';
   }
@@ -710,6 +794,22 @@ export function selectChatIndexView(state: ReadModelEntityState): ChatIndexView 
   };
 }
 
+export function selectChatIndexWindowView(
+  state: ReadModelEntityState,
+  request: ChatIndexWindowRequest = {}
+): ChatIndexView & { window: ChatIndexWindow | null } {
+  const key = canonicalChatIndexWindowKey(request);
+  const window = state.chatWindows[key] ?? null;
+  if (!window) return { rows: [], groups: [], counters: emptyChatCounters, cursor: null, window: null };
+  return {
+    rows: window.rowIds.map((id) => state.chats[id]).filter(Boolean),
+    groups: window.groupIds.map((id) => state.chatGroups[id]).filter(Boolean),
+    counters: window.counters,
+    cursor: window.cursor,
+    window
+  };
+}
+
 export function selectChatDetailView(state: ReadModelEntityState, chatId: string | null): ChatDetailView {
   if (!chatId) return { thread: null, timeline: [], queue: null, artifacts: [] };
   const detail = state.chatDetails[chatId] ?? { thread: null, queue: null, artifactIds: [] };
@@ -735,6 +835,7 @@ function cloneState(state: ReadModelEntityState): ReadModelEntityState {
     chatGroups: { ...state.chatGroups },
     chatGroupOrder: [...state.chatGroupOrder],
     chatCounters: { ...state.chatCounters },
+    chatWindows: Object.fromEntries(Object.entries(state.chatWindows).map(([key, window]) => [key, cloneChatIndexWindow(window)])),
     chatDetails: { ...state.chatDetails },
     timelines: { ...state.timelines },
     chatTranscripts: { ...state.chatTranscripts },
@@ -799,6 +900,67 @@ function cloneChatTranscript(transcript: { cardsById: Record<string, ChatTranscr
   };
 }
 
+function cloneChatIndexWindow(window: ChatIndexWindow): ChatIndexWindow {
+  return {
+    ...window,
+    request: { ...window.request },
+    rowIds: [...window.rowIds],
+    groupIds: [...window.groupIds],
+    counters: { ...window.counters },
+    window: window.window ? { ...window.window } : null
+  };
+}
+
+function emptyChatIndexWindow(request: Required<Pick<ChatIndexWindowRequest, 'filter'>> & {
+  query: string | null;
+  surfaceKind: string | null;
+  limit: number;
+}): ChatIndexWindow {
+  const key = canonicalChatIndexWindowKey(request);
+  return {
+    key,
+    request,
+    rowIds: [],
+    groupIds: [],
+    counters: emptyChatCounters,
+    cursor: null,
+    window: null,
+    status: 'idle',
+    refreshing: false,
+    lastLoadedAt: null,
+    error: null
+  };
+}
+
+export function canonicalChatIndexWindowKey(request: ChatIndexWindowRequest = {}): string {
+  const normalized = normalizeChatIndexWindowRequest(request);
+  return JSON.stringify({
+    filter: normalized.filter,
+    query: normalized.query,
+    surfaceKind: normalized.surfaceKind,
+    limit: normalized.limit
+  });
+}
+
+function normalizeChatIndexWindowRequest(request: ChatIndexWindowRequest = {}): Required<Pick<ChatIndexWindowRequest, 'filter'>> & {
+  query: string | null;
+  surfaceKind: string | null;
+  limit: number;
+} {
+  const query = request.query?.trim() || null;
+  const surfaceKind = request.surfaceKind?.trim() || null;
+  return {
+    filter: request.filter ?? 'all',
+    query,
+    surfaceKind,
+    limit: request.limit ?? 200
+  };
+}
+
+function isDefaultChatIndexWindow(request: ReturnType<typeof normalizeChatIndexWindowRequest>): boolean {
+  return request.filter === 'all' && request.query === null && request.surfaceKind === null;
+}
+
 function keyed<T>(items: T[], key: (item: T) => string): Record<string, T> {
   const record: Record<string, T> = {};
   for (const item of items) record[key(item)] = item;
@@ -816,7 +978,10 @@ function uniqueChatIndexRows(rows: ChatIndexRow[]): ChatIndexRow[] {
 }
 
 function seedDetailBackedChatRow(state: ReadModelEntityState, thread: ChatThreadProjection): void {
-  if (state.chats[thread.chatId]) return;
+  if (state.chats[thread.chatId]) {
+    if (!state.chatOrder.includes(thread.chatId)) state.chatOrder.push(thread.chatId);
+    return;
+  }
   state.chats[thread.chatId] = {
     chatId: thread.chatId,
     surface: chatIndexSurface(thread.surface),

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -312,54 +312,40 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     this.commit(next);
   }
 
-  applyChatIndexPatchEvent(event: ChatIndexPatchEvent, request: ChatIndexWindowRequest = {}): 'applied' | 'ignored' | 'repair_required' {
+  applyChatIndexPatchEvent(event: ChatIndexPatchEvent): 'applied' | 'ignored' | 'repair_required' {
     if (isRepairEvent(event.envelope.eventType, event.envelope.operation)) {
       this.markRepairRequired(event.envelope.cursor);
       return 'repair_required';
     }
-    const windowRequest = normalizeChatIndexWindowRequest(request);
-    const windowKey = canonicalChatIndexWindowKey(windowRequest);
-    const cursorKey = `chat.index.window:${windowKey}`;
-    if (!isNewer(this.state.cursors[cursorKey] ?? this.state.cursors['chat.index'], event.envelope.cursor)) return 'ignored';
+    if (!isNewer(this.state.cursors['chat.index'], event.envelope.cursor)) return 'ignored';
     const next = cloneState(this.state);
-    const existingWindow = cloneChatIndexWindow(next.chatWindows[windowKey] ?? emptyChatIndexWindow(windowRequest));
     for (const row of event.patch.rows) {
       next.chats[row.chatId] = row;
       if (!next.chatOrder.includes(row.chatId)) next.chatOrder.push(row.chatId);
-      if (!existingWindow.rowIds.includes(row.chatId)) existingWindow.rowIds.push(row.chatId);
       bump(next, 'chat', row.chatId);
     }
     for (const id of event.patch.removedRowIds) {
+      delete next.chats[id];
       next.chatOrder = next.chatOrder.filter((rowId) => rowId !== id);
-      existingWindow.rowIds = existingWindow.rowIds.filter((rowId) => rowId !== id);
       bump(next, 'chat', id);
     }
     for (const group of event.patch.groups) {
       next.chatGroups[group.groupId] = group;
       if (!next.chatGroupOrder.includes(group.groupId)) next.chatGroupOrder.push(group.groupId);
-      if (!existingWindow.groupIds.includes(group.groupId)) existingWindow.groupIds.push(group.groupId);
       bump(next, 'chatGroup', group.groupId);
     }
     for (const id of event.patch.removedGroupIds) {
+      delete next.chatGroups[id];
       next.chatGroupOrder = next.chatGroupOrder.filter((groupId) => groupId !== id);
-      existingWindow.groupIds = existingWindow.groupIds.filter((groupId) => groupId !== id);
       bump(next, 'chatGroup', id);
     }
     if (event.patch.order) {
       next.chatOrder = event.patch.order.filter((id) => Boolean(next.chats[id]));
-      existingWindow.rowIds = event.patch.order.filter((id) => Boolean(next.chats[id]));
     }
-    if (event.patch.counters && isDefaultChatIndexWindow(windowRequest)) next.chatCounters = event.patch.counters;
-    if (event.patch.counters) existingWindow.counters = event.patch.counters;
-    existingWindow.cursor = event.envelope.cursor;
-    existingWindow.status = 'ready';
-    existingWindow.refreshing = false;
-    existingWindow.lastLoadedAt = new Date().toISOString();
-    existingWindow.error = null;
-    next.chatWindows[windowKey] = existingWindow;
+    if (event.patch.counters) next.chatCounters = event.patch.counters;
+    reconcileChatIndexWindowsAfterEntityPatch(next, event);
     next.chatIndexCursor = event.envelope.cursor;
     rememberCursor(next, 'chat.index', event.envelope.cursor);
-    rememberCursor(next, cursorKey, event.envelope.cursor);
     this.commit(next);
     return 'applied';
   }
@@ -930,6 +916,55 @@ function emptyChatIndexWindow(request: Required<Pick<ChatIndexWindowRequest, 'fi
     lastLoadedAt: null,
     error: null
   };
+}
+
+function reconcileChatIndexWindowsAfterEntityPatch(next: ReadModelEntityState, event: ChatIndexPatchEvent): void {
+  const changedRowIds = new Set([...event.patch.rows.map((row) => row.chatId), ...event.patch.removedRowIds]);
+  for (const [key, window] of Object.entries(next.chatWindows)) {
+    const defaultWindow = isDefaultChatIndexWindow(window.request);
+    const existingIds = new Set(window.rowIds);
+    window.rowIds = window.rowIds.filter((rowId) => {
+      const row = next.chats[rowId];
+      return Boolean(row && chatIndexRowMatchesWindow(row, window.request));
+    });
+    window.groupIds = window.groupIds.filter((groupId) => Boolean(next.chatGroups[groupId]));
+    if (defaultWindow && event.patch.order) window.rowIds = event.patch.order.filter((rowId) => Boolean(next.chats[rowId]));
+    if (defaultWindow && event.patch.counters) window.counters = event.patch.counters;
+    if (defaultWindow) {
+      window.cursor = event.envelope.cursor;
+      window.status = 'ready';
+      window.refreshing = false;
+      window.lastLoadedAt = new Date().toISOString();
+      window.error = null;
+      rememberCursor(next, `chat.index.window:${key}`, event.envelope.cursor);
+      continue;
+    }
+    const affected = event.patch.removedRowIds.some((rowId) => existingIds.has(rowId)) || event.patch.rows.some((row) => existingIds.has(row.chatId) || chatIndexRowMatchesWindow(row, window.request));
+    if (affected || changedRowIds.size > 0) {
+      window.status = 'interrupted';
+      window.refreshing = true;
+      window.error = null;
+    }
+  }
+}
+
+function chatIndexRowMatchesWindow(row: ChatIndexRow, request: ChatIndexWindow['request']): boolean {
+  if (request.surfaceKind && row.surface !== request.surfaceKind) return false;
+  if (!chatIndexRowMatchesFilter(row, request.filter)) return false;
+  if (!request.query) return true;
+  const query = request.query.toLocaleLowerCase();
+  return [row.title, row.repoId, row.worktreeId, row.ticketId, row.runId, row.agent, row.agentProfile, row.model]
+    .some((value) => (value ?? '').toLocaleLowerCase().includes(query));
+}
+
+function chatIndexRowMatchesFilter(row: ChatIndexRow, filter: ChatIndexSnapshot['filter']): boolean {
+  if (filter === 'waiting') return row.status === 'waiting';
+  if (filter === 'active') return row.status === 'running';
+  if (filter === 'unread') return row.unreadCount > 0;
+  if (filter === 'archived') return row.status === 'archived';
+  if (filter === 'ticket_runs') return Boolean(row.groupId);
+  if (filter === 'external') return row.surface !== 'pma';
+  return true;
 }
 
 export function canonicalChatIndexWindowKey(request: ChatIndexWindowRequest = {}): string {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -897,29 +897,7 @@ function cloneChatIndexWindow(window: ChatIndexWindow): ChatIndexWindow {
   };
 }
 
-function emptyChatIndexWindow(request: Required<Pick<ChatIndexWindowRequest, 'filter'>> & {
-  query: string | null;
-  surfaceKind: string | null;
-  limit: number;
-}): ChatIndexWindow {
-  const key = canonicalChatIndexWindowKey(request);
-  return {
-    key,
-    request,
-    rowIds: [],
-    groupIds: [],
-    counters: emptyChatCounters,
-    cursor: null,
-    window: null,
-    status: 'idle',
-    refreshing: false,
-    lastLoadedAt: null,
-    error: null
-  };
-}
-
 function reconcileChatIndexWindowsAfterEntityPatch(next: ReadModelEntityState, event: ChatIndexPatchEvent): void {
-  const changedRowIds = new Set([...event.patch.rows.map((row) => row.chatId), ...event.patch.removedRowIds]);
   for (const [key, window] of Object.entries(next.chatWindows)) {
     const defaultWindow = isDefaultChatIndexWindow(window.request);
     const existingIds = new Set(window.rowIds);
@@ -940,7 +918,7 @@ function reconcileChatIndexWindowsAfterEntityPatch(next: ReadModelEntityState, e
       continue;
     }
     const affected = event.patch.removedRowIds.some((rowId) => existingIds.has(rowId)) || event.patch.rows.some((row) => existingIds.has(row.chatId) || chatIndexRowMatchesWindow(row, window.request));
-    if (affected || changedRowIds.size > 0) {
+    if (affected) {
       window.status = 'interrupted';
       window.refreshing = true;
       window.error = null;

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
@@ -22,7 +22,7 @@ import {
 import { normalizeManagedThreadChatKind } from '$lib/viewModels/managedThreadChatKind';
 import type { PmaQueuedTurn } from '$lib/api/client';
 import type { ChatTranscriptCard } from '$lib/viewModels/pmaChat';
-import type { ReadModelEntityState } from './readModelStore';
+import { selectChatIndexWindowView, type ChatIndexWindowRequest, type ReadModelEntityState } from './readModelStore';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -151,7 +151,10 @@ export function chatIndexRowToPmaChatSummary(row: ChatIndexRow): PmaChatSummary 
   };
 }
 
-export function selectPmaChats(state: ReadModelEntityState): PmaChatSummary[] {
+export function selectPmaChats(state: ReadModelEntityState, request?: ChatIndexWindowRequest): PmaChatSummary[] {
+  if (request) {
+    return selectChatIndexWindowView(state, request).rows.map(chatIndexRowToPmaChatSummary);
+  }
   return state.chatOrder.map((id) => state.chats[id]).filter(Boolean).map(chatIndexRowToPmaChatSummary);
 }
 

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -18,6 +18,8 @@
     readModelEntityStore,
     readModelEntityTags,
     type ReadModelLoaderResult,
+    type ChatIndexWindowRequest,
+    canonicalChatIndexWindowKey,
     selectRepoSummaries,
     selectPmaArtifacts,
     selectPmaChats,
@@ -135,13 +137,6 @@
   // New chats are local drafts until the first send commits agent/scope/model
   // and message in one backend call.
   let localDraftChat = $state<PmaChatSummary | null>(null);
-  const persistedChats = $derived<PmaChatSummary[]>(selectPmaChats(readModelState));
-  const chats = $derived<PmaChatSummary[]>(localDraftChat ? [localDraftChat, ...persistedChats] : persistedChats);
-  const transcriptCards = $derived<ChatTranscriptCard[]>(selectChatTranscript(readModelState, activeChatId));
-  const progress = $derived<PmaRunProgress | null>(selectPmaProgress(readModelState, activeChatId));
-  const artifacts = $derived<SurfaceArtifact[]>(selectPmaArtifacts(readModelState, activeChatId));
-  const queuedTurns = $derived<PmaQueuedTurn[]>(selectPmaQueue(readModelState, activeChatId));
-  const lastSeenMap = $derived<ChatLastSeenMap>(selectReadMarkers(readModelState) as ChatLastSeenMap);
   let agents = $state<JsonRecord[]>([]);
   let models = $state<JsonRecord[]>([]);
   let scopeOptions = $state<PmaChatScopeOption[]>(buildPmaChatScopeOptions([], []));
@@ -159,6 +154,14 @@
   let filter = $state<ChatFilter>('all');
   let detailMode = $state<'list' | 'detail'>('list');
   let search = $state('');
+  const currentChatIndexRequest = $derived<ChatIndexWindowRequest>(chatIndexRequestForCurrentFilters());
+  const persistedChats = $derived<PmaChatSummary[]>(selectPmaChats(readModelState, currentChatIndexRequest));
+  const chats = $derived<PmaChatSummary[]>(localDraftChat ? [localDraftChat, ...persistedChats] : persistedChats);
+  const transcriptCards = $derived<ChatTranscriptCard[]>(selectChatTranscript(readModelState, activeChatId));
+  const progress = $derived<PmaRunProgress | null>(selectPmaProgress(readModelState, activeChatId));
+  const artifacts = $derived<SurfaceArtifact[]>(selectPmaArtifacts(readModelState, activeChatId));
+  const queuedTurns = $derived<PmaQueuedTurn[]>(selectPmaQueue(readModelState, activeChatId));
+  const lastSeenMap = $derived<ChatLastSeenMap>(selectReadMarkers(readModelState) as ChatLastSeenMap);
   let draft = $state('');
   let loadingChats = $state(true);
   let loadingActive = $state(false);
@@ -313,14 +316,15 @@
     })
   );
   const filteredEntries = $derived(sortEntriesForPins(filterChatEntries(chatListEntries, filter, search, lastSeenMap), pinnedChatIds));
-  const filterCounts = $derived(summarizeFilterCounts(chats, lastSeenMap));
+  const filterCounts = $derived(chatStatusFilterCounts());
   const surfaceFilterChips = $derived(chatSurfaceFilterOptions(chats));
   const ticketRunGroupCount = $derived(countTicketRunGroups(chats));
   const activeChatCount = $derived(chats.filter((chat) => !isPmaChatArchived(chat)).length);
   const hasUsableChatIndex = $derived(Boolean(readModelState.chatIndexCursor || readModelState.chatOrder.length > 0));
+  const hasSelectedChatWindow = $derived(Boolean(readModelState.chatWindows[canonicalChatIndexWindowKey(currentChatIndexRequest)]));
   const initialChatIndexError = $derived(chatIndexLoadError());
   const visibleChatError = $derived(chatError ?? (!hasUsableChatIndex ? initialChatIndexError : null));
-  const showChatListSkeleton = $derived(loadingChats && !hasUsableChatIndex && !visibleChatError);
+  const showChatListSkeleton = $derived(loadingChats && !hasSelectedChatWindow && !visibleChatError);
 
   function isGroupExpanded(group: ChatRunGroup): boolean {
     if (group.key in expandedRunGroups) return expandedRunGroups[group.key];
@@ -578,6 +582,32 @@
     return 'all';
   }
 
+  function chatIndexRequestForCurrentFilters(): ChatIndexWindowRequest {
+    return {
+      filter: readModelChatIndexFilter(filter),
+      query: search.trim() || null,
+      surfaceKind: filter.startsWith('surface:') ? filter.slice('surface:'.length) : null,
+      limit: 200
+    };
+  }
+
+  function chatStatusFilterCounts(): Record<ChatStatusFilter, number> {
+    const counters = readModelState.chatCounters;
+    const localDraftBump = localDraftChat && !isPmaChatArchived(localDraftChat) ? 1 : 0;
+    const knownPersistedChats = selectPmaChats(readModelState, { filter: 'all', limit: 200 });
+    const knownChats = localDraftChat ? [localDraftChat, ...knownPersistedChats] : knownPersistedChats;
+    // Backend counters are authoritative for status chips. Unread remains client-adjusted
+    // until backend read markers fully match local last-seen semantics.
+    const clientUnread = summarizeFilterCounts(knownChats, lastSeenMap).unread;
+    return {
+      all: counters.total + localDraftBump,
+      active: counters.running,
+      waiting: counters.waiting,
+      unread: clientUnread,
+      archived: counters.archived
+    };
+  }
+
   function composerRecipientLabel(chat: PmaChatSummary | null): string {
     if (!chat) return 'Chat';
     if (chat.repoId) {
@@ -599,7 +629,7 @@
     unsubscribeReadModels = readModelEntityStore.subscribe((state) => {
       const replacementChatId = replacementForActiveChat(readModelState, state);
       readModelState = state;
-      if (state.chatIndexCursor || state.chatOrder.length > 0) {
+      if (state.chatWindows[canonicalChatIndexWindowKey(currentChatIndexRequest)] || state.chatIndexCursor || state.chatOrder.length > 0) {
         loadingChats = false;
         chatError = null;
         activateRequestedChatFromCurrentRows();
@@ -607,7 +637,7 @@
       if (replacementChatId) void selectChat(replacementChatId);
     });
     unsubscribeChatIndexSession = chatIndexSession.state.subscribe((session) => {
-      if (session.status === 'loading' && !readModelEntityStore.snapshot().chatIndexCursor) {
+      if (session.status === 'loading' && !readModelEntityStore.snapshot().chatWindows[canonicalChatIndexWindowKey(currentChatIndexRequest)]) {
         loadingChats = true;
       }
       if (session.error) {
@@ -656,18 +686,12 @@
   });
 
   $effect(() => {
-    const requestedFilter = readModelChatIndexFilter(filter);
-    const requestedSurfaceKind = filter.startsWith('surface:') ? filter.slice('surface:'.length) : null;
-    const requestedQuery = search.trim() || null;
+    const request = currentChatIndexRequest;
+    loadingChats = !readModelState.chatWindows[canonicalChatIndexWindowKey(request)] && !hasChatIndexProjection(readModelState);
     if (chatIndexFilterRefreshTimer) window.clearTimeout(chatIndexFilterRefreshTimer);
     chatIndexFilterRefreshTimer = window.setTimeout(() => {
       chatIndexFilterRefreshTimer = null;
-      void chatIndexSession.refresh({
-        filter: requestedFilter,
-        query: requestedQuery,
-        surfaceKind: requestedSurfaceKind,
-        limit: 200
-      });
+      void chatIndexSession.refresh(request);
     }, 180);
   });
 
@@ -718,7 +742,7 @@
 
   function activateRequestedChatFromCurrentRows(): void {
     if (isLocalDraftChatId(activeChatId)) return;
-    const loadedChats = selectPmaChats(readModelEntityStore.snapshot());
+    const loadedChats = selectPmaChats(readModelEntityStore.snapshot(), currentChatIndexRequest);
     const requestedChat = page.params.chatId ?? page.url.searchParams.get('chat');
     const selectedChatId = chooseActiveChatId(loadedChats, activeChatId, requestedChat);
     if (!selectedChatId || activeChatId === selectedChatId) return;
@@ -735,10 +759,10 @@
     nextState: typeof readModelState
   ): string | null {
     if (!activeChatId) return null;
-    const previousActive = selectPmaChats(previousState).find((chat) => chat.id === activeChatId) ?? null;
+    const previousActive = selectPmaChats(previousState, currentChatIndexRequest).find((chat) => chat.id === activeChatId) ?? null;
     const previousBinding = pmaChatBindingKey(previousActive);
     if (!previousBinding) return null;
-    const nextChats = selectPmaChats(nextState);
+    const nextChats = selectPmaChats(nextState, currentChatIndexRequest);
     const nextActive = nextChats.find((chat) => chat.id === activeChatId) ?? null;
     if (nextActive && !isPmaChatArchived(nextActive)) return null;
     const replacement = nextChats.find(

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -687,7 +687,8 @@
 
   $effect(() => {
     const request = currentChatIndexRequest;
-    loadingChats = !readModelState.chatWindows[canonicalChatIndexWindowKey(request)] && !hasChatIndexProjection(readModelState);
+    const snapshot = readModelEntityStore.snapshot();
+    loadingChats = !snapshot.chatWindows[canonicalChatIndexWindowKey(request)] && !hasChatIndexProjection(snapshot);
     if (chatIndexFilterRefreshTimer) window.clearTimeout(chatIndexFilterRefreshTimer);
     chatIndexFilterRefreshTimer = window.setTimeout(() => {
       chatIndexFilterRefreshTimer = null;

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -583,6 +583,7 @@ def test_chat_index_snapshot_reads_rebuilt_sql_projection_without_reprojecting(
     assert len(all_rows["rows"]) == 1
     assert all_rows["counters"]["total"] == 2
     assert all_rows["counters"]["running"] == 1
+    assert all_rows["counters"]["archived"] == 1
     assert all_rows["window"]["total_count"] == 2
 
     active = service.chat_index_snapshot(view="active", limit=20)

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -558,6 +558,40 @@ def test_chat_index_sorts_by_conversation_activity_not_metadata_hydration(
     assert older["last_activity_at"] == "2026-05-11T00:00:10Z"
 
 
+def test_chat_index_snapshot_reads_rebuilt_sql_projection_without_reprojecting(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(hub_root, thread_id="thread-idle")
+    _seed_thread(hub_root, thread_id="thread-running", runtime_status="running")
+    _seed_thread(
+        hub_root,
+        thread_id="thread-archived",
+        lifecycle_status="archived",
+        runtime_status="completed",
+    )
+    service = ChatSurfaceReadService(hub_root, durable=False)
+    service.rebuild_chat_index_projection()
+
+    def fail_projected_surfaces(*_args, **_kwargs):
+        raise AssertionError("chat index snapshot should read SQL projection")
+
+    monkeypatch.setattr(service, "_projected_surfaces", fail_projected_surfaces)
+
+    all_rows = service.chat_index_snapshot(view="all", limit=1)
+    assert len(all_rows["rows"]) == 1
+    assert all_rows["counters"]["total"] == 2
+    assert all_rows["counters"]["running"] == 1
+    assert all_rows["window"]["total_count"] == 2
+
+    active = service.chat_index_snapshot(view="active", limit=20)
+    assert [row["managed_thread_id"] for row in active["rows"]] == ["thread-running"]
+
+    archived = service.chat_index_snapshot(view="archived", limit=20)
+    assert [row["managed_thread_id"] for row in archived["rows"]] == ["thread-archived"]
+
+
 def test_chat_index_and_detail_prefer_bound_chat_display_for_fallback_titles(
     tmp_path: Path,
 ) -> None:

--- a/tests/core/orchestration/test_sqlite_migrations.py
+++ b/tests/core/orchestration/test_sqlite_migrations.py
@@ -33,6 +33,34 @@ def test_apply_orchestration_migrations_sets_latest_schema_version(
     assert runs[0]["target_version"] == ORCHESTRATION_SCHEMA_VERSION
 
 
+def test_apply_orchestration_migrations_adds_chat_index_projection(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "orchestration.sqlite3"
+
+    with _connect(db_path) as conn:
+        apply_orchestration_migrations(conn)
+        table_names = {
+            row["name"]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        index_names = {
+            row["name"]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index'"
+            ).fetchall()
+        }
+
+    assert "orch_chat_index_projection" in table_names
+    assert "orch_chat_index_projection_meta" in table_names
+    assert "idx_orch_chat_index_projection_status" in index_names
+    assert "idx_orch_chat_index_projection_surface" in index_names
+    assert "idx_orch_chat_index_projection_group" in index_names
+    assert "idx_orch_chat_index_projection_activity" in index_names
+
+
 def test_apply_orchestration_migrations_copies_legacy_backfill_flags_into_operation_flags(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- split the chat frontend store into stable entities plus request-keyed windows so filtered snapshots no longer erase unrelated chats
- use authoritative chat index counters and stale-while-refresh window rendering for filter chips and list switching
- add a materialized SQLite chat-index projection with indexed SQL snapshot/counter queries
- move chat index streaming toward a stable entity stream key across filter changes

## Root Cause
The chat UI treated the latest filtered `/hub/read-models/chats` response as both the global entity cache and the visible query window. Changing filters replaced the whole browser chat index, so counters and rows reflected only the selected filter. Backend reads also rebuilt the chat index by replaying projection inputs on each request, adding visible lag.

## Validation
- `.venv/bin/python -m pytest tests/core/orchestration/test_chat_surface_read_model.py tests/core/orchestration/test_sqlite_migrations.py tests/surfaces/web/test_hub_chat_read_model_routes.py`
- `pnpm web:test`
