### PR TITLE
[codex] Bound chat index projection streaming

### DIFF
--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -2086,57 +2086,6 @@ def _chat_patch_from_event(event: ChatSurfaceEvent) -> dict[str, Any]:
     }
 
 
-def _chat_index_patch_event_from_surface_event(
-    event: ChatSurfaceEvent,
-    *,
-    snapshot: Mapping[str, Any],
-) -> dict[str, Any]:
-    rows_raw = snapshot.get("rows") or []
-    rows = [row for row in rows_raw if isinstance(row, Mapping)]
-    chat_id = _chat_id_for_event(event)
-    matching_rows = [
-        dict(row)
-        for row in rows
-        if _normalize_text(row.get("managed_thread_id")) == event.managed_thread_id
-        or _normalize_text(row.get("chat_id")) == chat_id
-        or _normalize_text(row.get("row_id"))
-        == f"surface:{event.surface_kind}:{event.surface_key}"
-    ]
-    removed = [] if matching_rows else [chat_id]
-    return {
-        "envelope": {
-            "event_type": "chat.index.patch",
-            "cursor": event.cursor,
-            "entity_kind": "chat",
-            "entity_id": chat_id,
-            "operation": "patch" if matching_rows else "delete",
-            "generated_at": event.created_at,
-        },
-        "patch": {
-            "rows": matching_rows,
-            "groups": [
-                dict(group)
-                for group in snapshot.get("groups") or []
-                if isinstance(group, Mapping)
-            ],
-            "removed_row_ids": removed,
-            "removed_group_ids": [],
-            "order": [
-                str(
-                    row.get("managed_thread_id")
-                    or row.get("chat_id")
-                    or row.get("row_id")
-                )
-                for row in rows
-                if row.get("managed_thread_id")
-                or row.get("chat_id")
-                or row.get("row_id")
-            ],
-            "counters": _chat_index_patch_counters(snapshot, rows),
-        },
-    }
-
-
 def _chat_index_cursor_gap_event(
     *,
     cursor: int,
@@ -2201,12 +2150,6 @@ def _chat_index_projection_invalidated_event(
             "snapshot_route": "/hub/read-models/chats",
         },
     }
-
-
-def _chat_id_for_event(event: ChatSurfaceEvent) -> str:
-    if event.managed_thread_id:
-        return event.managed_thread_id
-    return f"surface:{event.surface_kind}:{event.surface_key}"
 
 
 def _chat_index_patch_counters(

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -283,7 +283,7 @@ class ChatSurfaceReadService:
         bounded_offset = int(projection["offset"])
         bounded_limit = int(projection["limit"])
 
-        cursor = self.latest_cursor()
+        cursor = self.latest_chat_index_projection_revision()
         payload = {
             "contract_version": "chat_index_read.v1",
             "cursor": cursor,
@@ -341,12 +341,17 @@ class ChatSurfaceReadService:
         limit: int = DEFAULT_CHAT_SURFACE_EVENT_LIMIT,
         window_limit: int = DEFAULT_CHAT_INDEX_LIMIT,
     ) -> dict[str, Any]:
-        """Return typed chat-index patches backed by the chat-surface journal."""
+        """Return compact chat-index projection revision patches.
+
+        The browser stream cursor is intentionally the chat-index projection
+        revision, not the raw chat-surface journal offset.  Raw events remain the
+        reconstruction source, but stale clients repair from a bounded snapshot
+        instead of replaying historical journal rows.
+        """
 
         started_at = time.perf_counter()
         after_cursor = max(0, int(cursor or 0))
-        latest_cursor = self.latest_cursor()
-        event_limit = _bounded_limit(limit, MAX_CHAT_SURFACE_EVENT_LIMIT)
+        latest_cursor = self.latest_chat_index_projection_revision()
         if after_cursor > latest_cursor:
             gap_cursor = latest_cursor
             return {
@@ -366,18 +371,7 @@ class ChatSurfaceReadService:
                 },
             }
 
-        events = self._journal.read_events_since(after_cursor, limit=event_limit)
-        if events and events[0].cursor > after_cursor + 1:
-            gap_cursor = events[0].cursor
-            payload_events = [
-                _chat_index_cursor_gap_event(
-                    cursor=gap_cursor,
-                    requested_cursor=after_cursor,
-                    latest_cursor=latest_cursor,
-                )
-            ]
-            next_cursor = gap_cursor
-        else:
+        if after_cursor < latest_cursor:
             snapshot = self.chat_index_snapshot(
                 view=view,
                 query=query,
@@ -388,13 +382,16 @@ class ChatSurfaceReadService:
                 limit=window_limit,
             )
             payload_events = [
-                _chat_index_patch_event_from_surface_event(
-                    event,
+                _chat_index_projection_invalidated_event(
+                    cursor=latest_cursor,
+                    requested_cursor=after_cursor,
                     snapshot=snapshot,
                 )
-                for event in events
             ]
-            next_cursor = events[-1].cursor if events else after_cursor
+            next_cursor = latest_cursor
+        else:
+            payload_events = []
+            next_cursor = after_cursor
 
         payload = {
             "contract_version": "chat_index_patch_stream.v1",
@@ -631,6 +628,25 @@ class ChatSurfaceReadService:
     def latest_cursor(self) -> int:
         return self._journal.latest_cursor()
 
+    def latest_chat_index_projection_revision(self) -> int:
+        self._ensure_chat_index_projection_current()
+        with open_orchestration_sqlite(
+            self._hub_root, durable=self._durable, migrate=True
+        ) as conn:
+            row = conn.execute(
+                """
+                SELECT value
+                  FROM orch_chat_index_projection_meta
+                 WHERE key = 'projection_revision'
+                """
+            ).fetchone()
+        if row is None:
+            return 0
+        try:
+            return max(0, int(row["value"] or 0))
+        except (TypeError, ValueError):
+            return 0
+
     def rebuild_chat_index_projection(self) -> None:
         source_signature = self._chat_index_source_signature()
         surfaces = self._projected_surfaces(limit=None)
@@ -642,6 +658,24 @@ class ChatSurfaceReadService:
             self._hub_root, durable=self._durable, migrate=True
         ) as conn:
             with conn:
+                existing_meta = {
+                    str(row["key"]): str(row["value"])
+                    for row in conn.execute(
+                        """
+                        SELECT key, value
+                          FROM orch_chat_index_projection_meta
+                         WHERE key IN ('source_signature', 'projection_revision')
+                        """
+                    ).fetchall()
+                }
+                if existing_meta.get("source_signature") == source_signature:
+                    projection_revision = max(
+                        1, _safe_int(existing_meta.get("projection_revision"), 1)
+                    )
+                else:
+                    projection_revision = (
+                        _safe_int(existing_meta.get("projection_revision"), 0) + 1
+                    )
                 conn.execute("DELETE FROM orch_chat_index_projection")
                 conn.executemany(
                     """
@@ -693,6 +727,16 @@ class ChatSurfaceReadService:
                     ) VALUES ('source_signature', ?, ?)
                     """,
                     (source_signature, rebuilt_at),
+                )
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO orch_chat_index_projection_meta (
+                        key,
+                        value,
+                        updated_at
+                    ) VALUES ('projection_revision', ?, ?)
+                    """,
+                    (str(projection_revision), rebuilt_at),
                 )
 
     def _ensure_chat_index_projection_current(self) -> None:
@@ -2125,6 +2169,40 @@ def _chat_index_cursor_gap_event(
     }
 
 
+def _chat_index_projection_invalidated_event(
+    *,
+    cursor: int,
+    requested_cursor: int,
+    snapshot: Mapping[str, Any],
+) -> dict[str, Any]:
+    rows_raw = snapshot.get("rows") or []
+    rows = [row for row in rows_raw if isinstance(row, Mapping)]
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    return {
+        "envelope": {
+            "event_type": "projection.cursor_gap",
+            "cursor": cursor,
+            "entity_kind": "chat",
+            "entity_id": "chat.index",
+            "operation": "invalidate",
+            "generated_at": now,
+        },
+        "patch": {
+            "rows": [],
+            "groups": [],
+            "removed_row_ids": [],
+            "removed_group_ids": [],
+            "order": None,
+            "counters": _chat_index_patch_counters(snapshot, rows),
+        },
+        "repair": {
+            "requested_cursor": requested_cursor,
+            "latest_cursor": cursor,
+            "snapshot_route": "/hub/read-models/chats",
+        },
+    }
+
+
 def _chat_id_for_event(event: ChatSurfaceEvent) -> str:
     if event.managed_thread_id:
         return event.managed_thread_id
@@ -2152,6 +2230,13 @@ def _chat_index_patch_counters(
         "unread": sum(int(row.get("unread_count") or 0) for row in rows),
         "archived": sum(1 for row in rows if row.get("lifecycle_status") == "archived"),
     }
+
+
+def _safe_int(value: Any, fallback: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return fallback
 
 
 def _projection(

--- a/src/codex_autorunner/core/validation_lanes.py
+++ b/src/codex_autorunner/core/validation_lanes.py
@@ -48,6 +48,7 @@ _LANE_PREFIXES: dict[ScopedValidationLane, tuple[str, ...]] = {
         "tests/routes",
         "tests/contracts",
         "tests/surfaces/web",
+        "tests/web_ui_lab",
     ),
     "chat-apps": (
         "src/codex_autorunner/adapters/chat",

--- a/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
@@ -253,7 +253,9 @@ class ChatReadModelService:
         hub_off = _int_fallback(hub_window.get("offset"), offset)
         returned_len = len(hub_rows)
         win_limit = max(1, _int_fallback(hub_window.get("limit"), limit))
-        proj_cursor = projection_cursor_chat_index(self._surface.latest_cursor())
+        proj_cursor = projection_cursor_chat_index(
+            _int_fallback(payload.get("cursor"), 0)
+        )
         counters = counters_from_hub_payload(payload.get("counters"), rows, total)
 
         return ChatIndexSnapshot(
@@ -768,7 +770,7 @@ def projection_cursor_chat_index(sequence: Union[int, str]) -> ProjectionCursor:
     return ProjectionCursor(
         value=f"chat.index:{seq_eff}",
         sequence=seq_eff,
-        source="chat.surface.journal",
+        source="chat.index.projection",
         issued_at=read_model_now(),
     )
 

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -855,6 +855,53 @@ def build_managed_thread_crud_routes(
             "error_count": len(errors),
         }
 
+    @router.post("/threads/archive-active")
+    def archive_active_managed_threads(request: Request) -> dict[str, Any]:
+        service = build_managed_thread_orchestration_service(request)
+        context = get_pma_request_context(request)
+        store = context.thread_store()
+        active_thread_ids = [
+            str(thread["managed_thread_id"])
+            for thread in store.list_threads(status="active", limit=None)
+        ]
+        archived_threads: list[Any] = []
+        errors: list[dict[str, str]] = []
+
+        for managed_thread_id in active_thread_ids:
+            thread = service.get_thread_target(managed_thread_id)
+            if thread is None:
+                errors.append(
+                    {
+                        "thread_id": managed_thread_id,
+                        "detail": "Managed thread not found",
+                    }
+                )
+                continue
+
+            old_status = normalize_optional_text(thread.lifecycle_status)
+            updated = service.archive_thread_target(managed_thread_id)
+            store.append_action(
+                "managed_thread_archive",
+                managed_thread_id=managed_thread_id,
+                payload_json=json.dumps({"old_status": old_status}, ensure_ascii=True),
+            )
+            archived_threads.append(updated)
+
+        binding_metadata = _load_chat_binding_metadata_by_thread(context.hub_root)
+        return {
+            "threads": [
+                _serialize_thread_target(
+                    thread,
+                    binding_metadata_by_thread=binding_metadata,
+                )
+                for thread in archived_threads
+            ],
+            "archived_count": len(archived_threads),
+            "requested_count": len(active_thread_ids),
+            "errors": errors,
+            "error_count": len(errors),
+        }
+
     @router.get("/threads/{managed_thread_id}/turns")
     def list_managed_thread_turns(
         managed_thread_id: str,

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.test.ts
@@ -118,6 +118,15 @@ describe('API client error handling', () => {
   it('calls managed-thread slash command action endpoints', async () => {
     const fetcher = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
+      if (url.endsWith('/archive-active')) {
+        return Response.json({
+          threads: [{ thread_target_id: 'thread-1', display_name: 'PMA room' }],
+          archived_count: 1,
+          requested_count: 1,
+          error_count: 0,
+          errors: []
+        });
+      }
       if (url.endsWith('/resume') || url.endsWith('/compact') || url.endsWith('/archive')) {
         return Response.json({ thread: { thread_target_id: 'thread-1', display_name: 'PMA room' } });
       }
@@ -129,9 +138,12 @@ describe('API client error handling', () => {
     await client.pma.resumeThread('thread-1');
     await client.pma.compactThread('thread-1', 'summary');
     await client.pma.archiveThread('thread-1');
+    const archiveAll = await client.pma.archiveActiveThreads();
     await client.pma.clearQueue('thread-1');
 
+    expect(archiveAll.ok && archiveAll.data.archivedCount).toBe(1);
     expect(fetcher).toHaveBeenCalledWith('/hub/pma/threads/thread-1/interrupt', expect.objectContaining({ method: 'POST' }));
+    expect(fetcher).toHaveBeenCalledWith('/hub/pma/threads/archive-active', expect.objectContaining({ method: 'POST' }));
     expect(fetcher).toHaveBeenCalledWith(
       '/hub/pma/threads/thread-1/compact',
       expect.objectContaining({ body: JSON.stringify({ summary: 'summary', reset_backend: true }) })

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.ts
@@ -380,6 +380,19 @@ export class WebApiClient {
           errors: asArray(payload.errors)
         })
       ),
+    archiveActiveThreads: async (): Promise<ApiResult<PmaBulkArchiveResult>> =>
+      mapResult(
+        await this.requestJson<JsonRecord>('/hub/pma/threads/archive-active', {
+          method: 'POST'
+        }),
+        (payload) => ({
+          threads: asArray(payload.threads).map(mapPmaChatSummary),
+          archivedCount: numberValue(payload.archived_count ?? payload.archivedCount, 0),
+          requestedCount: numberValue(payload.requested_count ?? payload.requestedCount, 0),
+          errorCount: numberValue(payload.error_count ?? payload.errorCount, 0),
+          errors: asArray(payload.errors)
+        })
+      ),
     cancelQueuedTurn: async (chatId: string, turnId: string): Promise<ApiResult<JsonRecord>> =>
       this.requestJson<JsonRecord>(
         `/hub/pma/threads/${encodeURIComponent(chatId)}/queue/${encodeURIComponent(turnId)}/cancel`,

--- a/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
@@ -114,7 +114,7 @@ export type ChatIndexPatch = {
 };
 
 export type ChatIndexPatchEvent = {
-  envelope: ReadModelEventEnvelope<'chat.index.patch', 'chat'>;
+  envelope: ReadModelEventEnvelope<'chat.index.patch' | 'projection.cursor_gap', 'chat'>;
   patch: ChatIndexPatch;
 };
 

--- a/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.test.ts
@@ -89,6 +89,7 @@ describe('chat index session', () => {
     const session = createChatIndexSession({ client, store, streamFactory });
 
     session.start();
+    expect(streamFactory).not.toHaveBeenCalled();
     await session.refresh();
 
     const firstPage = store.subscribe(() => {});
@@ -104,6 +105,8 @@ describe('chat index session', () => {
       path: '/hub/read-models/chats/patches',
       eventTypes: ['chat.index.patch', 'projection.cursor_gap']
     }));
+    const streamOptions = streamFactory.mock.calls[0]?.[0] as ReadModelStreamOptions<ChatIndexPatchEvent>;
+    expect(streamOptions.cursorStorage?.getItem('car.readModel.cursor.chat.index.entity')).toBe('1');
     expect(selectPmaChats(store.snapshot()).map((chat) => chat.id)).toEqual(['chat-active']);
     expect(session.isStarted()).toBe(true);
 
@@ -187,6 +190,84 @@ describe('chat index session', () => {
       key: 'chat.index.entity',
       path: '/hub/read-models/chats/patches'
     }));
+  });
+
+  it('refreshes the current window when stream patches leave it under-filled', async () => {
+    const store = new ReadModelEntityStore();
+    let streamOptions: ReadModelStreamOptions<ChatIndexPatchEvent> | null = null;
+    const streamFactory = vi.fn((options: ReadModelStreamOptions<ChatIndexPatchEvent>) => {
+      streamOptions = options;
+      return {
+        open: vi.fn(),
+        close: vi.fn(),
+        cursor: vi.fn(() => null),
+        resetCursor: vi.fn()
+      } as unknown as ReadModelStreamManager<ChatIndexPatchEvent>;
+    }) as ReturnType<typeof vi.fn> & ChatIndexStreamFactory;
+    const client = {
+      chatIndex: vi
+        .fn()
+        .mockResolvedValueOnce(ok({
+          ...chatIndexSnapshot('all', [
+            indexRow('chat-visible', 'Visible chat', 'idle'),
+            indexRow('chat-window', 'Window chat', 'idle')
+          ]),
+          window: {
+            limit: 2,
+            nextCursor: null,
+            previousCursor: null,
+            totalEstimate: 3,
+            totalIsExact: true
+          },
+          counters: { total: 3, waiting: 0, running: 0, unread: 0, archived: 0 }
+        }))
+        .mockResolvedValue(ok({
+          ...chatIndexSnapshot('all', [
+            indexRow('chat-window', 'Window chat', 'idle'),
+            indexRow('chat-backfill', 'Backfill chat', 'idle')
+          ]),
+          window: {
+            limit: 2,
+            nextCursor: null,
+            previousCursor: null,
+            totalEstimate: 2,
+            totalIsExact: true
+          },
+          counters: { total: 2, waiting: 0, running: 0, unread: 0, archived: 1 }
+        }))
+    } as unknown as ReadModelSnapshotClient;
+    const session = createChatIndexSession({ client, store, streamFactory });
+
+    session.start();
+    await session.refresh({ filter: 'all', limit: 2 });
+    expect(streamOptions).not.toBeNull();
+    const options = streamOptions as unknown as ReadModelStreamOptions<ChatIndexPatchEvent>;
+    options.onEvent?.({
+      envelope: {
+        contractVersion: READ_MODEL_CONTRACT_VERSION,
+        eventType: 'chat.index.patch',
+        cursor: projCursor(2, 'test.chat.index'),
+        entityKind: 'chat',
+        entityId: 'chat-visible',
+        operation: 'patch',
+        generatedAt: issuedAt
+      },
+      patch: {
+        rows: [],
+        groups: [],
+        removedRowIds: ['chat-visible'],
+        removedGroupIds: [],
+        counters: { total: 2, waiting: 0, running: 0, unread: 0, archived: 1 }
+      }
+    }, null);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(client.chatIndex).toHaveBeenCalledTimes(2);
+    expect(client.chatIndex).toHaveBeenNthCalledWith(2, { filter: 'all', limit: 2 });
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 2 }).rows.map((row) => row.chatId)).toEqual([
+      'chat-window',
+      'chat-backfill'
+    ]);
   });
 });
 

--- a/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.test.ts
@@ -170,8 +170,8 @@ describe('chat index session', () => {
     expect(client.chatIndex).toHaveBeenNthCalledWith(1, { filter: 'all', limit: 200 });
     expect(client.chatIndex).toHaveBeenNthCalledWith(2, { filter: 'archived', limit: 200 });
     expect(store.snapshot().chatOrder).toEqual(['chat-archived']);
-    expect(Object.keys(store.snapshot().chats).sort()).toEqual(['chat-active', 'chat-archived']);
-    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual(['chat-active']);
+    expect(Object.keys(store.snapshot().chats).sort()).toEqual(['chat-archived']);
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual([]);
     expect(selectChatIndexWindowView(store.snapshot(), { filter: 'archived', limit: 200 }).rows.map((row) => row.chatId)).toEqual(['chat-archived']);
   });
 
@@ -269,6 +269,45 @@ describe('chat index session', () => {
       'chat-backfill'
     ]);
   });
+
+  it('repairs invalidated windows with one snapshot refresh', async () => {
+    const store = new ReadModelEntityStore();
+    let streamOptions: ReadModelStreamOptions<ChatIndexPatchEvent> | null = null;
+    const streamFactory = vi.fn((options: ReadModelStreamOptions<ChatIndexPatchEvent>) => {
+      streamOptions = options;
+      return {
+        open: vi.fn(),
+        close: vi.fn(),
+        cursor: vi.fn(() => null),
+        resetCursor: vi.fn()
+      } as unknown as ReadModelStreamManager<ChatIndexPatchEvent>;
+    }) as ReturnType<typeof vi.fn> & ChatIndexStreamFactory;
+    const client = mockClient();
+    const session = createChatIndexSession({ client, store, streamFactory });
+
+    session.start();
+    await session.refresh({ filter: 'all', limit: 200 });
+    const options = streamOptions as unknown as ReadModelStreamOptions<ChatIndexPatchEvent>;
+    options.onEvent?.({
+      ...chatPatchEvent(2, indexRow('chat-archived-history', 'Archived history', 'archived')),
+      envelope: {
+        ...chatPatchEvent(2, indexRow('chat-archived-history', 'Archived history', 'archived')).envelope,
+        eventType: 'projection.cursor_gap',
+        operation: 'invalidate'
+      },
+      patch: {
+        rows: [],
+        groups: [],
+        removedRowIds: [],
+        removedGroupIds: [],
+        counters: { total: 1, waiting: 0, running: 1, unread: 0, archived: 4000 }
+      }
+    }, null);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(client.chatIndex).toHaveBeenCalledTimes(2);
+    expect(Object.keys(store.snapshot().chats)).toEqual(['chat-active']);
+  });
 });
 
 function mockClient(): ReadModelSnapshotClient {
@@ -293,6 +332,33 @@ function mockStreamFactory(): ReturnType<typeof vi.fn> & ChatIndexStreamFactory 
     cursor: vi.fn(() => null),
     resetCursor: vi.fn()
   } as unknown as ReadModelStreamManager<ChatIndexPatchEvent>)) as ReturnType<typeof vi.fn> & ChatIndexStreamFactory;
+}
+
+function chatPatchEvent(sequence: number, row: ChatIndexRow): ChatIndexPatchEvent {
+  return {
+    envelope: {
+      contractVersion: READ_MODEL_CONTRACT_VERSION,
+      eventType: 'chat.index.patch',
+      cursor: projCursor(sequence, 'test.chat.index'),
+      entityKind: 'chat',
+      entityId: row.chatId,
+      operation: 'patch',
+      generatedAt: issuedAt
+    },
+    patch: {
+      rows: [row],
+      groups: [],
+      removedRowIds: [],
+      removedGroupIds: [],
+      counters: {
+        total: 1,
+        waiting: row.status === 'waiting' ? 1 : 0,
+        running: row.status === 'running' ? 1 : 0,
+        unread: 0,
+        archived: row.status === 'archived' ? 1 : 0
+      }
+    }
+  };
 }
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {

--- a/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.ts
@@ -7,8 +7,8 @@ import {
   type ChatIndexRequest,
   type ReadModelSnapshotClient
 } from './readModelClients';
-import { readModelEntityStore, type ReadModelEntityStore } from './readModelStore';
-import { openReadModelStream, type ReadModelStreamManager, type ReadModelStreamOptions } from './readModelStream';
+import { canonicalChatIndexWindowKey, readModelEntityStore, type ReadModelEntityStore } from './readModelStore';
+import { openReadModelStream, type CursorStorage, type ReadModelStreamManager, type ReadModelStreamOptions } from './readModelStream';
 
 export type ChatIndexSessionStatus = 'idle' | 'loading' | 'connected' | 'interrupted' | 'closed';
 
@@ -49,7 +49,10 @@ export function createChatIndexSession(deps: ChatIndexSessionDeps = {}): ChatInd
     if (started) return;
     started = true;
     const cached = Boolean(store.snapshot().chatIndexCursor);
-    if (!cached) void refresh();
+    if (!cached) {
+      void refresh();
+      return;
+    }
     openStream();
   }
 
@@ -99,12 +102,23 @@ export function createChatIndexSession(deps: ChatIndexSessionDeps = {}): ChatInd
       key: 'chat.index.entity',
       path: '/hub/read-models/chats/patches',
       eventTypes: ['chat.index.patch', 'projection.cursor_gap'],
+      cursorStorage: seededCursorStorage(
+        store.snapshot().chatIndexCursor?.sequence
+          ? String(store.snapshot().chatIndexCursor?.sequence)
+          : null
+      ),
       parse: parseChatIndexPatchEvent,
       onEvent: (event) => {
         const result = store.applyChatIndexPatchEvent(event);
         if (result === 'repair_required') {
           stream?.resetCursor();
           void refresh();
+          return;
+        }
+        if (result === 'applied') {
+          const key = canonicalChatIndexWindowKey(currentRequest);
+          const window = store.snapshot().chatWindows[key];
+          if (window?.status === 'interrupted') void refresh(currentRequest);
         }
       },
       onStatus: (status) => {
@@ -125,6 +139,37 @@ export function createChatIndexSession(deps: ChatIndexSessionDeps = {}): ChatInd
 }
 
 export const chatIndexSession = createChatIndexSession();
+
+const fallbackCursorMemory = new Map<string, string>();
+const fallbackCursorStorage: CursorStorage = {
+  getItem: (key) => fallbackCursorMemory.get(key) ?? null,
+  setItem: (key, value) => {
+    fallbackCursorMemory.set(key, value);
+  },
+  removeItem: (key) => {
+    fallbackCursorMemory.delete(key);
+  }
+};
+
+function seededCursorStorage(seed: string | null): CursorStorage {
+  const backing = typeof localStorage !== 'undefined' ? localStorage : fallbackCursorStorage;
+  return {
+    getItem: (key) => {
+      const current = backing.getItem(key);
+      if (cursorSequence(current) >= cursorSequence(seed)) return current;
+      return seed;
+    },
+    setItem: (key, value) => backing.setItem(key, value),
+    removeItem: (key) => backing.removeItem(key)
+  };
+}
+
+function cursorSequence(value: string | null): number {
+  if (!value) return 0;
+  const raw = value.startsWith('chat.index:') ? value.slice('chat.index:'.length) : value;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
 
 function parseChatIndexPatchEvent(event: SseEvent<unknown>): ChatIndexPatchEvent | null {
   if (event.event !== 'chat.index.patch' && event.event !== 'projection.cursor_gap' && event.event !== 'message') {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -532,7 +532,7 @@ describe('read model entity store', () => {
     expect(view.rows[0].status).toBe('running');
   });
 
-  it('keeps filtered chat index windows separate from cached chat entities', () => {
+  it('replaces the active chat index window when filters change', () => {
     const store = new ReadModelEntityStore();
     store.applyChatIndexSnapshot({
       cursor: cursor(1),
@@ -554,18 +554,15 @@ describe('read model entity store', () => {
       window: { limit: 200, totalIsExact: true, totalEstimate: 1 }
     }, { filter: 'archived', limit: 200 });
 
-    expect(Object.keys(store.snapshot().chats).sort()).toEqual(['chat-active', 'chat-archived', 'chat-waiting']);
-    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual([
-      'chat-active',
-      'chat-waiting'
-    ]);
+    expect(Object.keys(store.snapshot().chats).sort()).toEqual(['chat-archived']);
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual([]);
     expect(selectChatIndexWindowView(store.snapshot(), { filter: 'archived', limit: 200 }).rows.map((row) => row.chatId)).toEqual([
       'chat-archived'
     ]);
-    expect(store.snapshot().chatCounters).toEqual({ total: 2, waiting: 1, running: 1, unread: 0, archived: 1 });
+    expect(store.snapshot().chatCounters).toEqual({ total: 1, waiting: 0, running: 0, unread: 0, archived: 1 });
   });
 
-  it('returns cached chat index windows immediately by canonical request', () => {
+  it('keeps only the current chat index snapshot window hot', () => {
     const store = new ReadModelEntityStore();
     store.applyChatIndexSnapshot({
       cursor: cursor(1),
@@ -586,12 +583,13 @@ describe('read model entity store', () => {
       window: { limit: 200, totalIsExact: true, totalEstimate: 1 }
     }, { filter: 'archived', limit: 200 });
 
-    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual(['chat-active']);
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual([]);
     expect(selectChatIndexWindowView(store.snapshot(), { filter: 'archived', limit: 200 }).rows.map((row) => row.chatId)).toEqual(['chat-archived']);
     expect(selectChatIndexWindowView(store.snapshot(), { filter: 'waiting', limit: 200 }).rows).toEqual([]);
+    expect(Object.keys(store.snapshot().chats)).toEqual(['chat-archived']);
   });
 
-  it('applies entity chat-index patches once and marks affected cached windows stale', () => {
+  it('applies entity chat-index patches once and marks the active cached window stale', () => {
     const store = new ReadModelEntityStore();
     store.applyChatIndexSnapshot({
       cursor: cursor(1),
@@ -623,14 +621,38 @@ describe('read model entity store', () => {
     })).toBe('applied');
 
     const activeWindow = selectChatIndexWindowView(store.snapshot(), { filter: 'active', limit: 200 });
-    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual([
-      'chat-active',
-      'chat-waiting'
-    ]);
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual([]);
     expect(activeWindow.rows.map((row) => row.chatId)).toEqual([]);
     expect(activeWindow.window?.status).toBe('interrupted');
     expect(activeWindow.window?.refreshing).toBe(true);
     expect(store.snapshot().cursors['chat.index'].sequence).toBe(2);
+  });
+
+  it('does not retain off-window archived row patches in the chat index cache', () => {
+    const store = new ReadModelEntityStore();
+    store.applyChatIndexSnapshot({
+      cursor: cursor(10),
+      rows: [chat('chat-visible')],
+      groups: [],
+      counters: { total: 1, waiting: 0, running: 0, unread: 0, archived: 3000 },
+      filter: 'all',
+      query: null,
+      window: { limit: 1, totalIsExact: true, totalEstimate: 1 }
+    }, { filter: 'all', limit: 1 });
+
+    expect(store.applyChatIndexPatchEvent({
+      ...chatPatch(11, chat('chat-archived-history', 'archived')),
+      patch: {
+        rows: [chat('chat-archived-history', 'archived')],
+        groups: [],
+        removedRowIds: [],
+        removedGroupIds: [],
+        counters: { total: 1, waiting: 0, running: 0, unread: 0, archived: 3001 }
+      }
+    })).toBe('applied');
+
+    expect(Object.keys(store.snapshot().chats)).toEqual(['chat-visible']);
+    expect(store.snapshot().chatCounters.archived).toBe(3001);
   });
 
   it('marks the default chat window interrupted when archive patches under-fill it', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -633,6 +633,43 @@ describe('read model entity store', () => {
     expect(store.snapshot().cursors['chat.index'].sequence).toBe(2);
   });
 
+  it('marks the default chat window interrupted when archive patches under-fill it', () => {
+    const store = new ReadModelEntityStore();
+    store.applyChatIndexSnapshot({
+      cursor: cursor(1),
+      rows: [chat('chat-visible'), chat('chat-next-page')],
+      groups: [],
+      counters: { total: 3, waiting: 0, running: 0, unread: 0, archived: 0 },
+      filter: 'all',
+      query: null,
+      window: { limit: 2, totalIsExact: true, totalEstimate: 3 }
+    }, { filter: 'all', limit: 2 });
+
+    expect(store.applyChatIndexPatchEvent({
+      envelope: {
+        contractVersion: READ_MODEL_CONTRACT_VERSION,
+        eventType: 'chat.index.patch',
+        cursor: cursor(2),
+        entityKind: 'chat',
+        entityId: 'chat-visible',
+        operation: 'patch',
+        generatedAt: now
+      },
+      patch: {
+        rows: [],
+        groups: [],
+        removedRowIds: ['chat-visible'],
+        removedGroupIds: [],
+        counters: { total: 2, waiting: 0, running: 0, unread: 0, archived: 1 }
+      }
+    })).toBe('applied');
+
+    const allWindow = selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 2 });
+    expect(allWindow.rows.map((row) => row.chatId)).toEqual(['chat-next-page']);
+    expect(allWindow.window?.status).toBe('interrupted');
+    expect(allWindow.window?.refreshing).toBe(true);
+  });
+
   it('preserves chat kind when detail snapshots omit the durable field', () => {
     const store = new ReadModelEntityStore();
     const row = chat('chat-1');

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -559,7 +559,7 @@ describe('read model entity store', () => {
     expect(selectChatIndexWindowView(store.snapshot(), { filter: 'archived', limit: 200 }).rows.map((row) => row.chatId)).toEqual([
       'chat-archived'
     ]);
-    expect(store.snapshot().chatCounters).toEqual({ total: 1, waiting: 0, running: 0, unread: 0, archived: 1 });
+    expect(store.snapshot().chatCounters).toEqual({ total: 2, waiting: 1, running: 1, unread: 0, archived: 1 });
   });
 
   it('keeps only the current chat index snapshot window hot', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -906,12 +906,14 @@ function reconcileChatIndexWindowsAfterEntityPatch(next: ReadModelEntityState, e
       return Boolean(row && chatIndexRowMatchesWindow(row, window.request));
     });
     window.groupIds = window.groupIds.filter((groupId) => Boolean(next.chatGroups[groupId]));
-    if (defaultWindow && event.patch.order) window.rowIds = event.patch.order.filter((rowId) => Boolean(next.chats[rowId]));
-    if (defaultWindow && event.patch.counters) window.counters = event.patch.counters;
     if (defaultWindow) {
+      if (event.patch.order) window.rowIds = event.patch.order.filter((rowId) => Boolean(next.chats[rowId]));
+      if (event.patch.counters) window.counters = event.patch.counters;
       window.cursor = event.envelope.cursor;
-      window.status = 'ready';
-      window.refreshing = false;
+      const affected = event.patch.removedRowIds.some((rowId) => existingIds.has(rowId)) || event.patch.rows.some((row) => existingIds.has(row.chatId) || chatIndexRowMatchesWindow(row, window.request));
+      const needsBackfill = affected && !event.patch.order && (window.window?.totalEstimate ?? window.rowIds.length) > window.rowIds.length;
+      window.status = needsBackfill ? 'interrupted' : 'ready';
+      window.refreshing = needsBackfill;
       window.lastLoadedAt = new Date().toISOString();
       window.error = null;
       rememberCursor(next, `chat.index.window:${key}`, event.envelope.cursor);

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -255,7 +255,7 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     for (const group of snapshot.groups) next.chatGroups[group.groupId] = group;
     next.chatOrder = rows.map((row) => row.chatId);
     next.chatGroupOrder = snapshot.groups.map((group) => group.groupId);
-    next.chatCounters = snapshot.counters;
+    if (isDefaultChatIndexWindow(windowRequest)) next.chatCounters = snapshot.counters;
     next.chatIndexCursor = snapshot.cursor;
     next.chatWindows[windowKey] = {
       key: windowKey,

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -248,11 +248,14 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
       limit: request.limit ?? snapshot.window?.limit
     });
     const windowKey = canonicalChatIndexWindowKey(windowRequest);
+    next.chatWindows = {};
+    next.chats = {};
+    next.chatGroups = {};
     for (const row of rows) next.chats[row.chatId] = row;
     for (const group of snapshot.groups) next.chatGroups[group.groupId] = group;
     next.chatOrder = rows.map((row) => row.chatId);
     next.chatGroupOrder = snapshot.groups.map((group) => group.groupId);
-    if (isDefaultChatIndexWindow(windowRequest)) next.chatCounters = snapshot.counters;
+    next.chatCounters = snapshot.counters;
     next.chatIndexCursor = snapshot.cursor;
     next.chatWindows[windowKey] = {
       key: windowKey,
@@ -275,6 +278,7 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     }
     for (const row of rows) bump(next, 'chat', row.chatId);
     for (const group of snapshot.groups) bump(next, 'chatGroup', group.groupId);
+    pruneChatIndexCache(next);
     this.commit(next);
   }
 
@@ -318,8 +322,17 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
       return 'repair_required';
     }
     if (!isNewer(this.state.cursors['chat.index'], event.envelope.cursor)) return 'ignored';
+    if (Object.keys(this.state.chatWindows).length === 0) {
+      this.markRepairRequired(event.envelope.cursor);
+      return 'repair_required';
+    }
     const next = cloneState(this.state);
+    const incomingRows = new Map(event.patch.rows.map((row) => [row.chatId, row]));
+    const orderedRowIds = new Set(event.patch.order ?? []);
     for (const row of event.patch.rows) {
+      const known = Boolean(next.chats[row.chatId]);
+      const orderedIntoCachedWindow = orderedRowIds.has(row.chatId) && Object.values(next.chatWindows).some((window) => chatIndexRowMatchesWindow(row, window.request));
+      if (!known && !orderedIntoCachedWindow) continue;
       next.chats[row.chatId] = row;
       if (!next.chatOrder.includes(row.chatId)) next.chatOrder.push(row.chatId);
       bump(next, 'chat', row.chatId);
@@ -339,13 +352,12 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
       next.chatGroupOrder = next.chatGroupOrder.filter((groupId) => groupId !== id);
       bump(next, 'chatGroup', id);
     }
-    if (event.patch.order) {
-      next.chatOrder = event.patch.order.filter((id) => Boolean(next.chats[id]));
-    }
+    if (event.patch.order) next.chatOrder = event.patch.order.filter((id) => Boolean(next.chats[id] ?? incomingRows.get(id)));
     if (event.patch.counters) next.chatCounters = event.patch.counters;
     reconcileChatIndexWindowsAfterEntityPatch(next, event);
     next.chatIndexCursor = event.envelope.cursor;
     rememberCursor(next, 'chat.index', event.envelope.cursor);
+    pruneChatIndexCache(next);
     this.commit(next);
     return 'applied';
   }
@@ -898,6 +910,7 @@ function cloneChatIndexWindow(window: ChatIndexWindow): ChatIndexWindow {
 }
 
 function reconcileChatIndexWindowsAfterEntityPatch(next: ReadModelEntityState, event: ChatIndexPatchEvent): void {
+  const incomingRows = new Map(event.patch.rows.map((row) => [row.chatId, row]));
   for (const [key, window] of Object.entries(next.chatWindows)) {
     const defaultWindow = isDefaultChatIndexWindow(window.request);
     const existingIds = new Set(window.rowIds);
@@ -907,10 +920,14 @@ function reconcileChatIndexWindowsAfterEntityPatch(next: ReadModelEntityState, e
     });
     window.groupIds = window.groupIds.filter((groupId) => Boolean(next.chatGroups[groupId]));
     if (defaultWindow) {
-      if (event.patch.order) window.rowIds = event.patch.order.filter((rowId) => Boolean(next.chats[rowId]));
+      if (event.patch.order) {
+        window.rowIds = event.patch.order
+          .filter((rowId) => Boolean(next.chats[rowId] ?? incomingRows.get(rowId)))
+          .slice(0, window.request.limit);
+      }
       if (event.patch.counters) window.counters = event.patch.counters;
       window.cursor = event.envelope.cursor;
-      const affected = event.patch.removedRowIds.some((rowId) => existingIds.has(rowId)) || event.patch.rows.some((row) => existingIds.has(row.chatId) || chatIndexRowMatchesWindow(row, window.request));
+      const affected = event.patch.removedRowIds.some((rowId) => existingIds.has(rowId)) || event.patch.rows.some((row) => existingIds.has(row.chatId) || (event.patch.order ? event.patch.order.includes(row.chatId) : chatIndexRowMatchesWindow(row, window.request)));
       const needsBackfill = affected && !event.patch.order && (window.window?.totalEstimate ?? window.rowIds.length) > window.rowIds.length;
       window.status = needsBackfill ? 'interrupted' : 'ready';
       window.refreshing = needsBackfill;
@@ -926,6 +943,47 @@ function reconcileChatIndexWindowsAfterEntityPatch(next: ReadModelEntityState, e
       window.error = null;
     }
   }
+}
+
+function pruneChatIndexCache(state: ReadModelEntityState): void {
+  const retainedChatIds = retainedChatIndexRowIds(state);
+  for (const chatId of Object.keys(state.chats)) {
+    if (retainedChatIds.has(chatId)) continue;
+    delete state.chats[chatId];
+    delete state.versions.chat[chatId];
+  }
+  state.chatOrder = state.chatOrder.filter((chatId) => retainedChatIds.has(chatId) && Boolean(state.chats[chatId]));
+
+  const retainedGroupIds = new Set<string>();
+  for (const window of Object.values(state.chatWindows)) {
+    for (const groupId of window.groupIds) retainedGroupIds.add(groupId);
+  }
+  for (const groupId of Object.keys(state.chatGroups)) {
+    if (retainedGroupIds.has(groupId)) continue;
+    delete state.chatGroups[groupId];
+    delete state.versions.chatGroup[groupId];
+  }
+  state.chatGroupOrder = state.chatGroupOrder.filter((groupId) => retainedGroupIds.has(groupId) && Boolean(state.chatGroups[groupId]));
+}
+
+function retainedChatIndexRowIds(state: ReadModelEntityState): Set<string> {
+  const retained = new Set<string>();
+  for (const window of Object.values(state.chatWindows)) {
+    for (const chatId of window.rowIds) retained.add(chatId);
+  }
+  for (const [chatId, detail] of Object.entries(state.chatDetails)) {
+    if (detail.thread) retained.add(chatId);
+  }
+  for (const chatId of Object.keys(state.chatTranscripts)) retained.add(chatId);
+  for (const chatId of Object.keys(state.pmaProgress)) retained.add(chatId);
+  for (const chatId of Object.keys(state.pmaQueues)) retained.add(chatId);
+  for (const chatId of Object.keys(state.pmaArtifacts)) {
+    if (chatId !== '__global__') retained.add(chatId);
+  }
+  for (const mutation of Object.values(state.optimistic)) {
+    if (mutation.entityKind === 'chat' && mutation.entityId !== '*') retained.add(mutation.entityId);
+  }
+  return retained;
 }
 
 function chatIndexRowMatchesWindow(row: ChatIndexRow, request: ChatIndexWindow['request']): boolean {
@@ -1104,7 +1162,7 @@ function isNewer(previous: ProjectionCursor | undefined | null, next: Projection
 }
 
 function isRepairEvent(eventType: string, operation: string): boolean {
-  return eventType === 'projection.cursor_gap' || operation === 'reset';
+  return eventType === 'projection.cursor_gap' || operation === 'reset' || operation === 'invalidate';
 }
 
 function countersFromRows(rows: ChatIndexRow[]): ChatIndexCounters {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -319,7 +319,7 @@
   const filterCounts = $derived(chatStatusFilterCounts());
   const surfaceFilterChips = $derived(chatSurfaceFilterOptions(chats));
   const ticketRunGroupCount = $derived(countTicketRunGroups(chats));
-  const activeChatCount = $derived(chats.filter((chat) => !isPmaChatArchived(chat)).length);
+  const activeChatCount = $derived(readModelState.chatCounters.total + (localDraftChat && !isPmaChatArchived(localDraftChat) ? 1 : 0));
   const hasUsableChatIndex = $derived(Boolean(readModelState.chatIndexCursor || readModelState.chatOrder.length > 0));
   const hasSelectedChatWindow = $derived(Boolean(readModelState.chatWindows[canonicalChatIndexWindowKey(currentChatIndexRequest)]));
   const initialChatIndexError = $derived(chatIndexLoadError());
@@ -1044,19 +1044,19 @@
   }
 
   async function archiveAllActiveChats(): Promise<void> {
-    const targets = chats.filter((chat) => !isPmaChatArchived(chat)).map((chat) => chat.id);
-    if (!targets.length || archiving) return;
+    if (activeChatCount <= 0 || archiving) return;
     const ok = await confirmDialog({
       title: 'Archive active chats',
-      message: `Archive ${targets.length} active chat${targets.length === 1 ? '' : 's'}?`,
+      message: `Archive ${activeChatCount} active chat${activeChatCount === 1 ? '' : 's'}?`,
       confirmText: 'Archive',
       danger: true
     });
     if (!ok) return;
     archiving = true;
     composeError = null;
-    const result = await webApi.pma.archiveThreads(targets);
+    const result = await webApi.pma.archiveActiveThreads();
     if (result.ok) {
+      const targets = result.data.threads.map((chat) => chat.id);
       await invalidateChatMutations(targets);
       showCommandNotice(
         result.data.errorCount > 0

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -559,10 +559,10 @@ def test_hub_read_models_chats_includes_binding_display_contract_fields(
     assert row["sortKey"]["row_id"] == "thread:thread-0003"
 
 
-def test_hub_read_models_chats_patch_stream_replays_typed_events(hub_env) -> None:
+def test_hub_read_models_chats_patch_stream_uses_projection_revisions(hub_env) -> None:
     _seed_thread_rows(hub_env.hub_root, 2)
     journal = SQLiteChatSurfaceEventJournal(hub_env.hub_root, durable=True)
-    first = journal.append_event(
+    journal.append_event(
         idempotency_key="index-patch-1",
         event_type="queue.state_changed",
         surface_kind="pma",
@@ -570,8 +570,13 @@ def test_hub_read_models_chats_patch_stream_replays_typed_events(hub_env) -> Non
         managed_thread_id="thread-0000",
         repo_id="repo",
         status="queued",
-    ).event
-    second = journal.append_event(
+    )
+
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    snapshot = client.get("/hub/read-models/chats").json()
+    snapshot_cursor = snapshot["cursor"]["sequence"]
+
+    journal.append_event(
         idempotency_key="index-patch-2",
         event_type="delivery.status_changed",
         surface_kind="discord",
@@ -580,52 +585,85 @@ def test_hub_read_models_chats_patch_stream_replays_typed_events(hub_env) -> Non
         repo_id="repo",
         status="delivered",
         payload={"display": {"display_name": "Ops channel"}},
-    ).event
+    )
 
-    client = TestClient(create_hub_app(hub_env.hub_root))
     response = client.get(
         "/hub/read-models/chats/patches",
-        params={"cursor": str(first.cursor), "once": "true"},
+        params={"cursor": str(snapshot_cursor), "once": "true"},
     )
 
     assert response.status_code == 200
-    patches = _event_payloads(response.text, "chat.index.patch")
-    assert [patch["envelope"]["cursor"]["sequence"] for patch in patches] == [
-        second.cursor
-    ]
-    assert patches[0]["envelope"]["eventType"] == "chat.index.patch"
-    assert patches[0]["patch"]["rows"][0]["chatId"] == "thread-0001"
-    assert patches[0]["patch"]["order"]
+    repairs = _event_payloads(response.text, "projection.cursor_gap")
+    assert len(repairs) == 1
+    assert repairs[0]["envelope"]["cursor"]["sequence"] == snapshot_cursor + 1
+    assert repairs[0]["envelope"]["eventType"] == "projection.cursor_gap"
+    assert repairs[0]["patch"]["rows"] == []
+    assert repairs[0]["patch"]["counters"]["total"] == 2
 
 
-def test_hub_read_models_chats_patch_counters_cover_full_filtered_set(
+def test_hub_read_models_chats_patch_stream_does_not_replay_historical_events(
     hub_env,
 ) -> None:
-    _seed_thread_rows(hub_env.hub_root, 30)
-    event = (
-        SQLiteChatSurfaceEventJournal(hub_env.hub_root, durable=True)
-        .append_event(
-            idempotency_key="index-patch-windowed-counters",
-            event_type="delivery.status_changed",
+    _seed_thread_rows(hub_env.hub_root, 1)
+    journal = SQLiteChatSurfaceEventJournal(hub_env.hub_root, durable=True)
+    for index in range(1200):
+        journal.append_event(
+            idempotency_key=f"historical-archive-{index}",
+            event_type="surface.archived",
             surface_kind="pma",
-            surface_key="thread-0029",
-            managed_thread_id="thread-0029",
+            surface_key=f"old-thread-{index}",
+            managed_thread_id=f"old-thread-{index}",
             repo_id="repo",
-            status="delivered",
+            lifecycle_status="archived",
+            status="archived",
         )
-        .event
-    )
 
     client = TestClient(create_hub_app(hub_env.hub_root))
     response = client.get(
         "/hub/read-models/chats/patches",
-        params={"cursor": str(event.cursor - 1), "once": "true", "window_limit": 1},
+        params={"cursor": "0", "once": "true", "event_limit": 1000},
     )
 
     assert response.status_code == 200
-    patches = _event_payloads(response.text, "chat.index.patch")
-    assert patches[0]["patch"]["counters"]["total"] == 29
-    assert patches[0]["patch"]["counters"]["running"] == 1
+    assert _event_payloads(response.text, "chat.index.patch") == []
+    repairs = _event_payloads(response.text, "projection.cursor_gap")
+    assert len(repairs) == 1
+    assert repairs[0]["envelope"]["operation"] == "invalidate"
+    assert repairs[0]["envelope"]["cursor"]["sequence"] > 0
+
+
+def test_hub_read_models_chats_patch_stream_bulk_archive_is_bounded(
+    hub_env,
+) -> None:
+    _seed_thread_rows(hub_env.hub_root, 300)
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    snapshot = client.get("/hub/read-models/chats").json()
+    snapshot_cursor = snapshot["cursor"]["sequence"]
+
+    journal = SQLiteChatSurfaceEventJournal(hub_env.hub_root, durable=True)
+    for index in range(300):
+        journal.append_event(
+            idempotency_key=f"bulk-archive-{index}",
+            event_type="surface.archived",
+            surface_kind="pma",
+            surface_key=f"thread-{index:04d}",
+            managed_thread_id=f"thread-{index:04d}",
+            repo_id="repo",
+            lifecycle_status="archived",
+            status="archived",
+        )
+
+    response = client.get(
+        "/hub/read-models/chats/patches",
+        params={"cursor": str(snapshot_cursor), "once": "true", "event_limit": 1000},
+    )
+
+    assert response.status_code == 200
+    assert _event_payloads(response.text, "chat.index.patch") == []
+    repairs = _event_payloads(response.text, "projection.cursor_gap")
+    assert len(repairs) == 1
+    assert repairs[0]["envelope"]["cursor"]["sequence"] == snapshot_cursor + 1
+    assert repairs[0]["patch"]["counters"]["archived"] >= 300
 
 
 def test_hub_read_models_chats_patch_stream_repairs_future_cursor(hub_env) -> None:

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -87,6 +87,44 @@ def _seed_thread_rows(hub_root: Path, count: int) -> None:
                     )
 
 
+def _seed_archived_surface_events(hub_root: Path, count: int, *, prefix: str) -> None:
+    with open_orchestration_sqlite(hub_root, durable=True, migrate=True) as conn:
+        with conn:
+            conn.executemany(
+                """
+                INSERT INTO orch_chat_surface_events (
+                    idempotency_key,
+                    event_type,
+                    surface_kind,
+                    surface_key,
+                    managed_thread_id,
+                    repo_id,
+                    lifecycle_status,
+                    status,
+                    occurred_at,
+                    created_at,
+                    payload_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    (
+                        f"{prefix}-{index}",
+                        "surface.archived",
+                        "pma",
+                        f"old-thread-{index}",
+                        f"old-thread-{index}",
+                        "repo",
+                        "archived",
+                        "archived",
+                        "2026-05-11T00:00:00Z",
+                        "2026-05-11T00:00:00Z",
+                        "{}",
+                    )
+                    for index in range(count)
+                ),
+            )
+
+
 def _event_payloads(text: str, event_name: str) -> list[dict]:
     payloads: list[dict] = []
     current_event: str | None = None
@@ -605,18 +643,7 @@ def test_hub_read_models_chats_patch_stream_does_not_replay_historical_events(
     hub_env,
 ) -> None:
     _seed_thread_rows(hub_env.hub_root, 1)
-    journal = SQLiteChatSurfaceEventJournal(hub_env.hub_root, durable=True)
-    for index in range(1200):
-        journal.append_event(
-            idempotency_key=f"historical-archive-{index}",
-            event_type="surface.archived",
-            surface_kind="pma",
-            surface_key=f"old-thread-{index}",
-            managed_thread_id=f"old-thread-{index}",
-            repo_id="repo",
-            lifecycle_status="archived",
-            status="archived",
-        )
+    _seed_archived_surface_events(hub_env.hub_root, 1200, prefix="historical-archive")
 
     client = TestClient(create_hub_app(hub_env.hub_root))
     response = client.get(

--- a/tests/test_managed_threads_routes.py
+++ b/tests/test_managed_threads_routes.py
@@ -1790,6 +1790,45 @@ def test_archive_managed_threads_bulk_route_archives_multiple_threads(
     assert store.get_thread(second_id)["lifecycle_status"] == "archived"
 
 
+def test_archive_active_managed_threads_route_archives_beyond_list_window(
+    hub_env,
+) -> None:
+    app = create_hub_app(hub_env.hub_root)
+    store = ManagedThreadStore(hub_env.hub_root)
+    active_ids = [
+        store.create_thread(
+            "codex",
+            hub_env.repo_root.resolve(),
+            repo_id=hub_env.repo_id,
+            name=f"Thread {index}",
+        )["managed_thread_id"]
+        for index in range(205)
+    ]
+    archived = store.create_thread(
+        "codex",
+        hub_env.repo_root.resolve(),
+        repo_id=hub_env.repo_id,
+        name="Already archived",
+    )["managed_thread_id"]
+    store.archive_thread(archived)
+
+    with TestClient(app) as client:
+        archive_resp = client.post("/hub/pma/threads/archive-active")
+
+    assert archive_resp.status_code == 200
+    payload = archive_resp.json()
+    assert payload["requested_count"] == 205
+    assert payload["archived_count"] == 205
+    assert payload["error_count"] == 0
+
+    refreshed = ManagedThreadStore(hub_env.hub_root)
+    assert all(
+        refreshed.get_thread(managed_thread_id)["lifecycle_status"] == "archived"
+        for managed_thread_id in active_ids
+    )
+    assert refreshed.get_thread(archived)["lifecycle_status"] == "archived"
+
+
 def test_managed_thread_queue_routes_list_cancel_and_clear(hub_env) -> None:
     store = ManagedThreadStore(hub_env.hub_root)
     created = store.create_thread(

--- a/tests/test_select_ci_validation_jobs_script.py
+++ b/tests/test_select_ci_validation_jobs_script.py
@@ -102,6 +102,31 @@ def test_select_ci_validation_jobs_routes_web_core_contract_to_web_ui_job() -> N
     assert payload["run_aggregate"] is False
 
 
+def test_select_ci_validation_jobs_routes_web_ui_lab_to_web_ui_job() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_script_path()),
+            "--format",
+            "json",
+            "tests/web_ui_lab/test_scenario_corpus.py",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["lane"] == "web-ui"
+    assert payload["reason"] == "single-lane-diff"
+    assert payload["unknown_paths"] == []
+    assert payload["run_core"] is False
+    assert payload["run_web_ui"] is True
+    assert payload["run_chat_apps"] is False
+    assert payload["run_aggregate"] is False
+
+
 def test_select_ci_validation_jobs_script_runs_without_site_packages() -> None:
     result = subprocess.run(
         [

--- a/tests/web_ui_lab/corpus.py
+++ b/tests/web_ui_lab/corpus.py
@@ -229,6 +229,28 @@ WEB_UI_SCENARIOS: tuple[WebUiScenario, ...] = (
         tags=(ScenarioTag.FAST, ScenarioTag.BROWSER, ScenarioTag.CRITICAL),
     ),
     _scenario(
+        scenario_id="chat_index_high_history_bounded_startup",
+        title="Chat list with high archived history",
+        route_name="chat",
+        seed_fixture=SeedFixtureKind.CHAT_INDEX_HIGH_HISTORY,
+        visible_landmarks=(
+            "Chats",
+            "Search chats, repos, tickets",
+            "Visible active chat",
+        ),
+        read_model_routes=(
+            "/hub/read-models/chats?filter=all&limit=200",
+            "/hub/read-models/chats/patches",
+        ),
+        api_routes=("/hub/pma/threads",),
+        frontend_mappers=("pmaChat.ts", "readModelClients.ts", "readModelStore.ts"),
+        tags=(ScenarioTag.FAST, ScenarioTag.BROWSER, ScenarioTag.LARGE_STATE),
+        notes=(
+            "Regression seed: thousands of archived chat-index events with one visible "
+            "active chat; startup should use the snapshot cursor and avoid patch replay."
+        ),
+    ),
+    _scenario(
         scenario_id="pma_new_chat_creation",
         title="PMA new chat creation",
         route_name="chat",

--- a/tests/web_ui_lab/fixtures.py
+++ b/tests/web_ui_lab/fixtures.py
@@ -28,6 +28,7 @@ def build_fixture_payload(fixture_kind: SeedFixtureKind) -> JsonDict:
         SeedFixtureKind.PMA_DUPLICATE_REPAIR: _pma_duplicate_repair,
         SeedFixtureKind.PMA_DISCORD_WEB_HANDOFF: _pma_discord_web_handoff,
         SeedFixtureKind.PMA_GROUPED_TOOLS: _pma_grouped_tools,
+        SeedFixtureKind.CHAT_INDEX_HIGH_HISTORY: _chat_index_high_history,
     }
     return builders[fixture_kind]()
 
@@ -132,6 +133,29 @@ def _chat_list_detail() -> JsonDict:
             "last_activity_at": "2026-05-01T10:09:00Z",
         },
     ]
+    return payload
+
+
+def _chat_index_high_history() -> JsonDict:
+    payload = _seeded_repo_worktree_ticket()
+    payload["chats"] = [
+        {
+            "thread_target_id": "chat-visible-active",
+            "title": "Visible active chat",
+            "status": "idle",
+            "agent_id": "codex",
+            "repo_id": "smoke-repo",
+            "worktree_id": "smoke-repo--review",
+            "last_activity_at": "2026-05-01T10:10:00Z",
+            "progress_percent": 0,
+        }
+    ]
+    payload["chat_index_history"] = {
+        "archived_event_count": 4000,
+        "visible_active_chat_count": 1,
+        "expected_patch_stream_startup_events_max": 1,
+        "patch_route": "/hub/read-models/chats/patches",
+    }
     return payload
 
 

--- a/tests/web_ui_lab/scenario_models.py
+++ b/tests/web_ui_lab/scenario_models.py
@@ -23,6 +23,7 @@ class SeedFixtureKind(str, Enum):
     PMA_DUPLICATE_REPAIR = "pma_duplicate_repair"
     PMA_DISCORD_WEB_HANDOFF = "pma_discord_web_handoff"
     PMA_GROUPED_TOOLS = "pma_grouped_tools"
+    CHAT_INDEX_HIGH_HISTORY = "chat_index_high_history"
 
 
 class ViewportName(str, Enum):

--- a/tests/web_ui_lab/test_scenario_corpus.py
+++ b/tests/web_ui_lab/test_scenario_corpus.py
@@ -80,6 +80,7 @@ def test_high_signal_seed_states_are_present() -> None:
         SeedFixtureKind.PMA_DUPLICATE_REPAIR,
         SeedFixtureKind.PMA_DISCORD_WEB_HANDOFF,
         SeedFixtureKind.PMA_GROUPED_TOOLS,
+        SeedFixtureKind.CHAT_INDEX_HIGH_HISTORY,
     }
     missing = required.difference(fixture_kinds)
     assert not missing, f"high-signal fixture coverage missing: {missing}"
@@ -145,6 +146,24 @@ def test_unknown_status_invariant_uses_normalized_screen_model() -> None:
         for chat in screen_model["cursor_snapshot"]["normalized_records"]["chats"]
         if chat.get("status") == "mystery-new-state"
     )
+
+
+def test_chat_index_high_history_regression_seed_is_bounded() -> None:
+    scenario = next(
+        item
+        for item in WEB_UI_SCENARIOS
+        if item.seed_fixture is SeedFixtureKind.CHAT_INDEX_HIGH_HISTORY
+    )
+    payload = build_fixture_payload(scenario.seed_fixture)
+    screen_model = _normalize_screen_model(scenario, payload)
+
+    assert payload["chat_index_history"]["archived_event_count"] >= 4000
+    assert (
+        payload["chat_index_history"]["expected_patch_stream_startup_events_max"] == 1
+    )
+    assert screen_model["row_count"] == 1
+    assert screen_model["visible_rows"] == 1
+    assert "/hub/read-models/chats/patches" in scenario.read_models.read_model_routes
 
 
 def test_missing_optional_fields_invariant_reruns_screen_normalization() -> None:


### PR DESCRIPTION
## Summary

- replace chat-index patch streaming from raw journal replay with bounded projection-revision invalidation/repair events
- make Archive All operate against all active managed threads, not just the loaded list window
- bound frontend chat-index state around the active snapshot/window and repair by snapshot instead of replaying stale history
- add backend, frontend, and web UI lab coverage for high-history archived chats and bounded startup behavior

## Root Cause

The chat index SSE stream used raw chat-surface journal offsets as the browser maintenance cursor. A missing or stale cursor could replay thousands of historical events into the frontend even when only one chat was visible. Archive All also acted from list-window state, so it only archived the loaded recent rows and left counters/list windows inconsistent.

## Validation

- `python3 .codex-autorunner/bin/lint_tickets.py`
- `.venv/bin/python -m pytest tests/surfaces/web/test_hub_chat_read_model_routes.py -q`
- `.venv/bin/python -m pytest tests/core/orchestration/test_chat_surface_read_model.py -q`
- `.venv/bin/python -m pytest tests/test_managed_threads_routes.py -q`
- `.venv/bin/python -m pytest tests/web_ui_lab/test_scenario_corpus.py -q`
- `pnpm --dir src/codex_autorunner/web_frontend web:test`
- `pnpm --dir src/codex_autorunner/web_frontend lint`
