### PR TITLE
[codex] Avoid stale GitHub check wakes

### DIFF
--- a/src/codex_autorunner/adapters/github/polling_events.py
+++ b/src/codex_autorunner/adapters/github/polling_events.py
@@ -119,6 +119,17 @@ def _ingest_created_enqueue(result: Any) -> bool:
     return False
 
 
+def _check_targets_current_head(
+    payload: Mapping[str, Any],
+    *,
+    current_head_sha: str | None,
+) -> bool:
+    if current_head_sha is None:
+        return True
+    check_head_sha = _normalize_text(payload.get("head_sha"))
+    return check_head_sha == current_head_sha
+
+
 def emit_new_conditions(
     *,
     event_store: ScmEventStore,
@@ -156,10 +167,14 @@ def emit_new_conditions(
             has_new = True
             break
     if not has_new:
-        for key in current_checks:
+        for key, payload in current_checks.items():
             if key not in previous_checks:
-                has_new = True
-                break
+                has_new = _check_targets_current_head(
+                    _mapping(payload),
+                    current_head_sha=current_head_sha,
+                )
+                if has_new:
+                    break
     if not has_new:
         for key in current_issue_comments:
             if key not in previous_issue_comments:
@@ -204,11 +219,9 @@ def emit_new_conditions(
     for key, payload in current_checks.items():
         if key in previous_checks:
             continue
-        check_head_sha = _normalize_text(payload.get("head_sha"))
-        if (
-            current_head_sha is not None
-            and check_head_sha is not None
-            and check_head_sha != current_head_sha
+        if not _check_targets_current_head(
+            _mapping(payload),
+            current_head_sha=current_head_sha,
         ):
             continue
         event = event_store.record_event(

--- a/src/codex_autorunner/adapters/github/polling_snapshot.py
+++ b/src/codex_autorunner/adapters/github/polling_snapshot.py
@@ -240,13 +240,16 @@ def build_snapshot(
         conclusion = _normalize_lower_text(check.get("conclusion"))
         if status != "completed" or conclusion not in _FAILED_CHECK_CONCLUSIONS:
             continue
+        check_head_sha = _normalize_text(check.get("head_sha"))
+        if head_sha is not None and check_head_sha != head_sha:
+            continue
         payload = {
             "action": "completed",
             "name": _normalize_text(check.get("name")),
             "status": status,
             "conclusion": conclusion,
             "details_url": _normalize_text(check.get("details_url")),
-            "head_sha": _normalize_text(check.get("head_sha")) or head_sha,
+            "head_sha": check_head_sha,
         }
         failed_checks[_check_key(payload)] = {
             key: value for key, value in payload.items() if value is not None

--- a/src/codex_autorunner/adapters/github/webhooks.py
+++ b/src/codex_autorunner/adapters/github/webhooks.py
@@ -324,10 +324,17 @@ def _build_check_run_payload(
         return None, None, {}
     pull_requests = check_run.get("pull_requests")
     pr_number = None
+    pr_head_sha = None
     if isinstance(pull_requests, list):
         for item in pull_requests:
             if isinstance(item, Mapping):
                 pr_number = _normalize_optional_int(item.get("number"))
+                head = item.get("head")
+                pr_head_sha = (
+                    _normalize_optional_text(head.get("sha"))
+                    if isinstance(head, Mapping)
+                    else None
+                )
                 if pr_number is not None:
                     break
     app = check_run.get("app")
@@ -343,6 +350,7 @@ def _build_check_run_payload(
         "html_url": _normalize_optional_text(check_run.get("html_url")),
         "details_url": _normalize_optional_text(check_run.get("details_url")),
         "head_sha": _normalize_optional_text(check_run.get("head_sha")),
+        "pr_head_sha": pr_head_sha,
         "app_slug": app_slug,
         "started_at": _normalize_iso_timestamp(check_run.get("started_at")),
         "completed_at": _normalize_iso_timestamp(check_run.get("completed_at")),

--- a/src/codex_autorunner/core/scm_reaction_router.py
+++ b/src/codex_autorunner/core/scm_reaction_router.py
@@ -209,6 +209,14 @@ def _match_reaction_kind(
     if event.event_type == "check_run":
         status = _normalize_lower_text(payload.get("status"))
         conclusion = _normalize_lower_text(payload.get("conclusion"))
+        check_head_sha = _normalize_text(payload.get("head_sha"))
+        pr_head_sha = _normalize_text(payload.get("pr_head_sha"))
+        if (
+            check_head_sha is not None
+            and pr_head_sha is not None
+            and check_head_sha != pr_head_sha
+        ):
+            return None
         if status == "completed" and conclusion in _FAILED_CHECK_CONCLUSIONS:
             return "ci_failed"
         return None

--- a/tests/adapters/github/test_polling.py
+++ b/tests/adapters/github/test_polling.py
@@ -784,6 +784,7 @@ def test_arm_watch_captures_baseline_and_minimal_noise_profile(
                     "status": "COMPLETED",
                     "conclusion": "FAILURE",
                     "details_url": "https://example.invalid/checks/1",
+                    "head_sha": "abc123",
                 }
             ],
             issue_comments_payload=[
@@ -1464,6 +1465,7 @@ def test_process_due_watches_emits_only_new_review_and_check_transitions(
                     "status": "COMPLETED",
                     "conclusion": "FAILURE",
                     "details_url": "https://example.invalid/checks/2",
+                    "head_sha": "newsha",
                 }
             ],
         )
@@ -1559,6 +1561,143 @@ def test_emit_new_conditions_skips_failed_checks_from_stale_head(
     assert _AutomationServiceFake.ingested_events == []
     assert _AutomationServiceFake.process_calls == 0
     assert event_store.list_events(limit=10) == []
+
+
+def test_emit_new_conditions_skips_failed_checks_with_missing_head_when_head_known(
+    tmp_path: Path,
+) -> None:
+    binding = PrBindingStore(tmp_path).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        pr_number=17,
+        pr_state="open",
+        head_branch="feature/scm-polling",
+        base_branch="main",
+    )
+    watch = ScmPollingWatchStore(tmp_path).upsert_watch(
+        provider="github",
+        binding_id=binding.binding_id,
+        repo_slug=binding.repo_slug,
+        pr_number=binding.pr_number,
+        workspace_root=str((tmp_path / "repo").resolve()),
+        poll_interval_seconds=90,
+        next_poll_at="2026-03-30T00:00:00Z",
+        expires_at="2099-03-30T01:00:00Z",
+        reaction_config={"enabled": True},
+        snapshot={"head_sha": "oldsha"},
+    )
+    event_store = ScmEventStore(tmp_path)
+    _AutomationServiceFake.ingested_events = []
+    _AutomationServiceFake.process_calls = 0
+
+    emitted = emit_new_conditions(
+        event_store=event_store,
+        watch=watch,
+        binding=binding,
+        previous_snapshot={"head_sha": "oldsha", "failed_checks": {}},
+        snapshot={
+            "head_sha": "newsha",
+            "failed_checks": {
+                "-:unit-tests:failure:https://example.invalid/checks/1": {
+                    "action": "completed",
+                    "name": "unit-tests",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "details_url": "https://example.invalid/checks/1",
+                }
+            },
+        },
+        automation_service_factory=lambda: _AutomationServiceFake(tmp_path),
+        now_iso_fn=lambda: "2026-03-30T00:00:00Z",
+    )
+
+    assert emitted == 0
+    assert _AutomationServiceFake.ingested_events == []
+    assert _AutomationServiceFake.process_calls == 0
+    assert event_store.list_events(limit=10) == []
+
+
+def test_process_due_watches_ignores_ambiguous_old_check_failure_on_new_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding = PrBindingStore(tmp_path).upsert_binding(
+        provider="github",
+        repo_slug="acme/widgets",
+        pr_number=17,
+        pr_state="open",
+        head_branch="feature/scm-polling",
+        base_branch="main",
+    )
+    watch_store = ScmPollingWatchStore(tmp_path)
+    watch_store.upsert_watch(
+        provider="github",
+        binding_id=binding.binding_id,
+        repo_slug=binding.repo_slug,
+        pr_number=binding.pr_number,
+        workspace_root=str((tmp_path / "repo").resolve()),
+        poll_interval_seconds=90,
+        next_poll_at="2026-03-30T00:00:00Z",
+        expires_at="2099-03-30T01:00:00Z",
+        reaction_config={"enabled": True},
+        snapshot={"head_sha": "oldsha", "failed_checks": {}},
+    )
+
+    def _factory(repo_root: Path, raw_config=None) -> _GitHubServiceStub:
+        return _GitHubServiceStub(
+            repo_root,
+            raw_config,
+            pr_view_payload={
+                "state": "OPEN",
+                "isDraft": False,
+                "headRefOid": "newsha",
+            },
+            reviews_payload=[],
+            checks_payload=[
+                {
+                    "name": "unit-tests",
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                    "details_url": "https://example.invalid/checks/old",
+                },
+                {
+                    "name": "unit-tests",
+                    "status": "IN_PROGRESS",
+                    "conclusion": None,
+                    "details_url": "https://example.invalid/checks/new",
+                    "head_sha": "newsha",
+                },
+            ],
+        )
+
+    _AutomationServiceFake.ingested_events = []
+    _AutomationServiceFake.process_calls = 0
+    monkeypatch.setattr(
+        GitHubScmPollingService,
+        "_build_automation_service",
+        lambda self, reaction_config=None: _AutomationServiceFake(  # type: ignore[misc]
+            tmp_path,
+            reaction_config=reaction_config,
+        ),
+    )
+
+    service = GitHubScmPollingService(
+        tmp_path,
+        raw_config=_polling_config(),
+        github_service_factory=_factory,
+        watch_store=watch_store,
+        event_store=ScmEventStore(tmp_path),
+    )
+
+    result = service.process_due_watches(limit=10)
+
+    assert result["events_emitted"] == 0
+    assert _AutomationServiceFake.ingested_events == []
+    assert _AutomationServiceFake.process_calls == 0
+    refreshed = watch_store.get_watch(provider="github", binding_id=binding.binding_id)
+    assert refreshed is not None
+    assert refreshed.snapshot["head_sha"] == "newsha"
+    assert refreshed.snapshot["failed_checks"] == {}
 
 
 def test_process_due_watches_emits_new_pr_comment_and_inline_review_comment(

--- a/tests/adapters/github/test_webhooks.py
+++ b/tests/adapters/github/test_webhooks.py
@@ -304,7 +304,7 @@ def test_normalize_webhook_accepts_unsigned_when_allowed() -> None:
             "head_sha": "deadbeef",
             "started_at": "2026-03-24T15:00:00+00:00",
             "completed_at": "2026-03-24T15:02:00+00:00",
-            "pull_requests": [{"number": 42}],
+            "pull_requests": [{"number": 42, "head": {"sha": "deadbeef"}}],
             "app": {"slug": "github-actions"},
         },
     }
@@ -323,4 +323,5 @@ def test_normalize_webhook_accepts_unsigned_when_allowed() -> None:
     assert result.event.pr_number == 42
     assert result.event.occurred_at == "2026-03-24T15:02:00Z"
     assert result.event.payload["conclusion"] == "failure"
+    assert result.event.payload["pr_head_sha"] == "deadbeef"
     assert result.event.payload["app_slug"] == "github-actions"

--- a/tests/core/test_scm_reaction_router.py
+++ b/tests/core/test_scm_reaction_router.py
@@ -97,6 +97,25 @@ def test_route_scm_reactions_returns_threaded_ci_failure_intent() -> None:
     }
 
 
+def test_route_scm_reactions_ignores_stale_check_run_when_pr_head_is_known() -> None:
+    event = _event(
+        "check_run",
+        payload={
+            "action": "completed",
+            "status": "completed",
+            "conclusion": "failure",
+            "name": "ci / test",
+            "head_sha": "oldsha",
+            "pr_head_sha": "newsha",
+        },
+    )
+
+    assert (
+        route_scm_reactions(event, binding=_binding(thread_target_id="thread-123"))
+        == []
+    )
+
+
 def test_route_scm_reactions_returns_notify_intent_for_changes_requested_without_thread() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- Require GitHub polling check failures to explicitly target the current PR head before they can wake an agent.
- Preserve PR head SHA from check_run webhooks when GitHub includes it and suppress stale check-run reactions.
- Add regression coverage for stale, missing-SHA, and webhook check-run edge cases.

## Root Cause
GitHub follow-up logic could treat an older failed check as a new actionable condition after a PR head changed, especially while the new head checks were still running. That could wake the agent even though the current checks might pass and leave the agent with no useful follow-up work.

## Validation
- Commit hook aggregate lane passed: guardrails, black, ruff, import/contract checks, mypy, 8878 pytest tests, Web UI lab, Svelte lint/build, Vitest, SPA shell check.
- Focused checks passed earlier: ` .venv/bin/python -m pytest tests/adapters/github/test_polling.py tests/adapters/github/test_webhooks.py tests/core/test_scm_reaction_router.py -q`.