### PR TITLE
[codex] Fix chat index all archived filtering

### DIFF
--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -828,11 +828,11 @@ class ChatSurfaceReadService:
                 include_archived_rows=True,
             )
             counters_sql = f"""
-                SELECT COALESCE(SUM(CASE WHEN (lifecycle_status IS NULL OR lifecycle_status != 'archived') THEN 1 ELSE 0 END), 0) AS total,
-                       COALESCE(SUM(CASE WHEN (lifecycle_status IS NULL OR lifecycle_status != 'archived') AND queue_depth > 0 THEN 1 ELSE 0 END), 0) AS waiting,
-                       COALESCE(SUM(CASE WHEN (lifecycle_status IS NULL OR lifecycle_status != 'archived') AND effective_status = 'running' THEN 1 ELSE 0 END), 0) AS running,
-                       COALESCE(SUM(CASE WHEN (lifecycle_status IS NULL OR lifecycle_status != 'archived') THEN unread_count ELSE 0 END), 0) AS unread,
-                       COALESCE(SUM(CASE WHEN lifecycle_status = 'archived' THEN 1 ELSE 0 END), 0) AS archived
+                SELECT COALESCE(SUM(CASE WHEN {_CHAT_INDEX_NON_ARCHIVED_SQL} THEN 1 ELSE 0 END), 0) AS total,
+                       COALESCE(SUM(CASE WHEN {_CHAT_INDEX_NON_ARCHIVED_SQL} AND queue_depth > 0 THEN 1 ELSE 0 END), 0) AS waiting,
+                       COALESCE(SUM(CASE WHEN {_CHAT_INDEX_NON_ARCHIVED_SQL} AND effective_status = 'running' THEN 1 ELSE 0 END), 0) AS running,
+                       COALESCE(SUM(CASE WHEN {_CHAT_INDEX_NON_ARCHIVED_SQL} THEN unread_count ELSE 0 END), 0) AS unread,
+                       COALESCE(SUM(CASE WHEN NOT ({_CHAT_INDEX_NON_ARCHIVED_SQL}) THEN 1 ELSE 0 END), 0) AS archived
                   FROM orch_chat_index_projection
                  WHERE {where_counters_sql}
                 """
@@ -843,7 +843,7 @@ class ChatSurfaceReadService:
                        COALESCE(SUM(CASE WHEN queue_depth > 0 THEN 1 ELSE 0 END), 0) AS waiting,
                        COALESCE(SUM(CASE WHEN effective_status = 'running' THEN 1 ELSE 0 END), 0) AS running,
                        COALESCE(SUM(unread_count), 0) AS unread,
-                       COALESCE(SUM(CASE WHEN lifecycle_status = 'archived' THEN 1 ELSE 0 END), 0) AS archived
+                       COALESCE(SUM(CASE WHEN NOT ({_CHAT_INDEX_NON_ARCHIVED_SQL}) THEN 1 ELSE 0 END), 0) AS archived
                   FROM orch_chat_index_projection
                  WHERE {where_counters_sql}
                 """
@@ -1801,6 +1801,12 @@ def _chat_index_row_from_projection(row: Mapping[str, Any]) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+_CHAT_INDEX_NON_ARCHIVED_SQL = (
+    "(lifecycle_status IS NULL OR lifecycle_status != 'archived') "
+    "AND effective_status != 'archived'"
+)
+
+
 def _chat_index_projection_where(
     *,
     view: str,
@@ -1830,7 +1836,7 @@ def _chat_index_projection_where(
     elif normalized_view == "unread":
         clauses.append("unread != 0")
     elif normalized_view == "archived":
-        clauses.append("lifecycle_status = 'archived'")
+        clauses.append(f"NOT ({_CHAT_INDEX_NON_ARCHIVED_SQL})")
     elif normalized_view == "external":
         clauses.append("surface_kind_list != ''")
         clauses.append("surface_kind_list != '|pma|'")
@@ -1841,7 +1847,7 @@ def _chat_index_projection_where(
     if normalized_view != "archived" and not (
         include_archived_rows and normalized_view == "all"
     ):
-        clauses.append("(lifecycle_status IS NULL OR lifecycle_status != 'archived')")
+        clauses.append(_CHAT_INDEX_NON_ARCHIVED_SQL)
     if normalized_query is not None:
         clauses.append("search_text LIKE ?")
         params.append(f"%{normalized_query}%")

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -525,6 +525,82 @@ def test_hub_read_models_chats_counters_cover_full_filtered_set(hub_env) -> None
     assert snapshot.rows[0].status != "running"
 
 
+def test_hub_read_models_chats_all_excludes_effectively_archived_rows(
+    hub_env,
+) -> None:
+    with open_orchestration_sqlite(
+        hub_env.hub_root, durable=True, migrate=True
+    ) as conn:
+        with conn:
+            conn.executemany(
+                """
+                INSERT INTO orch_thread_targets (
+                    thread_target_id,
+                    agent_id,
+                    repo_id,
+                    resource_kind,
+                    resource_id,
+                    display_name,
+                    lifecycle_status,
+                    runtime_status,
+                    metadata_json,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    (
+                        "thread-active",
+                        "codex",
+                        "repo",
+                        "repo",
+                        "repo",
+                        "Active thread",
+                        "active",
+                        "idle",
+                        "{}",
+                        "2026-05-11T00:00:00Z",
+                        "2026-05-11T00:02:00Z",
+                    ),
+                    (
+                        "thread-stale-archived-runtime",
+                        "codex",
+                        "repo",
+                        "repo",
+                        "repo",
+                        "Stale archived runtime",
+                        "active",
+                        "archived",
+                        "{}",
+                        "2026-05-11T00:00:00Z",
+                        "2026-05-11T00:01:00Z",
+                    ),
+                ),
+            )
+
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    response = client.get(
+        "/hub/read-models/chats", params={"filter": "all", "limit": 20}
+    )
+
+    assert response.status_code == 200
+    snapshot = load_read_model_contract(ChatIndexSnapshot, response.json())
+    assert [row.chat_id for row in snapshot.rows] == ["thread-active"]
+    assert snapshot.counters.total == 1
+    assert snapshot.counters.archived == 1
+
+    archived_response = client.get(
+        "/hub/read-models/chats", params={"filter": "archived", "limit": 20}
+    )
+    assert archived_response.status_code == 200
+    archived_snapshot = load_read_model_contract(
+        ChatIndexSnapshot, archived_response.json()
+    )
+    assert [row.chat_id for row in archived_snapshot.rows] == [
+        "thread-stale-archived-runtime"
+    ]
+
+
 def test_hub_read_models_chats_contract_active_filter_matches_index_window(
     hub_env,
 ) -> None:


### PR DESCRIPTION
## Summary
- Exclude rows whose effective chat-index status is archived from the `filter=all` projection window and total counters.
- Count archived rows consistently when either lifecycle or effective status marks them archived.
- Add a regression covering stale active-lifecycle rows with archived runtime status.

Closes #1819

## Validation
- `.venv/bin/python -m pytest -q tests/surfaces/web/test_hub_chat_read_model_routes.py`
- `.venv/bin/python -m pytest -q tests/core/orchestration/test_chat_surface_read_model.py tests/surfaces/web/test_hub_chat_read_model_routes.py`
- `.venv/bin/python -m ruff check src/codex_autorunner/core/orchestration/chat_surface_read_model.py tests/surfaces/web/test_hub_chat_read_model_routes.py`
- `git diff --check`
- commit hook `web-core-contract` lane: full pytest 8882 passed, mypy, ruff, frontend lint/build/tests, web UI lab