### PR TITLE
[codex] Guard unindexed workspace scope resolution

### DIFF
--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -597,11 +597,6 @@ def terminal_run_event_from_outcome(
             reason="Runtime thread interrupted",
         )
     _error_detail = str(outcome.error or "").strip()
-    if _error_detail == "Runtime thread interrupted":
-        return Interrupted(
-            timestamp=now_iso(),
-            reason="Runtime thread interrupted",
-        )
     return Failed(
         timestamp=now_iso(),
         error_message=(

--- a/tests/core/domain/test_workspace_scope.py
+++ b/tests/core/domain/test_workspace_scope.py
@@ -86,6 +86,28 @@ def test_unknown_repo_id_preserves_supplied_workspace_path(tmp_path: Path) -> No
     assert resolution.owner_fields()["workspace_root"] == str(stale_path)
 
 
+def test_unknown_review_resource_repo_id_preserves_owner_context(
+    tmp_path: Path,
+) -> None:
+    review_checkout = tmp_path / "review-checkout"
+    review_checkout.mkdir()
+    index = workspace_scope_index_from_snapshots([])
+
+    resolution = index.resolve(
+        raw_repo_id="repo-from-review-diff",
+        workspace_path=str(review_checkout),
+        resource_kind="file",
+        resource_id="src/example.py",
+    )
+
+    assert resolution is not None
+    assert resolution.scope == ScopeRef(kind="repo", id="repo-from-review-diff")
+    fields = resolution.owner_fields()
+    assert fields["repo_id"] == "repo-from-review-diff"
+    assert fields["workspace_root"] == str(review_checkout.resolve())
+    assert fields["scope_urn"] == "repo:repo-from-review-diff"
+
+
 def test_scope_urn_miss_preserves_workspace_path_for_repo_urn(tmp_path: Path) -> None:
     """Stale rows may carry a scope URN that no longer maps into topology."""
     checkout = tmp_path / "orphan-checkout"

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -4,6 +4,9 @@ import json
 from pathlib import Path
 
 from codex_autorunner.adapters.chat.channel_directory import ChannelDirectoryStore
+from codex_autorunner.core.domain.workspace_scope import (
+    workspace_scope_index_from_snapshots,
+)
 from codex_autorunner.core.orchestration import (
     ChatSurfaceReadService,
     OrchestrationBindingStore,
@@ -11,6 +14,7 @@ from codex_autorunner.core.orchestration import (
 )
 from codex_autorunner.core.orchestration.chat_surface_read_model import (
     _chat_index_sort_key_parts,
+    canonical_owner_fields,
 )
 from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.pma_notification_store import PmaNotificationStore
@@ -21,6 +25,31 @@ _FIXTURE_PATH = (
     / "chat_surface"
     / "lifecycle_contract.json"
 )
+
+
+def test_canonical_owner_fields_preserves_unindexed_review_resource_repo_id(
+    tmp_path: Path,
+) -> None:
+    checkout = tmp_path / "review-checkout"
+    checkout.mkdir()
+    index = workspace_scope_index_from_snapshots([])
+
+    fields = canonical_owner_fields(
+        index,
+        repo_id="repo-from-review-diff",
+        resource_kind="file",
+        resource_id="src/example.py",
+        workspace_root=str(checkout),
+    )
+
+    assert fields == {
+        "repo_id": "repo-from-review-diff",
+        "worktree_id": None,
+        "resource_kind": "file",
+        "resource_id": "src/example.py",
+        "workspace_root": str(checkout.resolve()),
+        "scope_urn": "repo:repo-from-review-diff",
+    }
 
 
 def _seed_thread(

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -960,9 +960,7 @@ async def test_terminal_run_event_from_outcome_canonicalizes_surface_interrupts(
         assert event.reason == "Runtime thread interrupted"
 
 
-async def test_terminal_run_event_from_outcome_canonicalizes_stale_interrupt_error() -> (
-    None
-):
+async def test_terminal_run_event_from_outcome_redacts_stale_interrupt_error() -> None:
     state = RuntimeThreadRunEventState()
 
     event = terminal_run_event_from_outcome(
@@ -976,8 +974,8 @@ async def test_terminal_run_event_from_outcome_canonicalizes_stale_interrupt_err
         state,
     )
 
-    assert isinstance(event, Interrupted)
-    assert event.reason == "Runtime thread interrupted"
+    assert isinstance(event, Failed)
+    assert event.error_message == "Runtime thread failed"
 
 
 async def test_normalize_runtime_thread_raw_event_deduplicates_identical_stream_chunks() -> (

--- a/tests/surfaces/web/conftest.py
+++ b/tests/surfaces/web/conftest.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from codex_autorunner.surfaces.web import app as web_app_module
+
+
+@pytest.fixture(autouse=True)
+def _web_static_bundle_for_route_tests(monkeypatch, tmp_path: Path) -> None:
+    """Use a tiny SPA bundle when ignored built assets are absent.
+
+    Web route tests assert FastAPI routing and cache/header behavior. The real
+    SvelteKit build output is intentionally gitignored, so clean CI checkouts
+    need a deterministic test bundle without changing production behavior.
+    """
+
+    web_static_dir, context = web_app_module.resolve_web_static_dir()
+    if (web_static_dir / "index.html").exists():
+        if context is not None:
+            context.close()
+        return
+
+    static_dir = tmp_path / "web_static"
+    asset_dir = static_dir / "_app" / "immutable" / "entry"
+    asset_dir.mkdir(parents=True)
+    (asset_dir / "app.test.css").write_text(
+        "body { color: #111; }\n",
+        encoding="utf-8",
+    )
+    (asset_dir / "app.test.js").write_text(
+        "globalThis.__carTestApp = true;\n",
+        encoding="utf-8",
+    )
+    (asset_dir / "start.test.js").write_text(
+        "globalThis.__carTestStart = true;\n",
+        encoding="utf-8",
+    )
+    (static_dir / "_app" / "version.json").write_text(
+        '{"version":"test"}\n',
+        encoding="utf-8",
+    )
+    (static_dir / "index.html").write_text(
+        """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Web Hub</title>
+  <link rel="stylesheet" href="/_app/immutable/entry/app.test.css" />
+  <link href="/_app/immutable/entry/start.test.js" rel="modulepreload" />
+</head>
+<body>
+  <div id="app"></div>
+  <script>globalThis.__carBootstrap = true; __sveltekit_test = true; import("/_app/immutable/entry/start.test.js");</script>
+  <script type="module" src="/_app/immutable/entry/app.test.js"></script>
+</body>
+</html>
+""",
+        encoding="utf-8",
+    )
+
+    def _resolve_test_web_static_dir() -> tuple[Path, Optional[object]]:
+        return static_dir, None
+
+    monkeypatch.setattr(
+        web_app_module,
+        "resolve_web_static_dir",
+        _resolve_test_web_static_dir,
+    )


### PR DESCRIPTION
## Summary
- add regression coverage for unindexed PR-review resource owner fields preserving repo/workspace context
- add resolver coverage for unknown review repo IDs falling back without raising
- remove the stale string-based `Runtime thread interrupted` error fallback so terminal interrupts come from explicit interrupted outcomes

## Validation
- `.venv/bin/python -m pytest tests/core/domain/test_workspace_scope.py tests/core/orchestration/test_chat_surface_read_model.py tests/core/orchestration/test_runtime_thread_events.py`
- `.venv/bin/python -m black --check src/codex_autorunner/core/orchestration/runtime_thread_events.py tests/core/domain/test_workspace_scope.py tests/core/orchestration/test_chat_surface_read_model.py tests/core/orchestration/test_runtime_thread_events.py`
- `.venv/bin/python -m ruff check src/codex_autorunner/core/orchestration/runtime_thread_events.py tests/core/domain/test_workspace_scope.py tests/core/orchestration/test_chat_surface_read_model.py tests/core/orchestration/test_runtime_thread_events.py`
- commit hook core lane: guardrails, mypy, and pytest (`8883 passed`)

Closes #1802