### PR TITLE
[codex] Bound PMA chat live rendering

### DIFF
--- a/scripts/profile_web_chats_idle.py
+++ b/scripts/profile_web_chats_idle.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+"""Profile browser responsiveness while an opened Web UI chat sits idle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import time
+from urllib.error import URLError
+from urllib.request import urlopen
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+import web_ui_screens
+from codex_autorunner.bootstrap import seed_hub_files
+from codex_autorunner.core.utils import atomic_write
+from pma_live_hub_smoke import SMOKE_FIXTURE_MANIFEST
+from tests.chat_surface_lab.web_responsiveness_budgets import (
+    DEFAULT_SEED,
+    seed_large_web_hub,
+)
+
+DEFAULT_OUT_DIR = (
+    REPO_ROOT / ".codex-autorunner" / "diagnostics" / "web-chats-idle-profile"
+)
+
+PRIMARY_LOADING_MARKERS = (
+    "Opening Web Hub...",
+    "Opening PMA...",
+    "Loading chats",
+    "Loading PMA chats",
+    "Loading active chat",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Start a seeded hub, open the chats page and a chat in Chromium, "
+            "idle for at least 60 seconds, and write responsiveness evidence."
+        )
+    )
+    parser.add_argument("--mode", choices=("fixture", "hub", "url"), default="fixture")
+    parser.add_argument(
+        "--fixture-kind",
+        choices=("smoke", "large"),
+        default="large",
+        help="Fixture to seed when --mode fixture. Default: large.",
+    )
+    parser.add_argument("--hub-root", type=Path, default=Path.home() / "car-workspace")
+    parser.add_argument("--base-url", default=None)
+    parser.add_argument("--base-path", default="/car")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=0)
+    parser.add_argument("--chat-id", default=None)
+    parser.add_argument("--idle-seconds", type=float, default=75.0)
+    parser.add_argument("--sample-ms", type=int, default=250)
+    parser.add_argument("--chat-count", type=int, default=DEFAULT_SEED["chat_count"])
+    parser.add_argument("--repo-count", type=int, default=DEFAULT_SEED["repo_count"])
+    parser.add_argument(
+        "--worktree-count", type=int, default=DEFAULT_SEED["worktree_count"]
+    )
+    parser.add_argument(
+        "--ticket-run-group-count",
+        type=int,
+        default=DEFAULT_SEED["ticket_run_group_count"],
+    )
+    parser.add_argument(
+        "--timeline-event-count",
+        type=int,
+        default=DEFAULT_SEED["timeline_event_count"],
+    )
+    parser.add_argument(
+        "--journal-event-count",
+        type=int,
+        default=DEFAULT_SEED["journal_event_count"],
+    )
+    parser.add_argument("--viewport", default="1440x1000")
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--timeout-seconds", type=float, default=30.0)
+    parser.add_argument("--headed", action="store_true")
+    parser.add_argument("--no-clean", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.idle_seconds < 60:
+        print("profile-web-chats-idle: --idle-seconds must be at least 60", file=sys.stderr)
+        return 2
+    try:
+        viewport = web_ui_screens.parse_viewport(args.viewport)
+    except ValueError as exc:
+        print(f"profile-web-chats-idle: {exc}", file=sys.stderr)
+        return 2
+
+    out_dir = args.out_dir.resolve()
+    if out_dir.exists() and not args.no_clean:
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    base_path = web_ui_screens.normalize_base_path(args.base_path)
+    server = None
+    thread = None
+    hub_root: Path | None = None
+    original_cwd: Path | None = None
+    try:
+        if args.mode == "url":
+            if not args.base_url:
+                print("profile-web-chats-idle: --base-url is required with --mode url", file=sys.stderr)
+                return 2
+            base_url = args.base_url.rstrip("/")
+        else:
+            if args.mode == "fixture":
+                if args.fixture_kind == "large":
+                    hub_root = _seed_large_fixture_hub(out_dir / "fixture", args)
+                    seeded_chat_id = _large_fixture_chat_id(out_dir / "fixture")
+                    if seeded_chat_id and not args.chat_id:
+                        args.chat_id = seeded_chat_id
+                else:
+                    hub_root = web_ui_screens.seed_fixture_hub(out_dir / "fixture")
+            else:
+                hub_root = args.hub_root.expanduser().resolve()
+                if not hub_root.exists():
+                    print(f"profile-web-chats-idle: hub root does not exist: {hub_root}", file=sys.stderr)
+                    return 2
+            port = args.port or web_ui_screens.find_free_port(args.host)
+            base_url = f"http://{args.host}:{port}"
+            original_cwd = Path.cwd()
+            os.chdir(web_ui_screens.server_working_directory(hub_root))
+            server, thread = web_ui_screens.start_server(
+                hub_root, args.host, port, base_path or "/"
+            )
+            web_ui_screens.wait_for_server(base_url, base_path, args.timeout_seconds)
+
+        chat_id = args.chat_id or _fixture_chat_id(hub_root)
+        if not chat_id:
+            chat_id = _first_live_chat_id(base_url=base_url, base_path=base_path)
+        report = run_browser_profile(
+            base_url=base_url,
+            base_path=base_path,
+            chat_id=chat_id,
+            viewport=viewport,
+            idle_seconds=args.idle_seconds,
+            sample_ms=args.sample_ms,
+            timeout_seconds=args.timeout_seconds,
+            headed=args.headed,
+            out_dir=out_dir,
+            hub_root=hub_root,
+            mode=args.mode,
+        )
+    finally:
+        if server is not None:
+            server.should_exit = True
+        if thread is not None:
+            thread.join(timeout=5)
+        if original_cwd is not None:
+            os.chdir(original_cwd)
+
+    latest_path = out_dir / "latest.json"
+    report_path = out_dir / "runs" / str(report["run_id"]) / "report.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    atomic_write(latest_path, serialized)
+    atomic_write(report_path, serialized)
+
+    print(_format_summary(report, latest_path, report_path))
+    return 0 if report["signoff"]["reproduced_freeze"] is False else 1
+
+
+def run_browser_profile(
+    *,
+    base_url: str,
+    base_path: str,
+    chat_id: str | None,
+    viewport: tuple[int, int],
+    idle_seconds: float,
+    sample_ms: int,
+    timeout_seconds: float,
+    headed: bool,
+    out_dir: Path,
+    hub_root: Path | None,
+    mode: str,
+) -> dict[str, Any]:
+    try:
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+        from playwright.sync_api import sync_playwright
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "Playwright is not installed for this Python. Use the project venv "
+            "or install Playwright Chromium."
+        ) from exc
+
+    run_id = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
+    console_messages: list[dict[str, Any]] = []
+    page_errors: list[str] = []
+    failed_requests: list[dict[str, Any]] = []
+    screenshot_path = out_dir / "runs" / run_id / "chat-idle.png"
+    screenshot_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=not headed)
+        page = browser.new_page(
+            viewport={"width": viewport[0], "height": viewport[1]},
+            device_scale_factor=1,
+        )
+        page.on(
+            "console",
+            lambda message: console_messages.append(
+                {
+                    "type": message.type,
+                    "text": message.text,
+                    "location": message.location,
+                }
+            )
+            if message.type in {"error", "warning"}
+            else None,
+        )
+        page.on("pageerror", lambda error: page_errors.append(str(error)))
+        page.on(
+            "requestfailed",
+            lambda request: failed_requests.append(
+                {
+                    "url": request.url,
+                    "method": request.method,
+                    "resource_type": request.resource_type,
+                    "failure": request.failure,
+                }
+            ),
+        )
+        session = page.context.new_cdp_session(page)
+        session.send("Performance.enable")
+
+        index_url = web_ui_screens.route_url(base_url, base_path, "/chats")
+        detail_url = (
+            web_ui_screens.route_url(base_url, base_path, f"/chats/{chat_id}")
+            if chat_id
+            else None
+        )
+        navigation = []
+        navigation.append(_goto_and_wait(page, index_url, timeout_seconds))
+        if detail_url:
+            navigation.append(_goto_and_wait(page, detail_url, timeout_seconds))
+        else:
+            clicked = _click_first_chat_link(page, base_path, timeout_seconds)
+            navigation.append({"url": page.url, "clicked_first_chat_link": clicked})
+
+        page.evaluate(
+            """({ sampleMs }) => {
+                const state = {
+                    sampleMs,
+                    startedAt: performance.now(),
+                    lastAt: performance.now(),
+                    tickCount: 0,
+                    rafCount: 0,
+                    maxIntervalGapMs: 0,
+                    intervalGaps: [],
+                    longTasks: [],
+                    observerError: null,
+                };
+                window.__carIdleProfile = state;
+                window.__carIdleProfileInterval = window.setInterval(() => {
+                    const now = performance.now();
+                    const gap = now - state.lastAt;
+                    state.tickCount += 1;
+                    state.lastAt = now;
+                    state.maxIntervalGapMs = Math.max(state.maxIntervalGapMs, gap);
+                    state.intervalGaps.push({
+                        atMs: Math.round((now - state.startedAt) * 1000) / 1000,
+                        gapMs: Math.round(gap * 1000) / 1000,
+                    });
+                    if (state.intervalGaps.length > 2000) state.intervalGaps.shift();
+                }, sampleMs);
+                const raf = () => {
+                    state.rafCount += 1;
+                    window.__carIdleProfileRaf = requestAnimationFrame(raf);
+                };
+                window.__carIdleProfileRaf = requestAnimationFrame(raf);
+                try {
+                    const observer = new PerformanceObserver((list) => {
+                        for (const entry of list.getEntries()) {
+                            state.longTasks.push({
+                                name: entry.name,
+                                startTime: Math.round(entry.startTime * 1000) / 1000,
+                                duration: Math.round(entry.duration * 1000) / 1000,
+                            });
+                        }
+                    });
+                    observer.observe({ entryTypes: ['longtask'] });
+                    window.__carIdleProfileObserver = observer;
+                } catch (error) {
+                    state.observerError = String(error);
+                }
+            }""",
+            {"sampleMs": sample_ms},
+        )
+
+        page.wait_for_timeout(idle_seconds * 1000)
+        idle_metrics = page.evaluate(
+            """() => {
+                const state = window.__carIdleProfile || {};
+                const gapEntries = Array.isArray(state.intervalGaps) ? state.intervalGaps : [];
+                const gaps = gapEntries.map((entry) => typeof entry === 'number' ? entry : entry.gapMs || 0);
+                const post60GapEntries = gapEntries.filter((entry) => {
+                    if (typeof entry === 'number') return false;
+                    return (entry.atMs || 0) >= 60000;
+                });
+                const post60Gaps = post60GapEntries.map((entry) => entry.gapMs || 0);
+                const sorted = [...gaps].sort((a, b) => a - b);
+                const percentile = (values, p) => {
+                    const sortedValues = [...values].sort((a, b) => a - b);
+                    if (!sortedValues.length) return 0;
+                    const index = Math.min(sortedValues.length - 1, Math.max(0, Math.ceil(sortedValues.length * p) - 1));
+                    return sortedValues[index] || 0;
+                };
+                const longTasks = state.longTasks || [];
+                const post60LongTasks = longTasks.filter((entry) => (entry.startTime || 0) >= 60000);
+                return {
+                    measuredMs: Math.round((performance.now() - (state.startedAt || performance.now())) * 1000) / 1000,
+                    sampleMs: state.sampleMs || null,
+                    tickCount: state.tickCount || 0,
+                    rafCount: state.rafCount || 0,
+                    maxIntervalGapMs: state.maxIntervalGapMs || 0,
+                    intervalGapP95Ms: percentile(gaps, 0.95),
+                    intervalGapP99Ms: percentile(gaps, 0.99),
+                    intervalGapOver1000Ms: gaps.filter((gap) => gap > 1000).length,
+                    intervalGapOver5000Ms: gaps.filter((gap) => gap > 5000).length,
+                    maxPost60IntervalGapMs: Math.max(0, ...post60Gaps),
+                    post60IntervalGapP99Ms: percentile(post60Gaps, 0.99),
+                    post60IntervalGapOver1000Ms: post60Gaps.filter((gap) => gap > 1000).length,
+                    post60IntervalGapOver5000Ms: post60Gaps.filter((gap) => gap > 5000).length,
+                    intervalGaps: gapEntries.slice(-50),
+                    longTaskCount: Array.isArray(state.longTasks) ? state.longTasks.length : 0,
+                    maxLongTaskMs: Math.max(0, ...longTasks.map((entry) => entry.duration || 0)),
+                    post60LongTaskCount: post60LongTasks.length,
+                    maxPost60LongTaskMs: Math.max(0, ...post60LongTasks.map((entry) => entry.duration || 0)),
+                    longTasks: longTasks.slice(-50),
+                    observerError: state.observerError || null,
+                    dom: {
+                        elements: document.querySelectorAll('*').length,
+                        links: document.querySelectorAll('a[href]').length,
+                        buttons: document.querySelectorAll('button,[role="button"]').length,
+                        inputs: document.querySelectorAll('input,textarea,select').length,
+                        bodyTextChars: document.body?.innerText?.length || 0,
+                    },
+                    page: {
+                        title: document.title,
+                        url: window.location.href,
+                        visibilityState: document.visibilityState,
+                    },
+                };
+            }"""
+        )
+        perf_metrics = _performance_metrics(session)
+        page.screenshot(path=str(screenshot_path), full_page=False)
+        browser.close()
+
+    actionable_failed_requests = [
+        request
+        for request in failed_requests
+        if request.get("failure") != "net::ERR_ABORTED"
+    ]
+    reproduced = (
+        idle_metrics["maxPost60IntervalGapMs"] >= 5000
+        or idle_metrics["post60IntervalGapOver5000Ms"] > 0
+        or idle_metrics["maxPost60LongTaskMs"] >= 5000
+    )
+    laggy = (
+        reproduced
+        or idle_metrics["maxPost60IntervalGapMs"] >= 1000
+        or idle_metrics["post60IntervalGapOver1000Ms"] > 0
+        or idle_metrics["maxPost60LongTaskMs"] >= 1000
+    )
+    return {
+        "version": 1,
+        "suite": "web_chats_idle_profile",
+        "run_id": run_id,
+        "mode": mode,
+        "base_url": base_url,
+        "base_path": base_path,
+        "hub_root": str(hub_root) if hub_root else None,
+        "chat_id": chat_id,
+        "idle_seconds_requested": idle_seconds,
+        "viewport": {"width": viewport[0], "height": viewport[1]},
+        "navigation": navigation,
+        "idle_metrics": idle_metrics,
+        "chrome_performance_metrics": perf_metrics,
+        "console": {
+            "errors": [item for item in console_messages if item["type"] == "error"],
+            "warnings": [item for item in console_messages if item["type"] == "warning"],
+        },
+        "page_errors": page_errors,
+        "failed_requests": actionable_failed_requests,
+        "screenshot": {"path": str(screenshot_path), "size_bytes": screenshot_path.stat().st_size},
+        "signoff": {
+            "reproduced_freeze": reproduced,
+            "observed_lag": laggy,
+            "message": (
+                "freeze reproduced"
+                if reproduced
+                else "no freeze reproduced; lag observed"
+                if laggy
+                else "no freeze or severe lag reproduced"
+            ),
+        },
+    }
+
+
+def _goto_and_wait(page: Any, url: str, timeout_seconds: float) -> dict[str, Any]:
+    response_status = None
+    error = None
+    loading_timed_out = False
+    try:
+        response = page.goto(url, wait_until="domcontentloaded", timeout=timeout_seconds * 1000)
+        response_status = response.status if response is not None else None
+    except Exception as exc:
+        error = str(exc)
+    try:
+        page.wait_for_function(
+            """(loadingMarkers) => {
+                const text = document.body?.innerText || '';
+                if (!text.trim()) return false;
+                if (text.includes('Could not load')) return true;
+                return !loadingMarkers.some((marker) => text.includes(marker));
+            }""",
+            arg=list(PRIMARY_LOADING_MARKERS),
+            timeout=timeout_seconds * 1000,
+        )
+    except Exception:
+        loading_timed_out = True
+    return {
+        "url": url,
+        "final_url": page.url,
+        "status": response_status,
+        "error": error,
+        "loading_timed_out": loading_timed_out,
+    }
+
+
+def _click_first_chat_link(page: Any, base_path: str, timeout_seconds: float) -> bool:
+    href = page.evaluate(
+        """(basePath) => {
+            const prefix = `${basePath || ''}/chats/`;
+            const link = Array.from(document.querySelectorAll('a[href]'))
+                .find((node) => {
+                    const href = node.getAttribute('href') || '';
+                    return href.startsWith(prefix) || href.startsWith('/chats/');
+                });
+            return link ? link.getAttribute('href') : null;
+        }""",
+        base_path,
+    )
+    if not href:
+        return False
+    page.evaluate(
+        """(targetHref) => {
+            const link = Array.from(document.querySelectorAll('a[href]'))
+                .find((node) => node.getAttribute('href') === targetHref);
+            if (!link) throw new Error(`chat link disappeared: ${targetHref}`);
+            link.click();
+        }""",
+        href,
+    )
+    page.wait_for_load_state("domcontentloaded", timeout=timeout_seconds * 1000)
+    return True
+
+
+def _fixture_chat_id(hub_root: Path | None) -> str | None:
+    if hub_root is None:
+        return None
+    manifest_path = hub_root / SMOKE_FIXTURE_MANIFEST
+    if not manifest_path.exists():
+        return None
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    value = payload.get("final_thread_id") or payload.get("running_thread_id")
+    return str(value) if value else None
+
+
+def _seed_large_fixture_hub(evidence_dir: Path, args: argparse.Namespace) -> Path:
+    hub_root = evidence_dir / "hub"
+    if hub_root.exists():
+        shutil.rmtree(hub_root)
+    hub_root.mkdir(parents=True)
+    seed_hub_files(hub_root, force=True)
+    seed_stats = seed_large_web_hub(
+        hub_root,
+        chat_count=args.chat_count,
+        repo_count=args.repo_count,
+        worktree_count=args.worktree_count,
+        ticket_run_group_count=args.ticket_run_group_count,
+        timeline_event_count=args.timeline_event_count,
+        journal_event_count=args.journal_event_count,
+    )
+    (evidence_dir / "large-fixture-manifest.json").write_text(
+        json.dumps(seed_stats, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return hub_root
+
+
+def _large_fixture_chat_id(evidence_dir: Path) -> str | None:
+    manifest_path = evidence_dir / "large-fixture-manifest.json"
+    if not manifest_path.exists():
+        return None
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    value = payload.get("detail_thread_id")
+    return str(value) if value else None
+
+
+def _first_live_chat_id(*, base_url: str, base_path: str) -> str | None:
+    url = f"{base_url.rstrip('/')}{base_path}/hub/read-models/chats?limit=25"
+    try:
+        with urlopen(url, timeout=10) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, URLError, json.JSONDecodeError):
+        return None
+    rows = payload.get("rows")
+    if not isinstance(rows, list):
+        return None
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        status = str(row.get("status") or "").strip().lower()
+        lifecycle = str(row.get("lifecycle") or "").strip().lower()
+        chat_id = row.get("chatId")
+        if chat_id and status != "archived" and lifecycle != "archived":
+            return str(chat_id)
+    for row in rows:
+        if isinstance(row, dict) and row.get("chatId"):
+            return str(row["chatId"])
+    return None
+
+
+def _performance_metrics(session: Any) -> dict[str, float]:
+    payload = session.send("Performance.getMetrics")
+    return {
+        str(item["name"]): float(item["value"])
+        for item in payload.get("metrics", [])
+        if "name" in item and "value" in item
+    }
+
+
+def _format_summary(report: dict[str, Any], latest_path: Path, report_path: Path) -> str:
+    metrics = report["idle_metrics"]
+    signoff = report["signoff"]
+    return "\n".join(
+        [
+            "WEB CHATS IDLE PROFILE",
+            f"run_id={report['run_id']}",
+            f"status={signoff['message']}",
+            f"latest={latest_path}",
+            f"run_report={report_path}",
+            f"url={metrics['page']['url']}",
+            f"measured_ms={metrics['measuredMs']}",
+            f"max_interval_gap_ms={round(metrics['maxIntervalGapMs'], 3)}",
+            f"interval_gap_p99_ms={round(metrics['intervalGapP99Ms'], 3)}",
+            f"long_task_count={metrics['longTaskCount']}",
+            f"max_long_task_ms={round(metrics['maxLongTaskMs'], 3)}",
+            f"max_post60_interval_gap_ms={round(metrics['maxPost60IntervalGapMs'], 3)}",
+            f"post60_interval_gap_p99_ms={round(metrics['post60IntervalGapP99Ms'], 3)}",
+            f"post60_long_task_count={metrics['post60LongTaskCount']}",
+            f"max_post60_long_task_ms={round(metrics['maxPost60LongTaskMs'], 3)}",
+            f"dom_elements={metrics['dom']['elements']}",
+        ]
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterator, Optional
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
@@ -48,6 +48,29 @@ from .managed_threads import (
 _PERSISTED_TAIL_POLL_SECONDS = 1.0
 _PERSISTED_TAIL_HEARTBEAT_SECONDS = 15.0
 _TRANSCRIPT_STREAM_LIMIT = 200
+_TRANSCRIPT_APPEND_ROW_LIMIT = 80
+
+
+def _transcript_append_frames(
+    rows: list[dict[str, Any]],
+    append_event_id: int,
+    *,
+    chunk_limit: int = _TRANSCRIPT_APPEND_ROW_LIMIT,
+) -> Iterator[str]:
+    if not rows:
+        return
+    effective_limit = max(1, chunk_limit)
+    for offset in range(0, len(rows), effective_limit):
+        chunk = rows[offset : offset + effective_limit]
+        is_final_chunk = offset + effective_limit >= len(rows)
+        append_id_line = (
+            f"id: {append_event_id}\n" if is_final_chunk and append_event_id > 0 else ""
+        )
+        yield (
+            "event: transcript.append\n"
+            f"{append_id_line}"
+            f"data: {json.dumps({'rows': chunk}, ensure_ascii=True)}\n\n"
+        )
 
 
 def parse_tail_duration_seconds(value: Optional[str]) -> Optional[int]:
@@ -951,14 +974,8 @@ def build_managed_thread_tail_routes(
                     append_event_id = int(
                         refreshed.get("last_event_id") or last_event_id
                     )
-                    append_id_line = (
-                        f"id: {append_event_id}\n" if append_event_id > 0 else ""
-                    )
-                    yield (
-                        "event: transcript.append\n"
-                        f"{append_id_line}"
-                        f"data: {json.dumps({'rows': rows}, ensure_ascii=True)}\n\n"
-                    )
+                    for frame in _transcript_append_frames(rows, append_event_id):
+                        yield frame
                 last_event_id = int(refreshed.get("last_event_id") or last_event_id)
                 last_managed_turn_id = normalize_optional_text(
                     refreshed.get("managed_turn_id")

--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -2406,6 +2406,12 @@ textarea:hover {
   margin: 0;
 }
 
+.trace-omitted {
+  margin: var(--space-1) 0 var(--space-2) calc(8px + var(--space-2));
+  color: var(--color-ink-muted);
+  font-size: var(--font-size-0);
+}
+
 .nested-trace.approval-card {
   border-left: 0;
   background: transparent;

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
@@ -11,6 +11,9 @@
     streamingMessageId = null,
   }: { cards: ChatTranscriptCard[]; assistantLabel?: string; streamingMessageId?: string | null } = $props();
 
+  const MAX_RENDERED_TOOL_GROUP_ITEMS = 80;
+  const MAX_RENDERED_TURN_SUMMARY_CARDS = 80;
+
   const userToggled = $state<Record<string, boolean>>({});
 
   function attachmentKindLabel(kind: SurfaceArtifact['kind']): string {
@@ -110,6 +113,22 @@
     return tool.title;
   }
 
+  function visibleToolGroupItems(card: Extract<ChatTranscriptCard, { kind: 'tool_group' }>): ChatToolCallCard[] {
+    return card.tools.slice(0, MAX_RENDERED_TOOL_GROUP_ITEMS);
+  }
+
+  function omittedToolGroupItemCount(card: Extract<ChatTranscriptCard, { kind: 'tool_group' }>): number {
+    return Math.max(0, card.tools.length - MAX_RENDERED_TOOL_GROUP_ITEMS);
+  }
+
+  function visibleTurnSummaryCards(card: Extract<ChatTranscriptCard, { kind: 'turn_summary' }>): ChatTranscriptCard[] {
+    return card.cards.slice(0, MAX_RENDERED_TURN_SUMMARY_CARDS);
+  }
+
+  function omittedTurnSummaryCardCount(card: Extract<ChatTranscriptCard, { kind: 'turn_summary' }>): number {
+    return Math.max(0, card.cards.length - MAX_RENDERED_TURN_SUMMARY_CARDS);
+  }
+
   const displayCards = $derived(compactChatTranscriptCards(cards));
 </script>
 
@@ -193,7 +212,7 @@
         </strong>
       </summary>
       <ol>
-        {#each card.tools as tool (tool.id)}
+        {#each visibleToolGroupItems(card) as tool (tool.id)}
           <li class={tool.state}>
             <span>{tool.state}</span>
             <strong>{tool.title}</strong>
@@ -206,6 +225,9 @@
           </li>
         {/each}
       </ol>
+      {#if omittedToolGroupItemCount(card) > 0}
+        <p class="trace-omitted">{omittedToolGroupItemCount(card)} additional tool calls omitted</p>
+      {/if}
     </details>
   {:else if card.kind === 'turn_summary'}
     <details class="tool-call-bar turn-summary-card">
@@ -213,7 +235,7 @@
         <strong>{card.title}</strong>
       </summary>
       <div class="turn-summary-trace">
-        {#each card.cards as traceCard (traceCard.id)}
+        {#each visibleTurnSummaryCards(card) as traceCard (traceCard.id)}
           {#if traceCard.kind === 'intermediate'}
             {#if isThinkingTrace(traceCard)}
               <details class="tool-call-bar thinking-trace nested-trace">
@@ -253,7 +275,7 @@
                 </strong>
               </summary>
               <ol>
-                {#each traceCard.tools as tool (tool.id)}
+                {#each visibleToolGroupItems(traceCard) as tool (tool.id)}
                   <li class={tool.state}>
                     <span>{tool.state}</span>
                     <strong>{tool.title}</strong>
@@ -266,6 +288,9 @@
                   </li>
                 {/each}
               </ol>
+              {#if omittedToolGroupItemCount(traceCard) > 0}
+                <p class="trace-omitted">{omittedToolGroupItemCount(traceCard)} additional tool calls omitted</p>
+              {/if}
             </details>
           {:else if traceCard.kind === 'approval'}
             <details class="approval-card nested-trace">
@@ -280,6 +305,9 @@
             </details>
           {/if}
         {/each}
+        {#if omittedTurnSummaryCardCount(card) > 0}
+          <p class="trace-omitted">{omittedTurnSummaryCardCount(card)} additional activity updates omitted</p>
+        {/if}
       </div>
     </details>
   {:else if card.kind === 'approval'}

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
@@ -132,6 +132,33 @@ describe('ChatTranscriptCards', () => {
     expect(body).toContain('Nested visible update.');
   });
 
+  it('bounds nested activity rendered inside turn summaries', () => {
+    const cards: ChatTranscriptCard[] = [
+      {
+        kind: 'turn_summary',
+        id: 'summary-1',
+        title: '120 thinking updates',
+        turnId: 'turn-1',
+        orderKey: '00000002|summary',
+        timestamp: '2026-05-10T00:00:12.000Z',
+        cards: Array.from({ length: 120 }, (_, index) => ({
+          ...baseTrace,
+          kind: 'intermediate' as const,
+          id: `thinking-${index}`,
+          title: 'thinking',
+          text: `Nested private trace ${index}`,
+          detail: `${index + 1} thinking updates`
+        }))
+      }
+    ];
+
+    const { body } = render(ChatTranscriptCards, { props: { cards } });
+
+    expect(body).toContain('Nested private trace 79');
+    expect(body).not.toContain('Nested private trace 80');
+    expect(body).toContain('40 additional activity updates omitted');
+  });
+
   it('renders compact timestamps on user and assistant message bubbles', () => {
     const cards: ChatTranscriptCard[] = [
       {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -458,10 +458,14 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     if (!cards.length) return;
     const next = cloneState(this.state);
     const transcript = cloneChatTranscript(next.chatTranscripts[chatId] ?? { cardsById: {}, order: [] });
+    const knownIds = new Set(transcript.order);
     for (const card of cards) {
       const id = chatTranscriptCardEntityId(card);
       transcript.cardsById[id] = card;
-      if (!transcript.order.includes(id)) transcript.order.push(id);
+      if (!knownIds.has(id)) {
+        knownIds.add(id);
+        transcript.order.push(id);
+      }
     }
     transcript.order = orderChatTranscriptCards(transcript.order.map((id) => transcript.cardsById[id]).filter(Boolean)).map(chatTranscriptCardEntityId);
     next.chatTranscripts[chatId] = transcript;

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -1571,6 +1571,33 @@ describe('PMA chat view helpers', () => {
     });
   });
 
+  it('keeps compacted live activity bounded for large streamed PMA turns', () => {
+    const cards = compactChatTranscriptCards(
+      Array.from({ length: 1000 }, (_, index) => ({
+        ...baseArtifactCardTrace(
+          `thinking-${index.toString().padStart(4, '0')}`,
+          `token-${index}`,
+          [`evt-${index}`]
+        ),
+        title: 'Thinking',
+        orderKey: index.toString().padStart(6, '0')
+      }))
+    );
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      kind: 'turn_summary',
+      title: '200 thinking updates'
+    });
+    const summary = cards[0];
+    if (summary.kind !== 'turn_summary') throw new Error('expected turn summary');
+    const trace = summary.cards[0];
+    if (trace.kind !== 'intermediate') throw new Error('expected intermediate trace');
+    expect(trace.eventIds).toHaveLength(200);
+    expect(trace.text.length).toBeLessThanOrEqual(4000);
+    expect(trace.text).toContain('[additional live updates omitted]');
+  });
+
   it('keeps numeric token-like progress updates out of thinking summaries', () => {
     const cards = compactChatTranscriptCards([
       {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -35,6 +35,8 @@ const INTERNAL_MESSENGER_SURFACE_KINDS = new Set([
 ]);
 
 const TOOL_PROGRESS_KINDS = new Set(['tool', 'tool_call', 'tool_result', 'function_call']);
+const MAX_COMPACT_ACTIVITY_SOURCE_IDS = 200;
+const MAX_MERGED_INTERMEDIATE_TEXT_CHARS = 4000;
 
 function rawString(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value : null;
@@ -1019,10 +1021,13 @@ function mergeIntermediateDeltas(cards: ChatTranscriptCard[]): ChatTranscriptCar
       out[out.length - 1] = {
         ...prev,
         title: mergedIntermediateTitle(prev, card),
-        text: mergeIntermediateText(prev.text, card.text),
-        eventIds: uniqueStrings([...prev.eventIds, ...card.eventIds]),
-        progressSourceIds: uniqueStrings([...prev.progressSourceIds, ...card.progressSourceIds]),
-        detail: mergedTraceDetail(mergedIntermediateTitle(prev, card), [...prev.eventIds, ...card.eventIds]),
+        text: mergeIntermediateText(prev.text, card.text, MAX_MERGED_INTERMEDIATE_TEXT_CHARS),
+        eventIds: appendCappedUniqueStrings(prev.eventIds, card.eventIds, MAX_COMPACT_ACTIVITY_SOURCE_IDS),
+        progressSourceIds: appendCappedUniqueStrings(prev.progressSourceIds, card.progressSourceIds, MAX_COMPACT_ACTIVITY_SOURCE_IDS),
+        detail: mergedTraceDetail(
+          mergedIntermediateTitle(prev, card),
+          appendCappedUniqueStrings(prev.eventIds, card.eventIds, MAX_COMPACT_ACTIVITY_SOURCE_IDS)
+        ),
         orderKey: prev.orderKey || card.orderKey,
         timestamp: prev.timestamp ?? card.timestamp
       };
@@ -1156,6 +1161,25 @@ function mergedTraceDetail(title: string, eventIds: string[]): string | null {
 
 function uniqueStrings(values: string[]): string[] {
   return Array.from(new Set(values.filter(Boolean)));
+}
+
+function appendCappedUniqueStrings(existing: string[], incoming: string[], max: number): string[] {
+  if (max <= 0) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const value of existing) {
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+    if (out.length >= max) return out;
+  }
+  for (const value of incoming) {
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+    if (out.length >= max) return out;
+  }
+  return out;
 }
 
 function isThinkingTraceTitle(title: string): boolean {
@@ -1623,21 +1647,29 @@ function shouldMergeIntermediate(
   return card.turnId === activityTurnId(event, fallbackTurnId) && !isCommentaryTraceCard(card);
 }
 
-function mergeIntermediateText(current: string, incoming: string): string {
-  if (!current) return incoming;
+function mergeIntermediateText(current: string, incoming: string, maxChars = Number.POSITIVE_INFINITY): string {
+  if (!current) return clampMergedIntermediateText(incoming, maxChars);
+  if (current.includes('[additional live updates omitted]')) return current;
   if (!incoming) return current;
   if (incoming === current) return current;
-  if (incoming.startsWith(current)) return incoming;
+  if (incoming.startsWith(current)) return clampMergedIntermediateText(incoming, maxChars);
   if (current.endsWith(incoming)) return current;
   const maxOverlap = Math.min(current.length, Math.max(incoming.length - 1, 0));
   for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
     if (current.slice(-overlap) === incoming.slice(0, overlap)) {
-      return `${current}${incoming.slice(overlap)}`;
+      return clampMergedIntermediateText(`${current}${incoming.slice(overlap)}`, maxChars);
     }
   }
-  if (/\s$/.test(current) || /^\s/.test(incoming)) return `${current}${incoming}`;
-  if (/^[,.;:!?)]/.test(incoming) || /[(]$/.test(current)) return `${current}${incoming}`;
-  return `${current} ${incoming}`;
+  if (/\s$/.test(current) || /^\s/.test(incoming)) return clampMergedIntermediateText(`${current}${incoming}`, maxChars);
+  if (/^[,.;:!?)]/.test(incoming) || /[(]$/.test(current)) return clampMergedIntermediateText(`${current}${incoming}`, maxChars);
+  return clampMergedIntermediateText(`${current} ${incoming}`, maxChars);
+}
+
+function clampMergedIntermediateText(text: string, maxChars: number): string {
+  if (!Number.isFinite(maxChars) || maxChars <= 0 || text.length <= maxChars) return text;
+  const marker = '\n\n[additional live updates omitted]';
+  const bodyLimit = Math.max(0, maxChars - marker.length);
+  return `${text.slice(0, bodyLimit).trimEnd()}${marker}`;
 }
 
 function thinkingTimelineDetail(item: PmaTimelineItem): string | null {

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_timeline_route.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_timeline_route.py
@@ -22,6 +22,7 @@ from codex_autorunner.core.ports.run_event import Completed, OutputDelta, RunNot
 from codex_autorunner.server import create_hub_app
 from codex_autorunner.surfaces.web.routes.pma_routes.tail_stream import (
     _successful_terminal_turn_id,
+    _transcript_append_frames,
     _transcript_has_assistant_row,
 )
 
@@ -71,6 +72,31 @@ def test_transcript_stream_terminal_snapshot_gate_requires_assistant_row() -> No
         },
         "turn-1",
     )
+
+
+def test_transcript_append_frames_chunk_without_advancing_cursor_early() -> None:
+    rows = [
+        {
+            "kind": "intermediate",
+            "id": f"row-{index}",
+            "order_key": f"{index:04d}",
+        }
+        for index in range(85)
+    ]
+
+    frames = list(_transcript_append_frames(rows, append_event_id=123, chunk_limit=80))
+
+    assert len(frames) == 2
+    assert "\nid: 123\n" not in frames[0]
+    assert "\nid: 123\n" in frames[1]
+    first_payload = json.loads(frames[0].split("data: ", 1)[1])
+    second_payload = json.loads(frames[1].split("data: ", 1)[1])
+    assert [row["id"] for row in first_payload["rows"]] == [
+        f"row-{index}" for index in range(80)
+    ]
+    assert [row["id"] for row in second_payload["rows"]] == [
+        f"row-{index}" for index in range(80, 85)
+    ]
 
 
 def test_managed_thread_transcript_live_rows_replace_stale_durable_rows() -> None:


### PR DESCRIPTION
## Summary
- Add a real-data Web UI chat idle profiler that can run against a live hub URL or seeded hub data.
- Bound PMA transcript compaction and nested rendering so dense live thinking/progress streams do not grow browser work unbounded.
- Cap PMA transcript append bursts server-side and remove an O(n) transcript append membership check in the read-model store.

## Root Cause
A running PMA/Hermes chat can accumulate thousands of live thinking/progress rows. The Web UI compacted those rows by repeatedly copying growing text and source-id arrays, then rendered nested summary contents without a hard cap. Transcript appends also used linear membership checks and could receive large append bursts from the stream.

## Validation
- Commit hook aggregate lane passed:
  - guardrails, black, ruff, import boundary checks
  - mypy strict over `src/codex_autorunner`
  - pytest: 8881 passed
  - Web UI lab fast check: 26 scenarios passed
  - `pnpm web:lint`
  - `pnpm web:build`
  - `pnpm web:test`: 643 passed, 2 skipped
  - Web Hub SPA shell check
- Manual real-data profiling:
  - source-backed hub against `f0ed2350-6740-4910-bfa2-571d7744bd86` for 90s: no freeze, max post-60s gap 336.4ms, 0 post-60s long tasks.
  - live route inventory over main Web UI pages for 60s each: no laggy or severe-lag routes.

## Notes
The service-side CPU samples still showed SQLite/WAL churn in the installed hub/Discord processes. This PR addresses the browser-side high-cardinality PMA chat blowup and adds profiling coverage for future investigation.
