### PR TITLE
[codex] Auto-send Discord chat wrapup app artifacts

### DIFF
--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -46,6 +46,8 @@ from ...adapters.chat.models import ChatMessageEvent
 from ...adapters.chat.runtime_thread_errors import (
     sanitize_runtime_thread_error,
 )
+from ...core.apps.install import installed_apps_root
+from ...core.artifact_delivery import ArtifactDeliveryService
 from ...core.artifact_instructions import (
     ArtifactDeliveryContext,
     render_agent_artifact_instructions,
@@ -101,6 +103,7 @@ from ..chat.managed_turn_runner import (
     run_managed_surface_turn,
 )
 from ..chat.progress_primitives import TurnProgressTracker
+from ..chat.ticket_flow_artifacts import collect_terminal_wrapup_artifacts
 from ..chat.turn_metrics import (
     compose_turn_response_with_footer,
 )
@@ -169,6 +172,7 @@ DISCORD_MANAGED_THREAD_SUBMISSION_TIMEOUT_SECONDS = 45.0
 DISCORD_PMA_PROGRESS_MAX_ACTIONS = 12
 DISCORD_PMA_PROGRESS_MIN_EDIT_INTERVAL_SECONDS = 1.0
 DISCORD_PMA_PROGRESS_HEARTBEAT_INTERVAL_SECONDS = 2.0
+_MAX_CHAT_WRAPUP_ARTIFACT_BYTES = 8 * 1024 * 1024
 
 
 _sanitize_runtime_thread_result_error = sanitize_runtime_thread_error
@@ -229,6 +233,56 @@ def _record_pending_discord_direct_delivery(
             delivered=delivered,
             delivery_state=updated.state.value,
         )
+
+
+def _enqueue_chat_wrapup_artifacts(
+    *,
+    workspace_root: Path,
+    channel_id: str,
+) -> int:
+    artifacts = collect_terminal_wrapup_artifacts(
+        workspace_root,
+        max_file_size_bytes=_MAX_CHAT_WRAPUP_ARTIFACT_BYTES,
+    )
+    if not artifacts:
+        return 0
+
+    service = ArtifactDeliveryService(workspace_root)
+    enqueued = 0
+    for artifact in artifacts:
+        if not artifact.absolute_path.is_file():
+            continue
+        service.enqueue_file(
+            artifact.absolute_path,
+            target_surface="discord",
+            target_conversation_key=f"channel:{channel_id}",
+            workspace_scope=f"repo:{workspace_root}",
+            origin_root=workspace_root,
+            metadata={
+                "app_id": artifact.app_id,
+                "app_version": artifact.app_version,
+                "tool_id": artifact.tool_id,
+                "hook_point": artifact.hook_point,
+                "label": artifact.label,
+                "kind": artifact.kind,
+                "relative_path": artifact.relative_path,
+            },
+        )
+        enqueued += 1
+    return enqueued
+
+
+def _workspace_has_installed_apps(workspace_root: Path) -> bool:
+    apps_root = installed_apps_root(workspace_root)
+    if not apps_root.exists():
+        return False
+    try:
+        for child in apps_root.iterdir():
+            if child.is_dir() and (child / "app.lock.json").exists():
+                return True
+    except OSError:
+        return True
+    return False
 
 
 @dataclass(frozen=True)
@@ -1447,12 +1501,34 @@ async def _deliver_discord_turn_result(
         terminal_message_id=current_message_id,
         terminal_created_at=current_lease_created_at,
     )
+    enqueued_wrapup_artifacts = 0
     try:
         if dispatch.pending_compact_seed is not None:
             await dispatch.service._store.clear_pending_compact_seed(
                 channel_id=dispatch.channel_id
             )
-        if send_final_message:
+        if _workspace_has_installed_apps(workspace_root):
+            try:
+                enqueued_wrapup_artifacts = await asyncio.to_thread(
+                    _enqueue_chat_wrapup_artifacts,
+                    workspace_root=workspace_root,
+                    channel_id=dispatch.channel_id,
+                )
+            except Exception as exc:
+                log_event(
+                    dispatch.service._logger,
+                    logging.WARNING,
+                    "discord.turn.wrapup_artifacts_enqueue_failed",
+                    channel_id=dispatch.channel_id,
+                    session_key=dispatch.session_key,
+                    preview_message_id=preview_message_id,
+                    execution_id=execution_id,
+                    background_task_owner="discord.turn.delivery",
+                    workspace_root=str(workspace_root),
+                    agent=dispatch.agent,
+                    exc=exc,
+                )
+        if send_final_message or enqueued_wrapup_artifacts:
             await dispatch.service._flush_outbox_files(
                 workspace_root=workspace_root,
                 channel_id=dispatch.channel_id,
@@ -1492,7 +1568,8 @@ async def _deliver_discord_turn_result(
         visible_failure_notice=visible_failure_notice,
         send_final_message=send_final_message,
         response_chars=len(response_text or ""),
-        flushed_outbox_files=send_final_message,
+        flushed_outbox_files=send_final_message or bool(enqueued_wrapup_artifacts),
+        enqueued_wrapup_artifacts=enqueued_wrapup_artifacts,
         agent=dispatch.agent,
     )
     _dispatch_snapshot = getattr(dispatch, "chat_ux_snapshot", None)

--- a/tests/adapters/discord/test_message_turns_message_flow.py
+++ b/tests/adapters/discord/test_message_turns_message_flow.py
@@ -17,6 +17,7 @@ from tests.discord_message_turns_support import (
     test_message_create_flush_outbox_skips_symlink_outside_pending,
     test_message_create_flushes_pending_outbox_files_after_turn,
     test_message_create_flushes_root_outbox_files_after_turn,
+    test_message_create_flushes_root_outbox_when_wrapup_artifacts_fail,
     test_message_create_injects_car_context_for_car_trigger,
     test_message_create_mixed_audio_and_file_attachment_keeps_outbox_hint,
     test_message_create_non_pma_injects_filebox_hint_for_inbox_keyword,
@@ -24,6 +25,7 @@ from tests.discord_message_turns_support import (
     test_message_create_non_pma_injects_prompt_context_hints,
     test_message_create_non_pma_prompt_hint_ignores_reply_context_prompt_text,
     test_message_create_non_pma_uses_raw_message_for_github_link_source,
+    test_message_create_sends_chat_wrapup_app_artifacts_after_turn,
     test_message_create_video_attachment_does_not_transcribe,
     test_message_event_submits_through_surface_orchestration_ingress,
 )

--- a/tests/chat_surface_lab/scenarios/queued_visibility.json
+++ b/tests/chat_surface_lab/scenarios/queued_visibility.json
@@ -285,7 +285,8 @@
       "field": "chat_ux_delta_queue_visible_ms",
       "surfaces": [
         "discord"
-      ]
+      ],
+      "max_ms": 4000.0
     },
     {
       "budget_id": "queue_visible",

--- a/tests/discord_message_turns_support.py
+++ b/tests/discord_message_turns_support.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import logging
 import os
 import re
@@ -46,7 +47,8 @@ from codex_autorunner.adapters.discord.service import (
 )
 from codex_autorunner.adapters.discord.state import DiscordStateStore
 from codex_autorunner.agents.registry import AgentDescriptor
-from codex_autorunner.bootstrap import seed_hub_files
+from codex_autorunner.bootstrap import seed_hub_files, seed_repo_files
+from codex_autorunner.core.apps import compute_bundle_sha
 from codex_autorunner.core.context_awareness import (
     CAR_AWARENESS_BLOCK,
     PROMPT_WRITING_HINT,
@@ -75,6 +77,7 @@ from codex_autorunner.core.ports.run_event import (
     TokenUsage,
 )
 from codex_autorunner.core.sse import format_sse
+from codex_autorunner.core.state_roots import resolve_repo_state_root
 from codex_autorunner.core.utils import canonicalize_path
 from tests.support.discord_turn_fakes import (
     _BaseDiscordFakeHarness,
@@ -98,6 +101,54 @@ from tests.support.discord_turn_fakes import (
 )
 
 pytestmark = pytest.mark.slow
+
+
+def _write_installed_wrapup_app(workspace: Path) -> None:
+    seed_hub_files(workspace, force=True)
+    seed_repo_files(workspace, git_required=False)
+    state_root = resolve_repo_state_root(workspace)
+    app_root = state_root / "apps" / "local.wrapup"
+    bundle_root = app_root / "bundle"
+    bundle_root.mkdir(parents=True, exist_ok=True)
+    manifest_text = """schema_version: 1
+id: local.wrapup
+name: Wrapup App
+version: 1.0.0
+hooks:
+  before_chat_wrapup:
+    - artifacts:
+        - "artifacts/summary.md"
+        - "artifacts/summary.png"
+"""
+    (bundle_root / "car-app.yaml").write_text(manifest_text, encoding="utf-8")
+    bundle_sha = compute_bundle_sha(bundle_root)
+    (app_root / "artifacts").mkdir(parents=True, exist_ok=True)
+    (app_root / "artifacts" / "summary.md").write_text(
+        "# summary\n",
+        encoding="utf-8",
+    )
+    (app_root / "artifacts" / "summary.png").write_bytes(b"png-bytes")
+    (app_root / "state").mkdir(parents=True, exist_ok=True)
+    (app_root / "logs").mkdir(parents=True, exist_ok=True)
+    (app_root / "app.lock.json").write_text(
+        json.dumps(
+            {
+                "id": "local.wrapup",
+                "version": "1.0.0",
+                "source_repo_id": "local",
+                "source_url": "https://example.invalid/apps.git",
+                "source_path": "apps/wrapup",
+                "source_ref": "main",
+                "commit_sha": "deadbeef",
+                "manifest_sha": "manifest-sha",
+                "bundle_sha": bundle_sha,
+                "trusted": True,
+                "installed_at": "2026-04-28T00:00:00Z",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
 
 
 def _discord_test_queue_worker_hooks(
@@ -1942,6 +1993,161 @@ async def test_message_create_flushes_root_outbox_files_after_turn(
         assert sent_files
         assert sent_files[0].read_text(encoding="utf-8") == "root artifact payload\n"
         assert not root_file.exists()
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_message_create_flushes_root_outbox_when_wrapup_artifacts_fail(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    root_outbox = outbox_dir(workspace.resolve())
+    root_outbox.mkdir(parents=True, exist_ok=True)
+    root_file = root_outbox / "root-result.txt"
+    root_file.write_text("root artifact payload\n", encoding="utf-8")
+
+    def _fail_collect_wrapup_artifacts(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("bad app artifact config")
+
+    monkeypatch.setattr(
+        discord_message_turns_module,
+        "collect_terminal_wrapup_artifacts",
+        _fail_collect_wrapup_artifacts,
+    )
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway([("MESSAGE_CREATE", _message_create("ship it"))])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    async def _fake_run_turn(
+        self,
+        *,
+        workspace_root: Path,
+        prompt_text: str,
+        agent: str,
+        model_override: Optional[str],
+        reasoning_effort: Optional[str],
+        session_key: str,
+        orchestrator_channel_key: str,
+        source_message_id: Optional[str] = None,
+        managed_thread_surface_key: Optional[str] = None,
+        chat_ux_snapshot: Any = None,
+    ) -> str:
+        _ = (
+            self,
+            workspace_root,
+            prompt_text,
+            agent,
+            model_override,
+            reasoning_effort,
+            session_key,
+            orchestrator_channel_key,
+            source_message_id,
+            managed_thread_surface_key,
+            chat_ux_snapshot,
+        )
+        return "Done from fake turn"
+
+    service._run_agent_turn_for_message = _fake_run_turn.__get__(
+        service, DiscordBotService
+    )
+
+    try:
+        await service.run_forever()
+        assert rest.attachment_messages
+        assert any(
+            item["filename"] == "root-result.txt" for item in rest.attachment_messages
+        )
+        assert not root_file.exists()
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_message_create_sends_chat_wrapup_app_artifacts_after_turn(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_installed_wrapup_app(workspace)
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+    rest = _FakeRest()
+    gateway = _FakeGateway([("MESSAGE_CREATE", _message_create("ship it"))])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    async def _fake_run_turn(
+        self,
+        *,
+        workspace_root: Path,
+        prompt_text: str,
+        agent: str,
+        model_override: Optional[str],
+        reasoning_effort: Optional[str],
+        session_key: str,
+        orchestrator_channel_key: str,
+        source_message_id: Optional[str] = None,
+        managed_thread_surface_key: Optional[str] = None,
+        chat_ux_snapshot: Any = None,
+    ) -> DiscordMessageTurnResult:
+        _ = (
+            self,
+            workspace_root,
+            prompt_text,
+            agent,
+            model_override,
+            reasoning_effort,
+            session_key,
+            orchestrator_channel_key,
+            source_message_id,
+            managed_thread_surface_key,
+            chat_ux_snapshot,
+        )
+        return DiscordMessageTurnResult(
+            final_message="Done from fake turn",
+            send_final_message=False,
+        )
+
+    service._run_agent_turn_for_message = _fake_run_turn.__get__(
+        service, DiscordBotService
+    )
+
+    try:
+        await service.run_forever()
+        filenames = {item["filename"] for item in rest.attachment_messages}
+        assert {"summary.md", "summary.png"} <= filenames
     finally:
         await store.close()
 


### PR DESCRIPTION
## Summary

Automatically enqueue app `before_chat_wrapup` artifacts from normal Discord managed turns, then drain them through the existing artifact delivery/outbox path.

## Root Cause

AutoOptimize writes `summary.md` and `summary.png` as app artifacts, but normal Discord managed turns only flushed files that were already in the outbox. The app wrapup artifact collector was only wired into the ticket-flow terminal watcher, so a visible final Discord turn could mention the report paths without sending the files.

## Changes

- Collect app `before_chat_wrapup` artifacts during Discord turn cleanup.
- Enqueue those files through `ArtifactDeliveryService`, matching the `car artifacts send` delivery journal path.
- Drain delivery whenever a final message is sent or wrapup artifacts were enqueued.
- Add coverage for a no-final-message Discord turn sending both `summary.md` and `summary.png`.

## Validation

- Commit hook chat-apps lane passed.
- Full pytest from hook: `8885 passed, 10 warnings`.
- Chat surface lab: `20 passed, 1 warning` and latency budget suite PASS.
- Focused rerun: `.venv/bin/python -m pytest tests/adapters/discord/test_message_turns_message_flow.py::test_message_create_sends_chat_wrapup_app_artifacts_after_turn -q`.
- Focused lint: `.venv/bin/python -m ruff check src/codex_autorunner/adapters/discord/message_turns.py tests/discord_message_turns_support.py tests/adapters/discord/test_message_turns_message_flow.py`.
