### PR TITLE
feat: chat archive lifecycle authority + newt surface semantics (5 tickets)

### DIFF
--- a/src/codex_autorunner/adapters/chat/managed_thread_lifecycle.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_lifecycle.py
@@ -137,6 +137,8 @@ async def replace_surface_thread(
     display_name: str,
     binding_metadata: Optional[dict[str, Any]] = None,
     thread_metadata: Optional[dict[str, Any]] = None,
+    backend_thread_id: Optional[str] = None,
+    backend_runtime_instance_id: Optional[str] = None,
     binding: Optional[Any] = None,
     thread: Optional[Any] = None,
 ) -> ManagedThreadReplacementResult:
@@ -156,6 +158,15 @@ async def replace_surface_thread(
         if previous_thread_id:
             stop_outcome = await orchestration_service.stop_thread(previous_thread_id)
             orchestration_service.archive_thread_target(previous_thread_id)
+    replacement_metadata = dict(thread_metadata or {})
+    normalized_runtime_instance_id = _normalized_optional_text(
+        backend_runtime_instance_id
+    )
+    if normalized_runtime_instance_id is not None:
+        replacement_metadata.setdefault(
+            "backend_runtime_instance_id",
+            normalized_runtime_instance_id,
+        )
     replacement = orchestration_service.create_thread_target(
         agent_id,
         workspace_root,
@@ -163,7 +174,8 @@ async def replace_surface_thread(
         resource_kind=resource_kind,
         resource_id=resource_id,
         display_name=display_name,
-        metadata=dict(thread_metadata or {}) or None,
+        backend_thread_id=_normalized_optional_text(backend_thread_id),
+        metadata=replacement_metadata or None,
     )
     bound_thread = bind_surface_thread(
         orchestration_service,
@@ -176,6 +188,8 @@ async def replace_surface_thread(
         resource_id=resource_id,
         mode=mode,
         metadata=binding_metadata,
+        backend_thread_id=backend_thread_id,
+        backend_runtime_instance_id=backend_runtime_instance_id,
         thread=replacement,
     )
     return ManagedThreadReplacementResult(

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
@@ -771,22 +771,6 @@ async def _sync_telegram_thread_binding(
         surface_key=surface_key,
         mode=mode,
     )
-    if replace_existing and current_thread is not None:
-        stop_outcome = await orchestration_service.stop_thread(
-            current_thread.thread_target_id
-        )
-        if stop_outcome.recovered_lost_backend:
-            log_event(
-                handlers._logger,
-                logging.INFO,
-                "telegram.thread.recovered_lost_backend",
-                surface_key=surface_key,
-                managed_thread_id=current_thread.thread_target_id,
-                mode=mode,
-            )
-        orchestration_service.archive_thread_target(current_thread.thread_target_id)
-        binding = None
-        current_thread = None
     requested_backend_thread_id = None if pma_enabled else backend_thread_id
     runtime_binding = await resolve_chat_thread_runtime_binding(
         orchestration_service,
@@ -805,6 +789,40 @@ async def _sync_telegram_thread_binding(
             workspace_root=workspace_root,
             mode=mode,
         )
+    if replace_existing:
+        replacement = await replace_surface_thread(
+            orchestration_service,
+            surface_kind="telegram",
+            surface_key=surface_key,
+            workspace_root=workspace_root,
+            agent_id=agent,
+            repo_id=repo_id.strip() if isinstance(repo_id, str) else None,
+            resource_kind=resource_kind,
+            resource_id=resource_id,
+            mode=mode,
+            display_name=f"telegram:{surface_key}",
+            binding_metadata={
+                "topic_key": surface_key,
+                "pma_enabled": pma_enabled,
+                "surface_key": surface_key,
+            },
+            backend_thread_id=runtime_binding.backend_thread_id,
+            backend_runtime_instance_id=runtime_binding.backend_runtime_instance_id,
+            binding=binding,
+            thread=current_thread,
+        )
+        stop_outcome = replacement.stop_outcome
+        if stop_outcome is not None and stop_outcome.recovered_lost_backend:
+            previous_thread_id = replacement.previous_thread_id
+            log_event(
+                handlers._logger,
+                logging.INFO,
+                "telegram.thread.recovered_lost_backend",
+                surface_key=surface_key,
+                managed_thread_id=previous_thread_id,
+                mode=mode,
+            )
+        return orchestration_service, replacement.replacement_thread
     return _shared_resolve_managed_thread_target(
         orchestration_service,
         request=ManagedThreadTargetRequest(

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -1521,6 +1521,12 @@ def _chat_index_rows_from_surfaces(
         row["binding_display_name"] = (
             binding_display_names[0] if binding_display_names else None
         )
+        if (
+            row.get("managed_thread_id") is not None
+            and _normalize_kind(row.get("lifecycle_status")) != "archived"
+            and _normalize_kind(row.get("lifecycle")) == "archived"
+        ):
+            row["lifecycle"] = _managed_thread_row_lifecycle(row)
         row["archive_state"] = _archive_state(row.get("lifecycle_status"))
         row["sort_key"] = _chat_index_sort_key_parts(row)
         row["group_id"] = _chat_ticket_group_id(row)
@@ -1579,6 +1585,17 @@ def _primary_surface(row: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
 
 def _archive_state(lifecycle_status: Any) -> str:
     return "archived" if _normalize_kind(lifecycle_status) == "archived" else "active"
+
+
+def _managed_thread_row_lifecycle(row: Mapping[str, Any]) -> str:
+    if int(row.get("queue_depth") or 0) > 0:
+        return "queued"
+    runtime = _status_to_lifecycle(
+        row.get("runtime_status") or row.get("target_runtime_status")
+    )
+    if runtime in {"idle", "running", "failed"}:
+        return runtime
+    return "bound"
 
 
 def canonical_owner_fields(
@@ -1731,10 +1748,10 @@ def _chat_index_effective_status(row: Mapping[str, Any]) -> str:
     runtime = _status_to_lifecycle(
         row.get("runtime_status") or row.get("target_runtime_status")
     )
-    if (
-        lifecycle_status == "archived"
-        or lifecycle == "archived"
-        or runtime == "archived"
+    if lifecycle_status == "archived":
+        return "archived"
+    if row.get("managed_thread_id") is None and (
+        lifecycle == "archived" or runtime == "archived"
     ):
         return "archived"
     if int(row.get("queue_depth") or 0) > 0:

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -647,7 +647,196 @@ class ChatSurfaceReadService:
         except (TypeError, ValueError):
             return 0
 
-    def rebuild_chat_index_projection(self) -> None:
+    def chat_index_projection_status(self) -> dict[str, Any]:
+        """Return current SQL projection state without rebuilding it."""
+
+        source_signature = self._chat_index_source_signature()
+        with open_orchestration_sqlite(
+            self._hub_root, durable=self._durable, migrate=True
+        ) as conn:
+            if not _table_exists(
+                conn, "orch_chat_index_projection"
+            ) or not _table_exists(conn, "orch_chat_index_projection_meta"):
+                return {
+                    "source_signature": source_signature,
+                    "stored_source_signature": None,
+                    "projection_revision": 0,
+                    "row_count": 0,
+                    "needs_rebuild": True,
+                }
+            meta = {
+                str(row["key"]): str(row["value"])
+                for row in conn.execute(
+                    """
+                    SELECT key, value
+                      FROM orch_chat_index_projection_meta
+                     WHERE key IN ('source_signature', 'projection_revision')
+                    """
+                ).fetchall()
+            }
+            row = conn.execute(
+                "SELECT COUNT(*) AS row_count FROM orch_chat_index_projection"
+            ).fetchone()
+        stored_signature = meta.get("source_signature")
+        return {
+            "source_signature": source_signature,
+            "stored_source_signature": stored_signature,
+            "projection_revision": max(
+                0, _safe_int(meta.get("projection_revision"), 0)
+            ),
+            "row_count": int(row["row_count"] or 0) if row is not None else 0,
+            "needs_rebuild": stored_signature != source_signature,
+        }
+
+    def repair_stale_bound_surface_archive_state(
+        self, *, dry_run: bool = False
+    ) -> dict[str, Any]:
+        """Emit current-generation facts for active bindings shadowed by archives."""
+
+        surfaces = self._projected_surfaces(limit=None)
+        projected_by_surface = {
+            (
+                _normalize_kind(surface.get("surface_kind")),
+                _normalize_text(surface.get("surface_key")),
+            ): surface
+            for surface in surfaces
+        }
+        with open_orchestration_sqlite(
+            self._hub_root, durable=self._durable, migrate=True
+        ) as conn:
+            binding_rows = conn.execute(
+                """
+                SELECT b.binding_id,
+                       b.surface_kind,
+                       b.surface_key,
+                       b.target_id,
+                       b.repo_id AS binding_repo_id,
+                       b.resource_kind AS binding_resource_kind,
+                       b.resource_id AS binding_resource_id,
+                       b.metadata_json AS binding_metadata_json,
+                       b.updated_at AS binding_updated_at,
+                       t.repo_id AS thread_repo_id,
+                       t.resource_kind AS thread_resource_kind,
+                       t.resource_id AS thread_resource_id,
+                       t.workspace_root AS thread_workspace_root,
+                       t.lifecycle_status AS thread_lifecycle_status
+                  FROM orch_bindings b
+                  JOIN orch_thread_targets t
+                    ON t.thread_target_id = b.target_id
+                 WHERE b.disabled_at IS NULL
+                   AND lower(b.surface_kind) IN ('discord', 'telegram')
+                   AND COALESCE(t.lifecycle_status, 'active') != 'archived'
+                 ORDER BY b.surface_kind ASC, b.surface_key ASC, b.binding_id ASC
+                """
+            ).fetchall()
+
+        candidates: list[dict[str, Any]] = []
+        for row in binding_rows:
+            surface_kind = _normalize_kind(row["surface_kind"])
+            surface_key = _normalize_text(row["surface_key"])
+            managed_thread_id = _normalize_text(row["target_id"])
+            if (
+                surface_kind not in {"discord", "telegram"}
+                or surface_key is None
+                or managed_thread_id is None
+            ):
+                continue
+            surface = projected_by_surface.get((surface_kind, surface_key))
+            if surface is None:
+                continue
+            lifecycle_status = _normalize_kind(surface.get("lifecycle_status"))
+            lifecycle = _normalize_kind(surface.get("lifecycle"))
+            if lifecycle_status != "archived" and lifecycle != "archived":
+                continue
+            metadata = _json_object(row["binding_metadata_json"])
+            candidates.append(
+                {
+                    "surface_kind": surface_kind,
+                    "surface_key": surface_key,
+                    "managed_thread_id": managed_thread_id,
+                    "binding_id": _normalize_text(row["binding_id"]),
+                    "repo_id": _normalize_text(row["binding_repo_id"])
+                    or _normalize_text(row["thread_repo_id"]),
+                    "resource_kind": _normalize_text(row["binding_resource_kind"])
+                    or _normalize_text(row["thread_resource_kind"]),
+                    "resource_id": _normalize_text(row["binding_resource_id"])
+                    or _normalize_text(row["thread_resource_id"]),
+                    "workspace_root": _normalize_text(row["thread_workspace_root"]),
+                    "display_name": _normalize_text(metadata.get("display_name")),
+                    "stale_lifecycle": lifecycle,
+                    "stale_lifecycle_status": lifecycle_status,
+                }
+            )
+
+        result: dict[str, Any] = {
+            "dry_run": dry_run,
+            "matched": len(candidates),
+            "repaired": 0,
+            "already_recorded": 0,
+            "candidates": candidates,
+            "projection": None,
+        }
+        if dry_run:
+            return result
+
+        repaired = 0
+        already_recorded = 0
+        for candidate in candidates:
+            append = self._journal.append_event(
+                idempotency_key=(
+                    "repair.stale_bound_surface_archive_state:"
+                    f"{candidate['surface_kind']}:"
+                    f"{candidate['surface_key']}:"
+                    f"{candidate['managed_thread_id']}"
+                ),
+                event_type="surface.rebound",
+                surface_kind=str(candidate["surface_kind"]),
+                surface_key=str(candidate["surface_key"]),
+                managed_thread_id=str(candidate["managed_thread_id"]),
+                repo_id=_normalize_text(candidate.get("repo_id")),
+                resource_kind=_normalize_text(candidate.get("resource_kind")),
+                resource_id=_normalize_text(candidate.get("resource_id")),
+                workspace_root=_normalize_text(candidate.get("workspace_root")),
+                lifecycle_status="active",
+                status="bound",
+                source_kind="chat_index_repair",
+                source_id="stale_bound_surface_archive_state",
+                payload={
+                    "repair": "stale_bound_surface_archive_state",
+                    "binding_id": candidate.get("binding_id"),
+                    "display": {
+                        "display_name": candidate.get("display_name"),
+                    },
+                },
+            )
+            if append.inserted:
+                repaired += 1
+            else:
+                already_recorded += 1
+
+        projection = self.rebuild_chat_index_projection()
+        result.update(
+            {
+                "repaired": repaired,
+                "already_recorded": already_recorded,
+                "projection": projection,
+            }
+        )
+        if candidates:
+            logger.info(
+                "repaired stale bound surface archive state",
+                extra={
+                    "event": "chat_index_repair",
+                    "repair": "stale_bound_surface_archive_state",
+                    "matched": len(candidates),
+                    "repaired": repaired,
+                    "already_recorded": already_recorded,
+                },
+            )
+        return result
+
+    def rebuild_chat_index_projection(self) -> dict[str, Any]:
+        before = self.chat_index_projection_status()
         source_signature = self._chat_index_source_signature()
         surfaces = self._projected_surfaces(limit=None)
         rows = sorted(
@@ -738,6 +927,16 @@ class ChatSurfaceReadService:
                     """,
                     (str(projection_revision), rebuilt_at),
                 )
+        return {
+            "rebuilt": True,
+            "row_count": len(rows),
+            "projection_revision": projection_revision,
+            "previous_projection_revision": before.get("projection_revision", 0),
+            "source_signature": source_signature,
+            "previous_source_signature": before.get("stored_source_signature"),
+            "source_changed": before.get("stored_source_signature") != source_signature,
+            "rebuilt_at": rebuilt_at,
+        }
 
     def _ensure_chat_index_projection_current(self) -> None:
         source_signature = self._chat_index_source_signature()
@@ -2297,6 +2496,8 @@ def _choose_lifecycle(current: str, candidate: Optional[str]) -> str:
 def _choose_ordered_lifecycle(current: str, candidate: Optional[str]) -> str:
     if candidate is None:
         return current
+    if current == "archived" and candidate == "bound":
+        return candidate
     if current == "archived" or candidate == "archived":
         return "archived"
     if current in _DYNAMIC_LIFECYCLES and candidate in _DYNAMIC_LIFECYCLES:

--- a/src/codex_autorunner/docs/managed-threads.md
+++ b/src/codex_autorunner/docs/managed-threads.md
@@ -14,3 +14,18 @@ Common operations:
 - Archive: `car pma thread archive --id <thread_id> --path <hub_root>`
 
 Reuse a relevant active managed thread before spawning a new one.
+
+## Bound Chat Generations
+
+Managed threads own chat lifecycle. A row is active or archived from the
+managed thread target's `lifecycle_status`; Discord and Telegram surface
+bindings are pointers to the current channel or topic generation.
+
+`/newt` on a bound Discord channel or Telegram topic starts a new active
+managed thread generation and rebinds the surface key to that thread. The old
+generation may be archived, but it remains addressable through Archive and the
+direct chat detail route.
+
+Stale surface archive events are history for a previous binding generation.
+They must not own active row membership after a later `surface.rebound` points
+the same surface key at a fresh active managed thread.

--- a/src/codex_autorunner/surfaces/cli/commands/chat.py
+++ b/src/codex_autorunner/surfaces/cli/commands/chat.py
@@ -26,6 +26,7 @@ from ....adapters.discord.rest import DiscordRestClient
 from ....adapters.telegram.client import TelegramBotClient
 from ....adapters.telegram.state_types import parse_topic_key
 from ....core.config import ConfigError, load_hub_config
+from ....core.orchestration import ChatSurfaceReadService
 from ....core.orchestration.sqlite import resolve_orchestration_sqlite_path
 from ..hub_path_option import hub_root_path_option
 
@@ -642,8 +643,13 @@ def register_chat_commands(
         add_completion=False,
         help="Inspect and remediate live per-conversation chat dispatch queues.",
     )
+    index_app = typer.Typer(
+        add_completion=False,
+        help="Inspect and repair the chat index read-model projection.",
+    )
     app.add_typer(channels_app, name="channels")
     app.add_typer(queue_app, name="queue")
+    app.add_typer(index_app, name="index")
 
     @app.command("resolve")
     def chat_resolve(
@@ -719,6 +725,82 @@ def register_chat_commands(
 
         for result in results:
             typer.echo(_format_resolve_text_line(result))
+
+    @index_app.command("rebuild")
+    def chat_index_rebuild(
+        dry_run: bool = typer.Option(
+            False,
+            "--dry-run",
+            help="Report projection state without rebuilding.",
+        ),
+        output_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+        path: Optional[Path] = hub_root_path_option(),
+    ) -> None:
+        """Rebuild the chat index projection from canonical orchestration state."""
+        hub_root = resolve_hub_path(path)
+        service = ChatSurfaceReadService(hub_root, durable=True)
+        status = service.chat_index_projection_status()
+        if dry_run:
+            payload = {"dry_run": True, "projection": status}
+            if output_json:
+                typer.echo(json.dumps(payload, indent=2))
+                return
+            typer.echo(
+                "Chat index projection dry run: "
+                f"rows={status['row_count']} "
+                f"revision={status['projection_revision']} "
+                f"needs_rebuild={'yes' if status['needs_rebuild'] else 'no'}"
+            )
+            return
+
+        result = service.rebuild_chat_index_projection()
+        payload = {"dry_run": False, "projection": result}
+        if output_json:
+            typer.echo(json.dumps(payload, indent=2))
+            return
+        typer.echo(
+            "Rebuilt chat index projection: "
+            f"rows={result['row_count']} "
+            f"revision={result['projection_revision']} "
+            f"source_changed={'yes' if result['source_changed'] else 'no'}"
+        )
+
+    @index_app.command("repair-stale-bound-archives")
+    def chat_index_repair_stale_bound_archives(
+        dry_run: bool = typer.Option(
+            False,
+            "--dry-run",
+            help="Report matching active bindings without writing repair events.",
+        ),
+        output_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+        path: Optional[Path] = hub_root_path_option(),
+    ) -> None:
+        """Repair active Discord/Telegram chats shadowed by stale archive facts."""
+        hub_root = resolve_hub_path(path)
+        service = ChatSurfaceReadService(hub_root, durable=True)
+        result = service.repair_stale_bound_surface_archive_state(dry_run=dry_run)
+        if output_json:
+            typer.echo(json.dumps(result, indent=2))
+            return
+        if dry_run:
+            typer.echo(
+                "Stale bound archive repair dry run: " f"matched={result['matched']}"
+            )
+            for candidate in result["candidates"]:
+                typer.echo(
+                    "  "
+                    f"{candidate['surface_kind']}:{candidate['surface_key']} "
+                    f"-> {candidate['managed_thread_id']}"
+                )
+            return
+        projection = result.get("projection") or {}
+        typer.echo(
+            "Repaired stale bound archive state: "
+            f"matched={result['matched']} "
+            f"repaired={result['repaired']} "
+            f"already_recorded={result['already_recorded']} "
+            f"projection_revision={projection.get('projection_revision', 0)}"
+        )
 
     @channels_app.command("list")
     def chat_channels_list(

--- a/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
@@ -584,10 +584,11 @@ def _chat_surface_status_from_row(row: Mapping[str, Any]) -> ChatSurfaceStatus:
     lifecycle_status = str(row.get("lifecycle_status") or "").strip().lower()
     runtime = str(row.get("runtime_status") or row.get("target_runtime_status") or "")
     runtime_l = runtime.strip().lower()
-    if (
-        lifecycle_status == "archived"
-        or lifecycle == "archived"
-        or runtime_l == "archived"
+    archive_state = str(row.get("archive_state") or "").strip().lower()
+    if lifecycle_status == "archived" or archive_state == "archived":
+        return "archived"
+    if row.get("managed_thread_id") is None and (
+        lifecycle == "archived" or runtime_l == "archived"
     ):
         return "archived"
     queue_depth = _int_fallback(row.get("queue_depth"), 0)

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.test.ts
@@ -9,6 +9,7 @@ import {
   selectRepoSummaries,
   selectWorktreeSummaries
 } from './readModelViewModels';
+import { chatSurfaceFilterToken, filterPmaChats } from '$lib/viewModels/pmaChat';
 
 const now = '2026-05-11T12:00:00Z';
 const cursor = { value: 'c:1', sequence: 1, source: 'test', issuedAt: now };
@@ -59,6 +60,41 @@ describe('read model view-model selectors', () => {
     expect(pmaChatSummaryToChatIndexRow(summary).agentProfile).toBe('m4-pma');
     expect(pmaChatSummaryToChatIndexRow(summary).chatId).toBe('chat-1');
     expect(pmaChatSummaryToChatIndexRow(summary).unreadCount).toBe(2);
+  });
+
+  it('keeps active rebound chat-index rows visible despite stale raw surface archive fields', () => {
+    const row: ChatIndexRow = {
+      chatId: 'discord-rebound-active',
+      surface: 'discord',
+      title: 'Discord Ops',
+      lifecycle: 'archived',
+      runtimeStatus: 'running',
+      archiveState: 'active',
+      status: 'running',
+      unreadCount: 0,
+      lastActivityAt: now,
+      primarySurface: {
+        surface_kind: 'pma',
+        lifecycle: 'running'
+      },
+      surfaceBindings: [
+        {
+          surface_kind: 'discord',
+          surface_key: 'channel-1',
+          lifecycle: 'archived'
+        }
+      ]
+    };
+
+    const summary = chatIndexRowToPmaChatSummary(row);
+
+    expect(summary.lifecycleStatus).toBe('active');
+    expect(pmaChatSummaryToChatIndexRow(summary).status).toBe('running');
+    expect(filterPmaChats([summary], 'all', '').map((chat) => chat.id)).toEqual(['discord-rebound-active']);
+    expect(filterPmaChats([summary], chatSurfaceFilterToken('discord'), '').map((chat) => chat.id)).toEqual([
+      'discord-rebound-active'
+    ]);
+    expect(filterPmaChats([summary], 'archived', '').map((chat) => chat.id)).toEqual([]);
   });
 
   it('preserves unread counts through PMA chat row conversion', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
@@ -9,6 +9,7 @@ import {
   mapRepoSummary,
   mapWorktreeSummary,
   normalizeWorkStatus,
+  pmaLifecycleTokenIsActive,
   pmaLifecycleTokenIsArchived,
   pmaChatArchivedFromRawSignals,
   type PmaChatSummary,
@@ -287,8 +288,8 @@ function legacyChatIndexStatus(
 }
 
 function chatIndexStatus(chat: PmaChatSummary): ChatIndexRow['status'] {
-  if (pmaLifecycleTokenIsArchived(chat.lifecycleStatus) || pmaChatArchivedFromRawSignals(chat.raw))
-    return 'archived';
+  if (pmaLifecycleTokenIsArchived(chat.lifecycleStatus)) return 'archived';
+  if (!pmaLifecycleTokenIsActive(chat.lifecycleStatus) && pmaChatArchivedFromRawSignals(chat.raw)) return 'archived';
   if (chat.status === 'waiting') return 'waiting';
   if (chat.status === 'running') return 'running';
   if (chat.status === 'failed' || chat.status === 'blocked' || chat.status === 'invalid') return 'failed';

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/domain.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/domain.ts
@@ -37,13 +37,21 @@ export function pmaLifecycleTokenIsArchived(value: unknown): boolean {
   return String(value ?? '').trim().toLowerCase() === 'archived';
 }
 
+export function pmaLifecycleTokenIsActive(value: unknown): boolean {
+  return String(value ?? '').trim().toLowerCase() === 'active';
+}
+
 /**
  * Archived chat detection from durable raw fields (index rows, surface snapshots, detail loads).
  * Intentionally ignores generic `status` strings so live execution status cannot mask archival.
  */
 export function pmaChatArchivedFromRawSignals(raw: JsonRecord | null | undefined): boolean {
   if (!raw || typeof raw !== 'object') return false;
-  for (const key of ['lifecycle_status', 'lifecycleStatus', 'lifecycle', 'runtime_status'] as const) {
+  for (const key of ['archive_state', 'archiveState', 'lifecycle_status', 'lifecycleStatus'] as const) {
+    if (pmaLifecycleTokenIsArchived(raw[key])) return true;
+    if (pmaLifecycleTokenIsActive(raw[key])) return false;
+  }
+  for (const key of ['lifecycle', 'runtime_status'] as const) {
     if (pmaLifecycleTokenIsArchived(raw[key])) return true;
   }
   return false;
@@ -284,14 +292,23 @@ export function mapPmaChatSummary(raw: JsonRecord): PmaChatSummary {
     nullableString(raw.worktree_repo_id ?? raw.worktree_id) ?? (resourceKind === 'worktree' ? resourceId : null);
   const ticketId = ticketIdFromRaw(raw);
   const isTicketFlow = detectTicketFlowChat(raw, ticketId);
+  const archiveState = nullableString(raw.archive_state ?? raw.archiveState);
   const lifecycleField = nullableString(raw.lifecycle_status ?? raw.lifecycleStatus);
   const lifecycleRoot = nullableString(raw.lifecycle);
-  let lifecycleStatus: string | null =
-    pmaLifecycleTokenIsArchived(lifecycleField) || pmaLifecycleTokenIsArchived(lifecycleRoot)
-      ? 'archived'
-      : lifecycleField;
+  let lifecycleStatus: string | null = pmaLifecycleTokenIsArchived(archiveState)
+    ? 'archived'
+    : pmaLifecycleTokenIsActive(archiveState)
+      ? 'active'
+      : pmaLifecycleTokenIsArchived(lifecycleField)
+        ? 'archived'
+        : pmaLifecycleTokenIsActive(lifecycleField)
+          ? 'active'
+          : pmaLifecycleTokenIsArchived(lifecycleRoot)
+            ? 'archived'
+            : lifecycleField;
   if (
     lifecycleStatus !== 'archived' &&
+    lifecycleStatus !== 'active' &&
     pmaLifecycleTokenIsArchived(raw.runtime_status ?? raw.execution_status ?? raw.normalized_status)
   ) {
     lifecycleStatus = 'archived';

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -20,6 +20,7 @@ import {
   filterArtifactsForActiveChat,
   formatRelativeTime,
   formatCompactMessageDateTime,
+  isPmaChatArchived,
   isPrimaryProgressArtifact,
   mergeChatActivityEvents,
   mapChatTranscriptSnapshot,
@@ -292,6 +293,28 @@ describe('PMA chat view helpers', () => {
     expect(filterPmaChats(chats, 'archived', 'support').map((chat) => chat.id)).toEqual(['chat-2']);
     expect(filterPmaChats(chats, 'unread', '').map((chat) => chat.id).sort()).toEqual(['chat-1', 'chat-3']);
     expect(summarizeFilterCounts(chats)).toEqual({ all: 2, active: 1, waiting: 1, unread: 2, archived: 1 });
+  });
+
+  it('trusts active lifecycle status over stale raw archive fields for list membership', () => {
+    const rebound: PmaChatSummary = {
+      ...baseChat,
+      id: 'discord-rebound-active',
+      lifecycleStatus: 'active',
+      raw: {
+        archive_state: 'active',
+        lifecycle_status: 'active',
+        lifecycle: 'archived',
+        runtime_status: 'archived',
+        surface_kind: 'discord',
+        surface_bindings: [{ surface_kind: 'discord', surface_key: 'channel-1', lifecycle: 'archived' }],
+        primary_surface: { surface_kind: 'pma', lifecycle: 'running' }
+      }
+    };
+
+    expect(isPmaChatArchived(rebound)).toBe(false);
+    expect(filterPmaChats([rebound], 'all', '')).toEqual([rebound]);
+    expect(filterPmaChats([rebound], chatSurfaceFilterToken('discord'), '')).toEqual([rebound]);
+    expect(filterPmaChats([rebound], 'archived', '')).toEqual([]);
   });
 
   it('drops archived ticket-flow chats from grouped run rows when not on the archived filter', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -8,7 +8,7 @@ import type {
   WorktreeSummary,
   WorkStatus
 } from './domain';
-import { normalizeOptionalWorkStatus, pmaChatArchivedFromRawSignals, pmaLifecycleTokenIsArchived, pmaTimelineContractFields } from './domain';
+import { normalizeOptionalWorkStatus, pmaChatArchivedFromRawSignals, pmaLifecycleTokenIsActive, pmaLifecycleTokenIsArchived, pmaTimelineContractFields } from './domain';
 import { surfaceRefFromThreadRaw } from './thread';
 import { isChatUnread } from './unread';
 
@@ -565,7 +565,9 @@ const activeStatuses: WorkStatus[] = ['running'];
 const waitingStatuses: WorkStatus[] = ['waiting', 'blocked'];
 
 export function isPmaChatArchived(chat: PmaChatSummary): boolean {
-  return pmaLifecycleTokenIsArchived(chat.lifecycleStatus) || pmaChatArchivedFromRawSignals(chat.raw);
+  if (pmaLifecycleTokenIsArchived(chat.lifecycleStatus)) return true;
+  if (pmaLifecycleTokenIsActive(chat.lifecycleStatus)) return false;
+  return pmaChatArchivedFromRawSignals(chat.raw);
 }
 
 export function filterPmaChats(

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -32,6 +32,40 @@ describe('/chats page', () => {
     expect(body).toContain('Chat One');
     expect(body).not.toContain('Loading chats');
   });
+
+  it('renders active rebound rows from chat-index even when raw lifecycle fields are stale archived', () => {
+    readModelEntityStore.upsertChatIndexRows([
+      {
+        chatId: 'discord-rebound-active',
+        surface: 'discord',
+        title: 'Discord Rebound Active',
+        lifecycle: 'archived',
+        runtimeStatus: 'running',
+        archiveState: 'active',
+        status: 'running',
+        unreadCount: 0,
+        lastActivityAt: '2026-05-11T12:00:00Z',
+        primarySurface: { surface_kind: 'pma', lifecycle: 'running' },
+        surfaceBindings: [{ surface_kind: 'discord', surface_key: 'channel-1', lifecycle: 'archived' }]
+      },
+      {
+        chatId: 'discord-old-archived',
+        surface: 'discord',
+        title: 'Discord Old Archived',
+        lifecycle: 'archived',
+        archiveState: 'archived',
+        status: 'archived',
+        unreadCount: 0,
+        lastActivityAt: '2026-05-10T12:00:00Z'
+      }
+    ]);
+
+    const { body } = render(Page);
+
+    expect(body).toContain('Discord Rebound Active');
+    expect(body).toContain('Discord');
+    expect(body).not.toContain('Discord Old Archived');
+  });
 });
 
 function chatIndexRow(): ChatIndexRow {

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -241,6 +241,118 @@ def test_chat_index_omits_stale_bound_surfaces_without_managed_thread(
     assert [row["managed_thread_id"] for row in index["rows"]] == ["live-thread"]
 
 
+def test_chat_index_uses_managed_lifecycle_after_discord_surface_rebind(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(
+        hub_root,
+        thread_id="thread-a",
+        lifecycle_status="archived",
+        runtime_status="completed",
+    )
+    _seed_thread(
+        hub_root,
+        thread_id="thread-b",
+        lifecycle_status="active",
+        runtime_status="running",
+    )
+    bindings = OrchestrationBindingStore(hub_root, durable=False)
+    first = bindings.upsert_binding(
+        surface_kind="discord",
+        surface_key="guild:channel",
+        thread_target_id="thread-a",
+        repo_id="repo-1",
+        resource_kind="repo",
+        resource_id="repo-1",
+        metadata={"display_name": "Discord channel"},
+    )
+    bindings.disable_binding(binding_id=first.binding_id)
+    bindings.upsert_binding(
+        surface_kind="discord",
+        surface_key="guild:channel",
+        thread_target_id="thread-b",
+        repo_id="repo-1",
+        resource_kind="repo",
+        resource_id="repo-1",
+        metadata={"display_name": "Discord channel"},
+    )
+
+    service = ChatSurfaceReadService(hub_root, durable=False)
+
+    discord = service.chat_index_snapshot(
+        view="all",
+        surface_kind="discord",
+        limit=20,
+    )
+    assert [row["managed_thread_id"] for row in discord["rows"]] == ["thread-b"]
+    assert discord["rows"][0]["archive_state"] == "active"
+    assert discord["rows"][0]["lifecycle"] == "running"
+    assert discord["counters"]["total"] == 1
+    assert discord["counters"]["archived"] == 0
+
+    archived = service.chat_index_snapshot(view="archived", limit=20)
+    assert [row["managed_thread_id"] for row in archived["rows"]] == ["thread-a"]
+    assert archived["counters"]["total"] == 1
+
+
+def test_chat_index_uses_managed_lifecycle_after_telegram_surface_rebind(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(
+        hub_root,
+        thread_id="telegram-thread-a",
+        lifecycle_status="archived",
+        runtime_status="completed",
+    )
+    _seed_thread(
+        hub_root,
+        thread_id="telegram-thread-b",
+        lifecycle_status="active",
+        runtime_status="running",
+    )
+    bindings = OrchestrationBindingStore(hub_root, durable=False)
+    first = bindings.upsert_binding(
+        surface_kind="telegram",
+        surface_key="-1001:77",
+        thread_target_id="telegram-thread-a",
+        repo_id="repo-1",
+        resource_kind="repo",
+        resource_id="repo-1",
+        metadata={"display_name": "Telegram topic"},
+    )
+    bindings.disable_binding(binding_id=first.binding_id)
+    bindings.upsert_binding(
+        surface_kind="telegram",
+        surface_key="-1001:77",
+        thread_target_id="telegram-thread-b",
+        repo_id="repo-1",
+        resource_kind="repo",
+        resource_id="repo-1",
+        metadata={"display_name": "Telegram topic"},
+    )
+
+    service = ChatSurfaceReadService(hub_root, durable=False)
+
+    telegram = service.chat_index_snapshot(
+        view="all",
+        surface_kind="telegram",
+        limit=20,
+    )
+    assert [row["managed_thread_id"] for row in telegram["rows"]] == [
+        "telegram-thread-b"
+    ]
+    assert telegram["rows"][0]["archive_state"] == "active"
+    assert telegram["counters"]["total"] == 1
+    assert telegram["counters"]["archived"] == 0
+
+    archived = service.chat_index_snapshot(view="archived", limit=20)
+    assert [row["managed_thread_id"] for row in archived["rows"]] == [
+        "telegram-thread-a"
+    ]
+
+
 def test_chat_index_sort_key_parts_serializes_missing_activity_as_null() -> None:
     parts = _chat_index_sort_key_parts(
         {"managed_thread_id": "thread-1", "unread_count": 0}

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -126,6 +126,32 @@ def _seed_execution(
         )
 
 
+def _mark_projected_thread_archived(hub_root: Path, thread_id: str) -> None:
+    with open_orchestration_sqlite(hub_root, durable=False, migrate=True) as conn:
+        row = conn.execute(
+            """
+            SELECT row_json
+              FROM orch_chat_index_projection
+             WHERE managed_thread_id = ?
+            """,
+            (thread_id,),
+        ).fetchone()
+        assert row is not None
+        row_json = json.loads(row["row_json"])
+        row_json["lifecycle_status"] = "archived"
+        row_json["archive_state"] = "archived"
+        conn.execute(
+            """
+            UPDATE orch_chat_index_projection
+               SET lifecycle_status = 'archived',
+                   effective_status = 'archived',
+                   row_json = ?
+             WHERE managed_thread_id = ?
+            """,
+            (json.dumps(row_json, sort_keys=True, separators=(",", ":")), thread_id),
+        )
+
+
 def test_chat_surface_read_model_projects_contract_fixture_surface_inventory(
     tmp_path: Path,
 ) -> None:
@@ -732,6 +758,116 @@ def test_chat_index_snapshot_reads_rebuilt_sql_projection_without_reprojecting(
 
     archived = service.chat_index_snapshot(view="archived", limit=20)
     assert [row["managed_thread_id"] for row in archived["rows"]] == ["thread-archived"]
+
+
+def test_chat_index_rebuild_repairs_stale_archived_bound_surface_projection(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    bindings = OrchestrationBindingStore(hub_root, durable=False)
+    journal = SQLiteChatSurfaceEventJournal(hub_root, durable=False)
+
+    for surface_kind, surface_key, active_thread_id in (
+        ("discord", "guild:channel", "discord-thread-new"),
+        ("telegram", "-1001:77", "telegram-thread-new"),
+    ):
+        archived_thread_id = f"{surface_kind}-thread-old"
+        _seed_thread(
+            hub_root,
+            thread_id=archived_thread_id,
+            lifecycle_status="archived",
+            runtime_status="completed",
+        )
+        _seed_thread(
+            hub_root,
+            thread_id=active_thread_id,
+            lifecycle_status="active",
+            runtime_status="running",
+        )
+        first = bindings.upsert_binding(
+            surface_kind=surface_kind,
+            surface_key=surface_key,
+            thread_target_id=archived_thread_id,
+            repo_id="repo-1",
+            resource_kind="repo",
+            resource_id="repo-1",
+            metadata={"display_name": f"{surface_kind} chat"},
+        )
+        bindings.disable_binding(binding_id=first.binding_id)
+        bindings.upsert_binding(
+            surface_kind=surface_kind,
+            surface_key=surface_key,
+            thread_target_id=active_thread_id,
+            repo_id="repo-1",
+            resource_kind="repo",
+            resource_id="repo-1",
+            metadata={"display_name": f"{surface_kind} chat"},
+        )
+        journal.append_event(
+            idempotency_key=f"stale-archive-{surface_kind}",
+            event_type="surface.archived",
+            surface_kind=surface_kind,
+            surface_key=surface_key,
+            managed_thread_id=archived_thread_id,
+            lifecycle_status="archived",
+            status="archived",
+            source_kind="test",
+            occurred_at="2026-05-11T00:00:01Z",
+        )
+
+    service = ChatSurfaceReadService(hub_root, durable=False)
+    service.rebuild_chat_index_projection()
+    _mark_projected_thread_archived(hub_root, "discord-thread-new")
+    _mark_projected_thread_archived(hub_root, "telegram-thread-new")
+
+    assert service.chat_index_projection_status()["needs_rebuild"] is False
+    assert (
+        service.chat_index_snapshot(view="all", surface_kind="discord", limit=20)[
+            "rows"
+        ]
+        == []
+    )
+    assert (
+        service.chat_index_snapshot(view="all", surface_kind="telegram", limit=20)[
+            "rows"
+        ]
+        == []
+    )
+
+    dry_run = service.repair_stale_bound_surface_archive_state(dry_run=True)
+    first_repair = service.repair_stale_bound_surface_archive_state()
+    second_repair = service.repair_stale_bound_surface_archive_state()
+
+    assert dry_run["matched"] == 2
+    assert first_repair["matched"] == 2
+    assert first_repair["repaired"] == 2
+    assert first_repair["projection"]["row_count"] == 4
+    assert second_repair["matched"] == 0
+    assert second_repair["repaired"] == 0
+    discord = service.chat_index_snapshot(
+        view="all",
+        surface_kind="discord",
+        limit=20,
+    )
+    telegram = service.chat_index_snapshot(
+        view="all",
+        surface_kind="telegram",
+        limit=20,
+    )
+    archived = service.chat_index_snapshot(view="archived", limit=20)
+
+    assert [row["managed_thread_id"] for row in discord["rows"]] == [
+        "discord-thread-new"
+    ]
+    assert discord["rows"][0]["archive_state"] == "active"
+    assert [row["managed_thread_id"] for row in telegram["rows"]] == [
+        "telegram-thread-new"
+    ]
+    assert telegram["rows"][0]["archive_state"] == "active"
+    assert {row["managed_thread_id"] for row in archived["rows"]} == {
+        "discord-thread-old",
+        "telegram-thread-old",
+    }
 
 
 def test_chat_index_and_detail_prefer_bound_chat_display_for_fallback_titles(

--- a/tests/discord_message_turns_support.py
+++ b/tests/discord_message_turns_support.py
@@ -65,6 +65,9 @@ from codex_autorunner.core.managed_thread_identity import (
     pma_base_key,
 )
 from codex_autorunner.core.managed_thread_store import ManagedThreadStore
+from codex_autorunner.core.orchestration.chat_surface_events import (
+    SQLiteChatSurfaceEventJournal,
+)
 from codex_autorunner.core.ports.run_event import (
     RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
     RUN_EVENT_DELTA_TYPE_LOG_LINE,
@@ -7707,5 +7710,88 @@ async def test_reset_discord_thread_binding_preserves_logical_hermes_profile(
         assert binding is not None
         assert binding.thread_target_id == replacement_thread_id
         assert binding.agent_id == "hermes"
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_reset_discord_thread_binding_replaces_archived_generation(
+    tmp_path: Path,
+) -> None:
+    service, _rest, store, workspace = await _build_discord_service(
+        tmp_path,
+        [],
+        config_kwargs=dict(max_message_length=120),
+    )
+
+    try:
+        orchestration_service = service._discord_thread_service()
+        current_thread = orchestration_service.create_thread_target(
+            "codex",
+            workspace.resolve(),
+            repo_id="repo-1",
+            display_name="discord:channel-1",
+        )
+        service._attach_discord_thread_binding(
+            channel_id="channel-1",
+            thread_target_id=current_thread.thread_target_id,
+            agent="codex",
+            repo_id="repo-1",
+            workspace_root=workspace.resolve(),
+            pma_enabled=False,
+        )
+        orchestration_service.archive_thread_target(current_thread.thread_target_id)
+
+        had_previous, replacement_thread_id = (
+            await service._reset_discord_thread_binding(
+                channel_id="channel-1",
+                workspace_root=workspace.resolve(),
+                agent="codex",
+                repo_id="repo-1",
+                resource_kind=None,
+                resource_id=None,
+                pma_enabled=False,
+            )
+        )
+
+        assert had_previous is True
+        assert replacement_thread_id != current_thread.thread_target_id
+
+        replacement_thread = orchestration_service.get_thread_target(
+            replacement_thread_id
+        )
+        assert replacement_thread is not None
+        assert replacement_thread.lifecycle_status == "active"
+
+        old_thread = orchestration_service.get_thread_target(
+            current_thread.thread_target_id
+        )
+        assert old_thread is not None
+        assert old_thread.lifecycle_status == "archived"
+
+        binding = orchestration_service.get_binding(
+            surface_kind="discord",
+            surface_key="channel-1",
+        )
+        assert binding is not None
+        assert binding.thread_target_id == replacement_thread_id
+
+        events = SQLiteChatSurfaceEventJournal(tmp_path, durable=False).read_history(
+            limit=20
+        )
+        rebound_events = [
+            event
+            for event in events
+            if event.event_type == "surface.rebound"
+            and event.surface_kind == "discord"
+            and event.surface_key == "channel-1"
+        ]
+        assert rebound_events
+        assert rebound_events[-1].managed_thread_id == replacement_thread_id
+        assert rebound_events[-1].lifecycle_status == "active"
+        assert (
+            rebound_events[-1].payload["previous_thread_target_id"]
+            == current_thread.thread_target_id
+        )
     finally:
         await store.close()

--- a/tests/surfaces/cli/test_chat_commands.py
+++ b/tests/surfaces/cli/test_chat_commands.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from codex_autorunner.surfaces.cli.cli import app
+
+
+def test_chat_index_rebuild_dry_run_reports_projection_state(tmp_path) -> None:
+    result = CliRunner().invoke(
+        app,
+        [
+            "chat",
+            "index",
+            "rebuild",
+            "--path",
+            str(tmp_path),
+            "--dry-run",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["dry_run"] is True
+    assert payload["projection"]["needs_rebuild"] is True
+    assert payload["projection"]["row_count"] == 0
+
+
+def test_chat_index_repair_stale_bound_archives_dry_run_reports_matches(
+    tmp_path,
+) -> None:
+    result = CliRunner().invoke(
+        app,
+        [
+            "chat",
+            "index",
+            "repair-stale-bound-archives",
+            "--path",
+            str(tmp_path),
+            "--dry-run",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["dry_run"] is True
+    assert payload["matched"] == 0
+    assert payload["candidates"] == []

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -569,8 +569,8 @@ def test_hub_read_models_chats_all_excludes_effectively_archived_rows(
                         "repo",
                         "repo",
                         "Stale archived runtime",
-                        "active",
                         "archived",
+                        "completed",
                         "{}",
                         "2026-05-11T00:00:00Z",
                         "2026-05-11T00:01:00Z",
@@ -599,6 +599,103 @@ def test_hub_read_models_chats_all_excludes_effectively_archived_rows(
     assert [row.chat_id for row in archived_snapshot.rows] == [
         "thread-stale-archived-runtime"
     ]
+
+
+def test_hub_read_models_chats_discord_rebind_uses_managed_archive_state(
+    hub_env,
+) -> None:
+    with open_orchestration_sqlite(
+        hub_env.hub_root, durable=True, migrate=True
+    ) as conn:
+        with conn:
+            conn.executemany(
+                """
+                INSERT INTO orch_thread_targets (
+                    thread_target_id,
+                    agent_id,
+                    repo_id,
+                    resource_kind,
+                    resource_id,
+                    display_name,
+                    lifecycle_status,
+                    runtime_status,
+                    metadata_json,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    (
+                        "thread-discord-old",
+                        "codex",
+                        "repo",
+                        "repo",
+                        "repo",
+                        "Old Discord generation",
+                        "archived",
+                        "completed",
+                        "{}",
+                        "2026-05-11T00:00:00Z",
+                        "2026-05-11T00:01:00Z",
+                    ),
+                    (
+                        "thread-discord-new",
+                        "codex",
+                        "repo",
+                        "repo",
+                        "repo",
+                        "New Discord generation",
+                        "active",
+                        "running",
+                        "{}",
+                        "2026-05-11T00:02:00Z",
+                        "2026-05-11T00:03:00Z",
+                    ),
+                ),
+            )
+    bindings = OrchestrationBindingStore(hub_env.hub_root, durable=True)
+    first = bindings.upsert_binding(
+        surface_kind="discord",
+        surface_key="guild:channel",
+        thread_target_id="thread-discord-old",
+        repo_id="repo",
+        resource_kind="repo",
+        resource_id="repo",
+        metadata={"display_name": "Discord channel"},
+    )
+    bindings.disable_binding(binding_id=first.binding_id)
+    bindings.upsert_binding(
+        surface_kind="discord",
+        surface_key="guild:channel",
+        thread_target_id="thread-discord-new",
+        repo_id="repo",
+        resource_kind="repo",
+        resource_id="repo",
+        metadata={"display_name": "Discord channel"},
+    )
+
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    response = client.get(
+        "/hub/read-models/chats",
+        params={"filter": "all", "surface_kind": "discord", "limit": 20},
+    )
+
+    assert response.status_code == 200
+    snapshot = load_read_model_contract(ChatIndexSnapshot, response.json())
+    assert [row.chat_id for row in snapshot.rows] == ["thread-discord-new"]
+    assert snapshot.rows[0].archive_state == "active"
+    assert snapshot.rows[0].status == "running"
+    assert snapshot.counters.total == 1
+    assert snapshot.counters.archived == 0
+
+    archived_response = client.get(
+        "/hub/read-models/chats", params={"filter": "archived", "limit": 20}
+    )
+    assert archived_response.status_code == 200
+    archived_snapshot = load_read_model_contract(
+        ChatIndexSnapshot, archived_response.json()
+    )
+    assert [row.chat_id for row in archived_snapshot.rows] == ["thread-discord-old"]
 
 
 def test_hub_read_models_chats_contract_active_filter_matches_index_window(

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -87,6 +87,64 @@ def _seed_thread_rows(hub_root: Path, count: int) -> None:
                     )
 
 
+def _insert_thread_row(
+    hub_root: Path,
+    *,
+    thread_id: str,
+    display_name: str,
+    lifecycle_status: str = "active",
+    runtime_status: str = "idle",
+    updated_at: str = "2026-05-11T00:00:00Z",
+) -> None:
+    with open_orchestration_sqlite(hub_root, durable=True, migrate=True) as conn:
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO orch_thread_targets (
+                    thread_target_id,
+                    agent_id,
+                    repo_id,
+                    resource_kind,
+                    resource_id,
+                    display_name,
+                    lifecycle_status,
+                    runtime_status,
+                    metadata_json,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    thread_id,
+                    "codex",
+                    "repo",
+                    "repo",
+                    "repo",
+                    display_name,
+                    lifecycle_status,
+                    runtime_status,
+                    "{}",
+                    "2026-05-11T00:00:00Z",
+                    updated_at,
+                ),
+            )
+
+
+def _archive_thread_row(hub_root: Path, *, thread_id: str, updated_at: str) -> None:
+    with open_orchestration_sqlite(hub_root, durable=True, migrate=True) as conn:
+        with conn:
+            conn.execute(
+                """
+                UPDATE orch_thread_targets
+                   SET lifecycle_status = 'archived',
+                       runtime_status = 'completed',
+                       updated_at = ?
+                 WHERE thread_target_id = ?
+                """,
+                (updated_at, thread_id),
+            )
+
+
 def _seed_archived_surface_events(hub_root: Path, count: int, *, prefix: str) -> None:
     with open_orchestration_sqlite(hub_root, durable=True, migrate=True) as conn:
         with conn:
@@ -696,6 +754,149 @@ def test_hub_read_models_chats_discord_rebind_uses_managed_archive_state(
         ChatIndexSnapshot, archived_response.json()
     )
     assert [row.chat_id for row in archived_snapshot.rows] == ["thread-discord-old"]
+
+
+@pytest.mark.parametrize(
+    ("surface_kind", "surface_key", "display_name"),
+    [
+        ("discord", "guild:channel", "Discord channel"),
+        ("telegram", "-1001:77", "Telegram topic"),
+    ],
+)
+def test_hub_read_models_chats_bound_newt_rebind_moves_active_generation(
+    hub_env,
+    surface_kind: str,
+    surface_key: str,
+    display_name: str,
+) -> None:
+    old_thread_id = f"thread-{surface_kind}-old-generation"
+    new_thread_id = f"thread-{surface_kind}-new-generation"
+    _insert_thread_row(
+        hub_env.hub_root,
+        thread_id=old_thread_id,
+        display_name=f"Old {display_name}",
+        updated_at="2026-05-11T00:01:00Z",
+    )
+    bindings = OrchestrationBindingStore(hub_env.hub_root, durable=True)
+    bindings.upsert_binding(
+        surface_kind=surface_kind,
+        surface_key=surface_key,
+        thread_target_id=old_thread_id,
+        agent_id="codex",
+        repo_id="repo",
+        resource_kind="repo",
+        resource_id="repo",
+        metadata={"display_name": display_name},
+    )
+
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    initial = client.get(
+        "/hub/read-models/chats",
+        params={"filter": "all", "surface_kind": surface_kind, "limit": 20},
+    )
+    assert initial.status_code == 200
+    initial_snapshot = load_read_model_contract(ChatIndexSnapshot, initial.json())
+    assert [row.chat_id for row in initial_snapshot.rows] == [old_thread_id]
+
+    _archive_thread_row(
+        hub_env.hub_root,
+        thread_id=old_thread_id,
+        updated_at="2026-05-11T00:02:00Z",
+    )
+    SQLiteChatSurfaceEventJournal(hub_env.hub_root, durable=True).append_event(
+        idempotency_key=f"archive-old-{surface_kind}-generation",
+        event_type="surface.archived",
+        surface_kind=surface_kind,
+        surface_key=surface_key,
+        managed_thread_id=old_thread_id,
+        repo_id="repo",
+        lifecycle_status="archived",
+        status="archived",
+        occurred_at="2026-05-11T00:02:00Z",
+    )
+    archived_before_newt = client.get(
+        "/hub/read-models/chats",
+        params={"filter": "archived", "limit": 20},
+    )
+    assert archived_before_newt.status_code == 200
+    archived_before_snapshot = load_read_model_contract(
+        ChatIndexSnapshot, archived_before_newt.json()
+    )
+    patch_cursor = archived_before_snapshot.cursor.sequence
+    assert [row.chat_id for row in archived_before_snapshot.rows] == [old_thread_id]
+
+    _insert_thread_row(
+        hub_env.hub_root,
+        thread_id=new_thread_id,
+        display_name=f"New {display_name}",
+        lifecycle_status="active",
+        runtime_status="running",
+        updated_at="2026-05-11T00:03:00Z",
+    )
+    bindings.upsert_binding(
+        surface_kind=surface_kind,
+        surface_key=surface_key,
+        thread_target_id=new_thread_id,
+        agent_id="codex",
+        repo_id="repo",
+        resource_kind="repo",
+        resource_id="repo",
+        metadata={"display_name": display_name},
+    )
+
+    patch_response = client.get(
+        "/hub/read-models/chats/patches",
+        params={
+            "cursor": str(patch_cursor),
+            "filter": "all",
+            "surface_kind": surface_kind,
+            "once": "true",
+        },
+    )
+    assert patch_response.status_code == 200
+    repairs = _event_payloads(patch_response.text, "projection.cursor_gap")
+    assert len(repairs) == 1
+    assert repairs[0]["envelope"]["operation"] == "invalidate"
+    assert repairs[0]["patch"]["counters"]["total"] == 1
+    assert repairs[0]["patch"]["counters"]["archived"] == 0
+
+    all_response = client.get(
+        "/hub/read-models/chats", params={"filter": "all", "limit": 20}
+    )
+    surface_response = client.get(
+        "/hub/read-models/chats",
+        params={"filter": "all", "surface_kind": surface_kind, "limit": 20},
+    )
+    archived_response = client.get(
+        "/hub/read-models/chats", params={"filter": "archived", "limit": 20}
+    )
+    old_detail = client.get(f"/hub/read-models/chats/{old_thread_id}")
+
+    assert all_response.status_code == 200
+    assert surface_response.status_code == 200
+    assert archived_response.status_code == 200
+    assert old_detail.status_code == 200
+
+    all_snapshot = load_read_model_contract(ChatIndexSnapshot, all_response.json())
+    surface_snapshot = load_read_model_contract(
+        ChatIndexSnapshot, surface_response.json()
+    )
+    archived_snapshot = load_read_model_contract(
+        ChatIndexSnapshot, archived_response.json()
+    )
+    old_detail_snapshot = load_read_model_contract(
+        ChatDetailSnapshot, old_detail.json()
+    )
+
+    assert new_thread_id in [row.chat_id for row in all_snapshot.rows]
+    assert [row.chat_id for row in surface_snapshot.rows] == [new_thread_id]
+    assert surface_snapshot.rows[0].surface == surface_kind
+    assert surface_snapshot.rows[0].archive_state == "active"
+    assert surface_snapshot.rows[0].status == "running"
+    assert [row.chat_id for row in archived_snapshot.rows] == [old_thread_id]
+    assert archived_snapshot.rows[0].archive_state == "archived"
+    assert old_detail_snapshot.thread.chat_id == old_thread_id
+    assert old_detail_snapshot.thread.archived is True
 
 
 def test_hub_read_models_chats_contract_active_filter_matches_index_window(

--- a/tests/telegram_managed_thread_support.py
+++ b/tests/telegram_managed_thread_support.py
@@ -50,6 +50,9 @@ from codex_autorunner.core.managed_thread_store import (
     prepare_managed_thread_store,
 )
 from codex_autorunner.core.orchestration import SQLiteManagedThreadDeliveryEngine
+from codex_autorunner.core.orchestration.chat_surface_events import (
+    SQLiteChatSurfaceEventJournal,
+)
 from codex_autorunner.core.orchestration.managed_thread_delivery import (
     ManagedThreadDeliveryState,
 )
@@ -1679,6 +1682,103 @@ async def test_resolve_telegram_managed_thread_reuses_archived_thread(
     assert resolved is not None
     assert resolved.thread_target_id == current_thread.thread_target_id
     assert resolved.lifecycle_status == "active"
+
+
+@pytest.mark.anyio
+async def test_sync_telegram_thread_binding_replaces_archived_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    record = TelegramTopicRecord(
+        pma_enabled=False,
+        workspace_path=str(workspace),
+        repo_id="repo-1",
+        agent="codex",
+    )
+    handler = _ManagedThreadPMAHandler(record, tmp_path)
+
+    _patch_telegram_harness(
+        monkeypatch,
+        _BaseFakeHarness(),
+        execution_commands_module,
+    )
+
+    orchestration_service = (
+        execution_commands_module._build_telegram_thread_orchestration_service(handler)
+    )
+    current_thread = orchestration_service.create_thread_target(
+        "codex",
+        workspace.resolve(),
+        repo_id="repo-1",
+        display_name="telegram:test-topic",
+        backend_thread_id="old-backend-thread",
+    )
+    orchestration_service.upsert_binding(
+        surface_kind="telegram",
+        surface_key="telegram:-1001:101",
+        thread_target_id=current_thread.thread_target_id,
+        agent_id="codex",
+        repo_id="repo-1",
+        mode="repo",
+    )
+    orchestration_service.archive_thread_target(current_thread.thread_target_id)
+
+    (
+        _service,
+        replacement_thread,
+    ) = await execution_commands_module._sync_telegram_thread_binding(
+        handler,
+        surface_key="telegram:-1001:101",
+        workspace_root=workspace.resolve(),
+        agent="codex",
+        repo_id="repo-1",
+        resource_kind=None,
+        resource_id=None,
+        backend_thread_id="new-backend-thread",
+        mode="repo",
+        pma_enabled=False,
+        replace_existing=True,
+    )
+
+    assert replacement_thread.thread_target_id != current_thread.thread_target_id
+    assert replacement_thread.lifecycle_status == "active"
+    assert replacement_thread.backend_thread_id == "new-backend-thread"
+
+    binding = orchestration_service.get_binding(
+        surface_kind="telegram",
+        surface_key="telegram:-1001:101",
+    )
+    assert binding is not None
+    assert binding.thread_target_id == replacement_thread.thread_target_id
+
+    old_thread = orchestration_service.get_thread_target(
+        current_thread.thread_target_id
+    )
+    assert old_thread is not None
+    assert old_thread.lifecycle_status == "archived"
+
+    events = SQLiteChatSurfaceEventJournal(tmp_path, durable=False).read_history(
+        limit=20
+    )
+    rebound_events = [
+        event
+        for event in events
+        if event.event_type == "surface.rebound"
+        and event.surface_kind == "telegram"
+        and event.surface_key == "telegram:-1001:101"
+    ]
+    assert rebound_events
+    assert rebound_events[-1].managed_thread_id == replacement_thread.thread_target_id
+    assert rebound_events[-1].lifecycle_status == "active"
+    assert (
+        rebound_events[-1].payload["previous_thread_target_id"]
+        == current_thread.thread_target_id
+    )
+    assert (
+        rebound_events[-1].idempotency_key
+        != f"thread:{current_thread.thread_target_id}:telegram:telegram:-1001:101:archived"
+    )
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Chat archive lifecycle authority + newt surface generation semantics + stale state repair (5 tickets, 42m). Includes merged PRs #1824 (Web UI page load optimization) and #1825 (idle hub CPU sampling).

### Changes (7 commits, 17 files, +1,280/−36)

**TICKET-018: Chat Index Managed Thread Archive Truth**
- `7d4dffc71` — Fix chat index archive lifecycle authority

**TICKET-019: Newt Surface Generation Semantics**
- `9b236cd4d` — Fix surface newt generation rebinding

**TICKET-020: Repair Stale Bound Surface Archive State**
- `d8a19b90e` — Repair stale bound chat archive state

**TICKET-021: Frontend Chat Archive State Contract**
- `6f89d8b8c` — Align chat archive state contract

**TICKET-022: Bound Newt End-to-End Regression**
- `c96697b0c` — Test coverage for bound newt chat visibility (+300 test lines)

**Merged upstream:**
- `019492a41` — Optimize Web UI page load windows (**#1824**)
- `8ace56955` — Optimize idle hub CPU sampling (**#1825**)

### Relationship
Builds on [PR #1812](https://github.com/Git-on-my-level/codex-autorunner/pull/1812) (merged). Same discord-4 branch.
