### PR TITLE
[codex] Suppress informational recovery chat alerts

### DIFF
--- a/src/codex_autorunner/core/ticket_flow_recovery.py
+++ b/src/codex_autorunner/core/ticket_flow_recovery.py
@@ -369,6 +369,8 @@ def recovery_notification_intent_should_deliver(
     transport_key: str,
     now: Optional[str] = None,
 ) -> bool:
+    if not recovery_notification_intent_is_alert(record):
+        return False
     if record.resolved:
         return False
     attempts = record.delivery_attempts
@@ -390,6 +392,19 @@ def recovery_notification_intent_should_deliver(
     return (current - last_attempted).total_seconds() >= record.cooldown_seconds
 
 
+def recovery_notification_intent_is_alert(
+    record: FlowNotificationIntentRecord,
+) -> bool:
+    """Return whether a recovery intent should interrupt a chat surface."""
+    return _severity_value(record.severity) != RecoveryIntentSeverity.INFO.value
+
+
+def _severity_value(value: Any) -> str:
+    if isinstance(value, RecoveryIntentSeverity):
+        return value.value
+    return _normalize_optional_text(value) or RecoveryIntentSeverity.INFO.value
+
+
 def format_recovery_notification_intent(
     record: FlowNotificationIntentRecord,
 ) -> str:
@@ -399,12 +414,7 @@ def format_recovery_notification_intent(
     facet = facet_payload if isinstance(facet_payload, Mapping) else {}
     facet_name = _normalize_optional_text(facet.get("name")) or record.event_type
     facet_status = _normalize_optional_text(facet.get("status")) or "active"
-    raw_severity = record.severity
-    severity = (
-        raw_severity.value
-        if isinstance(raw_severity, RecoveryIntentSeverity)
-        else _normalize_optional_text(raw_severity)
-    ) or RecoveryIntentSeverity.INFO.value
+    severity = _severity_value(record.severity)
     is_escalation = severity != RecoveryIntentSeverity.INFO.value
 
     lines = [
@@ -478,6 +488,7 @@ __all__ = [
     "build_recovery_notification_intents",
     "build_recovery_projection",
     "format_recovery_notification_intent",
+    "recovery_notification_intent_is_alert",
     "recovery_notification_intent_should_deliver",
     "recovery_notification_transport_key",
 ]

--- a/tests/adapters/discord/test_flow_watchers_idle.py
+++ b/tests/adapters/discord/test_flow_watchers_idle.py
@@ -291,6 +291,61 @@ async def test_recovery_scan_marks_core_ledger_after_enqueue(monkeypatch) -> Non
     assert enqueued[0].record_id == "recovery:channel-1:intent-2"
 
 
+@pytest.mark.anyio
+async def test_recovery_scan_skips_info_status_updates(monkeypatch) -> None:
+    binding = {
+        "channel_id": "channel-1",
+        "guild_id": "guild-1",
+        "workspace_path": "/tmp/workspace",
+    }
+
+    service = MagicMock()
+    service._logger = logging.getLogger("test")
+    service._store = MagicMock()
+    service._store.list_bindings = AsyncMock(return_value=[binding])
+    service._store.enqueue_outbox = AsyncMock()
+    service._hub_raw_config_cache = {}
+    service._flow_run_mirror.return_value.mirror_outbound = MagicMock()
+
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.discord.flow_watchers._preferred_bound_sources_by_workspace",
+        lambda _service: {},
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.discord.flow_watchers._preferred_bound_source_for_workspace",
+        lambda _service, _workspace_root: None,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.discord.flow_watchers.list_active_ticket_flow_notification_intents",
+        lambda _workspace_root: [
+            SimpleNamespace(
+                intent_id="intent-info",
+                run_id="run-1",
+                event_type="ticket_flow.commit_barrier.active",
+                severity="info",
+                reason="done-current-ticket-has-uncommitted-worktree-changes",
+                recommended_actions=("car ticket-flow status --repo /tmp/workspace",),
+                cooldown_seconds=3600,
+                resolved=False,
+                payload={
+                    "primary_state": "commit_barrier_pending",
+                    "facet": {
+                        "name": "commit_barrier",
+                        "status": "active",
+                        "data": {},
+                    },
+                },
+                delivery_attempts={},
+            )
+        ],
+    )
+
+    notified = await _scan_and_enqueue_recovery_notifications(service)
+
+    assert notified == 0
+    service._store.enqueue_outbox.assert_not_awaited()
+
+
 def test_discord_recovery_watchers_do_not_reintroduce_snapshot_fingerprints() -> None:
     from codex_autorunner.adapters.discord import flow_watchers
 

--- a/tests/core/test_ticket_flow_recovery.py
+++ b/tests/core/test_ticket_flow_recovery.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 from codex_autorunner.core import ticket_flow_operator as operator_module
 from codex_autorunner.core.flows.models import FlowRunStatus
@@ -13,6 +14,7 @@ from codex_autorunner.core.ticket_flow_recovery import (
     build_recovery_notification_intents,
     build_recovery_projection,
     format_recovery_notification_intent,
+    recovery_notification_intent_should_deliver,
 )
 
 
@@ -299,6 +301,58 @@ def test_active_commit_barrier_notification_reads_as_status_update() -> None:
     assert "Severity:" not in message
     assert "Blocker:" not in message
     assert "Reason:" not in message
+
+
+def test_info_recovery_intents_are_not_chat_alerts() -> None:
+    record = SimpleNamespace(
+        intent_id="ticket_flow_recovery:test-intent",
+        run_id="run-1",
+        event_type="ticket_flow.commit_barrier.active",
+        severity=RecoveryIntentSeverity.INFO,
+        reason="done-current-ticket-has-uncommitted-worktree-changes",
+        recommended_actions=("car ticket-flow status --repo /tmp/repo",),
+        cooldown_seconds=3600,
+        resolved=False,
+        payload={
+            "primary_state": "commit_barrier_pending",
+            "facet": {"name": "commit_barrier", "status": "active", "data": {}},
+        },
+        delivery_attempts={},
+    )
+
+    assert (
+        recovery_notification_intent_should_deliver(
+            record,
+            transport_key="discord:channel-1",
+        )
+        is False
+    )
+
+
+def test_warning_recovery_intents_remain_chat_alerts() -> None:
+    record = SimpleNamespace(
+        intent_id="ticket_flow_recovery:test-intent",
+        run_id="run-1",
+        event_type="ticket_flow.commit_barrier.exhausted",
+        severity=RecoveryIntentSeverity.WARNING,
+        reason="commit-barrier-retry-budget-exhausted",
+        recommended_actions=("car ticket-flow status --repo /tmp/repo",),
+        cooldown_seconds=3600,
+        resolved=False,
+        payload={
+            "primary_state": "commit_barrier_exhausted",
+            "facet": {"name": "commit_barrier", "status": "exhausted", "data": {}},
+        },
+        delivery_attempts={},
+    )
+
+    assert (
+        recovery_notification_intent_should_deliver(
+            record,
+            transport_key="telegram:123:456",
+        )
+        is True
+    )
 
 
 def test_notification_intent_ledger_upserts_observation_without_duplicate(

--- a/tests/test_telegram_ticket_flow_bridge.py
+++ b/tests/test_telegram_ticket_flow_bridge.py
@@ -726,6 +726,72 @@ async def test_recovery_intent_sends_once_per_telegram_topic(
 
 
 @pytest.mark.anyio
+async def test_recovery_intent_skips_info_status_updates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "tg-recovery-info"
+    _init_repo(workspace)
+    record = _DummyRecord(workspace)
+    calls: list[tuple[int, str, Optional[int]]] = []
+
+    async def send_message_with_outbox(
+        chat_id: int,
+        text: str,
+        *,
+        thread_id: Optional[int],
+        reply_to: Optional[int],
+    ) -> bool:
+        _ = reply_to
+        calls.append((chat_id, text, thread_id))
+        return True
+
+    async def send_document(*args, **kwargs) -> bool:
+        return True
+
+    bridge = TelegramTicketFlowBridge(
+        logger=logging.getLogger("test"),
+        store=_DummyStore({"123:456": record}),
+        pause_targets={},
+        send_message_with_outbox=send_message_with_outbox,
+        send_document=send_document,
+        pause_config=PauseDispatchNotifications(
+            enabled=True,
+            send_attachments=False,
+            max_file_size_bytes=1024,
+            chunk_long_messages=True,
+        ),
+        default_notification_chat_id=None,
+    )
+    intent = SimpleNamespace(
+        intent_id="intent-telegram-info",
+        run_id="run-1",
+        event_type="ticket_flow.commit_barrier.active",
+        severity="info",
+        reason="done-current-ticket-has-uncommitted-worktree-changes",
+        recommended_actions=("car ticket-flow status --repo /tmp/repo",),
+        cooldown_seconds=3600,
+        resolved=False,
+        payload={
+            "primary_state": "commit_barrier_pending",
+            "facet": {
+                "name": "commit_barrier",
+                "status": "active",
+                "data": {},
+            },
+        },
+        delivery_attempts={},
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.telegram.ticket_flow_bridge.list_active_ticket_flow_notification_intents",
+        lambda _path: [intent],
+    )
+
+    await bridge._notify_recovery_for_workspace(workspace, [("123:456", record)])
+
+    assert calls == []
+
+
+@pytest.mark.anyio
 async def test_recovery_scan_runs_when_pause_notifications_disabled(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Keep informational ticket-flow recovery intents available for status/UI consumers, but exclude them from chat alert delivery.
- Centralize the alert-worthiness decision in the shared recovery delivery predicate used by both Discord and Telegram.
- Add core, Discord, and Telegram coverage that info status updates are skipped while warning recovery alerts still deliver.

## Root cause
The recovery notification ledger mixed informational status intents with actionable alerts. Discord and Telegram both used the shared dedupe predicate directly, so an info-level commit-barrier status update was delivered as a chat alert.

## Validation
- .venv/bin/python -m pytest tests/core/test_ticket_flow_recovery.py tests/adapters/discord/test_flow_watchers_idle.py tests/test_telegram_ticket_flow_bridge.py
- .venv/bin/python -m ruff check src/codex_autorunner/core/ticket_flow_recovery.py tests/core/test_ticket_flow_recovery.py tests/adapters/discord/test_flow_watchers_idle.py tests/test_telegram_ticket_flow_bridge.py
- commit hook aggregate lane: black check, ruff, import boundaries, hub interface contracts, mypy, full pytest suite, web UI lab fast check, frontend lint/build/tests