### PR TITLE
fix: Telegram durable delivery duplicate finalization (3 tickets)

### DIFF
--- a/src/codex_autorunner/adapters/telegram/handlers/commands_runtime.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands_runtime.py
@@ -430,57 +430,64 @@ class TelegramCommandHandlers(
                     model=getattr(outcome.record, "model", None),
                 )
                 intermediate_response = None
-        try:
-            response_sent = await self._deliver_turn_response(
-                chat_id=message.chat_id,
-                thread_id=message.thread_id,
-                reply_to=message.message_id,
-                placeholder_id=outcome.placeholder_id,
-                response=response_text,
-                intermediate_response=intermediate_response,
-                overflow_mode_override=overflow_mode_override,
-            )
-        except TypeError as exc:
-            if not any(
-                key in str(exc)
-                for key in ("intermediate_response", "overflow_mode_override")
-            ):
-                raise
-            response_sent = await self._deliver_turn_response(
-                chat_id=message.chat_id,
-                thread_id=message.thread_id,
-                reply_to=message.message_id,
-                placeholder_id=outcome.placeholder_id,
-                response=response_text,
-            )
         if _durable_handled:
             response_sent = True
-        elif response_sent:
-            _record_pending_telegram_direct_delivery(
-                self,
-                delivery_id=getattr(outcome, "durable_delivery_id", None),
-                claim_token=getattr(
-                    outcome,
-                    "durable_delivery_claim_token",
-                    None,
-                ),
-                chat_id=message.chat_id,
-                thread_id=message.thread_id,
-                delivered=True,
-            )
-        elif getattr(outcome, "durable_delivery_id", None):
-            _record_pending_telegram_direct_delivery(
-                self,
-                delivery_id=getattr(outcome, "durable_delivery_id", None),
-                claim_token=getattr(
-                    outcome,
-                    "durable_delivery_claim_token",
-                    None,
-                ),
-                chat_id=message.chat_id,
-                thread_id=message.thread_id,
-                delivered=False,
-            )
+            if outcome.placeholder_id is not None:
+                await self._delete_message(
+                    message.chat_id,
+                    outcome.placeholder_id,
+                    thread_id=message.thread_id,
+                )
+        else:
+            try:
+                response_sent = await self._deliver_turn_response(
+                    chat_id=message.chat_id,
+                    thread_id=message.thread_id,
+                    reply_to=message.message_id,
+                    placeholder_id=outcome.placeholder_id,
+                    response=response_text,
+                    intermediate_response=intermediate_response,
+                    overflow_mode_override=overflow_mode_override,
+                )
+            except TypeError as exc:
+                if not any(
+                    key in str(exc)
+                    for key in ("intermediate_response", "overflow_mode_override")
+                ):
+                    raise
+                response_sent = await self._deliver_turn_response(
+                    chat_id=message.chat_id,
+                    thread_id=message.thread_id,
+                    reply_to=message.message_id,
+                    placeholder_id=outcome.placeholder_id,
+                    response=response_text,
+                )
+            if response_sent:
+                _record_pending_telegram_direct_delivery(
+                    self,
+                    delivery_id=getattr(outcome, "durable_delivery_id", None),
+                    claim_token=getattr(
+                        outcome,
+                        "durable_delivery_claim_token",
+                        None,
+                    ),
+                    chat_id=message.chat_id,
+                    thread_id=message.thread_id,
+                    delivered=True,
+                )
+            elif getattr(outcome, "durable_delivery_id", None):
+                _record_pending_telegram_direct_delivery(
+                    self,
+                    delivery_id=getattr(outcome, "durable_delivery_id", None),
+                    claim_token=getattr(
+                        outcome,
+                        "durable_delivery_claim_token",
+                        None,
+                    ),
+                    chat_id=message.chat_id,
+                    thread_id=message.thread_id,
+                    delivered=False,
+                )
         if response_sent:
             key = await self._resolve_topic_key(message.chat_id, message.thread_id)
             log_event(

--- a/tests/test_telegram_turn_queue.py
+++ b/tests/test_telegram_turn_queue.py
@@ -698,6 +698,52 @@ async def test_normal_turn_append_to_progress_does_not_emit_separate_metrics() -
 
 
 @pytest.mark.anyio
+@pytest.mark.xfail(
+    reason="Durable Telegram final delivery still falls through to legacy progress-summary delivery.",
+    strict=True,
+)
+async def test_normal_turn_durable_delivery_handled_suppresses_legacy_progress_summary_send() -> (
+    None
+):
+    wait = asyncio.Event()
+    wait.set()
+    client = _ClientStub(turn_wait_events=[wait])
+    record = _record("thread-1")
+    records = {"10:11": record}
+    handler = _HandlerStub(
+        client=client,
+        max_parallel_turns=1,
+        records=records,
+    )
+
+    async def _fake_run_turn_and_collect_result(
+        _message: TelegramMessage,
+        _runtime: _RuntimeStub,
+        **_kwargs: object,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            record=record,
+            thread_id="thread-1",
+            turn_id="turn-1",
+            response="",
+            placeholder_id=456,
+            elapsed_seconds=None,
+            token_usage=None,
+            transcript_message_id=None,
+            transcript_text=None,
+            intermediate_response="done · agent codex · gpt-4.1-mini · 12s · step 3",
+            durable_delivery_handled=True,
+        )
+
+    handler._run_turn_and_collect_result = _fake_run_turn_and_collect_result  # type: ignore[assignment]
+
+    message = _message(message_id=1, thread_id=11)
+    await handler._handle_normal_message(message, _RuntimeStub(), record=record)
+
+    assert handler._deliver_calls == []
+
+
+@pytest.mark.anyio
 async def test_normal_turn_appends_metrics_footer_to_response_by_default() -> None:
     wait = asyncio.Event()
     wait.set()

--- a/tests/test_telegram_turn_queue.py
+++ b/tests/test_telegram_turn_queue.py
@@ -698,10 +698,6 @@ async def test_normal_turn_append_to_progress_does_not_emit_separate_metrics() -
 
 
 @pytest.mark.anyio
-@pytest.mark.xfail(
-    reason="Durable Telegram final delivery still falls through to legacy progress-summary delivery.",
-    strict=True,
-)
 async def test_normal_turn_durable_delivery_handled_suppresses_legacy_progress_summary_send() -> (
     None
 ):
@@ -741,6 +737,7 @@ async def test_normal_turn_durable_delivery_handled_suppresses_legacy_progress_s
     await handler._handle_normal_message(message, _RuntimeStub(), record=record)
 
     assert handler._deliver_calls == []
+    assert handler._delete_calls == [(10, 456)]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Fix Telegram durable delivery duplicate finalization + test coverage (3 tickets, 17m).

### Changes (2 commits, 2 files, +99/−49)

**Fix: Telegram durable delivery duplicate final**
- `d7d1538fe` → `aa8f8a90f` (rebased) — Fix duplicate final event emission in Telegram durable delivery path
- `779c63de6` → `a4b1b26f0` (rebased) — Test: capture and validate Telegram durable delivery deduplication (+43 new test lines)

### Scope
- `src/codex_autorunner/adapters/telegram/handlers/commands_runtime.py` — Fix duplicate final delivery when turn completes
- `tests/test_telegram_turn_queue.py` — Regression test for deduplication

### Context
Flow `eb4f034a` on discord-5 worktree. Branch rebased on top of merged PRs #1826, #1827, #1828.
