### PR TITLE
[codex] Move Web Chat toward turn-structured detail projection

### DIFF
--- a/docs/architecture/web-ui-read-model-contracts.md
+++ b/docs/architecture/web-ui-read-model-contracts.md
@@ -226,6 +226,18 @@ Chat detail:
 - Patch: `ChatDetailPatchEvent`.
 - Carries thread metadata, visible timeline window, queue summary, artifacts,
   and optimistic reconciliation ids (`clientMessageId`, `backendMessageId`).
+- Timeline items carry backend-authored turn and ordering fields:
+  `managedTurnId`, `orderKey`, `section`, and `sectionOrder`. The frontend may
+  sort visible items by `orderKey` for idempotent patch replay, but it must not
+  infer turn structure from timestamps, `/tail`, or `/timeline`.
+- Compatibility bridge: the snapshot route is authoritative at
+  `/hub/read-models/chats/{chatId}` and the typed detail stream lives at
+  `/hub/read-models/chats/{chatId}/patches`. While that stream is backed by the
+  older chat-surface journal, it emits repairable `ChatDetailPatchEvent` reset
+  events instead of exposing legacy patch payloads for the frontend to
+  reinterpret. `/hub/pma/threads/{id}/transcript` remains supported for legacy
+  diagnostics and PMA-specific tests; new Web Hub data code should prefer the
+  read-model snapshot/patch routes and normalized store.
 
 Repo/worktree:
 

--- a/src/codex_autorunner/core/orchestration/managed_thread_transcript.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_transcript.py
@@ -260,7 +260,7 @@ def _merge_transcript_rows(
     durable_rows: list[dict[str, Any]], live_rows: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
     if not live_rows:
-        return durable_rows
+        return _sort_transcript_rows(durable_rows)
     merged_by_id: dict[str, dict[str, Any]] = {}
     merged: list[dict[str, Any]] = []
     for row in durable_rows:
@@ -282,7 +282,7 @@ def _merge_transcript_rows(
         if row_id:
             merged_by_id[row_id] = row
         merged.append(row)
-    return sorted(merged, key=_row_sort_key)
+    return _sort_transcript_rows(merged)
 
 
 def _retain_transcript_window(
@@ -303,11 +303,64 @@ def _retain_transcript_window(
         anchor_id = anchor.get("id")
         if anchor_id and not any(row.get("id") == anchor_id for row in retained):
             retained = [anchor, *retained[1:]]
-    return sorted(retained, key=_row_sort_key)
+    return _sort_transcript_rows(retained)
 
 
-def _row_sort_key(row: Mapping[str, Any]) -> str:
+def _sort_transcript_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    turn_anchors: dict[str, str] = {}
+    turn_fallbacks: dict[str, str] = {}
+    for row in rows:
+        turn_id = _optional_text(row.get("turn_id"))
+        if turn_id is None:
+            continue
+        generic_key = _generic_row_sort_key(row)
+        existing_fallback = turn_fallbacks.get(turn_id)
+        if existing_fallback is None or generic_key < existing_fallback:
+            turn_fallbacks[turn_id] = generic_key
+        if _message_role(row) == "user":
+            existing_anchor = turn_anchors.get(turn_id)
+            if existing_anchor is None or generic_key < existing_anchor:
+                turn_anchors[turn_id] = generic_key
+
+    for turn_id, fallback_key in turn_fallbacks.items():
+        turn_anchors.setdefault(turn_id, fallback_key)
+
+    return sorted(rows, key=lambda row: _row_sort_key(row, turn_anchors))
+
+
+def _row_sort_key(
+    row: Mapping[str, Any], turn_anchors: Mapping[str, str]
+) -> tuple[str, int, str, str]:
+    generic_key = _generic_row_sort_key(row)
+    turn_id = _optional_text(row.get("turn_id"))
+    if turn_id is None:
+        return (generic_key, _row_phase(row), generic_key, str(row.get("id") or ""))
+    return (
+        str(turn_anchors.get(turn_id) or generic_key),
+        _row_phase(row),
+        generic_key,
+        str(row.get("id") or ""),
+    )
+
+
+def _generic_row_sort_key(row: Mapping[str, Any]) -> str:
     return str(row.get("order_key") or row.get("timestamp") or row.get("id") or "")
+
+
+def _row_phase(row: Mapping[str, Any]) -> int:
+    role = _message_role(row)
+    if role == "user":
+        return 0
+    if role == "assistant":
+        return 2
+    return 1
+
+
+def _message_role(row: Mapping[str, Any]) -> Optional[str]:
+    if row.get("kind") != "message":
+        return None
+    role = _mapping(row.get("message")).get("role")
+    return str(role) if role is not None else None
 
 
 def _source_event_ids(item: Mapping[str, Any]) -> list[str]:

--- a/src/codex_autorunner/surfaces/web/read_model_contracts.py
+++ b/src/codex_autorunner/surfaces/web/read_model_contracts.py
@@ -209,6 +209,16 @@ class ChatTimelineItem(ReadModelContract):
         "system",
     ]
     role: Optional[Literal["user", "assistant", "tool", "system"]] = None
+    managed_turn_id: Optional[str] = None
+    order_key: str
+    section: Literal[
+        "user_message",
+        "activity",
+        "assistant_message",
+        "terminal_metadata",
+        "thread_metadata",
+    ]
+    section_order: int = Field(ge=0)
     created_at: datetime
     text: Optional[str] = None
     artifact_ids: list[str] = Field(default_factory=list)

--- a/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
@@ -79,6 +79,10 @@ def _sse_frame(event: str, payload: dict[str, Any], *, event_id: Optional[str]) 
     )
 
 
+def _advance_chat_detail_stream_cursor(last_cursor: int, batch_cursor: int) -> int:
+    return max(last_cursor, batch_cursor)
+
+
 def build_hub_chat_read_model_router(context: HubAppContext) -> APIRouter:
     router = APIRouter()
 
@@ -157,8 +161,8 @@ def build_hub_chat_read_model_router(context: HubAppContext) -> APIRouter:
                         event_payload,
                         event_id=str(sequence),
                     )
+                last_cursor = max(last_cursor, batch_cursor)
                 if events:
-                    last_cursor = batch_cursor
                     if once:
                         return
                     continue
@@ -230,8 +234,10 @@ def build_hub_chat_read_model_router(context: HubAppContext) -> APIRouter:
                         event_payload,
                         event_id=str(sequence),
                     )
+                last_cursor = _advance_chat_detail_stream_cursor(
+                    last_cursor, batch_cursor
+                )
                 if events:
-                    last_cursor = batch_cursor
                     if once:
                         return
                     continue

--- a/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_chat_read_models.py
@@ -31,6 +31,8 @@ from codex_autorunner.core.orchestration import ChatSurfaceReadService
 
 from ..read_model_contracts import (
     ChatArtifactSummary,
+    ChatDetailPatch,
+    ChatDetailPatchEvent,
     ChatDetailSnapshot,
     ChatIndexCounters,
     ChatIndexGroup,
@@ -189,6 +191,59 @@ def build_hub_chat_read_model_router(context: HubAppContext) -> APIRouter:
             ) from exc
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.get("/hub/read-models/chats/{chat_id}/patches")
+    async def stream_chat_detail_patches(
+        request: Request,
+        chat_id: str,
+        cursor: Annotated[Optional[str], Query()] = None,
+        event_limit: Annotated[int, Query(ge=1, le=1000)] = 100,
+        once: bool = False,
+    ):
+        header_cursor = request.headers.get("last-event-id")
+        raw_cursor = cursor if cursor is not None else header_cursor
+        try:
+            parsed_cursor = _parse_chat_detail_cursor(raw_cursor)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        async def _stream() -> Any:
+            last_cursor = parsed_cursor
+            while True:
+                batch = await asyncio.to_thread(
+                    service.chat_detail_patch_contracts,
+                    chat_id,
+                    last_cursor,
+                    event_limit=event_limit,
+                )
+                events = batch["events"]
+                batch_cursor = _int_fallback(batch.get("cursor"), last_cursor)
+                for event_payload in events:
+                    envelope = event_payload.get("envelope") or {}
+                    cursor_payload = envelope.get("cursor") or {}
+                    sequence = _int_fallback(
+                        cursor_payload.get("sequence"), last_cursor
+                    )
+                    last_cursor = sequence
+                    yield _sse_frame(
+                        str(envelope.get("eventType") or "chat.detail.patch"),
+                        event_payload,
+                        event_id=str(sequence),
+                    )
+                if events:
+                    last_cursor = batch_cursor
+                    if once:
+                        return
+                    continue
+                if once:
+                    return
+                await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+
+        return StreamingResponse(
+            _stream(),
+            media_type="text/event-stream",
+            headers=SSE_HEADERS,
+        )
 
     return router
 
@@ -472,6 +527,45 @@ class ChatReadModelService:
             ),
         )
 
+    def chat_detail_patch_contracts(
+        self,
+        chat_id: str,
+        cursor: Optional[int],
+        *,
+        event_limit: int,
+    ) -> dict[str, Any]:
+        batch = self._surface.chat_patches_since(cursor, limit=event_limit)
+        events = [
+            dump_read_model_contract(
+                self._chat_detail_patch_event_from_hub(chat_id, raw)
+            )
+            for raw in batch.get("patches") or []
+            if isinstance(raw, Mapping)
+            and str(raw.get("managed_thread_id") or "") == chat_id
+        ]
+        return {"cursor": batch.get("cursor"), "events": events}
+
+    def _chat_detail_patch_event_from_hub(
+        self,
+        chat_id: str,
+        raw: Mapping[str, Any],
+    ) -> ChatDetailPatchEvent:
+        sequence = _int_fallback(raw.get("cursor"), 0)
+        occurred = (
+            parse_iso_optional(str(raw.get("occurred_at") or "")) or read_model_now()
+        )
+        return ChatDetailPatchEvent(
+            envelope=ReadModelEventEnvelope(
+                event_type="chat.detail.patch",
+                cursor=projection_cursor_chat_detail(sequence),
+                entity_kind="chat",
+                entity_id=chat_id,
+                operation="reset",
+                generated_at=occurred,
+            ),
+            patch=ChatDetailPatch(),
+        )
+
 
 def _contract_filter_to_hub_view(contract_filter: str) -> str:
     return "ticket_run" if contract_filter == "ticket_runs" else contract_filter
@@ -495,6 +589,21 @@ def _parse_chat_index_cursor(raw: Any) -> int:
     if value is None:
         return 0
     if value.startswith("chat.index:"):
+        value = value.split(":", 1)[1]
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise ValueError("cursor must be a non-negative integer") from exc
+    if parsed < 0:
+        raise ValueError("cursor must be a non-negative integer")
+    return parsed
+
+
+def _parse_chat_detail_cursor(raw: Any) -> int:
+    value = _str_or_none(raw)
+    if value is None:
+        return 0
+    if value.startswith("chat.detail:"):
         value = value.split(":", 1)[1]
     try:
         parsed = int(value)
@@ -904,6 +1013,39 @@ def _timeline_role(
     return None
 
 
+def _timeline_section(
+    kind: _ChatTimelineKind,
+    raw_kind: Any,
+) -> Literal[
+    "user_message",
+    "activity",
+    "assistant_message",
+    "terminal_metadata",
+    "thread_metadata",
+]:
+    text = str(raw_kind or "").strip().lower()
+    if kind == "user_message":
+        return "user_message"
+    if kind == "assistant_message":
+        return "assistant_message"
+    if text in {"status", "delivery", "terminal_metadata"}:
+        return "terminal_metadata"
+    if text in {"lifecycle", "compaction", "thread_metadata"}:
+        return "thread_metadata"
+    return "activity"
+
+
+def _timeline_section_order(section: str) -> int:
+    order = {
+        "user_message": 10,
+        "activity": 20,
+        "assistant_message": 30,
+        "terminal_metadata": 40,
+        "thread_metadata": 50,
+    }
+    return order.get(section, 90)
+
+
 def _str_list(values: Any) -> list[str]:
     if not isinstance(values, list):
         return []
@@ -952,13 +1094,28 @@ def hub_timeline_item_dict_to_contract(raw: dict[str, Any]) -> ChatTimelineItem:
         cursor_event_id=_str_or_none(prov_raw.get("cursor_event_id")),
     )
 
-    text_val = raw.get("text") or raw.get("summary") or raw.get("payload_text")
+    payload_raw = raw.get("payload")
+    payload = payload_raw if isinstance(payload_raw, Mapping) else {}
+    kind = _timeline_kind(raw.get("kind"))
+    section = _timeline_section(kind, raw.get("kind"))
+    text_val = (
+        raw.get("text")
+        or raw.get("summary")
+        or raw.get("payload_text")
+        or payload.get("text")
+        or payload.get("text_preview")
+        or payload.get("summary")
+    )
     text_out = _str_or_none(text_val) if text_val is not None else None
 
     return ChatTimelineItem(
         item_id=item_id,
-        kind=_timeline_kind(raw.get("kind")),
+        kind=kind,
         role=_timeline_role(raw.get("role")),
+        managed_turn_id=_str_or_none(raw.get("managed_turn_id")),
+        order_key=str(raw.get("order_key") or item_id),
+        section=section,
+        section_order=_timeline_section_order(section),
         created_at=created_dt,
         text=text_out,
         artifact_ids=[],

--- a/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
@@ -134,6 +134,10 @@ export type ChatTimelineItem = {
   itemId: string;
   kind: 'user_message' | 'assistant_message' | 'tool_event' | 'progress' | 'artifact' | 'system';
   role?: 'user' | 'assistant' | 'tool' | 'system' | null;
+  managedTurnId?: string | null;
+  orderKey?: string | null;
+  section?: 'user_message' | 'activity' | 'assistant_message' | 'terminal_metadata' | 'thread_metadata' | null;
+  sectionOrder?: number | null;
   createdAt: string;
   text?: string | null;
   artifactIds: string[];

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -101,6 +101,10 @@ function detailSnapshot(chatId = 'chat-1'): ChatDetailSnapshot {
         itemId: 'item-1',
         kind: 'user_message',
         role: 'user',
+        managedTurnId: 'turn-1',
+        orderKey: '00000010|turn-1|user',
+        section: 'user_message',
+        sectionOrder: 10,
         createdAt: now,
         text: 'hello',
         artifactIds: [],
@@ -179,6 +183,12 @@ describe('read model entity store', () => {
     expect(selectChatIndexView(store.snapshot()).rows.map((row) => row.chatId)).toEqual(['chat-1']);
     expect(selectChatDetailView(store.snapshot(), 'chat-1').thread?.agentProfile).toBe('m4-pma');
     expect(selectChatDetailView(store.snapshot(), 'chat-1').thread?.chatKind).toBe('coding_agent');
+    expect(selectChatDetailView(store.snapshot(), 'chat-1').timeline[0]).toMatchObject({
+      managedTurnId: 'turn-1',
+      orderKey: '00000010|turn-1|user',
+      section: 'user_message',
+      sectionOrder: 10
+    });
     store.optimisticSend(
       'chat-1',
       {
@@ -780,6 +790,10 @@ describe('read model entity store', () => {
             itemId: 'item-2',
             kind: 'assistant_message',
             role: 'assistant',
+            managedTurnId: 'turn-1',
+            orderKey: '00000030|turn-1|assistant',
+            section: 'assistant_message',
+            sectionOrder: 30,
             createdAt: now,
             text: 'done',
             artifactIds: []

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -225,6 +225,56 @@ describe('read model entity store', () => {
     expect(store.snapshot().optimistic['client-1'].status).toBe('reconciled');
   });
 
+  it('keeps same-turn activity after the user row when backend order keys arrive out of phase order', () => {
+    const store = new ReadModelEntityStore();
+    const snapshot = detailSnapshot();
+    snapshot.timeline = [
+      {
+        itemId: 'turn-1-progress',
+        kind: 'progress',
+        managedTurnId: 'turn-1',
+        orderKey: '00000005|turn-1|progress',
+        section: 'activity',
+        sectionOrder: 20,
+        createdAt: now,
+        text: 'Starting',
+        artifactIds: []
+      },
+      {
+        itemId: 'turn-1-user',
+        kind: 'user_message',
+        role: 'user',
+        managedTurnId: 'turn-1',
+        orderKey: '00000010|turn-1|user',
+        section: 'user_message',
+        sectionOrder: 10,
+        createdAt: now,
+        text: 'hello',
+        artifactIds: []
+      },
+      {
+        itemId: 'turn-1-assistant',
+        kind: 'assistant_message',
+        role: 'assistant',
+        managedTurnId: 'turn-1',
+        orderKey: '00000015|turn-1|assistant',
+        section: 'assistant_message',
+        sectionOrder: 30,
+        createdAt: now,
+        text: 'hi',
+        artifactIds: []
+      }
+    ];
+
+    store.applyChatDetailSnapshot(snapshot);
+
+    expect(selectChatDetailView(store.snapshot(), 'chat-1').timeline.map((item) => item.itemId)).toEqual([
+      'turn-1-user',
+      'turn-1-progress',
+      'turn-1-assistant'
+    ]);
+  });
+
   it('replaces and upserts backend-owned PMA transcript cards independently of timeline state', () => {
     const store = new ReadModelEntityStore();
     const first: ChatTranscriptCard = {
@@ -809,6 +859,48 @@ describe('read model entity store', () => {
     expect(store.applyChatDetailPatchEvent(event)).toBe('applied');
     expect(store.applyChatDetailPatchEvent(event)).toBe('ignored');
     expect(selectChatDetailView(store.snapshot(), 'chat-1').timeline.filter((item) => item.itemId === 'item-2')).toHaveLength(1);
+  });
+
+  it('keeps same-turn patched activity after the user row when its order key is earlier', () => {
+    const store = new ReadModelEntityStore();
+    store.applyChatDetailSnapshot(detailSnapshot());
+    const event: ChatDetailPatchEvent = {
+      envelope: {
+        contractVersion: READ_MODEL_CONTRACT_VERSION,
+        eventType: 'chat.detail.patch',
+        cursor: cursor(2),
+        entityKind: 'chat',
+        entityId: 'chat-1',
+        operation: 'upsert',
+        generatedAt: now
+      },
+      patch: {
+        appendedTimeline: [
+          {
+            itemId: 'turn-1-progress',
+            kind: 'progress',
+            managedTurnId: 'turn-1',
+            orderKey: '00000005|turn-1|progress',
+            section: 'activity',
+            sectionOrder: 20,
+            createdAt: now,
+            text: 'Starting',
+            artifactIds: []
+          }
+        ],
+        patchedTimeline: [],
+        removedTimelineIds: [],
+        queue: null,
+        artifacts: []
+      }
+    };
+
+    expect(store.applyChatDetailPatchEvent(event)).toBe('applied');
+
+    expect(selectChatDetailView(store.snapshot(), 'chat-1').timeline.map((item) => item.itemId)).toEqual([
+      'item-1',
+      'turn-1-progress'
+    ]);
   });
 
   it('caps retained PMA live progress events and drops hidden/debug-only progress', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -373,7 +373,7 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     next.timelines[snapshot.thread.chatId] = {
       chatId: snapshot.thread.chatId,
       itemsById: keyed(snapshot.timeline, (item) => item.itemId),
-      order: snapshot.timeline.map((item) => item.itemId),
+      order: orderChatTimelineItems(snapshot.timeline).map((item) => item.itemId),
       windowLimit: snapshot.timelineWindow.limit
     };
     next.pmaQueues[snapshot.thread.chatId] = snapshot.queue.queuedTurnIds.map((id, index) => ({
@@ -423,6 +423,7 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
       delete existingTimeline.itemsById[id];
       existingTimeline.order = existingTimeline.order.filter((itemId) => itemId !== id);
     }
+    existingTimeline.order = orderChatTimelineItems(existingTimeline.order.map((id) => existingTimeline.itemsById[id]).filter(Boolean)).map((item) => item.itemId);
     next.timelines[chatId] = existingTimeline;
     const detail = cloneChatDetailProjection(next.chatDetails[chatId] ?? { thread: null, queue: null, artifactIds: [] });
     if (event.patch.thread) {
@@ -893,6 +894,18 @@ function cloneTimelineProjection(timeline: TimelineProjection): TimelineProjecti
     order: [...timeline.order],
     windowLimit: timeline.windowLimit
   };
+}
+
+function orderChatTimelineItems(items: ChatTimelineItem[]): ChatTimelineItem[] {
+  return [...items].sort((a, b) => {
+    const aOrder = a.orderKey || a.itemId;
+    const bOrder = b.orderKey || b.itemId;
+    if (aOrder !== bOrder) return aOrder < bOrder ? -1 : 1;
+    const aSection = a.sectionOrder ?? 90;
+    const bSection = b.sectionOrder ?? 90;
+    if (aSection !== bSection) return aSection - bSection;
+    return a.itemId.localeCompare(b.itemId);
+  });
 }
 
 function cloneChatTranscript(transcript: { cardsById: Record<string, ChatTranscriptCard>; order: string[] }): { cardsById: Record<string, ChatTranscriptCard>; order: string[] } {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -896,16 +896,67 @@ function cloneTimelineProjection(timeline: TimelineProjection): TimelineProjecti
   };
 }
 
+function genericTimelineSortKey(item: ChatTimelineItem): string {
+  return item.orderKey || item.itemId;
+}
+
+function timelineTurnId(item: ChatTimelineItem): string | null {
+  const id = item.managedTurnId;
+  if (id == null) return null;
+  const trimmed = String(id).trim();
+  return trimmed ? trimmed : null;
+}
+
+function timelineItemPhase(item: ChatTimelineItem): number {
+  if (item.kind === 'user_message' || item.role === 'user') return 0;
+  if (item.kind === 'assistant_message' || item.role === 'assistant') return 2;
+  return 1;
+}
+
+function buildTimelineTurnAnchors(items: ChatTimelineItem[]): Map<string, string> {
+  const turnFallbacks: Record<string, string> = {};
+  const turnAnchors: Record<string, string> = {};
+  for (const item of items) {
+    const turnId = timelineTurnId(item);
+    if (!turnId) continue;
+    const g = genericTimelineSortKey(item);
+    const prevFb = turnFallbacks[turnId];
+    if (prevFb === undefined || g < prevFb) turnFallbacks[turnId] = g;
+    if (timelineItemPhase(item) === 0) {
+      const prevAnchor = turnAnchors[turnId];
+      if (prevAnchor === undefined || g < prevAnchor) turnAnchors[turnId] = g;
+    }
+  }
+  for (const turnId of Object.keys(turnFallbacks)) {
+    if (turnAnchors[turnId] === undefined) turnAnchors[turnId] = turnFallbacks[turnId]!;
+  }
+  return new Map(Object.entries(turnAnchors));
+}
+
+type TimelineSortTuple = readonly [string, number, string, string];
+
+function timelineRowSortKey(item: ChatTimelineItem, anchors: Map<string, string>): TimelineSortTuple {
+  const genericKey = genericTimelineSortKey(item);
+  const turnId = timelineTurnId(item);
+  const phase = timelineItemPhase(item);
+  if (!turnId) return [genericKey, phase, genericKey, item.itemId];
+  const anchor = anchors.get(turnId) ?? genericKey;
+  return [anchor, phase, genericKey, item.itemId];
+}
+
+function compareTimelineSortTuples(a: TimelineSortTuple, b: TimelineSortTuple): number {
+  if (a[0] !== b[0]) return a[0] < b[0] ? -1 : 1;
+  if (a[1] !== b[1]) return a[1] - b[1];
+  if (a[2] !== b[2]) return a[2] < b[2] ? -1 : 1;
+  if (a[3] !== b[3]) return a[3] < b[3] ? -1 : 1;
+  return 0;
+}
+
 function orderChatTimelineItems(items: ChatTimelineItem[]): ChatTimelineItem[] {
-  return [...items].sort((a, b) => {
-    const aOrder = a.orderKey || a.itemId;
-    const bOrder = b.orderKey || b.itemId;
-    if (aOrder !== bOrder) return aOrder < bOrder ? -1 : 1;
-    const aSection = a.sectionOrder ?? 90;
-    const bSection = b.sectionOrder ?? 90;
-    if (aSection !== bSection) return aSection - bSection;
-    return a.itemId.localeCompare(b.itemId);
-  });
+  const anchors = buildTimelineTurnAnchors(items);
+  return [...items].sort((a, b) =>
+    compareTimelineSortTuples(timelineRowSortKey(a, anchors), timelineRowSortKey(b, anchors))
+  );
 }
 
 function cloneChatTranscript(transcript: { cardsById: Record<string, ChatTranscriptCard>; order: string[] }): { cardsById: Record<string, ChatTranscriptCard>; order: string[] } {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -897,7 +897,7 @@ function cloneTimelineProjection(timeline: TimelineProjection): TimelineProjecti
 }
 
 function genericTimelineSortKey(item: ChatTimelineItem): string {
-  return item.orderKey || item.itemId;
+  return item.orderKey || item.createdAt || item.itemId;
 }
 
 function timelineTurnId(item: ChatTimelineItem): string | null {
@@ -908,9 +908,16 @@ function timelineTurnId(item: ChatTimelineItem): string | null {
 }
 
 function timelineItemPhase(item: ChatTimelineItem): number {
-  if (item.kind === 'user_message' || item.role === 'user') return 0;
-  if (item.kind === 'assistant_message' || item.role === 'assistant') return 2;
-  return 1;
+  if (typeof item.sectionOrder === 'number') return item.sectionOrder;
+  if (item.section === 'user_message' || item.kind === 'user_message' || item.role === 'user') return 10;
+  if (item.section === 'assistant_message' || item.kind === 'assistant_message' || item.role === 'assistant') return 30;
+  if (item.section === 'terminal_metadata') return 40;
+  if (item.section === 'thread_metadata') return 50;
+  return 20;
+}
+
+function timelineItemIsUserAnchor(item: ChatTimelineItem): boolean {
+  return item.section === 'user_message' || item.kind === 'user_message' || item.role === 'user';
 }
 
 function buildTimelineTurnAnchors(items: ChatTimelineItem[]): Map<string, string> {
@@ -922,7 +929,7 @@ function buildTimelineTurnAnchors(items: ChatTimelineItem[]): Map<string, string
     const g = genericTimelineSortKey(item);
     const prevFb = turnFallbacks[turnId];
     if (prevFb === undefined || g < prevFb) turnFallbacks[turnId] = g;
-    if (timelineItemPhase(item) === 0) {
+    if (timelineItemIsUserAnchor(item)) {
       const prevAnchor = turnAnchors[turnId];
       if (prevAnchor === undefined || g < prevAnchor) turnAnchors[turnId] = g;
     }

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -36,6 +36,8 @@ import {
   pmaChatScopeTagView,
   chatSurfaceFilterOptions,
   chatSurfaceFilterToken,
+  committedDraftChatPlaceholder,
+  mergeLocalChatPlaceholders,
   progressPercent,
   reconcileChatSurfaceEvent,
   reconcileChatSurfaceSnapshot,
@@ -1995,6 +1997,55 @@ describe('PMA chat view helpers', () => {
         title: 'https://example.test',
         url: 'https://example.test'
       }
+    ]);
+  });
+
+  it('builds a committed draft placeholder that keeps detail mounted while the chat index is stale', () => {
+    const draftChat: PmaChatSummary = {
+      ...baseChat,
+      id: 'draft:pma:1',
+      title: 'New chat',
+      lifecycleStatus: 'draft',
+      status: 'idle',
+      ticketId: null,
+      isTicketFlow: false,
+      updatedAt: '2026-05-11T12:00:00Z',
+      raw: {
+        draft: true,
+        scope_urn: 'hub',
+        chat_kind: 'pma'
+      }
+    };
+
+    const placeholder = committedDraftChatPlaceholder(
+      draftChat,
+      'managed-thread-1',
+      '2026-05-11T12:00:01Z'
+    );
+
+    expect(placeholder).toMatchObject({
+      id: 'managed-thread-1',
+      title: 'New chat',
+      lifecycleStatus: 'active',
+      status: 'running',
+      updatedAt: '2026-05-11T12:00:01Z',
+      agentId: draftChat.agentId,
+      repoId: draftChat.repoId,
+      worktreeId: draftChat.worktreeId,
+      raw: {
+        draft: false,
+        draft_committed_placeholder: true,
+        previous_draft_id: 'draft:pma:1',
+        managed_thread_id: 'managed-thread-1'
+      }
+    });
+    expect(mergeLocalChatPlaceholders([], [placeholder]).map((chat) => chat.id)).toEqual(['managed-thread-1']);
+    expect(mergeLocalChatPlaceholders([baseChat], [placeholder]).map((chat) => chat.id)).toEqual([
+      'managed-thread-1',
+      'chat-1'
+    ]);
+    expect(mergeLocalChatPlaceholders([{ ...baseChat, id: 'managed-thread-1' }], [placeholder]).map((chat) => chat.id)).toEqual([
+      'managed-thread-1'
     ]);
   });
 

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -546,6 +546,45 @@ export function reconcileChatSurfaceSnapshot(
   return { chats: nextChats, replacementChatId: replacement?.id ?? null };
 }
 
+export function committedDraftChatPlaceholder(
+  draftChat: PmaChatSummary,
+  committedChatId: string,
+  updatedAt = new Date().toISOString()
+): PmaChatSummary {
+  return {
+    ...draftChat,
+    id: committedChatId,
+    lifecycleStatus: 'active',
+    status: 'running',
+    updatedAt,
+    raw: {
+      ...draftChat.raw,
+      draft: false,
+      draft_committed_placeholder: true,
+      previous_draft_id: draftChat.id,
+      id: committedChatId,
+      managed_thread_id: committedChatId
+    }
+  };
+}
+
+export function mergeLocalChatPlaceholders(
+  persistedChats: PmaChatSummary[],
+  placeholders: Array<PmaChatSummary | null | undefined>
+): PmaChatSummary[] {
+  const visiblePlaceholders = visibleLocalChatPlaceholders(persistedChats, placeholders);
+  return visiblePlaceholders.length > 0 ? [...visiblePlaceholders, ...persistedChats] : persistedChats;
+}
+
+export function visibleLocalChatPlaceholders(
+  persistedChats: PmaChatSummary[],
+  placeholders: Array<PmaChatSummary | null | undefined>
+): PmaChatSummary[] {
+  return placeholders
+    .filter((chat): chat is PmaChatSummary => Boolean(chat))
+    .filter((chat) => !persistedChats.some((row) => row.id === chat.id));
+}
+
 export type ManagedThreadMessagePayload = {
   message: string;
   attachments?: DocumentFileIntentPayload[];

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -59,6 +59,7 @@
     buildManagedThreadMessagePayload,
     buildPmaStatusBar,
     chooseActiveChatId,
+    committedDraftChatPlaceholder,
     composeMessageWithAttachments,
     countTicketRunGroups,
     filterChatEntries,
@@ -66,6 +67,7 @@
     formatRelativeTime,
     isPmaChatArchived,
     localPmaChatScopeOption,
+    mergeLocalChatPlaceholders,
     CHAT_FILTER_ORDER,
     CHAT_TICKET_RUNS_FILTER,
     pmaChatKind,
@@ -78,6 +80,7 @@
     chatSurfaceFilterToken,
     progressPercent,
     mapChatTranscriptRows,
+    visibleLocalChatPlaceholders as selectVisibleLocalChatPlaceholders,
     removePendingAttachment,
     statusLabel,
     summarizeFilterCounts,
@@ -137,6 +140,7 @@
   // New chats are local drafts until the first send commits agent/scope/model
   // and message in one backend call.
   let localDraftChat = $state<PmaChatSummary | null>(null);
+  let committedDraftChat = $state<PmaChatSummary | null>(null);
   let agents = $state<JsonRecord[]>([]);
   let models = $state<JsonRecord[]>([]);
   let scopeOptions = $state<PmaChatScopeOption[]>(buildPmaChatScopeOptions([], []));
@@ -156,7 +160,11 @@
   let search = $state('');
   const currentChatIndexRequest = $derived<ChatIndexWindowRequest>(chatIndexRequestForCurrentFilters());
   const persistedChats = $derived<PmaChatSummary[]>(selectPmaChats(readModelState, currentChatIndexRequest));
-  const chats = $derived<PmaChatSummary[]>(localDraftChat ? [localDraftChat, ...persistedChats] : persistedChats);
+  const localChatPlaceholders = $derived<PmaChatSummary[]>([localDraftChat, committedDraftChat].filter((chat): chat is PmaChatSummary => Boolean(chat)));
+  const visibleLocalChatPlaceholders = $derived<PmaChatSummary[]>(
+    selectVisibleLocalChatPlaceholders(persistedChats, localChatPlaceholders)
+  );
+  const chats = $derived<PmaChatSummary[]>(mergeLocalChatPlaceholders(persistedChats, localChatPlaceholders));
   const transcriptCards = $derived<ChatTranscriptCard[]>(selectChatTranscript(readModelState, activeChatId));
   const progress = $derived<PmaRunProgress | null>(selectPmaProgress(readModelState, activeChatId));
   const artifacts = $derived<SurfaceArtifact[]>(selectPmaArtifacts(readModelState, activeChatId));
@@ -191,6 +199,7 @@
   let composerFocused = $state(false);
   let composerEditVersion = 0;
   let pendingPointerChatId: string | null = null;
+  let pendingCommittedDetailUrlChatId = $state<string | null>(null);
   let removeDocumentChatPointerCapture: (() => void) | null = null;
 
   const COMPOSER_DEFAULT_MAX_PX = 360;
@@ -319,7 +328,8 @@
   const filterCounts = $derived(chatStatusFilterCounts());
   const surfaceFilterChips = $derived(chatSurfaceFilterOptions(chats));
   const ticketRunGroupCount = $derived(countTicketRunGroups(chats));
-  const activeChatCount = $derived(readModelState.chatCounters.total + (localDraftChat && !isPmaChatArchived(localDraftChat) ? 1 : 0));
+  const localChatPlaceholderCount = $derived(visibleLocalChatPlaceholders.filter((chat) => !isPmaChatArchived(chat)).length);
+  const activeChatCount = $derived(readModelState.chatCounters.total + localChatPlaceholderCount);
   const hasUsableChatIndex = $derived(Boolean(readModelState.chatIndexCursor || readModelState.chatOrder.length > 0));
   const hasSelectedChatWindow = $derived(Boolean(readModelState.chatWindows[canonicalChatIndexWindowKey(currentChatIndexRequest)]));
   const initialChatIndexError = $derived(chatIndexLoadError());
@@ -593,16 +603,18 @@
 
   function chatStatusFilterCounts(): Record<ChatStatusFilter, number> {
     const counters = readModelState.chatCounters;
-    const localDraftBump = localDraftChat && !isPmaChatArchived(localDraftChat) ? 1 : 0;
     const knownPersistedChats = selectPmaChats(readModelState, { filter: 'all', limit: 50 });
-    const knownChats = localDraftChat ? [localDraftChat, ...knownPersistedChats] : knownPersistedChats;
+    const localKnownPlaceholders = selectVisibleLocalChatPlaceholders(knownPersistedChats, localChatPlaceholders);
+    const knownChats = localKnownPlaceholders.length > 0 ? [...localKnownPlaceholders, ...knownPersistedChats] : knownPersistedChats;
+    const localRunningCount = localKnownPlaceholders.filter((chat) => chat.status === 'running').length;
+    const localWaitingCount = localKnownPlaceholders.filter((chat) => chat.status === 'waiting' || chat.status === 'blocked').length;
     // Backend counters cover the full windowed result set; local read markers can only
     // raise the unread count for rows the client has already seen.
     const clientUnread = summarizeFilterCounts(knownChats, lastSeenMap).unread;
     return {
-      all: counters.total + localDraftBump,
-      active: counters.running,
-      waiting: counters.waiting,
+      all: counters.total + localChatPlaceholderCount,
+      active: counters.running + localRunningCount,
+      waiting: counters.waiting + localWaitingCount,
       unread: Math.max(counters.unread, clientUnread),
       archived: counters.archived
     };
@@ -666,7 +678,7 @@
     const requestedDetail = requestedDetailFromUrl();
     if (!requestedDetail) {
       if (isLocalDraftChatId(activeChatId)) return;
-      if (sending || creating) return;
+      if (pendingCommittedDetailUrlChatId && activeChatId === pendingCommittedDetailUrlChatId) return;
       if (activeChatId !== null) {
         closeStream();
         activeChatId = null;
@@ -679,6 +691,13 @@
     // and clear the draft on the first click.
     if (isLocalDraftChatId(activeChatId)) return;
     void activateDetailFromUrl(requestedDetail);
+  });
+
+  $effect(() => {
+    if (!committedDraftChat) return;
+    if (persistedChats.some((chat) => chat.id === committedDraftChat?.id)) {
+      committedDraftChat = null;
+    }
   });
 
   $effect(() => {
@@ -905,6 +924,8 @@
   async function selectChat(chatId: string): Promise<void> {
     const cached = hasCachedDetail(chatId);
     if (!isLocalDraftChatId(chatId)) localDraftChat = null;
+    if (committedDraftChat?.id !== chatId) committedDraftChat = null;
+    pendingCommittedDetailUrlChatId = null;
     activeChatId = chatId;
     detailMode = 'detail';
     loadingActive = !cached;
@@ -954,6 +975,8 @@
     if (detailId === activeChatId) return;
     if (!chats.some((chat) => chat.id === detailId)) {
       closeStream();
+      if (committedDraftChat?.id !== detailId) committedDraftChat = null;
+      pendingCommittedDetailUrlChatId = null;
       activeChatId = detailId;
       detailMode = 'detail';
       loadingActive = true;
@@ -974,6 +997,8 @@
     const loaderResult = activeDetailLoadResult(chatId);
     const loaderOwnsInitialDetail = Boolean(loaderResult && loaderResult.status !== 'cold');
     if (!isLocalDraftChatId(chatId)) localDraftChat = null;
+    if (committedDraftChat?.id !== chatId) committedDraftChat = null;
+    pendingCommittedDetailUrlChatId = null;
     activeChatId = chatId;
     detailMode = 'detail';
     loadingActive = !(cached || loaderOwnsInitialDetail);
@@ -1700,13 +1725,31 @@
         return;
       }
       if (targetIsDraft) {
+        const draftChatForPlaceholder =
+          localDraftChat?.id === targetChatId
+            ? localDraftChat
+            : activeChat && activeChat.id === targetChatId
+              ? activeChat
+              : null;
+        if (draftChatForPlaceholder) {
+          committedDraftChat = committedDraftChatPlaceholder(
+            draftChatForPlaceholder,
+            committedChatId,
+            optimisticTimestamp
+          );
+        }
         localDraftChat = null;
         activeChatId = committedChatId;
         detailMode = 'detail';
+        pendingCommittedDetailUrlChatId = committedChatId;
         moveOptimisticToCommittedChat(committedChatId);
-        // Must complete before `sending` clears: the URL effect treats no `chatId`
-        // segment as "list mode" unless we're still sending or on a local draft id.
-        await syncDetailUrl(committedChatId);
+        try {
+          await syncDetailUrl(committedChatId);
+        } finally {
+          if (pendingCommittedDetailUrlChatId === committedChatId) {
+            pendingCommittedDetailUrlChatId = null;
+          }
+        }
       }
       await invalidateChatMutation(committedChatId);
       await refreshActive(committedChatId, { quiet: true });

--- a/tests/contracts/web/test_read_model_contracts.py
+++ b/tests/contracts/web/test_read_model_contracts.py
@@ -159,6 +159,10 @@ def test_chat_detail_snapshot_and_patch_round_trip_without_legacy_thread_payload
         item_id="timeline-1",
         kind="assistant_message",
         role="assistant",
+        managed_turn_id="turn-1",
+        order_key="00000030|turn-1|assistant",
+        section="assistant_message",
+        section_order=30,
         created_at=NOW,
         text="Working on it.",
         backend_message_id="turn-1",
@@ -186,6 +190,10 @@ def test_chat_detail_snapshot_and_patch_round_trip_without_legacy_thread_payload
     assert payload["timelineWindow"]["limit"] == 50
     assert payload["thread"]["chatKind"] == "coding_agent"
     assert payload["timeline"][0]["backendMessageId"] == "turn-1"
+    assert payload["timeline"][0]["managedTurnId"] == "turn-1"
+    assert payload["timeline"][0]["orderKey"] == "00000030|turn-1|assistant"
+    assert payload["timeline"][0]["section"] == "assistant_message"
+    assert payload["timeline"][0]["sectionOrder"] == 30
     assert payload["timeline"][0]["identity"]["timelineItemId"] == "timeline-1"
     assert payload["timeline"][0]["identity"]["progressItemIds"] == ["progress-1"]
     assert payload["timeline"][0]["identity"]["correlationId"] == "client-corr-1"
@@ -217,6 +225,10 @@ def test_chat_timeline_item_canonical_identity_and_provenance_fields_round_trip(
         item_id="tl-canonical",
         kind="tool_event",
         role="tool",
+        managed_turn_id="turn-1",
+        order_key="00000020|turn-1|tool",
+        section="activity",
+        section_order=20,
         created_at=NOW,
         text="Ran npm test",
         identity=ChatTimelineIdentity(
@@ -232,6 +244,10 @@ def test_chat_timeline_item_canonical_identity_and_provenance_fields_round_trip(
     )
     payload = dump_read_model_contract(item)
     assert payload["identity"]["timelineItemId"] == "tl-canonical"
+    assert payload["managedTurnId"] == "turn-1"
+    assert payload["orderKey"] == "00000020|turn-1|tool"
+    assert payload["section"] == "activity"
+    assert payload["sectionOrder"] == 20
     assert payload["identity"]["progressItemIds"] == ["prog-1", "prog-2"]
     assert payload["provenance"]["sourceEventIds"] == ["src-1"]
     assert payload["provenance"]["cursorEventId"] == "sse-cursor-99"

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_timeline_route.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_timeline_route.py
@@ -11,6 +11,7 @@ from codex_autorunner.core.orchestration import SQLiteChatSurfaceEventJournal
 from codex_autorunner.core.orchestration.cold_trace_store import ColdTraceWriter
 from codex_autorunner.core.orchestration.managed_thread_transcript import (
     _merge_transcript_rows,
+    build_managed_thread_transcript,
 )
 from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.orchestration.turn_timeline import (
@@ -120,6 +121,81 @@ def test_managed_thread_transcript_live_rows_replace_stale_durable_rows() -> Non
     merged = _merge_transcript_rows(durable_rows, live_rows)
 
     assert merged == [live_rows[0]]
+
+
+def test_managed_thread_transcript_live_rows_stay_after_turn_user_row() -> None:
+    durable_rows = [
+        {
+            "kind": "message",
+            "id": "turn:turn-1:user",
+            "turn_id": "turn-1",
+            "order_key": "00000005|2026-05-12T10:00:00Z|turn:turn-1:user",
+            "message": {"role": "user", "text": "hello"},
+        }
+    ]
+    live_rows = [
+        {
+            "kind": "intermediate",
+            "id": "turn:turn-1:intermediate:0001",
+            "turn_id": "turn-1",
+            "order_key": "00000001|2026-05-12T09:59:59Z|progress",
+            "text": "thinking",
+        }
+    ]
+
+    merged = _merge_transcript_rows(durable_rows, live_rows)
+
+    assert [row["id"] for row in merged] == [
+        "turn:turn-1:user",
+        "turn:turn-1:intermediate:0001",
+    ]
+
+
+def test_managed_thread_transcript_running_first_turn_orders_live_progress_after_user(
+    hub_env,
+) -> None:
+    store = ManagedThreadStore(hub_env.hub_root)
+    created = store.create_thread(
+        "codex",
+        hub_env.repo_root.resolve(),
+        repo_id=hub_env.repo_id,
+    )
+    managed_thread_id = str(created["managed_thread_id"])
+    turn = store.create_turn(managed_thread_id, prompt="first prompt")
+    turn_id = str(turn["managed_turn_id"])
+
+    transcript = build_managed_thread_transcript(
+        hub_env.hub_root,
+        thread_store=store,
+        managed_thread_id=managed_thread_id,
+        progress_snapshot={
+            "managed_turn_id": turn_id,
+            "last_event_id": 1,
+            "events": [
+                {
+                    "event_id": 1,
+                    "event_type": "progress",
+                    "received_at": "2026-05-12T09:59:59Z",
+                    "summary": "Planning next step",
+                    "progress_kind": "assistant_update",
+                    "progress_state": "running",
+                    "progress_item": {
+                        "item_id": "progress:assistant_update:1",
+                        "kind": "assistant_update",
+                        "summary": "Planning next step",
+                        "event_ids": [1],
+                    },
+                }
+            ],
+        },
+    )
+
+    rows = transcript["rows"]
+    assert [row["kind"] for row in rows] == ["message", "intermediate"]
+    assert rows[0]["id"] == f"turn:{turn_id}:user"
+    assert rows[0]["message"]["role"] == "user"
+    assert rows[1]["id"] == f"turn:{turn_id}:intermediate:0001"
+    assert rows[1]["turn_id"] == turn_id
 
 
 def test_managed_thread_timeline_endpoint_returns_canonical_items(hub_env) -> None:

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -1151,3 +1151,49 @@ def test_hub_read_models_chat_detail_contract_snapshot(hub_env) -> None:
     assert snapshot.queue.active_turn_id == running["managed_turn_id"]
     assert snapshot.queue.depth == 1
     assert snapshot.timeline[0].kind == "user_message"
+    assert snapshot.timeline[0].managed_turn_id == running["managed_turn_id"]
+    assert snapshot.timeline[0].section == "user_message"
+    assert snapshot.timeline[0].section_order == 10
+    assert snapshot.timeline[0].order_key
+    assert snapshot.timeline[0].text == "hello detail"
+    assert body["timeline"][0]["managedTurnId"] == running["managed_turn_id"]
+    assert body["timeline"][0]["section"] == "user_message"
+    assert body["timeline"][0]["sectionOrder"] == 10
+
+
+def test_hub_read_models_chat_detail_patch_stream_is_repairable(hub_env) -> None:
+    store = ManagedThreadStore(hub_env.hub_root, durable=True)
+    thread = store.create_thread(
+        "hermes",
+        hub_env.repo_root,
+        repo_id="repo",
+        resource_kind="repo",
+        resource_id="repo",
+        name="Detail patch thread",
+    )
+    thread_id = str(thread["managed_thread_id"])
+    SQLiteChatSurfaceEventJournal(hub_env.hub_root, durable=True).append_event(
+        idempotency_key="detail-patch-contract-1",
+        event_type="execution.progress",
+        surface_kind="pma",
+        surface_key=thread_id,
+        managed_thread_id=thread_id,
+        repo_id="repo",
+        status="running",
+        payload={"patch_type": "timeline_append"},
+    )
+
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    response = client.get(
+        f"/hub/read-models/chats/{thread_id}/patches",
+        params={"once": "true"},
+    )
+
+    assert response.status_code == 200
+    body = response.text
+    assert "event: chat.detail.patch" in body
+    assert '"contractVersion": "web-read-models.v1"' in body
+    assert '"eventType": "chat.detail.patch"' in body
+    assert '"entityId": "' + thread_id + '"' in body
+    assert '"operation": "reset"' in body
+    assert '"appendedTimeline": []' in body

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -18,6 +18,7 @@ from codex_autorunner.surfaces.web.read_model_contracts import (
     ChatIndexSnapshot,
     load_read_model_contract,
 )
+from codex_autorunner.surfaces.web.routes import hub_chat_read_models
 from codex_autorunner.surfaces.web.routes.hub_chat_read_models import (
     hub_group_dict_to_contract,
 )
@@ -1197,3 +1198,68 @@ def test_hub_read_models_chat_detail_patch_stream_is_repairable(hub_env) -> None
     assert '"entityId": "' + thread_id + '"' in body
     assert '"operation": "reset"' in body
     assert '"appendedTimeline": []' in body
+
+
+def test_hub_read_models_chat_detail_patch_cursor_skips_unrelated_batches(
+    hub_env,
+) -> None:
+    store = ManagedThreadStore(hub_env.hub_root, durable=True)
+    target = store.create_thread(
+        "hermes",
+        hub_env.repo_root,
+        repo_id="repo",
+        resource_kind="repo",
+        resource_id="repo",
+        name="Target detail patch thread",
+    )
+    other = store.create_thread(
+        "hermes",
+        hub_env.repo_root,
+        repo_id="repo",
+        resource_kind="repo",
+        resource_id="repo",
+        name="Other detail patch thread",
+    )
+    target_id = str(target["managed_thread_id"])
+    other_id = str(other["managed_thread_id"])
+    service = hub_chat_read_models.ChatReadModelService(hub_env.hub_root)
+    baseline = service.chat_detail_patch_contracts(target_id, None, event_limit=100)
+    baseline_cursor = int(baseline["cursor"] or 0)
+    journal = SQLiteChatSurfaceEventJournal(hub_env.hub_root, durable=True)
+    journal.append_event(
+        idempotency_key="detail-patch-other-first",
+        event_type="execution.progress",
+        surface_kind="pma",
+        surface_key=other_id,
+        managed_thread_id=other_id,
+        repo_id="repo",
+        status="running",
+        payload={"patch_type": "timeline_append"},
+    )
+    journal.append_event(
+        idempotency_key="detail-patch-target-second",
+        event_type="execution.progress",
+        surface_kind="pma",
+        surface_key=target_id,
+        managed_thread_id=target_id,
+        repo_id="repo",
+        status="running",
+        payload={"patch_type": "timeline_append"},
+    )
+
+    first_batch = service.chat_detail_patch_contracts(
+        target_id, baseline_cursor, event_limit=1
+    )
+    assert first_batch["events"] == []
+    first_cursor = int(first_batch["cursor"])
+    assert first_cursor > 0
+
+    next_cursor = hub_chat_read_models._advance_chat_detail_stream_cursor(
+        0, first_cursor
+    )
+    second_batch = service.chat_detail_patch_contracts(
+        target_id, next_cursor, event_limit=1
+    )
+
+    assert len(second_batch["events"]) == 1
+    assert second_batch["events"][0]["envelope"]["entityId"] == target_id


### PR DESCRIPTION
## Summary

- enforce turn-structured transcript ordering so live progress renders under the user message for the active turn
- stabilize the new-chat draft-to-committed handoff so the detail pane does not disappear while the chat index catches up
- add the first chat detail read-model projection contract and migration docs for the longer-term single-projection architecture

## Root Cause

- backend transcript assembly merged durable timeline rows with live tail rows and sorted by generic row keys, so progress rows could surface before the turn user message
- frontend active detail depended on the active chat being present in the chat index; clearing the local draft before the committed thread appeared made `activeChat` temporarily null

## Validation

- `python3 .codex-autorunner/bin/lint_tickets.py`
- `.venv/bin/python -m pytest tests/surfaces/web/routes/pma_routes/test_managed_thread_timeline_route.py tests/surfaces/web/test_hub_chat_read_model_routes.py tests/contracts/web/test_read_model_contracts.py`
- `pnpm web:test`
