### PR TITLE
[codex] Canonical ticket-flow chat visibility

### DIFF
--- a/docs/RUN_HISTORY.md
+++ b/docs/RUN_HISTORY.md
@@ -4,13 +4,20 @@ This document defines the canonical run-history model in Codex Autorunner.
 
 ## Source Of Truth
 
-Use `FlowStore` at `.codex-autorunner/flows.db` as the single source of truth for run history.
+Use `FlowStore` at `.codex-autorunner/flows.db` as the single source of truth
+for flow-engine run history. This store proves what the ticket-flow engine ran;
+it does not by itself make a turn visible in Web Hub Chats.
 
 - Runs: `flow_runs`
 - Timeline/events: `flow_events`
 - Artifacts: `flow_artifacts`
 
 Legacy numeric run directories are compatibility-only and must not be used for new run history features.
+
+Web Hub chat visibility is sourced from hub orchestration records:
+`orch_thread_targets`, `orch_thread_executions`, bindings, delivery ledgers,
+and chat-surface events. A ticket-flow turn is visible only when orchestration
+contains a repairable `flow_run_id + ticket_id -> managed_thread_id` link.
 
 ### Archived Run Artifacts Are Not Live History
 

--- a/docs/architecture/ticket-flow-chat-ledger-contract.md
+++ b/docs/architecture/ticket-flow-chat-ledger-contract.md
@@ -1,0 +1,67 @@
+# Ticket-Flow Chat Ledger Contract
+
+Contract version: `ticket_flow_chat_ledger.v1`
+
+Ticket-flow sequencing may continue to use repo-local `flows.db`, but chat and
+flow visibility are orchestration concerns. Every executed ticket-flow agent
+turn must create or reuse a managed thread and persist a repairable
+`flow_run_id + ticket_id -> managed_thread_id` link in orchestration state before
+the turn is allowed to complete.
+
+## Canonical Facts
+
+Required lifecycle facts:
+
+- `flow_run.started`
+- `flow_run.completed`
+- `flow_run.failed`
+- `ticket.selected`
+- `managed_thread.created`
+- `managed_thread.reused`
+- `ticket_thread.linked`
+- `ticket_turn.started`
+- `ticket_turn.completed`
+- `ticket_turn.failed`
+
+Repo-local `flows.db` remains responsible for native flow-engine execution
+state: run status, current step, pause/resume state, terminal state, and
+`state.ticket_engine`. This proves what the sequencing engine did, but it is not
+the source of truth for Web Hub chat visibility.
+
+Hub orchestration state must contain:
+
+- Flow lifecycle events for run start, completion, and failure with `run_id`,
+  `flow_type=ticket_flow`, `workspace_root`, and timestamps.
+- Ticket selection events with `flow_run_id`, `ticket_id`, `ticket_path`,
+  `workspace_root`, and timestamps.
+- A managed thread target in `orch_thread_targets` for each executed ticket turn.
+  Its metadata must include `flow_type=ticket_flow`, `thread_kind=ticket_flow`,
+  `run_id`, `flow_run_id`, `ticket_id`, `workspace_root`, and
+  `ticket_flow_link_key`.
+- A durable thread-link fact with `flow_run_id`, `ticket_id`,
+  `managed_thread_id`, and `workspace_root`.
+- Managed turn execution state in `orch_thread_executions`, including
+  `managed_thread_id`, turn status, start time, and terminal time.
+- Chat-surface events and bindings derived from the managed thread, not from
+  Discord or Telegram status notices.
+
+## Rebuild Rules
+
+The Web Hub chat index rebuilds from orchestration-owned managed thread targets,
+thread executions, bindings, delivery records, channel-directory entries, and
+`orch_chat_surface_events`. It must not read repo-local `flows.db` or
+`.codex-autorunner/flows/<run_id>/chat/*.jsonl`.
+
+A future flow index rebuilds from orchestration flow lifecycle, ticket
+selection, thread-link, and turn lifecycle facts. `flows.db` can be used as
+engine state and as repair/backfill input for older runs, but projected Hub
+visibility must be recoverable from orchestration after repair.
+
+Discord and Telegram flow status messages are delivery artifacts. During the
+transition they may keep compatibility shims, but their content should be
+rendered from the same canonical projections used by Web Hub.
+
+## Code Anchor
+
+The testable source for this contract is
+`codex_autorunner.core.orchestration.ticket_flow_chat_ledger_contract`.

--- a/docs/car_constitution/20_ARCHITECTURE_MAP.md
+++ b/docs/car_constitution/20_ARCHITECTURE_MAP.md
@@ -42,7 +42,9 @@ Mapping the conceptual layers to the codebase:
     - `contextspace/`: Optional context (`active_context.md`, `decisions.md`, `spec.md`).
     - `config.yml`: Generated config.
     - `state.sqlite3`, logs, lock.
-    - `flows.db`: Flow engine internals (source of truth).
+    - `flows.db`: Flow engine execution state for sequencing, pause/resume,
+      and terminal run history. Web Hub chat visibility is not sourced from
+      this database; it is rebuilt from hub orchestration records.
     - `discord_state.sqlite3`, `telegram_state.sqlite3`: Transport delivery/outbox state.
 - **Global Root** (cross-repo caches):
   - `~/.codex-autorunner/`: update cache, update status/lock, shared app-server workspaces.
@@ -55,10 +57,13 @@ Mapping the conceptual layers to the codebase:
 4. **Update State**: Handle stop rules (exit code, stop_after_runs, limits).
 
 ## Ticket Flow Lifecycle Ownership
-- **Filesystem is source of truth**: `.codex-autorunner/tickets/`,
-  `.codex-autorunner/contextspace/`, `.codex-autorunner/flows.db`, and
-  `.codex-autorunner/flows/<run_id>/` artifacts are authoritative over in-memory
-  surface state.
+- **Filesystem/orchestration stores are source of truth**:
+  `.codex-autorunner/tickets/`, `.codex-autorunner/contextspace/`,
+  `.codex-autorunner/flows.db`, and `.codex-autorunner/flows/<run_id>/`
+  artifacts are authoritative for ticket-flow engine state over in-memory
+  surface state. Hub `orchestration.sqlite3` thread targets, executions,
+  bindings, deliveries, and chat-surface events are authoritative for Web Hub
+  chat visibility.
 - **Reducer/supervisor own lifecycle transitions**:
   `core/flows/supervisor.py` classifies recovery observations, emits typed
   recovery effects, and hands lifecycle triggers to

--- a/docs/car_constitution/50_OBSERVABILITY_OPERATIONS.md
+++ b/docs/car_constitution/50_OBSERVABILITY_OPERATIONS.md
@@ -71,3 +71,19 @@ From artifacts alone, a debugger must be able to answer:
 - A stream or snapshot regression must identify the failing family: chat index,
   chat detail, repo/worktree topology, repo/worktree runtime, ticket detail, or
   a newer documented family.
+
+## Ticket-flow visibility diagnostics
+- Treat `.codex-autorunner/flows.db` as flow-engine execution state: it proves
+  run sequencing, status, and terminal history.
+- Treat hub orchestration records as Web Hub chat visibility state:
+  `orch_thread_targets`, `orch_thread_executions`, bindings, delivery ledgers,
+  and chat-surface events must rebuild the Chats view.
+- A completed ticket-flow turn without a repairable
+  `flow_run_id + ticket_id -> managed_thread_id` orchestration link is a
+  projection gap. Hub Messages surfaces these gaps under
+  `ticket_flow_visibility` diagnostics; repair/backfill should use the
+  ticket-flow visibility repair path.
+- Discord and Telegram terminal status watchers still have a temporary
+  `flows.db` fallback while flow notifications finish migrating to canonical
+  projections. These reads emit `legacy_flows_db_status_fallback` diagnostic log
+  events and must not be expanded into new chat visibility sources.

--- a/src/codex_autorunner/adapters/agents/agent_pool_impl.py
+++ b/src/codex_autorunner/adapters/agents/agent_pool_impl.py
@@ -34,6 +34,11 @@ from ...core.orchestration.runtime_threads import (
     RuntimeThreadExecution,
     begin_next_queued_runtime_thread_execution,
 )
+from ...core.orchestration.ticket_flow_chat_ledger_contract import (
+    ticket_flow_thread_link_key,
+    ticket_flow_thread_metadata,
+    validate_ticket_flow_thread_metadata,
+)
 from ...core.orchestration.turn_timeline import (
     append_turn_events_to_cold_trace,
     persist_turn_timeline,
@@ -339,6 +344,147 @@ class DefaultAgentPool:
                     f"(missing capability: {capability})"
                 )
         return resolved_agent_id
+
+    def _ticket_flow_display_name(
+        self,
+        *,
+        agent_id: str,
+        agent_profile: Optional[str],
+        ticket_id: Optional[str],
+        ticket_path: Optional[str],
+    ) -> str:
+        ticket_label = ticket_id or (
+            Path(ticket_path).name if isinstance(ticket_path, str) else None
+        )
+        agent_label = (
+            agent_id if agent_profile is None else f"{agent_id}@{agent_profile}"
+        )
+        if ticket_label:
+            return f"Ticket Flow {ticket_label} ({agent_label})"
+        return f"Ticket Flow ({agent_label})"
+
+    def _ticket_flow_thread_metadata(
+        self,
+        *,
+        agent_profile: Optional[str],
+        workspace_root: Path,
+        ticket_flow_run_id: Optional[str],
+        ticket_id: Optional[str],
+        ticket_path: Optional[str],
+    ) -> dict[str, Any]:
+        extra: dict[str, Any] = {}
+        if agent_profile is not None:
+            extra["agent_profile"] = agent_profile
+        if ticket_flow_run_id is None or ticket_id is None:
+            # Keep legacy/direct callers functional, but ticket-flow runner calls
+            # must pass both fields so the canonical link can be repaired.
+            extra.update(
+                {
+                    "thread_kind": "ticket_flow",
+                    "flow_type": "ticket_flow",
+                    "run_id": ticket_flow_run_id,
+                    "flow_run_id": ticket_flow_run_id,
+                    "ticket_id": ticket_id,
+                    "ticket_path": ticket_path,
+                    "workspace_root": str(workspace_root),
+                }
+            )
+            return extra
+        metadata = ticket_flow_thread_metadata(
+            flow_run_id=ticket_flow_run_id,
+            ticket_id=ticket_id,
+            workspace_root=str(workspace_root),
+            repo_id=self._repo_id,
+            ticket_path=ticket_path,
+            extra=extra,
+        )
+        validate_ticket_flow_thread_metadata(metadata)
+        return metadata
+
+    def _find_ticket_flow_thread_target_id(
+        self,
+        *,
+        agent_id: str,
+        workspace_root: Path,
+        ticket_flow_run_id: Optional[str],
+        ticket_id: Optional[str],
+    ) -> Optional[str]:
+        if ticket_flow_run_id is None or ticket_id is None:
+            return None
+        link_key = ticket_flow_thread_link_key(ticket_flow_run_id, ticket_id)
+        try:
+            candidates = list(
+                self._thread_store.list_threads(
+                    agent=agent_id,
+                    repo_id=self._repo_id,
+                    limit=1000,
+                )
+            )
+            if self._repo_id is not None:
+                candidates.extend(
+                    self._thread_store.list_threads(
+                        agent=agent_id,
+                        limit=1000,
+                    )
+                )
+        except (sqlite3.Error, OSError, ValueError, TypeError):
+            _logger.debug(
+                "Failed to scan ticket-flow thread links for run=%s ticket=%s",
+                ticket_flow_run_id,
+                ticket_id,
+                exc_info=True,
+            )
+            return None
+        seen_thread_ids: set[str] = set()
+        workspace_text = str(workspace_root)
+        for candidate in candidates:
+            candidate_thread_id = _normalize_optional_text(
+                candidate.get("managed_thread_id") or candidate.get("thread_target_id")
+            )
+            if candidate_thread_id is None or candidate_thread_id in seen_thread_ids:
+                continue
+            seen_thread_ids.add(candidate_thread_id)
+            metadata = candidate.get("metadata")
+            if not isinstance(metadata, dict):
+                continue
+            candidate_workspace = _normalize_optional_text(
+                candidate.get("workspace_root") or metadata.get("workspace_root")
+            )
+            if candidate_workspace != workspace_text:
+                continue
+            if (
+                _normalize_optional_text(metadata.get("ticket_flow_link_key"))
+                == link_key
+            ):
+                return candidate_thread_id
+            if (
+                _normalize_optional_text(metadata.get("flow_run_id"))
+                == ticket_flow_run_id
+                and _normalize_optional_text(metadata.get("ticket_id")) == ticket_id
+            ):
+                return candidate_thread_id
+        return None
+
+    def _refresh_ticket_flow_thread_target(
+        self,
+        thread_target_id: str,
+        *,
+        display_name: str,
+        metadata: dict[str, Any],
+    ) -> None:
+        try:
+            self._thread_store.update_thread_metadata(thread_target_id, metadata)
+            self._thread_store.update_thread_title(
+                thread_target_id,
+                display_name,
+                metadata=metadata,
+                only_if_generic=False,
+            )
+        except (sqlite3.Error, OSError, ValueError, TypeError):
+            _logger.exception(
+                "Failed to refresh ticket-flow thread metadata (thread=%s)",
+                thread_target_id,
+            )
 
     async def close_all(self) -> None:
         worker_lock = self._ensure_worker_lock()
@@ -879,28 +1025,57 @@ class DefaultAgentPool:
         ticket_flow_run_id = _normalize_optional_text(options.get("ticket_flow_run_id"))
         ticket_id = _normalize_optional_text(options.get("ticket_id"))
         ticket_path = _normalize_optional_text(options.get("ticket_path"))
-        display_name = f"ticket-flow:{agent_id}"
-        if agent_profile:
-            display_name = f"{display_name}@{agent_profile}"
-        thread = service.resolve_thread_target(
-            thread_target_id=_normalize_optional_text(req.conversation_id),
+        workspace_root = req.workspace_root.resolve()
+        display_name = self._ticket_flow_display_name(
             agent_id=agent_id,
-            workspace_root=req.workspace_root.resolve(),
+            agent_profile=agent_profile,
+            ticket_id=ticket_id,
+            ticket_path=ticket_path,
+        )
+        metadata = self._ticket_flow_thread_metadata(
+            agent_profile=agent_profile,
+            workspace_root=workspace_root,
+            ticket_flow_run_id=ticket_flow_run_id,
+            ticket_id=ticket_id,
+            ticket_path=ticket_path,
+        )
+        requested_thread_id = _normalize_optional_text(req.conversation_id)
+        thread_target_id = (
+            requested_thread_id
+            or self._find_ticket_flow_thread_target_id(
+                agent_id=agent_id,
+                workspace_root=workspace_root,
+                ticket_flow_run_id=ticket_flow_run_id,
+                ticket_id=ticket_id,
+            )
+        )
+        thread = service.resolve_thread_target(
+            thread_target_id=thread_target_id,
+            agent_id=agent_id,
+            workspace_root=workspace_root,
             repo_id=self._repo_id,
             display_name=display_name,
             backend_thread_id=None,
-            metadata={
-                "agent_profile": agent_profile,
-                "thread_kind": "ticket_flow",
-                "flow_type": "ticket_flow",
-                "run_id": ticket_flow_run_id,
-                "ticket_id": ticket_id,
-                "ticket_path": ticket_path,
-            },
+            metadata=metadata,
         )
+        self._refresh_ticket_flow_thread_target(
+            thread.thread_target_id,
+            display_name=display_name,
+            metadata=metadata,
+        )
+        refreshed_thread = service.get_thread_target(thread.thread_target_id)
+        if refreshed_thread is not None:
+            thread = refreshed_thread
         request_metadata = {
             "execution_error_message": _DEFAULT_EXECUTION_ERROR,
             "runtime_prompt": prompt,
+            "thread_kind": "ticket_flow",
+            "flow_type": "ticket_flow",
+            "run_id": ticket_flow_run_id,
+            "flow_run_id": ticket_flow_run_id,
+            "ticket_id": ticket_id,
+            "ticket_path": ticket_path,
+            "ticket_flow_link_key": metadata.get("ticket_flow_link_key"),
         }
         if existing_session_prompt is not None:
             request_metadata["existing_session_runtime_prompt"] = (

--- a/src/codex_autorunner/adapters/discord/flow_watchers.py
+++ b/src/codex_autorunner/adapters/discord/flow_watchers.py
@@ -82,6 +82,16 @@ def _load_latest_terminal_ticket_flow_run(
                     latest_run = run
     if latest_run is None:
         return None
+    log_event(
+        service._logger,
+        logging.DEBUG,
+        "discord.terminal_watch.legacy_flows_db_status_fallback",
+        run_id=latest_run.id,
+        status=latest_run.status.value,
+        workspace_root=str(workspace_root),
+        fallback="flows.db",
+        canonical_owner="orchestration",
+    )
     return (latest_run.id, latest_run.status.value, latest_run.error_message)
 
 

--- a/src/codex_autorunner/adapters/telegram/ticket_flow_bridge.py
+++ b/src/codex_autorunner/adapters/telegram/ticket_flow_bridge.py
@@ -1036,6 +1036,16 @@ class TelegramTicketFlowBridge:
             store.close()
         if latest_run is None:
             return None
+        log_event(
+            self._logger,
+            logging.DEBUG,
+            "telegram.ticket_flow.terminal_legacy_flows_db_status_fallback",
+            run_id=latest_run.id,
+            status=latest_run.status.value,
+            workspace_root=str(workspace_root),
+            fallback="flows.db",
+            canonical_owner="orchestration",
+        )
         terminal_at = latest_run.finished_at or latest_run.created_at
         return (
             latest_run.id,

--- a/src/codex_autorunner/core/hub_read_model.py
+++ b/src/codex_autorunner/core/hub_read_model.py
@@ -41,6 +41,9 @@ from .hub_projection_store import (
 from .logging_utils import safe_log
 from .managed_thread_store import default_managed_threads_db_path
 from .orchestration.sqlite import resolve_orchestration_sqlite_path
+from .orchestration.ticket_flow_visibility_repair import (
+    diagnose_ticket_flow_projection_gaps,
+)
 from .pma_context import (
     PMA_MAX_TEXT,
     _gather_inbox,
@@ -628,6 +631,51 @@ def _collect_inbox_messages(
     if limit and limit > 0:
         return messages[: int(limit)]
     return messages
+
+
+def _collect_ticket_flow_projection_diagnostics(
+    *,
+    hub_root: Path,
+    repo_context: _HubRepoMessageContext,
+) -> list[dict[str, str]]:
+    diagnostics: list[dict[str, str]] = []
+    for snap in repo_context.snapshots:
+        repo_id = str(getattr(snap, "id", "") or "").strip()
+        repo_root = getattr(snap, "path", None)
+        if not repo_id or not isinstance(repo_root, Path):
+            continue
+        try:
+            gaps = diagnose_ticket_flow_projection_gaps(
+                repo_root=repo_root,
+                hub_root=hub_root,
+                repo_id=repo_id,
+            )
+        except Exception as exc:
+            diagnostics.append(
+                {
+                    "section": "ticket_flow_visibility",
+                    "reason": str(exc) or type(exc).__name__,
+                    "source": f"ticket_flow_projection_gaps:{repo_id}",
+                }
+            )
+            continue
+        for gap in gaps:
+            payload = gap.to_dict()
+            diagnostics.append(
+                {
+                    "section": "ticket_flow_visibility",
+                    "reason": str(payload["reason"]),
+                    "source": "flows.db->orchestration_link",
+                    "repo_id": repo_id,
+                    "repo_root": str(payload["repo_root"]),
+                    "run_id": str(payload["run_id"]),
+                    "status": str(payload["status"]),
+                    "ticket_id": str(payload["ticket_id"] or ""),
+                    "ticket_path": str(payload["ticket_path"] or ""),
+                    "expected_link_key": str(payload["expected_link_key"] or ""),
+                }
+            )
+    return diagnostics
 
 
 def _serialize_hub_snapshot(
@@ -1269,6 +1317,13 @@ class HubReadModelService:
             filtered_action_queue=filtered_action_queue,
             unreadable_diagnostics=unreadable_diagnostics,
         )
+        if isinstance(hub_root, Path):
+            unreadable_diagnostics.extend(
+                _collect_ticket_flow_projection_diagnostics(
+                    hub_root=hub_root,
+                    repo_context=repo_context,
+                )
+            )
         snapshot = _serialize_hub_snapshot(
             generated_at=settings.generated_at,
             requested=requested,

--- a/src/codex_autorunner/core/hub_repo_projection.py
+++ b/src/codex_autorunner/core/hub_repo_projection.py
@@ -257,6 +257,7 @@ class HubRepoProjectionService:
         from .archive import has_car_state
         from .flows.models import flow_run_duration_seconds
         from .flows.store import FlowStore
+        from .orchestration.flow_run_projection import project_ticket_flow_run_records
         from .pma_context import get_latest_ticket_flow_run_state_with_record
         from .ticket_flow_projection import build_canonical_state_v1
         from .ticket_flow_summary import build_ticket_flow_summary
@@ -270,6 +271,7 @@ class HubRepoProjectionService:
             "ticket_flow": None,
             "ticket_flow_display": None,
             "run_state": None,
+            "flow_run_projection": [],
             "current_run_artifacts": [],
             "canonical_state_v1": None,
             "git_status": self._compute_git_status(snapshot),
@@ -320,6 +322,20 @@ class HubRepoProjectionService:
                 store=store,
             )
             payload["run_state"] = run_state
+            if store is not None:
+                try:
+                    records = store.list_flow_runs(flow_type="ticket_flow")
+                    payload["flow_run_projection"] = project_ticket_flow_run_records(
+                        self._context.config.root,
+                        snapshot.path,
+                        snapshot.id,
+                        records,
+                        ticket_flow_summary=(
+                            ticket_flow if isinstance(ticket_flow, dict) else None
+                        ),
+                    )[:5]
+                except Exception:
+                    payload["flow_run_projection"] = []
             if run_record is not None:
                 if str(snapshot.last_run_id) != str(run_record.id):
                     payload["last_exit_code"] = None

--- a/src/codex_autorunner/core/orchestration/__init__.py
+++ b/src/codex_autorunner/core/orchestration/__init__.py
@@ -143,6 +143,19 @@ from .sqlite import (
     resolve_orchestration_sqlite_path,
 )
 from .threads import SurfaceThreadMessageRequest
+from .ticket_flow_chat_ledger_contract import (
+    TICKET_FLOW_CHAT_LEDGER_CONTRACT_VERSION,
+    TICKET_FLOW_FLOW_TYPE,
+    TICKET_FLOW_LEDGER_LIFECYCLE,
+    TICKET_FLOW_LEDGER_RECORDS,
+    TICKET_FLOW_THREAD_KIND,
+    TicketFlowLedgerRecord,
+    TicketFlowThreadLink,
+    ticket_flow_chat_ledger_contract,
+    ticket_flow_thread_link_key,
+    ticket_flow_thread_metadata,
+    validate_ticket_flow_thread_metadata,
+)
 
 if TYPE_CHECKING:
     from . import runtime_threads as runtime_threads_module
@@ -253,10 +266,17 @@ __all__ = [
     "SQLiteManagedThreadSideEffectEngine",
     "SQLiteManagedThreadSideEffectLedger",
     "SurfaceThreadMessageRequest",
+    "TICKET_FLOW_CHAT_LEDGER_CONTRACT_VERSION",
+    "TICKET_FLOW_FLOW_TYPE",
+    "TICKET_FLOW_LEDGER_LIFECYCLE",
+    "TICKET_FLOW_LEDGER_RECORDS",
+    "TICKET_FLOW_THREAD_KIND",
     "ThreadExecutionStore",
     "Thread",
     "ThreadStopOutcome",
     "ThreadTarget",
+    "TicketFlowLedgerRecord",
+    "TicketFlowThreadLink",
     "WorkspaceRuntimeAcquisition",
     "apply_orchestration_migrations",
     "audit_execution_history",
@@ -300,5 +320,9 @@ __all__ = [
     "resolve_execution_history_maintenance_policy",
     "resolve_orchestration_sqlite_path",
     "serialize_chat_surface_event",
+    "ticket_flow_chat_ledger_contract",
+    "ticket_flow_thread_link_key",
+    "ticket_flow_thread_metadata",
+    "validate_ticket_flow_thread_metadata",
     "vacuum_execution_history",
 ]

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -970,6 +970,7 @@ class ChatSurfaceReadService:
                 "orch_managed_thread_deliveries": "MAX(COALESCE(updated_at, delivered_at, created_at))",
                 "orch_notification_conversations": "MAX(COALESCE(updated_at, created_at))",
                 "orch_chat_surface_events": "MAX(COALESCE(created_at, occurred_at, event_id))",
+                "orch_flow_run_projections": "MAX(updated_at)",
             }
             facts: dict[str, Any] = {}
             for table, updated_expr in table_updated_exprs.items():
@@ -2083,10 +2084,12 @@ def _chat_index_sort_key_parts(row: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _chat_ticket_group_id(row: Mapping[str, Any]) -> Optional[str]:
+    run_id = _normalize_text(row.get("run_id"))
+    if _normalize_kind(row.get("flow_type")) == "ticket_flow" and run_id is not None:
+        return f"run:{run_id}"
     ticket_id = _normalize_text(row.get("ticket_id") or row.get("current_ticket_id"))
     if ticket_id is not None:
         return f"ticket:{ticket_id}"
-    run_id = _normalize_text(row.get("run_id"))
     if run_id is not None:
         return f"run:{run_id}"
     kind = _normalize_kind(row.get("resource_kind"))

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -984,6 +984,37 @@ class ChatSurfaceReadService:
                     "count": int(row["count"] or 0),
                     "max_updated": row["max_updated"],
                 }
+            if _table_exists(conn, "orch_thread_targets"):
+                row = conn.execute(
+                    """
+                    SELECT COUNT(*) AS count,
+                           MAX(COALESCE(updated_at, created_at)) AS max_updated
+                      FROM orch_thread_targets
+                     WHERE json_extract(metadata_json, '$.flow_type') = 'ticket_flow'
+                       AND json_extract(metadata_json, '$.ticket_flow_link_key') IS NOT NULL
+                    """
+                ).fetchone()
+                facts["ticket_flow_thread_links"] = {
+                    "count": int(row["count"] or 0),
+                    "max_updated": row["max_updated"],
+                }
+            else:
+                facts["ticket_flow_thread_links"] = None
+            if _table_exists(conn, "orch_flow_run_projections"):
+                row = conn.execute(
+                    """
+                    SELECT COUNT(*) AS count,
+                           MAX(updated_at) AS max_updated
+                      FROM orch_flow_run_projections
+                     WHERE flow_type = 'ticket_flow'
+                    """
+                ).fetchone()
+                facts["ticket_flow_flow_projections"] = {
+                    "count": int(row["count"] or 0),
+                    "max_updated": row["max_updated"],
+                }
+            else:
+                facts["ticket_flow_flow_projections"] = None
         directory_path = (
             self._hub_root / ".codex-autorunner" / "chat" / "channel_directory.json"
         )

--- a/src/codex_autorunner/core/orchestration/flow_run_projection.py
+++ b/src/codex_autorunner/core/orchestration/flow_run_projection.py
@@ -78,40 +78,6 @@ def project_ticket_flow_run_records(
     return [dict(row["public"]) for row in rows]
 
 
-def list_projected_flow_runs(
-    hub_root: Path,
-    *,
-    repo_id: Optional[str] = None,
-    flow_type: Optional[str] = None,
-    limit: int = 100,
-    durable: bool = True,
-) -> list[dict[str, Any]]:
-    bounded = max(1, min(int(limit or 100), 500))
-    clauses = ["1 = 1"]
-    params: list[Any] = []
-    if repo_id:
-        clauses.append("repo_id = ?")
-        params.append(str(repo_id))
-    if flow_type:
-        clauses.append("flow_type = ?")
-        params.append(str(flow_type))
-    params.append(bounded)
-    with open_orchestration_sqlite(hub_root, durable=durable, migrate=True) as conn:
-        rows = conn.execute(
-            f"""
-            SELECT *
-              FROM orch_flow_run_projections
-             WHERE {' AND '.join(clauses)}
-             ORDER BY COALESCE(started_at, updated_at) DESC,
-                      updated_at DESC,
-                      flow_run_id ASC
-             LIMIT ?
-            """,
-            params,
-        ).fetchall()
-    return [_public_projection(row) for row in rows]
-
-
 def _projection_row(
     *,
     repo_root: Path,
@@ -198,21 +164,6 @@ def _summary_payload(
         "projection_source": "repo_flow_store",
         "projection_owner": "orchestration",
         "repo_id": repo_id,
-    }
-
-
-def _public_projection(row: Mapping[str, Any]) -> dict[str, Any]:
-    summary = _json_object(row.get("summary_json"))
-    return {
-        "run_id": str(row.get("flow_run_id") or ""),
-        "flow_run_id": str(row.get("flow_run_id") or ""),
-        "repo_id": row.get("repo_id"),
-        "flow_type": row.get("flow_type"),
-        "status": row.get("status"),
-        "started_at": row.get("started_at"),
-        "finished_at": row.get("finished_at"),
-        "updated_at": row.get("updated_at"),
-        **summary,
     }
 
 

--- a/src/codex_autorunner/core/orchestration/flow_run_projection.py
+++ b/src/codex_autorunner/core/orchestration/flow_run_projection.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional
+
+from ..flows.models import FlowRunRecord, FlowRunStatus
+from .sqlite import open_orchestration_sqlite
+
+
+def project_ticket_flow_run_records(
+    hub_root: Path,
+    repo_root: Path,
+    repo_id: str,
+    records: Iterable[FlowRunRecord],
+    *,
+    ticket_flow_summary: Optional[Mapping[str, Any]] = None,
+    durable: bool = True,
+) -> list[dict[str, Any]]:
+    """Upsert flow-run read-model rows from canonical ticket-flow records."""
+
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    rows = [
+        _projection_row(
+            repo_root=repo_root,
+            repo_id=repo_id,
+            record=record,
+            ticket_flow_summary=(
+                ticket_flow_summary
+                if ticket_flow_summary
+                and str(ticket_flow_summary.get("run_id") or "") == str(record.id)
+                else None
+            ),
+            updated_at=now,
+        )
+        for record in records
+    ]
+    if not rows:
+        return []
+    with open_orchestration_sqlite(hub_root, durable=durable, migrate=True) as conn:
+        with conn:
+            conn.executemany(
+                """
+                INSERT INTO orch_flow_run_projections (
+                    flow_run_id,
+                    repo_id,
+                    flow_type,
+                    status,
+                    summary_json,
+                    started_at,
+                    finished_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(flow_run_id) DO UPDATE SET
+                    repo_id = excluded.repo_id,
+                    flow_type = excluded.flow_type,
+                    status = excluded.status,
+                    summary_json = excluded.summary_json,
+                    started_at = excluded.started_at,
+                    finished_at = excluded.finished_at,
+                    updated_at = excluded.updated_at
+                """,
+                [
+                    (
+                        row["flow_run_id"],
+                        row["repo_id"],
+                        row["flow_type"],
+                        row["status"],
+                        row["summary_json"],
+                        row["started_at"],
+                        row["finished_at"],
+                        row["updated_at"],
+                    )
+                    for row in rows
+                ],
+            )
+    return [dict(row["public"]) for row in rows]
+
+
+def list_projected_flow_runs(
+    hub_root: Path,
+    *,
+    repo_id: Optional[str] = None,
+    flow_type: Optional[str] = None,
+    limit: int = 100,
+    durable: bool = True,
+) -> list[dict[str, Any]]:
+    bounded = max(1, min(int(limit or 100), 500))
+    clauses = ["1 = 1"]
+    params: list[Any] = []
+    if repo_id:
+        clauses.append("repo_id = ?")
+        params.append(str(repo_id))
+    if flow_type:
+        clauses.append("flow_type = ?")
+        params.append(str(flow_type))
+    params.append(bounded)
+    with open_orchestration_sqlite(hub_root, durable=durable, migrate=True) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT *
+              FROM orch_flow_run_projections
+             WHERE {' AND '.join(clauses)}
+             ORDER BY COALESCE(started_at, updated_at) DESC,
+                      updated_at DESC,
+                      flow_run_id ASC
+             LIMIT ?
+            """,
+            params,
+        ).fetchall()
+    return [_public_projection(row) for row in rows]
+
+
+def _projection_row(
+    *,
+    repo_root: Path,
+    repo_id: str,
+    record: FlowRunRecord,
+    ticket_flow_summary: Optional[Mapping[str, Any]],
+    updated_at: str,
+) -> dict[str, Any]:
+    status = _status_value(record.status)
+    summary = _summary_payload(
+        repo_root=repo_root,
+        repo_id=repo_id,
+        record=record,
+        ticket_flow_summary=ticket_flow_summary,
+    )
+    return {
+        "flow_run_id": record.id,
+        "repo_id": repo_id,
+        "flow_type": record.flow_type,
+        "status": status,
+        "summary_json": json.dumps(summary, sort_keys=True, separators=(",", ":")),
+        "started_at": record.started_at,
+        "finished_at": record.finished_at,
+        "updated_at": updated_at,
+        "public": {
+            "run_id": record.id,
+            "flow_run_id": record.id,
+            "repo_id": repo_id,
+            "flow_type": record.flow_type,
+            "status": status,
+            "started_at": record.started_at,
+            "finished_at": record.finished_at,
+            "updated_at": updated_at,
+            **summary,
+        },
+    }
+
+
+def _summary_payload(
+    *,
+    repo_root: Path,
+    repo_id: str,
+    record: FlowRunRecord,
+    ticket_flow_summary: Optional[Mapping[str, Any]],
+) -> dict[str, Any]:
+    state = record.state if isinstance(record.state, dict) else {}
+    ticket_engine = state.get("ticket_engine")
+    ticket_engine = ticket_engine if isinstance(ticket_engine, dict) else {}
+    current_ticket = _text(ticket_engine.get("current_ticket")) or _text(
+        state.get("current_ticket")
+    )
+    total_turns = _int_or_none(ticket_engine.get("total_turns"))
+    ticket_turns = _int_or_none(ticket_engine.get("ticket_turns"))
+    total_count = _int_or_none(
+        ticket_flow_summary.get("total_count") if ticket_flow_summary else None
+    )
+    done_count = _int_or_none(
+        ticket_flow_summary.get("done_count") if ticket_flow_summary else None
+    )
+    progress_percent = None
+    if total_count is not None and done_count is not None and total_count > 0:
+        progress_percent = max(0, min(100, round((done_count / total_count) * 100)))
+    status = _status_value(record.status)
+    return {
+        "workspace_root": str(repo_root.resolve()),
+        "current_ticket": current_ticket,
+        "current_step": record.current_step,
+        "ticket_engine": {
+            "status": _text(ticket_engine.get("status")) or status,
+            "current_ticket": current_ticket,
+            "ticket_turns": ticket_turns,
+            "total_turns": total_turns,
+            "reason": _text(ticket_engine.get("reason")),
+            "reason_details": ticket_engine.get("reason_details"),
+        },
+        "progress": {
+            "done_count": done_count,
+            "total_count": total_count,
+            "progress_percent": progress_percent,
+        },
+        "archive_ready": _is_terminal_status(record.status),
+        "error_message": record.error_message,
+        "metadata": dict(record.metadata or {}),
+        "projection_source": "repo_flow_store",
+        "projection_owner": "orchestration",
+        "repo_id": repo_id,
+    }
+
+
+def _public_projection(row: Mapping[str, Any]) -> dict[str, Any]:
+    summary = _json_object(row.get("summary_json"))
+    return {
+        "run_id": str(row.get("flow_run_id") or ""),
+        "flow_run_id": str(row.get("flow_run_id") or ""),
+        "repo_id": row.get("repo_id"),
+        "flow_type": row.get("flow_type"),
+        "status": row.get("status"),
+        "started_at": row.get("started_at"),
+        "finished_at": row.get("finished_at"),
+        "updated_at": row.get("updated_at"),
+        **summary,
+    }
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    try:
+        parsed = json.loads(str(value or "{}"))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _status_value(status: FlowRunStatus | str) -> str:
+    return status.value if isinstance(status, FlowRunStatus) else str(status or "")
+
+
+def _is_terminal_status(status: FlowRunStatus | str) -> bool:
+    if isinstance(status, FlowRunStatus):
+        return status.is_terminal()
+    return str(status or "").strip().lower() in {
+        "completed",
+        "failed",
+        "stopped",
+        "superseded",
+    }
+
+
+def _text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _int_or_none(value: Any) -> Optional[int]:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/src/codex_autorunner/core/orchestration/ticket_flow_chat_ledger_contract.py
+++ b/src/codex_autorunner/core/orchestration/ticket_flow_chat_ledger_contract.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal, Mapping, Optional
+
+from ..text_utils import _normalize_optional_text
+
+TICKET_FLOW_CHAT_LEDGER_CONTRACT_VERSION = "ticket_flow_chat_ledger.v1"
+TICKET_FLOW_FLOW_TYPE = "ticket_flow"
+TICKET_FLOW_THREAD_KIND = "ticket_flow"
+
+TicketFlowLedgerSource = Literal["flows.db", "orchestration"]
+TicketFlowLedgerArtifact = Literal[
+    "flow_run",
+    "flow_event",
+    "thread_target",
+    "thread_execution",
+    "thread_link",
+    "chat_surface_event",
+]
+TicketFlowLedgerLifecycle = Literal[
+    "flow_run.started",
+    "flow_run.completed",
+    "flow_run.failed",
+    "ticket.selected",
+    "managed_thread.created",
+    "managed_thread.reused",
+    "ticket_thread.linked",
+    "ticket_turn.started",
+    "ticket_turn.completed",
+    "ticket_turn.failed",
+]
+
+
+@dataclass(frozen=True)
+class TicketFlowLedgerRecord:
+    """One canonical fact required for ticket-flow chat visibility."""
+
+    name: str
+    source: TicketFlowLedgerSource
+    artifact: TicketFlowLedgerArtifact
+    required_fields: tuple[str, ...]
+    rebuilds: tuple[str, ...] = ()
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TicketFlowThreadLink:
+    """Repairable link between a ticket-flow turn and its managed thread."""
+
+    flow_run_id: str
+    ticket_id: str
+    managed_thread_id: str
+    workspace_root: str
+    repo_id: Optional[str] = None
+    worktree_id: Optional[str] = None
+    turn_id: Optional[str] = None
+    ticket_path: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def link_key(self) -> str:
+        return ticket_flow_thread_link_key(self.flow_run_id, self.ticket_id)
+
+    def to_thread_metadata(self) -> dict[str, Any]:
+        return ticket_flow_thread_metadata(
+            flow_run_id=self.flow_run_id,
+            ticket_id=self.ticket_id,
+            workspace_root=self.workspace_root,
+            repo_id=self.repo_id,
+            worktree_id=self.worktree_id,
+            turn_id=self.turn_id,
+            ticket_path=self.ticket_path,
+            extra=self.metadata,
+        )
+
+
+TICKET_FLOW_LEDGER_LIFECYCLE: tuple[TicketFlowLedgerLifecycle, ...] = (
+    "flow_run.started",
+    "ticket.selected",
+    "managed_thread.created",
+    "managed_thread.reused",
+    "ticket_thread.linked",
+    "ticket_turn.started",
+    "ticket_turn.completed",
+    "ticket_turn.failed",
+    "flow_run.completed",
+    "flow_run.failed",
+)
+
+TICKET_FLOW_LEDGER_RECORDS: tuple[TicketFlowLedgerRecord, ...] = (
+    TicketFlowLedgerRecord(
+        name="repo-local flow run state",
+        source="flows.db",
+        artifact="flow_run",
+        required_fields=(
+            "run_id",
+            "flow_type",
+            "status",
+            "current_step",
+            "state.ticket_engine",
+            "created_at",
+            "updated_at",
+        ),
+        notes=(
+            "The ticket-flow engine keeps sequencing, pause/resume, and terminal "
+            "execution state here. This store is not sufficient for Web Hub chat "
+            "visibility."
+        ),
+    ),
+    TicketFlowLedgerRecord(
+        name="orchestration flow lifecycle event",
+        source="orchestration",
+        artifact="flow_event",
+        required_fields=(
+            "event_type",
+            "flow_run_id",
+            "flow_type",
+            "workspace_root",
+            "occurred_at",
+        ),
+        rebuilds=("future_flow_index", "status_notifications"),
+        notes="Required for flow start, completion, and failure projections.",
+    ),
+    TicketFlowLedgerRecord(
+        name="orchestration ticket selection event",
+        source="orchestration",
+        artifact="flow_event",
+        required_fields=(
+            "event_type",
+            "flow_run_id",
+            "ticket_id",
+            "ticket_path",
+            "workspace_root",
+            "occurred_at",
+        ),
+        rebuilds=("future_flow_index", "ticket_thread_grouping"),
+        notes="Records the selected ticket before an agent turn is executed.",
+    ),
+    TicketFlowLedgerRecord(
+        name="managed ticket-flow thread target",
+        source="orchestration",
+        artifact="thread_target",
+        required_fields=(
+            "managed_thread_id",
+            "agent_id",
+            "workspace_root",
+            "thread_kind",
+            "flow_type",
+            "flow_run_id",
+            "ticket_id",
+        ),
+        rebuilds=("web_hub_chat_index", "web_hub_chat_detail"),
+        notes=(
+            "Stored in orch_thread_targets. The metadata fields make ticket-flow "
+            "threads visible without reading repo-local flow chat JSONL files."
+        ),
+    ),
+    TicketFlowLedgerRecord(
+        name="ticket-flow thread link",
+        source="orchestration",
+        artifact="thread_link",
+        required_fields=(
+            "flow_run_id",
+            "ticket_id",
+            "managed_thread_id",
+            "workspace_root",
+        ),
+        rebuilds=("repair_backfill", "future_flow_index", "web_hub_chat_index"),
+        notes=(
+            "The durable invariant is exactly one repairable link for every "
+            "executed ticket-flow agent turn."
+        ),
+    ),
+    TicketFlowLedgerRecord(
+        name="ticket-flow managed turn execution",
+        source="orchestration",
+        artifact="thread_execution",
+        required_fields=(
+            "turn_id",
+            "managed_thread_id",
+            "flow_run_id",
+            "ticket_id",
+            "status",
+            "started_at",
+            "finished_at",
+        ),
+        rebuilds=("web_hub_chat_index", "web_hub_chat_detail", "status_notifications"),
+        notes="Records ticket-flow turn start, completion, and failure.",
+    ),
+    TicketFlowLedgerRecord(
+        name="ticket-flow chat surface event",
+        source="orchestration",
+        artifact="chat_surface_event",
+        required_fields=(
+            "event_type",
+            "surface_kind",
+            "surface_key",
+            "managed_thread_id",
+            "workspace_root",
+            "occurred_at",
+        ),
+        rebuilds=("web_hub_chat_index", "web_hub_chat_detail"),
+        notes=(
+            "Surface bindings and status changes are projections from the managed "
+            "thread, not source-of-truth flow status messages."
+        ),
+    ),
+)
+
+
+def ticket_flow_thread_link_key(flow_run_id: Any, ticket_id: Any) -> str:
+    normalized_run = _require_text(flow_run_id, "flow_run_id")
+    normalized_ticket = _require_text(ticket_id, "ticket_id")
+    return f"ticket_flow:{normalized_run}:{normalized_ticket}"
+
+
+def ticket_flow_thread_metadata(
+    *,
+    flow_run_id: Any,
+    ticket_id: Any,
+    workspace_root: Any,
+    repo_id: Any = None,
+    worktree_id: Any = None,
+    turn_id: Any = None,
+    ticket_path: Any = None,
+    extra: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    """Build the metadata shape Web Hub read models use for ticket-flow chats."""
+
+    run_id = _require_text(flow_run_id, "flow_run_id")
+    normalized_ticket_id = _require_text(ticket_id, "ticket_id")
+    normalized_workspace = _require_text(workspace_root, "workspace_root")
+    payload: dict[str, Any] = dict(extra or {})
+    payload.update(
+        {
+            "contract_version": TICKET_FLOW_CHAT_LEDGER_CONTRACT_VERSION,
+            "flow_type": TICKET_FLOW_FLOW_TYPE,
+            "thread_kind": TICKET_FLOW_THREAD_KIND,
+            "run_id": run_id,
+            "flow_run_id": run_id,
+            "ticket_id": normalized_ticket_id,
+            "workspace_root": normalized_workspace,
+            "ticket_flow_link_key": ticket_flow_thread_link_key(
+                run_id, normalized_ticket_id
+            ),
+        }
+    )
+    for key, value in {
+        "repo_id": repo_id,
+        "worktree_id": worktree_id,
+        "turn_id": turn_id,
+        "ticket_path": ticket_path,
+    }.items():
+        normalized = _normalize_optional_text(value)
+        if normalized is not None:
+            payload[key] = normalized
+    return payload
+
+
+def ticket_flow_chat_ledger_contract() -> dict[str, Any]:
+    """Return a serializable description of the canonical ledger contract."""
+
+    return {
+        "contract_version": TICKET_FLOW_CHAT_LEDGER_CONTRACT_VERSION,
+        "flow_type": TICKET_FLOW_FLOW_TYPE,
+        "thread_kind": TICKET_FLOW_THREAD_KIND,
+        "lifecycle_events": list(TICKET_FLOW_LEDGER_LIFECYCLE),
+        "records": [record.to_dict() for record in TICKET_FLOW_LEDGER_RECORDS],
+        "invariant": (
+            "Every executed ticket-flow agent turn must have a repairable "
+            "flow_run_id + ticket_id -> managed_thread_id link in orchestration "
+            "state before the turn is allowed to complete."
+        ),
+        "read_models": {
+            "web_hub_chat_index": (
+                "Rebuild from orch_thread_targets, orch_thread_executions, "
+                "orch_bindings, delivery ledgers, and orch_chat_surface_events. "
+                "It must not read repo-local flows.db or flow chat JSONL files."
+            ),
+            "future_flow_index": (
+                "Rebuild from orchestration flow lifecycle, ticket selection, "
+                "thread-link, and turn lifecycle facts. Repo-local flows.db may "
+                "be used only as engine state or as repair input."
+            ),
+        },
+    }
+
+
+def validate_ticket_flow_thread_metadata(metadata: Mapping[str, Any]) -> None:
+    required = {
+        "flow_type": TICKET_FLOW_FLOW_TYPE,
+        "thread_kind": TICKET_FLOW_THREAD_KIND,
+    }
+    for key, expected in required.items():
+        actual = _normalize_optional_text(metadata.get(key))
+        if actual != expected:
+            raise ValueError(f"ticket-flow thread metadata requires {key}={expected!r}")
+    for key in ("run_id", "flow_run_id", "ticket_id", "workspace_root"):
+        _require_text(metadata.get(key), key)
+    if _normalize_optional_text(metadata.get("run_id")) != _normalize_optional_text(
+        metadata.get("flow_run_id")
+    ):
+        raise ValueError("ticket-flow thread metadata run_id must match flow_run_id")
+
+
+def _require_text(value: Any, field_name: str) -> str:
+    normalized = _normalize_optional_text(value)
+    if normalized is None:
+        raise ValueError(f"{field_name} is required")
+    return normalized
+
+
+__all__ = [
+    "TICKET_FLOW_CHAT_LEDGER_CONTRACT_VERSION",
+    "TICKET_FLOW_FLOW_TYPE",
+    "TICKET_FLOW_LEDGER_LIFECYCLE",
+    "TICKET_FLOW_LEDGER_RECORDS",
+    "TICKET_FLOW_THREAD_KIND",
+    "TicketFlowLedgerRecord",
+    "TicketFlowThreadLink",
+    "ticket_flow_chat_ledger_contract",
+    "ticket_flow_thread_link_key",
+    "ticket_flow_thread_metadata",
+    "validate_ticket_flow_thread_metadata",
+]

--- a/src/codex_autorunner/core/orchestration/ticket_flow_visibility_repair.py
+++ b/src/codex_autorunner/core/orchestration/ticket_flow_visibility_repair.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from ...tickets.frontmatter import parse_markdown_frontmatter
+from ..flows.models import FlowEvent, FlowEventType, FlowRunRecord, FlowRunStatus
+from ..flows.store import FlowStore
+from ..managed_thread_store import ManagedThreadStore
+from ..state_roots import resolve_repo_flows_db_path
+from .ticket_flow_chat_ledger_contract import (
+    ticket_flow_thread_link_key,
+    ticket_flow_thread_metadata,
+    validate_ticket_flow_thread_metadata,
+)
+
+
+@dataclass(frozen=True)
+class TicketFlowVisibilityRepairDiagnostic:
+    run_id: str
+    status: str
+    reason: str
+    ticket_id: Optional[str] = None
+    ticket_path: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "status": self.status,
+            "reason": self.reason,
+            "ticket_id": self.ticket_id,
+            "ticket_path": self.ticket_path,
+        }
+
+
+@dataclass(frozen=True)
+class TicketFlowVisibilityRepairAction:
+    run_id: str
+    ticket_id: str
+    ticket_path: str
+    action: str
+    managed_thread_id: Optional[str] = None
+    diagnostic: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "ticket_id": self.ticket_id,
+            "ticket_path": self.ticket_path,
+            "action": self.action,
+            "managed_thread_id": self.managed_thread_id,
+            "diagnostic": self.diagnostic,
+        }
+
+
+@dataclass(frozen=True)
+class TicketFlowVisibilityRepairReport:
+    repo_root: str
+    hub_root: str
+    scanned_runs: int = 0
+    repaired: int = 0
+    already_linked: int = 0
+    dry_run: bool = False
+    actions: tuple[TicketFlowVisibilityRepairAction, ...] = ()
+    diagnostics: tuple[TicketFlowVisibilityRepairDiagnostic, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "repo_root": self.repo_root,
+            "hub_root": self.hub_root,
+            "scanned_runs": self.scanned_runs,
+            "repaired": self.repaired,
+            "already_linked": self.already_linked,
+            "dry_run": self.dry_run,
+            "actions": [action.to_dict() for action in self.actions],
+            "diagnostics": [diagnostic.to_dict() for diagnostic in self.diagnostics],
+        }
+
+
+@dataclass(frozen=True)
+class _TicketTurnEvidence:
+    run_id: str
+    ticket_path: str
+    ticket_id: str
+    agent_id: str
+    profile: Optional[str] = None
+    legacy_thread_target_id: Optional[str] = None
+    turn_id: Optional[str] = None
+    source: str = "flow_events"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def repair_ticket_flow_chat_visibility(
+    *,
+    repo_root: Path,
+    hub_root: Path,
+    repo_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    dry_run: bool = False,
+    durable: bool = True,
+) -> TicketFlowVisibilityRepairReport:
+    """Backfill ticket-flow managed-thread links from conservative runtime evidence."""
+
+    normalized_repo_root = repo_root.resolve()
+    normalized_hub_root = hub_root.resolve()
+    db_path = resolve_repo_flows_db_path(normalized_repo_root)
+    actions: list[TicketFlowVisibilityRepairAction] = []
+    diagnostics: list[TicketFlowVisibilityRepairDiagnostic] = []
+    repaired = 0
+    already_linked = 0
+
+    if not db_path.exists():
+        return TicketFlowVisibilityRepairReport(
+            repo_root=str(normalized_repo_root),
+            hub_root=str(normalized_hub_root),
+            dry_run=dry_run,
+            diagnostics=(
+                TicketFlowVisibilityRepairDiagnostic(
+                    run_id=run_id or "",
+                    status="unrecoverable",
+                    reason=f"missing flow store: {db_path}",
+                ),
+            ),
+        )
+
+    with FlowStore(db_path, durable=durable) as flow_store:
+        if run_id:
+            record = flow_store.get_flow_run(run_id)
+            records = [record] if record is not None else []
+            if not records:
+                diagnostics.append(
+                    TicketFlowVisibilityRepairDiagnostic(
+                        run_id=run_id,
+                        status="unrecoverable",
+                        reason="flow run not found",
+                    )
+                )
+        else:
+            records = flow_store.list_flow_runs(flow_type="ticket_flow")
+        thread_store = ManagedThreadStore(normalized_hub_root, durable=durable)
+        for record in records:
+            if record.flow_type != "ticket_flow":
+                continue
+            if not _is_repairable_terminal(record):
+                diagnostics.append(
+                    TicketFlowVisibilityRepairDiagnostic(
+                        run_id=record.id,
+                        status="skipped",
+                        reason=f"run status is not terminal/recoverable: {record.status.value}",
+                    )
+                )
+                continue
+            evidence_items = list(
+                _collect_ticket_turn_evidence(
+                    record,
+                    flow_store=flow_store,
+                    repo_root=normalized_repo_root,
+                )
+            )
+            if not evidence_items:
+                diagnostics.append(
+                    TicketFlowVisibilityRepairDiagnostic(
+                        run_id=record.id,
+                        status="unrecoverable",
+                        reason=(
+                            "missing completed ticket-turn evidence in flow events "
+                            "or ticket thread state"
+                        ),
+                    )
+                )
+                continue
+            for evidence in evidence_items:
+                existing = _find_existing_ticket_flow_thread(
+                    thread_store,
+                    evidence=evidence,
+                    repo_root=normalized_repo_root,
+                    repo_id=repo_id,
+                )
+                if existing is not None:
+                    already_linked += 1
+                    actions.append(
+                        TicketFlowVisibilityRepairAction(
+                            run_id=evidence.run_id,
+                            ticket_id=evidence.ticket_id,
+                            ticket_path=evidence.ticket_path,
+                            action="already_linked",
+                            managed_thread_id=existing,
+                        )
+                    )
+                    continue
+                if dry_run:
+                    actions.append(
+                        TicketFlowVisibilityRepairAction(
+                            run_id=evidence.run_id,
+                            ticket_id=evidence.ticket_id,
+                            ticket_path=evidence.ticket_path,
+                            action="would_repair",
+                        )
+                    )
+                    continue
+                created = _create_repaired_ticket_flow_thread(
+                    thread_store,
+                    evidence=evidence,
+                    repo_root=normalized_repo_root,
+                    repo_id=repo_id,
+                )
+                repaired += 1
+                actions.append(
+                    TicketFlowVisibilityRepairAction(
+                        run_id=evidence.run_id,
+                        ticket_id=evidence.ticket_id,
+                        ticket_path=evidence.ticket_path,
+                        action="repaired",
+                        managed_thread_id=created,
+                    )
+                )
+
+    return TicketFlowVisibilityRepairReport(
+        repo_root=str(normalized_repo_root),
+        hub_root=str(normalized_hub_root),
+        scanned_runs=len(records),
+        repaired=repaired,
+        already_linked=already_linked,
+        dry_run=dry_run,
+        actions=tuple(actions),
+        diagnostics=tuple(diagnostics),
+    )
+
+
+def _is_repairable_terminal(record: FlowRunRecord) -> bool:
+    return record.status in {
+        FlowRunStatus.COMPLETED,
+        FlowRunStatus.FAILED,
+        FlowRunStatus.STOPPED,
+    }
+
+
+def _collect_ticket_turn_evidence(
+    record: FlowRunRecord,
+    *,
+    flow_store: FlowStore,
+    repo_root: Path,
+) -> Iterable[_TicketTurnEvidence]:
+    seen: set[tuple[str, str]] = set()
+    state = record.state if isinstance(record.state, dict) else {}
+    engine = state.get("ticket_engine")
+    engine = engine if isinstance(engine, dict) else {}
+
+    for evidence in _evidence_from_ticket_thread_state(record, repo_root=repo_root):
+        key = (evidence.run_id, evidence.ticket_id)
+        seen.add(key)
+        yield evidence
+
+    selected_ticket: Optional[str] = None
+    turn_id: Optional[str] = None
+    for event in flow_store.get_events(record.id):
+        if event.step_id != "ticket_turn":
+            continue
+        if event.event_type == FlowEventType.STEP_PROGRESS:
+            ticket = _selected_ticket_from_event(event)
+            if ticket is not None:
+                selected_ticket = ticket
+                turn_id = None
+        elif event.event_type == FlowEventType.AGENT_STREAM_DELTA:
+            turn_id = _text(event.data.get("turn_id")) or turn_id
+        elif event.event_type == FlowEventType.STEP_COMPLETED and selected_ticket:
+            path_evidence = _evidence_from_ticket_path(
+                record,
+                repo_root=repo_root,
+                ticket_path=selected_ticket,
+                agent_id=_text(engine.get("last_agent_id")) or "codex",
+                profile=_text(engine.get("profile")),
+                turn_id=turn_id,
+                source="flow_events",
+            )
+            selected_ticket = None
+            turn_id = None
+            if path_evidence is None:
+                continue
+            key = (path_evidence.run_id, path_evidence.ticket_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            yield path_evidence
+
+
+def _evidence_from_ticket_thread_state(
+    record: FlowRunRecord,
+    *,
+    repo_root: Path,
+) -> Iterable[_TicketTurnEvidence]:
+    state = record.state if isinstance(record.state, dict) else {}
+    engine = state.get("ticket_engine")
+    engine = engine if isinstance(engine, dict) else {}
+    bindings = engine.get("ticket_thread_bindings")
+    if isinstance(bindings, dict):
+        for raw_ticket_id, raw_payload in bindings.items():
+            payload = raw_payload if isinstance(raw_payload, dict) else {}
+            ticket_path = _text(payload.get("ticket_path"))
+            ticket_id = _text(raw_ticket_id)
+            if ticket_id is None or ticket_path is None:
+                continue
+            yield _TicketTurnEvidence(
+                run_id=record.id,
+                ticket_path=ticket_path,
+                ticket_id=ticket_id,
+                agent_id=_text(payload.get("agent_id")) or "codex",
+                profile=_text(payload.get("profile")),
+                legacy_thread_target_id=_text(payload.get("thread_target_id")),
+                source="ticket_thread_bindings",
+            )
+    debug = engine.get("ticket_thread_debug")
+    if isinstance(debug, dict) and _text(debug.get("thread_target_id")):
+        ticket_path = _text(debug.get("ticket_path"))
+        ticket_id = _text(debug.get("ticket_id"))
+        if ticket_path is not None and ticket_id is not None:
+            yield _TicketTurnEvidence(
+                run_id=record.id,
+                ticket_path=ticket_path,
+                ticket_id=ticket_id,
+                agent_id=_text(debug.get("agent_id")) or "codex",
+                profile=_text(debug.get("profile")),
+                legacy_thread_target_id=_text(debug.get("thread_target_id")),
+                source="ticket_thread_debug",
+            )
+
+    _ = repo_root
+
+
+def _selected_ticket_from_event(event: FlowEvent) -> Optional[str]:
+    if _text(event.data.get("message")) != "Selected ticket":
+        return None
+    return _text(event.data.get("current_ticket"))
+
+
+def _evidence_from_ticket_path(
+    record: FlowRunRecord,
+    *,
+    repo_root: Path,
+    ticket_path: str,
+    agent_id: str,
+    profile: Optional[str],
+    turn_id: Optional[str],
+    source: str,
+) -> Optional[_TicketTurnEvidence]:
+    path = (repo_root / ticket_path).resolve()
+    try:
+        raw = path.read_text(encoding="utf-8")
+        frontmatter, _body = parse_markdown_frontmatter(raw)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(frontmatter, dict) or frontmatter.get("done") is not True:
+        return None
+    ticket_id = _text(frontmatter.get("ticket_id"))
+    if ticket_id is None:
+        return None
+    return _TicketTurnEvidence(
+        run_id=record.id,
+        ticket_path=ticket_path,
+        ticket_id=ticket_id,
+        agent_id=_text(frontmatter.get("agent")) or agent_id,
+        profile=profile,
+        turn_id=turn_id,
+        source=source,
+    )
+
+
+def _find_existing_ticket_flow_thread(
+    thread_store: ManagedThreadStore,
+    *,
+    evidence: _TicketTurnEvidence,
+    repo_root: Path,
+    repo_id: Optional[str],
+) -> Optional[str]:
+    link_key = ticket_flow_thread_link_key(evidence.run_id, evidence.ticket_id)
+    candidates = thread_store.list_threads(
+        agent=evidence.agent_id,
+        repo_id=repo_id,
+        limit=1000,
+    )
+    if repo_id is not None:
+        candidates.extend(
+            thread_store.list_threads(agent=evidence.agent_id, limit=1000)
+        )
+    seen: set[str] = set()
+    for row in candidates:
+        thread_id = _text(row.get("managed_thread_id") or row.get("thread_target_id"))
+        if thread_id is None or thread_id in seen:
+            continue
+        seen.add(thread_id)
+        metadata = row.get("metadata")
+        metadata = metadata if isinstance(metadata, dict) else {}
+        if _text(row.get("workspace_root") or metadata.get("workspace_root")) != str(
+            repo_root
+        ):
+            continue
+        if repo_id is not None and _text(row.get("repo_id")) not in {None, repo_id}:
+            continue
+        if _text(metadata.get("ticket_flow_link_key")) == link_key:
+            return thread_id
+        if (
+            _text(metadata.get("flow_run_id")) == evidence.run_id
+            and _text(metadata.get("ticket_id")) == evidence.ticket_id
+        ):
+            return thread_id
+    return None
+
+
+def _create_repaired_ticket_flow_thread(
+    thread_store: ManagedThreadStore,
+    *,
+    evidence: _TicketTurnEvidence,
+    repo_root: Path,
+    repo_id: Optional[str],
+) -> str:
+    metadata = ticket_flow_thread_metadata(
+        flow_run_id=evidence.run_id,
+        ticket_id=evidence.ticket_id,
+        workspace_root=str(repo_root),
+        repo_id=repo_id,
+        ticket_path=evidence.ticket_path,
+        turn_id=evidence.turn_id,
+        extra={
+            "agent_profile": evidence.profile,
+            "repair_provenance": {
+                "source": evidence.source,
+                "legacy_thread_target_id": evidence.legacy_thread_target_id,
+                "backfilled": True,
+            },
+        },
+    )
+    metadata = _drop_none(metadata)
+    validate_ticket_flow_thread_metadata(metadata)
+    thread = thread_store.create_thread(
+        evidence.agent_id,
+        repo_root,
+        repo_id=repo_id,
+        name=f"Ticket Flow {evidence.ticket_path} ({evidence.agent_id})",
+        metadata=metadata,
+    )
+    thread_id = str(thread["managed_thread_id"])
+    turn = thread_store.create_turn(
+        thread_id,
+        prompt=(
+            "Backfilled ticket-flow visibility placeholder. Original runtime prompt "
+            "is unavailable in canonical orchestration records."
+        ),
+        metadata={
+            "repair_provenance": metadata["repair_provenance"],
+            "flow_run_id": evidence.run_id,
+            "ticket_id": evidence.ticket_id,
+            "ticket_path": evidence.ticket_path,
+        },
+    )
+    thread_store.mark_turn_finished(
+        str(turn["managed_turn_id"]),
+        status="ok",
+        assistant_text=(
+            "Ticket-flow chat visibility was repaired from repo-local runtime "
+            "evidence. The original transcript remains in legacy flow artifacts "
+            "if available."
+        ),
+    )
+    return thread_id
+
+
+def _drop_none(payload: dict[str, Any]) -> dict[str, Any]:
+    cleaned: dict[str, Any] = {}
+    for key, value in payload.items():
+        if isinstance(value, dict):
+            cleaned[key] = _drop_none(value)
+        elif value is not None:
+            cleaned[key] = value
+    return cleaned
+
+
+def _text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/src/codex_autorunner/core/orchestration/ticket_flow_visibility_repair.py
+++ b/src/codex_autorunner/core/orchestration/ticket_flow_visibility_repair.py
@@ -188,7 +188,7 @@ def repair_ticket_flow_chat_visibility(
                         run_id=record.id,
                         status="unrecoverable",
                         reason=(
-                            "missing completed ticket-turn evidence in flow events "
+                            "missing repairable ticket-turn evidence in flow events "
                             "or ticket thread state"
                         ),
                     )
@@ -297,7 +297,7 @@ def diagnose_ticket_flow_projection_gaps(
                         status=record.status.value,
                         reason=(
                             "repo-local flows.db has a terminal ticket-flow run, "
-                            "but no completed ticket-turn evidence that can be "
+                            "but no repairable ticket-turn evidence that can be "
                             "projected into a Web Hub managed-thread row"
                         ),
                     )
@@ -368,7 +368,15 @@ def _collect_ticket_turn_evidence(
                 turn_id = None
         elif event.event_type == FlowEventType.AGENT_STREAM_DELTA:
             turn_id = _text(event.data.get("turn_id")) or turn_id
-        elif event.event_type == FlowEventType.STEP_COMPLETED and selected_ticket:
+        elif (
+            event.event_type
+            in {
+                FlowEventType.STEP_COMPLETED,
+                FlowEventType.STEP_FAILED,
+                FlowEventType.AGENT_FAILED,
+            }
+            and selected_ticket
+        ):
             path_evidence = _evidence_from_ticket_path(
                 record,
                 repo_root=repo_root,
@@ -377,6 +385,7 @@ def _collect_ticket_turn_evidence(
                 profile=_text(engine.get("profile")),
                 turn_id=turn_id,
                 source="flow_events",
+                require_done=event.event_type == FlowEventType.STEP_COMPLETED,
             )
             selected_ticket = None
             turn_id = None
@@ -447,6 +456,7 @@ def _evidence_from_ticket_path(
     profile: Optional[str],
     turn_id: Optional[str],
     source: str,
+    require_done: bool = True,
 ) -> Optional[_TicketTurnEvidence]:
     path = (repo_root / ticket_path).resolve()
     try:
@@ -454,7 +464,11 @@ def _evidence_from_ticket_path(
         frontmatter, _body = parse_markdown_frontmatter(raw)
     except (OSError, ValueError):
         return None
-    if not isinstance(frontmatter, dict) or frontmatter.get("done") is not True:
+    if not isinstance(frontmatter, dict):
+        return None
+    if require_done and frontmatter.get("done") is not True:
+        return None
+    if not require_done and frontmatter.get("done") is not True and turn_id is None:
         return None
     ticket_id = _text(frontmatter.get("ticket_id"))
     if ticket_id is None:

--- a/src/codex_autorunner/core/orchestration/ticket_flow_visibility_repair.py
+++ b/src/codex_autorunner/core/orchestration/ticket_flow_visibility_repair.py
@@ -79,6 +79,30 @@ class TicketFlowVisibilityRepairReport:
 
 
 @dataclass(frozen=True)
+class TicketFlowProjectionGap:
+    repo_root: str
+    hub_root: str
+    run_id: str
+    status: str
+    reason: str
+    ticket_id: Optional[str] = None
+    ticket_path: Optional[str] = None
+    expected_link_key: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "repo_root": self.repo_root,
+            "hub_root": self.hub_root,
+            "run_id": self.run_id,
+            "status": self.status,
+            "reason": self.reason,
+            "ticket_id": self.ticket_id,
+            "ticket_path": self.ticket_path,
+            "expected_link_key": self.expected_link_key,
+        }
+
+
+@dataclass(frozen=True)
 class _TicketTurnEvidence:
     run_id: str
     ticket_path: str
@@ -226,6 +250,86 @@ def repair_ticket_flow_chat_visibility(
         actions=tuple(actions),
         diagnostics=tuple(diagnostics),
     )
+
+
+def diagnose_ticket_flow_projection_gaps(
+    *,
+    repo_root: Path,
+    hub_root: Path,
+    repo_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    durable: bool = True,
+) -> tuple[TicketFlowProjectionGap, ...]:
+    """Return terminal ticket-flow turns in flows.db that lack hub chat links."""
+
+    normalized_repo_root = repo_root.resolve()
+    normalized_hub_root = hub_root.resolve()
+    db_path = resolve_repo_flows_db_path(normalized_repo_root)
+    if not db_path.exists():
+        return ()
+
+    gaps: list[TicketFlowProjectionGap] = []
+    with FlowStore(db_path, durable=durable) as flow_store:
+        if run_id:
+            record = flow_store.get_flow_run(run_id)
+            records = [record] if record is not None else []
+        else:
+            records = flow_store.list_flow_runs(flow_type="ticket_flow")
+        thread_store = ManagedThreadStore(normalized_hub_root, durable=durable)
+        for record in records:
+            if record is None or record.flow_type != "ticket_flow":
+                continue
+            if not _is_repairable_terminal(record):
+                continue
+            evidence_items = list(
+                _collect_ticket_turn_evidence(
+                    record,
+                    flow_store=flow_store,
+                    repo_root=normalized_repo_root,
+                )
+            )
+            if not evidence_items:
+                gaps.append(
+                    TicketFlowProjectionGap(
+                        repo_root=str(normalized_repo_root),
+                        hub_root=str(normalized_hub_root),
+                        run_id=record.id,
+                        status=record.status.value,
+                        reason=(
+                            "repo-local flows.db has a terminal ticket-flow run, "
+                            "but no completed ticket-turn evidence that can be "
+                            "projected into a Web Hub managed-thread row"
+                        ),
+                    )
+                )
+                continue
+            for evidence in evidence_items:
+                existing = _find_existing_ticket_flow_thread(
+                    thread_store,
+                    evidence=evidence,
+                    repo_root=normalized_repo_root,
+                    repo_id=repo_id,
+                )
+                if existing is not None:
+                    continue
+                gaps.append(
+                    TicketFlowProjectionGap(
+                        repo_root=str(normalized_repo_root),
+                        hub_root=str(normalized_hub_root),
+                        run_id=evidence.run_id,
+                        status=record.status.value,
+                        reason=(
+                            "repo-local flows.db has an executed ticket-flow turn "
+                            "without a canonical orchestration managed-thread link"
+                        ),
+                        ticket_id=evidence.ticket_id,
+                        ticket_path=evidence.ticket_path,
+                        expected_link_key=ticket_flow_thread_link_key(
+                            evidence.run_id, evidence.ticket_id
+                        ),
+                    )
+                )
+    return tuple(gaps)
 
 
 def _is_repairable_terminal(record: FlowRunRecord) -> bool:
@@ -480,3 +584,13 @@ def _text(value: Any) -> Optional[str]:
         return None
     text = str(value).strip()
     return text or None
+
+
+__all__ = [
+    "TicketFlowProjectionGap",
+    "TicketFlowVisibilityRepairAction",
+    "TicketFlowVisibilityRepairDiagnostic",
+    "TicketFlowVisibilityRepairReport",
+    "diagnose_ticket_flow_projection_gaps",
+    "repair_ticket_flow_chat_visibility",
+]

--- a/src/codex_autorunner/surfaces/cli/commands/flow.py
+++ b/src/codex_autorunner/surfaces/cli/commands/flow.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Optional, cast
 
 import typer
 
+from ....core.config import find_nearest_hub_config_path
 from ....core.flows import FlowController, FlowStore
 from ....core.flows.flow_housekeeping import (
     FlowRetentionConfig,
@@ -48,6 +49,9 @@ from ....core.force_attestation import (
 from ....core.managed_processes import reap_managed_processes
 from ....core.orchestration import build_ticket_flow_orchestration_service
 from ....core.orchestration.models import FlowRunTarget
+from ....core.orchestration.ticket_flow_visibility_repair import (
+    repair_ticket_flow_chat_visibility,
+)
 from ....core.runtime import RuntimeContext
 from ....core.state_roots import resolve_repo_flows_db_path, resolve_repo_state_root
 from ....core.ticket_flow_operator import (
@@ -99,6 +103,15 @@ def _build_force_attestation(
         "user_request": force_attestation,
         "target_scope": target_scope,
     }
+
+
+def _resolve_ticket_flow_repair_hub_root(repo_root: Path, hub: Optional[Path]) -> Path:
+    if hub is not None:
+        return hub.expanduser().resolve()
+    hub_config_path = find_nearest_hub_config_path(repo_root)
+    if hub_config_path is not None:
+        return hub_config_path.parent.parent.resolve()
+    return repo_root.resolve()
 
 
 def register_flow_commands(
@@ -981,6 +994,49 @@ def register_flow_commands(
             typer.echo(json.dumps(payload, indent=2))
             return
         _print_ticket_flow_status(payload)
+
+    @ticket_flow_app.command("repair-visibility")
+    def ticket_flow_repair_visibility(
+        repo: Optional[Path] = typer.Option(None, "--repo", help="Repo path"),
+        hub: Optional[Path] = hub_root_path_option(),
+        run_id: Optional[str] = typer.Option(None, "--run-id", help="Flow run ID"),
+        repo_id: Optional[str] = typer.Option(
+            None,
+            "--repo-id",
+            help="Hub repo id to stamp on repaired managed-thread rows.",
+        ),
+        dry_run: bool = typer.Option(
+            True,
+            "--dry-run/--apply",
+            help="Preview repairs by default; pass --apply to mutate hub records.",
+        ),
+        output_json: bool = typer.Option(True, "--json/--no-json", help="Emit JSON"),
+    ):
+        """Repair missing Web Hub chat visibility for legacy ticket_flow runs."""
+        engine = require_repo_config(repo, hub)
+        normalized_run_id = _normalize_flow_run_id(run_id)
+        report = repair_ticket_flow_chat_visibility(
+            repo_root=engine.repo_root,
+            hub_root=_resolve_ticket_flow_repair_hub_root(engine.repo_root, hub),
+            repo_id=repo_id,
+            run_id=normalized_run_id,
+            dry_run=dry_run,
+            durable=engine.config.durable_writes,
+        )
+        payload = report.to_dict()
+        if output_json:
+            typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+            return
+        typer.echo(
+            f"scanned={payload['scanned_runs']} repaired={payload['repaired']} "
+            f"already_linked={payload['already_linked']} dry_run={payload['dry_run']}"
+        )
+        for diagnostic in payload["diagnostics"]:
+            typer.echo(
+                "diagnostic: "
+                f"run={diagnostic['run_id']} status={diagnostic['status']} "
+                f"reason={diagnostic['reason']}"
+            )
 
     @ticket_flow_app.command("stop")
     def ticket_flow_stop(

--- a/src/codex_autorunner/surfaces/web/routes/hub_messages.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_messages.py
@@ -107,6 +107,7 @@ def _build_hub_messages_payload(
         action_queue=(
             snapshot.action_queue if "action_queue" in requested_sections else None
         ),
+        unreadable_diagnostics=snapshot.unreadable_diagnostics,
     )
     return payload.model_dump(exclude_none=True)
 

--- a/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/read_models.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_repo_routes/read_models.py
@@ -4,12 +4,15 @@ import asyncio
 import json
 import sqlite3
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Optional, cast
+from typing import TYPE_CHECKING, Any, Literal, Mapping, Optional, cast
 
 from fastapi import APIRouter, HTTPException
 
 from .....contextspace.paths import read_contextspace_docs
 from .....core.freshness import iso_now
+from .....core.orchestration.flow_run_projection import (
+    project_ticket_flow_run_records,
+)
 from .....core.orchestration.sqlite import open_orchestration_sqlite
 from .....core.state_roots import resolve_repo_flows_db_path, resolve_repo_state_root
 from .....tickets.files import list_ticket_paths
@@ -138,12 +141,14 @@ def _runtime_projection(item: dict[str, Any]) -> RuntimeProjection:
     )
 
 
-def _run_payload(record: Any) -> dict[str, Any]:
+def _run_payload(
+    record: Any, projected: Optional[Mapping[str, Any]] = None
+) -> dict[str, Any]:
     status = getattr(getattr(record, "status", None), "value", None) or getattr(
         record, "status", None
     )
     state = getattr(record, "state", None)
-    return {
+    payload = {
         "id": str(getattr(record, "id", "")),
         "run_id": str(getattr(record, "id", "")),
         "flow_type": getattr(record, "flow_type", None),
@@ -155,6 +160,14 @@ def _run_payload(record: Any) -> dict[str, Any]:
         "error_message": getattr(record, "error_message", None),
         "state": state if isinstance(state, dict) else {},
     }
+    if projected:
+        payload["projection"] = dict(projected)
+        payload["current_ticket"] = projected.get("current_ticket")
+        payload["archive_ready"] = projected.get("archive_ready")
+        progress = projected.get("progress")
+        if isinstance(progress, Mapping):
+            payload["progress"] = dict(progress)
+    return payload
 
 
 def _ticket_projection_status(raw: object) -> str:
@@ -374,7 +387,34 @@ class RepoWorktreeReadModelService:
             recover_stuck=True,
             logger=self._context.logger,
         )
-        return [_run_payload(record) for record in records[:limit]]
+        repo_id = str(getattr(self._snapshot_by_path(workspace_root), "id", "") or "")
+        if repo_id:
+            projected = project_ticket_flow_run_records(
+                self._context.config.root,
+                workspace_root,
+                repo_id,
+                records,
+            )
+            projected_by_id = {
+                str(row.get("run_id") or row.get("flow_run_id")): row
+                for row in projected
+            }
+        else:
+            projected_by_id = {}
+        return [
+            _run_payload(record, projected_by_id.get(str(getattr(record, "id", ""))))
+            for record in records[:limit]
+        ]
+
+    def _snapshot_by_path(self, workspace_root: Path) -> Any:
+        resolved = workspace_root.resolve()
+        for snapshot in self._context.supervisor.list_repos(use_cache=True):
+            try:
+                if snapshot.path.resolve() == resolved:
+                    return snapshot
+            except OSError:
+                continue
+        return None
 
     def _scoped_chats(
         self, *, owner_kind: str, owner_id: str, limit: int

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -546,6 +546,7 @@ class HubMessagesResponse(ResponseModel):
     pma_files_detail: Optional[Dict[str, List[Dict[str, Any]]]] = None
     automation: Optional[Dict[str, Any]] = None
     action_queue: Optional[List[Dict[str, Any]]] = None
+    unreadable_diagnostics: Optional[List[Dict[str, str]]] = None
 
 
 class SessionStopRequest(Payload):

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -656,7 +656,7 @@ def test_chat_index_carries_ticket_flow_metadata_for_grouping(
     )
     assert row["ticket_id"] == "TICKET-015"
     assert row["run_id"] == "run-015"
-    assert row["group_id"] == "ticket:TICKET-015"
+    assert row["group_id"] == "run:run-015"
 
     grouped = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(
         view="ticket_run",
@@ -665,7 +665,7 @@ def test_chat_index_carries_ticket_flow_metadata_for_grouping(
     )
 
     assert grouped["rows"][0]["row_type"] == "group"
-    assert grouped["rows"][0]["group_id"] == "ticket:TICKET-015"
+    assert grouped["rows"][0]["group_id"] == "run:run-015"
 
     active = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(
         view="active",

--- a/tests/core/orchestration/test_ticket_flow_chat_ledger_contract.py
+++ b/tests/core/orchestration/test_ticket_flow_chat_ledger_contract.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import pytest
+
+from codex_autorunner.core.orchestration.ticket_flow_chat_ledger_contract import (
+    TICKET_FLOW_CHAT_LEDGER_CONTRACT_VERSION,
+    TICKET_FLOW_LEDGER_LIFECYCLE,
+    TICKET_FLOW_LEDGER_RECORDS,
+    TicketFlowThreadLink,
+    ticket_flow_chat_ledger_contract,
+    ticket_flow_thread_link_key,
+    ticket_flow_thread_metadata,
+    validate_ticket_flow_thread_metadata,
+)
+
+
+def test_ticket_flow_chat_ledger_contract_lists_required_lifecycle_facts() -> None:
+    assert TICKET_FLOW_CHAT_LEDGER_CONTRACT_VERSION == "ticket_flow_chat_ledger.v1"
+    assert set(TICKET_FLOW_LEDGER_LIFECYCLE) >= {
+        "flow_run.started",
+        "flow_run.completed",
+        "flow_run.failed",
+        "ticket.selected",
+        "managed_thread.created",
+        "managed_thread.reused",
+        "ticket_thread.linked",
+        "ticket_turn.started",
+        "ticket_turn.completed",
+        "ticket_turn.failed",
+    }
+
+
+def test_ticket_flow_chat_ledger_contract_separates_flows_db_from_orchestration() -> (
+    None
+):
+    contract = ticket_flow_chat_ledger_contract()
+    records = {record["name"]: record for record in contract["records"]}
+
+    assert records["repo-local flow run state"]["source"] == "flows.db"
+    assert (
+        "state.ticket_engine" in records["repo-local flow run state"]["required_fields"]
+    )
+
+    orchestration_records = [
+        record for record in contract["records"] if record["source"] == "orchestration"
+    ]
+    assert orchestration_records
+    assert any(
+        record["artifact"] == "thread_link"
+        and {
+            "flow_run_id",
+            "ticket_id",
+            "managed_thread_id",
+            "workspace_root",
+        }.issubset(set(record["required_fields"]))
+        for record in orchestration_records
+    )
+    assert "flows.db" in contract["read_models"]["future_flow_index"]
+    assert (
+        "must not read repo-local flows.db"
+        in contract["read_models"]["web_hub_chat_index"]
+    )
+
+
+def test_ticket_flow_thread_metadata_matches_chat_index_contract_shape() -> None:
+    metadata = ticket_flow_thread_metadata(
+        flow_run_id="run-123",
+        ticket_id="TICKET-002",
+        workspace_root="/repo/worktree",
+        repo_id="repo",
+        worktree_id="repo--discord-2",
+        ticket_path=".codex-autorunner/tickets/TICKET-002.md",
+        extra={"agent_profile": "codex"},
+    )
+
+    assert metadata == {
+        "contract_version": "ticket_flow_chat_ledger.v1",
+        "flow_type": "ticket_flow",
+        "thread_kind": "ticket_flow",
+        "run_id": "run-123",
+        "flow_run_id": "run-123",
+        "ticket_id": "TICKET-002",
+        "workspace_root": "/repo/worktree",
+        "ticket_flow_link_key": "ticket_flow:run-123:TICKET-002",
+        "repo_id": "repo",
+        "worktree_id": "repo--discord-2",
+        "ticket_path": ".codex-autorunner/tickets/TICKET-002.md",
+        "agent_profile": "codex",
+    }
+    validate_ticket_flow_thread_metadata(metadata)
+
+
+def test_ticket_flow_thread_link_is_repairable_from_flow_run_and_ticket() -> None:
+    link = TicketFlowThreadLink(
+        flow_run_id="run-123",
+        ticket_id="TICKET-002",
+        managed_thread_id="thread-abc",
+        workspace_root="/repo/worktree",
+        repo_id="repo",
+    )
+
+    assert link.link_key == "ticket_flow:run-123:TICKET-002"
+    metadata = link.to_thread_metadata()
+    assert metadata["ticket_flow_link_key"] == link.link_key
+    assert metadata["run_id"] == "run-123"
+    assert metadata["flow_run_id"] == "run-123"
+    assert metadata["ticket_id"] == "TICKET-002"
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {},
+        {"flow_type": "ticket_flow", "thread_kind": "ticket_flow"},
+        {
+            "flow_type": "ticket_flow",
+            "thread_kind": "ticket_flow",
+            "run_id": "run-1",
+            "flow_run_id": "run-2",
+            "ticket_id": "TICKET-002",
+            "workspace_root": "/repo",
+        },
+    ],
+)
+def test_ticket_flow_thread_metadata_validation_rejects_missing_or_split_links(
+    metadata: dict[str, str],
+) -> None:
+    with pytest.raises(ValueError):
+        validate_ticket_flow_thread_metadata(metadata)
+
+
+def test_ticket_flow_thread_link_key_requires_stable_identity() -> None:
+    with pytest.raises(ValueError):
+        ticket_flow_thread_link_key("", "TICKET-002")
+
+    with pytest.raises(ValueError):
+        ticket_flow_thread_link_key("run-123", None)
+
+
+def test_ticket_flow_ledger_records_are_serializable_and_named() -> None:
+    assert all(record.name for record in TICKET_FLOW_LEDGER_RECORDS)
+    assert all(record.required_fields for record in TICKET_FLOW_LEDGER_RECORDS)
+    assert ticket_flow_chat_ledger_contract()["records"] == [
+        record.to_dict() for record in TICKET_FLOW_LEDGER_RECORDS
+    ]

--- a/tests/core/orchestration/test_ticket_flow_visibility_repair.py
+++ b/tests/core/orchestration/test_ticket_flow_visibility_repair.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_autorunner.core.flows.models import FlowEventType, FlowRunStatus
+from codex_autorunner.core.flows.store import FlowStore
+from codex_autorunner.core.managed_thread_store import ManagedThreadStore
+from codex_autorunner.core.orchestration import ticket_flow_thread_metadata
+from codex_autorunner.core.orchestration.ticket_flow_visibility_repair import (
+    repair_ticket_flow_chat_visibility,
+)
+from codex_autorunner.core.state_roots import resolve_repo_flows_db_path
+
+
+def _write_ticket(repo_root: Path, name: str, *, ticket_id: str, done: bool) -> str:
+    rel = f".codex-autorunner/tickets/{name}"
+    path = repo_root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                "---",
+                f'title: "{name}"',
+                'agent: "codex"',
+                f"done: {'true' if done else 'false'}",
+                f'ticket_id: "{ticket_id}"',
+                "---",
+                "",
+                "## Goal",
+                "- Test ticket.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return rel
+
+
+def _seed_completed_run(
+    repo_root: Path,
+    *,
+    run_id: str,
+    ticket_path: str,
+    state: dict | None = None,
+) -> None:
+    db_path = resolve_repo_flows_db_path(repo_root)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with FlowStore(db_path) as store:
+        store.create_flow_run(run_id, "ticket_flow", input_data={})
+        store.create_event(
+            event_id=f"{run_id}-selected",
+            run_id=run_id,
+            event_type=FlowEventType.STEP_PROGRESS,
+            step_id="ticket_turn",
+            data={"message": "Selected ticket", "current_ticket": ticket_path},
+        )
+        store.create_event(
+            event_id=f"{run_id}-delta",
+            run_id=run_id,
+            event_type=FlowEventType.AGENT_STREAM_DELTA,
+            step_id="ticket_turn",
+            data={"delta": "done", "turn_id": "turn-1"},
+        )
+        store.create_event(
+            event_id=f"{run_id}-completed",
+            run_id=run_id,
+            event_type=FlowEventType.STEP_COMPLETED,
+            step_id="ticket_turn",
+            data={"step_id": "ticket_turn", "next_steps": []},
+        )
+        store.update_flow_run_status(
+            run_id,
+            FlowRunStatus.COMPLETED,
+            state=state or {"ticket_engine": {"last_agent_id": "codex"}},
+            started_at="2026-05-15T12:00:00Z",
+            finished_at="2026-05-15T12:05:00Z",
+        )
+
+
+def test_repair_ticket_flow_visibility_recovers_completed_run(hub_env) -> None:
+    run_id = "e603d3ea-45f0-4e1b-a2ae-b82e40c5566d"
+    ticket_path = _write_ticket(
+        hub_env.repo_root,
+        "TICKET-001.md",
+        ticket_id="ticket-1",
+        done=True,
+    )
+    _seed_completed_run(hub_env.repo_root, run_id=run_id, ticket_path=ticket_path)
+
+    dry = repair_ticket_flow_chat_visibility(
+        repo_root=hub_env.repo_root,
+        hub_root=hub_env.hub_root,
+        repo_id=hub_env.repo_id,
+        run_id=run_id,
+        dry_run=True,
+    )
+    assert dry.repaired == 0
+    assert dry.actions[0].action == "would_repair"
+
+    report = repair_ticket_flow_chat_visibility(
+        repo_root=hub_env.repo_root,
+        hub_root=hub_env.hub_root,
+        repo_id=hub_env.repo_id,
+        run_id=run_id,
+    )
+
+    assert report.repaired == 1
+    store = ManagedThreadStore(hub_env.hub_root, durable=True)
+    thread = store.get_thread(report.actions[0].managed_thread_id or "")
+    assert thread is not None
+    assert thread["repo_id"] == hub_env.repo_id
+    assert thread["resource_kind"] == "repo"
+    assert thread["resource_id"] == hub_env.repo_id
+    metadata = thread["metadata"]
+    assert metadata["flow_run_id"] == run_id
+    assert metadata["ticket_id"] == "ticket-1"
+    assert metadata["repair_provenance"]["backfilled"] is True
+    assert metadata["repair_provenance"]["source"] == "flow_events"
+    turns = store.list_turns(str(thread["managed_thread_id"]))
+    assert turns[0]["status"] == "ok"
+
+    again = repair_ticket_flow_chat_visibility(
+        repo_root=hub_env.repo_root,
+        hub_root=hub_env.hub_root,
+        repo_id=hub_env.repo_id,
+        run_id=run_id,
+    )
+    assert again.repaired == 0
+    assert again.already_linked == 1
+    assert again.actions[0].managed_thread_id == thread["managed_thread_id"]
+
+
+def test_repair_ticket_flow_visibility_reports_incomplete_evidence(hub_env) -> None:
+    ticket_path = _write_ticket(
+        hub_env.repo_root,
+        "TICKET-002.md",
+        ticket_id="ticket-2",
+        done=False,
+    )
+    _seed_completed_run(hub_env.repo_root, run_id="run-2", ticket_path=ticket_path)
+
+    report = repair_ticket_flow_chat_visibility(
+        repo_root=hub_env.repo_root,
+        hub_root=hub_env.hub_root,
+        repo_id=hub_env.repo_id,
+        run_id="run-2",
+    )
+
+    assert report.repaired == 0
+    assert report.diagnostics[0].status == "unrecoverable"
+    assert "missing completed ticket-turn evidence" in report.diagnostics[0].reason
+
+
+def test_repair_ticket_flow_visibility_skips_already_linked_run(hub_env) -> None:
+    ticket_path = _write_ticket(
+        hub_env.repo_root,
+        "TICKET-003.md",
+        ticket_id="ticket-3",
+        done=True,
+    )
+    _seed_completed_run(hub_env.repo_root, run_id="run-3", ticket_path=ticket_path)
+    store = ManagedThreadStore(hub_env.hub_root, durable=True)
+    existing = store.create_thread(
+        "codex",
+        hub_env.repo_root,
+        repo_id=hub_env.repo_id,
+        resource_kind="ticket",
+        resource_id="ticket-3",
+        metadata=ticket_flow_thread_metadata(
+            flow_run_id="run-3",
+            ticket_id="ticket-3",
+            workspace_root=str(hub_env.repo_root),
+            repo_id=hub_env.repo_id,
+            ticket_path=ticket_path,
+        ),
+    )
+
+    report = repair_ticket_flow_chat_visibility(
+        repo_root=hub_env.repo_root,
+        hub_root=hub_env.hub_root,
+        repo_id=hub_env.repo_id,
+        run_id="run-3",
+    )
+
+    assert report.repaired == 0
+    assert report.already_linked == 1
+    assert report.actions[0].managed_thread_id == existing["managed_thread_id"]
+
+
+def test_repair_ticket_flow_visibility_is_scoped_to_workspace_and_hub(
+    hub_env, tmp_path
+) -> None:
+    ticket_path = _write_ticket(
+        hub_env.repo_root,
+        "TICKET-004.md",
+        ticket_id="ticket-4",
+        done=True,
+    )
+    _seed_completed_run(hub_env.repo_root, run_id="run-4", ticket_path=ticket_path)
+    store = ManagedThreadStore(hub_env.hub_root, durable=True)
+    other_root = tmp_path / "other-worktree"
+    other_root.mkdir()
+    other = store.create_thread(
+        "codex",
+        other_root,
+        repo_id=hub_env.repo_id,
+        resource_kind="ticket",
+        resource_id="ticket-4",
+        metadata=ticket_flow_thread_metadata(
+            flow_run_id="run-4",
+            ticket_id="ticket-4",
+            workspace_root=str(other_root),
+            repo_id=hub_env.repo_id,
+            ticket_path=ticket_path,
+        ),
+    )
+
+    report = repair_ticket_flow_chat_visibility(
+        repo_root=hub_env.repo_root,
+        hub_root=hub_env.hub_root,
+        repo_id=hub_env.repo_id,
+        run_id="run-4",
+    )
+
+    assert report.repaired == 1
+    assert report.actions[0].managed_thread_id != other["managed_thread_id"]
+    rows = ManagedThreadStore(hub_env.hub_root, durable=True).list_threads(
+        agent="codex",
+        repo_id=hub_env.repo_id,
+        limit=20,
+    )
+    repaired = [
+        row
+        for row in rows
+        if (row.get("metadata") or {}).get("flow_run_id") == "run-4"
+        and row.get("workspace_root") == str(hub_env.repo_root)
+    ]
+    assert len(repaired) == 1

--- a/tests/core/orchestration/test_ticket_flow_visibility_repair.py
+++ b/tests/core/orchestration/test_ticket_flow_visibility_repair.py
@@ -7,6 +7,7 @@ from codex_autorunner.core.flows.store import FlowStore
 from codex_autorunner.core.managed_thread_store import ManagedThreadStore
 from codex_autorunner.core.orchestration import ticket_flow_thread_metadata
 from codex_autorunner.core.orchestration.ticket_flow_visibility_repair import (
+    diagnose_ticket_flow_projection_gaps,
     repair_ticket_flow_chat_visibility,
 )
 from codex_autorunner.core.state_roots import resolve_repo_flows_db_path
@@ -128,6 +129,47 @@ def test_repair_ticket_flow_visibility_recovers_completed_run(hub_env) -> None:
     assert again.repaired == 0
     assert again.already_linked == 1
     assert again.actions[0].managed_thread_id == thread["managed_thread_id"]
+
+
+def test_diagnostics_flag_completed_turn_without_canonical_link(hub_env) -> None:
+    run_id = "55b8aa99-ea89-4628-a7f7-9f4166534b6f"
+    ticket_path = _write_ticket(
+        hub_env.repo_root,
+        "TICKET-001A.md",
+        ticket_id="ticket-gap",
+        done=True,
+    )
+    _seed_completed_run(hub_env.repo_root, run_id=run_id, ticket_path=ticket_path)
+
+    gaps = diagnose_ticket_flow_projection_gaps(
+        repo_root=hub_env.repo_root,
+        hub_root=hub_env.hub_root,
+        repo_id=hub_env.repo_id,
+        run_id=run_id,
+    )
+
+    assert len(gaps) == 1
+    assert gaps[0].run_id == run_id
+    assert gaps[0].ticket_id == "ticket-gap"
+    assert gaps[0].expected_link_key == f"ticket_flow:{run_id}:ticket-gap"
+    assert "without a canonical orchestration managed-thread link" in gaps[0].reason
+
+    repair_ticket_flow_chat_visibility(
+        repo_root=hub_env.repo_root,
+        hub_root=hub_env.hub_root,
+        repo_id=hub_env.repo_id,
+        run_id=run_id,
+    )
+
+    assert (
+        diagnose_ticket_flow_projection_gaps(
+            repo_root=hub_env.repo_root,
+            hub_root=hub_env.hub_root,
+            repo_id=hub_env.repo_id,
+            run_id=run_id,
+        )
+        == ()
+    )
 
 
 def test_repair_ticket_flow_visibility_reports_incomplete_evidence(hub_env) -> None:

--- a/tests/core/orchestration/test_ticket_flow_visibility_repair.py
+++ b/tests/core/orchestration/test_ticket_flow_visibility_repair.py
@@ -43,6 +43,8 @@ def _seed_completed_run(
     run_id: str,
     ticket_path: str,
     state: dict | None = None,
+    status: FlowRunStatus = FlowRunStatus.COMPLETED,
+    terminal_event: FlowEventType = FlowEventType.STEP_COMPLETED,
 ) -> None:
     db_path = resolve_repo_flows_db_path(repo_root)
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -63,15 +65,15 @@ def _seed_completed_run(
             data={"delta": "done", "turn_id": "turn-1"},
         )
         store.create_event(
-            event_id=f"{run_id}-completed",
+            event_id=f"{run_id}-terminal",
             run_id=run_id,
-            event_type=FlowEventType.STEP_COMPLETED,
+            event_type=terminal_event,
             step_id="ticket_turn",
             data={"step_id": "ticket_turn", "next_steps": []},
         )
         store.update_flow_run_status(
             run_id,
-            FlowRunStatus.COMPLETED,
+            status,
             state=state or {"ticket_engine": {"last_agent_id": "codex"}},
             started_at="2026-05-15T12:00:00Z",
             finished_at="2026-05-15T12:05:00Z",
@@ -190,7 +192,41 @@ def test_repair_ticket_flow_visibility_reports_incomplete_evidence(hub_env) -> N
 
     assert report.repaired == 0
     assert report.diagnostics[0].status == "unrecoverable"
-    assert "missing completed ticket-turn evidence" in report.diagnostics[0].reason
+    assert "missing repairable ticket-turn evidence" in report.diagnostics[0].reason
+
+
+def test_repair_ticket_flow_visibility_recovers_failed_turn_with_open_ticket(
+    hub_env,
+) -> None:
+    run_id = "failed-run-with-open-ticket"
+    ticket_path = _write_ticket(
+        hub_env.repo_root,
+        "TICKET-002A.md",
+        ticket_id="ticket-failed",
+        done=False,
+    )
+    _seed_completed_run(
+        hub_env.repo_root,
+        run_id=run_id,
+        ticket_path=ticket_path,
+        status=FlowRunStatus.FAILED,
+        terminal_event=FlowEventType.STEP_FAILED,
+    )
+
+    report = repair_ticket_flow_chat_visibility(
+        repo_root=hub_env.repo_root,
+        hub_root=hub_env.hub_root,
+        repo_id=hub_env.repo_id,
+        run_id=run_id,
+    )
+
+    assert report.repaired == 1
+    assert report.actions[0].ticket_id == "ticket-failed"
+    store = ManagedThreadStore(hub_env.hub_root, durable=True)
+    thread = store.get_thread(report.actions[0].managed_thread_id or "")
+    assert thread is not None
+    assert thread["metadata"]["ticket_id"] == "ticket-failed"
+    assert thread["metadata"]["repair_provenance"]["source"] == "flow_events"
 
 
 def test_repair_ticket_flow_visibility_skips_already_linked_run(hub_env) -> None:

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -351,7 +351,7 @@ def test_chat_index_contract_uses_terminal_thread_status_and_ticket_flow_metadat
     assert row.status == "idle"
     assert row.ticket_id == "TICKET-015"
     assert row.run_id == "run-015"
-    assert row.group_id == "ticket:TICKET-015"
+    assert row.group_id == "run:run-015"
 
     active_response = client.get(
         "/hub/read-models/chats", params={"filter": "active", "limit": 20}

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -10,6 +10,7 @@ from codex_autorunner.core.managed_thread_store import ManagedThreadStore
 from codex_autorunner.core.orchestration import (
     OrchestrationBindingStore,
     SQLiteChatSurfaceEventJournal,
+    ticket_flow_thread_metadata,
 )
 from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.server import create_hub_app
@@ -294,12 +295,11 @@ def test_chat_index_contract_uses_terminal_thread_status_and_ticket_flow_metadat
                     "active",
                     "completed",
                     json.dumps(
-                        {
-                            "flow_type": "ticket_flow",
-                            "thread_kind": "ticket_flow",
-                            "ticket_id": "TICKET-015",
-                            "run_id": "run-015",
-                        }
+                        ticket_flow_thread_metadata(
+                            flow_run_id="run-015",
+                            ticket_id="TICKET-015",
+                            workspace_root=str(hub_env.repo_root),
+                        )
                     ),
                     "2026-05-15T11:57:27Z",
                     "2026-05-15T12:08:56Z",

--- a/tests/surfaces/web/test_hub_repo_list_routes.py
+++ b/tests/surfaces/web/test_hub_repo_list_routes.py
@@ -9,6 +9,7 @@ from tests.surfaces.web._hub_test_support import (
 )
 
 from codex_autorunner.core.flows import FlowRunStatus
+from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.state import RunnerState, save_state
 from codex_autorunner.server import create_hub_app
 
@@ -73,6 +74,22 @@ def test_hub_repo_list_includes_ticket_flow_summary_and_run_state(
     assert run_state["recommended_action"]
     assert_repo_canonical_state_v1(repo_entry)
     assert repo_entry["canonical_state_v1"]["represented_run_id"] == "run-paused"
+    assert repo_entry["flow_run_projection"][0]["run_id"] == "run-paused"
+
+    with open_orchestration_sqlite(hub_root, durable=True, migrate=True) as conn:
+        row = conn.execute(
+            """
+            SELECT repo_id, flow_type, status, summary_json
+              FROM orch_flow_run_projections
+             WHERE flow_run_id = ?
+            """,
+            ("run-paused",),
+        ).fetchone()
+    assert row is not None
+    assert row["repo_id"] == "base"
+    assert row["flow_type"] == "ticket_flow"
+    assert row["status"] == "paused"
+    assert '"archive_ready":false' in row["summary_json"]
 
 
 def test_hub_scan_reuses_repo_summary_enrichment(tmp_path: Path) -> None:

--- a/tests/test_hub_messages.py
+++ b/tests/test_hub_messages.py
@@ -15,7 +15,7 @@ from codex_autorunner.core.config import (
     REPO_OVERRIDE_FILENAME,
     ROOT_CONFIG_FILENAME,
 )
-from codex_autorunner.core.flows.models import FlowRunStatus
+from codex_autorunner.core.flows.models import FlowEventType, FlowRunStatus
 from codex_autorunner.core.flows.store import FlowStore
 from codex_autorunner.core.hub import HubSupervisor
 from codex_autorunner.core.hub_inbox_resolution import (
@@ -207,6 +207,26 @@ def _write_ticket(repo_root: Path, ticket_name: str) -> None:
         ("---\n" f"title: {ticket_name}\n" "done: false\n" "---\n\n" "Body\n"),
         encoding="utf-8",
     )
+
+
+def _write_done_ticket_with_id(
+    repo_root: Path, ticket_name: str, ticket_id: str
+) -> str:
+    rel = f".codex-autorunner/tickets/{ticket_name}"
+    path = repo_root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        (
+            "---\n"
+            f"title: {ticket_name}\n"
+            "done: true\n"
+            f"ticket_id: {ticket_id}\n"
+            "---\n\n"
+            "Body\n"
+        ),
+        encoding="utf-8",
+    )
+    return rel
 
 
 def _write_dead_worker_artifacts(repo_root: Path, run_id: str) -> None:
@@ -1452,6 +1472,64 @@ def test_hub_messages_surfaces_mismatched_ticket_engine_state(
         assert item["run_id"] == run_id
         run_state = item.get("run_state") or {}
         assert run_state.get("state") in ("paused", "blocked")
+
+
+def test_hub_messages_diagnose_terminal_ticket_flow_without_chat_link(
+    hub_env, monkeypatch
+) -> None:
+    run_id = "cccc0000-cccc-cccc-cccc-cccccccc0000"
+    ticket_path = _write_done_ticket_with_id(
+        hub_env.repo_root,
+        "TICKET-101.md",
+        "ticket-chat-gap",
+    )
+    db_path = hub_env.repo_root / ".codex-autorunner" / "flows.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with FlowStore(db_path) as store:
+        store.initialize()
+        store.create_flow_run(
+            run_id,
+            "ticket_flow",
+            input_data={
+                "workspace_root": str(hub_env.repo_root),
+                "runs_dir": ".codex-autorunner/runs",
+            },
+            state={"ticket_engine": {"last_agent_id": "codex"}},
+            metadata={},
+        )
+        store.create_event(
+            event_id=f"{run_id}-selected",
+            run_id=run_id,
+            event_type=FlowEventType.STEP_PROGRESS,
+            step_id="ticket_turn",
+            data={"message": "Selected ticket", "current_ticket": ticket_path},
+        )
+        store.create_event(
+            event_id=f"{run_id}-completed",
+            run_id=run_id,
+            event_type=FlowEventType.STEP_COMPLETED,
+            step_id="ticket_turn",
+            data={"step_id": "ticket_turn"},
+        )
+        store.update_flow_run_status(
+            run_id,
+            FlowRunStatus.COMPLETED,
+            state={"ticket_engine": {"last_agent_id": "codex"}},
+        )
+
+    app = _build_hub_messages_app(hub_env.hub_root, monkeypatch)
+    with TestClient(app) as client:
+        res = client.get("/hub/messages")
+
+    assert res.status_code == 200
+    diagnostics = res.json()["unreadable_diagnostics"]
+    gap = next(
+        item for item in diagnostics if item.get("section") == "ticket_flow_visibility"
+    )
+    assert gap["run_id"] == run_id
+    assert gap["ticket_id"] == "ticket-chat-gap"
+    assert gap["expected_link_key"] == f"ticket_flow:{run_id}:ticket-chat-gap"
+    assert "without a canonical orchestration managed-thread link" in gap["reason"]
 
 
 def test_hub_messages_distinguishes_no_dispatch_from_unreadable_dispatch(

--- a/tests/test_opencode_agent_pool.py
+++ b/tests/test_opencode_agent_pool.py
@@ -1271,7 +1271,7 @@ async def test_run_turn_supports_runtime_backed_hermes_agent(tmp_path: Path):
 
     threads = pool._thread_store.list_threads(agent="hermes", limit=1)
     assert len(threads) == 1
-    assert threads[0]["name"] == "ticket-flow:hermes"
+    assert threads[0]["name"] == "Ticket Flow (hermes)"
     assert harness.calls[0]["conversation_id"] == "session-1"
 
 
@@ -1356,7 +1356,7 @@ async def test_run_turn_uses_profile_aware_runtime_resolution_for_hermes_queue_d
                 for candidate in pool._thread_store.list_threads(
                     agent="hermes", limit=1
                 )
-                if candidate.get("name") == "ticket-flow:hermes@m4-pma"
+                if candidate.get("name") == "Ticket Flow tkt-123 (hermes@m4-pma)"
                 and isinstance(candidate.get("metadata"), dict)
                 and candidate["metadata"].get("agent_profile") == "m4-pma"
             ),
@@ -1365,11 +1365,13 @@ async def test_run_turn_uses_profile_aware_runtime_resolution_for_hermes_queue_d
         timeout_s=2.0,
     )
     thread_id = str(thread["managed_thread_id"])
-    assert thread["name"] == "ticket-flow:hermes@m4-pma"
+    assert thread["name"] == "Ticket Flow tkt-123 (hermes@m4-pma)"
     assert thread["metadata"]["agent_profile"] == "m4-pma"
     assert thread["metadata"]["run_id"] == "run-123"
+    assert thread["metadata"]["flow_run_id"] == "run-123"
     assert thread["metadata"]["ticket_id"] == "tkt-123"
     assert thread["metadata"]["ticket_path"] == options["ticket_path"]
+    assert thread["metadata"]["ticket_flow_link_key"] == "ticket_flow:run-123:tkt-123"
 
     second_task = asyncio.create_task(
         pool.run_turn(
@@ -1400,6 +1402,91 @@ async def test_run_turn_uses_profile_aware_runtime_resolution_for_hermes_queue_d
     assert factory.calls == [("hermes-m4-pma", None), ("hermes-m4-pma", None)]
     assert alias_harness.calls[0]["conversation_id"] == "session-1"
     assert alias_harness.calls[1]["conversation_id"] == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_run_turn_reuses_ticket_flow_thread_link_without_runner_state(
+    tmp_path: Path,
+):
+    harness = _FakeHarness(
+        [
+            _HarnessScript(assistant_text="done-1"),
+            _HarnessScript(assistant_text="done-2"),
+        ]
+    )
+    pool = _make_pool(tmp_path, harness, approval_mode="review")
+    options = {
+        "ticket_flow_run_id": "run-reuse",
+        "ticket_id": "tkt-reuse",
+        "ticket_path": ".codex-autorunner/tickets/TICKET-123.md",
+    }
+
+    first = await pool.run_turn(
+        AgentTurnRequest(
+            agent_id="codex",
+            prompt="first",
+            workspace_root=tmp_path,
+            options=options,
+        )
+    )
+    second = await pool.run_turn(
+        AgentTurnRequest(
+            agent_id="codex",
+            prompt="second",
+            workspace_root=tmp_path,
+            options=options,
+        )
+    )
+
+    assert first.conversation_id == second.conversation_id
+    threads = [
+        thread
+        for thread in pool._thread_store.list_threads(agent="codex", limit=10)
+        if isinstance(thread.get("metadata"), dict)
+        and thread["metadata"].get("ticket_flow_link_key")
+        == "ticket_flow:run-reuse:tkt-reuse"
+    ]
+    assert len(threads) == 1
+    assert harness.calls[0]["conversation_id"] == "session-1"
+    assert harness.calls[1]["conversation_id"] == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_failed_run_turn_still_persists_ticket_flow_link(tmp_path: Path):
+    harness = _FakeHarness(
+        [
+            _HarnessScript(
+                assistant_text="",
+                status="error",
+                errors=["runtime failed"],
+            )
+        ]
+    )
+    pool = _make_pool(tmp_path, harness, approval_mode="review")
+
+    result = await pool.run_turn(
+        AgentTurnRequest(
+            agent_id="codex",
+            prompt="first",
+            workspace_root=tmp_path,
+            options={
+                "ticket_flow_run_id": "run-failed",
+                "ticket_id": "tkt-failed",
+                "ticket_path": ".codex-autorunner/tickets/TICKET-999.md",
+            },
+        )
+    )
+
+    assert result.error
+    thread = pool._thread_store.get_thread(result.conversation_id)
+    assert thread is not None
+    metadata = thread["metadata"]
+    assert metadata["thread_kind"] == "ticket_flow"
+    assert metadata["flow_type"] == "ticket_flow"
+    assert metadata["run_id"] == "run-failed"
+    assert metadata["flow_run_id"] == "run-failed"
+    assert metadata["ticket_id"] == "tkt-failed"
+    assert metadata["ticket_flow_link_key"] == "ticket_flow:run-failed:tkt-failed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- define a canonical ticket-flow chat ledger contract and docs
- persist ticket-flow managed-thread links into orchestration state
- project flow/ticket visibility into Web Hub read models
- add repair/backfill support for missing ticket-flow chat visibility
- retire divergent status paths with regression coverage

## Root Cause
Ticket-flow execution state lived in repo-local `flows.db` and flow chat JSONL records, while Web Hub Chats only projected orchestration managed-thread state. A completed flow could therefore be visible in Discord status cards but absent from the Web Hub chat index.

## Validation
- `python3 .codex-autorunner/bin/lint_tickets.py`

## Notes
This PR is opened ready for review.