### PR TITLE
[codex] Separate injected prompt context in web chat

### DIFF
--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -2060,6 +2060,65 @@ textarea:hover {
   display: none;
 }
 
+.injected-prompt-card {
+  align-self: flex-end;
+  width: min(560px, 100%);
+  margin-left: auto;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--color-surface-muted) 84%, var(--color-bg));
+  color: var(--color-ink-muted);
+  overflow: hidden;
+}
+
+.injected-prompt-card > summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 32px;
+  padding: 6px var(--space-3);
+  cursor: pointer;
+  list-style: none;
+  color: var(--color-ink-muted);
+  font-size: var(--font-size-0);
+  font-weight: 700;
+}
+
+.injected-prompt-card > summary::-webkit-details-marker {
+  display: none;
+}
+
+.injected-prompt-card > summary::before {
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border: 4px solid transparent;
+  border-left-color: currentColor;
+  transition: transform 120ms ease;
+  flex-shrink: 0;
+}
+
+.injected-prompt-card[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.injected-prompt-card > summary span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.injected-prompt-body {
+  max-height: min(48vh, 520px);
+  overflow: auto;
+  border-top: 1px solid var(--color-border-subtle);
+  padding: var(--space-3);
+  color: var(--color-ink-soft);
+  font-size: var(--font-size-1);
+}
+
 .message-timestamp {
   display: block;
   margin-top: var(--space-2);

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
@@ -2,7 +2,13 @@
   import SurfaceArtifactCard from '$lib/components/SurfaceArtifactCard.svelte';
   import { withRuntimeBasePath as href } from '$lib/runtime/basePath';
   import { renderMarkdownToHtml } from '$lib/viewModels/contextspace';
-  import { compactChatTranscriptCards, formatCompactMessageDateTime, type ChatTranscriptCard, type ChatToolCallCard } from '$lib/viewModels/pmaChat';
+  import {
+    compactChatTranscriptCards,
+    formatCompactMessageDateTime,
+    splitInjectedPromptContext,
+    type ChatTranscriptCard,
+    type ChatToolCallCard
+  } from '$lib/viewModels/pmaChat';
   import type { SurfaceArtifact } from '$lib/viewModels/domain';
 
   let {
@@ -135,13 +141,25 @@
 {#each displayCards as card (card.id)}
   {#if card.kind === 'message'}
     {@const isStreaming = card.message.role === 'assistant' && card.id === streamingMessageId}
+    {@const promptParts = card.message.role === 'user' ? splitInjectedPromptContext(card.message.text) : null}
+    {@const visibleMessageText = promptParts?.userText ?? card.message.text}
+    {#if promptParts?.systemContext}
+      <details class="injected-prompt-card">
+        <summary>
+          <span>CAR system prompt</span>
+        </summary>
+        <div class="injected-prompt-body markdown-body">
+          {@html renderMarkdownToHtml(promptParts.systemContext, { openLinksInNewTab: true })}
+        </div>
+      </details>
+    {/if}
     <article class={`message ${card.message.role === 'user' ? 'user' : 'assistant'}`}>
       <span>{card.message.role === 'user' ? 'You' : assistantLabel}</span>
       {#if isStreaming}
-        <div class="message-markdown streaming">{card.message.text}</div>
+        <div class="message-markdown streaming">{visibleMessageText}</div>
       {:else}
         <div class="message-markdown markdown-body">
-          {@html renderMarkdownToHtml(card.message.text, { openLinksInNewTab: true })}
+          {@html renderMarkdownToHtml(visibleMessageText, { openLinksInNewTab: true })}
         </div>
       {/if}
       {#if card.message.role === 'user' && card.message.artifacts.length > 0}

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
@@ -201,4 +201,35 @@ describe('ChatTranscriptCards', () => {
     expect(body).toContain('datetime="2026-05-10T12:00:00.000Z"');
     expect(body).toContain('datetime="2026-05-10T12:05:00.000Z"');
   });
+
+  it('renders injected prompt context as a separate collapsed card above the user message', () => {
+    const cards: ChatTranscriptCard[] = [
+      {
+        kind: 'message',
+        id: 'u1',
+        turnId: 't1',
+        orderKey: '00000001|u1',
+        timestamp: '2026-05-10T12:00:00.000Z',
+        message: {
+          id: 'u1',
+          chatId: 'c1',
+          role: 'user',
+          text: '<injected context>\nCAR setup details\n</injected context>\n\nPlease fix the archive button.',
+          createdAt: '2026-05-10T12:00:00.000Z',
+          status: null,
+          artifacts: [],
+          raw: {}
+        }
+      }
+    ];
+
+    const { body } = render(ChatTranscriptCards, { props: { cards } });
+
+    expect(body).toContain('class="injected-prompt-card"');
+    expect(body).toContain('<span>CAR system prompt</span>');
+    expect(body).toContain('CAR setup details');
+    expect(body).toContain('Please fix the archive button.');
+    expect(body.indexOf('class="injected-prompt-card"')).toBeLessThan(body.indexOf('class="message user"'));
+    expect(body).not.toContain('&lt;injected context&gt;');
+  });
 });

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -44,6 +44,7 @@ import {
   removePendingAttachment,
   sortChatsUnreadFirst,
   sortChatsWaitingFirst,
+  splitInjectedPromptContext,
   summarizeFilterCounts,
   buildChatListEntries
 } from './pmaChat';
@@ -140,6 +141,17 @@ function baseArtifactCardTrace(id: string, text: string, eventIds: string[]) {
 }
 
 describe('PMA chat view helpers', () => {
+  it('splits injected prompt context out of user-visible message text', () => {
+    expect(
+      splitInjectedPromptContext(
+        '<injected context>\nSystem setup\n</injected context>\n\nFix this\n\n<injected context>\nArtifact delivery\n</injected context>'
+      )
+    ).toEqual({
+      userText: 'Fix this',
+      systemContext: 'System setup\n\n---\n\nArtifact delivery'
+    });
+  });
+
   it('collapses ticket-flow chats sharing a worktree into one run group, even without ticket ids', () => {
     const chats: PmaChatSummary[] = [
       { ...baseChat, id: 'tf-1', ticketId: null, isTicketFlow: true, worktreeId: 'wt-A', repoId: 'repo-1' },

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -1027,6 +1027,30 @@ export function compactChatTranscriptCards(cards: ChatTranscriptCard[]): ChatTra
   return summarizeTurnActivity(mergeIntermediateDeltas(foldAdjacentToolGroups(cards)));
 }
 
+export type UserMessagePromptParts = {
+  userText: string;
+  systemContext: string | null;
+};
+
+const INJECTED_CONTEXT_PATTERN = /<injected context>\s*([\s\S]*?)\s*<\/injected context>/gi;
+
+export function splitInjectedPromptContext(text: string): UserMessagePromptParts {
+  const contexts: string[] = [];
+  const userText = text
+    .replace(INJECTED_CONTEXT_PATTERN, (_match, context: string) => {
+      const trimmed = String(context ?? '').trim();
+      if (trimmed) contexts.push(trimmed);
+      return '\n\n';
+    })
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+  return {
+    userText,
+    systemContext: contexts.length ? contexts.join('\n\n---\n\n') : null
+  };
+}
+
 function foldAdjacentToolGroups(cards: ChatTranscriptCard[]): ChatTranscriptCard[] {
   const out: ChatTranscriptCard[] = [];
   for (const card of cards) {


### PR DESCRIPTION
## Summary
- split tagged `<injected context>` blocks out of web chat user message text
- render extracted context as a collapsed `CAR system prompt` disclosure above the cleaned user bubble
- cover the split helper and component rendering with frontend tests

## Validation
- `pnpm vitest run src/lib/components/ChatTranscriptCards.test.ts src/lib/viewModels/pmaChat.test.ts`
- `pnpm web:lint`
- `pnpm web:test`
- `pnpm run build`
- pre-commit web-ui lane passed with `CODEX_FAST_TEST_WORKERS=4 git commit ...` after two default-worker runs hit unrelated timing-test contention in repo-wide core pytest
