### PR TITLE
[codex] Preserve chat filter windows

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.test.ts
@@ -169,9 +169,9 @@ describe('chat index session', () => {
     expect(client.chatIndex).toHaveBeenCalledTimes(2);
     expect(client.chatIndex).toHaveBeenNthCalledWith(1, { filter: 'all', limit: 200 });
     expect(client.chatIndex).toHaveBeenNthCalledWith(2, { filter: 'archived', limit: 200 });
-    expect(store.snapshot().chatOrder).toEqual(['chat-archived']);
-    expect(Object.keys(store.snapshot().chats).sort()).toEqual(['chat-archived']);
-    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual([]);
+    expect(store.snapshot().chatOrder).toEqual(['chat-active', 'chat-archived']);
+    expect(Object.keys(store.snapshot().chats).sort()).toEqual(['chat-active', 'chat-archived']);
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual(['chat-active']);
     expect(selectChatIndexWindowView(store.snapshot(), { filter: 'archived', limit: 200 }).rows.map((row) => row.chatId)).toEqual(['chat-archived']);
   });
 

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -592,7 +592,7 @@ describe('read model entity store', () => {
     expect(view.rows[0].status).toBe('running');
   });
 
-  it('replaces the active chat index window when filters change', () => {
+  it('preserves bounded chat index windows when filters change', () => {
     const store = new ReadModelEntityStore();
     store.applyChatIndexSnapshot({
       cursor: cursor(1),
@@ -614,15 +614,18 @@ describe('read model entity store', () => {
       window: { limit: 200, totalIsExact: true, totalEstimate: 1 }
     }, { filter: 'archived', limit: 200 });
 
-    expect(Object.keys(store.snapshot().chats).sort()).toEqual(['chat-archived']);
-    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual([]);
+    expect(Object.keys(store.snapshot().chats).sort()).toEqual(['chat-active', 'chat-archived', 'chat-waiting']);
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual([
+      'chat-active',
+      'chat-waiting'
+    ]);
     expect(selectChatIndexWindowView(store.snapshot(), { filter: 'archived', limit: 200 }).rows.map((row) => row.chatId)).toEqual([
       'chat-archived'
     ]);
     expect(store.snapshot().chatCounters).toEqual({ total: 2, waiting: 1, running: 1, unread: 0, archived: 1 });
   });
 
-  it('keeps only the current chat index snapshot window hot', () => {
+  it('keeps previously loaded filter windows addressable after a default refresh', () => {
     const store = new ReadModelEntityStore();
     store.applyChatIndexSnapshot({
       cursor: cursor(1),
@@ -643,10 +646,21 @@ describe('read model entity store', () => {
       window: { limit: 200, totalIsExact: true, totalEstimate: 1 }
     }, { filter: 'archived', limit: 200 });
 
-    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual([]);
+    store.applyChatIndexSnapshot({
+      cursor: cursor(3),
+      rows: [chat('chat-visible')],
+      groups: [],
+      counters: { total: 1, waiting: 0, running: 0, unread: 0, archived: 1 },
+      filter: 'all',
+      query: null,
+      window: { limit: 50, totalIsExact: true, totalEstimate: 1 }
+    }, { filter: 'all', limit: 50 });
+
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual(['chat-active']);
     expect(selectChatIndexWindowView(store.snapshot(), { filter: 'archived', limit: 200 }).rows.map((row) => row.chatId)).toEqual(['chat-archived']);
     expect(selectChatIndexWindowView(store.snapshot(), { filter: 'waiting', limit: 200 }).rows).toEqual([]);
-    expect(Object.keys(store.snapshot().chats)).toEqual(['chat-archived']);
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 50 }).rows.map((row) => row.chatId)).toEqual(['chat-visible']);
+    expect(Object.keys(store.snapshot().chats).sort()).toEqual(['chat-active', 'chat-archived', 'chat-visible']);
   });
 
   it('applies entity chat-index patches once and marks the active cached window stale', () => {
@@ -681,7 +695,10 @@ describe('read model entity store', () => {
     })).toBe('applied');
 
     const activeWindow = selectChatIndexWindowView(store.snapshot(), { filter: 'active', limit: 200 });
-    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual([]);
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 200 }).rows.map((row) => row.chatId)).toEqual([
+      'chat-active',
+      'chat-waiting'
+    ]);
     expect(activeWindow.rows.map((row) => row.chatId)).toEqual([]);
     expect(activeWindow.window?.status).toBe('interrupted');
     expect(activeWindow.window?.refreshing).toBe(true);

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -248,13 +248,8 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
       limit: request.limit ?? snapshot.window?.limit
     });
     const windowKey = canonicalChatIndexWindowKey(windowRequest);
-    next.chatWindows = {};
-    next.chats = {};
-    next.chatGroups = {};
     for (const row of rows) next.chats[row.chatId] = row;
     for (const group of snapshot.groups) next.chatGroups[group.groupId] = group;
-    next.chatOrder = rows.map((row) => row.chatId);
-    next.chatGroupOrder = snapshot.groups.map((group) => group.groupId);
     if (isDefaultChatIndexWindow(windowRequest)) next.chatCounters = snapshot.counters;
     next.chatIndexCursor = snapshot.cursor;
     next.chatWindows[windowKey] = {
@@ -276,6 +271,7 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     for (const detail of Object.values(next.chatDetails)) {
       if (detail.thread) seedDetailBackedChatRow(next, detail.thread);
     }
+    rebuildChatIndexEntityOrder(next);
     for (const row of rows) bump(next, 'chat', row.chatId);
     for (const group of snapshot.groups) bump(next, 'chatGroup', group.groupId);
     pruneChatIndexCache(next);
@@ -982,6 +978,30 @@ function cloneChatIndexWindow(window: ChatIndexWindow): ChatIndexWindow {
     counters: { ...window.counters },
     window: window.window ? { ...window.window } : null
   };
+}
+
+function rebuildChatIndexEntityOrder(state: ReadModelEntityState): void {
+  const chatIds: string[] = [];
+  const groupIds: string[] = [];
+  const pushUnique = (target: string[], id: string): void => {
+    if (!target.includes(id)) target.push(id);
+  };
+  for (const window of Object.values(state.chatWindows)) {
+    for (const chatId of window.rowIds) {
+      if (state.chats[chatId]) pushUnique(chatIds, chatId);
+    }
+    for (const groupId of window.groupIds) {
+      if (state.chatGroups[groupId]) pushUnique(groupIds, groupId);
+    }
+  }
+  for (const chatId of state.chatOrder) {
+    if (state.chats[chatId]) pushUnique(chatIds, chatId);
+  }
+  for (const groupId of state.chatGroupOrder) {
+    if (state.chatGroups[groupId]) pushUnique(groupIds, groupId);
+  }
+  state.chatOrder = chatIds;
+  state.chatGroupOrder = groupIds;
 }
 
 function reconcileChatIndexWindowsAfterEntityPatch(next: ReadModelEntityState, event: ChatIndexPatchEvent): void {


### PR DESCRIPTION
## Summary

- Preserve previously loaded bounded chat-index windows when another filter window refreshes.
- Rebuild chat/group entity order from retained windows and detail-backed rows before pruning.
- Update chat index store/session tests to cover filter-window retention after default refreshes.

## Root Cause

Selecting a chat under a non-all filter navigates to the chat detail route. That route load fetches the default all chat-index window. The read-model store treated every chat-index snapshot as a full replacement and cleared the previously loaded filtered window and its rows. The chat page derives activeChat from the current filter window, so after the filtered row disappeared the master/detail layout entered detail mode with no active chat and rendered a blank surface.

## Validation

- pnpm web:test -- src/lib/data/readModelStore.test.ts src/routes/chats/load.test.ts src/routes/chats/page.test.ts
- pnpm web:lint
- pnpm web:test
- pnpm run build from src/codex_autorunner/web_frontend
- Commit hook web-ui lane: guardrails, mypy, pytest 8920 passed, Web UI lab fast check, web lint, web build, web tests 651 passed / 2 skipped, SPA shell check
