### PR TITLE
[codex] Make Web Hub route loads non-blocking

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.test.ts
@@ -37,6 +37,20 @@ describe('read model loaders', () => {
     expect(selectChatDetailView(store.snapshot(), 'chat-1').thread?.title).toBe('Chat detail');
   });
 
+  it('can return a cold placeholder on a cache miss without blocking route navigation', async () => {
+    const store = new ReadModelEntityStore();
+    const client = mockClient({
+      chatDetail: vi.fn().mockResolvedValue(ok(chatDetailSnapshot('chat-1')))
+    });
+    const { ensureChatDetailLoaded } = await importLoaders(true);
+
+    const result = await ensureChatDetailLoaded('chat-1', { store, client, blocking: false });
+
+    expect(result).toEqual({ status: 'cold', tags: ['entity:chat:chat-1'] });
+    expect(client.chatDetail).not.toHaveBeenCalled();
+    expect(selectChatDetailView(store.snapshot(), 'chat-1').thread).toBeNull();
+  });
+
   it('returns an error result without mutating the store when fetch fails', async () => {
     const store = new ReadModelEntityStore();
     const error = apiError('Snapshot unavailable');
@@ -79,6 +93,21 @@ describe('read model loaders', () => {
     expect(client.repoWorktreeRuntime).toHaveBeenCalledWith('all', 200);
     expect(store.snapshot().repos['repo-1']?.label).toBe('Repo One');
     expect(store.snapshot().runtime['repo:repo-1']?.activeRunStatus).toBe('running');
+  });
+
+  it('can defer repo-worktree index snapshots for non-blocking page loads', async () => {
+    const store = new ReadModelEntityStore();
+    const client = mockClient({
+      repoWorktreeTopology: vi.fn().mockResolvedValue(ok(repoWorktreeTopologySnapshot())),
+      repoWorktreeRuntime: vi.fn().mockResolvedValue(ok(repoWorktreeRuntimeSnapshot()))
+    });
+    const { ensureRepoWorktreeIndexLoaded } = await importLoaders(true);
+
+    const result = await ensureRepoWorktreeIndexLoaded({ store, client, blocking: false });
+
+    expect(result).toEqual({ status: 'cold', tags: ['entity:repo-worktree:index'] });
+    expect(client.repoWorktreeTopology).not.toHaveBeenCalled();
+    expect(client.repoWorktreeRuntime).not.toHaveBeenCalled();
   });
 
   it('allows repo-worktree index callers to request a smaller profile window explicitly', async () => {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.ts
@@ -18,6 +18,7 @@ export type ReadModelDepends = (...dependencies: ReadModelDependency[]) => void;
 export type ReadModelLoaderOptions = {
   depends?: ReadModelDepends;
   refresh?: boolean;
+  blocking?: boolean;
   stale?: (state: ReadModelEntityState) => boolean;
   store?: ReadModelEntityStore;
   client?: ReadModelSnapshotClient;
@@ -62,7 +63,9 @@ export async function ensureChatIndexLoaded(
   if (!browser) return { status: 'cold', tags };
 
   const state = store.snapshot();
-  if (!shouldRefresh(state, Boolean(state.chatIndexCursor), options)) return { status: 'cache-hit', tags };
+  const cached = Boolean(state.chatIndexCursor);
+  if (!shouldRefresh(state, cached, options)) return { status: 'cache-hit', tags };
+  if (options.blocking === false) return cached ? { status: 'cache-hit', tags } : { status: 'cold', tags };
 
   const client = options.client ?? readModelSnapshotClient;
   const result = await client.chatIndex(request);
@@ -83,6 +86,7 @@ export async function ensureChatDetailLoaded(
   const state = store.snapshot();
   const cached = Boolean(state.chatDetails[chatId]?.thread && state.timelines[chatId]);
   if (!shouldRefresh(state, cached, options)) return { status: 'cache-hit', tags };
+  if (options.blocking === false) return cached ? { status: 'cache-hit', tags } : { status: 'cold', tags };
 
   const client = options.client ?? readModelSnapshotClient;
   const result = await client.chatDetail(chatId, options.timelineLimit);
@@ -102,6 +106,7 @@ export async function ensureRepoWorktreeIndexLoaded(
   const state = store.snapshot();
   const cached = Boolean(state.cursors['repo_worktree.topology'] && state.cursors['repo_worktree.runtime']);
   if (!shouldRefresh(state, cached, options)) return { status: 'cache-hit', tags };
+  if (options.blocking === false) return cached ? { status: 'cache-hit', tags } : { status: 'cold', tags };
 
   const client = options.client ?? readModelSnapshotClient;
   const [topology, runtime] = await Promise.all([
@@ -131,6 +136,7 @@ export async function ensureTicketDetailLoaded(
   const state = store.snapshot();
   const cached = Boolean(state.tickets[ticketId] && state.cursors[`ticket.detail:${ticketId}`]);
   if (!shouldRefresh(state, cached, options)) return { status: 'cache-hit', tags };
+  if (options.blocking === false) return cached ? { status: 'cache-hit', tags } : { status: 'cold', tags };
 
   const client = options.client ?? readModelSnapshotClient;
   const result = await client.ticketDetail(ticketId, owner);
@@ -151,6 +157,7 @@ export async function ensureRepoDetailLoaded(
   const state = store.snapshot();
   const cached = Boolean(state.repoDetails[repoId]);
   if (!shouldRefresh(state, cached, options)) return { status: 'cache-hit', tags };
+  if (options.blocking === false) return cached ? { status: 'cache-hit', tags } : { status: 'cold', tags };
 
   const client = options.client ?? readModelSnapshotClient;
   const result = await client.repoDetail(repoId);
@@ -171,6 +178,7 @@ export async function ensureWorktreeDetailLoaded(
   const state = store.snapshot();
   const cached = Boolean(state.worktreeDetails[worktreeId]);
   if (!shouldRefresh(state, cached, options)) return { status: 'cache-hit', tags };
+  if (options.blocking === false) return cached ? { status: 'cache-hit', tags } : { status: 'cold', tags };
 
   const client = options.client ?? readModelSnapshotClient;
   const result = await client.worktreeDetail(worktreeId);
@@ -195,6 +203,7 @@ export async function ensureTicketIndexLoaded(
   const state = store.snapshot();
   const cached = Boolean(state.ticketOrderByOwner[ownerKey]);
   if (!shouldRefresh(state, cached, options)) return { status: 'cache-hit', tags };
+  if (options.blocking === false) return cached ? { status: 'cache-hit', tags } : { status: 'cold', tags };
 
   const client = options.client ?? readModelSnapshotClient;
   const result = await client.ticketIndex(options.owner);

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.ts
@@ -761,12 +761,15 @@ function mergeRunCards(
   parentRepoId: string | null = null
 ): RepoWorktreeRunCard[] {
   const cards = new Map<string, RepoWorktreeRunCard>();
+  const chatsById = new Map(chats.map((chat) => [chat.id, chat]));
+  const runChatIds = new Set<string>();
   for (const run of runs) {
-    const chat = run.chatId ? chats.find((candidate) => candidate.id === run.chatId) ?? null : null;
+    const chat = run.chatId ? chatsById.get(run.chatId) ?? null : null;
+    if (run.chatId) runChatIds.add(run.chatId);
     cards.set(`run:${run.id}`, runToCard(run, chat, scopeKind, scopeId, parentRepoId));
   }
   for (const chat of chats) {
-    if ([...cards.values()].some((card) => card.chatHref === `/chats?chat=${encodeURIComponent(chat.id)}`)) continue;
+    if (runChatIds.has(chat.id)) continue;
     cards.set(`chat:${chat.id}`, chatToCard(chat, scopeKind, scopeId, parentRepoId));
   }
   return [...cards.values()].sort(byRunRecent);

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/loadChatRoute.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/loadChatRoute.ts
@@ -27,7 +27,8 @@ export async function loadChatRoute(options: {
     {
       ...options.loaderOptions,
       depends: options.depends,
-      refresh: true
+      refresh: true,
+      blocking: options.loaderOptions?.blocking ?? false
     }
   );
   if (!chatId) return { chatId: null, chatIndex: await chatIndexPromise, activeDetail: null };
@@ -35,7 +36,8 @@ export async function loadChatRoute(options: {
   const activeDetailPromise = ensureChatDetailLoaded(chatId, {
     ...options.loaderOptions,
     depends: options.depends,
-    timelineLimit: CHAT_DETAIL_TIMELINE_LIMIT
+    timelineLimit: CHAT_DETAIL_TIMELINE_LIMIT,
+    blocking: options.loaderOptions?.blocking ?? false
   });
   const [chatIndex, activeDetail] = await Promise.all([chatIndexPromise, activeDetailPromise]);
 

--- a/src/codex_autorunner/web_frontend/src/routes/chats/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/load.test.ts
@@ -15,7 +15,7 @@ import type { ReadModelSnapshotClient } from '$lib/data/readModelClients';
 const now = '2026-05-11T12:00:00Z';
 
 describe('/chats route load', () => {
-  it('loads the chat index and returns list-mode data when no active chat id is present', async () => {
+  it('returns cold list-mode data without blocking navigation when no active chat id is present', async () => {
     const depends = vi.fn();
     const client = mockClient();
     const { loadChatRoute } = await importPageLoad(true);
@@ -24,12 +24,11 @@ describe('/chats route load', () => {
 
     expect(result).toEqual({
       chatId: null,
-      chatIndex: { status: 'fetched', tags: ['entity:chat:index'] },
+      chatIndex: { status: 'cold', tags: ['entity:chat:index'] },
       activeDetail: null
     });
     expect(depends).toHaveBeenCalledWith('entity:chat:index');
-    expect(client.chatIndex).toHaveBeenCalledTimes(1);
-    expect(client.chatIndex).toHaveBeenCalledWith({ limit: 50 });
+    expect(client.chatIndex).not.toHaveBeenCalled();
   });
 
   it('registers the chat index and active chat entity dependencies', async () => {
@@ -54,7 +53,7 @@ describe('/chats route load', () => {
 
     expect(result).toEqual({
       chatId: 'chat-1',
-      chatIndex: { status: 'fetched', tags: ['entity:chat:index'] },
+      chatIndex: { status: 'cold', tags: ['entity:chat:index'] },
       activeDetail: { status: 'cache-hit', tags: ['entity:chat:chat-1'] }
     });
     expect(result.activeDetail?.status).not.toBe('cold');
@@ -73,10 +72,10 @@ describe('/chats route load', () => {
     });
     const { loadChatRoute } = await importPageLoad(true);
 
-    await loadChatRoute({ loaderOptions: { store, client } });
+    await loadChatRoute({ loaderOptions: { store, client, blocking: true } });
     const firstOrder = [...store.snapshot().chatOrder];
     const firstTitles = firstOrder.map((id) => store.snapshot().chats[id]?.title);
-    await loadChatRoute({ loaderOptions: { store, client } });
+    await loadChatRoute({ loaderOptions: { store, client, blocking: true } });
 
     expect(client.chatIndex).toHaveBeenCalledTimes(2);
     expect(store.snapshot().chatOrder).toEqual(firstOrder);
@@ -91,7 +90,7 @@ describe('/chats route load', () => {
     });
     const { loadChatRoute } = await importPageLoad(true);
 
-    const result = await loadChatRoute({ chatId: 'chat-2', loaderOptions: { store, client } });
+    const result = await loadChatRoute({ chatId: 'chat-2', loaderOptions: { store, client, blocking: true } });
 
     expect(result.chatIndex.status).toBe('fetched');
     expect(result.activeDetail?.status).toBe('fetched');
@@ -107,7 +106,7 @@ describe('/chats route load', () => {
     });
     const { loadChatRoute } = await importPageLoad(true);
 
-    const result = await loadChatRoute({ chatId: 'chat-1', loaderOptions: { store, client } });
+    const result = await loadChatRoute({ chatId: 'chat-1', loaderOptions: { store, client, blocking: true } });
 
     expect(result).toEqual({
       chatId: 'chat-1',

--- a/src/codex_autorunner/web_frontend/src/routes/repos/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/+page.svelte
@@ -29,8 +29,9 @@
     })
   );
   let refreshing = $state<boolean>(false);
+  let coldHydrating = $state<boolean>(true);
   let refreshError = $state<ApiError | null>(null);
-  const loading = $derived(data.status === 'cold' || refreshing);
+  const loading = $derived((data.status === 'cold' && coldHydrating) || refreshing);
   const error = $derived(refreshError ?? (data.status === 'error' ? data.error : null));
   let sectionIssues = $state<PartialPageIssue[]>([]);
   let notice = $state<ActionNotice | null>(null);
@@ -45,6 +46,7 @@
     unsubscribeReadModels = readModelEntityStore.subscribe((state) => {
       readModelState = state;
     });
+    if (data.status === 'cold') void loadRepos();
   });
 
   onDestroy(() => {
@@ -55,11 +57,15 @@
     refreshing = true;
     refreshError = null;
     sectionIssues = [];
-    const result = await ensureRepoWorktreeIndexLoaded({ refresh: true });
-    if (result.status === 'error') {
-      refreshError = result.error;
+    try {
+      const result = await ensureRepoWorktreeIndexLoaded({ refresh: true });
+      if (result.status === 'error') {
+        refreshError = result.error;
+      }
+    } finally {
+      coldHydrating = false;
+      refreshing = false;
     }
-    refreshing = false;
   }
 
   async function handleCleanupWorktree(target: Parameters<typeof confirmAndCleanupWorktree>[0]): Promise<void> {

--- a/src/codex_autorunner/web_frontend/src/routes/repos/+page.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/+page.ts
@@ -1,4 +1,4 @@
 import { ensureRepoWorktreeIndexLoaded } from '$lib/data';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = ({ depends }) => ensureRepoWorktreeIndexLoaded({ depends });
+export const load: PageLoad = ({ depends }) => ensureRepoWorktreeIndexLoaded({ depends, blocking: false });

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/+page.svelte
@@ -62,8 +62,10 @@
     const snapshot = readModelEntityStore.snapshot().repoDetails[repoId];
     if (snapshot) {
       detail = buildDetailFromSnapshot(snapshot as unknown as Record<string, unknown>);
+      loading = false;
+      return;
     }
-    loading = false;
+    void loadRepoDetail(true);
   });
 
   async function loadRepoDetail(showLoading = true): Promise<void> {

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/+page.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/+page.ts
@@ -25,7 +25,8 @@ export async function loadRepoDetailRoute(options: {
     repoId,
     result: await ensureRepoDetailLoaded(repoId, {
       ...options.loaderOptions,
-      depends: options.depends
+      depends: options.depends,
+      blocking: options.loaderOptions?.blocking ?? false
     })
   };
 }

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/load.test.ts
@@ -25,7 +25,7 @@ describe('/repos/[repoId] route load', () => {
     expect(client.repoDetail).not.toHaveBeenCalled();
   });
 
-  it('fetches and hydrates a missing repo detail', async () => {
+  it('returns cold on a missing repo detail so navigation can commit immediately', async () => {
     const store = new ReadModelEntityStore();
     const client = mockClient({
       repoDetail: vi.fn().mockResolvedValue(ok(repoDetailSnapshot('repo-2')))
@@ -33,6 +33,20 @@ describe('/repos/[repoId] route load', () => {
     const { loadRepoDetailRoute } = await importPageLoad(true);
 
     const result = await loadRepoDetailRoute({ repoId: 'repo-2', loaderOptions: { store, client } });
+
+    expect(result.result).toEqual({ status: 'cold', tags: ['entity:repo:repo-2'] });
+    expect(client.repoDetail).not.toHaveBeenCalled();
+    expect(store.snapshot().repoDetails['repo-2']).toBeUndefined();
+  });
+
+  it('can fetch and hydrate a missing repo detail when explicitly blocking', async () => {
+    const store = new ReadModelEntityStore();
+    const client = mockClient({
+      repoDetail: vi.fn().mockResolvedValue(ok(repoDetailSnapshot('repo-2')))
+    });
+    const { loadRepoDetailRoute } = await importPageLoad(true);
+
+    const result = await loadRepoDetailRoute({ repoId: 'repo-2', loaderOptions: { store, client, blocking: true } });
 
     expect(result.result.status).toBe('fetched');
     expect(client.repoDetail).toHaveBeenCalledWith('repo-2');
@@ -50,7 +64,7 @@ describe('/repos/[repoId] route load', () => {
     expect(depends).toHaveBeenCalledWith('entity:repo:repo-1');
   });
 
-  it('returns an error handle when repo detail fetch fails', async () => {
+  it('returns an error handle when blocking repo detail fetch fails', async () => {
     const store = new ReadModelEntityStore();
     const error = apiError('Snapshot unavailable');
     const client = mockClient({
@@ -58,7 +72,7 @@ describe('/repos/[repoId] route load', () => {
     });
     const { loadRepoDetailRoute } = await importPageLoad(true);
 
-    const result = await loadRepoDetailRoute({ repoId: 'repo-1', loaderOptions: { store, client } });
+    const result = await loadRepoDetailRoute({ repoId: 'repo-1', loaderOptions: { store, client, blocking: true } });
 
     expect(result.result).toEqual({ status: 'error', tags: ['entity:repo:repo-1'], error });
     expect(store.snapshot().repoDetails['repo-1']).toBeUndefined();

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/tickets/[ticketId]/+page.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/tickets/[ticketId]/+page.ts
@@ -29,7 +29,8 @@ export async function loadRepoTicketDetailRoute(options: {
     ticketId,
     result: await ensureTicketDetailLoaded(ticketId, { kind: 'repo', id: repoId }, {
       ...options.loaderOptions,
-      depends: options.depends
+      depends: options.depends,
+      blocking: options.loaderOptions?.blocking ?? false
     })
   };
 }

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/tickets/[ticketId]/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/tickets/[ticketId]/load.test.ts
@@ -23,7 +23,7 @@ describe('/repos/[repoId]/tickets/[ticketId] route load', () => {
       repoId: 'repo-1',
       ticketId: 't-1',
       depends,
-      loaderOptions: { store, client }
+      loaderOptions: { store, client, blocking: true }
     });
 
     expect(result.repoId).toBe('repo-1');
@@ -53,7 +53,27 @@ describe('/repos/[repoId]/tickets/[ticketId] route load', () => {
     expect(client.ticketDetail).not.toHaveBeenCalled();
   });
 
-  it('returns error when ticket detail fetch fails', async () => {
+  it('returns cold without blocking when ticket detail is missing', async () => {
+    const store = new ReadModelEntityStore();
+    const client = mockClient({
+      ticketDetail: vi.fn().mockResolvedValue(ok(ticketDetailSnapshot('t-1', 'repo-1')))
+    });
+    const { loadRepoTicketDetailRoute } = await importPageLoad(true);
+
+    const result = await loadRepoTicketDetailRoute({
+      repoId: 'repo-1',
+      ticketId: 't-1',
+      loaderOptions: { store, client }
+    });
+
+    expect(result.result).toEqual({
+      status: 'cold',
+      tags: ['entity:ticket:t-1', 'entity:repo:repo-1']
+    });
+    expect(client.ticketDetail).not.toHaveBeenCalled();
+  });
+
+  it('returns error when blocking ticket detail fetch fails', async () => {
     const store = new ReadModelEntityStore();
     const error = apiError('Not found');
     const client = mockClient({
@@ -64,7 +84,7 @@ describe('/repos/[repoId]/tickets/[ticketId] route load', () => {
     const result = await loadRepoTicketDetailRoute({
       repoId: 'repo-1',
       ticketId: 't-1',
-      loaderOptions: { store, client }
+      loaderOptions: { store, client, blocking: true }
     });
 
     expect(result.result).toEqual({

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/worktrees/[worktreeId]/+page.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/worktrees/[worktreeId]/+page.ts
@@ -25,7 +25,8 @@ export async function loadWorktreeDetailRoute(options: {
     worktreeId,
     result: await ensureWorktreeDetailLoaded(worktreeId, {
       ...options.loaderOptions,
-      depends: options.depends
+      depends: options.depends,
+      blocking: options.loaderOptions?.blocking ?? false
     })
   };
 }

--- a/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/worktrees/[worktreeId]/tickets/[ticketId]/+page.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/[repoId]/worktrees/[worktreeId]/tickets/[ticketId]/+page.ts
@@ -29,7 +29,8 @@ export async function loadRepoWorktreeTicketDetailRoute(options: {
     ticketId,
     result: await ensureTicketDetailLoaded(ticketId, { kind: 'worktree', id: worktreeId }, {
       ...options.loaderOptions,
-      depends: options.depends
+      depends: options.depends,
+      blocking: options.loaderOptions?.blocking ?? false
     })
   };
 }

--- a/src/codex_autorunner/web_frontend/src/routes/tickets/+page.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/tickets/+page.ts
@@ -21,7 +21,8 @@ export async function loadTicketIndexRoute(options: {
   return {
     result: await ensureTicketIndexLoaded({
       ...options.loaderOptions,
-      depends: options.depends
+      depends: options.depends,
+      blocking: options.loaderOptions?.blocking ?? false
     })
   };
 }

--- a/src/codex_autorunner/web_frontend/src/routes/tickets/[ticketId]/+page.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/tickets/[ticketId]/+page.ts
@@ -30,7 +30,8 @@ export async function loadTicketDetailRoute(options: {
   const ticketId = options.ticketId ?? '';
   const indexResult = await ensureTicketIndexLoaded({
     ...options.loaderOptions,
-    depends: options.depends
+    depends: options.depends,
+    blocking: options.loaderOptions?.blocking ?? false
   });
 
   const store = options.loaderOptions?.store;
@@ -48,7 +49,8 @@ export async function loadTicketDetailRoute(options: {
     if (matched?.workspaceId && (matched.workspaceKind === 'repo' || matched.workspaceKind === 'worktree')) {
       detailResult = await ensureTicketDetailLoaded(ticketId, { kind: matched.workspaceKind, id: matched.workspaceId }, {
         ...options.loaderOptions,
-        depends: undefined
+        depends: undefined,
+        blocking: options.loaderOptions?.blocking ?? false
       });
     }
   }

--- a/src/codex_autorunner/web_frontend/src/routes/tickets/[ticketId]/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/tickets/[ticketId]/load.test.ts
@@ -22,7 +22,7 @@ describe('/tickets/[ticketId] route load', () => {
     });
     const { loadTicketDetailRoute } = await importPageLoad(true);
 
-    const result = await loadTicketDetailRoute({ ticketId: 't-1', depends, loaderOptions: { store, client } });
+    const result = await loadTicketDetailRoute({ ticketId: 't-1', depends, loaderOptions: { store, client, blocking: true } });
 
     expect(result.ticketId).toBe('t-1');
     expect(result.indexResult.status).toBe('fetched');
@@ -44,7 +44,7 @@ describe('/tickets/[ticketId] route load', () => {
     });
     const { loadTicketDetailRoute } = await importPageLoad(true);
 
-    await loadTicketDetailRoute({ ticketId: 't-1', depends, loaderOptions: { store, client } });
+    await loadTicketDetailRoute({ ticketId: 't-1', depends, loaderOptions: { store, client, blocking: true } });
 
     expect(client.ticketDetail).toHaveBeenCalledWith('t-1', { kind: 'repo', id: 'repo-right' });
   });
@@ -58,6 +58,19 @@ describe('/tickets/[ticketId] route load', () => {
     const result = await loadTicketDetailRoute({ ticketId: 't-1', loaderOptions: { store, client } });
 
     expect(result.indexResult).toEqual({ status: 'cache-hit', tags: ['entity:ticket:index'] });
+  });
+
+  it('returns cold and defers detail lookup when the ticket index is missing', async () => {
+    const store = new ReadModelEntityStore();
+    const client = mockClient();
+    const { loadTicketDetailRoute } = await importPageLoad(true);
+
+    const result = await loadTicketDetailRoute({ ticketId: 't-1', loaderOptions: { store, client } });
+
+    expect(result.indexResult).toEqual({ status: 'cold', tags: ['entity:ticket:index'] });
+    expect(result.detailResult).toBeNull();
+    expect(client.ticketIndex).not.toHaveBeenCalled();
+    expect(client.ticketDetail).not.toHaveBeenCalled();
   });
 
   it('returns cold when not in the browser', async () => {

--- a/src/codex_autorunner/web_frontend/src/routes/tickets/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/tickets/load.test.ts
@@ -12,7 +12,7 @@ import type { ReadModelSnapshotClient } from '$lib/data/readModelClients';
 const now = '2026-05-11T12:00:00Z';
 
 describe('/tickets route load', () => {
-  it('fetches and returns ticket index result', async () => {
+  it('returns cold without blocking navigation when the ticket index is missing', async () => {
     const store = new ReadModelEntityStore();
     const depends = vi.fn();
     const summaries = [ticketSummary('t-1', 'Ticket A')];
@@ -22,6 +22,23 @@ describe('/tickets route load', () => {
     const { loadTicketIndexRoute } = await importPageLoad(true);
 
     const result = await loadTicketIndexRoute({ depends, loaderOptions: { store, client } });
+
+    expect(result.result).toEqual({ status: 'cold', tags: ['entity:ticket:index'] });
+    expect(depends).toHaveBeenCalledWith('entity:ticket:index');
+    expect(client.ticketIndex).not.toHaveBeenCalled();
+    expect(store.snapshot().ticketOrderByOwner['all']).toBeUndefined();
+  });
+
+  it('can fetch and return ticket index result when explicitly blocking', async () => {
+    const store = new ReadModelEntityStore();
+    const depends = vi.fn();
+    const summaries = [ticketSummary('t-1', 'Ticket A')];
+    const client = mockClient({
+      ticketIndex: vi.fn().mockResolvedValue(ok(summaries))
+    });
+    const { loadTicketIndexRoute } = await importPageLoad(true);
+
+    const result = await loadTicketIndexRoute({ depends, loaderOptions: { store, client, blocking: true } });
 
     expect(result.result.status).toBe('fetched');
     expect(depends).toHaveBeenCalledWith('entity:ticket:index');

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/+page.svelte
@@ -28,8 +28,9 @@
     )
   );
   let refreshing = $state<boolean>(false);
+  let coldHydrating = $state<boolean>(true);
   let refreshError = $state<ApiError | null>(null);
-  const loading = $derived(data.status === 'cold' || refreshing);
+  const loading = $derived((data.status === 'cold' && coldHydrating) || refreshing);
   const error = $derived(refreshError ?? (data.status === 'error' ? data.error : null));
   let notice = $state<ActionNotice | null>(null);
 
@@ -37,6 +38,7 @@
     unsubscribeReadModels = readModelEntityStore.subscribe((state) => {
       readModelState = state;
     });
+    if (data.status === 'cold') void loadWorktrees();
   });
 
   onDestroy(() => {
@@ -46,11 +48,15 @@
   async function loadWorktrees(): Promise<void> {
     refreshing = true;
     refreshError = null;
-    const result = await ensureRepoWorktreeIndexLoaded({ refresh: true });
-    if (result.status === 'error') {
-      refreshError = result.error;
+    try {
+      const result = await ensureRepoWorktreeIndexLoaded({ refresh: true });
+      if (result.status === 'error') {
+        refreshError = result.error;
+      }
+    } finally {
+      coldHydrating = false;
+      refreshing = false;
     }
-    refreshing = false;
   }
 
   async function handleCleanupWorktree(target: Parameters<typeof confirmAndCleanupWorktree>[0]): Promise<void> {

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/+page.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/+page.ts
@@ -1,4 +1,4 @@
 import { ensureRepoWorktreeIndexLoaded } from '$lib/data';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = ({ depends }) => ensureRepoWorktreeIndexLoaded({ depends });
+export const load: PageLoad = ({ depends }) => ensureRepoWorktreeIndexLoaded({ depends, blocking: false });

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/+page.svelte
@@ -67,8 +67,10 @@
         return;
       }
       detail = buildDetailFromSnapshot(snapshot as unknown as Record<string, unknown>);
+      loading = false;
+      return;
     }
-    loading = false;
+    void loadWorktreeDetail(true);
   });
 
   async function loadWorktreeDetail(showLoading = true): Promise<void> {

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/+page.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/+page.ts
@@ -25,7 +25,8 @@ export async function loadWorktreeDetailRoute(options: {
     worktreeId,
     result: await ensureWorktreeDetailLoaded(worktreeId, {
       ...options.loaderOptions,
-      depends: options.depends
+      depends: options.depends,
+      blocking: options.loaderOptions?.blocking ?? false
     })
   };
 }

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/load.test.ts
@@ -23,7 +23,7 @@ describe('/worktrees/[worktreeId] route load', () => {
     expect(client.worktreeDetail).not.toHaveBeenCalled();
   });
 
-  it('fetches and hydrates a missing worktree detail', async () => {
+  it('returns cold on a missing worktree detail so navigation can commit immediately', async () => {
     const store = new ReadModelEntityStore();
     const client = mockClient({
       worktreeDetail: vi.fn().mockResolvedValue(ok(worktreeDetailSnapshot('wt-2')))
@@ -31,6 +31,20 @@ describe('/worktrees/[worktreeId] route load', () => {
     const { loadWorktreeDetailRoute } = await importPageLoad(true);
 
     const result = await loadWorktreeDetailRoute({ worktreeId: 'wt-2', loaderOptions: { store, client } });
+
+    expect(result.result).toEqual({ status: 'cold', tags: ['entity:worktree:wt-2'] });
+    expect(client.worktreeDetail).not.toHaveBeenCalled();
+    expect(store.snapshot().worktreeDetails['wt-2']).toBeUndefined();
+  });
+
+  it('can fetch and hydrate a missing worktree detail when explicitly blocking', async () => {
+    const store = new ReadModelEntityStore();
+    const client = mockClient({
+      worktreeDetail: vi.fn().mockResolvedValue(ok(worktreeDetailSnapshot('wt-2')))
+    });
+    const { loadWorktreeDetailRoute } = await importPageLoad(true);
+
+    const result = await loadWorktreeDetailRoute({ worktreeId: 'wt-2', loaderOptions: { store, client, blocking: true } });
 
     expect(result.result.status).toBe('fetched');
     expect(client.worktreeDetail).toHaveBeenCalledWith('wt-2');
@@ -48,7 +62,7 @@ describe('/worktrees/[worktreeId] route load', () => {
     expect(depends).toHaveBeenCalledWith('entity:worktree:wt-1');
   });
 
-  it('returns an error handle when worktree detail fetch fails', async () => {
+  it('returns an error handle when blocking worktree detail fetch fails', async () => {
     const store = new ReadModelEntityStore();
     const error = apiError('Snapshot unavailable');
     const client = mockClient({
@@ -56,7 +70,7 @@ describe('/worktrees/[worktreeId] route load', () => {
     });
     const { loadWorktreeDetailRoute } = await importPageLoad(true);
 
-    const result = await loadWorktreeDetailRoute({ worktreeId: 'wt-1', loaderOptions: { store, client } });
+    const result = await loadWorktreeDetailRoute({ worktreeId: 'wt-1', loaderOptions: { store, client, blocking: true } });
 
     expect(result.result).toEqual({ status: 'error', tags: ['entity:worktree:wt-1'], error });
     expect(store.snapshot().worktreeDetails['wt-1']).toBeUndefined();

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/tickets/[ticketId]/+page.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/tickets/[ticketId]/+page.ts
@@ -29,7 +29,8 @@ export async function loadWorktreeTicketDetailRoute(options: {
     ticketId,
     result: await ensureTicketDetailLoaded(ticketId, { kind: 'worktree', id: worktreeId }, {
       ...options.loaderOptions,
-      depends: options.depends
+      depends: options.depends,
+      blocking: options.loaderOptions?.blocking ?? false
     })
   };
 }

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/tickets/[ticketId]/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/[worktreeId]/tickets/[ticketId]/load.test.ts
@@ -23,7 +23,7 @@ describe('/worktrees/[worktreeId]/tickets/[ticketId] route load', () => {
       worktreeId: 'wt-1',
       ticketId: 't-1',
       depends,
-      loaderOptions: { store, client }
+      loaderOptions: { store, client, blocking: true }
     });
 
     expect(result.worktreeId).toBe('wt-1');
@@ -48,6 +48,26 @@ describe('/worktrees/[worktreeId]/tickets/[ticketId] route load', () => {
 
     expect(result.result).toEqual({
       status: 'cache-hit',
+      tags: ['entity:ticket:t-1', 'entity:worktree:wt-1']
+    });
+    expect(client.ticketDetail).not.toHaveBeenCalled();
+  });
+
+  it('returns cold without blocking when ticket detail is missing', async () => {
+    const store = new ReadModelEntityStore();
+    const client = mockClient({
+      ticketDetail: vi.fn().mockResolvedValue(ok(ticketDetailSnapshot('t-1', 'wt-1')))
+    });
+    const { loadWorktreeTicketDetailRoute } = await importPageLoad(true);
+
+    const result = await loadWorktreeTicketDetailRoute({
+      worktreeId: 'wt-1',
+      ticketId: 't-1',
+      loaderOptions: { store, client }
+    });
+
+    expect(result.result).toEqual({
+      status: 'cold',
       tags: ['entity:ticket:t-1', 'entity:worktree:wt-1']
     });
     expect(client.ticketDetail).not.toHaveBeenCalled();

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/load.test.ts
@@ -30,7 +30,7 @@ describe('/worktrees index route load', () => {
     expect(client.repoWorktreeTopology).not.toHaveBeenCalled();
   });
 
-  it('fetches and hydrates when the store is empty', async () => {
+  it('returns cold when the store is empty so navigation can commit immediately', async () => {
     const store = new ReadModelEntityStore();
     const client = mockClient();
     vi.doMock('$lib/data/readModelStore', () => ({ readModelEntityStore: store }));
@@ -39,9 +39,9 @@ describe('/worktrees index route load', () => {
 
     const result = await load({ depends: vi.fn() } as any) as any;
 
-    expect(result.status).toBe('fetched');
-    expect(client.repoWorktreeTopology).toHaveBeenCalled();
-    expect(client.repoWorktreeRuntime).toHaveBeenCalled();
+    expect(result.status).toBe('cold');
+    expect(client.repoWorktreeTopology).not.toHaveBeenCalled();
+    expect(client.repoWorktreeRuntime).not.toHaveBeenCalled();
   });
 
   it('returns cold when not in the browser', async () => {


### PR DESCRIPTION
## Summary

- Make Web Hub route loads non-blocking by default so top-level nav and repo/worktree detail clicks commit immediately instead of waiting for read-model snapshot HTTP calls.
- Hydrate cold repo, worktree, chat, ticket, and scoped detail data after page mount while preserving cache-hit behavior and explicit blocking loader support for tests/opt-in callers.
- Reduce repo/worktree VM merge work by replacing nested chat scans with lookup sets.

## Root Cause

SvelteKit page `load` functions awaited read-model snapshots on cold cache. Slow snapshots delayed route commitment, which made nav clicks and worktree detail clicks feel ignored. The repo/worktree VM also repeated per-row scans while building run cards.

## Validation

- `pnpm web:lint`
- `pnpm web:test`
- `pnpm run build` from `src/codex_autorunner/web_frontend`
- Commit hook web-ui lane: guardrails, mypy, 8920 pytest tests, Web UI lab, web lint, web build, web tests, SPA shell check
