### PR TITLE
[codex] Confine web-origin PMA notifications

### DIFF
--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -1516,6 +1516,8 @@ class PmaAutomationStore:
             metadata=metadata,
             origin_thread_id=origin_thread_id,
             origin_lane_id=origin_lane_id,
+            origin_surface_kind=origin_surface_kind,
+            origin_surface_key=origin_surface_key,
         )
         if not normalized_event_types:
             logger.warning(

--- a/src/codex_autorunner/core/pma_automation_store.py
+++ b/src/codex_autorunner/core/pma_automation_store.py
@@ -1443,11 +1443,15 @@ class PmaAutomationStore:
         metadata: Optional[dict[str, Any]],
         origin_thread_id: Optional[str] = None,
         origin_lane_id: Optional[str] = None,
+        origin_surface_kind: Optional[str] = None,
+        origin_surface_key: Optional[str] = None,
     ) -> dict[str, Any]:
         resolved_metadata = merge_pma_origin_metadata(
             metadata,
             origin_thread_id=origin_thread_id,
             origin_lane_id=origin_lane_id,
+            origin_surface_kind=origin_surface_kind,
+            origin_surface_key=origin_surface_key,
         )
         delivery_target = _normalize_delivery_target(
             resolved_metadata.get("delivery_target")
@@ -1494,6 +1498,8 @@ class PmaAutomationStore:
         metadata: Optional[dict[str, Any]] = None,
         origin_thread_id: Optional[str] = None,
         origin_lane_id: Optional[str] = None,
+        origin_surface_kind: Optional[str] = None,
+        origin_surface_key: Optional[str] = None,
     ) -> tuple[PmaLifecycleSubscription, bool]:
         key = _normalize_text(idempotency_key)
         normalized_event_types = self._normalize_subscription_event_types(event_types)
@@ -1560,6 +1566,10 @@ class PmaAutomationStore:
         normalized_idempotency_key = _normalize_text(data.get("idempotency_key"))
         normalized_origin_thread_id = _normalize_text(data.get("origin_thread_id"))
         normalized_origin_lane_id = _normalize_text(data.get("origin_lane_id"))
+        normalized_origin_surface_kind = _normalize_text(
+            data.get("origin_surface_kind")
+        )
+        normalized_origin_surface_key = _normalize_text(data.get("origin_surface_key"))
         confirm_duplicate = _normalize_bool(data.get("confirm"), fallback=False)
         is_auto_subscription = self._is_auto_subscription_key(
             normalized_idempotency_key
@@ -1618,6 +1628,8 @@ class PmaAutomationStore:
             ),
             origin_thread_id=normalized_origin_thread_id,
             origin_lane_id=normalized_origin_lane_id,
+            origin_surface_kind=normalized_origin_surface_kind,
+            origin_surface_key=normalized_origin_surface_key,
         )
         result = {"subscription": created.to_dict(), "deduped": deduped}
         scope_warning = _repo_scoped_subscription_warning(

--- a/src/codex_autorunner/core/pma_chat_delivery.py
+++ b/src/codex_autorunner/core/pma_chat_delivery.py
@@ -27,6 +27,7 @@ from .pma_domain.models import (
     PmaDeliveryTarget,
 )
 from .pma_domain.publish_policy import evaluate_publish_suppression
+from .pma_origin import extract_pma_origin_metadata
 from .text_utils import _normalize_optional_text, _normalize_pma_delivery_target
 
 logger = logging.getLogger(__name__)
@@ -172,6 +173,27 @@ def _attempts_from_dispatch_decision(
     return attempts
 
 
+def _context_origin_surface_kind(
+    context_payload: Optional[Mapping[str, Any]],
+) -> Optional[str]:
+    if not isinstance(context_payload, Mapping):
+        return None
+
+    def _from_metadata(metadata: Any) -> Optional[str]:
+        origin = extract_pma_origin_metadata(
+            metadata if isinstance(metadata, Mapping) else None
+        )
+        return _normalize_optional_text(origin.surface_kind) if origin else None
+
+    direct = _from_metadata(context_payload.get("metadata"))
+    if direct is not None:
+        return direct
+    wake_up = context_payload.get("wake_up")
+    if isinstance(wake_up, Mapping):
+        return _from_metadata(wake_up.get("metadata"))
+    return None
+
+
 async def deliver_pma_notification(
     *,
     hub_root: Path,
@@ -211,6 +233,10 @@ async def deliver_pma_notification(
             dispatch_decision=dispatch_decision,
             normalized_repo_id=normalized_repo_id,
         )
+        if _context_origin_surface_kind(context_payload) == "web":
+            persisted_attempts = [
+                attempt for attempt in persisted_attempts if attempt.route == "explicit"
+            ]
         suppression_target = _suppression_target_for_dispatch_decision_path(
             delivery_target=delivery_target,
             context_payload=context_payload,

--- a/src/codex_autorunner/core/pma_chat_delivery.py
+++ b/src/codex_autorunner/core/pma_chat_delivery.py
@@ -21,13 +21,15 @@ from .chat_bindings import (
     preferred_non_pma_chat_notification_source_for_workspace,
 )
 from .config import load_hub_config
-from .pma_dispatch_decision import _lane_delivery_target_from_context
+from .pma_dispatch_decision import (
+    _lane_delivery_target_from_context,
+    _origin_surface_from_context,
+)
 from .pma_domain.models import (
     PmaDeliveryAttempt,
     PmaDeliveryTarget,
 )
 from .pma_domain.publish_policy import evaluate_publish_suppression
-from .pma_origin import extract_pma_origin_metadata
 from .text_utils import _normalize_optional_text, _normalize_pma_delivery_target
 
 logger = logging.getLogger(__name__)
@@ -173,27 +175,6 @@ def _attempts_from_dispatch_decision(
     return attempts
 
 
-def _context_origin_surface_kind(
-    context_payload: Optional[Mapping[str, Any]],
-) -> Optional[str]:
-    if not isinstance(context_payload, Mapping):
-        return None
-
-    def _from_metadata(metadata: Any) -> Optional[str]:
-        origin = extract_pma_origin_metadata(
-            metadata if isinstance(metadata, Mapping) else None
-        )
-        return _normalize_optional_text(origin.surface_kind) if origin else None
-
-    direct = _from_metadata(context_payload.get("metadata"))
-    if direct is not None:
-        return direct
-    wake_up = context_payload.get("wake_up")
-    if isinstance(wake_up, Mapping):
-        return _from_metadata(wake_up.get("metadata"))
-    return None
-
-
 async def deliver_pma_notification(
     *,
     hub_root: Path,
@@ -233,7 +214,8 @@ async def deliver_pma_notification(
             dispatch_decision=dispatch_decision,
             normalized_repo_id=normalized_repo_id,
         )
-        if _context_origin_surface_kind(context_payload) == "web":
+        origin_surface = _origin_surface_from_context(context_payload)
+        if origin_surface is not None and origin_surface[0] == "web":
             persisted_attempts = [
                 attempt for attempt in persisted_attempts if attempt.route == "explicit"
             ]

--- a/src/codex_autorunner/core/pma_dispatch_decision.py
+++ b/src/codex_autorunner/core/pma_dispatch_decision.py
@@ -146,6 +146,33 @@ def _lane_delivery_target_from_context(
     )
 
 
+def _origin_surface_from_context(
+    context_payload: Optional[Mapping[str, Any]],
+) -> Optional[tuple[str, str]]:
+    if not isinstance(context_payload, Mapping):
+        return None
+
+    def _from_metadata(metadata: Any) -> Optional[tuple[str, str]]:
+        origin = extract_pma_origin_metadata(
+            metadata if isinstance(metadata, Mapping) else None
+        )
+        if origin is None:
+            return None
+        surface_kind = _normalize_optional_text(origin.surface_kind)
+        surface_key = _normalize_optional_text(origin.surface_key)
+        if surface_kind is None:
+            return None
+        return surface_kind, surface_key or ""
+
+    direct = _from_metadata(context_payload.get("metadata"))
+    if direct is not None:
+        return direct
+    wake_up = context_payload.get("wake_up")
+    if isinstance(wake_up, Mapping):
+        return _from_metadata(wake_up.get("metadata"))
+    return None
+
+
 def build_pma_dispatch_decision(
     *,
     message: str,
@@ -168,6 +195,10 @@ def build_pma_dispatch_decision(
     normalized_source_kind = _normalize_optional_text(source_kind) or "automation"
     normalized_repo_id = _normalize_optional_text(repo_id)
     lane_surface_binding = _surface_binding_from_lane_id(lane_id)
+    origin_surface = _origin_surface_from_context(context_payload)
+    external_fallback_allowed = not (
+        origin_surface is not None and origin_surface[0] == "web"
+    )
 
     if normalized_delivery == "none":
         return PmaDispatchDecision(requested_delivery="none")
@@ -221,7 +252,11 @@ def build_pma_dispatch_decision(
                 )
             )
 
-    if normalized_delivery in {"auto", "primary_pma"} and normalized_repo_id:
+    if (
+        external_fallback_allowed
+        and normalized_delivery in {"auto", "primary_pma"}
+        and normalized_repo_id
+    ):
         attempts.extend(
             PmaDispatchAttempt(
                 route="primary_pma",
@@ -238,7 +273,11 @@ def build_pma_dispatch_decision(
             for surface_kind in ("discord", "telegram")
         )
 
-    if normalized_delivery in {"auto", "bound"} and workspace_root is not None:
+    if (
+        external_fallback_allowed
+        and normalized_delivery in {"auto", "bound"}
+        and workspace_root is not None
+    ):
         attempts.extend(
             PmaDispatchAttempt(
                 route="bound",

--- a/src/codex_autorunner/core/pma_origin.py
+++ b/src/codex_autorunner/core/pma_origin.py
@@ -14,9 +14,20 @@ class PmaOriginContext:
     lane_id: Optional[str] = None
     agent: Optional[str] = None
     profile: Optional[str] = None
+    surface_kind: Optional[str] = None
+    surface_key: Optional[str] = None
 
     def is_empty(self) -> bool:
-        return not any((self.thread_id, self.lane_id, self.agent, self.profile))
+        return not any(
+            (
+                self.thread_id,
+                self.lane_id,
+                self.agent,
+                self.profile,
+                self.surface_kind,
+                self.surface_key,
+            )
+        )
 
     def to_metadata(self) -> dict[str, str]:
         metadata: dict[str, str] = {}
@@ -28,6 +39,10 @@ class PmaOriginContext:
             metadata["agent"] = self.agent
         if self.profile:
             metadata["profile"] = self.profile
+        if self.surface_kind:
+            metadata["surface_kind"] = self.surface_kind
+        if self.surface_key:
+            metadata["surface_key"] = self.surface_key
         return metadata
 
 
@@ -39,6 +54,8 @@ def normalize_pma_origin_context(value: Any) -> Optional[PmaOriginContext]:
         lane_id=_normalize_optional_text(value.get("lane_id")),
         agent=_normalize_optional_text(value.get("agent")),
         profile=_normalize_optional_text(value.get("profile")),
+        surface_kind=_normalize_optional_text(value.get("surface_kind")),
+        surface_key=_normalize_optional_text(value.get("surface_key")),
     )
     return None if origin.is_empty() else origin
 
@@ -60,6 +77,8 @@ def merge_pma_origin_metadata(
     origin: Optional[PmaOriginContext] = None,
     origin_thread_id: Optional[str] = None,
     origin_lane_id: Optional[str] = None,
+    origin_surface_kind: Optional[str] = None,
+    origin_surface_key: Optional[str] = None,
 ) -> dict[str, Any]:
     resolved = dict(metadata or {})
     existing_origin = extract_pma_origin_metadata(resolved)
@@ -81,6 +100,16 @@ def merge_pma_origin_metadata(
         profile=(
             (origin.profile if origin else None)
             or (existing_origin.profile if existing_origin else None)
+        ),
+        surface_kind=(
+            _normalize_optional_text(origin_surface_kind)
+            or (origin.surface_kind if origin else None)
+            or (existing_origin.surface_kind if existing_origin else None)
+        ),
+        surface_key=(
+            _normalize_optional_text(origin_surface_key)
+            or (origin.surface_key if origin else None)
+            or (existing_origin.surface_key if existing_origin else None)
         ),
     )
     if merged_origin.is_empty():

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_queue_execution.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_queue_execution.py
@@ -267,7 +267,15 @@ async def execute_queue_item(
         )
 
     started = await runtime.begin_turn(
-        client_turn_id, store=store, lane_id=getattr(item, "lane_id", None)
+        client_turn_id,
+        store=store,
+        lane_id=getattr(item, "lane_id", None),
+        origin_surface_kind=None if automation_trigger else "web",
+        origin_surface_key=(
+            None
+            if automation_trigger
+            else _normalize_optional_text(getattr(item, "lane_id", None))
+        ),
     )
     if not started:
         detail = "Another PMA turn is already active; queue item was not started"

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/runtime_state.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/runtime_state.py
@@ -157,6 +157,8 @@ class PmaRuntimeState:
         *,
         store: Optional[PmaStateStore] = None,
         lane_id: Optional[str] = None,
+        origin_surface_kind: Optional[str] = None,
+        origin_surface_key: Optional[str] = None,
     ) -> bool:
         async with await self.get_pma_lock():
             if self.pma_active:
@@ -169,6 +171,8 @@ class PmaRuntimeState:
                 "thread_id": None,
                 "turn_id": None,
                 "lane_id": lane_id or "",
+                "surface_kind": origin_surface_kind or "",
+                "surface_key": origin_surface_key or "",
                 "started_at": datetime.now(timezone.utc).isoformat(),
             }
         if store is not None:

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_followup.py
@@ -81,6 +81,10 @@ def build_managed_thread_terminal_notify_payload(
         payload["origin_thread_id"] = origin.thread_id
     if origin and origin.lane_id:
         payload["origin_lane_id"] = origin.lane_id
+    if origin and origin.surface_kind:
+        payload["origin_surface_kind"] = origin.surface_kind
+    if origin and origin.surface_key:
+        payload["origin_surface_key"] = origin.surface_key
     return payload
 
 
@@ -202,6 +206,10 @@ def apply_origin_followup_context(
         resolved_payload.setdefault("origin_thread_id", origin.thread_id)
     if origin.lane_id:
         resolved_payload.setdefault("origin_lane_id", origin.lane_id)
+    if origin.surface_kind:
+        resolved_payload.setdefault("origin_surface_kind", origin.surface_kind)
+    if origin.surface_key:
+        resolved_payload.setdefault("origin_surface_key", origin.surface_key)
     resolved_payload["metadata"] = merge_pma_origin_metadata(
         (
             resolved_payload.get("metadata")

--- a/tests/core/test_pma_chat_delivery.py
+++ b/tests/core/test_pma_chat_delivery.py
@@ -450,6 +450,81 @@ async def test_deliver_pma_notification_suppresses_duplicate_when_lane_explicit_
 
 
 @pytest.mark.anyio
+async def test_deliver_pma_notification_confines_persisted_web_origin_dispatch(
+    tmp_path: Path,
+) -> None:
+    hub_root = _hub(tmp_path)
+    workspace = (hub_root / "worktrees" / "repo-web-origin").resolve()
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_manifest(hub_root, "repo-web-origin", workspace)
+
+    discord_store = DiscordStateStore(
+        hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+    )
+    try:
+        await discord_store.upsert_binding(
+            channel_id="repo-web-origin-discord",
+            guild_id="guild-1",
+            workspace_path=str(workspace),
+            repo_id="repo-web-origin",
+        )
+        await discord_store.update_pma_state(
+            channel_id="repo-web-origin-discord",
+            pma_enabled=True,
+            pma_prev_workspace_path=str(workspace),
+            pma_prev_repo_id="repo-web-origin",
+        )
+
+        dispatch_decision = {
+            "suppress_publish": False,
+            "attempts": [
+                {
+                    "route": "primary_pma",
+                    "delivery_mode": "primary_pma",
+                    "surface_kind": "discord",
+                    "repo_id": "repo-web-origin",
+                },
+                {
+                    "route": "bound",
+                    "delivery_mode": "bound",
+                    "surface_kind": "discord",
+                    "repo_id": "repo-web-origin",
+                    "workspace_root": str(workspace),
+                },
+            ],
+        }
+
+        outcome = await deliver_pma_notification(
+            hub_root=hub_root,
+            repo_id="repo-web-origin",
+            workspace_root=workspace,
+            message="Web-origin completion",
+            correlation_id="corr-web-origin",
+            delivery="auto",
+            source_kind="managed_thread_completed",
+            managed_thread_id="managed-thread-web-origin",
+            context_payload={
+                "wake_up": {
+                    "metadata": {
+                        "pma_origin": {
+                            "thread_id": "pma-thread",
+                            "lane_id": "pma:default",
+                            "surface_kind": "web",
+                            "surface_key": "pma:default",
+                        }
+                    }
+                }
+            },
+            dispatch_decision=dispatch_decision,
+        )
+
+        assert outcome == {"route": "auto", "targets": 0, "published": 0}
+        assert await discord_store.list_outbox() == []
+    finally:
+        await discord_store.close()
+
+
+@pytest.mark.anyio
 async def test_deliver_pma_notification_does_not_suppress_duplicate_notice_without_thread_id(
     tmp_path: Path,
 ) -> None:

--- a/tests/core/test_pma_dispatch_decision.py
+++ b/tests/core/test_pma_dispatch_decision.py
@@ -366,3 +366,70 @@ def test_build_pma_dispatch_decision_keeps_surface_keys_empty_without_lane_id(
         None,
         None,
     ]
+
+
+def test_build_pma_dispatch_decision_confines_web_origin_without_explicit_target(
+    tmp_path: Path,
+) -> None:
+    decision = build_pma_dispatch_decision(
+        message="Web-origin follow-up",
+        requested_delivery="auto",
+        source_kind="managed_thread_completed",
+        repo_id="repo-a",
+        workspace_root=tmp_path / "repo-a",
+        managed_thread_id="watched-thread",
+        delivery_target=None,
+        context_payload={
+            "wake_up": {
+                "metadata": {
+                    "pma_origin": {
+                        "thread_id": "pma-thread",
+                        "lane_id": "pma:default",
+                        "surface_kind": "web",
+                        "surface_key": "pma:default",
+                    }
+                }
+            }
+        },
+        binding_metadata_by_thread={},
+        preferred_bound_surface_kinds=("discord", "telegram"),
+    )
+
+    assert decision.suppress_publish is False
+    assert decision.attempts == ()
+
+
+def test_build_pma_dispatch_decision_allows_explicit_target_from_web_origin(
+    tmp_path: Path,
+) -> None:
+    decision = build_pma_dispatch_decision(
+        message="Web-origin explicit follow-up",
+        requested_delivery="auto",
+        source_kind="managed_thread_completed",
+        repo_id="repo-a",
+        workspace_root=tmp_path / "repo-a",
+        managed_thread_id="watched-thread",
+        delivery_target=None,
+        context_payload={
+            "wake_up": {
+                "lane_id": "discord:12345",
+                "metadata": {
+                    "pma_origin": {
+                        "thread_id": "pma-thread",
+                        "lane_id": "pma:default",
+                        "surface_kind": "web",
+                        "surface_key": "pma:default",
+                    }
+                },
+            }
+        },
+        binding_metadata_by_thread={},
+        preferred_bound_surface_kinds=("discord", "telegram"),
+    )
+
+    assert [
+        (attempt.route, attempt.surface_kind, attempt.surface_key)
+        for attempt in decision.attempts
+    ] == [
+        ("explicit", "discord", "12345"),
+    ]

--- a/tests/surfaces/web/test_pma_common_service.py
+++ b/tests/surfaces/web/test_pma_common_service.py
@@ -332,6 +332,8 @@ async def test_managed_thread_automation_client_forwards_origin_thread_context(
             "lane_id": "discord",
             "agent": "hermes",
             "profile": "m4-pma",
+            "surface_kind": "web",
+            "surface_key": "pma:default",
         }
     )
     client = ManagedThreadAutomationClient(request, lambda: runtime_state)
@@ -369,11 +371,15 @@ async def test_managed_thread_automation_client_forwards_origin_thread_context(
     }
     assert captured["origin_thread_id"] == "pma-thread-1"
     assert captured["origin_lane_id"] == "discord"
+    assert captured["origin_surface_kind"] == "web"
+    assert captured["origin_surface_key"] == "pma:default"
     assert captured["metadata"]["pma_origin"] == {
         "thread_id": "pma-thread-1",
         "lane_id": "discord",
         "agent": "hermes",
         "profile": "m4-pma",
+        "surface_kind": "web",
+        "surface_key": "pma:default",
     }
 
 


### PR DESCRIPTION
## Summary
- add origin surface metadata to PMA origin propagation
- stamp direct web PMA turns with a web origin surface
- suppress repo-bound Discord/Telegram fallback for web-origin dispatches unless an explicit external target is provided

## Root cause
PMA origin metadata tracked thread/lane/agent/profile, but not the chat surface that initiated the PMA turn. A web-origin PMA follow-up could therefore fall through to repo-level primary PMA or bound chat delivery and publish into Discord/Telegram even when the initiating chat was web-only.

## Validation
- `.venv/bin/python -m pytest tests/core/test_pma_dispatch_decision.py tests/core/test_pma_chat_delivery.py tests/surfaces/web/test_pma_common_service.py`
- `.venv/bin/python -m pytest tests/core/test_pma_automation_store.py tests/test_managed_threads_routes.py tests/surfaces/web/routes/pma_routes/test_chat_runtime_execution_fresh_base_prompt.py`
- pre-commit `web-core-contract` lane: guardrails, mypy, 8923 pytest tests, web lint/build/test, SPA shell check