### PR TITLE
Fix Codex app-server process leaks

### DIFF
--- a/src/codex_autorunner/adapters/app_server/supervisor.py
+++ b/src/codex_autorunner/adapters/app_server/supervisor.py
@@ -5,7 +5,7 @@ import logging
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, Optional, Sequence
+from typing import Any, Callable, Dict, Optional, Sequence
 
 from ...core.logging_utils import log_event
 from ...core.managed_processes import reap_managed_processes
@@ -15,6 +15,16 @@ from ...workspace import canonical_workspace_root, workspace_id_for_path
 from .client import ApprovalHandler, CodexAppServerClient, NotificationHandler
 
 EnvBuilder = Callable[[Path, str, Path], Dict[str, str]]
+
+
+def _reap_and_list_codex_app_server_records(
+    registry_root: Path,
+) -> tuple[list[Any], Optional[Exception]]:
+    try:
+        reap_managed_processes(registry_root)
+        return list_process_records(registry_root, kind="codex_app_server"), None
+    except Exception as exc:
+        return [], exc
 
 
 @dataclass
@@ -248,12 +258,12 @@ class WorkspaceAppServerSupervisor:
             if existing is not None:
                 existing.last_used_at = time.monotonic()
                 return existing
+            await self._enforce_process_budget_locked(workspace_root)
             handles_to_close.extend(self._pop_idle_handles_locked())
             evicted = self._evict_lru_handle_locked()
             if evicted is not None:
                 evicted_id = evicted.workspace_id
                 handles_to_close.append(evicted)
-            self._enforce_process_budget_locked(workspace_root)
             state_dir = self._state_root / workspace_id
             env = self._env_builder(workspace_root, workspace_id, state_dir)
             client = CodexAppServerClient(
@@ -376,14 +386,14 @@ class WorkspaceAppServerSupervisor:
             state_dir=str(self._state_root / handle.workspace_id),
         )
 
-    def _enforce_process_budget_locked(self, workspace_root: Path) -> None:
+    async def _enforce_process_budget_locked(self, workspace_root: Path) -> None:
         if self._max_processes is None:
             return
         registry_root = self._registry_root or workspace_root
-        try:
-            reap_managed_processes(registry_root)
-            records = list_process_records(registry_root, kind="codex_app_server")
-        except Exception as exc:
+        records, exc = await asyncio.to_thread(
+            _reap_and_list_codex_app_server_records, registry_root
+        )
+        if exc is not None:
             log_event(
                 self._logger,
                 logging.WARNING,

--- a/src/codex_autorunner/adapters/app_server/supervisor.py
+++ b/src/codex_autorunner/adapters/app_server/supervisor.py
@@ -258,12 +258,40 @@ class WorkspaceAppServerSupervisor:
             if existing is not None:
                 existing.last_used_at = time.monotonic()
                 return existing
-            await self._enforce_process_budget_locked(workspace_root)
             handles_to_close.extend(self._pop_idle_handles_locked())
             evicted = self._evict_lru_handle_locked()
             if evicted is not None:
                 evicted_id = evicted.workspace_id
                 handles_to_close.append(evicted)
+
+        for handle in handles_to_close:
+            try:
+                reason = (
+                    "max_handles" if handle.workspace_id == evicted_id else "idle_ttl"
+                )
+                log_event(
+                    self._logger,
+                    logging.INFO,
+                    "app_server.handle.closing",
+                    reason=reason,
+                    workspace_id=handle.workspace_id,
+                    workspace_root=str(handle.workspace_root),
+                    idle_ttl_seconds=self._idle_ttl_seconds,
+                    max_handles=self._max_handles,
+                    last_used_at=handle.last_used_at,
+                )
+                await handle.client.close()
+            except Exception as exc:  # intentional: best-effort cleanup during eviction
+                self._logger.debug("Failed to close handle: %s", exc)
+                continue
+
+        await self._enforce_process_budget(workspace_root)
+
+        async with self._lock:
+            existing = self._handles.get(workspace_id)
+            if existing is not None:
+                existing.last_used_at = time.monotonic()
+                return existing
             state_dir = self._state_root / workspace_id
             env = self._env_builder(workspace_root, workspace_id, state_dir)
             client = CodexAppServerClient(
@@ -305,26 +333,6 @@ class WorkspaceAppServerSupervisor:
                 last_used_at=time.monotonic(),
             )
             self._handles[workspace_id] = handle
-        for handle in handles_to_close:
-            try:
-                reason = (
-                    "max_handles" if handle.workspace_id == evicted_id else "idle_ttl"
-                )
-                log_event(
-                    self._logger,
-                    logging.INFO,
-                    "app_server.handle.closing",
-                    reason=reason,
-                    workspace_id=handle.workspace_id,
-                    workspace_root=str(handle.workspace_root),
-                    idle_ttl_seconds=self._idle_ttl_seconds,
-                    max_handles=self._max_handles,
-                    last_used_at=handle.last_used_at,
-                )
-                await handle.client.close()
-            except Exception as exc:  # intentional: best-effort cleanup during eviction
-                self._logger.debug("Failed to close handle: %s", exc)
-                continue
         return handle
 
     async def _ensure_started(self, handle: AppServerHandle) -> None:
@@ -386,7 +394,7 @@ class WorkspaceAppServerSupervisor:
             state_dir=str(self._state_root / handle.workspace_id),
         )
 
-    async def _enforce_process_budget_locked(self, workspace_root: Path) -> None:
+    async def _enforce_process_budget(self, workspace_root: Path) -> None:
         if self._max_processes is None:
             return
         registry_root = self._registry_root or workspace_root

--- a/src/codex_autorunner/adapters/app_server/supervisor.py
+++ b/src/codex_autorunner/adapters/app_server/supervisor.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Callable, Dict, Optional, Sequence
 
 from ...core.logging_utils import log_event
+from ...core.managed_processes import reap_managed_processes
+from ...core.managed_processes.registry import list_process_records
 from ...core.supervisor_utils import evict_lru_handle_locked, pop_idle_handles_locked
 from ...workspace import canonical_workspace_root, workspace_id_for_path
 from .client import ApprovalHandler, CodexAppServerClient, NotificationHandler
@@ -91,6 +93,7 @@ class WorkspaceAppServerSupervisor:
         terminate_kill_seconds: Optional[float] = None,
         registry_root: Optional[Path] = None,
         runtime_profile: Optional[str] = None,
+        max_processes: Optional[int] = 6,
     ) -> None:
         self._command = [str(arg) for arg in command]
         self._state_root = state_root
@@ -129,6 +132,9 @@ class WorkspaceAppServerSupervisor:
         self._terminate_kill_seconds = terminate_kill_seconds
         self._registry_root = registry_root
         self._runtime_profile = runtime_profile
+        self._max_processes = (
+            max_processes if max_processes is not None and max_processes > 0 else None
+        )
         self._handles: dict[str, AppServerHandle] = {}
         self._lock = asyncio.Lock()
 
@@ -247,6 +253,7 @@ class WorkspaceAppServerSupervisor:
             if evicted is not None:
                 evicted_id = evicted.workspace_id
                 handles_to_close.append(evicted)
+            self._enforce_process_budget_locked(workspace_root)
             state_dir = self._state_root / workspace_id
             env = self._env_builder(workspace_root, workspace_id, state_dir)
             client = CodexAppServerClient(
@@ -367,6 +374,43 @@ class WorkspaceAppServerSupervisor:
             healthy=handle.started and self._client_pid(handle.client) is not None,
             last_used_at=handle.last_used_at,
             state_dir=str(self._state_root / handle.workspace_id),
+        )
+
+    def _enforce_process_budget_locked(self, workspace_root: Path) -> None:
+        if self._max_processes is None:
+            return
+        registry_root = self._registry_root or workspace_root
+        try:
+            reap_managed_processes(registry_root)
+            records = list_process_records(registry_root, kind="codex_app_server")
+        except Exception as exc:
+            log_event(
+                self._logger,
+                logging.WARNING,
+                "app_server.process_budget_check_failed",
+                max_processes=self._max_processes,
+                registry_root=str(registry_root),
+                exc=exc,
+            )
+            return
+        running_records = [
+            record
+            for record in records
+            if record.pid is not None or record.pgid is not None
+        ]
+        if len(running_records) < self._max_processes:
+            return
+        log_event(
+            self._logger,
+            logging.ERROR,
+            "app_server.process_budget_exceeded",
+            max_processes=self._max_processes,
+            process_records=len(running_records),
+            registry_root=str(registry_root),
+        )
+        raise RuntimeError(
+            "Codex app-server process budget exceeded "
+            f"({len(running_records)}/{self._max_processes}); waiting for reaper"
         )
 
     def _client_pid(self, client: CodexAppServerClient) -> Optional[int]:

--- a/src/codex_autorunner/adapters/discord/service.py
+++ b/src/codex_autorunner/adapters/discord/service.py
@@ -878,8 +878,8 @@ class DiscordBotService(DiscordInteractionResponseMixin):
                 self.app_server_events.handle_notification,
             ),
             logger=self._logger,
-            server_scope=getattr(root_app_server_config, "server_scope", "global"),
-            max_handles=getattr(root_app_server_config, "max_handles", 1),
+            server_scope="global",
+            max_handles=1,
             idle_ttl_seconds=getattr(root_app_server_config, "idle_ttl_seconds", 3600),
             startup_timeout_seconds=getattr(
                 root_app_server_config, "startup_timeout_seconds", 30
@@ -3279,40 +3279,25 @@ class DiscordBotService(DiscordInteractionResponseMixin):
     async def _app_server_supervisor_for_workspace(
         self, workspace_root: Path
     ) -> WorkspaceAppServerSupervisor:
-        repo_config = load_repo_config(
-            workspace_root,
-            hub_path=self._hub_config_path,
-        )
-        app_cfg = getattr(repo_config, "app_server", None)
-        scope = getattr(app_cfg, "server_scope", "global") if app_cfg else "global"
-        if scope != "workspace":
-            return self._app_server_supervisor
-        key = str(canonicalize_path(workspace_root))
+        workspace_supervisors: list[WorkspaceAppServerSupervisor] = []
         async with self._app_server_lock:
-            existing = self._app_server_workspace_supervisors.get(key)
-            if existing is not None:
-                return existing
-            command = list(getattr(app_cfg, "command", None) or ["codex", "app-server"])
-            supervisor = WorkspaceAppServerSupervisor(
-                command,
-                state_root=self._app_server_state_root,
-                env_builder=self._build_workspace_env,
-                notification_handler=cast(
-                    Callable[[Mapping[str, object]], Awaitable[None]],
-                    self.app_server_events.handle_notification,
-                ),
-                logger=self._logger,
-                server_scope="workspace",
-                max_handles=getattr(app_cfg, "max_handles", 1),
-                idle_ttl_seconds=getattr(app_cfg, "idle_ttl_seconds", 3600),
-                startup_timeout_seconds=getattr(app_cfg, "startup_timeout_seconds", 30),
-                terminate_grace_seconds=getattr(app_cfg, "terminate_grace_seconds", 2),
-                terminate_kill_seconds=getattr(app_cfg, "terminate_kill_seconds", 3),
-                registry_root=getattr(self, "_hub_root", None) or self._config.root,
-            )
-            self._app_server_workspace_supervisors[key] = supervisor
-            self._runtime_services.register_owned_supervisor(supervisor)
-            return supervisor
+            if self._app_server_workspace_supervisors:
+                workspace_supervisors = list(
+                    self._app_server_workspace_supervisors.values()
+                )
+                self._app_server_workspace_supervisors.clear()
+        for supervisor in workspace_supervisors:
+            try:
+                await supervisor.close_all()
+            except Exception as exc:
+                log_event(
+                    self._logger,
+                    logging.WARNING,
+                    "discord.app_server.workspace_supervisor_close_failed",
+                    workspace_root=str(workspace_root),
+                    exc=exc,
+                )
+        return self._app_server_supervisor
 
     async def _client_for_workspace(
         self, workspace_path: Optional[str]

--- a/src/codex_autorunner/core/managed_processes/__init__.py
+++ b/src/codex_autorunner/core/managed_processes/__init__.py
@@ -1,4 +1,5 @@
 from .reaper import (
+    CODEX_APP_SERVER_WORKSPACE_MAX_AGE_SECONDS,
     DEFAULT_MAX_RECORD_AGE_SECONDS,
     ReapSummary,
     reap_managed_processes,
@@ -13,6 +14,7 @@ from .registry import (
 
 __all__ = [
     "DEFAULT_MAX_RECORD_AGE_SECONDS",
+    "CODEX_APP_SERVER_WORKSPACE_MAX_AGE_SECONDS",
     "ProcessRecord",
     "ReapSummary",
     "delete_process_record",

--- a/src/codex_autorunner/core/managed_processes/reaper.py
+++ b/src/codex_autorunner/core/managed_processes/reaper.py
@@ -25,6 +25,7 @@ REAPER_GRACE_SECONDS: Final = 0.2
 REAPER_KILL_SECONDS: Final = 0.2
 
 DEFAULT_MAX_RECORD_AGE_SECONDS = 6 * 60 * 60
+CODEX_APP_SERVER_WORKSPACE_MAX_AGE_SECONDS = 5 * 60
 _OWNER_PROCESS_CMD_HINTS: Final = ("codex_autorunner", "codex-autorunner", "car ")
 
 
@@ -56,6 +57,14 @@ def _is_older_than(record: ProcessRecord, max_age_seconds: int) -> bool:
         return True
     threshold = datetime.now(timezone.utc) - timedelta(seconds=max_age_seconds)
     return started < threshold
+
+
+def _is_stale_workspace_codex_app_server(record: ProcessRecord) -> bool:
+    if record.kind != "codex_app_server":
+        return False
+    if record.metadata.get("server_scope") != "workspace":
+        return False
+    return _is_older_than(record, CODEX_APP_SERVER_WORKSPACE_MAX_AGE_SECONDS)
 
 
 @dataclass
@@ -151,7 +160,10 @@ def reap_managed_processes(
                 owner_running = False
                 owner_mismatch = True
         record_old = _is_older_than(record, max_record_age_seconds)
-        should_reap = force or (not owner_running) or record_old
+        stale_workspace_codex = _is_stale_workspace_codex_app_server(record)
+        should_reap = (
+            force or (not owner_running) or record_old or stale_workspace_codex
+        )
 
         if not should_reap:
             summary.skipped += 1

--- a/tests/adapters/discord/test_service_startup.py
+++ b/tests/adapters/discord/test_service_startup.py
@@ -465,7 +465,7 @@ async def test_service_exposes_app_server_event_buffer_context(
 
 
 @pytest.mark.anyio
-async def test_workspace_supervisor_uses_resolved_repo_app_server_command(
+async def test_workspace_app_server_config_uses_hub_singleton_command(
     tmp_path: Path, monkeypatch
 ) -> None:
     captured: list[dict[str, object]] = []
@@ -501,7 +501,7 @@ async def test_workspace_supervisor_uses_resolved_repo_app_server_command(
     try:
         await service._app_server_supervisor_for_workspace(workspace)
         assert captured
-        assert captured[0]["command"] == ["/custom/codex", "app-server", "--x"]
+        assert captured[0]["command"] == ["codex", "app-server"]
     finally:
         await store.close()
 
@@ -525,7 +525,7 @@ async def test_app_server_supervisor_is_shared_across_workspaces(
         lambda *args, **kwargs: SimpleNamespace(
             app_server=SimpleNamespace(
                 command=["/custom/codex", "app-server"],
-                server_scope="global",
+                server_scope="workspace",
                 max_handles=1,
                 idle_ttl_seconds=3600,
                 startup_timeout_seconds=30,
@@ -559,7 +559,7 @@ async def test_app_server_supervisor_is_shared_across_workspaces(
 
         assert supervisor_a is supervisor_b
         assert supervisor_a is service._runtime_services.app_server_supervisor
-        assert captured == [["/custom/codex", "app-server"]]
+        assert captured == [["codex", "app-server"]]
     finally:
         await service._runtime_services.close()
         await store.close()

--- a/tests/fixtures/app_server_fixture.py
+++ b/tests/fixtures/app_server_fixture.py
@@ -101,6 +101,8 @@ class FixtureServer:
             self._send_error(req_id, "not initialized")
             return
         if method == "initialize":
+            if self._scenario == "initialize_hang":
+                time.sleep(60)
             self._initialized = True
             self.send(
                 {

--- a/tests/test_app_server_client.py
+++ b/tests/test_app_server_client.py
@@ -95,6 +95,32 @@ async def test_request_response_out_of_order(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
+async def test_startup_timeout_terminates_hung_initialize_and_allows_fresh_start(
+    tmp_path: Path,
+) -> None:
+    client = CodexAppServerClient(
+        fixture_command("initialize_hang"),
+        cwd=tmp_path,
+        startup_timeout_seconds=0.2,
+    )
+
+    try:
+        with pytest.raises(CodexAppServerDisconnected, match="startup timed out"):
+            await client.start()
+
+        assert client._process is None
+        assert client._initialized is False
+
+        client._command = fixture_command("basic")
+        await client.start()
+
+        assert client._process is not None
+        assert client._initialized is True
+    finally:
+        await client.close()
+
+
+@pytest.mark.anyio
 async def test_turn_completion_and_agent_message(tmp_path: Path) -> None:
     client = CodexAppServerClient(fixture_command("basic"), cwd=tmp_path)
     try:

--- a/tests/test_app_server_supervisor.py
+++ b/tests/test_app_server_supervisor.py
@@ -313,3 +313,99 @@ async def test_lifecycle_snapshot_reports_global_handle_fields(
     assert snapshot.handles[0].handle_id == "global"
     assert snapshot.handles[0].pid == 43210
     assert snapshot.handles[0].state_dir == str(tmp_path / "state" / "global")
+
+
+@pytest.mark.anyio
+async def test_process_budget_rejects_new_app_server_spawn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FakeClient:
+        instances: list["FakeClient"] = []
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            FakeClient.instances.append(self)
+
+        async def start(self) -> None:
+            return
+
+        async def close(self) -> None:
+            return
+
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.app_server.supervisor.CodexAppServerClient",
+        FakeClient,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.app_server.supervisor.reap_managed_processes",
+        lambda _root: None,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.app_server.supervisor.list_process_records",
+        lambda _root, kind=None: [
+            type("Record", (), {"pid": 1001, "pgid": 1001})(),
+            type("Record", (), {"pid": 1002, "pgid": 1002})(),
+        ],
+    )
+
+    supervisor = WorkspaceAppServerSupervisor(
+        [sys.executable, "-c", "print('noop')"],
+        state_root=tmp_path / "state",
+        env_builder=lambda _root, _id, _state: {},
+        registry_root=tmp_path,
+        max_processes=2,
+    )
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+
+    with pytest.raises(RuntimeError, match="process budget exceeded"):
+        await supervisor.get_client(workspace)
+
+    assert FakeClient.instances == []
+
+
+@pytest.mark.anyio
+async def test_process_budget_allows_spawn_after_reaper_reduces_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FakeClient:
+        instances: list["FakeClient"] = []
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            FakeClient.instances.append(self)
+
+        async def start(self) -> None:
+            return
+
+        async def close(self) -> None:
+            return
+
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.app_server.supervisor.CodexAppServerClient",
+        FakeClient,
+    )
+    reaped: list[Path] = []
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.app_server.supervisor.reap_managed_processes",
+        lambda root: reaped.append(root),
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.app_server.supervisor.list_process_records",
+        lambda _root, kind=None: [
+            type("Record", (), {"pid": 1001, "pgid": 1001})(),
+        ],
+    )
+
+    supervisor = WorkspaceAppServerSupervisor(
+        [sys.executable, "-c", "print('noop')"],
+        state_root=tmp_path / "state",
+        env_builder=lambda _root, _id, _state: {},
+        registry_root=tmp_path,
+        max_processes=2,
+    )
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+
+    await supervisor.get_client(workspace)
+
+    assert reaped == [tmp_path]
+    assert len(FakeClient.instances) == 1

--- a/tests/test_app_server_supervisor.py
+++ b/tests/test_app_server_supervisor.py
@@ -409,3 +409,59 @@ async def test_process_budget_allows_spawn_after_reaper_reduces_records(
 
     assert reaped == [tmp_path]
     assert len(FakeClient.instances) == 1
+
+
+@pytest.mark.anyio
+async def test_process_budget_rejection_closes_evicted_handles_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Evicted LRU handles must close before budget enforcement can raise."""
+
+    closed_handle_ids: list[str] = []
+
+    class FakeClient:
+        instances: list["FakeClient"] = []
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+            FakeClient.instances.append(self)
+
+        async def start(self) -> None:
+            return
+
+        async def close(self) -> None:
+            closed_handle_ids.append(str(self.kwargs["handle_id"]))
+
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.app_server.supervisor.CodexAppServerClient",
+        FakeClient,
+    )
+
+    supervisor = WorkspaceAppServerSupervisor(
+        [sys.executable, "-c", "print('noop')"],
+        state_root=tmp_path / "state",
+        env_builder=lambda _root, _id, _state: {},
+        server_scope="workspace",
+        max_handles=1,
+        registry_root=tmp_path,
+        max_processes=2,
+    )
+    one = tmp_path / "one"
+    two = tmp_path / "two"
+    one.mkdir()
+    two.mkdir()
+
+    await supervisor.get_client(one)
+    assert len(FakeClient.instances) == 1
+    first_handle_id = str(FakeClient.instances[0].kwargs["handle_id"])
+
+    async def reject_budget(_workspace_root: Path) -> None:
+        raise RuntimeError("process budget exceeded (test)")
+
+    monkeypatch.setattr(supervisor, "_enforce_process_budget", reject_budget)
+
+    with pytest.raises(RuntimeError, match="process budget exceeded"):
+        await supervisor.get_client(two)
+
+    assert closed_handle_ids == [first_handle_id]
+    assert len(FakeClient.instances) == 1

--- a/tests/test_managed_process_reaper.py
+++ b/tests/test_managed_process_reaper.py
@@ -303,6 +303,86 @@ def test_reaper_reaps_old_records_even_if_owner_running(
     assert kill_calls == [(5111, signal.SIGTERM), (5111, signal.SIGKILL)]
 
 
+def test_reaper_reaps_stale_workspace_codex_app_server_even_if_owner_running(
+    monkeypatch, tmp_path: Path
+) -> None:
+    rec = _record(
+        kind="codex_app_server",
+        workspace_id="ws-codex",
+        pid=5211,
+        pgid=5211,
+        owner_pid=1234,
+        started_at=(datetime.now(timezone.utc) - timedelta(seconds=6 * 60))
+        .isoformat()
+        .replace("+00:00", "Z"),
+    )
+    rec.metadata = {"server_scope": "workspace"}
+    registry.write_process_record(tmp_path, rec)
+    monkeypatch.setattr(reaper_module, "REAPER_GRACE_SECONDS", 0.0)
+    monkeypatch.setattr(reaper_module, "REAPER_KILL_SECONDS", 0.0)
+    monkeypatch.setattr(
+        "codex_autorunner.core.managed_processes.reaper._pid_is_running",
+        lambda pid: pid == 1234,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.managed_processes.reaper._pgid_is_running",
+        lambda _pgid: False,
+    )
+    killpg_calls: list[tuple[int, int]] = []
+    kill_calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        "codex_autorunner.core.process_termination.os.killpg",
+        lambda pgid, sig: killpg_calls.append((pgid, sig)),
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.process_termination.os.kill",
+        lambda pid, sig: kill_calls.append((pid, sig)),
+    )
+
+    summary = reap_managed_processes(tmp_path, max_record_age_seconds=24 * 60 * 60)
+
+    assert summary.removed == 1
+    assert summary.skipped == 0
+    assert killpg_calls == [(5211, signal.SIGTERM), (5211, signal.SIGKILL)]
+    assert kill_calls == [(5211, signal.SIGTERM), (5211, signal.SIGKILL)]
+    assert (
+        registry.read_process_record(tmp_path, "codex_app_server", "ws-codex") is None
+    )
+
+
+def test_reaper_preserves_old_global_codex_app_server_when_owner_running(
+    monkeypatch, tmp_path: Path
+) -> None:
+    rec = _record(
+        kind="codex_app_server",
+        workspace_id="global",
+        pid=5311,
+        pgid=5311,
+        owner_pid=1234,
+        started_at=(datetime.now(timezone.utc) - timedelta(seconds=6 * 60))
+        .isoformat()
+        .replace("+00:00", "Z"),
+    )
+    rec.metadata = {"server_scope": "global"}
+    registry.write_process_record(tmp_path, rec)
+    monkeypatch.setattr(
+        "codex_autorunner.core.managed_processes.reaper._pid_is_running",
+        lambda pid: pid == 1234,
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.managed_processes.reaper._pgid_is_running",
+        lambda _pgid: False,
+    )
+
+    summary = reap_managed_processes(tmp_path, max_record_age_seconds=24 * 60 * 60)
+
+    assert summary.removed == 0
+    assert summary.skipped == 1
+    assert (
+        registry.read_process_record(tmp_path, "codex_app_server", "global") is not None
+    )
+
+
 def test_reaper_treats_zombie_owner_pid_as_not_running(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- force Discord Codex app-server usage through a single hub-scoped supervisor, ignoring repo-level workspace scope for this runtime
- add app-server process-budget enforcement that reaps managed records before allowing a new spawn
- reap stale workspace-scoped Codex app-server process records after 5 minutes while preserving live global singleton records
- add regression coverage for initialize timeout recovery, process budget rejection, stale workspace reaping, and Discord singleton routing

## Validation
- pre-commit aggregate lane passed:
  - black + ruff + import/contract guardrails
  - mypy strict over `src/codex_autorunner`
  - `8923 passed` Python tests
  - Web UI lab fast check, Svelte check, static build, Vitest `651 passed`
- focused run before commit: `.venv/bin/python -m pytest tests/test_app_server_client.py tests/test_app_server_supervisor.py tests/test_managed_process_reaper.py tests/adapters/discord/test_service_startup.py -q` (`85 passed`)

Closes #1793
