### PR TITLE
[codex] Ensure SCM enqueues start queue workers

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/scm_webhooks.py
+++ b/src/codex_autorunner/surfaces/web/routes/scm_webhooks.py
@@ -29,10 +29,12 @@ from ....core.scm_webhook_config import (
     resolve_github_webhook_config,
     resolve_payload_limits,
 )
+from .pma_routes.managed_thread_runtime import ensure_managed_thread_queue_worker
 
 ScmDrainCallback = Callable[[Request, ScmEvent], object]
 _DEFAULT_INSPECT_LIMIT = 50
 _MAX_INSPECT_LIMIT = 200
+logger = logging.getLogger(__name__)
 
 
 def _to_webhook_config(resolved) -> GitHubWebhookConfig:
@@ -135,9 +137,40 @@ def _default_drain_callback_factory(
 
     def callback(_request: Request, event: ScmEvent) -> None:
         service.ingest_event(event)
-        service.process_now()
+        processed = service.process_now()
+        _ensure_managed_thread_queue_workers_for_scm_operations(_request, processed)
 
     return callback
+
+
+def _ensure_managed_thread_queue_workers_for_scm_operations(
+    request: Request,
+    processed_operations: object,
+) -> None:
+    if not isinstance(processed_operations, (list, tuple)):
+        return
+    ensured_thread_ids: set[str] = set()
+    for operation in processed_operations:
+        if getattr(operation, "operation_kind", None) != "enqueue_managed_turn":
+            continue
+        if getattr(operation, "state", None) not in {"succeeded", "effect_applied"}:
+            continue
+        response = getattr(operation, "response", None)
+        if not isinstance(response, dict):
+            continue
+        thread_target_id = str(response.get("thread_target_id") or "").strip()
+        if not thread_target_id or thread_target_id in ensured_thread_ids:
+            continue
+        ensured_thread_ids.add(thread_target_id)
+        try:
+            ensure_managed_thread_queue_worker(request.app, thread_target_id)
+        except Exception:
+            logger.exception(
+                "Failed to ensure managed-thread queue worker after SCM enqueue "
+                "(thread_target_id=%s, operation_id=%s)",
+                thread_target_id,
+                getattr(operation, "operation_id", None),
+            )
 
 
 def build_scm_webhook_routes(

--- a/tests/routes/test_scm_webhooks.py
+++ b/tests/routes/test_scm_webhooks.py
@@ -712,6 +712,85 @@ def test_scm_webhook_inline_drain_delegates_to_scm_automation_service(
     ]
 
 
+def test_scm_webhook_inline_drain_ensures_worker_for_scm_enqueue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir(parents=True, exist_ok=True)
+    cfg = _enable_github_webhooks(_hub_config(), drain_inline=True)
+    calls: list[tuple[str, object]] = []
+
+    class _ServiceStub:
+        def __init__(self, hub_root: Path, *, reaction_config=None, **kwargs) -> None:
+            _ = (reaction_config, kwargs)
+            calls.append(("init", hub_root))
+
+        def ingest_event(self, event) -> None:
+            calls.append(("ingest_event", event.event_id))
+
+        def process_now(self, limit: int = 10) -> list[object]:
+            calls.append(("process_now", limit))
+            return [
+                SimpleNamespace(
+                    operation_id="op-enqueue-1",
+                    operation_kind="enqueue_managed_turn",
+                    state="succeeded",
+                    response={
+                        "thread_target_id": "thread-1",
+                        "managed_turn_id": "turn-1",
+                        "status": "queued",
+                    },
+                )
+            ]
+
+    def _ensure_worker(app, managed_thread_id: str) -> None:
+        calls.append(("ensure_worker", managed_thread_id))
+        assert app.state.config.root == hub_root
+
+    monkeypatch.setattr(scm_webhooks_module, "ScmAutomationService", _ServiceStub)
+    monkeypatch.setattr(
+        scm_webhooks_module,
+        "ensure_managed_thread_queue_worker",
+        _ensure_worker,
+    )
+
+    payload = {
+        "action": "opened",
+        "repository": {"full_name": "acme/widgets", "id": 99},
+        "sender": {"login": "octocat", "id": 7, "type": "User"},
+        "pull_request": {
+            "number": 42,
+            "title": "Wake bound thread",
+            "state": "open",
+            "merged": False,
+            "draft": False,
+            "html_url": "https://github.com/acme/widgets/pull/42",
+            "created_at": "2026-03-24T10:00:00+00:00",
+            "updated_at": "2026-03-24T10:01:02+00:00",
+            "base": {"ref": "main"},
+            "head": {"ref": "feature/scm-automation"},
+            "user": {"login": "octocat"},
+        },
+    }
+    body = json.dumps(payload).encode("utf-8")
+    app = _build_route_app(hub_root, cfg=cfg)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/hub/scm/webhooks/github",
+            content=body,
+            headers=_headers(body, event="pull_request"),
+        )
+
+    assert response.status_code == 200
+    assert calls == [
+        ("init", hub_root),
+        ("ingest_event", "github:delivery-1"),
+        ("process_now", 10),
+        ("ensure_worker", "thread-1"),
+    ]
+
+
 def test_scm_webhook_preserves_explicit_correlation_id_header(tmp_path: Path) -> None:
     hub_root = tmp_path / "hub"
     hub_root.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- ensure the web SCM inline drain starts the managed-thread queue worker after a successful `enqueue_managed_turn` operation
- keep the queue worker startup best-effort and logged so SCM webhook handling still returns cleanly if worker startup fails
- add route coverage for the default SCM drain path returning a queued managed turn

## Root Cause
SCM-triggered review feedback is intentionally persisted as a queued managed-thread turn, but the webhook inline drain only processed publish operations. When no existing queue worker was running for the bound thread, the turn could remain queued indefinitely, causing the dependent chat notification to time out with “managed turn stayed queued.”

## Validation
- `.venv/bin/python -m pytest -q tests/routes/test_scm_webhooks.py -q`
- commit hook web-ui lane: guardrails, black check, ruff, import boundaries, mypy, full pytest (`8923 passed`), web UI lab, Svelte lint/build/tests, SPA shell check
