### PR TITLE
[codex] Reseed stale Codex app-server auth

### DIFF
--- a/src/codex_autorunner/adapters/app_server/env.py
+++ b/src/codex_autorunner/adapters/app_server/env.py
@@ -77,34 +77,52 @@ def seed_codex_home(
 
     source_auth = source_root / "auth.json"
     auth_path = codex_home / "auth.json"
-    if auth_path.exists():
-        if not (
-            auth_path.is_symlink() and auth_path.resolve() == source_auth.resolve()
-        ):
+    if source_auth.exists():
+        should_seed_auth = True
+        if auth_path.exists() or auth_path.is_symlink():
+            try:
+                should_seed_auth = not (
+                    auth_path.is_symlink()
+                    and auth_path.resolve() == source_auth.resolve()
+                )
+            except OSError:
+                should_seed_auth = True
+        if should_seed_auth:
+            temp_auth_path = auth_path.with_name(f".{auth_path.name}.tmp.{os.getpid()}")
+            try:
+                if temp_auth_path.exists() or temp_auth_path.is_symlink():
+                    temp_auth_path.unlink()
+                temp_auth_path.symlink_to(source_auth)
+                os.replace(temp_auth_path, auth_path)
+                log_event(
+                    logger,
+                    __import__("logging").INFO,
+                    f"{event_prefix}.codex_home.seeded",
+                    source=str(source_root),
+                    target=str(codex_home),
+                )
+            except OSError as exc:
+                log_event(
+                    logger,
+                    __import__("logging").WARNING,
+                    f"{event_prefix}.codex_home.seed.failed",
+                    exc=exc,
+                    source=str(source_auth),
+                    target=str(auth_path),
+                )
+            finally:
+                try:
+                    if temp_auth_path.exists() or temp_auth_path.is_symlink():
+                        temp_auth_path.unlink()
+                except OSError:
+                    pass
+    elif auth_path.exists():
+        if not auth_path.is_symlink():
             log_event(
                 logger,
                 __import__("logging").INFO,
                 f"{event_prefix}.codex_home.seed.skipped",
                 reason="auth_exists",
-                source=str(source_root),
-                target=str(codex_home),
-            )
-    elif source_auth.exists():
-        try:
-            auth_path.symlink_to(source_auth)
-            log_event(
-                logger,
-                __import__("logging").INFO,
-                f"{event_prefix}.codex_home.seeded",
-                source=str(source_root),
-                target=str(codex_home),
-            )
-        except OSError as exc:
-            log_event(
-                logger,
-                __import__("logging").WARNING,
-                f"{event_prefix}.codex_home.seed.failed",
-                exc=exc,
                 source=str(source_root),
                 target=str(codex_home),
             )

--- a/tests/test_app_server_utils.py
+++ b/tests/test_app_server_utils.py
@@ -132,3 +132,78 @@ def test_seed_codex_home_resyncs_config_when_auth_already_seeded(
     assert (target_home / "config.toml").read_text(
         encoding="utf-8"
     ) == "multi_agent = true\n"
+
+
+def test_seed_codex_home_replaces_stale_managed_auth_file(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source_home = tmp_path / "source-codex-home"
+    source_home.mkdir()
+    source_auth = source_home / "auth.json"
+    source_auth.write_text('{"token":"fresh"}\n', encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(source_home))
+
+    target_home = tmp_path / "target-codex-home"
+    target_home.mkdir()
+    target_auth = target_home / "auth.json"
+    target_auth.write_text('{"token":"stale"}\n', encoding="utf-8")
+
+    seed_codex_home(target_home, event_prefix="test")
+
+    assert target_auth.is_symlink()
+    assert target_auth.resolve() == source_auth.resolve()
+    assert target_auth.read_text(encoding="utf-8") == '{"token":"fresh"}\n'
+
+
+def test_seed_codex_home_replaces_stale_managed_auth_symlink(
+    tmp_path: Path, monkeypatch
+) -> None:
+    old_home = tmp_path / "old-codex-home"
+    old_home.mkdir()
+    old_auth = old_home / "auth.json"
+    old_auth.write_text('{"token":"stale"}\n', encoding="utf-8")
+    source_home = tmp_path / "source-codex-home"
+    source_home.mkdir()
+    source_auth = source_home / "auth.json"
+    source_auth.write_text('{"token":"fresh"}\n', encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(source_home))
+
+    target_home = tmp_path / "target-codex-home"
+    target_home.mkdir()
+    target_auth = target_home / "auth.json"
+    target_auth.symlink_to(old_auth)
+
+    seed_codex_home(target_home, event_prefix="test")
+
+    assert target_auth.is_symlink()
+    assert target_auth.resolve() == source_auth.resolve()
+    assert target_auth.read_text(encoding="utf-8") == '{"token":"fresh"}\n'
+
+
+def test_seed_codex_home_preserves_existing_auth_when_relink_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source_home = tmp_path / "source-codex-home"
+    source_home.mkdir()
+    source_auth = source_home / "auth.json"
+    source_auth.write_text('{"token":"fresh"}\n', encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(source_home))
+
+    target_home = tmp_path / "target-codex-home"
+    target_home.mkdir()
+    target_auth = target_home / "auth.json"
+    target_auth.write_text('{"token":"still-usable"}\n', encoding="utf-8")
+
+    original_symlink_to = Path.symlink_to
+
+    def fail_temp_auth_symlink(self: Path, target: Path, *args, **kwargs) -> None:
+        if self.name.startswith(".auth.json.tmp."):
+            raise OSError("symlink unavailable")
+        return original_symlink_to(self, target, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "symlink_to", fail_temp_auth_symlink)
+
+    seed_codex_home(target_home, event_prefix="test")
+
+    assert not target_auth.is_symlink()
+    assert target_auth.read_text(encoding="utf-8") == '{"token":"still-usable"}\n'


### PR DESCRIPTION
## Summary

Fixes #1820. CAR-managed Codex app-server homes now refresh their `auth.json` link from the operator's current `CODEX_HOME` when the managed file or symlink is stale. This keeps PMA/app-server restarts from continuing to use credentials copied before a Codex account swap.

## Root cause

`seed_codex_home()` skipped auth seeding whenever the managed app-server `auth.json` already existed and was not the expected symlink. If an older CAR run or prior setup left a copied/stale auth file under the workspace-scoped `CODEX_HOME`, restarting `car serve` preserved that stale token even after `codex login` updated the normal Codex auth file.

## Validation

- `.venv/bin/python -m pytest tests/test_app_server_utils.py`
- `.venv/bin/python -m ruff check src/codex_autorunner/adapters/app_server/env.py tests/test_app_server_utils.py`
- Commit hook aggregate lane: guardrails, black, ruff, import checks, mypy, 8932 Python tests, Web UI lab fast check, web lint/build/tests, SPA shell check
