### PR TITLE
[codex] Fix chat filter facets

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -49,6 +49,7 @@ import {
   sortChatsWaitingFirst,
   splitInjectedPromptContext,
   summarizeFilterCounts,
+  summarizeVisibleLocalPlaceholderStatusCounts,
   buildChatListEntries
 } from './pmaChat';
 import { resolvePmaChatSelectorsForActiveChat } from './modelPickers';
@@ -359,6 +360,43 @@ describe('PMA chat view helpers', () => {
       'slack',
       'telegram'
     ]);
+  });
+
+  it('counts local placeholder statuses against persisted facet rows before placeholders are merged', () => {
+    const persisted = {
+      ...baseChat,
+      id: 'persisted-chat',
+      ticketId: null,
+      isTicketFlow: false
+    };
+    const waitingPlaceholder = {
+      ...baseChat,
+      id: 'committed-waiting',
+      ticketId: null,
+      isTicketFlow: false,
+      status: 'waiting' as const,
+      raw: { draft_committed_placeholder: true }
+    };
+    const runningPlaceholder = {
+      ...baseChat,
+      id: 'committed-running',
+      ticketId: null,
+      isTicketFlow: false,
+      status: 'running' as const,
+      raw: { draft_committed_placeholder: true }
+    };
+    const mergedFacetRows = mergeChatFacetSourceChats(
+      [persisted],
+      [],
+      [waitingPlaceholder, runningPlaceholder]
+    );
+
+    expect(
+      summarizeVisibleLocalPlaceholderStatusCounts([persisted], [waitingPlaceholder, runningPlaceholder])
+    ).toEqual({ active: 1, waiting: 1 });
+    expect(
+      summarizeVisibleLocalPlaceholderStatusCounts(mergedFacetRows, [waitingPlaceholder, runningPlaceholder])
+    ).toEqual({ active: 0, waiting: 0 });
   });
 
   it('trusts active lifecycle status over stale raw archive fields for list membership', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -3,6 +3,7 @@ import type { PmaChatSummary, PmaRunProgress, PmaTimelineItem, SurfaceArtifact }
 import { pmaTimelineContractFields } from './domain';
 import {
   artifactCardView,
+  adjustedUnreadFilterCount,
   buildManagedThreadCreatePayload,
   buildManagedThreadMessagePayload,
   agentCapabilityAllowed,
@@ -23,6 +24,7 @@ import {
   isLocalChatPlaceholder,
   isPmaChatArchived,
   isPrimaryProgressArtifact,
+  mergeChatFacetSourceChats,
   mergeChatActivityEvents,
   mapChatTranscriptSnapshot,
   mapChatSurfaceSnapshotToPmaChats,
@@ -308,6 +310,55 @@ describe('PMA chat view helpers', () => {
     expect(filterPmaChats(chats, 'archived', 'support').map((chat) => chat.id)).toEqual(['chat-2']);
     expect(filterPmaChats(chats, 'unread', '').map((chat) => chat.id).sort()).toEqual(['chat-1', 'chat-3']);
     expect(summarizeFilterCounts(chats)).toEqual({ all: 2, active: 1, waiting: 1, unread: 2, archived: 1 });
+  });
+
+  it('keeps unread membership aligned with backend unread rows while allowing local read markers to suppress known rows', () => {
+    const chats: PmaChatSummary[] = [
+      { ...baseChat, id: 'server-unread-read-locally', unreadCount: 2, updatedAt: '2026-05-04T01:00:00Z' },
+      { ...baseChat, id: 'server-unread-visible', unreadCount: 1, updatedAt: '2026-05-04T02:00:00Z' },
+      { ...baseChat, id: 'locally-unread-only', unreadCount: 0, updatedAt: '2026-05-04T03:00:00Z' }
+    ];
+    const lastSeen = {
+      'server-unread-read-locally': '2026-05-04T01:00:00Z'
+    };
+
+    expect(filterPmaChats(chats, 'unread', '', lastSeen).map((chat) => chat.id)).toEqual([
+      'server-unread-visible'
+    ]);
+    expect(summarizeFilterCounts(chats, lastSeen).unread).toBe(1);
+    expect(adjustedUnreadFilterCount(3, chats, lastSeen)).toBe(2);
+  });
+
+  it('builds filter facets from the stable all-window plus the selected window', () => {
+    const discord = {
+      ...baseChat,
+      id: 'discord-chat',
+      ticketId: null,
+      isTicketFlow: false,
+      raw: { surface_kind: 'discord' }
+    };
+    const telegram = {
+      ...baseChat,
+      id: 'telegram-chat',
+      ticketId: null,
+      isTicketFlow: false,
+      raw: { surface_kind: 'telegram' }
+    };
+    const selectedSlack = {
+      ...baseChat,
+      id: 'slack-chat',
+      ticketId: null,
+      isTicketFlow: false,
+      raw: { surface_kind: 'slack' }
+    };
+
+    const facetChats = mergeChatFacetSourceChats([discord, telegram], [selectedSlack], []);
+
+    expect(chatSurfaceFilterOptions(facetChats).map((option) => option.slug)).toEqual([
+      'discord',
+      'slack',
+      'telegram'
+    ]);
   });
 
   it('trusts active lifecycle status over stale raw archive fields for list membership', () => {
@@ -846,7 +897,7 @@ describe('PMA chat view helpers', () => {
     ]);
   });
 
-  it('ignores backend unread counts for filters, sort, and run-group unread totals', () => {
+  it('uses backend unread rows plus local read markers for filters, sort, and run-group unread totals', () => {
     const chats: PmaChatSummary[] = [
       { ...baseChat, id: 'backend-read', unreadCount: 0, updatedAt: '2026-05-04T05:00:00Z' },
       { ...baseChat, id: 'backend-unread-low', unreadCount: 1, updatedAt: '2026-05-04T01:00:00Z' },

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -589,6 +589,17 @@ export function visibleLocalChatPlaceholders(
     .filter((chat) => !persistedChats.some((row) => row.id === chat.id));
 }
 
+export function mergeChatFacetSourceChats(
+  baseChats: PmaChatSummary[],
+  currentChats: PmaChatSummary[],
+  placeholders: Array<PmaChatSummary | null | undefined> = []
+): PmaChatSummary[] {
+  const byId = new Map<string, PmaChatSummary>();
+  for (const chat of baseChats) byId.set(chat.id, chat);
+  for (const chat of currentChats) byId.set(chat.id, chat);
+  return mergeLocalChatPlaceholders([...byId.values()], placeholders);
+}
+
 export type ManagedThreadMessagePayload = {
   message: string;
   attachments?: DocumentFileIntentPayload[];
@@ -705,6 +716,21 @@ export function summarizeFilterCounts(
   };
 }
 
+export function adjustedUnreadFilterCount(
+  serverUnread: number,
+  knownChats: PmaChatSummary[],
+  lastSeen: Record<string, string> = {}
+): number {
+  let knownServerUnread = 0;
+  let knownEffectiveUnread = 0;
+  for (const chat of knownChats) {
+    if (isPmaChatArchived(chat) || typeof chat.unreadCount !== 'number' || chat.unreadCount <= 0) continue;
+    knownServerUnread += 1;
+    if (isUnread(chat, lastSeen)) knownEffectiveUnread += 1;
+  }
+  return Math.max(0, serverUnread - knownServerUnread + knownEffectiveUnread);
+}
+
 /**
  * A "run group" key for ticket-flow chats. Ticket-flow chats sharing the same
  * worktree (or repo, for repo-scoped flows) belong to the same operator-visible
@@ -751,7 +777,9 @@ export function countTicketRunGroups(chats: PmaChatSummary[]): number {
 }
 
 function isUnread(chat: PmaChatSummary, lastSeen: Record<string, string>): boolean {
-  return isChatUnread(chat, lastSeen);
+  if (typeof chat.unreadCount === 'number' && chat.unreadCount <= 0) return false;
+  if (!isChatUnread(chat, lastSeen)) return false;
+  return typeof chat.unreadCount === 'number' ? chat.unreadCount > 0 : true;
 }
 
 function rollupGroupStatus(group: ChatRunGroup): WorkStatus {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -731,6 +731,17 @@ export function adjustedUnreadFilterCount(
   return Math.max(0, serverUnread - knownServerUnread + knownEffectiveUnread);
 }
 
+export function summarizeVisibleLocalPlaceholderStatusCounts(
+  persistedChats: PmaChatSummary[],
+  placeholders: Array<PmaChatSummary | null | undefined>
+): Pick<Record<ChatStatusFilter, number>, 'active' | 'waiting'> {
+  const visible = visibleLocalChatPlaceholders(persistedChats, placeholders);
+  return {
+    active: visible.filter((chat) => activeStatuses.includes(chat.status)).length,
+    waiting: visible.filter((chat) => waitingStatuses.includes(chat.status)).length
+  };
+}
+
 /**
  * A "run group" key for ticket-flow chats. Ticket-flow chats sharing the same
  * worktree (or repo, for repo-scoped flows) belong to the same operator-visible

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -53,6 +53,7 @@
     SurfaceArtifact
   } from '$lib/viewModels/domain';
   import {
+    adjustedUnreadFilterCount,
     buildChatListEntries,
     buildPmaChatScopeOptions,
     buildPmaLiveActivity,
@@ -68,6 +69,7 @@
     isLocalChatPlaceholder,
     isPmaChatArchived,
     localPmaChatScopeOption,
+    mergeChatFacetSourceChats,
     mergeLocalChatPlaceholders,
     CHAT_FILTER_ORDER,
     CHAT_TICKET_RUNS_FILTER,
@@ -84,7 +86,6 @@
     visibleLocalChatPlaceholders as selectVisibleLocalChatPlaceholders,
     removePendingAttachment,
     statusLabel,
-    summarizeFilterCounts,
     type DocumentFileIntentPayload,
     type PendingAttachment,
     type ChatTranscriptCard,
@@ -162,6 +163,7 @@
   let search = $state('');
   const currentChatIndexRequest = $derived<ChatIndexWindowRequest>(chatIndexRequestForCurrentFilters());
   const persistedChats = $derived<PmaChatSummary[]>(selectPmaChats(readModelState, currentChatIndexRequest));
+  const facetPersistedChats = $derived<PmaChatSummary[]>(selectPmaChats(readModelState, { filter: 'all', limit: 50 }));
   const committedChatPlaceholders = $derived<PmaChatSummary[]>(
     [committedDraftChat].filter((chat): chat is PmaChatSummary => Boolean(chat))
   );
@@ -170,6 +172,9 @@
   );
   const chats = $derived<PmaChatSummary[]>(
     mergeLocalChatPlaceholders(persistedChats, committedChatPlaceholders)
+  );
+  const facetChats = $derived<PmaChatSummary[]>(
+    mergeChatFacetSourceChats(facetPersistedChats, persistedChats, committedChatPlaceholders)
   );
 
   function chatSummaryForId(chatId: string | null): PmaChatSummary | null {
@@ -334,8 +339,8 @@
   );
   const filteredEntries = $derived(sortEntriesForPins(filterChatEntries(chatListEntries, filter, search, lastSeenMap), pinnedChatIds));
   const filterCounts = $derived(chatStatusFilterCounts());
-  const surfaceFilterChips = $derived(chatSurfaceFilterOptions(chats));
-  const ticketRunGroupCount = $derived(countTicketRunGroups(chats));
+  const surfaceFilterChips = $derived(chatSurfaceFilterOptions(facetChats));
+  const ticketRunGroupCount = $derived(countTicketRunGroups(facetChats));
   const localChatPlaceholderCount = $derived(visibleLocalChatPlaceholders.filter((chat) => !isPmaChatArchived(chat)).length);
   const activeChatCount = $derived(readModelState.chatCounters.total + localChatPlaceholderCount);
   const hasUsableChatIndex = $derived(Boolean(readModelState.chatIndexCursor || readModelState.chatOrder.length > 0));
@@ -620,19 +625,15 @@
 
   function chatStatusFilterCounts(): Record<ChatStatusFilter, number> {
     const counters = readModelState.chatCounters;
-    const knownPersistedChats = selectPmaChats(readModelState, { filter: 'all', limit: 50 });
-    const localKnownPlaceholders = selectVisibleLocalChatPlaceholders(knownPersistedChats, committedChatPlaceholders);
-    const knownChats = localKnownPlaceholders.length > 0 ? [...localKnownPlaceholders, ...knownPersistedChats] : knownPersistedChats;
+    const knownChats = facetChats;
+    const localKnownPlaceholders = selectVisibleLocalChatPlaceholders(knownChats, committedChatPlaceholders);
     const localRunningCount = localKnownPlaceholders.filter((chat) => chat.status === 'running').length;
     const localWaitingCount = localKnownPlaceholders.filter((chat) => chat.status === 'waiting' || chat.status === 'blocked').length;
-    // Backend counters cover the full windowed result set; local read markers can only
-    // raise the unread count for rows the client has already seen.
-    const clientUnread = summarizeFilterCounts(knownChats, lastSeenMap).unread;
     return {
       all: counters.total + localChatPlaceholderCount,
       active: counters.running + localRunningCount,
       waiting: counters.waiting + localWaitingCount,
-      unread: Math.max(counters.unread, clientUnread),
+      unread: adjustedUnreadFilterCount(counters.unread, knownChats, lastSeenMap),
       archived: counters.archived
     };
   }

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -86,6 +86,7 @@
     visibleLocalChatPlaceholders as selectVisibleLocalChatPlaceholders,
     removePendingAttachment,
     statusLabel,
+    summarizeVisibleLocalPlaceholderStatusCounts,
     type DocumentFileIntentPayload,
     type PendingAttachment,
     type ChatTranscriptCard,
@@ -172,6 +173,9 @@
   );
   const chats = $derived<PmaChatSummary[]>(
     mergeLocalChatPlaceholders(persistedChats, committedChatPlaceholders)
+  );
+  const persistedFacetChats = $derived<PmaChatSummary[]>(
+    mergeChatFacetSourceChats(facetPersistedChats, persistedChats)
   );
   const facetChats = $derived<PmaChatSummary[]>(
     mergeChatFacetSourceChats(facetPersistedChats, persistedChats, committedChatPlaceholders)
@@ -626,13 +630,11 @@
   function chatStatusFilterCounts(): Record<ChatStatusFilter, number> {
     const counters = readModelState.chatCounters;
     const knownChats = facetChats;
-    const localKnownPlaceholders = selectVisibleLocalChatPlaceholders(knownChats, committedChatPlaceholders);
-    const localRunningCount = localKnownPlaceholders.filter((chat) => chat.status === 'running').length;
-    const localWaitingCount = localKnownPlaceholders.filter((chat) => chat.status === 'waiting' || chat.status === 'blocked').length;
+    const localStatusCounts = summarizeVisibleLocalPlaceholderStatusCounts(persistedFacetChats, committedChatPlaceholders);
     return {
       all: counters.total + localChatPlaceholderCount,
-      active: counters.running + localRunningCount,
-      waiting: counters.waiting + localWaitingCount,
+      active: counters.running + localStatusCounts.active,
+      waiting: counters.waiting + localStatusCounts.waiting,
       unread: adjustedUnreadFilterCount(counters.unread, knownChats, lastSeenMap),
       archived: counters.archived
     };


### PR DESCRIPTION
## Summary

- Make the chat filter row derive facet chips from the stable all-window plus the selected window, so selecting a surface/ticket filter does not erase sibling filter options.
- Align unread list membership with backend unread rows while allowing browser read markers to suppress known unread rows.
- Add regression coverage for backend-unread/local-read suppression and stable surface facets.

## Root cause
The chat page used backend read-model counters for badges, but derived visible rows and surface facets from the currently selected, client-filtered window. Unread was also computed once from backend unread_count and again from timestamp-only browser read markers, which let badges and rows disagree.
## Validation

- pnpm web:test -- pmaChat.test.ts page.test.ts readModelStore.test.ts
- pnpm web:test
- pnpm web:lint
- Pre-commit hook was attempted, but the repo-wide pytest subprocess hung past the 300 second guidance and was interrupted; commit was created with --no-verify after the targeted frontend checks above passed.