### PR TITLE
[codex] Make PMA chat genesis explicit

### DIFF
--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -1767,6 +1767,9 @@ def _chat_index_rows_from_surfaces(
                 if _is_fallback_chat_title(row.get("title"), row):
                     row["title"] = friendly_title
         else:
+            # Chat identity is owned by the managed thread. Delivery surfaces,
+            # notification reply contexts, and channel bindings stay visible as
+            # bindings, but they must not replace the PMA-owned display title.
             identity_title = _managed_thread_identity_title(row)
             row["title"] = identity_title
             row["chat_display_name"] = identity_title

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -1760,11 +1760,16 @@ def _chat_index_rows_from_surfaces(
             )
     rows = list(by_thread.values()) + external_rows
     for row in rows:
-        friendly_title = _friendly_chat_title(row)
-        if friendly_title is not None:
-            row["chat_display_name"] = friendly_title
-            if _is_fallback_chat_title(row.get("title"), row):
-                row["title"] = friendly_title
+        if row.get("managed_thread_id") is None:
+            friendly_title = _friendly_chat_title(row)
+            if friendly_title is not None:
+                row["chat_display_name"] = friendly_title
+                if _is_fallback_chat_title(row.get("title"), row):
+                    row["title"] = friendly_title
+        else:
+            identity_title = _managed_thread_identity_title(row)
+            row["title"] = identity_title
+            row["chat_display_name"] = identity_title
         row["display_title"] = _normalize_text(row.get("chat_display_name")) or str(
             row.get("title") or row.get("chat_id") or row.get("row_id") or ""
         )
@@ -1811,6 +1816,19 @@ def _display_title(display: Mapping[str, Any], fallback: str) -> str:
         or _normalize_text(display.get("display_name"))
         or fallback
     )
+
+
+def _managed_thread_identity_title(row: Mapping[str, Any]) -> str:
+    """Return the primary PMA-owned title for a managed-thread chat row."""
+
+    managed_thread_id = _normalize_text(row.get("managed_thread_id"))
+    title = _normalize_text(row.get("title"))
+    if title is not None and not _is_fallback_chat_title(title, row):
+        return title
+    preview = _normalize_text(row.get("last_message_preview"))
+    if preview is not None:
+        return preview
+    return managed_thread_id or _normalize_text(row.get("chat_id")) or title or ""
 
 
 def _surface_binding_display_name(surface: Mapping[str, Any]) -> Optional[str]:
@@ -1950,7 +1968,10 @@ def _is_fallback_chat_title(value: Any, row: Mapping[str, Any]) -> bool:
     title = _normalize_text(value)
     if title is None:
         return True
-    if title == _normalize_text(row.get("managed_thread_id")):
+    managed_thread_id = _normalize_text(row.get("managed_thread_id"))
+    if title == managed_thread_id:
+        return True
+    if managed_thread_id is not None and title == f"Thread {managed_thread_id}":
         return True
     if _is_surface_id_title(title, row):
         return True

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
@@ -223,6 +223,155 @@ def _scope_ref_from_payload(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
+def _validate_legacy_scope_field_consistency(
+    payload: ManagedThreadCreateRequest,
+) -> None:
+    workspace_root = normalize_optional_text(payload.workspace_root)
+    repo_id = normalize_optional_text(payload.repo_id)
+    resource_kind = normalize_optional_text(payload.resource_kind)
+    resource_id = normalize_optional_text(payload.resource_id)
+    if workspace_root is not None and any((repo_id, resource_kind, resource_id)):
+        raise HTTPException(
+            status_code=400,
+            detail="workspace_root cannot be combined with legacy owner fields",
+        )
+    if repo_id is None:
+        return
+    if resource_kind is None and resource_id is None:
+        return
+    if resource_kind != "repo" or resource_id != repo_id:
+        raise HTTPException(
+            status_code=400,
+            detail="repo_id conflicts with resource_kind/resource_id",
+        )
+
+
+def _scope_urn_for_create_resolution(
+    *,
+    scope_ref: Optional[ScopeRef],
+    resource_kind: Optional[str],
+    resource_id: Optional[str],
+    workspace_root: Path,
+    hub_root: Path,
+) -> str:
+    if scope_ref is not None:
+        return scope_ref.to_urn()
+    if resource_kind == "repo" and resource_id is not None:
+        return ScopeRef(kind="repo", id=resource_id).to_urn()
+    try:
+        if workspace_root.resolve() == hub_root.resolve():
+            return ScopeRef(kind="hub").to_urn()
+    except OSError:
+        pass
+    return ScopeRef(kind="filesystem", path=str(workspace_root)).to_urn()
+
+
+def _create_genesis_metadata(
+    *,
+    payload: ManagedThreadCreateRequest,
+    scope_ref: Optional[ScopeRef],
+    resource_kind: Optional[str],
+    resource_id: Optional[str],
+    repo_id: Optional[str],
+    workspace_root: Path,
+    hub_root: Path,
+) -> dict[str, Any]:
+    genesis_provided = any(
+        value is not None
+        for value in (
+            payload.genesis,
+            normalize_optional_text(payload.origin),
+            normalize_optional_text(payload.scope_source),
+            normalize_optional_text(payload.parent_thread_id),
+            normalize_optional_text(payload.fork_mode),
+            payload.client_intent,
+        )
+    )
+    if genesis_provided:
+        origin = normalize_optional_text(payload.origin) or "unknown"
+        scope_source = normalize_optional_text(payload.scope_source) or "unspecified"
+    else:
+        origin = "legacy"
+        if normalize_optional_text(payload.scope_urn) is not None:
+            scope_source = "legacy_scope_urn"
+        elif any(
+            normalize_optional_text(value) is not None
+            for value in (
+                payload.workspace_root,
+                payload.repo_id,
+                payload.resource_kind,
+                payload.resource_id,
+            )
+        ):
+            scope_source = "legacy_scope_fields"
+        else:
+            scope_source = "legacy_default_hub"
+
+    scope_urn = _scope_urn_for_create_resolution(
+        scope_ref=scope_ref,
+        resource_kind=resource_kind,
+        resource_id=resource_id,
+        workspace_root=workspace_root,
+        hub_root=hub_root,
+    )
+    scope_kind = scope_ref.kind if scope_ref is not None else None
+    if scope_kind is None:
+        scope_kind = resource_kind or (
+            "hub" if scope_urn == ScopeRef(kind="hub").to_urn() else "filesystem"
+        )
+    client_intent_fields = {
+        "scope_urn": normalize_optional_text(payload.scope_urn),
+        "workspace_root": normalize_optional_text(payload.workspace_root),
+        "repo_id": normalize_optional_text(payload.repo_id),
+        "resource_kind": normalize_optional_text(payload.resource_kind),
+        "resource_id": normalize_optional_text(payload.resource_id),
+    }
+    metadata: dict[str, Any] = {
+        "origin": origin,
+        "scope_source": scope_source,
+        "legacy": not genesis_provided,
+        "scope": {
+            "urn": scope_urn,
+            "kind": scope_kind,
+            "repo_id": repo_id,
+            "resource_kind": resource_kind,
+            "resource_id": resource_id,
+            "workspace_root": str(workspace_root),
+        },
+        "client_scope_request": {
+            key: value
+            for key, value in client_intent_fields.items()
+            if value is not None
+        },
+    }
+    parent_thread_id = normalize_optional_text(payload.parent_thread_id)
+    if parent_thread_id is not None:
+        metadata["parent_thread_id"] = parent_thread_id
+    fork_mode = normalize_optional_text(payload.fork_mode)
+    if fork_mode is not None:
+        metadata["fork_mode"] = fork_mode
+    if payload.client_intent is not None:
+        metadata["client_intent"] = payload.client_intent
+    return metadata
+
+
+def managed_thread_metadata_for_provisioned_workspace(
+    resolution: ManagedThreadCreateResolution,
+    provisioned_workspace: ManagedThreadWorkspaceProvision,
+) -> dict[str, Any]:
+    metadata = dict(resolution.metadata)
+    genesis = metadata.get("genesis")
+    if isinstance(genesis, dict):
+        genesis = dict(genesis)
+        scope = genesis.get("scope")
+        if isinstance(scope, dict):
+            scope = dict(scope)
+            scope["actual_workspace_root"] = str(provisioned_workspace.workspace_root)
+            genesis["scope"] = scope
+        metadata["genesis"] = genesis
+    return metadata
+
+
 def _build_operator_status_fields(
     *,
     normalized_status: Optional[str],
@@ -690,6 +839,7 @@ def resolve_managed_thread_create_resolution(
     context = get_pma_request_context(request)
     hub_root = context.hub_root
     scope_ref = _scope_ref_from_payload(payload)
+    _validate_legacy_scope_field_consistency(payload)
     scope_workspace_root: Optional[str] = None
     scope_resource_kind: Optional[str] = None
     scope_resource_id: Optional[str] = None
@@ -805,6 +955,15 @@ def resolve_managed_thread_create_resolution(
         "context_profile": context_profile,
         "approval_mode": approval_mode,
         "chat_kind": normalize_managed_thread_chat_kind(payload.chat_kind),
+        "genesis": _create_genesis_metadata(
+            payload=payload,
+            scope_ref=scope_ref,
+            resource_kind=resource_kind,
+            resource_id=resource_id,
+            repo_id=resolved_repo_id,
+            workspace_root=resolved_workspace,
+            hub_root=hub_root,
+        ),
     }
     chat_kind = normalize_optional_text(payload.chat_kind)
     if chat_kind is not None:

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
@@ -251,6 +251,7 @@ def _scope_urn_for_create_resolution(
     scope_ref: Optional[ScopeRef],
     resource_kind: Optional[str],
     resource_id: Optional[str],
+    worktree_parent_repo_id: Optional[str],
     workspace_root: Path,
     hub_root: Path,
 ) -> str:
@@ -258,6 +259,16 @@ def _scope_urn_for_create_resolution(
         return scope_ref.to_urn()
     if resource_kind == "repo" and resource_id is not None:
         return ScopeRef(kind="repo", id=resource_id).to_urn()
+    if (
+        resource_kind == "worktree"
+        and resource_id is not None
+        and worktree_parent_repo_id is not None
+    ):
+        return ScopeRef(
+            kind="worktree",
+            id=resource_id,
+            parent_repo_id=worktree_parent_repo_id,
+        ).to_urn()
     try:
         if workspace_root.resolve() == hub_root.resolve():
             return ScopeRef(kind="hub").to_urn()
@@ -273,6 +284,7 @@ def _create_genesis_metadata(
     resource_kind: Optional[str],
     resource_id: Optional[str],
     repo_id: Optional[str],
+    worktree_parent_repo_id: Optional[str],
     workspace_root: Path,
     hub_root: Path,
 ) -> dict[str, Any]:
@@ -311,6 +323,7 @@ def _create_genesis_metadata(
         scope_ref=scope_ref,
         resource_kind=resource_kind,
         resource_id=resource_id,
+        worktree_parent_repo_id=worktree_parent_repo_id,
         workspace_root=workspace_root,
         hub_root=hub_root,
     )
@@ -353,6 +366,19 @@ def _create_genesis_metadata(
     if payload.client_intent is not None:
         metadata["client_intent"] = payload.client_intent
     return metadata
+
+
+def _worktree_parent_repo_id(
+    repos: Any,
+    worktree_id: Optional[str],
+) -> Optional[str]:
+    if worktree_id is None:
+        return None
+    for snapshot in repos or ():
+        if normalize_optional_text(getattr(snapshot, "id", None)) != worktree_id:
+            continue
+        return normalize_optional_text(getattr(snapshot, "worktree_of", None))
+    return None
 
 
 def managed_thread_metadata_for_provisioned_workspace(
@@ -918,6 +944,10 @@ def resolve_managed_thread_create_resolution(
     resource_kind = pma_context.resource_kind
     resource_id = pma_context.resource_id
     resolved_repo_id = pma_context.repo_id
+    worktree_parent_repo_id = _worktree_parent_repo_id(
+        repos,
+        resource_id if resource_kind == "worktree" else None,
+    )
     followup_policy = resolve_managed_thread_followup_policy(
         payload,
         # Terminal follow-up defaults now apply when the thread is used, not at
@@ -961,6 +991,7 @@ def resolve_managed_thread_create_resolution(
             resource_kind=resource_kind,
             resource_id=resource_id,
             repo_id=resolved_repo_id,
+            worktree_parent_repo_id=worktree_parent_repo_id,
             workspace_root=resolved_workspace,
             hub_root=hub_root,
         ),

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_route_helpers.py
@@ -375,10 +375,16 @@ def _worktree_parent_repo_id(
     if worktree_id is None:
         return None
     for snapshot in repos or ():
-        if normalize_optional_text(getattr(snapshot, "id", None)) != worktree_id:
+        if normalize_optional_text(_repo_snapshot_value(snapshot, "id")) != worktree_id:
             continue
-        return normalize_optional_text(getattr(snapshot, "worktree_of", None))
+        return normalize_optional_text(_repo_snapshot_value(snapshot, "worktree_of"))
     return None
+
+
+def _repo_snapshot_value(snapshot: Any, attr: str) -> Any:
+    if isinstance(snapshot, dict):
+        return snapshot.get(attr)
+    return getattr(snapshot, attr, None)
 
 
 def managed_thread_metadata_for_provisioned_workspace(
@@ -948,6 +954,11 @@ def resolve_managed_thread_create_resolution(
         repos,
         resource_id if resource_kind == "worktree" else None,
     )
+    if resource_kind == "worktree" and worktree_parent_repo_id is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Worktree scope requires worktree_of metadata",
+        )
     followup_policy = resolve_managed_thread_followup_policy(
         payload,
         # Terminal follow-up defaults now apply when the thread is used, not at

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_thread_runtime.py
@@ -60,6 +60,7 @@ from ...services.pma.managed_thread_followup import (
 )
 from .automation_adapter import normalize_optional_text
 from .managed_thread_route_helpers import (
+    managed_thread_metadata_for_provisioned_workspace,
     provision_managed_thread_workspace,
     resolve_managed_thread_create_resolution,
 )
@@ -167,6 +168,10 @@ async def _create_managed_thread_for_first_message(
     )
     service = _build_managed_thread_orchestration_service(request)
     try:
+        metadata = managed_thread_metadata_for_provisioned_workspace(
+            resolved,
+            provisioned_workspace,
+        )
         try:
             if resolved.scope is not None:
                 thread = service.create_thread_target(
@@ -174,7 +179,7 @@ async def _create_managed_thread_for_first_message(
                     provisioned_workspace.workspace_root,
                     scope=resolved.scope,
                     display_name=normalize_optional_text(payload.name),
-                    metadata=resolved.metadata,
+                    metadata=metadata,
                 )
             else:
                 thread = service.create_thread_target(
@@ -184,7 +189,7 @@ async def _create_managed_thread_for_first_message(
                     resource_kind=resolved.resource_kind,
                     resource_id=resolved.resource_id,
                     display_name=normalize_optional_text(payload.name),
-                    metadata=resolved.metadata,
+                    metadata=metadata,
                 )
         except Exception:
             await _cleanup_failed_provisioned_worktree(

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -60,6 +60,7 @@ from .managed_thread_route_helpers import (
     _resolve_running_or_latest_execution,
     _serialize_managed_thread,
     _serialize_thread_target,
+    managed_thread_metadata_for_provisioned_workspace,
     provision_managed_thread_workspace,
     resolve_managed_thread_create_resolution,
     resolve_managed_thread_list_query,
@@ -490,6 +491,10 @@ def build_managed_thread_crud_routes(
 
         service = build_managed_thread_orchestration_service(request)
         try:
+            metadata = managed_thread_metadata_for_provisioned_workspace(
+                resolved,
+                provisioned_workspace,
+            )
             try:
                 if resolved.scope is not None:
                     thread = service.create_thread_target(
@@ -497,7 +502,7 @@ def build_managed_thread_crud_routes(
                         provisioned_workspace.workspace_root,
                         scope=resolved.scope,
                         display_name=normalize_optional_text(payload.name),
-                        metadata=resolved.metadata,
+                        metadata=metadata,
                     )
                 else:
                     thread = service.create_thread_target(
@@ -507,7 +512,7 @@ def build_managed_thread_crud_routes(
                         resource_kind=resolved.resource_kind,
                         resource_id=resolved.resource_id,
                         display_name=normalize_optional_text(payload.name),
-                        metadata=resolved.metadata,
+                        metadata=metadata,
                     )
             except Exception:
                 await _cleanup_failed_provisioned_worktree(

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -251,6 +251,25 @@ class AppServerThreadArchiveRequest(Payload):
     thread_id: str = Field(validation_alias=AliasChoices("thread_id", "threadId", "id"))
 
 
+class ManagedThreadGenesisRequest(Payload):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    origin: Optional[str] = None
+    scope_source: Optional[str] = Field(
+        default=None, validation_alias=AliasChoices("scope_source", "scopeSource")
+    )
+    parent_thread_id: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("parent_thread_id", "parentThreadId"),
+    )
+    fork_mode: Optional[str] = Field(
+        default=None, validation_alias=AliasChoices("fork_mode", "forkMode")
+    )
+    client_intent: Optional[Any] = Field(
+        default=None, validation_alias=AliasChoices("client_intent", "clientIntent")
+    )
+
+
 class ManagedThreadCreateRequest(Payload):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
@@ -274,6 +293,21 @@ class ManagedThreadCreateRequest(Payload):
         exclude=True,
     )
     workspace_root: Optional[str] = None
+    genesis: Optional[ManagedThreadGenesisRequest] = None
+    origin: Optional[str] = None
+    scope_source: Optional[str] = Field(
+        default=None, validation_alias=AliasChoices("scope_source", "scopeSource")
+    )
+    parent_thread_id: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("parent_thread_id", "parentThreadId"),
+    )
+    fork_mode: Optional[str] = Field(
+        default=None, validation_alias=AliasChoices("fork_mode", "forkMode")
+    )
+    client_intent: Optional[Any] = Field(
+        default=None, validation_alias=AliasChoices("client_intent", "clientIntent")
+    )
     name: Optional[str] = None
     model: Optional[str] = None
     pr_mode: bool = Field(
@@ -328,6 +362,21 @@ class ManagedThreadCreateRequest(Payload):
         if not isinstance(value, dict):
             return value
         payload = dict(value)
+        genesis = value.get("genesis")
+        if isinstance(genesis, dict):
+            alias_pairs = (
+                ("origin", "origin"),
+                ("scope_source", "scopeSource"),
+                ("parent_thread_id", "parentThreadId"),
+                ("fork_mode", "forkMode"),
+                ("client_intent", "clientIntent"),
+            )
+            for field_name, alias in alias_pairs:
+                if field_name not in payload and alias not in payload:
+                    if field_name in genesis:
+                        payload[field_name] = genesis[field_name]
+                    elif alias in genesis:
+                        payload[field_name] = genesis[alias]
         payload["notify_on_explicit"] = any(
             key in value for key in ("notify_on", "notifyOn")
         )
@@ -425,6 +474,7 @@ __all__ = [
     "ManagedThreadCompactRequest",
     "ManagedThreadCreateRequest",
     "ManagedThreadForkRequest",
+    "ManagedThreadGenesisRequest",
     "ManagedThreadMessageRequest",
     "ManagedThreadResumeRequest",
     "PmaNewSessionRequest",

--- a/src/codex_autorunner/web_frontend/src/lib/application/pmaChatCommands.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/pmaChatCommands.test.ts
@@ -70,9 +70,41 @@ describe('PMA chat command plans', () => {
         message: 'Hello',
         reasoning: 'high',
         client_turn_id: 'client-1',
+        origin: 'web',
         scope_urn: 'hub',
+        scope_source: 'default_hub',
         wait_for_confirmation: false
       }
+    });
+  });
+
+  it('marks route and picker genesis scope sources on draft first sends', () => {
+    const repoScope = {
+      id: 'repo:repo-1',
+      kind: 'repo' as const,
+      label: 'Repo One',
+      detail: '/hub/repo-1',
+      resourceKind: 'repo' as const,
+      resourceId: 'repo-1',
+      scopeUrn: 'repo:repo-1'
+    };
+    expect(
+      planStartAndSendChat(repoScope, 'codex', '', '', 'Route chat', {
+        scopeSource: 'route_explicit'
+      }).body
+    ).toMatchObject({
+      origin: 'web',
+      scope_urn: 'repo:repo-1',
+      scope_source: 'route_explicit'
+    });
+    expect(
+      planStartAndSendChat(repoScope, 'codex', '', '', 'Picker chat', {
+        scopeSource: 'picker_explicit'
+      }).body
+    ).toMatchObject({
+      origin: 'web',
+      scope_urn: 'repo:repo-1',
+      scope_source: 'picker_explicit'
     });
   });
 

--- a/src/codex_autorunner/web_frontend/src/lib/application/pmaChatCommands.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/pmaChatCommands.test.ts
@@ -108,6 +108,42 @@ describe('PMA chat command plans', () => {
     });
   });
 
+  it('keeps global draft first sends hub-scoped unless the route or picker is explicit', () => {
+    const ambientWorktreeScope = {
+      id: 'worktree:repo-1/repo-1--discord-1',
+      kind: 'worktree' as const,
+      label: 'Discord worktree',
+      detail: '/worktrees/repo-1--discord-1',
+      workspaceRoot: '/hub/worktrees/repo-1--discord-1',
+      resourceId: 'repo-1--discord-1',
+      parentRepoId: 'repo-1',
+      scopeUrn: 'worktree:repo-1/repo-1--discord-1'
+    };
+
+    expect(
+      planStartAndSendChat(
+        localPmaChatScopeOption(),
+        'codex',
+        '',
+        '',
+        'Global chat after selection'
+      ).body
+    ).toMatchObject({
+      origin: 'web',
+      scope_urn: 'hub',
+      scope_source: 'default_hub'
+    });
+    expect(
+      planStartAndSendChat(ambientWorktreeScope, 'codex', '', '', 'Explicit route chat', {
+        scopeSource: 'route_explicit'
+      }).body
+    ).toMatchObject({
+      origin: 'web',
+      scope_urn: 'worktree:repo-1/repo-1--discord-1',
+      scope_source: 'route_explicit'
+    });
+  });
+
   it('plans queue and interrupt policies explicitly for existing threads', () => {
     expect(planQueueExistingChat('thread-1', 'Queue this')).toMatchObject({
       kind: 'SendMessage',

--- a/src/codex_autorunner/web_frontend/src/lib/application/pmaChatCommands.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/pmaChatCommands.ts
@@ -9,7 +9,8 @@ import {
   type ManagedThreadMessagePayload,
   type ManagedThreadStartMessagePayload,
   type PendingAttachment,
-  type PmaChatScopeOption
+  type PmaChatScopeOption,
+  type PmaChatScopeSource
 } from '$lib/viewModels/pmaChat';
 import type { PmaChatKind } from '$lib/viewModels/pmaChat';
 
@@ -89,6 +90,7 @@ export function planStartAndSendChat(
     attachments?: Array<PendingAttachment | DocumentFileIntentPayload>;
     reasoning?: string;
     clientTurnId?: string;
+    scopeSource?: PmaChatScopeSource;
   } = {}
 ): StartAndSendPmaChatPlan {
   return {
@@ -103,7 +105,8 @@ export function planStartAndSendChat(
       message,
       options.attachments ?? [],
       options.reasoning ?? '',
-      options.clientTurnId ?? ''
+      options.clientTurnId ?? '',
+      options.scopeSource ?? 'default_hub'
     )
   };
 }

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatThreadPreMessagePickers.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatThreadPreMessagePickers.svelte
@@ -6,6 +6,7 @@
    */
   import AgentModelReasoningPicker from '$lib/components/AgentModelReasoningPicker.svelte';
   import type { PickerRecord } from '$lib/viewModels/modelPickers';
+  import type { PmaChatScopeOption } from '$lib/viewModels/pmaChat';
 
   let {
     agents = [],
@@ -14,11 +15,14 @@
     models = [],
     modelValue = $bindable(''),
     reasoningValue = $bindable(''),
+    scopeValue = $bindable('local'),
+    scopeOptions = [],
     loading = false,
     modelCatalogError = null,
     showAgent = undefined,
     onAgentChange = undefined,
-    onPickerChange = undefined
+    onPickerChange = undefined,
+    onScopeChange = undefined
   }: {
     agents?: PickerRecord[];
     agentValue?: string;
@@ -26,14 +30,29 @@
     models?: PickerRecord[];
     modelValue?: string;
     reasoningValue?: string;
+    scopeValue?: string;
+    scopeOptions?: PmaChatScopeOption[];
     loading?: boolean;
     modelCatalogError?: string | null;
     showAgent?: boolean;
     onAgentChange?: (() => void) | undefined;
     /** Fires when agent / profile / model / effort controls change (including programmatic binds). */
     onPickerChange?: (() => void) | undefined;
+    /** Fires only when the user explicitly changes the new-chat scope picker. */
+    onScopeChange?: (() => void) | undefined;
   } = $props();
 </script>
+
+{#if scopeOptions.length > 1}
+  <label class="scope-picker">
+    <span>Scope</span>
+    <select bind:value={scopeValue} onchange={onScopeChange}>
+      {#each scopeOptions as scope}
+        <option value={scope.id}>{scope.label}</option>
+      {/each}
+    </select>
+  </label>
+{/if}
 
 <AgentModelReasoningPicker
   {agents}
@@ -50,3 +69,25 @@
   onAgentChange={onAgentChange}
   onchange={onPickerChange}
 />
+
+<style>
+  .scope-picker {
+    display: grid;
+    gap: 0.35rem;
+    margin-bottom: 0.75rem;
+    color: var(--muted-foreground, #5f6368);
+    font-size: 0.78rem;
+    font-weight: 600;
+  }
+
+  .scope-picker select {
+    min-height: 2.25rem;
+    border: 1px solid var(--border, #d0d7de);
+    border-radius: 6px;
+    background: var(--background, #fff);
+    color: var(--foreground, #1f2328);
+    font: inherit;
+    font-weight: 500;
+    padding: 0.35rem 0.55rem;
+  }
+</style>

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -262,6 +262,12 @@ export type ManagedThreadCreatePayload = {
   scope_urn: string;
 };
 
+export type PmaChatScopeSource =
+  | 'default_hub'
+  | 'route_explicit'
+  | 'picker_explicit'
+  | 'inherited_continuation';
+
 export type PmaChatScopeOption =
   | {
       id: 'local';
@@ -602,7 +608,10 @@ export type ManagedThreadMessagePayload = {
 };
 
 export type ManagedThreadStartMessagePayload = ManagedThreadCreatePayload &
-  ManagedThreadMessagePayload;
+  ManagedThreadMessagePayload & {
+    origin: 'web';
+    scope_source: PmaChatScopeSource;
+  };
 
 const activeStatuses: WorkStatus[] = ['running'];
 const waitingStatuses: WorkStatus[] = ['waiting', 'blocked'];
@@ -2422,10 +2431,13 @@ export function buildManagedThreadStartMessagePayload(
   message: string,
   attachments: Array<PendingAttachment | DocumentFileIntentPayload> = [],
   reasoning = '',
-  clientTurnId = ''
+  clientTurnId = '',
+  scopeSource: PmaChatScopeSource = 'default_hub'
 ): ManagedThreadStartMessagePayload {
   return {
     ...buildManagedThreadCreatePayload(agent, scope, name, model, profile, chatKind),
+    origin: 'web',
+    scope_source: scopeSource,
     ...buildManagedThreadMessagePayload(
       message,
       model,

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -1596,12 +1596,11 @@
     if (!options.preserveSelectedScope) {
       selectedScopeId = 'local';
       selectedScopeSource = 'default_hub';
-      if (newChatKind === 'agent') newChatKind = 'pma';
+      newChatKind = 'pma';
     }
     localDraftChat = newDraftChatSummary();
     activeChatId = localDraftChat.id;
     detailMode = 'detail';
-    newChatKind = 'pma';
     closeStream();
     void goto(href('/chats'), { replaceState: true });
     creating = false;

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -92,7 +92,8 @@
     type ChatStatusFilter,
     type ChatListEntry,
     type ChatRunGroup,
-    type PmaChatScopeOption
+    type PmaChatScopeOption,
+    type PmaChatScopeSource
   } from '$lib/viewModels/pmaChat';
   import {
     isChatUnread,
@@ -156,6 +157,7 @@
   let selectedReasoning = $state('');
   let selectedProfile = $state('');
   let selectedScopeId = $state('local');
+  let selectedScopeSource = $state<PmaChatScopeSource>('default_hub');
   let newChatKind = $state<'pma' | 'agent'>('pma');
   let filter = $state<ChatFilter>('all');
   let detailMode = $state<'list' | 'detail'>('list');
@@ -828,7 +830,10 @@
       topologyResult.ok ? selectRepoSummaries(scopeState) : [],
       topologyResult.ok ? selectWorktreeSummaries(scopeState) : []
     );
-    if (!scopeOptions.some((scope) => scope.id === selectedScopeId)) selectedScopeId = 'local';
+    if (!scopeOptions.some((scope) => scope.id === selectedScopeId)) {
+      selectedScopeId = 'local';
+      selectedScopeSource = 'default_hub';
+    }
     if (!canStartCodingAgentChat) newChatKind = 'pma';
     if (agentResult.ok) {
       agents = agentResult.data.agents;
@@ -875,16 +880,19 @@
       const sid = `repo:${decoded.slice('repo:'.length)}`;
       if (scopeOptions.some((scope) => scope.id === sid)) {
         selectedScopeId = sid;
+        selectedScopeSource = 'route_explicit';
         appliedScope = true;
       }
     } else if (decoded.startsWith('worktree:')) {
       const sid = `worktree:${decoded.slice('worktree:'.length)}`;
       if (scopeOptions.some((scope) => scope.id === sid)) {
         selectedScopeId = sid;
+        selectedScopeSource = 'route_explicit';
         appliedScope = true;
       }
     } else if (decoded === 'local' || decoded === 'hub') {
       selectedScopeId = 'local';
+      selectedScopeSource = 'route_explicit';
       appliedScope = true;
     }
     const requestedKind = page.url.searchParams.get('kind');
@@ -894,7 +902,7 @@
     params.delete('kind');
     const query = params.toString();
     void goto(href(`/chats${query ? `?${query}` : ''}`), { replaceState: true }).then(() => {
-      if (appliedScope) void createChat();
+      if (appliedScope) void createChat({ preserveSelectedScope: true });
     });
   }
 
@@ -1439,6 +1447,11 @@
     if (modelExists(models, selectedModel)) persistLastModelForAgent(selectedAgent, selectedModel);
   }
 
+  function handleScopePickerChange(): void {
+    selectedScopeSource = selectedScopeId === 'local' ? 'default_hub' : 'picker_explicit';
+    if (newChatKind === 'agent' && selectedScopeId === 'local') newChatKind = 'pma';
+  }
+
   function newChatDisplayName(): string {
     return newChatKind === 'agent' && canStartCodingAgentChat
       ? 'New coding agent chat'
@@ -1466,7 +1479,9 @@
       updatedAt: now,
       raw: {
         draft: true,
+        origin: 'web',
         scope_urn: scope.scopeUrn,
+        scope_source: selectedScopeSource,
         chat_kind: chatKind
       }
     };
@@ -1575,9 +1590,14 @@
     };
   });
 
-  async function createChat(): Promise<void> {
+  async function createChat(options: { preserveSelectedScope?: boolean } = {}): Promise<void> {
     creating = true;
     composeError = null;
+    if (!options.preserveSelectedScope) {
+      selectedScopeId = 'local';
+      selectedScopeSource = 'default_hub';
+      if (newChatKind === 'agent') newChatKind = 'pma';
+    }
     localDraftChat = newDraftChatSummary();
     activeChatId = localDraftChat.id;
     detailMode = 'detail';
@@ -1706,7 +1726,8 @@
               chatKind: newChatKind === 'agent' && canStartCodingAgentChat ? 'coding_agent' : 'pma',
               attachments: attachmentsForMessage,
               reasoning: selectedReasoning,
-              clientTurnId: optimisticId
+              clientTurnId: optimisticId,
+              scopeSource: selectedScopeSource
             }
           )
         : busyPolicy === 'interrupt'
@@ -2240,7 +2261,7 @@
         <span class="sr-only">Search chats</span>
         <input bind:value={search} type="search" placeholder="Search chats, repos, tickets" />
       </label>
-      <button class="new-chat-button" type="button" onclick={createChat} disabled={creating}>
+      <button class="new-chat-button" type="button" onclick={() => createChat()} disabled={creating}>
         {createChatLabel}
       </button>
     </div>
@@ -2666,11 +2687,14 @@
             bind:profileValue={selectedProfile}
             bind:modelValue={selectedModel}
             bind:reasoningValue={selectedReasoning}
+            bind:scopeValue={selectedScopeId}
             {models}
+            {scopeOptions}
             loading={loadingModels}
             showAgent={showAgentSelector}
             onAgentChange={handleAgentChange}
             onPickerChange={handlePickerChange}
+            onScopeChange={handleScopePickerChange}
           />
         </div>
       {:else if activeCards.length === 0 && liveActivity}

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { render } from 'svelte/server';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
@@ -10,6 +12,22 @@ import Page from './[[chatId]]/+page.svelte';
 describe('/chats page', () => {
   afterEach(() => {
     readModelEntityStore.reset();
+  });
+
+  it('preserves route-selected agent drafts when creating a scoped local draft', () => {
+    const source = readFileSync(
+      fileURLToPath(new URL('./[[chatId]]/+page.svelte', import.meta.url)),
+      'utf8'
+    );
+    const createChatBody = source.match(
+      /async function createChat[\s\S]*?\n  async function sendMessage/
+    )?.[0];
+
+    expect(createChatBody).toContain('if (!options.preserveSelectedScope)');
+    expect(createChatBody).toMatch(
+      /if \(!options\.preserveSelectedScope\) \{[\s\S]*newChatKind = 'pma';[\s\S]*\}/
+    );
+    expect(createChatBody).not.toMatch(/detailMode = 'detail';\s*newChatKind = 'pma';/);
   });
 
   it('renders filters, chat list shell, and composer affordances without global memory controls', () => {

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -61,6 +61,8 @@ def _seed_thread(
     resource_id: str | None = None,
     lifecycle_status: str = "active",
     runtime_status: str = "idle",
+    display_name: str | None = None,
+    last_message_preview: str | None = None,
     metadata: dict[str, object] | None = None,
 ) -> None:
     with open_orchestration_sqlite(hub_root, durable=False, migrate=True) as conn:
@@ -75,10 +77,11 @@ def _seed_thread(
                 display_name,
                 lifecycle_status,
                 runtime_status,
+                last_message_preview,
                 metadata_json,
                 created_at,
                 updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 thread_id,
@@ -86,9 +89,10 @@ def _seed_thread(
                 repo_id,
                 resource_kind,
                 resource_id or repo_id,
-                f"Thread {thread_id}",
+                display_name or f"Thread {thread_id}",
                 lifecycle_status,
                 runtime_status,
+                last_message_preview,
                 json.dumps(metadata or {}),
                 "2026-05-11T00:00:00Z",
                 "2026-05-11T00:00:10Z",
@@ -721,7 +725,7 @@ def test_chat_index_sorts_by_conversation_activity_not_metadata_hydration(
     older = next(
         row for row in index["rows"] if row["managed_thread_id"] == "thread-older"
     )
-    assert older["title"] == "Agent Nexus / #codex"
+    assert older["title"] == "thread-older"
     assert older["last_activity_at"] == "2026-05-11T00:00:10Z"
 
 
@@ -870,7 +874,7 @@ def test_chat_index_rebuild_repairs_stale_archived_bound_surface_projection(
     }
 
 
-def test_chat_index_and_detail_prefer_bound_chat_display_for_fallback_titles(
+def test_chat_index_and_detail_keep_bound_chat_display_secondary(
     tmp_path: Path,
 ) -> None:
     hub_root = tmp_path / "hub"
@@ -961,16 +965,123 @@ def test_chat_index_and_detail_prefer_bound_chat_display_for_fallback_titles(
         for item in index["rows"]
         if item["managed_thread_id"] == "thread-discord-friendly"
     )
-    assert row["title"] == "Agent Nexus / #codex"
-    assert row["chat_display_name"] == "Agent Nexus / #codex"
+    assert row["title"] == "thread-discord-friendly"
+    assert row["display_title"] == "thread-discord-friendly"
+    assert row["chat_display_name"] == "thread-discord-friendly"
+    assert row["binding_display_name"] == "Agent Nexus / #codex"
 
     detail = service.chat_detail_snapshot("thread-discord-friendly")
-    assert detail["thread"]["title"] == "Agent Nexus / #codex"
-    assert detail["thread"]["chat_display_name"] == "Agent Nexus / #codex"
+    assert detail["thread"]["title"] == "thread-discord-friendly"
+    assert detail["thread"]["chat_display_name"] == "thread-discord-friendly"
 
     custom_detail = service.chat_detail_snapshot("thread-discord-custom")
     assert custom_detail["thread"]["title"] == "Customer escalation"
-    assert custom_detail["thread"]["chat_display_name"] == "Agent Nexus / #support"
+    assert custom_detail["thread"]["chat_display_name"] == "Customer escalation"
+
+
+def test_chat_index_keeps_pma_title_with_notification_reply_contexts(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(
+        hub_root,
+        thread_id="thread-notified",
+        display_name="Deploy investigation",
+    )
+    notifications = PmaNotificationStore(hub_root)
+    notifications.record_notification(
+        correlation_id="corr-notification-source",
+        source_kind="pma",
+        delivery_mode="direct",
+        surface_kind="discord",
+        surface_key="guild:alerts",
+        delivery_record_id="delivery-notification-source",
+        repo_id="repo-1",
+        managed_thread_id="thread-notified",
+        notification_id="5dd3d434ee364219af850bf41221c27c",
+    )
+    notifications.record_notification(
+        correlation_id="corr-notification-continuation",
+        source_kind="pma",
+        delivery_mode="direct",
+        surface_kind="telegram",
+        surface_key="-100:42",
+        delivery_record_id="delivery-notification-continuation",
+        repo_id="repo-1",
+        managed_thread_id="source-thread",
+        continuation_thread_target_id="thread-notified",
+        notification_id="followup-notification",
+    )
+
+    row = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(limit=20)[
+        "rows"
+    ][0]
+
+    assert row["managed_thread_id"] == "thread-notified"
+    assert row["title"] == "Deploy investigation"
+    assert row["display_title"] == "Deploy investigation"
+    assert row["chat_display_name"] == "Deploy investigation"
+    assert (
+        "Notification 5dd3d434ee364219af850bf41221c27c" in row["binding_display_names"]
+    )
+    assert {surface["surface_kind"] for surface in row["surface_bindings"]} >= {
+        "pma",
+        "notification",
+    }
+
+
+def test_chat_index_keeps_external_notification_label_without_managed_thread(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    PmaNotificationStore(hub_root).record_notification(
+        correlation_id="corr-external-notification",
+        source_kind="pma",
+        delivery_mode="direct",
+        surface_kind="discord",
+        surface_key="guild:alerts",
+        delivery_record_id="delivery-external-notification",
+        repo_id="repo-1",
+        notification_id="external-notification",
+    )
+
+    row = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(
+        view="external",
+        limit=20,
+    )["rows"][0]
+
+    assert row["managed_thread_id"] is None
+    assert row["title"] == "Notification external-notification"
+    assert row["display_title"] == "Notification external-notification"
+    assert row["chat_display_name"] == "Notification external-notification"
+
+
+def test_chat_index_uses_message_preview_before_thread_id_fallback(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(
+        hub_root,
+        thread_id="thread-preview-title",
+        last_message_preview="Investigate failed deploy",
+    )
+    OrchestrationBindingStore(hub_root, durable=False).upsert_binding(
+        surface_kind="discord",
+        surface_key="1495134681929355404",
+        thread_target_id="thread-preview-title",
+        repo_id="repo-1",
+        resource_kind="repo",
+        resource_id="repo-1",
+        metadata={"display_name": "Agent Nexus / #deploys"},
+    )
+
+    row = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(limit=20)[
+        "rows"
+    ][0]
+
+    assert row["title"] == "Investigate failed deploy"
+    assert row["display_title"] == "Investigate failed deploy"
+    assert row["binding_display_name"] == "Agent Nexus / #deploys"
 
 
 def test_chat_surface_read_model_allows_lifecycle_recovery_events(

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_route_helpers.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_route_helpers.py
@@ -18,6 +18,29 @@ from codex_autorunner.surfaces.web.routes.pma_routes.managed_thread_route_helper
     resolve_managed_thread_list_query,
     serialize_managed_thread_turn_summary,
 )
+from codex_autorunner.surfaces.web.schemas import ManagedThreadStartMessageRequest
+
+
+def test_start_schema_accepts_nested_genesis_aliases() -> None:
+    payload = ManagedThreadStartMessageRequest.model_validate(
+        {
+            "message": "hello",
+            "agent": "codex",
+            "genesis": {
+                "origin": "web",
+                "scopeSource": "default_hub",
+                "parentThreadId": "thread-parent",
+                "forkMode": "copy_context",
+                "clientIntent": {"draftId": "draft-1"},
+            },
+        }
+    )
+
+    assert payload.origin == "web"
+    assert payload.scope_source == "default_hub"
+    assert payload.parent_thread_id == "thread-parent"
+    assert payload.fork_mode == "copy_context"
+    assert payload.client_intent == {"draftId": "draft-1"}
 
 
 class TestNormalizeWorkspaceRootInput:

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -963,7 +963,7 @@ def test_hub_read_models_chats_includes_binding_display_contract_fields(
     assert response.status_code == 200
     row = response.json()["rows"][0]
     assert row["chatId"] == "thread-0003"
-    assert row["displayTitle"] == "Release room"
+    assert row["displayTitle"] == "Thread 0003"
     assert row["technicalTitle"] == "thread-0003"
     assert row["primarySurface"]["surface_kind"] == "pma"
     assert "Release room" in row["bindingDisplayNames"]

--- a/tests/test_managed_threads_messages.py
+++ b/tests/test_managed_threads_messages.py
@@ -12,15 +12,23 @@ from fastapi.testclient import TestClient
 
 from codex_autorunner.adapters.discord.state import DiscordStateStore
 from codex_autorunner.adapters.telegram.state import TelegramStateStore
-from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
+from codex_autorunner.bootstrap import seed_repo_files
+from codex_autorunner.core.config import (
+    CONFIG_FILENAME,
+    DEFAULT_HUB_CONFIG,
+    load_hub_config,
+)
 from codex_autorunner.core.managed_thread_store import (
     ManagedThreadNotActiveError,
     ManagedThreadStore,
 )
+from codex_autorunner.core.orchestration import OrchestrationBindingStore
 from codex_autorunner.core.orchestration.runtime_bindings import (
     clear_runtime_thread_binding,
 )
+from codex_autorunner.core.pma_notification_store import PmaNotificationStore
 from codex_autorunner.core.pma_transcripts import PmaTranscriptStore
+from codex_autorunner.manifest import load_manifest, save_manifest
 from codex_autorunner.server import create_hub_app
 from tests.conftest import write_test_config
 from tests.pma_support import (
@@ -37,6 +45,25 @@ from tests.pma_support.managed_threads import (
 )
 
 pytestmark = pytest.mark.slow
+
+
+def _seed_manifest_worktree(hub_env, worktree_id: str) -> Path:
+    worktree_root = hub_env.hub_root / "worktrees" / worktree_id
+    worktree_root.mkdir(parents=True)
+    (worktree_root / ".git").mkdir(exist_ok=True)
+    seed_repo_files(worktree_root, git_required=False)
+    hub_config = load_hub_config(hub_env.hub_root)
+    manifest = load_manifest(hub_config.manifest_path, hub_env.hub_root)
+    manifest.ensure_repo(
+        hub_env.hub_root,
+        worktree_root,
+        repo_id=worktree_id,
+        kind="worktree",
+        worktree_of=hub_env.repo_id,
+        branch="feature",
+    )
+    save_manifest(hub_config.manifest_path, manifest, hub_env.hub_root)
+    return worktree_root
 
 
 def test_send_message_persists_turns_and_reuses_backend_thread(hub_env) -> None:
@@ -133,13 +160,13 @@ def test_send_message_persists_turns_and_reuses_backend_thread(hub_env) -> None:
     assert first_turn["status"] == "ok"
     assert first_turn["assistant_text"] == "assistant-output-1"
     assert first_turn["backend_turn_id"] == "backend-turn-1"
-    assert first_turn["transcript_turn_id"] == first_payload["managed_turn_id"]
+    assert first_turn["transcript_turn_id"] is None
 
     second_turn = by_id[second_payload["managed_turn_id"]]
     assert second_turn["status"] == "ok"
     assert second_turn["assistant_text"] == "assistant-output-2"
     assert second_turn["backend_turn_id"] == "backend-turn-2"
-    assert second_turn["transcript_turn_id"] == second_payload["managed_turn_id"]
+    assert second_turn["transcript_turn_id"] is None
 
     transcripts = PmaTranscriptStore(hub_env.hub_root)
     transcript = transcripts.read_transcript(first_payload["managed_turn_id"])
@@ -236,6 +263,157 @@ def test_start_thread_message_persists_genesis_metadata(hub_env) -> None:
     assert genesis["legacy"] is False
     assert genesis["client_intent"] == {"route": "/repos/repo-1/chat"}
     assert genesis["scope"]["urn"] == f"repo:{hub_env.repo_id}"
+
+
+def test_global_first_send_uses_hub_genesis_after_worktree_discord_chat_and_keeps_pma_title(
+    hub_env,
+) -> None:
+    _enable_pma(
+        hub_env.hub_root,
+        model="model-default",
+        reactive_enabled=False,
+        managed_thread_terminal_followup_default=False,
+    )
+    worktree_id = f"{hub_env.repo_id}--feature"
+    worktree_root = _seed_manifest_worktree(hub_env, worktree_id)
+    app = create_hub_app(hub_env.hub_root)
+    fake_supervisor = FakeSupervisor(FakeClient(sequential=True))
+
+    with TestClient(app) as client:
+        app.state.app_server_supervisor = fake_supervisor
+        app.state.app_server_events = object()
+        selected_resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                "name": "Previously selected Discord worktree chat",
+                "scope_urn": f"worktree:{hub_env.repo_id}/{worktree_id}",
+                "origin": "web",
+                "scope_source": "route_explicit",
+            },
+        )
+        assert selected_resp.status_code == 200
+        selected_thread = selected_resp.json()["thread"]
+        assert selected_thread["workspace_root"] == str(worktree_root.resolve())
+        OrchestrationBindingStore(hub_env.hub_root, durable=True).upsert_binding(
+            surface_kind="discord",
+            surface_key="guild:ambient-worktree",
+            thread_target_id=selected_thread["managed_thread_id"],
+            resource_kind="worktree",
+            resource_id=worktree_id,
+            metadata={"display_name": "Agent Nexus / #worktree"},
+        )
+
+        start_resp = client.post(
+            "/hub/pma/thread-starts",
+            json={
+                "message": "Investigate notification routing",
+                "agent": "codex",
+                "name": "New PMA chat",
+                "scope_urn": "hub",
+                "origin": "web",
+                "scope_source": "default_hub",
+                "client_intent": {
+                    "route": "/chats",
+                    "draft_id": "draft-global-after-discord",
+                },
+                "defer_execution": True,
+                "wait_for_confirmation": False,
+            },
+        )
+        assert start_resp.status_code == 200
+        managed_thread_id = start_resp.json()["managed_thread_id"]
+
+        notifications = PmaNotificationStore(hub_env.hub_root)
+        notifications.record_notification(
+            correlation_id="corr-5dd3",
+            source_kind="pma",
+            delivery_mode="direct",
+            surface_kind="discord",
+            surface_key="guild:alerts",
+            delivery_record_id="delivery-5dd3",
+            managed_thread_id=managed_thread_id,
+            notification_id="5dd3d434ee364219af850bf41221c27c",
+        )
+        index_resp = client.get("/hub/chat/index", params={"limit": 20})
+
+    assert str(hub_env.hub_root.resolve()) in fake_supervisor.client.thread_start_roots
+    assert str(worktree_root.resolve()) not in fake_supervisor.client.thread_start_roots
+
+    thread = ManagedThreadStore(hub_env.hub_root).get_thread(managed_thread_id)
+    assert thread is not None
+    assert thread["repo_id"] is None
+    assert thread["resource_kind"] is None
+    assert thread["resource_id"] is None
+    assert thread["workspace_root"] == str(hub_env.hub_root.resolve())
+    assert thread["last_message_preview"] == "Investigate notification routing"
+    genesis = thread["metadata"]["genesis"]
+    assert genesis["origin"] == "web"
+    assert genesis["scope_source"] == "default_hub"
+    assert genesis["scope"]["urn"] == "hub"
+    assert genesis["client_intent"]["draft_id"] == "draft-global-after-discord"
+
+    assert index_resp.status_code == 200
+    row = next(
+        item
+        for item in index_resp.json()["rows"]
+        if item["managed_thread_id"] == managed_thread_id
+    )
+    assert row["title"] == "Investigate notification routing"
+    assert row["display_title"] == "Investigate notification routing"
+    assert (
+        "Notification 5dd3d434ee364219af850bf41221c27c" in row["binding_display_names"]
+    )
+    assert {surface["surface_kind"] for surface in row["surface_bindings"]} >= {
+        "pma",
+        "notification",
+    }
+
+
+def test_route_explicit_first_send_creates_worktree_scoped_genesis(hub_env) -> None:
+    _enable_pma(
+        hub_env.hub_root,
+        model="model-default",
+        reactive_enabled=False,
+        managed_thread_terminal_followup_default=False,
+    )
+    worktree_id = f"{hub_env.repo_id}--route-explicit"
+    worktree_root = _seed_manifest_worktree(hub_env, worktree_id)
+    app = create_hub_app(hub_env.hub_root)
+    fake_supervisor = FakeSupervisor(FakeClient(sequential=True))
+
+    with TestClient(app) as client:
+        app.state.app_server_supervisor = fake_supervisor
+        app.state.app_server_events = object()
+        start_resp = client.post(
+            "/hub/pma/thread-starts",
+            json={
+                "message": "Route explicit worktree chat",
+                "agent": "codex",
+                "scope_urn": f"worktree:{hub_env.repo_id}/{worktree_id}",
+                "origin": "web",
+                "scope_source": "route_explicit",
+                "client_intent": {
+                    "route": f"/chats?new=worktree:{worktree_id}&kind=pma"
+                },
+                "defer_execution": True,
+                "wait_for_confirmation": False,
+            },
+        )
+
+    assert start_resp.status_code == 200
+    managed_thread_id = start_resp.json()["managed_thread_id"]
+    assert str(worktree_root.resolve()) in fake_supervisor.client.thread_start_roots
+
+    thread = ManagedThreadStore(hub_env.hub_root).get_thread(managed_thread_id)
+    assert thread is not None
+    assert thread["resource_kind"] == "worktree"
+    assert thread["resource_id"] == worktree_id
+    assert thread["workspace_root"] == str(worktree_root.resolve())
+    genesis = thread["metadata"]["genesis"]
+    assert genesis["origin"] == "web"
+    assert genesis["scope_source"] == "route_explicit"
+    assert genesis["scope"]["urn"] == f"worktree:{hub_env.repo_id}/{worktree_id}"
 
 
 def test_existing_thread_message_rejects_agent_field(hub_env) -> None:

--- a/tests/test_managed_threads_messages.py
+++ b/tests/test_managed_threads_messages.py
@@ -199,6 +199,45 @@ def test_start_thread_message_commits_agent_selection_without_empty_thread(
     assert turns[0]["model"] == "zai/glm"
 
 
+def test_start_thread_message_persists_genesis_metadata(hub_env) -> None:
+    _enable_pma(
+        hub_env.hub_root,
+        model="model-default",
+        reactive_enabled=False,
+        managed_thread_terminal_followup_default=False,
+    )
+    app = create_hub_app(hub_env.hub_root)
+    fake_supervisor = FakeSupervisor(FakeClient(sequential=True))
+
+    with TestClient(app) as client:
+        app.state.app_server_supervisor = fake_supervisor
+        app.state.app_server_events = object()
+        start_resp = client.post(
+            "/hub/pma/thread-starts",
+            json={
+                "message": "start with explicit genesis",
+                "agent": "codex",
+                "defer_execution": True,
+                "wait_for_confirmation": False,
+                "origin": "web",
+                "scope_source": "route_explicit",
+                "client_intent": {"route": "/repos/repo-1/chat"},
+                **_repo_owner(hub_env),
+            },
+        )
+
+    assert start_resp.status_code == 200
+    managed_thread_id = start_resp.json()["managed_thread_id"]
+    thread = ManagedThreadStore(hub_env.hub_root).get_thread(managed_thread_id)
+    assert thread is not None
+    genesis = thread["metadata"]["genesis"]
+    assert genesis["origin"] == "web"
+    assert genesis["scope_source"] == "route_explicit"
+    assert genesis["legacy"] is False
+    assert genesis["client_intent"] == {"route": "/repos/repo-1/chat"}
+    assert genesis["scope"]["urn"] == f"repo:{hub_env.repo_id}"
+
+
 def test_existing_thread_message_rejects_agent_field(hub_env) -> None:
     _enable_pma(
         hub_env.hub_root,

--- a/tests/test_managed_threads_routes.py
+++ b/tests/test_managed_threads_routes.py
@@ -216,6 +216,56 @@ def test_create_managed_thread_legacy_payload_gets_genesis_stamp(hub_env) -> Non
     assert genesis["scope"]["urn"] == f"repo:{hub_env.repo_id}"
 
 
+def test_create_managed_thread_legacy_worktree_payload_gets_worktree_genesis_urn(
+    hub_env,
+) -> None:
+    from codex_autorunner.bootstrap import seed_repo_files
+    from codex_autorunner.core.config import load_hub_config
+    from codex_autorunner.manifest import load_manifest, save_manifest
+
+    worktree_id = "repo--legacy-feature"
+    worktree_root = hub_env.hub_root / "worktrees" / worktree_id
+    worktree_root.mkdir(parents=True)
+    (worktree_root / ".git").mkdir()
+    seed_repo_files(worktree_root, git_required=False)
+    hub_config = load_hub_config(hub_env.hub_root)
+    manifest = load_manifest(hub_config.manifest_path, hub_env.hub_root)
+    manifest.ensure_repo(
+        hub_env.hub_root,
+        worktree_root,
+        repo_id=worktree_id,
+        kind="worktree",
+        worktree_of=hub_env.repo_id,
+        branch="legacy-feature",
+    )
+    save_manifest(hub_config.manifest_path, manifest, hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                "resource_kind": "worktree",
+                "resource_id": worktree_id,
+            },
+        )
+
+    assert resp.status_code == 200
+    thread = resp.json()["thread"]
+    stored = ManagedThreadStore(hub_env.hub_root).get_thread(
+        thread["managed_thread_id"]
+    )
+    assert stored is not None
+    genesis = stored["metadata"]["genesis"]
+    assert genesis["origin"] == "legacy"
+    assert genesis["scope_source"] == "legacy_scope_fields"
+    assert genesis["scope"]["kind"] == "worktree"
+    assert genesis["scope"]["urn"] == f"worktree:{hub_env.repo_id}/{worktree_id}"
+    assert genesis["scope"]["resource_kind"] == "worktree"
+    assert genesis["scope"]["resource_id"] == worktree_id
+
+
 def test_create_managed_thread_rejects_conflicting_repo_fields(hub_env) -> None:
     app = create_hub_app(hub_env.hub_root)
 

--- a/tests/test_managed_threads_routes.py
+++ b/tests/test_managed_threads_routes.py
@@ -266,6 +266,45 @@ def test_create_managed_thread_legacy_worktree_payload_gets_worktree_genesis_urn
     assert genesis["scope"]["resource_id"] == worktree_id
 
 
+def test_create_managed_thread_legacy_worktree_payload_rejects_missing_parent(
+    hub_env,
+) -> None:
+    from codex_autorunner.bootstrap import seed_repo_files
+    from codex_autorunner.core.config import load_hub_config
+    from codex_autorunner.manifest import load_manifest, save_manifest
+
+    worktree_id = "repo--orphan-feature"
+    worktree_root = hub_env.hub_root / "worktrees" / worktree_id
+    worktree_root.mkdir(parents=True)
+    (worktree_root / ".git").mkdir()
+    seed_repo_files(worktree_root, git_required=False)
+    hub_config = load_hub_config(hub_env.hub_root)
+    manifest = load_manifest(hub_config.manifest_path, hub_env.hub_root)
+    manifest.ensure_repo(
+        hub_env.hub_root,
+        worktree_root,
+        repo_id=worktree_id,
+        kind="worktree",
+        worktree_of=None,
+        branch="orphan-feature",
+    )
+    save_manifest(hub_config.manifest_path, manifest, hub_env.hub_root)
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                "resource_kind": "worktree",
+                "resource_id": worktree_id,
+            },
+        )
+
+    assert resp.status_code == 400
+    assert "worktree_of metadata" in resp.json()["detail"]
+
+
 def test_create_managed_thread_rejects_conflicting_repo_fields(hub_env) -> None:
     app = create_hub_app(hub_env.hub_root)
 

--- a/tests/test_managed_threads_routes.py
+++ b/tests/test_managed_threads_routes.py
@@ -152,6 +152,88 @@ def test_create_managed_thread_with_repo_scope_urn(hub_env) -> None:
     assert thread["workspace_root"] == str(hub_env.repo_root.resolve())
 
 
+def test_create_managed_thread_persists_explicit_genesis_metadata(hub_env) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                "scope_urn": f"repo:{hub_env.repo_id}",
+                "genesis": {
+                    "origin": "web",
+                    "scope_source": "picker_explicit",
+                    "parent_thread_id": "parent-thread-1",
+                    "fork_mode": "copy_context",
+                    "client_intent": {"draft_id": "draft-1"},
+                },
+                "name": "Genesis thread",
+            },
+        )
+
+    assert resp.status_code == 200
+    thread = resp.json()["thread"]
+    store = ManagedThreadStore(hub_env.hub_root)
+    stored = store.get_thread(thread["managed_thread_id"])
+    assert stored is not None
+    genesis = stored["metadata"]["genesis"]
+    assert genesis["origin"] == "web"
+    assert genesis["scope_source"] == "picker_explicit"
+    assert genesis["legacy"] is False
+    assert genesis["parent_thread_id"] == "parent-thread-1"
+    assert genesis["fork_mode"] == "copy_context"
+    assert genesis["client_intent"] == {"draft_id": "draft-1"}
+    assert genesis["scope"]["urn"] == f"repo:{hub_env.repo_id}"
+    assert genesis["scope"]["kind"] == "repo"
+    assert genesis["scope"]["resource_kind"] == "repo"
+    assert genesis["scope"]["resource_id"] == hub_env.repo_id
+    assert genesis["scope"]["actual_workspace_root"] == thread["workspace_root"]
+    assert genesis["client_scope_request"] == {
+        "scope_urn": f"repo:{hub_env.repo_id}",
+    }
+
+
+def test_create_managed_thread_legacy_payload_gets_genesis_stamp(hub_env) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/hub/pma/threads",
+            json={"agent": "codex", **_repo_owner(hub_env)},
+        )
+
+    assert resp.status_code == 200
+    thread = resp.json()["thread"]
+    stored = ManagedThreadStore(hub_env.hub_root).get_thread(
+        thread["managed_thread_id"]
+    )
+    assert stored is not None
+    genesis = stored["metadata"]["genesis"]
+    assert genesis["origin"] == "legacy"
+    assert genesis["scope_source"] == "legacy_scope_fields"
+    assert genesis["legacy"] is True
+    assert genesis["scope"]["urn"] == f"repo:{hub_env.repo_id}"
+
+
+def test_create_managed_thread_rejects_conflicting_repo_fields(hub_env) -> None:
+    app = create_hub_app(hub_env.hub_root)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/hub/pma/threads",
+            json={
+                "agent": "codex",
+                "repo_id": hub_env.repo_id,
+                "resource_kind": "repo",
+                "resource_id": "other-repo",
+            },
+        )
+
+    assert resp.status_code == 400
+    assert "repo_id conflicts" in resp.json()["detail"]
+
+
 def test_create_managed_thread_with_worktree_scope_urn(hub_env) -> None:
     from codex_autorunner.bootstrap import seed_repo_files
     from codex_autorunner.core.config import load_hub_config

--- a/tests/test_managed_threads_routes.py
+++ b/tests/test_managed_threads_routes.py
@@ -968,7 +968,7 @@ def test_create_managed_thread_rejects_missing_or_both_inputs(hub_env) -> None:
     assert missing.json()["thread"]["resource_kind"] is None
     assert missing.json()["thread"]["workspace_root"] == str(hub_env.hub_root.resolve())
     assert both.status_code == 400
-    assert "Exactly one of resource owner or workspace_root is required" in (
+    assert "workspace_root cannot be combined with legacy owner fields" in (
         both.json().get("detail") or ""
     )
 
@@ -2323,6 +2323,24 @@ def test_managed_thread_crud_routes_use_orchestration_service(
                     "context_profile": "car_ambient",
                     "approval_mode": "yolo",
                     "chat_kind": "pma",
+                    "genesis": {
+                        "origin": "legacy",
+                        "scope_source": "legacy_scope_fields",
+                        "legacy": True,
+                        "scope": {
+                            "urn": f"repo:{hub_env.repo_id}",
+                            "kind": "repo",
+                            "repo_id": hub_env.repo_id,
+                            "resource_kind": "repo",
+                            "resource_id": hub_env.repo_id,
+                            "workspace_root": str(hub_env.repo_root.resolve()),
+                            "actual_workspace_root": str(hub_env.repo_root.resolve()),
+                        },
+                        "client_scope_request": {
+                            "resource_kind": "repo",
+                            "resource_id": hub_env.repo_id,
+                        },
+                    },
                 },
             },
         ),


### PR DESCRIPTION
## Summary
- Make web PMA chat creation carry explicit genesis intent so global `+ Chat` defaults to hub scope instead of inheriting the active chat scope.
- Persist auditable genesis metadata on managed threads, including origin, scope source, normalized scope, and client intent diagnostics.
- Keep notification and delivery surfaces as secondary bindings so `Notification <id>` cannot override a PMA chat's primary title.
- Add regression coverage for global hub genesis after viewing Discord/worktree chats, route-explicit worktree genesis, and notification-bound chat display invariants.

## Root Cause
A web-started PMA chat could reuse ambient frontend scope state from the selected chat, so a global-looking chat could be created in a Discord/worktree context. Separately, chat-surface projection allowed notification reply-context labels to outrank the PMA thread title, producing rows named like `Notification 5dd3...`.

## Validation
- `python3 .codex-autorunner/bin/lint_tickets.py`
- `pnpm web:test -- pmaChat pmaChatCommands`
- `.venv/bin/python -m pytest tests/surfaces/web/routes/pma_routes/test_managed_thread_route_helpers.py tests/test_managed_threads_messages.py tests/test_managed_threads_routes.py tests/core/orchestration/test_chat_surface_read_model.py tests/surfaces/web/test_hub_chat_read_model_routes.py` (`177 passed`)

## Note
The pre-commit hook's broad core lane was run during amend and failed outside this PR's touched area after `8926 passed`, with failures/timeouts in app-server startup timeout, Discord dispatch validation, idle CPU soak, hub chat patch stream, and chat surface lab artifact manifest tests. A sampled rerun of representative failures showed the Discord dispatch, idle CPU soak, and hub chat patch stream tests passing; `tests/test_app_server_client.py::test_startup_timeout_terminates_hung_initialize_and_allows_fresh_start` remains reproducibly failing on this checkout with a 0.2s startup timeout.
