### PR TITLE
[codex] Improve chat transcript efficiency

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
@@ -946,6 +946,8 @@ def build_managed_thread_tail_routes(
             terminal_transcript_snapshots_sent: set[str] = set()
             while True:
                 await asyncio.sleep(_PERSISTED_TAIL_POLL_SECONDS)
+                if await request.is_disconnected():
+                    return
                 refreshed = await _build_managed_thread_tail_snapshot(
                     request=request,
                     service=service,
@@ -1110,6 +1112,8 @@ def build_managed_thread_tail_routes(
             last_heartbeat_at = asyncio.get_running_loop().time()
             while True:
                 await asyncio.sleep(_PERSISTED_TAIL_POLL_SECONDS)
+                if await request.is_disconnected():
+                    return
                 refreshed = await _build_managed_thread_tail_snapshot(
                     request=request,
                     service=service,

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -19,6 +19,7 @@ import {
   selectChatIndexWindowView,
   selectorFingerprint
 } from './readModelStore';
+import { selectChatTranscript } from './readModelViewModels';
 
 const now = '2026-05-11T12:00:00Z';
 
@@ -327,6 +328,16 @@ describe('read model entity store', () => {
     store.setPmaProgress('chat-1', progress('chat-1', 1));
 
     expect(store.snapshot().chatTranscripts['chat-2']).toBe(inactiveBefore);
+  });
+
+  it('keeps selected transcript arrays stable across unrelated state updates', () => {
+    const store = new ReadModelEntityStore();
+    store.replaceChatTranscript('chat-1', [pmaMessageCard('chat-1', 'turn:1:user', 'hello')]);
+    const selectedBefore = selectChatTranscript(store.snapshot(), 'chat-1');
+
+    store.setPmaProgress('chat-1', progress('chat-1', 1));
+
+    expect(selectChatTranscript(store.snapshot(), 'chat-1')).toBe(selectedBefore);
   });
 
   it('does not clone untouched cached details when another detail patches', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -455,16 +455,20 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     if (!cards.length) return;
     const next = cloneState(this.state);
     const transcript = cloneChatTranscript(next.chatTranscripts[chatId] ?? { cardsById: {}, order: [] });
-    const knownIds = new Set(transcript.order);
+    let changed = false;
     for (const card of cards) {
       const id = chatTranscriptCardEntityId(card);
+      const previous = transcript.cardsById[id];
+      if (previous === card) continue;
       transcript.cardsById[id] = card;
-      if (!knownIds.has(id)) {
-        knownIds.add(id);
-        transcript.order.push(id);
+      if (previous) {
+        const currentIndex = transcript.order.indexOf(id);
+        if (currentIndex >= 0) transcript.order.splice(currentIndex, 1);
       }
+      insertOrderedChatTranscriptId(transcript, id);
+      changed = true;
     }
-    transcript.order = orderChatTranscriptCards(transcript.order.map((id) => transcript.cardsById[id]).filter(Boolean)).map(chatTranscriptCardEntityId);
+    if (!changed) return;
     next.chatTranscripts[chatId] = transcript;
     bump(next, 'timeline', chatId);
     this.commit(next);
@@ -1183,6 +1187,23 @@ function chatTranscriptCardEntityId(card: ChatTranscriptCard): string {
 
 function orderChatTranscriptCards(cards: ChatTranscriptCard[]): ChatTranscriptCard[] {
   return [...cards].sort(compareChatTranscriptCards);
+}
+
+function insertOrderedChatTranscriptId(
+  transcript: { cardsById: Record<string, ChatTranscriptCard>; order: string[] },
+  id: string
+): void {
+  const card = transcript.cardsById[id];
+  if (!card) return;
+  let low = 0;
+  let high = transcript.order.length;
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    const midCard = transcript.cardsById[transcript.order[mid]];
+    if (!midCard || compareChatTranscriptCards(midCard, card) <= 0) low = mid + 1;
+    else high = mid;
+  }
+  transcript.order.splice(low, 0, id);
 }
 
 function compareChatTranscriptCards(left: ChatTranscriptCard, right: ChatTranscriptCard): number {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
@@ -27,6 +27,10 @@ import type { ChatTranscriptCard } from '$lib/viewModels/pmaChat';
 import { selectChatIndexWindowView, type ChatIndexWindowRequest, type ReadModelEntityState } from './readModelStore';
 
 type JsonRecord = Record<string, unknown>;
+type ChatTranscriptProjection = ReadModelEntityState['chatTranscripts'][string];
+
+const emptyChatTranscript: ChatTranscriptCard[] = [];
+const chatTranscriptSelectionCache = new WeakMap<ChatTranscriptProjection, ChatTranscriptCard[]>();
 
 export function syntheticProjectionCursor(source: string, sequence = Date.now()): ProjectionCursor {
   return {
@@ -163,9 +167,14 @@ export function selectPmaChats(state: ReadModelEntityState, request?: ChatIndexW
 }
 
 export function selectChatTranscript(state: ReadModelEntityState, chatId: string | null): ChatTranscriptCard[] {
-  if (!chatId) return [];
+  if (!chatId) return emptyChatTranscript;
   const transcript = state.chatTranscripts[chatId];
-  return transcript ? transcript.order.map((id) => transcript.cardsById[id]).filter(Boolean) : [];
+  if (!transcript) return emptyChatTranscript;
+  const cached = chatTranscriptSelectionCache.get(transcript);
+  if (cached) return cached;
+  const selected = transcript.order.map((id) => transcript.cardsById[id]).filter(Boolean);
+  chatTranscriptSelectionCache.set(transcript, selected);
+  return selected;
 }
 
 export function selectPmaProgress(state: ReadModelEntityState, chatId: string | null): PmaRunProgress | null {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/markdown.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/markdown.ts
@@ -20,6 +20,11 @@ const PURIFY_CONFIG = {
   FORBID_ATTR: ['style', 'onerror', 'onload', 'onclick', 'onmouseover']
 };
 
+const MAX_RENDER_CACHE_ENTRIES = 250;
+const MAX_RENDER_CACHE_CHARS = 1_000_000;
+const renderCache = new Map<string, string>();
+let renderCacheChars = 0;
+
 export type RenderMarkdownOptions = {
   /** When true, every `<a>` gets `target="_blank"` and `rel="noopener noreferrer"`. */
   openLinksInNewTab?: boolean;
@@ -43,6 +48,13 @@ function forceMarkdownLinksOpenInNewTab(html: string): string {
 
 export function renderMarkdownToHtml(markdown: string, options?: RenderMarkdownOptions): string {
   if (!markdown) return '';
+  const cacheKey = `${options?.openLinksInNewTab ? '1' : '0'}:${markdown}`;
+  const cached = renderCache.get(cacheKey);
+  if (cached !== undefined) {
+    renderCache.delete(cacheKey);
+    renderCache.set(cacheKey, cached);
+    return cached;
+  }
   const rawHtml = marked.parse(markdown, { async: false }) as string;
   const purified = DOMPurify.sanitize(rawHtml, PURIFY_CONFIG);
   // Strip any href that survived sanitize but resolves to a dangerous scheme.
@@ -50,5 +62,18 @@ export function renderMarkdownToHtml(markdown: string, options?: RenderMarkdownO
   // `data:` and `vbscript:` to match the legacy renderer's contract.
   let out = purified.replace(/href="(data|vbscript):[^"]*"/gi, 'href="#"');
   if (options?.openLinksInNewTab) out = forceMarkdownLinksOpenInNewTab(out);
+  rememberRenderedMarkdown(cacheKey, out);
   return out;
+}
+
+function rememberRenderedMarkdown(cacheKey: string, html: string): void {
+  renderCache.set(cacheKey, html);
+  renderCacheChars += cacheKey.length + html.length;
+  while (renderCache.size > MAX_RENDER_CACHE_ENTRIES || renderCacheChars > MAX_RENDER_CACHE_CHARS) {
+    const oldestKey = renderCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    const oldestValue = renderCache.get(oldestKey) ?? '';
+    renderCache.delete(oldestKey);
+    renderCacheChars -= oldestKey.length + oldestValue.length;
+  }
 }

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -324,8 +324,10 @@
     slashSelectedIndex = Math.min(slashSelectedIndex, Math.max(slashSuggestions.length - 1, 0));
   });
   let pendingRefreshTimer: number | null = null;
+  let pendingQueueRefreshTimer: number | null = null;
   let activeClockInterval: number | null = null;
   let activeRefreshSeq = 0;
+  let activeQueueRefreshSeq = 0;
   let clockNowMs = $state(Date.now());
   let lastScrolledChatId: string | null = null;
   let lastScrolledCardCount = 0;
@@ -763,6 +765,7 @@
     unsubscribeChatIndexSession?.();
     chatIndexSession.stop();
     if (pendingRefreshTimer) window.clearTimeout(pendingRefreshTimer);
+    if (pendingQueueRefreshTimer) window.clearTimeout(pendingQueueRefreshTimer);
     if (chatIndexFilterRefreshTimer) window.clearTimeout(chatIndexFilterRefreshTimer);
     if (activeClockInterval) window.clearInterval(activeClockInterval);
     closeStream();
@@ -1186,6 +1189,17 @@
     if (!options.quiet || loadingActive) loadingActive = false;
   }
 
+  async function refreshActiveQueue(chatId: string): Promise<void> {
+    const refreshSeq = ++activeQueueRefreshSeq;
+    const queueResult = await webApi.pma.getQueue(chatId);
+    if (activeChatId !== chatId || refreshSeq !== activeQueueRefreshSeq) return;
+    if (queueResult.ok) {
+      readModelEntityStore.setPmaQueue(chatId, queueResult.data.queuedTurns);
+    } else if (isMissingManagedThreadError(queueResult.error)) {
+      readModelEntityStore.setPmaQueue(chatId, []);
+    }
+  }
+
   function connectStream(chatId: string): void {
     closeStream();
     const seedProgress = currentProgress(chatId);
@@ -1217,7 +1231,18 @@
           const rows = mapChatTranscriptRows(event.payload.rows);
           replaceChatTranscriptPreservingPendingOptimistic(chatId, rows);
           const status = event.payload.status;
-          if (status && typeof status === 'object' && !Array.isArray(status)) updateProgress(mapPmaRunProgress(status as JsonRecord));
+          if (status && typeof status === 'object' && !Array.isArray(status)) {
+            const nextProgress = mapPmaRunProgress(status as JsonRecord);
+            updateProgress(nextProgress);
+            if (
+              nextProgress.terminal &&
+              nextProgress.id &&
+              transcriptHasAssistantMessageForTurn(rows, nextProgress.id)
+            ) {
+              refreshedTerminalTurnId = nextProgress.id;
+              scheduleActiveQueueRefresh(chatId, 700);
+            }
+          }
           return;
         }
         if (event.kind === 'transcript_append') {
@@ -1272,6 +1297,14 @@
     }, delayMs);
   }
 
+  function scheduleActiveQueueRefresh(chatId: string, delayMs = 600): void {
+    if (pendingQueueRefreshTimer) window.clearTimeout(pendingQueueRefreshTimer);
+    pendingQueueRefreshTimer = window.setTimeout(() => {
+      pendingQueueRefreshTimer = null;
+      if (activeChatId === chatId) void refreshActiveQueue(chatId);
+    }, delayMs);
+  }
+
   function closeStream(): void {
     streamSubscription?.close();
     streamSubscription = null;
@@ -1280,6 +1313,15 @@
 
   function isMissingManagedThreadError(error: ApiError): boolean {
     return error.status === 404 && error.message.toLowerCase().includes('managed thread not found');
+  }
+
+  function transcriptHasAssistantMessageForTurn(cards: ChatTranscriptCard[], turnId: string): boolean {
+    return cards.some((card) =>
+      card.kind === 'message' &&
+      card.turnId === turnId &&
+      card.message.role === 'assistant' &&
+      card.message.text.trim().length > 0
+    );
   }
 
   /** Elapsed seconds capped by wall clock while status is running (matches live UI). */

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -30,6 +30,20 @@ describe('/chats page', () => {
     expect(createChatBody).not.toMatch(/detailMode = 'detail';\s*newChatKind = 'pma';/);
   });
 
+  it('keeps terminal snapshot queue reconciliation separate from full transcript repair', () => {
+    const source = readFileSync(
+      fileURLToPath(new URL('./[[chatId]]/+page.svelte', import.meta.url)),
+      'utf8'
+    );
+    const snapshotBranch = source.match(
+      /if \(event\.kind === 'transcript_snapshot'\)[\s\S]*?return;\n        \}/
+    )?.[0];
+
+    expect(snapshotBranch).toContain('refreshedTerminalTurnId = nextProgress.id');
+    expect(snapshotBranch).toContain('scheduleActiveQueueRefresh(chatId, 700)');
+    expect(source).toContain('async function refreshActiveQueue');
+  });
+
   it('renders filters, chat list shell, and composer affordances without global memory controls', () => {
     const { body } = render(Page);
 


### PR DESCRIPTION
## Summary
- keep chat transcript selector results stable across unrelated read-model updates
- replace full transcript re-sorts on append with ordered incremental insertion
- cache sanitized markdown renders with bounded LRU storage
- avoid redundant terminal transcript refreshes after SSE terminal snapshots
- stop transcript/tail SSE polling work when the request disconnects

## Root cause
The chat detail pane could repeatedly invalidate and re-render the full transcript while waiting for a final response. Progress ticks, terminal patches, duplicate refreshes, markdown sanitization, and long-lived SSE polling all compounded into main-thread pressure and stale server work.

## Validation
- pnpm web:lint
- pnpm web:test
- pnpm web:test -- page.test.ts readModelStore.test.ts streaming.test.ts
- .venv/bin/python -m pytest tests/surfaces/web/routes/pma_routes/test_tail_stream_characterization.py tests/surfaces/web/routes/pma_routes/test_managed_thread_timeline_route.py
- commit hook web-ui lane: guardrails, mypy, repo pytest 8943 passed, web UI lab, frontend lint/build/tests, SPA shell check
