### PR TITLE
[codex] Fix ticket loop guard dirty diff fingerprint

### DIFF
--- a/src/codex_autorunner/core/flows/controller.py
+++ b/src/codex_autorunner/core/flows/controller.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, AsyncGenerator, Callable, Dict, Optional, Set
 
 from ...manifest import ManifestError, load_manifest
-from ..git_utils import GitError, run_git
+from ..git_utils import git_content_sensitive_repo_fingerprint
 from ..lifecycle_events import LifecycleEventEmitter, LifecycleEventType
 from ..state_roots import resolve_hub_manifest_path
 from ..utils import find_repo_root
@@ -310,17 +310,7 @@ class FlowController:
         repo_root = self._repo_root()
         if repo_root is None:
             return None
-        try:
-            head_proc = run_git(["rev-parse", "HEAD"], cwd=repo_root, check=True)
-            status_proc = run_git(["status", "--porcelain"], cwd=repo_root, check=True)
-            head = (head_proc.stdout or "").strip()
-            status = (status_proc.stdout or "").strip()
-            if not head:
-                return None
-            return f"{head}\n{status}"
-        except GitError:
-            _logger.exception("Failed to get git state")
-            return None
+        return git_content_sensitive_repo_fingerprint(repo_root)
 
     def _has_new_user_reply_signal(
         self, *, run_id: str, input_data: dict[str, Any]

--- a/src/codex_autorunner/core/git_utils.py
+++ b/src/codex_autorunner/core/git_utils.py
@@ -2,6 +2,8 @@
 Centralized Git utilities for consistent git operations across the codebase.
 """
 
+import hashlib
+import os
 import subprocess
 from contextlib import contextmanager
 from pathlib import Path
@@ -61,6 +63,123 @@ def run_git(
         raise GitError(f"git {args[0]} failed: {detail}", returncode=proc.returncode)
 
     return proc
+
+
+def _run_git_bytes(
+    args: List[str],
+    cwd: Path,
+    *,
+    timeout_seconds: int = 30,
+    check: bool = False,
+) -> subprocess.CompletedProcess[bytes]:
+    try:
+        proc = subprocess.run(
+            ["git"] + args,
+            cwd=str(cwd),
+            capture_output=True,
+            timeout=timeout_seconds,
+            env=subprocess_env(),
+        )
+    except FileNotFoundError as exc:
+        raise GitError("git binary not found", returncode=127) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise GitError(
+            f"git command timed out: git {' '.join(args)}", returncode=124
+        ) from exc
+
+    if check and proc.returncode != 0:
+        stderr = (proc.stderr or b"").decode("utf-8", errors="replace").strip()
+        stdout = (proc.stdout or b"").decode("utf-8", errors="replace").strip()
+        detail = stderr or stdout or f"exit {proc.returncode}"
+        raise GitError(f"git {args[0]} failed: {detail}", returncode=proc.returncode)
+
+    return proc
+
+
+def _run_git_stdout(args: List[str], *, workspace_root: Path) -> str:
+    proc = run_git(args, cwd=workspace_root, check=True)
+    return proc.stdout or ""
+
+
+def _untracked_file_fingerprint(path: Path) -> str:
+    try:
+        stat = path.lstat()
+        if path.is_symlink():
+            payload = f"symlink:{path.readlink()}".encode(
+                "utf-8", errors="surrogateescape"
+            )
+        elif path.is_file():
+            payload = path.read_bytes()
+        else:
+            payload = b""
+        content_hash = hashlib.sha256(payload).hexdigest()
+        return f"{stat.st_mode}:{stat.st_size}:{content_hash}"
+    except OSError as exc:
+        return f"unreadable:{type(exc).__name__}"
+
+
+def _is_control_plane_path(rel_path: str) -> bool:
+    return rel_path == ".codex-autorunner" or rel_path.startswith(".codex-autorunner/")
+
+
+def git_content_sensitive_repo_fingerprint(workspace_root: Path) -> Optional[str]:
+    """Return HEAD, status, and content hashes for dirty repository state."""
+    try:
+        head = _run_git_stdout(
+            ["rev-parse", "HEAD"], workspace_root=workspace_root
+        ).strip()
+        if not head:
+            return None
+
+        status = _run_git_stdout(
+            ["status", "--porcelain"], workspace_root=workspace_root
+        ).strip()
+        staged_diff = _run_git_stdout(
+            ["diff", "--cached", "--full-index", "--binary"],
+            workspace_root=workspace_root,
+        )
+        worktree_diff = _run_git_stdout(
+            ["diff", "--full-index", "--binary"],
+            workspace_root=workspace_root,
+        )
+        untracked_proc = _run_git_bytes(
+            ["ls-files", "--others", "--exclude-standard", "-z"],
+            cwd=workspace_root,
+            check=True,
+        )
+    except (GitError, UnicodeDecodeError):
+        return None
+
+    digest = hashlib.sha256()
+    for label, value in (
+        ("head", head),
+        ("status", status),
+        ("staged", staged_diff),
+        ("worktree", worktree_diff),
+    ):
+        digest.update(label.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(value.encode("utf-8", errors="surrogateescape"))
+        digest.update(b"\0")
+
+    untracked_paths = sorted(
+        path for path in (untracked_proc.stdout or b"").split(b"\0") if path
+    )
+    for rel_path_bytes in untracked_paths:
+        rel_path = os.fsdecode(rel_path_bytes)
+        if _is_control_plane_path(rel_path):
+            continue
+        digest.update(b"untracked\0")
+        digest.update(rel_path_bytes)
+        digest.update(b"\0")
+        digest.update(
+            _untracked_file_fingerprint(workspace_root / rel_path).encode(
+                "utf-8", errors="surrogateescape"
+            )
+        )
+        digest.update(b"\0")
+
+    return f"{head}\n{status}\ncontent:{digest.hexdigest()}"
 
 
 def git_linked_worktree_git_dir(repo_root: Path) -> Optional[Path]:

--- a/src/codex_autorunner/tickets/runner_execution.py
+++ b/src/codex_autorunner/tickets/runner_execution.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import Any, Optional
 
-from ..core.git_utils import GitError, run_git
+from ..core.git_utils import GitError, git_content_sensitive_repo_fingerprint, run_git
 from .agent_pool import AgentPool, AgentTurnRequest
 from .runner_types import TurnExecutionResult
 
@@ -97,10 +97,10 @@ def capture_git_state(*, workspace_root: Path) -> dict[str, Any]:
     try:
         head_proc = run_git(["rev-parse", "HEAD"], cwd=workspace_root, check=True)
         head_before_turn = (head_proc.stdout or "").strip() or None
-        status_proc = run_git(["status", "--porcelain"], cwd=workspace_root, check=True)
-        status_before = (status_proc.stdout or "").strip() or ""
         if head_before_turn:
-            repo_fingerprint_before = f"{head_before_turn}\n{status_before}"
+            repo_fingerprint_before = git_content_sensitive_repo_fingerprint(
+                workspace_root
+            )
     except GitError:
         head_before_turn = None
         repo_fingerprint_before = None
@@ -132,7 +132,9 @@ def capture_git_state_after(
         if head_before_turn and head_after_turn:
             agent_committed_this_turn = head_after_turn != head_before_turn
         if head_after_turn:
-            repo_fingerprint_after = f"{head_after_turn}\n{status_after_turn}"
+            repo_fingerprint_after = git_content_sensitive_repo_fingerprint(
+                workspace_root
+            )
     except GitError:
         head_after_turn = None
         clean_after_turn = None

--- a/src/codex_autorunner/tickets/runner_post_turn.py
+++ b/src/codex_autorunner/tickets/runner_post_turn.py
@@ -7,7 +7,12 @@ from typing import Any, Optional
 
 from ..core.file_chat_keys import ticket_instance_token
 from ..core.flows.models import FlowEventType
-from ..core.git_utils import GitError, git_diff_stats, run_git
+from ..core.git_utils import (
+    GitError,
+    git_content_sensitive_repo_fingerprint,
+    git_diff_stats,
+    run_git,
+)
 from .files import read_ticket_frontmatter
 from .models import TicketResult
 from .outbox import (
@@ -246,17 +251,8 @@ def checkpoint_git(
 
 
 def get_repo_fingerprint(workspace_root: Path) -> Optional[str]:
-    """Return a stable snapshot of HEAD + porcelain status."""
-    try:
-        head_proc = run_git(["rev-parse", "HEAD"], cwd=workspace_root, check=True)
-        status_proc = run_git(["status", "--porcelain"], cwd=workspace_root, check=True)
-        head = (head_proc.stdout or "").strip()
-        status = (status_proc.stdout or "").strip()
-        if not head:
-            return None
-        return f"{head}\n{status}"
-    except GitError:
-        return None
+    """Return a content-sensitive snapshot of repository state."""
+    return git_content_sensitive_repo_fingerprint(workspace_root)
 
 
 def build_pause_result(

--- a/tests/core/test_flow_runtime_resume.py
+++ b/tests/core/test_flow_runtime_resume.py
@@ -218,6 +218,43 @@ async def test_ticket_flow_resume_requires_signal_or_force(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
+async def test_ticket_flow_resume_allows_content_sensitive_repo_change(
+    tmp_path: Path,
+) -> None:
+    _init_git_repo(tmp_path)
+    dirty_file = tmp_path / "README.md"
+    dirty_file.write_text("first dirty edit\n", encoding="utf-8")
+
+    async def step(_record, _input):
+        return StepOutcome.complete()
+
+    controller = _make_controller(tmp_path, {"step": step}, flow_type="ticket_flow")
+    run_id = "run-dirty-change"
+    record = await controller.start_flow(input_data={}, run_id=run_id)
+
+    fingerprint = controller._repo_fingerprint()
+    assert isinstance(fingerprint, str)
+    blocked_state = {
+        "ticket_engine": {
+            "status": "paused",
+            "reason_code": "loop_no_diff",
+            "pause_context": {
+                "paused_reply_seq": 0,
+                "repo_fingerprint": fingerprint,
+            },
+        }
+    }
+    controller.store.update_flow_run_status(
+        run_id=record.id, status=FlowRunStatus.PAUSED, state=blocked_state
+    )
+
+    dirty_file.write_text("second dirty edit\n", encoding="utf-8")
+
+    resumed = await controller.resume_flow(record.id)
+    assert resumed.status == FlowRunStatus.RUNNING
+
+
+@pytest.mark.asyncio
 async def test_ticket_flow_resume_signal_uses_workspace_root(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
     workspace = tmp_path / "nested-workspace"

--- a/tests/tickets/test_runner_state_transitions.py
+++ b/tests/tickets/test_runner_state_transitions.py
@@ -481,6 +481,36 @@ class TestGetRepoFingerprint:
         assert fp is not None
         assert "dirty.txt" in fp
 
+    def test_changes_when_already_dirty_tracked_content_changes(self, tmp_path):
+        _init_git_repo(tmp_path)
+        tracked = tmp_path / "README.md"
+        tracked.write_text("first edit\n", encoding="utf-8")
+        fp1 = get_repo_fingerprint(tmp_path)
+
+        tracked.write_text("second edit\n", encoding="utf-8")
+        fp2 = get_repo_fingerprint(tmp_path)
+
+        assert fp1 is not None
+        assert fp2 is not None
+        assert "M README.md" in fp1
+        assert "M README.md" in fp2
+        assert fp1 != fp2
+
+    def test_changes_when_untracked_content_changes(self, tmp_path):
+        _init_git_repo(tmp_path)
+        untracked = tmp_path / "new.txt"
+        untracked.write_text("first\n", encoding="utf-8")
+        fp1 = get_repo_fingerprint(tmp_path)
+
+        untracked.write_text("second\n", encoding="utf-8")
+        fp2 = get_repo_fingerprint(tmp_path)
+
+        assert fp1 is not None
+        assert fp2 is not None
+        assert "new.txt" in fp1
+        assert "new.txt" in fp2
+        assert fp1 != fp2
+
 
 class TestCheckTicketFrontmatter:
     def test_rewrites_error_prefix_for_read_failure(self, tmp_path):


### PR DESCRIPTION
## Summary

Fixes #1849 by making ticket-flow loop guard fingerprints content-sensitive instead of relying only on `HEAD + git status --porcelain`.

The runner now includes staged diff, worktree diff, and untracked file content fingerprints in the repository snapshot used before and after each turn. Pause context also uses the same content-sensitive fingerprint helper.

## Impact

Long-running dirty ticket flows no longer accumulate false no-change turns when an agent keeps editing files that were already modified before the turn.

## Validation

- `.venv/bin/python -m pytest tests/tickets/test_runner_state_transitions.py::TestGetRepoFingerprint tests/tickets/test_runner_invariants.py::TestLoopGuardInvariants`
- `.venv/bin/python -m pytest tests/tickets/test_runner_state_transitions.py tests/tickets/test_runner_invariants.py tests/tickets/test_ticket_runner.py -q`
- commit hook aggregate validation: `8948 passed`, mypy clean, Ruff clean, Web UI lint/build/tests clean
