### PR TITLE
[codex] Preserve backend bindings across runtime replacement

### DIFF
--- a/src/codex_autorunner/adapters/app_server/client.py
+++ b/src/codex_autorunner/adapters/app_server/client.py
@@ -774,6 +774,7 @@ class CodexAppServerClient:
             "app_server.spawned",
             command=list(self._command),
             cwd=self._cwd,
+            pid=self._process.pid,
             runtime_instance_id=self._runtime_instance_id,
         )
         disconnected = self._ensure_disconnect_event()
@@ -1682,6 +1683,7 @@ class CodexAppServerClient:
             logging.WARNING,
             "app_server.disconnected",
             auto_restart=self._auto_restart,
+            runtime_instance_id=self._runtime_instance_id,
             returncode=returncode,
             pid=pid,
             pending_requests=len(self._pending),

--- a/src/codex_autorunner/core/orchestration/recovery_lifecycle.py
+++ b/src/codex_autorunner/core/orchestration/recovery_lifecycle.py
@@ -498,19 +498,7 @@ class _ThreadRecoveryHelper:
                 backend_thread_id=backend_thread_id,
                 stored_runtime_instance_id=runtime_binding.backend_runtime_instance_id,
                 current_runtime_instance_id=runtime_instance_id,
-            )
-            interrupted = self.interrupt_lost_backend_execution(
-                thread_target_id=thread_target_id,
-                execution=execution,
-                backend_thread_id=backend_thread_id,
-                reason="stale_backend_runtime_instance",
-            )
-            return ThreadStopOutcome(
-                thread_target_id=thread_target_id,
-                cancelled_queued=cancelled_queued,
-                execution=interrupted,
-                interrupted_active=True,
-                recovered_lost_backend=True,
+                action="attempt_interrupt",
             )
 
         try:

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -1655,7 +1655,7 @@ async def test_stop_thread_marks_interrupted_when_backend_binding_is_missing(
     assert service.get_running_execution(thread.thread_target_id) is None
 
 
-async def test_stop_thread_marks_interrupted_when_runtime_instance_is_stale_without_interrupt(
+async def test_stop_thread_attempts_interrupt_when_runtime_instance_is_stale(
     tmp_path: Path,
 ) -> None:
     harness = _FakeHarness(backend_runtime_instance_id_value="runtime-old")
@@ -1679,9 +1679,11 @@ async def test_stop_thread_marks_interrupted_when_runtime_instance_is_stale_with
 
     outcome = await service.stop_thread(thread.thread_target_id)
 
-    assert harness.interrupt_calls == []
+    assert harness.interrupt_calls == [
+        (workspace_root, "backend-conversation-1", "backend-turn-1")
+    ]
     assert outcome.interrupted_active is True
-    assert outcome.recovered_lost_backend is True
+    assert outcome.recovered_lost_backend is False
     assert outcome.execution is not None
     assert outcome.execution.execution_id == execution.execution_id
     assert outcome.execution.status == "interrupted"
@@ -1689,8 +1691,46 @@ async def test_stop_thread_marks_interrupted_when_runtime_instance_is_stale_with
     refreshed_thread = service.get_thread_target(thread.thread_target_id)
     assert refreshed_thread is not None
     binding = _thread_runtime_binding(service, thread.thread_target_id)
-    assert binding is None
+    assert binding is not None
+    assert binding.backend_thread_id == "backend-conversation-1"
     assert service.get_running_execution(thread.thread_target_id) is None
+
+
+async def test_stop_thread_recovers_lost_backend_when_stale_runtime_interrupt_fails(
+    tmp_path: Path,
+) -> None:
+    harness = _FakeHarness(backend_runtime_instance_id_value="runtime-old")
+    service = _build_service(tmp_path, harness)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target(
+        "codex",
+        workspace_root,
+        metadata={"backend_runtime_instance_id": "runtime-old"},
+    )
+    execution = await service.send_message(
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="Need an answer",
+        )
+    )
+
+    harness.backend_runtime_instance_id_value = "runtime-new"
+    harness.interrupt_error = RuntimeError("Unknown Hermes turn 'backend-turn-1'")
+
+    outcome = await service.stop_thread(thread.thread_target_id)
+
+    assert harness.interrupt_calls == [
+        (workspace_root, "backend-conversation-1", "backend-turn-1")
+    ]
+    assert outcome.interrupted_active is True
+    assert outcome.recovered_lost_backend is True
+    assert outcome.execution is not None
+    assert outcome.execution.execution_id == execution.execution_id
+    assert outcome.execution.status == "interrupted"
+    binding = _thread_runtime_binding(service, thread.thread_target_id)
+    assert binding is None
 
 
 async def test_stop_thread_marks_interrupted_when_runtime_binding_is_lost_after_restart(


### PR DESCRIPTION
## Summary
- Preserve managed-thread backend bindings when only the app-server runtime instance changes.
- Continue attempting the backend interrupt on the saved thread/turn; only clear the binding when the runtime reports a recoverable missing-thread/turn failure.
- Add app-server lifecycle correlation fields so spawned/disconnected logs include pid and runtime instance id.

## Root Cause
CAR already resumes durable Codex threads for normal message turns, but the stop/interrupt recovery path treated a backend runtime instance mismatch as a lost backend before trying the saved backend thread id. That cleared the durable binding and forced the next message to start a fresh session, losing conversation context even when the agent runtime could still resume the old thread.

## Validation
- Pre-commit aggregate validation passed: black, ruff, import boundaries, hub contracts, mypy, pytest, web lint/build/tests.
- Full pytest suite from hook: 9012 passed, 10 warnings.
- Web frontend tests from hook: 692 passed, 2 skipped.
- Targeted local check before commit: .venv/bin/python -m pytest tests/core/orchestration/test_service.py (58 passed).
