### PR TITLE
fix(voice): fail-fast dependency check at VoiceService startup

### DIFF
--- a/src/codex_autorunner/voice/provider_catalog.py
+++ b/src/codex_autorunner/voice/provider_catalog.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib
+import logging
 from typing import Any, Optional, Sequence, Tuple, Union
 
 from ..core.utils import resolve_executable
@@ -52,3 +54,38 @@ def missing_local_voice_runtime_commands(provider: Any) -> list[str]:
     normalized = normalize_voice_provider(provider)
     commands = _LOCAL_PROVIDER_RUNTIME_COMMANDS.get(normalized, ())
     return [command for command in commands if resolve_executable(command) is None]
+
+
+def check_local_voice_provider_available(
+    provider: Any,
+    *,
+    logger: Optional[logging.Logger] = None,
+) -> Optional[str]:
+    """Check whether a local voice provider's Python package is importable.
+
+    Returns ``None`` when the provider is available (or is not a local
+    provider – e.g. ``openai_whisper``).  Returns a human-readable error
+    string describing what is missing so the caller can log / raise
+    appropriately.
+    """
+    _log = logger or logging.getLogger(__name__)
+    spec = local_voice_provider_spec(provider)
+    if spec is None:
+        # Not a local provider (e.g. openai_whisper) – nothing to check here.
+        return None
+
+    _name, dep_groups, extra = spec
+    for group in dep_groups:
+        for import_name in group:
+            try:
+                importlib.import_module(import_name)
+                return None  # first successful import means we're good
+            except ImportError:
+                continue
+
+    # All import candidates exhausted – report the install command.
+    return (
+        f"Local voice provider '{_name}' is configured but its Python "
+        f"package is not installed.  Install it with:\n"
+        f"  pip install 'codex-autorunner[{extra}]'"
+    )

--- a/src/codex_autorunner/voice/provider_catalog.py
+++ b/src/codex_autorunner/voice/provider_catalog.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib
-import logging
 from typing import Any, Optional, Sequence, Tuple, Union
 
 from ..core.utils import resolve_executable
@@ -56,11 +55,7 @@ def missing_local_voice_runtime_commands(provider: Any) -> list[str]:
     return [command for command in commands if resolve_executable(command) is None]
 
 
-def check_local_voice_provider_available(
-    provider: Any,
-    *,
-    logger: Optional[logging.Logger] = None,
-) -> Optional[str]:
+def check_local_voice_provider_available(provider: Any) -> Optional[str]:
     """Check whether a local voice provider's Python package is importable.
 
     Returns ``None`` when the provider is available (or is not a local
@@ -68,24 +63,27 @@ def check_local_voice_provider_available(
     string describing what is missing so the caller can log / raise
     appropriately.
     """
-    _log = logger or logging.getLogger(__name__)
     spec = local_voice_provider_spec(provider)
     if spec is None:
         # Not a local provider (e.g. openai_whisper) – nothing to check here.
         return None
 
     _name, dep_groups, extra = spec
-    for group in dep_groups:
-        for import_name in group:
+    for module_names, _display_name in dep_groups:
+        candidates = (
+            [module_names] if isinstance(module_names, str) else list(module_names)
+        )
+        for import_name in candidates:
             try:
                 importlib.import_module(import_name)
-                return None  # first successful import means we're good
+                break
             except ImportError:
                 continue
+        else:
+            return (
+                f"Local voice provider '{_name}' is configured but its Python "
+                f"package is not installed.  Install it with:\n"
+                f"  pip install 'codex-autorunner[{extra}]'"
+            )
 
-    # All import candidates exhausted – report the install command.
-    return (
-        f"Local voice provider '{_name}' is configured but its Python "
-        f"package is not installed.  Install it with:\n"
-        f"  pip install 'codex-autorunner[{extra}]'"
-    )
+    return None

--- a/src/codex_autorunner/voice/service.py
+++ b/src/codex_autorunner/voice/service.py
@@ -92,9 +92,7 @@ class VoiceService:
         # startup so the operator gets a clear error instead of a silent
         # failure on the first voice message.
         if config.enabled:
-            dep_error = check_local_voice_provider_available(
-                config.provider, logger=self._logger
-            )
+            dep_error = check_local_voice_provider_available(config.provider)
             if dep_error is not None:
                 self._logger.error(
                     "Voice provider dependency check failed at startup:\n%s",

--- a/src/codex_autorunner/voice/service.py
+++ b/src/codex_autorunner/voice/service.py
@@ -11,7 +11,11 @@ from ..core.exceptions import CodexError, PermanentError, TransientError
 from .capture import CaptureCallbacks, CaptureState, PushToTalkCapture
 from .config import VoiceConfig
 from .provider import SpeechSessionMetadata
-from .provider_catalog import local_voice_provider_spec, normalize_voice_provider
+from .provider_catalog import (
+    check_local_voice_provider_available,
+    local_voice_provider_spec,
+    normalize_voice_provider,
+)
 from .resolver import resolve_speech_provider
 
 
@@ -83,6 +87,19 @@ class VoiceService:
         self._provider = provider
         self._env = env if env is not None else os.environ
         self._circuit_breaker = CircuitBreaker("Voice", logger=self._logger)
+
+        # Fail-fast: detect missing local voice provider dependencies at
+        # startup so the operator gets a clear error instead of a silent
+        # failure on the first voice message.
+        if config.enabled:
+            dep_error = check_local_voice_provider_available(
+                config.provider, logger=self._logger
+            )
+            if dep_error is not None:
+                self._logger.error(
+                    "Voice provider dependency check failed at startup:\n%s",
+                    dep_error,
+                )
 
     def config_payload(self) -> dict:
         """Expose safe config fields to the UI."""

--- a/tests/test_voice_service.py
+++ b/tests/test_voice_service.py
@@ -139,3 +139,49 @@ def test_voice_service_passes_env_to_provider_resolver():
     result = service.transcribe(b"audio bytes", client="web")
     assert result["text"] == "ok"
     assert captured["env"].get("OPENAI_API_KEY") == "workspace-key"
+
+
+def test_voice_service_logs_error_at_startup_when_local_provider_missing(caplog):
+    """VoiceService should log a clear ERROR at __init__ time when a local
+    voice provider is configured but its Python package is not installed."""
+    import logging
+    import sys
+
+    from codex_autorunner.voice.provider_catalog import (
+        check_local_voice_provider_available,
+    )
+
+    # Block mlx_whisper to simulate a missing install.
+    class _Blocker:
+        def find_module(self, name, path=None):
+            if name == "mlx_whisper":
+                return self
+            return None
+
+        def load_module(self, name):
+            raise ImportError("blocked by test")
+
+    sys.meta_path.insert(0, _Blocker())
+    # Remove any cached import so the blocker actually fires.
+    sys.modules.pop("mlx_whisper", None)
+
+    try:
+        # Verify the check function detects the missing package.
+        err = check_local_voice_provider_available("mlx_whisper")
+        assert err is not None
+        assert "voice-mlx" in err
+
+        # Verify VoiceService logs the error during __init__.
+        with caplog.at_level(logging.ERROR, logger="codex_autorunner.voice.service"):
+            cfg = VoiceConfig.from_raw(
+                {"enabled": True, "provider": "mlx_whisper"},
+            )
+            VoiceService(cfg)
+
+        assert any(
+            "Voice provider dependency check failed" in rec.message
+            for rec in caplog.records
+        )
+    finally:
+        # Clean up meta-path blocker so we don't break subsequent tests.
+        sys.meta_path.pop(0)


### PR DESCRIPTION
## Summary

When a local voice provider (`mlx_whisper` or `local_whisper`) is configured but its Python package is not installed, the error was only surfaced **when the first voice message arrived** — often days after a hub update or pip cache purge. This made misconfiguration easy to miss.

### Changes

- **`provider_catalog.py`**: New function `check_local_voice_provider_available()` that attempts to import the configured local provider's package and returns a clear error string with the exact `pip install` command if missing.
- **`service.py`**: `VoiceService.__init__` now runs the check at construction time (when voice is enabled) and logs an **ERROR** with the install command.
- **`test_voice_service.py`**: New test that blocks `mlx_whisper` import via meta-path and verifies the error is logged at startup.

### Behavior change

| Before | After |
|--------|-------|
| Silent failure on first voice message | **ERROR in hub logs at startup** |
| Buried in transcription error output | Clear message with `pip install` command before any voice message arrives |

## Test Plan
- [x] Unit tests pass (`tests/test_voice_service.py` — 8/8 including new test)
- [ ] CI green