### PR TITLE
[codex] Fix Hermes cumulative turn output trimming

### DIFF
--- a/src/codex_autorunner/core/orchestration/service.py
+++ b/src/codex_autorunner/core/orchestration/service.py
@@ -436,6 +436,14 @@ class ManagedThreadExecutionStore(ThreadExecutionStore):
             return None
         return _execution_record_from_store_row(record)
 
+    def list_turns(
+        self, thread_target_id: str, *, limit: int = 50
+    ) -> list[ExecutionRecord]:
+        return [
+            _execution_record_from_store_row(record)
+            for record in self._store.list_turns(thread_target_id, limit=limit)
+        ]
+
     def list_queued_executions(
         self, thread_target_id: str, *, limit: int = 200
     ) -> list[ExecutionRecord]:

--- a/tests/adapters/chat/test_managed_thread_turns.py
+++ b/tests/adapters/chat/test_managed_thread_turns.py
@@ -30,6 +30,7 @@ from codex_autorunner.core.orchestration.runtime_threads import (
     RuntimeThreadExecution,
     RuntimeThreadOutcome,
 )
+from codex_autorunner.core.orchestration.service import ManagedThreadExecutionStore
 from codex_autorunner.core.orchestration.turn_output_reducer import (
     build_assistant_transcript_prefix,
     trim_cumulative_assistant_text,
@@ -225,6 +226,45 @@ def test_prior_completed_assistant_text_prefix_reconstructs_trimmed_history() ->
         service,
         managed_thread_id="thread-1",
         managed_turn_id="turn-current",
+    )
+
+    assert prefix == "first answersecond answer"
+    assert (
+        trim_cumulative_assistant_text(
+            "first answersecond answerthird answer",
+            prefix,
+        )[0]
+        == "third answer"
+    )
+
+
+def test_prior_completed_assistant_text_prefix_reads_execution_store_wrapper(
+    tmp_path: Path,
+) -> None:
+    store = ManagedThreadExecutionStore(ManagedThreadStore(tmp_path / "hub"))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    thread = store.create_thread_target("hermes", workspace)
+    first = store.create_execution(thread.thread_target_id, prompt="first")
+    store.record_execution_result(
+        thread.thread_target_id,
+        first.execution_id,
+        status="ok",
+        assistant_text="first answer",
+    )
+    second = store.create_execution(thread.thread_target_id, prompt="second")
+    store.record_execution_result(
+        thread.thread_target_id,
+        second.execution_id,
+        status="ok",
+        assistant_text="first answersecond answer",
+    )
+    current = store.create_execution(thread.thread_target_id, prompt="third")
+
+    prefix = managed_thread_turns_module._prior_completed_assistant_text_prefix(
+        SimpleNamespace(thread_store=store),
+        managed_thread_id=thread.thread_target_id,
+        managed_turn_id=current.execution_id,
     )
 
     assert prefix == "first answersecond answer"


### PR DESCRIPTION
## Summary
- expose `list_turns` on `ManagedThreadExecutionStore` so CAR can build the full prior assistant-text prefix
- add a regression test covering the real execution-store wrapper path used by hub-level Discord PMA threads

## Root Cause
Hermes ACP final output can be cumulative for durable sessions. CAR already has reducer logic to trim cumulative output, but the chat managed-thread path could not see full prior turn history when the orchestration service held a `ManagedThreadExecutionStore` wrapper. It fell back to only the immediate previous completed execution, so outputs shaped like turn A + turn B + current turn did not match the prior prefix and were delivered to Discord as accumulated final text.

## Validation
- `.venv/bin/python -m pytest tests/adapters/chat/test_managed_thread_turns.py -k "prior_completed_assistant_text_prefix or trim_cumulative"`
- `.venv/bin/python -m pytest tests/core/orchestration/test_turn_output_reducer.py`
- pre-commit aggregate lane: guardrails, mypy, repo pytest (`9013 passed`), web lint/build/tests passed; optional chat-surface lab skipped by local aggregate default
