### PR TITLE
[codex] Fix Discord queue interrupt message lifecycle

### DIFF
--- a/src/codex_autorunner/adapters/discord/car_handlers/queue_interrupt_handlers.py
+++ b/src/codex_autorunner/adapters/discord/car_handlers/queue_interrupt_handlers.py
@@ -18,6 +18,10 @@ from ..interaction_runtime import (
     defer_and_update_runtime_component_message,
     ensure_ephemeral_response_deferred,
 )
+from ..queue_status_lifecycle import (
+    DiscordQueueComponentAction,
+    QueueStatusCleanupPolicy,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -301,9 +305,15 @@ async def handle_queue_cancel_button(
         channel_id=channel_id,
         guild_id=guild_id,
     )
+    action = DiscordQueueComponentAction.build(
+        conversation_id=conversation_id,
+        channel_id=channel_id,
+        queued_user_message_id=source_message_id,
+        component_source_message_id=message_id,
+    )
     cancelled = await service._dispatcher.cancel_pending_message(
-        conversation_id,
-        source_message_id,
+        action.conversation_id,
+        action.queued_user_message_id,
     )
     if not cancelled:
         await service.respond_ephemeral(
@@ -320,8 +330,10 @@ async def handle_queue_cancel_button(
         components=[],
     )
     await service._refresh_queue_status_message(
-        conversation_id=conversation_id,
-        channel_id=channel_id,
+        conversation_id=action.conversation_id,
+        channel_id=action.channel_id,
+        cleanup_policy=QueueStatusCleanupPolicy.PRESERVE_COMPONENT_SOURCE,
+        component_source_message_id=action.component_source_message_id,
     )
     await service.respond_ephemeral(
         interaction_id,
@@ -354,9 +366,15 @@ async def handle_queue_interrupt_send_button(
         channel_id=channel_id,
         guild_id=guild_id,
     )
+    action = DiscordQueueComponentAction.build(
+        conversation_id=conversation_id,
+        channel_id=channel_id,
+        queued_user_message_id=source_message_id,
+        component_source_message_id=message_id,
+    )
     promoted = await service._dispatcher.promote_pending_message(
-        conversation_id,
-        source_message_id,
+        action.conversation_id,
+        action.queued_user_message_id,
     )
     if not promoted:
         await send_interrupt_component_response(
@@ -366,10 +384,6 @@ async def handle_queue_interrupt_send_button(
             "Queued request is no longer pending.",
         )
         return
-    await service._refresh_queue_status_message(
-        conversation_id=conversation_id,
-        channel_id=channel_id,
-    )
     binding = await service._store.get_binding(channel_id=channel_id)
     pma_enabled = bool(binding.get("pma_enabled", False)) if binding else False
     mode = "pma" if pma_enabled else "repo"
@@ -377,14 +391,27 @@ async def handle_queue_interrupt_send_button(
         service._get_discord_thread_binding(channel_id=channel_id, mode=mode)
     )
     if current_thread is None:
-        await service._wake_dispatcher_conversation(conversation_id)
-        await send_interrupt_component_response(
+        await defer_and_update_runtime_component_message(
             service,
             interaction_id,
             interaction_token,
             "Queued request moved to the front.",
+            components=[],
         )
+        await service._refresh_queue_status_message(
+            conversation_id=action.conversation_id,
+            channel_id=action.channel_id,
+            cleanup_policy=QueueStatusCleanupPolicy.PRESERVE_COMPONENT_SOURCE,
+            component_source_message_id=action.component_source_message_id,
+        )
+        await service._wake_dispatcher_conversation(action.conversation_id)
         return
+    await service._refresh_queue_status_message(
+        conversation_id=action.conversation_id,
+        channel_id=action.channel_id,
+        cleanup_policy=QueueStatusCleanupPolicy.PRESERVE_COMPONENT_SOURCE,
+        component_source_message_id=action.component_source_message_id,
+    )
     await defer_and_update_runtime_component_message(
         service,
         interaction_id,
@@ -398,12 +425,12 @@ async def handle_queue_interrupt_send_button(
         channel_id=channel_id,
         active_turn_text="Message received. Switching to it now...",
         allow_promoted_no_active_success=True,
-        progress_reuse_source_message_id=source_message_id,
+        progress_reuse_source_message_id=action.queued_user_message_id,
         progress_reuse_acknowledgement="Message received. Switching to it now...",
-        dispatcher_conversation_id=conversation_id,
+        dispatcher_conversation_id=action.conversation_id,
         source="component",
         source_custom_id=custom_id,
-        source_message_id=message_id,
+        source_message_id=action.component_source_message_id,
         source_user_id=user_id,
     )
 

--- a/src/codex_autorunner/adapters/discord/queue_status_lifecycle.py
+++ b/src/codex_autorunner/adapters/discord/queue_status_lifecycle.py
@@ -1,0 +1,38 @@
+"""Discord queue-status message lifecycle helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class QueueStatusCleanupPolicy(Enum):
+    DELETE_STALE = "delete_stale"
+    PRESERVE_COMPONENT_SOURCE = "preserve_component_source"
+
+
+@dataclass(frozen=True)
+class DiscordQueueComponentAction:
+    conversation_id: str
+    channel_id: str
+    queued_user_message_id: str
+    component_source_message_id: Optional[str]
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        conversation_id: str,
+        channel_id: str,
+        queued_user_message_id: str,
+        component_source_message_id: Optional[str],
+    ) -> "DiscordQueueComponentAction":
+        return cls(
+            conversation_id=str(conversation_id or "").strip(),
+            channel_id=str(channel_id or "").strip(),
+            queued_user_message_id=str(queued_user_message_id or "").strip(),
+            component_source_message_id=(
+                str(component_source_message_id or "").strip() or None
+            ),
+        )

--- a/src/codex_autorunner/adapters/discord/service.py
+++ b/src/codex_autorunner/adapters/discord/service.py
@@ -351,6 +351,7 @@ from .pma_commands import (
     handle_pma_on,
     handle_pma_status,
 )
+from .queue_status_lifecycle import QueueStatusCleanupPolicy
 from .rendering import (
     format_discord_message,
 )
@@ -1992,6 +1993,8 @@ class DiscordBotService(DiscordInteractionResponseMixin):
         *,
         conversation_id: str,
         channel_id: Optional[str] = None,
+        cleanup_policy: QueueStatusCleanupPolicy = QueueStatusCleanupPolicy.DELETE_STALE,
+        component_source_message_id: Optional[str] = None,
     ) -> None:
         entry = self._queue_status_messages.pop(conversation_id, None)
         if not isinstance(entry, tuple):
@@ -1999,6 +2002,11 @@ class DiscordBotService(DiscordInteractionResponseMixin):
         stored_channel_id, message_id = entry
         resolved_channel_id = channel_id or stored_channel_id
         if not resolved_channel_id or not message_id:
+            return
+        if (
+            cleanup_policy == QueueStatusCleanupPolicy.PRESERVE_COMPONENT_SOURCE
+            and message_id == str(component_source_message_id or "").strip()
+        ):
             return
         await self._delete_channel_message_safe(
             resolved_channel_id,
@@ -2031,6 +2039,8 @@ class DiscordBotService(DiscordInteractionResponseMixin):
         conversation_id: str,
         channel_id: str,
         repost: bool = False,
+        cleanup_policy: QueueStatusCleanupPolicy = QueueStatusCleanupPolicy.DELETE_STALE,
+        component_source_message_id: Optional[str] = None,
     ) -> None:
         queue_status = await self._dispatcher.queue_status(conversation_id)
         pending_items_raw = []
@@ -2044,6 +2054,8 @@ class DiscordBotService(DiscordInteractionResponseMixin):
             await self._clear_queue_status_message(
                 conversation_id=conversation_id,
                 channel_id=channel_id,
+                cleanup_policy=cleanup_policy,
+                component_source_message_id=component_source_message_id,
             )
             return
         busy_label, allow_interrupt = await self._queued_notice_config_for_conversation(

--- a/tests/adapters/discord/test_service_routing.py
+++ b/tests/adapters/discord/test_service_routing.py
@@ -3026,9 +3026,8 @@ async def test_component_interaction_queue_cancel_cancels_selected_pending_messa
             message_id="notice-1",
         )
 
-        assert rest.deleted_channel_messages == [
-            {"channel_id": "channel-1", "message_id": "notice-1"}
-        ]
+        assert rest.deleted_channel_messages == []
+        assert conversation_id not in service._queue_status_messages
         assert len(rest.interaction_responses) == 1
         assert rest.interaction_responses[0]["payload"]["type"] == 6
         assert len(rest.edited_original_interaction_responses) == 2
@@ -3106,6 +3105,7 @@ async def test_component_interaction_queue_interrupt_send_promotes_and_interrupt
             channel_id="channel-1",
             guild_id="guild-1",
         )
+        service._queue_status_messages[conversation_id] = ("channel-1", "notice-1")
 
         async def _promote_pending_message(
             _conversation_id: str, message_id: str
@@ -3161,6 +3161,8 @@ async def test_component_interaction_queue_interrupt_send_promotes_and_interrupt
         assert (
             rest.edited_original_interaction_responses[0]["payload"]["components"] == []
         )
+        assert rest.deleted_channel_messages == []
+        assert conversation_id not in service._queue_status_messages
     finally:
         await store.close()
 
@@ -3177,6 +3179,7 @@ async def test_component_interaction_queue_interrupt_send_wakes_dispatcher_witho
             channel_id="channel-1",
             guild_id="guild-1",
         )
+        service._queue_status_messages[conversation_id] = ("channel-1", "notice-1")
 
         async def _promote_pending_message(
             _conversation_id: str, message_id: str
@@ -3210,12 +3213,18 @@ async def test_component_interaction_queue_interrupt_send_wakes_dispatcher_witho
 
         assert wake_calls == [conversation_id]
         assert len(rest.interaction_responses) == 1
-        assert rest.interaction_responses[0]["payload"]["type"] == 5
-        assert len(rest.followup_messages) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
+        assert rest.followup_messages == []
+        assert rest.deleted_channel_messages == []
+        assert len(rest.edited_original_interaction_responses) == 1
         assert (
-            rest.followup_messages[0]["payload"]["content"]
+            rest.edited_original_interaction_responses[0]["payload"]["content"]
             == "Queued request moved to the front."
         )
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["components"] == []
+        )
+        assert conversation_id not in service._queue_status_messages
     finally:
         await store.close()
 


### PR DESCRIPTION
## Summary
- add an explicit Discord queue component action and queue-status cleanup policy
- preserve the clicked Discord queue-status component message while acknowledging queue cancel / interrupt-send actions
- cover queue cancel and interrupt-send regressions so the component source is not deleted before update

## Root cause
Queue interrupt promotion refreshed queue status before the component acknowledgement finished. When the promoted item was the final queued item, Discord deleted the bot queue-status message that owned the clicked button, causing Discord to show an "Original message was deleted" fallback around the acknowledgement.

## Validation
- .venv/bin/ruff check src/codex_autorunner/adapters/discord/queue_status_lifecycle.py src/codex_autorunner/adapters/discord/service.py src/codex_autorunner/adapters/discord/car_handlers/queue_interrupt_handlers.py tests/adapters/discord/test_service_routing.py
- .venv/bin/python -m pytest tests/adapters/discord/test_service_routing.py -k "queue_interrupt_send or queue_cancel or refresh_queue_status"
- .venv/bin/python -m pytest tests/test_telegram_interrupt_cleanup.py tests/adapters/chat/test_interrupt_surface_parity.py
- .venv/bin/python -m pytest tests/adapters/discord/test_message_turns_transient_progress.py -k "progress_reuse or interrupted" tests/adapters/discord/test_service_routing.py -k "car_interrupt or queue_interrupt_send or queue_cancel"
- pre-commit hook passed with CODEX_FAST_TEST_WORKERS=4: 9012 fast tests + 20 chat-surface-lab tests + latency budget suite