### PR TITLE
[codex] Fix Hermes mutated cumulative output trimming

### DIFF
--- a/src/codex_autorunner/core/orchestration/turn_output_reducer.py
+++ b/src/codex_autorunner/core/orchestration/turn_output_reducer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from difflib import SequenceMatcher
 from typing import Any, Literal, Mapping, Sequence
 
 from .runtime_thread_events import RuntimeThreadRunEventState
@@ -95,6 +96,30 @@ def _whitespace_insensitive_prefix_end(value: str, prefix: str) -> int | None:
     return value_index
 
 
+def _near_prefix_end(value: str, prefix: str) -> int | None:
+    current = str(value or "")
+    previous = str(prefix or "")
+    if len(previous.strip()) < 500 or not current.strip():
+        return None
+    window = current[: min(len(current), len(previous) + 1000)]
+    matcher = SequenceMatcher(None, previous, window, autojunk=False)
+    blocks = [block for block in matcher.get_matching_blocks() if block.size]
+    if not blocks:
+        return None
+    first = blocks[0]
+    if first.a > 0 or first.b > len(current) - len(current.lstrip()):
+        return None
+    matched = sum(block.size for block in blocks)
+    if matched / len(previous) < 0.98:
+        return None
+    last_end_in_previous = max(block.a + block.size for block in blocks)
+    if last_end_in_previous / len(previous) < 0.95:
+        return None
+    leading = len(current) - len(current.lstrip())
+    nominal_prefix_end = leading + len(previous)
+    return min(max(block.b + block.size for block in blocks), nominal_prefix_end)
+
+
 def assistant_text_extends_prefix(assistant_text: str, prefix: str) -> bool:
     current = str(assistant_text or "")
     previous = str(prefix or "")
@@ -108,7 +133,10 @@ def assistant_text_extends_prefix(assistant_text: str, prefix: str) -> bool:
     previous_stripped = previous.strip()
     if current_lstrip.startswith(previous_stripped):
         return True
-    return _whitespace_insensitive_prefix_end(current, previous) is not None
+    return (
+        _whitespace_insensitive_prefix_end(current, previous) is not None
+        or _near_prefix_end(current, previous) is not None
+    )
 
 
 def trim_cumulative_assistant_text(
@@ -149,6 +177,8 @@ def trim_cumulative_assistant_text(
             else ("", "stale_prior_output")
         )
     prefix_end = _whitespace_insensitive_prefix_end(current, previous)
+    if prefix_end is None:
+        prefix_end = _near_prefix_end(current, previous)
     if prefix_end is None:
         return current, "current_turn_final"
     trimmed = current[prefix_end:].lstrip()

--- a/tests/core/orchestration/test_turn_output_reducer.py
+++ b/tests/core/orchestration/test_turn_output_reducer.py
@@ -36,6 +36,67 @@ def test_reduce_turn_output_trims_cumulative_transcript_prefix() -> None:
     assert envelope.provenance["candidate_source"] == "outcome"
 
 
+def test_reduce_turn_output_trims_mutated_cumulative_transcript_prefix() -> None:
+    state = RuntimeThreadRunEventState()
+    previous = "\n".join(
+        [
+            "Earlier diagnosis.",
+            "",
+            "```text",
+            "/Users/example/.local/pipx/venvs/codex-autorunner.next-20260518-024620/bin/python",
+            "```",
+            "",
+            *[
+                f"Step {index}: verify the installed package and restart state."
+                for index in range(80)
+            ],
+            "The package needs to be installed in that venv.",
+        ]
+    )
+    current = (
+        previous.replace("```text\n", "``\n", 1).replace(
+            "that venv.\nEarlier diagnosis.",
+            "that venv.Earlier diagnosis.",
+            1,
+        )
+        + "\n\nCurrent turn answer only."
+    )
+
+    envelope = reduce_turn_output(
+        managed_thread_id="thread-1",
+        managed_turn_id="turn-2",
+        backend_thread_id="session-1",
+        backend_turn_id="turn-2",
+        outcome=_outcome(current),
+        event_state=state,
+        prior_assistant_texts=[previous],
+    )
+
+    assert envelope.text == "Current turn answer only."
+    assert envelope.ownership == "trimmed_from_cumulative"
+    assert envelope.source == "reducer"
+
+
+def test_reduce_turn_output_keeps_new_answer_when_near_prefix_tail_repeats() -> None:
+    state = RuntimeThreadRunEventState()
+    previous = "prefix block with ABCD near tail\n" + ("filler line\n" * 60) + "ABCD"
+    current = previous[:-4] + "WXYZ" + "ABCD extra answer"
+
+    envelope = reduce_turn_output(
+        managed_thread_id="thread-1",
+        managed_turn_id="turn-2",
+        backend_thread_id="session-1",
+        backend_turn_id="turn-2",
+        outcome=_outcome(current),
+        event_state=state,
+        prior_assistant_texts=[previous],
+    )
+
+    assert envelope.text == "ABCD extra answer"
+    assert envelope.ownership == "trimmed_from_cumulative"
+    assert envelope.source == "reducer"
+
+
 def test_reduce_turn_output_rejects_exact_prior_output_as_stale() -> None:
     state = RuntimeThreadRunEventState()
 

--- a/tests/core/orchestration/test_turn_output_reducer.py
+++ b/tests/core/orchestration/test_turn_output_reducer.py
@@ -55,8 +55,8 @@ def test_reduce_turn_output_trims_mutated_cumulative_transcript_prefix() -> None
     )
     current = (
         previous.replace("```text\n", "``\n", 1).replace(
-            "that venv.\nEarlier diagnosis.",
-            "that venv.Earlier diagnosis.",
+            "Earlier diagnosis.\n\n```text",
+            "Earlier diagnosis.\n```text",
             1,
         )
         + "\n\nCurrent turn answer only."


### PR DESCRIPTION
## Summary
- add high-confidence near-prefix detection for long cumulative assistant outputs
- keep exact and whitespace-insensitive prefix handling, then fall back to fuzzy prefix trimming only for long prior text with 98% ordered match coverage
- add a regression test for Hermes replaying old assistant output with small Markdown mutations before the current answer

## Root Cause
Hermes ACP can replay durable-session assistant output into a new turn, but the replay is not always byte-stable. In the observed `#pma-2` row, old Markdown changed around a code fence/newline boundary, so CAR could see prior history but exact prefix trimming failed and Discord received old turns plus the current final answer.

## Validation
- `.venv/bin/python -m pytest tests/core/orchestration/test_turn_output_reducer.py tests/adapters/chat/test_managed_thread_turns.py -k "turn_output or trim_cumulative or prior_completed_assistant_text_prefix"`
- real bad row simulation: `06240482...` trims from 8847 chars to 1052 chars as `cumulative_transcript_trimmed`
- commit hook core lane: guardrails, ruff, mypy, repo pytest (`9026 passed`)
