### PR TITLE
[codex] Fix safe refresh voice provider resolution

### DIFF
--- a/scripts/safe-refresh-local-mac-hub.sh
+++ b/scripts/safe-refresh-local-mac-hub.sh
@@ -395,15 +395,15 @@ _normalize_voice_provider() {
 _voice_provider_for_hub_root() {
   local root provider
   root="$1"
-  provider="$(_dotenv_value "${root}" "CODEX_AUTORUNNER_VOICE_PROVIDER" || true)"
-  if [[ -z "${provider}" ]]; then
-    provider="$(_config_python "${root}" "repo_defaults.voice.provider" || true)"
-  fi
+  provider="$(_config_python "${root}" "repo_defaults.voice.provider" || true)"
   if [[ -z "${provider}" ]]; then
     provider="$(_config_python "${root}" "voice.provider" || true)"
     if [[ -n "${provider}" ]]; then
       echo "Hint: Found legacy top-level voice.provider; migrate to repo_defaults.voice.provider in hub config." >&2
     fi
+  fi
+  if [[ -z "${provider}" ]]; then
+    provider="$(_dotenv_value "${root}" "CODEX_AUTORUNNER_VOICE_PROVIDER" || true)"
   fi
   _normalize_voice_provider "${provider}"
 }

--- a/tests/test_safe_refresh_local_mac_hub_script.py
+++ b/tests/test_safe_refresh_local_mac_hub_script.py
@@ -1,9 +1,53 @@
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
+
+
+def test_safe_refresh_local_mac_hub_voice_provider_prefers_config_over_env(
+    tmp_path: Path,
+) -> None:
+    script_path = Path("scripts/safe-refresh-local-mac-hub.sh").resolve()
+    script = script_path.read_text(encoding="utf-8")
+    helper_source = script.split("_resolve_pyenv_python()", 1)[0]
+    helper_path = tmp_path / "safe-refresh-helpers.sh"
+    hub_root = tmp_path / "hub"
+    car_dir = hub_root / ".codex-autorunner"
+    car_dir.mkdir(parents=True)
+    helper_path.write_text(helper_source, encoding="utf-8")
+    (car_dir / ".env").write_text(
+        "CODEX_AUTORUNNER_VOICE_PROVIDER=local_whisper\n",
+        encoding="utf-8",
+    )
+    (car_dir / "config.yml").write_text(
+        "repo_defaults:\n" "  voice:\n" "    provider: mlx_whisper\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            "source "
+            f"{shlex.quote(str(helper_path))}; "
+            f"_voice_provider_for_hub_root {shlex.quote(str(hub_root))}",
+        ],
+        cwd=script_path.parent.parent,
+        env={
+            "HOME": str(tmp_path),
+            "HELPER_PYTHON": sys.executable,
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "mlx_whisper"
 
 
 def test_safe_refresh_local_mac_hub_script_runs_past_parse_stage(


### PR DESCRIPTION
## Summary
- Prefer `repo_defaults.voice.provider` from hub config before `.env` when safe-refresh resolves voice extras.
- Preserve legacy top-level `voice.provider` fallback and only use `CODEX_AUTORUNNER_VOICE_PROVIDER` when config has no provider.
- Add a regression test covering mismatched `.env` and config values.

Fixes #1864.

## Validation
- `.venv/bin/python -m pytest tests/test_safe_refresh_local_mac_hub_script.py`
- `git diff --check`
- Commit hook aggregate lane: guardrails, ruff/black, import boundaries, mypy, full pytest (9028 passed), web UI lint/build/tests
