### PR TITLE
[codex] Add ticket flow cleanliness status

### DIFF
--- a/src/codex_autorunner/adapters/chat/command_diagnostics.py
+++ b/src/codex_autorunner/adapters/chat/command_diagnostics.py
@@ -18,6 +18,7 @@ def build_status_text(
     channel_id: str,
     *,
     include_flow_hint: bool = True,
+    ticket_flow_line: Optional[str] = None,
 ) -> list[str]:
     if binding is None:
         lines = [
@@ -58,6 +59,8 @@ def build_status_text(
 
     if active_flow:
         lines.append(f"Active flow: {active_flow.flow_id} ({active_flow.status})")
+    if ticket_flow_line:
+        lines.append(ticket_flow_line)
 
     if collaboration_summary_lines:
         lines.extend(collaboration_summary_lines)

--- a/src/codex_autorunner/adapters/chat/ticket_flow_cleanliness.py
+++ b/src/codex_autorunner/adapters/chat/ticket_flow_cleanliness.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+from ...core.archive import dirty_car_state_paths
+
+_PREVIOUS_RUN_KEYS = frozenset({"runs", "flows", "flows.db"})
+_RELEVANT_KEYS = frozenset({"tickets", "contextspace", *_PREVIOUS_RUN_KEYS})
+TicketFlowCleanlinessState = Literal["clean", "dirty", "unknown"]
+
+
+@dataclass(frozen=True)
+class TicketFlowCleanliness:
+    state: TicketFlowCleanlinessState
+    labels: tuple[str, ...] = ()
+    dirty_keys: tuple[str, ...] = ()
+
+    @property
+    def is_clean(self) -> bool:
+        return self.state == "clean"
+
+    @property
+    def is_dirty(self) -> bool:
+        return self.state == "dirty"
+
+    @property
+    def line(self) -> str:
+        if self.state == "unknown":
+            return "Ticket flow: Unknown"
+        if self.state == "clean":
+            return "Ticket flow: Clean"
+        return f"Ticket flow: Dirty ({', '.join(self.labels)})"
+
+
+def get_ticket_flow_cleanliness(workspace_root: Optional[Any]) -> TicketFlowCleanliness:
+    """Return compact live ticket-flow cleanliness state for chat surfaces."""
+    if workspace_root is None:
+        return TicketFlowCleanliness("unknown")
+    root = Path(workspace_root)
+    try:
+        dirty_keys = set(dirty_car_state_paths(root))
+    except (OSError, RuntimeError, ValueError):
+        return TicketFlowCleanliness("unknown")
+
+    relevant_dirty = dirty_keys & _RELEVANT_KEYS
+    if relevant_dirty & _PREVIOUS_RUN_KEYS and not _has_previous_run_state(root):
+        relevant_dirty -= _PREVIOUS_RUN_KEYS
+    if not relevant_dirty:
+        return TicketFlowCleanliness("clean")
+
+    labels: list[str] = []
+    if "tickets" in relevant_dirty:
+        labels.append("tickets")
+    if "contextspace" in relevant_dirty:
+        labels.append("contextspace")
+    if relevant_dirty & _PREVIOUS_RUN_KEYS:
+        labels.append("previous runs")
+    return TicketFlowCleanliness(
+        "dirty",
+        labels=tuple(labels),
+        dirty_keys=tuple(sorted(relevant_dirty)),
+    )
+
+
+def format_ticket_flow_cleanliness_line(workspace_root: Optional[Any]) -> str:
+    """Render the compact live ticket-flow state line for chat surfaces."""
+    return get_ticket_flow_cleanliness(workspace_root).line
+
+
+def _has_previous_run_state(workspace_root: Path) -> bool:
+    car_root = workspace_root / ".codex-autorunner"
+    for key in ("runs", "flows"):
+        path = car_root / key
+        if path.exists() and path.is_dir():
+            try:
+                next(path.iterdir())
+            except StopIteration:
+                pass
+            except OSError:
+                return True
+            else:
+                return True
+    db_path = car_root / "flows.db"
+    if not db_path.exists():
+        return False
+    try:
+        with sqlite3.connect(str(db_path)) as conn:
+            row = conn.execute("SELECT COUNT(*) FROM flow_runs").fetchone()
+    except sqlite3.Error:
+        return True
+    count = row[0] if row else 0
+    return isinstance(count, int) and count > 0
+
+
+__all__ = [
+    "TicketFlowCleanliness",
+    "TicketFlowCleanlinessState",
+    "format_ticket_flow_cleanliness_line",
+    "get_ticket_flow_cleanliness",
+]

--- a/src/codex_autorunner/adapters/chat/ticket_flow_cleanliness.py
+++ b/src/codex_autorunner/adapters/chat/ticket_flow_cleanliness.py
@@ -65,11 +65,6 @@ def get_ticket_flow_cleanliness(workspace_root: Optional[Any]) -> TicketFlowClea
     )
 
 
-def format_ticket_flow_cleanliness_line(workspace_root: Optional[Any]) -> str:
-    """Render the compact live ticket-flow state line for chat surfaces."""
-    return get_ticket_flow_cleanliness(workspace_root).line
-
-
 def _has_previous_run_state(workspace_root: Path) -> bool:
     car_root = workspace_root / ".codex-autorunner"
     for key in ("runs", "flows"):
@@ -98,6 +93,5 @@ def _has_previous_run_state(workspace_root: Path) -> bool:
 __all__ = [
     "TicketFlowCleanliness",
     "TicketFlowCleanlinessState",
-    "format_ticket_flow_cleanliness_line",
     "get_ticket_flow_cleanliness",
 ]

--- a/src/codex_autorunner/adapters/discord/car_handlers/session_commands.py
+++ b/src/codex_autorunner/adapters/discord/car_handlers/session_commands.py
@@ -30,6 +30,7 @@ from ...chat.session_messages import (
     build_fresh_session_started_lines,
     build_thread_detail_lines,
 )
+from ...chat.ticket_flow_cleanliness import get_ticket_flow_cleanliness
 from ..components import (
     DISCORD_BUTTON_STYLE_DANGER,
     DISCORD_SELECT_OPTION_MAX_OPTIONS,
@@ -275,6 +276,7 @@ async def _finalize_car_newt(
                     actor_label=actor_label,
                     model=service._status_model_label(binding),
                     effort=service._status_effort_label(binding, agent),
+                    extra_lines=(get_ticket_flow_cleanliness(workspace_root).line,),
                 ),
             ]
         )
@@ -410,6 +412,7 @@ async def handle_car_new(
                     actor_label=actor_label,
                     model=service._status_model_label(binding),
                     effort=service._status_effort_label(binding, agent),
+                    extra_lines=(get_ticket_flow_cleanliness(workspace_root).line,),
                 ),
             ]
         )

--- a/src/codex_autorunner/adapters/discord/flow_commands.py
+++ b/src/codex_autorunner/adapters/discord/flow_commands.py
@@ -31,6 +31,7 @@ from ...core.flows.ux_helpers import (
 from ...core.logging_utils import log_event
 from ...core.utils import atomic_write
 from ...tickets.outbox import resolve_outbox_paths
+from ..chat.ticket_flow_cleanliness import get_ticket_flow_cleanliness
 from .components import (
     DISCORD_SELECT_OPTION_MAX_OPTIONS,
     build_action_row,
@@ -471,10 +472,17 @@ def build_flow_status_components(
 def format_flow_status_response_text(
     record: FlowRunRecord,
     snapshot: dict[str, Any],
+    *,
+    workspace_root: Path,
 ) -> str:
     from ...core.flows.ux_helpers import format_ticket_flow_status_lines
 
-    return "\n".join(format_ticket_flow_status_lines(record, snapshot))
+    return "\n".join(
+        [
+            get_ticket_flow_cleanliness(workspace_root).line,
+            *format_ticket_flow_status_lines(record, snapshot),
+        ]
+    )
 
 
 def build_flow_status_message(
@@ -482,9 +490,14 @@ def build_flow_status_message(
     record: FlowRunRecord,
     runs: list[FlowRunRecord],
     snapshot: dict[str, Any],
+    workspace_root: Path,
     prefix: Optional[str] = None,
 ) -> tuple[str, list[dict[str, Any]]]:
-    response_text = format_flow_status_response_text(record, snapshot)
+    response_text = format_flow_status_response_text(
+        record,
+        snapshot,
+        workspace_root=workspace_root,
+    )
     if isinstance(prefix, str) and prefix.strip():
         response_text = f"{prefix.strip()}\n\n{response_text}"
     return response_text, build_flow_status_components(record, runs)
@@ -761,6 +774,7 @@ async def handle_flow_status(
             if runs and not explicit_run_requested:
                 content = (
                     "No ticket_flow run found.\n\n"
+                    f"{get_ticket_flow_cleanliness(workspace_root).line}\n\n"
                     "Use the picker below to inspect historical runs."
                 )
                 components = build_historical_runs_picker(runs)
@@ -784,7 +798,12 @@ async def handle_flow_status(
             message = (
                 f"Ticket_flow run {run_id_opt.strip()} not found."
                 if explicit_run_requested
-                else "No ticket_flow runs found."
+                else "\n".join(
+                    [
+                        "No ticket_flow runs found.",
+                        get_ticket_flow_cleanliness(workspace_root).line,
+                    ]
+                )
             )
             await service.send_or_respond_ephemeral(
                 interaction_id=interaction_id,
@@ -836,6 +855,7 @@ async def handle_flow_status(
         record=record,
         runs=runs,
         snapshot=snapshot,
+        workspace_root=workspace_root,
         prefix=prefix,
     )
     run_mirror = service._flow_run_mirror(workspace_root)
@@ -1183,6 +1203,7 @@ async def handle_flow_start(
                 record=record,
                 runs=runs,
                 snapshot=snapshot,
+                workspace_root=workspace_root,
                 prefix=(
                     f"Reusing ticket_flow run {record.id} ({record.status.value})."
                 ),
@@ -1293,6 +1314,7 @@ async def handle_flow_start(
         record=record,
         runs=runs,
         snapshot=snapshot,
+        workspace_root=workspace_root,
         prefix=f"{prefix} ticket_flow run {record.id}.",
     )
     await _send_flow_public_response(

--- a/src/codex_autorunner/adapters/discord/workspace_commands.py
+++ b/src/codex_autorunner/adapters/discord/workspace_commands.py
@@ -15,6 +15,9 @@ from ...adapters.chat.picker_filter import filter_picker_items, resolve_picker_q
 from ...adapters.chat.status_diagnostics import (
     build_process_monitor_lines_for_root,
 )
+from ...adapters.chat.ticket_flow_cleanliness import (
+    get_ticket_flow_cleanliness,
+)
 from ...core.chat_bindings import emit_adapter_binding_chat_surface_event
 from ...core.flows import FlowRunStatus
 from ...core.logging_utils import log_event
@@ -709,6 +712,9 @@ async def handle_status(
         active_flow,
         channel_id,
         include_flow_hint=False,
+        ticket_flow_line=(
+            get_ticket_flow_cleanliness(workspace_path).line if workspace_path else None
+        ),
     )
     if binding is None:
         await send_runtime_ephemeral(

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/flows.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/flows.py
@@ -53,6 +53,7 @@ from .....manifest import load_manifest
 from .....tickets.files import list_ticket_paths
 from .....tickets.frontmatter import generate_ticket_id
 from ....chat.run_mirror import ChatRunMirror
+from ....chat.ticket_flow_cleanliness import get_ticket_flow_cleanliness
 from ....github.service import GitHubError, GitHubService
 from ...adapter import (
     FlowCallback,
@@ -651,7 +652,10 @@ class FlowCommands(TelegramCommandSupportMixin):
                     summary_text = self._build_flow_status_summary_fallback(repo_root)
                     if summary_text:
                         return summary_text, {"inline_keyboard": []}
-                return error, {"inline_keyboard": []}
+                return (
+                    "\n".join([error, get_ticket_flow_cleanliness(repo_root).line]),
+                    {"inline_keyboard": []},
+                )
             if record is not None:
                 record, _updated, locked = reconcile_flow_run(repo_root, record, store)
                 if locked:
@@ -937,7 +941,7 @@ class FlowCommands(TelegramCommandSupportMixin):
         lines = format_ticket_flow_summary_lines(summary)
         if not lines:
             return None
-        return "\n".join(lines)
+        return "\n".join([get_ticket_flow_cleanliness(repo_root).line, *lines])
 
     def _format_flow_status_lines(
         self,
@@ -949,13 +953,16 @@ class FlowCommands(TelegramCommandSupportMixin):
         snapshot: Optional[dict] = None,
     ) -> list[str]:
         if record is None:
-            return ["Run: none"]
+            return [get_ticket_flow_cleanliness(repo_root).line, "Run: none"]
         if snapshot is None:
             snapshot = build_flow_status_snapshot(repo_root, record, store)
         run = record
         status = getattr(run, "status", None)
         status_value = status.value if status else "unknown"
-        lines = format_ticket_flow_status_lines(run, snapshot)
+        lines = [
+            get_ticket_flow_cleanliness(repo_root).line,
+            *format_ticket_flow_status_lines(run, snapshot),
+        ]
         created_at = getattr(run, "created_at", None)
         if created_at:
             lines.append(f"Created: {created_at}")
@@ -1297,7 +1304,7 @@ class FlowCommands(TelegramCommandSupportMixin):
                         return
                 await self._send_message(
                     message.chat_id,
-                    error,
+                    "\n".join([error, get_ticket_flow_cleanliness(repo_root).line]),
                     thread_id=message.thread_id,
                     reply_to=message.message_id,
                 )

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/workspace_session_commands.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/workspace_session_commands.py
@@ -30,6 +30,7 @@ from ....chat.session_messages import (
     build_reset_state_lines,
     build_thread_detail_lines,
 )
+from ....chat.ticket_flow_cleanliness import get_ticket_flow_cleanliness
 from ...adapter import TelegramMessage
 from ...config import AppServerUnavailableError
 from ...constants import MAX_TOPIC_THREAD_HISTORY
@@ -652,6 +653,9 @@ class WorkspaceSessionCommandsMixin:
                         model=record.model
                         or DEFAULT_CHAT_AGENT_MODELS.get(agent, "default"),
                         effort=effort_label,
+                        extra_lines=(
+                            get_ticket_flow_cleanliness(record.workspace_path).line,
+                        ),
                     ),
                 ]
             ),
@@ -974,6 +978,7 @@ class WorkspaceSessionCommandsMixin:
                 actor_label=self._effective_agent_label(record),
                 model=record.model or DEFAULT_CHAT_AGENT_MODELS.get(agent, "default"),
                 effort=effort_label,
+                extra_lines=(get_ticket_flow_cleanliness(workspace_root).line,),
             ),
         ]
         await self._send_message(

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/workspace_status.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/workspace_status.py
@@ -13,6 +13,7 @@ from ....chat.status_diagnostics import (
     build_process_monitor_lines_for_root,
     build_status_block_lines,
 )
+from ....chat.ticket_flow_cleanliness import get_ticket_flow_cleanliness
 from ...adapter import TelegramMessage
 from ...collaboration_helpers import (
     collaboration_summary_lines,
@@ -49,6 +50,11 @@ def _telegram_status_base_lines(
     lines.extend(
         [
             f"Workspace: {workspace_label}",
+            *(
+                [get_ticket_flow_cleanliness(record.workspace_path).line]
+                if record.workspace_path
+                else []
+            ),
             f"Workspace ID: {record.workspace_id or 'unknown'}",
             f"Active thread: {record.active_thread_id or 'none'}",
             f"Active turn: {runtime.current_turn_id or 'none'}",

--- a/tests/adapters/chat/test_command_diagnostics.py
+++ b/tests/adapters/chat/test_command_diagnostics.py
@@ -6,6 +6,10 @@ from codex_autorunner.adapters.chat.command_diagnostics import (
     build_ids_text,
     build_status_text,
 )
+from codex_autorunner.adapters.chat.ticket_flow_cleanliness import (
+    TicketFlowCleanliness,
+    get_ticket_flow_cleanliness,
+)
 
 
 class TestBuildStatusText:
@@ -87,6 +91,26 @@ class TestBuildStatusText:
         lines_str = "\n".join(lines)
 
         assert "Active flow: run-123 (running)" in lines_str
+
+    def test_includes_ticket_flow_line(self):
+        binding = {
+            "workspace_path": "/path/to/workspace",
+            "repo_id": "my-repo",
+            "guild_id": "guild-1",
+            "pma_enabled": False,
+            "pma_prev_workspace_path": None,
+            "updated_at": "2024-01-01",
+        }
+
+        lines = build_status_text(
+            binding,
+            None,
+            None,
+            "channel-123",
+            ticket_flow_line="Ticket flow: Clean",
+        )
+
+        assert "Ticket flow: Clean" in lines
 
     def test_includes_collaboration_summary(self):
         binding = {
@@ -251,6 +275,35 @@ class TestBuildDebugText:
 
         assert "Policy mode: command_only" in lines_str
         assert "Policy plain-text: disabled" in lines_str
+
+
+class TestFormatTicketFlowCleanlinessLine:
+    def test_clean_when_no_live_ticket_flow_material(self, tmp_path: Path):
+        cleanliness = get_ticket_flow_cleanliness(tmp_path)
+
+        assert cleanliness == TicketFlowCleanliness("clean")
+        assert cleanliness.is_clean is True
+        assert cleanliness.line == "Ticket flow: Clean"
+
+    def test_dirty_summarizes_ticket_context_and_previous_runs(self, tmp_path: Path):
+        car_root = tmp_path / ".codex-autorunner"
+        tickets = car_root / "tickets"
+        contextspace = car_root / "contextspace"
+        tickets.mkdir(parents=True)
+        contextspace.mkdir()
+        (tickets / "TICKET-001.md").write_text("goal: test\n", encoding="utf-8")
+        (contextspace / "active_context.md").write_text("active\n", encoding="utf-8")
+        (car_root / "flows.db").write_text("placeholder\n", encoding="utf-8")
+
+        cleanliness = get_ticket_flow_cleanliness(tmp_path)
+
+        assert cleanliness.state == "dirty"
+        assert cleanliness.labels == ("tickets", "contextspace", "previous runs")
+        assert cleanliness.dirty_keys == ("contextspace", "flows.db", "tickets")
+        assert (
+            cleanliness.line
+            == "Ticket flow: Dirty (tickets, contextspace, previous runs)"
+        )
 
 
 class TestBuildIdsText:

--- a/tests/adapters/discord/test_flow_handlers.py
+++ b/tests/adapters/discord/test_flow_handlers.py
@@ -417,6 +417,7 @@ async def test_flow_status_and_runs_render_expected_output(tmp_path: Path) -> No
         runs_payload = rest.followup_messages[-1]["payload"]["content"]
 
         assert f"Run: {paused_run_id}" in status_payload
+        assert "Ticket flow: Dirty" in status_payload
         assert "Status: paused" in status_payload
         assert "Freshness:" in status_payload
         assert "Worker:" in status_payload
@@ -493,6 +494,7 @@ async def test_flow_status_without_run_id_uses_authoritative_run_and_includes_pi
         components = payload["components"]
 
         assert f"Run: {paused_run_id}" in content
+        assert "Ticket flow: Dirty" in content
         assert "Status: paused" in content
         picker_rows = [
             row
@@ -550,6 +552,7 @@ async def test_flow_status_without_run_id_shows_no_current_run_for_history_only(
         components = payload["components"]
 
         assert f"Run: {newest_completed_run_id}" in content
+        assert "Ticket flow: Dirty" in content
         assert "Status: completed" in content
         assert "Retire: ready" in content
         picker_rows = [
@@ -602,7 +605,41 @@ async def test_flow_status_without_run_reports_no_runs_when_no_flow_exists(
         assert len(rest.interaction_responses) == 1
         assert rest.interaction_responses[0]["payload"]["type"] == 5
         content = rest.followup_messages[0]["payload"]["content"]
-        assert content == "No ticket_flow runs found."
+        assert content == "No ticket_flow runs found.\nTicket flow: Dirty (tickets)"
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+async def test_flow_status_without_run_reports_clean_when_no_live_material(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path)
+
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    await store.upsert_binding(
+        channel_id="channel-1",
+        guild_id="guild-1",
+        workspace_path=str(workspace),
+        repo_id=None,
+    )
+
+    rest = _FakeRest()
+    gateway = _FakeGateway([_flow_interaction(name="status", options=[])])
+    service = DiscordBotService(
+        _config(tmp_path),
+        logger=logging.getLogger("test"),
+        rest_client=rest,
+        gateway_client=gateway,
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+
+    try:
+        await _invoke_flow_status(service, workspace_root=workspace)
+        content = rest.followup_messages[0]["payload"]["content"]
+        assert content == "No ticket_flow runs found.\nTicket flow: Clean"
     finally:
         await store.close()
 

--- a/tests/adapters/discord/test_service_routing.py
+++ b/tests/adapters/discord/test_service_routing.py
@@ -5799,6 +5799,7 @@ async def test_car_new_resets_repo_session_key(tmp_path: Path) -> None:
         assert "agent: codex" in normalized
         assert "Model: default" in content
         assert "Effort: default" in content
+        assert "Ticket flow: Clean" in content
     finally:
         await store.close()
 
@@ -5885,6 +5886,7 @@ async def test_car_newt_resets_current_workspace_branch_and_session(
         assert "agent: codex" in normalized
         assert "Model: default" in content
         assert "Effort: default" in content
+        assert "Ticket flow: Clean" in content
     finally:
         await store.close()
 

--- a/tests/adapters/discord/test_status.py
+++ b/tests/adapters/discord/test_status.py
@@ -113,6 +113,7 @@ async def test_status_bound_channel_includes_shared_and_discord_specific_details
     assert "Guild ID: guild-456" in content
     assert "Channel ID: channel-789" in content
     assert "Active flow: flow-123 (running)" in content
+    assert "Ticket flow: Clean" in content
     assert "Agent: codex" in content
     assert "Resume: supported" in content
     assert "Model: gpt-5.4" in content

--- a/tests/test_telegram_flow_status.py
+++ b/tests/test_telegram_flow_status.py
@@ -113,6 +113,7 @@ def test_flow_status_includes_effective_current_ticket(
     handler = FlowCommands()
     lines = handler._format_flow_status_lines(tmp_path, record, store)
 
+    assert lines[0] == "Ticket flow: Dirty (previous runs)"
     assert any(line == "Current ticket: TICKET-002" for line in lines)
     store.close()
 
@@ -131,6 +132,7 @@ def test_flow_status_includes_reason_summary_and_error(tmp_path: Path) -> None:
         tmp_path, record, store=None, health=_health(tmp_path)
     )
 
+    assert lines[0] == "Ticket flow: Dirty (previous runs)"
     assert any(line == "Summary: agent error" for line in lines)
     assert any(line == "Reason: failed to parse" for line in lines)
     assert any(line == "Error: Traceback" for line in lines)
@@ -1003,7 +1005,34 @@ async def test_flow_status_action_without_run_uses_ticket_summary_fallback(
 
     await handler._handle_flow_status_action(message, tmp_path, argv=[])
 
-    assert handler.sent == ["Status: Done\nTickets: 2/2"]
+    assert handler.sent == ["Ticket flow: Dirty (tickets)\nStatus: Done\nTickets: 2/2"]
+    assert handler.markups == [None]
+
+
+@pytest.mark.anyio
+async def test_flow_status_action_without_run_reports_clean_when_no_live_material(
+    tmp_path: Path,
+) -> None:
+    seed_repo_files(tmp_path, git_required=False)
+
+    handler = _FlowStatusHandler()
+    message = TelegramMessage(
+        update_id=1,
+        message_id=2,
+        chat_id=3,
+        thread_id=4,
+        from_user_id=5,
+        text="/flow status",
+        date=None,
+        is_topic_message=True,
+    )
+
+    await handler._handle_flow_status_action(message, tmp_path, argv=[])
+
+    assert handler.sent == [
+        "No ticket flow run found. Use /pma to start a new flow via web app.\n"
+        "Ticket flow: Clean"
+    ]
     assert handler.markups == [None]
 
 
@@ -1028,7 +1057,12 @@ async def test_flow_status_callback_without_run_uses_ticket_summary_fallback(
 
     await handler._render_flow_status_callback(callback, tmp_path, None)
 
-    assert handler.edits == [("Status: Done\nTickets: 2/2", {"inline_keyboard": []})]
+    assert handler.edits == [
+        (
+            "Ticket flow: Dirty (tickets)\nStatus: Done\nTickets: 2/2",
+            {"inline_keyboard": []},
+        )
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_status_rate_limits.py
+++ b/tests/test_telegram_status_rate_limits.py
@@ -125,6 +125,7 @@ async def test_status_opencode_skips_rate_limits() -> None:
     assert handler._client_calls == 0
     text = handler._sent_messages[-1]
     assert "Workspace ID: unknown" in text
+    assert "Ticket flow: Clean" in text
     assert "Active thread: none" in text
     assert "Agent: opencode" in text
     assert "Resume: supported" in text


### PR DESCRIPTION
## Summary
- Add a structured `TicketFlowCleanliness` result for compact CAR ticket-flow cleanliness state.
- Show `Ticket flow: Clean` / `Dirty (...)` in `/car status`, `/car new`, `/car newt`, and `/flow status` across Discord and Telegram.
- Treat empty `flows.db` files created by status reads as clean instead of previous-run state.

## Impact
This makes it clear from common chat commands whether live tickets, contextspace docs, or previous run state should be retired before writing new ticket-flow material.

## Validation
- Commit hook passed: black, ruff, import boundaries, contract checks, mypy, repo-wide pytest (`9129 passed`), chat-surface lab (`20 passed`), and chat latency budgets.
- Focused reruns before commit covered Discord/Telegram status, new/newt, and flow status paths.
