### PR TITLE
[codex] Improve web UI resource efficiency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
 VENV ?= .venv
 VENV_PYTHON := $(VENV)/bin/python
 VENV_PIP := $(VENV)/bin/pip
+MIN_PYTHON := (3, 10)
+BOOTSTRAP_PYTHON := $(shell for bin in python3.13 python3.12 python3.11 python3.10 python3; do \
+	if command -v $$bin >/dev/null 2>&1 && $$bin -c 'import sys; raise SystemExit(0 if sys.version_info >= $(MIN_PYTHON) else 1)' >/dev/null 2>&1; then \
+		echo $$bin; \
+		break; \
+	fi; \
+done)
 
 # Prefer venv python if it exists
-PYTHON := $(shell if [ -x $(VENV_PYTHON) ]; then echo $(VENV_PYTHON); else echo python3; fi)
+PYTHON := $(shell if [ -x $(VENV_PYTHON) ] && $(VENV_PYTHON) -c 'import sys; raise SystemExit(0 if sys.version_info >= $(MIN_PYTHON) else 1)' >/dev/null 2>&1; then echo $(VENV_PYTHON); elif [ -n "$(BOOTSTRAP_PYTHON)" ]; then echo $(BOOTSTRAP_PYTHON); else echo python3; fi)
 PYTHON_ABS := $(abspath $(PYTHON))
 PYTEST_FAST_WORKERS ?= $(shell $(PYTHON) -c "import os;print(os.cpu_count() or 4)")
 
@@ -50,15 +57,27 @@ install:
 dev:
 	$(PYTHON) -m pip install -e .[dev]
 
-venv: $(VENV_PYTHON)
+venv: $(VENV)/.python-ok
 
-$(VENV_PYTHON):
-	$(PYTHON) -m venv $(VENV)
+$(VENV)/.python-ok: pyproject.toml
+	@if [ -x "$(VENV_PYTHON)" ] && "$(VENV_PYTHON)" -c 'import sys; raise SystemExit(0 if sys.version_info >= $(MIN_PYTHON) else 1)' >/dev/null 2>&1; then \
+		"$(VENV_PYTHON)" -c 'import sys; print(f"Using existing venv Python {sys.version.split()[0]}")'; \
+	else \
+		if [ -z "$(BOOTSTRAP_PYTHON)" ]; then \
+			echo "Python >=3.10 is required. Install python3.10+ or put it on PATH." >&2; \
+			exit 1; \
+		fi; \
+		echo "Creating $(VENV) with $$("$(BOOTSTRAP_PYTHON)" --version 2>&1)..."; \
+		rm -rf "$(VENV)"; \
+		"$(BOOTSTRAP_PYTHON)" -m venv "$(VENV)"; \
+		rm -f "$(VENV)/.installed-dev"; \
+	fi
 	$(VENV_PYTHON) -m pip install --upgrade pip
+	@touch "$(VENV)/.python-ok"
 
 venv-dev: $(VENV)/.installed-dev
 
-$(VENV)/.installed-dev: $(VENV_PYTHON) pyproject.toml
+$(VENV)/.installed-dev: $(VENV)/.python-ok pyproject.toml
 	$(VENV_PIP) install -e .[dev]
 	@touch $(VENV)/.installed-dev
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VENV ?= .venv
 VENV_PYTHON := $(VENV)/bin/python
 VENV_PIP := $(VENV)/bin/pip
 MIN_PYTHON := (3, 10)
-BOOTSTRAP_PYTHON := $(shell for bin in python3.13 python3.12 python3.11 python3.10 python3; do \
+BOOTSTRAP_PYTHON := $(shell for bin in python python3 python3.13 python3.12 python3.11 python3.10; do \
 	if command -v $$bin >/dev/null 2>&1 && $$bin -c 'import sys; raise SystemExit(0 if sys.version_info >= $(MIN_PYTHON) else 1)' >/dev/null 2>&1; then \
 		echo $$bin; \
 		break; \

--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -3677,8 +3677,12 @@ textarea:hover {
   background: var(--color-accent);
   opacity: 0.55;
   transform-origin: left center;
-  transition: transform 80ms linear;
+  animation: toast-timeout-progress var(--notice-timeout, 3500ms) linear forwards;
   pointer-events: none;
+}
+
+.auto-dismiss-notice.no-timeout .auto-dismiss-notice__bar {
+  animation: none;
 }
 
 @keyframes toast-slide-in {
@@ -3692,8 +3696,18 @@ textarea:hover {
   }
 }
 
+@keyframes toast-timeout-progress {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .auto-dismiss-notice {
+  .auto-dismiss-notice,
+  .auto-dismiss-notice__bar {
     animation: none;
   }
 }

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailLiveProjection.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailLiveProjection.test.ts
@@ -80,6 +80,64 @@ describe('ChatDetailLiveProjection', () => {
     expect(projection.snapshot().streamState).toBe('interrupted');
   });
 
+  it('cancels pending repair refreshes when the stream reconnects before the repair fires', async () => {
+    const store = new ReadModelEntityStore();
+    const timers = timerFixture();
+    const stream = streamFixture();
+    const api = apiFixture({ transcriptRows: [messageCard('chat-1', 'assistant-1', 'assistant', 'repaired')] });
+    const projection = projectionFixture(store, api, {
+      openStream: stream.open,
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout
+    });
+
+    projection.connect('chat-1');
+    stream.options?.onError?.(new Event('error'));
+    expect(timers.pending()).toHaveLength(1);
+
+    stream.options?.onStatus?.('connected');
+    expect(timers.pending()).toHaveLength(0);
+    timers.runPending();
+    await Promise.resolve();
+
+    expect(api.getTranscriptCalls).toBe(0);
+    expect(projection.snapshot().streamState).toBe('connected');
+  });
+
+  it('does not cancel terminal refresh timers when later stream events arrive', async () => {
+    const store = new ReadModelEntityStore();
+    const timers = timerFixture();
+    const stream = streamFixture();
+    const api = apiFixture({ transcriptRows: [messageCard('chat-1', 'assistant-1', 'assistant', 'refreshed')] });
+    const projection = projectionFixture(store, api, {
+      openStream: stream.open,
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout
+    });
+
+    projection.connect('chat-1');
+    stream.options?.onEvent({
+      kind: 'transcript_patch',
+      lastEventId: '1',
+      payload: { status: rawProgress('chat-1', 'turn-1', { terminal: true }) }
+    });
+    expect(timers.pending()).toHaveLength(1);
+
+    stream.options?.onStatus?.('connected');
+    stream.options?.onEvent({
+      kind: 'transcript_append',
+      lastEventId: '2',
+      payload: { rows: [rawMessageRow('chat-1', 'assistant-2', 'assistant', 'after terminal', 'turn-1')] }
+    });
+    expect(timers.pending()).toHaveLength(1);
+
+    timers.runPending();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(api.getTranscriptCalls).toBe(1);
+  });
+
   it('refreshes queue once for a terminal managed turn with assistant output', async () => {
     const store = new ReadModelEntityStore();
     const timers = timerFixture();

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailLiveProjection.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailLiveProjection.ts
@@ -84,6 +84,7 @@ export class ChatDetailLiveProjection {
   private activeRefreshSeq = 0;
   private activeQueueRefreshSeq = 0;
   private pendingRefreshTimer: unknown = null;
+  private pendingRefreshReason: 'terminal' | 'repair' | null = null;
   private pendingQueueRefreshTimer: unknown = null;
   private refreshedTerminalTurnId: string | null = null;
 
@@ -193,12 +194,16 @@ export class ChatDetailLiveProjection {
   private handleStreamStatus(chatId: string, status: 'connecting' | 'connected' | 'interrupted' | 'closed'): void {
     if (this.getActiveChatId() !== chatId) return;
     if (status === 'connecting' && this.state.streamState !== 'connected') this.setState({ streamState: 'connecting' });
-    if (status === 'connected') this.setState({ streamState: 'connected', streamError: null });
+    if (status === 'connected') {
+      this.clearPendingRepairRefresh();
+      this.setState({ streamState: 'connected', streamError: null });
+    }
     if (status === 'interrupted') this.setState({ streamState: 'interrupted' });
   }
 
   private handleStreamEvent(chatId: string, event: ChatTranscriptStreamEvent): void {
     if (this.getActiveChatId() !== chatId) return;
+    this.clearPendingRepairRefresh();
     this.setState({ streamState: 'connected' });
     if (event.kind === 'transcript_snapshot') {
       const rows = mapChatTranscriptRows(event.payload.rows);
@@ -225,7 +230,7 @@ export class ChatDetailLiveProjection {
       this.updateProgress(nextProgress);
       if (nextProgress.terminal && nextProgress.id && this.refreshedTerminalTurnId !== nextProgress.id) {
         this.refreshedTerminalTurnId = nextProgress.id;
-        this.scheduleRefresh(chatId, this.refreshDelayMs);
+        this.scheduleRefresh(chatId, this.refreshDelayMs, 'terminal');
       }
       if (nextProgress.streamShouldClose) this.closeStream();
     }
@@ -241,7 +246,7 @@ export class ChatDetailLiveProjection {
       streamState: 'interrupted',
       streamError: 'Live chat updates were interrupted. Reconnecting and repairing from the latest snapshot.'
     });
-    this.scheduleRefresh(chatId, this.repairDelayMs);
+    this.scheduleRefresh(chatId, this.repairDelayMs, 'repair');
   }
 
   private ensureStreamAfterSnapshot(chatId: string): void {
@@ -251,10 +256,12 @@ export class ChatDetailLiveProjection {
     if (this.shouldUseStream(seedChat, seedProgress, this.currentQueueDepth(chatId))) this.connect(chatId);
   }
 
-  private scheduleRefresh(chatId: string, delayMs: number): void {
+  private scheduleRefresh(chatId: string, delayMs: number, reason: 'terminal' | 'repair'): void {
     if (this.pendingRefreshTimer) this.clearTimer(this.pendingRefreshTimer);
+    this.pendingRefreshReason = reason;
     this.pendingRefreshTimer = this.setTimer(() => {
       this.pendingRefreshTimer = null;
+      this.pendingRefreshReason = null;
       if (this.getActiveChatId() === chatId) void this.refresh(chatId, { quiet: true });
     }, delayMs);
   }
@@ -271,7 +278,15 @@ export class ChatDetailLiveProjection {
     if (this.pendingRefreshTimer) this.clearTimer(this.pendingRefreshTimer);
     if (this.pendingQueueRefreshTimer) this.clearTimer(this.pendingQueueRefreshTimer);
     this.pendingRefreshTimer = null;
+    this.pendingRefreshReason = null;
     this.pendingQueueRefreshTimer = null;
+  }
+
+  private clearPendingRepairRefresh(): void {
+    if (!this.pendingRefreshTimer || this.pendingRefreshReason !== 'repair') return;
+    this.clearTimer(this.pendingRefreshTimer);
+    this.pendingRefreshTimer = null;
+    this.pendingRefreshReason = null;
   }
 
   private closeStream(): void {

--- a/src/codex_autorunner/web_frontend/src/lib/components/AutoDismissNotice.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/AutoDismissNotice.svelte
@@ -89,6 +89,8 @@
     <span class="auto-dismiss-notice__msg">{visibleMessage}</span>
     <span class="auto-dismiss-notice__dot" aria-hidden="true"></span>
     <button type="button" aria-label="Dismiss notice" onclick={dismiss}>×</button>
-    <span class="auto-dismiss-notice__bar" aria-hidden="true"></span>
+    {#key visibleMessage}
+      <span class="auto-dismiss-notice__bar" aria-hidden="true"></span>
+    {/key}
   </div>
 {/if}

--- a/src/codex_autorunner/web_frontend/src/lib/components/AutoDismissNotice.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/AutoDismissNotice.svelte
@@ -13,10 +13,7 @@
 
   let visibleMessage = $state<string | null>(null);
   let lastSeen = $state<string | null>(null);
-  let progress = $state(0);
   let timer: ReturnType<typeof setTimeout> | null = null;
-  let raf: number | null = null;
-  let startedAt = 0;
   let toastEl: HTMLDivElement | null = $state(null);
   let portalParent: HTMLElement | null = null;
 
@@ -24,10 +21,6 @@
     if (timer) {
       clearTimeout(timer);
       timer = null;
-    }
-    if (raf !== null) {
-      cancelAnimationFrame(raf);
-      raf = null;
     }
   }
 
@@ -39,16 +32,6 @@
   function startCountdown(): void {
     clearTimer();
     if (!visibleMessage || timeoutMs <= 0) return;
-    startedAt = performance.now();
-    progress = 0;
-    const tick = () => {
-      const elapsed = performance.now() - startedAt;
-      progress = Math.min(1, elapsed / timeoutMs);
-      if (progress < 1 && visibleMessage) {
-        raf = requestAnimationFrame(tick);
-      }
-    };
-    raf = requestAnimationFrame(tick);
     timer = setTimeout(() => {
       visibleMessage = null;
       timer = null;
@@ -96,14 +79,16 @@
 </script>
 
 {#if visibleMessage}
-  <div bind:this={toastEl} class={`auto-dismiss-notice ${tone}`} role="status">
+  <div
+    bind:this={toastEl}
+    class={`auto-dismiss-notice ${tone}`}
+    class:no-timeout={timeoutMs <= 0}
+    role="status"
+    style={`--notice-timeout: ${Math.max(0, timeoutMs)}ms;`}
+  >
     <span class="auto-dismiss-notice__msg">{visibleMessage}</span>
     <span class="auto-dismiss-notice__dot" aria-hidden="true"></span>
     <button type="button" aria-label="Dismiss notice" onclick={dismiss}>×</button>
-    <span
-      class="auto-dismiss-notice__bar"
-      aria-hidden="true"
-      style:transform={`scaleX(${1 - progress})`}
-    ></span>
+    <span class="auto-dismiss-notice__bar" aria-hidden="true"></span>
   </div>
 {/if}

--- a/src/codex_autorunner/web_frontend/src/lib/components/MemoryRail.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/MemoryRail.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import MemoryView from '$lib/components/MemoryView.svelte';
   import { webApi, type ApiError } from '$lib/api/client';
   import { buildMemoryViewModel, type MemoryViewModel } from '$lib/viewModels/memory';
-  import type { ScopeRef } from '$lib/viewModels/scope';
+  import { formatScopeUrn, type ScopeRef } from '$lib/viewModels/scope';
 
   let {
     open = false,
@@ -18,19 +17,22 @@
   let vm = $state<MemoryViewModel | null>(null);
   let loading = $state(true);
   let error = $state<ApiError | null>(null);
-
-  onMount(() => {
-    if (open) void loadMemory();
-  });
+  let loadedScopeUrn: string | null = null;
+  let loadSeq = 0;
 
   $effect(() => {
-    if (open) void loadMemory();
+    const scopeUrn = formatScopeUrn(scope);
+    if (!open) return;
+    if (loadedScopeUrn === scopeUrn && vm) return;
+    void loadMemory(scopeUrn);
   });
 
-  async function loadMemory(): Promise<void> {
+  async function loadMemory(scopeUrn: string): Promise<void> {
+    const seq = ++loadSeq;
     loading = true;
     error = null;
     const docs = await webApi.pma.listDocsWithContent();
+    if (seq !== loadSeq) return;
     if (!docs.ok) {
       error = docs.error;
       vm = null;
@@ -38,6 +40,7 @@
       return;
     }
     vm = buildMemoryViewModel(scope, docs.data);
+    loadedScopeUrn = scopeUrn;
     loading = false;
   }
 

--- a/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.svelte
@@ -493,20 +493,21 @@
               </div>
             {/if}
 
-            {#if !collapsed && visibleChildren(row).length > 0}
+            {#if !collapsed}
               {@const childRows = visibleChildren(row)}
-              <VirtualList
-                items={childRows}
-                key={(worktree) => worktree.id}
-                estimatedItemSize={54}
-                overscan={6}
-                initialCount={32}
-                ariaLabel={`Worktrees owned by ${row.label}`}
-                class="worktree-list"
-                scrollable={false}
-              >
-                {#snippet children(worktree)}
-                  <div class={`worktree-item status-${worktree.status}`} role="listitem">
+              {#if childRows.length > 0}
+                <VirtualList
+                  items={childRows}
+                  key={(worktree) => worktree.id}
+                  estimatedItemSize={54}
+                  overscan={6}
+                  initialCount={32}
+                  ariaLabel={`Worktrees owned by ${row.label}`}
+                  class="worktree-list"
+                  scrollable={false}
+                >
+                  {#snippet children(worktree)}
+                    <div class={`worktree-item status-${worktree.status}`} role="listitem">
                     <div
                       class="worktree-card row-click-target"
                       role="link"
@@ -639,9 +640,10 @@
                         {/if}
                       </div>
                     </div>
-                  </div>
-                {/snippet}
-              </VirtualList>
+                    </div>
+                  {/snippet}
+                </VirtualList>
+              {/if}
             {/if}
           </div>
         {/snippet}

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -683,9 +683,11 @@
       webApi.readModels.repoWorktreeTopology('all', 50),
       webApi.readModels.repoWorktreeRuntime('all', 50)
     );
-    activeClockInterval = window.setInterval(() => {
-      if (progress?.status === 'running') clockNowMs = Date.now();
-    }, 1000);
+  });
+
+  $effect(() => {
+    if (progress?.status === 'running') startActiveClock();
+    else stopActiveClock();
   });
 
   $effect(() => {
@@ -748,9 +750,23 @@
     unsubscribeChatIndexSession?.();
     chatIndexSession.stop();
     if (chatIndexFilterRefreshTimer) window.clearTimeout(chatIndexFilterRefreshTimer);
-    if (activeClockInterval) window.clearInterval(activeClockInterval);
+    stopActiveClock();
     closeStream();
   });
+
+  function startActiveClock(): void {
+    if (activeClockInterval !== null) return;
+    clockNowMs = Date.now();
+    activeClockInterval = window.setInterval(() => {
+      clockNowMs = Date.now();
+    }, 1000);
+  }
+
+  function stopActiveClock(): void {
+    if (activeClockInterval === null) return;
+    window.clearInterval(activeClockInterval);
+    activeClockInterval = null;
+  }
 
   $effect(() => {
     const cardCount = activeCards.length;


### PR DESCRIPTION
## Summary
- make `make setup` recover from stale Python 3.9 virtualenvs by selecting Python 3.10+ and recreating `.venv` when needed
- reduce idle web UI work: start the chat elapsed-time clock only while a turn is running, move toast countdown progress from `requestAnimationFrame` to CSS, and avoid duplicate MemoryRail initial fetches
- avoid extra recovery work after transient SSE reconnects by cancelling only pending repair refreshes once the chat stream is healthy again
- avoid repeated worktree child filtering for expanded repo rows

## Benchmark
- Before UI changes: `time pnpm web:test` -> 20.016s wall, 32.81s user, 5.47s sys, 191% CPU
- After UI changes: `time pnpm web:test` -> 12.608s wall, 31.00s user, 5.19s sys, 287% CPU
- This is a coarse local benchmark, but the direct resource wins are deterministic: idle chat pages no longer keep a 1s interval alive, toasts no longer run a JS frame loop, reconnect recovery avoids redundant transcript+queue repair fetches, and MemoryRail no longer double-fetches on initial open.

## Validation
- `make setup`
- `pnpm exec vitest run src/lib/application/chatDetailLiveProjection.test.ts src/lib/components/MemoryRail.test.ts src/routes/chats/page.test.ts`
- `pnpm run lint`
- `time pnpm web:test`
- `pnpm run build`
- pre-commit aggregate lane passed: black, ruff, import/contracts checks, mypy, pytest 9129 passed, web-ui lab, web lint, web build, web tests, SPA shell check
