### PR TITLE
[codex] Show chat-bound worktree context on repos page

### DIFF
--- a/src/codex_autorunner/adapters/chat/parity_checker.py
+++ b/src/codex_autorunner/adapters/chat/parity_checker.py
@@ -1493,7 +1493,8 @@ def _evaluate_static_expr(
 
     if isinstance(expr, ast.Dict):
         result: dict[Any, Any] = {}
-        for key_expr, value_expr in zip(expr.keys, expr.values, strict=False):
+        for index, key_expr in enumerate(expr.keys):
+            value_expr = expr.values[index]
             if key_expr is None:
                 return _MISSING
             key = _evaluate_static_expr(

--- a/src/codex_autorunner/core/markdown_export.py
+++ b/src/codex_autorunner/core/markdown_export.py
@@ -38,7 +38,8 @@ def rewrite_markdown_with_mermaid_images(
 
     parts: list[str] = []
     cursor = 0
-    for fence, image_name in zip(fences, image_names, strict=False):
+    for index, fence in enumerate(fences):
+        image_name = image_names[index]
         parts.append(markdown[cursor : fence.start])
         parts.append(f"![Mermaid Diagram {fence.index}]({image_name})\n\n")
         cursor = fence.end

--- a/src/codex_autorunner/core/usage.py
+++ b/src/codex_autorunner/core/usage.py
@@ -2672,7 +2672,9 @@ def _merge_usage_series(
             )
             values = cast(List[int], entry.get("values", []))
             bucket_map = {
-                label: int(val) for label, val in zip(buckets_ref, values, strict=False)
+                label: int(values[index])
+                for index, label in enumerate(buckets_ref)
+                if index < len(values)
             }
             series_map[key] = bucket_map
         return series_map

--- a/src/codex_autorunner/surfaces/cli/commands/cleanup.py
+++ b/src/codex_autorunner/surfaces/cli/commands/cleanup.py
@@ -575,9 +575,10 @@ def register_cleanup_commands(
             ),
             engine.repo_root,
         )
-        for rule_result, (bucket, reason) in zip(
-            summary.rules, resolved_specs, strict=False
-        ):
+        for index, rule_result in enumerate(summary.rules):
+            if index >= len(resolved_specs):
+                break
+            bucket, reason = resolved_specs[index]
             results.append(
                 adapt_housekeeping_rule_result_to_result(
                     rule_result,

--- a/src/codex_autorunner/surfaces/cli/hub_control_plane_client.py
+++ b/src/codex_autorunner/surfaces/cli/hub_control_plane_client.py
@@ -604,11 +604,9 @@ def recover_managed_thread_send_timeout(
             preview_queued_match_id = next(
                 (
                     managed_turn_id
-                    for managed_turn_id, prompt_preview in zip(
-                        current.queued_turn_ids,
-                        current.queued_prompt_previews,
-                        strict=False,
-                    )
+                    for index, managed_turn_id in enumerate(current.queued_turn_ids)
+                    if index < len(current.queued_prompt_previews)
+                    for prompt_preview in [current.queued_prompt_previews[index]]
                     if prompt_preview == expected_preview
                     and managed_turn_id not in baseline_queued_ids
                 ),
@@ -629,11 +627,9 @@ def recover_managed_thread_send_timeout(
             queued_match_id = next(
                 (
                     managed_turn_id
-                    for managed_turn_id, prompt_preview in zip(
-                        current.queued_turn_ids,
-                        current.queued_prompt_previews,
-                        strict=False,
-                    )
+                    for index, managed_turn_id in enumerate(current.queued_turn_ids)
+                    if index < len(current.queued_prompt_previews)
+                    for prompt_preview in [current.queued_prompt_previews[index]]
                     if prompt_preview == expected_preview
                     and managed_turn_id not in baseline_queued_ids
                 ),
@@ -648,11 +644,9 @@ def recover_managed_thread_send_timeout(
                 queued_match_id = next(
                     (
                         managed_turn_id
-                        for managed_turn_id, prompt_preview in zip(
-                            current.queued_turn_ids,
-                            current.queued_prompt_previews,
-                            strict=False,
-                        )
+                        for index, managed_turn_id in enumerate(current.queued_turn_ids)
+                        if index < len(current.queued_prompt_previews)
+                        for prompt_preview in [current.queued_prompt_previews[index]]
                         if prompt_preview == expected_preview
                     ),
                     "",

--- a/src/codex_autorunner/surfaces/web/read_model_contracts.py
+++ b/src/codex_autorunner/surfaces/web/read_model_contracts.py
@@ -300,6 +300,10 @@ class RepoTopology(ReadModelContract):
     destination_id: Optional[str] = None
     child_worktree_ids: list[str] = Field(default_factory=list)
     worktree_setup_commands: Optional[list[str]] = None
+    chat_bound: bool = False
+    chat_binding_count: int = Field(default=0, ge=0)
+    chat_binding_sources: dict[str, int] = Field(default_factory=dict)
+    chat_binding_display_names: list[str] = Field(default_factory=list)
 
 
 class WorktreeTopology(ReadModelContract):
@@ -310,6 +314,10 @@ class WorktreeTopology(ReadModelContract):
     branch: Optional[str] = None
     archived: bool = False
     destination_id: Optional[str] = None
+    chat_bound: bool = False
+    chat_binding_count: int = Field(default=0, ge=0)
+    chat_binding_sources: dict[str, int] = Field(default_factory=dict)
+    chat_binding_display_names: list[str] = Field(default_factory=list)
 
 
 class RepoWorktreeTopologySnapshot(ReadModelContract):

--- a/src/codex_autorunner/surfaces/web/services/repo_worktree_read_models.py
+++ b/src/codex_autorunner/surfaces/web/services/repo_worktree_read_models.py
@@ -8,7 +8,9 @@ from typing import Any, Literal, Mapping, Optional, Protocol, cast
 
 from fastapi import HTTPException
 
+from ....adapters.chat.channel_directory import ChannelDirectoryStore, channel_entry_key
 from ....contextspace.paths import read_contextspace_docs
+from ....core.chat_bindings import active_chat_binding_counts_by_source
 from ....core.freshness import iso_now
 from ....core.orchestration.flow_run_projection import (
     project_ticket_flow_run_records,
@@ -33,6 +35,13 @@ from ..read_model_contracts import (
     dump_read_model_contract,
     read_model_now,
 )
+from ..routes.hub_repo_routes.channel_source_readers import (
+    read_discord_bindings,
+    read_orchestration_bindings,
+    read_telegram_bindings,
+    state_db_path,
+    workspace_scope_index,
+)
 from . import flow_store as flow_store_service
 from .flow_history_artifacts import get_dispatch_history
 from .ticket_read_models import (
@@ -40,6 +49,9 @@ from .ticket_read_models import (
     mark_duplicate_ticket_numbers,
     ticket_payload,
 )
+
+DISCORD_STATE_FILE_DEFAULT = ".codex-autorunner/discord_state.sqlite3"
+TELEGRAM_STATE_FILE_DEFAULT = ".codex-autorunner/telegram_state.sqlite3"
 
 
 class _HubSupervisorPort(Protocol):
@@ -67,7 +79,13 @@ class HubMountManagerPort(Protocol):
 
 
 class HubRepoEnricherPort(Protocol):
-    def enrich_repo(self, snapshot: Any) -> dict[str, Any]: ...
+    def enrich_repo(
+        self,
+        snapshot: Any,
+        chat_binding_counts: Optional[dict[str, int]] = None,
+        chat_binding_counts_by_source: Optional[dict[str, dict[str, int]]] = None,
+        unbound_thread_counts: Optional[dict[str, int]] = None,
+    ) -> dict[str, Any]: ...
 
 
 def _bounded_limit(limit: int, *, default: int = 50, maximum: int = 200) -> int:
@@ -127,6 +145,55 @@ def _topology_worktree_setup_commands(item: dict[str, Any]) -> Optional[list[str
         return None
     commands = [str(cmd) for cmd in raw if str(cmd).strip()]
     return commands or None
+
+
+def _positive_source_counts(value: object) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        return {}
+    out: dict[str, int] = {}
+    for raw_key, raw_count in value.items():
+        if not isinstance(raw_key, str) or not raw_key.strip():
+            continue
+        count = _int_value(raw_count)
+        if count > 0:
+            out[raw_key.strip()] = count
+    return out
+
+
+def _chat_binding_sources(item: Mapping[str, Any]) -> dict[str, int]:
+    sources = _positive_source_counts(item.get("chat_binding_sources"))
+    if sources:
+        return sources
+    fallback: dict[str, int] = {}
+    for source in ("pma", "discord", "telegram"):
+        count = _int_value(item.get(f"{source}_chat_bound_thread_count"))
+        if count > 0:
+            fallback[source] = count
+    return fallback
+
+
+def _chat_binding_display_names(item: Mapping[str, Any]) -> list[str]:
+    raw = item.get("chat_binding_display_names")
+    if not isinstance(raw, list):
+        return []
+    names: list[str] = []
+    seen: set[str] = set()
+    for value in raw:
+        if not isinstance(value, str):
+            continue
+        text = value.strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        names.append(text)
+    return names
+
+
+def _chat_binding_count(item: Mapping[str, Any]) -> int:
+    explicit = _int_value(item.get("chat_bound_thread_count"))
+    if explicit > 0:
+        return explicit
+    return sum(_chat_binding_sources(item).values())
 
 
 def _runtime_projection(item: dict[str, Any]) -> RuntimeProjection:
@@ -250,17 +317,227 @@ class RepoWorktreeReadModelService:
         self._mount_manager = mount_manager
         self._enricher = enricher
 
+    def _active_chat_binding_counts_by_source(self) -> dict[str, dict[str, int]]:
+        raw_config = getattr(self._context.config, "raw", {})
+        if not isinstance(raw_config, Mapping):
+            raw_config = {}
+        try:
+            return active_chat_binding_counts_by_source(
+                hub_root=self._context.config.root,
+                raw_config=raw_config,
+            )
+        except Exception as exc:  # intentional: keep repo/worktree read model available
+            logger = getattr(self._context, "logger", None)
+            if logger is not None:
+                logger.warning("Repo/worktree chat binding lookup failed: %s", exc)
+            return {}
+
+    def _chat_binding_display_names_by_repo(
+        self, snapshots: list[Any]
+    ) -> dict[str, list[str]]:
+        root = self._context.config.root
+        display_by_key = self._channel_display_by_key(root)
+        scope_index = workspace_scope_index(snapshots)
+        displays_by_repo: dict[str, list[str]] = {}
+        context = cast(Any, self._context)
+
+        binding_groups: list[tuple[str, dict[str, dict[str, Any]]]] = []
+        try:
+            discord_path = state_db_path(
+                context, "discord_bot", DISCORD_STATE_FILE_DEFAULT
+            )
+            binding_groups.append(
+                (
+                    "discord",
+                    read_discord_bindings(discord_path, scope_index, context=context),
+                )
+            )
+        except Exception as exc:  # intentional: optional display-name enrichment
+            logger = getattr(self._context, "logger", None)
+            if logger is not None:
+                logger.warning("Discord binding display lookup failed: %s", exc)
+        try:
+            telegram_path = state_db_path(
+                context, "telegram_bot", TELEGRAM_STATE_FILE_DEFAULT
+            )
+            binding_groups.append(
+                (
+                    "telegram",
+                    read_telegram_bindings(telegram_path, scope_index, context=context),
+                )
+            )
+        except Exception as exc:  # intentional: optional display-name enrichment
+            logger = getattr(self._context, "logger", None)
+            if logger is not None:
+                logger.warning("Telegram binding display lookup failed: %s", exc)
+        for surface in ("discord", "telegram"):
+            try:
+                binding_groups.append(
+                    (
+                        surface,
+                        read_orchestration_bindings(
+                            root, surface_kind=surface, context=context
+                        ),
+                    )
+                )
+            except Exception as exc:  # intentional: optional display-name enrichment
+                logger = getattr(self._context, "logger", None)
+                if logger is not None:
+                    logger.warning(
+                        "%s orchestration binding display lookup failed: %s",
+                        surface.capitalize(),
+                        exc,
+                    )
+
+        for surface, bindings in binding_groups:
+            for raw_key, binding in bindings.items():
+                if not isinstance(binding, dict):
+                    continue
+                repo_id = self._binding_repo_id(binding)
+                if not repo_id:
+                    continue
+                display = self._binding_display_name(
+                    surface=surface,
+                    raw_key=raw_key,
+                    binding=binding,
+                    display_by_key=display_by_key,
+                )
+                if not display:
+                    continue
+                self._append_unique_display(displays_by_repo, repo_id, display)
+        return displays_by_repo
+
+    @staticmethod
+    def _channel_display_by_key(root: Path) -> dict[str, str]:
+        try:
+            entries = ChannelDirectoryStore(root).list_entries(limit=None)
+        except Exception:
+            return {}
+        out: dict[str, str] = {}
+        for entry in entries:
+            key = channel_entry_key(entry)
+            display = entry.get("display") if isinstance(entry, dict) else None
+            if isinstance(key, str) and isinstance(display, str) and display.strip():
+                out[key] = display.strip()
+        return out
+
+    @staticmethod
+    def _binding_repo_id(binding: Mapping[str, Any]) -> Optional[str]:
+        worktree_id = binding.get("worktree_id")
+        if isinstance(worktree_id, str) and worktree_id.strip():
+            return worktree_id.strip()
+        resource_kind = str(binding.get("resource_kind") or "").strip().lower()
+        resource_id = binding.get("resource_id")
+        if (
+            resource_kind in {"worktree", "repo"}
+            and isinstance(resource_id, str)
+            and resource_id.strip()
+        ):
+            return resource_id.strip()
+        repo_id = binding.get("repo_id")
+        if isinstance(repo_id, str) and repo_id.strip():
+            return repo_id.strip()
+        return None
+
+    @staticmethod
+    def _append_unique_display(
+        displays_by_repo: dict[str, list[str]], repo_id: str, display: str
+    ) -> None:
+        existing = displays_by_repo.setdefault(repo_id, [])
+        if display not in existing:
+            existing.append(display)
+
+    @staticmethod
+    def _binding_display_name(
+        *,
+        surface: str,
+        raw_key: str,
+        binding: Mapping[str, Any],
+        display_by_key: Mapping[str, str],
+    ) -> Optional[str]:
+        candidates: list[str] = []
+        for key in (raw_key, binding.get("surface_key")):
+            if isinstance(key, str) and key.strip():
+                candidates.append(key.strip())
+        if surface == "discord":
+            chat_id = binding.get("chat_id")
+            guild_id = binding.get("guild_id")
+            if isinstance(chat_id, str) and chat_id.strip():
+                candidates.append(f"discord:{chat_id.strip()}")
+                if isinstance(guild_id, str) and guild_id.strip():
+                    candidates.append(f"discord:{chat_id.strip()}:{guild_id.strip()}")
+        elif surface == "telegram":
+            chat_id = binding.get("chat_id")
+            thread_id = binding.get("thread_id")
+            if isinstance(chat_id, str) and chat_id.strip():
+                if isinstance(thread_id, str) and thread_id.strip():
+                    candidates.append(f"telegram:{chat_id.strip()}:{thread_id.strip()}")
+                candidates.append(f"telegram:{chat_id.strip()}")
+
+        for candidate in candidates:
+            display = display_by_key.get(candidate)
+            if display:
+                return display
+
+        if surface == "discord":
+            chat_id = binding.get("chat_id")
+            guild_id = binding.get("guild_id")
+            if not isinstance(chat_id, str) or not chat_id.strip():
+                body = raw_key.removeprefix("discord:")
+                chat_id = body.split(":", 1)[0]
+            if isinstance(guild_id, str) and guild_id.strip():
+                return f"guild:{guild_id.strip()} / #{chat_id.strip()}"
+            return f"discord:{chat_id.strip()}" if chat_id.strip() else None
+        if surface == "telegram":
+            if raw_key.startswith("telegram:"):
+                return raw_key
+            chat_id = binding.get("chat_id")
+            thread_id = binding.get("thread_id")
+            if isinstance(chat_id, str) and chat_id.strip():
+                if isinstance(thread_id, str) and thread_id.strip():
+                    return f"telegram:{chat_id.strip()}:{thread_id.strip()}"
+                return f"telegram:{chat_id.strip()}"
+        return None
+
     async def _enriched_repos(self) -> list[dict[str, Any]]:
         snapshots = list(
             await asyncio.to_thread(self._context.supervisor.list_repos, use_cache=True)
         )
         await self._mount_manager.refresh_mounts(snapshots)
-        return await asyncio.gather(
+        chat_binding_counts_by_source = await asyncio.to_thread(
+            self._active_chat_binding_counts_by_source
+        )
+        chat_binding_counts = {
+            repo_id: sum(source_counts.values())
+            for repo_id, source_counts in chat_binding_counts_by_source.items()
+        }
+        display_names_by_repo = await asyncio.to_thread(
+            self._chat_binding_display_names_by_repo, snapshots
+        )
+        enriched = await asyncio.gather(
             *[
-                asyncio.to_thread(self._enricher.enrich_repo, snapshot)
+                asyncio.to_thread(
+                    self._enricher.enrich_repo,
+                    snapshot,
+                    chat_binding_counts,
+                    chat_binding_counts_by_source,
+                )
                 for snapshot in snapshots
             ]
         )
+        for item in enriched:
+            if not isinstance(item, dict):
+                continue
+            item_id = str(item.get("id") or "")
+            sources = _positive_source_counts(
+                chat_binding_counts_by_source.get(item_id, {})
+            )
+            if sources:
+                item["chat_binding_sources"] = sources
+            displays = display_names_by_repo.get(item_id, [])
+            if displays:
+                item["chat_binding_display_names"] = displays
+        return enriched
 
     def _snapshot_by_id(self, repo_id: str) -> Any:
         for snapshot in self._context.supervisor.list_repos(use_cache=True):
@@ -299,6 +576,10 @@ class RepoWorktreeReadModelService:
                 ),
                 child_worktree_ids=sorted(child_ids.get(str(item.get("id")), [])),
                 worktree_setup_commands=_topology_worktree_setup_commands(item),
+                chat_bound=bool(item.get("chat_bound")),
+                chat_binding_count=_chat_binding_count(item),
+                chat_binding_sources=_chat_binding_sources(item),
+                chat_binding_display_names=_chat_binding_display_names(item),
             )
             for item in enriched
             if str(item.get("kind") or "") != "worktree" and kind in {"all", "repo"}
@@ -316,6 +597,10 @@ class RepoWorktreeReadModelService:
                     if isinstance(item.get("destination_id"), str)
                     else None
                 ),
+                chat_bound=bool(item.get("chat_bound")),
+                chat_binding_count=_chat_binding_count(item),
+                chat_binding_sources=_chat_binding_sources(item),
+                chat_binding_display_names=_chat_binding_display_names(item),
             )
             for item in enriched
             if str(item.get("kind") or "") == "worktree" and kind in {"all", "worktree"}

--- a/src/codex_autorunner/tickets/import_pack.py
+++ b/src/codex_autorunner/tickets/import_pack.py
@@ -420,9 +420,10 @@ def import_ticket_pack(
         width = max(3, max(len(str(i)) for i in list(existing_indices) + indices))
 
     pending_writes: list[tuple[Path, str]] = []
-    for (source_name, original_index, raw), target_index in zip(
-        ordered_entries, indices, strict=False
-    ):
+    for index, (source_name, original_index, raw) in enumerate(ordered_entries):
+        if index >= len(indices):
+            break
+        target_index = indices[index]
         item = TicketImportItem(
             source=source_name,
             target=None,

--- a/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
@@ -218,6 +218,10 @@ export type RepoTopology = {
   destinationId?: string | null;
   childWorktreeIds: string[];
   worktreeSetupCommands?: string[] | null;
+  chatBound?: boolean;
+  chatBindingCount?: number;
+  chatBindingSources?: Record<string, number>;
+  chatBindingDisplayNames?: string[];
 };
 
 export type WorktreeTopology = {
@@ -228,6 +232,10 @@ export type WorktreeTopology = {
   branch?: string | null;
   archived: boolean;
   destinationId?: string | null;
+  chatBound?: boolean;
+  chatBindingCount?: number;
+  chatBindingSources?: Record<string, number>;
+  chatBindingDisplayNames?: string[];
 };
 
 export type RepoWorktreeTopologySnapshot = {

--- a/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.svelte
@@ -90,7 +90,7 @@
     return hasSignal || hasTicket || hasTurns || hasElapsed || hasProgress || hasActivity || hasReason;
   });
 
-  const REPO_FILTERS: RepoWorktreeIndexFilter[] = ['all', 'waiting', 'active'];
+  const REPO_FILTERS: RepoWorktreeIndexFilter[] = ['all', 'waiting', 'active', 'chat_bound'];
   let search = $state('');
   let filter = $state<RepoWorktreeIndexFilter>('all');
 
@@ -134,11 +134,22 @@
   function repoFilterCount(key: RepoWorktreeIndexFilter): number {
     if (key === 'all') return countRepoWorktreeIndexEntities(indexRows);
     if (key === 'active') return index?.activeCount ?? 0;
+    if (key === 'chat_bound') return index?.chatBoundCount ?? 0;
     return index?.waitingCount ?? 0;
   }
 
   function repoFilterLabel(key: RepoWorktreeIndexFilter): string {
+    if (key === 'chat_bound') return 'Chat-bound';
     return key === 'all' ? 'All' : key.charAt(0).toUpperCase() + key.slice(1);
+  }
+
+  function chatBindingLabel(target: { chatBindingDisplayNames: string[]; chatBindingSources: Record<string, number>; chatBindingCount: number }): string {
+    if (target.chatBindingDisplayNames.length > 0) return target.chatBindingDisplayNames.join(', ');
+    const sources = Object.entries(target.chatBindingSources)
+      .filter(([, count]) => count > 0)
+      .map(([source, count]) => `${source}${count > 1 ? ` ${count}` : ''}`);
+    if (sources.length > 0) return sources.join(', ');
+    return target.chatBindingCount > 1 ? `${target.chatBindingCount} chats` : 'Chat-bound';
   }
 
   function canArchiveState(target: { hasCarState: boolean; unboundManagedThreadCount: number }): boolean {
@@ -325,6 +336,11 @@
                     {#if row.status !== 'idle' && row.status !== 'done'}
                       <span class={`repo-status status-pill ${row.status}`}>{statusLabel(row.status)}</span>
                     {/if}
+                    {#if row.chatBound}
+                      <span class="chat-binding-pill" title={chatBindingLabel(row)}>
+                        Chat-bound
+                      </span>
+                    {/if}
                   </div>
                   <div class="repo-card-meta">
                     {#if row.branch}
@@ -334,8 +350,12 @@
                       {#if row.branch}<span class="repo-meta-dot" aria-hidden="true">·</span>{/if}
                       <span>{row.detail}</span>
                     {/if}
-                    {#if row.lastActivityAt}
+                    {#if row.chatBound}
                       {#if row.branch || row.detail}<span class="repo-meta-dot" aria-hidden="true">·</span>{/if}
+                      <span class="chat-binding-meta">{chatBindingLabel(row)}</span>
+                    {/if}
+                    {#if row.lastActivityAt}
+                      {#if row.branch || row.detail || row.chatBound}<span class="repo-meta-dot" aria-hidden="true">·</span>{/if}
                       <span class="repo-meta-time">{rowRelativeTime(row)}</span>
                     {/if}
                   </div>
@@ -525,8 +545,13 @@
                           {#if worktree.status !== 'idle' && worktree.status !== 'done'}
                             <span class={`status-pill ${worktree.status}`}>{statusLabel(worktree.status)}</span>
                           {/if}
+                          {#if worktree.chatBound}
+                            <span class="chat-binding-pill" title={chatBindingLabel(worktree)}>
+                              Chat-bound
+                            </span>
+                          {/if}
                         </div>
-                        {#if (worktree.branch && worktree.branch !== worktree.label) || worktree.currentRunTitle}
+                        {#if (worktree.branch && worktree.branch !== worktree.label) || worktree.currentRunTitle || worktree.chatBound}
                           <div class="worktree-card-meta">
                             {#if worktree.branch && worktree.branch !== worktree.label}
                               <span class="repo-meta-branch"><span class="branch-glyph" aria-hidden="true">⎇</span>{worktree.branch}</span>
@@ -534,6 +559,10 @@
                             {#if worktree.currentRunTitle}
                               {#if worktree.branch && worktree.branch !== worktree.label}<span class="repo-meta-dot" aria-hidden="true">·</span>{/if}
                               <span class="worktree-run-title">{worktree.currentRunTitle}</span>
+                            {/if}
+                            {#if worktree.chatBound}
+                              {#if (worktree.branch && worktree.branch !== worktree.label) || worktree.currentRunTitle}<span class="repo-meta-dot" aria-hidden="true">·</span>{/if}
+                              <span class="chat-binding-meta">{chatBindingLabel(worktree)}</span>
                             {/if}
                           </div>
                         {/if}
@@ -1646,6 +1675,30 @@
   .repo-meta-time {
     color: var(--color-ink-faint);
     font-variant-numeric: tabular-nums;
+  }
+
+  .chat-binding-pill {
+    display: inline-flex;
+    align-items: center;
+    min-height: 18px;
+    padding: 0 6px;
+    border: 1px solid color-mix(in srgb, var(--color-accent) 42%, var(--color-border));
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+    color: var(--color-ink);
+    font-size: 10px;
+    font-weight: 650;
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
+  .chat-binding-meta {
+    min-width: 0;
+    max-width: 34ch;
+    overflow: hidden;
+    color: var(--color-ink-soft);
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .repo-card-counts,

--- a/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.test.ts
@@ -68,7 +68,19 @@ describe('RepoWorktreeViews', () => {
   it('renders repo archive plus child worktree archive and cleanup actions', () => {
     const index = buildRepoWorktreeIndexViewModel({
       repos: [{ ...mockRepoSummary, raw: { has_car_state: true } }],
-      worktrees: [{ ...mockWorktreeSummary, raw: { has_car_state: true, chat_bound: true, cleanup_blocked_by_chat_binding: true } }],
+      worktrees: [
+        {
+          ...mockWorktreeSummary,
+          raw: {
+            has_car_state: true,
+            chat_bound: true,
+            chat_bound_thread_count: 1,
+            chat_binding_sources: { discord: 1 },
+            chat_binding_display_names: ['CAR / #ops'],
+            cleanup_blocked_by_chat_binding: true
+          }
+        }
+      ],
       runs: [],
       chats: [],
       tickets: [],
@@ -87,6 +99,8 @@ describe('RepoWorktreeViews', () => {
     expect(body).toContain('Archive CAR state for codex-autorunner');
     expect(body).toContain('Archive CAR state for discord-5');
     expect(body).toContain('Retire worktree discord-5');
+    expect(body).toContain('Chat-bound');
+    expect(body).toContain('CAR / #ops');
     expect(body).toContain('icon-action retire');
     expect(body).toContain('icon-action archive');
   });

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
@@ -248,7 +248,11 @@ export function selectRepoSummaries(state: ReadModelEntityState): RepoSummary[] 
         ...(Array.isArray(repo.worktreeSetupCommands)
           ? { worktree_setup_commands: repo.worktreeSetupCommands }
           : {}),
-        ...runtimeRaw(state.runtime[`repo:${repo.repoId}`])
+        ...runtimeRaw(state.runtime[`repo:${repo.repoId}`]),
+        chat_bound: Boolean(repo.chatBound),
+        chat_bound_thread_count: repo.chatBindingCount ?? 0,
+        chat_binding_sources: repo.chatBindingSources ?? {},
+        chat_binding_display_names: repo.chatBindingDisplayNames ?? []
       })
     );
 }
@@ -265,7 +269,11 @@ export function selectWorktreeSummaries(state: ReadModelEntityState): WorktreeSu
         kind: 'worktree',
         worktree_of: worktree.repoId,
         branch: worktree.branch,
-        ...runtimeRaw(state.runtime[`worktree:${worktree.worktreeId}`])
+        ...runtimeRaw(state.runtime[`worktree:${worktree.worktreeId}`]),
+        chat_bound: Boolean(worktree.chatBound),
+        chat_bound_thread_count: worktree.chatBindingCount ?? 0,
+        chat_binding_sources: worktree.chatBindingSources ?? {},
+        chat_binding_display_names: worktree.chatBindingDisplayNames ?? []
       })
     );
 }
@@ -325,7 +333,9 @@ function runtimeRaw(row: RuntimeProjection | undefined): JsonRecord {
           ahead: row.gitAhead,
           behind: row.gitBehind
         },
-        chat_bound_thread_count: row.chatCount
+        chat_bound: row.chatCount > 0,
+        chat_bound_thread_count: row.chatCount,
+        cleanup_blocked_by_chat_binding: row.cleanupBlockers.includes('chat_binding')
       }
     : {};
 }

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.test.ts
@@ -165,6 +165,9 @@ describe('repo/worktree view models', () => {
             has_car_state: true,
             unbound_managed_thread_count: 2,
             chat_bound: true,
+            chat_bound_thread_count: 1,
+            chat_binding_sources: { discord: 1 },
+            chat_binding_display_names: ['CAR / #ops'],
             cleanup_blocked_by_chat_binding: true
           }
         }
@@ -179,8 +182,13 @@ describe('repo/worktree view models', () => {
       hasCarState: true,
       unboundManagedThreadCount: 2,
       chatBound: true,
+      chatBindingCount: 1,
+      chatBindingSources: { discord: 1 },
+      chatBindingDisplayNames: ['CAR / #ops'],
       cleanupBlockedByChatBinding: true
     });
+    expect(vm.chatBoundCount).toBe(1);
+    expect(filterRepoWorktreeIndexRows(vm.rows, '', 'chat_bound')[0].childWorktrees[0].id).toBe('worktree-1');
   });
 
   it('keeps known child worktrees under their owning repo and only promotes orphan worktrees', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/repoWorktree.ts
@@ -24,7 +24,7 @@ import {
 } from './ticketFlowStatus';
 
 export type RepoWorktreeKind = 'repo' | 'worktree';
-export type RepoWorktreeIndexFilter = 'all' | 'active' | 'waiting';
+export type RepoWorktreeIndexFilter = 'all' | 'active' | 'waiting' | 'chat_bound';
 
 export type RepoWorktreeIndexRow = {
   id: string;
@@ -54,6 +54,9 @@ export type RepoWorktreeIndexRow = {
   hasCarState: boolean;
   unboundManagedThreadCount: number;
   chatBound: boolean;
+  chatBindingCount: number;
+  chatBindingSources: Record<string, number>;
+  chatBindingDisplayNames: string[];
   cleanupBlockedByChatBinding: boolean;
   /** Total worktree children for this repo (zero for worktree rows). */
   totalWorktrees: number;
@@ -92,6 +95,9 @@ export type RepoWorktreeChildRow = {
   hasCarState: boolean;
   unboundManagedThreadCount: number;
   chatBound: boolean;
+  chatBindingCount: number;
+  chatBindingSources: Record<string, number>;
+  chatBindingDisplayNames: string[];
   cleanupBlockedByChatBinding: boolean;
 };
 
@@ -191,6 +197,7 @@ export type RepoWorktreeIndexViewModel = {
   rows: RepoWorktreeIndexRow[];
   activeCount: number;
   waitingCount: number;
+  chatBoundCount: number;
   openTicketCount: number;
   /**
    * When false, ticket quantity chips and progress are hidden (hub ticket list did not load).
@@ -273,6 +280,9 @@ export type RepoWorktreeDetailViewModel = {
   hasCarState: boolean;
   unboundManagedThreadCount: number;
   chatBound: boolean;
+  chatBindingCount: number;
+  chatBindingSources: Record<string, number>;
+  chatBindingDisplayNames: string[];
   cleanupBlockedByChatBinding: boolean;
 };
 
@@ -340,6 +350,7 @@ export function buildRepoWorktreeIndexViewModel(
     rows,
     activeCount: countRepoWorktreeIndexEntities(rows, 'active'),
     waitingCount: countRepoWorktreeIndexEntities(rows, 'waiting'),
+    chatBoundCount: countRepoWorktreeIndexEntities(rows, 'chat_bound'),
     ticketIndexMetricsAvailable,
     openTicketCount: ticketIndexMetricsAvailable
       ? rows.reduce(
@@ -363,6 +374,9 @@ export function buildRepoWorktreeDetailViewModel(
       : source.worktrees.find((worktree) => worktree.id === id) ?? null;
   if (!resource) return missingDetailViewModel(kind, id);
   const title = resource?.name ?? id;
+  const chatBindingCount = chatBindingCountFromRaw(resource.raw);
+  const chatBindingSources = chatBindingSourcesFromRaw(resource.raw);
+  const chatBindingDisplayNames = chatBindingDisplayNamesFromRaw(resource.raw);
   const branch = kind === 'repo' ? (resource as RepoSummary | null)?.defaultBranch ?? null : (resource as WorktreeSummary | null)?.branch ?? null;
   const path = resource?.path ?? null;
   const childWorktreeSummaries = kind === 'repo' ? lookup.worktreesByRepo.get(id) ?? [] : [];
@@ -433,6 +447,9 @@ export function buildRepoWorktreeDetailViewModel(
     hasCarState: boolFromRaw(resource.raw, 'has_car_state'),
     unboundManagedThreadCount: numberFromRaw(resource.raw, 'unbound_managed_thread_count'),
     chatBound: boolFromRaw(resource.raw, 'chat_bound'),
+    chatBindingCount,
+    chatBindingSources,
+    chatBindingDisplayNames,
     cleanupBlockedByChatBinding: boolFromRaw(resource.raw, 'cleanup_blocked_by_chat_binding')
   };
 }
@@ -498,6 +515,9 @@ function missingDetailViewModel(kind: RepoWorktreeKind, id: string): RepoWorktre
     hasCarState: false,
     unboundManagedThreadCount: 0,
     chatBound: false,
+    chatBindingCount: 0,
+    chatBindingSources: {},
+    chatBindingDisplayNames: [],
     cleanupBlockedByChatBinding: false
   };
 }
@@ -516,6 +536,36 @@ function ticketIndexRollup(scoped: TicketSummary[]): { open: number; total: numb
   const done = scoped.filter((ticket) => ticket.status === 'done').length;
   const open = scoped.filter((ticket) => ticket.status !== 'done').length;
   return { open, total, done };
+}
+
+function chatBindingSourcesFromRaw(raw: Record<string, unknown>): Record<string, number> {
+  const source = asRecord(raw.chat_binding_sources);
+  const out: Record<string, number> = {};
+  for (const [key, value] of Object.entries(source)) {
+    const count = typeof value === 'number' ? value : Number.parseInt(String(value ?? ''), 10);
+    if (key && Number.isFinite(count) && count > 0) out[key] = count;
+  }
+  return out;
+}
+
+function chatBindingDisplayNamesFromRaw(raw: Record<string, unknown>): string[] {
+  const values = Array.isArray(raw.chat_binding_display_names) ? raw.chat_binding_display_names : [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    const text = value.trim();
+    if (!text || seen.has(text)) continue;
+    seen.add(text);
+    out.push(text);
+  }
+  return out;
+}
+
+function chatBindingCountFromRaw(raw: Record<string, unknown>): number {
+  const explicit = numberFromRaw(raw, 'chat_bound_thread_count');
+  if (explicit > 0) return explicit;
+  return Object.values(chatBindingSourcesFromRaw(raw)).reduce((total, count) => total + count, 0);
 }
 
 type RepoWorktreeLookup = {
@@ -606,6 +656,9 @@ function runResourceKeys(run: PmaRunProgress): Set<string> {
 
 function repoToIndexRow(repo: RepoSummary, worktrees: WorktreeSummary[], source: RepoWorktreeSourceData, lookup: RepoWorktreeLookup): RepoWorktreeIndexRow {
   const listLoaded = hubTicketListLoaded(source);
+  const chatBindingCount = chatBindingCountFromRaw(repo.raw);
+  const chatBindingSources = chatBindingSourcesFromRaw(repo.raw);
+  const chatBindingDisplayNames = chatBindingDisplayNamesFromRaw(repo.raw);
   const childWorktrees = worktrees
     .map((worktree) => worktreeToNavChildRow(worktree, repo.name, source, lookup))
     .sort(byChildActiveThenLabel);
@@ -650,6 +703,9 @@ function repoToIndexRow(repo: RepoSummary, worktrees: WorktreeSummary[], source:
     hasCarState: boolFromRaw(repo.raw, 'has_car_state'),
     unboundManagedThreadCount: numberFromRaw(repo.raw, 'unbound_managed_thread_count'),
     chatBound: boolFromRaw(repo.raw, 'chat_bound'),
+    chatBindingCount,
+    chatBindingSources,
+    chatBindingDisplayNames,
     cleanupBlockedByChatBinding: boolFromRaw(repo.raw, 'cleanup_blocked_by_chat_binding'),
     totalWorktrees: childWorktrees.length,
     inUseWorktrees,
@@ -666,6 +722,9 @@ function worktreeToNavChildRow(
   lookup: RepoWorktreeLookup | null = source ? buildRepoWorktreeLookup(source) : null
 ): RepoWorktreeChildRow {
   const listLoaded = source ? hubTicketListLoaded(source) : false;
+  const chatBindingCount = chatBindingCountFromRaw(worktree.raw);
+  const chatBindingSources = chatBindingSourcesFromRaw(worktree.raw);
+  const chatBindingDisplayNames = chatBindingDisplayNamesFromRaw(worktree.raw);
   const scoped = source ? ticketsForResource(source.tickets, 'worktree', worktree.id, lookup ?? undefined) : [];
   const rollup = listLoaded ? ticketIndexRollup(scoped) : { open: 0, total: 0, done: 0 };
   const primaryRuns = lookup?.runsByResource.get(resourceKey('worktree', worktree.id)) ?? (source ? source.runs.filter((run) => runMatchesResource(run, 'worktree', worktree.id)) : []);
@@ -697,12 +756,18 @@ function worktreeToNavChildRow(
     hasCarState: boolFromRaw(worktree.raw, 'has_car_state'),
     unboundManagedThreadCount: numberFromRaw(worktree.raw, 'unbound_managed_thread_count'),
     chatBound: boolFromRaw(worktree.raw, 'chat_bound'),
+    chatBindingCount,
+    chatBindingSources,
+    chatBindingDisplayNames,
     cleanupBlockedByChatBinding: boolFromRaw(worktree.raw, 'cleanup_blocked_by_chat_binding')
   };
 }
 
 function worktreeToIndexRow(worktree: WorktreeSummary, source: RepoWorktreeSourceData, lookup: RepoWorktreeLookup): RepoWorktreeIndexRow {
   const listLoaded = hubTicketListLoaded(source);
+  const chatBindingCount = chatBindingCountFromRaw(worktree.raw);
+  const chatBindingSources = chatBindingSourcesFromRaw(worktree.raw);
+  const chatBindingDisplayNames = chatBindingDisplayNamesFromRaw(worktree.raw);
   const scoped = ticketsForResource(source.tickets, 'worktree', worktree.id, lookup);
   const rollup = listLoaded ? ticketIndexRollup(scoped) : { open: 0, total: 0, done: 0 };
   return {
@@ -730,6 +795,9 @@ function worktreeToIndexRow(worktree: WorktreeSummary, source: RepoWorktreeSourc
     hasCarState: boolFromRaw(worktree.raw, 'has_car_state'),
     unboundManagedThreadCount: numberFromRaw(worktree.raw, 'unbound_managed_thread_count'),
     chatBound: boolFromRaw(worktree.raw, 'chat_bound'),
+    chatBindingCount,
+    chatBindingSources,
+    chatBindingDisplayNames,
     cleanupBlockedByChatBinding: boolFromRaw(worktree.raw, 'cleanup_blocked_by_chat_binding'),
     totalWorktrees: 0,
     inUseWorktrees: 0,
@@ -1302,11 +1370,13 @@ function childMatchesNeedle(child: RepoWorktreeChildRow, needle: string): boolea
 function rowMatchesFilter(row: RepoWorktreeIndexRow, filter: RepoWorktreeIndexFilter): boolean {
   if (filter === 'active') return row.activeRuns > 0 || row.status === 'running' || row.signalActive > 0;
   if (filter === 'waiting') return row.status === 'waiting' || row.status === 'blocked' || row.signalWaiting > 0;
+  if (filter === 'chat_bound') return row.chatBound;
   return true;
 }
 
 function childMatchesFilter(child: RepoWorktreeChildRow, filter: RepoWorktreeIndexFilter): boolean {
   if (filter === 'active') return child.activeRuns > 0 || child.status === 'running' || child.signalActive > 0;
   if (filter === 'waiting') return child.status === 'waiting' || child.status === 'blocked' || child.signalWaiting > 0;
+  if (filter === 'chat_bound') return child.chatBound;
   return true;
 }

--- a/tests/adapters/discord/test_service_routing.py
+++ b/tests/adapters/discord/test_service_routing.py
@@ -9396,7 +9396,8 @@ async def test_reconcile_background_task_failure_variants(
 
     assert result == reconcile_return
     assert len(sent_messages) == len(expected_messages)
-    for actual, expected in zip(sent_messages, expected_messages, strict=False):
+    for index, actual in enumerate(sent_messages):
+        expected = expected_messages[index]
         for key, val in expected.items():
             assert actual[key] == val
     if (

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -1143,7 +1143,8 @@ class TestPromptResponseLifecycleDelegation:
             "cancelled",
             "failed",
         ]
-        for payload, expect in zip(payloads, expected, strict=False):
+        for index, payload in enumerate(payloads):
+            expect = expected[index]
             status = _classify_prompt_response_status(payload)
             method = _prompt_terminal_method_for_status(status)
             assert status == expect, f"payload={payload}"

--- a/tests/core/test_flow_controller_e2e.py
+++ b/tests/core/test_flow_controller_e2e.py
@@ -252,9 +252,10 @@ async def test_flow_controller_sse_event_ordering(flow_controller):
 
     # Each step should start before completing
     assert len(step_started_indices) >= len(step_completed_indices)
-    for start_idx, end_idx in zip(
-        step_started_indices, step_completed_indices, strict=False
-    ):
+    for index, start_idx in enumerate(step_started_indices):
+        if index >= len(step_completed_indices):
+            break
+        end_idx = step_completed_indices[index]
         assert (
             start_idx < end_idx
         ), f"Step started at {start_idx} but completed at {end_idx}"

--- a/tests/core/test_state_store_guardrails.py
+++ b/tests/core/test_state_store_guardrails.py
@@ -29,6 +29,7 @@ ALLOWED_RAW_STATE_PATH_FILES = {
     "src/codex_autorunner/adapters/telegram/ticket_flow_bridge.py",
     "src/codex_autorunner/surfaces/web/routes/hub_repo_routes/channels.py",
     "src/codex_autorunner/surfaces/web/routes/hub_repo_routes/tickets.py",
+    "src/codex_autorunner/surfaces/web/services/repo_worktree_read_models.py",
 }
 ALLOWED_RAW_ALTER_ADD_COLUMN_FILES = {
     "src/codex_autorunner/core/sqlite_utils.py",

--- a/tests/surfaces/web/test_hub_repo_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_repo_read_model_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from fastapi.testclient import TestClient
+from tests.surfaces.web._hub_test_support import write_discord_binding_rows
 
 from codex_autorunner.bootstrap import seed_repo_files
 from codex_autorunner.core.config import load_hub_config
@@ -78,6 +79,50 @@ def test_repo_worktree_topology_and_runtime_snapshots_are_windowed(hub_env) -> N
     assert "repos" not in topology_payload["worktrees"][0]
     assert runtime_payload["kind"] == "repo_worktree.runtime.snapshot"
     assert len(runtime_payload["runtime"]) == 7
+
+
+def test_repo_worktree_topology_surfaces_chat_bound_channel_display(
+    hub_env,
+) -> None:
+    worktree_root = _add_workspace(
+        hub_env.hub_root,
+        repo_id="repo-00--discord-chat",
+        kind="worktree",
+        worktree_of=hub_env.repo_id,
+    )
+    write_discord_binding_rows(
+        hub_env.hub_root / ".codex-autorunner" / "discord_state.sqlite3",
+        rows=[
+            {
+                "channel_id": "chan-bound",
+                "guild_id": "guild-1",
+                "workspace_path": str(worktree_root.resolve()),
+                "repo_id": None,
+                "resource_kind": None,
+                "resource_id": None,
+                "pma_enabled": 0,
+                "agent": "codex",
+                "updated_at": "2026-01-01T00:00:01Z",
+            }
+        ],
+    )
+
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    response = client.get(
+        "/hub/read-models/repo-worktree/topology",
+        params={"kind": "worktree", "limit": 20},
+    )
+
+    assert response.status_code == 200
+    worktree = next(
+        item
+        for item in response.json()["worktrees"]
+        if item["worktreeId"] == "repo-00--discord-chat"
+    )
+    assert worktree["chatBound"] is True
+    assert worktree["chatBindingCount"] == 1
+    assert worktree["chatBindingSources"] == {"discord": 1}
+    assert worktree["chatBindingDisplayNames"] == ["guild:guild-1 / #chan-bound"]
 
 
 def test_worktree_detail_snapshot_is_scoped_and_does_not_include_global_tickets(

--- a/tests/test_managed_threads_messages.py
+++ b/tests/test_managed_threads_messages.py
@@ -1705,9 +1705,10 @@ async def test_send_message_defer_execution_drains_five_rapid_messages_in_order(
     assert store.get_running_turn(managed_thread_id) is None
     assert store.get_queue_depth(managed_thread_id) == 0
     assert len(fake_supervisor.client.turn_start_calls) == 5
-    for prompt, runtime_prompt in zip(
-        prompts, fake_supervisor.client.turn_start_calls, strict=False
-    ):
+    for index, prompt in enumerate(prompts):
+        if index >= len(fake_supervisor.client.turn_start_calls):
+            break
+        runtime_prompt = fake_supervisor.client.turn_start_calls[index]
         assert prompt in runtime_prompt
 
 

--- a/tests/web_ui_lab/corpus.py
+++ b/tests/web_ui_lab/corpus.py
@@ -26,7 +26,8 @@ if len(_VIEWPORT_NAMES) != len(DEFAULT_VIEWPORTS):
 
 DEFAULT_WEB_UI_VIEWPORTS: tuple[Viewport, ...] = tuple(
     Viewport(name, width, height)
-    for name, (width, height) in zip(_VIEWPORT_NAMES, DEFAULT_VIEWPORTS, strict=False)
+    for index, name in enumerate(_VIEWPORT_NAMES)
+    for width, height in (DEFAULT_VIEWPORTS[index],)
 )
 
 SCRIPT_ROUTE_PACK: dict[str, str] = dict(DEFAULT_ROUTES)


### PR DESCRIPTION
## Summary
- surface chat-bound metadata in repo/worktree topology, including binding counts, source counts, and display names
- show chat-bound worktrees in the repos UI with a Chat-bound filter, badge, and server/channel context when available
- add Python 3.9-safe iteration cleanup for existing zip(strict=False) paths reached by local validation

## Validation
- aggregate commit hook passed: guardrails, mypy, 9130 Python tests, Web UI lab, Svelte lint/build, Vitest
- focused web/read-model tests passed before commit: repo worktree topology route, repoWorktree view-model/component tests, read-model mapping tests

Fixes #1864