### PR TITLE
feat(chat): chat activity clocks and unified read model contracts

### DIFF
--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -73,6 +73,11 @@ from ...core.orchestration.runtime_threads import (
     begin_next_queued_runtime_thread_execution,
     begin_runtime_thread_execution,
 )
+from ...core.orchestration.turn_context import (
+    ChatTurnDeliveryTarget,
+    ChatTurnEnvelope,
+    ChatTurnSource,
+)
 from ...core.pma_context import (
     build_hub_unavailable_snapshot,
     format_pma_discoverability_preamble,
@@ -1173,14 +1178,38 @@ async def _execute_discord_thread_message(
     if not visible_seed and transcript_message:
         visible_seed = transcript_message
     if visible_seed:
-        run_turn_kwargs["user_visible_text"] = visible_seed
-        run_turn_kwargs["title_seed"] = visible_seed
+        turn_envelope = ChatTurnEnvelope(
+            source=ChatTurnSource(
+                surface_kind="discord",
+                surface_key=dispatch.channel_id,
+                message_id=dispatch.event.message.message_id,
+                thread_id=dispatch.event.thread.thread_id,
+                update_id=dispatch.event.update_id,
+            ),
+            user_visible_text=visible_seed,
+            runtime_prompt=prompt_text,
+            title_seed=visible_seed,
+            input_items=turn_input_items,
+            existing_session_runtime_prompt=existing_session_prompt_text,
+            delivery_targets=(
+                ChatTurnDeliveryTarget(
+                    surface_kind="discord",
+                    surface_key=resolved_managed_thread_surface_key
+                    or dispatch.channel_id,
+                ),
+            ),
+        )
+        run_turn_kwargs["turn_envelope"] = turn_envelope
+        run_turn_kwargs["user_visible_text"] = turn_envelope.user_visible_text
+        run_turn_kwargs["title_seed"] = turn_envelope.title_seed
     if existing_session_prompt_text is not None:
         run_turn_kwargs["existing_session_prompt_text"] = existing_session_prompt_text
     run_turn_kwargs["chat_ux_snapshot"] = dispatch.chat_ux_snapshot
     try:
         try:
             run_turn = dispatch.service._run_agent_turn_for_message
+            if not _callable_accepts_keyword(run_turn, "turn_envelope"):
+                run_turn_kwargs.pop("turn_envelope", None)
             if not _callable_accepts_keyword(run_turn, "user_visible_text"):
                 run_turn_kwargs.pop("user_visible_text", None)
                 run_turn_kwargs.pop("title_seed", None)
@@ -1783,6 +1812,7 @@ async def run_agent_turn_for_message(
     *,
     workspace_root: Path,
     prompt_text: str,
+    turn_envelope: Optional[ChatTurnEnvelope] = None,
     input_items: Optional[list[dict[str, Any]]] = None,
     managed_thread_surface_key: Optional[str] = None,
     source_message_id: Optional[str] = None,
@@ -1816,6 +1846,7 @@ async def run_agent_turn_for_message(
         service,
         workspace_root=workspace_root,
         prompt_text=prompt_text,
+        turn_envelope=turn_envelope,
         input_items=input_items,
         managed_thread_surface_key=managed_thread_surface_key,
         source_message_id=source_message_id,
@@ -1847,6 +1878,7 @@ async def _run_discord_orchestrated_turn_for_message(
     *,
     workspace_root: Path,
     prompt_text: str,
+    turn_envelope: Optional[ChatTurnEnvelope] = None,
     input_items: Optional[list[dict[str, Any]]] = None,
     source_message_id: Optional[str] = None,
     agent: str,
@@ -1899,7 +1931,7 @@ async def _run_discord_orchestrated_turn_for_message(
     )
     execution_input_items = _build_managed_thread_input_items(
         execution_prompt,
-        input_items,
+        turn_envelope.input_items if turn_envelope is not None else input_items,
     )
     max_progress_len = max(int(service._config.max_message_length), 32)
     managed_thread_id = thread.thread_target_id
@@ -2535,25 +2567,43 @@ async def _run_discord_orchestrated_turn_for_message(
     async def _after_completion(_flow: Any) -> None:
         await _stop_progress_heartbeat()
 
+    if turn_envelope is None:
+        visible_text = (
+            user_visible_text
+            if isinstance(user_visible_text, str) and user_visible_text.strip()
+            else prompt_text
+        )
+        turn_envelope = ChatTurnEnvelope(
+            source=ChatTurnSource(
+                surface_kind="discord",
+                surface_key=channel_id,
+                message_id=source_message_id,
+            ),
+            user_visible_text=visible_text,
+            runtime_prompt=execution_prompt,
+            title_seed=(
+                title_seed
+                if isinstance(title_seed, str) and title_seed.strip()
+                else visible_text
+            ),
+            input_items=input_items,
+            existing_session_runtime_prompt=existing_session_prompt_text,
+            delivery_targets=(
+                ChatTurnDeliveryTarget(
+                    surface_kind="discord",
+                    surface_key=managed_thread_surface_key or channel_id,
+                ),
+            ),
+        )
     metadata = {
         "runtime_prompt": execution_prompt,
         "execution_error_message": public_execution_error,
     }
-    if isinstance(user_visible_text, str) and user_visible_text.strip():
-        metadata["user_visible_text"] = user_visible_text
-        metadata["title_seed"] = title_seed or user_visible_text
-    if (
-        isinstance(existing_session_prompt_text, str)
-        and existing_session_prompt_text.strip()
-    ):
-        metadata["existing_session_runtime_prompt"] = existing_session_prompt_text
     surface_key = managed_thread_surface_key or channel_id
     return await run_managed_surface_turn(
-        MessageRequest(
+        turn_envelope.to_message_request(
             target_id=thread.thread_target_id,
             target_kind="thread",
-            message_text=prompt_text,
-            busy_policy="queue",
             model=model_override,
             reasoning=reasoning_effort,
             approval_mode=approval_mode,
@@ -2654,6 +2704,7 @@ async def run_managed_thread_turn_for_message(
     *,
     workspace_root: Path,
     prompt_text: str,
+    turn_envelope: Optional[ChatTurnEnvelope] = None,
     input_items: Optional[list[dict[str, Any]]] = None,
     source_message_id: Optional[str] = None,
     agent: str,
@@ -2686,6 +2737,7 @@ async def run_managed_thread_turn_for_message(
         service,
         workspace_root=workspace_root,
         prompt_text=prompt_text,
+        turn_envelope=turn_envelope,
         input_items=input_items,
         source_message_id=source_message_id,
         agent=agent,

--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -1200,8 +1200,6 @@ async def _execute_discord_thread_message(
             ),
         )
         run_turn_kwargs["turn_envelope"] = turn_envelope
-        run_turn_kwargs["user_visible_text"] = turn_envelope.user_visible_text
-        run_turn_kwargs["title_seed"] = turn_envelope.title_seed
     if existing_session_prompt_text is not None:
         run_turn_kwargs["existing_session_prompt_text"] = existing_session_prompt_text
     run_turn_kwargs["chat_ux_snapshot"] = dispatch.chat_ux_snapshot
@@ -1210,7 +1208,15 @@ async def _execute_discord_thread_message(
             run_turn = dispatch.service._run_agent_turn_for_message
             if not _callable_accepts_keyword(run_turn, "turn_envelope"):
                 run_turn_kwargs.pop("turn_envelope", None)
-            if not _callable_accepts_keyword(run_turn, "user_visible_text"):
+                if turn_envelope is not None:
+                    run_turn_kwargs["user_visible_text"] = (
+                        turn_envelope.user_visible_text
+                    )
+                    run_turn_kwargs["title_seed"] = turn_envelope.title_seed
+                if not _callable_accepts_keyword(run_turn, "user_visible_text"):
+                    run_turn_kwargs.pop("user_visible_text", None)
+                    run_turn_kwargs.pop("title_seed", None)
+            elif not _callable_accepts_keyword(run_turn, "user_visible_text"):
                 run_turn_kwargs.pop("user_visible_text", None)
                 run_turn_kwargs.pop("title_seed", None)
             return cast(

--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -1937,9 +1937,11 @@ async def _run_discord_orchestrated_turn_for_message(
     )
     execution_input_items = _build_managed_thread_input_items(
         execution_prompt,
-        turn_envelope.input_items
-        if turn_envelope is not None and turn_envelope.input_items is not None
-        else input_items,
+        (
+            turn_envelope.input_items
+            if turn_envelope is not None and turn_envelope.input_items is not None
+            else input_items
+        ),
     )
     max_progress_len = max(int(service._config.max_message_length), 32)
     managed_thread_id = thread.thread_target_id

--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -1931,7 +1931,9 @@ async def _run_discord_orchestrated_turn_for_message(
     )
     execution_input_items = _build_managed_thread_input_items(
         execution_prompt,
-        turn_envelope.input_items if turn_envelope is not None else input_items,
+        turn_envelope.input_items
+        if turn_envelope is not None and turn_envelope.input_items is not None
+        else input_items,
     )
     max_progress_len = max(int(service._config.max_message_length), 32)
     managed_thread_id = thread.thread_target_id

--- a/src/codex_autorunner/adapters/discord/service.py
+++ b/src/codex_autorunner/adapters/discord/service.py
@@ -3738,6 +3738,8 @@ class DiscordBotService(DiscordInteractionResponseMixin):
         supervision: Optional[Any] = None,
         existing_session_prompt_text: Optional[str] = None,
         chat_ux_snapshot: Optional[Any] = None,
+        user_visible_text: Optional[str] = None,
+        title_seed: Optional[str] = None,
     ) -> DiscordMessageTurnResult:
         async def _run_turn() -> DiscordMessageTurnResult:
             if orchestrator_channel_key.startswith("pma:"):
@@ -3757,6 +3759,8 @@ class DiscordBotService(DiscordInteractionResponseMixin):
                     supervision=supervision,
                     existing_session_prompt_text=existing_session_prompt_text,
                     chat_ux_snapshot=chat_ux_snapshot,
+                    user_visible_text=user_visible_text,
+                    title_seed=title_seed,
                 )
             return await run_agent_turn_for_message(
                 self,
@@ -3775,6 +3779,8 @@ class DiscordBotService(DiscordInteractionResponseMixin):
                 heartbeat_interval_seconds=DISCORD_TURN_PROGRESS_HEARTBEAT_INTERVAL_SECONDS,
                 log_event_fn=log_event,
                 chat_ux_snapshot=chat_ux_snapshot,
+                user_visible_text=user_visible_text,
+                title_seed=title_seed,
             )
 
         turn_result: Optional[DiscordMessageTurnResult] = None

--- a/src/codex_autorunner/adapters/discord/service.py
+++ b/src/codex_autorunner/adapters/discord/service.py
@@ -186,6 +186,7 @@ from ...core.orchestration.chat_operation_scheduler_projection import (
 from ...core.orchestration.managed_thread_delivery_ledger import (
     SQLiteManagedThreadDeliveryEngine,
 )
+from ...core.orchestration.turn_context import ChatTurnEnvelope
 from ...core.runtime_services import RuntimeServices
 from ...core.state import now_iso
 from ...core.state_roots import resolve_global_state_root
@@ -3726,6 +3727,7 @@ class DiscordBotService(DiscordInteractionResponseMixin):
         *,
         workspace_root: Path,
         prompt_text: str,
+        turn_envelope: Optional[ChatTurnEnvelope] = None,
         input_items: Optional[list[dict[str, Any]]] = None,
         source_message_id: Optional[str] = None,
         agent: str,
@@ -3747,6 +3749,7 @@ class DiscordBotService(DiscordInteractionResponseMixin):
                     self,
                     workspace_root=workspace_root,
                     prompt_text=prompt_text,
+                    turn_envelope=turn_envelope,
                     input_items=input_items,
                     source_message_id=source_message_id,
                     agent=agent,
@@ -3766,6 +3769,7 @@ class DiscordBotService(DiscordInteractionResponseMixin):
                 self,
                 workspace_root=workspace_root,
                 prompt_text=prompt_text,
+                turn_envelope=turn_envelope,
                 input_items=input_items,
                 source_message_id=source_message_id,
                 agent=agent,

--- a/src/codex_autorunner/adapters/discord/service.py
+++ b/src/codex_autorunner/adapters/discord/service.py
@@ -3744,6 +3744,11 @@ class DiscordBotService(DiscordInteractionResponseMixin):
         title_seed: Optional[str] = None,
     ) -> DiscordMessageTurnResult:
         async def _run_turn() -> DiscordMessageTurnResult:
+            legacy_turn_text_kwargs = (
+                {}
+                if turn_envelope is not None
+                else {"user_visible_text": user_visible_text, "title_seed": title_seed}
+            )
             if orchestrator_channel_key.startswith("pma:"):
                 return await run_managed_thread_turn_for_message(
                     self,
@@ -3762,8 +3767,7 @@ class DiscordBotService(DiscordInteractionResponseMixin):
                     supervision=supervision,
                     existing_session_prompt_text=existing_session_prompt_text,
                     chat_ux_snapshot=chat_ux_snapshot,
-                    user_visible_text=user_visible_text,
-                    title_seed=title_seed,
+                    **legacy_turn_text_kwargs,
                 )
             return await run_agent_turn_for_message(
                 self,
@@ -3783,8 +3787,7 @@ class DiscordBotService(DiscordInteractionResponseMixin):
                 heartbeat_interval_seconds=DISCORD_TURN_PROGRESS_HEARTBEAT_INTERVAL_SECONDS,
                 log_event_fn=log_event,
                 chat_ux_snapshot=chat_ux_snapshot,
-                user_visible_text=user_visible_text,
-                title_seed=title_seed,
+                **legacy_turn_text_kwargs,
             )
 
         turn_result: Optional[DiscordMessageTurnResult] = None

--- a/src/codex_autorunner/core/injected_context.py
+++ b/src/codex_autorunner/core/injected_context.py
@@ -6,7 +6,7 @@ INJECTED_CONTEXT_START = "<injected context>"
 INJECTED_CONTEXT_END = "</injected context>"
 
 _INJECTED_CONTEXT_BLOCK_RE = re.compile(
-    rf"(?is){re.escape(INJECTED_CONTEXT_START)}\s*.*?\s*{re.escape(INJECTED_CONTEXT_END)}"
+    rf"(?is){re.escape(INJECTED_CONTEXT_START)}\s*(.*?)\s*{re.escape(INJECTED_CONTEXT_END)}"
 )
 
 
@@ -25,3 +25,28 @@ def strip_legacy_injected_context_transport_blocks(text: str | None) -> str | No
     stripped = _INJECTED_CONTEXT_BLOCK_RE.sub("", text)
     stripped = re.sub(r"\n{3,}", "\n\n", stripped)
     return stripped.strip()
+
+
+def split_legacy_injected_context_transport(
+    text: str | None,
+) -> tuple[str | None, str | None]:
+    """Normalize archived transport markers at backend read-model boundaries.
+
+    Removal note: this exists only for transcripts that predate structured
+    model-context fields. New turn paths should provide explicit capsule refs
+    and model context metadata instead of relying on these markers.
+    """
+
+    if not isinstance(text, str) or not text:
+        return text, None
+    lowered = text.lower()
+    if INJECTED_CONTEXT_START not in lowered and INJECTED_CONTEXT_END not in lowered:
+        return text, None
+    contexts = [
+        match.group(1).strip()
+        for match in _INJECTED_CONTEXT_BLOCK_RE.finditer(text)
+        if match.group(1).strip()
+    ]
+    stripped = _INJECTED_CONTEXT_BLOCK_RE.sub("", text)
+    stripped = re.sub(r"\n{3,}", "\n\n", stripped).strip()
+    return stripped or text, "\n\n".join(contexts) or None

--- a/src/codex_autorunner/core/managed_thread_store.py
+++ b/src/codex_autorunner/core/managed_thread_store.py
@@ -70,6 +70,7 @@ from .orchestration.runtime_bindings import (
 )
 from .orchestration.thread_titles import (
     choose_owned_thread_title,
+    is_deprioritized_thread_title,
     is_generic_thread_title,
     normalize_thread_title,
 )
@@ -898,6 +899,7 @@ class ManagedThreadStore:
                 and (
                     not only_if_generic
                     or is_generic_thread_title(current_title)
+                    or is_deprioritized_thread_title(current_title)
                     or may_replace_preview_title
                 )
             )

--- a/src/codex_autorunner/core/orchestration/__init__.py
+++ b/src/codex_autorunner/core/orchestration/__init__.py
@@ -171,6 +171,7 @@ from .ticket_flow_chat_ledger_contract import (
     ticket_flow_thread_metadata,
     validate_ticket_flow_thread_metadata,
 )
+from .turn_context import ChatTurnDeliveryTarget, ChatTurnEnvelope, ChatTurnSource
 
 if TYPE_CHECKING:
     from . import runtime_threads as runtime_threads_module
@@ -250,6 +251,9 @@ __all__ = [
     "AgentDefinitionCatalog",
     "BackendBinding",
     "Binding",
+    "ChatTurnDeliveryTarget",
+    "ChatTurnEnvelope",
+    "ChatTurnSource",
     "ChatOperationDuplicateAction",
     "ChatOperationRecoveryAction",
     "ChatOperationRegistration",

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -2479,7 +2479,36 @@ def _ticket_run_groups(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
             grouped.setdefault(group_id, []).append(row)
     groups: list[dict[str, Any]] = []
     for group_id, children in grouped.items():
-        latest = max(str(child.get("updated_at") or "") for child in children)
+        latest_sort_activity = max(
+            str(
+                child.get("last_sort_activity_at")
+                or child.get("last_activity_at")
+                or child.get("last_visible_message_at")
+                or ""
+            )
+            for child in children
+        )
+        latest_visible_message = max(
+            str(child.get("last_visible_message_at") or "") for child in children
+        )
+        latest_lifecycle_update = max(
+            str(child.get("last_lifecycle_update_at") or child.get("updated_at") or "")
+            for child in children
+        )
+        latest_internal_update = max(
+            str(child.get("last_internal_update_at") or child.get("updated_at") or "")
+            for child in children
+        )
+        latest_legacy_update = max(
+            str(child.get("updated_at") or "") for child in children
+        )
+        waiting_count = sum(
+            1 for child in children if int(child.get("queue_depth") or 0) > 0
+        )
+        running_count = sum(
+            1 for child in children if _chat_index_effective_status(child) == "running"
+        )
+        unread_count = sum(1 for child in children if child.get("unread"))
         groups.append(
             {
                 "row_type": "group",
@@ -2487,16 +2516,24 @@ def _ticket_run_groups(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "group_id": group_id,
                 "title": group_id,
                 "child_count": len(children),
-                "waiting_count": sum(
-                    1 for child in children if int(child.get("queue_depth") or 0) > 0
-                ),
-                "running_count": sum(
-                    1
-                    for child in children
-                    if _chat_index_effective_status(child) == "running"
-                ),
-                "unread_count": sum(1 for child in children if child.get("unread")),
-                "updated_at": latest,
+                "waiting_count": waiting_count,
+                "running_count": running_count,
+                "unread_count": unread_count,
+                "last_activity_at": latest_sort_activity or None,
+                "last_visible_message_at": latest_visible_message or None,
+                "last_lifecycle_update_at": latest_lifecycle_update or None,
+                "last_internal_update_at": latest_internal_update or None,
+                "last_sort_activity_at": latest_sort_activity or None,
+                "updated_at": latest_sort_activity or latest_legacy_update,
+                "debug": {
+                    "activity": {
+                        "selected": latest_sort_activity or None,
+                        "selected_source": "last_sort_activity_at",
+                        "last_visible_message_at": latest_visible_message or None,
+                        "last_lifecycle_update_at": latest_lifecycle_update or None,
+                        "last_internal_update_at": latest_internal_update or None,
+                    }
+                },
                 "sample_child_ids": [
                     child.get("row_id") for child in children[:3] if child.get("row_id")
                 ],
@@ -2504,7 +2541,11 @@ def _ticket_run_groups(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
             }
         )
     return sorted(
-        groups, key=lambda group: str(group.get("updated_at") or ""), reverse=True
+        groups,
+        key=lambda group: str(
+            group.get("last_sort_activity_at") or group.get("updated_at") or ""
+        ),
+        reverse=True,
     )
 
 

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -239,7 +239,14 @@ class ChatSurfaceReadService:
     def pma_compat_snapshot(
         self, *, limit: int = DEFAULT_CHAT_SURFACE_SNAPSHOT_LIMIT
     ) -> dict[str, Any]:
-        """Return the legacy PMA chat snapshot shape from the generic projection."""
+        """Return the legacy PMA chat snapshot shape from the generic projection.
+
+        PMA compatibility keeps legacy field names: ``updated_at`` means the
+        PMA thread/runtime lifecycle changed, while chat-index recency is exposed
+        as ``last_visible_message_at`` and ``last_sort_activity_at`` on
+        chat-index rows. Consumers that sort chat rows should use the chat-index
+        contract instead of PMA ``updated_at``.
+        """
 
         snapshot = self.snapshot(limit=limit)
         threads = [
@@ -1941,6 +1948,7 @@ def _chat_index_rows_from_surfaces(
             }
         )
         row["search_text"] = _chat_row_search_text(row)
+        row["debug"] = _chat_row_debug_info(row)
     return rows
 
 
@@ -2004,6 +2012,70 @@ def _managed_thread_identity_title(row: Mapping[str, Any]) -> str:
         )
         or ""
     )
+
+
+def _chat_row_debug_info(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Return diagnostic-only row resolution hints for support tooling."""
+
+    selected_title = _normalize_text(row.get("display_title") or row.get("title"))
+    title_candidates = {
+        "stored_title": _visible_chrome_text(row.get("title")),
+        "provider_title": _visible_chrome_text(row.get("provider_conversation_title")),
+        "visible_message_seed": _visible_chrome_text(row.get("last_message_preview")),
+        "binding_display_name": _normalize_text(row.get("binding_display_name")),
+        "technical_title": _normalize_text(row.get("technical_title")),
+    }
+    selected_title_source = "fallback"
+    for source in (
+        "provider_title",
+        "visible_message_seed",
+        "binding_display_name",
+        "technical_title",
+        "stored_title",
+    ):
+        value = title_candidates.get(source)
+        if value is not None and selected_title == value:
+            selected_title_source = source
+            break
+    if (
+        selected_title_source == "fallback"
+        and _normalize_text(row.get("ticket_id")) is not None
+        and selected_title == f"Ticket flow · {_normalize_text(row.get('ticket_id'))}"
+    ):
+        selected_title_source = "ticket_id"
+
+    activity_clock = {
+        "selected": _normalize_text(row.get("last_sort_activity_at")),
+        "selected_source": "last_sort_activity_at",
+        "last_visible_message_at": _normalize_text(row.get("last_visible_message_at")),
+        "last_lifecycle_update_at": _normalize_text(
+            row.get("last_lifecycle_update_at")
+        ),
+        "last_internal_update_at": _normalize_text(row.get("last_internal_update_at")),
+        "last_activity_at": _normalize_text(row.get("last_activity_at")),
+    }
+    if activity_clock["selected"] == activity_clock["last_visible_message_at"]:
+        activity_clock["selected_source"] = "last_visible_message_at"
+    elif activity_clock["selected"] is None:
+        activity_clock["selected_source"] = "none"
+
+    return {
+        "title": {
+            "selected": selected_title,
+            "selected_source": selected_title_source,
+            "candidates": {
+                key: value for key, value in title_candidates.items() if value
+            },
+        },
+        "activity": activity_clock,
+        "status": {
+            "effective_status": _chat_index_effective_status(row),
+            "lifecycle": _normalize_text(row.get("lifecycle")),
+            "lifecycle_status": _normalize_text(row.get("lifecycle_status")),
+            "runtime_status": _normalize_text(row.get("runtime_status")),
+            "queue_depth": int(row.get("queue_depth") or 0),
+        },
+    }
 
 
 def _surface_binding_display_name(surface: Mapping[str, Any]) -> Optional[str]:

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -927,6 +927,10 @@ class ChatSurfaceReadService:
                         queue_depth,
                         unread_count,
                         unread,
+                        last_visible_message_at,
+                        last_lifecycle_update_at,
+                        last_internal_update_at,
+                        last_sort_activity_at,
                         last_activity_at,
                         updated_at,
                         created_at,
@@ -943,7 +947,7 @@ class ChatSurfaceReadService:
                         row_json,
                         source_signature,
                         rebuilt_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     [
                         _chat_index_projection_params(
@@ -1362,10 +1366,20 @@ class ChatSurfaceReadService:
             metadata = _json_object(_row_get(row, "metadata_json"))
             chat_kind = _normalize_text(metadata.get("chat_kind"))
             visible_execution = visible_execution_by_thread.get(thread_id)
-            last_activity_at = (
+            last_visible_message_at = (
                 _normalize_text(_row_get(visible_execution, "created_at"))
                 if visible_execution is not None
-                else _normalize_text(row["updated_at"])
+                else None
+            )
+            last_lifecycle_update_at = _normalize_text(row["updated_at"])
+            last_internal_update_at = _max_iso(
+                last_lifecycle_update_at,
+                _normalize_text(execution["created_at"]) if execution else None,
+            )
+            last_sort_activity_at = _chat_clock_sort_fallback(
+                last_visible_message_at,
+                created_at=_normalize_text(row["created_at"]),
+                updated_at=last_lifecycle_update_at,
             )
             last_message_preview = _visible_turn_chrome_text(
                 _row_get(row, "last_message_preview"),
@@ -1383,10 +1397,7 @@ class ChatSurfaceReadService:
                 managed_thread_id=thread_id,
                 display_name=_visible_chrome_text(row["display_name"]) or thread_id,
                 created_at=_normalize_text(row["created_at"]),
-                updated_at=_max_iso(
-                    _normalize_text(row["updated_at"]),
-                    _normalize_text(execution["created_at"]) if execution else None,
-                ),
+                updated_at=last_internal_update_at,
                 archived_at=(
                     _normalize_text(row["updated_at"])
                     if lifecycle_status == "archived"
@@ -1405,7 +1416,11 @@ class ChatSurfaceReadService:
                     ),
                     "model": _normalize_text(metadata.get("model")),
                     "thread_kind": _normalize_text(metadata.get("thread_kind")),
-                    "last_activity_at": last_activity_at,
+                    "last_visible_message_at": last_visible_message_at,
+                    "last_lifecycle_update_at": last_lifecycle_update_at,
+                    "last_internal_update_at": last_internal_update_at,
+                    "last_sort_activity_at": last_sort_activity_at,
+                    "last_activity_at": last_sort_activity_at,
                     "runtime_status": _normalize_text(row["runtime_status"]),
                     "target_runtime_status": _normalize_text(row["runtime_status"]),
                     "queue_depth": queue_depth_by_thread.get(thread_id, 0),
@@ -1463,9 +1478,22 @@ class ChatSurfaceReadService:
                 lifecycle = _choose_lifecycle(
                     lifecycle, _status_to_lifecycle(delivery["state"])
                 )
-            binding_last_activity_at = _max_iso(
-                _normalize_text(_row_get(owner, "updated_at")),
+            visible_execution = visible_execution_by_thread.get(binding_thread_id or "")
+            binding_visible_message_at = (
+                _normalize_text(_row_get(visible_execution, "created_at"))
+                if visible_execution is not None
+                else None
+            )
+            binding_lifecycle_update_at = _normalize_text(_row_get(owner, "updated_at"))
+            binding_internal_update_at = _max_iso(
+                binding_lifecycle_update_at,
                 _normalize_text(execution["created_at"]) if execution else None,
+            )
+            binding_sort_activity_at = _chat_clock_sort_fallback(
+                binding_visible_message_at,
+                created_at=_normalize_text(_row_get(owner, "created_at"))
+                or _normalize_text(row["created_at"]),
+                updated_at=binding_lifecycle_update_at,
             )
             projection = _projection(projections, surface_kind, surface_key)
             projection.merge(
@@ -1490,7 +1518,11 @@ class ChatSurfaceReadService:
                 metadata={
                     "mode": _normalize_text(row["mode"]),
                     "agent_id": _normalize_text(row["agent_id"]),
-                    "last_activity_at": binding_last_activity_at,
+                    "last_visible_message_at": binding_visible_message_at,
+                    "last_lifecycle_update_at": binding_lifecycle_update_at,
+                    "last_internal_update_at": binding_internal_update_at,
+                    "last_sort_activity_at": binding_sort_activity_at,
+                    "last_activity_at": binding_sort_activity_at,
                     "queue_depth": queue_depth_by_thread.get(
                         binding_thread_id or "", 0
                     ),
@@ -1685,6 +1717,20 @@ def _chat_index_rows_from_surfaces(
                     "lifecycle_status": surface.get("lifecycle_status"),
                     "runtime_status": metadata_map.get("runtime_status"),
                     "latest_event_cursor": surface.get("latest_event_cursor"),
+                    "last_visible_message_at": metadata_map.get(
+                        "last_visible_message_at"
+                    ),
+                    "last_lifecycle_update_at": metadata_map.get(
+                        "last_lifecycle_update_at"
+                    )
+                    or surface.get("updated_at"),
+                    "last_internal_update_at": metadata_map.get(
+                        "last_internal_update_at"
+                    )
+                    or surface.get("updated_at"),
+                    "last_sort_activity_at": metadata_map.get("last_sort_activity_at")
+                    or metadata_map.get("last_activity_at")
+                    or surface.get("created_at"),
                     "last_activity_at": metadata_map.get("last_activity_at"),
                     "updated_at": surface.get("updated_at"),
                     "created_at": surface.get("created_at"),
@@ -1720,8 +1766,17 @@ def _chat_index_rows_from_surfaces(
                 "runtime_status": metadata_map.get("runtime_status"),
                 "target_runtime_status": metadata_map.get("target_runtime_status"),
                 "latest_event_cursor": surface.get("latest_event_cursor"),
-                "last_activity_at": metadata_map.get("last_activity_at")
+                "last_visible_message_at": metadata_map.get("last_visible_message_at"),
+                "last_lifecycle_update_at": metadata_map.get("last_lifecycle_update_at")
                 or surface.get("updated_at"),
+                "last_internal_update_at": metadata_map.get("last_internal_update_at")
+                or surface.get("updated_at"),
+                "last_sort_activity_at": metadata_map.get("last_sort_activity_at")
+                or metadata_map.get("last_activity_at")
+                or surface.get("created_at"),
+                "last_activity_at": metadata_map.get("last_activity_at")
+                or metadata_map.get("last_sort_activity_at")
+                or surface.get("created_at"),
                 "updated_at": surface.get("updated_at"),
                 "created_at": surface.get("created_at"),
                 "last_message_preview": last_message_preview,
@@ -1743,8 +1798,29 @@ def _chat_index_rows_from_surfaces(
             str(row["lifecycle"] or "bound"), surface.get("lifecycle")
         )
         if surface_kind == "pma" or row.get("managed_thread_id") is None:
+            row["last_visible_message_at"] = _max_iso(
+                row.get("last_visible_message_at"),
+                metadata_map.get("last_visible_message_at"),
+            )
+            row["last_lifecycle_update_at"] = _max_iso(
+                row.get("last_lifecycle_update_at"),
+                metadata_map.get("last_lifecycle_update_at")
+                or surface.get("updated_at"),
+            )
+            row["last_internal_update_at"] = _max_iso(
+                row.get("last_internal_update_at"),
+                metadata_map.get("last_internal_update_at")
+                or surface.get("updated_at"),
+            )
+            row["last_sort_activity_at"] = _max_iso(
+                row.get("last_sort_activity_at"),
+                metadata_map.get("last_sort_activity_at")
+                or metadata_map.get("last_activity_at"),
+            )
             row["last_activity_at"] = _max_iso(
-                row.get("last_activity_at"), metadata_map.get("last_activity_at")
+                row.get("last_activity_at"),
+                metadata_map.get("last_activity_at")
+                or metadata_map.get("last_sort_activity_at"),
             )
         row["updated_at"] = _max_iso(row.get("updated_at"), surface.get("updated_at"))
         row["latest_event_cursor"] = (
@@ -1785,8 +1861,15 @@ def _chat_index_rows_from_surfaces(
                     row["agent" if key == "agent_id" else key] = metadata_map.get(key)
             if last_message_preview is not None:
                 row["last_message_preview"] = last_message_preview
-            if metadata_map.get("last_activity_at") is not None:
-                row["last_activity_at"] = metadata_map.get("last_activity_at")
+            for clock_key in (
+                "last_visible_message_at",
+                "last_lifecycle_update_at",
+                "last_internal_update_at",
+                "last_sort_activity_at",
+                "last_activity_at",
+            ):
+                if metadata_map.get(clock_key) is not None:
+                    row[clock_key] = metadata_map.get(clock_key)
             row["queue_depth"] = max(
                 int(row.get("queue_depth") or 0),
                 int(metadata_map.get("queue_depth") or 0),
@@ -1796,6 +1879,7 @@ def _chat_index_rows_from_surfaces(
         row["last_message_preview"] = _visible_chrome_text(
             row.get("last_message_preview")
         )
+        _normalize_chat_index_clocks(row)
         if row.get("managed_thread_id") is None:
             friendly_title = _friendly_chat_title(row)
             if friendly_title is not None:
@@ -1938,6 +2022,42 @@ def _primary_surface(row: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
 
 def _archive_state(lifecycle_status: Any) -> str:
     return "archived" if _normalize_kind(lifecycle_status) == "archived" else "active"
+
+
+def _normalize_chat_index_clocks(row: dict[str, Any]) -> None:
+    visible_at = _normalize_text(row.get("last_visible_message_at"))
+    lifecycle_at = _normalize_text(
+        row.get("last_lifecycle_update_at")
+    ) or _normalize_text(row.get("updated_at"))
+    internal_at = _max_iso(
+        _max_iso(_normalize_text(row.get("last_internal_update_at")), lifecycle_at),
+        _normalize_text(row.get("updated_at")),
+    )
+    sort_at = _normalize_text(
+        row.get("last_sort_activity_at")
+    ) or _chat_clock_sort_fallback(
+        visible_at,
+        created_at=_normalize_text(row.get("created_at")),
+        updated_at=lifecycle_at,
+    )
+    row["last_visible_message_at"] = visible_at
+    row["last_lifecycle_update_at"] = lifecycle_at
+    row["last_internal_update_at"] = internal_at
+    row["last_sort_activity_at"] = sort_at
+    row["last_activity_at"] = sort_at
+
+
+def _chat_clock_sort_fallback(
+    visible_at: Any,
+    *,
+    created_at: Any,
+    updated_at: Any,
+) -> Optional[str]:
+    return (
+        _normalize_text(visible_at)
+        or _normalize_text(created_at)
+        or _normalize_text(updated_at)
+    )
 
 
 def _managed_thread_row_lifecycle(row: Mapping[str, Any]) -> str:
@@ -2083,12 +2203,7 @@ def _chat_row_search_text(row: Mapping[str, Any]) -> str:
 
 def _chat_index_sort_key(row: Mapping[str, Any]) -> tuple[int, float, str]:
     priority = 1 if row.get("unread") else 0
-    raw = str(
-        row.get("last_activity_at")
-        or row.get("updated_at")
-        or row.get("created_at")
-        or ""
-    )
+    raw = str(row.get("last_sort_activity_at") or row.get("last_activity_at") or "")
     parsed = _parse_iso_timestamp(raw)
     updated_key = float("inf") if parsed is None else -parsed.timestamp()
     return (
@@ -2147,6 +2262,10 @@ def _chat_index_projection_params(
         int(row.get("queue_depth") or 0),
         int(row.get("unread_count") or 0),
         1 if row.get("unread") else 0,
+        _normalize_text(row.get("last_visible_message_at")),
+        _normalize_text(row.get("last_lifecycle_update_at")),
+        _normalize_text(row.get("last_internal_update_at")),
+        _normalize_text(row.get("last_sort_activity_at")),
         _normalize_text(row.get("last_activity_at")),
         _normalize_text(row.get("updated_at")),
         _normalize_text(row.get("created_at")),

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -19,6 +19,10 @@ from ..injected_context import strip_legacy_injected_context_transport_blocks
 from ..text_utils import _normalize_optional_text, _parse_iso_timestamp
 from .chat_surface_events import ChatSurfaceEvent, SQLiteChatSurfaceEventJournal
 from .sqlite import open_orchestration_sqlite
+from .thread_titles import (
+    ManagedThreadTitleInputs,
+    resolve_managed_thread_display_title,
+)
 
 CHAT_SURFACE_READ_CONTRACT_VERSION = "chat_surface_read.v1"
 PMA_CHAT_EVENTS_CONTRACT_VERSION = "pma_chat_events.v1"
@@ -1416,6 +1420,9 @@ class ChatSurfaceReadService:
                     ),
                     "model": _normalize_text(metadata.get("model")),
                     "thread_kind": _normalize_text(metadata.get("thread_kind")),
+                    "provider_conversation_title": _normalize_text(
+                        metadata.get("provider_conversation_title")
+                    ),
                     "last_visible_message_at": last_visible_message_at,
                     "last_lifecycle_update_at": last_lifecycle_update_at,
                     "last_internal_update_at": last_internal_update_at,
@@ -1791,6 +1798,9 @@ def _chat_index_rows_from_surfaces(
                 "flow_type": metadata_map.get("flow_type"),
                 "ticket_id": metadata_map.get("ticket_id"),
                 "run_id": metadata_map.get("run_id"),
+                "provider_conversation_title": metadata_map.get(
+                    "provider_conversation_title"
+                ),
             }
             by_thread[managed_thread_id] = row
         row["surfaces"].append(base_surface)
@@ -1856,6 +1866,7 @@ def _chat_index_rows_from_surfaces(
                 "active_turn_id",
                 "ticket_id",
                 "run_id",
+                "provider_conversation_title",
             ):
                 if metadata_map.get(key) is not None:
                     row["agent" if key == "agent_id" else key] = metadata_map.get(key)
@@ -1975,13 +1986,24 @@ def _managed_thread_identity_title(row: Mapping[str, Any]) -> str:
     """Return the primary PMA-owned title for a managed-thread chat row."""
 
     managed_thread_id = _normalize_text(row.get("managed_thread_id"))
-    title = _visible_chrome_text(row.get("title"))
-    if title is not None and not _is_fallback_chat_title(title, row):
-        return title
-    preview = _visible_chrome_text(row.get("last_message_preview"))
-    if preview is not None:
-        return preview
-    return managed_thread_id or _normalize_text(row.get("chat_id")) or title or ""
+    return (
+        resolve_managed_thread_display_title(
+            ManagedThreadTitleInputs(
+                stored_title=_visible_chrome_text(row.get("title")),
+                provider_title=_visible_chrome_text(
+                    row.get("provider_conversation_title")
+                ),
+                user_visible_title_seed=_visible_chrome_text(
+                    row.get("last_message_preview")
+                ),
+                chat_display_name=_friendly_chat_title(row),
+                ticket_id=row.get("ticket_id"),
+                run_id=row.get("run_id"),
+                fallback_id=managed_thread_id or _normalize_text(row.get("chat_id")),
+            )
+        )
+        or ""
+    )
 
 
 def _surface_binding_display_name(surface: Mapping[str, Any]) -> Optional[str]:
@@ -2453,11 +2475,17 @@ def _chat_detail_thread_metadata(
         ),
         None,
     )
-    title = stored_title
-    if chat_display_name and _is_fallback_chat_title(
-        stored_title, {"managed_thread_id": managed_thread_id}
-    ):
-        title = chat_display_name
+    title = resolve_managed_thread_display_title(
+        ManagedThreadTitleInputs(
+            stored_title=stored_title,
+            provider_title=metadata_map.get("provider_conversation_title"),
+            user_visible_title_seed=thread.get("last_message_preview"),
+            chat_display_name=chat_display_name,
+            ticket_id=metadata_map.get("ticket_id"),
+            run_id=metadata_map.get("run_id"),
+            fallback_id=managed_thread_id,
+        )
+    )
     return {
         "managed_thread_id": managed_thread_id,
         "title": title,
@@ -3048,6 +3076,17 @@ def _pma_thread_from_surface(surface: Mapping[str, Any]) -> dict[str, Any]:
     )
     managed_thread_id = _normalize_text(surface.get("managed_thread_id"))
     chat_display_name = _visible_chrome_text(metadata.get("chat_display_name"))
+    display_title = resolve_managed_thread_display_title(
+        ManagedThreadTitleInputs(
+            stored_title=_visible_chrome_text(display.get("display_name")),
+            provider_title=metadata.get("provider_conversation_title"),
+            user_visible_title_seed=metadata.get("last_message_preview"),
+            chat_display_name=chat_display_name,
+            ticket_id=metadata.get("ticket_id"),
+            run_id=metadata.get("run_id"),
+            fallback_id=managed_thread_id,
+        )
+    )
     payload: dict[str, Any] = {
         "managed_thread_id": managed_thread_id,
         "agent": _normalize_text(metadata.get("agent_id")) or "unknown",
@@ -3056,7 +3095,9 @@ def _pma_thread_from_surface(surface: Mapping[str, Any]) -> dict[str, Any]:
         "resource_kind": _normalize_text(owner.get("resource_kind")),
         "resource_id": _normalize_text(owner.get("resource_id")),
         "workspace_root": _normalize_text(owner.get("workspace_root")),
-        "name": _visible_chrome_text(display.get("display_name")) or managed_thread_id,
+        "name": display_title or managed_thread_id,
+        "display_title": display_title,
+        "technical_title": managed_thread_id,
         "chat_display_name": chat_display_name,
         "model": _normalize_text(metadata.get("model")),
         "backend_thread_id": _normalize_text(metadata.get("backend_thread_id")),

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -15,6 +15,7 @@ from ..domain.workspace_scope import (
     workspace_scope_index_from_snapshots,
 )
 from ..hub_topology import load_hub_state
+from ..injected_context import strip_legacy_injected_context_transport_blocks
 from ..text_utils import _normalize_optional_text, _parse_iso_timestamp
 from .chat_surface_events import ChatSurfaceEvent, SQLiteChatSurfaceEventJournal
 from .sqlite import open_orchestration_sqlite
@@ -1324,6 +1325,9 @@ class ChatSurfaceReadService:
             )
 
         execution_by_thread = _latest_execution_by_thread(execution_rows)
+        visible_execution_by_thread = _latest_visible_execution_by_thread(
+            execution_rows
+        )
         queue_depth_by_thread = _queue_depth_by_thread(execution_rows)
         delivery_by_surface = _latest_delivery_by_surface(delivery_rows)
         delivery_by_thread = _latest_delivery_by_thread(delivery_rows)
@@ -1357,13 +1361,15 @@ class ChatSurfaceReadService:
             lifecycle_status = _normalize_text(row["lifecycle_status"]) or "active"
             metadata = _json_object(_row_get(row, "metadata_json"))
             chat_kind = _normalize_text(metadata.get("chat_kind"))
-            last_activity_at = _max_iso(
-                _normalize_text(row["updated_at"]),
-                _normalize_text(execution["created_at"]) if execution else None,
+            visible_execution = visible_execution_by_thread.get(thread_id)
+            last_activity_at = (
+                _normalize_text(_row_get(visible_execution, "created_at"))
+                if visible_execution is not None
+                else _normalize_text(row["updated_at"])
             )
             last_message_preview = _visible_turn_chrome_text(
                 _row_get(row, "last_message_preview"),
-                execution,
+                visible_execution,
             )
             projection.merge(
                 lifecycle=lifecycle,
@@ -1377,7 +1383,10 @@ class ChatSurfaceReadService:
                 managed_thread_id=thread_id,
                 display_name=_visible_chrome_text(row["display_name"]) or thread_id,
                 created_at=_normalize_text(row["created_at"]),
-                updated_at=last_activity_at,
+                updated_at=_max_iso(
+                    _normalize_text(row["updated_at"]),
+                    _normalize_text(execution["created_at"]) if execution else None,
+                ),
                 archived_at=(
                     _normalize_text(row["updated_at"])
                     if lifecycle_status == "archived"
@@ -1733,9 +1742,10 @@ def _chat_index_rows_from_surfaces(
         row["lifecycle"] = _choose_lifecycle(
             str(row["lifecycle"] or "bound"), surface.get("lifecycle")
         )
-        row["last_activity_at"] = _max_iso(
-            row.get("last_activity_at"), metadata_map.get("last_activity_at")
-        )
+        if surface_kind == "pma" or row.get("managed_thread_id") is None:
+            row["last_activity_at"] = _max_iso(
+                row.get("last_activity_at"), metadata_map.get("last_activity_at")
+            )
         row["updated_at"] = _max_iso(row.get("updated_at"), surface.get("updated_at"))
         row["latest_event_cursor"] = (
             max(
@@ -1775,6 +1785,8 @@ def _chat_index_rows_from_surfaces(
                     row["agent" if key == "agent_id" else key] = metadata_map.get(key)
             if last_message_preview is not None:
                 row["last_message_preview"] = last_message_preview
+            if metadata_map.get("last_activity_at") is not None:
+                row["last_activity_at"] = metadata_map.get("last_activity_at")
             row["queue_depth"] = max(
                 int(row.get("queue_depth") or 0),
                 int(metadata_map.get("queue_depth") or 0),
@@ -1850,7 +1862,7 @@ def _visible_chrome_text(value: Any) -> Optional[str]:
     if text is None:
         return None
     if _contains_legacy_transport_marker(text):
-        return None
+        return _normalize_text(strip_legacy_injected_context_transport_blocks(text))
     cleaned = text
     for pattern in _COMPACT_SEED_BLOCK_PATTERNS:
         cleaned = pattern.sub(" ", cleaned)
@@ -2764,6 +2776,20 @@ def _latest_execution_by_thread(
         thread_id = _normalize_text(row["thread_target_id"])
         if thread_id is not None:
             result[thread_id] = row
+    return result
+
+
+def _latest_visible_execution_by_thread(
+    rows: Iterable[Mapping[str, Any]],
+) -> dict[str, Mapping[str, Any]]:
+    result: dict[str, Mapping[str, Any]] = {}
+    for row in rows:
+        thread_id = _normalize_text(row["thread_target_id"])
+        if thread_id is None:
+            continue
+        if _visible_turn_chrome_text(None, row) is None:
+            continue
+        result[thread_id] = row
     return result
 
 

--- a/src/codex_autorunner/core/orchestration/managed_thread_transcript.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_transcript.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any, Iterable, Mapping, Optional
 
+from ..injected_context import split_legacy_injected_context_transport
 from .managed_thread_timeline import (
     MAX_MANAGED_THREAD_TIMELINE_LIMIT,
     build_managed_thread_timeline,
@@ -135,6 +136,16 @@ def _timeline_item_to_transcript_rows(item: Mapping[str, Any]) -> list[dict[str,
             _optional_text(payload.get("user_visible_text")) if role == "user" else None
         )
         capsule_refs = _capsule_ref_list(payload.get("capsule_refs"))
+        raw_model_prompt = _optional_text(payload.get("raw_model_prompt"))
+        visible_text, model_context_text = _message_context_fields(
+            role=role,
+            text=text,
+            user_visible_text=user_visible_text,
+            raw_model_prompt=raw_model_prompt,
+        )
+        model_context_refs = [
+            ref for ref in capsule_refs if ref.get("visibility") == "model_only"
+        ]
         return [
             {
                 "kind": "message",
@@ -143,6 +154,10 @@ def _timeline_item_to_transcript_rows(item: Mapping[str, Any]) -> list[dict[str,
                 "client_turn_id": client_turn_id,
                 "correlation_id": correlation_id,
                 "visibility": visibility,
+                "visible_text": visible_text,
+                "model_context_text": model_context_text,
+                "model_context_refs": model_context_refs,
+                "raw_model_prompt": raw_model_prompt,
                 "user_visible_text": user_visible_text,
                 "capsule_refs": capsule_refs,
                 "identity": dict(identity),
@@ -154,6 +169,10 @@ def _timeline_item_to_transcript_rows(item: Mapping[str, Any]) -> list[dict[str,
                     "role": role,
                     "text": text,
                     "visibility": visibility,
+                    "visible_text": visible_text,
+                    "model_context_text": model_context_text,
+                    "model_context_refs": model_context_refs,
+                    "raw_model_prompt": raw_model_prompt,
                     "user_visible_text": user_visible_text,
                     "capsule_refs": capsule_refs,
                     "created_at": timestamp,
@@ -241,6 +260,25 @@ def _timeline_item_to_transcript_rows(item: Mapping[str, Any]) -> list[dict[str,
     if kind == "artifact":
         return [{"kind": "artifact", "id": item_id, "artifact": dict(payload)}]
     return []
+
+
+def _message_context_fields(
+    *,
+    role: str,
+    text: str,
+    user_visible_text: Optional[str],
+    raw_model_prompt: Optional[str],
+) -> tuple[str, Optional[str]]:
+    if role != "user":
+        return text, None
+    visible_text = user_visible_text or text
+    normalized_visible, visible_context = split_legacy_injected_context_transport(
+        visible_text
+    )
+    _, raw_context = split_legacy_injected_context_transport(raw_model_prompt)
+    if visible_context:
+        return normalized_visible or visible_text, visible_context
+    return normalized_visible or visible_text, raw_context
 
 
 def _tool_card_from_item(

--- a/src/codex_autorunner/core/orchestration/migrations.py
+++ b/src/codex_autorunner/core/orchestration/migrations.py
@@ -9,7 +9,7 @@ from ..sqlite_utils import table_columns, table_exists
 from ..time_utils import now_iso
 from .models import OrchestrationTableDefinition
 
-ORCHESTRATION_SCHEMA_VERSION = 35
+ORCHESTRATION_SCHEMA_VERSION = 36
 
 
 @dataclass(frozen=True)
@@ -1769,6 +1769,10 @@ def _apply_v33(conn: sqlite3.Connection) -> None:
             queue_depth INTEGER NOT NULL DEFAULT 0,
             unread_count INTEGER NOT NULL DEFAULT 0,
             unread INTEGER NOT NULL DEFAULT 0,
+            last_visible_message_at TEXT,
+            last_lifecycle_update_at TEXT,
+            last_internal_update_at TEXT,
+            last_sort_activity_at TEXT,
             last_activity_at TEXT,
             updated_at TEXT,
             created_at TEXT,
@@ -2064,6 +2068,42 @@ def _apply_v35(conn: sqlite3.Connection) -> None:
     )
 
 
+def _apply_v36(conn: sqlite3.Connection) -> None:
+    _ensure_column(
+        conn,
+        "orch_chat_index_projection",
+        "last_visible_message_at",
+        "last_visible_message_at TEXT",
+    )
+    _ensure_column(
+        conn,
+        "orch_chat_index_projection",
+        "last_lifecycle_update_at",
+        "last_lifecycle_update_at TEXT",
+    )
+    _ensure_column(
+        conn,
+        "orch_chat_index_projection",
+        "last_internal_update_at",
+        "last_internal_update_at TEXT",
+    )
+    _ensure_column(
+        conn,
+        "orch_chat_index_projection",
+        "last_sort_activity_at",
+        "last_sort_activity_at TEXT",
+    )
+    conn.execute(
+        """
+        UPDATE orch_chat_index_projection
+           SET last_visible_message_at = COALESCE(last_visible_message_at, last_activity_at),
+               last_lifecycle_update_at = COALESCE(last_lifecycle_update_at, updated_at),
+               last_internal_update_at = COALESCE(last_internal_update_at, updated_at),
+               last_sort_activity_at = COALESCE(last_sort_activity_at, last_activity_at, created_at, updated_at)
+        """
+    )
+
+
 _MIGRATIONS = (
     _MigrationStep(1, "create_core_orchestration_schema", _apply_v1),
     _MigrationStep(2, "add_binding_and_flow_projection_scaffolding", _apply_v2),
@@ -2135,6 +2175,11 @@ _MIGRATIONS = (
         35,
         "add_context_capsule_ledger",
         _apply_v35,
+    ),
+    _MigrationStep(
+        36,
+        "add_explicit_chat_activity_clocks",
+        _apply_v36,
     ),
 )
 

--- a/src/codex_autorunner/core/orchestration/thread_titles.py
+++ b/src/codex_autorunner/core/orchestration/thread_titles.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import re
+import uuid
+from dataclasses import dataclass
 from typing import Any, Optional
 
 _TITLE_LIMIT = 80
@@ -12,6 +14,26 @@ _GENERIC_TITLES = {
     "untitled",
     "untitled chat",
 }
+_CAR_TICKET_ID_RE = re.compile(r"\bTICKET-\d+[A-Za-z0-9_-]*\b")
+_THREAD_ID_RE = re.compile(r"^(?:thread|chat|run|exec|turn)[-_:][A-Za-z0-9_.:-]+$")
+_PROTOCOL_ID_RE = re.compile(r"^(?:discord|telegram):\S+$", re.IGNORECASE)
+_TRANSPORT_MARKER_RE = re.compile(
+    r"(?is)<injected context>.*?</injected context>|"
+    r"<CAR_TICKET_FLOW_PROMPT.*?(?:</CAR_TICKET_FLOW_PROMPT>|$)"
+)
+
+
+@dataclass(frozen=True)
+class ManagedThreadTitleInputs:
+    stored_title: Any = None
+    provider_title: Any = None
+    user_visible_title_seed: Any = None
+    chat_display_name: Any = None
+    ticket_title: Any = None
+    ticket_id: Any = None
+    run_title: Any = None
+    run_id: Any = None
+    fallback_id: Any = None
 
 
 def normalize_thread_title(value: Any, *, limit: int = _TITLE_LIMIT) -> Optional[str]:
@@ -19,6 +41,7 @@ def normalize_thread_title(value: Any, *, limit: int = _TITLE_LIMIT) -> Optional
 
     if not isinstance(value, str):
         return None
+    value = _TRANSPORT_MARKER_RE.sub(" ", value)
     normalized = re.sub(r"\s+", " ", value).strip()
     if not normalized:
         return None
@@ -37,6 +60,68 @@ def is_generic_thread_title(value: Any) -> bool:
     return lowered.startswith("chat · ")
 
 
+def is_deprioritized_thread_title(value: Any) -> bool:
+    title = normalize_thread_title(value)
+    if title is None:
+        return True
+    lowered = title.casefold()
+    if lowered.startswith("ticket-flow:"):
+        return True
+    if _PROTOCOL_ID_RE.match(title) or _THREAD_ID_RE.match(title):
+        return True
+    if _CAR_TICKET_ID_RE.fullmatch(title):
+        return True
+    try:
+        uuid.UUID(title)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def is_usable_managed_thread_title(value: Any) -> bool:
+    return not is_generic_thread_title(value) and not is_deprioritized_thread_title(
+        value
+    )
+
+
+def resolve_managed_thread_display_title(
+    inputs: ManagedThreadTitleInputs,
+) -> Optional[str]:
+    """Resolve backend-owned managed-thread display title precedence.
+
+    Precedence favors explicit human titles, then provider titles, then visible
+    user seeds. Technical ids and transport/control prompts are retained only as
+    last-resort fallbacks.
+    """
+
+    fallback_id = normalize_thread_title(inputs.fallback_id)
+    for candidate in (
+        inputs.stored_title,
+        inputs.provider_title,
+        inputs.user_visible_title_seed,
+        inputs.chat_display_name,
+        inputs.ticket_title,
+        inputs.run_title,
+    ):
+        title = normalize_thread_title(candidate)
+        if (
+            title is not None
+            and title != f"Thread {fallback_id}"
+            and is_usable_managed_thread_title(title)
+        ):
+            return title
+
+    ticket_id = normalize_thread_title(inputs.ticket_id)
+    if ticket_id:
+        return f"Ticket flow · {ticket_id}"
+
+    for candidate in (inputs.run_id, fallback_id, inputs.stored_title):
+        title = normalize_thread_title(candidate)
+        if title is not None:
+            return title
+    return None
+
+
 def choose_owned_thread_title(
     current_title: Any,
     *,
@@ -46,14 +131,14 @@ def choose_owned_thread_title(
 ) -> Optional[str]:
     """Choose CAR's durable title without overwriting explicit existing titles."""
 
-    current = normalize_thread_title(current_title)
-    if current is not None and not is_generic_thread_title(current):
-        return current
-    for candidate in (provider_title, message_preview, fallback, current):
-        title = normalize_thread_title(candidate)
-        if title is not None and not is_generic_thread_title(title):
-            return title
-    return current
+    return resolve_managed_thread_display_title(
+        ManagedThreadTitleInputs(
+            stored_title=current_title,
+            provider_title=provider_title,
+            user_visible_title_seed=message_preview,
+            fallback_id=fallback,
+        )
+    )
 
 
 def provider_title_metadata(

--- a/src/codex_autorunner/core/orchestration/turn_context.py
+++ b/src/codex_autorunner/core/orchestration/turn_context.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
-from typing import Any, Iterable, Mapping, Optional
+from dataclasses import asdict, dataclass, field
+from typing import Any, Iterable, Literal, Mapping, Optional
 
 from ..context_capsules import ContextCapsule, ContextCapsuleRenderPlan
 from ..injected_context import render_legacy_injected_context_transport
+from .models import BusyThreadPolicy, MessageRequest, MessageRequestKind
 
 
 @dataclass(frozen=True)
@@ -65,6 +66,140 @@ class ManagedThreadTurnAssembly:
             "title_seed": self.title_seed,
             "capsule_refs": [ref.to_dict() for ref in self.capsule_refs],
         }
+
+
+@dataclass(frozen=True)
+class ChatTurnDeliveryTarget:
+    surface_kind: str
+    surface_key: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"surface_kind": self.surface_kind, "surface_key": self.surface_key}
+
+
+@dataclass(frozen=True)
+class ChatTurnSource:
+    surface_kind: str
+    surface_key: str
+    message_id: Optional[str] = None
+    thread_id: Optional[str] = None
+    update_id: Optional[str] = None
+
+    def metadata_patch(self) -> dict[str, Any]:
+        metadata: dict[str, Any] = {
+            "source_surface_kind": self.surface_kind,
+            "source_surface_key": self.surface_key,
+        }
+        if self.message_id:
+            metadata["source_message_id"] = self.message_id
+        if self.thread_id:
+            metadata["source_thread_id"] = self.thread_id
+        if self.update_id:
+            metadata["source_update_id"] = self.update_id
+        return metadata
+
+
+@dataclass(frozen=True)
+class ChatTurnEnvelope:
+    """Typed surface-to-runtime turn submission contract.
+
+    The visible text is the user-facing transcript/title seed. The runtime
+    prompt is the model-facing prompt and may include injected context.
+    """
+
+    source: ChatTurnSource
+    user_visible_text: str
+    runtime_prompt: str
+    title_seed: str
+    busy_policy: BusyThreadPolicy = "queue"
+    kind: MessageRequestKind = "message"
+    input_items: Optional[list[dict[str, Any]]] = None
+    model_context_refs: tuple[ManagedThreadCapsuleRef, ...] = ()
+    delivery_targets: tuple[ChatTurnDeliveryTarget, ...] = ()
+    existing_session_runtime_prompt: Optional[str] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        visible = str(self.user_visible_text or "")
+        runtime_prompt = str(self.runtime_prompt or "")
+        title_seed = str(self.title_seed or visible)
+        if not visible.strip():
+            raise ValueError("ChatTurnEnvelope requires user_visible_text")
+        if not runtime_prompt.strip():
+            raise ValueError("ChatTurnEnvelope requires runtime_prompt")
+        if not title_seed.strip():
+            raise ValueError("ChatTurnEnvelope requires title_seed")
+        object.__setattr__(self, "user_visible_text", visible)
+        object.__setattr__(self, "runtime_prompt", runtime_prompt)
+        object.__setattr__(self, "title_seed", title_seed)
+        object.__setattr__(
+            self,
+            "model_context_refs",
+            capsule_refs_from_values(self.model_context_refs),
+        )
+        if self.input_items is not None:
+            object.__setattr__(
+                self,
+                "input_items",
+                [dict(item) for item in self.input_items if isinstance(item, dict)]
+                or None,
+            )
+
+    def metadata_patch(self) -> dict[str, Any]:
+        metadata = dict(self.metadata)
+        metadata.update(
+            {
+                "runtime_prompt": self.runtime_prompt,
+                "raw_model_prompt": self.runtime_prompt,
+                "user_visible_text": self.user_visible_text,
+                "title_seed": self.title_seed,
+                "source": self.source.metadata_patch(),
+            }
+        )
+        metadata.update(self.source.metadata_patch())
+        if self.model_context_refs:
+            metadata["capsule_refs"] = [
+                ref.to_dict() for ref in self.model_context_refs
+            ]
+        if self.delivery_targets:
+            metadata["delivery_targets"] = [
+                target.to_dict() for target in self.delivery_targets
+            ]
+        if (
+            isinstance(self.existing_session_runtime_prompt, str)
+            and self.existing_session_runtime_prompt.strip()
+        ):
+            metadata["existing_session_runtime_prompt"] = (
+                self.existing_session_runtime_prompt
+            )
+        return metadata
+
+    def to_message_request(
+        self,
+        *,
+        target_id: str,
+        target_kind: Literal["thread", "flow"] = "thread",
+        model: Optional[str] = None,
+        reasoning: Optional[str] = None,
+        approval_mode: Optional[str] = None,
+        input_items: Optional[list[dict[str, Any]]] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> MessageRequest:
+        request_metadata = self.metadata_patch()
+        if metadata:
+            request_metadata.update(dict(metadata))
+        return MessageRequest(
+            target_id=target_id,
+            target_kind=target_kind,
+            message_text=self.user_visible_text,
+            kind=self.kind,
+            busy_policy=self.busy_policy,
+            model=model,
+            reasoning=reasoning,
+            approval_mode=approval_mode,
+            input_items=input_items if input_items is not None else self.input_items,
+            metadata=request_metadata,
+        )
 
 
 def render_context_capsule_for_prompt(capsule: ContextCapsule) -> str:
@@ -173,6 +308,9 @@ def _present_text(value: Any) -> Optional[str]:
 __all__ = [
     "ManagedThreadCapsuleRef",
     "ManagedThreadTurnAssembly",
+    "ChatTurnDeliveryTarget",
+    "ChatTurnEnvelope",
+    "ChatTurnSource",
     "assemble_managed_thread_turn",
     "capsule_refs_from_values",
     "render_context_capsule_for_prompt",

--- a/src/codex_autorunner/surfaces/web/read_model_contracts.py
+++ b/src/codex_autorunner/surfaces/web/read_model_contracts.py
@@ -179,6 +179,21 @@ class ChatIndexGroup(ReadModelContract):
     kind: Literal["ticket_run", "surface", "repo", "worktree"]
     label: str
     child_count: int = Field(ge=0)
+    waiting_count: int = Field(default=0, ge=0)
+    running_count: int = Field(default=0, ge=0)
+    unread_count: int = Field(default=0, ge=0)
+    last_activity_at: Optional[datetime] = None
+    last_visible_message_at: Optional[datetime] = None
+    last_lifecycle_update_at: Optional[datetime] = None
+    last_internal_update_at: Optional[datetime] = None
+    last_sort_activity_at: Optional[datetime] = None
+    debug: Optional[dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Non-authoritative diagnostic hints explaining group activity clock "
+            "resolution for support/debug UIs."
+        ),
+    )
     expanded_child_window: Optional[PageWindow] = None
 
 

--- a/src/codex_autorunner/surfaces/web/read_model_contracts.py
+++ b/src/codex_autorunner/surfaces/web/read_model_contracts.py
@@ -117,6 +117,22 @@ class ReadModelEventEnvelope(ReadModelContract):
 
 
 class ChatIndexRow(ReadModelContract):
+    """Chat row contract shared by snapshots and patch payloads.
+
+    Timestamp semantics:
+    - ``last_visible_message_at`` is the newest user-visible conversation input.
+    - ``last_lifecycle_update_at`` is durable thread/binding lifecycle churn.
+    - ``last_internal_update_at`` is runtime/execution/delivery bookkeeping.
+    - ``last_sort_activity_at`` is the backend-owned recency clock for row order.
+    - ``last_activity_at`` is a compatibility alias for ``last_sort_activity_at``.
+
+    Title semantics:
+    - ``title``/``display_title`` are backend-resolved human display strings.
+    - ``technical_title`` preserves the stable thread/surface identifier.
+    - binding display fields describe attached delivery surfaces and do not own
+      managed-thread identity.
+    """
+
     chat_id: str
     surface: Literal["pma", "file_chat", "telegram", "discord", "app_server", "other"]
     title: str
@@ -149,6 +165,13 @@ class ChatIndexRow(ReadModelContract):
     chat_kind: Optional[Literal["pma", "coding_agent"]] = None
     model: Optional[str] = None
     group_id: Optional[str] = None
+    debug: Optional[dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Non-authoritative diagnostic hints explaining title and activity "
+            "clock resolution for support/debug UIs."
+        ),
+    )
 
 
 class ChatIndexGroup(ReadModelContract):

--- a/src/codex_autorunner/surfaces/web/read_model_contracts.py
+++ b/src/codex_autorunner/surfaces/web/read_model_contracts.py
@@ -132,6 +132,10 @@ class ChatIndexRow(ReadModelContract):
     status: Literal["waiting", "running", "idle", "archived", "failed"]
     unread_count: int = Field(ge=0)
     last_activity_at: Optional[datetime] = None
+    last_visible_message_at: Optional[datetime] = None
+    last_lifecycle_update_at: Optional[datetime] = None
+    last_internal_update_at: Optional[datetime] = None
+    last_sort_activity_at: Optional[datetime] = None
     sort_key: Optional[dict[str, Any]] = None
     resource_kind: Optional[str] = None
     resource_id: Optional[str] = None

--- a/src/codex_autorunner/surfaces/web/services/chat_read_models.py
+++ b/src/codex_autorunner/surfaces/web/services/chat_read_models.py
@@ -547,9 +547,9 @@ def hub_chat_row_to_chat_index_row(raw: Mapping[str, Any]) -> ChatIndexRow:
     last_internal_iso = _str_or_none(raw.get("last_internal_update_at"))
     last_sort_iso = _str_or_none(raw.get("last_sort_activity_at"))
     last_iso = (
-        last_visible_iso
-        or last_sort_iso
+        last_sort_iso
         or _str_or_none(raw.get("last_activity_at"))
+        or last_visible_iso
         or _str_or_none(raw.get("created_at"))
     )
     last_activity: Optional[datetime] = None
@@ -655,12 +655,44 @@ def hub_group_dict_to_contract(raw: Mapping[str, Any]) -> ChatIndexGroup:
     )
     label = str(raw.get("title") or group_id)
     child_count = max(0, _int_fallback(raw.get("child_count"), 0))
+    last_visible_iso = _str_or_none(raw.get("last_visible_message_at"))
+    last_lifecycle_iso = _str_or_none(raw.get("last_lifecycle_update_at"))
+    last_internal_iso = _str_or_none(raw.get("last_internal_update_at"))
+    last_sort_iso = _str_or_none(raw.get("last_sort_activity_at")) or _str_or_none(
+        raw.get("updated_at")
+    )
+    last_activity_iso = (
+        last_sort_iso or _str_or_none(raw.get("last_activity_at")) or last_visible_iso
+    )
 
     return ChatIndexGroup(
         group_id=group_id,
         kind=kind,
         label=label,
         child_count=child_count,
+        waiting_count=max(0, _int_fallback(raw.get("waiting_count"), 0)),
+        running_count=max(0, _int_fallback(raw.get("running_count"), 0)),
+        unread_count=max(0, _int_fallback(raw.get("unread_count"), 0)),
+        last_activity_at=(
+            parse_iso_optional(last_activity_iso) if last_activity_iso else None
+        ),
+        last_visible_message_at=(
+            parse_iso_optional(last_visible_iso) if last_visible_iso else None
+        ),
+        last_lifecycle_update_at=(
+            parse_iso_optional(last_lifecycle_iso) if last_lifecycle_iso else None
+        ),
+        last_internal_update_at=(
+            parse_iso_optional(last_internal_iso) if last_internal_iso else None
+        ),
+        last_sort_activity_at=(
+            parse_iso_optional(last_sort_iso) if last_sort_iso else None
+        ),
+        debug=(
+            dict(cast(Mapping[str, Any], raw.get("debug")))
+            if isinstance(raw.get("debug"), Mapping)
+            else None
+        ),
         expanded_child_window=None,
     )
 

--- a/src/codex_autorunner/surfaces/web/services/chat_read_models.py
+++ b/src/codex_autorunner/surfaces/web/services/chat_read_models.py
@@ -638,6 +638,11 @@ def hub_chat_row_to_chat_index_row(raw: Mapping[str, Any]) -> ChatIndexRow:
         chat_kind=ck_type,
         model=_str_or_none(raw.get("model")),
         group_id=_str_or_none(raw.get("group_id")),
+        debug=(
+            dict(cast(Mapping[str, Any], raw.get("debug")))
+            if isinstance(raw.get("debug"), Mapping)
+            else None
+        ),
     )
 
 

--- a/src/codex_autorunner/surfaces/web/services/chat_read_models.py
+++ b/src/codex_autorunner/surfaces/web/services/chat_read_models.py
@@ -542,9 +542,14 @@ def hub_chat_row_to_chat_index_row(raw: Mapping[str, Any]) -> ChatIndexRow:
     if raw.get("unread") is True and unread_count == 0:
         unread_count = 1
 
+    last_visible_iso = _str_or_none(raw.get("last_visible_message_at"))
+    last_lifecycle_iso = _str_or_none(raw.get("last_lifecycle_update_at"))
+    last_internal_iso = _str_or_none(raw.get("last_internal_update_at"))
+    last_sort_iso = _str_or_none(raw.get("last_sort_activity_at"))
     last_iso = (
-        _str_or_none(raw.get("last_activity_at"))
-        or _str_or_none(raw.get("updated_at"))
+        last_visible_iso
+        or last_sort_iso
+        or _str_or_none(raw.get("last_activity_at"))
         or _str_or_none(raw.get("created_at"))
     )
     last_activity: Optional[datetime] = None
@@ -604,6 +609,18 @@ def hub_chat_row_to_chat_index_row(raw: Mapping[str, Any]) -> ChatIndexRow:
         status=normalized_status,
         unread_count=unread_count,
         last_activity_at=last_activity,
+        last_visible_message_at=(
+            parse_iso_optional(last_visible_iso) if last_visible_iso else None
+        ),
+        last_lifecycle_update_at=(
+            parse_iso_optional(last_lifecycle_iso) if last_lifecycle_iso else None
+        ),
+        last_internal_update_at=(
+            parse_iso_optional(last_internal_iso) if last_internal_iso else None
+        ),
+        last_sort_activity_at=(
+            parse_iso_optional(last_sort_iso) if last_sort_iso else None
+        ),
         sort_key=(
             dict(cast(Mapping[str, Any], raw.get("sort_key")))
             if isinstance(raw.get("sort_key"), Mapping)

--- a/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.test.ts
@@ -50,9 +50,15 @@ const chatRow = {
   chatId: 'chat-1',
   surface: 'pma' as const,
   title: 'Ticket chat',
+  displayTitle: 'Ticket chat',
+  technicalTitle: 'chat-1',
   status: 'running' as const,
   unreadCount: 2,
   lastActivityAt: now,
+  lastVisibleMessageAt: now,
+  lastLifecycleUpdateAt: '2026-05-11T11:59:00Z',
+  lastInternalUpdateAt: now,
+  lastSortActivityAt: now,
   repoId: 'repo-1',
   worktreeId: 'wt-1',
   ticketId: 'TICKET-001',
@@ -60,7 +66,11 @@ const chatRow = {
   agent: 'codex',
   agentProfile: 'm4-pma',
   model: 'gpt-5.3-codex',
-  groupId: 'ticket-run:run-1'
+  groupId: 'ticket-run:run-1',
+  debug: {
+    title: { selected: 'Ticket chat', selected_source: 'stored_title' },
+    activity: { selected: now, selected_source: 'last_visible_message_at' }
+  }
 };
 
 function envelope(eventType: string, entityKind: string, entityId: string, operation = 'patch') {
@@ -100,6 +110,8 @@ describe('read model contracts', () => {
     });
 
     expect(snapshot.rows[0].chatId).toBe('chat-1');
+    expect(snapshot.rows[0].lastActivityAt).toBe(snapshot.rows[0].lastSortActivityAt);
+    expect(snapshot.rows[0].debug?.activity).toEqual(event.patch.rows[0].debug?.activity);
     expect(event.patch.rows[0].unreadCount).toBe(2);
   });
 

--- a/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.test.ts
@@ -94,7 +94,21 @@ describe('read model contracts', () => {
       window: window(),
       filter: 'active',
       rows: [chatRow],
-      groups: [],
+      groups: [
+        {
+          groupId: 'run:run-1',
+          kind: 'ticket_run',
+          label: 'run:run-1',
+          childCount: 2,
+          waitingCount: 1,
+          runningCount: 1,
+          unreadCount: 3,
+          lastActivityAt: now,
+          lastSortActivityAt: now,
+          lastLifecycleUpdateAt: now,
+          debug: { activity: { selectedSource: 'lastSortActivityAt' } }
+        }
+      ],
       counters: { total: 1, waiting: 0, running: 1, unread: 2, archived: 0 },
       repair: repair('/hub/read-models/chats')
     });
@@ -111,6 +125,9 @@ describe('read model contracts', () => {
 
     expect(snapshot.rows[0].chatId).toBe('chat-1');
     expect(snapshot.rows[0].lastActivityAt).toBe(snapshot.rows[0].lastSortActivityAt);
+    expect(snapshot.groups[0].lastActivityAt).toBe(snapshot.groups[0].lastSortActivityAt);
+    expect(snapshot.groups[0].waitingCount).toBe(1);
+    expect(snapshot.groups[0].debug?.activity).toEqual({ selectedSource: 'lastSortActivityAt' });
     expect(snapshot.rows[0].debug?.activity).toEqual(event.patch.rows[0].debug?.activity);
     expect(event.patch.rows[0].unreadCount).toBe(2);
   });

--- a/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
@@ -65,6 +65,10 @@ export type ChatIndexRow = {
   status: 'waiting' | 'running' | 'idle' | 'archived' | 'failed';
   unreadCount: number;
   lastActivityAt?: string | null;
+  lastVisibleMessageAt?: string | null;
+  lastLifecycleUpdateAt?: string | null;
+  lastInternalUpdateAt?: string | null;
+  lastSortActivityAt?: string | null;
   sortKey?: Record<string, unknown> | null;
   resourceKind?: string | null;
   resourceId?: string | null;

--- a/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
@@ -101,6 +101,15 @@ export type ChatIndexGroup = {
   kind: 'ticket_run' | 'surface' | 'repo' | 'worktree';
   label: string;
   childCount: number;
+  waitingCount?: number;
+  runningCount?: number;
+  unreadCount?: number;
+  lastActivityAt?: string | null;
+  lastVisibleMessageAt?: string | null;
+  lastLifecycleUpdateAt?: string | null;
+  lastInternalUpdateAt?: string | null;
+  lastSortActivityAt?: string | null;
+  debug?: Record<string, unknown> | null;
   expandedChildWindow?: PageWindow | null;
 };
 

--- a/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
@@ -50,6 +50,17 @@ export type ReadModelEventEnvelope<TEvent extends string = string, TEntityKind e
 };
 
 export type ChatIndexRow = {
+  /**
+   * Timestamp semantics: lastVisibleMessageAt is the newest user-visible
+   * conversation input, lastLifecycleUpdateAt is thread/binding lifecycle
+   * churn, lastInternalUpdateAt is runtime/delivery bookkeeping,
+   * lastSortActivityAt is the backend-owned row-order clock, and
+   * lastActivityAt is a compatibility alias for lastSortActivityAt.
+   *
+   * Title semantics: title/displayTitle are backend-resolved human display
+   * strings, technicalTitle preserves the stable identifier, and binding
+   * display names describe attached delivery surfaces.
+   */
   chatId: string;
   surface: 'pma' | 'file_chat' | 'telegram' | 'discord' | 'app_server' | 'other';
   title: string;
@@ -82,6 +93,7 @@ export type ChatIndexRow = {
   chatKind?: 'pma' | 'coding_agent' | null;
   model?: string | null;
   groupId?: string | null;
+  debug?: Record<string, unknown> | null;
 };
 
 export type ChatIndexGroup = {

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
@@ -142,50 +142,9 @@
 
   function modelOnlyCapsuleRefs(card: Extract<ChatTranscriptCard, { kind: 'message' }>): PmaMessageCapsuleRef[] {
     if (card.message.role !== 'user') return [];
+    const structuredRefs = card.message.modelContextRefs ?? [];
+    if (structuredRefs.length > 0) return structuredRefs;
     return (card.message.capsuleRefs ?? []).filter((ref) => ref.visibility === 'model_only');
-  }
-
-  type PromptParts = {
-    visibleText: string;
-    injectedContext: string | null;
-  };
-
-  function splitInjectedPromptContext(text: string): PromptParts {
-    const match = text.match(/<injected context>\s*([\s\S]*?)\s*<\/injected context>\s*/i);
-    if (!match) return { visibleText: text, injectedContext: null };
-    const before = text.slice(0, match.index).trim();
-    const after = text.slice((match.index ?? 0) + match[0].length).trim();
-    const visibleText = [before, after].filter(Boolean).join('\n\n');
-    return {
-      visibleText: visibleText || text,
-      injectedContext: match[1]?.trim() || null
-    };
-  }
-
-  function rawRecord(value: unknown): Record<string, unknown> {
-    return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
-  }
-
-  function rawText(value: unknown): string | null {
-    return typeof value === 'string' && value.trim() ? value : null;
-  }
-
-  function rawInjectedPromptText(card: Extract<ChatTranscriptCard, { kind: 'message' }>): string | null {
-    const raw = rawRecord(card.message.raw);
-    const payload = rawRecord(raw.payload);
-    return rawText(payload.raw_model_prompt) ?? rawText(payload.runtime_prompt) ?? rawText(raw.raw_model_prompt) ?? rawText(raw.runtime_prompt);
-  }
-
-  function userPromptParts(card: Extract<ChatTranscriptCard, { kind: 'message' }>): PromptParts {
-    const visibleParts = splitInjectedPromptContext(card.message.text);
-    if (visibleParts.injectedContext) return visibleParts;
-    const rawPrompt = rawInjectedPromptText(card);
-    if (!rawPrompt) return visibleParts;
-    const rawParts = splitInjectedPromptContext(rawPrompt);
-    return {
-      visibleText: card.message.text,
-      injectedContext: rawParts.injectedContext
-    };
   }
 
   function capsuleRefLabel(ref: PmaMessageCapsuleRef): string {
@@ -199,15 +158,16 @@
   {#if card.kind === 'message'}
     {@const isStreaming = card.message.role === 'assistant' && card.id === streamingMessageId}
     {@const modelContextRefs = modelOnlyCapsuleRefs(card)}
-    {@const promptParts = card.message.role === 'user' ? userPromptParts(card) : { visibleText: card.message.text, injectedContext: null }}
-    {#if modelContextRefs.length > 0 || promptParts.injectedContext}
+    {@const visibleText = card.message.visibleText ?? card.message.text}
+    {@const modelContextText = card.message.role === 'user' ? card.message.modelContextText : null}
+    {#if modelContextRefs.length > 0 || modelContextText}
       <details class="injected-prompt-card">
         <summary>
-          <span>{promptParts.injectedContext ? 'Injected prompt' : 'Model-only context'}</span>
+          <span>{modelContextText ? 'Injected prompt' : 'Model-only context'}</span>
         </summary>
         <div class="injected-prompt-body markdown-body">
-          {#if promptParts.injectedContext}
-            {@html renderMarkdownToHtml(promptParts.injectedContext, { openLinksInNewTab: true })}
+          {#if modelContextText}
+            {@html renderMarkdownToHtml(modelContextText, { openLinksInNewTab: true })}
           {/if}
           {#if modelContextRefs.length > 0}
             <ul>
@@ -227,10 +187,10 @@
     <article class={`message ${card.message.role === 'user' ? 'user' : 'assistant'}`}>
       <span>{card.message.role === 'user' ? 'You' : assistantLabel}</span>
       {#if isStreaming}
-        <div class="message-markdown streaming">{promptParts.visibleText}</div>
+        <div class="message-markdown streaming">{visibleText}</div>
       {:else}
         <div class="message-markdown markdown-body">
-          {@html renderMarkdownToHtml(promptParts.visibleText, { openLinksInNewTab: true })}
+          {@html renderMarkdownToHtml(visibleText, { openLinksInNewTab: true })}
         </div>
       {/if}
       {#if card.message.role === 'user' && card.message.artifacts.length > 0}

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
@@ -145,6 +145,49 @@
     return (card.message.capsuleRefs ?? []).filter((ref) => ref.visibility === 'model_only');
   }
 
+  type PromptParts = {
+    visibleText: string;
+    injectedContext: string | null;
+  };
+
+  function splitInjectedPromptContext(text: string): PromptParts {
+    const match = text.match(/<injected context>\s*([\s\S]*?)\s*<\/injected context>\s*/i);
+    if (!match) return { visibleText: text, injectedContext: null };
+    const before = text.slice(0, match.index).trim();
+    const after = text.slice((match.index ?? 0) + match[0].length).trim();
+    const visibleText = [before, after].filter(Boolean).join('\n\n');
+    return {
+      visibleText: visibleText || text,
+      injectedContext: match[1]?.trim() || null
+    };
+  }
+
+  function rawRecord(value: unknown): Record<string, unknown> {
+    return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+  }
+
+  function rawText(value: unknown): string | null {
+    return typeof value === 'string' && value.trim() ? value : null;
+  }
+
+  function rawInjectedPromptText(card: Extract<ChatTranscriptCard, { kind: 'message' }>): string | null {
+    const raw = rawRecord(card.message.raw);
+    const payload = rawRecord(raw.payload);
+    return rawText(payload.raw_model_prompt) ?? rawText(payload.runtime_prompt) ?? rawText(raw.raw_model_prompt) ?? rawText(raw.runtime_prompt);
+  }
+
+  function userPromptParts(card: Extract<ChatTranscriptCard, { kind: 'message' }>): PromptParts {
+    const visibleParts = splitInjectedPromptContext(card.message.text);
+    if (visibleParts.injectedContext) return visibleParts;
+    const rawPrompt = rawInjectedPromptText(card);
+    if (!rawPrompt) return visibleParts;
+    const rawParts = splitInjectedPromptContext(rawPrompt);
+    return {
+      visibleText: card.message.text,
+      injectedContext: rawParts.injectedContext
+    };
+  }
+
   function capsuleRefLabel(ref: PmaMessageCapsuleRef): string {
     return `${ref.capsuleId} v${ref.capsuleVersion} · ${ref.scope}`;
   }
@@ -156,32 +199,38 @@
   {#if card.kind === 'message'}
     {@const isStreaming = card.message.role === 'assistant' && card.id === streamingMessageId}
     {@const modelContextRefs = modelOnlyCapsuleRefs(card)}
-    {#if modelContextRefs.length > 0}
+    {@const promptParts = card.message.role === 'user' ? userPromptParts(card) : { visibleText: card.message.text, injectedContext: null }}
+    {#if modelContextRefs.length > 0 || promptParts.injectedContext}
       <details class="injected-prompt-card">
         <summary>
-          <span>Model-only context</span>
+          <span>{promptParts.injectedContext ? 'Injected prompt' : 'Model-only context'}</span>
         </summary>
         <div class="injected-prompt-body markdown-body">
-          <ul>
-            {#each modelContextRefs as ref (`${ref.capsuleId}:${ref.capsuleVersion}:${ref.sourceDigest}`)}
-              <li>
-                <strong>{capsuleRefLabel(ref)}</strong>
-                {#if ref.reason}
-                  <small>{ref.reason}</small>
-                {/if}
-              </li>
-            {/each}
-          </ul>
+          {#if promptParts.injectedContext}
+            {@html renderMarkdownToHtml(promptParts.injectedContext, { openLinksInNewTab: true })}
+          {/if}
+          {#if modelContextRefs.length > 0}
+            <ul>
+              {#each modelContextRefs as ref (`${ref.capsuleId}:${ref.capsuleVersion}:${ref.sourceDigest}`)}
+                <li>
+                  <strong>{capsuleRefLabel(ref)}</strong>
+                  {#if ref.reason}
+                    <small>{ref.reason}</small>
+                  {/if}
+                </li>
+              {/each}
+            </ul>
+          {/if}
         </div>
       </details>
     {/if}
     <article class={`message ${card.message.role === 'user' ? 'user' : 'assistant'}`}>
       <span>{card.message.role === 'user' ? 'You' : assistantLabel}</span>
       {#if isStreaming}
-        <div class="message-markdown streaming">{card.message.text}</div>
+        <div class="message-markdown streaming">{promptParts.visibleText}</div>
       {:else}
         <div class="message-markdown markdown-body">
-          {@html renderMarkdownToHtml(card.message.text, { openLinksInNewTab: true })}
+          {@html renderMarkdownToHtml(promptParts.visibleText, { openLinksInNewTab: true })}
         </div>
       {/if}
       {#if card.message.role === 'user' && card.message.artifacts.length > 0}

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
@@ -261,14 +261,13 @@ describe('ChatTranscriptCards', () => {
           chatId: 'c1',
           role: 'user',
           text: 'Please fix the archive button.',
+          visibleText: 'Please fix the archive button.',
+          modelContextText: 'CAR managed repo',
+          rawModelPrompt: '<injected context>\nCAR managed repo\n</injected context>\n\nPlease fix the archive button.',
           createdAt: '2026-05-10T12:00:00.000Z',
           status: null,
           artifacts: [],
-          raw: {
-            payload: {
-              raw_model_prompt: '<injected context>\nCAR managed repo\n</injected context>\n\nPlease fix the archive button.'
-            }
-          }
+          raw: {}
         }
       }
     ];

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
@@ -248,6 +248,41 @@ describe('ChatTranscriptCards', () => {
     expect(body).not.toContain('&lt;injected context&gt;');
   });
 
+  it('hides legacy injected prompt text in a collapsed card and leaves only the user text visible', () => {
+    const cards: ChatTranscriptCard[] = [
+      {
+        kind: 'message',
+        id: 'u1',
+        turnId: 't1',
+        orderKey: '00000001|u1',
+        timestamp: '2026-05-10T12:00:00.000Z',
+        message: {
+          id: 'u1',
+          chatId: 'c1',
+          role: 'user',
+          text: 'Please fix the archive button.',
+          createdAt: '2026-05-10T12:00:00.000Z',
+          status: null,
+          artifacts: [],
+          raw: {
+            payload: {
+              raw_model_prompt: '<injected context>\nCAR managed repo\n</injected context>\n\nPlease fix the archive button.'
+            }
+          }
+        }
+      }
+    ];
+
+    const { body } = render(ChatTranscriptCards, { props: { cards } });
+
+    expect(body).toContain('class="injected-prompt-card"');
+    expect(body).toContain('<span>Injected prompt</span>');
+    expect(body).toContain('CAR managed repo');
+    expect(body).toContain('Please fix the archive button.');
+    expect(body).not.toContain('&lt;injected context&gt;');
+    expect(body.indexOf('CAR managed repo')).toBeLessThan(body.indexOf('class="message user"'));
+  });
+
   it('never renders raw JSON detail as a trace headline', () => {
     const jsonDetail = '{ "event_id": 1, "event_type": "progress", "lines": ["1"] }';
     const cards: ChatTranscriptCard[] = [

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.test.ts
@@ -148,6 +148,28 @@ describe('read model view-model selectors', () => {
     expect(summary.worktreeId).toBe('repo-1--discord-1');
   });
 
+  it('uses explicit visible-message clocks for chat row recency before lifecycle updates', () => {
+    const row = legacyChatIndexRecordToChatIndexRow({
+      row_id: 'thread:chat-clock',
+      managed_thread_id: 'chat-clock',
+      surface: 'pma',
+      title: 'Visible message',
+      lifecycle: 'bound',
+      runtime_status: 'idle',
+      last_visible_message_at: '2026-05-11T00:01:00Z',
+      last_sort_activity_at: '2026-05-11T00:01:00Z',
+      last_lifecycle_update_at: '2026-05-11T00:05:00Z',
+      last_internal_update_at: '2026-05-11T00:05:00Z',
+      updated_at: '2026-05-11T00:05:00Z',
+      created_at: '2026-05-11T00:00:00Z'
+    });
+
+    expect(row.lastActivityAt).toBe('2026-05-11T00:01:00Z');
+    expect(row.lastVisibleMessageAt).toBe('2026-05-11T00:01:00Z');
+    expect(row.lastLifecycleUpdateAt).toBe('2026-05-11T00:05:00Z');
+    expect(chatIndexRowToPmaChatSummary(row).updatedAt).toBe('2026-05-11T00:01:00Z');
+  });
+
   it('selects chat and repo/worktree summaries from normalized state', () => {
     const store = new ReadModelEntityStore();
     store.applyChatIndexSnapshot({

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.test.ts
@@ -160,6 +160,12 @@ describe('read model view-model selectors', () => {
       last_sort_activity_at: '2026-05-11T00:01:00Z',
       last_lifecycle_update_at: '2026-05-11T00:05:00Z',
       last_internal_update_at: '2026-05-11T00:05:00Z',
+      debug: {
+        activity: {
+          selected: '2026-05-11T00:01:00Z',
+          selected_source: 'last_visible_message_at'
+        }
+      },
       updated_at: '2026-05-11T00:05:00Z',
       created_at: '2026-05-11T00:00:00Z'
     });
@@ -167,7 +173,10 @@ describe('read model view-model selectors', () => {
     expect(row.lastActivityAt).toBe('2026-05-11T00:01:00Z');
     expect(row.lastVisibleMessageAt).toBe('2026-05-11T00:01:00Z');
     expect(row.lastLifecycleUpdateAt).toBe('2026-05-11T00:05:00Z');
-    expect(chatIndexRowToPmaChatSummary(row).updatedAt).toBe('2026-05-11T00:01:00Z');
+    const summary = chatIndexRowToPmaChatSummary(row);
+    expect(summary.updatedAt).toBe('2026-05-11T00:01:00Z');
+    expect(summary.raw.debug).toEqual(row.debug);
+    expect(pmaChatSummaryToChatIndexRow(summary).debug).toEqual(row.debug);
   });
 
   it('selects chat and repo/worktree summaries from normalized state', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
@@ -58,7 +58,8 @@ export function pmaChatSummaryToChatIndexRow(chat: PmaChatSummary): ChatIndexRow
       chat.chatKind ??
       normalizeManagedThreadChatKind(chat.raw.chat_kind ?? chat.raw.thread_kind),
     model: chat.model,
-    groupId: chat.ticketId ? `ticket:${chat.ticketId}` : chat.runId ? `run:${chat.runId}` : null
+    groupId: chat.ticketId ? `ticket:${chat.ticketId}` : chat.runId ? `run:${chat.runId}` : null,
+    debug: recordValue(chat.raw.debug)
   };
 }
 
@@ -98,7 +99,8 @@ export function legacyChatIndexRecordToChatIndexRow(raw: JsonRecord): ChatIndexR
     agentProfile: stringValue(raw.agent_profile ?? raw.agentProfile),
     chatKind: normalizeManagedThreadChatKind(raw.chat_kind ?? raw.chatKind ?? raw.thread_kind),
     model: stringValue(raw.model),
-    groupId: stringValue(raw.group_id)
+    groupId: stringValue(raw.group_id),
+    debug: recordValue(raw.debug)
   };
 }
 
@@ -141,7 +143,8 @@ export function chatIndexRowToPmaChatSummary(row: ChatIndexRow): PmaChatSummary 
     last_internal_update_at: row.lastInternalUpdateAt,
     last_sort_activity_at: row.lastSortActivityAt,
     surface_kind: row.surface,
-    sort_key: row.sortKey
+    sort_key: row.sortKey,
+    debug: row.debug
   };
   return {
     id: row.chatId,
@@ -362,6 +365,13 @@ function stringValue(value: unknown, fallback: string | null = null): string | n
 function numberValue(value: unknown): number {
   const parsed = typeof value === 'number' ? value : Number.parseInt(String(value ?? ''), 10);
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
 }
 
 function unreadCountFromRaw(raw: JsonRecord): number {

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
@@ -86,7 +86,7 @@ export function legacyChatIndexRecordToChatIndexRow(raw: JsonRecord): ChatIndexR
     title,
     status: legacyChatIndexStatus(lifecycle, lifecycleStatus, runtimeStatus, queueDepth),
     unreadCount: numberValue(raw.unread_count ?? raw.unreadCount) || (raw.unread === true ? 1 : 0),
-    lastActivityAt: lastVisibleMessageAt ?? lastSortActivityAt ?? stringValue(raw.last_activity_at ?? raw.created_at),
+    lastActivityAt: lastSortActivityAt ?? stringValue(raw.last_activity_at) ?? lastVisibleMessageAt ?? stringValue(raw.created_at),
     lastVisibleMessageAt,
     lastLifecycleUpdateAt,
     lastInternalUpdateAt,

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
@@ -75,13 +75,21 @@ export function legacyChatIndexRecordToChatIndexRow(raw: JsonRecord): ChatIndexR
   const runtimeStatus = stringValue(raw.runtime_status ?? raw.target_runtime_status)?.toLowerCase() ?? '';
   const rawTitle = stringValue(raw.title ?? raw.display_name, chatId) ?? chatId;
   const title = rawTitle.trim() || chatId;
+  const lastVisibleMessageAt = stringValue(raw.last_visible_message_at);
+  const lastLifecycleUpdateAt = stringValue(raw.last_lifecycle_update_at);
+  const lastInternalUpdateAt = stringValue(raw.last_internal_update_at);
+  const lastSortActivityAt = stringValue(raw.last_sort_activity_at);
   return {
     chatId,
     surface: surfaceFromKinds(raw.surface_kinds, raw.surface),
     title,
     status: legacyChatIndexStatus(lifecycle, lifecycleStatus, runtimeStatus, queueDepth),
     unreadCount: numberValue(raw.unread_count ?? raw.unreadCount) || (raw.unread === true ? 1 : 0),
-    lastActivityAt: stringValue(raw.last_activity_at ?? raw.updated_at ?? raw.created_at),
+    lastActivityAt: lastVisibleMessageAt ?? lastSortActivityAt ?? stringValue(raw.last_activity_at ?? raw.created_at),
+    lastVisibleMessageAt,
+    lastLifecycleUpdateAt,
+    lastInternalUpdateAt,
+    lastSortActivityAt,
     repoId: stringValue(raw.repo_id),
     worktreeId,
     ticketId: resourceKind === 'ticket' ? resourceId : stringValue(raw.ticket_id ?? raw.current_ticket_id),
@@ -128,6 +136,10 @@ export function chatIndexRowToPmaChatSummary(row: ChatIndexRow): PmaChatSummary 
     model: row.model,
     unreadCount: row.unreadCount,
     last_activity_at: row.lastActivityAt,
+    last_visible_message_at: row.lastVisibleMessageAt,
+    last_lifecycle_update_at: row.lastLifecycleUpdateAt,
+    last_internal_update_at: row.lastInternalUpdateAt,
+    last_sort_activity_at: row.lastSortActivityAt,
     surface_kind: row.surface,
     sort_key: row.sortKey
   };

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/domain.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/domain.test.ts
@@ -123,9 +123,10 @@ describe('view model mappers', () => {
     expect(vm.title).toBe('The web UI gets frozen after a while');
   });
 
-  it('falls back to first message excerpt when display title is generic', () => {
+  it('uses backend-projected display title instead of rebuilding from message excerpts', () => {
     const vm = mapPmaChatSummary({
       thread_target_id: 'thread-inj-only',
+      display_title: 'User-visible first line',
       display_name: 'New chat',
       first_message_excerpt: 'User-visible first line',
       agent_id: 'codex',
@@ -137,7 +138,7 @@ describe('view model mappers', () => {
     expect(vm.title).toBe('User-visible first line');
   });
 
-  it('uses backend-projected user-visible excerpts when name is generic', () => {
+  it('does not derive summary titles from backend-visible excerpt fields', () => {
     const vm = mapPmaChatSummary({
       thread_target_id: 'thread-ex-inj',
       name: 'New chat',
@@ -148,12 +149,13 @@ describe('view model mappers', () => {
       normalized_status: 'idle'
     });
 
-    expect(vm.title).toBe('Real question here');
+    expect(vm.title).toBe('New chat');
   });
 
-  it('uses backend user-visible title seed before raw prompt fallbacks', () => {
+  it('trusts backend display title before raw prompt fallbacks', () => {
     const vm = mapPmaChatSummary({
       thread_target_id: 'thread-visible-seed',
+      display_title: 'Real visible request',
       name: 'New chat',
       user_visible_text: 'Real visible request',
       last_message_preview:
@@ -170,6 +172,7 @@ describe('view model mappers', () => {
   it('uses chat channel display names instead of surface id fallback titles', () => {
     const vm = mapPmaChatSummary({
       thread_target_id: 'thread-1',
+      display_title: 'CAR Workspace / #hermes',
       display_name: 'discord:1488827014600331415',
       chat_bound: true,
       binding_kind: 'discord',
@@ -244,6 +247,7 @@ describe('view model mappers', () => {
   it('derives readable ticket-flow chat summaries from managed thread payload fields', () => {
     const vm = mapPmaChatSummary({
       managed_thread_id: 'thread-ticket-flow',
+      display_title: 'Ticket flow · TICKET-330-pma-chat-managed-thread-readability',
       name: 'ticket-flow:codex',
       agent: 'codex',
       status: 'running',
@@ -259,7 +263,7 @@ describe('view model mappers', () => {
 
     expect(vm).toMatchObject({
       id: 'thread-ticket-flow',
-      title: 'Ticket flow · TICKET-330-pma-chat-managed-thread-readability · worktree codex-autorunner--discord-5',
+      title: 'Ticket flow · TICKET-330-pma-chat-managed-thread-readability',
       ticketId: 'TICKET-330-pma-chat-managed-thread-readability',
       repoId: 'codex-autorunner',
       worktreeId: 'codex-autorunner--discord-5',

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/domain.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/domain.ts
@@ -64,6 +64,10 @@ export type PmaChatMessage = {
   role: 'user' | 'assistant' | 'system' | 'tool';
   text: string;
   visibility?: string | null;
+  visibleText?: string | null;
+  modelContextText?: string | null;
+  modelContextRefs?: PmaMessageCapsuleRef[];
+  rawModelPrompt?: string | null;
   userVisibleText?: string | null;
   capsuleRefs?: PmaMessageCapsuleRef[];
   createdAt: string | null;
@@ -372,6 +376,12 @@ export function mapPmaChatMessage(raw: JsonRecord): PmaChatMessage {
     role,
     text,
     visibility: nullableString(raw.visibility),
+    visibleText: nullableString(raw.visible_text ?? raw.visibleText),
+    modelContextText: nullableString(raw.model_context_text ?? raw.modelContextText),
+    modelContextRefs: asArray(raw.model_context_refs ?? raw.modelContextRefs)
+      .map((item) => mapPmaMessageCapsuleRef(asRecord(item)))
+      .filter((item): item is PmaMessageCapsuleRef => item !== null),
+    rawModelPrompt: nullableString(raw.raw_model_prompt ?? raw.rawModelPrompt),
     userVisibleText: nullableString(raw.user_visible_text ?? raw.userVisibleText),
     capsuleRefs: asArray(raw.capsule_refs ?? raw.capsuleRefs)
       .map((item) => mapPmaMessageCapsuleRef(asRecord(item)))

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/domain.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/domain.ts
@@ -782,23 +782,14 @@ function normalizeMessageText(raw: JsonRecord, role: PmaChatMessage['role']): st
 }
 
 function readableThreadTitle(raw: JsonRecord, fallback: string, ticketId: string | null): string {
-  const explicitRaw = stringValue(raw.display_name ?? raw.name ?? raw.title, fallback);
+  const explicitRaw = stringValue(raw.display_title ?? raw.display_name ?? raw.name ?? raw.title, fallback);
   let explicit = explicitRaw.trim();
   if (!explicit) {
     explicit = explicitRaw === fallback ? fallback : '';
   }
-  const chatDisplayName = nullableString(raw.chat_display_name);
-  if (chatDisplayName && isChatSurfaceIdTitle(explicit, raw)) return chatDisplayName;
-  if (
-    !isGenericChatTitle(explicit) &&
-    !isGenericTicketFlowTitle(explicit) &&
-    !isCarTicketFlowControlPrompt(explicit)
-  ) {
+  if (!isCarTicketFlowControlPrompt(explicit)) {
     return explicit;
   }
-
-  const firstMessageExcerpt = firstUserMessageExcerpt(raw);
-  if (firstMessageExcerpt) return firstMessageExcerpt;
 
   const workspace = workspaceLabel(raw.workspace_root);
   const repo = nullableString(raw.repo_id);
@@ -822,34 +813,6 @@ function readableThreadTitle(raw: JsonRecord, fallback: string, ticketId: string
 function isGenericChatTitle(value: string): boolean {
   const text = value.trim().toLowerCase();
   return text === 'new pma chat' || text === 'new chat' || text === 'untitled chat' || text === '';
-}
-
-function isChatSurfaceIdTitle(value: string, raw: JsonRecord): boolean {
-  const text = value.trim().toLowerCase();
-  if (!/^(discord|telegram):\S+$/.test(text)) return false;
-  const bindingKind = nullableString(raw.binding_kind)?.toLowerCase();
-  if (bindingKind === 'discord' || bindingKind === 'telegram') return true;
-  return raw.chat_bound === true;
-}
-
-function firstUserMessageExcerpt(raw: JsonRecord): string | null {
-  const candidate = firstText(
-    raw.first_user_visible_text,
-    raw.user_visible_text,
-    raw.title_seed,
-    raw.first_message_excerpt,
-    raw.first_user_message,
-    raw.last_user_message,
-    raw.prompt_preview
-  );
-  if (!candidate) return null;
-  const trimmed = candidate.trim();
-  if (!trimmed) return null;
-  if (isCarTicketFlowControlPrompt(trimmed)) return null;
-  const oneLine = trimmed.split(/\r?\n/)[0]?.trim() ?? '';
-  if (!oneLine) return null;
-  const truncated = oneLine.length > 60 ? `${oneLine.slice(0, 57)}…` : oneLine;
-  return truncated;
 }
 
 function isGenericTicketFlowTitle(value: string): boolean {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -1131,6 +1131,8 @@ describe('PMA chat view helpers', () => {
             turn_id: '1',
             order_key: '001',
             visibility: 'user_visible',
+            visible_text: 'Fix this',
+            model_context_text: 'repo guidance',
             user_visible_text: 'Fix this',
             capsule_refs: [
               {
@@ -1142,11 +1144,24 @@ describe('PMA chat view helpers', () => {
                 reason: 'repo_context'
               }
             ],
+            model_context_refs: [
+              {
+                capsule_id: 'car.repo_basics',
+                capsule_version: '1',
+                visibility: 'model_only',
+                scope: 'repo',
+                source_digest: 'sha256:repo',
+                reason: 'repo_context'
+              }
+            ],
+            raw_model_prompt: '<injected context>\nrepo guidance\n</injected context>\n\nFix this',
             message: {
               id: 'turn:1:user',
               chat_id: 'chat-1',
               role: 'user',
               text: 'Fix this',
+              visible_text: 'Fix this',
+              model_context_text: 'repo guidance',
               user_visible_text: 'Fix this',
               artifacts: []
             }
@@ -1161,7 +1176,20 @@ describe('PMA chat view helpers', () => {
       message: {
         text: 'Fix this',
         visibility: 'user_visible',
+        visibleText: 'Fix this',
+        modelContextText: 'repo guidance',
+        rawModelPrompt: '<injected context>\nrepo guidance\n</injected context>\n\nFix this',
         userVisibleText: 'Fix this',
+        modelContextRefs: [
+          {
+            capsuleId: 'car.repo_basics',
+            capsuleVersion: '1',
+            visibility: 'model_only',
+            scope: 'repo',
+            sourceDigest: 'sha256:repo',
+            reason: 'repo_context'
+          }
+        ],
         capsuleRefs: [
           {
             capsuleId: 'car.repo_basics',

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -1330,6 +1330,12 @@ function mapChatTranscriptRow(raw: Record<string, unknown>): ChatTranscriptCard 
     const capsuleRefs = asRecordArray(raw.capsule_refs ?? message.capsule_refs)
       .map(mapPmaMessageCapsuleRef)
       .filter((item): item is PmaMessageCapsuleRef => item !== null);
+    const visibleText = nullableString(raw.visible_text ?? message.visible_text);
+    const modelContextText = nullableString(raw.model_context_text ?? message.model_context_text);
+    const modelContextRefs = asRecordArray(raw.model_context_refs ?? message.model_context_refs)
+      .map(mapPmaMessageCapsuleRef)
+      .filter((item): item is PmaMessageCapsuleRef => item !== null);
+    const rawModelPrompt = nullableString(raw.raw_model_prompt ?? message.raw_model_prompt);
     return {
       kind: 'message',
       id,
@@ -1340,8 +1346,12 @@ function mapChatTranscriptRow(raw: Record<string, unknown>): ChatTranscriptCard 
         id: stringValue(message.id) || id,
         chatId: stringValue(message.chat_id),
         role,
-        text: role === 'user' ? userVisibleText ?? stringValue(message.text) : stringValue(message.text),
+        text: role === 'user' ? visibleText ?? userVisibleText ?? stringValue(message.text) : stringValue(message.text),
         visibility: nullableString(raw.visibility ?? message.visibility),
+        visibleText,
+        modelContextText,
+        modelContextRefs,
+        rawModelPrompt,
         userVisibleText,
         capsuleRefs,
         createdAt: nullableString(message.created_at),

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -382,10 +382,12 @@ export function mapChatSurfaceToPmaChatSummary(surface: Record<string, unknown>)
     isTicketFlow: firstRawString(metadata.flow_type) === 'ticket' || firstRawString(metadata.ticket_id) !== null,
     progressPercent: rawNumber(metadata.progress_percent),
     updatedAt: firstRawString(
+      metadata.last_sort_activity_at,
       metadata.last_activity_at,
       metadata.latest_turn_finished_at,
       metadata.latest_turn_started_at,
       metadata.latest_event_at,
+      surface.last_sort_activity_at,
       surface.last_activity_at,
       surface.updated_at,
       surface.created_at

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/thread.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/thread.test.ts
@@ -114,6 +114,7 @@ describe('mapThreadSummary', () => {
   it('builds readable title from first message excerpt', () => {
     const vm = mapThreadSummary({
       managed_thread_id: 'thread-excerpt',
+      display_title: 'Please fix the login bug',
       name: 'New PMA chat',
       first_message_excerpt: 'Please fix the login bug',
       agent: 'codex',
@@ -134,9 +135,10 @@ describe('mapThreadSummary', () => {
     expect(vm.title).toBe('Fix login');
   });
 
-  it('uses backend user-visible title seed before raw prompt fallbacks', () => {
+  it('uses backend display title before raw prompt fallbacks', () => {
     const vm = mapThreadSummary({
       managed_thread_id: 'thread-visible-seed',
+      display_title: 'Fix login',
       name: 'New chat',
       title_seed: 'Fix login',
       last_message_preview:
@@ -151,6 +153,7 @@ describe('mapThreadSummary', () => {
   it('builds title from scope for generic chat name', () => {
     const vm = mapThreadSummary({
       managed_thread_id: 'thread-generic',
+      display_title: 'Chat · my-repo',
       name: 'New PMA chat',
       repo_id: 'my-repo',
       agent: 'codex',

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/thread.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/thread.ts
@@ -90,21 +90,14 @@ function buildThreadTitle(
   ticketId: string | null,
   scope: ScopeRef
 ): string {
-  const explicitRaw = stringValue(raw.display_name ?? raw.name ?? raw.title, fallback);
+  const explicitRaw = stringValue(raw.display_title ?? raw.display_name ?? raw.name ?? raw.title, fallback);
   let explicit = explicitRaw.trim();
   if (!explicit) {
     explicit = explicitRaw === fallback ? fallback : '';
   }
-  if (
-    !isGenericChatTitle(explicit) &&
-    !isGenericTicketFlowTitle(explicit) &&
-    !isCarTicketFlowControlPrompt(explicit)
-  ) {
+  if (!isCarTicketFlowControlPrompt(explicit)) {
     return explicit;
   }
-
-  const firstMessageExcerpt = firstUserMessageExcerpt(raw);
-  if (firstMessageExcerpt) return firstMessageExcerpt;
 
   if (isGenericChatTitle(explicit) && !ticketId && !isCarTicketFlowControlPrompt(explicit)) {
     const scopeStr = scopeLabelStr(scope);
@@ -151,33 +144,9 @@ function isGenericChatTitle(value: string): boolean {
   return text === 'new pma chat' || text === 'new chat' || text === 'untitled chat' || text === '';
 }
 
-function isGenericTicketFlowTitle(value: string): boolean {
-  return /^ticket-flow(?::\S+)?$/i.test(value.trim());
-}
-
 function isCarTicketFlowControlPrompt(value: string): boolean {
   const text = value.trim();
   return text.startsWith('<CAR_TICKET_FLOW_PROMPT') || text.includes('<CAR_CURRENT_TICKET_FILE>');
-}
-
-function firstUserMessageExcerpt(raw: Record<string, unknown>): string | null {
-  const candidate = firstText(
-    raw.first_user_visible_text,
-    raw.user_visible_text,
-    raw.title_seed,
-    raw.first_message_excerpt,
-    raw.first_user_message,
-    raw.last_user_message,
-    raw.last_message_preview,
-    raw.prompt_preview
-  );
-  if (!candidate) return null;
-  const trimmed = candidate.trim();
-  if (!trimmed) return null;
-  if (isCarTicketFlowControlPrompt(trimmed)) return null;
-  const oneLine = trimmed.split(/\r?\n/)[0]?.trim() ?? '';
-  if (!oneLine) return null;
-  return oneLine.length > 60 ? `${oneLine.slice(0, 57)}…` : oneLine;
 }
 
 function extractTicketId(raw: Record<string, unknown>): string | null {

--- a/tests/adapters/chat/test_managed_thread_turns.py
+++ b/tests/adapters/chat/test_managed_thread_turns.py
@@ -31,6 +31,12 @@ from codex_autorunner.core.orchestration.runtime_threads import (
     RuntimeThreadOutcome,
 )
 from codex_autorunner.core.orchestration.service import ManagedThreadExecutionStore
+from codex_autorunner.core.orchestration.turn_context import (
+    ChatTurnDeliveryTarget,
+    ChatTurnEnvelope,
+    ChatTurnSource,
+    ManagedThreadCapsuleRef,
+)
 from codex_autorunner.core.orchestration.turn_output_reducer import (
     build_assistant_transcript_prefix,
     trim_cumulative_assistant_text,
@@ -120,6 +126,84 @@ def _build_queue_delivery_hooks(
         send_failure=_send_failure,
         cleanup=_cleanup,
     )
+
+
+def test_chat_turn_envelope_builds_message_request_without_losing_metadata() -> None:
+    envelope = ChatTurnEnvelope(
+        source=ChatTurnSource(
+            surface_kind="discord",
+            surface_key="channel-1",
+            message_id="msg-1",
+            thread_id="thread-1",
+            update_id="update-1",
+        ),
+        user_visible_text="Visible user request",
+        runtime_prompt="<context>model-only</context>\n\nVisible user request",
+        title_seed="Visible title",
+        input_items=[
+            {"type": "text", "text": "placeholder"},
+            {"type": "input_image", "image_url": "file:///tmp/image.png"},
+        ],
+        model_context_refs=(
+            ManagedThreadCapsuleRef(
+                capsule_id="cap-1",
+                capsule_version="v1",
+                visibility="model_only",
+                scope="turn",
+                source_digest="sha256:abc",
+            ),
+        ),
+        delivery_targets=(
+            ChatTurnDeliveryTarget(surface_kind="discord", surface_key="channel-1"),
+        ),
+        existing_session_runtime_prompt="compact runtime prompt",
+    )
+
+    request = envelope.to_message_request(
+        target_id="managed-thread-1",
+        model="gpt-test",
+        reasoning="medium",
+        approval_mode="never",
+    )
+
+    assert request == MessageRequest(
+        target_id="managed-thread-1",
+        target_kind="thread",
+        message_text="Visible user request",
+        busy_policy="queue",
+        model="gpt-test",
+        reasoning="medium",
+        approval_mode="never",
+        input_items=[
+            {"type": "text", "text": "placeholder"},
+            {"type": "input_image", "image_url": "file:///tmp/image.png"},
+        ],
+        metadata=request.metadata,
+    )
+    assert request.metadata["runtime_prompt"] == (
+        "<context>model-only</context>\n\nVisible user request"
+    )
+    assert request.metadata["raw_model_prompt"] == (
+        "<context>model-only</context>\n\nVisible user request"
+    )
+    assert request.metadata["user_visible_text"] == "Visible user request"
+    assert request.metadata["title_seed"] == "Visible title"
+    assert request.metadata["existing_session_runtime_prompt"] == (
+        "compact runtime prompt"
+    )
+    assert request.metadata["capsule_refs"] == [
+        {
+            "capsule_id": "cap-1",
+            "capsule_version": "v1",
+            "visibility": "model_only",
+            "scope": "turn",
+            "source_digest": "sha256:abc",
+        }
+    ]
+    assert request.metadata["delivery_targets"] == [
+        {"surface_kind": "discord", "surface_key": "channel-1"}
+    ]
+    assert request.metadata["source_message_id"] == "msg-1"
 
 
 def test_render_managed_thread_response_text_prepends_session_notice() -> None:

--- a/tests/adapters/chat/test_thread_title_policy.py
+++ b/tests/adapters/chat/test_thread_title_policy.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from codex_autorunner.core.orchestration.thread_titles import (
+    ManagedThreadTitleInputs,
+    resolve_managed_thread_display_title,
+)
+
+
+@pytest.mark.parametrize(
+    ("surface", "inputs", "expected"),
+    [
+        (
+            "discord",
+            ManagedThreadTitleInputs(
+                stored_title="discord:1488827014600331415",
+                user_visible_title_seed="Investigate Discord delivery",
+                chat_display_name="CAR Workspace / #ops",
+                fallback_id="thread-discord",
+            ),
+            "Investigate Discord delivery",
+        ),
+        (
+            "telegram",
+            ManagedThreadTitleInputs(
+                stored_title="telegram:-1001:77",
+                chat_display_name="Release room / Deploys",
+                fallback_id="thread-telegram",
+            ),
+            "Release room / Deploys",
+        ),
+        (
+            "web_pma",
+            ManagedThreadTitleInputs(
+                stored_title="New PMA chat",
+                provider_title="Native provider title",
+                user_visible_title_seed="Lower priority visible seed",
+                fallback_id="thread-web",
+            ),
+            "Native provider title",
+        ),
+    ],
+)
+def test_chat_adapter_managed_thread_title_policy_contract(
+    surface: str,
+    inputs: ManagedThreadTitleInputs,
+    expected: str,
+) -> None:
+    assert surface
+    assert resolve_managed_thread_display_title(inputs) == expected

--- a/tests/adapters/discord/test_service_routing.py
+++ b/tests/adapters/discord/test_service_routing.py
@@ -9410,8 +9410,8 @@ async def test_run_agent_turn_for_message_forwards_typed_turn_envelope(
         assert captured["turn_envelope"] is envelope
         assert captured["input_items"] is None
         assert captured["prompt_text"] == "legacy prompt"
-        assert captured["user_visible_text"] == "legacy visible"
-        assert captured["title_seed"] == "legacy title"
+        assert "user_visible_text" not in captured
+        assert "title_seed" not in captured
     finally:
         await store.close()
 

--- a/tests/adapters/discord/test_service_routing.py
+++ b/tests/adapters/discord/test_service_routing.py
@@ -9322,9 +9322,13 @@ async def test_run_agent_turn_for_message_forwards_delivery_suppression(
             session_key="session-1",
             orchestrator_channel_key=orchestrator_key,
             suppress_managed_thread_delivery=True,
+            user_visible_text="visible hello",
+            title_seed="visible hello",
         )
         assert result.final_message == "ok"
         assert captured[suppress_kwarg] is True
+        assert captured["user_visible_text"] == "visible hello"
+        assert captured["title_seed"] == "visible hello"
     finally:
         await store.close()
 

--- a/tests/adapters/discord/test_service_routing.py
+++ b/tests/adapters/discord/test_service_routing.py
@@ -102,6 +102,10 @@ from codex_autorunner.core.hub_control_plane import (
 from codex_autorunner.core.orchestration.chat_operation_state import (
     ChatOperationState,
 )
+from codex_autorunner.core.orchestration.turn_context import (
+    ChatTurnEnvelope,
+    ChatTurnSource,
+)
 from codex_autorunner.core.update import UpdateInProgressError
 from codex_autorunner.manifest import (
     MANIFEST_VERSION,
@@ -6040,6 +6044,7 @@ async def test_message_turn_waits_for_ingressed_slash_command_to_finish(
         *,
         workspace_root: Path,
         prompt_text: str,
+        turn_envelope: ChatTurnEnvelope | None = None,
         input_items: list[dict[str, Any]] | None = None,
         source_message_id: str | None = None,
         agent: str,
@@ -6196,6 +6201,7 @@ async def test_run_forever_drains_message_queued_behind_ingressed_slash_command(
         *,
         workspace_root: Path,
         prompt_text: str,
+        turn_envelope: ChatTurnEnvelope | None = None,
         input_items: list[dict[str, Any]] | None = None,
         source_message_id: str | None = None,
         agent: str,
@@ -6208,6 +6214,7 @@ async def test_run_forever_drains_message_queued_behind_ingressed_slash_command(
     ) -> DiscordMessageTurnResult:
         _ = (
             workspace_root,
+            turn_envelope,
             input_items,
             source_message_id,
             agent,
@@ -9194,6 +9201,7 @@ async def test_run_agent_turn_for_message_wraps_typing_indicator(
         *,
         workspace_root: Path,
         prompt_text: str,
+        turn_envelope: ChatTurnEnvelope | None = None,
         input_items: list[dict[str, Any]] | None = None,
         source_message_id: str | None = None,
         agent: str,
@@ -9207,10 +9215,13 @@ async def test_run_agent_turn_for_message_wraps_typing_indicator(
         heartbeat_interval_seconds: float,
         log_event_fn: Any,
         chat_ux_snapshot: Any = None,
+        user_visible_text: str | None = None,
+        title_seed: str | None = None,
     ) -> DiscordMessageTurnResult:
         _ = (
             workspace_root,
             prompt_text,
+            turn_envelope,
             input_items,
             source_message_id,
             agent,
@@ -9224,6 +9235,8 @@ async def test_run_agent_turn_for_message_wraps_typing_indicator(
             heartbeat_interval_seconds,
             log_event_fn,
             chat_ux_snapshot,
+            user_visible_text,
+            title_seed,
         )
         started.set()
         await release.wait()
@@ -9329,6 +9342,76 @@ async def test_run_agent_turn_for_message_forwards_delivery_suppression(
         assert captured[suppress_kwarg] is True
         assert captured["user_visible_text"] == "visible hello"
         assert captured["title_seed"] == "visible hello"
+    finally:
+        await store.close()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "orchestrator_key,monkeypatch_fn",
+    [
+        pytest.param("pma:channel-1", "run_managed_thread_turn_for_message", id="pma"),
+        pytest.param("channel-1", "run_agent_turn_for_message", id="repo"),
+    ],
+)
+async def test_run_agent_turn_for_message_forwards_typed_turn_envelope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    orchestrator_key: str,
+    monkeypatch_fn: str,
+) -> None:
+    store = DiscordStateStore(tmp_path / "discord_state.sqlite3")
+    await store.initialize()
+    service = DiscordBotService(
+        _config(tmp_path, allow_user_ids=frozenset({"user-1"})),
+        logger=logging.getLogger("test"),
+        rest_client=_FakeRest(),
+        gateway_client=_FakeGateway([]),
+        state_store=store,
+        outbox_manager=_FakeOutboxManager(),
+    )
+    envelope = ChatTurnEnvelope(
+        source=ChatTurnSource(
+            surface_kind="discord",
+            surface_key="channel-1",
+            message_id="msg-1",
+        ),
+        user_visible_text="visible request",
+        runtime_prompt="runtime prompt",
+        title_seed="visible request",
+        input_items=[{"type": "text", "text": "runtime prompt"}],
+    )
+    captured: dict[str, Any] = {}
+
+    async def _fake_run(
+        _service: Any,
+        **kwargs: Any,
+    ) -> DiscordMessageTurnResult:
+        captured.update(kwargs)
+        return DiscordMessageTurnResult(final_message="ok")
+
+    monkeypatch.setattr(discord_service_module, monkeypatch_fn, _fake_run)
+
+    try:
+        result = await service._run_agent_turn_for_message(
+            workspace_root=tmp_path,
+            prompt_text="legacy prompt",
+            turn_envelope=envelope,
+            agent="codex",
+            model_override=None,
+            reasoning_effort=None,
+            session_key="session-1",
+            orchestrator_channel_key=orchestrator_key,
+            user_visible_text="legacy visible",
+            title_seed="legacy title",
+        )
+
+        assert result.final_message == "ok"
+        assert captured["turn_envelope"] is envelope
+        assert captured["input_items"] is None
+        assert captured["prompt_text"] == "legacy prompt"
+        assert captured["user_visible_text"] == "legacy visible"
+        assert captured["title_seed"] == "legacy title"
     finally:
         await store.close()
 

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -761,6 +761,44 @@ def test_chat_index_carries_ticket_flow_metadata_for_grouping(
             "run_id": "run-015",
         },
     )
+    _seed_thread(
+        hub_root,
+        thread_id="thread-ticket-flow-stale-lifecycle",
+        repo_id="repo-1",
+        resource_kind="worktree",
+        resource_id="repo-1--ticket-flow",
+        runtime_status="completed",
+        metadata={
+            "flow_type": "ticket_flow",
+            "thread_kind": "ticket_flow",
+            "ticket_id": "TICKET-016",
+            "run_id": "run-015",
+        },
+    )
+    _seed_execution(
+        hub_root,
+        thread_id="thread-ticket-flow",
+        status="completed",
+        prompt_text="Newer visible ticket turn",
+        metadata={"user_visible_text": "Newer visible ticket turn"},
+        created_at="2026-05-11T00:02:00Z",
+    )
+    _seed_execution(
+        hub_root,
+        thread_id="thread-ticket-flow-stale-lifecycle",
+        status="completed",
+        prompt_text="Older visible ticket turn",
+        metadata={"user_visible_text": "Older visible ticket turn"},
+        created_at="2026-05-11T00:01:00Z",
+    )
+    with open_orchestration_sqlite(hub_root, durable=False, migrate=True) as conn:
+        conn.execute(
+            "UPDATE orch_thread_targets SET updated_at = ? WHERE thread_target_id = ?",
+            (
+                "2026-05-11T00:05:00Z",
+                "thread-ticket-flow-stale-lifecycle",
+            ),
+        )
     SQLiteChatSurfaceEventJournal(hub_root, durable=False).append_event(
         idempotency_key="stale-running-progress",
         event_type="execution.progress",
@@ -796,6 +834,14 @@ def test_chat_index_carries_ticket_flow_metadata_for_grouping(
 
     assert grouped["rows"][0]["row_type"] == "group"
     assert grouped["rows"][0]["group_id"] == "run:run-015"
+    assert grouped["rows"][0]["child_count"] == 2
+    assert grouped["rows"][0]["last_sort_activity_at"] == "2026-05-11T00:02:00Z"
+    assert grouped["rows"][0]["last_lifecycle_update_at"] == "2026-05-11T00:05:00Z"
+    assert grouped["rows"][0]["updated_at"] == "2026-05-11T00:02:00Z"
+    assert (
+        grouped["rows"][0]["debug"]["activity"]["selected_source"]
+        == "last_sort_activity_at"
+    )
 
     active = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(
         view="active",

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -11,6 +11,7 @@ from codex_autorunner.core.orchestration import (
     ChatSurfaceReadService,
     OrchestrationBindingStore,
     SQLiteChatSurfaceEventJournal,
+    ticket_flow_thread_metadata,
 )
 from codex_autorunner.core.orchestration.chat_surface_read_model import (
     _chat_index_sort_key_parts,
@@ -1491,3 +1492,117 @@ def test_chat_surface_read_model_builds_pma_compat_snapshot(tmp_path: Path) -> N
             "cleanup_protected": False,
         }
     ]
+
+
+def test_chat_read_model_contract_matrix_documents_shared_semantics(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(
+        hub_root,
+        thread_id="thread-pma",
+        display_name="Web PMA chat",
+        last_message_preview="Web visible request",
+    )
+    _seed_execution(
+        hub_root,
+        thread_id="thread-pma",
+        status="ok",
+        metadata={"user_visible_text": "Web visible request"},
+        created_at="2026-05-11T00:01:00Z",
+    )
+    _seed_thread(
+        hub_root,
+        thread_id="thread-discord",
+        display_name="Thread thread-discord",
+        metadata={"provider_conversation_title": "Discord deploy triage"},
+    )
+    OrchestrationBindingStore(hub_root, durable=False).upsert_binding(
+        surface_kind="discord",
+        surface_key="guild:deploy",
+        thread_target_id="thread-discord",
+        repo_id="repo-1",
+        resource_kind="repo",
+        resource_id="repo-1",
+        metadata={"display_name": "Agent Nexus / #deploy"},
+    )
+    _seed_thread(
+        hub_root,
+        thread_id="thread-ticket",
+        display_name="ticket-flow:codex",
+        resource_kind="ticket",
+        resource_id="TICKET-005",
+        metadata=ticket_flow_thread_metadata(
+            flow_run_id="run-005",
+            ticket_id="TICKET-005",
+            workspace_root=str(hub_root),
+        ),
+    )
+    _seed_thread(hub_root, thread_id="thread-queued", display_name="Queued work")
+    _seed_execution(
+        hub_root,
+        thread_id="thread-queued",
+        status="queued",
+        metadata={"user_visible_text": "Queued visible request"},
+        created_at="2026-05-11T00:02:00Z",
+    )
+    _seed_thread(
+        hub_root,
+        thread_id="thread-archived",
+        display_name="Archived chat",
+        lifecycle_status="archived",
+        runtime_status="completed",
+    )
+    ChannelDirectoryStore(hub_root).record_seen(
+        "discord",
+        "guild-external",
+        None,
+        "External diagnostics channel",
+    )
+
+    service = ChatSurfaceReadService(hub_root, durable=False)
+    active_rows = {
+        row["managed_thread_id"]: row
+        for row in service.chat_index_snapshot(view="all", limit=20)["rows"]
+    }
+    archived_rows = {
+        row["managed_thread_id"]: row
+        for row in service.chat_index_snapshot(view="archived", limit=20)["rows"]
+    }
+    external_rows = {
+        row["chat_id"]: row
+        for row in service.chat_index_snapshot(view="external", limit=20)["rows"]
+    }
+    matrix = {
+        "web_pma": active_rows["thread-pma"],
+        "discord_bound": active_rows["thread-discord"],
+        "ticket_flow": active_rows["thread-ticket"],
+        "queued_only": active_rows["thread-queued"],
+        "archived": archived_rows["thread-archived"],
+        "external_unbound": external_rows["surface:discord:guild-external"],
+    }
+
+    assert matrix["web_pma"]["title"] == "Web PMA chat"
+    assert matrix["web_pma"]["last_visible_message_at"] == "2026-05-11T00:01:00Z"
+    assert matrix["web_pma"]["last_sort_activity_at"] == "2026-05-11T00:01:00Z"
+    assert matrix["discord_bound"]["title"] == "Discord deploy triage"
+    assert matrix["discord_bound"]["binding_display_name"] == "Agent Nexus / #deploy"
+    assert matrix["ticket_flow"]["group_id"] == "run:run-005"
+    assert matrix["queued_only"]["queue_depth"] == 1
+    assert matrix["queued_only"]["last_sort_activity_at"] == "2026-05-11T00:02:00Z"
+    assert matrix["archived"]["archive_state"] == "archived"
+    assert matrix["external_unbound"]["managed_thread_id"] is None
+    assert matrix["external_unbound"]["title"] == "External diagnostics channel"
+
+    for row in matrix.values():
+        assert row["last_activity_at"] == row["last_sort_activity_at"]
+        assert row["debug"]["title"]["selected"] == row["display_title"]
+        assert row["debug"]["activity"]["selected"] == row["last_sort_activity_at"]
+
+    pma_thread = next(
+        thread
+        for thread in service.pma_compat_snapshot()["threads"]
+        if thread["managed_thread_id"] == "thread-pma"
+    )
+    assert pma_thread["updated_at"] == "2026-05-11T00:01:00Z"
+    assert matrix["web_pma"]["last_lifecycle_update_at"] == "2026-05-11T00:00:10Z"

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -867,6 +867,85 @@ def test_chat_index_sorts_by_conversation_activity_not_metadata_hydration(
     )
     assert older["title"] == "Older visible message"
     assert older["last_activity_at"] == "2026-05-11T00:01:00Z"
+    assert older["last_visible_message_at"] == "2026-05-11T00:01:00Z"
+    assert older["last_lifecycle_update_at"] == "2026-05-11T00:05:00Z"
+    assert older["last_internal_update_at"] > older["last_lifecycle_update_at"]
+    assert older["last_sort_activity_at"] == "2026-05-11T00:01:00Z"
+
+
+def test_chat_index_persists_explicit_activity_clocks_in_sql_projection(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(hub_root, thread_id="thread-clock")
+    _seed_execution(
+        hub_root,
+        thread_id="thread-clock",
+        status="completed",
+        prompt_text="Visible clock source",
+        created_at="2026-05-11T00:01:00Z",
+    )
+    with open_orchestration_sqlite(hub_root, durable=False, migrate=True) as conn:
+        conn.execute(
+            "UPDATE orch_thread_targets SET updated_at = ? WHERE thread_target_id = ?",
+            ("2026-05-11T00:05:00Z", "thread-clock"),
+        )
+
+    service = ChatSurfaceReadService(hub_root, durable=False)
+    service.rebuild_chat_index_projection()
+
+    with open_orchestration_sqlite(hub_root, durable=False, migrate=True) as conn:
+        row = conn.execute(
+            """
+            SELECT last_visible_message_at,
+                   last_lifecycle_update_at,
+                   last_internal_update_at,
+                   last_sort_activity_at,
+                   last_activity_at,
+                   updated_at
+              FROM orch_chat_index_projection
+             WHERE managed_thread_id = ?
+            """,
+            ("thread-clock",),
+        ).fetchone()
+
+    assert dict(row) == {
+        "last_visible_message_at": "2026-05-11T00:01:00Z",
+        "last_lifecycle_update_at": "2026-05-11T00:05:00Z",
+        "last_internal_update_at": "2026-05-11T00:05:00Z",
+        "last_sort_activity_at": "2026-05-11T00:01:00Z",
+        "last_activity_at": "2026-05-11T00:01:00Z",
+        "updated_at": "2026-05-11T00:05:00Z",
+    }
+
+
+def test_chat_index_queued_visible_turn_sets_sort_clock_without_thread_churn(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(hub_root, thread_id="thread-queued")
+    _seed_execution(
+        hub_root,
+        thread_id="thread-queued",
+        status="queued",
+        prompt_text="Queued visible message",
+        metadata={"user_visible_text": "Queued visible message"},
+        created_at="2026-05-11T00:02:00Z",
+    )
+    with open_orchestration_sqlite(hub_root, durable=False, migrate=True) as conn:
+        conn.execute(
+            "UPDATE orch_thread_targets SET updated_at = ? WHERE thread_target_id = ?",
+            ("2026-05-11T00:00:10Z", "thread-queued"),
+        )
+
+    row = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(limit=20)[
+        "rows"
+    ][0]
+
+    assert row["last_visible_message_at"] == "2026-05-11T00:02:00Z"
+    assert row["last_sort_activity_at"] == "2026-05-11T00:02:00Z"
+    assert row["last_activity_at"] == "2026-05-11T00:02:00Z"
+    assert row["queue_depth"] == 1
 
 
 def test_chat_index_snapshot_reads_rebuilt_sql_projection_without_reprojecting(

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -810,10 +810,25 @@ def test_chat_index_sorts_by_conversation_activity_not_metadata_hydration(
     hub_root = tmp_path / "hub"
     _seed_thread(hub_root, thread_id="thread-older")
     _seed_thread(hub_root, thread_id="thread-newer")
+    _seed_execution(
+        hub_root,
+        thread_id="thread-older",
+        status="ok",
+        prompt_text="<injected context>runtime notes</injected context>\n\nOlder visible message",
+        created_at="2026-05-11T00:01:00Z",
+    )
+    _seed_execution(
+        hub_root,
+        thread_id="thread-newer",
+        status="ok",
+        prompt_text="Newer visible message",
+        metadata={"user_visible_text": "Newer visible message"},
+        created_at="2026-05-11T00:02:00Z",
+    )
     with open_orchestration_sqlite(hub_root, durable=False, migrate=True) as conn:
         conn.execute(
             "UPDATE orch_thread_targets SET updated_at = ? WHERE thread_target_id = ?",
-            ("2026-05-11T00:00:10Z", "thread-older"),
+            ("2026-05-11T00:05:00Z", "thread-older"),
         )
         conn.execute(
             "UPDATE orch_thread_targets SET display_name = ? WHERE thread_target_id = ?",
@@ -821,7 +836,7 @@ def test_chat_index_sorts_by_conversation_activity_not_metadata_hydration(
         )
         conn.execute(
             "UPDATE orch_thread_targets SET updated_at = ? WHERE thread_target_id = ?",
-            ("2026-05-11T00:05:00Z", "thread-newer"),
+            ("2026-05-11T00:00:10Z", "thread-newer"),
         )
     OrchestrationBindingStore(hub_root, durable=False).upsert_binding(
         surface_kind="discord",
@@ -850,8 +865,8 @@ def test_chat_index_sorts_by_conversation_activity_not_metadata_hydration(
     older = next(
         row for row in index["rows"] if row["managed_thread_id"] == "thread-older"
     )
-    assert older["title"] == "thread-older"
-    assert older["last_activity_at"] == "2026-05-11T00:00:10Z"
+    assert older["title"] == "Older visible message"
+    assert older["last_activity_at"] == "2026-05-11T00:01:00Z"
 
 
 def test_chat_index_snapshot_reads_rebuilt_sql_projection_without_reprojecting(

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -1184,14 +1184,14 @@ def test_chat_index_and_detail_keep_bound_chat_display_secondary(
         for item in index["rows"]
         if item["managed_thread_id"] == "thread-discord-friendly"
     )
-    assert row["title"] == "thread-discord-friendly"
-    assert row["display_title"] == "thread-discord-friendly"
-    assert row["chat_display_name"] == "thread-discord-friendly"
+    assert row["title"] == "Agent Nexus / #codex"
+    assert row["display_title"] == "Agent Nexus / #codex"
+    assert row["chat_display_name"] == "Agent Nexus / #codex"
     assert row["binding_display_name"] == "Agent Nexus / #codex"
 
     detail = service.chat_detail_snapshot("thread-discord-friendly")
-    assert detail["thread"]["title"] == "thread-discord-friendly"
-    assert detail["thread"]["chat_display_name"] == "thread-discord-friendly"
+    assert detail["thread"]["title"] == "Agent Nexus / #codex"
+    assert detail["thread"]["chat_display_name"] == "Agent Nexus / #codex"
 
     custom_detail = service.chat_detail_snapshot("thread-discord-custom")
     assert custom_detail["thread"]["title"] == "Customer escalation"
@@ -1301,6 +1301,48 @@ def test_chat_index_uses_message_preview_before_thread_id_fallback(
     assert row["title"] == "Investigate failed deploy"
     assert row["display_title"] == "Investigate failed deploy"
     assert row["binding_display_name"] == "Agent Nexus / #deploys"
+
+
+def test_chat_index_uses_provider_title_before_visible_seed(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(
+        hub_root,
+        thread_id="thread-provider-title",
+        display_name="New PMA chat",
+        last_message_preview="First visible request",
+        metadata={"provider_conversation_title": "Native runtime title"},
+    )
+
+    row = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(limit=20)[
+        "rows"
+    ][0]
+
+    assert row["title"] == "Native runtime title"
+    assert row["display_title"] == "Native runtime title"
+
+
+def test_chat_index_deprioritizes_uuid_and_ticket_flow_control_prompt_titles(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(
+        hub_root,
+        thread_id="12345678-1234-5678-1234-567812345678",
+        display_name="12345678-1234-5678-1234-567812345678",
+        last_message_preview=(
+            "<CAR_TICKET_FLOW_PROMPT><CAR_CURRENT_TICKET_FILE>"
+            "PATH: .codex-autorunner/tickets/TICKET-002.md"
+            "</CAR_CURRENT_TICKET_FILE></CAR_TICKET_FLOW_PROMPT>"
+        ),
+        metadata={"ticket_id": "TICKET-002"},
+    )
+
+    row = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(limit=20)[
+        "rows"
+    ][0]
+
+    assert row["title"] == "Ticket flow · TICKET-002"
+    assert row["technical_title"] == "12345678-1234-5678-1234-567812345678"
 
 
 def test_chat_surface_read_model_allows_lifecycle_recovery_events(
@@ -1413,7 +1455,9 @@ def test_chat_surface_read_model_builds_pma_compat_snapshot(tmp_path: Path) -> N
             "resource_kind": "repo",
             "resource_id": "repo-1",
             "workspace_root": None,
-            "name": "Thread thread-pma",
+            "name": "Discord channel",
+            "display_title": "Discord channel",
+            "technical_title": "thread-pma",
             "model": None,
             "backend_thread_id": None,
             "lifecycle_status": "active",

--- a/tests/core/orchestration/test_managed_thread_transcript.py
+++ b/tests/core/orchestration/test_managed_thread_transcript.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from codex_autorunner.core.orchestration.managed_thread_transcript import (
+    transcript_rows_from_timeline_items,
+)
+
+
+def _user_item(payload: dict) -> dict:
+    return {
+        "kind": "user_message",
+        "item_id": "turn:1:user",
+        "order_key": "001",
+        "timestamp": "2026-05-10T12:00:00Z",
+        "managed_thread_id": "thread-1",
+        "managed_turn_id": "turn-1",
+        "payload": payload,
+        "identity": {"timeline_item_id": "turn:1:user"},
+    }
+
+
+def test_transcript_projects_legacy_injected_prompt_as_model_context() -> None:
+    rows = transcript_rows_from_timeline_items(
+        [
+            _user_item(
+                {
+                    "text": "<injected context>\nrepo guidance\n</injected context>\n\nFix login",
+                    "raw_model_prompt": (
+                        "<injected context>\nrepo guidance\n</injected context>\n\nFix login"
+                    ),
+                }
+            )
+        ]
+    )
+
+    row = rows[0]
+    assert row["visible_text"] == "Fix login"
+    assert row["model_context_text"] == "repo guidance"
+    assert row["raw_model_prompt"].startswith("<injected context>")
+    assert row["message"]["text"].startswith("<injected context>")
+    assert row["message"]["visible_text"] == "Fix login"
+    assert row["message"]["model_context_text"] == "repo guidance"
+
+
+def test_transcript_projects_capsule_only_model_context_refs() -> None:
+    capsule_ref = {
+        "capsule_id": "car.repo_basics",
+        "capsule_version": "1",
+        "visibility": "model_only",
+        "scope": "repo",
+        "source_digest": "sha256:repo",
+    }
+    rows = transcript_rows_from_timeline_items(
+        [_user_item({"text": "Fix login", "capsule_refs": [capsule_ref]})]
+    )
+
+    row = rows[0]
+    assert row["visible_text"] == "Fix login"
+    assert row["model_context_text"] is None
+    assert row["model_context_refs"] == [capsule_ref]
+    assert row["message"]["model_context_refs"] == [capsule_ref]
+
+
+def test_transcript_projects_structured_refs_and_model_context_text() -> None:
+    capsule_ref = {
+        "capsule_id": "car.issue",
+        "capsule_version": "2",
+        "visibility": "model_only",
+        "scope": "ticket",
+        "source_digest": "sha256:ticket",
+        "reason": "ticket_context",
+    }
+    rows = transcript_rows_from_timeline_items(
+        [
+            _user_item(
+                {
+                    "text": "Fix login",
+                    "user_visible_text": "Fix login",
+                    "raw_model_prompt": (
+                        "<injected context>\nticket notes\n</injected context>\n\nFix login"
+                    ),
+                    "capsule_refs": [capsule_ref],
+                }
+            )
+        ]
+    )
+
+    row = rows[0]
+    assert row["visible_text"] == "Fix login"
+    assert row["model_context_text"] == "ticket notes"
+    assert row["model_context_refs"] == [capsule_ref]

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -1773,7 +1773,10 @@ async def test_runtime_thread_stall_timeout_allows_short_prompt_return_grace(
             await asyncio.Future()
 
     original_grace = runtime_threads_module._STALL_COMPLETION_GRACE_SECONDS
-    runtime_threads_module._STALL_COMPLETION_GRACE_SECONDS = 0.05
+    # Keep this above the synthetic 30 ms prompt-return delay with enough margin
+    # for xdist aggregate runs on loaded local machines. The behavior under test
+    # is the grace path, not scheduler precision.
+    runtime_threads_module._STALL_COMPLETION_GRACE_SECONDS = 0.2
     try:
         harness = _HarnessWithLatePromptReturn()
         service = _build_service(tmp_path, harness)

--- a/tests/core/orchestration/test_thread_titles.py
+++ b/tests/core/orchestration/test_thread_titles.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from codex_autorunner.core.orchestration.thread_titles import (
+    ManagedThreadTitleInputs,
+    choose_owned_thread_title,
+    resolve_managed_thread_display_title,
+)
+
+
+@pytest.mark.parametrize(
+    ("inputs", "expected"),
+    [
+        (
+            ManagedThreadTitleInputs(
+                stored_title="Release investigation",
+                provider_title="Provider title",
+                user_visible_title_seed="Visible request",
+            ),
+            "Release investigation",
+        ),
+        (
+            ManagedThreadTitleInputs(
+                stored_title="New PMA chat",
+                provider_title="Native Codex thread",
+                user_visible_title_seed="Visible request",
+            ),
+            "Native Codex thread",
+        ),
+        (
+            ManagedThreadTitleInputs(
+                stored_title="discord:1488827014600331415",
+                user_visible_title_seed="Investigate notification routing",
+                chat_display_name="CAR Workspace / #hermes",
+            ),
+            "Investigate notification routing",
+        ),
+        (
+            ManagedThreadTitleInputs(
+                stored_title="New chat",
+                chat_display_name="Deploys / Thread 12",
+                fallback_id="thread-1",
+            ),
+            "Deploys / Thread 12",
+        ),
+        (
+            ManagedThreadTitleInputs(
+                stored_title=(
+                    "<CAR_TICKET_FLOW_PROMPT><CAR_CURRENT_TICKET_FILE />"
+                    "</CAR_TICKET_FLOW_PROMPT>"
+                ),
+                ticket_id="TICKET-002",
+                fallback_id="thread-ticket-flow",
+            ),
+            "Ticket flow · TICKET-002",
+        ),
+        (
+            ManagedThreadTitleInputs(
+                stored_title=str(uuid.UUID("12345678-1234-5678-1234-567812345678")),
+                provider_title="",
+                user_visible_title_seed="Fix Discord title regression",
+                fallback_id="thread-uuid",
+            ),
+            "Fix Discord title regression",
+        ),
+        (
+            ManagedThreadTitleInputs(
+                stored_title="Thread thread-no-message",
+                fallback_id="thread-no-message",
+            ),
+            "thread-no-message",
+        ),
+    ],
+)
+def test_resolve_managed_thread_display_title_policy_matrix(
+    inputs: ManagedThreadTitleInputs,
+    expected: str,
+) -> None:
+    assert resolve_managed_thread_display_title(inputs) == expected
+
+
+def test_choose_owned_thread_title_uses_central_policy() -> None:
+    assert (
+        choose_owned_thread_title(
+            "Thread thread-1",
+            provider_title=None,
+            message_preview="Compare chat title sources",
+            fallback="thread-1",
+        )
+        == "Compare chat title sources"
+    )

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_timeline_route.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_timeline_route.py
@@ -335,6 +335,9 @@ def test_managed_thread_transcript_endpoint_exposes_capsule_visibility_contract(
     assert payload["contract_version"] == "managed_thread_transcript.v2"
     user_row = payload["rows"][0]
     assert user_row["message"]["text"] == "Fix login"
+    assert user_row["visible_text"] == "Fix login"
+    assert user_row["model_context_text"] == "repo guidance"
+    assert user_row["raw_model_prompt"].startswith("<injected context>")
     assert user_row["visibility"] == "user_visible"
     assert user_row["user_visible_text"] == "Fix login"
     assert user_row["capsule_refs"] == [
@@ -346,6 +349,10 @@ def test_managed_thread_transcript_endpoint_exposes_capsule_visibility_contract(
             "source_digest": "sha256:repo",
         }
     ]
+    assert user_row["model_context_refs"] == user_row["capsule_refs"]
+    assert user_row["message"]["visible_text"] == "Fix login"
+    assert user_row["message"]["model_context_text"] == "repo guidance"
+    assert user_row["message"]["model_context_refs"] == user_row["capsule_refs"]
     assert user_row["message"]["capsule_refs"] == user_row["capsule_refs"]
 
 

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -353,6 +353,13 @@ def test_chat_index_contract_uses_terminal_thread_status_and_ticket_flow_metadat
     assert row.ticket_id == "TICKET-015"
     assert row.run_id == "run-015"
     assert row.group_id == "run:run-015"
+    assert row.last_activity_at == row.last_sort_activity_at
+    assert row.debug is not None
+    assert row.debug["activity"]["selected_source"] in {
+        "last_visible_message_at",
+        "last_sort_activity_at",
+    }
+    assert row.debug["title"]["selected"] == row.display_title
 
     active_response = client.get(
         "/hub/read-models/chats", params={"filter": "active", "limit": 20}

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -255,11 +255,24 @@ def test_chat_index_group_contract_accepts_legacy_ticket_run_prefix() -> None:
             "group_id": "ticket-run:run-1",
             "title": "Legacy ticket run",
             "child_count": 3,
+            "waiting_count": 1,
+            "running_count": 2,
+            "unread_count": 4,
+            "last_sort_activity_at": "2026-05-11T00:01:00Z",
+            "last_lifecycle_update_at": "2026-05-11T00:05:00Z",
+            "debug": {"activity": {"selected_source": "last_sort_activity_at"}},
         }
     )
 
     assert group.kind == "ticket_run"
     assert group.group_id == "ticket-run:run-1"
+    assert group.waiting_count == 1
+    assert group.running_count == 2
+    assert group.unread_count == 4
+    assert group.last_activity_at is not None
+    assert group.last_sort_activity_at is not None
+    assert group.last_sort_activity_at.isoformat() == group.last_activity_at.isoformat()
+    assert group.debug == {"activity": {"selected_source": "last_sort_activity_at"}}
 
 
 def test_chat_index_contract_uses_terminal_thread_status_and_ticket_flow_metadata(


### PR DESCRIPTION
## Summary

- Persist explicit chat activity clocks for row sorting and relative-time labels.
- Centralize managed-thread title policy and structured transcript model context.
- Unify chat read-model contracts across backend/frontend.
- Correct the follow-up misses from review: ticket-run groups now use explicit sort clocks, typed group contracts preserve status/recency fields, and Discord typed turn envelopes no longer carry parallel legacy visible/title kwargs once the envelope exists.

## Tickets

- 5/5 completed (run `845225a9`, ~51m)
- Follow-up corrective commit: `c557ad5aa` / `Fix chat group clocks and turn envelopes`

## Validation

- Aggregate pre-commit lane passed on commit:
  - black, ruff, import boundaries, hub interface contracts, destination contract drift, keyword contracts
  - repo-wide mypy over `src/codex_autorunner`
  - Python test suite: 9,185 passed
  - Web UI lab fast check: 26 scenarios passed
  - Web frontend lint/typecheck/build
  - Web frontend tests: 766 passed, 2 skipped
- Post-rebase targeted checks:
  - `119 passed` for affected Python chat/read-model/turn-envelope tests
  - `93 passed` for affected frontend read-model/view-model tests