### PR TITLE
[codex] Hide internal chat notices at projection layer

### DIFF
--- a/src/codex_autorunner/adapters/chat/execution_event_journal.py
+++ b/src/codex_autorunner/adapters/chat/execution_event_journal.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from typing import Any, Iterable, Mapping, Optional, Sequence
 
+from ...core.orchestration.run_notice_visibility import (
+    CHAT_EXECUTION_JOURNAL_NOTICE_KIND,
+)
 from ...core.orchestration.turn_timeline import append_turn_timeline, list_turn_timeline
 from ...core.ports.run_event import (
     ApprovalRequested,
@@ -19,7 +22,6 @@ from ...core.ports.run_event import (
 )
 from ...core.time_utils import now_iso
 
-CHAT_EXECUTION_JOURNAL_NOTICE_KIND = "chat_execution_journal"
 CHAT_EXECUTION_JOURNAL_SCHEMA_VERSION = 1
 
 

--- a/src/codex_autorunner/adapters/chat/managed_thread_progress.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_progress.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from ...core.orchestration.run_notice_visibility import is_internal_run_notice_kind
 from ...core.ports.run_event import (
     RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
     RUN_EVENT_DELTA_TYPE_LOG_LINE,
@@ -113,7 +114,7 @@ def apply_run_event_to_progress_tracker(
         notice = run_event.message.strip() if run_event.message else ""
         if not notice:
             notice = run_event.kind.strip() if run_event.kind else "notice"
-        if run_event.kind == "decode_failure":
+        if is_internal_run_notice_kind(run_event.kind):
             return ProgressTrackerEventOutcome(changed=False)
         if run_event.kind in {"thinking", "reasoning"}:
             prior_transient = tracker.transient_action

--- a/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
@@ -375,7 +375,7 @@ def _progress_item_for_entry(
             event=run_event,
         ),
     )
-    if item is None or item.hidden:
+    if item is None:
         return None
     return item
 

--- a/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
@@ -702,6 +702,9 @@ def _append_timeline_event_items(
             progress_item_ids, progress_event_ids = _progress_item_metadata(
                 progress_item
             )
+            progress_item_dict = (
+                progress_item.to_dict() if progress_item is not None else None
+            )
             items.append(
                 ManagedThreadTimelineItem(
                     item_id=item_id,
@@ -727,11 +730,10 @@ def _append_timeline_event_items(
                         "source_event_ids": [event_index],
                         "source_event_type": event_type,
                         "detail_available": True,
-                        "progress_item": (
-                            progress_item.to_dict()
-                            if progress_item is not None
-                            else None
+                        "hidden": bool(
+                            progress_item is not None and progress_item.hidden
                         ),
+                        "progress_item": progress_item_dict,
                     },
                 )
             )
@@ -945,6 +947,7 @@ def timeline_item_from_tail_event(
                 "source_event_ids": source_event_ids,
                 "source_event_type": event_type,
                 "detail_available": True,
+                "hidden": bool(progress.get("hidden") is True),
                 "progress_item": progress or None,
                 "live_tail_event": dict(tail_event),
             },

--- a/src/codex_autorunner/core/orchestration/managed_thread_transcript.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_transcript.py
@@ -483,10 +483,11 @@ def _json_detail(value: Any) -> Optional[str]:
 def _is_hidden_intermediate(payload: Mapping[str, Any]) -> bool:
     if payload.get("hidden") is True:
         return True
+    progress_item = _mapping(payload.get("progress_item"))
+    if progress_item.get("hidden") is True:
+        return True
     intermediate_kind = str(payload.get("intermediate_kind") or "").lower()
     event_type = str(payload.get("event_type") or "").lower()
-    if intermediate_kind == "decode_failure":
-        return True
     return event_type == "output_delta" and intermediate_kind in {
         "assistant_stream",
         "assistant_message",

--- a/src/codex_autorunner/core/orchestration/progress_projection.py
+++ b/src/codex_autorunner/core/orchestration/progress_projection.py
@@ -20,6 +20,7 @@ from ..ports.run_event import (
 )
 from ..redaction import redact_text
 from ..text_utils import _truncate_text
+from .run_notice_visibility import is_internal_run_notice_kind
 from .stream_text_merge import merge_assistant_stream_text
 
 PROGRESS_PROJECTION_VERSION = "pma_progress_projection.v1"
@@ -278,14 +279,9 @@ def reduce_progress_event(
         )
 
     if isinstance(event, RunNotice):
-        # decode_failure notices are operator/debug telemetry emitted when
-        # the decoder doesn't have a handler for a runtime method. They are
-        # logged via `_log_decode_failure`; surfacing them as user-visible
-        # cards would leak internal plumbing into the chat. Keep them in
-        # the projection (so journal replay sees them too) but hide them.
-        if event.kind == "decode_failure":
+        if is_internal_run_notice_kind(event.kind):
             return ProgressProjectionItem(
-                item_id=f"progress:hidden:decode_failure:{event_key}",
+                item_id=f"progress:hidden:{event.kind or 'notice'}:{event_key}",
                 kind="hidden",
                 state="hidden",
                 title="Hidden progress",

--- a/src/codex_autorunner/core/orchestration/run_notice_visibility.py
+++ b/src/codex_autorunner/core/orchestration/run_notice_visibility.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any
+
+CHAT_EXECUTION_JOURNAL_NOTICE_KIND = "chat_execution_journal"
+COMPACTION_SUMMARY_NOTICE_KIND = "compaction_summary"
+DECODE_FAILURE_NOTICE_KIND = "decode_failure"
+
+INTERNAL_RUN_NOTICE_KINDS = frozenset(
+    {
+        CHAT_EXECUTION_JOURNAL_NOTICE_KIND,
+        COMPACTION_SUMMARY_NOTICE_KIND,
+        DECODE_FAILURE_NOTICE_KIND,
+    }
+)
+
+
+def is_internal_run_notice_kind(kind: Any) -> bool:
+    return str(kind or "").strip().lower() in INTERNAL_RUN_NOTICE_KINDS

--- a/tests/core/orchestration/test_managed_thread_timeline.py
+++ b/tests/core/orchestration/test_managed_thread_timeline.py
@@ -488,6 +488,35 @@ def test_live_tail_event_uses_progress_metadata_for_intermediate_titles() -> Non
     assert item["payload"]["intermediate_kind"] == "progress"
 
 
+def test_live_tail_event_carries_hidden_progress_metadata() -> None:
+    item = timeline_item_from_tail_event(
+        managed_thread_id="thread-1",
+        managed_turn_id="turn-1",
+        tail_event={
+            "event_id": 4,
+            "event_type": "progress",
+            "summary": "terminal=3977ms",
+            "received_at": "2026-05-06T10:00:04Z",
+            "progress_item": {
+                "item_id": "progress:hidden:chat_execution_journal:0004",
+                "kind": "hidden",
+                "state": "hidden",
+                "title": "Hidden progress",
+                "summary": None,
+                "event_ids": [4],
+                "hidden": True,
+            },
+            "progress_kind": "hidden",
+            "progress_state": "hidden",
+        },
+    )
+
+    assert item is not None
+    assert item["kind"] == "intermediate"
+    assert item["payload"]["hidden"] is True
+    assert item["payload"]["progress_item"]["hidden"] is True
+
+
 def test_timeline_includes_delivery_state_items(tmp_path: Path) -> None:
     hub_root, store, thread_id = _store(tmp_path)
     turn = store.create_turn(thread_id, prompt="deliver this")

--- a/tests/core/orchestration/test_managed_thread_transcript.py
+++ b/tests/core/orchestration/test_managed_thread_transcript.py
@@ -18,6 +18,19 @@ def _user_item(payload: dict) -> dict:
     }
 
 
+def _intermediate_item(payload: dict) -> dict:
+    return {
+        "kind": "intermediate",
+        "item_id": f"turn:1:intermediate:{payload.get('intermediate_kind', 'notice')}",
+        "order_key": "002",
+        "timestamp": "2026-05-10T12:00:01Z",
+        "managed_thread_id": "thread-1",
+        "managed_turn_id": "turn-1",
+        "payload": payload,
+        "identity": {"timeline_item_id": "turn:1:intermediate"},
+    }
+
+
 def test_transcript_projects_legacy_injected_prompt_as_model_context() -> None:
     rows = transcript_rows_from_timeline_items(
         [
@@ -39,6 +52,51 @@ def test_transcript_projects_legacy_injected_prompt_as_model_context() -> None:
     assert row["message"]["text"].startswith("<injected context>")
     assert row["message"]["visible_text"] == "Fix login"
     assert row["message"]["model_context_text"] == "repo guidance"
+
+
+def test_transcript_hides_internal_lifecycle_notices() -> None:
+    rows = transcript_rows_from_timeline_items(
+        [
+            _intermediate_item(
+                {
+                    "intermediate_kind": "chat_execution_journal",
+                    "text": "terminal=3977ms",
+                    "event_type": "run_notice",
+                    "event": {"kind": "chat_execution_journal"},
+                    "hidden": True,
+                }
+            ),
+            _intermediate_item(
+                {
+                    "intermediate_kind": "notice",
+                    "text": "Compacted hot timeline rows.",
+                    "event_type": "run_notice",
+                    "event": {"kind": "compaction_summary"},
+                    "progress_item": {"hidden": True},
+                }
+            ),
+            _intermediate_item(
+                {
+                    "intermediate_kind": "notice",
+                    "text": "Decoder missed event shape.",
+                    "event_type": "run_notice",
+                    "progress_item": {"hidden": True},
+                }
+            ),
+            _intermediate_item(
+                {
+                    "intermediate_kind": "thinking",
+                    "title": "Thinking",
+                    "text": "Reading files",
+                    "event_type": "assistant_update",
+                }
+            ),
+        ]
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "intermediate"
+    assert rows[0]["text"] == "Reading files"
 
 
 def test_transcript_projects_capsule_only_model_context_refs() -> None:

--- a/tests/core/orchestration/test_progress_projection.py
+++ b/tests/core/orchestration/test_progress_projection.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from codex_autorunner.core.orchestration.progress_projection import (
     ProgressProjectionInput,
+    ProgressProjectionState,
     project_progress_events,
+    reduce_progress_event,
 )
 from codex_autorunner.core.ports.run_event import (
     RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
@@ -80,6 +82,41 @@ def test_progress_projection_keeps_strict_assistant_deltas_append_only() -> None
     assert len(items) == 1
     assert items[0].summary == "Reading files now"
     assert items[0].merge_strategy == "delta"
+
+
+def test_progress_projection_marks_internal_run_notices_hidden() -> None:
+    state = ProgressProjectionState()
+    items = [
+        reduce_progress_event(
+            state,
+            ProgressProjectionInput(
+                event_id=index,
+                timestamp=f"2026-05-06T10:00:0{index}Z",
+                event=RunNotice(
+                    timestamp=f"2026-05-06T10:00:0{index}Z",
+                    kind=kind,
+                    message="internal telemetry",
+                ),
+            ),
+        )
+        for index, kind in enumerate(
+            ("chat_execution_journal", "compaction_summary", "decode_failure"),
+            start=1,
+        )
+    ]
+
+    assert all(item is not None and item.kind == "hidden" for item in items)
+    assert all(item is not None and item.hidden for item in items)
+    assert (
+        _project(
+            RunNotice(
+                timestamp="2026-05-06T10:00:01Z",
+                kind="chat_execution_journal",
+                message="terminal=3977ms",
+            )
+        )
+        == []
+    )
 
 
 def test_progress_projection_groups_tool_call_and_result_pairs() -> None:


### PR DESCRIPTION
## Summary

- centralize internal RunNotice visibility in the core orchestration layer
- project chat execution journal, compaction summary, and decode failure notices as hidden progress items
- propagate hidden progress metadata through durable/live timeline rows so transcript rendering follows metadata instead of kind-specific blocklists
- add regression coverage for projection, timeline, and transcript behavior

## Root Cause

Internal RunNotice events were treated like normal intermediate timeline rows. The transcript layer had to know specific internal notice names, and chat execution journal notices could appear after the final assistant response because they are appended near terminal delivery time.

## Validation

- aggregate commit hook passed: guardrails, ruff, black, mypy, repo pytest, web lab fast scenarios, web lint, web build, web tests
- post-rebase focused pytest: tests/core/orchestration/test_progress_projection.py tests/core/orchestration/test_managed_thread_timeline.py tests/core/orchestration/test_managed_thread_transcript.py tests/test_managed_thread_progress.py
- post-rebase focused ruff check on changed Python files
