### PR TITLE
[codex] Label PMA launch actions

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/RepoWorktreeViews.svelte
@@ -414,7 +414,7 @@
                 aria-label={`Start PMA chat for ${row.label}`}
                 data-sveltekit-preload-data="tap"
               >
-                + Chat
+                + PMA
               </a>
               <a
                 class="row-action-button row-action-link"
@@ -624,7 +624,7 @@
                           aria-label={`Start PMA chat for ${worktree.label}`}
                           data-sveltekit-preload-data="tap"
                         >
-                          + Chat
+                          + PMA
                         </a>
                         <a
                           class="row-action-button row-action-link"
@@ -980,7 +980,7 @@
         <div class="panel-heading-row chats-panel-heading">
           <h2>Chats</h2>
           <div class="panel-heading-actions">
-            <a class="chip-button" href={href(detail.pmaChatHref)} data-sveltekit-preload-data="tap">+ Chat</a>
+            <a class="chip-button" href={href(detail.pmaChatHref)} data-sveltekit-preload-data="tap">+ PMA</a>
             <a class="chip-button" href={href(detail.codingAgentChatHref)} data-sveltekit-preload-data="tap">+ Coding agent</a>
           </div>
         </div>
@@ -1249,7 +1249,7 @@
     font-weight: 550;
   }
 
-  /* Primary affordance: "+ Chat" reads as the strongest of the row.
+  /* Primary affordance: "+ PMA" reads as the strongest of the row.
      Still ghost-shaped — accent-tinted border and ink-strong text at rest. */
   .row-action-button.is-primary-affordance {
     border-color: color-mix(in srgb, var(--color-accent) 22%, var(--color-border-subtle));

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -532,7 +532,7 @@
   const activeMessengerSurface = $derived(chatMessengerSurface(activeChat));
   const activeRepoIngress = $derived(repoIngressForChat(activeChat));
   const createChatLabel = $derived(
-    creating ? 'Creating...' : newChatKind === 'agent' && canStartCodingAgentChat ? '+ Coding agent' : '+ Chat'
+    creating ? 'Creating...' : newChatKind === 'agent' && canStartCodingAgentChat ? '+ Coding agent' : '+ PMA'
   );
   const headerScopeLine = $derived(pmaChatHeaderScopeLine(activeChat, repoLabelForRepoId));
   /** Omit connected “Live · …” — redundant with the turn-status pill on the scope row. */

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -95,7 +95,7 @@ describe('/chats page', () => {
 
     expect(body).toContain('Chats workspace');
     expect(body).not.toContain('memory-toggle-button');
-    expect(body).toContain('+ Chat');
+    expect(body).toContain('+ PMA');
     expect(body).toContain('chat-list');
     expect(body).toContain('Waiting');
     expect(body).toContain('Active');


### PR DESCRIPTION
## Summary
- Rename PMA launch buttons from `+ Chat` to `+ PMA` on the chat and repo/worktree surfaces.
- Leave coding-agent launch affordances unchanged.
- Update the chat page test expectation for the new PMA label.

## Validation
- `pnpm web:test`
- `pnpm web:lint`
- `pnpm web:build`
- `rg "+ Chat" src tests -S`
- Commit hook validation lane: guardrails, repo pytest (`9203 passed`), web-ui lab, frontend lint/build/tests, SPA shell check

Ready for review.