### PR TITLE
[codex] Fix worktree chat ownership projection

### DIFF
--- a/src/codex_autorunner/adapters/discord/workspace_commands.py
+++ b/src/codex_autorunner/adapters/discord/workspace_commands.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence, cast
 
@@ -19,6 +20,7 @@ from ...adapters.chat.ticket_flow_cleanliness import (
     get_ticket_flow_cleanliness,
 )
 from ...core.chat_bindings import emit_adapter_binding_chat_surface_event
+from ...core.domain.workspace_scope import workspace_scope_index_from_snapshots
 from ...core.flows import FlowRunStatus
 from ...core.logging_utils import log_event
 from ...core.utils import canonicalize_path
@@ -68,6 +70,14 @@ from .state import ChannelBinding
 _logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class _ManifestWorkspace:
+    resource_kind: str
+    resource_id: str
+    repo_id: Optional[str]
+    path: str
+
+
 def _resolve_process_monitor_root(
     service: Any,
     binding: Optional[Mapping[str, Any]],
@@ -92,30 +102,66 @@ def _resolve_process_monitor_root(
     return None
 
 
-def _list_manifest_repos(
-    service: Any,
-) -> list[tuple[str, str]]:
+def _list_manifest_workspaces(service: Any) -> list[_ManifestWorkspace]:
     if not service._manifest_path or not service._manifest_path.exists():
         return []
     try:
         manifest = load_manifest(service._manifest_path, service._config.root)
-        ordered: list[tuple[int, int, str, str]] = []
+        snapshots: list[dict[str, Any]] = []
         for index, repo in enumerate(manifest.repos):
             if not repo.id:
                 continue
-            worktree_priority = 0 if repo.kind == "worktree" else 1
+            snapshots.append(
+                {
+                    "id": repo.id,
+                    "kind": repo.kind,
+                    "worktree_of": repo.worktree_of,
+                    "path": str(canonicalize_path(service._config.root / repo.path)),
+                    "_index": index,
+                }
+            )
+        scope_index = workspace_scope_index_from_snapshots(snapshots)
+        ordered: list[tuple[int, int, str, _ManifestWorkspace]] = []
+        for snapshot in snapshots:
+            repo_id = str(snapshot["id"])
+            resolution = scope_index.resolve(
+                raw_repo_id=repo_id,
+                workspace_path=snapshot["path"],
+            )
+            if resolution is None:
+                continue
+            owner = resolution.owner_fields()
+            resource_kind = owner.get("resource_kind")
+            resource_id = owner.get("resource_id")
+            if not resource_kind or not resource_id:
+                continue
+            kind = str(snapshot.get("kind") or "")
+            worktree_priority = 0 if kind == "worktree" else 1
             ordered.append(
                 (
                     worktree_priority,
-                    -index,
-                    repo.id,
-                    str(service._config.root / repo.path),
+                    -int(snapshot["_index"]),
+                    repo_id,
+                    _ManifestWorkspace(
+                        resource_kind=resource_kind,
+                        resource_id=resource_id,
+                        repo_id=owner.get("repo_id"),
+                        path=str(snapshot["path"]),
+                    ),
                 )
             )
         ordered.sort(key=lambda item: (item[0], item[1], item[2]))
-        return [(repo_id, path) for _, _, repo_id, path in ordered]
+        return [entry for _, _, _, entry in ordered]
     except (ManifestError, OSError, ValueError):
         return []
+
+
+def _list_manifest_repos(
+    service: Any,
+) -> list[tuple[str, str]]:
+    return [
+        (entry.resource_id, entry.path) for entry in _list_manifest_workspaces(service)
+    ]
 
 
 def _resource_owner_for_workspace(
@@ -139,15 +185,27 @@ def _resource_owner_for_workspace(
         if isinstance(resource_id, str) and resource_id.strip()
         else None
     )
-    if normalized_resource_kind == "repo" and normalized_resource_id:
-        return "repo", normalized_resource_id, normalized_resource_id
+    manifest_workspaces = _list_manifest_workspaces(service)
+    if normalized_resource_kind and normalized_resource_id:
+        for entry in manifest_workspaces:
+            if (
+                entry.resource_kind == normalized_resource_kind
+                and entry.resource_id == normalized_resource_id
+            ):
+                return entry.resource_kind, entry.resource_id, entry.repo_id
+        if normalized_resource_kind == "repo":
+            return "repo", normalized_resource_id, normalized_resource_id
+        return normalized_resource_kind, normalized_resource_id, None
     if normalized_repo_id:
+        for entry in manifest_workspaces:
+            if entry.resource_id == normalized_repo_id:
+                return entry.resource_kind, entry.resource_id, entry.repo_id
         return "repo", normalized_repo_id, normalized_repo_id
 
     canonical_workspace = str(canonicalize_path(workspace_root))
-    for listed_repo_id, listed_path in service._list_manifest_repos():
-        if str(canonicalize_path(Path(listed_path))) == canonical_workspace:
-            return "repo", listed_repo_id, listed_repo_id
+    for entry in manifest_workspaces:
+        if str(canonicalize_path(Path(entry.path))) == canonical_workspace:
+            return entry.resource_kind, entry.resource_id, entry.repo_id
     return None, None, None
 
 
@@ -157,9 +215,9 @@ def _list_bind_workspace_candidates(
     candidates: list[tuple[Optional[str], Optional[str], str]] = []
     manifest_paths: set[str] = set()
 
-    for repo_id, path in service._list_manifest_repos():
-        normalized_path = str(canonicalize_path(Path(path)))
-        candidates.append(("repo", repo_id, normalized_path))
+    for entry in _list_manifest_workspaces(service):
+        normalized_path = str(canonicalize_path(Path(entry.path)))
+        candidates.append((entry.resource_kind, entry.resource_id, normalized_path))
         manifest_paths.add(normalized_path)
 
     seen_paths: set[str] = set(manifest_paths)

--- a/src/codex_autorunner/adapters/discord/workspace_commands.py
+++ b/src/codex_autorunner/adapters/discord/workspace_commands.py
@@ -195,7 +195,6 @@ def _resource_owner_for_workspace(
                 return entry.resource_kind, entry.resource_id, entry.repo_id
         if normalized_resource_kind == "repo":
             return "repo", normalized_resource_id, normalized_resource_id
-        return normalized_resource_kind, normalized_resource_id, None
     if normalized_repo_id:
         for entry in manifest_workspaces:
             if entry.resource_id == normalized_repo_id:

--- a/src/codex_autorunner/surfaces/web/services/repo_worktree_read_models.py
+++ b/src/codex_autorunner/surfaces/web/services/repo_worktree_read_models.py
@@ -758,6 +758,7 @@ class RepoWorktreeReadModelService:
     ) -> list[dict[str, Any]]:
         db_rows: list[dict[str, Any]] = []
         try:
+            self._repair_chat_resource_owners_from_topology()
             with open_orchestration_sqlite(
                 self._context.config.root, durable=True, migrate=True
             ) as conn:
@@ -802,6 +803,67 @@ class RepoWorktreeReadModelService:
                 }
             )
         return db_rows
+
+    def _repair_chat_resource_owners_from_topology(self) -> None:
+        """Normalize legacy repo-shaped rows whose id is now known as a worktree."""
+
+        snapshots = self._context.supervisor.list_repos(use_cache=True)
+        scope_index = workspace_scope_index(snapshots)
+        try:
+            with open_orchestration_sqlite(
+                self._context.config.root, durable=True, migrate=True
+            ) as conn:
+                rows = conn.execute(
+                    """
+                    SELECT thread_target_id, repo_id, resource_kind, resource_id,
+                           workspace_root
+                    FROM orch_thread_targets
+                    WHERE resource_kind = 'repo'
+                    """
+                ).fetchall()
+                for row in rows:
+                    resolution = scope_index.resolve(
+                        raw_repo_id=row["repo_id"],
+                        workspace_path=row["workspace_root"],
+                        resource_kind=row["resource_kind"],
+                        resource_id=row["resource_id"],
+                    )
+                    if resolution is None or resolution.scope.kind != "worktree":
+                        continue
+                    owner = resolution.owner_fields()
+                    conn.execute(
+                        """
+                        UPDATE orch_thread_targets
+                           SET repo_id = ?,
+                               resource_kind = ?,
+                               resource_id = ?
+                         WHERE thread_target_id = ?
+                        """,
+                        (
+                            owner.get("repo_id"),
+                            owner.get("resource_kind"),
+                            owner.get("resource_id"),
+                            row["thread_target_id"],
+                        ),
+                    )
+                    conn.execute(
+                        """
+                        UPDATE orch_bindings
+                           SET repo_id = ?,
+                               resource_kind = ?,
+                               resource_id = ?
+                         WHERE target_kind = 'thread'
+                           AND target_id = ?
+                        """,
+                        (
+                            owner.get("repo_id"),
+                            owner.get("resource_kind"),
+                            owner.get("resource_id"),
+                            row["thread_target_id"],
+                        ),
+                    )
+        except sqlite3.Error:
+            return
 
     def _contextspace_summary(self, workspace_root: Path) -> list[dict[str, Any]]:
         docs = read_contextspace_docs(workspace_root)

--- a/tests/adapters/discord/test_state_store.py
+++ b/tests/adapters/discord/test_state_store.py
@@ -13,6 +13,8 @@ from codex_autorunner.adapters.discord.state import (
 )
 from codex_autorunner.adapters.discord.workspace_commands import (
     _bind_to_workspace_candidate,
+    _list_bind_workspace_candidates,
+    _resource_owner_for_workspace,
 )
 from codex_autorunner.core.managed_thread_store import ManagedThreadStore
 from codex_autorunner.core.orchestration import (
@@ -67,6 +69,55 @@ async def test_channel_binding_crud(tmp_path: Path) -> None:
         assert len(all_bindings) == 1
     finally:
         await store.close()
+
+
+def test_workspace_scope_resolution_preserves_manifest_worktrees(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    base = hub_root / "base"
+    worktree = hub_root / "worktrees" / "base--feature"
+    base.mkdir(parents=True)
+    worktree.mkdir(parents=True)
+    manifest_path = hub_root / ".codex-autorunner" / "manifest.yml"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        "\n".join(
+            [
+                "version: 3",
+                "repos:",
+                "  - id: base",
+                "    path: base",
+                "    kind: base",
+                "  - id: base--feature",
+                "    path: worktrees/base--feature",
+                "    kind: worktree",
+                "    worktree_of: base",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    service = SimpleNamespace(
+        _config=SimpleNamespace(root=hub_root),
+        _manifest_path=manifest_path,
+    )
+
+    assert _resource_owner_for_workspace(service, worktree) == (
+        "worktree",
+        "base--feature",
+        "base",
+    )
+    assert _resource_owner_for_workspace(
+        service,
+        worktree,
+        repo_id="base--feature",
+    ) == ("worktree", "base--feature", "base")
+    assert _list_bind_workspace_candidates(service)[0] == (
+        "worktree",
+        "base--feature",
+        str(worktree.resolve()),
+    )
 
 
 @pytest.mark.anyio

--- a/tests/surfaces/web/test_repo_worktree_read_models.py
+++ b/tests/surfaces/web/test_repo_worktree_read_models.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from codex_autorunner.core.managed_thread_store import ManagedThreadStore
+from codex_autorunner.core.orchestration import OrchestrationBindingStore
+from codex_autorunner.surfaces.web.services.repo_worktree_read_models import (
+    RepoWorktreeReadModelService,
+)
+
+
+def test_scoped_chats_repairs_legacy_worktree_rows(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    worktree_root = hub_root / "worktrees" / "base--feature"
+    worktree_root.mkdir(parents=True)
+    thread_store = ManagedThreadStore(hub_root)
+    thread = thread_store.create_thread(
+        "codex",
+        worktree_root,
+        repo_id="base--feature",
+        resource_kind="repo",
+        resource_id="base--feature",
+        name="discord:channel-1",
+    )
+    thread_id = str(thread["managed_thread_id"])
+    OrchestrationBindingStore(hub_root).upsert_binding(
+        surface_kind="discord",
+        surface_key="channel-1",
+        thread_target_id=thread_id,
+        agent_id="codex",
+        repo_id="base--feature",
+        resource_kind="repo",
+        resource_id="base--feature",
+        mode="repo",
+    )
+    snapshot = SimpleNamespace(
+        id="base--feature",
+        kind="worktree",
+        worktree_of="base",
+        path=worktree_root,
+    )
+    context = SimpleNamespace(
+        config=SimpleNamespace(root=hub_root),
+        supervisor=SimpleNamespace(list_repos=lambda use_cache=True: [snapshot]),
+    )
+    service = RepoWorktreeReadModelService(
+        context,
+        mount_manager=SimpleNamespace(),
+        enricher=SimpleNamespace(),
+    )
+
+    chats = service._scoped_chats(
+        owner_kind="worktree",
+        owner_id="base--feature",
+        limit=10,
+    )
+
+    assert [chat["thread_target_id"] for chat in chats] == [thread_id]
+    assert chats[0]["resource_kind"] == "worktree"
+    assert chats[0]["resource_id"] == "base--feature"


### PR DESCRIPTION
## Summary

Fixes worktree chat visibility by preserving CAR workspace ownership when Discord binds or resumes a manifest worktree.

## Root Cause

Discord workspace binding resolution collapsed every manifest entry to `resource_kind=repo`, even when the manifest entry was a worktree. The worktree detail read model correctly queried `orch_thread_targets` by `resource_kind=worktree`, so Discord-backed worktree chats existed in durable orchestration state but were invisible on the worktree page.

## Changes

- Resolve Discord manifest entries through the shared workspace scope model so worktrees persist as `resource_kind=worktree` with the correct parent repo.
- Add topology-based repair of legacy repo-shaped chat rows before worktree chat projection reads.
- Add regression coverage for Discord worktree binding resolution and legacy row repair.

## Validation

- Pre-commit aggregate lane passed:
  - Black, Ruff, import boundaries, hub interface contracts, migration docs sync
  - mypy strict over `src/codex_autorunner`
  - Python test suite: `9205 passed`
  - Web UI lab fast scenarios: `27 passed`
  - Svelte check, Web Hub build, Vitest: `779 passed`
- Targeted checks also passed:
  - `.venv/bin/python -m pytest tests/surfaces/web/test_repo_worktree_read_models.py tests/adapters/discord/test_state_store.py -q`
  - `.venv/bin/python -m pytest tests/surfaces/web/test_hub_chat_read_model_routes.py tests/surfaces/web/test_hub_channel_directory_routes.py -q`
