### PR TITLE
[codex] Speed up automations workspace load

### DIFF
--- a/src/codex_autorunner/core/automation/product.py
+++ b/src/codex_autorunner/core/automation/product.py
@@ -213,7 +213,7 @@ def automation_store(hub_root: Path) -> AutomationStore:
 def automation_overview(store: AutomationStore, *, limit: int = 100) -> dict[str, Any]:
     take = max(1, min(int(limit or 100), 500))
     rules = store.list_rules()[:take]
-    rows = [automation_row(store, rule) for rule in rules]
+    rows = automation_rows(store, rules, recent_job_limit=25)
     summary = {
         "total": len(rows),
         "active": sum(1 for row in rows if row["enabled"]),
@@ -227,6 +227,29 @@ def automation_overview(store: AutomationStore, *, limit: int = 100) -> dict[str
     return {"automations": rows, "summary": summary, "presets": automation_presets()}
 
 
+def automation_rows(
+    store: AutomationStore,
+    rules: list[AutomationRule],
+    *,
+    recent_job_limit: int = 25,
+) -> list[dict[str, Any]]:
+    rule_ids = [rule.rule_id for rule in rules]
+    schedules_by_rule = store.schedules_by_rule(rule_ids)
+    recent_jobs_by_rule = store.recent_jobs_by_rule(
+        rule_ids, per_rule_limit=recent_job_limit
+    )
+    job_counts_by_rule = store.job_counts_by_rule(rule_ids)
+    return [
+        _automation_row_from_enrichment(
+            rule,
+            schedules=schedules_by_rule.get(rule.rule_id, []),
+            recent_jobs=recent_jobs_by_rule.get(rule.rule_id, []),
+            job_count=job_counts_by_rule.get(rule.rule_id, 0),
+        )
+        for rule in rules
+    ]
+
+
 def automation_presets() -> list[dict[str, Any]]:
     return [
         descriptor.to_dict() for descriptor in AUTOMATION_PRESET_DESCRIPTORS.values()
@@ -236,8 +259,20 @@ def automation_presets() -> list[dict[str, Any]]:
 def automation_row(store: AutomationStore, rule: AutomationRule) -> dict[str, Any]:
     schedules = store.list_schedules(rule_id=rule.rule_id)
     recent_jobs = store.list_jobs(rule_id=rule.rule_id, limit=25, order="newest")
-    last_job = recent_jobs[0] if recent_jobs else None
     job_count = store.count_jobs(rule_id=rule.rule_id)
+    return _automation_row_from_enrichment(
+        rule, schedules=schedules, recent_jobs=recent_jobs, job_count=job_count
+    )
+
+
+def _automation_row_from_enrichment(
+    rule: AutomationRule,
+    *,
+    schedules: list[AutomationSchedule],
+    recent_jobs: list[AutomationJob],
+    job_count: int,
+) -> dict[str, Any]:
+    last_job = recent_jobs[0] if recent_jobs else None
     schedule = schedules[0] if schedules else None
     typed = _typed_product_projection(rule, schedule)
     return {

--- a/src/codex_autorunner/core/automation/store.py
+++ b/src/codex_autorunner/core/automation/store.py
@@ -298,6 +298,43 @@ class AutomationStore:
             ).fetchall()
         return [self._row_to_job(row) for row in rows]
 
+    def recent_jobs_by_rule(
+        self, rule_ids: list[str], *, per_rule_limit: int = 25
+    ) -> dict[str, list[AutomationJob]]:
+        normalized_rule_ids = [
+            rule_id for rule_id in dict.fromkeys(rule_ids) if rule_id
+        ]
+        if not normalized_rule_ids:
+            return {}
+        bounded_limit = max(0, min(int(per_rule_limit), 100))
+        if bounded_limit == 0:
+            return {rule_id: [] for rule_id in normalized_rule_ids}
+        placeholders = ",".join("?" for _ in normalized_rule_ids)
+        with open_orchestration_sqlite(self._hub_root, durable=self._durable) as conn:
+            rows = conn.execute(
+                f"""
+                SELECT *
+                  FROM (
+                    SELECT jobs.*,
+                           ROW_NUMBER() OVER (
+                             PARTITION BY rule_id
+                             ORDER BY updated_at DESC, available_at DESC, job_id DESC
+                           ) AS row_number
+                      FROM orch_automation_jobs AS jobs
+                     WHERE rule_id IN ({placeholders})
+                  )
+                 WHERE row_number <= ?
+                 ORDER BY rule_id ASC, updated_at DESC, available_at DESC, job_id DESC
+                """,
+                (*normalized_rule_ids, bounded_limit),
+            ).fetchall()
+        grouped: dict[str, list[AutomationJob]] = {
+            rule_id: [] for rule_id in normalized_rule_ids
+        }
+        for row in rows:
+            grouped.setdefault(str(row["rule_id"]), []).append(self._row_to_job(row))
+        return grouped
+
     def count_jobs(
         self, *, state: Optional[str] = None, rule_id: Optional[str] = None
     ) -> int:
@@ -316,6 +353,27 @@ class AutomationStore:
                 tuple(params),
             ).fetchone()
         return int(row["count"] if row is not None else 0)
+
+    def job_counts_by_rule(self, rule_ids: list[str]) -> dict[str, int]:
+        normalized_rule_ids = [
+            rule_id for rule_id in dict.fromkeys(rule_ids) if rule_id
+        ]
+        if not normalized_rule_ids:
+            return {}
+        placeholders = ",".join("?" for _ in normalized_rule_ids)
+        with open_orchestration_sqlite(self._hub_root, durable=self._durable) as conn:
+            rows = conn.execute(
+                f"""
+                SELECT rule_id, COUNT(*) AS count
+                  FROM orch_automation_jobs
+                 WHERE rule_id IN ({placeholders})
+                 GROUP BY rule_id
+                """,
+                tuple(normalized_rule_ids),
+            ).fetchall()
+        counts = {rule_id: 0 for rule_id in normalized_rule_ids}
+        counts.update({str(row["rule_id"]): int(row["count"]) for row in rows})
+        return counts
 
     def claim_next_job(
         self, *, lock_key: Optional[str] = None, now: Optional[str] = None
@@ -685,6 +743,34 @@ class AutomationStore:
                 tuple(params),
             ).fetchall()
         return [self._row_to_schedule(row) for row in rows]
+
+    def schedules_by_rule(
+        self, rule_ids: list[str]
+    ) -> dict[str, list[AutomationSchedule]]:
+        normalized_rule_ids = [
+            rule_id for rule_id in dict.fromkeys(rule_ids) if rule_id
+        ]
+        if not normalized_rule_ids:
+            return {}
+        placeholders = ",".join("?" for _ in normalized_rule_ids)
+        with open_orchestration_sqlite(self._hub_root, durable=self._durable) as conn:
+            rows = conn.execute(
+                f"""
+                SELECT *
+                  FROM orch_automation_schedules
+                 WHERE rule_id IN ({placeholders})
+                 ORDER BY rule_id ASC, next_fire_at ASC, created_at ASC
+                """,
+                tuple(normalized_rule_ids),
+            ).fetchall()
+        grouped: dict[str, list[AutomationSchedule]] = {
+            rule_id: [] for rule_id in normalized_rule_ids
+        }
+        for row in rows:
+            grouped.setdefault(str(row["rule_id"]), []).append(
+                self._row_to_schedule(row)
+            )
+        return grouped
 
     def list_due_schedules(
         self, *, now: Optional[str] = None, limit: int = 100

--- a/src/codex_autorunner/surfaces/web/routes/automations.py
+++ b/src/codex_autorunner/surfaces/web/routes/automations.py
@@ -18,7 +18,10 @@ from ....core.automation.product import (
 from ....core.automation.product import (
     set_automation_enabled as set_automation_enabled_core,
 )
+from ....core.time_utils import now_iso
 from ..app_state import HubAppContext
+
+AUTOMATION_WORKSPACE_ROUTE = "/hub/read-models/automations/workspace"
 
 
 class AutomationCreateRequest(BaseModel):
@@ -65,16 +68,26 @@ class AutomationUpdatePayload(BaseModel):
 
 
 def build_automation_routes(context: HubAppContext) -> APIRouter:
-    router = APIRouter(prefix="/hub/automations", tags=["hub-automations"])
+    router = APIRouter(tags=["hub-automations"])
 
     def store() -> AutomationStore:
         return AutomationStore(context.config.root)
 
-    @router.get("")
+    @router.get(AUTOMATION_WORKSPACE_ROUTE)
+    async def automation_workspace(limit: int = 100) -> dict[str, Any]:
+        overview = automation_overview(store(), limit=limit)
+        return {
+            **overview,
+            "target_options": _automation_target_options(context),
+            "agent_defaults": _automation_agent_defaults(context),
+            "generated_at": now_iso(),
+        }
+
+    @router.get("/hub/automations")
     async def list_automations(limit: int = 100) -> dict[str, Any]:
         return automation_overview(store(), limit=limit)
 
-    @router.get("/{rule_id}")
+    @router.get("/hub/automations/{rule_id}")
     async def get_automation(rule_id: str) -> dict[str, Any]:
         try:
             return {"automation": automation_detail(store(), rule_id)}
@@ -83,7 +96,7 @@ def build_automation_routes(context: HubAppContext) -> APIRouter:
                 status_code=404, detail=f"Automation not found: {rule_id}"
             ) from exc
 
-    @router.post("")
+    @router.post("/hub/automations")
     async def create_automation(payload: AutomationCreateRequest) -> dict[str, Any]:
         try:
             created = create_preset_automation(
@@ -109,7 +122,7 @@ def build_automation_routes(context: HubAppContext) -> APIRouter:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         return {"automation": created}
 
-    @router.patch("/{rule_id}")
+    @router.patch("/hub/automations/{rule_id}")
     async def update_automation_route(
         rule_id: str, payload: AutomationUpdatePayload
     ) -> dict[str, Any]:
@@ -141,7 +154,7 @@ def build_automation_routes(context: HubAppContext) -> APIRouter:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         return {"automation": updated}
 
-    @router.post("/{rule_id}/run")
+    @router.post("/hub/automations/{rule_id}/run")
     async def run_automation(rule_id: str) -> dict[str, Any]:
         try:
             return run_automation_now(
@@ -152,7 +165,7 @@ def build_automation_routes(context: HubAppContext) -> APIRouter:
                 status_code=404, detail=f"Automation not found: {rule_id}"
             ) from exc
 
-    @router.post("/{rule_id}/enabled")
+    @router.post("/hub/automations/{rule_id}/enabled")
     async def set_automation_enabled(
         rule_id: str, payload: AutomationEnabledRequest
     ) -> dict[str, Any]:
@@ -170,4 +183,38 @@ def build_automation_routes(context: HubAppContext) -> APIRouter:
     return router
 
 
-__all__ = ["build_automation_routes"]
+def _automation_target_options(context: HubAppContext) -> list[dict[str, Any]]:
+    options: list[dict[str, Any]] = []
+    for snapshot in context.supervisor.list_repos(use_cache=True):
+        repo_id = str(getattr(snapshot, "id", "") or "").strip()
+        if not repo_id:
+            continue
+        kind = "worktree" if getattr(snapshot, "kind", None) == "worktree" else "repo"
+        label = str(
+            getattr(snapshot, "display_name", None)
+            or getattr(snapshot, "branch", None)
+            or repo_id
+        )
+        disabled = not bool(getattr(snapshot, "exists_on_disk", True)) or not bool(
+            getattr(snapshot, "initialized", True)
+        )
+        option: dict[str, Any] = {"id": repo_id, "label": label, "kind": kind}
+        if disabled:
+            option["disabled"] = True
+        options.append(option)
+    return sorted(options, key=lambda item: (item["kind"] == "worktree", item["label"]))
+
+
+def _automation_agent_defaults(context: HubAppContext) -> dict[str, Any]:
+    raw_config = getattr(context.config, "raw", {})
+    pma_config = raw_config.get("pma", {}) if isinstance(raw_config, dict) else {}
+    defaults = pma_config if isinstance(pma_config, dict) else {}
+    return {
+        "default_agent": str(defaults.get("default_agent") or "codex"),
+        "default_profile": defaults.get("profile") or None,
+        "default_model": defaults.get("model") or None,
+        "default_reasoning": defaults.get("reasoning") or None,
+    }
+
+
+__all__ = ["AUTOMATION_WORKSPACE_ROUTE", "build_automation_routes"]

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.ts
@@ -263,6 +263,28 @@ export type AutomationOverview = {
   };
 };
 
+export type AutomationTargetOption = {
+  id: string;
+  label: string;
+  kind: 'repo' | 'worktree';
+  disabled: boolean;
+  raw: JsonRecord;
+};
+
+export type AutomationAgentDefaults = {
+  defaultAgent: string;
+  defaultProfile: string | null;
+  defaultModel: string | null;
+  defaultReasoning: string | null;
+  raw: JsonRecord;
+};
+
+export type AutomationWorkspace = AutomationOverview & {
+  targetOptions: AutomationTargetOption[];
+  agentDefaults: AutomationAgentDefaults;
+  generatedAt: string | null;
+};
+
 export type AutomationCreateRequest = {
   preset: 'security_scan_pr' | 'weekly_ticket_flow';
   name?: string | null;
@@ -654,6 +676,8 @@ export class WebApiClient {
         await this.getJson<JsonRecord>('/hub/messages?sections=inbox,managed_threads,pma_files_detail,automation,action_queue,freshness'),
         mapDashboardSummary
       ),
+    getAutomationWorkspace: async (): Promise<ApiResult<AutomationWorkspace>> =>
+      mapResult(await this.getJson<JsonRecord>('/hub/read-models/automations/workspace'), mapAutomationWorkspace),
     listAutomations: async (): Promise<ApiResult<AutomationOverview>> =>
       mapResult(await this.getJson<JsonRecord>('/hub/automations'), mapAutomationOverview),
     getAutomation: async (ruleId: string): Promise<ApiResult<AutomationSummary>> =>
@@ -1057,6 +1081,36 @@ function mapAutomationOverview(raw: JsonRecord): AutomationOverview {
       paused: numberValue(summary.paused, 0),
       failedJobs: numberValue(summary.failed_jobs ?? summary.failedJobs, 0)
     }
+  };
+}
+
+function mapAutomationWorkspace(raw: JsonRecord): AutomationWorkspace {
+  return {
+    ...mapAutomationOverview(raw),
+    targetOptions: asArray(raw.target_options ?? raw.targetOptions).map(mapAutomationTargetOption),
+    agentDefaults: mapAutomationAgentDefaults(asRecord(raw.agent_defaults ?? raw.agentDefaults)),
+    generatedAt: nullableString(raw.generated_at ?? raw.generatedAt)
+  };
+}
+
+function mapAutomationTargetOption(raw: JsonRecord): AutomationTargetOption {
+  const rawKind = stringValue(raw.kind, 'repo');
+  return {
+    id: stringValue(raw.id, ''),
+    label: stringValue(raw.label, stringValue(raw.id, '')),
+    kind: rawKind === 'worktree' ? 'worktree' : 'repo',
+    disabled: Boolean(raw.disabled),
+    raw
+  };
+}
+
+function mapAutomationAgentDefaults(raw: JsonRecord): AutomationAgentDefaults {
+  return {
+    defaultAgent: stringValue(raw.default_agent ?? raw.defaultAgent, ''),
+    defaultProfile: nullableString(raw.default_profile ?? raw.defaultProfile),
+    defaultModel: nullableString(raw.default_model ?? raw.defaultModel),
+    defaultReasoning: nullableString(raw.default_reasoning ?? raw.defaultReasoning),
+    raw
   };
 }
 

--- a/src/codex_autorunner/web_frontend/src/routes/automations/[[ruleId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/automations/[[ruleId]]/+page.svelte
@@ -72,6 +72,7 @@
   const userAutomations = $derived(automations.filter((automation) => !isManagedAutomation(automation)));
   const managedAutomations = $derived(automations.filter(isManagedAutomation));
   const routeRuleId = $derived(decodeURIComponent(page.params.ruleId ?? ''));
+  const presetTargetOptions = $derived(targetOptions.filter((option) => option.kind === 'repo'));
   const selectedRepo = $derived(targetOptions.find((repo) => repo.id === selectedRepoId) ?? null);
   const scheduleTimeValue = $derived(`${pad(detailHour)}:${pad(detailMinute)}`);
 
@@ -90,7 +91,7 @@
       overview = automationResult.data;
       targetOptions = automationResult.data.targetOptions;
       if (!selectedRepoId) {
-        selectedRepoId = targetOptions.find((option) => !option.disabled)?.id ?? targetOptions[0]?.id ?? '';
+        selectedRepoId = presetTargetOptions.find((option) => !option.disabled)?.id ?? presetTargetOptions[0]?.id ?? '';
       }
       defaultAgentId = automationResult.data.agentDefaults.defaultAgent;
       defaultProfile = automationResult.data.agentDefaults.defaultProfile ?? '';
@@ -993,7 +994,7 @@
             <label class="field">
               <span>Repo</span>
               <select bind:value={selectedRepoId}>
-                {#each targetOptions as repo}
+                {#each presetTargetOptions as repo}
                   <option value={repo.id} disabled={repo.disabled}>{repo.label || repo.id}</option>
                 {/each}
               </select>

--- a/src/codex_autorunner/web_frontend/src/routes/automations/[[ruleId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/automations/[[ruleId]]/+page.svelte
@@ -15,10 +15,10 @@
     type AutomationOverview,
     type AutomationPresetDescriptor,
     type AutomationSummary,
+    type AutomationTargetOption,
     type AutomationUpdateRequest,
     type JsonRecord
   } from '$lib/api/client';
-  import type { RepoSummary } from '$lib/viewModels/domain';
   import { resolveAgentModelSelection } from '$lib/viewModels/modelPickers';
 
   type PresetId = 'security_scan_pr' | 'weekly_ticket_flow';
@@ -27,10 +27,11 @@
   type TicketPackTicket = { path: string; content: string };
 
   let overview = $state<AutomationOverview | null>(null);
-  let repos = $state<RepoSummary[]>([]);
+  let targetOptions = $state<AutomationTargetOption[]>([]);
   let agents = $state<JsonRecord[]>([]);
   let models = $state<JsonRecord[]>([]);
   let loading = $state(true);
+  let loadingAgents = $state(false);
   let loadingModels = $state(false);
   let saving = $state(false);
   let actionId = $state<string | null>(null);
@@ -48,6 +49,7 @@
   let selectedProfile = $state('');
   let selectedModel = $state('');
   let selectedReasoning = $state('');
+  let agentCatalogError = $state<string | null>(null);
   let modelCatalogError = $state<string | null>(null);
   let timezone = $state(Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC');
   let detailName = $state('');
@@ -70,7 +72,7 @@
   const userAutomations = $derived(automations.filter((automation) => !isManagedAutomation(automation)));
   const managedAutomations = $derived(automations.filter(isManagedAutomation));
   const routeRuleId = $derived(decodeURIComponent(page.params.ruleId ?? ''));
-  const selectedRepo = $derived(repos.find((repo) => repo.id === selectedRepoId) ?? null);
+  const selectedRepo = $derived(targetOptions.find((repo) => repo.id === selectedRepoId) ?? null);
   const scheduleTimeValue = $derived(`${pad(detailHour)}:${pad(detailMinute)}`);
 
   onMount(() => {
@@ -83,24 +85,37 @@
   async function load(): Promise<void> {
     loading = true;
     error = null;
-    const [automationResult, repoResult, agentResult] = await Promise.all([
-      webApi.hub.listAutomations(),
-      webApi.hub.listRepos(),
-      webApi.pma.listAgents()
-    ]);
-    if (automationResult.ok) overview = automationResult.data;
-    else error = automationResult.error;
-    if (repoResult.ok) {
-      repos = repoResult.data;
-      if (!selectedRepoId && repos[0]) selectedRepoId = repos[0].id;
+    const automationResult = await webApi.hub.getAutomationWorkspace();
+    if (automationResult.ok) {
+      overview = automationResult.data;
+      targetOptions = automationResult.data.targetOptions;
+      if (!selectedRepoId) {
+        selectedRepoId = targetOptions.find((option) => !option.disabled)?.id ?? targetOptions[0]?.id ?? '';
+      }
+      defaultAgentId = automationResult.data.agentDefaults.defaultAgent;
+      defaultProfile = automationResult.data.agentDefaults.defaultProfile ?? '';
+      selectedModel = selectedModel || automationResult.data.agentDefaults.defaultModel || '';
+      selectedReasoning = selectedReasoning || automationResult.data.agentDefaults.defaultReasoning || '';
     }
+    else error = automationResult.error;
+    loading = false;
+    syncDraftsForSelection(true);
+    void hydrateAgentCatalog();
+  }
+
+  async function hydrateAgentCatalog(): Promise<void> {
+    loadingAgents = true;
+    agentCatalogError = null;
+    const agentResult = await webApi.pma.listAgents();
+    loadingAgents = false;
     if (agentResult.ok) {
       agents = agentResult.data.agents;
       defaultAgentId = agentResult.data.default;
       defaultProfile = String(agentResult.data.defaults.profile ?? '');
+      syncDraftsForSelection(true);
+    } else {
+      agentCatalogError = agentResult.error.message;
     }
-    loading = false;
-    syncDraftsForSelection(true);
   }
 
   // The URL is the source of truth for which automation is open. Presets have no
@@ -417,7 +432,7 @@
     return [
       `I want to create an automation based on the ${preset.name} preset.`,
       '',
-      `Repo: ${(selectedRepo?.name ?? selectedRepoId) || '(choose repo)'}`,
+      `Repo: ${(selectedRepo?.label ?? selectedRepoId) || '(choose repo)'}`,
       ...agentLines,
       `Schedule: ${preset.schedule.kind} at ${pad(detailHour)}:${pad(detailMinute)} ${timezone}`,
       '',
@@ -441,11 +456,11 @@
   }
 
   function targetLabel(automation: AutomationSummary | null): string {
-    if (!automation) return selectedRepo?.name || selectedRepoId || 'Hub';
+    if (!automation) return selectedRepo?.label || selectedRepoId || 'Hub';
     const repoId = String(automation.product.targetSummary.repo_id ?? automation.product.targetSummary.base_repo_id ?? automation.target.repo_id ?? automation.target.base_repo_id ?? '');
     if (repoId) {
-      const repo = repos.find((entry) => entry.id === repoId);
-      return repo?.name || repoId;
+      const repo = targetOptions.find((entry) => entry.id === repoId);
+      return repo?.label || repoId;
     }
     return String(automation.product.targetSummary.label ?? automation.target.worktree_id ?? 'Hub');
   }
@@ -978,8 +993,8 @@
             <label class="field">
               <span>Repo</span>
               <select bind:value={selectedRepoId}>
-                {#each repos as repo}
-                  <option value={repo.id}>{repo.name || repo.id}</option>
+                {#each targetOptions as repo}
+                  <option value={repo.id} disabled={repo.disabled}>{repo.label || repo.id}</option>
                 {/each}
               </select>
             </label>
@@ -1031,15 +1046,21 @@
 
         {#if selectedExecutorKind() === 'pma_turn' && canEditPrompt()}
           <div class="agent-picker-row">
+            {#if loadingAgents}
+              <p class="detail-hint">Loading agent controls…</p>
+            {:else if agentCatalogError}
+              <p class="detail-hint error-text">{agentCatalogError}</p>
+            {/if}
             <AgentModelReasoningPicker
               {agents}
+              fallbackAgentIds={defaultAgentId ? [defaultAgentId] : []}
               bind:agentValue={selectedAgent}
               bind:profileValue={selectedProfile}
               bind:modelValue={selectedModel}
               bind:reasoningValue={selectedReasoning}
               {models}
-              loading={loadingModels}
-              {modelCatalogError}
+              loading={loadingAgents || loadingModels}
+              modelCatalogError={agentCatalogError ?? modelCatalogError}
               variant="ticket"
               allowEmptyModelOption={true}
               unsetModelLabel="Default model"

--- a/src/codex_autorunner/web_frontend/src/routes/automations/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/automations/page.test.ts
@@ -50,6 +50,8 @@ describe('/automations page', () => {
 
     expect(source).toContain('webApi.hub.getAutomationWorkspace()');
     expect(source).toContain('targetOptions = automationResult.data.targetOptions');
+    expect(source).toContain("const presetTargetOptions = $derived(targetOptions.filter((option) => option.kind === 'repo'))");
+    expect(source).toContain('{#each presetTargetOptions as repo}');
     expect(source).toContain('void hydrateAgentCatalog()');
     expect(source).toContain('Loading agent controls');
     expect(source).not.toContain('webApi.hub.listRepos()');

--- a/src/codex_autorunner/web_frontend/src/routes/automations/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/automations/page.test.ts
@@ -44,4 +44,15 @@ describe('/automations page', () => {
     expect(source).toContain('preset.ticketBodyTemplate ? renderPresetTemplate(preset.ticketBodyTemplate, selectedRepoId) :');
     expect(source).not.toContain('const PRESETS');
   });
+
+  it('loads the workspace read model before hydrating repo and agent controls', () => {
+    const source = pageSource();
+
+    expect(source).toContain('webApi.hub.getAutomationWorkspace()');
+    expect(source).toContain('targetOptions = automationResult.data.targetOptions');
+    expect(source).toContain('void hydrateAgentCatalog()');
+    expect(source).toContain('Loading agent controls');
+    expect(source).not.toContain('webApi.hub.listRepos()');
+    expect(source).not.toContain('Promise.all([');
+  });
 });

--- a/tests/surfaces/web/test_hub_automation_routes.py
+++ b/tests/surfaces/web/test_hub_automation_routes.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from fastapi.testclient import TestClient
 
 from codex_autorunner.bootstrap import seed_hub_files
@@ -9,12 +11,16 @@ from codex_autorunner.core.automation import (
 from codex_autorunner.core.automation.models import (
     EXECUTOR_PMA_TURN,
     EXECUTOR_PUBLISH_OPERATION,
+    JOB_FAILED,
+    JOB_SUCCEEDED,
     SCHEDULE_ONE_SHOT,
     TARGET_POLICY_HUB,
     TRIGGER_KIND_EVENT,
     TRIGGER_KIND_SCHEDULE,
 )
+from codex_autorunner.core.automation.product import automation_overview
 from codex_autorunner.server import create_hub_app
+from codex_autorunner.surfaces.web.routes.automations import _automation_target_options
 
 
 def test_hub_automations_create_security_scan_saved_disabled(tmp_path):
@@ -141,6 +147,130 @@ def test_hub_automations_create_weekly_ticket_flow_and_run_now(tmp_path):
     assert weekly_preset["executor_kind"] == "ticket_flow"
     assert weekly_preset["target_policy"] == "new_automation_worktree"
     assert "{ticket_id}" in weekly_preset["ticket_body_template"]
+
+
+def test_hub_automation_workspace_batches_jobs_and_target_options(
+    tmp_path, monkeypatch
+):
+    hub_root = tmp_path / "hub"
+    seed_hub_files(hub_root, force=True)
+    store = AutomationStore(hub_root)
+    rule_ids: list[str] = []
+    for index in range(2):
+        rule = store.upsert_rule(
+            AutomationRule.create(
+                rule_id=f"rule-{index}",
+                name=f"Rule {index}",
+                enabled=index == 0,
+                trigger_kind=TRIGGER_KIND_SCHEDULE,
+                trigger={"event_types": ["schedule.fire"]},
+                target_policy=TARGET_POLICY_HUB,
+                target={"repo_id": f"repo-{index}"},
+                executor_kind=EXECUTOR_PMA_TURN,
+                executor={"message": f"Run rule {index}"},
+            )
+        )
+        rule_ids.append(rule.rule_id)
+        store.upsert_schedule(
+            AutomationSchedule.create(
+                schedule_id=f"schedule-{index}",
+                rule_id=rule.rule_id,
+                schedule_kind="daily",
+                next_fire_at=f"2026-01-0{index + 1}T00:00:00Z",
+                schedule={"hour": index, "minute": 0},
+            )
+        )
+        event = store.create_event(
+            event_id=f"event-{index}",
+            event_type="schedule.fire",
+            source="test",
+            target={"rule_id": rule.rule_id},
+            payload={},
+        )
+        job_total = 30 if index == 0 else 3
+        for job_index in range(job_total):
+            store.create_job(
+                job_id=f"job-{index}-{job_index:02d}",
+                rule_id=rule.rule_id,
+                event_id=event.event_id,
+                state=(
+                    JOB_FAILED
+                    if index == 0 and job_index == job_total - 1
+                    else JOB_SUCCEEDED
+                ),
+                dedupe_key=f"dedupe-{index}-{job_index}",
+                target=rule.target,
+                executor=rule.executor,
+                created_at=f"2026-01-01T00:{job_index:02d}:00Z",
+            )
+
+    def fail_per_rule_query(*args, **kwargs):
+        raise AssertionError("per-rule automation overview query was called")
+
+    monkeypatch.setattr(store, "list_schedules", fail_per_rule_query)
+    monkeypatch.setattr(store, "list_jobs", fail_per_rule_query)
+    monkeypatch.setattr(store, "count_jobs", fail_per_rule_query)
+
+    overview = automation_overview(store)
+
+    rows = {row["id"]: row for row in overview["automations"]}
+    assert overview["summary"] == {
+        "total": 2,
+        "active": 1,
+        "paused": 1,
+        "failed_jobs": 1,
+    }
+    assert rows["rule-0"]["job_count"] == 30
+    assert rows["rule-1"]["job_count"] == 3
+    assert len(rows["rule-0"]["jobs"]) == 25
+    assert rows["rule-0"]["last_job"]["state"] == "failed"
+    assert rows["rule-1"]["schedule"]["schedule_id"] == "schedule-1"
+
+    client = TestClient(create_hub_app(hub_root))
+    response = client.get("/hub/read-models/automations/workspace")
+
+    assert response.status_code == 200
+    workspace = response.json()
+    assert workspace["summary"]["failed_jobs"] == 1
+    assert len(workspace["automations"][0]["jobs"]) <= 25
+    assert set(workspace["agent_defaults"]) == {
+        "default_agent",
+        "default_profile",
+        "default_model",
+        "default_reasoning",
+    }
+    assert workspace["generated_at"]
+
+    context = SimpleNamespace(
+        supervisor=SimpleNamespace(
+            list_repos=lambda use_cache=True: [
+                SimpleNamespace(
+                    id="repo-1",
+                    display_name="Repo One",
+                    kind="repo",
+                    exists_on_disk=True,
+                    initialized=True,
+                ),
+                SimpleNamespace(
+                    id="repo-1--feature",
+                    display_name="Feature worktree",
+                    kind="worktree",
+                    exists_on_disk=False,
+                    initialized=True,
+                ),
+            ]
+        )
+    )
+    target_options = _automation_target_options(context)
+    assert target_options == [
+        {"id": "repo-1", "label": "Repo One", "kind": "repo"},
+        {
+            "id": "repo-1--feature",
+            "label": "Feature worktree",
+            "kind": "worktree",
+            "disabled": True,
+        },
+    ]
 
 
 def test_hub_automations_pause_and_resume(tmp_path):


### PR DESCRIPTION
## Summary

- Add a backend-owned `/hub/read-models/automations/workspace` snapshot for the automations screen.
- Batch automation schedules, latest jobs, and job counts instead of doing per-rule enrichment queries in the primary overview path.
- Update `/automations` to render from the workspace snapshot first, then hydrate agent controls independently.
- Remove the legacy `/hub/repos` first-paint dependency from the automations route.

## Root Cause

The automations page was slow because it waited for three independent calls before leaving global loading: `/hub/automations`, `/hub/pma/agents`, and legacy `/hub/repos`. The automations payload itself was fast, but `/hub/repos` can be seconds slower because it performs broad repo topology/enrichment work. The backend overview also had a future scaling issue: each automation row separately loaded schedules, latest jobs, and job counts.

## Architecture

The automations screen now has a screen-shaped workspace read model with automations, summary counters, presets, lightweight target options, agent defaults, and a generation timestamp. The frontend uses that snapshot for first paint and treats agent/model catalog loading as local control hydration rather than a page-level blocker.

## Timing Evidence

Live hub before reload/current old endpoints:

- `/hub/automations`: HTTP 200, `total=0.093257`, size 99,703 bytes.
- `/hub/repos`: HTTP 200, `total=21.610828`, size 241,464 bytes.

Current-code in-process TestClient against the hub root:

- `/hub/read-models/automations/workspace`: HTTP 200, `total=0.029520`, size 106,418 bytes.
- `/hub/automations`: HTTP 200, `total=0.022683`, size 99,703 bytes.

The running hub had not reloaded this branch yet, so the new route returned 404 from the already-running process; the TestClient measurement exercises the current code directly.

## Validation

Targeted checks run manually:

- `.venv/bin/python -m pytest tests/surfaces/web/test_hub_automation_routes.py` passed: 10 passed.
- `pnpm web:test -- automations` passed: 1 file, 4 tests.
- `pnpm web:lint` passed: 0 Svelte errors/warnings.

Pre-commit selected lane also passed:

- black check.
- ruff.
- import boundaries.
- hub interface contracts.
- destination contract drift.
- keyword contracts.
- migration observability sync.
- mypy over `src/codex_autorunner`.
- broad pytest: 9,204 passed.
- Web UI lab fast scenarios: 27 passed.
- Web lint.
- Web build.
- full Web frontend tests: 780 passed, 2 skipped.
- Web Hub SPA shell check.

## Review Notes

I reviewed the staged implementation before publishing and did not find a blocking issue. Remaining operational note: the live hub needs to reload before the new endpoint can be timed via the running server process.
