### PR TITLE
[codex] Fix chat deep-link activation race

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.test.ts
@@ -4,6 +4,7 @@ import type { PmaChatSummary } from '$lib/viewModels/domain';
 import type { ChatListEntry } from '$lib/viewModels/pmaChat';
 import {
   activateChatDetailFromUrl,
+  activateRequestedChatFromRows,
   clearCommittedDraftPlaceholderIfPersisted,
   commitLocalDraftChat,
   initialChatDetailSessionState,
@@ -51,6 +52,24 @@ describe('chat detail session', () => {
     expect(command.state.loadingActive).toBe(false);
     expect(command.state.activeError).toBe(error);
     expect(command.refresh).toBeNull();
+  });
+
+  it('does not replace a deep-linked chat with the first loaded row while the requested row is absent', () => {
+    const state = {
+      ...initialChatDetailSessionState(),
+      activeChatId: 'deep-linked-chat',
+      detailMode: 'detail' as const
+    };
+
+    const command = activateRequestedChatFromRows(state, {
+      loadedChats: [chat({ id: 'visible-chat' })],
+      requestedChatId: 'deep-linked-chat',
+      hasCachedDetail: () => false
+    });
+
+    expect(command.state.activeChatId).toBe('deep-linked-chat');
+    expect(command.refresh).toBeNull();
+    expect(command.syncUrl).toBe(false);
   });
 
   it('chooses a sibling replacement when the active chat is archived out of the active window', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.ts
@@ -189,6 +189,9 @@ export function activateRequestedChatFromRows(
   input: ChatDetailRequestedRowsInput
 ): ChatDetailSelectionCommand {
   if (isLocalDraftChatId(state.activeChatId)) return noDetailCommand(state);
+  if (input.requestedChatId && !input.loadedChats.some((chat) => chat.id === input.requestedChatId)) {
+    return noDetailCommand(state);
+  }
   const selectedChatId = chooseActiveChatId(input.loadedChats, state.activeChatId, input.requestedChatId);
   if (!selectedChatId || state.activeChatId === selectedChatId) return noDetailCommand(state);
   const command = selectChatDetail(state, selectedChatId, {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -208,7 +208,8 @@
   );
 
   function chatSummaryForId(chatId: string | null): PmaChatSummary | null {
-    return chatSummaryForSessionId(chatId, chats, localDraftChat);
+    return chatSummaryForSessionId(chatId, chats, localDraftChat)
+      ?? (chatId ? selectPmaChats(readModelState).find((chat) => chat.id === chatId) ?? null : null);
   }
   const transcriptCards = $derived<ChatTranscriptCard[]>(selectChatTranscript(readModelState, activeChatId));
   const progress = $derived<PmaRunProgress | null>(selectPmaProgress(readModelState, activeChatId));


### PR DESCRIPTION
## Summary
- Fixes the chat detail activation race for newly created or deep-linked chats whose row is not yet in the active chat-index window.
- Keeps the requested chat selected instead of falling back to the first visible row while read models catch up.
- Lets the chat page resolve the active summary from the global read-model cache when the current window does not contain it.

## Root Cause
After creating a chat, navigation updated the URL before the committed chat row was guaranteed to appear in the current index window. The row-activation path could then select the first loaded row, leaving the detail pane without the intended chat until a later refresh or stream update repaired the state.

## Validation
- `pnpm web:lint`
- `pnpm web:test`
- Commit hook web-ui lane: guardrails, repo pytest (`9291 passed`), Web UI lab scenarios, Web UI build, Web UI tests, SPA shell route check
