### PR TITLE
[codex] Own chat transcript stream activation

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailLiveProjection.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailLiveProjection.test.ts
@@ -209,6 +209,41 @@ describe('ChatDetailLiveProjection', () => {
     expect(stream.closeCalls).toBe(1);
     expect(projection.snapshot().streamState).toBe('idle');
   });
+
+  it('replaces the owned transcript stream when activating a different chat', async () => {
+    const store = new ReadModelEntityStore();
+    const stream = streamFixture();
+    let streamEligible = true;
+    const projection = projectionFixture(store, apiFixture(), {
+      openStream: stream.open,
+      shouldUseStream: () => streamEligible
+    });
+
+    projection.connect('old-running-chat');
+    streamEligible = false;
+    await projection.activate('new-idle-chat', { quiet: true });
+
+    expect(stream.closeCalls).toBe(1);
+    expect(stream.openedChatIds).toEqual(['old-running-chat']);
+    stream.options?.onEvent({
+      kind: 'transcript_append',
+      lastEventId: 'old-1',
+      payload: { rows: [rawMessageRow('old-running-chat', 'old-row', 'assistant', 'old', 'turn-old')] }
+    });
+    expect(store.snapshot().chatTranscripts['old-running-chat']).toBeUndefined();
+  });
+
+  it('does not churn the transcript stream when reactivating the same chat', async () => {
+    const store = new ReadModelEntityStore();
+    const stream = streamFixture();
+    const projection = projectionFixture(store, apiFixture(), { openStream: stream.open });
+
+    projection.connect('same-chat');
+    await projection.activate('same-chat', { quiet: true });
+
+    expect(stream.closeCalls).toBe(0);
+    expect(stream.openedChatIds).toEqual(['same-chat']);
+  });
 });
 
 function projectionFixture(
@@ -216,11 +251,9 @@ function projectionFixture(
   api: ReturnType<typeof apiFixture>,
   overrides: Partial<ChatDetailLiveProjectionDeps> = {}
 ): ChatDetailLiveProjection {
-  const activeChatId: string | null = 'chat-1';
   return new ChatDetailLiveProjection({
     api,
     readModelStore: store,
-    getActiveChatId: () => activeChatId,
     getChatSummary: (chatId) => chatSummary(chatId),
     shouldUseStream: () => true,
     now: () => 1_768_176_123_000,
@@ -257,16 +290,20 @@ function apiFixture(options: {
 function streamFixture(): {
   options: TranscriptStreamOptions | null;
   closeCalls: number;
+  openedChatIds: string[];
   open: (chatId: string, options: TranscriptStreamOptions) => { close: () => void };
 } {
   const fixture: {
     options: TranscriptStreamOptions | null;
     closeCalls: number;
+    openedChatIds: string[];
     open: (chatId: string, options: TranscriptStreamOptions) => { close: () => void };
   } = {
     options: null,
     closeCalls: 0,
-    open(_chatId: string, options: TranscriptStreamOptions) {
+    openedChatIds: [],
+    open(chatId: string, options: TranscriptStreamOptions) {
+      fixture.openedChatIds.push(chatId);
       fixture.options = options;
       return {
         close: () => {

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailLiveProjection.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailLiveProjection.test.ts
@@ -233,6 +233,21 @@ describe('ChatDetailLiveProjection', () => {
     expect(store.snapshot().chatTranscripts['old-running-chat']).toBeUndefined();
   });
 
+  it('preserves active errors when deactivating the active chat runtime', async () => {
+    const store = new ReadModelEntityStore();
+    const stream = streamFixture();
+    const missing = missingThreadError();
+    const projection = projectionFixture(store, apiFixture(), { openStream: stream.open });
+
+    projection.connect('chat-1');
+    projection.replaceState({ activeError: missing, streamState: 'connected' });
+    await projection.activate(null);
+
+    expect(stream.closeCalls).toBe(1);
+    expect(projection.snapshot().activeError).toBe(missing);
+    expect(projection.snapshot().streamState).toBe('idle');
+  });
+
   it('does not churn the transcript stream when reactivating the same chat', async () => {
     const store = new ReadModelEntityStore();
     const stream = streamFixture();

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailLiveProjection.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailLiveProjection.ts
@@ -42,7 +42,6 @@ export type ChatDetailLiveProjectionOptions = {
 export type ChatDetailLiveProjectionDeps = {
   api: ChatDetailLiveProjectionApi;
   readModelStore: ReadModelEntityStore;
-  getActiveChatId: () => string | null;
   getChatSummary: (chatId: string) => PmaChatSummary | null;
   onStateChange?: (state: ChatDetailLiveProjectionState) => void;
   openStream?: (chatId: string, options: TranscriptStreamOptions) => StreamSubscription;
@@ -61,7 +60,6 @@ const DEFAULT_REPAIR_DELAY_MS = 900;
 export class ChatDetailLiveProjection {
   private readonly api: ChatDetailLiveProjectionApi;
   private readonly readModelStore: ReadModelEntityStore;
-  private readonly getActiveChatId: () => string | null;
   private readonly getChatSummary: (chatId: string) => PmaChatSummary | null;
   private readonly onStateChange: ((state: ChatDetailLiveProjectionState) => void) | undefined;
   private readonly openStream: (chatId: string, options: TranscriptStreamOptions) => StreamSubscription;
@@ -80,6 +78,7 @@ export class ChatDetailLiveProjection {
     streamState: 'idle',
     streamError: null
   };
+  private activeChatId: string | null = null;
   private subscription: StreamSubscription | null = null;
   private activeRefreshSeq = 0;
   private activeQueueRefreshSeq = 0;
@@ -91,7 +90,6 @@ export class ChatDetailLiveProjection {
   constructor(deps: ChatDetailLiveProjectionDeps) {
     this.api = deps.api;
     this.readModelStore = deps.readModelStore;
-    this.getActiveChatId = deps.getActiveChatId;
     this.getChatSummary = deps.getChatSummary;
     this.onStateChange = deps.onStateChange;
     this.openStream = deps.openStream ?? openChatTranscriptEventSource;
@@ -113,7 +111,32 @@ export class ChatDetailLiveProjection {
     this.setState(next);
   }
 
+  async activate(chatId: string | null, options: { quiet?: boolean } = {}): Promise<void> {
+    if (!chatId) {
+      this.close();
+      this.setState({ loadingActive: false, activeError: null });
+      return;
+    }
+    if (this.activeChatId !== chatId) {
+      this.activeRefreshSeq += 1;
+      this.activeQueueRefreshSeq += 1;
+      this.clearScheduledRefreshes();
+      this.closeStream();
+      this.activeChatId = chatId;
+      this.refreshedTerminalTurnId = null;
+    }
+    await this.refreshActive(chatId, options);
+  }
+
   async refresh(chatId: string, options: { quiet?: boolean } = {}): Promise<void> {
+    if (this.activeChatId !== chatId) {
+      await this.activate(chatId, options);
+      return;
+    }
+    await this.refreshActive(chatId, options);
+  }
+
+  private async refreshActive(chatId: string, options: { quiet?: boolean } = {}): Promise<void> {
     const refreshSeq = ++this.activeRefreshSeq;
     if (!options.quiet) this.setState({ loadingActive: true, activeError: null });
 
@@ -154,7 +177,7 @@ export class ChatDetailLiveProjection {
   async refreshQueue(chatId: string): Promise<void> {
     const refreshSeq = ++this.activeQueueRefreshSeq;
     const result = await this.api.getQueue(chatId);
-    if (this.getActiveChatId() !== chatId || refreshSeq !== this.activeQueueRefreshSeq) return;
+    if (this.activeChatId !== chatId || refreshSeq !== this.activeQueueRefreshSeq) return;
     if (result.ok) {
       this.readModelStore.setPmaQueue(chatId, result.data.queuedTurns);
     } else if (isMissingManagedThreadError(result.error)) {
@@ -163,7 +186,15 @@ export class ChatDetailLiveProjection {
   }
 
   connect(chatId: string): void {
-    this.closeStream();
+    if (this.activeChatId !== chatId) {
+      this.activeRefreshSeq += 1;
+      this.activeQueueRefreshSeq += 1;
+      this.clearScheduledRefreshes();
+      this.closeStream();
+      this.activeChatId = chatId;
+    } else {
+      this.closeStream();
+    }
     const seedProgress = this.currentProgress(chatId);
     const seedChat = this.getChatSummary(chatId);
     if (!this.shouldUseStream(seedChat, seedProgress, this.currentQueueDepth(chatId))) {
@@ -187,12 +218,15 @@ export class ChatDetailLiveProjection {
   }
 
   close(): void {
+    this.activeChatId = null;
+    this.activeRefreshSeq += 1;
+    this.activeQueueRefreshSeq += 1;
     this.clearScheduledRefreshes();
     this.closeStream();
   }
 
   private handleStreamStatus(chatId: string, status: 'connecting' | 'connected' | 'interrupted' | 'closed'): void {
-    if (this.getActiveChatId() !== chatId) return;
+    if (this.activeChatId !== chatId) return;
     if (status === 'connecting' && this.state.streamState !== 'connected') this.setState({ streamState: 'connecting' });
     if (status === 'connected') {
       this.clearPendingRepairRefresh();
@@ -202,7 +236,7 @@ export class ChatDetailLiveProjection {
   }
 
   private handleStreamEvent(chatId: string, event: ChatTranscriptStreamEvent): void {
-    if (this.getActiveChatId() !== chatId) return;
+    if (this.activeChatId !== chatId) return;
     this.clearPendingRepairRefresh();
     this.setState({ streamState: 'connected' });
     if (event.kind === 'transcript_snapshot') {
@@ -237,7 +271,7 @@ export class ChatDetailLiveProjection {
   }
 
   private handleStreamError(chatId: string): void {
-    if (this.getActiveChatId() !== chatId) return;
+    if (this.activeChatId !== chatId) return;
     if (this.currentProgress(chatId)?.streamShouldClose) {
       this.closeStream();
       return;
@@ -250,7 +284,7 @@ export class ChatDetailLiveProjection {
   }
 
   private ensureStreamAfterSnapshot(chatId: string): void {
-    if (this.getActiveChatId() !== chatId || this.subscription) return;
+    if (this.activeChatId !== chatId || this.subscription) return;
     const seedProgress = this.currentProgress(chatId);
     const seedChat = this.getChatSummary(chatId);
     if (this.shouldUseStream(seedChat, seedProgress, this.currentQueueDepth(chatId))) this.connect(chatId);
@@ -262,7 +296,7 @@ export class ChatDetailLiveProjection {
     this.pendingRefreshTimer = this.setTimer(() => {
       this.pendingRefreshTimer = null;
       this.pendingRefreshReason = null;
-      if (this.getActiveChatId() === chatId) void this.refresh(chatId, { quiet: true });
+      if (this.activeChatId === chatId) void this.refreshActive(chatId, { quiet: true });
     }, delayMs);
   }
 
@@ -270,7 +304,7 @@ export class ChatDetailLiveProjection {
     if (this.pendingQueueRefreshTimer) this.clearTimer(this.pendingQueueRefreshTimer);
     this.pendingQueueRefreshTimer = this.setTimer(() => {
       this.pendingQueueRefreshTimer = null;
-      if (this.getActiveChatId() === chatId) void this.refreshQueue(chatId);
+      if (this.activeChatId === chatId) void this.refreshQueue(chatId);
     }, delayMs);
   }
 
@@ -296,7 +330,7 @@ export class ChatDetailLiveProjection {
   }
 
   private updateProgress(nextProgress: PmaRunProgress): void {
-    const chatId = nextProgress.chatId ?? this.getActiveChatId();
+    const chatId = nextProgress.chatId ?? this.activeChatId;
     if (!chatId) return;
     this.readModelStore.setPmaProgress(
       chatId,
@@ -321,7 +355,7 @@ export class ChatDetailLiveProjection {
   }
 
   private isCurrent(chatId: string, refreshSeq: number): boolean {
-    return this.getActiveChatId() === chatId && refreshSeq === this.activeRefreshSeq;
+    return this.activeChatId === chatId && refreshSeq === this.activeRefreshSeq;
   }
 
   private setState(next: Partial<ChatDetailLiveProjectionState>): void {

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailLiveProjection.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailLiveProjection.ts
@@ -111,10 +111,19 @@ export class ChatDetailLiveProjection {
     this.setState(next);
   }
 
-  async activate(chatId: string | null, options: { quiet?: boolean } = {}): Promise<void> {
+  async activate(
+    chatId: string | null,
+    options: { quiet?: boolean; sessionActiveError?: ApiError | null } = {}
+  ): Promise<void> {
     if (!chatId) {
+      if ('sessionActiveError' in options) {
+        this.state.activeError = options.sessionActiveError ?? null;
+      }
       this.close();
-      this.setState({ loadingActive: false, activeError: null });
+      this.setState({
+        loadingActive: false,
+        ...('sessionActiveError' in options ? {} : { activeError: null })
+      });
       return;
     }
     if (this.activeChatId !== chatId) {

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailLiveProjection.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailLiveProjection.ts
@@ -111,19 +111,10 @@ export class ChatDetailLiveProjection {
     this.setState(next);
   }
 
-  async activate(
-    chatId: string | null,
-    options: { quiet?: boolean; sessionActiveError?: ApiError | null } = {}
-  ): Promise<void> {
+  async activate(chatId: string | null, options: { quiet?: boolean } = {}): Promise<void> {
     if (!chatId) {
-      if ('sessionActiveError' in options) {
-        this.state.activeError = options.sessionActiveError ?? null;
-      }
       this.close();
-      this.setState({
-        loadingActive: false,
-        ...('sessionActiveError' in options ? {} : { activeError: null })
-      });
+      this.setState({ loadingActive: false });
       return;
     }
     if (this.activeChatId !== chatId) {

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.test.ts
@@ -67,7 +67,7 @@ describe('chat detail session', () => {
     });
 
     expect(command.state.activeChatId).toBe('deep-linked-chat');
-    expect(command.refresh).toBeNull();
+    expect(command.runtime).toBeNull();
     expect(command.syncUrl).toBe(false);
   });
 

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.test.ts
@@ -35,8 +35,7 @@ describe('chat detail session', () => {
       loadingActive: true,
       activeError: null
     });
-    expect(command.refresh).toEqual({ chatId: 'deep-linked-chat', quiet: false });
-    expect(command.closeStream).toBe(true);
+    expect(command.runtime).toEqual({ chatId: 'deep-linked-chat', quiet: false });
     expect(command.markRead).toBe(false);
   });
 
@@ -51,7 +50,7 @@ describe('chat detail session', () => {
 
     expect(command.state.loadingActive).toBe(false);
     expect(command.state.activeError).toBe(error);
-    expect(command.refresh).toBeNull();
+    expect(command.runtime).toEqual({ chatId: null, quiet: true });
   });
 
   it('does not replace a deep-linked chat with the first loaded row while the requested row is absent', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.ts
@@ -35,11 +35,10 @@ export type ChatDetailSessionState = {
 
 export type ChatDetailSelectionCommand = {
   state: ChatDetailSessionState;
-  refresh: { chatId: string; quiet: boolean } | null;
+  runtime: { chatId: string | null; quiet: boolean } | null;
   syncUrl: boolean;
   markRead: boolean;
   syncSelectors: boolean;
-  closeStream: boolean;
 };
 
 export type ChatDetailActivationInput = {
@@ -117,11 +116,10 @@ export function selectChatDetail(
       loadingActive: activeError ? false : !(options.cached || loaderOwnsInitialDetail),
       activeError
     },
-    refresh: activeError ? null : { chatId, quiet: options.cached || loaderOwnsInitialDetail },
+    runtime: activeError ? { chatId: null, quiet: true } : { chatId, quiet: options.cached || loaderOwnsInitialDetail },
     syncUrl: options.syncUrl ?? false,
     markRead: true,
-    syncSelectors: true,
-    closeStream: false
+    syncSelectors: true
   };
 }
 
@@ -144,11 +142,10 @@ export function activateChatDetailFromUrl(
         loadingActive: false,
         activeError: null
       },
-      refresh: null,
+      runtime: { chatId: null, quiet: true },
       syncUrl: false,
       markRead: false,
-      syncSelectors: false,
-      closeStream: true
+      syncSelectors: false
     };
   }
   if (detailId === state.activeChatId) return noDetailCommand(state);
@@ -169,11 +166,10 @@ export function activateChatDetailFromUrl(
         loadingActive: !activeError,
         activeError
       },
-      refresh: activeError ? null : { chatId: detailId, quiet: false },
+      runtime: activeError ? { chatId: null, quiet: true } : { chatId: detailId, quiet: false },
       syncUrl: false,
       markRead: false,
-      syncSelectors: false,
-      closeStream: true
+      syncSelectors: false
     };
   }
   const loaderResult = input.activeDetailLoadResult(detailId);
@@ -409,11 +405,10 @@ export function sortEntriesForPinnedChats(entries: ChatListEntry[], pinned: Pinn
 function noDetailCommand(state: ChatDetailSessionState): ChatDetailSelectionCommand {
   return {
     state,
-    refresh: null,
+    runtime: null,
     syncUrl: false,
     markRead: false,
-    syncSelectors: false,
-    closeStream: false
+    syncSelectors: false
   };
 }
 

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -240,7 +240,6 @@
   const liveProjection = createChatDetailLiveProjection({
     api: webApi.pma,
     readModelStore: readModelEntityStore,
-    getActiveChatId: () => activeChatId,
     getChatSummary: (chatId) => chatSummaryForId(chatId),
     onStateChange: writeLiveProjectionState
   });
@@ -832,10 +831,9 @@
 
   function applyChatDetailSelectionCommand(command: ChatDetailSelectionCommand): void {
     writeChatDetailSessionState(command.state);
-    if (command.closeStream) closeStream();
     if (command.syncSelectors) syncSelectorsToActiveChat();
     if (command.markRead) markActiveChatRead();
-    if (command.refresh) void refreshActive(command.refresh.chatId, { quiet: command.refresh.quiet });
+    if (command.runtime) void liveProjection.activate(command.runtime.chatId, { quiet: command.runtime.quiet });
   }
 
   function writeLiveProjectionState(state: ChatDetailLiveProjectionState): void {
@@ -1178,10 +1176,6 @@
 
   async function refreshActive(chatId: string, options: { quiet?: boolean } = {}): Promise<void> {
     await liveProjection.refresh(chatId, options);
-  }
-
-  function connectStream(chatId: string): void {
-    liveProjection.connect(chatId);
   }
 
   function closeStream(): void {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -830,15 +830,10 @@
   }
 
   function applyChatDetailSelectionCommand(command: ChatDetailSelectionCommand): void {
+    if (command.runtime) void liveProjection.activate(command.runtime.chatId, { quiet: command.runtime.quiet });
     writeChatDetailSessionState(command.state);
     if (command.syncSelectors) syncSelectorsToActiveChat();
     if (command.markRead) markActiveChatRead();
-    if (command.runtime) {
-      void liveProjection.activate(command.runtime.chatId, {
-        quiet: command.runtime.quiet,
-        ...(command.runtime.chatId === null ? { sessionActiveError: command.state.activeError } : {})
-      });
-    }
   }
 
   function writeLiveProjectionState(state: ChatDetailLiveProjectionState): void {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -833,7 +833,12 @@
     writeChatDetailSessionState(command.state);
     if (command.syncSelectors) syncSelectorsToActiveChat();
     if (command.markRead) markActiveChatRead();
-    if (command.runtime) void liveProjection.activate(command.runtime.chatId, { quiet: command.runtime.quiet });
+    if (command.runtime) {
+      void liveProjection.activate(command.runtime.chatId, {
+        quiet: command.runtime.quiet,
+        ...(command.runtime.chatId === null ? { sessionActiveError: command.state.activeError } : {})
+      });
+    }
   }
 
   function writeLiveProjectionState(state: ChatDetailLiveProjectionState): void {


### PR DESCRIPTION
## Summary

- Move chat detail transcript stream ownership into the live projection controller via an explicit `activate(chatId)` lifecycle.
- Keep `ChatDetailSession` focused on pure selection state by replacing stream-control flags with runtime activation intent.
- Ensure switching away from a noisy/running chat closes the old transcript EventSource and ignores stale stream events.

## Root Cause

The chat page coordinated active selection and transcript stream ownership across separate reactive effects and command flags. A tab could retain the previous chat transcript stream after navigation when the new active chat did not open its own stream, letting stale live updates keep consuming the renderer.

## Validation

- `pnpm web:lint`
- `pnpm web:test`
- Commit hook web-ui lane: guardrails, mypy, full pytest (`9291 passed`), Web UI lab, web lint, build, web tests, SPA shell check
