### PR TITLE
[codex] Fix PMA automation edit chat defaults

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/lastNewChatPreferences.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/lastNewChatPreferences.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getLastNewChatPreference,
+  loadLastNewChatPreferences,
+  persistLastNewChatPreference
+} from './lastNewChatPreferences';
+
+describe('lastNewChatPreferences', () => {
+  const store: Record<string, string> = {};
+
+  beforeEach(() => {
+    for (const key of Object.keys(store)) delete store[key];
+    const localStorage = {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      setItem: (key: string, value: string) => {
+        store[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        for (const key of Object.keys(store)) delete store[key];
+      },
+      length: 0,
+      key: () => null
+    };
+    vi.stubGlobal('window', { localStorage });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('persists PMA and coding-agent new-chat scopes separately', () => {
+    persistLastNewChatPreference('pma', { scopeId: 'local' });
+    persistLastNewChatPreference('agent', { scopeId: 'worktree:wt-1' });
+
+    expect(getLastNewChatPreference('pma')).toEqual({ scopeId: 'local' });
+    expect(getLastNewChatPreference('agent')).toEqual({ scopeId: 'worktree:wt-1' });
+    expect(loadLastNewChatPreferences()).toEqual({
+      pma: { scopeId: 'local' },
+      agent: { scopeId: 'worktree:wt-1' }
+    });
+  });
+
+  it('ignores malformed stored values', () => {
+    window.localStorage.setItem('car.web.chat.lastNewChatPreferences.v1', '{"pma":{"scopeId":""},"agent":{"scopeId":42}}');
+
+    expect(loadLastNewChatPreferences()).toEqual({});
+  });
+});

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/lastNewChatPreferences.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/lastNewChatPreferences.ts
@@ -1,0 +1,53 @@
+/** Browser persistence for `/chats` new-chat pickers. */
+
+const STORAGE_KEY = 'car.web.chat.lastNewChatPreferences.v1';
+
+export type NewChatPreferenceKind = 'pma' | 'agent';
+
+export type NewChatPreference = {
+  scopeId: string;
+};
+
+export type LastNewChatPreferences = Partial<Record<NewChatPreferenceKind, NewChatPreference>>;
+
+export function loadLastNewChatPreferences(): LastNewChatPreferences {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return {};
+    const out: LastNewChatPreferences = {};
+    for (const kind of ['pma', 'agent'] as const) {
+      const value = (parsed as Record<string, unknown>)[kind];
+      if (!value || typeof value !== 'object') continue;
+      const scopeId = (value as Record<string, unknown>).scopeId;
+      if (typeof scopeId !== 'string' || !scopeId.trim()) continue;
+      out[kind] = { scopeId: scopeId.trim() };
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function saveLastNewChatPreferences(preferences: LastNewChatPreferences): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+  } catch {
+    // Best-effort; ignore quota / disabled storage.
+  }
+}
+
+export function getLastNewChatPreference(kind: NewChatPreferenceKind): NewChatPreference | null {
+  return loadLastNewChatPreferences()[kind] ?? null;
+}
+
+export function persistLastNewChatPreference(kind: NewChatPreferenceKind, preference: NewChatPreference): void {
+  const scopeId = preference.scopeId.trim();
+  if (!scopeId) return;
+  const preferences = loadLastNewChatPreferences();
+  preferences[kind] = { scopeId };
+  saveLastNewChatPreferences(preferences);
+}

--- a/src/codex_autorunner/web_frontend/src/routes/automations/[[ruleId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/automations/[[ruleId]]/+page.svelte
@@ -395,29 +395,13 @@
   function editWithPmaPrompt(): string {
     const automation = selectedAutomation();
     if (automation) {
-      const agentLines =
-        automation.executorKind === 'pma_turn'
-          ? [
-              `Agent: ${selectedAgent || '(default)'}`,
-              `Model: ${selectedModel || '(default)'}`,
-              `Reasoning: ${selectedReasoning || '(default)'}`,
-              `Profile: ${selectedProfile || '(default)'}`
-            ]
-          : ['Ticket-flow agent/model assignment is controlled by ticket frontmatter.'];
       return [
-        `I want to edit automation ${automation.id}.`,
+        `Please edit CAR automation ${automation.id}.`,
         '',
-        `Name: ${automation.name}`,
-        `Kind: ${automation.kind}`,
-        `Executor: ${automation.executorKind}`,
-        ...agentLines,
-        `Target policy: ${automation.targetPolicy}`,
-        `Schedule: ${scheduleLabel(automation)}`,
+        'Read the existing automation rule and related run history from the hub automation data before making changes.',
         '',
-        'Current prompt or ticket body:',
-        promptDraft || ticketDraft || '(none)',
-        '',
-        'Help me make the right semantic changes, then tell me what direct fields to update in the automation detail view.'
+        'Change request:',
+        '<describe the change you want>'
       ].join('\n');
     }
     const preset = selectedPreset();

--- a/src/codex_autorunner/web_frontend/src/routes/automations/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/automations/page.test.ts
@@ -57,4 +57,17 @@ describe('/automations page', () => {
     expect(source).not.toContain('webApi.hub.listRepos()');
     expect(source).not.toContain('Promise.all([');
   });
+
+  it('keeps edit-with-PMA drafts minimal and points PMA at the stored automation data', () => {
+    const source = pageSource();
+    const promptBody = source.match(
+      /function editWithPmaPrompt\(\): string \{[\s\S]*?\n  function openPmaWithDraft/
+    )?.[0] ?? '';
+
+    expect(promptBody).toContain('Please edit CAR automation ${automation.id}.');
+    expect(promptBody).toContain('Read the existing automation rule and related run history from the hub automation data before making changes.');
+    expect(promptBody).toContain('<describe the change you want>');
+    expect(promptBody).not.toContain('Current prompt or ticket body:');
+    expect(promptBody).not.toContain('promptDraft || ticketDraft');
+  });
 });

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -141,6 +141,11 @@
   } from '$lib/viewModels/modelPickers';
   import { getLastModelForAgent, persistLastModelForAgent } from '$lib/viewModels/lastModelByAgent';
   import {
+    getLastNewChatPreference,
+    persistLastNewChatPreference,
+    type NewChatPreferenceKind
+  } from '$lib/viewModels/lastNewChatPreferences';
+  import {
     buildSlashCommandSuggestions,
     parseSlashCommand,
     WEB_SLASH_COMMANDS,
@@ -252,6 +257,7 @@
   let slashSelectedIndex = $state(0);
   let composerFocused = $state(false);
   let composerEditVersion = 0;
+  let pendingInitialDraftCreate = false;
   let pendingPointerChatId: string | null = null;
   let pendingCommittedDetailUrlChatId = $state<string | null>(null);
   let removeDocumentChatPointerCapture: (() => void) | null = null;
@@ -682,9 +688,9 @@
     pinnedChatIds = loadPinnedChats();
     const initialDraft = page.url.searchParams.get('draft');
     draft = initialDraft ?? draft;
+    pendingInitialDraftCreate = Boolean(initialDraft && !requestedDetailFromUrl());
     loadingChats = !hasChatIndexProjection(readModelEntityStore.snapshot());
     if (!loadingChats) activateRequestedChatFromCurrentRows();
-    if (initialDraft && !requestedDetailFromUrl()) void createChat({ preserveSelectedScope: true });
     void loadInitialSupportingData(
       webApi.pma.listFiles(),
       webApi.pma.listAgents(),
@@ -919,6 +925,11 @@
       void loadModels(selectedAgent, activeChat?.model ?? selectedModel);
     }
     applyNewChatQueryParam();
+    if (pendingInitialDraftCreate && !page.url.searchParams.get('new')) {
+      pendingInitialDraftCreate = false;
+      applyLastNewChatPreference('pma');
+      void createChat({ preserveSelectedScope: true });
+    }
   }
 
   function applyNewChatQueryParam(): void {
@@ -958,8 +969,22 @@
     params.delete('kind');
     const query = params.toString();
     void goto(href(`/chats${query ? `?${query}` : ''}`), { replaceState: true }).then(() => {
-      if (appliedScope) void createChat({ preserveSelectedScope: true });
+      if (appliedScope) {
+        pendingInitialDraftCreate = false;
+        persistCurrentNewChatPreference();
+        void createChat({ preserveSelectedScope: true });
+      }
     });
+  }
+
+  function applyLastNewChatPreference(kind: NewChatPreferenceKind): boolean {
+    const preference = getLastNewChatPreference(kind);
+    if (!preference) return false;
+    if (!scopeOptions.some((scope) => scope.id === preference.scopeId)) return false;
+    selectedScopeId = preference.scopeId;
+    selectedScopeSource = preference.scopeId === 'local' ? 'default_hub' : 'picker_explicit';
+    newChatKind = kind === 'agent' && preference.scopeId !== 'local' ? 'agent' : 'pma';
+    return true;
   }
 
   async function loadModels(agentId: string, preferredModel?: string): Promise<void> {
@@ -1272,6 +1297,15 @@
   function handleScopePickerChange(): void {
     selectedScopeSource = selectedScopeId === 'local' ? 'default_hub' : 'picker_explicit';
     if (newChatKind === 'agent' && selectedScopeId === 'local') newChatKind = 'pma';
+    persistCurrentNewChatPreference();
+  }
+
+  function currentNewChatPreferenceKind(): NewChatPreferenceKind {
+    return newChatKind === 'agent' && canStartCodingAgentChat ? 'agent' : 'pma';
+  }
+
+  function persistCurrentNewChatPreference(): void {
+    persistLastNewChatPreference(currentNewChatPreferenceKind(), { scopeId: selectedScopeId });
   }
 
   function newChatDisplayName(): string {
@@ -1412,10 +1446,14 @@
     creating = true;
     composeError = null;
     if (!options.preserveSelectedScope) {
-      selectedScopeId = 'local';
-      selectedScopeSource = 'default_hub';
-      newChatKind = 'pma';
+      const applied = applyLastNewChatPreference(newChatKind === 'agent' ? 'agent' : 'pma');
+      if (!applied) {
+        selectedScopeId = 'local';
+        selectedScopeSource = 'default_hub';
+        newChatKind = 'pma';
+      }
     }
+    persistCurrentNewChatPreference();
     writeChatDetailSessionState(startLocalDraftChat(readChatDetailSessionState(), newDraftChatSummary()));
     closeStream();
     void goto(href('/chats'), { replaceState: true });

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -22,7 +22,7 @@ describe('/chats page', () => {
     );
   }
 
-  it('preserves route-selected agent drafts when creating a scoped local draft', () => {
+  it('uses remembered new-chat preferences unless a route-selected draft is being created', () => {
     const source = chatDetailPageSource();
     const createChatBody = source.match(
       /async function createChat[\s\S]*?\n  async function sendMessage/
@@ -30,8 +30,9 @@ describe('/chats page', () => {
 
     expect(createChatBody).toContain('if (!options.preserveSelectedScope)');
     expect(createChatBody).toMatch(
-      /if \(!options\.preserveSelectedScope\) \{[\s\S]*newChatKind = 'pma';[\s\S]*\}/
+      /applyLastNewChatPreference\(newChatKind === 'agent' \? 'agent' : 'pma'\)/
     );
+    expect(createChatBody).toContain('persistCurrentNewChatPreference();');
     expect(createChatBody).not.toMatch(/detailMode = 'detail';\s*newChatKind = 'pma';/);
   });
 


### PR DESCRIPTION
## Summary
- remember the last selected new-chat scope separately for PMA chats and coding-agent chats
- apply the remembered PMA chat scope after repo/worktree options load before creating a `?draft=` chat
- simplify the automation "Edit with PMA" prompt to point PMA at the stored automation rule/run history and leave a change-request placeholder

## Root Cause
`Edit with PMA` only navigated to `/chats?draft=...`. The chat page created the draft immediately, before repo/worktree scope options and remembered new-chat choices were available, so it used the page's current/default scope selector state. That could produce a PMA draft bound to a worktree instead of the user's last PMA chat preference.

## Validation
- commit hook web-ui lane, including guardrails, mypy, full pytest, Web UI lab scenarios, `pnpm web:lint`, Web Hub build, `pnpm web:test`, and SPA shell route check
- targeted local checks before commit: `pnpm web:lint`, `pnpm web:test`
