### PR TITLE
[codex] add web outbox artifact support

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/filebox.py
+++ b/src/codex_autorunner/surfaces/web/routes/filebox.py
@@ -126,8 +126,21 @@ def build_filebox_routes() -> APIRouter:
     ) -> dict[str, Any]:
         repo_root = _resolve_repo_root(request)
         return service.list_artifact_deliveries(
-            repo_root, state=state, surface=surface, conversation=conversation
+            repo_root,
+            url_scope=_filebox_url_scope(request),
+            state=state,
+            surface=surface,
+            conversation=conversation,
         )
+
+    @router.get("/artifacts/deliveries/{delivery_id}/download")
+    def download_artifact_delivery(delivery_id: str, request: Request):
+        repo_root = _resolve_repo_root(request)
+        try:
+            resource = service.open_delivery_artifact(repo_root, delivery_id)
+        except WorkspaceResourceError as exc:
+            _raise_http(exc)
+        return _file_download_response(resource.entry, resource.handle)
 
     @router.get("/filebox/{box}")
     def list_single_box(box: str, request: Request) -> dict[str, Any]:
@@ -212,11 +225,23 @@ def build_hub_filebox_routes() -> APIRouter:
         repo_root = _resolve_hub_repo_root(request, repo_id)
         return service.list_artifact_deliveries(
             repo_root,
+            url_scope=_filebox_url_scope(request, repo_id),
             state=state,
             surface=surface,
             conversation=conversation,
             repo_id=repo_id,
         )
+
+    @router.get("/{repo_id}/artifacts/deliveries/{delivery_id}/download")
+    def download_repo_artifact_delivery(
+        repo_id: str, delivery_id: str, request: Request
+    ):
+        repo_root = _resolve_hub_repo_root(request, repo_id)
+        try:
+            resource = service.open_delivery_artifact(repo_root, delivery_id)
+        except WorkspaceResourceError as exc:
+            _raise_http(exc)
+        return _file_download_response(resource.entry, resource.handle)
 
     @router.post("/{repo_id}/{box}")
     async def hub_upload(repo_id: str, box: str, request: Request) -> dict[str, Any]:

--- a/src/codex_autorunner/surfaces/web/services/workspace_resources.py
+++ b/src/codex_autorunner/surfaces/web/services/workspace_resources.py
@@ -354,6 +354,37 @@ class FileBoxResourceService:
         entry, handle = result
         return FileBoxDownloadResource(entry=entry, handle=handle)
 
+    def open_delivery_artifact(
+        self, repo_root: Path, delivery_id: str
+    ) -> FileBoxDownloadResource:
+        result = ArtifactDeliveryService(repo_root).inspect_with_artifact(delivery_id)
+        if result is None or result[1] is None:
+            raise WorkspaceResourceError(404, "Delivery artifact not found")
+        _intent, artifact_or_none = result
+        artifact = artifact_or_none
+        assert artifact is not None
+        try:
+            path = artifact.storage_path
+            stat_result = path.stat()
+            handle = path.open("rb")
+        except FileNotFoundError as exc:
+            raise WorkspaceResourceError(
+                404, "Delivery artifact file not found"
+            ) from exc
+        except OSError as exc:
+            raise WorkspaceResourceError(
+                500, "Failed to open delivery artifact"
+            ) from exc
+        entry = FileBoxEntry(
+            name=artifact.filename,
+            box="outbox",
+            size=stat_result.st_size,
+            modified_at=artifact.updated_at,
+            source="artifact_delivery",
+            path=path,
+        )
+        return FileBoxDownloadResource(entry=entry, handle=handle)
+
     def delete_file(self, repo_root: Path, box: str, filename: str) -> dict[str, Any]:
         self.validate_box(box)
         try:
@@ -372,6 +403,7 @@ class FileBoxResourceService:
         self,
         repo_root: Path,
         *,
+        url_scope: FileBoxUrlScope,
         state: str | None = None,
         surface: str | None = None,
         conversation: str | None = None,
@@ -387,9 +419,12 @@ class FileBoxResourceService:
         payload = {
             "root": str(repo_root),
             "deliveries": [
-                serialize_delivery(
-                    intent,
-                    artifact=service.store.get_artifact(intent.artifact_id),
+                add_delivery_download_url(
+                    serialize_delivery(
+                        intent,
+                        artifact=service.store.get_artifact(intent.artifact_id),
+                    ),
+                    url_scope=url_scope,
                 )
                 for intent in deliveries
             ],
@@ -436,6 +471,32 @@ def serialize_filebox_entry(
     return payload
 
 
+def add_delivery_download_url(
+    delivery: dict[str, Any], *, url_scope: FileBoxUrlScope
+) -> dict[str, Any]:
+    delivery_id = delivery.get("delivery_id")
+    artifact = delivery.get("artifact")
+    if not isinstance(delivery_id, str) or not delivery_id:
+        return delivery
+    if not isinstance(artifact, dict) or not artifact:
+        return delivery
+    root_path = url_scope.root_path or ""
+    if url_scope.repo_id:
+        download = (
+            f"{root_path}/hub/filebox/{quote(url_scope.repo_id, safe='')}/"
+            f"artifacts/deliveries/{quote(delivery_id, safe='')}/download"
+        )
+    else:
+        download = (
+            f"{root_path}/api/artifacts/deliveries/"
+            f"{quote(delivery_id, safe='')}/download"
+        )
+    artifact["url"] = download
+    artifact["href"] = download
+    delivery["download_url"] = download
+    return delivery
+
+
 def normalize_delivery_states(state: str | None) -> tuple[DeliveryState, ...] | None:
     values = tuple(item.strip() for item in (state or "").split(",") if item.strip())
     return values or None  # type: ignore[return-value]
@@ -477,6 +538,7 @@ __all__ = [
     "normalize_delivery_states",
     "read_upload_limited",
     "resolve_max_upload_bytes",
+    "add_delivery_download_url",
     "serialize_filebox_entry",
     "serialize_filebox_listing",
 ]

--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -2218,6 +2218,10 @@ textarea:hover {
   justify-content: flex-end;
 }
 
+.assistant-attachments {
+  justify-content: flex-start;
+}
+
 .message-attachment-pill {
   display: inline-flex;
   align-items: center;
@@ -2238,6 +2242,20 @@ textarea:hover {
 .message-attachment-pill:hover {
   border-color: var(--color-border-strong, var(--color-border));
   background: var(--color-surface-muted);
+}
+
+.message-attachment-pill.delivery-sent {
+  border-color: color-mix(in srgb, var(--color-success) 42%, var(--color-border));
+}
+
+.message-attachment-pill.delivery-failed {
+  border-color: color-mix(in srgb, var(--color-danger) 52%, var(--color-border));
+  background: color-mix(in srgb, var(--color-danger) 8%, var(--color-surface));
+}
+
+.message-attachment-pill.delivery-pending,
+.message-attachment-pill.delivery-sending {
+  border-color: color-mix(in srgb, var(--color-warning) 48%, var(--color-border));
 }
 
 .message-attachment-pill .attachment-kind {
@@ -2589,6 +2607,127 @@ textarea:hover {
   border-radius: 8px;
   container-type: inline-size;
   container-name: status-bar;
+}
+
+.chat-files-drawer {
+  display: grid;
+  gap: var(--space-3);
+  width: 100%;
+  margin-top: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-1);
+}
+
+.chat-files-drawer-head,
+.chat-files-drawer-actions,
+.chat-files-list li {
+  display: flex;
+  align-items: center;
+}
+
+.chat-files-drawer-head {
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.chat-files-drawer h2,
+.chat-files-drawer h3 {
+  margin: 0;
+  letter-spacing: 0;
+}
+
+.chat-files-drawer h2 {
+  font-size: var(--font-size-3);
+}
+
+.chat-files-drawer h3 {
+  font-size: var(--font-size-1);
+  color: var(--color-ink-muted);
+}
+
+.chat-files-drawer-actions {
+  gap: var(--space-2);
+}
+
+.chat-files-sections {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.chat-files-section {
+  display: grid;
+  align-content: start;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.chat-files-list {
+  display: grid;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.chat-files-list li {
+  gap: var(--space-2);
+  min-width: 0;
+  padding: var(--space-2);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-2);
+  background: var(--color-panel-tint);
+}
+
+.chat-files-list strong,
+.chat-files-list em,
+.chat-files-list small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-files-list em,
+.chat-files-list small,
+.chat-files-empty {
+  color: var(--color-ink-faint);
+  font-size: var(--font-size-0);
+  font-style: normal;
+}
+
+.chat-files-empty {
+  margin: 0;
+}
+
+.chat-files-empty.error {
+  color: var(--color-danger);
+}
+
+.chat-files-list .attachment-kind {
+  flex: 0 0 auto;
+}
+
+.chat-files-list li.delivery-sent {
+  border-color: color-mix(in srgb, var(--color-success) 36%, var(--color-border-subtle));
+}
+
+.chat-files-list li.delivery-failed {
+  border-color: color-mix(in srgb, var(--color-danger) 48%, var(--color-border-subtle));
+}
+
+.chat-files-list li.delivery-pending,
+.chat-files-list li.delivery-sending {
+  border-color: color-mix(in srgb, var(--color-warning) 42%, var(--color-border-subtle));
+}
+
+@media (max-width: 760px) {
+  .chat-files-sections {
+    grid-template-columns: 1fr;
+  }
 }
 
 @container status-bar (max-width: 640px) {

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.test.ts
@@ -810,6 +810,37 @@ describe('API client error handling', () => {
     expect(result).toEqual({ ok: true, data: ['screen.png'] });
   });
 
+  it('lists repo artifact deliveries through the hub filebox route', async () => {
+    const fetcher = vi.fn(async () =>
+      Response.json({
+        deliveries: [
+          {
+            delivery_id: 'delivery:abc',
+            artifact_id: 'sha256:abc',
+            state: 'pending',
+            artifact: { filename: 'report.md' },
+            download_url: '/hub/filebox/repo-1/artifacts/deliveries/delivery%3Aabc/download'
+          }
+        ]
+      })
+    ) as unknown as typeof fetch;
+    const client = new WebApiClient(fetcher);
+
+    const result = await client.pma.listArtifactDeliveries('repo-1');
+
+    expect(fetcher).toHaveBeenCalledWith('/hub/filebox/repo-1/artifacts/deliveries', expect.any(Object));
+    expect(result).toEqual({
+      ok: true,
+      data: [
+        expect.objectContaining({
+          deliveryId: 'delivery:abc',
+          filename: 'report.md',
+          downloadUrl: '/hub/filebox/repo-1/artifacts/deliveries/delivery%3Aabc/download'
+        })
+      ]
+    });
+  });
+
   it('maps workspace contextspace responses through pinned standard docs', async () => {
     const fetcher = vi.fn(async () =>
       Response.json({

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.ts
@@ -7,6 +7,7 @@ import {
 } from '$lib/api/readModelContracts';
 import {
   mapContextspaceDocument,
+  mapArtifactDelivery,
   mapDashboardSummary,
   mapPmaChatMessage,
   mapPmaTimelineItem,
@@ -18,6 +19,7 @@ import {
   mapTicketSummary,
   mapWorktreeSummary,
   type ContextspaceDocument,
+  type ArtifactDelivery,
   type DashboardSummary,
   type PmaChatMessage,
   type PmaChatSummary,
@@ -596,6 +598,14 @@ export class WebApiClient {
       mapResult(await this.getJson<JsonRecord>('/hub/pma/files'), (payload) =>
         [...asArray(payload.inbox), ...asArray(payload.outbox)].map(mapSurfaceArtifact)
       ),
+    listArtifactDeliveries: async (repoId?: string | null): Promise<ApiResult<ArtifactDelivery[]>> => {
+      const route = repoId
+        ? `/hub/filebox/${encodeURIComponent(repoId)}/artifacts/deliveries`
+        : '/api/artifacts/deliveries';
+      return mapResult(await this.getJson<JsonRecord>(route), (payload) =>
+        asArray(payload.deliveries).map(mapArtifactDelivery)
+      );
+    },
     uploadInboxFile: async (file: File): Promise<ApiResult<string[]>> => {
       const form = new FormData();
       form.append('file', file, file.name);

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
@@ -9,13 +9,19 @@
     type ChatToolCallCard
   } from '$lib/viewModels/pmaChat';
   import type { PmaMessageCapsuleRef } from '$lib/viewModels/domain';
-  import type { SurfaceArtifact } from '$lib/viewModels/domain';
+  import type { ArtifactDelivery, SurfaceArtifact } from '$lib/viewModels/domain';
 
   let {
     cards,
     assistantLabel = 'Assistant',
     streamingMessageId = null,
-  }: { cards: ChatTranscriptCard[]; assistantLabel?: string; streamingMessageId?: string | null } = $props();
+    sharedFiles = []
+  }: {
+    cards: ChatTranscriptCard[];
+    assistantLabel?: string;
+    streamingMessageId?: string | null;
+    sharedFiles?: ArtifactDelivery[];
+  } = $props();
 
   const MAX_RENDERED_TOOL_GROUP_ITEMS = 80;
   const MAX_RENDERED_TURN_SUMMARY_CARDS = 80;
@@ -35,6 +41,23 @@
     const size = raw.size_label ?? raw.sizeLabel ?? raw.size;
     if (typeof size === 'string' && size.trim()) return size;
     return null;
+  }
+
+  function deliveryStateLabel(state: string): string {
+    const normalized = state.trim().toLowerCase();
+    if (normalized === 'sent') return 'sent';
+    if (normalized === 'failed') return 'failed';
+    if (normalized === 'cancelled') return 'cancelled';
+    if (normalized === 'sending' || normalized === 'claimed') return 'sending';
+    return 'pending';
+  }
+
+  function deliveryMeta(delivery: ArtifactDelivery): string | null {
+    const parts = [
+      delivery.targetSurface ? `to ${delivery.targetSurface}` : null,
+      delivery.size !== null ? `${Math.round(delivery.size / 1024)} KB` : null
+    ].filter((part): part is string => Boolean(part));
+    return parts.length ? parts.join(' · ') : null;
   }
 
   function isThinkingTrace(card: Extract<ChatTranscriptCard, { kind: 'intermediate' }>): boolean {
@@ -400,3 +423,27 @@
     <SurfaceArtifactCard artifact={card.artifact} />
   {/if}
 {/each}
+
+{#if sharedFiles.length > 0}
+  <article class="message assistant shared-files-message">
+    <span>{assistantLabel}</span>
+    <ul class="message-attachments assistant-attachments" aria-label="Files shared by assistant">
+      {#each sharedFiles as file (file.deliveryId)}
+        {@const stateLabel = deliveryStateLabel(file.state)}
+        {@const meta = deliveryMeta(file)}
+        <li class={`message-attachment-pill delivery-${stateLabel}`}>
+          <span class="attachment-kind">file</span>
+          {#if file.downloadUrl}
+            <a href={href(file.downloadUrl)} target="_blank" rel="noopener" title={file.filename}><strong>{file.filename}</strong></a>
+          {:else}
+            <strong title={file.filename}>{file.filename}</strong>
+          {/if}
+          <em>{stateLabel}</em>
+          {#if meta}
+            <em>{meta}</em>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  </article>
+{/if}

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
@@ -310,4 +310,40 @@ describe('ChatTranscriptCards', () => {
     expect(body).toContain('Working on it');
     expect(body).toContain('Reasoning through the request');
   });
+
+  it('renders assistant shared delivery files as downloadable pills', () => {
+    const { body } = render(ChatTranscriptCards, {
+      props: {
+        cards: [],
+        assistantLabel: 'Codex',
+        sharedFiles: [
+          {
+            deliveryId: 'delivery:abc',
+            artifactId: 'sha256:abc',
+            filename: 'spec.md',
+            state: 'sent',
+            targetSurface: 'discord',
+            targetConversation: 'channel:1',
+            workspaceScope: null,
+            attempts: 1,
+            size: 1024,
+            mimeType: 'text/markdown',
+            downloadUrl: '/hub/filebox/repo/artifacts/deliveries/delivery%3Aabc/download',
+            createdAt: '2026-05-21T00:00:00Z',
+            updatedAt: '2026-05-21T00:01:00Z',
+            sentAt: '2026-05-21T00:01:00Z',
+            failedAt: null,
+            lastError: null,
+            raw: {}
+          }
+        ]
+      }
+    });
+
+    expect(body).toContain('class="message assistant shared-files-message"');
+    expect(body).toContain('Codex');
+    expect(body).toContain('spec.md');
+    expect(body).toContain('delivery-sent');
+    expect(body).toContain('/hub/filebox/repo/artifacts/deliveries/delivery%3Aabc/download');
+  });
 });

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/domain.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/domain.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   mapContextspaceDocument,
+  mapArtifactDelivery,
   mapDashboardSummary,
   mapPmaChatSummary,
   mapPmaRunProgress,
@@ -340,6 +341,35 @@ describe('view model mappers', () => {
     expect(mapSurfaceArtifact({ name: 'Preview URL', url: 'http://localhost:4173' }).kind).toBe('preview_url');
     expect(mapSurfaceArtifact({ kind: 'link', title: 'Fixture preview', url: 'https://example.test' }).kind).toBe('link');
     expect(mapSurfaceArtifact({ name: 'pull request', url: 'https://github.com/org/repo/pull/1' }).kind).toBe('link');
+  });
+
+  it('maps artifact delivery records with download metadata', () => {
+    const delivery = mapArtifactDelivery({
+      delivery_id: 'delivery:abc',
+      artifact_id: 'sha256:abc',
+      state: 'sent',
+      target_surface: 'discord',
+      target_conversation_key: 'channel:1',
+      attempts: 1,
+      download_url: '/hub/filebox/repo/artifacts/deliveries/delivery%3Aabc/download',
+      artifact: {
+        filename: 'spec.md',
+        mime_type: 'text/markdown',
+        size: 42
+      },
+      created_at: '2026-05-21T00:00:00Z',
+      updated_at: '2026-05-21T00:01:00Z'
+    });
+
+    expect(delivery).toMatchObject({
+      deliveryId: 'delivery:abc',
+      filename: 'spec.md',
+      state: 'sent',
+      targetSurface: 'discord',
+      targetConversation: 'channel:1',
+      size: 42,
+      downloadUrl: '/hub/filebox/repo/artifacts/deliveries/delivery%3Aabc/download'
+    });
   });
 
   it('maps ticket dispatch history attachments into ticket details', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/domain.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/domain.ts
@@ -191,6 +191,28 @@ export type SurfaceArtifact = {
   raw: JsonRecord;
 };
 
+export type ArtifactDeliveryState = 'pending' | 'claimed' | 'sending' | 'sent' | 'failed' | 'cancelled' | string;
+
+export type ArtifactDelivery = {
+  deliveryId: string;
+  artifactId: string;
+  filename: string;
+  state: ArtifactDeliveryState;
+  targetSurface: string | null;
+  targetConversation: string | null;
+  workspaceScope: string | null;
+  attempts: number;
+  size: number | null;
+  mimeType: string | null;
+  downloadUrl: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  sentAt: string | null;
+  failedAt: string | null;
+  lastError: string | null;
+  raw: JsonRecord;
+};
+
 /** Dashboard rollup used by the overview page. */
 export type DashboardSummary = {
   activeRuns: number;
@@ -492,6 +514,35 @@ export function mapSurfaceArtifact(raw: JsonRecord): SurfaceArtifact {
     summary: nullableString(raw.summary ?? raw.description ?? raw.message),
     url: nullableString(raw.url ?? raw.href ?? raw.preview_url),
     createdAt: dateString(raw.created_at ?? raw.modified_at ?? raw.received_at),
+    raw
+  };
+}
+
+export function mapArtifactDelivery(raw: JsonRecord): ArtifactDelivery {
+  const artifact = asRecord(raw.artifact);
+  const deliveryId = stringValue(raw.delivery_id ?? raw.deliveryId, 'delivery');
+  const artifactId = stringValue(raw.artifact_id ?? raw.artifactId ?? artifact.artifact_id, deliveryId);
+  const filename = stringValue(
+    artifact.filename ?? raw.filename ?? asRecord(raw.metadata).filename ?? artifact.name,
+    artifactId
+  );
+  return {
+    deliveryId,
+    artifactId,
+    filename,
+    state: stringValue(raw.state, 'pending'),
+    targetSurface: nullableString(raw.target_surface ?? raw.targetSurface),
+    targetConversation: nullableString(raw.target_conversation_key ?? raw.targetConversationKey ?? raw.targetConversation),
+    workspaceScope: nullableString(raw.workspace_scope ?? raw.workspaceScope),
+    attempts: numberOrNull(raw.attempts) ?? 0,
+    size: numberOrNull(artifact.size ?? raw.size),
+    mimeType: nullableString(artifact.mime_type ?? artifact.mimeType ?? raw.mime_type ?? raw.mimeType),
+    downloadUrl: nullableString(raw.download_url ?? raw.downloadUrl ?? artifact.url ?? artifact.href),
+    createdAt: dateString(raw.created_at ?? raw.createdAt),
+    updatedAt: dateString(raw.updated_at ?? raw.updatedAt),
+    sentAt: dateString(raw.sent_at ?? raw.sentAt),
+    failedAt: dateString(raw.failed_at ?? raw.failedAt),
+    lastError: nullableString(raw.last_error ?? raw.lastError),
     raw
   };
 }

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -69,6 +69,7 @@
   import type {
     PmaChatSummary,
     PmaRunProgress,
+    ArtifactDelivery,
     SurfaceArtifact
   } from '$lib/viewModels/domain';
   import {
@@ -116,6 +117,7 @@
     type ChatLastSeenMap
   } from '$lib/viewModels/unread';
   import { repoAccent, repoInitials } from '$lib/viewModels/repoIdentity';
+  import { surfaceRefFromThreadRaw } from '$lib/viewModels/thread';
   import {
     agentProfileEntriesForRecord,
     agentCanListModels,
@@ -162,7 +164,12 @@
   let configuredDefaultAgentId = $state<string | undefined>(undefined);
   let configuredDefaultProfile = $state('');
   let linkDialogOpen = $state(false);
+  let fileDrawerOpen = $state(false);
   let linkDraft = $state('');
+  let artifactDeliveries = $state<ArtifactDelivery[]>([]);
+  let loadingArtifactDeliveries = $state(false);
+  let artifactDeliveryError = $state<ApiError | null>(null);
+  let artifactDeliveryLoadKey = '';
   let selectedAgent = $state('codex');
   let selectedModel = $state('');
   let selectedReasoning = $state('');
@@ -208,6 +215,7 @@
   const transcriptCards = $derived<ChatTranscriptCard[]>(selectChatTranscript(readModelState, activeChatId));
   const progress = $derived<PmaRunProgress | null>(selectPmaProgress(readModelState, activeChatId));
   const artifacts = $derived<SurfaceArtifact[]>(selectPmaArtifacts(readModelState, activeChatId));
+  const inboxArtifacts = $derived(artifacts.filter((artifact) => String(artifact.raw.box ?? '').toLowerCase() === 'inbox'));
   const queuedTurns = $derived<PmaQueuedTurn[]>(selectPmaQueue(readModelState, activeChatId));
   const lastSeenMap = $derived<ChatLastSeenMap>(selectReadMarkers(readModelState) as ChatLastSeenMap);
   let draft = $state('');
@@ -396,6 +404,8 @@
   let messageStackResizeObserver: ResizeObserver | null = null;
 
   const activeChat = $derived(activeChatId ? chatSummaryForId(activeChatId) : null);
+  const activeSurfaceDeliveries = $derived<ArtifactDelivery[]>(artifactDeliveriesForActiveSurface(activeChat, artifactDeliveries));
+  const assistantSharedFiles = $derived<ArtifactDelivery[]>(activeSurfaceDeliveries.slice(0, 4));
   let expandedRunGroups = $state<Record<string, boolean>>({});
   let pinnedChatIds = $state<Record<string, true>>({});
   const chatListEntries = $derived(
@@ -564,6 +574,7 @@
     return text.length > 120 ? text.slice(text.length - 120) : text;
   });
   const activeMessengerSurface = $derived(chatMessengerSurface(activeChat));
+  const activeSharedFileCount = $derived(activeSurfaceDeliveries.length);
   const activeRepoIngress = $derived(repoIngressForChat(activeChat));
   const createChatLabel = $derived(
     creating ? 'Creating...' : newChatKind === 'agent' && canStartCodingAgentChat ? '+ Coding agent' : '+ PMA'
@@ -741,6 +752,20 @@
     const next = markActiveSummaryRead(lastSeenMap, activeChat);
     if (next === lastSeenMap) return;
     readModelEntityStore.optimisticReadMarkers(next, `read-active:${activeChat.id}:${Date.now()}`);
+  });
+
+  $effect(() => {
+    const chat = activeChat;
+    if (!chat || isLocalDraftChatId(chat.id)) {
+      artifactDeliveries = [];
+      artifactDeliveryError = null;
+      artifactDeliveryLoadKey = '';
+      return;
+    }
+    const key = `${chat.id}|${chat.repoId ?? ''}`;
+    if (key === artifactDeliveryLoadKey) return;
+    artifactDeliveryLoadKey = key;
+    void refreshArtifactDeliveries(chat.repoId ?? null, key, { quiet: true });
   });
 
   onDestroy(() => {
@@ -1086,6 +1111,73 @@
 
   async function refreshActive(chatId: string, options: { quiet?: boolean } = {}): Promise<void> {
     await pageController.refreshActive(chatId, options);
+  }
+
+  async function refreshArtifactDeliveries(
+    repoId: string | null,
+    key = `${activeChatId ?? ''}|${repoId ?? ''}`,
+    options: { quiet?: boolean } = {}
+  ): Promise<void> {
+    if (!options.quiet) loadingArtifactDeliveries = true;
+    const result = await webApi.pma.listArtifactDeliveries(repoId);
+    if (key !== artifactDeliveryLoadKey) return;
+    loadingArtifactDeliveries = false;
+    if (result.ok) {
+      artifactDeliveryError = null;
+      artifactDeliveries = [...result.data].sort(compareArtifactDeliveries);
+    } else {
+      artifactDeliveryError = result.error;
+    }
+  }
+
+  function compareArtifactDeliveries(left: ArtifactDelivery, right: ArtifactDelivery): number {
+    return deliveryTimeValue(right) - deliveryTimeValue(left);
+  }
+
+  function deliveryTimeValue(delivery: ArtifactDelivery): number {
+    const value = delivery.updatedAt ?? delivery.createdAt ?? delivery.sentAt ?? delivery.failedAt;
+    const timestamp = value ? Date.parse(value) : 0;
+    return Number.isFinite(timestamp) ? timestamp : 0;
+  }
+
+  function artifactDeliveryStateLabel(delivery: ArtifactDelivery): string {
+    const state = delivery.state.trim().toLowerCase();
+    if (state === 'claimed' || state === 'sending') return 'sending';
+    return state || 'pending';
+  }
+
+  function artifactDeliveryMeta(delivery: ArtifactDelivery): string {
+    const parts = [
+      delivery.targetSurface ? `to ${delivery.targetSurface}` : null,
+      delivery.size !== null ? formatBytes(delivery.size) : null,
+      delivery.updatedAt ? formatRelativeTime(delivery.updatedAt) : null
+    ].filter((part): part is string => Boolean(part));
+    return parts.join(' · ');
+  }
+
+  function artifactDeliveriesForActiveSurface(
+    chat: PmaChatSummary | null,
+    deliveries: ArtifactDelivery[]
+  ): ArtifactDelivery[] {
+    if (!chat) return [];
+    const ref = surfaceRefFromThreadRaw(chat.raw as Record<string, unknown>);
+    if (!ref) return [];
+    const targetKeys = new Set([ref.key, `${ref.kind}:${ref.key}`].map((value) => value.toLowerCase()));
+    const surface = ref.kind.toLowerCase();
+    return deliveries.filter((delivery) => {
+      const deliverySurface = delivery.targetSurface?.toLowerCase() ?? '';
+      const deliveryTarget = delivery.targetConversation?.toLowerCase() ?? '';
+      return (!deliverySurface || deliverySurface === surface) && targetKeys.has(deliveryTarget);
+    });
+  }
+
+  async function openFileDrawer(): Promise<void> {
+    fileDrawerOpen = true;
+    if (activeChat && !isLocalDraftChatId(activeChat.id)) {
+      const key = `${activeChat.id}|${activeChat.repoId ?? ''}`;
+      artifactDeliveryLoadKey = key;
+      await refreshArtifactDeliveries(activeChat.repoId ?? null, key);
+    }
   }
 
   function closeStream(): void {
@@ -1545,6 +1637,11 @@
       if (!result.ok) composeError = result.error;
       else {
         readModelEntityStore.setPmaArtifacts(activeChatId ?? '__global__', result.data);
+        if (activeChat && !isLocalDraftChatId(activeChat.id)) {
+          const key = `${activeChat.id}|${activeChat.repoId ?? ''}`;
+          artifactDeliveryLoadKey = key;
+          await refreshArtifactDeliveries(activeChat.repoId ?? null, key, { quiet: true });
+        }
         showCommandNotice(result.data.length ? `Files refreshed (${result.data.length}).` : 'No PMA files yet.');
         clearSlashDraft();
       }
@@ -2086,8 +2183,16 @@
           </p>
         {/if}
       </div>
-      {#if activeChat && (showStreamHealthAside || !isPmaChatArchived(activeChat))}
+      {#if activeChat && (showStreamHealthAside || !isPmaChatArchived(activeChat) || activeSharedFileCount > 0 || inboxArtifacts.length > 0)}
         <div class="chat-header-tools">
+          <button
+            class="chat-header-action files-action"
+            type="button"
+            onclick={() => void openFileDrawer()}
+            aria-label="Open chat files"
+          >
+            Files{activeSharedFileCount > 0 ? ` ${activeSharedFileCount}` : ''}
+          </button>
           {#if !isPmaChatArchived(activeChat) && !isLocalDraftChatId(activeChat.id)}
             <button
               class="chat-header-action"
@@ -2165,7 +2270,12 @@
           <p>This chat has no visible timeline yet.</p>
         </div>
       {:else}
-        <ChatTranscriptCards cards={activeCards} assistantLabel={chatAgentDisplayLabel} {streamingMessageId} />
+        <ChatTranscriptCards
+          cards={activeCards}
+          assistantLabel={chatAgentDisplayLabel}
+          {streamingMessageId}
+          sharedFiles={assistantSharedFiles}
+        />
         {#if showTypingIndicator}
           {@render typingDots('Assistant is typing')}
         {/if}
@@ -2219,6 +2329,86 @@
           </span>
         {/if}
       </div>
+    {/if}
+
+    {#if fileDrawerOpen}
+      <section class="chat-files-drawer" aria-label="Chat files">
+        <div class="chat-files-drawer-head">
+          <div>
+            <span class="artifact-type">Files</span>
+            <h2>Shared files</h2>
+          </div>
+          <div class="chat-files-drawer-actions">
+            <button
+              type="button"
+              class="chat-header-action"
+              disabled={!activeChat || loadingArtifactDeliveries}
+              onclick={() => activeChat && void refreshArtifactDeliveries(activeChat.repoId ?? null)}
+            >
+              {loadingArtifactDeliveries ? 'Refreshing...' : 'Refresh'}
+            </button>
+            <button
+              type="button"
+              class="icon-button"
+              aria-label="Close files"
+              title="Close files"
+              onclick={() => (fileDrawerOpen = false)}
+            >
+              x
+            </button>
+          </div>
+        </div>
+        <div class="chat-files-sections">
+          <section class="chat-files-section" aria-label="Files from you">
+            <h3>From you</h3>
+            {#if inboxArtifacts.length === 0}
+              <p class="chat-files-empty">No uploaded files for this chat.</p>
+            {:else}
+              <ul class="chat-files-list">
+                {#each inboxArtifacts as artifact (artifact.id)}
+                  <li>
+                    <span class="attachment-kind">{artifact.kind}</span>
+                    {#if artifact.url}
+                      <a href={href(artifact.url)} target="_blank" rel="noopener"><strong>{artifact.title}</strong></a>
+                    {:else}
+                      <strong>{artifact.title}</strong>
+                    {/if}
+                    {#if artifact.summary}
+                      <em>{artifact.summary}</em>
+                    {/if}
+                  </li>
+                {/each}
+              </ul>
+            {/if}
+          </section>
+          <section class="chat-files-section" aria-label="Files from assistant">
+            <h3>From agent</h3>
+            {#if artifactDeliveryError}
+              <p class="chat-files-empty error">{artifactDeliveryError.message}</p>
+            {:else if activeSurfaceDeliveries.length === 0}
+              <p class="chat-files-empty">No agent-shared files yet.</p>
+            {:else}
+              <ul class="chat-files-list delivery-list">
+                {#each activeSurfaceDeliveries as delivery (delivery.deliveryId)}
+                  {@const stateLabel = artifactDeliveryStateLabel(delivery)}
+                  <li class={`delivery-${stateLabel}`}>
+                    <span class="attachment-kind">{stateLabel}</span>
+                    {#if delivery.downloadUrl}
+                      <a href={href(delivery.downloadUrl)} target="_blank" rel="noopener"><strong>{delivery.filename}</strong></a>
+                    {:else}
+                      <strong>{delivery.filename}</strong>
+                    {/if}
+                    <em>{artifactDeliveryMeta(delivery)}</em>
+                    {#if delivery.lastError}
+                      <small>{delivery.lastError}</small>
+                    {/if}
+                  </li>
+                {/each}
+              </ul>
+            {/if}
+          </section>
+        </div>
+      </section>
     {/if}
 
     <form

--- a/tests/surfaces/web/services/test_workspace_resources.py
+++ b/tests/surfaces/web/services/test_workspace_resources.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from codex_autorunner.core.artifact_filebox_storage import ArtifactFileBoxStorage
+from codex_autorunner.surfaces.web.services.workspace_resources import (
+    FileBoxResourceService,
+    FileBoxUrlScope,
+)
+
+
+def test_artifact_delivery_listing_includes_download_url(tmp_path: Path) -> None:
+    source = tmp_path / "spec.md"
+    source.write_text("# Spec\n", encoding="utf-8")
+    intent = ArtifactFileBoxStorage(tmp_path).enqueue_delivery_file(
+        source,
+        target_surface="discord",
+        target_conversation_key="channel:1",
+    )
+
+    payload = FileBoxResourceService().list_artifact_deliveries(
+        tmp_path,
+        url_scope=FileBoxUrlScope(root_path="/base", repo_id="repo-1"),
+    )
+
+    delivery = payload["deliveries"][0]
+    assert delivery["delivery_id"] == intent.delivery_id
+    assert delivery["download_url"] == (
+        f"/base/hub/filebox/repo-1/artifacts/deliveries/"
+        f"{intent.delivery_id.replace(':', '%3A')}/download"
+    )
+    assert delivery["artifact"]["url"] == delivery["download_url"]
+
+
+def test_open_delivery_artifact_returns_downloadable_file(tmp_path: Path) -> None:
+    source = tmp_path / "report.txt"
+    source.write_text("payload\n", encoding="utf-8")
+    intent = ArtifactFileBoxStorage(tmp_path).enqueue_delivery_file(
+        source,
+        target_surface="discord",
+        target_conversation_key="channel:1",
+    )
+
+    resource = FileBoxResourceService().open_delivery_artifact(
+        tmp_path, intent.delivery_id
+    )
+
+    try:
+        assert resource.entry.name == "report.txt"
+        assert resource.entry.source == "artifact_delivery"
+        assert resource.handle.read() == b"payload\n"
+    finally:
+        resource.handle.close()


### PR DESCRIPTION
## Summary
- Add HTTP download URLs and download routes for artifact delivery records.
- Add typed frontend artifact-delivery mapping and API client support.
- Show agent-shared delivery files in chat and add a Files drawer for inbound uploads plus agent outbox records.

## Validation
- pre-commit web-ui lane: guardrails, repo-wide mypy, full pytest, web lab, web lint, web build, web tests, SPA shell check
- pnpm web:test
- pnpm web:lint
- pnpm run build
- .venv/bin/python -m pytest tests/surfaces/web/services/test_workspace_resources.py
- .venv/bin/python -m ruff check src/codex_autorunner/surfaces/web/routes/filebox.py src/codex_autorunner/surfaces/web/services/workspace_resources.py tests/surfaces/web/services/test_workspace_resources.py
