### PR TITLE
[codex] Fix chat filter overflow collapse

### DIFF
--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -650,9 +650,12 @@ a {
   width: 100%;
 }
 
-.chat-filter-bar > .chat-filter-chips-row {
+.chat-filter-bar > .filter-row-container {
   flex: 1 1 auto;
   min-width: 0;
+}
+
+.chat-filter-bar .chat-filter-chips-row {
   flex-wrap: wrap;
   gap: var(--space-2);
 }

--- a/src/codex_autorunner/web_frontend/src/lib/components/FilterRow.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/FilterRow.svelte
@@ -66,9 +66,8 @@
   });
 
   $effect(() => {
-    // Re-measure when item set changes.
-    items.length;
-    items.map((i) => i.key).join('|');
+    // Re-measure when visible chip content changes.
+    items.map((i) => `${i.key}:${i.label}:${i.count ?? ''}`).join('|');
     queueMicrotask(recompute);
   });
 
@@ -174,6 +173,7 @@
 <style>
   .filter-row-container {
     position: relative;
+    min-width: 0;
   }
 
   .filter-row-measure {

--- a/src/codex_autorunner/web_frontend/src/lib/components/FilterRow.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/FilterRow.svelte
@@ -94,7 +94,7 @@
 </script>
 
 <div class="filter-row-container" bind:this={containerEl}>
-  <div class="filter-row filter-row-measure" bind:this={measureEl} aria-hidden="true">
+  <div class="{rowClass} filter-row-measure" bind:this={measureEl} aria-hidden="true">
     {#each items as item (item.key)}
       <button class="chip" type="button" tabindex="-1" data-filter-chip>
         {item.label}

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -1726,6 +1726,7 @@
       <FilterRow
         rootClass="chat-filter-chips-row"
         ariaLabel="Chat filters"
+        maxRows={1}
         items={[
           ...CHAT_FILTER_ORDER.filter(
             (item) => item !== 'unread' || filterCounts.unread > 0 || filter === 'unread'


### PR DESCRIPTION
## Summary
- Collapse the chat filter row after one measured line so overflowing filters use the dropdown consistently.
- Let the FilterRow wrapper participate in chat filter flex sizing and remeasure when chip labels or counts change.

## Root cause
The chat page used FilterRow with its default two-row collapse threshold, so rows that wrapped once remained inline. The chat CSS also targeted the old direct child row instead of the component wrapper, and FilterRow only remeasured item keys rather than visible chip content.

## Validation
- Commit hook web-ui lane passed: guardrails, mypy, pytest, web UI lab, web lint, build, web tests, and SPA shell check.
- Additional manual screenshots captured at 1440x900, 1000x900, 760x900, and 390x844 under .codex-autorunner/render/chat-filter-hub-check/.
- Mocked overflow screenshots captured under .codex-autorunner/render/chat-filter-overflow-mock/ to verify narrow/constrained rows collapse while full-width rows stay inline when they fit.
