### PR TITLE
[codex] Fix repo worktree cache windows

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.test.ts
@@ -125,6 +125,37 @@ describe('read model loaders', () => {
     expect(client.repoWorktreeRuntime).toHaveBeenCalledWith('all', 50);
   });
 
+  it('does not treat a smaller support window as the full repo-worktree index', async () => {
+    const store = new ReadModelEntityStore();
+    store.applyRepoWorktreeTopologySnapshot(repoWorktreeTopologySnapshot({ limit: 50, totalEstimate: 67 }));
+    store.applyRepoWorktreeRuntimeSnapshot(repoWorktreeRuntimeSnapshot({ limit: 50, totalEstimate: 67 }));
+    const client = mockClient({
+      repoWorktreeTopology: vi.fn().mockResolvedValue(ok(repoWorktreeTopologySnapshot({ limit: 200, totalEstimate: 67 }))),
+      repoWorktreeRuntime: vi.fn().mockResolvedValue(ok(repoWorktreeRuntimeSnapshot({ limit: 200, totalEstimate: 67 })))
+    });
+    const { ensureRepoWorktreeIndexLoaded } = await importLoaders(true);
+
+    const result = await ensureRepoWorktreeIndexLoaded({ store, client, blocking: false });
+
+    expect(result).toEqual({ status: 'cold', tags: ['entity:repo-worktree:index'] });
+    expect(client.repoWorktreeTopology).not.toHaveBeenCalled();
+    expect(client.repoWorktreeRuntime).not.toHaveBeenCalled();
+  });
+
+  it('returns a cache hit for a complete repo-worktree index window', async () => {
+    const store = new ReadModelEntityStore();
+    store.applyRepoWorktreeTopologySnapshot(repoWorktreeTopologySnapshot());
+    store.applyRepoWorktreeRuntimeSnapshot(repoWorktreeRuntimeSnapshot());
+    const client = mockClient();
+    const { ensureRepoWorktreeIndexLoaded } = await importLoaders(true);
+
+    const result = await ensureRepoWorktreeIndexLoaded({ store, client, blocking: false });
+
+    expect(result).toEqual({ status: 'cache-hit', tags: ['entity:repo-worktree:index'] });
+    expect(client.repoWorktreeTopology).not.toHaveBeenCalled();
+    expect(client.repoWorktreeRuntime).not.toHaveBeenCalled();
+  });
+
   it('uses ticket and owner entity tags for scoped ticket details', async () => {
     const store = new ReadModelEntityStore();
     const depends = vi.fn();
@@ -294,24 +325,24 @@ function chatDetailSnapshot(chatId = 'chat-1'): ChatDetailSnapshot {
   };
 }
 
-function repoWorktreeTopologySnapshot(): RepoWorktreeTopologySnapshot {
+function repoWorktreeTopologySnapshot(options: { limit?: number; totalEstimate?: number } = {}): RepoWorktreeTopologySnapshot {
   return {
     contractVersion: READ_MODEL_CONTRACT_VERSION,
     kind: 'repo_worktree.topology.snapshot',
     cursor: cursor(3, 'repo_worktree.topology'),
-    window: { limit: 200, totalEstimate: 2, totalIsExact: true },
+    window: { limit: options.limit ?? 200, totalEstimate: options.totalEstimate ?? 2, totalIsExact: true },
     repos: [{ repoId: 'repo-1', label: 'Repo One', path: '/repo', archived: false, childWorktreeIds: ['worktree-1'] }],
     worktrees: [{ worktreeId: 'worktree-1', repoId: 'repo-1', label: 'Worktree One', path: '/repo/wt', branch: 'main', archived: false }],
     repair: repair('/hub/read-models/repo-worktree/topology')
   };
 }
 
-function repoWorktreeRuntimeSnapshot(): RepoWorktreeRuntimeSnapshot {
+function repoWorktreeRuntimeSnapshot(options: { limit?: number; totalEstimate?: number } = {}): RepoWorktreeRuntimeSnapshot {
   return {
     contractVersion: READ_MODEL_CONTRACT_VERSION,
     kind: 'repo_worktree.runtime.snapshot',
     cursor: cursor(4, 'repo_worktree.runtime'),
-    window: { limit: 200, totalEstimate: 1, totalIsExact: true },
+    window: { limit: options.limit ?? 200, totalEstimate: options.totalEstimate ?? 1, totalIsExact: true },
     runtime: [{
       entityKind: 'repo',
       entityId: 'repo-1',

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelLoaders.ts
@@ -2,6 +2,7 @@ import { browser } from '$app/environment';
 import type { ApiError } from '$lib/api/client';
 import {
   readModelEntityStore,
+  repoWorktreeWindowKey,
   type ReadModelEntityState,
   type ReadModelEntityStore
 } from './readModelStore';
@@ -92,14 +93,15 @@ export async function ensureRepoWorktreeIndexLoaded(
   options: ReadModelLoaderOptions & { limit?: number } = {}
 ): Promise<ReadModelLoaderResult> {
   const tags = [readModelEntityTags.repoWorktreeIndex];
+  const limit = options.limit ?? 200;
   return ensureSnapshotLoaded({
     tags,
     options,
-    isCached: (state) => Boolean(state.cursors['repo_worktree.topology'] && state.cursors['repo_worktree.runtime']),
+    isCached: (state) => isRepoWorktreeIndexWindowCached(state, limit),
     fetchAndApply: async (client, store) => {
       const [topology, runtime] = await Promise.all([
-        client.repoWorktreeTopology('all', options.limit ?? 200),
-        client.repoWorktreeRuntime('all', options.limit ?? 200)
+        client.repoWorktreeTopology('all', limit),
+        client.repoWorktreeRuntime('all', limit)
       ]);
       if (!topology.ok) return topology;
       if (!runtime.ok) return runtime;
@@ -108,6 +110,30 @@ export async function ensureRepoWorktreeIndexLoaded(
       return runtime;
     }
   });
+}
+
+export function isRepoWorktreeIndexWindowCached(
+  state: ReadModelEntityState,
+  limit = 200
+): boolean {
+  const window = state.repoWorktreeWindows[repoWorktreeWindowKey('all', limit)];
+  if (!window?.topologyWindow || !window.runtimeWindow) return false;
+  const topologyLoaded = window.repoIds.length + window.worktreeIds.length;
+  const runtimeLoaded = window.runtimeIds.length;
+  return (
+    windowCompletesRequest(window.topologyWindow, topologyLoaded, limit) &&
+    windowCompletesRequest(window.runtimeWindow, runtimeLoaded, limit)
+  );
+}
+
+function windowCompletesRequest(
+  window: { limit: number; totalEstimate?: number | null; totalIsExact: boolean },
+  loaded: number,
+  requestedLimit: number
+): boolean {
+  if (window.limit < requestedLimit) return false;
+  if (!window.totalIsExact || window.totalEstimate == null) return loaded >= requestedLimit;
+  return loaded >= Math.min(window.totalEstimate, requestedLimit);
 }
 
 export async function ensureTicketDetailLoaded(

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -107,6 +107,18 @@ export type ChatIndexWindow = {
   error: string | null;
 };
 
+export type RepoWorktreeIndexWindow = {
+  key: string;
+  kind: 'all' | 'repo' | 'worktree';
+  limit: number;
+  repoIds: string[];
+  worktreeIds: string[];
+  runtimeIds: string[];
+  topologyWindow: PageWindow | null;
+  runtimeWindow: PageWindow | null;
+  lastLoadedAt: string;
+};
+
 export type ReadModelEntityState = {
   cursors: Record<string, ProjectionCursor>;
   chatIndexCursor: ProjectionCursor | null;
@@ -128,6 +140,7 @@ export type ReadModelEntityState = {
   repoOrder: string[];
   worktrees: Record<string, WorktreeTopology>;
   worktreeOrder: string[];
+  repoWorktreeWindows: Record<string, RepoWorktreeIndexWindow>;
   runtime: Record<string, RepoWorktreeRuntimeEntity>;
   tickets: Record<string, TicketProjection>;
   ticketSummaries: Record<string, TicketSummary>;
@@ -191,6 +204,7 @@ export function createInitialReadModelState(): ReadModelEntityState {
     repoOrder: [],
     worktrees: {},
     worktreeOrder: [],
+    repoWorktreeWindows: {},
     runtime: {},
     tickets: {},
     ticketSummaries: {},
@@ -545,6 +559,15 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     next.repoOrder = snapshot.repos.map((repo) => repo.repoId);
     next.worktrees = keyed(snapshot.worktrees, (worktree) => worktree.worktreeId);
     next.worktreeOrder = snapshot.worktrees.map((worktree) => worktree.worktreeId);
+    const windowKey = repoWorktreeWindowKey('all', snapshot.window?.limit ?? snapshot.repos.length + snapshot.worktrees.length);
+    const previousWindow = next.repoWorktreeWindows[windowKey] ?? emptyRepoWorktreeIndexWindow(windowKey, snapshot.window?.limit ?? 0);
+    next.repoWorktreeWindows[windowKey] = {
+      ...previousWindow,
+      repoIds: next.repoOrder,
+      worktreeIds: next.worktreeOrder,
+      topologyWindow: snapshot.window ?? null,
+      lastLoadedAt: new Date().toISOString()
+    };
     for (const repo of snapshot.repos) bump(next, 'repo', repo.repoId);
     for (const worktree of snapshot.worktrees) bump(next, 'worktree', worktree.worktreeId);
     rememberCursor(next, 'repo_worktree.topology', snapshot.cursor);
@@ -553,11 +576,21 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
 
   applyRepoWorktreeRuntimeSnapshot(snapshot: RepoWorktreeRuntimeSnapshot): void {
     const next = cloneState(this.state);
+    const runtimeIds: string[] = [];
     for (const runtime of snapshot.runtime) {
       const id = `${runtime.entityKind}:${runtime.entityId}`;
       next.runtime[id] = { ...runtime, id };
+      runtimeIds.push(id);
       bump(next, runtime.entityKind, runtime.entityId);
     }
+    const windowKey = repoWorktreeWindowKey('all', snapshot.window?.limit ?? snapshot.runtime.length);
+    const previousWindow = next.repoWorktreeWindows[windowKey] ?? emptyRepoWorktreeIndexWindow(windowKey, snapshot.window?.limit ?? 0);
+    next.repoWorktreeWindows[windowKey] = {
+      ...previousWindow,
+      runtimeIds,
+      runtimeWindow: snapshot.window ?? null,
+      lastLoadedAt: new Date().toISOString()
+    };
     rememberCursor(next, 'repo_worktree.runtime', snapshot.cursor);
     this.commit(next);
   }
@@ -857,6 +890,7 @@ function cloneState(state: ReadModelEntityState): ReadModelEntityState {
     repoOrder: [...state.repoOrder],
     worktrees: { ...state.worktrees },
     worktreeOrder: [...state.worktreeOrder],
+    repoWorktreeWindows: Object.fromEntries(Object.entries(state.repoWorktreeWindows).map(([key, window]) => [key, cloneRepoWorktreeIndexWindow(window)])),
     runtime: { ...state.runtime },
     tickets: { ...state.tickets },
     ticketSummaries: { ...state.ticketSummaries },
@@ -890,6 +924,35 @@ function cloneChatDetailProjection(detail: ChatDetailProjection): ChatDetailProj
     thread: detail.thread,
     queue: detail.queue,
     artifactIds: [...detail.artifactIds]
+  };
+}
+
+export function repoWorktreeWindowKey(kind: 'all' | 'repo' | 'worktree' = 'all', limit = 200): string {
+  return `${kind}:limit=${limit}`;
+}
+
+function emptyRepoWorktreeIndexWindow(key: string, limit: number): RepoWorktreeIndexWindow {
+  return {
+    key,
+    kind: 'all',
+    limit,
+    repoIds: [],
+    worktreeIds: [],
+    runtimeIds: [],
+    topologyWindow: null,
+    runtimeWindow: null,
+    lastLoadedAt: new Date().toISOString()
+  };
+}
+
+function cloneRepoWorktreeIndexWindow(window: RepoWorktreeIndexWindow): RepoWorktreeIndexWindow {
+  return {
+    ...window,
+    repoIds: [...window.repoIds],
+    worktreeIds: [...window.worktreeIds],
+    runtimeIds: [...window.runtimeIds],
+    topologyWindow: window.topologyWindow ? { ...window.topologyWindow } : null,
+    runtimeWindow: window.runtimeWindow ? { ...window.runtimeWindow } : null
   };
 }
 

--- a/src/codex_autorunner/web_frontend/src/routes/repos/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/+page.svelte
@@ -33,7 +33,7 @@
   let coldHydrating = $state<boolean>(true);
   let refreshError = $state<ApiError | null>(null);
   const loading = $derived((data.status === 'cold' && coldHydrating && !hasCachedRows) || (refreshing && !hasCachedRows));
-  const error = $derived(refreshError ?? (data.status === 'error' ? data.error : null));
+  const error = $derived(!hasCachedRows ? refreshError ?? (data.status === 'error' ? data.error : null) : null);
   let sectionIssues = $state<PartialPageIssue[]>([]);
   let notice = $state<ActionNotice | null>(null);
 

--- a/src/codex_autorunner/web_frontend/src/routes/repos/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/repos/+page.svelte
@@ -28,10 +28,11 @@
       ticketsListLoaded: false
     })
   );
+  const hasCachedRows = $derived(Boolean(index && index.rows.length > 0));
   let refreshing = $state<boolean>(false);
   let coldHydrating = $state<boolean>(true);
   let refreshError = $state<ApiError | null>(null);
-  const loading = $derived((data.status === 'cold' && coldHydrating) || refreshing);
+  const loading = $derived((data.status === 'cold' && coldHydrating && !hasCachedRows) || (refreshing && !hasCachedRows));
   const error = $derived(refreshError ?? (data.status === 'error' ? data.error : null));
   let sectionIssues = $state<PartialPageIssue[]>([]);
   let notice = $state<ActionNotice | null>(null);
@@ -46,15 +47,15 @@
     unsubscribeReadModels = readModelEntityStore.subscribe((state) => {
       readModelState = state;
     });
-    if (data.status === 'cold') void loadRepos();
+    void loadRepos({ showLoading: data.status === 'cold' && !hasCachedRows });
   });
 
   onDestroy(() => {
     unsubscribeReadModels?.();
   });
 
-  async function loadRepos(): Promise<void> {
-    refreshing = true;
+  async function loadRepos(options: { showLoading?: boolean } = {}): Promise<void> {
+    if (options.showLoading !== false) refreshing = true;
     refreshError = null;
     sectionIssues = [];
     try {

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/+page.svelte
@@ -27,10 +27,11 @@
       'worktree'
     )
   );
+  const hasCachedRows = $derived(Boolean(index && index.rows.length > 0));
   let refreshing = $state<boolean>(false);
   let coldHydrating = $state<boolean>(true);
   let refreshError = $state<ApiError | null>(null);
-  const loading = $derived((data.status === 'cold' && coldHydrating) || refreshing);
+  const loading = $derived((data.status === 'cold' && coldHydrating && !hasCachedRows) || (refreshing && !hasCachedRows));
   const error = $derived(refreshError ?? (data.status === 'error' ? data.error : null));
   let notice = $state<ActionNotice | null>(null);
 
@@ -38,15 +39,15 @@
     unsubscribeReadModels = readModelEntityStore.subscribe((state) => {
       readModelState = state;
     });
-    if (data.status === 'cold') void loadWorktrees();
+    void loadWorktrees({ showLoading: data.status === 'cold' && !hasCachedRows });
   });
 
   onDestroy(() => {
     unsubscribeReadModels?.();
   });
 
-  async function loadWorktrees(): Promise<void> {
-    refreshing = true;
+  async function loadWorktrees(options: { showLoading?: boolean } = {}): Promise<void> {
+    if (options.showLoading !== false) refreshing = true;
     refreshError = null;
     try {
       const result = await ensureRepoWorktreeIndexLoaded({ refresh: true });

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/+page.svelte
@@ -32,7 +32,7 @@
   let coldHydrating = $state<boolean>(true);
   let refreshError = $state<ApiError | null>(null);
   const loading = $derived((data.status === 'cold' && coldHydrating && !hasCachedRows) || (refreshing && !hasCachedRows));
-  const error = $derived(refreshError ?? (data.status === 'error' ? data.error : null));
+  const error = $derived(!hasCachedRows ? refreshError ?? (data.status === 'error' ? data.error : null) : null);
   let notice = $state<ActionNotice | null>(null);
 
   onMount(() => {

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/load.test.ts
@@ -18,7 +18,7 @@ describe('/worktrees index route load', () => {
     store.applyRepoWorktreeRuntimeSnapshot(runtimeSnapshot());
     const client = mockClient();
     const depends = vi.fn();
-    vi.doMock('$lib/data/readModelStore', () => ({ readModelEntityStore: store }));
+    vi.doMock('$lib/data/readModelStore', () => ({ readModelEntityStore: store, repoWorktreeWindowKey }));
     vi.doMock('$lib/data/readModelClients', () => ({ readModelSnapshotClient: client, createReadModelSnapshotClient: () => client }));
     const { load } = await importPageLoad(true);
 
@@ -33,7 +33,7 @@ describe('/worktrees index route load', () => {
   it('returns cold when the store is empty so navigation can commit immediately', async () => {
     const store = new ReadModelEntityStore();
     const client = mockClient();
-    vi.doMock('$lib/data/readModelStore', () => ({ readModelEntityStore: store }));
+    vi.doMock('$lib/data/readModelStore', () => ({ readModelEntityStore: store, repoWorktreeWindowKey }));
     vi.doMock('$lib/data/readModelClients', () => ({ readModelSnapshotClient: client, createReadModelSnapshotClient: () => client }));
     const { load } = await importPageLoad(true);
 
@@ -90,6 +90,10 @@ function repair(snapshotRoute: string) {
     gapEventType: 'projection.cursor_gap' as const,
     behavior: 'repair_snapshot_required' as const
   };
+}
+
+function repoWorktreeWindowKey(kind: 'all' | 'repo' | 'worktree' = 'all', limit = 200): string {
+  return `${kind}:limit=${limit}`;
 }
 
 function topologySnapshot(): RepoWorktreeTopologySnapshot {

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/page.test.ts
@@ -11,16 +11,9 @@ import Page from './+page.svelte';
 
 const now = '2026-05-11T12:00:00Z';
 
-describe('/repos index page', () => {
+describe('/worktrees index page', () => {
   afterEach(() => {
     readModelEntityStore.reset();
-  });
-
-  it('starts in a loading state before client workspace inventory resolves', () => {
-    const { body } = render(Page, { props: { data: { status: 'cold', tags: [] } } });
-
-    expect(body).toContain('skeleton-page');
-    expect(body).toContain('aria-busy="true"');
   });
 
   it('keeps cached rows visible when a background refresh has failed', () => {
@@ -37,7 +30,7 @@ describe('/repos index page', () => {
       }
     });
 
-    expect(body).toContain('Repo One');
+    expect(body).toContain('Worktree One');
     expect(body).not.toContain('Could not load workspace state');
   });
 });


### PR DESCRIPTION
## Summary
- Track repo/worktree read-model windows so partial support snapshots do not satisfy the full repos index cache.
- Revalidate repos and worktrees pages in the background while preserving instant cached renders.
- Add loader coverage for the 50-row support-window regression and complete-window cache hits.

## Root Cause
The chats page could seed the shared repo/worktree store with a 50-row support snapshot. The repos page only checked for topology/runtime cursors, so it treated that partial window as a complete index and showed stale/missing worktrees until manual refresh.

## Validation
- pnpm web:lint
- pnpm web:test
- commit hook web-ui lane: guardrails, pytest, web lint, build, web tests, SPA shell check
