### PR TITLE
Normalize context usage across agents

### DIFF
--- a/src/codex_autorunner/adapters/agents/opencode_backend.py
+++ b/src/codex_autorunner/adapters/agents/opencode_backend.py
@@ -29,6 +29,7 @@ from ...agents.opencode.turn_runtime import (
 )
 from ...agents.opencode.usage_decoder import extract_usage
 from ...core.logging_utils import log_event
+from ...core.orchestration.runtime_payload_shapes import canonicalize_token_usage
 from ...core.ports.agent_backend import (
     AgentBackend,
     AgentEvent,
@@ -480,6 +481,8 @@ class OpenCodeBackend(AgentBackend):
 
             canonical_usage = output_result.usage or latest_usage_snapshot
             if isinstance(canonical_usage, dict):
+                canonical_usage = canonicalize_token_usage(canonical_usage)
+            if isinstance(canonical_usage, dict):
                 persist_opencode_usage_snapshot(
                     workspace_root,
                     session_id=self._session_id,
@@ -593,7 +596,11 @@ class OpenCodeBackend(AgentBackend):
             if usage is None:
                 usage = extract_usage(payload)
             if isinstance(usage, dict):
-                events.append(TokenUsage(timestamp=now_iso(), usage=dict(usage)))
+                canonical_usage = canonicalize_token_usage(usage)
+                if canonical_usage:
+                    events.append(
+                        TokenUsage(timestamp=now_iso(), usage=canonical_usage)
+                    )
 
         elif payload_type == "messageEnd":
             final_message = parse_message_response(payload).text or payload.get(

--- a/src/codex_autorunner/adapters/chat/turn_metrics.py
+++ b/src/codex_autorunner/adapters/chat/turn_metrics.py
@@ -43,6 +43,8 @@ def _select_context_usage_bucket(
     total = token_usage.get("total")
     if isinstance(total, dict):
         return total
+    if isinstance(token_usage.get("totalTokens"), int):
+        return token_usage
     return None
 
 

--- a/src/codex_autorunner/core/acp_lifecycle.py
+++ b/src/codex_autorunner/core/acp_lifecycle.py
@@ -104,6 +104,15 @@ def extract_usage(payload: Mapping[str, Any]) -> dict[str, Any]:
     token_usage = payload.get("tokenUsage")
     if isinstance(token_usage, Mapping):
         return dict(token_usage)
+    size = payload.get("size")
+    used = payload.get("used")
+    if isinstance(size, int) or isinstance(used, int):
+        result: dict[str, Any] = {}
+        if isinstance(used, int):
+            result["totalTokens"] = used
+        if isinstance(size, int):
+            result["modelContextWindow"] = size
+        return result
     return {}
 
 

--- a/src/codex_autorunner/core/orchestration/runtime_payload_shapes.py
+++ b/src/codex_autorunner/core/orchestration/runtime_payload_shapes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 
 @dataclass(frozen=True)
@@ -30,15 +30,38 @@ class TokenUsageShape:
             return None
 
         return cls(
-            total_tokens=_int_key("totalTokens", "total_tokens"),
-            input_tokens=_int_key("inputTokens", "input_tokens"),
-            output_tokens=_int_key("outputTokens", "output_tokens"),
-            cached_tokens=_int_key(
-                "cachedInputTokens", "cached_tokens", "cached_input_tokens"
+            total_tokens=_int_key("totalTokens", "total_tokens", "total"),
+            input_tokens=_int_key(
+                "inputTokens", "input_tokens", "input", "promptTokens", "prompt_tokens"
             ),
-            reasoning_tokens=_int_key("reasoningTokens", "reasoning_tokens"),
+            output_tokens=_int_key(
+                "outputTokens",
+                "output_tokens",
+                "output",
+                "completionTokens",
+                "completion_tokens",
+            ),
+            cached_tokens=_int_key(
+                "cachedInputTokens",
+                "cached_tokens",
+                "cached_input_tokens",
+                "cachedRead",
+                "cached_read",
+                "cacheRead",
+                "cache_read",
+            ),
+            reasoning_tokens=_int_key(
+                "reasoningTokens",
+                "reasoning_tokens",
+                "reasoning",
+                "reasoningOutputTokens",
+                "reasoning_output_tokens",
+            ),
             context_window=_int_key(
-                "modelContextWindow", "context_window", "contextWindow"
+                "modelContextWindow",
+                "context_window",
+                "contextWindow",
+                "size",
             ),
         )
 
@@ -70,6 +93,118 @@ class TokenUsageShape:
                 self.context_window,
             )
         )
+
+
+def canonicalize_token_usage(raw: Mapping[str, Any]) -> Optional[dict[str, Any]]:
+    """Normalize provider token/context usage into CAR's canonical shape.
+
+    The canonical wire shape is either flat token counters or Codex-style
+    ``last``/``total`` buckets, with ``modelContextWindow`` at the top level.
+    ACP/Hermes native usage uses ``used``/``size``; OpenCode commonly emits flat
+    counters plus model metadata; Codex already emits the bucketed form.
+    """
+
+    if not isinstance(raw, Mapping):
+        return None
+
+    result: dict[str, Any] = {}
+    for key in ("providerID", "providerId", "provider", "modelID", "modelId", "model"):
+        value = raw.get(key)
+        if isinstance(value, str) and value:
+            result[key] = value
+
+    last = _canonicalize_usage_bucket(raw.get("last"))
+    total = _canonicalize_usage_bucket(raw.get("total"))
+    if last:
+        result["last"] = last
+    if total:
+        result["total"] = total
+
+    flat_source = _usage_counter_source(raw)
+    flat = _canonicalize_usage_bucket(flat_source)
+    if flat:
+        if last or total:
+            for key, value in flat.items():
+                if key == "modelContextWindow":
+                    continue
+                result.setdefault(key, value)
+        else:
+            result.update(flat)
+
+    context_window = _first_int(
+        raw,
+        "modelContextWindow",
+        "contextWindow",
+        "context_window",
+        "contextLength",
+        "context_length",
+        "size",
+    )
+    if context_window is None:
+        context_window = _bucket_context_window(last) or _bucket_context_window(total)
+    if context_window is not None and context_window > 0:
+        result["modelContextWindow"] = context_window
+
+    return result or None
+
+
+def _usage_counter_source(raw: Mapping[str, Any]) -> Mapping[str, Any]:
+    usage = raw.get("usage")
+    if isinstance(usage, Mapping):
+        return usage
+    token_usage = raw.get("tokenUsage")
+    if isinstance(token_usage, Mapping):
+        return token_usage
+    return raw
+
+
+def _canonicalize_usage_bucket(raw: Any) -> Optional[dict[str, Any]]:
+    if not isinstance(raw, Mapping):
+        return None
+    shape = TokenUsageShape.from_raw(dict(raw))
+    used = _first_int(raw, "used", "usageUsed", "tokensUsed")
+    total_tokens = shape.total_tokens
+    if total_tokens is None and used is not None:
+        total_tokens = used
+    if total_tokens is None:
+        parts = [
+            value
+            for value in (
+                shape.input_tokens,
+                shape.cached_tokens,
+                shape.output_tokens,
+                shape.reasoning_tokens,
+            )
+            if isinstance(value, int)
+        ]
+        if parts:
+            total_tokens = sum(parts)
+    if total_tokens != shape.total_tokens:
+        shape = TokenUsageShape(
+            total_tokens=total_tokens,
+            input_tokens=shape.input_tokens,
+            output_tokens=shape.output_tokens,
+            cached_tokens=shape.cached_tokens,
+            reasoning_tokens=shape.reasoning_tokens,
+            context_window=shape.context_window,
+        )
+    result = shape.to_dict()
+    return result or None
+
+
+def _bucket_context_window(bucket: Optional[dict[str, Any]]) -> Optional[int]:
+    if not bucket:
+        return None
+    value = bucket.get("modelContextWindow")
+    return value if isinstance(value, int) else None
+
+
+def _first_int(raw: Mapping[str, Any], *keys: str) -> Optional[int]:
+    for key in keys:
+        value = raw.get(key)
+        if isinstance(value, int):
+            return value
+    return None
 
 
 @dataclass(frozen=True)
@@ -148,6 +283,7 @@ def _coerce_tool_input_payload(value: Any) -> dict[str, Any]:
 
 
 __all__ = [
+    "canonicalize_token_usage",
     "OpenCodeToolPartShape",
     "TokenUsageShape",
 ]

--- a/src/codex_autorunner/core/orchestration/runtime_payload_shapes.py
+++ b/src/codex_autorunner/core/orchestration/runtime_payload_shapes.py
@@ -169,12 +169,7 @@ def _canonicalize_usage_bucket(raw: Any) -> Optional[dict[str, Any]]:
     if total_tokens is None:
         parts = [
             value
-            for value in (
-                shape.input_tokens,
-                shape.cached_tokens,
-                shape.output_tokens,
-                shape.reasoning_tokens,
-            )
+            for value in (shape.input_tokens, shape.output_tokens)
             if isinstance(value, int)
         ]
         if parts:

--- a/src/codex_autorunner/core/orchestration/runtime_state_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_state_events.py
@@ -30,6 +30,7 @@ from .codex_item_normalizers import (
     extract_codex_usage,
     is_commentary_agent_message,
 )
+from .runtime_payload_shapes import canonicalize_token_usage
 
 RuntimeStateEventStatus = Literal["ok", "error", "interrupted"]
 
@@ -119,7 +120,9 @@ def normalize_runtime_state_events(raw_event: Any) -> list[RuntimeStateEvent]:
     if not usage and lifecycle.usage:
         usage = dict(lifecycle.usage)
     if usage:
-        events.append(TokenUsage(usage=dict(usage), source=method))
+        canonical_usage = canonicalize_token_usage(usage)
+        if canonical_usage:
+            events.append(TokenUsage(usage=canonical_usage, source=method))
 
     assistant_message_text = None
     assistant_stream_text = None

--- a/src/codex_autorunner/core/orchestration/runtime_thread_decoders.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_decoders.py
@@ -82,6 +82,7 @@ from .opencode_event_fields import (
 from .runtime_payload_shapes import (
     OpenCodeToolPartShape,
     TokenUsageShape,
+    canonicalize_token_usage,
 )
 
 
@@ -146,7 +147,9 @@ def _coerce_dict(value: Any) -> dict[str, Any]:
 
 def _extract_usage(params: dict[str, Any]) -> Optional[dict[str, Any]]:
     result = _shared_extract_usage(params)
-    return result if result else None
+    if result:
+        return canonicalize_token_usage(result)
+    return canonicalize_token_usage(params)
 
 
 def _extract_output_delta(params: dict[str, Any]) -> str:
@@ -506,7 +509,7 @@ def _extract_opencode_usage_part(part: dict[str, Any]) -> Optional[dict[str, Any
     shape = TokenUsageShape.from_raw(part)
     if shape.is_empty():
         return None
-    return shape.to_dict()
+    return canonicalize_token_usage(shape.to_dict())
 
 
 def _normalize_message_part_updated(
@@ -611,7 +614,6 @@ def _reasoning_summary_part_text(params: dict[str, Any]) -> str:
 
 
 class CodexItemDecoder(MessageDecoder):
-
     def methods(self) -> frozenset[str]:
         return (
             frozenset(
@@ -768,7 +770,6 @@ class CodexItemDecoder(MessageDecoder):
 
 
 class LifecycleBoundaryDecoder(MessageDecoder):
-
     def methods(self) -> frozenset[str]:
         return frozenset(
             {
@@ -996,7 +997,6 @@ class PermissionDecoder(MessageDecoder):
 
 
 class UsageDecoder(MessageDecoder):
-
     def methods(self) -> frozenset[str]:
         return frozenset(
             {
@@ -1018,7 +1018,6 @@ class UsageDecoder(MessageDecoder):
 
 
 class SessionUpdateDecoder(MessageDecoder):
-
     def methods(self) -> frozenset[str]:
         return frozenset(
             {
@@ -1105,7 +1104,6 @@ class SessionUpdateDecoder(MessageDecoder):
 
 
 class OpenCodeMessageDecoder(MessageDecoder):
-
     def methods(self) -> frozenset[str]:
         return frozenset(
             {
@@ -1170,7 +1168,6 @@ class OpenCodeMessageDecoder(MessageDecoder):
 
 
 class StreamDeltaDecoder(MessageDecoder):
-
     def methods(self) -> frozenset[str]:
         return frozenset({"turn/streamDelta"})
 
@@ -1187,7 +1184,6 @@ class StreamDeltaDecoder(MessageDecoder):
 
 
 class ErrorDecoder(MessageDecoder):
-
     def methods(self) -> frozenset[str]:
         return frozenset({"turn/error", "error"})
 

--- a/tests/core/orchestration/test_runtime_payload_shapes.py
+++ b/tests/core/orchestration/test_runtime_payload_shapes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from codex_autorunner.core.orchestration.runtime_payload_shapes import (
     OpenCodeToolPartShape,
     TokenUsageShape,
+    canonicalize_token_usage,
 )
 
 
@@ -114,6 +115,52 @@ class TestTokenUsageShape:
         assert shape.total_tokens == 42
         assert shape.input_tokens is None
         assert not shape.is_empty()
+
+
+class TestCanonicalizeTokenUsage:
+    def test_preserves_codex_bucketed_usage(self) -> None:
+        assert canonicalize_token_usage(
+            {
+                "last": {"total_tokens": 80, "input_tokens": 60},
+                "total": {"totalTokens": 120},
+                "modelContextWindow": 100,
+            }
+        ) == {
+            "last": {"totalTokens": 80, "inputTokens": 60},
+            "total": {"totalTokens": 120},
+            "modelContextWindow": 100,
+        }
+
+    def test_accepts_flat_opencode_usage(self) -> None:
+        assert canonicalize_token_usage(
+            {"totalTokens": 80, "inputTokens": 60, "modelContextWindow": 100}
+        ) == {
+            "totalTokens": 80,
+            "inputTokens": 60,
+            "modelContextWindow": 100,
+        }
+
+    def test_maps_acp_size_used_usage_update(self) -> None:
+        assert canonicalize_token_usage({"size": 200000, "used": 50000}) == {
+            "totalTokens": 50000,
+            "modelContextWindow": 200000,
+        }
+
+    def test_computes_total_from_component_counters(self) -> None:
+        assert canonicalize_token_usage(
+            {
+                "input_tokens": 10,
+                "cached_input_tokens": 5,
+                "output_tokens": 3,
+                "reasoning_tokens": 2,
+            }
+        ) == {
+            "totalTokens": 20,
+            "inputTokens": 10,
+            "cachedInputTokens": 5,
+            "outputTokens": 3,
+            "reasoningTokens": 2,
+        }
 
 
 class TestOpenCodeToolPartShape:

--- a/tests/core/orchestration/test_runtime_payload_shapes.py
+++ b/tests/core/orchestration/test_runtime_payload_shapes.py
@@ -155,7 +155,7 @@ class TestCanonicalizeTokenUsage:
                 "reasoning_tokens": 2,
             }
         ) == {
-            "totalTokens": 20,
+            "totalTokens": 13,
             "inputTokens": 10,
             "cachedInputTokens": 5,
             "outputTokens": 3,

--- a/tests/core/orchestration/test_runtime_thread_decoders.py
+++ b/tests/core/orchestration/test_runtime_thread_decoders.py
@@ -623,6 +623,22 @@ class TestUsageDecoder:
         assert len(events) == 1
         assert isinstance(events[0], TokenUsage)
 
+    def test_session_update_usage_update_maps_acp_size_used_context(self) -> None:
+        state, ctx = _ctx(
+            "session/update",
+            {"update": {"sessionUpdate": "usage_update", "size": 200, "used": 50}},
+        )
+        events = SessionUpdateDecoder().decode(
+            "session/update",
+            {"update": {"sessionUpdate": "usage_update", "size": 200, "used": 50}},
+            state,
+            ctx,
+        )
+        assert len(events) == 1
+        assert isinstance(events[0], TokenUsage)
+        assert events[0].usage == {"totalTokens": 50, "modelContextWindow": 200}
+        assert state.token_usage == {"totalTokens": 50, "modelContextWindow": 200}
+
 
 class TestSessionUpdateDecoder:
     def setup_method(self) -> None:

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -325,7 +325,7 @@ async def test_normalize_runtime_thread_raw_event_handles_codex_app_server_updat
     assert isinstance(approval[0], ApprovalRequested)
     assert approval[0].description == "rm -rf /tmp/example"
     assert isinstance(usage[0], TokenUsage)
-    assert usage[0].usage == {"total_tokens": 12}
+    assert usage[0].usage == {"totalTokens": 12}
     assert isinstance(output[0], OutputDelta)
     assert output[0].content == "partial reply"
     assert state.best_assistant_text() == "partial reply"
@@ -581,7 +581,7 @@ async def test_normalize_runtime_thread_raw_event_handles_acp_failure_and_usage(
     )
 
     assert isinstance(usage[0], TokenUsage)
-    assert usage[0].usage == {"total_tokens": 42}
+    assert usage[0].usage == {"totalTokens": 42}
     assert isinstance(failure[0], Failed)
     assert failure[0].error_message == "boom"
     assert state.last_error_message == "boom"
@@ -647,9 +647,9 @@ async def test_normalize_runtime_thread_raw_event_handles_official_session_updat
     assert isinstance(output[0], OutputDelta)
     assert output[0].content == "hello"
     assert isinstance(usage[0], TokenUsage)
-    assert usage[0].usage == {"total_tokens": 42}
+    assert usage[0].usage == {"totalTokens": 42}
     assert state.best_assistant_text() == "hello"
-    assert state.token_usage == {"total_tokens": 42}
+    assert state.token_usage == {"totalTokens": 42}
 
 
 async def test_normalize_runtime_thread_raw_event_preserves_session_update_object_shapes() -> (
@@ -1900,6 +1900,38 @@ class TestCrossBackendUsageParity:
         assert events[0].usage == {"totalTokens": 100}
         assert state.token_usage == {"totalTokens": 100}
 
+    async def test_session_update_usage_update_maps_acp_size_used_context(
+        self,
+    ) -> None:
+        state = RuntimeThreadRunEventState()
+
+        events = await normalize_runtime_thread_raw_event(
+            {
+                "message": {
+                    "method": "session/update",
+                    "params": {
+                        "update": {
+                            "sessionUpdate": "usage_update",
+                            "size": 200000,
+                            "used": 50000,
+                        }
+                    },
+                }
+            },
+            state,
+        )
+
+        assert len(events) == 1
+        assert isinstance(events[0], TokenUsage)
+        assert events[0].usage == {
+            "totalTokens": 50000,
+            "modelContextWindow": 200000,
+        }
+        assert state.token_usage == {
+            "totalTokens": 50000,
+            "modelContextWindow": 200000,
+        }
+
     async def test_thread_token_usage_updated_produces_token_usage_event(self) -> None:
         state = RuntimeThreadRunEventState()
 
@@ -1969,7 +2001,7 @@ class TestCrossBackendUsageParity:
         )
 
         assert canonical_state.token_usage == {"totalTokens": 42}
-        assert snake_state.token_usage == {"total_tokens": 42}
+        assert snake_state.token_usage == {"totalTokens": 42}
 
 
 class TestCrossBackendToolParity:

--- a/tests/core/orchestration/test_runtime_turn_terminal_state.py
+++ b/tests/core/orchestration/test_runtime_turn_terminal_state.py
@@ -283,7 +283,11 @@ def test_runtime_turn_terminal_state_machine_builds_compact_checkpoint() -> None
     assert checkpoint.backend_turn_id == "turn-1"
     assert checkpoint.status == "running"
     assert checkpoint.last_runtime_method == "turn/completed"
-    assert checkpoint.token_usage == {"input": 12, "output": 7}
+    assert checkpoint.token_usage == {
+        "totalTokens": 19,
+        "inputTokens": 12,
+        "outputTokens": 7,
+    }
     assert checkpoint.assistant_text_preview == "hello world"
     assert checkpoint.assistant_char_count == len("hello world")
     assert checkpoint.raw_event_count == 2

--- a/tests/core/test_acp_lifecycle_invariants.py
+++ b/tests/core/test_acp_lifecycle_invariants.py
@@ -1112,6 +1112,25 @@ class TestSessionUpdateKindAliases:
         )
         assert snap.normalized_kind == "token_usage"
 
+    def test_usage_update_size_used_maps_to_token_usage(self) -> None:
+        snap = analyze_acp_lifecycle_message(
+            {
+                "method": "session/update",
+                "params": {
+                    "update": {
+                        "sessionUpdate": "usage_update",
+                        "size": 200000,
+                        "used": 50000,
+                    }
+                },
+            }
+        )
+        assert snap.normalized_kind == "token_usage"
+        assert snap.usage == {
+            "totalTokens": 50000,
+            "modelContextWindow": 200000,
+        }
+
 
 class TestOutputDeltaKeyAliases:
     def test_delta_key(self) -> None:

--- a/tests/test_backend_run_event_contract.py
+++ b/tests/test_backend_run_event_contract.py
@@ -368,7 +368,7 @@ def test_codex_notification_parser_golden_transcript() -> None:
     )
     usage = [event for event in events if isinstance(event, TokenUsage)]
     assert len(usage) == 1
-    assert usage[0].usage["total_tokens"] == 20
+    assert usage[0].usage["totalTokens"] == 20
     assert isinstance(events[-1], Failed)
     assert "permission denied" in events[-1].error_message
 
@@ -459,7 +459,9 @@ def test_codex_notification_parser_supports_outputdelta_reasoning_and_item_compl
     assert events[6].delta_type == "assistant_message"
 
     assert isinstance(events[7], TokenUsage)
-    assert events[7].usage["input_tokens"] == 10
+    assert events[7].usage["inputTokens"] == 10
+    assert events[7].usage["outputTokens"] == 5
+    assert events[7].usage["totalTokens"] == 15
 
 
 def test_codex_notification_parser_accumulates_reasoning_deltas_per_item() -> None:
@@ -526,7 +528,7 @@ def test_opencode_sse_parser_golden_transcript() -> None:
     )
     usage = [event for event in events if isinstance(event, TokenUsage)]
     assert len(usage) == 1
-    assert usage[0].usage["total_tokens"] == 20
+    assert usage[0].usage["totalTokens"] == 20
     assert isinstance(events[-1], Failed)
     assert "permission denied" in events[-1].error_message
 

--- a/tests/test_opencode_agent_pool.py
+++ b/tests/test_opencode_agent_pool.py
@@ -368,7 +368,11 @@ async def test_run_turn_maps_runtime_events_to_result_and_emits(tmp_path: Path):
     assert result.turn_id == "turn-1"
     assert result.raw["final_status"] == "completed"
     assert result.raw["log_lines"] == ["log line"]
-    assert result.raw["token_usage"] == {"input": 3, "output": 5}
+    assert result.raw["token_usage"] == {
+        "totalTokens": 8,
+        "inputTokens": 3,
+        "outputTokens": 5,
+    }
     assert isinstance(result.raw["execution_id"], str)
     assert result.raw["backend_thread_id"] == "session-1"
 

--- a/tests/test_telegram_context_usage_percent.py
+++ b/tests/test_telegram_context_usage_percent.py
@@ -29,3 +29,17 @@ def test_format_tui_token_usage_uses_last_for_ctx_percent() -> None:
     }
     line = _format_tui_token_usage(token_usage)
     assert line == "Token usage: total 80 input 60 output 20 ctx 20%"
+
+
+def test_format_tui_token_usage_accepts_flat_canonical_usage() -> None:
+    token_usage = {
+        "totalTokens": 50,
+        "inputTokens": 40,
+        "outputTokens": 10,
+        "modelContextWindow": 200,
+    }
+    assert _extract_context_usage_percent(token_usage) == 75
+    assert (
+        _format_tui_token_usage(token_usage)
+        == "Token usage: total 50 input 40 output 10 ctx 75%"
+    )


### PR DESCRIPTION
## Summary
- Add a provider-neutral token/context usage canonicalizer shared by runtime event decoding and backend adapters.
- Normalize Codex bucketed usage, OpenCode flat usage, and Hermes/ACP size-used usage into a canonical shape with modelContextWindow.
- Preserve context usage through runtime checkpoints and chat turn metrics so Web, Discord, and Telegram can all render context remaining from the same data contract.

## Validation
- Commit hook aggregate lane passed: guardrails, ruff, black, strict mypy, import/contracts checks, 9,299 Python tests, Web UI lab, web lint/build, and 816 frontend tests.
- Focused regression checks passed for runtime payload shapes, thread decoders/events, ACP lifecycle, Telegram context percentage formatting, cross-surface parity, PMA routes, backend run-event contracts, and OpenCode agent pool token usage.