### PR TITLE
[codex] Improve repo and chat first-load responsiveness

### DIFF
--- a/src/codex_autorunner/surfaces/web/services/repo_worktree_read_models.py
+++ b/src/codex_autorunner/surfaces/web/services/repo_worktree_read_models.py
@@ -890,8 +890,8 @@ class RepoWorktreeReadModelService:
             self._active_chat_binding_counts_by_source
         )
         chat_binding_counts = {
-            repo_id: sum(source_counts.values())
-            for repo_id, source_counts in chat_binding_counts_by_source.items()
+            workspace_id: sum(source_counts.values())
+            for workspace_id, source_counts in chat_binding_counts_by_source.items()
         }
         display_names_by_repo = await asyncio.to_thread(
             self._chat_binding_display_names_by_repo, snapshots

--- a/src/codex_autorunner/surfaces/web/services/repo_worktree_read_models.py
+++ b/src/codex_autorunner/surfaces/web/services/repo_worktree_read_models.py
@@ -128,6 +128,10 @@ def _dict_value(value: object) -> dict[str, Any]:
     return cast(dict[str, Any], value) if isinstance(value, dict) else {}
 
 
+async def _empty_list() -> list[Any]:
+    return []
+
+
 def _int_value(value: object) -> int:
     if isinstance(value, int):
         return value
@@ -508,8 +512,8 @@ class RepoWorktreeReadModelService:
             self._active_chat_binding_counts_by_source
         )
         chat_binding_counts = {
-            repo_id: sum(source_counts.values())
-            for repo_id, source_counts in chat_binding_counts_by_source.items()
+            workspace_id: sum(source_counts.values())
+            for workspace_id, source_counts in chat_binding_counts_by_source.items()
         }
         display_names_by_repo = await asyncio.to_thread(
             self._chat_binding_display_names_by_repo, snapshots
@@ -878,6 +882,55 @@ class RepoWorktreeReadModelService:
             for kind, content in docs.items()
         ]
 
+    async def _child_worktrees(self, repo_id: str) -> list[dict[str, Any]]:
+        snapshots = await asyncio.to_thread(
+            self._context.supervisor.list_repos, use_cache=True
+        )
+        chat_binding_counts_by_source = await asyncio.to_thread(
+            self._active_chat_binding_counts_by_source
+        )
+        chat_binding_counts = {
+            repo_id: sum(source_counts.values())
+            for repo_id, source_counts in chat_binding_counts_by_source.items()
+        }
+        display_names_by_repo = await asyncio.to_thread(
+            self._chat_binding_display_names_by_repo, snapshots
+        )
+        children = [
+            snapshot
+            for snapshot in snapshots
+            if str(getattr(snapshot, "kind", "") or "") == "worktree"
+            and str(getattr(snapshot, "worktree_of", "") or "") == repo_id
+        ]
+        if not children:
+            return []
+        enriched = await asyncio.gather(
+            *[
+                asyncio.to_thread(
+                    self._enricher.enrich_repo,
+                    snapshot,
+                    chat_binding_counts,
+                    chat_binding_counts_by_source,
+                )
+                for snapshot in children
+            ]
+        )
+        out: list[dict[str, Any]] = []
+        for item in enriched:
+            if not isinstance(item, dict):
+                continue
+            item_id = str(item.get("id") or "")
+            sources = _positive_source_counts(
+                chat_binding_counts_by_source.get(item_id, {})
+            )
+            if sources:
+                item["chat_binding_sources"] = sources
+            displays = display_names_by_repo.get(item_id, [])
+            if displays:
+                item["chat_binding_display_names"] = displays
+            out.append(item)
+        return out
+
     async def detail(
         self,
         *,
@@ -900,24 +953,35 @@ class RepoWorktreeReadModelService:
         run_limit = _bounded_limit(run_limit, maximum=100)
         chat_limit = _bounded_limit(chat_limit, maximum=100)
         artifact_limit = _bounded_limit(artifact_limit, maximum=100)
-        tickets = self._scoped_tickets(snapshot_obj, limit=ticket_limit)
-        runs = self._scoped_runs(snapshot_obj.path, limit=run_limit)
-        chats = self._scoped_chats(
-            owner_kind=owner_kind, owner_id=owner_id, limit=chat_limit
+        tickets_task = asyncio.to_thread(
+            self._scoped_tickets, snapshot_obj, limit=ticket_limit
+        )
+        runs_task = asyncio.to_thread(
+            self._scoped_runs, snapshot_obj.path, limit=run_limit
+        )
+        chats_task = asyncio.to_thread(
+            self._scoped_chats,
+            owner_kind=owner_kind,
+            owner_id=owner_id,
+            limit=chat_limit,
+        )
+        contextspace_task = asyncio.to_thread(
+            self._contextspace_summary, snapshot_obj.path
+        )
+        children_task = (
+            self._child_worktrees(owner_id) if owner_kind == "repo" else _empty_list()
+        )
+        tickets, runs, chats, contextspace, children = await asyncio.gather(
+            tickets_task,
+            runs_task,
+            chats_task,
+            contextspace_task,
+            children_task,
         )
         artifacts = list(enriched.get("current_run_artifacts") or [])[:artifact_limit]
-        contextspace = self._contextspace_summary(snapshot_obj.path)
         parent_links: dict[str, Any] = {}
         if owner_kind == "worktree":
             parent_links["repo_id"] = getattr(snapshot_obj, "worktree_of", None)
-        children = []
-        if owner_kind == "repo":
-            children = [
-                item
-                for item in await self._enriched_repos()
-                if str(item.get("kind") or "") == "worktree"
-                and item.get("worktree_of") == owner_id
-            ]
         detail = RepoWorktreeDetailSnapshot(
             cursor=_cursor(f"{owner_kind}.detail"),
             owner_kind=owner_kind,

--- a/src/codex_autorunner/web_frontend/src/lib/application/repoWorktreeDetailSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/repoWorktreeDetailSession.test.ts
@@ -3,7 +3,8 @@ import type { ApiError } from '$lib/api/client';
 import {
   READ_MODEL_CONTRACT_VERSION,
   type ProjectionCursor,
-  type RepoWorktreeDetailSnapshot
+  type RepoWorktreeDetailSnapshot,
+  type RepoWorktreeTopologySnapshot
 } from '$lib/api/readModelContracts';
 import { ReadModelEntityStore } from '$lib/data/readModelStore';
 import {
@@ -172,6 +173,29 @@ describe('repo worktree detail session', () => {
     expect(session.state.ownerId).toBe('repo-2');
     expect(session.state.detail?.id).toBe('repo-2');
   });
+
+  it('ignores stale provisional topology after the route owner changes during hydrate', async () => {
+    const store = new ReadModelEntityStore();
+    const topologyLoad = deferred<{ status: 'fetched'; tags: string[] }>();
+    const session = createSession('repo', 'repo-1', {
+      store,
+      loadRepoWorktreeIndex: vi.fn(() => topologyLoad.promise),
+      loadRepoDetail: vi.fn(async (repoId: string) => {
+        store.applyRepoDetailSnapshot(repoDetailSnapshot(repoId));
+        return { status: 'fetched' as const, tags: [`entity:repo:${repoId}`] };
+      })
+    });
+
+    const staleHydrate = session.hydrate();
+    session.setOwner('repo', 'repo-2', { status: 'cold', tags: ['entity:repo:repo-2'] });
+    await session.load();
+    store.applyRepoWorktreeTopologySnapshot(repoTopologySnapshot('repo-1'));
+    topologyLoad.resolve({ status: 'fetched', tags: ['entity:repo-worktree:index'] });
+    await staleHydrate;
+
+    expect(session.state.ownerId).toBe('repo-2');
+    expect(session.state.detail?.id).toBe('repo-2');
+  });
 });
 
 function createSession(
@@ -185,6 +209,7 @@ function createSession(
     loaderResult: { status: 'cold', tags: [] },
     dependencies: {
       store: new ReadModelEntityStore(),
+      loadRepoWorktreeIndex: vi.fn(async () => ({ status: 'cold' as const, tags: [] })),
       loadRepoDetail: vi.fn(async () => ({ status: 'cold' as const, tags: [] })),
       loadWorktreeDetail: vi.fn(async () => ({ status: 'cold' as const, tags: [] })),
       syncRepoMain: vi.fn(async () => ({ ok: true as const })),
@@ -203,6 +228,38 @@ function repoDetailSnapshot(repoId: string): RepoWorktreeDetailSnapshot {
     identity: { id: repoId, name: `Repo ${repoId}`, path: `/repos/${repoId}`, kind: 'base', worktree_count: 0 },
     topology: { children: [] }
   });
+}
+
+function repoTopologySnapshot(repoId: string): RepoWorktreeTopologySnapshot {
+  return {
+    contractVersion: READ_MODEL_CONTRACT_VERSION,
+    kind: 'repo_worktree.topology.snapshot',
+    cursor: cursor(1, 'repo_worktree.topology'),
+    window: window(),
+    repos: [
+      {
+        repoId,
+        label: `Repo ${repoId}`,
+        path: `/repos/${repoId}`,
+        archived: false,
+        isPinned: false,
+        destinationId: null,
+        childWorktreeIds: [],
+        worktreeSetupCommands: null,
+        chatBound: false,
+        chatBindingCount: 0,
+        chatBindingSources: {},
+        chatBindingDisplayNames: []
+      }
+    ],
+    worktrees: [],
+    repair: {
+      snapshotRoute: '/hub/read-models/repo-worktree/topology',
+      cursorQueryParam: 'after',
+      gapEventType: 'projection.cursor_gap',
+      behavior: 'repair_snapshot_required'
+    }
+  };
 }
 
 function worktreeDetailSnapshot(worktreeId: string, repoId: string | null): RepoWorktreeDetailSnapshot {

--- a/src/codex_autorunner/web_frontend/src/lib/application/repoWorktreeDetailSession.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/repoWorktreeDetailSession.ts
@@ -6,11 +6,14 @@ import type {
   RetireWorktreeTarget
 } from '$lib/actions/repoWorktreeActions';
 import {
+  ensureRepoWorktreeIndexLoaded,
   ensureRepoDetailLoaded,
   ensureWorktreeDetailLoaded,
   invalidateReadModelTags,
   readModelEntityStore,
   readModelEntityTags,
+  selectRepoSummaries,
+  selectWorktreeSummaries,
   type ReadModelDependency,
   type ReadModelEntityStore,
   type ReadModelLoaderResult
@@ -47,6 +50,7 @@ export type RepoWorktreeDetailSessionState = {
 
 export type RepoWorktreeDetailSessionDependencies = {
   store?: Pick<ReadModelEntityStore, 'snapshot'>;
+  loadRepoWorktreeIndex?: typeof ensureRepoWorktreeIndexLoaded;
   loadRepoDetail?: typeof ensureRepoDetailLoaded;
   loadWorktreeDetail?: typeof ensureWorktreeDetailLoaded;
   syncRepoMain: (repoId: string) => Promise<{ ok: true } | { ok: false; error: ApiError }>;
@@ -71,9 +75,9 @@ type OwnerRef = {
 
 export class RepoWorktreeDetailSession {
   private readonly dependencies: Required<
-    Pick<RepoWorktreeDetailSessionDependencies, 'loadRepoDetail' | 'loadWorktreeDetail' | 'invalidateTags'>
+    Pick<RepoWorktreeDetailSessionDependencies, 'loadRepoWorktreeIndex' | 'loadRepoDetail' | 'loadWorktreeDetail' | 'invalidateTags'>
   > &
-    Omit<RepoWorktreeDetailSessionDependencies, 'loadRepoDetail' | 'loadWorktreeDetail' | 'invalidateTags'>;
+    Omit<RepoWorktreeDetailSessionDependencies, 'loadRepoWorktreeIndex' | 'loadRepoDetail' | 'loadWorktreeDetail' | 'invalidateTags'>;
   private readonly store: Pick<ReadModelEntityStore, 'snapshot'>;
   private requestVersion = 0;
   private currentLoaderResult: ReadModelLoaderResult | null;
@@ -83,6 +87,7 @@ export class RepoWorktreeDetailSession {
     this.store = options.dependencies.store ?? readModelEntityStore;
     this.dependencies = {
       ...options.dependencies,
+      loadRepoWorktreeIndex: options.dependencies.loadRepoWorktreeIndex ?? ensureRepoWorktreeIndexLoaded,
       loadRepoDetail: options.dependencies.loadRepoDetail ?? ensureRepoDetailLoaded,
       loadWorktreeDetail: options.dependencies.loadWorktreeDetail ?? ensureWorktreeDetailLoaded,
       invalidateTags: options.dependencies.invalidateTags ?? invalidateReadModelTags
@@ -114,10 +119,24 @@ export class RepoWorktreeDetailSession {
 
   async hydrate(): Promise<void> {
     const owner = this.owner();
+    const requestVersion = ++this.requestVersion;
     const cached = this.cachedSnapshot(owner);
     if (cached) {
+      if (!this.isCurrentRequest(requestVersion, owner)) return;
       await this.applySnapshot(owner, cached);
       this.state = { ...this.state, loading: false };
+      return;
+    }
+    let provisional = this.provisionalDetail(owner);
+    if (!provisional) {
+      await this.dependencies.loadRepoWorktreeIndex({ blocking: true });
+      if (!this.isCurrentRequest(requestVersion, owner)) return;
+      provisional = this.provisionalDetail(owner);
+    }
+    if (provisional) {
+      if (!this.isCurrentRequest(requestVersion, owner)) return;
+      this.state = { ...this.state, detail: provisional, loading: false };
+      await this.load(false);
       return;
     }
     await this.load(true);
@@ -189,11 +208,12 @@ export class RepoWorktreeDetailSession {
 
   private initialState(owner: OwnerRef, loaderResult: ReadModelLoaderResult | null): RepoWorktreeDetailSessionState {
     const cached = this.cachedSnapshot(owner);
+    const provisional = cached ? null : this.provisionalDetail(owner);
     return {
       ownerKind: owner.kind,
       ownerId: owner.id,
-      detail: null,
-      loading: loaderResult?.status === 'cold' && !cached,
+      detail: provisional,
+      loading: loaderResult?.status === 'cold' && !cached && !provisional,
       error: loaderResult?.status === 'error' ? loaderResult.error : null,
       sectionIssues: [],
       notice: null,
@@ -209,6 +229,30 @@ export class RepoWorktreeDetailSession {
   private cachedSnapshot(owner: OwnerRef): RepoWorktreeDetailSnapshot | undefined {
     const snapshot = this.store.snapshot();
     return owner.kind === 'repo' ? snapshot.repoDetails[owner.id] : snapshot.worktreeDetails[owner.id];
+  }
+
+  private provisionalDetail(owner: OwnerRef): RepoWorktreeDetailViewModel | null {
+    const snapshot = this.store.snapshot();
+    const repos = selectRepoSummaries(snapshot);
+    const worktrees = selectWorktreeSummaries(snapshot);
+    const found =
+      owner.kind === 'repo'
+        ? repos.some((repo) => repo.id === owner.id)
+        : worktrees.some((worktree) => worktree.id === owner.id);
+    if (!found) return null;
+    return buildRepoWorktreeDetailViewModel(
+      {
+        repos,
+        worktrees,
+        runs: [],
+        chats: [],
+        tickets: [],
+        artifacts: [],
+        ticketsListLoaded: false
+      },
+      owner.kind,
+      owner.id
+    );
   }
 
   private async applySnapshot(owner: OwnerRef, snapshot: RepoWorktreeDetailSnapshot): Promise<boolean> {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -153,7 +153,8 @@
     'Summarize the conversation so far into a concise context block I can paste into a new thread. Include goals, constraints, decisions, and current state.';
   type ChatTranscriptListItem =
     | { kind: 'card'; id: string; card: ChatTranscriptCard }
-    | { kind: 'typing'; id: string; title: string };
+    | { kind: 'typing'; id: string; title: string }
+    | { kind: 'shared-files'; id: string };
   let readModelState = $state(readModelEntityStore.snapshot());
   let activeChatId = $state<string | null>(null);
   // Unsent new chats are page-local only: `localDraftChat` drives the composer until
@@ -572,7 +573,10 @@
   });
   const transcriptListItems = $derived<ChatTranscriptListItem[]>([
     ...displayTranscriptCards.map((card) => ({ kind: 'card' as const, id: card.id, card })),
-    ...(showTypingIndicator ? [{ kind: 'typing' as const, id: 'typing-indicator', title: 'Assistant is typing' }] : [])
+    ...(showTypingIndicator ? [{ kind: 'typing' as const, id: 'typing-indicator', title: 'Assistant is typing' }] : []),
+    ...(assistantSharedFiles.length > 0
+      ? [{ kind: 'shared-files' as const, id: 'assistant-shared-files' }]
+      : [])
   ]);
   const srAnnouncement = $derived.by<string>(() => {
     if (displayedProgress?.status !== 'running') return '';
@@ -2296,6 +2300,11 @@
                 cards={[item.card]}
                 assistantLabel={chatAgentDisplayLabel}
                 {streamingMessageId}
+              />
+            {:else if item.kind === 'shared-files'}
+              <ChatTranscriptCards
+                cards={[]}
+                assistantLabel={chatAgentDisplayLabel}
                 sharedFiles={assistantSharedFiles}
               />
             {:else}

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -80,6 +80,7 @@
     buildPmaLiveActivity,
     buildManagedThreadMessagePayload,
     buildPmaStatusBar,
+    compactChatTranscriptCards,
     countSemanticTicketRunGroups,
     filterChatEntries,
     formatBytes,
@@ -150,6 +151,9 @@
 
   const COMPACT_SUMMARY_PROMPT =
     'Summarize the conversation so far into a concise context block I can paste into a new thread. Include goals, constraints, decisions, and current state.';
+  type ChatTranscriptListItem =
+    | { kind: 'card'; id: string; card: ChatTranscriptCard }
+    | { kind: 'typing'; id: string; title: string };
   let readModelState = $state(readModelEntityStore.snapshot());
   let activeChatId = $state<string | null>(null);
   // Unsent new chats are page-local only: `localDraftChat` drives the composer until
@@ -473,6 +477,7 @@
   const displayedProgress = $derived(progressWithLiveElapsed(progress, clockNowMs));
   const liveActivity = $derived(buildPmaLiveActivity(displayedProgress));
   const activeCards = $derived<ChatTranscriptCard[]>(visibleChatDetailTranscriptCards(transcriptCards, queuedTurns));
+  const displayTranscriptCards = $derived<ChatTranscriptCard[]>(compactChatTranscriptCards(activeCards));
   const lastAssistantMessageCard = $derived.by<ChatTranscriptCard | null>(() => {
     for (let i = activeCards.length - 1; i >= 0; i -= 1) {
       const card = activeCards[i];
@@ -565,6 +570,10 @@
     if (!last) return false;
     return last.kind === 'message' && last.message.role === 'user';
   });
+  const transcriptListItems = $derived<ChatTranscriptListItem[]>([
+    ...displayTranscriptCards.map((card) => ({ kind: 'card' as const, id: card.id, card })),
+    ...(showTypingIndicator ? [{ kind: 'typing' as const, id: 'typing-indicator', title: 'Assistant is typing' }] : [])
+  ]);
   const srAnnouncement = $derived.by<string>(() => {
     if (displayedProgress?.status !== 'running') return '';
     const card = lastAssistantMessageCard;
@@ -2271,15 +2280,29 @@
           <p>This chat has no visible timeline yet.</p>
         </div>
       {:else}
-        <ChatTranscriptCards
-          cards={activeCards}
-          assistantLabel={chatAgentDisplayLabel}
-          {streamingMessageId}
-          sharedFiles={assistantSharedFiles}
-        />
-        {#if showTypingIndicator}
-          {@render typingDots('Assistant is typing')}
-        {/if}
+        <VirtualList
+          items={transcriptListItems}
+          key={(item) => item.id}
+          estimatedItemSize={220}
+          overscan={6}
+          initialCount={24}
+          ariaLabel="Chat transcript"
+          class="chat-transcript-virtual-list"
+          itemClass="chat-transcript-virtual-item"
+        >
+          {#snippet children(item)}
+            {#if item.kind === 'card'}
+              <ChatTranscriptCards
+                cards={[item.card]}
+                assistantLabel={chatAgentDisplayLabel}
+                {streamingMessageId}
+                sharedFiles={assistantSharedFiles}
+              />
+            {:else}
+              {@render typingDots(item.title)}
+            {/if}
+          {/snippet}
+        </VirtualList>
       {/if}
     </div>
     <div class="sr-only" aria-live="polite" aria-atomic="false">{srAnnouncement}</div>

--- a/tests/surfaces/web/test_hub_repo_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_repo_read_model_routes.py
@@ -123,6 +123,47 @@ def test_repo_worktree_topology_surfaces_chat_bound_channel_display(
     assert worktree["chatBindingDisplayNames"] == ["guild:guild-1 / #chan-bound"]
 
 
+def test_repo_detail_child_worktrees_preserve_chat_binding_metadata(
+    hub_env,
+) -> None:
+    worktree_root = _add_workspace(
+        hub_env.hub_root,
+        repo_id="repo-00--detail-discord-chat",
+        kind="worktree",
+        worktree_of=hub_env.repo_id,
+    )
+    write_discord_binding_rows(
+        hub_env.hub_root / ".codex-autorunner" / "discord_state.sqlite3",
+        rows=[
+            {
+                "channel_id": "chan-detail-bound",
+                "guild_id": "guild-1",
+                "workspace_path": str(worktree_root.resolve()),
+                "repo_id": None,
+                "resource_kind": None,
+                "resource_id": None,
+                "pma_enabled": 0,
+                "agent": "codex",
+                "updated_at": "2026-01-01T00:00:01Z",
+            }
+        ],
+    )
+
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    response = client.get(f"/hub/read-models/repos/{hub_env.repo_id}/detail")
+
+    assert response.status_code == 200
+    child = next(
+        item
+        for item in response.json()["topology"]["children"]
+        if item["id"] == "repo-00--detail-discord-chat"
+    )
+    assert child["chat_bound"] is True
+    assert child["chat_bound_thread_count"] == 1
+    assert child["chat_binding_sources"] == {"discord": 1}
+    assert child["chat_binding_display_names"] == ["guild:guild-1 / #chan-detail-bound"]
+
+
 def test_worktree_detail_snapshot_is_scoped_and_does_not_include_global_tickets(
     hub_env,
 ) -> None:


### PR DESCRIPTION
## Summary

- Render repo/worktree detail from warm topology/runtime read models before the heavier detail snapshot finishes.
- Parallelize repo detail section assembly and keep child worktree chat-binding metadata intact.
- Virtualize per-chat transcript rendering while preserving live typing rows and shared-file props.

## Validation

- Commit hook web-ui lane passed: guardrails, mypy, full pytest (`9292 passed`), Web UI lab, `pnpm web:lint`, web build, full `pnpm web:test`, SPA shell check.
- Post-rebase: `pnpm web:lint`
- Post-rebase: `pnpm web:test -- repoWorktreeDetailSession ChatTranscriptCards`
- Post-rebase: `.venv/bin/python -m pytest tests/surfaces/web/test_hub_repo_read_model_routes.py tests/surfaces/web/test_hub_chat_read_model_routes.py -q`

## Review Notes

A sub-agent reviewed the initial diff and found three issues: stale provisional repo detail after route changes, lost child chat-binding metadata, and typing indicator placement outside the virtualized transcript scroller. This PR addresses all three and adds focused coverage for the first two.
