### PR TITLE
[codex] Add filebox delete controls

### DIFF
--- a/src/codex_autorunner/surfaces/web/routes/filebox.py
+++ b/src/codex_autorunner/surfaces/web/routes/filebox.py
@@ -157,6 +157,14 @@ def build_filebox_routes() -> APIRouter:
         repo_root = _resolve_repo_root(request)
         return await _upload_files_to_box(repo_root=repo_root, box=box, request=request)
 
+    @router.delete("/filebox/{box}")
+    def delete_box_entries(box: str, request: Request) -> dict[str, Any]:
+        repo_root = _resolve_repo_root(request)
+        try:
+            return service.delete_box(repo_root, box)
+        except WorkspaceResourceError as exc:
+            _raise_http(exc)
+
     @router.get("/filebox/{box}/{filename}")
     def download_file(box: str, filename: str, request: Request):
         repo_root = _resolve_repo_root(request)
@@ -247,6 +255,14 @@ def build_hub_filebox_routes() -> APIRouter:
     async def hub_upload(repo_id: str, box: str, request: Request) -> dict[str, Any]:
         repo_root = _resolve_hub_repo_root(request, repo_id)
         return await _upload_files_to_box(repo_root=repo_root, box=box, request=request)
+
+    @router.delete("/{repo_id}/{box}")
+    def hub_delete_box(repo_id: str, box: str, request: Request) -> dict[str, Any]:
+        repo_root = _resolve_hub_repo_root(request, repo_id)
+        try:
+            return service.delete_box(repo_root, box)
+        except WorkspaceResourceError as exc:
+            _raise_http(exc)
 
     @router.get("/{repo_id}/{box}/{filename}")
     def hub_download(repo_id: str, box: str, filename: str, request: Request):

--- a/src/codex_autorunner/surfaces/web/services/workspace_resources.py
+++ b/src/codex_autorunner/surfaces/web/services/workspace_resources.py
@@ -399,6 +399,30 @@ class FileBoxResourceService:
             raise WorkspaceResourceError(404, "File not found")
         return {"status": "ok"}
 
+    def delete_box(self, repo_root: Path, box: str) -> dict[str, Any]:
+        self.validate_box(box)
+        try:
+            entries = ArtifactFileBoxStorage(repo_root).list_filebox()
+        except ValueError as exc:
+            raise WorkspaceResourceError(400, str(exc)) from exc
+        except OSError as exc:
+            raise WorkspaceResourceError(500, "Failed to list files") from exc
+
+        deleted_files: list[str] = []
+        for entry in entries.get(box, []):
+            try:
+                entry.path.unlink()
+                deleted_files.append(entry.name)
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                raise WorkspaceResourceError(500, "Failed to delete files") from exc
+        return {
+            "status": "ok",
+            "deleted": deleted_files,
+            "deleted_count": len(deleted_files),
+        }
+
     def list_artifact_deliveries(
         self,
         repo_root: Path,

--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -2668,6 +2668,14 @@ textarea:hover {
   min-width: 0;
 }
 
+.chat-files-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
 .chat-files-list {
   display: grid;
   gap: var(--space-2);
@@ -2712,6 +2720,34 @@ textarea:hover {
 
 .chat-files-list .attachment-kind {
   flex: 0 0 auto;
+}
+
+.chat-file-delete,
+.chat-file-delete-all {
+  flex: 0 0 auto;
+  min-height: 28px;
+  border: 1px solid color-mix(in srgb, var(--color-danger) 48%, var(--color-border));
+  border-radius: var(--radius-1);
+  background: transparent;
+  color: var(--color-danger);
+  font: inherit;
+  font-size: var(--font-size-0);
+  cursor: pointer;
+}
+
+.chat-file-delete {
+  margin-left: auto;
+  padding: 0 var(--space-2);
+}
+
+.chat-file-delete-all {
+  padding: 0 var(--space-2);
+}
+
+.chat-file-delete:disabled,
+.chat-file-delete-all:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
 }
 
 .chat-files-list li.delivery-sent {

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.test.ts
@@ -831,6 +831,38 @@ describe('API client error handling', () => {
     expect(boxResult.ok).toBe(true);
   });
 
+  it('manages repo-scoped filebox files through generic helpers', async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input) === '/hub/filebox/repo-1') {
+        return Response.json({
+          inbox: [{ name: 'screen.png', box: 'inbox', url: '/hub/filebox/repo-1/inbox/screen.png' }],
+          outbox: []
+        });
+      }
+      return Response.json({ status: 'ok' });
+    }) as unknown as typeof fetch;
+    const client = new WebApiClient(fetcher);
+
+    const listed = await client.filebox.listFiles({ kind: 'repo', repoId: 'repo-1' });
+    const deleted = await client.filebox.deleteFile({ kind: 'repo', repoId: 'repo-1' }, 'inbox', 'screen.png');
+    const cleared = await client.filebox.deleteBox({ kind: 'repo', repoId: 'repo-1' }, 'outbox');
+
+    expect(fetcher).toHaveBeenNthCalledWith(1, '/hub/filebox/repo-1', expect.any(Object));
+    expect(fetcher).toHaveBeenNthCalledWith(
+      2,
+      '/hub/filebox/repo-1/inbox/screen.png',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+    expect(fetcher).toHaveBeenNthCalledWith(
+      3,
+      '/hub/filebox/repo-1/outbox',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+    expect(listed.ok && listed.data[0]).toMatchObject({ title: 'screen.png', raw: { box: 'inbox' } });
+    expect(deleted.ok).toBe(true);
+    expect(cleared.ok).toBe(true);
+  });
+
   it('lists repo artifact deliveries through the hub filebox route', async () => {
     const fetcher = vi.fn(async () =>
       Response.json({

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.test.ts
@@ -810,6 +810,27 @@ describe('API client error handling', () => {
     expect(result).toEqual({ ok: true, data: ['screen.png'] });
   });
 
+  it('deletes PMA filebox files and boxes', async () => {
+    const fetcher = vi.fn(async () => Response.json({ status: 'ok' })) as unknown as typeof fetch;
+    const client = new WebApiClient(fetcher);
+
+    const fileResult = await client.pma.deleteFile('inbox', 'screen shot.png');
+    const boxResult = await client.pma.deleteFileBox('outbox');
+
+    expect(fetcher).toHaveBeenNthCalledWith(
+      1,
+      '/hub/pma/files/inbox/screen%20shot.png',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+    expect(fetcher).toHaveBeenNthCalledWith(
+      2,
+      '/hub/pma/files/outbox',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+    expect(fileResult.ok).toBe(true);
+    expect(boxResult.ok).toBe(true);
+  });
+
   it('lists repo artifact deliveries through the hub filebox route', async () => {
     const fetcher = vi.fn(async () =>
       Response.json({

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.ts
@@ -94,6 +94,12 @@ export type PmaBulkRetireResult = {
   errors: JsonRecord[];
 };
 
+export type FileBoxName = 'inbox' | 'outbox';
+
+export type ChatFileBoxScope =
+  | { kind: 'hub' }
+  | { kind: 'repo'; repoId: string };
+
 export type WorktreeRetireRequest = {
   worktreeRepoId: string;
   force?: boolean;
@@ -403,6 +409,11 @@ function readableErrorText(text: string, status: number): string {
   return text.length > 220 ? `${text.slice(0, 217)}...` : text;
 }
 
+function fileBoxRoute(scope: ChatFileBoxScope): string {
+  if (scope.kind === 'repo') return `/hub/filebox/${encodeURIComponent(scope.repoId)}`;
+  return '/hub/pma/files';
+}
+
 export class WebApiClient {
   constructor(
     private readonly fetcher: typeof fetch = fetch,
@@ -467,6 +478,21 @@ export class WebApiClient {
   url(path: string): string {
     return withRuntimeBasePath(path, this.basePath);
   }
+
+  filebox = {
+    listFiles: async (scope: ChatFileBoxScope = { kind: 'hub' }): Promise<ApiResult<SurfaceArtifact[]>> => {
+      const route = fileBoxRoute(scope);
+      return mapResult(await this.getJson<JsonRecord>(route), (payload) =>
+        [...asArray(payload.inbox), ...asArray(payload.outbox)].map(mapSurfaceArtifact)
+      );
+    },
+    deleteFile: async (scope: ChatFileBoxScope, box: FileBoxName, filename: string): Promise<ApiResult<JsonRecord>> =>
+      this.requestJson<JsonRecord>(`${fileBoxRoute(scope)}/${encodeURIComponent(box)}/${encodeURIComponent(filename)}`, {
+        method: 'DELETE'
+      }),
+    deleteBox: async (scope: ChatFileBoxScope, box: FileBoxName): Promise<ApiResult<JsonRecord>> =>
+      this.requestJson<JsonRecord>(`${fileBoxRoute(scope)}/${encodeURIComponent(box)}`, { method: 'DELETE' })
+  };
 
   pma = {
     // Legacy diagnostics/tests only. Screen routes use chat index/detail projections.
@@ -594,10 +620,7 @@ export class WebApiClient {
       ),
     clearQueue: async (chatId: string): Promise<ApiResult<JsonRecord>> =>
       this.requestJson<JsonRecord>(`/hub/pma/threads/${encodeURIComponent(chatId)}/queue/clear`, { method: 'POST' }),
-    listFiles: async (): Promise<ApiResult<SurfaceArtifact[]>> =>
-      mapResult(await this.getJson<JsonRecord>('/hub/pma/files'), (payload) =>
-        [...asArray(payload.inbox), ...asArray(payload.outbox)].map(mapSurfaceArtifact)
-      ),
+    listFiles: async (): Promise<ApiResult<SurfaceArtifact[]>> => this.filebox.listFiles({ kind: 'hub' }),
     listArtifactDeliveries: async (repoId?: string | null): Promise<ApiResult<ArtifactDelivery[]>> => {
       const route = repoId
         ? `/hub/filebox/${encodeURIComponent(repoId)}/artifacts/deliveries`
@@ -613,12 +636,10 @@ export class WebApiClient {
         Array.isArray(payload.saved) ? payload.saved.filter((name): name is string => typeof name === 'string') : []
       );
     },
-    deleteFile: async (box: 'inbox' | 'outbox', filename: string): Promise<ApiResult<JsonRecord>> =>
-      this.requestJson<JsonRecord>(`/hub/pma/files/${encodeURIComponent(box)}/${encodeURIComponent(filename)}`, {
-        method: 'DELETE'
-      }),
-    deleteFileBox: async (box: 'inbox' | 'outbox'): Promise<ApiResult<JsonRecord>> =>
-      this.requestJson<JsonRecord>(`/hub/pma/files/${encodeURIComponent(box)}`, { method: 'DELETE' }),
+    deleteFile: async (box: FileBoxName, filename: string): Promise<ApiResult<JsonRecord>> =>
+      this.filebox.deleteFile({ kind: 'hub' }, box, filename),
+    deleteFileBox: async (box: FileBoxName): Promise<ApiResult<JsonRecord>> =>
+      this.filebox.deleteBox({ kind: 'hub' }, box),
     listAgents: async (): Promise<ApiResult<{ agents: JsonRecord[]; default: string; defaults: JsonRecord }>> =>
       mapResult(await this.getJson<JsonRecord>('/hub/pma/agents'), (payload) => ({
         agents: asArray(payload.agents),

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.ts
@@ -613,6 +613,12 @@ export class WebApiClient {
         Array.isArray(payload.saved) ? payload.saved.filter((name): name is string => typeof name === 'string') : []
       );
     },
+    deleteFile: async (box: 'inbox' | 'outbox', filename: string): Promise<ApiResult<JsonRecord>> =>
+      this.requestJson<JsonRecord>(`/hub/pma/files/${encodeURIComponent(box)}/${encodeURIComponent(filename)}`, {
+        method: 'DELETE'
+      }),
+    deleteFileBox: async (box: 'inbox' | 'outbox'): Promise<ApiResult<JsonRecord>> =>
+      this.requestJson<JsonRecord>(`/hub/pma/files/${encodeURIComponent(box)}`, { method: 'DELETE' }),
     listAgents: async (): Promise<ApiResult<{ agents: JsonRecord[]; default: string; defaults: JsonRecord }>> =>
       mapResult(await this.getJson<JsonRecord>('/hub/pma/agents'), (payload) => ({
         agents: asArray(payload.agents),

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/slashCommands.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/slashCommands.ts
@@ -208,7 +208,7 @@ export const WEB_SLASH_COMMANDS: SlashCommandSpec[] = [
     id: 'files',
     name: 'files',
     title: 'Refresh files',
-    description: 'Refresh PMA inbox and outbox artifacts.',
+    description: 'Refresh chat inbox and outbox files.',
     usage: '/files',
     group: 'Chat'
   },

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -2282,7 +2282,7 @@
           </p>
         {/if}
       </div>
-      {#if activeChat && (showStreamHealthAside || !isPmaChatArchived(activeChat) || activeSharedFileCount > 0 || inboxArtifacts.length > 0)}
+      {#if activeChat && (showStreamHealthAside || !isPmaChatArchived(activeChat) || activeSharedFileCount > 0 || inboxArtifacts.length > 0 || outboxArtifacts.length > 0)}
         <div class="chat-header-tools">
           <button
             class="chat-header-action files-action"

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -155,6 +155,7 @@
     | { kind: 'card'; id: string; card: ChatTranscriptCard }
     | { kind: 'typing'; id: string; title: string }
     | { kind: 'shared-files'; id: string };
+  type FileBoxName = 'inbox' | 'outbox';
   let readModelState = $state(readModelEntityStore.snapshot());
   let activeChatId = $state<string | null>(null);
   // Unsent new chats are page-local only: `localDraftChat` drives the composer until
@@ -175,6 +176,8 @@
   let loadingArtifactDeliveries = $state(false);
   let artifactDeliveryError = $state<ApiError | null>(null);
   let artifactDeliveryLoadKey = '';
+  let deletingFileKeys = $state<Set<string>>(new Set());
+  let deletingFileBox = $state<FileBoxName | null>(null);
   let selectedAgent = $state('codex');
   let selectedModel = $state('');
   let selectedReasoning = $state('');
@@ -221,6 +224,7 @@
   const progress = $derived<PmaRunProgress | null>(selectPmaProgress(readModelState, activeChatId));
   const artifacts = $derived<SurfaceArtifact[]>(selectPmaArtifacts(readModelState, activeChatId));
   const inboxArtifacts = $derived(artifacts.filter((artifact) => String(artifact.raw.box ?? '').toLowerCase() === 'inbox'));
+  const outboxArtifacts = $derived(artifacts.filter((artifact) => String(artifact.raw.box ?? '').toLowerCase() === 'outbox'));
   const queuedTurns = $derived<PmaQueuedTurn[]>(selectPmaQueue(readModelState, activeChatId));
   const lastSeenMap = $derived<ChatLastSeenMap>(selectReadMarkers(readModelState) as ChatLastSeenMap);
   let draft = $state('');
@@ -1143,6 +1147,89 @@
     }
   }
 
+  async function refreshPmaFiles(options: { quiet?: boolean } = {}): Promise<number | null> {
+    const result = await webApi.pma.listFiles();
+    if (!result.ok) {
+      composeError = result.error;
+      return null;
+    }
+    readModelEntityStore.setPmaArtifacts('__global__', result.data);
+    if (activeChatId) readModelEntityStore.setPmaArtifacts(activeChatId, result.data);
+    if (!options.quiet) showCommandNotice(result.data.length ? `Files refreshed (${result.data.length}).` : 'No PMA files yet.');
+    return result.data.length;
+  }
+
+  function fileBoxNameFromArtifact(artifact: SurfaceArtifact): FileBoxName | null {
+    const box = String(artifact.raw.box ?? '').toLowerCase();
+    return box === 'inbox' || box === 'outbox' ? box : null;
+  }
+
+  function fileBoxFilenameFromArtifact(artifact: SurfaceArtifact): string | null {
+    const rawName = artifact.raw.name;
+    return typeof rawName === 'string' && rawName.trim() ? rawName : artifact.title;
+  }
+
+  function deletingFileKey(box: FileBoxName, filename: string): string {
+    return `${box}:${filename}`;
+  }
+
+  function isDeletingFile(box: FileBoxName, filename: string): boolean {
+    return deletingFileKeys.has(deletingFileKey(box, filename));
+  }
+
+  function setDeletingFile(box: FileBoxName, filename: string, deleting: boolean): void {
+    const next = new Set(deletingFileKeys);
+    const key = deletingFileKey(box, filename);
+    if (deleting) next.add(key);
+    else next.delete(key);
+    deletingFileKeys = next;
+  }
+
+  async function deletePmaFile(artifact: SurfaceArtifact): Promise<void> {
+    const box = fileBoxNameFromArtifact(artifact);
+    const filename = fileBoxFilenameFromArtifact(artifact);
+    if (!box || !filename) return;
+    if (isDeletingFile(box, filename)) return;
+    const ok = await confirmDialog({
+      title: 'Delete file',
+      message: `Delete "${filename}" from ${box}?`,
+      confirmText: 'Delete',
+      danger: true
+    });
+    if (!ok) return;
+    setDeletingFile(box, filename, true);
+    composeError = null;
+    const result = await webApi.pma.deleteFile(box, filename);
+    if (result.ok) {
+      await refreshPmaFiles({ quiet: true });
+      showCommandNotice(`Deleted ${filename}.`);
+    } else {
+      composeError = result.error;
+    }
+    setDeletingFile(box, filename, false);
+  }
+
+  async function deletePmaFileBox(box: FileBoxName, count: number): Promise<void> {
+    if (count <= 0 || deletingFileBox) return;
+    const ok = await confirmDialog({
+      title: `Clear ${box}`,
+      message: `Delete all ${count} file${count === 1 ? '' : 's'} from ${box}?`,
+      confirmText: 'Delete all',
+      danger: true
+    });
+    if (!ok) return;
+    deletingFileBox = box;
+    composeError = null;
+    const result = await webApi.pma.deleteFileBox(box);
+    if (result.ok) {
+      await refreshPmaFiles({ quiet: true });
+      showCommandNotice(`Cleared ${box}.`);
+    } else {
+      composeError = result.error;
+    }
+    deletingFileBox = null;
+  }
+
   function compareArtifactDeliveries(left: ArtifactDelivery, right: ArtifactDelivery): number {
     return deliveryTimeValue(right) - deliveryTimeValue(left);
   }
@@ -1646,16 +1733,14 @@
       return true;
     }
     if (spec.id === 'files') {
-      const result = await webApi.pma.listFiles();
-      if (!result.ok) composeError = result.error;
-      else {
-        readModelEntityStore.setPmaArtifacts(activeChatId ?? '__global__', result.data);
+      const refreshedCount = await refreshPmaFiles({ quiet: true });
+      if (refreshedCount !== null) {
         if (activeChat && !isLocalDraftChatId(activeChat.id)) {
           const key = `${activeChat.id}|${activeChat.repoId ?? ''}`;
           artifactDeliveryLoadKey = key;
           await refreshArtifactDeliveries(activeChat.repoId ?? null, key, { quiet: true });
         }
-        showCommandNotice(result.data.length ? `Files refreshed (${result.data.length}).` : 'No PMA files yet.');
+        showCommandNotice(refreshedCount ? `Files refreshed (${refreshedCount}).` : 'No PMA files yet.');
         clearSlashDraft();
       }
       return true;
@@ -2393,12 +2478,24 @@
         </div>
         <div class="chat-files-sections">
           <section class="chat-files-section" aria-label="Files from you">
-            <h3>From you</h3>
+            <div class="chat-files-section-head">
+              <h3>From you</h3>
+              <button
+                type="button"
+                class="chat-file-delete-all"
+                disabled={inboxArtifacts.length === 0 || deletingFileBox !== null}
+                onclick={() => deletePmaFileBox('inbox', inboxArtifacts.length)}
+              >
+                {deletingFileBox === 'inbox' ? 'Deleting...' : 'Delete all'}
+              </button>
+            </div>
             {#if inboxArtifacts.length === 0}
               <p class="chat-files-empty">No uploaded files for this chat.</p>
             {:else}
               <ul class="chat-files-list">
                 {#each inboxArtifacts as artifact (artifact.id)}
+                  {@const box = fileBoxNameFromArtifact(artifact)}
+                  {@const filename = fileBoxFilenameFromArtifact(artifact)}
                   <li>
                     <span class="attachment-kind">{artifact.kind}</span>
                     {#if artifact.url}
@@ -2409,18 +2506,71 @@
                     {#if artifact.summary}
                       <em>{artifact.summary}</em>
                     {/if}
+                    {#if box && filename}
+                      <button
+                        type="button"
+                        class="chat-file-delete"
+                        disabled={isDeletingFile(box, filename) || deletingFileBox !== null}
+                        aria-label={`Delete ${filename}`}
+                        title={`Delete ${filename}`}
+                        onclick={() => deletePmaFile(artifact)}
+                      >
+                        {isDeletingFile(box, filename) ? 'Deleting...' : 'Delete'}
+                      </button>
+                    {/if}
                   </li>
                 {/each}
               </ul>
             {/if}
           </section>
           <section class="chat-files-section" aria-label="Files from assistant">
-            <h3>From agent</h3>
+            <div class="chat-files-section-head">
+              <h3>From agent</h3>
+              <button
+                type="button"
+                class="chat-file-delete-all"
+                disabled={outboxArtifacts.length === 0 || deletingFileBox !== null}
+                onclick={() => deletePmaFileBox('outbox', outboxArtifacts.length)}
+              >
+                {deletingFileBox === 'outbox' ? 'Deleting...' : 'Delete all'}
+              </button>
+            </div>
+            {#if outboxArtifacts.length > 0}
+              <ul class="chat-files-list">
+                {#each outboxArtifacts as artifact (artifact.id)}
+                  {@const box = fileBoxNameFromArtifact(artifact)}
+                  {@const filename = fileBoxFilenameFromArtifact(artifact)}
+                  <li>
+                    <span class="attachment-kind">{artifact.kind}</span>
+                    {#if artifact.url}
+                      <a href={href(artifact.url)} target="_blank" rel="noopener"><strong>{artifact.title}</strong></a>
+                    {:else}
+                      <strong>{artifact.title}</strong>
+                    {/if}
+                    {#if artifact.summary}
+                      <em>{artifact.summary}</em>
+                    {/if}
+                    {#if box && filename}
+                      <button
+                        type="button"
+                        class="chat-file-delete"
+                        disabled={isDeletingFile(box, filename) || deletingFileBox !== null}
+                        aria-label={`Delete ${filename}`}
+                        title={`Delete ${filename}`}
+                        onclick={() => deletePmaFile(artifact)}
+                      >
+                        {isDeletingFile(box, filename) ? 'Deleting...' : 'Delete'}
+                      </button>
+                    {/if}
+                  </li>
+                {/each}
+              </ul>
+            {/if}
             {#if artifactDeliveryError}
               <p class="chat-files-empty error">{artifactDeliveryError.message}</p>
-            {:else if activeSurfaceDeliveries.length === 0}
+            {:else if activeSurfaceDeliveries.length === 0 && outboxArtifacts.length === 0}
               <p class="chat-files-empty">No agent-shared files yet.</p>
-            {:else}
+            {:else if activeSurfaceDeliveries.length > 0}
               <ul class="chat-files-list delivery-list">
                 {#each activeSurfaceDeliveries as delivery (delivery.deliveryId)}
                   {@const stateLabel = artifactDeliveryStateLabel(delivery)}

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -11,7 +11,14 @@
   import VoiceComposerButton from '$lib/components/VoiceComposerButton.svelte';
   import ContentSkeleton from '$lib/components/ContentSkeleton.svelte';
   import { confirmDialog } from '$lib/components/confirmDialog';
-  import { webApi, type ApiError, type JsonRecord, type PmaQueuedTurn } from '$lib/api/client';
+  import {
+    webApi,
+    type ApiError,
+    type ChatFileBoxScope,
+    type FileBoxName,
+    type JsonRecord,
+    type PmaQueuedTurn
+  } from '$lib/api/client';
   import {
     invalidateReadModelTags,
     readModelEntityStore,
@@ -155,7 +162,6 @@
     | { kind: 'card'; id: string; card: ChatTranscriptCard }
     | { kind: 'typing'; id: string; title: string }
     | { kind: 'shared-files'; id: string };
-  type FileBoxName = 'inbox' | 'outbox';
   let readModelState = $state(readModelEntityStore.snapshot());
   let activeChatId = $state<string | null>(null);
   // Unsent new chats are page-local only: `localDraftChat` drives the composer until
@@ -259,7 +265,7 @@
     chatIndexSession,
     liveProjection,
     supportApi: {
-      listFiles: webApi.pma.listFiles,
+      listFiles: () => webApi.filebox.listFiles({ kind: 'hub' }),
       listAgents: webApi.pma.listAgents,
       repoWorktreeTopology: webApi.readModels.repoWorktreeTopology,
       repoWorktreeRuntime: webApi.readModels.repoWorktreeRuntime
@@ -783,6 +789,7 @@
     if (key === artifactDeliveryLoadKey) return;
     artifactDeliveryLoadKey = key;
     void refreshArtifactDeliveries(chat.repoId ?? null, key, { quiet: true });
+    if (fileDrawerOpen) void refreshChatFileBox({ quiet: true });
   });
 
   onDestroy(() => {
@@ -1147,15 +1154,24 @@
     }
   }
 
-  async function refreshPmaFiles(options: { quiet?: boolean } = {}): Promise<number | null> {
-    const result = await webApi.pma.listFiles();
+  function fileBoxScopeForChat(chat: PmaChatSummary | null): ChatFileBoxScope {
+    return chat?.repoId ? { kind: 'repo', repoId: chat.repoId } : { kind: 'hub' };
+  }
+
+  function fileBoxScopeLabel(scope: ChatFileBoxScope): string {
+    return scope.kind === 'repo' ? 'repo filebox' : 'hub filebox';
+  }
+
+  async function refreshChatFileBox(options: { quiet?: boolean } = {}): Promise<number | null> {
+    const scope = fileBoxScopeForChat(activeChat);
+    const result = await webApi.filebox.listFiles(scope);
     if (!result.ok) {
       composeError = result.error;
       return null;
     }
-    readModelEntityStore.setPmaArtifacts('__global__', result.data);
     if (activeChatId) readModelEntityStore.setPmaArtifacts(activeChatId, result.data);
-    if (!options.quiet) showCommandNotice(result.data.length ? `Files refreshed (${result.data.length}).` : 'No PMA files yet.');
+    if (!activeChatId || scope.kind === 'hub') readModelEntityStore.setPmaArtifacts('__global__', result.data);
+    if (!options.quiet) showCommandNotice(result.data.length ? `Files refreshed (${result.data.length}).` : 'No files yet.');
     return result.data.length;
   }
 
@@ -1185,23 +1201,24 @@
     deletingFileKeys = next;
   }
 
-  async function deletePmaFile(artifact: SurfaceArtifact): Promise<void> {
+  async function deleteChatFileBoxFile(artifact: SurfaceArtifact): Promise<void> {
     const box = fileBoxNameFromArtifact(artifact);
     const filename = fileBoxFilenameFromArtifact(artifact);
+    const scope = fileBoxScopeForChat(activeChat);
     if (!box || !filename) return;
     if (isDeletingFile(box, filename)) return;
     const ok = await confirmDialog({
       title: 'Delete file',
-      message: `Delete "${filename}" from ${box}?`,
+      message: `Delete "${filename}" from ${fileBoxScopeLabel(scope)} ${box}?`,
       confirmText: 'Delete',
       danger: true
     });
     if (!ok) return;
     setDeletingFile(box, filename, true);
     composeError = null;
-    const result = await webApi.pma.deleteFile(box, filename);
+    const result = await webApi.filebox.deleteFile(scope, box, filename);
     if (result.ok) {
-      await refreshPmaFiles({ quiet: true });
+      await refreshChatFileBox({ quiet: true });
       showCommandNotice(`Deleted ${filename}.`);
     } else {
       composeError = result.error;
@@ -1209,20 +1226,21 @@
     setDeletingFile(box, filename, false);
   }
 
-  async function deletePmaFileBox(box: FileBoxName, count: number): Promise<void> {
+  async function deleteChatFileBox(box: FileBoxName, count: number): Promise<void> {
     if (count <= 0 || deletingFileBox) return;
+    const scope = fileBoxScopeForChat(activeChat);
     const ok = await confirmDialog({
       title: `Clear ${box}`,
-      message: `Delete all ${count} file${count === 1 ? '' : 's'} from ${box}?`,
+      message: `Delete all ${count} file${count === 1 ? '' : 's'} from ${fileBoxScopeLabel(scope)} ${box}?`,
       confirmText: 'Delete all',
       danger: true
     });
     if (!ok) return;
     deletingFileBox = box;
     composeError = null;
-    const result = await webApi.pma.deleteFileBox(box);
+    const result = await webApi.filebox.deleteBox(scope, box);
     if (result.ok) {
-      await refreshPmaFiles({ quiet: true });
+      await refreshChatFileBox({ quiet: true });
       showCommandNotice(`Cleared ${box}.`);
     } else {
       composeError = result.error;
@@ -1273,11 +1291,13 @@
 
   async function openFileDrawer(): Promise<void> {
     fileDrawerOpen = true;
+    const refreshes: Promise<unknown>[] = [refreshChatFileBox({ quiet: true })];
     if (activeChat && !isLocalDraftChatId(activeChat.id)) {
       const key = `${activeChat.id}|${activeChat.repoId ?? ''}`;
       artifactDeliveryLoadKey = key;
-      await refreshArtifactDeliveries(activeChat.repoId ?? null, key);
+      refreshes.push(refreshArtifactDeliveries(activeChat.repoId ?? null, key));
     }
+    await Promise.all(refreshes);
   }
 
   function closeStream(): void {
@@ -1733,14 +1753,14 @@
       return true;
     }
     if (spec.id === 'files') {
-      const refreshedCount = await refreshPmaFiles({ quiet: true });
+      const refreshedCount = await refreshChatFileBox({ quiet: true });
       if (refreshedCount !== null) {
         if (activeChat && !isLocalDraftChatId(activeChat.id)) {
           const key = `${activeChat.id}|${activeChat.repoId ?? ''}`;
           artifactDeliveryLoadKey = key;
           await refreshArtifactDeliveries(activeChat.repoId ?? null, key, { quiet: true });
         }
-        showCommandNotice(refreshedCount ? `Files refreshed (${refreshedCount}).` : 'No PMA files yet.');
+        showCommandNotice(refreshedCount ? `Files refreshed (${refreshedCount}).` : 'No files yet.');
         clearSlashDraft();
       }
       return true;
@@ -2484,7 +2504,7 @@
                 type="button"
                 class="chat-file-delete-all"
                 disabled={inboxArtifacts.length === 0 || deletingFileBox !== null}
-                onclick={() => deletePmaFileBox('inbox', inboxArtifacts.length)}
+                onclick={() => deleteChatFileBox('inbox', inboxArtifacts.length)}
               >
                 {deletingFileBox === 'inbox' ? 'Deleting...' : 'Delete all'}
               </button>
@@ -2513,7 +2533,7 @@
                         disabled={isDeletingFile(box, filename) || deletingFileBox !== null}
                         aria-label={`Delete ${filename}`}
                         title={`Delete ${filename}`}
-                        onclick={() => deletePmaFile(artifact)}
+                        onclick={() => deleteChatFileBoxFile(artifact)}
                       >
                         {isDeletingFile(box, filename) ? 'Deleting...' : 'Delete'}
                       </button>
@@ -2530,7 +2550,7 @@
                 type="button"
                 class="chat-file-delete-all"
                 disabled={outboxArtifacts.length === 0 || deletingFileBox !== null}
-                onclick={() => deletePmaFileBox('outbox', outboxArtifacts.length)}
+                onclick={() => deleteChatFileBox('outbox', outboxArtifacts.length)}
               >
                 {deletingFileBox === 'outbox' ? 'Deleting...' : 'Delete all'}
               </button>
@@ -2557,7 +2577,7 @@
                         disabled={isDeletingFile(box, filename) || deletingFileBox !== null}
                         aria-label={`Delete ${filename}`}
                         title={`Delete ${filename}`}
-                        onclick={() => deletePmaFile(artifact)}
+                        onclick={() => deleteChatFileBoxFile(artifact)}
                       >
                         {isDeletingFile(box, filename) ? 'Deleting...' : 'Delete'}
                       </button>

--- a/tests/test_filebox_routes.py
+++ b/tests/test_filebox_routes.py
@@ -68,6 +68,43 @@ def test_hub_filebox_delete_ignores_legacy_duplicates(_filebox_env) -> None:
     assert (legacy_topic_pending / "shared.txt").exists()
 
 
+def test_hub_filebox_bulk_delete_only_clears_requested_box(_filebox_env) -> None:
+    env = _filebox_env
+    filebox.ensure_structure(env.repo_root)
+    filebox.delete_regular_files(filebox.inbox_dir(env.repo_root))
+    filebox.delete_regular_files(filebox.outbox_dir(env.repo_root))
+    (filebox.inbox_dir(env.repo_root) / "upload.txt").write_bytes(b"upload")
+    (filebox.outbox_dir(env.repo_root) / "reply.txt").write_bytes(b"reply")
+
+    resp = env.client.delete(f"/hub/filebox/{env.repo_id}/inbox")
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "status": "ok",
+        "deleted": ["upload.txt"],
+        "deleted_count": 1,
+    }
+    assert not (filebox.inbox_dir(env.repo_root) / "upload.txt").exists()
+    assert (filebox.outbox_dir(env.repo_root) / "reply.txt").exists()
+
+
+def test_repo_filebox_bulk_delete_parity_with_hub(_filebox_env) -> None:
+    env = _filebox_env
+    filebox.ensure_structure(env.repo_root)
+    filebox.delete_regular_files(filebox.inbox_dir(env.repo_root))
+    (filebox.inbox_dir(env.repo_root) / "repo-upload.txt").write_bytes(b"upload")
+
+    resp = env.client.delete(f"/repos/{env.repo_id}/api/filebox/inbox")
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "status": "ok",
+        "deleted": ["repo-upload.txt"],
+        "deleted_count": 1,
+    }
+    assert not (filebox.inbox_dir(env.repo_root) / "repo-upload.txt").exists()
+
+
 def test_hub_filebox_legacy_only_file_returns_404(_filebox_env) -> None:
     env = _filebox_env
     legacy_topic_pending = (


### PR DESCRIPTION
## Summary
- add generic filebox client helpers for hub and repo-scoped chat fileboxes
- add confirmed Delete and Delete all controls to the chat files drawer
- make repo/worktree chats load and manage `/hub/filebox/{repo_id}` while hub chats use the hub filebox
- add generic repo/hub filebox bulk-delete routes and keep mutable outbox files separate from artifact delivery history
- rename new chat-drawer filebox helpers and `/files` copy away from PMA-specific wording where the behavior is chat-generic

## Impact
Users can clear processed voice messages, screenshots, uploaded files, and generated outbox files from the chat file drawer. Repo/worktree chats now manage their repo filebox instead of only the hub/PMA filebox.

## Validation
- `git diff --check`
- `.venv/bin/python -m pytest -q tests/test_filebox_routes.py tests/pma_support/files.py`
- `pnpm test src/lib/viewModels/slashCommands.test.ts src/lib/api/client.test.ts`
- `pnpm lint` in `src/codex_autorunner/web_frontend`
- pre-commit web-core-contract lane: guardrails, mypy, full pytest (`9302 passed`), Web UI lab, Svelte lint, Vite build, full frontend tests (`826 passed, 2 skipped`), SPA shell check

## Review
Final local review found no blocking issues.