### PR TITLE
[codex] expose chat mode selector

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatThreadPreMessagePickers.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatThreadPreMessagePickers.svelte
@@ -17,12 +17,14 @@
     modelValue = $bindable(''),
     reasoningValue = $bindable(''),
     scopeValue = $bindable('local'),
+    modeValue = $bindable<'pma' | 'agent'>('pma'),
     scopeOptions = [],
     loading = false,
     modelCatalogError = null,
     showAgent = undefined,
     onAgentChange = undefined,
     onPickerChange = undefined,
+    onModeChange = undefined,
     onScopeChange = undefined
   }: {
     agents?: PickerRecord[];
@@ -32,6 +34,7 @@
     modelValue?: string;
     reasoningValue?: string;
     scopeValue?: string;
+    modeValue?: 'pma' | 'agent';
     scopeOptions?: PmaChatScopeOption[];
     loading?: boolean;
     modelCatalogError?: string | null;
@@ -39,13 +42,51 @@
     onAgentChange?: (() => void) | undefined;
     /** Fires when agent / profile / model / effort controls change (including programmatic binds). */
     onPickerChange?: (() => void) | undefined;
+    /** Fires only when the user explicitly changes the new-chat mode picker. */
+    onModeChange?: (() => void) | undefined;
     /** Fires only when the user explicitly changes the new-chat scope picker. */
     onScopeChange?: (() => void) | undefined;
   } = $props();
+
+  const scopedOptions = $derived(scopeOptions.filter((scope) => scope.kind !== 'local'));
+  const visibleScopeOptions = $derived(modeValue === 'agent' ? scopedOptions : scopeOptions);
+
+  function selectMode(next: 'pma' | 'agent'): void {
+    if (next === 'agent' && scopedOptions.length === 0) return;
+    if (modeValue === next) return;
+    modeValue = next;
+    onModeChange?.();
+  }
 </script>
 
+<div class="start-picker-row mode-picker-row">
+  <span>mode</span>
+  <div class="mode-segment" role="radiogroup" aria-label="Chat mode">
+    <button
+      type="button"
+      class:active={modeValue === 'pma'}
+      aria-checked={modeValue === 'pma'}
+      role="radio"
+      onclick={() => selectMode('pma')}
+    >
+      PMA
+    </button>
+    <button
+      type="button"
+      class:active={modeValue === 'agent'}
+      aria-checked={modeValue === 'agent'}
+      role="radio"
+      disabled={scopedOptions.length === 0}
+      title={scopedOptions.length === 0 ? 'Add a repo or worktree to start an agent chat' : 'Agent chat'}
+      onclick={() => selectMode('agent')}
+    >
+      Agent
+    </button>
+  </div>
+</div>
+
 {#if scopeOptions.length > 1}
-  <ChatScopePicker {scopeOptions} bind:value={scopeValue} onChange={onScopeChange} />
+  <ChatScopePicker scopeOptions={visibleScopeOptions} bind:value={scopeValue} onChange={onScopeChange} />
 {/if}
 
 <AgentModelReasoningPicker
@@ -64,3 +105,43 @@
   onchange={onPickerChange}
 />
 
+<style>
+  .mode-segment {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 2px;
+    min-width: 0;
+    padding: 2px;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 7px;
+    background: var(--color-surface);
+  }
+
+  .mode-segment button {
+    min-width: 0;
+    min-height: 26px;
+    padding: 0 var(--space-2);
+    border: none;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--color-ink-muted);
+    font-size: var(--font-size-1);
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .mode-segment button.active {
+    background: var(--color-accent-soft);
+    color: var(--color-accent);
+  }
+
+  .mode-segment button:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+  }
+
+  .mode-segment button:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
+</style>

--- a/src/codex_autorunner/web_frontend/src/lib/components/DropdownSelect.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/DropdownSelect.svelte
@@ -12,6 +12,20 @@
     label?: string;
     options: DropdownSelectOption[];
   };
+
+  export function dropdownSearchTerms(query: string): string[] {
+    return query
+      .trim()
+      .toLowerCase()
+      .split(/\s+/)
+      .filter(Boolean);
+  }
+
+  export function dropdownSearchMatches(fields: Array<string | undefined>, terms: string[]): boolean {
+    if (terms.length === 0) return true;
+    const haystack = fields.filter(Boolean).join(' ').toLowerCase();
+    return terms.every((term) => haystack.includes(term));
+  }
 </script>
 
 <script lang="ts">
@@ -63,19 +77,15 @@
   const selectedBadge = $derived(selectedOption?.triggerBadge ?? selectedOption?.badge ?? '');
 
   const visibleGroups = $derived.by<DropdownSelectGroup[]>(() => {
-    const needle = query.trim().toLowerCase();
-    if (!needle) return sourceGroups;
+    const terms = dropdownSearchTerms(query);
+    if (terms.length === 0) return sourceGroups;
     return sourceGroups
       .map((group) => {
-        const groupMatches = (group.label ?? '').toLowerCase().includes(needle);
+        const groupMatches = dropdownSearchMatches([group.label], terms);
         const filtered = groupMatches
           ? group.options
           : group.options.filter((option) =>
-              [option.label, option.detail, option.badge, option.value]
-                .filter(Boolean)
-                .join(' ')
-                .toLowerCase()
-                .includes(needle)
+              dropdownSearchMatches([group.label, option.label, option.detail, option.badge, option.value], terms)
             );
         return { ...group, options: filtered };
       })

--- a/src/codex_autorunner/web_frontend/src/lib/components/DropdownSelect.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/DropdownSelect.test.ts
@@ -1,7 +1,7 @@
 import { render } from 'svelte/server';
 import { describe, expect, it } from 'vitest';
 import ChatScopePicker from './ChatScopePicker.svelte';
-import DropdownSelect from './DropdownSelect.svelte';
+import DropdownSelect, { dropdownSearchMatches, dropdownSearchTerms } from './DropdownSelect.svelte';
 
 describe('DropdownSelect', () => {
   it('renders the shared trigger without falling back to a native select', () => {
@@ -35,5 +35,11 @@ describe('DropdownSelect', () => {
     expect(body).toContain('Hub');
     expect(body).toContain('Local hub');
     expect(body).not.toContain('LOCAL');
+  });
+
+  it('splits dropdown search into required terms', () => {
+    expect(dropdownSearchTerms(' codex-  retire ')).toEqual(['codex-', 'retire']);
+    expect(dropdownSearchMatches(['CODEX-AUTORUNNER', 'codex/retire-lifecycle'], dropdownSearchTerms('codex- retire'))).toBe(true);
+    expect(dropdownSearchMatches(['CODEX-AUTORUNNER', 'thread-chat-1'], dropdownSearchTerms('codex- retire'))).toBe(false);
   });
 });

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -2513,8 +2513,7 @@ const ORPHAN_SCOPE_GROUP_KEY = '__orphan__';
  * single trailing "Other worktrees" group.
  */
 export function groupPmaChatScopeOptions(options: PmaChatScopeOption[]): PmaChatScopeGroupView {
-  // The local-hub option is a static constant; `buildPmaChatScopeOptions` always prepends it.
-  const local: PmaChatScopeLocalOption = localPmaChatScopeOption();
+  const local = options.find((opt): opt is PmaChatScopeLocalOption => opt.kind === 'local') ?? null;
   const groups: PmaChatScopeGroup[] = [];
   const byKey = new Map<string, PmaChatScopeGroup>();
 

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -589,9 +589,7 @@
   const activeMessengerSurface = $derived(chatMessengerSurface(activeChat));
   const activeSharedFileCount = $derived(activeSurfaceDeliveries.length);
   const activeRepoIngress = $derived(repoIngressForChat(activeChat));
-  const createChatLabel = $derived(
-    creating ? 'Creating...' : newChatKind === 'agent' && canStartCodingAgentChat ? '+ Coding agent' : '+ PMA'
-  );
+  const createChatLabel = $derived(creating ? 'Creating...' : '+ New');
   const headerScopeLine = $derived(pmaChatHeaderScopeLine(activeChat, repoLabelForRepoId));
   /** Omit connected “Live · …” — redundant with the turn-status pill on the scope row. */
   const showStreamHealthAside = $derived(
@@ -736,7 +734,15 @@
   });
 
   $effect(() => {
-    if (!canStartCodingAgentChat && newChatKind === 'agent') newChatKind = 'pma';
+    if (newChatKind !== 'agent') return;
+    if (canStartCodingAgentChat) return;
+    const scoped = firstScopedScopeOption();
+    if (scoped) {
+      selectedScopeId = scoped.id;
+      selectedScopeSource = 'picker_explicit';
+      return;
+    }
+    newChatKind = 'pma';
   });
 
   $effect(() => {
@@ -1272,6 +1278,23 @@
   function handleScopePickerChange(): void {
     selectedScopeSource = selectedScopeId === 'local' ? 'default_hub' : 'picker_explicit';
     if (newChatKind === 'agent' && selectedScopeId === 'local') newChatKind = 'pma';
+    persistCurrentNewChatPreference();
+  }
+
+  function firstScopedScopeOption(): PmaChatScopeOption | null {
+    return scopeOptions.find((scope) => scope.kind !== 'local') ?? null;
+  }
+
+  function handleModePickerChange(): void {
+    if (newChatKind === 'agent' && selectedScopeId === 'local') {
+      const scoped = firstScopedScopeOption();
+      if (scoped) {
+        selectedScopeId = scoped.id;
+        selectedScopeSource = 'picker_explicit';
+      } else {
+        newChatKind = 'pma';
+      }
+    }
     persistCurrentNewChatPreference();
   }
 
@@ -2267,12 +2290,14 @@
             bind:modelValue={selectedModel}
             bind:reasoningValue={selectedReasoning}
             bind:scopeValue={selectedScopeId}
+            bind:modeValue={newChatKind}
             {models}
             {scopeOptions}
             loading={loadingModels}
             showAgent={showAgentSelector}
             onAgentChange={handleAgentChange}
             onPickerChange={handlePickerChange}
+            onModeChange={handleModePickerChange}
             onScopeChange={handleScopePickerChange}
           />
         </div>

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -96,7 +96,7 @@ describe('/chats page', () => {
 
     expect(body).toContain('Chats workspace');
     expect(body).not.toContain('memory-toggle-button');
-    expect(body).toContain('+ PMA');
+    expect(body).toContain('+ New');
     expect(body).toContain('chat-list');
     expect(body).toContain('Waiting');
     expect(body).toContain('Active');


### PR DESCRIPTION
## Summary
- Rename the chats page create button to `+ New`.
- Add a PMA/Agent mode selector to new chat setup, with Agent mode limited to repo/worktree scopes.
- Upgrade the shared dropdown search so every whitespace-separated term must match across group and option text.

## Validation
- `pnpm web:lint`
- `pnpm web:test`
- `pnpm run build` from `src/codex_autorunner/web_frontend`
- commit hook web-ui lane, including repo guardrails, `pytest` (9302 passed), web lint/build/tests, and SPA shell check
