### PR TITLE
[codex] Track automation child executions

### DIFF
--- a/src/codex_autorunner/core/automation/child_reconciler.py
+++ b/src/codex_autorunner/core/automation/child_reconciler.py
@@ -7,6 +7,8 @@ from typing import Callable, Optional
 
 from ..flows.models import FlowRunRecord, FlowRunStatus
 from ..flows.store import FlowStore
+from ..pma_queue import PmaQueue, QueueItemState
+from .execution_graph import automation_execution_snapshot
 from .models import JOB_RUNNING, AutomationJob
 from .store import AutomationStore
 
@@ -35,18 +37,20 @@ class AutomationChildRunReconciler:
         store: AutomationStore,
         *,
         resolve_repo_path: RepoPathResolver,
+        hub_root: Optional[Path] = None,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self._store = store
         self._resolve_repo_path = resolve_repo_path
+        self._hub_root = hub_root or getattr(store, "hub_root", None)
         self._logger = logger or logging.getLogger(__name__)
 
     def reconcile_running_jobs(self, *, limit: int = 100) -> ChildReconcileResult:
         inspected = completed = failed = cancelled = paused = missing = 0
-        for job in self._running_ticket_flow_jobs(limit=limit):
+        for job in self._running_child_jobs(limit=limit):
             inspected += 1
             try:
-                result = self._reconcile_ticket_flow_job(job)
+                result = self._reconcile_child_job(job)
             except (OSError, RuntimeError, ValueError, TypeError) as exc:
                 self._logger.exception(
                     "Failed reconciling automation child run for job_id=%s",
@@ -72,14 +76,108 @@ class AutomationChildRunReconciler:
             missing=missing,
         )
 
-    def _running_ticket_flow_jobs(self, *, limit: int) -> list[AutomationJob]:
+    def _running_child_jobs(self, *, limit: int) -> list[AutomationJob]:
         jobs = self._store.list_jobs(state=JOB_RUNNING, limit=max(0, int(limit)))
         return [
             job
             for job in jobs
-            if str(job.executor.get("kind") or "").strip() == "ticket_flow"
-            and job.ticket_flow_run_id
+            if (
+                str(job.executor.get("kind") or "").strip() == "ticket_flow"
+                and job.ticket_flow_run_id
+            )
+            or (
+                str(job.executor.get("kind") or "").strip() == "pma_turn"
+                and job.pma_queue_item_id
+            )
         ]
+
+    def _reconcile_child_job(self, job: AutomationJob) -> ChildReconcileResult:
+        kind = str(job.executor.get("kind") or "").strip()
+        if kind == "pma_turn":
+            return self._reconcile_pma_queue_job(job)
+        return self._reconcile_ticket_flow_job(job)
+
+    def _reconcile_pma_queue_job(self, job: AutomationJob) -> ChildReconcileResult:
+        if self._hub_root is None:
+            self._store.fail_job(
+                job.job_id,
+                error_text="pma_queue child reconcile missing hub root",
+            )
+            return ChildReconcileResult(missing=1)
+        item = PmaQueue(Path(self._hub_root)).get_item_sync(str(job.pma_queue_item_id))
+        if item is None:
+            self._store.fail_job(
+                job.job_id,
+                error_text=f"pma queue item not found: {job.pma_queue_item_id}",
+            )
+            return ChildReconcileResult(missing=1)
+        if item.state in {QueueItemState.PENDING, QueueItemState.RUNNING}:
+            return ChildReconcileResult()
+        refs = {"pma_lane_id": item.lane_id, "pma_queue_item_id": item.item_id}
+        if item.state == QueueItemState.COMPLETED:
+            result = item.result if isinstance(item.result, dict) else {}
+            status = str(result.get("status") or "").strip().lower()
+            if status in {"error", "failed", "failure"}:
+                self._store.fail_job(
+                    job.job_id,
+                    error_text=_pma_queue_error_summary(item),
+                )
+                return ChildReconcileResult(failed=1)
+            child_result = self._reconcile_completed_pma_child(job, item)
+            if child_result.changed or child_result.inspected:
+                return child_result
+            self._store.complete_job(
+                job.job_id,
+                result_summary=_pma_queue_success_summary(item),
+                execution_refs=refs,
+            )
+            return ChildReconcileResult(completed=1)
+        if item.state == QueueItemState.CANCELLED:
+            self._store.cancel_job(job.job_id)
+            return ChildReconcileResult(cancelled=1)
+        self._store.fail_job(
+            job.job_id,
+            error_text=_pma_queue_error_summary(item),
+        )
+        return ChildReconcileResult(failed=1)
+
+    def _reconcile_completed_pma_child(
+        self, job: AutomationJob, item: object
+    ) -> ChildReconcileResult:
+        snapshot = automation_execution_snapshot(job, hub_root=self._hub_root).to_dict()
+        managed_thread = snapshot.get("managed_thread")
+        if not isinstance(managed_thread, dict):
+            return ChildReconcileResult()
+        latest_execution = managed_thread.get("latest_execution")
+        if not isinstance(latest_execution, dict):
+            return ChildReconcileResult(inspected=1)
+        status = str(latest_execution.get("status") or "").strip().lower()
+        if status in {"pending", "queued", "running", "starting"}:
+            return ChildReconcileResult(inspected=1)
+        refs = {
+            "pma_lane_id": getattr(item, "lane_id", None),
+            "pma_queue_item_id": getattr(item, "item_id", None),
+            "managed_thread_target_id": managed_thread.get("thread_target_id"),
+            "managed_thread_execution_id": latest_execution.get("execution_id"),
+        }
+        if status in {"error", "failed", "failure"}:
+            self._store.fail_job(
+                job.job_id,
+                error_text=_managed_thread_error_summary(latest_execution),
+                execution_refs=refs,
+            )
+            return ChildReconcileResult(inspected=1, failed=1)
+        if status in {"completed", "succeeded", "success", "done"}:
+            self._store.complete_job(
+                job.job_id,
+                result_summary=_pma_queue_success_summary(item),
+                execution_refs=refs,
+            )
+            return ChildReconcileResult(inspected=1, completed=1)
+        if status in {"cancelled", "canceled", "stopped", "archived"}:
+            self._store.cancel_job(job.job_id)
+            return ChildReconcileResult(inspected=1, cancelled=1)
+        return ChildReconcileResult(inspected=1)
 
     def _reconcile_ticket_flow_job(self, job: AutomationJob) -> ChildReconcileResult:
         repo_id = job.ticket_flow_worktree_id or job.ticket_flow_repo_id
@@ -161,6 +259,37 @@ def _ticket_flow_success_summary(repo_path: Path, record: FlowRunRecord) -> str:
     if census.open_pr_url:
         parts.append(f"pr_url={census.open_pr_url}")
     return "; ".join(parts)
+
+
+def _pma_queue_success_summary(item: object) -> str:
+    result = getattr(item, "result", None)
+    if isinstance(result, dict):
+        for key in ("summary", "detail", "message"):
+            value = result.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()[:500]
+    return f"PMA automation turn completed: {getattr(item, 'item_id', '')}"
+
+
+def _pma_queue_error_summary(item: object) -> str:
+    error = getattr(item, "error", None)
+    if isinstance(error, str) and error.strip():
+        return error.strip()[:500]
+    result = getattr(item, "result", None)
+    if isinstance(result, dict):
+        for key in ("detail", "error", "message", "summary"):
+            value = result.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()[:500]
+    return f"PMA automation turn failed: {getattr(item, 'item_id', '')}"
+
+
+def _managed_thread_error_summary(execution: dict[str, object]) -> str:
+    error = execution.get("error_text")
+    if isinstance(error, str) and error.strip():
+        return error.strip()[:500]
+    execution_id = execution.get("execution_id")
+    return f"Managed automation thread failed: {execution_id or 'unknown execution'}"
 
 
 __all__ = [

--- a/src/codex_autorunner/core/automation/child_reconciler.py
+++ b/src/codex_autorunner/core/automation/child_reconciler.py
@@ -106,6 +106,9 @@ class AutomationChildRunReconciler:
             return ChildReconcileResult(missing=1)
         item = PmaQueue(Path(self._hub_root)).get_item_sync(str(job.pma_queue_item_id))
         if item is None:
+            child_result = self._reconcile_completed_pma_child(job, None)
+            if child_result.changed or child_result.inspected:
+                return child_result
             self._store.fail_job(
                 job.job_id,
                 error_text=f"pma queue item not found: {job.pma_queue_item_id}",
@@ -134,7 +137,7 @@ class AutomationChildRunReconciler:
             )
             return ChildReconcileResult(completed=1)
         if item.state == QueueItemState.CANCELLED:
-            self._store.cancel_job(job.job_id)
+            self._store.cancel_job(job.job_id, execution_refs=refs)
             return ChildReconcileResult(cancelled=1)
         self._store.fail_job(
             job.job_id,
@@ -144,7 +147,7 @@ class AutomationChildRunReconciler:
         return ChildReconcileResult(failed=1)
 
     def _reconcile_completed_pma_child(
-        self, job: AutomationJob, item: object
+        self, job: AutomationJob, item: object | None
     ) -> ChildReconcileResult:
         snapshot = automation_execution_snapshot(job, hub_root=self._hub_root).to_dict()
         managed_thread = snapshot.get("managed_thread")
@@ -157,8 +160,9 @@ class AutomationChildRunReconciler:
         if status in {"pending", "queued", "running", "starting"}:
             return ChildReconcileResult(inspected=1)
         refs = {
-            "pma_lane_id": getattr(item, "lane_id", None),
-            "pma_queue_item_id": getattr(item, "item_id", None),
+            "pma_lane_id": getattr(item, "lane_id", None) or job.pma_lane_id,
+            "pma_queue_item_id": getattr(item, "item_id", None)
+            or job.pma_queue_item_id,
             "managed_thread_target_id": managed_thread.get("thread_target_id"),
             "managed_thread_execution_id": latest_execution.get("execution_id"),
         }
@@ -172,12 +176,16 @@ class AutomationChildRunReconciler:
         if status in {"completed", "succeeded", "success", "done"}:
             self._store.complete_job(
                 job.job_id,
-                result_summary=_pma_queue_success_summary(item),
+                result_summary=(
+                    _pma_queue_success_summary(item)
+                    if item is not None
+                    else _managed_thread_success_summary(latest_execution)
+                ),
                 execution_refs=refs,
             )
             return ChildReconcileResult(inspected=1, completed=1)
-        if status in {"cancelled", "canceled", "stopped", "archived"}:
-            self._store.cancel_job(job.job_id)
+        if status in {"cancelled", "canceled", "interrupted", "stopped", "archived"}:
+            self._store.cancel_job(job.job_id, execution_refs=refs)
             return ChildReconcileResult(inspected=1, cancelled=1)
         return ChildReconcileResult(inspected=1)
 
@@ -248,7 +256,10 @@ class AutomationChildRunReconciler:
             )
             return ChildReconcileResult(failed=1)
         if status in {FlowRunStatus.STOPPED, FlowRunStatus.SUPERSEDED}:
-            self._store.cancel_job(job.job_id)
+            self._store.cancel_job(
+                job.job_id,
+                execution_refs={"ticket_flow_run_id": record.id},
+            )
             return ChildReconcileResult(cancelled=1)
         return ChildReconcileResult()
 
@@ -292,6 +303,11 @@ def _managed_thread_error_summary(execution: dict[str, object]) -> str:
         return error.strip()[:500]
     execution_id = execution.get("execution_id")
     return f"Managed automation thread failed: {execution_id or 'unknown execution'}"
+
+
+def _managed_thread_success_summary(execution: dict[str, object]) -> str:
+    execution_id = execution.get("execution_id")
+    return f"Managed automation thread completed: {execution_id or 'unknown execution'}"
 
 
 __all__ = [

--- a/src/codex_autorunner/core/automation/child_reconciler.py
+++ b/src/codex_autorunner/core/automation/child_reconciler.py
@@ -121,6 +121,7 @@ class AutomationChildRunReconciler:
                 self._store.fail_job(
                     job.job_id,
                     error_text=_pma_queue_error_summary(item),
+                    execution_refs=refs,
                 )
                 return ChildReconcileResult(failed=1)
             child_result = self._reconcile_completed_pma_child(job, item)
@@ -138,6 +139,7 @@ class AutomationChildRunReconciler:
         self._store.fail_job(
             job.job_id,
             error_text=_pma_queue_error_summary(item),
+            execution_refs=refs,
         )
         return ChildReconcileResult(failed=1)
 

--- a/src/codex_autorunner/core/automation/execution_graph.py
+++ b/src/codex_autorunner/core/automation/execution_graph.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
 from ..orchestration.sqlite import open_orchestration_sqlite
-from ..pma_queue import PmaQueue, PmaQueueItem
+from ..pma_queue import PmaQueue, PmaQueueItem, PmaQueueRepository
 from .models import AutomationJob
 
 
@@ -37,11 +37,16 @@ class AutomationExecutionSnapshot:
 
 
 def automation_execution_snapshot(
-    job: AutomationJob, *, hub_root: Optional[Path] = None
+    job: AutomationJob,
+    *,
+    hub_root: Optional[Path] = None,
+    cache: Optional["_AutomationExecutionSnapshotCache"] = None,
 ) -> AutomationExecutionSnapshot:
-    pma_item = _pma_item_for_job(job, hub_root=hub_root)
+    pma_item = _pma_item_for_job(job, hub_root=hub_root, cache=cache)
     pma_queue = _pma_queue_snapshot(pma_item)
-    managed_thread = _managed_thread_snapshot(job, pma_item=pma_item, hub_root=hub_root)
+    managed_thread = _managed_thread_snapshot(
+        job, pma_item=pma_item, hub_root=hub_root, cache=cache
+    )
     ticket_flow = _ticket_flow_snapshot(job)
     publish_operation = _publish_operation_snapshot(job)
     primary_child_kind = _primary_child_kind(
@@ -65,12 +70,118 @@ def automation_execution_snapshot(
     )
 
 
+def automation_execution_snapshots_by_job_id(
+    jobs: list[AutomationJob], *, hub_root: Optional[Path] = None
+) -> dict[str, AutomationExecutionSnapshot]:
+    if not jobs:
+        return {}
+    if hub_root is None:
+        return {
+            job.job_id: automation_execution_snapshot(job, hub_root=None)
+            for job in jobs
+        }
+    cache = _AutomationExecutionSnapshotCache(hub_root)
+    try:
+        return {
+            job.job_id: automation_execution_snapshot(job, hub_root=hub_root, cache=cache)
+            for job in jobs
+        }
+    finally:
+        cache.close()
+
+
+@dataclass
+class _AutomationExecutionSnapshotCache:
+    hub_root: Path
+    _repository: PmaQueueRepository = field(init=False)
+    _conn: Any = field(default=None, init=False, repr=False)
+    _conn_cm: Any = field(default=None, init=False, repr=False)
+    _pma_items: dict[str, Optional[PmaQueueItem]] = field(default_factory=dict)
+    _thread_prefixes: dict[str, Optional[str]] = field(default_factory=dict)
+    _latest_executions: dict[
+        tuple[Optional[str], Optional[str], Optional[str]], Optional[dict[str, Any]]
+    ] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self._repository = PmaQueueRepository(self.hub_root)
+
+    def close(self) -> None:
+        if self._conn_cm is not None:
+            self._conn_cm.__exit__(None, None, None)
+            self._conn_cm = None
+            self._conn = None
+
+    def _connection(self) -> Any:
+        if self._conn is None:
+            self._conn_cm = open_orchestration_sqlite(
+                self.hub_root, durable=True, migrate=False
+            )
+            self._conn = self._conn_cm.__enter__()
+        return self._conn
+
+    def pma_item(self, item_id: str) -> Optional[PmaQueueItem]:
+        normalized = str(item_id or "").strip()
+        if not normalized:
+            return None
+        if normalized in self._pma_items:
+            return self._pma_items[normalized]
+        row = self._connection().execute(
+            """
+            SELECT *
+              FROM orch_queue_items
+             WHERE queue_item_id = ?
+             LIMIT 1
+            """,
+            (normalized,),
+        ).fetchone()
+        item = self._repository.row_to_item(row) if row is not None else None
+        self._pma_items[normalized] = item
+        return item
+
+    def resolve_thread_prefix(self, prefix: str) -> Optional[str]:
+        normalized = prefix.strip()
+        if not normalized:
+            return None
+        if normalized in self._thread_prefixes:
+            return self._thread_prefixes[normalized]
+        resolved = _resolve_thread_prefix_with_conn(self._connection(), normalized)
+        self._thread_prefixes[normalized] = resolved
+        return resolved
+
+    def latest_thread_execution(
+        self,
+        *,
+        thread_id: Optional[str],
+        execution_id: Optional[str],
+        backend_thread_id: Optional[str],
+    ) -> Optional[dict[str, Any]]:
+        key = (thread_id, execution_id, backend_thread_id)
+        if key in self._latest_executions:
+            return self._latest_executions[key]
+        latest = _latest_thread_execution_with_conn(
+            self._connection(),
+            thread_id=thread_id,
+            execution_id=execution_id,
+            backend_thread_id=backend_thread_id,
+        )
+        self._latest_executions[key] = latest
+        return latest
+
+
 def _pma_item_for_job(
-    job: AutomationJob, *, hub_root: Optional[Path]
+    job: AutomationJob,
+    *,
+    hub_root: Optional[Path],
+    cache: Optional[_AutomationExecutionSnapshotCache] = None,
 ) -> Optional[PmaQueueItem]:
-    if hub_root is None or not job.pma_queue_item_id:
+    if not job.pma_queue_item_id:
         return None
-    return PmaQueue(Path(hub_root)).get_item_sync(str(job.pma_queue_item_id))
+    item_id = str(job.pma_queue_item_id)
+    if cache is not None:
+        return cache.pma_item(item_id)
+    if hub_root is None:
+        return None
+    return PmaQueue(Path(hub_root)).get_item_sync(item_id)
 
 
 def _pma_queue_snapshot(item: Optional[PmaQueueItem]) -> Optional[dict[str, Any]]:
@@ -92,9 +203,10 @@ def _managed_thread_snapshot(
     *,
     pma_item: Optional[PmaQueueItem],
     hub_root: Optional[Path],
+    cache: Optional[_AutomationExecutionSnapshotCache] = None,
 ) -> Optional[dict[str, Any]]:
     thread_id = job.managed_thread_target_id or _managed_thread_id_from_pma_item(
-        pma_item, hub_root=hub_root
+        pma_item, hub_root=hub_root, cache=cache
     )
     execution_id = job.managed_thread_execution_id
     backend_thread_id = _pma_result_string(
@@ -102,12 +214,19 @@ def _managed_thread_snapshot(
     ) or _pma_result_string(pma_item, "thread_id")
     if not thread_id and not execution_id:
         return None
-    latest_execution = _latest_thread_execution(
-        hub_root=hub_root,
-        thread_id=thread_id,
-        execution_id=execution_id,
-        backend_thread_id=backend_thread_id,
-    )
+    if cache is not None:
+        latest_execution = cache.latest_thread_execution(
+            thread_id=thread_id,
+            execution_id=execution_id,
+            backend_thread_id=backend_thread_id,
+        )
+    else:
+        latest_execution = _latest_thread_execution(
+            hub_root=hub_root,
+            thread_id=thread_id,
+            execution_id=execution_id,
+            backend_thread_id=backend_thread_id,
+        )
     return {
         "thread_target_id": thread_id,
         "execution_id": execution_id,
@@ -168,7 +287,10 @@ def _target_href(
 
 
 def _managed_thread_id_from_pma_item(
-    item: Optional[PmaQueueItem], *, hub_root: Optional[Path]
+    item: Optional[PmaQueueItem],
+    *,
+    hub_root: Optional[Path],
+    cache: Optional[_AutomationExecutionSnapshotCache] = None,
 ) -> Optional[str]:
     explicit = (
         _pma_result_string(item, "managed_thread_id")
@@ -181,6 +303,8 @@ def _managed_thread_id_from_pma_item(
     prefix = _thread_prefix_from_pma_result(item)
     if not prefix or hub_root is None:
         return prefix
+    if cache is not None:
+        return cache.resolve_thread_prefix(prefix) or prefix
     return _resolve_thread_prefix(Path(hub_root), prefix) or prefix
 
 
@@ -213,19 +337,23 @@ def _resolve_thread_prefix(hub_root: Path, prefix: str) -> Optional[str]:
         return None
     try:
         with open_orchestration_sqlite(hub_root, durable=True, migrate=False) as conn:
-            row = conn.execute(
-                """
-                SELECT thread_target_id
-                  FROM orch_thread_targets
-                 WHERE thread_target_id = ?
-                    OR thread_target_id LIKE ?
-                 ORDER BY updated_at DESC
-                 LIMIT 1
-                """,
-                (normalized, f"{normalized}%"),
-            ).fetchone()
+            return _resolve_thread_prefix_with_conn(conn, normalized)
     except Exception:
         return None
+
+
+def _resolve_thread_prefix_with_conn(conn: Any, prefix: str) -> Optional[str]:
+    row = conn.execute(
+        """
+        SELECT thread_target_id
+          FROM orch_thread_targets
+         WHERE thread_target_id = ?
+            OR thread_target_id LIKE ?
+         ORDER BY updated_at DESC
+         LIMIT 1
+        """,
+        (prefix, f"{prefix}%"),
+    ).fetchone()
     if row is None:
         return None
     return str(row["thread_target_id"] or "").strip() or None
@@ -244,36 +372,53 @@ def _latest_thread_execution(
         with open_orchestration_sqlite(
             Path(hub_root), durable=True, migrate=False
         ) as conn:
-            row = conn.execute(
-                """
-                SELECT execution_id,
-                       thread_target_id,
-                       status,
-                       backend_turn_id,
-                       error_text,
-                       assistant_text,
-                       model_id,
-                       started_at,
-                       finished_at,
-                       created_at
-                  FROM orch_thread_executions
-                 WHERE (? IS NOT NULL AND execution_id = ?)
-                    OR (? IS NOT NULL AND thread_target_id = ?)
-                    OR (? IS NOT NULL AND backend_turn_id LIKE ?)
-                 ORDER BY COALESCE(finished_at, started_at, created_at) DESC
-                 LIMIT 1
-                """,
-                (
-                    execution_id,
-                    execution_id,
-                    thread_id,
-                    thread_id,
-                    backend_thread_id,
-                    f"{backend_thread_id}:%" if backend_thread_id else None,
-                ),
-            ).fetchone()
+            return _latest_thread_execution_with_conn(
+                conn,
+                thread_id=thread_id,
+                execution_id=execution_id,
+                backend_thread_id=backend_thread_id,
+            )
     except Exception:
         return None
+
+
+def _latest_thread_execution_with_conn(
+    conn: Any,
+    *,
+    thread_id: Optional[str],
+    execution_id: Optional[str],
+    backend_thread_id: Optional[str],
+) -> Optional[dict[str, Any]]:
+    if not (thread_id or execution_id or backend_thread_id):
+        return None
+    row = conn.execute(
+        """
+        SELECT execution_id,
+               thread_target_id,
+               status,
+               backend_turn_id,
+               error_text,
+               assistant_text,
+               model_id,
+               started_at,
+               finished_at,
+               created_at
+          FROM orch_thread_executions
+         WHERE (? IS NOT NULL AND execution_id = ?)
+            OR (? IS NOT NULL AND thread_target_id = ?)
+            OR (? IS NOT NULL AND backend_turn_id LIKE ?)
+         ORDER BY COALESCE(finished_at, started_at, created_at) DESC
+         LIMIT 1
+        """,
+        (
+            execution_id,
+            execution_id,
+            thread_id,
+            thread_id,
+            backend_thread_id,
+            f"{backend_thread_id}:%" if backend_thread_id else None,
+        ),
+    ).fetchone()
     if row is None:
         return None
     return {
@@ -316,4 +461,8 @@ def _nested_string(data: Any, path: tuple[str, ...]) -> Optional[str]:
     return None
 
 
-__all__ = ["AutomationExecutionSnapshot", "automation_execution_snapshot"]
+__all__ = [
+    "AutomationExecutionSnapshot",
+    "automation_execution_snapshot",
+    "automation_execution_snapshots_by_job_id",
+]

--- a/src/codex_autorunner/core/automation/execution_graph.py
+++ b/src/codex_autorunner/core/automation/execution_graph.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from ..orchestration.sqlite import open_orchestration_sqlite
+from ..pma_queue import PmaQueue, PmaQueueItem
+from .models import AutomationJob
+
+
+@dataclass(frozen=True)
+class AutomationExecutionSnapshot:
+    """Read-side projection of an automation job and its child execution."""
+
+    job_id: str
+    primary_child_kind: str
+    target_href: Optional[str] = None
+    chat_href: Optional[str] = None
+    managed_thread: Optional[dict[str, Any]] = None
+    pma_queue: Optional[dict[str, Any]] = None
+    ticket_flow: Optional[dict[str, Any]] = None
+    publish_operation: Optional[dict[str, Any]] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "job_id": self.job_id,
+            "primary_child_kind": self.primary_child_kind,
+            "target_href": self.target_href,
+            "chat_href": self.chat_href,
+            "managed_thread": self.managed_thread,
+            "pma_queue": self.pma_queue,
+            "ticket_flow": self.ticket_flow,
+            "publish_operation": self.publish_operation,
+        }
+
+
+def automation_execution_snapshot(
+    job: AutomationJob, *, hub_root: Optional[Path] = None
+) -> AutomationExecutionSnapshot:
+    pma_item = _pma_item_for_job(job, hub_root=hub_root)
+    pma_queue = _pma_queue_snapshot(pma_item)
+    managed_thread = _managed_thread_snapshot(job, pma_item=pma_item, hub_root=hub_root)
+    ticket_flow = _ticket_flow_snapshot(job)
+    publish_operation = _publish_operation_snapshot(job)
+    primary_child_kind = _primary_child_kind(
+        job,
+        pma_queue=pma_queue,
+        managed_thread=managed_thread,
+        ticket_flow=ticket_flow,
+        publish_operation=publish_operation,
+    )
+    chat_id = _dict_string(managed_thread, "thread_target_id")
+    target_href = _target_href(chat_id=chat_id, ticket_flow=ticket_flow)
+    return AutomationExecutionSnapshot(
+        job_id=job.job_id,
+        primary_child_kind=primary_child_kind,
+        target_href=target_href,
+        chat_href=f"/chats/{chat_id}" if chat_id else None,
+        managed_thread=managed_thread,
+        pma_queue=pma_queue,
+        ticket_flow=ticket_flow,
+        publish_operation=publish_operation,
+    )
+
+
+def _pma_item_for_job(
+    job: AutomationJob, *, hub_root: Optional[Path]
+) -> Optional[PmaQueueItem]:
+    if hub_root is None or not job.pma_queue_item_id:
+        return None
+    return PmaQueue(Path(hub_root)).get_item_sync(str(job.pma_queue_item_id))
+
+
+def _pma_queue_snapshot(item: Optional[PmaQueueItem]) -> Optional[dict[str, Any]]:
+    if item is None:
+        return None
+    return {
+        "item_id": item.item_id,
+        "lane_id": item.lane_id,
+        "state": item.state.value,
+        "started_at": item.started_at,
+        "finished_at": item.finished_at,
+        "error": item.error,
+        "result": item.result or {},
+    }
+
+
+def _managed_thread_snapshot(
+    job: AutomationJob,
+    *,
+    pma_item: Optional[PmaQueueItem],
+    hub_root: Optional[Path],
+) -> Optional[dict[str, Any]]:
+    thread_id = job.managed_thread_target_id or _managed_thread_id_from_pma_item(
+        pma_item, hub_root=hub_root
+    )
+    execution_id = job.managed_thread_execution_id
+    backend_thread_id = _pma_result_string(
+        pma_item, "backend_thread_id"
+    ) or _pma_result_string(pma_item, "thread_id")
+    if not thread_id and not execution_id:
+        return None
+    latest_execution = _latest_thread_execution(
+        hub_root=hub_root,
+        thread_id=thread_id,
+        execution_id=execution_id,
+        backend_thread_id=backend_thread_id,
+    )
+    return {
+        "thread_target_id": thread_id,
+        "execution_id": execution_id,
+        "backend_thread_id": backend_thread_id,
+        "latest_execution": latest_execution,
+    }
+
+
+def _ticket_flow_snapshot(job: AutomationJob) -> Optional[dict[str, Any]]:
+    if not (
+        job.ticket_flow_run_id or job.ticket_flow_worktree_id or job.ticket_flow_repo_id
+    ):
+        return None
+    return {
+        "repo_id": job.ticket_flow_repo_id,
+        "run_id": job.ticket_flow_run_id,
+        "worktree_id": job.ticket_flow_worktree_id,
+    }
+
+
+def _publish_operation_snapshot(job: AutomationJob) -> Optional[dict[str, Any]]:
+    if not job.publish_operation_id:
+        return None
+    return {"operation_id": job.publish_operation_id}
+
+
+def _primary_child_kind(
+    job: AutomationJob,
+    *,
+    pma_queue: Optional[dict[str, Any]],
+    managed_thread: Optional[dict[str, Any]],
+    ticket_flow: Optional[dict[str, Any]],
+    publish_operation: Optional[dict[str, Any]],
+) -> str:
+    kind = str(job.executor.get("kind") or "").strip()
+    if kind == "pma_turn" and pma_queue is not None:
+        return "pma_queue"
+    if managed_thread is not None:
+        return "managed_thread"
+    if ticket_flow is not None:
+        return "ticket_flow"
+    if publish_operation is not None:
+        return "publish_operation"
+    if pma_queue is not None:
+        return "pma_queue"
+    return "none"
+
+
+def _target_href(
+    *, chat_id: Optional[str], ticket_flow: Optional[dict[str, Any]]
+) -> Optional[str]:
+    if chat_id:
+        return f"/chats/{chat_id}"
+    worktree_id = _dict_string(ticket_flow, "worktree_id")
+    if worktree_id:
+        return f"/worktrees/{worktree_id}/tickets"
+    return None
+
+
+def _managed_thread_id_from_pma_item(
+    item: Optional[PmaQueueItem], *, hub_root: Optional[Path]
+) -> Optional[str]:
+    explicit = (
+        _pma_result_string(item, "managed_thread_id")
+        or _pma_result_string(item, "managedThreadId")
+        or _pma_result_string(item, "thread_target_id")
+        or _pma_result_string(item, "threadTargetId")
+    )
+    if explicit:
+        return explicit
+    prefix = _thread_prefix_from_pma_result(item)
+    if not prefix or hub_root is None:
+        return prefix
+    return _resolve_thread_prefix(Path(hub_root), prefix) or prefix
+
+
+def _thread_prefix_from_pma_result(item: Optional[PmaQueueItem]) -> Optional[str]:
+    result = item.result if item is not None and isinstance(item.result, dict) else {}
+    message = result.get("message")
+    if isinstance(message, str):
+        match = re.search(r"Thread\s+`([0-9a-fA-F]{8,36})`", message)
+        if match:
+            return match.group(1)
+    raw_events = result.get("raw_events")
+    if isinstance(raw_events, list):
+        for event in raw_events:
+            output = _nested_string(
+                event,
+                ("message", "params", "properties", "part", "state", "output"),
+            )
+            match = re.search(
+                r"\b([0-9a-fA-F]{8}-[0-9a-fA-F-]{27}|[0-9a-fA-F]{8})\b",
+                output or "",
+            )
+            if match:
+                return match.group(1)
+    return None
+
+
+def _resolve_thread_prefix(hub_root: Path, prefix: str) -> Optional[str]:
+    normalized = prefix.strip()
+    if not normalized:
+        return None
+    try:
+        with open_orchestration_sqlite(hub_root, durable=True, migrate=False) as conn:
+            row = conn.execute(
+                """
+                SELECT thread_target_id
+                  FROM orch_thread_targets
+                 WHERE thread_target_id = ?
+                    OR thread_target_id LIKE ?
+                 ORDER BY updated_at DESC
+                 LIMIT 1
+                """,
+                (normalized, f"{normalized}%"),
+            ).fetchone()
+    except Exception:
+        return None
+    if row is None:
+        return None
+    return str(row["thread_target_id"] or "").strip() or None
+
+
+def _latest_thread_execution(
+    *,
+    hub_root: Optional[Path],
+    thread_id: Optional[str],
+    execution_id: Optional[str],
+    backend_thread_id: Optional[str],
+) -> Optional[dict[str, Any]]:
+    if hub_root is None or not (thread_id or execution_id or backend_thread_id):
+        return None
+    try:
+        with open_orchestration_sqlite(
+            Path(hub_root), durable=True, migrate=False
+        ) as conn:
+            row = conn.execute(
+                """
+                SELECT execution_id,
+                       thread_target_id,
+                       status,
+                       backend_turn_id,
+                       error_text,
+                       assistant_text,
+                       model_id,
+                       started_at,
+                       finished_at,
+                       created_at
+                  FROM orch_thread_executions
+                 WHERE (? IS NOT NULL AND execution_id = ?)
+                    OR (? IS NOT NULL AND thread_target_id = ?)
+                    OR (? IS NOT NULL AND backend_turn_id LIKE ?)
+                 ORDER BY COALESCE(finished_at, started_at, created_at) DESC
+                 LIMIT 1
+                """,
+                (
+                    execution_id,
+                    execution_id,
+                    thread_id,
+                    thread_id,
+                    backend_thread_id,
+                    f"{backend_thread_id}:%" if backend_thread_id else None,
+                ),
+            ).fetchone()
+    except Exception:
+        return None
+    if row is None:
+        return None
+    return {
+        "execution_id": row["execution_id"],
+        "thread_target_id": row["thread_target_id"],
+        "status": row["status"],
+        "backend_turn_id": row["backend_turn_id"],
+        "error_text": row["error_text"],
+        "assistant_text": row["assistant_text"],
+        "model_id": row["model_id"],
+        "started_at": row["started_at"],
+        "finished_at": row["finished_at"],
+        "created_at": row["created_at"],
+    }
+
+
+def _pma_result_string(item: Optional[PmaQueueItem], key: str) -> Optional[str]:
+    result = item.result if item is not None and isinstance(item.result, dict) else {}
+    value = result.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _dict_string(data: Optional[dict[str, Any]], key: str) -> Optional[str]:
+    value = data.get(key) if data else None
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _nested_string(data: Any, path: tuple[str, ...]) -> Optional[str]:
+    value = data
+    for key in path:
+        if not isinstance(value, dict):
+            return None
+        value = value.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+__all__ = ["AutomationExecutionSnapshot", "automation_execution_snapshot"]

--- a/src/codex_autorunner/core/automation/execution_graph.py
+++ b/src/codex_autorunner/core/automation/execution_graph.py
@@ -83,7 +83,9 @@ def automation_execution_snapshots_by_job_id(
     cache = _AutomationExecutionSnapshotCache(hub_root)
     try:
         return {
-            job.job_id: automation_execution_snapshot(job, hub_root=hub_root, cache=cache)
+            job.job_id: automation_execution_snapshot(
+                job, hub_root=hub_root, cache=cache
+            )
             for job in jobs
         }
     finally:
@@ -125,15 +127,19 @@ class _AutomationExecutionSnapshotCache:
             return None
         if normalized in self._pma_items:
             return self._pma_items[normalized]
-        row = self._connection().execute(
-            """
+        row = (
+            self._connection()
+            .execute(
+                """
             SELECT *
               FROM orch_queue_items
              WHERE queue_item_id = ?
              LIMIT 1
             """,
-            (normalized,),
-        ).fetchone()
+                (normalized,),
+            )
+            .fetchone()
+        )
         item = self._repository.row_to_item(row) if row is not None else None
         self._pma_items[normalized] = item
         return item

--- a/src/codex_autorunner/core/automation/product.py
+++ b/src/codex_autorunner/core/automation/product.py
@@ -10,7 +10,11 @@ from zoneinfo import ZoneInfo
 
 from ..time_utils import now_iso
 from .engine import AutomationRuleEngine
-from .execution_graph import automation_execution_snapshot
+from .execution_graph import (
+    AutomationExecutionSnapshot,
+    automation_execution_snapshot,
+    automation_execution_snapshots_by_job_id,
+)
 from .models import (
     EXECUTOR_GITHUB_COMMENT,
     EXECUTOR_GITHUB_REACTION,
@@ -240,6 +244,14 @@ def automation_rows(
         rule_ids, per_rule_limit=recent_job_limit
     )
     job_counts_by_rule = store.job_counts_by_rule(rule_ids)
+    all_jobs = [
+        job
+        for rule in rules
+        for job in recent_jobs_by_rule.get(rule.rule_id, [])
+    ]
+    execution_snapshots = automation_execution_snapshots_by_job_id(
+        all_jobs, hub_root=store.hub_root
+    )
     return [
         _automation_row_from_enrichment(
             rule,
@@ -247,6 +259,7 @@ def automation_rows(
             schedules=schedules_by_rule.get(rule.rule_id, []),
             recent_jobs=recent_jobs_by_rule.get(rule.rule_id, []),
             job_count=job_counts_by_rule.get(rule.rule_id, 0),
+            execution_snapshots=execution_snapshots,
         )
         for rule in rules
     ]
@@ -278,10 +291,16 @@ def _automation_row_from_enrichment(
     schedules: list[AutomationSchedule],
     recent_jobs: list[AutomationJob],
     job_count: int,
+    execution_snapshots: Optional[dict[str, AutomationExecutionSnapshot]] = None,
 ) -> dict[str, Any]:
     last_job = recent_jobs[0] if recent_jobs else None
     schedule = schedules[0] if schedules else None
     typed = _typed_product_projection(rule, schedule)
+    snapshots = execution_snapshots
+    if snapshots is None and recent_jobs:
+        snapshots = automation_execution_snapshots_by_job_id(
+            recent_jobs, hub_root=store.hub_root
+        )
     return {
         "id": rule.rule_id,
         "name": rule.name,
@@ -299,7 +318,10 @@ def _automation_row_from_enrichment(
         "metadata": rule.metadata,
         "schedule": schedule.to_dict() if schedule is not None else None,
         "last_job": last_job.to_dict() if last_job is not None else None,
-        "jobs": [_automation_job_row(job, store=store) for job in recent_jobs],
+        "jobs": [
+            _automation_job_row(job, store=store, execution_snapshots=snapshots)
+            for job in recent_jobs
+        ],
         "job_count": job_count,
         "created_at": rule.created_at,
         "updated_at": rule.updated_at,
@@ -308,12 +330,22 @@ def _automation_row_from_enrichment(
 
 
 def _automation_job_row(
-    job: AutomationJob, *, store: Optional[AutomationStore] = None
+    job: AutomationJob,
+    *,
+    store: Optional[AutomationStore] = None,
+    execution_snapshots: Optional[dict[str, AutomationExecutionSnapshot]] = None,
 ) -> dict[str, Any]:
-    child_execution = automation_execution_snapshot(
-        job,
-        hub_root=store.hub_root if store is not None else None,
-    ).to_dict()
+    snapshot = (
+        execution_snapshots.get(job.job_id)
+        if execution_snapshots is not None
+        else None
+    )
+    if snapshot is None:
+        snapshot = automation_execution_snapshot(
+            job,
+            hub_root=store.hub_root if store is not None else None,
+        )
+    child_execution = snapshot.to_dict()
     pma_queue_result = child_execution.get("pma_queue")
     return {
         "job_id": job.job_id,

--- a/src/codex_autorunner/core/automation/product.py
+++ b/src/codex_autorunner/core/automation/product.py
@@ -245,9 +245,7 @@ def automation_rows(
     )
     job_counts_by_rule = store.job_counts_by_rule(rule_ids)
     all_jobs = [
-        job
-        for rule in rules
-        for job in recent_jobs_by_rule.get(rule.rule_id, [])
+        job for rule in rules for job in recent_jobs_by_rule.get(rule.rule_id, [])
     ]
     execution_snapshots = automation_execution_snapshots_by_job_id(
         all_jobs, hub_root=store.hub_root
@@ -336,9 +334,7 @@ def _automation_job_row(
     execution_snapshots: Optional[dict[str, AutomationExecutionSnapshot]] = None,
 ) -> dict[str, Any]:
     snapshot = (
-        execution_snapshots.get(job.job_id)
-        if execution_snapshots is not None
-        else None
+        execution_snapshots.get(job.job_id) if execution_snapshots is not None else None
     )
     if snapshot is None:
         snapshot = automation_execution_snapshot(

--- a/src/codex_autorunner/core/automation/product.py
+++ b/src/codex_autorunner/core/automation/product.py
@@ -10,6 +10,7 @@ from zoneinfo import ZoneInfo
 
 from ..time_utils import now_iso
 from .engine import AutomationRuleEngine
+from .execution_graph import automation_execution_snapshot
 from .models import (
     EXECUTOR_GITHUB_COMMENT,
     EXECUTOR_GITHUB_REACTION,
@@ -242,6 +243,7 @@ def automation_rows(
     return [
         _automation_row_from_enrichment(
             rule,
+            store=store,
             schedules=schedules_by_rule.get(rule.rule_id, []),
             recent_jobs=recent_jobs_by_rule.get(rule.rule_id, []),
             job_count=job_counts_by_rule.get(rule.rule_id, 0),
@@ -261,13 +263,18 @@ def automation_row(store: AutomationStore, rule: AutomationRule) -> dict[str, An
     recent_jobs = store.list_jobs(rule_id=rule.rule_id, limit=25, order="newest")
     job_count = store.count_jobs(rule_id=rule.rule_id)
     return _automation_row_from_enrichment(
-        rule, schedules=schedules, recent_jobs=recent_jobs, job_count=job_count
+        rule,
+        store=store,
+        schedules=schedules,
+        recent_jobs=recent_jobs,
+        job_count=job_count,
     )
 
 
 def _automation_row_from_enrichment(
     rule: AutomationRule,
     *,
+    store: AutomationStore,
     schedules: list[AutomationSchedule],
     recent_jobs: list[AutomationJob],
     job_count: int,
@@ -292,7 +299,7 @@ def _automation_row_from_enrichment(
         "metadata": rule.metadata,
         "schedule": schedule.to_dict() if schedule is not None else None,
         "last_job": last_job.to_dict() if last_job is not None else None,
-        "jobs": [_automation_job_row(job) for job in recent_jobs],
+        "jobs": [_automation_job_row(job, store=store) for job in recent_jobs],
         "job_count": job_count,
         "created_at": rule.created_at,
         "updated_at": rule.updated_at,
@@ -300,7 +307,14 @@ def _automation_row_from_enrichment(
     }
 
 
-def _automation_job_row(job: AutomationJob) -> dict[str, Any]:
+def _automation_job_row(
+    job: AutomationJob, *, store: Optional[AutomationStore] = None
+) -> dict[str, Any]:
+    child_execution = automation_execution_snapshot(
+        job,
+        hub_root=store.hub_root if store is not None else None,
+    ).to_dict()
+    pma_queue_result = child_execution.get("pma_queue")
     return {
         "job_id": job.job_id,
         "state": job.state,
@@ -311,6 +325,12 @@ def _automation_job_row(job: AutomationJob) -> dict[str, Any]:
         "result_summary": job.result_summary,
         "error_text": job.error_text,
         "attempt_count": job.attempt_count,
+        "managed_thread_target_id": job.managed_thread_target_id,
+        "managed_thread_execution_id": job.managed_thread_execution_id,
+        "pma_lane_id": job.pma_lane_id,
+        "pma_queue_item_id": job.pma_queue_item_id,
+        "pma_queue_result": pma_queue_result,
+        "child_execution": child_execution,
         "ticket_flow_run_id": job.ticket_flow_run_id,
         "ticket_flow_worktree_id": job.ticket_flow_worktree_id,
     }

--- a/src/codex_autorunner/core/automation/store.py
+++ b/src/codex_autorunner/core/automation/store.py
@@ -40,6 +40,10 @@ class AutomationStore:
         self._hub_root = Path(hub_root)
         self._durable = durable
 
+    @property
+    def hub_root(self) -> Path:
+        return self._hub_root
+
     def upsert_rule(self, rule: AutomationRule) -> AutomationRule:
         with open_orchestration_sqlite(self._hub_root, durable=self._durable) as conn:
             with conn:
@@ -502,6 +506,7 @@ class AutomationStore:
         *,
         error_text: str,
         dead_letter: bool = False,
+        execution_refs: Optional[dict[str, Any]] = None,
         now: Optional[str] = None,
     ) -> AutomationJob:
         return self._transition_job(
@@ -509,6 +514,7 @@ class AutomationStore:
             JOB_DEAD_LETTERED if dead_letter else JOB_FAILED,
             now=now,
             error_text=error_text,
+            execution_refs=execution_refs,
             finished=True,
         )
 

--- a/src/codex_autorunner/core/automation/store.py
+++ b/src/codex_autorunner/core/automation/store.py
@@ -606,8 +606,20 @@ class AutomationStore:
             raise RuntimeError("failed to revive automation job")
         return self._row_to_job(saved)
 
-    def cancel_job(self, job_id: str, *, now: Optional[str] = None) -> AutomationJob:
-        return self._transition_job(job_id, JOB_CANCELLED, now=now, finished=True)
+    def cancel_job(
+        self,
+        job_id: str,
+        *,
+        execution_refs: Optional[dict[str, Any]] = None,
+        now: Optional[str] = None,
+    ) -> AutomationJob:
+        return self._transition_job(
+            job_id,
+            JOB_CANCELLED,
+            now=now,
+            execution_refs=execution_refs,
+            finished=True,
+        )
 
     def skip_job(
         self, job_id: str, *, result_summary: Optional[str] = None

--- a/src/codex_autorunner/core/hub.py
+++ b/src/codex_autorunner/core/hub.py
@@ -23,7 +23,7 @@ from .automation import (
     ManagedThreadTurnAutomationExecutor,
     PublishOperationAutomationExecutor,
 )
-from .automation.models import JOB_SKIPPED
+from .automation.models import JOB_RUNNING, JOB_SKIPPED
 from .automation.ticket_flow_executor import TicketFlowAutomationExecutor
 from .config import (
     HubConfig,
@@ -189,6 +189,7 @@ class _PmaTurnAutomationExecutor:
                 },
             )
         return AutomationExecutorResult(
+            status=JOB_RUNNING,
             summary="queued PMA automation turn",
             data={"created_queue_item": created},
             execution_refs={"pma_lane_id": lane_id, "pma_queue_item_id": item.item_id},
@@ -1154,7 +1155,7 @@ class HubSupervisor:
         worker = self._lifecycle_orchestrator._automation_job_worker
         scheduler.process_due(limit=take)
         worker_result = worker.process_once(limit=take)
-        return worker_result.succeeded + worker_result.skipped
+        return worker_result.running + worker_result.succeeded + worker_result.skipped
 
     def ensure_pma_safety_checker(self) -> PmaSafetyChecker:
         if self._pma_safety_checker is not None:

--- a/src/codex_autorunner/core/hub_lifecycle.py
+++ b/src/codex_autorunner/core/hub_lifecycle.py
@@ -359,6 +359,7 @@ class HubLifecycleOrchestrator:
         self._automation_child_reconciler = AutomationChildRunReconciler(
             self._automation_store,
             resolve_repo_path=self._resolve_repo_path_for_automation,
+            hub_root=hub_config.root,
             logger=logger,
         )
         self._automation_executor_registry = (

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -1396,6 +1396,7 @@ class ChatSurfaceReadService:
             projection = _projection(projections, "pma", thread_id)
             lifecycle_status = _normalize_text(row["lifecycle_status"]) or "active"
             metadata = _json_object(_row_get(row, "metadata_json"))
+            automation_metadata = metadata.get("automation")
             chat_kind = _normalize_text(metadata.get("chat_kind"))
             run_id = _normalize_text(metadata.get("run_id"))
             visible_execution = visible_execution_by_thread.get(thread_id)
@@ -1459,6 +1460,17 @@ class ChatSurfaceReadService:
                     ),
                     "model": _normalize_text(metadata.get("model")),
                     "thread_kind": _normalize_text(metadata.get("thread_kind")),
+                    "automation": (
+                        dict(automation_metadata)
+                        if isinstance(automation_metadata, Mapping)
+                        else None
+                    ),
+                    "automation_job_id": _normalize_text(
+                        metadata.get("automation_job_id")
+                    ),
+                    "automation_rule_id": _normalize_text(
+                        metadata.get("automation_rule_id")
+                    ),
                     "provider_conversation_title": _normalize_text(
                         metadata.get("provider_conversation_title")
                     ),

--- a/src/codex_autorunner/core/pma_queue.py
+++ b/src/codex_autorunner/core/pma_queue.py
@@ -531,6 +531,22 @@ class PmaQueue:
                 conn, lane_id, idempotency_key
             )
 
+    def get_item_sync(self, item_id: str) -> Optional[PmaQueueItem]:
+        normalized = str(item_id or "").strip()
+        if not normalized:
+            return None
+        with open_orchestration_sqlite(self._hub_root, durable=True) as conn:
+            row = conn.execute(
+                """
+                SELECT *
+                  FROM orch_queue_items
+                 WHERE queue_item_id = ?
+                 LIMIT 1
+                """,
+                (normalized,),
+            ).fetchone()
+        return self._repository.row_to_item(row) if row is not None else None
+
     def ensure_active_item_sync(
         self,
         lane_id: str,

--- a/src/codex_autorunner/surfaces/web/services/chat_read_models.py
+++ b/src/codex_autorunner/surfaces/web/services/chat_read_models.py
@@ -588,6 +588,21 @@ def hub_chat_row_to_chat_index_row(raw: Mapping[str, Any]) -> ChatIndexRow:
         binding_display_names[0] if binding_display_names else None
     )
 
+    debug_payload = (
+        dict(cast(Mapping[str, Any], raw.get("debug")))
+        if isinstance(raw.get("debug"), Mapping)
+        else {}
+    )
+    automation_payload = raw.get("automation")
+    if isinstance(automation_payload, Mapping):
+        debug_payload["automation"] = dict(cast(Mapping[str, Any], automation_payload))
+    automation_job_id = _str_or_none(raw.get("automation_job_id"))
+    automation_rule_id = _str_or_none(raw.get("automation_rule_id"))
+    if automation_job_id:
+        debug_payload["automation_job_id"] = automation_job_id
+    if automation_rule_id:
+        debug_payload["automation_rule_id"] = automation_rule_id
+
     return ChatIndexRow(
         chat_id=chat_id,
         surface=surface_from_hub_row(raw),
@@ -650,11 +665,7 @@ def hub_chat_row_to_chat_index_row(raw: Mapping[str, Any]) -> ChatIndexRow:
         ticket_status=(
             _ticket_status_from_raw(raw, normalized_status) if is_ticket_flow else None
         ),
-        debug=(
-            dict(cast(Mapping[str, Any], raw.get("debug")))
-            if isinstance(raw.get("debug"), Mapping)
-            else None
-        ),
+        debug=debug_payload or None,
     )
 
 
@@ -894,6 +905,9 @@ def _detail_thread_as_index_shape(thread: Mapping[str, Any]) -> dict[str, Any]:
         "model": thread.get("model") or meta.get("model"),
         "chat_kind": meta.get("chat_kind") or meta.get("thread_kind"),
         "thread_kind": meta.get("thread_kind"),
+        "automation": meta.get("automation"),
+        "automation_job_id": meta.get("automation_job_id"),
+        "automation_rule_id": meta.get("automation_rule_id"),
         "surface_kinds": surface_kinds,
         "surface": first_surface_dict,
         "unread_count": thread.get("unread_count", 0),

--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -6968,6 +6968,12 @@ textarea:disabled {
   background: color-mix(in srgb, var(--color-success) 12%, var(--color-surface));
 }
 
+.chat-kind-badge.automation {
+  color: var(--color-warning);
+  border-color: color-mix(in srgb, var(--color-warning) 32%, var(--color-border));
+  background: color-mix(in srgb, var(--color-warning) 12%, var(--color-surface));
+}
+
 .chat-surface-badge {
   display: inline-flex;
   align-items: center;

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.ts
@@ -148,6 +148,12 @@ export type AutomationJobSummary = {
   resultSummary: string | null;
   errorText: string | null;
   attemptCount: number;
+  managedThreadTargetId: string | null;
+  managedThreadExecutionId: string | null;
+  pmaLaneId: string | null;
+  pmaQueueItemId: string | null;
+  pmaQueueResult: JsonRecord | null;
+  childExecution: JsonRecord | null;
   ticketFlowRunId: string | null;
   ticketFlowWorktreeId: string | null;
   raw: JsonRecord;
@@ -1267,6 +1273,16 @@ function mapAutomationJob(raw: JsonRecord): AutomationJobSummary {
     resultSummary: nullableString(raw.result_summary ?? raw.resultSummary),
     errorText: nullableString(raw.error_text ?? raw.errorText),
     attemptCount: numberValue(raw.attempt_count ?? raw.attemptCount, 0),
+    managedThreadTargetId: nullableString(raw.managed_thread_target_id ?? raw.managedThreadTargetId),
+    managedThreadExecutionId: nullableString(raw.managed_thread_execution_id ?? raw.managedThreadExecutionId),
+    pmaLaneId: nullableString(raw.pma_lane_id ?? raw.pmaLaneId),
+    pmaQueueItemId: nullableString(raw.pma_queue_item_id ?? raw.pmaQueueItemId),
+    pmaQueueResult: Object.keys(asRecord(raw.pma_queue_result ?? raw.pmaQueueResult)).length
+      ? asRecord(raw.pma_queue_result ?? raw.pmaQueueResult)
+      : null,
+    childExecution: Object.keys(asRecord(raw.child_execution ?? raw.childExecution)).length
+      ? asRecord(raw.child_execution ?? raw.childExecution)
+      : null,
     ticketFlowRunId: nullableString(raw.ticket_flow_run_id ?? raw.ticketFlowRunId),
     ticketFlowWorktreeId: nullableString(raw.ticket_flow_worktree_id ?? raw.ticketFlowWorktreeId),
     raw

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -39,6 +39,7 @@ import {
   pmaChatKind,
   pmaChatKindLabel,
   pmaChatHeaderScopeLine,
+  pmaChatIsAutomation,
   chatRunGroupSummaryParts,
   chatMessengerSurface,
   pmaChatScopeLabelFromChat,
@@ -403,6 +404,18 @@ describe('PMA chat view helpers', () => {
       'chat-3'
     ]);
     expect(summarizeFilterCounts(chats, lastSeen)).toEqual({ all: 3, active: 1, waiting: 1, unread: 2, archived: 0 });
+  });
+
+  it('filters automation-owned chats by backend metadata', () => {
+    const automationChat: PmaChatSummary = {
+      ...baseChat,
+      id: 'automation-chat',
+      raw: { debug: { automation_job_id: 'job-1' } }
+    };
+    const chats = [baseChat, automationChat];
+
+    expect(pmaChatIsAutomation(automationChat)).toBe(true);
+    expect(filterPmaChats(chats, 'automation', '').map((chat) => chat.id)).toEqual(['automation-chat']);
   });
 
   it('keeps archived chats out of the working filters and exposes them through archived', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -17,8 +17,8 @@ import { isChatUnread } from './unread';
 /** Status chips (All / Waiting / …) on the chat list. */
 export type ChatStatusFilter = 'all' | 'active' | 'waiting' | 'unread' | 'archived';
 
-/** Full list filter: status chips, grouped ticket runs, or `surface:<slug>` messenger filters. */
-export type ChatFilter = ChatStatusFilter | 'ticket_runs' | `surface:${string}`;
+/** Full list filter: status chips, grouped ticket runs, automation chats, or `surface:<slug>` messenger filters. */
+export type ChatFilter = ChatStatusFilter | 'ticket_runs' | 'automation' | `surface:${string}`;
 
 /** Token for the chats sidebar filter that lists only ticket-flow run groups (collapsed headers). */
 export const CHAT_TICKET_RUNS_FILTER = 'ticket_runs' as const satisfies ChatFilter;
@@ -661,6 +661,7 @@ export function filterPmaChats(
         return chatMessengerSurface(chat)?.slug === slug;
       }
       if (filter === 'ticket_runs') return chatRunGroupKey(chat) !== null;
+      if (filter === 'automation') return pmaChatIsAutomation(chat);
       if (filter === 'active') return activeStatuses.includes(chat.status);
       if (filter === 'waiting') return waitingStatuses.includes(chat.status);
       if (filter === 'unread') {
@@ -734,6 +735,23 @@ export function summarizeFilterCounts(
     unread: activeChats.filter((chat) => isUnread(chat, lastSeen)).length,
     archived: chats.filter(isPmaChatArchived).length
   };
+}
+
+export function pmaChatIsAutomation(chat: PmaChatSummary | null): boolean {
+  if (!chat) return false;
+  const debug = recordValue(chat.raw.debug);
+  const row = recordValue(chat.raw.row);
+  return Boolean(
+    recordValue(debug?.automation) ||
+      stringValue(debug?.automation_job_id) ||
+      stringValue(debug?.automation_rule_id) ||
+      recordValue(row?.automation) ||
+      stringValue(row?.automation_job_id) ||
+      stringValue(row?.automation_rule_id) ||
+      recordValue(chat.raw.automation) ||
+      stringValue(chat.raw.automation_job_id) ||
+      stringValue(chat.raw.automation_rule_id)
+  );
 }
 
 export function adjustedUnreadFilterCount(

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/runHistory.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/runHistory.test.ts
@@ -56,4 +56,25 @@ describe('runHistoryFromAutomationJobs', () => {
     expect(row.timestamp).toBe('2026-05-17T09:03:00Z');
     expect(row.href).toBeNull();
   });
+
+  it('links PMA automation runs to spawned chats', () => {
+    const [row] = runHistoryFromAutomationJobs([
+      {
+        job_id: 'job-pma',
+        state: 'running',
+        child_execution: {
+          chat_href: '/chats/thread-target-1',
+          target_href: '/worktrees/wt-ignored/tickets'
+        },
+        pma_queue_result: {
+          result: {
+            thread_id: 'thread-1'
+          }
+        },
+        ticket_flow_worktree_id: 'wt-ignored'
+      }
+    ]);
+
+    expect(row.href).toBe('/chats/thread-target-1');
+  });
 });

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/runHistory.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/runHistory.ts
@@ -17,6 +17,16 @@ export function runHistoryFromAutomationJobs(jobs: JsonRecord[]): RunHistoryEntr
     const id = stringValue(job.jobId ?? job.job_id, `job-${index + 1}`);
     const state = stringValue(job.state, 'idle');
     const worktreeId = nullableString(job.ticketFlowWorktreeId ?? job.ticket_flow_worktree_id);
+    const managedThreadId = nullableString(job.managedThreadTargetId ?? job.managed_thread_target_id);
+    const childExecution = recordValue(job.childExecution ?? job.child_execution);
+    const queueResult = recordValue(job.pmaQueueResult ?? job.pma_queue_result);
+    const queuePayloadResult = recordValue(queueResult?.result);
+    const spawnedChatId = managedThreadId ?? nullableString(
+      queuePayloadResult?.managed_thread_id ??
+        queuePayloadResult?.managedThreadId ??
+        queuePayloadResult?.thread_id ??
+        queuePayloadResult?.threadId
+    );
     return {
       id,
       title: `Run ${shortId(id)}`,
@@ -26,7 +36,9 @@ export function runHistoryFromAutomationJobs(jobs: JsonRecord[]): RunHistoryEntr
         nullableString(job.finishedAt ?? job.finished_at) ??
         nullableString(job.updatedAt ?? job.updated_at) ??
         nullableString(job.createdAt ?? job.created_at),
-      href: worktreeId ? worktreeTicketRoute(worktreeId) : null,
+      href:
+        nullableString(childExecution?.chat_href ?? childExecution?.target_href) ??
+        (spawnedChatId ? `/chats/${encodeURIComponent(spawnedChatId)}` : worktreeId ? worktreeTicketRoute(worktreeId) : null),
       attempts: numberValue(job.attemptCount ?? job.attempt_count, 0)
     };
   });
@@ -57,4 +69,8 @@ function nullableString(value: unknown): string | null {
 function numberValue(value: unknown, fallback: number): number {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function recordValue(value: unknown): JsonRecord | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as JsonRecord) : null;
 }

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -94,6 +94,7 @@
     pmaChatKind,
     pmaChatKindLabel,
     pmaChatHeaderScopeLine,
+    pmaChatIsAutomation,
     chatMessengerSurface,
     pmaChatScopeTagView,
     chatSurfaceFilterOptions,
@@ -669,6 +670,7 @@
 
   function readModelChatIndexFilter(value: ChatFilter): 'all' | 'waiting' | 'active' | 'unread' | 'archived' | 'ticket_runs' | 'external' {
     if (value === 'ticket_runs') return 'ticket_runs';
+    if (value === 'automation') return 'all';
     if (value.startsWith('surface:')) return 'external';
     if (value === 'all' || value === 'waiting' || value === 'active' || value === 'unread' || value === 'archived') return value;
     return 'all';
@@ -696,6 +698,8 @@
       archived: counters.archived
     };
   }
+
+  const automationChatCount = $derived(facetChats.filter(pmaChatIsAutomation).length);
 
   function composerRecipientLabel(chat: PmaChatSummary | null): string {
     if (!chat) return 'Chat';
@@ -1858,6 +1862,17 @@
                 }
               ]
             : []),
+          ...(automationChatCount > 0 || filter === 'automation'
+            ? [
+                {
+                  key: 'automation',
+                  label: 'Automation',
+                  count: automationChatCount,
+                  active: filter === 'automation',
+                  onSelect: () => (filter = 'automation')
+                }
+              ]
+            : []),
           ...surfaceFilterChips
             .filter((surf) => surf.count > 0 || filter === chatSurfaceFilterToken(surf.slug))
             // Suppress the surface chip when it is the only surface available and its
@@ -1967,6 +1982,9 @@
                 {/if}
                 {#if pmaChatKind(chat) === 'coding_agent'}
                   <span class={`chat-kind-badge ${pmaChatKind(chat)}`}>{pmaChatKindLabel(pmaChatKind(chat))}</span>
+                {/if}
+                {#if pmaChatIsAutomation(chat)}
+                  <span class="chat-kind-badge automation">Automation</span>
                 {/if}
                 {#if messengerSurface}
                   <span class={`chat-surface-badge ${messengerSurface.badgeClass}`}>{messengerSurface.label}</span>
@@ -2168,6 +2186,9 @@
           </div>
           <p class="chat-header-subtitle">
             <span class={`chat-kind-badge ${activeChatKind}`}>{activeChatKindLabel}</span>
+            {#if pmaChatIsAutomation(activeChat)}
+              <span class="chat-kind-badge automation">Automation</span>
+            {/if}
             {#if activeMessengerSurface}
               <span class={`chat-surface-badge ${activeMessengerSurface.badgeClass}`}>{activeMessengerSurface.label}</span>
             {/if}

--- a/tests/core/test_automation_child_reconciler.py
+++ b/tests/core/test_automation_child_reconciler.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 from codex_autorunner.core.automation import (
+    EXECUTOR_PMA_TURN,
     EXECUTOR_TICKET_FLOW,
     JOB_FAILED,
     JOB_PAUSED,
@@ -16,12 +18,17 @@ from codex_autorunner.core.automation import (
 from codex_autorunner.core.automation.child_reconciler import (
     AutomationChildRunReconciler,
 )
+from codex_autorunner.core.automation.execution_graph import (
+    automation_execution_snapshot,
+)
 from codex_autorunner.core.automation.models import (
     TARGET_POLICY_EXISTING_REPO,
     TRIGGER_KIND_EVENT,
 )
 from codex_autorunner.core.flows.models import FlowRunStatus
 from codex_autorunner.core.flows.store import FlowStore
+from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
+from codex_autorunner.core.pma_queue import PmaQueue
 
 
 def _store_with_running_ticket_flow_job(
@@ -162,3 +169,252 @@ def test_reconciler_pauses_parent_when_child_ticket_flow_pauses(tmp_path: Path) 
     assert result.paused == 1
     assert saved.state == JOB_PAUSED
     assert saved.result_summary == "ticket-flow run paused: run-1"
+
+
+def _store_with_running_pma_queue_job(hub: Path) -> AutomationStore:
+    store = AutomationStore(hub)
+    store.upsert_rule(
+        AutomationRule.create(
+            rule_id="rule-pma",
+            name="PMA turn",
+            trigger_kind=TRIGGER_KIND_EVENT,
+            trigger={"event_types": ["manual.run"]},
+            target_policy=TARGET_POLICY_EXISTING_REPO,
+            executor_kind=EXECUTOR_PMA_TURN,
+        )
+    )
+    store.record_event(
+        AutomationEvent.create(event_id="event-pma", event_type="manual.run")
+    )
+    queue_item, _ = PmaQueue(hub).enqueue_sync(
+        "pma:default",
+        "automation-job:job-pma",
+        {"message": "run automation", "client_turn_id": "job-pma"},
+    )
+    store.enqueue_job(
+        AutomationJob.create(
+            job_id="job-pma",
+            rule_id="rule-pma",
+            event_id="event-pma",
+            state=JOB_RUNNING,
+            target={"policy": TARGET_POLICY_EXISTING_REPO, "repo_id": "repo-1"},
+            executor={"kind": EXECUTOR_PMA_TURN},
+            available_at="2026-01-01T00:00:00Z",
+            created_at="2026-01-01T00:00:00Z",
+            dedupe_key="job-pma",
+        )
+    )
+    store.update_running_job(
+        "job-pma",
+        execution_refs={
+            "pma_lane_id": queue_item.lane_id,
+            "pma_queue_item_id": queue_item.item_id,
+        },
+    )
+    return store
+
+
+def test_reconciler_completes_pma_queue_job_when_queue_succeeds(
+    tmp_path: Path,
+) -> None:
+    hub = tmp_path / "hub"
+    store = _store_with_running_pma_queue_job(hub)
+    queue = PmaQueue(hub)
+    item = queue.find_active_by_idempotency_key_sync(
+        "pma:default", "automation-job:job-pma"
+    )
+    assert item is not None
+    asyncio.run(queue.complete_item(item, {"status": "ok", "detail": "done"}))
+
+    result = AutomationChildRunReconciler(
+        store, resolve_repo_path=lambda _repo_id: None, hub_root=hub
+    ).reconcile_running_jobs()
+
+    saved = store.get_job("job-pma")
+    assert result.completed == 1
+    assert saved.state == JOB_SUCCEEDED
+    assert saved.result_summary == "done"
+
+
+def test_reconciler_fails_pma_queue_job_when_queue_result_errors(
+    tmp_path: Path,
+) -> None:
+    hub = tmp_path / "hub"
+    store = _store_with_running_pma_queue_job(hub)
+    queue = PmaQueue(hub)
+    item = queue.find_active_by_idempotency_key_sync(
+        "pma:default", "automation-job:job-pma"
+    )
+    assert item is not None
+    asyncio.run(queue.complete_item(item, {"status": "error", "detail": "failed"}))
+
+    result = AutomationChildRunReconciler(
+        store, resolve_repo_path=lambda _repo_id: None, hub_root=hub
+    ).reconcile_running_jobs()
+
+    saved = store.get_job("job-pma")
+    assert result.failed == 1
+    assert saved.state == JOB_FAILED
+    assert saved.error_text == "failed"
+
+
+def test_reconciler_fails_pma_job_when_spawned_thread_fails(
+    tmp_path: Path,
+) -> None:
+    hub = tmp_path / "hub"
+    store = _store_with_running_pma_queue_job(hub)
+    queue = PmaQueue(hub)
+    item = queue.find_active_by_idempotency_key_sync(
+        "pma:default", "automation-job:job-pma"
+    )
+    assert item is not None
+    asyncio.run(
+        queue.complete_item(
+            item,
+            {
+                "status": "ok",
+                "message": "Spawned and dispatched. Thread `29998b57` is running.",
+                "thread_id": "backend-session-1",
+            },
+        )
+    )
+    _insert_thread_execution(
+        hub,
+        thread_id="29998b57-94e9-49a4-8299-0349872e4b70",
+        backend_thread_id="backend-session-1",
+        execution_id="exec-1",
+        status="error",
+        error_text="opencode_first_event_timeout: no relevant events received within 60.0s",
+    )
+
+    result = AutomationChildRunReconciler(
+        store, resolve_repo_path=lambda _repo_id: None, hub_root=hub
+    ).reconcile_running_jobs()
+
+    saved = store.get_job("job-pma")
+    assert result.failed == 1
+    assert saved.state == JOB_FAILED
+    assert saved.managed_thread_target_id == "29998b57-94e9-49a4-8299-0349872e4b70"
+    assert saved.managed_thread_execution_id == "exec-1"
+    assert saved.error_text == (
+        "opencode_first_event_timeout: no relevant events received within 60.0s"
+    )
+
+
+def test_execution_snapshot_links_pma_spawned_thread_prefix(
+    tmp_path: Path,
+) -> None:
+    hub = tmp_path / "hub"
+    store = _store_with_running_pma_queue_job(hub)
+    queue = PmaQueue(hub)
+    item = queue.find_active_by_idempotency_key_sync(
+        "pma:default", "automation-job:job-pma"
+    )
+    assert item is not None
+    asyncio.run(
+        queue.complete_item(
+            item,
+            {
+                "status": "ok",
+                "message": "Spawned and dispatched. Thread `29998b57` is running.",
+                "thread_id": "backend-session-1",
+            },
+        )
+    )
+    _insert_thread_execution(
+        hub,
+        thread_id="29998b57-94e9-49a4-8299-0349872e4b70",
+        backend_thread_id="backend-session-1",
+        execution_id="exec-1",
+        status="running",
+        error_text=None,
+    )
+
+    job = store.get_job("job-pma")
+    assert job is not None
+    snapshot = automation_execution_snapshot(job, hub_root=hub).to_dict()
+
+    assert snapshot["primary_child_kind"] == "pma_queue"
+    assert snapshot["chat_href"] == "/chats/29998b57-94e9-49a4-8299-0349872e4b70"
+    assert snapshot["managed_thread"]["latest_execution"]["status"] == "running"
+
+
+def _insert_thread_execution(
+    hub: Path,
+    *,
+    thread_id: str,
+    backend_thread_id: str,
+    execution_id: str,
+    status: str,
+    error_text: str | None,
+) -> None:
+    with open_orchestration_sqlite(hub, durable=True) as conn:
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO orch_thread_targets (
+                    thread_target_id, agent_id, backend_thread_id, repo_id,
+                    workspace_root, display_name, lifecycle_status, runtime_status,
+                    status_reason, status_turn_id, last_execution_id,
+                    last_message_preview, created_at, updated_at, status_updated_at,
+                    status_terminal, resource_kind, resource_id, metadata_json,
+                    scope_urn, surface_urn, backend_binding_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    thread_id,
+                    "opencode",
+                    backend_thread_id,
+                    "repo-1",
+                    "/tmp/repo-1",
+                    "weekly-tech-debt-scan",
+                    "active",
+                    status,
+                    None,
+                    None,
+                    execution_id,
+                    None,
+                    "2026-01-01T00:00:00Z",
+                    "2026-01-01T00:01:00Z",
+                    "2026-01-01T00:01:00Z",
+                    1 if status in {"error", "completed"} else 0,
+                    None,
+                    None,
+                    "{}",
+                    None,
+                    None,
+                    "{}",
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO orch_thread_executions (
+                    execution_id, thread_target_id, client_request_id, request_kind,
+                    prompt_text, status, backend_turn_id, assistant_text, error_text,
+                    model_id, reasoning_level, transcript_mirror_id, started_at,
+                    finished_at, created_at, metadata_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    execution_id,
+                    thread_id,
+                    None,
+                    "message",
+                    "prompt",
+                    status,
+                    f"{backend_thread_id}:turn-1",
+                    None,
+                    error_text,
+                    "zai-coding-plan/glm-5.1",
+                    None,
+                    None,
+                    "2026-01-01T00:00:00Z",
+                    (
+                        "2026-01-01T00:01:00Z"
+                        if status in {"error", "completed"}
+                        else None
+                    ),
+                    "2026-01-01T00:00:00Z",
+                    "{}",
+                ),
+            )

--- a/tests/core/test_automation_child_reconciler.py
+++ b/tests/core/test_automation_child_reconciler.py
@@ -20,6 +20,7 @@ from codex_autorunner.core.automation.child_reconciler import (
 )
 from codex_autorunner.core.automation.execution_graph import (
     automation_execution_snapshot,
+    automation_execution_snapshots_by_job_id,
 )
 from codex_autorunner.core.automation.models import (
     TARGET_POLICY_EXISTING_REPO,
@@ -256,6 +257,8 @@ def test_reconciler_fails_pma_queue_job_when_queue_result_errors(
     assert result.failed == 1
     assert saved.state == JOB_FAILED
     assert saved.error_text == "failed"
+    assert saved.pma_lane_id == "pma:default"
+    assert saved.pma_queue_item_id == item.item_id
 
 
 def test_reconciler_fails_pma_job_when_spawned_thread_fails(
@@ -301,6 +304,87 @@ def test_reconciler_fails_pma_job_when_spawned_thread_fails(
     )
 
 
+def test_reconciler_cancels_pma_job_when_spawned_thread_is_interrupted(
+    tmp_path: Path,
+) -> None:
+    hub = tmp_path / "hub"
+    store = _store_with_running_pma_queue_job(hub)
+    queue = PmaQueue(hub)
+    item = queue.find_active_by_idempotency_key_sync(
+        "pma:default", "automation-job:job-pma"
+    )
+    assert item is not None
+    asyncio.run(
+        queue.complete_item(
+            item,
+            {
+                "status": "ok",
+                "message": "Spawned and dispatched. Thread `29998b57` is running.",
+                "thread_id": "backend-session-1",
+            },
+        )
+    )
+    _insert_thread_execution(
+        hub,
+        thread_id="29998b57-94e9-49a4-8299-0349872e4b70",
+        backend_thread_id="backend-session-1",
+        execution_id="exec-1",
+        status="interrupted",
+        error_text=None,
+    )
+
+    result = AutomationChildRunReconciler(
+        store, resolve_repo_path=lambda _repo_id: None, hub_root=hub
+    ).reconcile_running_jobs()
+
+    saved = store.get_job("job-pma")
+    assert result.cancelled == 1
+    assert saved.state == "cancelled"
+    assert saved.managed_thread_target_id == "29998b57-94e9-49a4-8299-0349872e4b70"
+    assert saved.managed_thread_execution_id == "exec-1"
+
+
+def test_reconciler_uses_managed_thread_refs_when_pma_queue_row_is_missing(
+    tmp_path: Path,
+) -> None:
+    hub = tmp_path / "hub"
+    store = _store_with_running_pma_queue_job(hub)
+    job = store.get_job("job-pma")
+    assert job is not None
+    queue_item_id = str(job.pma_queue_item_id)
+    with open_orchestration_sqlite(hub, durable=True) as conn:
+        with conn:
+            conn.execute(
+                "DELETE FROM orch_queue_items WHERE queue_item_id = ?",
+                (queue_item_id,),
+            )
+    store.update_running_job(
+        "job-pma",
+        execution_refs={
+            "managed_thread_target_id": "29998b57-94e9-49a4-8299-0349872e4b70",
+            "managed_thread_execution_id": "exec-1",
+        },
+    )
+    _insert_thread_execution(
+        hub,
+        thread_id="29998b57-94e9-49a4-8299-0349872e4b70",
+        backend_thread_id="backend-session-1",
+        execution_id="exec-1",
+        status="error",
+        error_text="reattach failed",
+    )
+
+    result = AutomationChildRunReconciler(
+        store, resolve_repo_path=lambda _repo_id: None, hub_root=hub
+    ).reconcile_running_jobs()
+
+    saved = store.get_job("job-pma")
+    assert result.failed == 1
+    assert saved.state == JOB_FAILED
+    assert saved.error_text == "reattach failed"
+    assert saved.pma_queue_item_id == queue_item_id
+
+
 def test_execution_snapshot_links_pma_spawned_thread_prefix(
     tmp_path: Path,
 ) -> None:
@@ -335,6 +419,43 @@ def test_execution_snapshot_links_pma_spawned_thread_prefix(
     snapshot = automation_execution_snapshot(job, hub_root=hub).to_dict()
 
     assert snapshot["primary_child_kind"] == "pma_queue"
+    assert snapshot["chat_href"] == "/chats/29998b57-94e9-49a4-8299-0349872e4b70"
+    assert snapshot["managed_thread"]["latest_execution"]["status"] == "running"
+
+
+def test_execution_snapshots_batch_links_pma_spawned_thread_prefix(
+    tmp_path: Path,
+) -> None:
+    hub = tmp_path / "hub"
+    store = _store_with_running_pma_queue_job(hub)
+    queue = PmaQueue(hub)
+    item = queue.find_active_by_idempotency_key_sync(
+        "pma:default", "automation-job:job-pma"
+    )
+    assert item is not None
+    asyncio.run(
+        queue.complete_item(
+            item,
+            {
+                "status": "ok",
+                "message": "Spawned and dispatched. Thread `29998b57` is running.",
+                "thread_id": "backend-session-1",
+            },
+        )
+    )
+    _insert_thread_execution(
+        hub,
+        thread_id="29998b57-94e9-49a4-8299-0349872e4b70",
+        backend_thread_id="backend-session-1",
+        execution_id="exec-1",
+        status="running",
+        error_text=None,
+    )
+
+    jobs = store.list_jobs(rule_id="rule-pma", limit=25)
+    snapshots = automation_execution_snapshots_by_job_id(jobs, hub_root=hub)
+    snapshot = snapshots["job-pma"].to_dict()
+
     assert snapshot["chat_href"] == "/chats/29998b57-94e9-49a4-8299-0349872e4b70"
     assert snapshot["managed_thread"]["latest_execution"]["status"] == "running"
 


### PR DESCRIPTION
## Summary
- add an automation execution snapshot that joins automation jobs with PMA queue items and managed-thread executions
- keep PMA automation jobs running until spawned chats finish, and propagate child failures back to run history
- link automation run history to spawned chats and tag/filter automation-owned chats

## Root cause
Automation PMA turns were marked succeeded after queue/spawn success, even when the spawned PMA chat later failed. The specific failed run `fd72cf18` spawned thread `29998b57`, whose execution failed with `opencode_first_event_timeout: no relevant events received within 60.0s`.

## Impact
Next automation failures should be root-causeable from the automation detail page: run history links to the spawned chat, automation chats are filterable, and failed child executions reconcile into automation job status.

## Validation
- pre-commit web-core-contract lane passed
- repo-wide pytest: 9306 passed
- mypy strict repo-wide passed
- ruff/black passed
- Web UI lab fast check passed
- frontend lint, build, and vitest suite passed