### PR TITLE
[codex] Refactor chat index pagination architecture

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.test.ts
@@ -156,6 +156,7 @@ function createHarness(options: {
     start: vi.fn(),
     stop: vi.fn(),
     refresh: vi.fn(async () => undefined),
+    loadMore: vi.fn(async () => undefined),
     setCompanionRequests: vi.fn()
   } satisfies ChatDetailPageIndexSession;
   const liveProjection = {

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.ts
@@ -45,6 +45,7 @@ export type ChatDetailPageIndexSession = {
   start: () => void;
   stop: () => void;
   refresh: (request?: ChatIndexWindowRequest) => Promise<void>;
+  loadMore: (request?: ChatIndexWindowRequest) => Promise<void>;
   setCompanionRequests: (requests: ChatIndexWindowRequest[]) => void;
 };
 
@@ -216,6 +217,10 @@ export class ChatDetailPageController {
 
   async refreshIndex(request?: ChatIndexWindowRequest): Promise<void> {
     await this.deps.chatIndexSession.refresh(request);
+  }
+
+  async loadMoreIndex(request?: ChatIndexWindowRequest): Promise<void> {
+    await this.deps.chatIndexSession.loadMore(request ?? this.currentRequest);
   }
 
   destroy(): void {

--- a/src/codex_autorunner/web_frontend/src/lib/components/VirtualList.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/VirtualList.svelte
@@ -79,6 +79,12 @@
     return Math.max(0, Math.min(offsets.length - 2, low));
   }
 
+  function checkEndReached(): void {
+    if (!onEndReached || !viewport || !scrollable) return;
+    const distanceFromBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+    if (distanceFromBottom <= safeItemSize * 4) onEndReached();
+  }
+
   function updateMeasurements(): void {
     if (!viewport) return;
     scrollTop = viewport.scrollTop;
@@ -87,14 +93,19 @@
       const gap = Number.parseFloat(getComputedStyle(windowNode).rowGap);
       rowGap = Number.isFinite(gap) ? gap : 0;
     }
+    checkEndReached();
   }
 
   function handleScroll(): void {
     updateMeasurements();
-    if (!onEndReached || !viewport || !scrollable) return;
-    const distanceFromBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
-    if (distanceFromBottom <= safeItemSize * 4) onEndReached();
   }
+
+  $effect(() => {
+    void items.length;
+    void totalHeight;
+    if (!mounted) return;
+    void tick().then(updateMeasurements);
+  });
 
   function measureItem(node: HTMLElement, itemKey: string) {
     let currentKey = itemKey;

--- a/src/codex_autorunner/web_frontend/src/lib/components/VirtualList.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/VirtualList.svelte
@@ -11,7 +11,8 @@
     ariaLabel = 'Virtualized list',
     class: className = '',
     itemClass = '',
-    scrollable = true
+    scrollable = true,
+    onEndReached
   }: {
     items: T[];
     children: Snippet<[T, number]>;
@@ -23,6 +24,7 @@
     class?: string;
     itemClass?: string;
     scrollable?: boolean;
+    onEndReached?: () => void;
   } = $props();
 
   let viewport: HTMLDivElement | null = $state(null);
@@ -89,6 +91,9 @@
 
   function handleScroll(): void {
     updateMeasurements();
+    if (!onEndReached || !viewport || !scrollable) return;
+    const distanceFromBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+    if (distanceFromBottom <= safeItemSize * 4) onEndReached();
   }
 
   function measureItem(node: HTMLElement, itemKey: string) {

--- a/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.test.ts
@@ -186,6 +186,44 @@ describe('chat index session', () => {
     expect(store.snapshot().chatOrder).toEqual(['chat-active']);
   });
 
+  it('loads the next backend window into the same filtered search result', async () => {
+    const store = new ReadModelEntityStore();
+    const client = {
+      chatIndex: vi.fn(async (request = {}) => {
+        const pageTwo = request.cursor === '2';
+        return ok({
+          ...chatIndexSnapshot('archived', [
+            pageTwo
+              ? indexRow('chat-archived-2', 'Needle archived page 2', 'archived')
+              : indexRow('chat-archived-1', 'Needle archived page 1', 'archived')
+          ]),
+          query: 'needle',
+          window: {
+            limit: 1,
+            nextCursor: pageTwo ? null : '2',
+            previousCursor: pageTwo ? '0' : null,
+            totalEstimate: 2,
+            totalIsExact: true
+          },
+          counters: { total: 2, waiting: 0, running: 0, unread: 0, archived: 2 }
+        });
+      })
+    } as unknown as ReadModelSnapshotClient & { chatIndex: ReturnType<typeof vi.fn> };
+    const session = createChatIndexSession({ client, store, streamFactory: mockStreamFactory() });
+    const request = { filter: 'archived' as const, query: 'needle', limit: 1 };
+
+    await session.refresh(request);
+    await session.loadMore(request);
+
+    expect(client.chatIndex).toHaveBeenNthCalledWith(1, request);
+    expect(client.chatIndex).toHaveBeenNthCalledWith(2, { ...request, cursor: '2' });
+    expect(selectChatIndexWindowView(store.snapshot(), request).rows.map((row) => row.chatId)).toEqual([
+      'chat-archived-1',
+      'chat-archived-2'
+    ]);
+    expect(selectChatIndexWindowView(store.snapshot(), request).window?.window?.nextCursor).toBeNull();
+  });
+
   it('queues a follow-up snapshot when refresh parameters change during an in-flight request', async () => {
     const store = new ReadModelEntityStore();
     const firstResponse = deferred<ApiResult<ChatIndexSnapshot>>();

--- a/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/chatIndexSession.ts
@@ -1,6 +1,6 @@
 import { writable, type Readable } from 'svelte/store';
 import type { ApiError } from '$lib/api/client';
-import { mapReadModelContract, type ChatIndexPatchEvent } from '$lib/api/readModelContracts';
+import { mapReadModelContract, type ChatIndexPatchEvent, type ChatIndexSnapshot } from '$lib/api/readModelContracts';
 import type { SseEvent } from '$lib/api/streaming';
 import {
   createDocumentStreamVisibilityPolicy,
@@ -11,6 +11,7 @@ import {
   type ChatIndexRequest,
   type ReadModelSnapshotClient
 } from './readModelClients';
+import { createPaginatedWindowSession } from './paginatedWindowSession';
 import { canonicalChatIndexWindowKey, readModelEntityStore, type ReadModelEntityStore } from './readModelStore';
 import { openReadModelStream, type CursorStorage, type ReadModelStreamManager, type ReadModelStreamOptions } from './readModelStream';
 
@@ -27,6 +28,7 @@ export type ChatIndexSession = {
   start: () => void;
   stop: () => void;
   refresh: (request?: ChatIndexRequest) => Promise<void>;
+  loadMore: (request?: ChatIndexRequest) => Promise<void>;
   setCompanionRequests: (requests: ChatIndexRequest[]) => void;
   isStarted: () => boolean;
 };
@@ -62,6 +64,19 @@ export function createChatIndexSession(deps: ChatIndexSessionDeps = {}): ChatInd
   let inFlightRequest: ChatIndexRequest | null = null;
   let inFlightCompanionRequests: ChatIndexRequest[] = [];
   let refreshAgain = false;
+  const paginatedWindows = createPaginatedWindowSession<ChatIndexRequest, ChatIndexSnapshot>({
+    key: canonicalChatIndexWindowKey,
+    normalize: normalizedChatIndexRequest,
+    nextCursor: (request) => store.snapshot().chatWindows[canonicalChatIndexWindowKey(request)]?.window?.nextCursor,
+    fetchPage: async (request) => {
+      const result = await client.chatIndex(request);
+      if (!result.ok) throw result.error;
+      return result.data;
+    },
+    appendPage: (snapshot, request) => {
+      store.applyChatIndexSnapshot(snapshot, request, { append: true });
+    }
+  });
 
   async function activate(activation: ChatIndexSessionActivation): Promise<void> {
     const nextPrimary = activation.primaryRequest ? normalizedChatIndexRequest(activation.primaryRequest) : activeRequest;
@@ -121,6 +136,10 @@ export function createChatIndexSession(deps: ChatIndexSessionDeps = {}): ChatInd
         refreshPromise = null;
       });
     return refreshPromise;
+  }
+
+  async function loadMore(request: ChatIndexRequest = activeRequest): Promise<void> {
+    await paginatedWindows.loadMore(request);
   }
 
   async function refreshChatListUntilSettled(): Promise<void> {
@@ -194,6 +213,7 @@ export function createChatIndexSession(deps: ChatIndexSessionDeps = {}): ChatInd
     start,
     stop,
     refresh,
+    loadMore,
     setCompanionRequests,
     isStarted: () => started
   };

--- a/src/codex_autorunner/web_frontend/src/lib/data/index.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/index.ts
@@ -1,4 +1,5 @@
 export * from './chatIndexSession';
+export * from './paginatedWindowSession';
 export * from './readModelClients';
 export * from './readModelInvalidation';
 export * from './readModelLoaders';

--- a/src/codex_autorunner/web_frontend/src/lib/data/paginatedWindowSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/paginatedWindowSession.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPaginatedWindowSession } from './paginatedWindowSession';
+
+type Request = {
+  filter?: string;
+  cursor?: string | null;
+};
+
+type Snapshot = {
+  rows: string[];
+  window: {
+    nextCursor: string | null;
+  };
+};
+
+describe('paginated window session', () => {
+  it('loads and appends the next cursor for a canonical window', async () => {
+    let nextCursor: string | null = 'page-2';
+    const appended: Array<{ snapshot: Snapshot; request: Request }> = [];
+    const fetchPage = vi.fn(async (request: Request): Promise<Snapshot> => ({
+      rows: [`row:${request.cursor}`],
+      window: { nextCursor: null }
+    }));
+    const session = createPaginatedWindowSession<Request, Snapshot>({
+      key: (request) => request.filter ?? 'all',
+      normalize: (request) => ({ filter: request.filter ?? 'all' }),
+      nextCursor: () => nextCursor,
+      fetchPage,
+      appendPage: (snapshot, request) => {
+        nextCursor = snapshot.window.nextCursor;
+        appended.push({ snapshot, request });
+      }
+    });
+
+    await session.loadMore({ filter: 'archived' });
+    await session.loadMore({ filter: 'archived' });
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(fetchPage).toHaveBeenCalledWith({ filter: 'archived', cursor: 'page-2' });
+    expect(appended).toEqual([
+      {
+        snapshot: { rows: ['row:page-2'], window: { nextCursor: null } },
+        request: { filter: 'archived' }
+      }
+    ]);
+  });
+
+  it('deduplicates concurrent loads for the same canonical window', async () => {
+    const deferred = createDeferred<Snapshot>();
+    const fetchPage = vi.fn(() => deferred.promise);
+    const appendPage = vi.fn();
+    const session = createPaginatedWindowSession<Request, Snapshot>({
+      key: (request) => request.filter ?? 'all',
+      normalize: (request) => ({ filter: request.filter ?? 'all' }),
+      nextCursor: () => 'page-2',
+      fetchPage,
+      appendPage
+    });
+
+    const first = session.loadMore({ filter: 'archived' });
+    const second = session.loadMore({ filter: 'archived' });
+    deferred.resolve({ rows: ['row'], window: { nextCursor: null } });
+    await Promise.all([first, second]);
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(appendPage).toHaveBeenCalledTimes(1);
+  });
+});
+
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}

--- a/src/codex_autorunner/web_frontend/src/lib/data/paginatedWindowSession.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/paginatedWindowSession.ts
@@ -1,0 +1,43 @@
+export type PaginatedWindowRequest = {
+  cursor?: string | null;
+};
+
+export type PaginatedWindowSnapshot = {
+  window?: {
+    nextCursor?: string | null;
+  } | null;
+};
+
+export type PaginatedWindowSession<Request extends PaginatedWindowRequest, Snapshot extends PaginatedWindowSnapshot> = {
+  loadMore: (request: Request) => Promise<void>;
+};
+
+export function createPaginatedWindowSession<Request extends PaginatedWindowRequest, Snapshot extends PaginatedWindowSnapshot>(deps: {
+  key: (request: Request) => string;
+  normalize: (request: Request) => Request;
+  nextCursor: (request: Request) => string | null | undefined;
+  fetchPage: (request: Request) => Promise<Snapshot>;
+  appendPage: (snapshot: Snapshot, request: Request) => void;
+}): PaginatedWindowSession<Request, Snapshot> {
+  const inFlight = new Map<string, Promise<void>>();
+
+  async function loadMore(request: Request): Promise<void> {
+    const baseRequest = deps.normalize(request);
+    const windowKey = deps.key(baseRequest);
+    const nextCursor = deps.nextCursor(baseRequest);
+    if (!nextCursor) return;
+    const existing = inFlight.get(windowKey);
+    if (existing) return existing;
+    const promise = deps.fetchPage({ ...baseRequest, cursor: nextCursor })
+      .then((snapshot) => {
+        deps.appendPage(snapshot, baseRequest);
+      })
+      .finally(() => {
+        inFlight.delete(windowKey);
+      });
+    inFlight.set(windowKey, promise);
+    return promise;
+  }
+
+  return { loadMore };
+}

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.test.ts
@@ -836,6 +836,44 @@ describe('read model entity store', () => {
     expect(allWindow.window?.refreshing).toBe(true);
   });
 
+  it('preserves appended default chat pages when live order patches arrive', () => {
+    const store = new ReadModelEntityStore();
+    store.applyChatIndexSnapshot({
+      cursor: cursor(1),
+      rows: [chat('chat-1'), chat('chat-2')],
+      groups: [],
+      counters: { total: 4, waiting: 0, running: 0, unread: 0, archived: 0 },
+      filter: 'all',
+      query: null,
+      window: { limit: 2, nextCursor: '2', totalIsExact: true, totalEstimate: 4 }
+    }, { filter: 'all', limit: 2 });
+    store.applyChatIndexSnapshot({
+      cursor: cursor(1),
+      rows: [chat('chat-3'), chat('chat-4')],
+      groups: [],
+      counters: { total: 4, waiting: 0, running: 0, unread: 0, archived: 0 },
+      filter: 'all',
+      query: null,
+      window: { limit: 2, nextCursor: null, previousCursor: '0', totalIsExact: true, totalEstimate: 4 }
+    }, { filter: 'all', limit: 2 }, { append: true });
+
+    expect(store.applyChatIndexPatchEvent({
+      ...chatPatch(2, chat('chat-2', 'running')),
+      patch: {
+        ...chatPatch(2, chat('chat-2', 'running')).patch,
+        order: ['chat-2', 'chat-1'],
+        counters: { total: 4, waiting: 0, running: 1, unread: 0, archived: 0 }
+      }
+    })).toBe('applied');
+
+    expect(selectChatIndexWindowView(store.snapshot(), { filter: 'all', limit: 2 }).rows.map((row) => row.chatId)).toEqual([
+      'chat-2',
+      'chat-1',
+      'chat-3',
+      'chat-4'
+    ]);
+  });
+
   it('preserves chat kind when detail snapshots omit the durable field', () => {
     const store = new ReadModelEntityStore();
     const row = chat('chat-1');

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -1094,9 +1094,12 @@ function reconcileChatIndexWindowsAfterEntityPatch(next: ReadModelEntityState, e
     window.groupIds = window.groupIds.filter((groupId) => Boolean(next.chatGroups[groupId]));
     if (defaultWindow) {
       if (event.patch.order) {
+        const loadedLimit = Math.max(window.request.limit, window.rowIds.length);
+        const orderedIds = new Set(event.patch.order);
         window.rowIds = event.patch.order
           .filter((rowId) => Boolean(next.chats[rowId] ?? incomingRows.get(rowId)))
-          .slice(0, window.request.limit);
+          .concat(window.rowIds.filter((rowId) => !orderedIds.has(rowId)))
+          .slice(0, loadedLimit);
       }
       if (event.patch.counters) window.counters = event.patch.counters;
       window.cursor = event.envelope.cursor;

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelStore.ts
@@ -256,7 +256,7 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     filter?: ChatIndexSnapshot['filter'];
     query?: string | null;
     window?: PageWindow;
-  }, request: ChatIndexWindowRequest = {}): void {
+  }, request: ChatIndexWindowRequest = {}, options: { append?: boolean } = {}): void {
     const rows = uniqueChatIndexRows(snapshot.rows);
     const next = cloneState(this.state);
     const windowRequest = normalizeChatIndexWindowRequest({
@@ -268,6 +268,7 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
       limit: request.limit ?? snapshot.window?.limit
     });
     const windowKey = canonicalChatIndexWindowKey(windowRequest);
+    const previousWindow = options.append ? next.chatWindows[windowKey] : null;
     for (const row of rows) next.chats[row.chatId] = row;
     for (const group of snapshot.groups) next.chatGroups[group.groupId] = group;
     if (isDefaultChatIndexWindow(windowRequest)) next.chatCounters = snapshot.counters;
@@ -275,8 +276,12 @@ export class ReadModelEntityStore implements Readable<ReadModelEntityState> {
     next.chatWindows[windowKey] = {
       key: windowKey,
       request: windowRequest,
-      rowIds: rows.map((row) => row.chatId),
-      groupIds: snapshot.groups.map((group) => group.groupId),
+      rowIds: previousWindow
+        ? uniqueStrings([...previousWindow.rowIds, ...rows.map((row) => row.chatId)])
+        : rows.map((row) => row.chatId),
+      groupIds: previousWindow
+        ? uniqueStrings([...previousWindow.groupIds, ...snapshot.groups.map((group) => group.groupId)])
+        : snapshot.groups.map((group) => group.groupId),
       counters: snapshot.counters,
       cursor: snapshot.cursor,
       window: snapshot.window ?? null,
@@ -1224,6 +1229,17 @@ function uniqueChatIndexRows(rows: ChatIndexRow[]): ChatIndexRow[] {
     byChatId.set(row.chatId, row);
   }
   return order.map((chatId) => byChatId.get(chatId)).filter((row): row is ChatIndexRow => Boolean(row));
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    unique.push(value);
+  }
+  return unique;
 }
 
 function seedDetailBackedChatRow(state: ReadModelEntityState, thread: ChatThreadProjection): void {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -17,7 +17,7 @@
     readModelEntityStore,
     readModelEntityTags,
     type ChatIndexWindowRequest,
-    canonicalChatIndexWindowKey,
+    selectChatIndexWindowView,
     selectPmaArtifacts,
     selectPmaChats,
     selectPmaProgress,
@@ -194,6 +194,11 @@
   const persistedChats = $derived<PmaChatSummary[]>(selectPmaChats(readModelState, currentChatIndexRequest));
   const facetPersistedChats = $derived<PmaChatSummary[]>(selectPmaChats(readModelState, { filter: 'all', limit: 50 }));
   const backendTicketRunGroups = $derived(selectTicketRunGroups(readModelState, ticketRunGroupRequest));
+  const currentTicketRunGroups = $derived(
+    filter === CHAT_TICKET_RUNS_FILTER
+      ? selectTicketRunGroups(readModelState, currentChatIndexRequest)
+      : backendTicketRunGroups
+  );
   const committedChatPlaceholders = $derived<PmaChatSummary[]>(
     [committedDraftChat].filter((chat): chat is PmaChatSummary => Boolean(chat))
   );
@@ -225,6 +230,7 @@
   const lastSeenMap = $derived<ChatLastSeenMap>(selectReadMarkers(readModelState) as ChatLastSeenMap);
   let draft = $state('');
   let loadingChats = $state(true);
+  let loadingMoreChats = $state(false);
   let loadingActive = $state(false);
   let sending = $state(false);
   let creating = $state(false);
@@ -414,21 +420,24 @@
   let expandedRunGroups = $state<Record<string, boolean>>({});
   let pinnedChatIds = $state<Record<string, true>>({});
   const chatListEntries = $derived(
-    buildSemanticChatListEntries(chatListSourceChats, backendTicketRunGroups, {
+    buildSemanticChatListEntries(chatListSourceChats, currentTicketRunGroups, {
       lastSeen: lastSeenMap,
       repoLabel: repoLabelForRepoId,
       worktreeLabel: (wid) => worktreeScopeOption(wid)?.label ?? null,
       groupRuns: true
     })
   );
-  const filteredEntries = $derived(sortEntriesForPinnedChats(filterChatEntries(chatListEntries, filter, search, lastSeenMap), pinnedChatIds));
+  const filteredEntries = $derived(sortEntriesForPinnedChats(filterChatEntries(chatListEntries, filter, '', lastSeenMap), pinnedChatIds));
   const filterCounts = $derived(chatStatusFilterCounts());
   const surfaceFilterChips = $derived(chatSurfaceFilterOptions(facetChats));
   const ticketRunGroupCount = $derived(countSemanticTicketRunGroups(backendTicketRunGroups, facetChats));
   const localChatPlaceholderCount = $derived(visibleLocalChatPlaceholders.filter((chat) => !isPmaChatArchived(chat)).length);
   const activeChatCount = $derived(readModelState.chatCounters.total + localChatPlaceholderCount);
   const hasUsableChatIndex = $derived(Boolean(readModelState.chatIndexCursor || readModelState.chatOrder.length > 0));
-  const hasSelectedChatWindow = $derived(Boolean(readModelState.chatWindows[canonicalChatIndexWindowKey(currentChatIndexRequest)]));
+  const selectedChatWindowView = $derived(selectChatIndexWindowView(readModelState, currentChatIndexRequest));
+  const selectedChatWindow = $derived(selectedChatWindowView.window);
+  const hasSelectedChatWindow = $derived(Boolean(selectedChatWindow));
+  const canLoadMoreChats = $derived(Boolean(selectedChatWindow?.window?.nextCursor));
   const initialChatIndexError = $derived(chatIndexLoadError());
   const visibleChatError = $derived(chatError ?? (!hasUsableChatIndex ? initialChatIndexError : null));
   const showChatListSkeleton = $derived(loadingChats && !hasSelectedChatWindow && !visibleChatError);
@@ -474,6 +483,25 @@
 
   function groupSummaryParts(group: ChatRunGroup): string[] {
     return chatRunGroupSummaryParts(group);
+  }
+
+  async function loadMoreChats(): Promise<void> {
+    if (loadingMoreChats || !canLoadMoreChats) return;
+    loadingMoreChats = true;
+    try {
+      await pageController.loadMoreIndex(currentChatIndexRequest);
+      chatError = null;
+    } catch (error) {
+      chatError = {
+        kind: 'network',
+        status: 0,
+        code: 'chat_index_load_more_failed',
+        message: error instanceof Error ? error.message : 'Could not load more chats',
+        details: error
+      };
+    } finally {
+      loadingMoreChats = false;
+    }
   }
   const displayedProgress = $derived(progressWithLiveElapsed(progress, clockNowMs));
   const liveActivity = $derived(buildPmaLiveActivity(displayedProgress));
@@ -2045,6 +2073,7 @@
           initialCount={48}
           ariaLabel="Chat rows"
           class="chat-list-virtual-list"
+          onEndReached={() => void loadMoreChats()}
         >
         {#snippet children(entry)}
           {#if entry.kind === 'chat'}
@@ -2127,6 +2156,9 @@
           {/if}
         {/snippet}
         </VirtualList>
+        {#if loadingMoreChats}
+          <div class="chat-list-loading-more" role="status">Loading more chats...</div>
+        {/if}
         {#if filteredEntries.length === 0}
           <div class="state-panel empty-state compact-empty chat-filter-empty">
             <strong>No chats match this filter</strong>

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -106,6 +106,13 @@ describe('/chats page', () => {
     expect(body).toContain('Attach files');
   });
 
+  it('does not re-apply chat search locally after requesting a backend search window', () => {
+    const pageSource = chatDetailPageSource();
+
+    expect(pageSource).toContain('query: search.trim() || null');
+    expect(pageSource).toContain("filterChatEntries(chatListEntries, filter, '', lastSeenMap)");
+  });
+
   it('renders cached chat rows instead of the skeleton while the index cursor is still missing', () => {
     readModelEntityStore.upsertChatIndexRows([chatIndexRow()]);
 

--- a/src/codex_autorunner/web_frontend/src/routes/worktrees/load.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/worktrees/load.test.ts
@@ -18,7 +18,7 @@ describe('/worktrees index route load', () => {
     store.applyRepoWorktreeRuntimeSnapshot(runtimeSnapshot());
     const client = mockClient();
     const depends = vi.fn();
-    vi.doMock('$lib/data/readModelStore', () => ({ readModelEntityStore: store, repoWorktreeWindowKey }));
+    vi.doMock('$lib/data/readModelStore', () => ({ readModelEntityStore: store, repoWorktreeWindowKey, canonicalChatIndexWindowKey }));
     vi.doMock('$lib/data/readModelClients', () => ({ readModelSnapshotClient: client, createReadModelSnapshotClient: () => client }));
     const { load } = await importPageLoad(true);
 
@@ -33,7 +33,7 @@ describe('/worktrees index route load', () => {
   it('returns cold when the store is empty so navigation can commit immediately', async () => {
     const store = new ReadModelEntityStore();
     const client = mockClient();
-    vi.doMock('$lib/data/readModelStore', () => ({ readModelEntityStore: store, repoWorktreeWindowKey }));
+    vi.doMock('$lib/data/readModelStore', () => ({ readModelEntityStore: store, repoWorktreeWindowKey, canonicalChatIndexWindowKey }));
     vi.doMock('$lib/data/readModelClients', () => ({ readModelSnapshotClient: client, createReadModelSnapshotClient: () => client }));
     const { load } = await importPageLoad(true);
 
@@ -94,6 +94,10 @@ function repair(snapshotRoute: string) {
 
 function repoWorktreeWindowKey(kind: 'all' | 'repo' | 'worktree' = 'all', limit = 200): string {
   return `${kind}:limit=${limit}`;
+}
+
+function canonicalChatIndexWindowKey(request: { filter?: string; limit?: number } = {}): string {
+  return `${request.filter ?? 'all'}:limit=${request.limit ?? 50}`;
 }
 
 function topologySnapshot(): RepoWorktreeTopologySnapshot {


### PR DESCRIPTION
## What changed

- Added a reusable paginated read-model window session for cursor-based infinite scroll.
- Routed chat index next-page loading through that shared session instead of page-local API choreography.
- Appended backend chat windows into the canonical read-model store window while preserving cursor metadata.
- Stopped re-applying chat search locally after the backend has already returned the searched window, so backend search fields remain authoritative.
- Added VirtualList end-reached signaling and wired chat scrolling to load more results.

## Why

Filtered chat lists were bounded to the first backend window, and the frontend still had page-specific pagination/search behavior. The new shape keeps search/filter/pagination backend-owned and gives the frontend a reusable primitive for future high-cardinality read-model windows.

## Validation

- pnpm --dir src/codex_autorunner/web_frontend exec vitest run src/lib/data/paginatedWindowSession.test.ts src/lib/data/chatIndexSession.test.ts src/lib/application/chatDetailPageController.test.ts src/routes/chats/page.test.ts
- pnpm --dir src/codex_autorunner/web_frontend test
- pnpm --dir src/codex_autorunner/web_frontend run lint
- commit hook: guardrails, mypy, pytest 9302 passed, web UI lab, web lint, web build, web tests, SPA shell check
