### PR TITLE
[codex] Canonical turn execution contract

### DIFF
--- a/src/codex_autorunner/adapters/chat/canonical_turns.py
+++ b/src/codex_autorunner/adapters/chat/canonical_turns.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from ...agents.runtime_options import resolve_opencode_model_payload
+from ...core.orchestration import (
+    DeliveryIntentRef,
+    MessageRequest,
+    TurnExecutionOrigin,
+    TurnExecutionRequest,
+)
+from .agents import DEFAULT_CHAT_AGENT_MODELS
+
+
+def _surface_source_id(surface_kind: str, surface_key: str) -> str:
+    return f"{surface_kind}:{surface_key}"
+
+
+def _resolved_model_payload(
+    agent: str, model: Optional[str]
+) -> tuple[Optional[str], dict[str, str]]:
+    resolved_model = model
+    if agent == "opencode" and not resolved_model:
+        resolved_model = DEFAULT_CHAT_AGENT_MODELS.get(agent)
+    payload = (
+        resolve_opencode_model_payload(resolved_model) if agent == "opencode" else None
+    )
+    return resolved_model, dict(payload or {})
+
+
+def build_surface_turn_execution_request(
+    request: MessageRequest,
+    *,
+    request_id: str,
+    workspace_root: Path | str,
+    surface_kind: str,
+    surface_key: str,
+    agent: str,
+    approval_policy: str,
+    sandbox_policy: Any,
+    profile: Optional[str] = None,
+    client_request_id: Optional[str] = None,
+    origin_metadata: Optional[Mapping[str, Any]] = None,
+    delivery_surface_key: Optional[str] = None,
+    delivery_metadata: Optional[Mapping[str, Any]] = None,
+) -> TurnExecutionRequest:
+    """Build the durable turn contract at chat-surface ingress."""
+
+    model, model_payload = _resolved_model_payload(agent, request.model)
+    delivery_key = delivery_surface_key or surface_key
+    return TurnExecutionRequest(
+        request_id=request_id,
+        target_id=request.target_id,
+        target_kind=request.target_kind,
+        workspace_root=str(workspace_root),
+        request_kind=request.kind,
+        busy_policy=request.busy_policy,
+        prompt_text=request.message_text,
+        input_items=tuple(dict(item) for item in request.input_items or ()),
+        context_profile=request.context_profile,
+        agent=agent,
+        profile=profile if profile is not None else request.agent_profile,
+        model=model,
+        model_payload=model_payload,
+        reasoning=request.reasoning,
+        approval_policy=approval_policy,
+        approval_mode=request.approval_mode or approval_policy,
+        sandbox_policy=sandbox_policy,
+        client_request_id=client_request_id,
+        idempotency_key=client_request_id or request_id,
+        correlation_id=client_request_id or request_id,
+        origin=TurnExecutionOrigin(
+            kind="surface",
+            source_id=_surface_source_id(surface_kind, surface_key),
+            surface_kind=surface_kind,
+            surface_key=surface_key,
+            metadata=dict(origin_metadata or {}),
+        ),
+        metadata=dict(request.metadata),
+        delivery_intents=(
+            DeliveryIntentRef(
+                kind="chat_surface",
+                intent_id=_surface_source_id(surface_kind, delivery_key),
+                metadata={
+                    "surface_kind": surface_kind,
+                    "surface_key": delivery_key,
+                    **dict(delivery_metadata or {}),
+                },
+            ),
+        ),
+    )

--- a/src/codex_autorunner/adapters/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_turns.py
@@ -99,6 +99,7 @@ from ...core.orchestration.turn_assistant_output import (
     TurnAssistantOutput,
     TurnAssistantOutputOwnership,
 )
+from ...core.orchestration.turn_execution_contract import TurnExecutionRequest
 from ...core.orchestration.turn_output_reducer import (
     assistant_text_extends_prefix,
     build_assistant_transcript_prefix,
@@ -130,7 +131,7 @@ class ManagedThreadExecutionStarter(Protocol):
     async def __call__(
         self,
         orchestration_service: Any,
-        request: MessageRequest,
+        request: MessageRequest | TurnExecutionRequest,
         *,
         client_request_id: Optional[str],
         sandbox_policy: Optional[Any],
@@ -1506,7 +1507,7 @@ class ManagedThreadTurnCoordinator:
 
     async def submit_execution(
         self,
-        request: MessageRequest,
+        request: MessageRequest | TurnExecutionRequest,
         *,
         client_request_id: Optional[str],
         sandbox_policy: Optional[Any],
@@ -2140,7 +2141,7 @@ async def _shutdown_progress_pump(
 
 async def submit_managed_thread_execution(
     orchestration_service: Any,
-    request: MessageRequest,
+    request: MessageRequest | TurnExecutionRequest,
     *,
     client_request_id: Optional[str],
     sandbox_policy: Optional[Any],

--- a/src/codex_autorunner/adapters/chat/managed_thread_turns.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_turns.py
@@ -1535,7 +1535,12 @@ class ManagedThreadTurnCoordinator:
         turn_preview = self.turn_preview
         if self.preview_builder is not None:
             try:
-                turn_preview = self.preview_builder(started.request.message_text)
+                request_message = (
+                    getattr(started.request, "message_text", None)
+                    or getattr(started.request, "prompt_text", None)
+                    or ""
+                )
+                turn_preview = self.preview_builder(str(request_message))
             except (
                 RuntimeError,
                 ValueError,

--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -62,7 +62,6 @@ from ...core.filebox import inbox_dir
 from ...core.logging_utils import log_event
 from ...core.orchestration import (
     FlowTarget,
-    MessageRequest,
     PausedFlowTarget,
     SurfaceThreadMessageRequest,
     build_surface_orchestration_ingress,
@@ -91,6 +90,7 @@ from ...core.pma_notification_store import (
 from ...core.utils import canonicalize_path
 from ..chat.agents import DEFAULT_CHAT_AGENT_MODELS
 from ..chat.bound_chat_execution_metadata import merge_bound_chat_execution_metadata
+from ..chat.canonical_turns import build_surface_turn_execution_request
 from ..chat.managed_thread_progress_projector import (
     ManagedThreadProgressProjector,
 )
@@ -2170,7 +2170,7 @@ async def _run_discord_orchestrated_turn_for_message(
 
     async def _begin_execution(
         orchestration_service: Any,
-        request: MessageRequest,
+        request: Any,
         *,
         client_request_id: Optional[str],
         sandbox_policy: Optional[Any],
@@ -2610,25 +2610,47 @@ async def _run_discord_orchestrated_turn_for_message(
         "execution_error_message": public_execution_error,
     }
     surface_key = managed_thread_surface_key or channel_id
-    return await run_managed_surface_turn(
-        turn_envelope.to_message_request(
-            target_id=thread.thread_target_id,
-            target_kind="thread",
-            model=model_override,
-            reasoning=reasoning_effort,
-            approval_mode=approval_mode,
-            input_items=execution_input_items,
-            metadata=merge_bound_chat_execution_metadata(
-                metadata,
-                origin_kind="surface",
-                origin_surface_kind="discord",
-                origin_surface_key=surface_key,
-                progress_targets=(("discord", surface_key),),
-            ),
+    client_request_id = f"discord:{channel_id}:{uuid.uuid4().hex[:12]}"
+    message_request = turn_envelope.to_message_request(
+        target_id=thread.thread_target_id,
+        target_kind="thread",
+        model=model_override,
+        reasoning=reasoning_effort,
+        approval_mode=approval_mode,
+        input_items=execution_input_items,
+        metadata=merge_bound_chat_execution_metadata(
+            metadata,
+            origin_kind="surface",
+            origin_surface_kind="discord",
+            origin_surface_key=surface_key,
+            progress_targets=(("discord", surface_key),),
         ),
+    )
+    turn_request = build_surface_turn_execution_request(
+        message_request,
+        request_id=uuid.uuid4().hex,
+        workspace_root=workspace_root,
+        surface_kind="discord",
+        surface_key=surface_key,
+        agent=agent,
+        approval_policy=approval_mode,
+        sandbox_policy=sandbox_policy,
+        profile=getattr(thread, "agent_profile", None),
+        client_request_id=client_request_id,
+        origin_metadata={
+            "channel_id": channel_id,
+            "session_key": session_key,
+            "mode": mode,
+            "pma_enabled": pma_enabled,
+            "source_message_id": source_message_id,
+        },
+        delivery_surface_key=surface_key,
+    )
+    return await run_managed_surface_turn(
+        turn_request,
         config=ManagedSurfaceRunnerConfig(
             coordinator=coordinator,
-            client_request_id=f"discord:{channel_id}:{uuid.uuid4().hex[:12]}",
+            client_request_id=client_request_id,
             sandbox_policy=sandbox_policy,
             hooks=runner_hooks,
             queue=ManagedSurfaceQueueConfig(

--- a/src/codex_autorunner/adapters/discord/workspace_commands.py
+++ b/src/codex_autorunner/adapters/discord/workspace_commands.py
@@ -214,10 +214,25 @@ def _list_bind_workspace_candidates(
     candidates: list[tuple[Optional[str], Optional[str], str]] = []
     manifest_paths: set[str] = set()
 
-    for entry in _list_manifest_workspaces(service):
-        normalized_path = str(canonicalize_path(Path(entry.path)))
-        candidates.append((entry.resource_kind, entry.resource_id, normalized_path))
-        manifest_paths.add(normalized_path)
+    manifest_workspaces = _list_manifest_workspaces(service)
+    if manifest_workspaces:
+        for entry in manifest_workspaces:
+            normalized_path = str(canonicalize_path(Path(entry.path)))
+            candidates.append((entry.resource_kind, entry.resource_id, normalized_path))
+            manifest_paths.add(normalized_path)
+    else:
+        try:
+            manifest_repos = service._list_manifest_repos()
+        except (AttributeError, TypeError, RuntimeError, OSError, ValueError):
+            manifest_repos = []
+        if not isinstance(manifest_repos, list):
+            manifest_repos = []
+        for repo_id, workspace_path in manifest_repos:
+            if not isinstance(repo_id, str) or not repo_id.strip():
+                continue
+            normalized_path = str(canonicalize_path(Path(str(workspace_path))))
+            candidates.append(("repo", repo_id.strip(), normalized_path))
+            manifest_paths.add(normalized_path)
 
     seen_paths: set[str] = set(manifest_paths)
     try:
@@ -247,7 +262,11 @@ def _bind_candidate_value(
     resource_id: Optional[str],
     workspace_path: str,
 ) -> str:
-    if resource_kind == "repo" and isinstance(resource_id, str) and resource_id:
+    if (
+        resource_kind in {"repo", "worktree"}
+        and isinstance(resource_id, str)
+        and resource_id
+    ):
         return repo_autocomplete_value(resource_id)
     return workspace_autocomplete_value(workspace_path)
 
@@ -566,11 +585,14 @@ async def _bind_to_workspace_candidate(
         return
 
     previous_binding = await service._store.get_binding(channel_id=channel_id)
+    selected_repo_id = (
+        selected_resource_id if selected_resource_kind in {"repo", "worktree"} else None
+    )
     await service._store.upsert_binding(
         channel_id=channel_id,
         guild_id=guild_id,
         workspace_path=str(workspace),
-        repo_id=(selected_resource_id if selected_resource_kind == "repo" else None),
+        repo_id=selected_repo_id,
         resource_kind=selected_resource_kind,
         resource_id=selected_resource_id,
     )
@@ -579,7 +601,7 @@ async def _bind_to_workspace_candidate(
         surface_kind="discord",
         surface_key=channel_id,
         workspace_root=str(workspace),
-        repo_id=(selected_resource_id if selected_resource_kind == "repo" else None),
+        repo_id=selected_repo_id,
         resource_kind=selected_resource_kind,
         resource_id=selected_resource_id,
         previous_workspace_root=(

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/execution.py
@@ -20,6 +20,7 @@ from .....adapters.chat.bound_live_progress import (
     cleanup_bound_chat_live_progress_success,
     resolve_bound_chat_queue_progress_context,
 )
+from .....adapters.chat.canonical_turns import build_surface_turn_execution_request
 from .....adapters.chat.chat_ux_telemetry import (
     ChatUxFailureReason,
     ChatUxMilestone,
@@ -997,16 +998,27 @@ def _build_telegram_delivery_cleanup(handlers: Any, *, topic_key: str) -> Any:
         target_chat_id = int(transport_target.get("chat_id") or 0)
         target_thread_id = transport_target.get("thread_id")
         target_topic_key = str(context.transport_target.get("topic_key") or topic_key)
-        await handlers._flush_outbox_files(
-            SimpleNamespace(
-                workspace_path=context.transport_target.get("workspace_path"),
-                pma_enabled=bool(context.transport_target.get("pma_enabled")),
-            ),
-            chat_id=target_chat_id,
-            thread_id=target_thread_id,
-            reply_to=None,
-            topic_key=target_topic_key,
+        outbox_record = SimpleNamespace(
+            workspace_path=context.transport_target.get("workspace_path"),
+            pma_enabled=bool(context.transport_target.get("pma_enabled")),
         )
+        try:
+            await handlers._flush_outbox_files(
+                outbox_record,
+                chat_id=target_chat_id,
+                thread_id=target_thread_id,
+                reply_to=None,
+                topic_key=target_topic_key,
+            )
+        except TypeError as exc:
+            if "topic_key" not in str(exc):
+                raise
+            await handlers._flush_outbox_files(
+                outbox_record,
+                chat_id=target_chat_id,
+                thread_id=target_thread_id,
+                reply_to=None,
+            )
         await cleanup_bound_chat_live_progress_success(
             hub_root=handlers._config.root,
             raw_config=(
@@ -1660,27 +1672,49 @@ async def _run_telegram_managed_thread_turn(
         and existing_session_prompt_text.strip()
     ):
         metadata["existing_session_runtime_prompt"] = existing_session_prompt_text
-    return await run_managed_surface_turn(
-        MessageRequest(
-            target_id=thread.thread_target_id,
-            target_kind="thread",
-            message_text=prompt_text,
-            busy_policy="queue",
-            model=record.model,
-            reasoning=record.effort,
-            approval_mode=approval_policy,
-            input_items=execution_input_items,
-            metadata=merge_bound_chat_execution_metadata(
-                metadata,
-                origin_kind="surface",
-                origin_surface_kind="telegram",
-                origin_surface_key=topic_key,
-                progress_targets=(("telegram", topic_key),),
-            ),
+    client_request_id = f"telegram:{topic_key}:{secrets.token_hex(6)}"
+    message_request = MessageRequest(
+        target_id=thread.thread_target_id,
+        target_kind="thread",
+        message_text=prompt_text,
+        busy_policy="queue",
+        model=record.model,
+        reasoning=record.effort,
+        approval_mode=approval_policy,
+        input_items=execution_input_items,
+        metadata=merge_bound_chat_execution_metadata(
+            metadata,
+            origin_kind="surface",
+            origin_surface_kind="telegram",
+            origin_surface_key=topic_key,
+            progress_targets=(("telegram", topic_key),),
         ),
+    )
+    turn_request = build_surface_turn_execution_request(
+        message_request,
+        request_id=secrets.token_hex(16),
+        workspace_root=workspace_root,
+        surface_kind="telegram",
+        surface_key=topic_key,
+        agent=runtime_agent,
+        approval_policy=approval_policy or "never",
+        sandbox_policy=sandbox_policy or "dangerFullAccess",
+        profile=agent_profile,
+        client_request_id=client_request_id,
+        origin_metadata={
+            "chat_id": message.chat_id,
+            "thread_id": message.thread_id,
+            "message_id": message.message_id,
+            "mode": mode,
+            "pma_enabled": pma_enabled,
+        },
+        delivery_surface_key=topic_key,
+    )
+    return await run_managed_surface_turn(
+        turn_request,
         config=ManagedSurfaceRunnerConfig(
             coordinator=coordinator,
-            client_request_id=(f"telegram:{topic_key}:{secrets.token_hex(6)}"),
+            client_request_id=client_request_id,
             sandbox_policy=sandbox_policy,
             hooks=ManagedThreadCoordinatorHooks(
                 on_progress_event=_handle_progress_event,
@@ -2775,6 +2809,47 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 turn_kwargs["effort"] = record.effort
             if record.summary:
                 turn_kwargs["summary"] = record.summary
+            canonical_client_request_id = f"telegram:{key}:{secrets.token_hex(6)}"
+
+            def _build_direct_turn_request(current_thread_id: str) -> Any:
+                message_request = MessageRequest(
+                    target_id=current_thread_id,
+                    target_kind="thread",
+                    message_text=prompt_text,
+                    busy_policy="reject",
+                    model=record.model,
+                    reasoning=record.effort if supports_effort else None,
+                    approval_mode=approval_policy,
+                    input_items=input_items,
+                    metadata={
+                        "runtime_prompt": prompt_text,
+                        "legacy_runtime": "telegram_app_server",
+                        "repo_id": record.repo_id,
+                    },
+                )
+                return build_surface_turn_execution_request(
+                    message_request,
+                    request_id=secrets.token_hex(16),
+                    workspace_root=record.workspace_path or "",
+                    surface_kind="telegram",
+                    surface_key=key,
+                    agent=agent or "codex",
+                    approval_policy=approval_policy or "never",
+                    sandbox_policy=sandbox_policy or "dangerFullAccess",
+                    profile=profile,
+                    client_request_id=canonical_client_request_id,
+                    origin_metadata={
+                        "chat_id": message.chat_id,
+                        "thread_id": message.thread_id,
+                        "message_id": message.message_id,
+                        "codex_thread_id": current_thread_id,
+                        "runtime": "app_server",
+                        "pma_enabled": pma_mode,
+                        "repo_id": record.repo_id,
+                    },
+                    delivery_surface_key=key,
+                )
+
             log_event(
                 self._logger,
                 logging.INFO,
@@ -2831,6 +2906,20 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                 )
 
                 try:
+                    canonical_turn_request = _build_direct_turn_request(thread_id)
+                    runtime.current_turn_request = canonical_turn_request.to_dict()
+                    log_event(
+                        self._logger,
+                        logging.INFO,
+                        "telegram.turn.canonical_request_built",
+                        topic_key=key,
+                        chat_id=message.chat_id,
+                        thread_id=message.thread_id,
+                        codex_thread_id=thread_id,
+                        request_id=canonical_turn_request.request_id,
+                        target_id=canonical_turn_request.target_id,
+                        agent=canonical_turn_request.agent,
+                    )
                     turn_handle = await client.turn_start(
                         thread_id,
                         prompt_text,
@@ -2882,6 +2971,20 @@ class ExecutionCommands(TelegramCommandSupportMixin):
                         )
                         if thread_id is None:
                             raise
+                        canonical_turn_request = _build_direct_turn_request(thread_id)
+                        runtime.current_turn_request = canonical_turn_request.to_dict()
+                        log_event(
+                            self._logger,
+                            logging.INFO,
+                            "telegram.turn.canonical_request_built",
+                            topic_key=key,
+                            chat_id=message.chat_id,
+                            thread_id=message.thread_id,
+                            codex_thread_id=thread_id,
+                            request_id=canonical_turn_request.request_id,
+                            target_id=canonical_turn_request.target_id,
+                            agent=canonical_turn_request.agent,
+                        )
                         turn_handle = await client.turn_start(
                             thread_id,
                             prompt_text,

--- a/src/codex_autorunner/adapters/telegram/handlers/commands/github.py
+++ b/src/codex_autorunner/adapters/telegram/handlers/commands/github.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import secrets
 import time
 from contextlib import suppress
 from dataclasses import dataclass
@@ -13,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import httpx
 
+from .....adapters.chat.canonical_turns import build_surface_turn_execution_request
 from .....agents.base import harness_progress_event_stream
 from .....agents.opencode.harness import OpenCodeHarness
 from .....agents.opencode.runtime import (
@@ -22,6 +24,7 @@ from .....agents.opencode.runtime import (
 )
 from .....agents.runtime_options import resolve_opencode_model_payload
 from .....core.logging_utils import log_event
+from .....core.orchestration import MessageRequest
 from .....core.orchestration.runtime_thread_events import (
     RuntimeThreadRunEventState,
     normalize_runtime_thread_raw_event,
@@ -889,6 +892,58 @@ class GitHubCommands(TelegramCommandSupportMixin):
                 turn_started_at = time.monotonic()
                 self._token_usage_by_thread.pop(setup.review_session_id, None)
                 harness = OpenCodeHarness(setup.supervisor)
+                topic_key = await self._resolve_topic_key(
+                    message.chat_id, message.thread_id
+                )
+                message_request = MessageRequest(
+                    target_id=setup.review_session_id,
+                    target_kind="thread",
+                    message_text=setup.review_args,
+                    kind="review",
+                    busy_policy="reject",
+                    model=record.model,
+                    approval_mode=setup.approval_mode,
+                    metadata={
+                        "runtime_prompt": setup.review_args,
+                        "legacy_runtime": "telegram_opencode_review",
+                        "repo_id": record.repo_id,
+                    },
+                )
+                canonical_turn_request = build_surface_turn_execution_request(
+                    message_request,
+                    request_id=secrets.token_hex(16),
+                    workspace_root=setup.workspace_root,
+                    surface_kind="telegram",
+                    surface_key=topic_key,
+                    agent="opencode",
+                    approval_policy=setup.approval_mode or "never",
+                    sandbox_policy=setup.sandbox_policy or "dangerFullAccess",
+                    client_request_id=(
+                        f"telegram:{topic_key}:review:{secrets.token_hex(6)}"
+                    ),
+                    origin_metadata={
+                        "chat_id": message.chat_id,
+                        "thread_id": message.thread_id,
+                        "message_id": message.message_id,
+                        "codex_thread_id": setup.review_session_id,
+                        "runtime": "opencode_review",
+                        "repo_id": record.repo_id,
+                    },
+                    delivery_surface_key=topic_key,
+                )
+                runtime.current_turn_request = canonical_turn_request.to_dict()
+                log_event(
+                    self._logger,
+                    logging.INFO,
+                    "telegram.review.canonical_request_built",
+                    topic_key=topic_key,
+                    chat_id=message.chat_id,
+                    thread_id=message.thread_id,
+                    codex_thread_id=setup.review_session_id,
+                    request_id=canonical_turn_request.request_id,
+                    target_id=canonical_turn_request.target_id,
+                    agent=canonical_turn_request.agent,
+                )
                 turn_ref = await harness.start_review(
                     setup.workspace_root,
                     setup.review_session_id,
@@ -901,9 +956,6 @@ class GitHubCommands(TelegramCommandSupportMixin):
                 turn_id = turn_ref.turn_id
                 runtime.current_turn_id = turn_id
                 runtime.current_turn_key = (setup.review_session_id, turn_id)
-                topic_key = await self._resolve_topic_key(
-                    message.chat_id, message.thread_id
-                )
                 ctx = TurnContext(
                     topic_key=topic_key,
                     chat_id=message.chat_id,

--- a/src/codex_autorunner/core/automation/executors.py
+++ b/src/codex_autorunner/core/automation/executors.py
@@ -2,18 +2,17 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
-from typing import Any, Optional, cast
-from typing import Callable
+from typing import Any, Callable, Optional, cast
 
 from ..domain.refs import AgentRef, ScopeRef
 from ..managed_thread_store import ManagedThreadStore
-from ..pma_reactive import PmaReactiveStore
 from ..orchestration.turn_execution_contract import (
     TurnExecutionContractError,
     TurnExecutionOrigin,
     TurnExecutionRequest,
     TurnExecutionRequestKind,
 )
+from ..pma_reactive import PmaReactiveStore
 from ..publish_executor import PublishExecutorRegistry, drain_pending_publish_operations
 from ..publish_journal import PublishJournalStore
 from ..text_utils import _normalize_text

--- a/src/codex_autorunner/core/automation/executors.py
+++ b/src/codex_autorunner/core/automation/executors.py
@@ -2,11 +2,18 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Optional, cast
+from typing import Callable
 
 from ..domain.refs import AgentRef, ScopeRef
 from ..managed_thread_store import ManagedThreadStore
 from ..pma_reactive import PmaReactiveStore
+from ..orchestration.turn_execution_contract import (
+    TurnExecutionContractError,
+    TurnExecutionOrigin,
+    TurnExecutionRequest,
+    TurnExecutionRequestKind,
+)
 from ..publish_executor import PublishExecutorRegistry, drain_pending_publish_operations
 from ..publish_journal import PublishJournalStore
 from ..text_utils import _normalize_text
@@ -36,6 +43,26 @@ _PUBLISH_KIND_BY_AUTOMATION_EXECUTOR = {
     EXECUTOR_GITHUB_REACTION: "react_pr_review_comment",
     EXECUTOR_GITHUB_COMMENT: "post_pr_comment",
 }
+
+_TURN_EXECUTION_REQUEST_KINDS = frozenset(
+    {"message", "review", "automation", "publish", "recovery", "lifecycle"}
+)
+
+
+def _opencode_model_payload(model: Optional[str]) -> dict[str, str]:
+    if model is None or "/" not in model:
+        return {}
+    provider_id, model_id = (part.strip() for part in model.split("/", 1))
+    if not provider_id or not model_id:
+        return {}
+    return {"providerID": provider_id, "modelID": model_id}
+
+
+def _turn_request_kind(value: Any) -> TurnExecutionRequestKind:
+    normalized = _normalize_text(value)
+    if normalized in _TURN_EXECUTION_REQUEST_KINDS:
+        return cast(TurnExecutionRequestKind, normalized)
+    return "automation"
 
 
 class ManagedThreadTurnAutomationExecutor:
@@ -144,6 +171,7 @@ class ManagedThreadTurnAutomationExecutor:
                 ),
             )
 
+        thread = self._thread_store.get_thread(thread_id) or {}
         metadata = request.get("metadata")
         if not isinstance(metadata, dict):
             metadata = {}
@@ -161,29 +189,71 @@ class ManagedThreadTurnAutomationExecutor:
         elif approval == APPROVAL_INHERIT_PROFILE:
             metadata["automation"]["approval_override"] = "inherit_profile"
 
-        queue_payload = {
-            "request": {
-                "target_id": thread_id,
-                "target_kind": "thread",
-                "message_text": prompt,
-                "kind": request.get("kind") or request.get("request_kind") or "message",
-                "busy_policy": request.get("busy_policy") or "queue",
-                "agent_profile": request.get("agent_profile") or request.get("profile"),
-                "model": request.get("model"),
-                "reasoning": request.get("reasoning"),
-                "approval_mode": (
-                    request.get("approval_mode")
-                    if approval == APPROVAL_INHERIT_PROFILE
-                    else None
+        agent = _require_text(
+            request.get("agent")
+            or thread.get("agent_id")
+            or thread.get("agent")
+            or "codex",
+            "agent",
+        )
+        model = _normalize_text(request.get("model"))
+        approval_mode = (
+            _normalize_text(request.get("approval_mode"))
+            if approval == APPROVAL_INHERIT_PROFILE
+            else None
+        )
+        try:
+            turn_request = TurnExecutionRequest(
+                request_id=client_turn_id,
+                target_id=thread_id,
+                target_kind="thread",
+                workspace_root=_normalize_text(thread.get("workspace_root")),
+                request_kind=_turn_request_kind(
+                    request.get("request_kind") or request.get("kind")
                 ),
-                "input_items": request.get("input_items"),
-                "context_profile": request.get("context_profile"),
-                "metadata": metadata,
-            },
-            "client_request_id": client_turn_id,
-            "sandbox_policy": request.get("sandbox_policy"),
-            "stream": request.get("stream"),
-        }
+                busy_policy=request.get("busy_policy") or "queue",
+                prompt_text=prompt,
+                input_items=(
+                    tuple(
+                        dict(item)
+                        for item in request.get("input_items", ())
+                        if isinstance(item, dict)
+                    )
+                    if isinstance(request.get("input_items"), (list, tuple))
+                    else ()
+                ),
+                context_profile=request.get("context_profile"),
+                agent=agent,
+                profile=request.get("agent_profile") or request.get("profile"),
+                model=model,
+                model_payload=(
+                    _opencode_model_payload(model) if agent == "opencode" else {}
+                ),
+                reasoning=_normalize_text(request.get("reasoning")),
+                approval_policy=(
+                    _normalize_text(request.get("approval_policy"))
+                    or approval_mode
+                    or approval
+                ),
+                approval_mode=approval_mode,
+                sandbox_policy=request.get("sandbox_policy") or "dangerFullAccess",
+                client_request_id=client_turn_id,
+                idempotency_key=client_turn_id,
+                correlation_id=_normalize_text(
+                    request.get("correlation_id") or job.payload.get("correlation_id")
+                )
+                or job.job_id,
+                origin=TurnExecutionOrigin(
+                    kind="automation",
+                    source_id=job.job_id,
+                    automation_rule_id=job.rule_id,
+                    metadata={"event_id": job.event_id},
+                ),
+                metadata=metadata,
+            )
+        except TurnExecutionContractError as exc:
+            return AutomationExecutorResult(status=JOB_FAILED, summary=str(exc))
+
         turn = self._thread_store.create_turn(
             thread_id,
             prompt=prompt,
@@ -191,11 +261,11 @@ class ManagedThreadTurnAutomationExecutor:
                 request.get("kind") or request.get("request_kind") or "message"
             ),
             busy_policy=str(request.get("busy_policy") or "queue"),
-            model=_normalize_text(request.get("model")),
+            model=model,
             reasoning=_normalize_text(request.get("reasoning")),
             client_turn_id=client_turn_id,
             metadata=metadata,
-            queue_payload=queue_payload,
+            turn_request=turn_request,
             force_queue=True,
         )
         self._request_queue_worker_start(thread_id)

--- a/src/codex_autorunner/core/hub_control_plane/_executions.py
+++ b/src/codex_autorunner/core/hub_control_plane/_executions.py
@@ -21,6 +21,7 @@ from ._normalizers import (
 class ExecutionCreateRequest:
     thread_target_id: str
     prompt: str
+    turn_request: TurnExecutionRequest
     request_kind: MessageRequestKind = "message"
     busy_policy: BusyThreadPolicy = "reject"
     model: Optional[str] = None
@@ -28,7 +29,6 @@ class ExecutionCreateRequest:
     client_request_id: Optional[str] = None
     metadata: dict[str, Any] = field(default_factory=dict)
     queue_payload: dict[str, Any] = field(default_factory=dict)
-    turn_request: Optional[TurnExecutionRequest] = None
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "ExecutionCreateRequest":
@@ -48,10 +48,8 @@ class ExecutionCreateRequest:
             client_request_id=normalize_optional_text(data.get("client_request_id")),
             metadata=copy_mapping(data.get("metadata")),
             queue_payload=copy_mapping(data.get("queue_payload")),
-            turn_request=(
-                TurnExecutionRequest.from_mapping(data["turn_request"])
-                if isinstance(data.get("turn_request"), Mapping)
-                else None
+            turn_request=TurnExecutionRequest.from_mapping(
+                _required_mapping(data.get("turn_request"), field_name="turn_request")
             ),
         )
 
@@ -68,9 +66,14 @@ class ExecutionCreateRequest:
         }
         if self.metadata:
             payload["metadata"] = dict(self.metadata)
-        if self.turn_request is not None:
-            payload["turn_request"] = self.turn_request.to_dict()
+        payload["turn_request"] = self.turn_request.to_dict()
         return payload
+
+
+def _required_mapping(value: Any, *, field_name: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field_name} is required")
+    return dict(value)
 
 
 @dataclass(frozen=True)

--- a/src/codex_autorunner/core/hub_control_plane/_executions.py
+++ b/src/codex_autorunner/core/hub_control_plane/_executions.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping, Optional
 
 from ..orchestration.models import BusyThreadPolicy, ExecutionRecord, MessageRequestKind
+from ..orchestration.turn_execution_contract import TurnExecutionRequest
 from ._normalizers import (
     coerce_int,
     copy_mapping,
@@ -27,6 +28,7 @@ class ExecutionCreateRequest:
     client_request_id: Optional[str] = None
     metadata: dict[str, Any] = field(default_factory=dict)
     queue_payload: dict[str, Any] = field(default_factory=dict)
+    turn_request: Optional[TurnExecutionRequest] = None
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "ExecutionCreateRequest":
@@ -46,6 +48,11 @@ class ExecutionCreateRequest:
             client_request_id=normalize_optional_text(data.get("client_request_id")),
             metadata=copy_mapping(data.get("metadata")),
             queue_payload=copy_mapping(data.get("queue_payload")),
+            turn_request=(
+                TurnExecutionRequest.from_mapping(data["turn_request"])
+                if isinstance(data.get("turn_request"), Mapping)
+                else None
+            ),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -61,6 +68,8 @@ class ExecutionCreateRequest:
         }
         if self.metadata:
             payload["metadata"] = dict(self.metadata)
+        if self.turn_request is not None:
+            payload["turn_request"] = self.turn_request.to_dict()
         return payload
 
 

--- a/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
+++ b/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
@@ -17,6 +17,14 @@ from ..orchestration.models import (
     owner_fields_from_scope_ref,
 )
 from ..orchestration.runtime_bindings import RuntimeThreadBinding
+from ..orchestration.turn_execution_contract import (
+    TurnExecutionRecord,
+    TurnExecutionRequest,
+)
+from ..orchestration.turn_execution_storage import (
+    build_turn_execution_record_from_storage,
+    build_turn_execution_request_from_storage,
+)
 from .background_runner import BackgroundRunnerSaturated, BoundedBackgroundRunner
 from .client import HubControlPlaneClient
 from .errors import HubControlPlaneError
@@ -69,6 +77,9 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
         self._client = client
         self._timeout_seconds = timeout_seconds
         self._background_runner = background_runner or _BACKGROUND_RUNNER
+        self._thread_cache: dict[str, ThreadTarget] = {}
+        self._turn_request_cache: dict[tuple[str, str], TurnExecutionRequest] = {}
+        self._turn_record_cache: dict[tuple[str, str], TurnExecutionRecord] = {}
 
     def _hub_unavailable(
         self,
@@ -238,10 +249,12 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
                 )
             ),
         )
-        return self._require_thread(
+        thread = self._require_thread(
             response.thread,
             operation="create_thread_target",
         )
+        self._thread_cache[thread.thread_target_id] = thread
+        return thread
 
     def get_thread_target(self, thread_target_id: str) -> Optional[ThreadTarget]:
         response = self._run(
@@ -250,6 +263,8 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
                 ThreadTargetLookupRequest(thread_target_id=thread_target_id)
             ),
         )
+        if response.thread is not None:
+            self._thread_cache[response.thread.thread_target_id] = response.thread
         return response.thread
 
     def get_thread_runtime_binding(
@@ -302,7 +317,10 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
                 )
             ),
         )
-        return list(response.threads)
+        threads = list(response.threads)
+        for thread in threads:
+            self._thread_cache[thread.thread_target_id] = thread
+        return threads
 
     def resume_thread_target(
         self,
@@ -325,6 +343,8 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
                 )
             ),
         )
+        if response.thread is not None:
+            self._thread_cache[response.thread.thread_target_id] = response.thread
         return response.thread
 
     def archive_thread_target(self, thread_target_id: str) -> Optional[ThreadTarget]:
@@ -334,6 +354,8 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
                 ThreadTargetArchiveRequest(thread_target_id=thread_target_id)
             ),
         )
+        if response.thread is not None:
+            self._thread_cache[response.thread.thread_target_id] = response.thread
         return response.thread
 
     def set_thread_backend_binding(
@@ -410,10 +432,39 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
                 )
             ),
         )
-        return self._require_execution(
+        execution = self._require_execution(
             response.execution,
             operation="create_execution",
         )
+        thread = self._thread_cache.get(thread_target_id)
+        if thread is None:
+            thread = self.get_thread_target(thread_target_id)
+        if thread is not None:
+            request = build_turn_execution_request_from_storage(
+                execution=execution.to_dict(),
+                thread=thread.to_dict(),
+                queue_payload=dict(queue_payload or {}),
+            )
+            record = build_turn_execution_record_from_storage(
+                execution=execution.to_dict(),
+                thread=thread.to_dict(),
+                request=request,
+                queue_item={},
+            )
+            cache_key = (thread_target_id, execution.execution_id)
+            self._turn_request_cache[cache_key] = request
+            self._turn_record_cache[cache_key] = record
+        return execution
+
+    def get_turn_execution_request(
+        self, thread_target_id: str, execution_id: str
+    ) -> Optional[TurnExecutionRequest]:
+        return self._turn_request_cache.get((thread_target_id, execution_id))
+
+    def get_turn_execution_record(
+        self, thread_target_id: str, execution_id: str
+    ) -> Optional[TurnExecutionRecord]:
+        return self._turn_record_cache.get((thread_target_id, execution_id))
 
     def get_execution(
         self, thread_target_id: str, execution_id: str

--- a/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
+++ b/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
@@ -23,7 +23,6 @@ from ..orchestration.turn_execution_contract import (
 )
 from ..orchestration.turn_execution_storage import (
     build_turn_execution_record_from_storage,
-    build_turn_execution_request_from_storage,
 )
 from .background_runner import BackgroundRunnerSaturated, BoundedBackgroundRunner
 from .client import HubControlPlaneClient
@@ -417,6 +416,10 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
         queue_payload: Optional[dict[str, Any]] = None,
         turn_request: Optional[TurnExecutionRequest] = None,
     ) -> ExecutionRecord:
+        if turn_request is None:
+            raise RuntimeError(
+                "remote execution creation requires a canonical TurnExecutionRequest"
+            )
         response = self._run(
             operation="create_execution",
             action=lambda client: client.create_execution(
@@ -442,11 +445,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
         if thread is None:
             thread = self.get_thread_target(thread_target_id)
         if thread is not None:
-            request = turn_request or build_turn_execution_request_from_storage(
-                execution=execution.to_dict(),
-                thread=thread.to_dict(),
-                queue_payload=dict(queue_payload or {}),
-            )
+            request = turn_request
             record = build_turn_execution_record_from_storage(
                 execution=execution.to_dict(),
                 thread=thread.to_dict(),

--- a/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
+++ b/src/codex_autorunner/core/hub_control_plane/remote_execution_store.py
@@ -415,6 +415,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
         client_request_id: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
         queue_payload: Optional[dict[str, Any]] = None,
+        turn_request: Optional[TurnExecutionRequest] = None,
     ) -> ExecutionRecord:
         response = self._run(
             operation="create_execution",
@@ -429,6 +430,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
                     client_request_id=client_request_id,
                     metadata=dict(metadata or {}),
                     queue_payload=dict(queue_payload or {}),
+                    turn_request=turn_request,
                 )
             ),
         )
@@ -440,7 +442,7 @@ class RemoteThreadExecutionStore(ThreadExecutionStore):
         if thread is None:
             thread = self.get_thread_target(thread_target_id)
         if thread is not None:
-            request = build_turn_execution_request_from_storage(
+            request = turn_request or build_turn_execution_request_from_storage(
                 execution=execution.to_dict(),
                 thread=thread.to_dict(),
                 queue_payload=dict(queue_payload or {}),

--- a/src/codex_autorunner/core/hub_control_plane/service.py
+++ b/src/codex_autorunner/core/hub_control_plane/service.py
@@ -614,6 +614,7 @@ class HubSharedStateService:
                 client_request_id=request.client_request_id,
                 metadata=request.metadata or None,
                 queue_payload=request.queue_payload or None,
+                turn_request=request.turn_request,
             )
         except (KeyError, RuntimeError, ValueError) as exc:
             raise self._execution_rejected(

--- a/src/codex_autorunner/core/managed_thread_store.py
+++ b/src/codex_autorunner/core/managed_thread_store.py
@@ -1413,6 +1413,9 @@ class ManagedThreadStore:
                     thread=thread_row,
                     queue_payload=queue_payload or {},
                 )
+                canonical_queue_payload = {
+                    "turn_request": turn_request.to_dict(),
+                }
                 turn_record = build_turn_execution_record_from_storage(
                     execution=execution_mapping,
                     thread=thread_row,
@@ -1474,7 +1477,7 @@ class ManagedThreadStore:
                         dedupe_key=client_turn_id or managed_turn_id,
                         state="queued",
                         visible_at=started_at,
-                        payload_json=_json_dumps(queue_payload or {}),
+                        payload_json=_json_dumps(canonical_queue_payload),
                         created_at=started_at,
                         idempotency_key=client_turn_id or managed_turn_id,
                     )
@@ -2039,9 +2042,7 @@ class ManagedThreadStore:
                 execution_cursor = conn.execute(
                     """
                     UPDATE orch_thread_executions
-                       SET prompt_text = ?,
-                           turn_request_json = NULL,
-                           turn_record_json = NULL
+                       SET prompt_text = ?
                      WHERE execution_id = ?
                        AND thread_target_id = ?
                        AND status = 'queued'
@@ -2054,6 +2055,28 @@ class ManagedThreadStore:
                 )
                 if execution_cursor.rowcount == 0:
                     return None
+                row = conn.execute(
+                    """
+                    SELECT *
+                      FROM orch_thread_executions
+                     WHERE execution_id = ?
+                    """,
+                    (managed_turn_id,),
+                ).fetchone()
+                if row is None:
+                    return None
+                execution = {key: row[key] for key in row.keys()}
+                thread = self._fetch_thread(conn, managed_thread_id)
+                if thread is None:
+                    return None
+                turn_request = build_turn_execution_request_from_storage(
+                    execution=execution,
+                    thread=thread,
+                    queue_payload=queue_payload,
+                )
+                canonical_queue_payload = {
+                    "turn_request": turn_request.to_dict(),
+                }
                 queue_cursor = conn.execute(
                     """
                     UPDATE orch_queue_items
@@ -2065,7 +2088,7 @@ class ManagedThreadStore:
                        AND state IN ('pending', 'queued', 'waiting')
                     """,
                     (
-                        _json_dumps(queue_payload),
+                        _json_dumps(canonical_queue_payload),
                         updated_at,
                         managed_turn_id,
                         thread_queue_lane_id(managed_thread_id),
@@ -2076,15 +2099,27 @@ class ManagedThreadStore:
                         "Queued turn execution was updated but no matching queue item "
                         "was found; refusing partial commit"
                     )
-                self._refresh_turn_execution_envelopes(conn, managed_turn_id)
-                row = conn.execute(
+                turn_record = build_turn_execution_record_from_storage(
+                    execution=execution,
+                    thread=thread,
+                    request=turn_request,
+                    queue_item=self._queue_item_for_execution(conn, managed_turn_id),
+                )
+                conn.execute(
                     """
-                    SELECT *
-                      FROM orch_thread_executions
+                    UPDATE orch_thread_executions
+                       SET turn_contract_version = ?,
+                           turn_request_json = ?,
+                           turn_record_json = ?
                      WHERE execution_id = ?
                     """,
-                    (managed_turn_id,),
-                ).fetchone()
+                    (
+                        TURN_EXECUTION_CONTRACT_VERSION,
+                        turn_request.to_json(),
+                        turn_record.to_json(),
+                        managed_turn_id,
+                    ),
+                )
         record = _execution_row_to_record(row) if row is not None else None
         if record is not None:
             self._emit_thread_event(

--- a/src/codex_autorunner/core/managed_thread_store.py
+++ b/src/codex_autorunner/core/managed_thread_store.py
@@ -1349,7 +1349,9 @@ class ManagedThreadStore:
         turn_request: Optional[TurnExecutionRequest] = None,
         force_queue: bool = False,
     ) -> dict[str, Any]:
-        managed_turn_id = str(uuid.uuid4())
+        managed_turn_id = (
+            turn_request.request_id if turn_request is not None else str(uuid.uuid4())
+        )
         started_at = now_iso()
         queue_item_id = uuid.uuid4().hex
         normalized_request_kind = _normalize_request_kind(request_kind)

--- a/src/codex_autorunner/core/managed_thread_store.py
+++ b/src/codex_autorunner/core/managed_thread_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from contextlib import contextmanager
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, Iterator, Optional
 
@@ -81,13 +82,13 @@ from .orchestration.thread_titles import (
     normalize_thread_title,
 )
 from .orchestration.turn_execution_contract import (
+    TurnExecutionOrigin,
     TurnExecutionRecord,
     TurnExecutionRequest,
 )
 from .orchestration.turn_execution_storage import (
     TURN_EXECUTION_CONTRACT_VERSION,
     build_turn_execution_record_from_storage,
-    build_turn_execution_request_from_storage,
 )
 from .ports.thread_store import ThreadRecord, ThreadStatus
 from .text_utils import _json_dumps, _json_loads_object
@@ -130,6 +131,60 @@ def _resolve_stale_running_threshold_seconds(
         )
     except Exception:
         return resolve_stale_threshold_seconds(None)
+
+
+def _opencode_model_payload(model: Optional[str]) -> dict[str, str]:
+    if model is None or "/" not in model:
+        return {}
+    provider_id, model_id = (part.strip() for part in model.split("/", 1))
+    if not provider_id or not model_id:
+        return {}
+    return {"providerID": provider_id, "modelID": model_id}
+
+
+def _turn_request_for_direct_create(
+    *,
+    managed_turn_id: str,
+    managed_thread_id: str,
+    thread: dict[str, Any],
+    prompt: str,
+    request_kind: str,
+    busy_policy: str,
+    model: Optional[str],
+    reasoning: Optional[str],
+    client_turn_id: Optional[str],
+    metadata: dict[str, Any],
+) -> TurnExecutionRequest:
+    agent = str(thread.get("agent_id") or thread.get("agent") or "codex")
+    resolved_model = model
+    if agent == "opencode" and resolved_model is None:
+        resolved_model = "openai/gpt-5"
+    return TurnExecutionRequest(
+        request_id=managed_turn_id,
+        target_id=managed_thread_id,
+        target_kind="thread",
+        workspace_root=_coerce_text(thread.get("workspace_root")),
+        request_kind=request_kind,  # type: ignore[arg-type]
+        busy_policy=busy_policy,  # type: ignore[arg-type]
+        prompt_text=prompt,
+        agent=agent,
+        model=resolved_model,
+        model_payload=(
+            _opencode_model_payload(resolved_model) if agent == "opencode" else {}
+        ),
+        reasoning=reasoning,
+        approval_policy=str(metadata.get("approval_policy") or "never"),
+        approval_mode=_coerce_text(metadata.get("approval_mode")),
+        sandbox_policy=metadata.get("sandbox_policy") or "dangerFullAccess",
+        client_request_id=client_turn_id,
+        idempotency_key=client_turn_id or managed_turn_id,
+        origin=TurnExecutionOrigin(
+            kind="system",
+            source_id="managed-thread-store",
+            metadata={"source": "direct_create_turn"},
+        ),
+        metadata=dict(metadata),
+    )
 
 
 def _thread_row_to_record(row: Any) -> dict[str, Any]:
@@ -771,14 +826,11 @@ class ManagedThreadStore:
         if thread is None:
             return
         existing_request = _coerce_text(execution.get("turn_request_json"))
-        if existing_request is not None:
-            request = TurnExecutionRequest.from_json(existing_request)
-        else:
-            request = build_turn_execution_request_from_storage(
-                execution=execution,
-                thread=thread,
-                queue_payload=self._queue_payload_for_execution(conn, managed_turn_id),
+        if existing_request is None:
+            raise RuntimeError(
+                f"Managed turn '{managed_turn_id}' is missing canonical turn request"
             )
+        request = TurnExecutionRequest.from_json(existing_request)
         record = build_turn_execution_record_from_storage(
             execution=execution,
             thread=thread,
@@ -1412,12 +1464,19 @@ class ManagedThreadStore:
                     "created_at": started_at,
                 }
                 if turn_request is None:
-                    turn_request = build_turn_execution_request_from_storage(
-                        execution=execution_mapping,
+                    turn_request = _turn_request_for_direct_create(
+                        managed_turn_id=managed_turn_id,
+                        managed_thread_id=managed_thread_id,
                         thread=thread_row,
-                        queue_payload=queue_payload or {},
+                        prompt=prompt,
+                        request_kind=normalized_request_kind,
+                        busy_policy=busy_policy,
+                        model=model,
+                        reasoning=reasoning,
+                        client_turn_id=client_turn_id,
+                        metadata=dict(metadata or {}),
                     )
-                elif turn_request.target_id != managed_thread_id:
+                if turn_request.target_id != managed_thread_id:
                     raise ValueError(
                         "canonical turn request target_id must match managed_thread_id"
                     )
@@ -2077,11 +2136,17 @@ class ManagedThreadStore:
                 thread = self._fetch_thread(conn, managed_thread_id)
                 if thread is None:
                     return None
-                turn_request = build_turn_execution_request_from_storage(
-                    execution=execution,
-                    thread=thread,
-                    queue_payload=queue_payload,
-                )
+                requested_turn = queue_payload.get("turn_request")
+                if not isinstance(requested_turn, dict):
+                    raise ValueError(
+                        "Queued turn update requires canonical turn_request"
+                    )
+                turn_request = TurnExecutionRequest.from_mapping(requested_turn)
+                if turn_request.target_id != managed_thread_id:
+                    raise ValueError(
+                        "canonical turn request target_id must match managed_thread_id"
+                    )
+                turn_request = replace(turn_request, prompt_text=prompt)
                 canonical_queue_payload = {
                     "turn_request": turn_request.to_dict(),
                 }

--- a/src/codex_autorunner/core/managed_thread_store.py
+++ b/src/codex_autorunner/core/managed_thread_store.py
@@ -1346,6 +1346,7 @@ class ManagedThreadStore:
         client_turn_id: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
         queue_payload: Optional[dict[str, Any]] = None,
+        turn_request: Optional[TurnExecutionRequest] = None,
         force_queue: bool = False,
     ) -> dict[str, Any]:
         managed_turn_id = str(uuid.uuid4())
@@ -1408,11 +1409,16 @@ class ManagedThreadStore:
                     "finished_at": None,
                     "created_at": started_at,
                 }
-                turn_request = build_turn_execution_request_from_storage(
-                    execution=execution_mapping,
-                    thread=thread_row,
-                    queue_payload=queue_payload or {},
-                )
+                if turn_request is None:
+                    turn_request = build_turn_execution_request_from_storage(
+                        execution=execution_mapping,
+                        thread=thread_row,
+                        queue_payload=queue_payload or {},
+                    )
+                elif turn_request.target_id != managed_thread_id:
+                    raise ValueError(
+                        "canonical turn request target_id must match managed_thread_id"
+                    )
                 canonical_queue_payload = {
                     "turn_request": turn_request.to_dict(),
                 }

--- a/src/codex_autorunner/core/managed_thread_store.py
+++ b/src/codex_autorunner/core/managed_thread_store.py
@@ -80,6 +80,15 @@ from .orchestration.thread_titles import (
     is_generic_thread_title,
     normalize_thread_title,
 )
+from .orchestration.turn_execution_contract import (
+    TurnExecutionRecord,
+    TurnExecutionRequest,
+)
+from .orchestration.turn_execution_storage import (
+    TURN_EXECUTION_CONTRACT_VERSION,
+    build_turn_execution_record_from_storage,
+    build_turn_execution_request_from_storage,
+)
 from .ports.thread_store import ThreadRecord, ThreadStatus
 from .text_utils import _json_dumps, _json_loads_object
 from .time_utils import now_iso
@@ -712,6 +721,130 @@ class ManagedThreadStore:
         with self._read_conn() as conn:
             return self._fetch_thread(conn, managed_thread_id)
 
+    def _queue_payload_for_execution(
+        self, conn: Any, managed_turn_id: str
+    ) -> dict[str, Any]:
+        row = conn.execute(
+            """
+            SELECT payload_json
+              FROM orch_queue_items
+             WHERE source_kind = 'thread_execution'
+               AND source_key = ?
+             ORDER BY rowid DESC
+             LIMIT 1
+            """,
+            (managed_turn_id,),
+        ).fetchone()
+        return _json_loads_object(row["payload_json"]) if row is not None else {}
+
+    def _queue_item_for_execution(
+        self, conn: Any, managed_turn_id: str
+    ) -> dict[str, Any]:
+        row = conn.execute(
+            """
+            SELECT *
+              FROM orch_queue_items
+             WHERE source_kind = 'thread_execution'
+               AND source_key = ?
+             ORDER BY rowid DESC
+             LIMIT 1
+            """,
+            (managed_turn_id,),
+        ).fetchone()
+        return {key: row[key] for key in row.keys()} if row is not None else {}
+
+    def _refresh_turn_execution_envelopes(
+        self, conn: Any, managed_turn_id: str
+    ) -> None:
+        row = conn.execute(
+            """
+            SELECT *
+              FROM orch_thread_executions
+             WHERE execution_id = ?
+            """,
+            (managed_turn_id,),
+        ).fetchone()
+        if row is None:
+            return
+        execution = {key: row[key] for key in row.keys()}
+        thread = self._fetch_thread(conn, str(execution["thread_target_id"]))
+        if thread is None:
+            return
+        existing_request = _coerce_text(execution.get("turn_request_json"))
+        if existing_request is not None:
+            request = TurnExecutionRequest.from_json(existing_request)
+        else:
+            request = build_turn_execution_request_from_storage(
+                execution=execution,
+                thread=thread,
+                queue_payload=self._queue_payload_for_execution(conn, managed_turn_id),
+            )
+        record = build_turn_execution_record_from_storage(
+            execution=execution,
+            thread=thread,
+            request=request,
+            queue_item=self._queue_item_for_execution(conn, managed_turn_id),
+        )
+        conn.execute(
+            """
+            UPDATE orch_thread_executions
+               SET turn_contract_version = ?,
+                   turn_request_json = ?,
+                   turn_record_json = ?
+             WHERE execution_id = ?
+            """,
+            (
+                TURN_EXECUTION_CONTRACT_VERSION,
+                request.to_json(),
+                record.to_json(),
+                managed_turn_id,
+            ),
+        )
+
+    def get_turn_execution_request(
+        self, managed_thread_id: str, managed_turn_id: str
+    ) -> Optional[TurnExecutionRequest]:
+        with self._read_conn() as conn:
+            row = conn.execute(
+                """
+                SELECT turn_request_json
+                  FROM orch_thread_executions
+                 WHERE thread_target_id = ?
+                   AND execution_id = ?
+                """,
+                (managed_thread_id, managed_turn_id),
+            ).fetchone()
+        if row is None:
+            return None
+        payload = _coerce_text(row["turn_request_json"])
+        if payload is None:
+            raise RuntimeError(
+                f"Managed turn '{managed_turn_id}' is missing canonical turn request"
+            )
+        return TurnExecutionRequest.from_json(payload)
+
+    def get_turn_execution_record(
+        self, managed_thread_id: str, managed_turn_id: str
+    ) -> Optional[TurnExecutionRecord]:
+        with self._read_conn() as conn:
+            row = conn.execute(
+                """
+                SELECT turn_record_json
+                  FROM orch_thread_executions
+                 WHERE thread_target_id = ?
+                   AND execution_id = ?
+                """,
+                (managed_thread_id, managed_turn_id),
+            ).fetchone()
+        if row is None:
+            return None
+        payload = _coerce_text(row["turn_record_json"])
+        if payload is None:
+            raise RuntimeError(
+                f"Managed turn '{managed_turn_id}' is missing canonical turn record"
+            )
+        return TurnExecutionRecord.from_json(payload)
+
     def list_threads(
         self,
         *,
@@ -1223,7 +1356,7 @@ class ManagedThreadStore:
         with self._write_conn() as conn:
             status_row = conn.execute(
                 """
-                SELECT lifecycle_status
+                SELECT *
                   FROM orch_thread_targets
                  WHERE thread_target_id = ?
                 """,
@@ -1256,6 +1389,36 @@ class ManagedThreadStore:
                 )
                 if execution_status == "queued" and busy_policy != "queue":
                     raise ManagedThreadAlreadyHasRunningTurnError(managed_thread_id)
+                thread_row = {key: status_row[key] for key in status_row.keys()}
+                execution_mapping = {
+                    "execution_id": managed_turn_id,
+                    "thread_target_id": managed_thread_id,
+                    "client_request_id": client_turn_id,
+                    "request_kind": normalized_request_kind,
+                    "prompt_text": prompt,
+                    "status": execution_status,
+                    "backend_turn_id": None,
+                    "assistant_text": None,
+                    "error_text": None,
+                    "model_id": model,
+                    "reasoning_level": reasoning,
+                    "metadata_json": _json_dumps(dict(metadata or {})),
+                    "transcript_mirror_id": None,
+                    "started_at": started_at,
+                    "finished_at": None,
+                    "created_at": started_at,
+                }
+                turn_request = build_turn_execution_request_from_storage(
+                    execution=execution_mapping,
+                    thread=thread_row,
+                    queue_payload=queue_payload or {},
+                )
+                turn_record = build_turn_execution_record_from_storage(
+                    execution=execution_mapping,
+                    thread=thread_row,
+                    request=turn_request,
+                    queue_item={},
+                )
                 conn.execute(
                     """
                     INSERT INTO orch_thread_executions (
@@ -1274,8 +1437,11 @@ class ManagedThreadStore:
                         transcript_mirror_id,
                         started_at,
                         finished_at,
-                        created_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        created_at,
+                        turn_contract_version,
+                        turn_request_json,
+                        turn_record_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         managed_turn_id,
@@ -1294,6 +1460,9 @@ class ManagedThreadStore:
                         started_at,
                         None,
                         started_at,
+                        TURN_EXECUTION_CONTRACT_VERSION,
+                        turn_request.to_json(),
+                        turn_record.to_json(),
                     ),
                 )
                 if execution_status == "queued":
@@ -1309,6 +1478,7 @@ class ManagedThreadStore:
                         created_at=started_at,
                         idempotency_key=client_turn_id or managed_turn_id,
                     )
+                    self._refresh_turn_execution_envelopes(conn, managed_turn_id)
                 else:
                     conn.execute(
                         """
@@ -1437,6 +1607,7 @@ class ManagedThreadStore:
                 changed_at=finished_at,
                 turn_id=managed_turn_id,
             )
+            self._refresh_turn_execution_envelopes(conn, managed_turn_id)
         self._emit_thread_event(
             managed_thread_id,
             idempotency_action=f"execution:{managed_turn_id}:{status}",
@@ -1507,6 +1678,7 @@ class ManagedThreadStore:
                         """,
                         (normalized_backend_turn_id, managed_turn_id),
                     )
+                self._refresh_turn_execution_envelopes(conn, managed_turn_id)
 
     def update_turn_metadata(
         self,
@@ -1541,6 +1713,7 @@ class ManagedThreadStore:
                     """,
                     (_json_dumps(updated_metadata), managed_turn_id),
                 )
+                self._refresh_turn_execution_envelopes(conn, managed_turn_id)
             updated = conn.execute(
                 """
                 SELECT *
@@ -1593,6 +1766,7 @@ class ManagedThreadStore:
                 changed_at=finished_at,
                 turn_id=managed_turn_id,
             )
+            self._refresh_turn_execution_envelopes(conn, managed_turn_id)
         self._emit_thread_event(
             managed_thread_id,
             idempotency_action=f"execution:{managed_turn_id}:interrupted",
@@ -1865,7 +2039,9 @@ class ManagedThreadStore:
                 execution_cursor = conn.execute(
                     """
                     UPDATE orch_thread_executions
-                       SET prompt_text = ?
+                       SET prompt_text = ?,
+                           turn_request_json = NULL,
+                           turn_record_json = NULL
                      WHERE execution_id = ?
                        AND thread_target_id = ?
                        AND status = 'queued'
@@ -1900,6 +2076,7 @@ class ManagedThreadStore:
                         "Queued turn execution was updated but no matching queue item "
                         "was found; refusing partial commit"
                     )
+                self._refresh_turn_execution_envelopes(conn, managed_turn_id)
                 row = conn.execute(
                     """
                     SELECT *
@@ -2000,6 +2177,8 @@ class ManagedThreadStore:
     def cancel_queued_turns(self, managed_thread_id: str) -> list[str]:
         with self._write_conn() as conn:
             cancelled = self._lifecycle.cancel_queued_turns(conn, managed_thread_id)
+            for execution_id in cancelled:
+                self._refresh_turn_execution_envelopes(conn, execution_id)
         for execution_id in cancelled:
             self._emit_thread_event(
                 managed_thread_id,
@@ -2019,6 +2198,8 @@ class ManagedThreadStore:
                 managed_thread_id,
                 execution_id,
             )
+            if cancelled:
+                self._refresh_turn_execution_envelopes(conn, execution_id)
         if cancelled:
             self._emit_thread_event(
                 managed_thread_id,
@@ -2055,6 +2236,25 @@ class ManagedThreadStore:
     ) -> Optional[tuple[dict[str, Any], dict[str, Any]]]:
         with self._write_conn() as conn:
             claimed = self._lifecycle.claim_next_queued_turn(conn, managed_thread_id)
+            if claimed is not None:
+                execution, _payload = claimed
+                execution_id = str(execution.get("managed_turn_id") or "")
+                if execution_id:
+                    self._refresh_turn_execution_envelopes(conn, execution_id)
+                    refreshed_row = conn.execute(
+                        """
+                        SELECT *
+                          FROM orch_thread_executions
+                         WHERE thread_target_id = ?
+                           AND execution_id = ?
+                        """,
+                        (managed_thread_id, execution_id),
+                    ).fetchone()
+                    if refreshed_row is not None:
+                        claimed = (
+                            _execution_row_to_record(refreshed_row),
+                            self._queue_payload_for_execution(conn, execution_id),
+                        )
         if claimed is not None:
             execution, payload = claimed
             execution_id = str(execution.get("managed_turn_id") or "")

--- a/src/codex_autorunner/core/managed_thread_store_lifecycle.py
+++ b/src/codex_autorunner/core/managed_thread_store_lifecycle.py
@@ -174,7 +174,8 @@ class ManagedThreadStoreLifecycle:
                 e.prompt_text,
                 e.model_id,
                 e.reasoning_level,
-                e.client_request_id
+                e.client_request_id,
+                e.turn_request_json
               FROM orch_queue_items AS q
               JOIN orch_thread_executions AS e
                 ON e.execution_id = q.source_key

--- a/src/codex_autorunner/core/managed_thread_store_rows.py
+++ b/src/codex_autorunner/core/managed_thread_store_rows.py
@@ -478,6 +478,8 @@ class PmaExecutionRecord:
     started_at: Optional[str]
     finished_at: Optional[str]
     metadata: dict[str, Any]
+    turn_request: dict[str, Any]
+    turn_record: dict[str, Any]
 
     @classmethod
     def from_orchestration_row(cls, row: Any) -> "PmaExecutionRecord":
@@ -502,13 +504,30 @@ class PmaExecutionRecord:
             started_at=coerce_text(row["started_at"]),
             finished_at=coerce_text(row["finished_at"]),
             metadata=metadata,
+            turn_request=(
+                _json_loads_object(row["turn_request_json"])
+                if "turn_request_json" in row.keys()
+                else {}
+            ),
+            turn_record=(
+                _json_loads_object(row["turn_record_json"])
+                if "turn_record_json" in row.keys()
+                else {}
+            ),
         )
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
     def to_execution_record(self) -> ExecutionRecord:
-        return ExecutionRecord.from_mapping(self.to_dict())
+        payload = self.to_dict()
+        metadata = dict(self.metadata)
+        if self.turn_request:
+            metadata["turn_request"] = dict(self.turn_request)
+        if self.turn_record:
+            metadata["turn_record"] = dict(self.turn_record)
+        payload["metadata"] = metadata
+        return ExecutionRecord.from_mapping(payload)
 
 
 @dataclass(frozen=True)
@@ -523,6 +542,7 @@ class PmaPendingQueueItem:
     model: Optional[str]
     reasoning: Optional[str]
     client_turn_id: Optional[str]
+    turn_request: dict[str, Any]
 
     @classmethod
     def from_queue_row(cls, row: Any) -> "PmaPendingQueueItem":
@@ -537,6 +557,11 @@ class PmaPendingQueueItem:
             model=coerce_text(row["model_id"]),
             reasoning=coerce_text(row["reasoning_level"]),
             client_turn_id=coerce_text(row["client_request_id"]),
+            turn_request=(
+                _json_loads_object(row["turn_request_json"])
+                if "turn_request_json" in row.keys()
+                else {}
+            ),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/codex_autorunner/core/orchestration/__init__.py
+++ b/src/codex_autorunner/core/orchestration/__init__.py
@@ -187,6 +187,14 @@ from .ticket_flow_chat_ledger_contract import (
     validate_ticket_flow_thread_metadata,
 )
 from .turn_context import ChatTurnDeliveryTarget, ChatTurnEnvelope, ChatTurnSource
+from .turn_execution_contract import (
+    TURN_EXECUTION_CONTRACT_VERSION,
+    DeliveryIntentRef,
+    TurnExecutionContractError,
+    TurnExecutionOrigin,
+    TurnExecutionRecord,
+    TurnExecutionRequest,
+)
 
 if TYPE_CHECKING:
     from . import runtime_threads as runtime_threads_module
@@ -351,6 +359,12 @@ __all__ = [
     "ThreadTarget",
     "TicketFlowLedgerRecord",
     "TicketFlowThreadLink",
+    "TURN_EXECUTION_CONTRACT_VERSION",
+    "DeliveryIntentRef",
+    "TurnExecutionContractError",
+    "TurnExecutionOrigin",
+    "TurnExecutionRecord",
+    "TurnExecutionRequest",
     "WorkspaceRuntimeAcquisition",
     "apply_orchestration_migrations",
     "audit_execution_history",

--- a/src/codex_autorunner/core/orchestration/canary.py
+++ b/src/codex_autorunner/core/orchestration/canary.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import time
+import uuid
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, cast
@@ -28,8 +29,32 @@ from .execution_history_maintenance import (
     vacuum_execution_history,
 )
 from .sqlite import open_orchestration_sqlite, resolve_orchestration_sqlite_path
+from .turn_execution_contract import TurnExecutionOrigin, TurnExecutionRequest
 
 _CREATE_HUB_APP: Callable[[Path], Any]
+
+
+def _canary_turn_request(
+    *,
+    request_id: str,
+    thread_target_id: str,
+    workspace_root: Path,
+    prompt: str,
+) -> TurnExecutionRequest:
+    return TurnExecutionRequest(
+        request_id=request_id,
+        target_id=thread_target_id,
+        target_kind="thread",
+        workspace_root=str(workspace_root),
+        request_kind="recovery",
+        busy_policy="reject",
+        prompt_text=prompt,
+        agent="codex",
+        approval_policy="never",
+        sandbox_policy="dangerFullAccess",
+        origin=TurnExecutionOrigin(kind="system", source_id="canary"),
+        metadata={"source": "orchestration_canary"},
+    )
 
 
 def _round_duration(value: float) -> float:
@@ -392,7 +417,17 @@ async def _run_recovery_validation(
             "codex", workspace_root.resolve(), repo_id="repo-canary"
         )
         managed_thread_id = str(managed_thread["managed_thread_id"])
-        pma_turn = store.create_turn(managed_thread_id, prompt="recover pma turn")
+        pma_turn_id_seed = uuid.uuid4().hex
+        pma_turn = store.create_turn(
+            managed_thread_id,
+            prompt="recover pma turn",
+            turn_request=_canary_turn_request(
+                request_id=pma_turn_id_seed,
+                thread_target_id=managed_thread_id,
+                workspace_root=workspace_root.resolve(),
+                prompt="recover pma turn",
+            ),
+        )
         pma_turn_id = str(pma_turn["managed_turn_id"])
         store.set_thread_backend_binding(managed_thread_id, None)
         store.set_turn_backend_turn_id(pma_turn_id, None)
@@ -413,8 +448,16 @@ async def _run_recovery_validation(
             repo_id="repo-canary",
         )
         discord_thread_id = str(discord_thread["managed_thread_id"])
+        discord_turn_id_seed = uuid.uuid4().hex
         discord_turn = store.create_turn(
-            discord_thread_id, prompt="recover discord turn"
+            discord_thread_id,
+            prompt="recover discord turn",
+            turn_request=_canary_turn_request(
+                request_id=discord_turn_id_seed,
+                thread_target_id=discord_thread_id,
+                workspace_root=workspace_root.resolve(),
+                prompt="recover discord turn",
+            ),
         )
         discord_turn_id = str(discord_turn["managed_turn_id"])
         store.set_thread_backend_binding(discord_thread_id, None)

--- a/src/codex_autorunner/core/orchestration/execution_history_diagnostics.py
+++ b/src/codex_autorunner/core/orchestration/execution_history_diagnostics.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import dataclasses
 import logging
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
-from ..text_utils import _json_dumps
+from ..freshness import parse_iso_datetime
+from ..text_utils import _json_dumps, _json_loads_object
 from ..time_utils import now_iso
 from .cold_trace_store import ColdTraceStore
 from .execution_history import timeline_hot_family_for_event_type
@@ -103,10 +105,27 @@ class ExecutionHistoryThresholdBreach:
 
 
 @dataclasses.dataclass(frozen=True)
+class CanonicalTurnStateDiagnostic:
+    request_id: str
+    execution_id: str
+    surface_origin: Optional[str]
+    target: dict[str, Any]
+    lifecycle_phase: str
+    terminal_status: Optional[str]
+    runtime_options: dict[str, Any]
+    recovery_action: str
+    evidence: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass(frozen=True)
 class ExecutionHistoryDiagnosticReport:
     metrics: ExecutionHistoryMetrics
     top_n: ExecutionHistoryTopN
     threshold_breaches: tuple[ExecutionHistoryThresholdBreach, ...]
+    canonical_turns: tuple[CanonicalTurnStateDiagnostic, ...]
     startup_recovery_duration_seconds: Optional[float]
     generated_at: str
 
@@ -459,6 +478,178 @@ def detect_completion_gap_repeated_attempts(
     return tuple(detections)
 
 
+def _surface_origin(request: dict[str, Any]) -> Optional[str]:
+    origin = request.get("origin")
+    if not isinstance(origin, dict):
+        return None
+    surface_kind = str(origin.get("surface_kind") or "").strip()
+    surface_key = str(origin.get("surface_key") or "").strip()
+    if surface_kind and surface_key:
+        return f"{surface_kind}:{surface_key}"
+    source_id = str(origin.get("source_id") or "").strip()
+    return source_id or None
+
+
+def _terminal_status_from_record(status: str) -> Optional[str]:
+    normalized = str(status or "").strip().lower()
+    if normalized in {"ok", "completed", "complete", "success", "succeeded"}:
+        return "completed"
+    if normalized in {"error", "failed"}:
+        return "failed"
+    if normalized in {"cancelled", "canceled"}:
+        return "cancelled"
+    if normalized in {"interrupted", "lost"}:
+        return normalized
+    return None
+
+
+def _terminal_write_evidence(conn: Any, execution_id: str) -> dict[str, Any]:
+    rows = conn.execute(
+        """
+        SELECT event_id, event_type, timestamp, status, payload_json
+          FROM orch_event_projections
+         WHERE event_family = ?
+           AND execution_id = ?
+           AND event_type IN ('turn_completed', 'turn_failed', 'turn_interrupted')
+         ORDER BY timestamp ASC, event_id ASC
+        """,
+        (_TIMELINE_EVENT_FAMILY, execution_id),
+    ).fetchall()
+    writes: list[dict[str, Any]] = []
+    signatures: set[tuple[str, str, str]] = set()
+    for row in rows:
+        payload = _json_loads_object(row["payload_json"])
+        event_obj = payload.get("event")
+        event: dict[str, Any] = event_obj if isinstance(event_obj, dict) else {}
+        signature = (
+            str(row["event_type"] or ""),
+            str(row["status"] or ""),
+            str(event.get("final_message") or event.get("error_message") or ""),
+        )
+        signatures.add(signature)
+        writes.append(
+            {
+                "event_id": str(row["event_id"] or ""),
+                "event_type": str(row["event_type"] or ""),
+                "status": str(row["status"] or ""),
+                "timestamp": str(row["timestamp"] or ""),
+                "message": signature[2] or None,
+            }
+        )
+    evidence: dict[str, Any] = {"terminal_write_count": len(writes)}
+    if writes:
+        evidence["terminal_writes"] = writes
+    if len(writes) > 1:
+        evidence["duplicate_terminal_writes"] = True
+        evidence["conflicting_terminal_writes"] = len(signatures) > 1
+    return evidence
+
+
+def _recovery_action_for_record(
+    *,
+    status: str,
+    started_at: Optional[str],
+    created_at: Optional[str],
+    terminal_status: Optional[str],
+    stale_after_seconds: float,
+    now: datetime,
+) -> tuple[str, str]:
+    normalized = str(status or "").strip().lower()
+    if terminal_status is not None:
+        return "none", "terminal"
+    if normalized == "queued":
+        return "replay_queued", "queued"
+    if normalized == "running":
+        basis = parse_iso_datetime(started_at) or parse_iso_datetime(created_at)
+        if basis is None:
+            return "record_conflict", "running_unknown_age"
+        age_seconds = max(0.0, (now - basis).total_seconds())
+        if age_seconds >= stale_after_seconds:
+            return "classify_stale_running", "stale_running"
+        return "wait", "running"
+    if normalized in {"claiming"}:
+        return "replay_queued", normalized
+    return "record_conflict", normalized or "unknown"
+
+
+def collect_canonical_turn_state_diagnostics(
+    hub_root: Path,
+    *,
+    stale_after_seconds: float = 30 * 60,
+    now: Optional[datetime] = None,
+) -> tuple[CanonicalTurnStateDiagnostic, ...]:
+    resolved_now = now or datetime.now(timezone.utc)
+    diagnostics: list[CanonicalTurnStateDiagnostic] = []
+    with open_orchestration_sqlite(hub_root) as conn:
+        rows = conn.execute(
+            """
+            SELECT execution_id, thread_target_id, status, started_at, finished_at,
+                   created_at, turn_request_json, turn_record_json, error_text
+              FROM orch_thread_executions
+             ORDER BY created_at ASC, execution_id ASC
+            """
+        ).fetchall()
+        for row in rows:
+            execution_id = str(row["execution_id"] or "").strip()
+            request = _json_loads_object(row["turn_request_json"])
+            record = _json_loads_object(row["turn_record_json"])
+            if not execution_id or not request or not record:
+                continue
+            record_status = str(record.get("status") or row["status"] or "").strip()
+            terminal_status = _terminal_status_from_record(record_status)
+            recovery_action, lifecycle_phase = _recovery_action_for_record(
+                status=record_status,
+                started_at=record.get("started_at") or row["started_at"],
+                created_at=row["created_at"],
+                terminal_status=terminal_status,
+                stale_after_seconds=stale_after_seconds,
+                now=resolved_now,
+            )
+            evidence = _terminal_write_evidence(conn, execution_id)
+            error_text = (
+                str(record.get("error_text") or row["error_text"] or "").strip() or None
+            )
+            if error_text is not None:
+                evidence["error_text"] = error_text
+                if "opencode_first_event_timeout" in error_text:
+                    evidence["runtime_error_code"] = "opencode_first_event_timeout"
+            conflict_evidence = record.get("conflict_evidence")
+            if isinstance(conflict_evidence, dict) and conflict_evidence:
+                evidence["record_conflict_evidence"] = conflict_evidence
+            diagnostics.append(
+                CanonicalTurnStateDiagnostic(
+                    request_id=str(
+                        record.get("request_id")
+                        or request.get("request_id")
+                        or execution_id
+                    ),
+                    execution_id=execution_id,
+                    surface_origin=_surface_origin(request),
+                    target={
+                        "target_id": request.get("target_id")
+                        or row["thread_target_id"],
+                        "target_kind": request.get("target_kind") or "thread",
+                        "workspace_root": request.get("workspace_root"),
+                    },
+                    lifecycle_phase=lifecycle_phase,
+                    terminal_status=terminal_status,
+                    runtime_options={
+                        "agent": request.get("agent"),
+                        "profile": request.get("profile"),
+                        "model": request.get("model"),
+                        "model_payload": request.get("model_payload") or {},
+                        "reasoning": request.get("reasoning"),
+                        "approval_policy": request.get("approval_policy"),
+                        "approval_mode": request.get("approval_mode"),
+                        "sandbox_policy": request.get("sandbox_policy"),
+                    },
+                    recovery_action=recovery_action,
+                    evidence=evidence,
+                )
+            )
+    return tuple(diagnostics)
+
+
 def run_execution_history_diagnostics(
     hub_root: Path,
     *,
@@ -473,6 +664,7 @@ def run_execution_history_diagnostics(
     top_n = collect_top_n_heavy_executions(hub_root, top_n=t.top_n_heavy_executions)
     breaches = check_thresholds(metrics, thresholds=t)
     gap_detections = detect_completion_gap_repeated_attempts(hub_root, thresholds=t)
+    canonical_turns = collect_canonical_turn_state_diagnostics(hub_root)
 
     gap_breaches = [
         ExecutionHistoryThresholdBreach(
@@ -525,6 +717,7 @@ def run_execution_history_diagnostics(
         metrics=metrics,
         top_n=top_n,
         threshold_breaches=all_breaches,
+        canonical_turns=canonical_turns,
         startup_recovery_duration_seconds=startup_duration,
         generated_at=now_iso(),
     )
@@ -728,6 +921,7 @@ def log_startup_recovery(
 
 
 __all__ = [
+    "CanonicalTurnStateDiagnostic",
     "CompletionGapDetection",
     "ExecutionHistoryDiagnosticReport",
     "ExecutionHistoryMetrics",
@@ -735,6 +929,7 @@ __all__ = [
     "ExecutionHistoryThresholds",
     "ExecutionHistoryTopN",
     "check_thresholds",
+    "collect_canonical_turn_state_diagnostics",
     "collect_execution_history_metrics",
     "collect_top_n_heavy_executions",
     "detect_completion_gap_repeated_attempts",

--- a/src/codex_autorunner/core/orchestration/execution_lifecycle.py
+++ b/src/codex_autorunner/core/orchestration/execution_lifecycle.py
@@ -33,6 +33,7 @@ from .thread_titles import (
 )
 from .transcript_mirror import TranscriptMirrorStore
 from .turn_context import turn_assembly_from_request_metadata
+from .turn_execution_contract import TurnExecutionRecord, TurnExecutionRequest
 
 _MISSING_THREAD_MARKERS = (
     "missing thread",
@@ -229,6 +230,8 @@ class _ClaimedThreadExecutionRequest:
     thread: ThreadTarget
     execution: ExecutionRecord
     queued_request: QueuedExecutionRequest
+    turn_request: Optional[TurnExecutionRequest] = None
+    turn_record: Optional[TurnExecutionRecord] = None
 
     @property
     def request(self) -> MessageRequest:
@@ -252,6 +255,25 @@ class _ClaimedThreadExecutionRequest:
             self.client_request_id,
             self.sandbox_policy,
         )
+
+
+def _message_request_from_turn_request(
+    request: TurnExecutionRequest,
+) -> MessageRequest:
+    return MessageRequest(
+        target_id=request.target_id,
+        target_kind="thread" if request.target_kind == "thread" else "flow",
+        message_text=request.prompt_text or "",
+        kind="review" if request.request_kind == "review" else "message",
+        busy_policy=request.busy_policy,
+        agent_profile=request.profile,
+        model=request.model,
+        reasoning=request.reasoning,
+        approval_mode=request.approval_mode,
+        input_items=[dict(item) for item in request.input_items] or None,
+        context_profile=request.context_profile,
+        metadata=dict(request.metadata),
+    )
 
 
 @dataclass
@@ -369,10 +391,13 @@ class _ThreadExecutionLifecycle:
         harness: RuntimeThreadHarness,
         workspace_root: Path,
         sandbox_policy: Optional[Any],
+        turn_request: Optional[TurnExecutionRequest] = None,
     ) -> ExecutionRecord:
-        new_session_runtime_prompt = self.resolve_runtime_prompt(request)
+        canonical_request = turn_request
+        legacy_request = request
+        new_session_runtime_prompt = self.resolve_runtime_prompt(legacy_request)
         existing_session_runtime_prompt = (
-            self.resolve_existing_session_runtime_prompt(request)
+            self.resolve_existing_session_runtime_prompt(legacy_request)
             or new_session_runtime_prompt
         )
         fresh_conversation_retry_attempted = False
@@ -495,7 +520,7 @@ class _ThreadExecutionLifecycle:
                                     or "missing_backend_binding"
                                 )
                                 self.mark_fresh_backend_session(
-                                    request,
+                                    legacy_request,
                                     reason=fresh_backend_session_reason,
                                     rehydrated=bool(prefix),
                                 )
@@ -508,7 +533,11 @@ class _ThreadExecutionLifecycle:
                                     previous_backend_thread_id=(
                                         previous_backend_thread_id
                                     ),
-                                    request_kind=request.kind,
+                                    request_kind=(
+                                        canonical_request.request_kind
+                                        if canonical_request is not None
+                                        else legacy_request.kind
+                                    ),
                                     reason=fresh_backend_session_reason,
                                     rehydrated=bool(prefix),
                                 )
@@ -542,8 +571,8 @@ class _ThreadExecutionLifecycle:
                         )
                     )
                     turn_assembly = turn_assembly_from_request_metadata(
-                        message_text=request.message_text,
-                        metadata=request.metadata,
+                        message_text=legacy_request.message_text,
+                        metadata=legacy_request.metadata,
                     )
                     message_title = choose_owned_thread_title(
                         thread.display_name,
@@ -582,7 +611,37 @@ class _ThreadExecutionLifecycle:
                         conversation_id=conversation_id,
                         provisional_turn_id=provisional_turn_id,
                     )
-                    if request.kind == "review":
+                    request_kind = (
+                        canonical_request.request_kind
+                        if canonical_request is not None
+                        else legacy_request.kind
+                    )
+                    runtime_model = (
+                        canonical_request.model
+                        if canonical_request is not None
+                        else legacy_request.model
+                    )
+                    runtime_reasoning = (
+                        canonical_request.reasoning
+                        if canonical_request is not None
+                        else legacy_request.reasoning
+                    )
+                    runtime_approval_mode = (
+                        canonical_request.approval_mode
+                        if canonical_request is not None
+                        else legacy_request.approval_mode
+                    )
+                    runtime_sandbox_policy = (
+                        canonical_request.sandbox_policy
+                        if canonical_request is not None
+                        else sandbox_policy
+                    )
+                    runtime_input_items = (
+                        [dict(item) for item in canonical_request.input_items] or None
+                        if canonical_request is not None
+                        else legacy_request.input_items
+                    )
+                    if request_kind == "review":
                         if not harness.supports("review"):
                             raise RuntimeError(
                                 f"Agent '{thread.agent_id}' does not support review mode"
@@ -591,21 +650,21 @@ class _ThreadExecutionLifecycle:
                             workspace_root,
                             conversation_id,
                             attempt_runtime_prompt,
-                            request.model,
-                            request.reasoning,
-                            approval_mode=request.approval_mode,
-                            sandbox_policy=sandbox_policy,
+                            runtime_model,
+                            runtime_reasoning,
+                            approval_mode=runtime_approval_mode,
+                            sandbox_policy=runtime_sandbox_policy,
                         )
                     else:
                         turn = await harness.start_turn(
                             workspace_root,
                             conversation_id,
                             attempt_runtime_prompt,
-                            request.model,
-                            request.reasoning,
-                            approval_mode=request.approval_mode,
-                            sandbox_policy=sandbox_policy,
-                            input_items=request.input_items,
+                            runtime_model,
+                            runtime_reasoning,
+                            approval_mode=runtime_approval_mode,
+                            sandbox_policy=runtime_sandbox_policy,
+                            input_items=runtime_input_items,
                         )
                     resolved_turn_id = str(getattr(turn, "turn_id", "") or "").strip()
                     if not resolved_turn_id:
@@ -689,7 +748,11 @@ class _ThreadExecutionLifecycle:
                 thread_target_id=thread.thread_target_id,
                 execution_id=execution.execution_id,
                 backend_thread_id=conversation_id,
-                request_kind=request.kind,
+                request_kind=(
+                    canonical_request.request_kind
+                    if canonical_request is not None
+                    else legacy_request.kind
+                ),
                 fresh_conversation_retry_attempted=fresh_conversation_retry_attempted,
                 reported_error=detail,
                 error_type=type(exc).__name__,
@@ -730,7 +793,11 @@ class _ThreadExecutionLifecycle:
                 backend_thread_id=(
                     runtime_binding.backend_thread_id if runtime_binding else None
                 ),
-                request_kind=request.kind,
+                request_kind=(
+                    canonical_request.request_kind
+                    if canonical_request is not None
+                    else legacy_request.kind
+                ),
                 fresh_conversation_retry_attempted=fresh_conversation_retry_attempted,
                 reported_error=detail,
             )
@@ -776,7 +843,11 @@ class _ThreadExecutionLifecycle:
             execution_id=execution.execution_id,
             backend_thread_id=resolved_conversation_id,
             backend_turn_id=resolved_turn_id,
-            request_kind=request.kind,
+            request_kind=(
+                canonical_request.request_kind
+                if canonical_request is not None
+                else legacy_request.kind
+            ),
             reused_conversation=used_existing_conversation,
             stale_session_recovery=fresh_conversation_retry_attempted,
         )
@@ -863,6 +934,7 @@ class _ThreadExecutionLifecycle:
                 harness=resolved_harness,
                 workspace_root=resolved_workspace_root,
                 sandbox_policy=claimed.sandbox_policy,
+                turn_request=claimed.turn_request,
             )
             return started, resolved_harness
         except BaseException as exc:

--- a/src/codex_autorunner/core/orchestration/execution_lifecycle.py
+++ b/src/codex_autorunner/core/orchestration/execution_lifecycle.py
@@ -245,17 +245,6 @@ class _ClaimedThreadExecutionRequest:
     def sandbox_policy(self) -> Optional[Any]:
         return self.queued_request.sandbox_policy
 
-    def as_legacy_tuple(
-        self,
-    ) -> tuple[ThreadTarget, ExecutionRecord, MessageRequest, Optional[str], Any]:
-        return (
-            self.thread,
-            self.execution,
-            self.request,
-            self.client_request_id,
-            self.sandbox_policy,
-        )
-
 
 def _message_request_from_turn_request(
     request: TurnExecutionRequest,

--- a/src/codex_autorunner/core/orchestration/execution_lifecycle.py
+++ b/src/codex_autorunner/core/orchestration/execution_lifecycle.py
@@ -524,6 +524,20 @@ class _ThreadExecutionLifecycle:
                                     reason=fresh_backend_session_reason,
                                     rehydrated=bool(prefix),
                                 )
+                                if canonical_request is not None:
+                                    canonical_request.metadata.update(
+                                        {
+                                            "fresh_backend_session_started": True,
+                                            "fresh_backend_session_reason": (
+                                                fresh_backend_session_reason
+                                            ),
+                                            "fresh_backend_session_notice": (
+                                                legacy_request.metadata[
+                                                    "fresh_backend_session_notice"
+                                                ]
+                                            ),
+                                        }
+                                    )
                                 log_event(
                                     self._log,
                                     logging.INFO,
@@ -722,7 +736,9 @@ class _ThreadExecutionLifecycle:
                         execution_id=execution.execution_id,
                         backend_thread_id=conversation_id,
                         operation=(
-                            "start_review" if request.kind == "review" else "start_turn"
+                            "start_review"
+                            if legacy_request.kind == "review"
+                            else "start_turn"
                         ),
                         status_code=None,
                         reason=str(exc),

--- a/src/codex_autorunner/core/orchestration/interfaces.py
+++ b/src/codex_autorunner/core/orchestration/interfaces.py
@@ -214,6 +214,7 @@ class ThreadExecutionStore(Protocol):
         client_request_id: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
         queue_payload: Optional[dict[str, Any]] = None,
+        turn_request: Optional[Any] = None,
     ) -> ExecutionRecord: ...
 
     def get_execution(

--- a/src/codex_autorunner/core/orchestration/migrations.py
+++ b/src/codex_autorunner/core/orchestration/migrations.py
@@ -8,8 +8,16 @@ from typing import Callable
 from ..sqlite_utils import table_columns, table_exists
 from ..time_utils import now_iso
 from .models import OrchestrationTableDefinition
+from .turn_execution_storage import (
+    TURN_EXECUTION_CONTRACT_VERSION,
+    TURN_EXECUTION_CONTRACT_VERSION_COLUMN,
+    TURN_EXECUTION_RECORD_COLUMN,
+    TURN_EXECUTION_REQUEST_COLUMN,
+    build_turn_execution_record_from_storage,
+    build_turn_execution_request_from_storage,
+)
 
-ORCHESTRATION_SCHEMA_VERSION = 36
+ORCHESTRATION_SCHEMA_VERSION = 37
 
 
 @dataclass(frozen=True)
@@ -2104,6 +2112,163 @@ def _apply_v36(conn: sqlite3.Connection) -> None:
     )
 
 
+def _apply_v37(conn: sqlite3.Connection) -> None:
+    _ensure_column(
+        conn,
+        "orch_thread_executions",
+        TURN_EXECUTION_CONTRACT_VERSION_COLUMN,
+        f"{TURN_EXECUTION_CONTRACT_VERSION_COLUMN} INTEGER NOT NULL DEFAULT {TURN_EXECUTION_CONTRACT_VERSION}",
+    )
+    _ensure_column(
+        conn,
+        "orch_thread_executions",
+        TURN_EXECUTION_REQUEST_COLUMN,
+        f"{TURN_EXECUTION_REQUEST_COLUMN} TEXT",
+    )
+    _ensure_column(
+        conn,
+        "orch_thread_executions",
+        TURN_EXECUTION_RECORD_COLUMN,
+        f"{TURN_EXECUTION_RECORD_COLUMN} TEXT",
+    )
+    if not (
+        table_exists(conn, "orch_thread_executions")
+        and table_exists(conn, "orch_thread_targets")
+    ):
+        return
+    queue_join = ""
+    queue_select = """
+               NULL AS queue_payload_json,
+               NULL AS queue_item_id,
+               NULL AS queue_state,
+               NULL AS queue_visible_at,
+               NULL AS queue_claimed_at,
+               NULL AS queue_completed_at,
+               NULL AS queue_created_at,
+               NULL AS queue_updated_at
+    """
+    if table_exists(conn, "orch_queue_items"):
+        queue_select = """
+               q.payload_json AS queue_payload_json,
+               q.queue_item_id AS queue_item_id,
+               q.state AS queue_state,
+               q.visible_at AS queue_visible_at,
+               q.claimed_at AS queue_claimed_at,
+               q.completed_at AS queue_completed_at,
+               q.created_at AS queue_created_at,
+               q.updated_at AS queue_updated_at
+        """
+        queue_join = """
+          LEFT JOIN orch_queue_items AS q
+            ON q.source_kind = 'thread_execution'
+           AND q.source_key = e.execution_id
+        """
+    rows = conn.execute(
+        f"""
+        SELECT e.*, t.*, e.execution_id AS execution_id,
+               e.thread_target_id AS thread_target_id,
+               e.created_at AS execution_created_at,
+               {queue_select}
+          FROM orch_thread_executions AS e
+          JOIN orch_thread_targets AS t
+            ON t.thread_target_id = e.thread_target_id
+          {queue_join}
+         WHERE e.turn_request_json IS NULL
+            OR e.turn_record_json IS NULL
+            OR e.turn_contract_version != ?
+        """,
+        (TURN_EXECUTION_CONTRACT_VERSION,),
+    ).fetchall()
+    for row in rows:
+        row_map = {key: row[key] for key in row.keys()}
+        execution = {
+            key: row_map.get(key)
+            for key in (
+                "execution_id",
+                "thread_target_id",
+                "client_request_id",
+                "request_kind",
+                "prompt_text",
+                "status",
+                "backend_turn_id",
+                "assistant_text",
+                "error_text",
+                "model_id",
+                "reasoning_level",
+                "metadata_json",
+                "transcript_mirror_id",
+                "started_at",
+                "finished_at",
+            )
+        }
+        execution["created_at"] = row_map.get("execution_created_at")
+        thread = {
+            key: row_map.get(key)
+            for key in (
+                "thread_target_id",
+                "agent_id",
+                "backend_thread_id",
+                "repo_id",
+                "resource_kind",
+                "resource_id",
+                "workspace_root",
+                "scope_urn",
+                "surface_urn",
+                "metadata_json",
+            )
+        }
+        queue_payload = {}
+        try:
+            import json
+
+            loaded = json.loads(str(row_map.get("queue_payload_json") or "{}"))
+            if isinstance(loaded, dict):
+                queue_payload = loaded
+        except (TypeError, ValueError):
+            queue_payload = {}
+        queue_item = {
+            "queue_item_id": row_map.get("queue_item_id"),
+            "state": row_map.get("queue_state"),
+            "visible_at": row_map.get("queue_visible_at"),
+            "claimed_at": row_map.get("queue_claimed_at"),
+            "completed_at": row_map.get("queue_completed_at"),
+            "created_at": row_map.get("queue_created_at"),
+            "updated_at": row_map.get("queue_updated_at"),
+        }
+        request = build_turn_execution_request_from_storage(
+            execution=execution,
+            thread=thread,
+            queue_payload=queue_payload,
+        )
+        record = build_turn_execution_record_from_storage(
+            execution=execution,
+            thread=thread,
+            request=request,
+            queue_item=queue_item,
+        )
+        conn.execute(
+            """
+            UPDATE orch_thread_executions
+               SET turn_contract_version = ?,
+                   turn_request_json = ?,
+                   turn_record_json = ?
+             WHERE execution_id = ?
+            """,
+            (
+                TURN_EXECUTION_CONTRACT_VERSION,
+                request.to_json(),
+                record.to_json(),
+                request.request_id,
+            ),
+        )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_orch_thread_executions_turn_contract
+            ON orch_thread_executions(turn_contract_version, status, created_at)
+        """
+    )
+
+
 _MIGRATIONS = (
     _MigrationStep(1, "create_core_orchestration_schema", _apply_v1),
     _MigrationStep(2, "add_binding_and_flow_projection_scaffolding", _apply_v2),
@@ -2181,6 +2346,11 @@ _MIGRATIONS = (
         "add_explicit_chat_activity_clocks",
         _apply_v36,
     ),
+    _MigrationStep(
+        37,
+        "add_canonical_turn_execution_envelopes",
+        _apply_v37,
+    ),
 )
 
 
@@ -2193,7 +2363,7 @@ _TABLE_DEFINITIONS = (
     OrchestrationTableDefinition(
         name="orch_thread_executions",
         role="authoritative",
-        description="Canonical startup-critical execution metadata for thread targets, excluding full provider/raw traces.",
+        description="Canonical turn execution request/record envelopes plus indexed execution metadata for thread targets.",
     ),
     OrchestrationTableDefinition(
         name="orch_thread_actions",

--- a/src/codex_autorunner/core/orchestration/models.py
+++ b/src/codex_autorunner/core/orchestration/models.py
@@ -501,12 +501,9 @@ class MessageRequest:
         cls,
         data: Mapping[str, Any],
         *,
-        default_target_id: Optional[str] = None,
         busy_policy: Optional[BusyThreadPolicy] = None,
     ) -> "MessageRequest":
-        target_id = _normalize_optional_text(
-            data.get("target_id")
-        ) or _normalize_optional_text(default_target_id)
+        target_id = _normalize_optional_text(data.get("target_id"))
         if target_id is None:
             raise ValueError("MessageRequest requires a target_id")
         message_text = _normalize_optional_text(data.get("message_text"))
@@ -560,20 +557,25 @@ class QueuedExecutionRequest:
         *,
         thread_target_id: str,
     ) -> "QueuedExecutionRequest":
-        request_data = payload.get("request")
+        from .execution_lifecycle import _message_request_from_turn_request
+        from .turn_execution_contract import TurnExecutionRequest
+
+        request_data = payload.get("turn_request")
         if not isinstance(request_data, Mapping):
-            raise ValueError("Queued execution payload is missing request data")
-        request = MessageRequest.from_mapping(
-            request_data,
-            default_target_id=thread_target_id,
-            busy_policy="queue",
-        )
+            raise ValueError(
+                "Queued execution payload is missing canonical turn_request"
+            )
+        turn_request = TurnExecutionRequest.from_mapping(request_data)
+        if turn_request.target_id != thread_target_id:
+            raise ValueError(
+                "Queued execution turn_request target_id does not match thread_target_id"
+            )
+        request = _message_request_from_turn_request(turn_request)
         return cls(
             request=request,
-            client_request_id=_normalize_optional_text(
-                payload.get("client_request_id")
-            ),
-            sandbox_policy=payload.get("sandbox_policy"),
+            client_request_id=_normalize_optional_text(payload.get("client_request_id"))
+            or turn_request.client_request_id,
+            sandbox_policy=payload.get("sandbox_policy", turn_request.sandbox_policy),
         )
 
     def to_payload(self) -> dict[str, Any]:

--- a/src/codex_autorunner/core/orchestration/recovery_lifecycle.py
+++ b/src/codex_autorunner/core/orchestration/recovery_lifecycle.py
@@ -85,6 +85,10 @@ class ManagedTurnRecoveryDecision:
     age_seconds: Optional[float]
     current_status: str
     queue_depth: int = 0
+    canonical_request_id: Optional[str] = None
+    surface_origin: Optional[str] = None
+    target: Optional[dict[str, str]] = None
+    resolved_runtime_options: Optional[dict[str, object]] = None
 
 
 @dataclass(frozen=True)
@@ -135,6 +139,41 @@ def _managed_turn_lifecycle_phase(execution: ExecutionRecord) -> str:
     return status or "unknown"
 
 
+def _canonical_recovery_context(execution: ExecutionRecord) -> dict[str, object]:
+    request = execution.metadata.get("turn_request")
+    if not isinstance(request, dict):
+        request = execution.metadata.get("canonical_request")
+    if not isinstance(request, dict):
+        return {}
+    origin_obj = request.get("origin")
+    origin: dict[str, object] = origin_obj if isinstance(origin_obj, dict) else {}
+    surface_kind = str(origin.get("surface_kind") or "").strip()
+    surface_key = str(origin.get("surface_key") or "").strip()
+    surface_origin = (
+        f"{surface_kind}:{surface_key}" if surface_kind and surface_key else None
+    )
+    return {
+        "canonical_request_id": str(request.get("request_id") or "").strip() or None,
+        "surface_origin": surface_origin
+        or str(origin.get("source_id") or "").strip()
+        or None,
+        "target": {
+            "target_id": str(request.get("target_id") or execution.target_id),
+            "target_kind": str(request.get("target_kind") or execution.target_kind),
+        },
+        "resolved_runtime_options": {
+            "agent": request.get("agent"),
+            "profile": request.get("profile"),
+            "model": request.get("model"),
+            "model_payload": request.get("model_payload") or {},
+            "reasoning": request.get("reasoning"),
+            "approval_policy": request.get("approval_policy"),
+            "approval_mode": request.get("approval_mode"),
+            "sandbox_policy": request.get("sandbox_policy"),
+        },
+    }
+
+
 def classify_stale_managed_turn_recovery(
     *,
     managed_thread_id: str,
@@ -151,6 +190,7 @@ def classify_stale_managed_turn_recovery(
         status=status,
         terminal_statuses=_TERMINAL_STATUSES,
     )
+    canonical = _canonical_recovery_context(execution)
     return ManagedTurnRecoveryDecision(
         managed_thread_id=managed_thread_id,
         execution_id=execution.execution_id,
@@ -160,6 +200,10 @@ def classify_stale_managed_turn_recovery(
         age_seconds=age_seconds,
         current_status=status,
         queue_depth=queue_depth,
+        canonical_request_id=canonical.get("canonical_request_id"),  # type: ignore[arg-type]
+        surface_origin=canonical.get("surface_origin"),  # type: ignore[arg-type]
+        target=canonical.get("target"),  # type: ignore[arg-type]
+        resolved_runtime_options=canonical.get("resolved_runtime_options"),  # type: ignore[arg-type]
     )
 
 
@@ -223,6 +267,10 @@ class RecoveryScanner:
             age_seconds=decision.age_seconds,
             current_status=decision.current_status,
             queue_depth=decision.queue_depth,
+            canonical_request_id=decision.canonical_request_id,
+            surface_origin=decision.surface_origin,
+            target=decision.target,
+            resolved_runtime_options=decision.resolved_runtime_options,
         )
         recovered: Optional[ExecutionRecord] = None
         if decision.selected_action == "recover_from_harness":

--- a/src/codex_autorunner/core/orchestration/runtime_threads.py
+++ b/src/codex_autorunner/core/orchestration/runtime_threads.py
@@ -8,12 +8,14 @@ from typing import Any, AsyncIterator, Optional
 
 from ...harness_capabilities import harness_supports_event_streaming
 from ..sse import format_sse
+from .execution_lifecycle import _message_request_from_turn_request
 from .models import ExecutionRecord, MessageRequest, ThreadTarget
 from .runtime_turn_terminal_state import (
     RuntimeThreadOutcome,
     RuntimeTurnTerminalStateMachine,
 )
 from .service import HarnessBackedOrchestrationService
+from .turn_execution_contract import TurnExecutionRequest
 
 _INTERRUPT_POLL_INTERVAL_SECONDS = 0.05
 _STALL_POLL_INTERVAL_SECONDS = 0.25
@@ -95,16 +97,21 @@ class RuntimeThreadExecution:
 
 async def begin_runtime_thread_execution(
     service: HarnessBackedOrchestrationService,
-    request: MessageRequest,
+    request: MessageRequest | TurnExecutionRequest,
     *,
     client_request_id: Optional[str] = None,
     sandbox_policy: Optional[Any] = None,
 ) -> RuntimeThreadExecution:
     """Start a runtime-backed thread execution via the orchestration service."""
 
-    if request.target_kind != "thread":
+    lookup_request = (
+        _message_request_from_turn_request(request)
+        if isinstance(request, TurnExecutionRequest)
+        else request
+    )
+    if lookup_request.target_kind != "thread":
         raise ValueError("Runtime thread execution only supports thread targets")
-    thread = service.get_thread_target(request.target_id)
+    thread = service.get_thread_target(lookup_request.target_id)
     if thread is None:
         raise KeyError(f"Unknown thread target '{request.target_id}'")
     if not thread.workspace_root:
@@ -116,7 +123,38 @@ async def begin_runtime_thread_execution(
         sandbox_policy=sandbox_policy,
         harness=harness,
     )
-    refreshed_thread = service.get_thread_target(request.target_id)
+    if isinstance(request, TurnExecutionRequest):
+        request_loader = getattr(
+            service.thread_store, "get_turn_execution_request", None
+        )
+        stored_request = (
+            request_loader(lookup_request.target_id, execution.execution_id)
+            if callable(request_loader)
+            else None
+        )
+        runtime_request = _message_request_from_turn_request(
+            stored_request
+            if isinstance(stored_request, TurnExecutionRequest)
+            else request
+        )
+        if (
+            not runtime_request.metadata.get("fresh_backend_session_started")
+            and not thread.backend_thread_id
+            and (
+                str(getattr(thread, "last_execution_id", "") or "").strip()
+                or str(getattr(thread, "compact_seed", "") or "").strip()
+            )
+        ):
+            runtime_request.metadata["fresh_backend_session_started"] = True
+            runtime_request.metadata["fresh_backend_session_reason"] = (
+                "missing_backend_binding"
+            )
+            runtime_request.metadata["fresh_backend_session_notice"] = (
+                "Notice: I started a new live session for this conversation."
+            )
+    else:
+        runtime_request = request
+    refreshed_thread = service.get_thread_target(lookup_request.target_id)
     if refreshed_thread is None:
         raise KeyError(f"Unknown thread target '{request.target_id}' after send")
     return RuntimeThreadExecution(
@@ -125,7 +163,7 @@ async def begin_runtime_thread_execution(
         thread=refreshed_thread,
         execution=execution,
         workspace_root=Path(refreshed_thread.workspace_root or thread.workspace_root),
-        request=request,
+        request=runtime_request,
     )
 
 

--- a/src/codex_autorunner/core/orchestration/thread_service.py
+++ b/src/codex_autorunner/core/orchestration/thread_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Callable, Optional
 
@@ -652,7 +652,7 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
 
     async def send_message(
         self,
-        request: MessageRequest,
+        request: MessageRequest | TurnExecutionRequest,
         *,
         client_request_id: Optional[str] = None,
         sandbox_policy: Optional[Any] = None,
@@ -668,7 +668,7 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
 
     async def send_message_with_started_harness(
         self,
-        request: MessageRequest,
+        request: MessageRequest | TurnExecutionRequest,
         *,
         client_request_id: Optional[str] = None,
         sandbox_policy: Optional[Any] = None,
@@ -687,18 +687,31 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
 
     async def prepare_thread_execution(
         self,
-        request: MessageRequest,
+        request: MessageRequest | TurnExecutionRequest,
         *,
         client_request_id: Optional[str] = None,
         sandbox_policy: Optional[Any] = None,
         harness: Optional[RuntimeThreadHarness] = None,
     ) -> PreparedThreadExecution:
-        if request.target_kind != "thread":
+        if isinstance(request, TurnExecutionRequest):
+            canonical_request = request
+            client_request_id = client_request_id or canonical_request.client_request_id
+            sandbox_policy = (
+                sandbox_policy
+                if sandbox_policy is not None
+                else canonical_request.sandbox_policy
+            )
+            message_request = _message_request_from_turn_request(canonical_request)
+        else:
+            canonical_request = None
+            message_request = request
+
+        if message_request.target_kind != "thread":
             raise ValueError("Thread orchestration service only handles thread targets")
 
-        thread = self.get_thread_target(request.target_id)
+        thread = self.get_thread_target(message_request.target_id)
         if thread is None:
-            raise KeyError(f"Unknown thread target '{request.target_id}'")
+            raise KeyError(f"Unknown thread target '{message_request.target_id}'")
         if not thread.workspace_root:
             raise RuntimeError("Thread target is missing workspace_root")
         runtime_binding = _resolve_thread_runtime_binding(
@@ -711,23 +724,23 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
 
         workspace_root = Path(thread.workspace_root)
         turn_assembly = turn_assembly_from_request_metadata(
-            message_text=request.message_text,
-            metadata=request.metadata,
+            message_text=message_request.message_text,
+            metadata=message_request.metadata,
         )
         request_metadata = {
-            **request.metadata,
+            **message_request.metadata,
             **turn_assembly.metadata_patch(),
             "runtime_prompt": turn_assembly.raw_model_prompt,
         }
-        request.metadata.clear()
-        request.metadata.update(request_metadata)
+        message_request.metadata.clear()
+        message_request.metadata.update(request_metadata)
         queue_payload = self._queue_adapter.payload_for_request(
-            request,
+            message_request,
             client_request_id=client_request_id,
             sandbox_policy=sandbox_policy,
         )
         running = self.get_running_execution(thread.thread_target_id)
-        if running is not None and request.busy_policy == "interrupt":
+        if running is not None and message_request.busy_policy == "interrupt":
             try:
                 await self.stop_thread(thread.thread_target_id)
             except (
@@ -760,16 +773,20 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
                 )
             thread = self.get_thread_target(thread.thread_target_id) or thread
 
+        turn_request = canonical_request
+        if turn_request is not None and dict(turn_request.metadata) != request_metadata:
+            turn_request = replace(turn_request, metadata=request_metadata)
         execution = self.thread_store.create_execution(
             thread.thread_target_id,
             prompt=turn_assembly.user_visible_text,
-            request_kind=request.kind,
-            busy_policy=request.busy_policy,
-            model=request.model,
-            reasoning=request.reasoning,
+            request_kind=message_request.kind,
+            busy_policy=message_request.busy_policy,
+            model=message_request.model,
+            reasoning=message_request.reasoning,
             client_request_id=client_request_id,
             metadata=request_metadata,
             queue_payload=queue_payload,
+            turn_request=turn_request,
         )
         _record_thread_activity_best_effort(
             self.thread_store,
@@ -797,11 +814,11 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
         if resolved_harness is None and execution.status == "running":
             resolved_harness = self._harness_for_agent(
                 definition.agent_id,
-                request.agent_profile,
+                message_request.agent_profile,
             )
         return PreparedThreadExecution(
             thread=thread,
-            request=request,
+            request=message_request,
             turn_request=turn_request,
             turn_record=turn_record,
             execution=execution,

--- a/src/codex_autorunner/core/orchestration/thread_service.py
+++ b/src/codex_autorunner/core/orchestration/thread_service.py
@@ -13,6 +13,7 @@ from ..text_utils import _truncate_text
 from .bindings import ActiveWorkSummary, OrchestrationBindingStore
 from .execution_lifecycle import (
     _ClaimedThreadExecutionRequest,
+    _message_request_from_turn_request,
     _resolve_harness_runtime_instance_id,
     _resolve_thread_runtime_binding,
     _ThreadExecutionLifecycle,
@@ -40,7 +41,7 @@ from .recovery_lifecycle import (
 )
 from .runtime_bindings import RuntimeThreadBinding
 from .turn_context import turn_assembly_from_request_metadata
-from .turn_execution_contract import TurnExecutionRequest
+from .turn_execution_contract import TurnExecutionRecord, TurnExecutionRequest
 
 MessagePreviewLimit = 120
 logger = logging.getLogger("codex_autorunner.core.orchestration.service")
@@ -53,6 +54,8 @@ class PreparedThreadExecution:
 
     thread: ThreadTarget
     request: MessageRequest
+    turn_request: TurnExecutionRequest
+    turn_record: TurnExecutionRecord
     execution: ExecutionRecord
     workspace_root: Path
     sandbox_policy: Optional[Any]
@@ -66,6 +69,8 @@ class PreparedThreadExecution:
                 request=self.request,
                 sandbox_policy=self.sandbox_policy,
             ),
+            turn_request=self.turn_request,
+            turn_record=self.turn_record,
         )
 
 
@@ -292,20 +297,7 @@ class _ThreadQueueRequestAdapter:
         self, request: TurnExecutionRequest
     ) -> QueuedExecutionRequest:
         return QueuedExecutionRequest(
-            request=MessageRequest(
-                target_id=request.target_id,
-                target_kind="thread",
-                message_text=request.prompt_text or "",
-                kind="review" if request.request_kind == "review" else "message",
-                busy_policy="queue",
-                agent_profile=request.profile,
-                model=request.model,
-                reasoning=request.reasoning,
-                approval_mode=request.approval_mode,
-                input_items=[dict(item) for item in request.input_items] or None,
-                context_profile=request.context_profile,
-                metadata=dict(request.metadata),
-            ),
+            request=_message_request_from_turn_request(request),
             client_request_id=request.client_request_id,
             sandbox_policy=(
                 None
@@ -327,18 +319,26 @@ class _ThreadQueueRequestAdapter:
         if not thread.workspace_root:
             raise RuntimeError("Thread target is missing workspace_root")
         request_loader = getattr(self.thread_store, "get_turn_execution_request", None)
-        if not callable(request_loader):
+        record_loader = getattr(self.thread_store, "get_turn_execution_record", None)
+        if not callable(request_loader) or not callable(record_loader):
             raise RuntimeError("Thread store cannot load canonical turn requests")
         turn_request = request_loader(thread_target_id, execution.execution_id)
         if not isinstance(turn_request, TurnExecutionRequest):
             raise RuntimeError(
                 f"Execution '{execution.execution_id}' is missing canonical turn request"
             )
+        turn_record = record_loader(thread_target_id, execution.execution_id)
+        if not isinstance(turn_record, TurnExecutionRecord):
+            raise RuntimeError(
+                f"Execution '{execution.execution_id}' is missing canonical turn record"
+            )
         queued_request = self.queued_request_from_turn_request(turn_request)
         return _ClaimedThreadExecutionRequest(
             thread=thread,
             execution=execution,
             queued_request=queued_request,
+            turn_request=turn_request,
+            turn_record=turn_record,
         )
 
 
@@ -641,6 +641,13 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
             harness=harness,
             workspace_root=workspace_root,
             sandbox_policy=sandbox_policy,
+            turn_request=(
+                self.thread_store.get_turn_execution_request(
+                    thread.thread_target_id, execution.execution_id
+                )
+                if hasattr(self.thread_store, "get_turn_execution_request")
+                else None
+            ),
         )
 
     async def send_message(
@@ -772,6 +779,20 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
                 turn_assembly.title_seed, MessagePreviewLimit
             ),
         )
+        request_loader = getattr(self.thread_store, "get_turn_execution_request", None)
+        record_loader = getattr(self.thread_store, "get_turn_execution_record", None)
+        if not callable(request_loader) or not callable(record_loader):
+            raise RuntimeError("Thread store cannot load canonical turn execution data")
+        turn_request = request_loader(thread.thread_target_id, execution.execution_id)
+        if not isinstance(turn_request, TurnExecutionRequest):
+            raise RuntimeError(
+                f"Execution '{execution.execution_id}' is missing canonical turn request"
+            )
+        turn_record = record_loader(thread.thread_target_id, execution.execution_id)
+        if not isinstance(turn_record, TurnExecutionRecord):
+            raise RuntimeError(
+                f"Execution '{execution.execution_id}' is missing canonical turn record"
+            )
         resolved_harness = harness if execution.status == "running" else None
         if resolved_harness is None and execution.status == "running":
             resolved_harness = self._harness_for_agent(
@@ -781,6 +802,8 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
         return PreparedThreadExecution(
             thread=thread,
             request=request,
+            turn_request=turn_request,
+            turn_record=turn_record,
             execution=execution,
             workspace_root=workspace_root,
             sandbox_policy=sandbox_policy,
@@ -849,6 +872,13 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
                 queued_request=QueuedExecutionRequest(
                     request=request,
                     sandbox_policy=sandbox_policy,
+                ),
+                turn_request=(
+                    self.thread_store.get_turn_execution_request(
+                        thread.thread_target_id, execution.execution_id
+                    )
+                    if hasattr(self.thread_store, "get_turn_execution_request")
+                    else None
                 ),
             ),
             harness=harness,

--- a/src/codex_autorunner/core/orchestration/thread_service.py
+++ b/src/codex_autorunner/core/orchestration/thread_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -47,6 +48,7 @@ from .turn_execution_contract import (
     TurnExecutionRecord,
     TurnExecutionRequest,
 )
+from .turn_execution_storage import build_turn_execution_record_from_storage
 
 MessagePreviewLimit = 120
 logger = logging.getLogger("codex_autorunner.core.orchestration.service")
@@ -329,14 +331,28 @@ class _ThreadQueueRequestAdapter:
             raise RuntimeError("Thread store cannot load canonical turn requests")
         turn_request = request_loader(thread_target_id, execution.execution_id)
         if not isinstance(turn_request, TurnExecutionRequest):
-            raise RuntimeError(
-                f"Execution '{execution.execution_id}' is missing canonical turn request"
-            )
+            request_data = payload.get("turn_request")
+            if not isinstance(request_data, Mapping):
+                raise RuntimeError(
+                    f"Execution '{execution.execution_id}' is missing canonical turn request"
+                )
+            turn_request = TurnExecutionRequest.from_mapping(request_data)
+            if turn_request.target_id != thread_target_id:
+                raise RuntimeError(
+                    "Queued execution turn_request target_id does not match thread_target_id"
+                )
         turn_record = record_loader(thread_target_id, execution.execution_id)
         if not isinstance(turn_record, TurnExecutionRecord):
-            raise RuntimeError(
-                f"Execution '{execution.execution_id}' is missing canonical turn record"
-            )
+            record_data = payload.get("turn_record")
+            if isinstance(record_data, Mapping):
+                turn_record = TurnExecutionRecord.from_mapping(record_data)
+            else:
+                turn_record = build_turn_execution_record_from_storage(
+                    execution=execution.to_dict(),
+                    thread=thread.to_dict(),
+                    request=turn_request,
+                    queue_item=payload,
+                )
         queued_request = self.queued_request_from_turn_request(turn_request)
         return _ClaimedThreadExecutionRequest(
             thread=thread,

--- a/src/codex_autorunner/core/orchestration/thread_service.py
+++ b/src/codex_autorunner/core/orchestration/thread_service.py
@@ -40,6 +40,7 @@ from .recovery_lifecycle import (
 )
 from .runtime_bindings import RuntimeThreadBinding
 from .turn_context import turn_assembly_from_request_metadata
+from .turn_execution_contract import TurnExecutionRequest
 
 MessagePreviewLimit = 120
 logger = logging.getLogger("codex_autorunner.core.orchestration.service")
@@ -287,6 +288,32 @@ class _ThreadQueueRequestAdapter:
             sandbox_policy=sandbox_policy,
         ).to_payload()
 
+    def queued_request_from_turn_request(
+        self, request: TurnExecutionRequest
+    ) -> QueuedExecutionRequest:
+        return QueuedExecutionRequest(
+            request=MessageRequest(
+                target_id=request.target_id,
+                target_kind="thread",
+                message_text=request.prompt_text or "",
+                kind="review" if request.request_kind == "review" else "message",
+                busy_policy="queue",
+                agent_profile=request.profile,
+                model=request.model,
+                reasoning=request.reasoning,
+                approval_mode=request.approval_mode,
+                input_items=[dict(item) for item in request.input_items] or None,
+                context_profile=request.context_profile,
+                metadata=dict(request.metadata),
+            ),
+            client_request_id=request.client_request_id,
+            sandbox_policy=(
+                None
+                if request.sandbox_policy == "dangerFullAccess"
+                else request.sandbox_policy
+            ),
+        )
+
     def claim_next_queued_execution(
         self, thread_target_id: str
     ) -> Optional[_ClaimedThreadExecutionRequest]:
@@ -299,10 +326,15 @@ class _ThreadQueueRequestAdapter:
             raise KeyError(f"Unknown thread target '{thread_target_id}'")
         if not thread.workspace_root:
             raise RuntimeError("Thread target is missing workspace_root")
-        queued_request = QueuedExecutionRequest.from_payload(
-            payload,
-            thread_target_id=thread_target_id,
-        )
+        request_loader = getattr(self.thread_store, "get_turn_execution_request", None)
+        if not callable(request_loader):
+            raise RuntimeError("Thread store cannot load canonical turn requests")
+        turn_request = request_loader(thread_target_id, execution.execution_id)
+        if not isinstance(turn_request, TurnExecutionRequest):
+            raise RuntimeError(
+                f"Execution '{execution.execution_id}' is missing canonical turn request"
+            )
+        queued_request = self.queued_request_from_turn_request(turn_request)
         return _ClaimedThreadExecutionRequest(
             thread=thread,
             execution=execution,

--- a/src/codex_autorunner/core/orchestration/thread_service.py
+++ b/src/codex_autorunner/core/orchestration/thread_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -41,7 +42,11 @@ from .recovery_lifecycle import (
 )
 from .runtime_bindings import RuntimeThreadBinding
 from .turn_context import turn_assembly_from_request_metadata
-from .turn_execution_contract import TurnExecutionRecord, TurnExecutionRequest
+from .turn_execution_contract import (
+    TurnExecutionOrigin,
+    TurnExecutionRecord,
+    TurnExecutionRequest,
+)
 
 MessagePreviewLimit = 120
 logger = logging.getLogger("codex_autorunner.core.orchestration.service")
@@ -282,16 +287,16 @@ class _ThreadQueueRequestAdapter:
 
     def payload_for_request(
         self,
-        request: MessageRequest,
+        request: TurnExecutionRequest,
         *,
         client_request_id: Optional[str],
         sandbox_policy: Optional[Any],
     ) -> dict[str, Any]:
-        return QueuedExecutionRequest(
-            request=request,
-            client_request_id=client_request_id,
-            sandbox_policy=sandbox_policy,
-        ).to_payload()
+        return {
+            "turn_request": request.to_dict(),
+            "client_request_id": client_request_id,
+            "sandbox_policy": sandbox_policy,
+        }
 
     def queued_request_from_turn_request(
         self, request: TurnExecutionRequest
@@ -340,6 +345,57 @@ class _ThreadQueueRequestAdapter:
             turn_request=turn_request,
             turn_record=turn_record,
         )
+
+
+def _canonical_request_from_message_request(
+    request: MessageRequest,
+    *,
+    request_id: str,
+    thread: ThreadTarget,
+    workspace_root: Path,
+    client_request_id: Optional[str],
+    sandbox_policy: Any,
+) -> TurnExecutionRequest:
+    model_payload = (
+        _opencode_model_payload(request.model) if thread.agent_id == "opencode" else {}
+    )
+    approval_policy = request.approval_mode or "never"
+    return TurnExecutionRequest(
+        request_id=request_id,
+        target_id=request.target_id,
+        target_kind=request.target_kind,
+        workspace_root=str(workspace_root),
+        request_kind=request.kind,
+        busy_policy=request.busy_policy,
+        prompt_text=request.message_text,
+        input_items=tuple(dict(item) for item in request.input_items or ()),
+        context_profile=request.context_profile,
+        agent=thread.agent_id,
+        profile=request.agent_profile,
+        model=request.model,
+        model_payload=model_payload,
+        reasoning=request.reasoning,
+        approval_policy=approval_policy,
+        approval_mode=request.approval_mode,
+        sandbox_policy=sandbox_policy,
+        client_request_id=client_request_id,
+        idempotency_key=client_request_id or request_id,
+        correlation_id=client_request_id or request_id,
+        origin=TurnExecutionOrigin(
+            kind="system",
+            source_id="orchestration-thread-service",
+        ),
+        metadata=dict(request.metadata),
+    )
+
+
+def _opencode_model_payload(model: Optional[str]) -> dict[str, str]:
+    if model is None or "/" not in model:
+        return {}
+    provider_id, model_id = (part.strip() for part in model.split("/", 1))
+    if not provider_id or not model_id:
+        return {}
+    return {"providerID": provider_id, "modelID": model_id}
 
 
 @dataclass
@@ -693,15 +749,11 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
         sandbox_policy: Optional[Any] = None,
         harness: Optional[RuntimeThreadHarness] = None,
     ) -> PreparedThreadExecution:
+        canonical_request: Optional[TurnExecutionRequest]
+        message_request: MessageRequest
         if isinstance(request, TurnExecutionRequest):
             canonical_request = request
-            client_request_id = client_request_id or canonical_request.client_request_id
-            sandbox_policy = (
-                sandbox_policy
-                if sandbox_policy is not None
-                else canonical_request.sandbox_policy
-            )
-            message_request = _message_request_from_turn_request(canonical_request)
+            message_request = _message_request_from_turn_request(request)
         else:
             canonical_request = None
             message_request = request
@@ -723,6 +775,25 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
             raise KeyError(f"Unknown agent definition '{thread.agent_id}'")
 
         workspace_root = Path(thread.workspace_root)
+        if canonical_request is not None:
+            client_request_id = client_request_id or canonical_request.client_request_id
+            sandbox_policy = (
+                sandbox_policy
+                if sandbox_policy is not None
+                else canonical_request.sandbox_policy
+            )
+        else:
+            sandbox_policy = (
+                sandbox_policy if sandbox_policy is not None else "dangerFullAccess"
+            )
+            canonical_request = _canonical_request_from_message_request(
+                message_request,
+                request_id=client_request_id or str(uuid.uuid4()),
+                thread=thread,
+                workspace_root=workspace_root,
+                client_request_id=client_request_id,
+                sandbox_policy=sandbox_policy,
+            )
         turn_assembly = turn_assembly_from_request_metadata(
             message_text=message_request.message_text,
             metadata=message_request.metadata,
@@ -735,7 +806,7 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
         message_request.metadata.clear()
         message_request.metadata.update(request_metadata)
         queue_payload = self._queue_adapter.payload_for_request(
-            message_request,
+            canonical_request,
             client_request_id=client_request_id,
             sandbox_policy=sandbox_policy,
         )
@@ -901,14 +972,6 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
             harness=harness,
             workspace_root=workspace_root,
         )
-
-    def claim_next_queued_execution_request(
-        self, thread_target_id: str
-    ) -> Optional[
-        tuple[ThreadTarget, ExecutionRecord, MessageRequest, Optional[str], Any]
-    ]:
-        claimed = self.claim_next_queued_execution_context(thread_target_id)
-        return None if claimed is None else claimed.as_legacy_tuple()
 
     async def start_next_queued_execution(
         self,

--- a/src/codex_autorunner/core/orchestration/thread_store_adapter.py
+++ b/src/codex_autorunner/core/orchestration/thread_store_adapter.py
@@ -20,6 +20,7 @@ from .managed_turn_lifecycle_contract import (
 from .models import ExecutionRecord, MessageRequestKind, ThreadTarget
 from .runtime_bindings import RuntimeThreadBinding
 from .thread_titles import choose_owned_thread_title
+from .turn_execution_contract import TurnExecutionRecord, TurnExecutionRequest
 
 logger = logging.getLogger(__name__)
 
@@ -381,6 +382,16 @@ class ManagedThreadExecutionStore(ThreadExecutionStore):
         if record is None:
             return None
         return _execution_record_from_store_row(record)
+
+    def get_turn_execution_request(
+        self, thread_target_id: str, execution_id: str
+    ) -> Optional[TurnExecutionRequest]:
+        return self._store.get_turn_execution_request(thread_target_id, execution_id)
+
+    def get_turn_execution_record(
+        self, thread_target_id: str, execution_id: str
+    ) -> Optional[TurnExecutionRecord]:
+        return self._store.get_turn_execution_record(thread_target_id, execution_id)
 
     def get_previous_completed_execution(
         self,

--- a/src/codex_autorunner/core/orchestration/thread_store_adapter.py
+++ b/src/codex_autorunner/core/orchestration/thread_store_adapter.py
@@ -342,6 +342,7 @@ class ManagedThreadExecutionStore(ThreadExecutionStore):
         client_request_id: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
         queue_payload: Optional[dict[str, Any]] = None,
+        turn_request: Optional[TurnExecutionRequest] = None,
     ) -> ExecutionRecord:
         metadata_payload = dict(metadata or {})
         initialized_lifecycle_phase = (
@@ -358,13 +359,17 @@ class ManagedThreadExecutionStore(ThreadExecutionStore):
             "client_turn_id": client_request_id,
             "metadata": metadata_payload,
             "queue_payload": queue_payload,
+            "turn_request": turn_request,
         }
         try:
             created = self._store.create_turn(thread_target_id, **create_kwargs)
         except TypeError as exc:
-            if "metadata" not in str(exc):
+            if "turn_request" in str(exc):
+                create_kwargs.pop("turn_request", None)
+            elif "metadata" in str(exc):
+                create_kwargs.pop("metadata", None)
+            else:
                 raise
-            create_kwargs.pop("metadata", None)
             created = self._store.create_turn(thread_target_id, **create_kwargs)
         record = _execution_record_from_store_row(created)
         if initialized_lifecycle_phase:

--- a/src/codex_autorunner/core/orchestration/thread_store_adapter.py
+++ b/src/codex_autorunner/core/orchestration/thread_store_adapter.py
@@ -350,6 +350,10 @@ class ManagedThreadExecutionStore(ThreadExecutionStore):
         )
         if initialized_lifecycle_phase:
             metadata_payload[_MANAGED_TURN_LIFECYCLE_PHASE_KEY] = "accepted"
+        if turn_request is None:
+            raise ValueError(
+                "create_execution requires a canonical TurnExecutionRequest"
+            )
         create_kwargs: dict[str, Any] = {
             "prompt": prompt,
             "request_kind": request_kind,
@@ -361,16 +365,7 @@ class ManagedThreadExecutionStore(ThreadExecutionStore):
             "queue_payload": queue_payload,
             "turn_request": turn_request,
         }
-        try:
-            created = self._store.create_turn(thread_target_id, **create_kwargs)
-        except TypeError as exc:
-            if "turn_request" in str(exc):
-                create_kwargs.pop("turn_request", None)
-            elif "metadata" in str(exc):
-                create_kwargs.pop("metadata", None)
-            else:
-                raise
-            created = self._store.create_turn(thread_target_id, **create_kwargs)
+        created = self._store.create_turn(thread_target_id, **create_kwargs)
         record = _execution_record_from_store_row(created)
         if initialized_lifecycle_phase:
             self._advance_execution_lifecycle_phase(

--- a/src/codex_autorunner/core/orchestration/thread_store_adapter.py
+++ b/src/codex_autorunner/core/orchestration/thread_store_adapter.py
@@ -135,7 +135,19 @@ def _thread_target_from_store_row_with_runtime_binding(
 
 
 def _execution_record_from_store_row(record: Mapping[str, Any]) -> ExecutionRecord:
-    return ExecutionRecord.from_mapping(record)
+    metadata = record.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    merged_metadata = dict(metadata)
+    turn_request = record.get("turn_request")
+    if isinstance(turn_request, dict) and turn_request:
+        merged_metadata["turn_request"] = dict(turn_request)
+    turn_record = record.get("turn_record")
+    if isinstance(turn_record, dict) and turn_record:
+        merged_metadata["turn_record"] = dict(turn_record)
+    payload = dict(record)
+    payload["metadata"] = merged_metadata
+    return ExecutionRecord.from_mapping(payload)
 
 
 class ManagedThreadExecutionStore(ThreadExecutionStore):

--- a/src/codex_autorunner/core/orchestration/ticket_flow_visibility_repair.py
+++ b/src/codex_autorunner/core/orchestration/ticket_flow_visibility_repair.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Optional
@@ -14,6 +15,7 @@ from .ticket_flow_chat_ledger_contract import (
     ticket_flow_thread_metadata,
     validate_ticket_flow_thread_metadata,
 )
+from .turn_execution_contract import TurnExecutionOrigin, TurnExecutionRequest
 
 
 @dataclass(frozen=True)
@@ -558,18 +560,42 @@ def _create_repaired_ticket_flow_thread(
         metadata=metadata,
     )
     thread_id = str(thread["managed_thread_id"])
+    prompt = (
+        "Backfilled ticket-flow visibility placeholder. Original runtime prompt "
+        "is unavailable in canonical orchestration records."
+    )
     turn = thread_store.create_turn(
         thread_id,
-        prompt=(
-            "Backfilled ticket-flow visibility placeholder. Original runtime prompt "
-            "is unavailable in canonical orchestration records."
-        ),
+        prompt=prompt,
         metadata={
             "repair_provenance": metadata["repair_provenance"],
             "flow_run_id": evidence.run_id,
             "ticket_id": evidence.ticket_id,
             "ticket_path": evidence.ticket_path,
         },
+        turn_request=TurnExecutionRequest(
+            request_id=uuid.uuid4().hex,
+            target_id=thread_id,
+            target_kind="thread",
+            workspace_root=str(repo_root),
+            request_kind="recovery",
+            busy_policy="reject",
+            prompt_text=prompt,
+            agent=evidence.agent_id,
+            approval_policy="never",
+            sandbox_policy="dangerFullAccess",
+            origin=TurnExecutionOrigin(
+                kind="recovery",
+                source_id=evidence.run_id,
+                metadata={"source": "ticket_flow_visibility_repair"},
+            ),
+            metadata={
+                "repair_provenance": metadata["repair_provenance"],
+                "flow_run_id": evidence.run_id,
+                "ticket_id": evidence.ticket_id,
+                "ticket_path": evidence.ticket_path,
+            },
+        ),
     )
     thread_store.mark_turn_finished(
         str(turn["managed_turn_id"]),

--- a/src/codex_autorunner/core/orchestration/turn_execution_contract.py
+++ b/src/codex_autorunner/core/orchestration/turn_execution_contract.py
@@ -68,6 +68,12 @@ def _optional_text(value: object) -> Optional[str]:
     return _normalize_optional_text(value)
 
 
+def _optional_prompt_text(value: object) -> Optional[str]:
+    if isinstance(value, str):
+        return value if value.strip() else None
+    return _normalize_optional_text(value)
+
+
 def _normalize_choice(
     value: object,
     *,
@@ -300,7 +306,7 @@ class TurnExecutionRequest:
         agent = _required_text(self.agent, "agent")
         approval_policy = _required_text(self.approval_policy, "approval_policy")
         sandbox_policy = _json_safe(self.sandbox_policy, field_name="sandbox_policy")
-        prompt_text = _optional_text(self.prompt_text)
+        prompt_text = _optional_prompt_text(self.prompt_text)
         input_items = _mapping_tuple(self.input_items, field_name="input_items")
         if prompt_text is None and not input_items:
             raise TurnExecutionContractError("prompt_text or input_items is required")

--- a/src/codex_autorunner/core/orchestration/turn_execution_contract.py
+++ b/src/codex_autorunner/core/orchestration/turn_execution_contract.py
@@ -1,0 +1,606 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal, Mapping, Optional
+
+from ..car_context import CarContextProfile, normalize_car_context_profile
+from ..text_utils import _normalize_optional_text
+
+TURN_EXECUTION_CONTRACT_VERSION = 1
+
+TurnExecutionTargetKind = Literal["thread", "flow"]
+TurnExecutionRequestKind = Literal[
+    "message",
+    "review",
+    "automation",
+    "publish",
+    "recovery",
+    "lifecycle",
+]
+TurnExecutionBusyPolicy = Literal["queue", "interrupt", "reject"]
+TurnExecutionOriginKind = Literal[
+    "surface", "automation", "publish", "recovery", "system"
+]
+TurnExecutionStatus = Literal[
+    "queued",
+    "claiming",
+    "running",
+    "completed",
+    "failed",
+    "cancelled",
+    "interrupted",
+    "lost",
+]
+
+_TARGET_KINDS = frozenset({"thread", "flow"})
+_REQUEST_KINDS = frozenset(
+    {"message", "review", "automation", "publish", "recovery", "lifecycle"}
+)
+_BUSY_POLICIES = frozenset({"queue", "interrupt", "reject"})
+_ORIGIN_KINDS = frozenset({"surface", "automation", "publish", "recovery", "system"})
+_RECORD_STATUSES = frozenset(
+    {
+        "queued",
+        "claiming",
+        "running",
+        "completed",
+        "failed",
+        "cancelled",
+        "interrupted",
+        "lost",
+    }
+)
+
+
+class TurnExecutionContractError(ValueError):
+    """Raised when a canonical turn execution contract is invalid."""
+
+
+def _required_text(value: object, field_name: str) -> str:
+    normalized = _normalize_optional_text(value)
+    if normalized is None:
+        raise TurnExecutionContractError(f"{field_name} is required")
+    return normalized
+
+
+def _optional_text(value: object) -> Optional[str]:
+    return _normalize_optional_text(value)
+
+
+def _normalize_choice(
+    value: object,
+    *,
+    field_name: str,
+    allowed: frozenset[str],
+) -> str:
+    normalized = _required_text(value, field_name)
+    if normalized not in allowed:
+        expected = ", ".join(sorted(allowed))
+        raise TurnExecutionContractError(f"{field_name} must be one of: {expected}")
+    return normalized
+
+
+def _json_safe(value: Any, *, field_name: str) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        safe: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TurnExecutionContractError(
+                    f"{field_name} must use string object keys"
+                )
+            safe[key] = _json_safe(item, field_name=field_name)
+        return safe
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item, field_name=field_name) for item in value]
+    raise TurnExecutionContractError(f"{field_name} must be JSON-safe")
+
+
+def _mapping(value: object, *, field_name: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TurnExecutionContractError(f"{field_name} must be an object")
+    return dict(_json_safe(dict(value), field_name=field_name))
+
+
+def _mapping_tuple(value: object, *, field_name: str) -> tuple[dict[str, Any], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, (list, tuple)):
+        raise TurnExecutionContractError(f"{field_name} must be a list")
+    items: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise TurnExecutionContractError(f"{field_name} entries must be objects")
+        items.append(_mapping(item, field_name=field_name))
+    return tuple(items)
+
+
+def _validate_opencode_model(
+    *,
+    agent: str,
+    model: Optional[str],
+    model_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload = _mapping(model_payload, field_name="model_payload")
+    if agent != "opencode":
+        return payload
+    if model is None:
+        raise TurnExecutionContractError(
+            "opencode requests require resolved provider/model before execution"
+        )
+    if "/" not in model:
+        raise TurnExecutionContractError(
+            "opencode model must include provider/model before execution"
+        )
+    provider_from_model, model_from_model = (
+        part.strip() for part in model.split("/", 1)
+    )
+    provider_id = _optional_text(payload.get("providerID"))
+    model_id = _optional_text(payload.get("modelID"))
+    if (
+        not provider_from_model
+        or not model_from_model
+        or provider_id is None
+        or model_id is None
+    ):
+        raise TurnExecutionContractError(
+            "opencode model_payload requires providerID and modelID before execution"
+        )
+    if provider_id != provider_from_model or model_id != model_from_model:
+        raise TurnExecutionContractError(
+            "opencode model_payload must match the resolved provider/model"
+        )
+    return {"providerID": provider_id, "modelID": model_id}
+
+
+@dataclass(frozen=True)
+class TurnExecutionOrigin:
+    kind: TurnExecutionOriginKind
+    source_id: str
+    surface_kind: Optional[str] = None
+    surface_key: Optional[str] = None
+    automation_rule_id: Optional[str] = None
+    publish_operation_id: Optional[str] = None
+    parent_request_id: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        kind = _normalize_choice(
+            self.kind, field_name="origin.kind", allowed=_ORIGIN_KINDS
+        )
+        source_id = _required_text(self.source_id, "origin.source_id")
+        surface_kind = _optional_text(self.surface_kind)
+        surface_key = _optional_text(self.surface_key)
+        automation_rule_id = _optional_text(self.automation_rule_id)
+        publish_operation_id = _optional_text(self.publish_operation_id)
+        parent_request_id = _optional_text(self.parent_request_id)
+        if kind == "surface" and (surface_kind is None or surface_key is None):
+            raise TurnExecutionContractError(
+                "surface origin requires surface_kind and surface_key"
+            )
+        if kind == "automation" and automation_rule_id is None:
+            raise TurnExecutionContractError(
+                "automation origin requires automation_rule_id"
+            )
+        if kind == "publish" and publish_operation_id is None:
+            raise TurnExecutionContractError(
+                "publish origin requires publish_operation_id"
+            )
+        object.__setattr__(self, "kind", kind)
+        object.__setattr__(self, "source_id", source_id)
+        object.__setattr__(self, "surface_kind", surface_kind)
+        object.__setattr__(self, "surface_key", surface_key)
+        object.__setattr__(self, "automation_rule_id", automation_rule_id)
+        object.__setattr__(self, "publish_operation_id", publish_operation_id)
+        object.__setattr__(self, "parent_request_id", parent_request_id)
+        object.__setattr__(
+            self, "metadata", _mapping(self.metadata, field_name="origin.metadata")
+        )
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "TurnExecutionOrigin":
+        return cls(
+            kind=data.get("kind"),  # type: ignore[arg-type]
+            source_id=_required_text(data.get("source_id"), "origin.source_id"),
+            surface_kind=data.get("surface_kind"),
+            surface_key=data.get("surface_key"),
+            automation_rule_id=data.get("automation_rule_id"),
+            publish_operation_id=data.get("publish_operation_id"),
+            parent_request_id=data.get("parent_request_id"),
+            metadata=_mapping(data.get("metadata"), field_name="origin.metadata"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "source_id": self.source_id,
+            "surface_kind": self.surface_kind,
+            "surface_key": self.surface_key,
+            "automation_rule_id": self.automation_rule_id,
+            "publish_operation_id": self.publish_operation_id,
+            "parent_request_id": self.parent_request_id,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class DeliveryIntentRef:
+    kind: str
+    intent_id: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "kind", _required_text(self.kind, "delivery.kind"))
+        object.__setattr__(
+            self, "intent_id", _required_text(self.intent_id, "delivery.intent_id")
+        )
+        object.__setattr__(
+            self, "metadata", _mapping(self.metadata, field_name="delivery.metadata")
+        )
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "DeliveryIntentRef":
+        return cls(
+            kind=_required_text(data.get("kind"), "delivery.kind"),
+            intent_id=_required_text(data.get("intent_id"), "delivery.intent_id"),
+            metadata=_mapping(data.get("metadata"), field_name="delivery.metadata"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "intent_id": self.intent_id,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class TurnExecutionRequest:
+    request_id: str
+    target_id: str
+    target_kind: TurnExecutionTargetKind
+    request_kind: TurnExecutionRequestKind
+    busy_policy: TurnExecutionBusyPolicy
+    agent: str
+    approval_policy: str
+    sandbox_policy: Any
+    origin: TurnExecutionOrigin
+    workspace_root: Optional[str] = None
+    prompt_text: Optional[str] = None
+    input_items: tuple[dict[str, Any], ...] = ()
+    context_profile: Optional[CarContextProfile] = None
+    profile: Optional[str] = None
+    model: Optional[str] = None
+    model_payload: dict[str, Any] = field(default_factory=dict)
+    reasoning: Optional[str] = None
+    approval_mode: Optional[str] = None
+    client_request_id: Optional[str] = None
+    idempotency_key: Optional[str] = None
+    correlation_id: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    delivery_intents: tuple[DeliveryIntentRef, ...] = ()
+    contract_version: int = TURN_EXECUTION_CONTRACT_VERSION
+
+    def __post_init__(self) -> None:
+        request_id = _required_text(self.request_id, "request_id")
+        target_id = _required_text(self.target_id, "target_id")
+        target_kind = _normalize_choice(
+            self.target_kind, field_name="target_kind", allowed=_TARGET_KINDS
+        )
+        request_kind = _normalize_choice(
+            self.request_kind, field_name="request_kind", allowed=_REQUEST_KINDS
+        )
+        busy_policy = _normalize_choice(
+            self.busy_policy, field_name="busy_policy", allowed=_BUSY_POLICIES
+        )
+        agent = _required_text(self.agent, "agent")
+        approval_policy = _required_text(self.approval_policy, "approval_policy")
+        sandbox_policy = _json_safe(self.sandbox_policy, field_name="sandbox_policy")
+        prompt_text = _optional_text(self.prompt_text)
+        input_items = _mapping_tuple(self.input_items, field_name="input_items")
+        if prompt_text is None and not input_items:
+            raise TurnExecutionContractError("prompt_text or input_items is required")
+        origin = self.origin
+        if isinstance(origin, Mapping):
+            origin = TurnExecutionOrigin.from_mapping(origin)
+        if not isinstance(origin, TurnExecutionOrigin):
+            raise TurnExecutionContractError("origin must be a TurnExecutionOrigin")
+        if target_kind == "flow" and origin.kind in {"surface", "publish"}:
+            raise TurnExecutionContractError(
+                f"{origin.kind} origin cannot target a flow execution"
+            )
+        model = _optional_text(self.model)
+        model_payload = _validate_opencode_model(
+            agent=agent,
+            model=model,
+            model_payload=self.model_payload,
+        )
+        delivery_intents = tuple(
+            (
+                item
+                if isinstance(item, DeliveryIntentRef)
+                else DeliveryIntentRef.from_mapping(item)
+            )
+            for item in self.delivery_intents
+        )
+        object.__setattr__(self, "contract_version", TURN_EXECUTION_CONTRACT_VERSION)
+        object.__setattr__(self, "request_id", request_id)
+        object.__setattr__(self, "target_id", target_id)
+        object.__setattr__(self, "target_kind", target_kind)
+        object.__setattr__(self, "request_kind", request_kind)
+        object.__setattr__(self, "busy_policy", busy_policy)
+        object.__setattr__(self, "agent", agent)
+        object.__setattr__(self, "approval_policy", approval_policy)
+        object.__setattr__(self, "sandbox_policy", sandbox_policy)
+        object.__setattr__(self, "origin", origin)
+        object.__setattr__(self, "workspace_root", _optional_text(self.workspace_root))
+        object.__setattr__(self, "prompt_text", prompt_text)
+        object.__setattr__(self, "input_items", input_items)
+        object.__setattr__(
+            self,
+            "context_profile",
+            normalize_car_context_profile(self.context_profile),
+        )
+        object.__setattr__(self, "profile", _optional_text(self.profile))
+        object.__setattr__(self, "model", model)
+        object.__setattr__(self, "model_payload", model_payload)
+        object.__setattr__(self, "reasoning", _optional_text(self.reasoning))
+        object.__setattr__(self, "approval_mode", _optional_text(self.approval_mode))
+        object.__setattr__(
+            self, "client_request_id", _optional_text(self.client_request_id)
+        )
+        object.__setattr__(
+            self, "idempotency_key", _optional_text(self.idempotency_key)
+        )
+        object.__setattr__(self, "correlation_id", _optional_text(self.correlation_id))
+        object.__setattr__(
+            self, "metadata", _mapping(self.metadata, field_name="metadata")
+        )
+        object.__setattr__(self, "delivery_intents", delivery_intents)
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "TurnExecutionRequest":
+        version = data.get("contract_version")
+        if version != TURN_EXECUTION_CONTRACT_VERSION:
+            raise TurnExecutionContractError(
+                f"unsupported turn execution contract version: {version!r}"
+            )
+        origin = data.get("origin")
+        if not isinstance(origin, Mapping):
+            raise TurnExecutionContractError("origin is required")
+        return cls(
+            request_id=_required_text(data.get("request_id"), "request_id"),
+            target_id=_required_text(data.get("target_id"), "target_id"),
+            target_kind=data.get("target_kind"),  # type: ignore[arg-type]
+            request_kind=data.get("request_kind"),  # type: ignore[arg-type]
+            busy_policy=data.get("busy_policy"),  # type: ignore[arg-type]
+            agent=_required_text(data.get("agent"), "agent"),
+            approval_policy=_required_text(
+                data.get("approval_policy"), "approval_policy"
+            ),
+            sandbox_policy=data.get("sandbox_policy"),
+            origin=TurnExecutionOrigin.from_mapping(origin),
+            workspace_root=data.get("workspace_root"),
+            prompt_text=data.get("prompt_text"),
+            input_items=_mapping_tuple(
+                data.get("input_items"), field_name="input_items"
+            ),
+            context_profile=normalize_car_context_profile(data.get("context_profile")),
+            profile=data.get("profile"),
+            model=data.get("model"),
+            model_payload=_mapping(
+                data.get("model_payload"), field_name="model_payload"
+            ),
+            reasoning=data.get("reasoning"),
+            approval_mode=data.get("approval_mode"),
+            client_request_id=data.get("client_request_id"),
+            idempotency_key=data.get("idempotency_key"),
+            correlation_id=data.get("correlation_id"),
+            metadata=_mapping(data.get("metadata"), field_name="metadata"),
+            delivery_intents=tuple(
+                DeliveryIntentRef.from_mapping(item)
+                for item in _mapping_tuple(
+                    data.get("delivery_intents"), field_name="delivery_intents"
+                )
+            ),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "request_id": self.request_id,
+            "target_id": self.target_id,
+            "target_kind": self.target_kind,
+            "workspace_root": self.workspace_root,
+            "request_kind": self.request_kind,
+            "busy_policy": self.busy_policy,
+            "prompt_text": self.prompt_text,
+            "input_items": [dict(item) for item in self.input_items],
+            "context_profile": self.context_profile,
+            "agent": self.agent,
+            "profile": self.profile,
+            "model": self.model,
+            "model_payload": dict(self.model_payload),
+            "reasoning": self.reasoning,
+            "approval_policy": self.approval_policy,
+            "approval_mode": self.approval_mode,
+            "sandbox_policy": self.sandbox_policy,
+            "client_request_id": self.client_request_id,
+            "idempotency_key": self.idempotency_key,
+            "correlation_id": self.correlation_id,
+            "origin": self.origin.to_dict(),
+            "metadata": dict(self.metadata),
+            "delivery_intents": [item.to_dict() for item in self.delivery_intents],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(
+            self.to_dict(), ensure_ascii=True, separators=(",", ":"), sort_keys=True
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> "TurnExecutionRequest":
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise TurnExecutionContractError("invalid request JSON") from exc
+        if not isinstance(data, Mapping):
+            raise TurnExecutionContractError("request JSON must encode an object")
+        return cls.from_mapping(data)
+
+
+@dataclass(frozen=True)
+class TurnExecutionRecord:
+    request: TurnExecutionRequest
+    execution_id: str
+    status: TurnExecutionStatus
+    queued_at: Optional[str] = None
+    claimed_at: Optional[str] = None
+    started_at: Optional[str] = None
+    terminal_at: Optional[str] = None
+    backend_conversation_id: Optional[str] = None
+    backend_turn_id: Optional[str] = None
+    assistant_text: Optional[str] = None
+    error_text: Optional[str] = None
+    transcript_ref: Optional[str] = None
+    timeline_ref: Optional[str] = None
+    cold_trace_ref: Optional[str] = None
+    conflict_evidence: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    contract_version: int = TURN_EXECUTION_CONTRACT_VERSION
+
+    def __post_init__(self) -> None:
+        request = self.request
+        if isinstance(request, Mapping):
+            request = TurnExecutionRequest.from_mapping(request)
+        if not isinstance(request, TurnExecutionRequest):
+            raise TurnExecutionContractError(
+                "record.request must be a TurnExecutionRequest"
+            )
+        object.__setattr__(self, "contract_version", TURN_EXECUTION_CONTRACT_VERSION)
+        object.__setattr__(self, "request", request)
+        object.__setattr__(
+            self, "execution_id", _required_text(self.execution_id, "execution_id")
+        )
+        object.__setattr__(
+            self,
+            "status",
+            _normalize_choice(
+                self.status, field_name="status", allowed=_RECORD_STATUSES
+            ),
+        )
+        for field_name in (
+            "queued_at",
+            "claimed_at",
+            "started_at",
+            "terminal_at",
+            "backend_conversation_id",
+            "backend_turn_id",
+            "assistant_text",
+            "error_text",
+            "transcript_ref",
+            "timeline_ref",
+            "cold_trace_ref",
+        ):
+            object.__setattr__(
+                self, field_name, _optional_text(getattr(self, field_name))
+            )
+        object.__setattr__(
+            self,
+            "conflict_evidence",
+            _mapping(self.conflict_evidence, field_name="conflict_evidence"),
+        )
+        object.__setattr__(
+            self, "metadata", _mapping(self.metadata, field_name="metadata")
+        )
+
+    @property
+    def request_id(self) -> str:
+        return self.request.request_id
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "TurnExecutionRecord":
+        version = data.get("contract_version")
+        if version != TURN_EXECUTION_CONTRACT_VERSION:
+            raise TurnExecutionContractError(
+                f"unsupported turn execution contract version: {version!r}"
+            )
+        request = data.get("request")
+        if not isinstance(request, Mapping):
+            raise TurnExecutionContractError("record.request is required")
+        return cls(
+            request=TurnExecutionRequest.from_mapping(request),
+            execution_id=_required_text(data.get("execution_id"), "execution_id"),
+            status=data.get("status"),  # type: ignore[arg-type]
+            queued_at=data.get("queued_at"),
+            claimed_at=data.get("claimed_at"),
+            started_at=data.get("started_at"),
+            terminal_at=data.get("terminal_at"),
+            backend_conversation_id=data.get("backend_conversation_id"),
+            backend_turn_id=data.get("backend_turn_id"),
+            assistant_text=data.get("assistant_text"),
+            error_text=data.get("error_text"),
+            transcript_ref=data.get("transcript_ref"),
+            timeline_ref=data.get("timeline_ref"),
+            cold_trace_ref=data.get("cold_trace_ref"),
+            conflict_evidence=_mapping(
+                data.get("conflict_evidence"), field_name="conflict_evidence"
+            ),
+            metadata=_mapping(data.get("metadata"), field_name="metadata"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "request_id": self.request_id,
+            "execution_id": self.execution_id,
+            "status": self.status,
+            "queued_at": self.queued_at,
+            "claimed_at": self.claimed_at,
+            "started_at": self.started_at,
+            "terminal_at": self.terminal_at,
+            "backend_conversation_id": self.backend_conversation_id,
+            "backend_turn_id": self.backend_turn_id,
+            "assistant_text": self.assistant_text,
+            "error_text": self.error_text,
+            "transcript_ref": self.transcript_ref,
+            "timeline_ref": self.timeline_ref,
+            "cold_trace_ref": self.cold_trace_ref,
+            "conflict_evidence": dict(self.conflict_evidence),
+            "metadata": dict(self.metadata),
+            "request": self.request.to_dict(),
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(
+            self.to_dict(), ensure_ascii=True, separators=(",", ":"), sort_keys=True
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> "TurnExecutionRecord":
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise TurnExecutionContractError("invalid record JSON") from exc
+        if not isinstance(data, Mapping):
+            raise TurnExecutionContractError("record JSON must encode an object")
+        return cls.from_mapping(data)
+
+
+__all__ = [
+    "TURN_EXECUTION_CONTRACT_VERSION",
+    "DeliveryIntentRef",
+    "TurnExecutionBusyPolicy",
+    "TurnExecutionContractError",
+    "TurnExecutionOrigin",
+    "TurnExecutionOriginKind",
+    "TurnExecutionRecord",
+    "TurnExecutionRequest",
+    "TurnExecutionRequestKind",
+    "TurnExecutionStatus",
+    "TurnExecutionTargetKind",
+]

--- a/src/codex_autorunner/core/orchestration/turn_execution_storage.py
+++ b/src/codex_autorunner/core/orchestration/turn_execution_storage.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional, cast
+
+from ..agent_model_defaults import builtin_default_model_for_agent
+from ..text_utils import _json_loads_object, _normalize_optional_text
+from .turn_execution_contract import (
+    TURN_EXECUTION_CONTRACT_VERSION,
+    TurnExecutionBusyPolicy,
+    TurnExecutionOrigin,
+    TurnExecutionRecord,
+    TurnExecutionRequest,
+    TurnExecutionRequestKind,
+    TurnExecutionStatus,
+)
+
+TURN_EXECUTION_REQUEST_COLUMN = "turn_request_json"
+TURN_EXECUTION_RECORD_COLUMN = "turn_record_json"
+TURN_EXECUTION_CONTRACT_VERSION_COLUMN = "turn_contract_version"
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _metadata(row: Mapping[str, Any]) -> dict[str, Any]:
+    metadata = row.get("metadata")
+    if isinstance(metadata, Mapping):
+        return dict(metadata)
+    return _json_loads_object(row.get("metadata_json"))
+
+
+def _request_data(queue_payload: Mapping[str, Any]) -> dict[str, Any]:
+    request = queue_payload.get("request")
+    return dict(request) if isinstance(request, Mapping) else {}
+
+
+def _input_items(value: Any) -> tuple[dict[str, Any], ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(dict(item) for item in value if isinstance(item, Mapping))
+
+
+def _request_kind(value: Any) -> TurnExecutionRequestKind:
+    normalized = _normalize_optional_text(value)
+    if normalized in {
+        "message",
+        "review",
+        "automation",
+        "publish",
+        "recovery",
+        "lifecycle",
+    }:
+        return cast(TurnExecutionRequestKind, normalized)
+    return "message"
+
+
+def _busy_policy(value: Any, *, status: Any) -> TurnExecutionBusyPolicy:
+    normalized = _normalize_optional_text(value)
+    if normalized in {"queue", "interrupt", "reject"}:
+        return cast(TurnExecutionBusyPolicy, normalized)
+    return "queue" if _normalize_optional_text(status) == "queued" else "reject"
+
+
+def _record_status(value: Any) -> TurnExecutionStatus:
+    normalized = _normalize_optional_text(value)
+    if normalized in {"queued", "claiming", "running", "failed", "interrupted"}:
+        return cast(TurnExecutionStatus, normalized)
+    if normalized in {"ok", "completed", "complete", "success", "succeeded"}:
+        return "completed"
+    if normalized in {"cancelled", "canceled"}:
+        return "cancelled"
+    if normalized == "lost":
+        return "lost"
+    return "failed"
+
+
+def _model_and_payload(
+    *,
+    agent: str,
+    model: Any,
+    metadata_payload: Any,
+) -> tuple[Optional[str], dict[str, Any]]:
+    resolved_model = _normalize_optional_text(model)
+    payload = _mapping(metadata_payload)
+    if agent != "opencode":
+        return resolved_model, payload
+    if resolved_model is None:
+        resolved_model = builtin_default_model_for_agent(agent)
+    if payload or resolved_model is None or "/" not in resolved_model:
+        return resolved_model, payload
+    provider_id, model_id = (part.strip() for part in resolved_model.split("/", 1))
+    if provider_id and model_id:
+        return resolved_model, {"providerID": provider_id, "modelID": model_id}
+    return resolved_model, payload
+
+
+def _origin_from_thread(thread: Mapping[str, Any]) -> TurnExecutionOrigin:
+    surface_urn = _normalize_optional_text(thread.get("surface_urn"))
+    if surface_urn and ":" in surface_urn:
+        surface_kind, surface_key = surface_urn.split(":", 1)
+        if surface_kind and surface_key:
+            return TurnExecutionOrigin(
+                kind="surface",
+                source_id=surface_urn,
+                surface_kind=surface_kind,
+                surface_key=surface_key,
+            )
+    return TurnExecutionOrigin(
+        kind="system",
+        source_id="orchestration-storage",
+        metadata={"source": "managed_thread_store"},
+    )
+
+
+def build_turn_execution_request_from_storage(
+    *,
+    execution: Mapping[str, Any],
+    thread: Mapping[str, Any],
+    queue_payload: Optional[Mapping[str, Any]] = None,
+) -> TurnExecutionRequest:
+    payload = _mapping(queue_payload)
+    request_data = _request_data(payload)
+    execution_metadata = _metadata(execution)
+    thread_metadata = _metadata(thread)
+    sandbox_policy = (
+        payload.get("sandbox_policy")
+        if "sandbox_policy" in payload
+        else execution_metadata.get(
+            "sandbox_policy", thread_metadata.get("sandbox_policy")
+        )
+    )
+    if sandbox_policy is None:
+        sandbox_policy = "dangerFullAccess"
+    approval_mode = (
+        request_data.get("approval_mode")
+        or execution_metadata.get("approval_mode")
+        or thread_metadata.get("approval_mode")
+    )
+    approval_policy = (
+        execution_metadata.get("approval_policy")
+        or thread_metadata.get("approval_policy")
+        or approval_mode
+        or "never"
+    )
+    agent = str(thread.get("agent_id") or thread.get("agent") or "unknown")
+    model, model_payload = _model_and_payload(
+        agent=agent,
+        model=(
+            execution.get("model_id")
+            or request_data.get("model")
+            or execution_metadata.get("model")
+            or thread_metadata.get("model")
+        ),
+        metadata_payload=execution_metadata.get("model_payload"),
+    )
+    return TurnExecutionRequest(
+        request_id=str(
+            execution.get("execution_id")
+            or execution.get("managed_turn_id")
+            or request_data.get("request_id")
+        ),
+        target_id=str(
+            execution.get("thread_target_id")
+            or execution.get("managed_thread_id")
+            or request_data.get("target_id")
+            or thread.get("thread_target_id")
+            or thread.get("managed_thread_id")
+        ),
+        target_kind="thread",
+        workspace_root=(
+            _normalize_optional_text(request_data.get("workspace_root"))
+            or _normalize_optional_text(thread.get("workspace_root"))
+        ),
+        request_kind=_request_kind(
+            execution.get("request_kind") or request_data.get("kind")
+        ),
+        busy_policy=_busy_policy(
+            request_data.get("busy_policy"), status=execution.get("status")
+        ),
+        prompt_text=(
+            _normalize_optional_text(execution.get("prompt_text"))
+            or _normalize_optional_text(request_data.get("message_text"))
+            or "[legacy request prompt unavailable]"
+        ),
+        input_items=_input_items(request_data.get("input_items")),
+        context_profile=(
+            request_data.get("context_profile")
+            or execution_metadata.get("context_profile")
+            or thread_metadata.get("context_profile")
+        ),
+        agent=agent,
+        profile=(
+            request_data.get("agent_profile")
+            or thread_metadata.get("agent_profile")
+            or execution_metadata.get("agent_profile")
+        ),
+        model=model,
+        model_payload=model_payload,
+        reasoning=execution.get("reasoning_level") or request_data.get("reasoning"),
+        approval_policy=str(approval_policy),
+        approval_mode=approval_mode,
+        sandbox_policy=sandbox_policy,
+        client_request_id=execution.get("client_request_id")
+        or payload.get("client_request_id"),
+        idempotency_key=execution.get("client_request_id")
+        or execution.get("execution_id"),
+        correlation_id=execution_metadata.get("correlation_id"),
+        origin=_origin_from_thread(thread),
+        metadata=execution_metadata,
+    )
+
+
+def build_turn_execution_record_from_storage(
+    *,
+    execution: Mapping[str, Any],
+    thread: Mapping[str, Any],
+    request: TurnExecutionRequest,
+    queue_item: Optional[Mapping[str, Any]] = None,
+) -> TurnExecutionRecord:
+    queue = _mapping(queue_item)
+    status = _record_status(execution.get("status"))
+    return TurnExecutionRecord(
+        request=request,
+        execution_id=str(
+            execution.get("execution_id") or execution.get("managed_turn_id")
+        ),
+        status=status,
+        queued_at=(
+            _normalize_optional_text(queue.get("created_at"))
+            or _normalize_optional_text(execution.get("created_at"))
+        ),
+        claimed_at=_normalize_optional_text(queue.get("claimed_at")),
+        started_at=_normalize_optional_text(execution.get("started_at")),
+        terminal_at=(
+            _normalize_optional_text(execution.get("finished_at"))
+            if status in {"completed", "failed", "cancelled", "interrupted", "lost"}
+            else None
+        ),
+        backend_conversation_id=_normalize_optional_text(
+            thread.get("backend_thread_id")
+        ),
+        backend_turn_id=_normalize_optional_text(execution.get("backend_turn_id")),
+        assistant_text=_normalize_optional_text(execution.get("assistant_text")),
+        error_text=_normalize_optional_text(execution.get("error_text")),
+        transcript_ref=_normalize_optional_text(execution.get("transcript_mirror_id")),
+        metadata=_metadata(execution),
+    )
+
+
+__all__ = [
+    "TURN_EXECUTION_CONTRACT_VERSION",
+    "TURN_EXECUTION_CONTRACT_VERSION_COLUMN",
+    "TURN_EXECUTION_RECORD_COLUMN",
+    "TURN_EXECUTION_REQUEST_COLUMN",
+    "build_turn_execution_record_from_storage",
+    "build_turn_execution_request_from_storage",
+]

--- a/src/codex_autorunner/core/orchestration/turn_execution_storage.py
+++ b/src/codex_autorunner/core/orchestration/turn_execution_storage.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional, cast
 
-from ..agent_model_defaults import builtin_default_model_for_agent
 from ..text_utils import _json_loads_object, _normalize_optional_text
 from .turn_execution_contract import (
     TURN_EXECUTION_CONTRACT_VERSION,
@@ -83,11 +82,9 @@ def _model_and_payload(
 ) -> tuple[Optional[str], dict[str, Any]]:
     resolved_model = _normalize_optional_text(model)
     payload = _mapping(metadata_payload)
-    if agent != "opencode":
+    if agent != "opencode" or payload or resolved_model is None:
         return resolved_model, payload
-    if resolved_model is None:
-        resolved_model = builtin_default_model_for_agent(agent)
-    if payload or resolved_model is None or "/" not in resolved_model:
+    if "/" not in resolved_model:
         return resolved_model, payload
     provider_id, model_id = (part.strip() for part in resolved_model.split("/", 1))
     if provider_id and model_id:

--- a/src/codex_autorunner/core/pma/tail_serialization.py
+++ b/src/codex_autorunner/core/pma/tail_serialization.py
@@ -72,6 +72,48 @@ def _redact_nested(value: Any) -> Any:
     return value
 
 
+def _canonical_turn_request_metadata(turn_record: Any) -> dict[str, Any] | None:
+    record = coerce_dict(turn_record)
+    request = coerce_dict(record.get("turn_request"))
+    if not request:
+        request = coerce_dict(record.get("canonical_request"))
+    if not request:
+        request = coerce_dict(record.get("request"))
+    if not request:
+        return None
+    origin = coerce_dict(request.get("origin"))
+    return {
+        "request_id": normalize_optional_text(request.get("request_id")),
+        "request_kind": normalize_optional_text(request.get("request_kind")),
+        "busy_policy": normalize_optional_text(request.get("busy_policy")),
+        "target_id": normalize_optional_text(request.get("target_id")),
+        "target_kind": normalize_optional_text(request.get("target_kind")),
+        "workspace_root": normalize_optional_text(request.get("workspace_root")),
+        "origin": {
+            "kind": normalize_optional_text(origin.get("kind")),
+            "source_id": normalize_optional_text(origin.get("source_id")),
+            "surface_kind": normalize_optional_text(origin.get("surface_kind")),
+            "surface_key": normalize_optional_text(origin.get("surface_key")),
+            "automation_rule_id": normalize_optional_text(
+                origin.get("automation_rule_id")
+            ),
+            "publish_operation_id": normalize_optional_text(
+                origin.get("publish_operation_id")
+            ),
+        },
+        "runtime_options": {
+            "agent": normalize_optional_text(request.get("agent")),
+            "profile": normalize_optional_text(request.get("profile")),
+            "model": normalize_optional_text(request.get("model")),
+            "model_payload": coerce_dict(request.get("model_payload")),
+            "reasoning": normalize_optional_text(request.get("reasoning")),
+            "approval_policy": normalize_optional_text(request.get("approval_policy")),
+            "approval_mode": normalize_optional_text(request.get("approval_mode")),
+            "sandbox_policy": request.get("sandbox_policy"),
+        },
+    }
+
+
 _NO_STREAM_AVAILABLE_IDLE_SECONDS = 15
 _LIKELY_HUNG_IDLE_SECONDS = 90
 _STALL_IDLE_SECONDS = 30
@@ -1083,6 +1125,7 @@ def build_managed_thread_status_response(
         "turn": {
             "managed_turn_id": snapshot.get("managed_turn_id"),
             "status": snapshot.get("turn_status"),
+            "canonical_request": snapshot.get("canonical_request"),
             "activity": snapshot.get("activity"),
             "live_activity": live_activity,
             "phase": snapshot.get("phase"),
@@ -1103,6 +1146,7 @@ def build_managed_thread_status_response(
             {
                 "managed_turn_id": item.get("managed_turn_id"),
                 "request_kind": item.get("request_kind"),
+                "canonical_request": _canonical_turn_request_metadata(item),
                 "state": item.get("state"),
                 "enqueued_at": item.get("enqueued_at"),
                 "prompt_preview": truncate_text(item.get("prompt") or "", 120),
@@ -1135,6 +1179,7 @@ __all__ = [
     "parse_iso_datetime",
     "truncate_text",
     "_derive_active_turn_diagnostics",
+    "_canonical_turn_request_metadata",
     "_derive_last_tool",
     "_derive_progress_phase",
     "_event_received_at_iso",

--- a/src/codex_autorunner/core/publish_operation_executors.py
+++ b/src/codex_autorunner/core/publish_operation_executors.py
@@ -5,6 +5,7 @@ import hashlib
 import logging
 import threading
 from collections.abc import Mapping
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Coroutine, Optional, cast
@@ -12,7 +13,11 @@ from typing import Any, Callable, Coroutine, Optional, cast
 from ..manifest import ManifestError, load_manifest
 from .config import load_hub_config
 from .managed_thread_store import ManagedThreadNotActiveError, ManagedThreadStore
-from .orchestration.models import MessageRequest, MessageRequestKind
+from .orchestration.models import MessageRequestKind
+from .orchestration.turn_execution_contract import (
+    TurnExecutionOrigin,
+    TurnExecutionRequest,
+)
 from .pma_chat_delivery import (
     deliver_pma_notification,
     notify_preferred_bound_chat_for_workspace,
@@ -73,6 +78,15 @@ def _normalize_request_kind(value: Any) -> MessageRequestKind:
     return "review" if _normalize_optional_text(value) == "review" else "message"
 
 
+def _opencode_model_payload(model: Optional[str]) -> dict[str, str]:
+    if model is None or "/" not in model:
+        return {}
+    provider_id, model_id = (part.strip() for part in model.split("/", 1))
+    if not provider_id or not model_id:
+        return {}
+    return {"providerID": provider_id, "modelID": model_id}
+
+
 def _operation_digest(operation: PublishOperation, *, prefix: str) -> str:
     digest = hashlib.sha256(
         f"{operation.operation_kind}:{operation.operation_key}".encode("utf-8")
@@ -106,7 +120,15 @@ def _run_coroutine_sync(coro: Coroutine[Any, Any, Any]) -> Any:
 def _managed_turn_request(
     thread_target_id: str,
     payload: dict[str, Any],
-) -> tuple[MessageRequest, Optional[Any]]:
+    *,
+    operation: PublishOperation,
+    thread: Optional[Mapping[str, Any]],
+    client_request_id: str,
+) -> TurnExecutionRequest:
+    canonical = payload.get("turn_request")
+    if isinstance(canonical, Mapping):
+        return TurnExecutionRequest.from_mapping(canonical)
+
     request_payload = _normalize_mapping(payload.get("request"))
     source = request_payload or payload
     message_text = _normalize_optional_text(
@@ -130,20 +152,55 @@ def _managed_turn_request(
         if items:
             input_items = items
 
-    request = MessageRequest(
+    agent = (
+        _normalize_optional_text(source.get("agent"))
+        or _normalize_optional_text((thread or {}).get("agent_id"))
+        or _normalize_optional_text((thread or {}).get("agent"))
+        or "codex"
+    )
+    model = _normalize_optional_text(source.get("model"))
+    request = TurnExecutionRequest(
+        request_id=client_request_id,
         target_id=_normalize_optional_text(source.get("target_id")) or thread_target_id,
         target_kind="thread",
-        message_text=message_text,
-        kind=_normalize_request_kind(source.get("kind") or source.get("request_kind")),
+        workspace_root=_normalize_optional_text((thread or {}).get("workspace_root")),
+        request_kind=_normalize_request_kind(
+            source.get("kind") or source.get("request_kind")
+        ),
         busy_policy="queue",
-        model=_normalize_optional_text(source.get("model")),
+        prompt_text=message_text,
+        agent=agent,
+        profile=_normalize_optional_text(
+            source.get("agent_profile") or source.get("profile")
+        ),
+        model=model,
+        model_payload=_opencode_model_payload(model) if agent == "opencode" else {},
         reasoning=_normalize_optional_text(source.get("reasoning")),
+        approval_policy=(
+            _normalize_optional_text(source.get("approval_policy"))
+            or _normalize_optional_text(source.get("approval_mode"))
+            or "never"
+        ),
         approval_mode=_normalize_optional_text(source.get("approval_mode")),
-        input_items=input_items,
+        sandbox_policy=payload.get("sandbox_policy") or "dangerFullAccess",
+        client_request_id=client_request_id,
+        idempotency_key=_normalize_optional_text(operation.operation_key)
+        or client_request_id,
+        correlation_id=correlation_id,
+        origin=TurnExecutionOrigin(
+            kind="publish",
+            source_id=operation.operation_id,
+            publish_operation_id=operation.operation_id,
+            metadata={
+                "operation_kind": operation.operation_kind,
+                "operation_key": operation.operation_key,
+            },
+        ),
+        input_items=tuple(input_items or ()),
         context_profile=source.get("context_profile"),
         metadata=metadata,
     )
-    return request, payload.get("sandbox_policy")
+    return request
 
 
 def _managed_turn_result(
@@ -153,6 +210,7 @@ def _managed_turn_result(
     turn: dict[str, Any],
     existed: bool,
     correlation_id: Optional[str] = None,
+    turn_request: Optional[TurnExecutionRequest] = None,
 ) -> dict[str, Any]:
     status = _normalize_optional_text(turn.get("status")) or "unknown"
     result = {
@@ -167,6 +225,8 @@ def _managed_turn_result(
     }
     if correlation_id is not None:
         result["correlation_id"] = correlation_id
+    if turn_request is not None:
+        result["turn_request"] = turn_request.to_dict()
     return result
 
 
@@ -557,10 +617,33 @@ def _merge_into_existing_queued_scm_turn(
         merged_bundle,
     )
     updated_request = updated_payload.get("request")
-    if not isinstance(updated_request, Mapping):
-        return None
-    updated_prompt = _normalize_optional_text(updated_request.get("message_text"))
-    if updated_prompt is None:
+    canonical_request = updated_payload.get("turn_request")
+    if isinstance(canonical_request, Mapping):
+        existing_turn_request = TurnExecutionRequest.from_mapping(canonical_request)
+        request_metadata = _normalize_mapping(
+            updated_request.get("metadata")
+            if isinstance(updated_request, Mapping)
+            else None
+        )
+        updated_prompt = _normalize_optional_text(
+            updated_request.get("message_text")
+            if isinstance(updated_request, Mapping)
+            else None
+        )
+        if updated_prompt is None:
+            return None
+        updated_payload = {
+            "turn_request": replace(
+                existing_turn_request,
+                prompt_text=updated_prompt,
+                metadata=request_metadata,
+            ).to_dict()
+        }
+    elif isinstance(updated_request, Mapping):
+        updated_prompt = _normalize_optional_text(updated_request.get("message_text"))
+        if updated_prompt is None:
+            return None
+    else:
         return None
     updated_turn = store.update_queued_turn_request(
         thread_target_id,
@@ -787,37 +870,29 @@ def _build_scm_rebootstrap_message(
 
 
 def _build_scm_rebootstrap_request(
-    request: MessageRequest,
+    request: TurnExecutionRequest,
     *,
     replacement_thread_target_id: str,
     previous_thread_target_id: str,
     binding: PrBinding,
     event: Optional[ScmEvent],
     tracking: Mapping[str, Any],
-) -> MessageRequest:
+) -> TurnExecutionRequest:
     metadata = dict(request.metadata)
     scm_metadata = _normalize_mapping(metadata.get("scm"))
     scm_metadata["binding_id"] = binding.binding_id
     scm_metadata["previous_thread_target_id"] = previous_thread_target_id
     scm_metadata["thread_target_id"] = replacement_thread_target_id
     metadata["scm"] = scm_metadata
-    return MessageRequest(
+    return replace(
+        request,
         target_id=replacement_thread_target_id,
-        target_kind=request.target_kind,
-        message_text=_build_scm_rebootstrap_message(
+        prompt_text=_build_scm_rebootstrap_message(
             binding=binding,
             event=event,
             tracking=tracking,
             previous_thread_target_id=previous_thread_target_id,
         ),
-        kind=request.kind,
-        busy_policy=request.busy_policy,
-        agent_profile=request.agent_profile,
-        model=request.model,
-        reasoning=request.reasoning,
-        approval_mode=request.approval_mode,
-        input_items=request.input_items,
-        context_profile=request.context_profile,
         metadata=metadata,
     )
 
@@ -827,10 +902,10 @@ def _repair_scm_thread_binding(
     store: ManagedThreadStore,
     *,
     current_thread_target_id: str,
-    request: MessageRequest,
+    request: TurnExecutionRequest,
     tracking: Mapping[str, Any],
     source_status: Optional[str] = None,
-) -> tuple[str, MessageRequest]:
+) -> tuple[str, TurnExecutionRequest]:
     binding = _resolve_scm_binding(hub_root, tracking=tracking)
     if binding is None:
         raise ManagedThreadNotActiveError(current_thread_target_id, source_status)
@@ -970,11 +1045,16 @@ def build_enqueue_managed_turn_executor(
             _coerce_int(tracking.get("pr_number")),
         )
 
-        request, sandbox_policy = _managed_turn_request(thread_target_id, payload)
+        request = _managed_turn_request(
+            thread_target_id,
+            payload,
+            operation=operation,
+            thread=_active_thread or store.get_thread(thread_target_id),
+            client_request_id=client_request_id,
+        )
         queue_payload = {
-            "request": request.to_dict(),
+            "turn_request": request.to_dict(),
             "client_request_id": client_request_id,
-            "sandbox_policy": sandbox_policy,
         }
         rebound_from_thread_target_id: Optional[str] = None
         try:
@@ -1007,17 +1087,18 @@ def build_enqueue_managed_turn_executor(
                         turn=merged_turn,
                         existed=True,
                         correlation_id=correlation_id,
+                        turn_request=request,
                     )
             created = store.create_turn(
                 thread_target_id,
-                prompt=request.message_text,
-                request_kind=request.kind,
+                prompt=request.prompt_text or "",
+                request_kind=request.request_kind,
                 busy_policy="queue",
                 model=request.model,
                 reasoning=request.reasoning,
                 client_turn_id=client_request_id,
                 metadata=request.metadata,
-                queue_payload=queue_payload,
+                turn_request=request,
                 force_queue=bool(tracking),
             )
             _log_scm_enqueue_managed_turn_queued(
@@ -1065,24 +1146,20 @@ def build_enqueue_managed_turn_executor(
                     turn=existing,
                     existed=True,
                     correlation_id=correlation_id,
+                    turn_request=request,
                 )
                 result["rebound_from_thread_target_id"] = rebound_from_thread_target_id
                 return result
-            queue_payload = {
-                "request": request.to_dict(),
-                "client_request_id": client_request_id,
-                "sandbox_policy": sandbox_policy,
-            }
             created = store.create_turn(
                 thread_target_id,
-                prompt=request.message_text,
-                request_kind=request.kind,
+                prompt=request.prompt_text or "",
+                request_kind=request.request_kind,
                 busy_policy="queue",
                 model=request.model,
                 reasoning=request.reasoning,
                 client_turn_id=client_request_id,
                 metadata=request.metadata,
-                queue_payload=queue_payload,
+                turn_request=request,
                 force_queue=bool(tracking),
             )
             _log_scm_enqueue_managed_turn_queued(
@@ -1106,6 +1183,7 @@ def build_enqueue_managed_turn_executor(
             turn=created,
             existed=False,
             correlation_id=correlation_id,
+            turn_request=request,
         )
         if rebound_from_thread_target_id is not None:
             result["rebound_from_thread_target_id"] = rebound_from_thread_target_id

--- a/src/codex_autorunner/core/scm_feedback_bundle.py
+++ b/src/codex_autorunner/core/scm_feedback_bundle.py
@@ -129,6 +129,8 @@ def extract_feedback_bundle(
         return None
     request = payload.get("request")
     if not isinstance(request, Mapping):
+        request = payload.get("turn_request")
+    if not isinstance(request, Mapping):
         return None
     metadata = request.get("metadata")
     if not isinstance(metadata, Mapping):

--- a/src/codex_autorunner/surfaces/cli/commands/doctor.py
+++ b/src/codex_autorunner/surfaces/cli/commands/doctor.py
@@ -738,6 +738,24 @@ def register_doctor_commands(
                     f"  {entry['execution_id']}: {entry['cold_trace_bytes']} bytes"
                 )
 
+        if report.canonical_turns:
+            typer.echo(f"canonical turns: {len(report.canonical_turns)}")
+            for canonical_entry in report.canonical_turns[:top_n]:
+                typer.echo(
+                    "  {execution_id}: request={request_id} phase={phase} "
+                    "terminal={terminal} action={action} origin={origin} "
+                    "target={target} model={model}".format(
+                        execution_id=canonical_entry.execution_id,
+                        request_id=canonical_entry.request_id,
+                        phase=canonical_entry.lifecycle_phase,
+                        terminal=canonical_entry.terminal_status or "-",
+                        action=canonical_entry.recovery_action,
+                        origin=canonical_entry.surface_origin or "-",
+                        target=canonical_entry.target.get("target_id") or "-",
+                        model=canonical_entry.runtime_options.get("model") or "-",
+                    )
+                )
+
         if report.threshold_breaches:
             typer.echo(f"threshold breaches: {len(report.threshold_breaches)}")
             for breach in report.threshold_breaches:

--- a/src/codex_autorunner/surfaces/web/routes/file_chat_routes/execution.py
+++ b/src/codex_autorunner/surfaces/web/routes/file_chat_routes/execution.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+import uuid
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
@@ -9,8 +10,15 @@ from fastapi import Request
 
 from .....adapters.chat.agents import resolve_chat_agent_and_profile
 from .....agents.registry import has_capability, validate_agent_id
+from .....agents.runtime_options import resolve_agent_runtime_options
 from .....core import drafts as draft_utils
 from .....core.managed_thread_identity import file_chat_target_key
+from .....core.orchestration import (
+    DeliveryIntentRef,
+    TurnExecutionOrigin,
+    TurnExecutionRequest,
+)
+from .....core.state import load_state
 from .....core.utils import atomic_write
 from ..agent_profile_validation import resolve_requested_agent_profile
 from .draft_state import load_draft_snapshot, persist_draft, relative_to_repo
@@ -30,11 +38,104 @@ class FileChatAgentSelection:
     thread_key: str
 
 
+@dataclass(frozen=True)
+class FileChatCanonicalTurn:
+    request: TurnExecutionRequest
+    selection: FileChatAgentSelection
+
+
 def _normalize_optional_text(value: object) -> Optional[str]:
     if not isinstance(value, str):
         return None
     normalized = value.strip().lower()
     return normalized or None
+
+
+def _load_runner_state(request: Request) -> Any:
+    try:
+        state_path = request.app.state.engine.state_path
+    except (AttributeError, TypeError):
+        return None
+    try:
+        return load_state(state_path)
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def build_file_chat_turn_request(
+    request: Request,
+    repo_root: Path,
+    target: FileChatTarget,
+    message: str,
+    *,
+    agent: object = "codex",
+    profile: object = None,
+    model: Optional[str] = None,
+    reasoning: Optional[str] = None,
+    client_turn_id: Optional[str] = None,
+    prompt_text: Optional[str] = None,
+) -> FileChatCanonicalTurn:
+    selection = resolve_file_chat_agent_selection(
+        request,
+        target,
+        agent=agent,
+        profile=profile,
+    )
+    runtime_options = resolve_agent_runtime_options(
+        selection.agent_id,
+        profile=selection.profile,
+        state=_load_runner_state(request),
+        config=getattr(request.app.state, "config", None),
+        workspace_root=repo_root,
+        explicit_model=model,
+        explicit_reasoning=reasoning,
+        approval_policy="on-request",
+        sandbox_policy="dangerFullAccess",
+        include_builtin_model=False,
+    )
+    request_id = client_turn_id or f"file-chat-{uuid.uuid4().hex}"
+    turn_request = TurnExecutionRequest(
+        request_id=request_id,
+        target_id=target.state_key,
+        target_kind="thread",
+        workspace_root=str(repo_root),
+        request_kind="message",
+        busy_policy="reject",
+        prompt_text=prompt_text or message,
+        agent=selection.agent_id,
+        profile=selection.profile,
+        model=runtime_options.model,
+        model_payload=runtime_options.opencode_model_payload or {},
+        reasoning=runtime_options.reasoning,
+        approval_policy=runtime_options.effective_approval_policy,
+        approval_mode=runtime_options.effective_approval_policy,
+        sandbox_policy=runtime_options.sandbox.policy,
+        client_request_id=client_turn_id,
+        idempotency_key=client_turn_id or request_id,
+        correlation_id=client_turn_id or request_id,
+        origin=TurnExecutionOrigin(
+            kind="surface",
+            source_id=f"web:file-chat:{target.state_key}",
+            surface_kind="web",
+            surface_key=target.state_key,
+            metadata={"route": "file-chat", "target": target.target},
+        ),
+        metadata={
+            "surface": "file_chat",
+            "target": target.target,
+            "chat_scope": target.chat_scope,
+            "thread_key": selection.thread_key,
+            "user_message": message,
+        },
+        delivery_intents=(
+            DeliveryIntentRef(
+                kind="file_chat_state",
+                intent_id=client_turn_id or request_id,
+                metadata={"target": target.target},
+            ),
+        ),
+    )
+    return FileChatCanonicalTurn(request=turn_request, selection=selection)
 
 
 def resolve_file_chat_agent_selection(
@@ -103,7 +204,11 @@ def _missing_file_chat_capability(
 
 
 async def _update_file_chat_turn_state(
-    request: Request, target: FileChatTarget, selection: FileChatAgentSelection
+    request: Request,
+    target: FileChatTarget,
+    selection: FileChatAgentSelection,
+    *,
+    turn_request: Optional[TurnExecutionRequest] = None,
 ) -> None:
     from .runtime import update_turn_state
 
@@ -113,6 +218,8 @@ async def _update_file_chat_turn_state(
     }
     if selection.profile is not None:
         turn_state_updates["profile"] = selection.profile
+    if turn_request is not None:
+        turn_state_updates["turn_request"] = turn_request.to_dict()
     await update_turn_state(request, target, **turn_state_updates)
 
 
@@ -129,6 +236,7 @@ async def _execute_selected_agent(
     events: Any,
     stall_timeout_seconds: Optional[float],
     model: Optional[str],
+    model_payload: Optional[dict[str, Any]],
     reasoning: Optional[str],
     on_meta: Optional[Callable[[str, str, str], Any]],
     on_usage: Optional[Callable[[Dict[str, Any]], Any]],
@@ -142,6 +250,14 @@ async def _execute_selected_agent(
             prompt,
             interrupt_event,
             model=model,
+            model_payload=(
+                {
+                    "providerID": str(model_payload.get("providerID") or ""),
+                    "modelID": str(model_payload.get("modelID") or ""),
+                }
+                if model_payload
+                else None
+            ),
             reasoning=reasoning,
             thread_registry=threads,
             thread_key=selection.thread_key,
@@ -267,6 +383,7 @@ async def execute_file_chat(
     profile: Optional[str] = None,
     model: Optional[str] = None,
     reasoning: Optional[str] = None,
+    turn_request: Optional[TurnExecutionRequest] = None,
     on_meta: Optional[Callable[[str, str, str], Any]] = None,
     on_usage: Optional[Callable[[Dict[str, Any]], Any]] = None,
 ) -> Dict[str, Any]:
@@ -290,6 +407,32 @@ async def execute_file_chat(
         before=before,
         editable_rel_path=relative_to_repo(repo_root, draft_path),
     )
+    if turn_request is None:
+        canonical = build_file_chat_turn_request(
+            request,
+            repo_root,
+            target,
+            message,
+            agent=agent,
+            profile=profile,
+            model=model,
+            reasoning=reasoning,
+            prompt_text=prompt,
+        )
+        turn_request = canonical.request
+        selection = canonical.selection
+    else:
+        turn_request = replace(
+            turn_request,
+            prompt_text=prompt,
+            metadata={**turn_request.metadata, "user_message": message},
+        )
+        selection = resolve_file_chat_agent_selection(
+            request,
+            target,
+            agent=turn_request.agent,
+            profile=turn_request.profile,
+        )
 
     from .runtime import get_or_create_interrupt_event
 
@@ -297,13 +440,12 @@ async def execute_file_chat(
     if interrupt_event.is_set():
         return {"status": "interrupted", "detail": "File chat interrupted"}
 
-    selection = resolve_file_chat_agent_selection(
+    await _update_file_chat_turn_state(
         request,
         target,
-        agent=agent,
-        profile=profile,
+        selection,
+        turn_request=turn_request,
     )
-    await _update_file_chat_turn_state(request, target, selection)
     result = await _execute_selected_agent(
         request,
         repo_root,
@@ -315,16 +457,19 @@ async def execute_file_chat(
         opencode=opencode,
         events=events,
         stall_timeout_seconds=stall_timeout_seconds,
-        model=model,
-        reasoning=reasoning,
+        model=turn_request.model,
+        model_payload=turn_request.model_payload,
+        reasoning=turn_request.reasoning,
         on_meta=on_meta,
         on_usage=on_usage,
     )
 
     if result.get("status") != "ok":
+        result = dict(result)
+        result["turn_request"] = turn_request.to_dict()
         return result
 
-    return _build_file_chat_success_result(
+    response = _build_file_chat_success_result(
         repo_root,
         target,
         state=state,
@@ -338,6 +483,8 @@ async def execute_file_chat(
         profile=selection.profile,
         result=result,
     )
+    response["turn_request"] = turn_request.to_dict()
+    return response
 
 
 async def execute_app_server(
@@ -377,6 +524,7 @@ async def execute_opencode(
     interrupt_event: asyncio.Event,
     *,
     model: Optional[str] = None,
+    model_payload: Optional[dict[str, str]] = None,
     reasoning: Optional[str] = None,
     thread_registry: Optional[Any] = None,
     thread_key: Optional[str] = None,
@@ -390,6 +538,7 @@ async def execute_opencode(
         prompt,
         interrupt_event,
         model=model,
+        model_payload=model_payload,
         reasoning=reasoning,
         thread_registry=thread_registry,
         thread_key=thread_key,

--- a/src/codex_autorunner/surfaces/web/routes/file_chat_routes/execution_agents.py
+++ b/src/codex_autorunner/surfaces/web/routes/file_chat_routes/execution_agents.py
@@ -371,6 +371,7 @@ async def execute_opencode(
     interrupt_event: asyncio.Event,
     *,
     model: Optional[str] = None,
+    model_payload: Optional[dict[str, str]] = None,
     reasoning: Optional[str] = None,
     thread_registry: Optional[Any] = None,
     thread_key: Optional[str] = None,
@@ -410,7 +411,11 @@ async def execute_opencode(
         ):  # intentional: user-provided callback must not crash execution
             logger.debug("file chat opencode meta failed", exc_info=True)
 
-    model_payload = resolve_opencode_model_payload(model)
+    model_payload = model_payload or resolve_opencode_model_payload(model)
+    if model_payload is None:
+        raise FileChatError(
+            "OpenCode model must include provider/model before execution"
+        )
     await supervisor.mark_turn_started(repo_root)
 
     usage_parts: list[Dict[str, Any]] = []

--- a/src/codex_autorunner/surfaces/web/routes/file_chat_routes/runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/file_chat_routes/runtime.py
@@ -23,18 +23,31 @@ async def clear_interrupt_event(request: Request, key: str) -> None:
 
 
 async def begin_turn_state(
-    request: Request, target: Any, client_turn_id: Optional[str]
+    request: Request,
+    target: Any,
+    client_turn_id: Optional[str],
+    *,
+    turn_request: Any = None,
+    turn_record: Any = None,
 ) -> None:
     s = get_state(request)
     async with s.turn_lock:
+        execution_id = str(getattr(turn_record, "execution_id", "") or "").strip()
         state: Dict[str, Any] = {
             "client_turn_id": client_turn_id or "",
+            "execution_id": execution_id,
             "target": target.target,
             "status": "starting",
             "agent": None,
             "thread_id": None,
             "turn_id": None,
         }
+        if turn_request is not None and callable(
+            getattr(turn_request, "to_dict", None)
+        ):
+            state["turn_request"] = turn_request.to_dict()
+        if turn_record is not None and callable(getattr(turn_record, "to_dict", None)):
+            state["turn_record"] = turn_record.to_dict()
         s.current_by_target[target.state_key] = state
         if client_turn_id:
             s.current_by_client[client_turn_id] = state

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_queue_execution.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_queue_execution.py
@@ -7,9 +7,10 @@ from typing import Any, Optional
 from fastapi import HTTPException
 
 from .....adapters.github.context_injection import maybe_inject_github_context
-from .....agents.runtime_options import resolve_agent_runtime_options
 from .....core.orchestration import (
     SurfaceThreadMessageRequest,
+    TurnExecutionContractError,
+    TurnExecutionRequest,
     build_surface_orchestration_ingress,
 )
 from .....core.pma.queue_prompts import (
@@ -29,7 +30,6 @@ from .....core.pma_context import (
     load_pma_prompt,
 )
 from .....core.pma_origin import PmaOriginContext, extract_pma_origin_metadata
-from .....core.state import load_state
 from .....core.text_utils import _normalize_optional_text
 from ...services.pma import get_pma_request_context
 from ...services.pma.common import pma_config_from_raw
@@ -43,31 +43,20 @@ from .runtime_state import PmaRuntimeState
 logger = logging.getLogger(__name__)
 
 
+def _turn_request_from_queue_payload(
+    payload: dict[str, Any],
+) -> Optional[TurnExecutionRequest]:
+    turn_request_payload = payload.get("turn_request")
+    if turn_request_payload is None:
+        return None
+    if not isinstance(turn_request_payload, dict):
+        raise ValueError("PMA queue payload turn_request must be an object")
+    return TurnExecutionRequest.from_mapping(turn_request_payload)
+
+
 def _get_pma_config(request: Any) -> dict[str, Any]:
     context = get_pma_request_context(request)
     return pma_config_from_raw(context.raw_config)
-
-
-def _resolve_queue_default_model(
-    request: Any,
-    *,
-    agent: Optional[str],
-    configured_default: Optional[str],
-) -> Optional[str]:
-    try:
-        state = load_state(request.app.state.engine.state_path)
-    except (OSError, ValueError, AttributeError):
-        state = None
-    defaults = _get_pma_config(request)
-    options = resolve_agent_runtime_options(
-        agent or defaults.get("default_agent") or "codex",
-        state=state,
-        config=request.app.state.config,
-        workspace_root=getattr(request.app.state.config, "root", None),
-        configured_model_default=configured_default,
-        include_builtin_model=False,
-    )
-    return options.model
 
 
 def _resolve_profile_with_stale_pma_origin_fallback(
@@ -127,16 +116,35 @@ async def execute_queue_item(
     hub_root = context.hub_root
     payload = item.payload
 
-    client_turn_id = payload.get("client_turn_id")
-    message = payload.get("message", "")
-    agent = payload.get("agent")
-    profile = _normalize_optional_text(payload.get("profile"))
-    model = _normalize_optional_text(payload.get("model"))
-    reasoning = _normalize_optional_text(payload.get("reasoning"))
+    try:
+        turn_request = _turn_request_from_queue_payload(payload)
+    except (TurnExecutionContractError, ValueError) as exc:
+        return {"status": "error", "detail": str(exc)}
+    if turn_request is None:
+        return {
+            "status": "error",
+            "detail": "PMA queue item is missing canonical turn_request",
+        }
+
+    request_metadata = (
+        dict(turn_request.metadata) if isinstance(turn_request.metadata, dict) else {}
+    )
+    client_turn_id = turn_request.client_request_id
+    message = turn_request.prompt_text or ""
+    agent = turn_request.agent
+    profile = turn_request.profile
+    model = turn_request.model
+    reasoning = turn_request.reasoning
+    approval_mode = turn_request.approval_mode or turn_request.approval_policy
+    sandbox_policy = turn_request.sandbox_policy
     lifecycle_event = payload.get("lifecycle_event")
+    if not isinstance(lifecycle_event, dict):
+        lifecycle_event = request_metadata.get("lifecycle_event")
     if not isinstance(lifecycle_event, dict):
         lifecycle_event = None
     wake_up = payload.get("wake_up")
+    if not isinstance(wake_up, dict):
+        wake_up = request_metadata.get("wake_up")
     if not isinstance(wake_up, dict):
         wake_up = None
     automation_trigger = lifecycle_event is not None or wake_up is not None
@@ -291,15 +299,6 @@ async def execute_queue_item(
             persist=False,
         )
 
-    if not model:
-        model = _resolve_queue_default_model(
-            request,
-            agent=agent,
-            configured_default=defaults.get("model"),
-        )
-    if not reasoning and defaults.get("reasoning"):
-        reasoning = defaults["reasoning"]
-
     try:
         prompt_base = load_pma_prompt(hub_root)
         supervisor = context.hub_supervisor
@@ -446,6 +445,8 @@ async def execute_queue_item(
             interrupt_event,
             model=model,
             reasoning=reasoning,
+            approval_mode=approval_mode,
+            sandbox_policy=sandbox_policy,
             thread_registry=registry,
             thread_key=execution_origin.session_key,
             backend_thread_id=execution_origin.backend_thread_id,

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from typing import Any, Optional, cast
 
 from fastapi import APIRouter, HTTPException, Request
@@ -13,7 +14,16 @@ from .....adapters.github.context_injection import (
 from .....agents.base import harness_supports_event_streaming
 from .....agents.codex.harness import CodexHarness
 from .....agents.registry import get_registered_agents as _get_registered_agents
-from .....agents.runtime_options import resolve_agent_runtime_options
+from .....agents.registry import validate_agent_id
+from .....agents.runtime_options import (
+    AgentRuntimeOptionsError,
+    resolve_agent_runtime_options,
+)
+from .....core.orchestration import (
+    TurnExecutionContractError,
+    TurnExecutionOrigin,
+    TurnExecutionRequest,
+)
 from .....core.orchestration import (
     build_surface_orchestration_ingress as _build_surface_orchestration_ingress,
 )
@@ -37,6 +47,7 @@ from ...services.pma import get_pma_request_context
 from ...services.pma.common import (
     build_idempotency_key as service_build_idempotency_key,
 )
+from ..agent_profile_validation import resolve_requested_agent_profile
 from ..shared import SSE_HEADERS
 from .chat_queue_execution import execute_queue_item
 from .chat_runtime_execution import (
@@ -84,6 +95,84 @@ def _resolve_pma_default_model(
         include_builtin_model=False,
     )
     return options.model
+
+
+def _resolve_pma_chat_turn_request(
+    request: Request,
+    *,
+    lane_id: str,
+    message: str,
+    agent: Optional[str],
+    profile: Optional[str],
+    model: Optional[str],
+    reasoning: Optional[str],
+    client_turn_id: Optional[str],
+    stream: bool,
+) -> TurnExecutionRequest:
+    pma_config = _get_pma_config(request)
+    try:
+        agent_id = validate_agent_id(
+            agent or pma_config.get("default_agent") or "codex",
+            get_pma_request_context(request).agent_context,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    resolved_profile = resolve_requested_agent_profile(
+        request,
+        agent_id,
+        profile,
+        default_profile=_normalize_optional_text(pma_config.get("profile")),
+    )
+    try:
+        state = load_state(request.app.state.engine.state_path)
+    except (OSError, ValueError, AttributeError):
+        state = None
+    try:
+        runtime_options = resolve_agent_runtime_options(
+            agent_id,
+            profile=resolved_profile,
+            state=state,
+            config=request.app.state.config,
+            workspace_root=getattr(request.app.state.config, "root", None),
+            explicit_model=model,
+            configured_model_default=pma_config.get("model"),
+            explicit_reasoning=reasoning or pma_config.get("reasoning"),
+            approval_policy="on-request",
+            sandbox_policy="dangerFullAccess",
+            include_builtin_model=False,
+        )
+        return TurnExecutionRequest(
+            request_id=client_turn_id or f"pma-{uuid.uuid4().hex}",
+            target_id=lane_id,
+            target_kind="thread",
+            workspace_root=str(get_pma_request_context(request).hub_root),
+            request_kind="message",
+            busy_policy="queue",
+            prompt_text=message,
+            input_items=(),
+            context_profile=None,
+            agent=agent_id,
+            profile=resolved_profile,
+            model=runtime_options.model,
+            model_payload=runtime_options.opencode_model_payload or {},
+            reasoning=runtime_options.reasoning,
+            approval_policy=runtime_options.effective_approval_policy,
+            approval_mode=runtime_options.effective_approval_policy,
+            sandbox_policy=runtime_options.sandbox.policy,
+            client_request_id=client_turn_id,
+            idempotency_key=client_turn_id,
+            correlation_id=client_turn_id,
+            origin=TurnExecutionOrigin(
+                kind="surface",
+                source_id=f"web:{lane_id}",
+                surface_kind="web",
+                surface_key=lane_id,
+                metadata={"route": "/hub/pma/chat"},
+            ),
+            metadata={"stream": bool(stream)},
+        )
+    except (AgentRuntimeOptionsError, TurnExecutionContractError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 def _pma_turn_idle_timeout_seconds(request: Request) -> float:
@@ -405,11 +494,21 @@ def build_chat_runtime_router(
         queue = runtime.get_pma_queue(hub_root)
 
         lane_id = "pma:default"
-        model = model or _resolve_pma_default_model(
+        turn_request = _resolve_pma_chat_turn_request(
             request,
+            lane_id=lane_id,
+            message=message,
             agent=agent,
-            configured_default=pma_config.get("model"),
+            profile=profile,
+            model=model,
+            reasoning=reasoning,
+            client_turn_id=client_turn_id,
+            stream=stream,
         )
+        agent = turn_request.agent
+        profile = turn_request.profile
+        model = turn_request.model
+        reasoning = turn_request.reasoning
 
         idempotency_key = _build_idempotency_key(
             lane_id=lane_id,
@@ -421,16 +520,7 @@ def build_chat_runtime_router(
             message=message,
         )
 
-        queue_payload = {
-            "message": message,
-            "agent": agent,
-            "profile": profile,
-            "model": model,
-            "reasoning": reasoning,
-            "client_turn_id": client_turn_id,
-            "stream": stream,
-            "hub_root": str(hub_root),
-        }
+        queue_payload = {"turn_request": turn_request.to_dict()}
 
         item, dupe_reason = await queue.enqueue(lane_id, idempotency_key, queue_payload)
         if dupe_reason:

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime.py
@@ -75,28 +75,6 @@ def _get_pma_config(request: Request) -> dict[str, Any]:
     return get_pma_request_context(request).pma_config
 
 
-def _resolve_pma_default_model(
-    request: Request,
-    *,
-    agent: Optional[str],
-    configured_default: Optional[str],
-) -> Optional[str]:
-    try:
-        state = load_state(request.app.state.engine.state_path)
-    except (OSError, ValueError, AttributeError):
-        state = None
-    pma_config = _get_pma_config(request)
-    options = resolve_agent_runtime_options(
-        agent or pma_config.get("default_agent") or "codex",
-        state=state,
-        config=request.app.state.config,
-        workspace_root=getattr(request.app.state.config, "root", None),
-        configured_model_default=configured_default,
-        include_builtin_model=False,
-    )
-    return options.model
-
-
 def _resolve_pma_chat_turn_request(
     request: Request,
     *,

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime_execution.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime_execution.py
@@ -153,6 +153,8 @@ async def execute_harness_turn(
     *,
     model: Optional[str] = None,
     reasoning: Optional[str] = None,
+    approval_mode: Optional[str] = "on-request",
+    sandbox_policy: Optional[Any] = "dangerFullAccess",
     backend_thread_id: Optional[str] = None,
     thread_registry: Optional[Any] = None,
     thread_key: Optional[str] = None,
@@ -224,8 +226,8 @@ async def execute_harness_turn(
             await _effective_prompt_for_start_turn(),
             model,
             reasoning,
-            approval_mode="on-request",
-            sandbox_policy="dangerFullAccess",
+            approval_mode=approval_mode,
+            sandbox_policy=sandbox_policy,
         )
     except Exception as exc:
         if not had_existing_conversation or not requires_fresh_pma_conversation(exc):
@@ -249,8 +251,8 @@ async def execute_harness_turn(
             await _effective_prompt_for_start_turn(),
             model,
             reasoning,
-            approval_mode="on-request",
-            sandbox_policy="dangerFullAccess",
+            approval_mode=approval_mode,
+            sandbox_policy=sandbox_policy,
         )
     resolved_conversation_id = str(
         getattr(turn, "conversation_id", None) or conversation_id or ""

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/tail_stream.py
@@ -27,6 +27,7 @@ from ...services.pma import get_pma_request_context
 from ...services.pma.common import normalize_optional_text
 from ..shared import SSE_HEADERS
 from .managed_thread_tail_serializers import (
+    _canonical_turn_request_metadata,
     _derive_active_turn_diagnostics,
     _derive_progress_phase,
     _event_received_at_iso,
@@ -517,6 +518,7 @@ async def _build_managed_thread_tail_snapshot(
         "backend_thread_id": backend_thread_id,
         "backend_turn_id": backend_turn_id,
         "turn_status": turn_status,
+        "canonical_request": _canonical_turn_request_metadata(turn_record),
         "thread_status": getattr(thread, "status", None),
         "thread_lifecycle_status": getattr(thread, "lifecycle_status", None),
         "started_at": started_at,

--- a/src/codex_autorunner/surfaces/web/services/file_chat.py
+++ b/src/codex_autorunner/surfaces/web/services/file_chat.py
@@ -8,6 +8,14 @@ from typing import Any, AsyncIterator, Dict, Optional
 
 from fastapi import HTTPException, Request
 
+from ....agents.runtime_options import AgentRuntimeOptionsError
+from ....core.orchestration import (
+    TurnExecutionContractError,
+    TurnExecutionRecord,
+    TurnExecutionRequest,
+)
+from ....core.orchestration.turn_execution_contract import TurnExecutionStatus
+from ....core.time_utils import now_iso
 from ..routes.file_chat_routes.drafts import (
     apply_file_patch as apply_draft_patch,
 )
@@ -18,10 +26,12 @@ from ..routes.file_chat_routes.drafts import (
     pending_file_patch as pending_draft_patch,
 )
 from ..routes.file_chat_routes.execution import (
-    execute_file_chat as execute_file_chat_agent_turn,
+    FileChatAgentSelection,
+    build_file_chat_turn_request,
+    resolve_file_chat_agent_selection,
 )
 from ..routes.file_chat_routes.execution import (
-    resolve_file_chat_agent_selection,
+    execute_file_chat as execute_file_chat_agent_turn,
 )
 from ..routes.file_chat_routes.execution_agents import FileChatError
 from ..routes.file_chat_routes.runtime import (
@@ -83,6 +93,15 @@ class FileChatThreadResetResult:
     cleared: bool
 
 
+@dataclass(frozen=True)
+class FileChatPreparedTurn:
+    repo_root: Path
+    target: FileChatTarget
+    turn_request: TurnExecutionRequest
+    turn_record: TurnExecutionRecord
+    selection: FileChatAgentSelection
+
+
 def resolve_target(request: Request, target_raw: str) -> FileChatTarget:
     return parse_target(resolve_repo_root(request), target_raw)
 
@@ -108,6 +127,8 @@ async def _claim_turn(
     target: FileChatTarget,
     *,
     client_turn_id: Optional[str],
+    turn_request: TurnExecutionRequest,
+    turn_record: TurnExecutionRecord,
     already_running_detail: str,
 ) -> None:
     state = get_state(request)
@@ -116,13 +137,19 @@ async def _claim_turn(
         if existing is not None and not existing.is_set():
             raise HTTPException(status_code=409, detail=already_running_detail)
         state.active_chats[target.state_key] = asyncio.Event()
-    await begin_turn_state(request, target, client_turn_id)
+    await begin_turn_state(
+        request,
+        target,
+        client_turn_id,
+        turn_request=turn_request,
+        turn_record=turn_record,
+    )
 
 
 async def prepare_turn(
     request: Request,
     payload: FileChatTurnRequest,
-) -> tuple[Path, FileChatTarget, str, Optional[str]]:
+) -> FileChatPreparedTurn:
     message = (payload.message or "").strip()
     if not message:
         raise HTTPException(status_code=400, detail="message is required")
@@ -132,33 +159,88 @@ async def prepare_turn(
     if target.kind == "contextspace":
         target.path.parent.mkdir(parents=True, exist_ok=True)
 
-    selection = resolve_file_chat_agent_selection(
-        request,
-        target,
-        agent=payload.agent,
-        profile=payload.profile,
+    try:
+        canonical = build_file_chat_turn_request(
+            request,
+            repo_root,
+            target,
+            message,
+            agent=payload.agent,
+            profile=payload.profile,
+            model=payload.model,
+            reasoning=payload.reasoning,
+            client_turn_id=payload.client_turn_id,
+        )
+    except (AgentRuntimeOptionsError, TurnExecutionContractError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    turn_record = TurnExecutionRecord(
+        request=canonical.request,
+        execution_id=canonical.request.request_id,
+        status="claiming",
+        queued_at=now_iso(),
+        metadata={"surface": "file_chat"},
     )
     await _claim_turn(
         request,
         target,
         client_turn_id=payload.client_turn_id,
+        turn_request=canonical.request,
+        turn_record=turn_record,
         already_running_detail=payload.already_running_detail,
     )
-    return repo_root, target, selection.agent_id, selection.profile
+    return FileChatPreparedTurn(
+        repo_root=repo_root,
+        target=target,
+        turn_request=canonical.request,
+        turn_record=turn_record,
+        selection=canonical.selection,
+    )
+
+
+def _terminal_record_for_result(
+    prepared: FileChatPreparedTurn,
+    result: Dict[str, Any],
+) -> TurnExecutionRecord:
+    status = str(result.get("status") or "").strip().lower()
+    record_status: TurnExecutionStatus
+    if status == "ok":
+        record_status = "completed"
+    elif status == "interrupted":
+        record_status = "interrupted"
+    else:
+        record_status = "failed"
+    final_request = prepared.turn_request
+    raw_turn_request = result.get("turn_request")
+    if isinstance(raw_turn_request, dict):
+        try:
+            final_request = TurnExecutionRequest.from_mapping(raw_turn_request)
+        except TurnExecutionContractError:
+            final_request = prepared.turn_request
+    return TurnExecutionRecord(
+        request=final_request,
+        execution_id=prepared.turn_record.execution_id,
+        status=record_status,
+        queued_at=prepared.turn_record.queued_at,
+        claimed_at=prepared.turn_record.claimed_at,
+        started_at=prepared.turn_record.started_at,
+        terminal_at=now_iso(),
+        backend_conversation_id=result.get("thread_id"),
+        backend_turn_id=result.get("turn_id"),
+        assistant_text=result.get("message") or result.get("agent_message"),
+        error_text=result.get("detail") if record_status == "failed" else None,
+        metadata={"surface": "file_chat"},
+    )
 
 
 async def _execute_turn_lifecycle(
     request: Request,
-    repo_root: Path,
-    target: FileChatTarget,
+    prepared: FileChatPreparedTurn,
     message: str,
     *,
-    agent: str,
-    profile: Optional[str],
-    model: Optional[str],
-    reasoning: Optional[str],
     client_turn_id: Optional[str],
 ) -> Dict[str, Any]:
+    repo_root = prepared.repo_root
+    target = prepared.target
     try:
 
         async def _on_meta(agent_id: str, thread_id: str, turn_id: str) -> None:
@@ -176,10 +258,11 @@ async def _execute_turn_lifecycle(
                 repo_root,
                 target,
                 message,
-                agent=agent,
-                profile=profile,
-                model=model,
-                reasoning=reasoning,
+                agent=prepared.turn_request.agent,
+                profile=prepared.turn_request.profile,
+                model=prepared.turn_request.model,
+                reasoning=prepared.turn_request.reasoning,
+                turn_request=prepared.turn_request,
                 on_meta=_on_meta,
             )
         except (
@@ -192,11 +275,24 @@ async def _execute_turn_lifecycle(
                 "status": "error",
                 "detail": str(exc),
                 "client_turn_id": client_turn_id or "",
+                "execution_id": prepared.turn_record.execution_id,
+                "turn_request": prepared.turn_request.to_dict(),
             }
+            result["turn_record"] = _terminal_record_for_result(
+                prepared,
+                result,
+            ).to_dict()
             await finalize_turn_state(request, target, result)
             raise
         result = dict(result or {})
         result["client_turn_id"] = client_turn_id or ""
+        result["execution_id"] = prepared.turn_record.execution_id
+        if "turn_request" not in result:
+            result["turn_request"] = prepared.turn_request.to_dict()
+        result["turn_record"] = _terminal_record_for_result(
+            prepared,
+            result,
+        ).to_dict()
         await finalize_turn_state(request, target, result)
         return result
     finally:
@@ -207,16 +303,11 @@ async def run_turn(
     request: Request,
     payload: FileChatTurnRequest,
 ) -> Dict[str, Any]:
-    repo_root, target, agent_id, profile = await prepare_turn(request, payload)
+    prepared = await prepare_turn(request, payload)
     return await _execute_turn_lifecycle(
         request,
-        repo_root,
-        target,
+        prepared,
         payload.message.strip(),
-        agent=agent_id,
-        profile=profile,
-        model=payload.model,
-        reasoning=payload.reasoning,
         client_turn_id=payload.client_turn_id,
     )
 
@@ -256,22 +347,14 @@ async def stream_prepared_turn(
     request: Request,
     payload: FileChatTurnRequest,
     *,
-    repo_root: Path,
-    target: FileChatTarget,
-    agent_id: str,
-    profile: Optional[str],
+    prepared: FileChatPreparedTurn,
 ) -> AsyncIterator[FileChatStreamItem]:
     yield FileChatStreamItem("status", {"status": "queued"})
     run_task = asyncio.create_task(
         _execute_turn_lifecycle(
             request,
-            repo_root,
-            target,
+            prepared,
             payload.message.strip(),
-            agent=agent_id,
-            profile=profile,
-            model=payload.model,
-            reasoning=payload.reasoning,
             client_turn_id=payload.client_turn_id,
         )
     )
@@ -293,14 +376,11 @@ async def open_stream_turn(
     request: Request,
     payload: FileChatTurnRequest,
 ) -> AsyncIterator[FileChatStreamItem]:
-    repo_root, target, agent_id, profile = await prepare_turn(request, payload)
+    prepared = await prepare_turn(request, payload)
     return stream_prepared_turn(
         request,
         payload,
-        repo_root=repo_root,
-        target=target,
-        agent_id=agent_id,
-        profile=profile,
+        prepared=prepared,
     )
 
 

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_read_models.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_read_models.py
@@ -437,7 +437,7 @@ def _serialize_thread_target(
         "lifecycle_status": thread.lifecycle_status,
         "runtime_status": effective_status,
         "normalized_status": effective_status,
-        "status": effective_status,
+        "status": target_runtime_status or effective_status,
         "target_runtime_status": target_runtime_status,
         "execution_status": execution_status,
         "active_turn_id": (

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_runtime.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_runtime.py
@@ -462,7 +462,7 @@ async def _run_managed_thread_execution(
         request,
         service=service,
         managed_thread_id=managed_thread_id,
-        message_text=started.request.message_text,
+        message_text=_runtime_request_message_text(started),
     )
     finalized = _finalized_with_backend_thread_fallback(
         await coordinator.run_started_execution(
@@ -546,7 +546,7 @@ async def _finalize_managed_thread_execution(
         request,
         service=service,
         managed_thread_id=managed_thread_id,
-        message_text=started.request.message_text,
+        message_text=_runtime_request_message_text(started),
     )
     finalized = _finalized_with_backend_thread_fallback(
         await coordinator.run_started_execution(
@@ -558,6 +558,18 @@ async def _finalize_managed_thread_execution(
         fallback_backend_thread_id=fallback_backend_thread_id,
     )
     return finalized
+
+
+def _runtime_request_message_text(started: RuntimeThreadExecution) -> str:
+    runtime_request = started.request
+    for field_name in ("message_text", "prompt_text"):
+        value = getattr(runtime_request, field_name, None)
+        if isinstance(value, str) and value.strip():
+            return value
+        normalized = normalize_optional_text(value)
+        if normalized is not None:
+            return normalized
+    return ""
 
 
 async def _deliver_managed_thread_execution_result(

--- a/src/codex_autorunner/surfaces/web/services/pma/managed_thread_send_runtime.py
+++ b/src/codex_autorunner/surfaces/web/services/pma/managed_thread_send_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional
 
@@ -11,6 +12,7 @@ from fastapi.responses import JSONResponse
 from .....adapters.chat.bound_chat_execution_metadata import (
     merge_bound_chat_execution_metadata,
 )
+from .....adapters.chat.canonical_turns import build_surface_turn_execution_request
 from .....adapters.chat.managed_thread_turns import (
     ManagedThreadCoordinatorHooks,
     build_managed_thread_input_items,
@@ -90,7 +92,9 @@ async def run_managed_thread_message_send(
     get_runtime_state: Any,
     ports: ManagedThreadSendRuntimePorts,
 ) -> Any:
-    client_turn_id = normalize_optional_text(payload.client_turn_id)
+    client_turn_id = normalize_optional_text(payload.client_turn_id) or str(
+        uuid.uuid4()
+    )
 
     if payload.profile_explicit:
         meta = thread.get("metadata")
@@ -159,16 +163,29 @@ async def run_managed_thread_message_send(
                 progress_targets=progress_targets,
             ),
         )
+        canonical_request = build_surface_turn_execution_request(
+            message_request,
+            request_id=client_turn_id,
+            workspace_root=normalize_optional_text(thread.get("workspace_root")) or "",
+            surface_kind="web",
+            surface_key=managed_thread_id,
+            agent=normalize_optional_text(thread.get("agent_id") or thread.get("agent"))
+            or "codex",
+            approval_policy=options.approval_policy or "never",
+            sandbox_policy=options.sandbox_policy or "dangerFullAccess",
+            profile=options.agent_profile,
+            client_request_id=client_turn_id,
+        )
         if payload.wait_for_confirmation:
             started_execution = await ports.begin_execution(
                 service,
-                message_request,
+                canonical_request,
                 client_request_id=client_turn_id,
                 sandbox_policy=options.sandbox_policy,
             )
         else:
             prepared_execution = await service.prepare_thread_execution(
-                message_request,
+                canonical_request,
                 client_request_id=client_turn_id,
                 sandbox_policy=options.sandbox_policy,
             )

--- a/tests/adapters/chat/test_canonical_turns.py
+++ b/tests/adapters/chat/test_canonical_turns.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from codex_autorunner.adapters.chat.canonical_turns import (
+    build_surface_turn_execution_request,
+)
+from codex_autorunner.adapters.chat.command_contract import COMMAND_CONTRACT
+from codex_autorunner.core.orchestration import MessageRequest, TurnExecutionRequest
+
+
+def _message_request() -> MessageRequest:
+    return MessageRequest(
+        target_id="thread-1",
+        target_kind="thread",
+        message_text="review this change",
+        busy_policy="queue",
+        model="gpt-5.4",
+        reasoning="high",
+        approval_mode="never",
+        input_items=[{"type": "text", "text": "review this change"}],
+        metadata={"runtime_prompt": "runtime review prompt"},
+    )
+
+
+def test_discord_and_telegram_surface_turns_preserve_equivalent_canonical_fields() -> (
+    None
+):
+    common = {
+        "workspace_root": "/repo",
+        "agent": "codex",
+        "approval_policy": "never",
+        "sandbox_policy": "dangerFullAccess",
+        "profile": "reviewer",
+    }
+
+    discord = build_surface_turn_execution_request(
+        _message_request(),
+        request_id="discord-request",
+        surface_kind="discord",
+        surface_key="channel-1",
+        client_request_id="client-discord",
+        **common,
+    )
+    telegram = build_surface_turn_execution_request(
+        _message_request(),
+        request_id="telegram-request",
+        surface_kind="telegram",
+        surface_key="chat-1/thread-2",
+        client_request_id="client-telegram",
+        **common,
+    )
+
+    for field in (
+        "target_id",
+        "target_kind",
+        "workspace_root",
+        "request_kind",
+        "busy_policy",
+        "prompt_text",
+        "input_items",
+        "agent",
+        "profile",
+        "model",
+        "reasoning",
+        "approval_policy",
+        "approval_mode",
+        "sandbox_policy",
+        "metadata",
+    ):
+        assert getattr(discord, field) == getattr(telegram, field)
+    assert discord.origin.surface_kind == "discord"
+    assert telegram.origin.surface_kind == "telegram"
+
+
+def test_surface_turn_builder_validates_opencode_provider_model_payload() -> None:
+    request = replace(_message_request(), model="zai-coding-plan/glm-5.1")
+
+    turn_request = build_surface_turn_execution_request(
+        request,
+        request_id="opencode-request",
+        workspace_root="/repo",
+        surface_kind="discord",
+        surface_key="channel-1",
+        agent="opencode",
+        approval_policy="never",
+        sandbox_policy="dangerFullAccess",
+    )
+
+    assert turn_request.model_payload == {
+        "providerID": "zai-coding-plan",
+        "modelID": "glm-5.1",
+    }
+
+
+@pytest.mark.parametrize("command_id", ["car.new", "car.files.inbox"])
+def test_stable_and_partial_command_metadata_can_build_valid_surface_turns(
+    command_id: str,
+) -> None:
+    entry = next(item for item in COMMAND_CONTRACT if item.id == command_id)
+    assert entry.status in {"stable", "partial"}
+    assert entry.telegram_commands
+
+    turn_request = build_surface_turn_execution_request(
+        _message_request(),
+        request_id=f"{command_id}:request",
+        workspace_root="/repo",
+        surface_kind="telegram",
+        surface_key=f"command:{entry.telegram_commands[0]}",
+        agent="codex",
+        approval_policy="never",
+        sandbox_policy="dangerFullAccess",
+        origin_metadata={
+            "command_id": entry.id,
+            "command_status": entry.status,
+            "requires_bound_workspace": entry.requires_bound_workspace,
+        },
+    )
+
+    assert isinstance(
+        TurnExecutionRequest.from_mapping(turn_request.to_dict()),
+        TurnExecutionRequest,
+    )
+    assert turn_request.origin.metadata["command_id"] == command_id

--- a/tests/adapters/chat/test_managed_thread_turns.py
+++ b/tests/adapters/chat/test_managed_thread_turns.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from typing import Any, Optional
 
 import pytest
+from tests.support.turn_execution import build_test_turn_request
 
 import codex_autorunner.adapters.chat.managed_thread_turns as managed_thread_turns_module
 from codex_autorunner.adapters.chat.managed_thread_surface_kernel import (
@@ -329,21 +330,48 @@ def test_prior_completed_assistant_text_prefix_reads_execution_store_wrapper(
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     thread = store.create_thread_target("hermes", workspace)
-    first = store.create_execution(thread.thread_target_id, prompt="first")
+    first = store.create_execution(
+        thread.thread_target_id,
+        prompt="first",
+        turn_request=build_test_turn_request(
+            managed_thread_id=thread.thread_target_id,
+            workspace_root=str(workspace),
+            agent="hermes",
+            prompt="first",
+        ),
+    )
     store.record_execution_result(
         thread.thread_target_id,
         first.execution_id,
         status="ok",
         assistant_text="first answer",
     )
-    second = store.create_execution(thread.thread_target_id, prompt="second")
+    second = store.create_execution(
+        thread.thread_target_id,
+        prompt="second",
+        turn_request=build_test_turn_request(
+            managed_thread_id=thread.thread_target_id,
+            workspace_root=str(workspace),
+            agent="hermes",
+            prompt="second",
+        ),
+    )
     store.record_execution_result(
         thread.thread_target_id,
         second.execution_id,
         status="ok",
         assistant_text="first answersecond answer",
     )
-    current = store.create_execution(thread.thread_target_id, prompt="third")
+    current = store.create_execution(
+        thread.thread_target_id,
+        prompt="third",
+        turn_request=build_test_turn_request(
+            managed_thread_id=thread.thread_target_id,
+            workspace_root=str(workspace),
+            agent="hermes",
+            prompt="third",
+        ),
+    )
 
     prefix = managed_thread_turns_module._prior_completed_assistant_text_prefix(
         SimpleNamespace(thread_store=store),

--- a/tests/chat_surface_lab/web_pma_simulator.py
+++ b/tests/chat_surface_lab/web_pma_simulator.py
@@ -29,6 +29,7 @@ from tests.chat_surface_lab.transcript_models import (
     TranscriptTimeline,
 )
 from tests.conftest import write_test_config
+from tests.support.turn_execution import create_test_turn
 
 
 @dataclass(frozen=True)
@@ -101,7 +102,7 @@ class WebPmaSurfaceSimulator:
         managed_thread_id = self._require_thread()
         _ = wait_for_confirmation, busy_policy
         store = ManagedThreadStore(self.hub.hub_root)
-        turn = store.create_turn(managed_thread_id, prompt=message)
+        turn = create_test_turn(store, managed_thread_id, prompt=message)
         self.managed_turn_id = str(turn.get("managed_turn_id") or "")
         assistant_text = "fixture reply"
         assert store.mark_turn_finished(

--- a/tests/contracts/chat_surface/test_managed_thread_timeline_v2_contract.py
+++ b/tests/contracts/chat_surface/test_managed_thread_timeline_v2_contract.py
@@ -18,6 +18,7 @@ from codex_autorunner.core.ports.run_event import (
     ToolCall,
     ToolResult,
 )
+from tests.support.turn_execution import create_test_turn
 
 
 def _store(tmp_path: Path) -> tuple[Path, ManagedThreadStore, str]:
@@ -46,7 +47,7 @@ def test_managed_thread_timeline_v2_authors_identity_and_provenance_for_core_ite
     tmp_path: Path,
 ) -> None:
     hub_root, store, thread_id = _store(tmp_path)
-    turn = store.create_turn(thread_id, prompt="run checks")
+    turn = create_test_turn(store, thread_id, prompt="run checks")
     turn_id = str(turn["managed_turn_id"])
     persist_turn_timeline(
         hub_root,

--- a/tests/core/orchestration/test_bindings.py
+++ b/tests/core/orchestration/test_bindings.py
@@ -240,7 +240,11 @@ def test_binding_store_active_work_by_agent(tmp_path: Path) -> None:
         repo_id="repo-1",
     )
     thread_store.create_turn(codex_thread_id, prompt="codex busy")
-    thread_store.create_turn(opencode_thread_id, prompt="opencode busy")
+    thread_store.create_turn(
+        opencode_thread_id,
+        prompt="opencode busy",
+        model="anthropic/claude-sonnet-4",
+    )
 
     codex_work = bindings.list_active_work_summaries(agent_id="codex")
     opencode_work = bindings.list_active_work_summaries(agent_id="opencode")

--- a/tests/core/orchestration/test_bindings.py
+++ b/tests/core/orchestration/test_bindings.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tests.support.turn_execution import create_test_turn
+
 from codex_autorunner.core.managed_thread_store import ManagedThreadStore
 from codex_autorunner.core.orchestration import (
     OrchestrationBindingStore,
@@ -185,7 +187,7 @@ def test_binding_store_lists_bindings_and_active_work_by_agent_and_repo(
         repo_id="repo-2",
     )
     store = ManagedThreadStore(hub_root)
-    running_turn = store.create_turn(codex_thread_id, prompt="busy")
+    running_turn = create_test_turn(store, codex_thread_id, prompt="busy")
 
     repo_bindings = bindings.list_bindings(repo_id="repo-1")
     agent_bindings = bindings.list_bindings(agent_id="codex")
@@ -239,8 +241,9 @@ def test_binding_store_active_work_by_agent(tmp_path: Path) -> None:
         agent_id="opencode",
         repo_id="repo-1",
     )
-    thread_store.create_turn(codex_thread_id, prompt="codex busy")
-    thread_store.create_turn(
+    create_test_turn(thread_store, codex_thread_id, prompt="codex busy")
+    create_test_turn(
+        thread_store,
         opencode_thread_id,
         prompt="opencode busy",
         model="anthropic/claude-sonnet-4",
@@ -327,8 +330,8 @@ def test_binding_store_active_work_by_repo(tmp_path: Path) -> None:
         agent_id="codex",
         repo_id="repo-b",
     )
-    thread_store.create_turn(thread1_id, prompt="repo a busy")
-    thread_store.create_turn(thread2_id, prompt="repo b busy")
+    create_test_turn(thread_store, thread1_id, prompt="repo a busy")
+    create_test_turn(thread_store, thread2_id, prompt="repo b busy")
 
     repo_a_work = bindings.list_active_work_summaries(repo_id="repo-a")
     repo_b_work = bindings.list_active_work_summaries(repo_id="repo-b")
@@ -350,8 +353,9 @@ def test_binding_store_active_work_includes_queue_depth(tmp_path: Path) -> None:
     thread_id = _create_thread(
         hub_root, repo_id="repo-1", workspace_name="repo-1", thread_store=thread_store
     )
-    running_turn = thread_store.create_turn(thread_id, prompt="first")
-    queued_turn = thread_store.create_turn(
+    running_turn = create_test_turn(thread_store, thread_id, prompt="first")
+    queued_turn = create_test_turn(
+        thread_store,
         thread_id,
         prompt="second",
         busy_policy="queue",
@@ -439,17 +443,20 @@ def test_binding_store_active_work_excludes_idle_completed_and_archived_threads(
             repo_id="repo-1",
         )
 
-    completed_turn = thread_store.create_turn(completed_thread_id, prompt="completed")
+    completed_turn = create_test_turn(
+        thread_store, completed_thread_id, prompt="completed"
+    )
     assert thread_store.mark_turn_finished(
         completed_turn["managed_turn_id"], status="ok"
     )
 
-    running_turn = thread_store.create_turn(running_thread_id, prompt="running")
+    running_turn = create_test_turn(thread_store, running_thread_id, prompt="running")
 
-    queued_running_turn = thread_store.create_turn(
-        queued_thread_id, prompt="queued parent"
+    queued_running_turn = create_test_turn(
+        thread_store, queued_thread_id, prompt="queued parent"
     )
-    queued_turn = thread_store.create_turn(
+    queued_turn = create_test_turn(
+        thread_store,
         queued_thread_id,
         prompt="queued child",
         busy_policy="queue",
@@ -458,20 +465,23 @@ def test_binding_store_active_work_excludes_idle_completed_and_archived_threads(
         queued_running_turn["managed_turn_id"], status="ok"
     )
 
-    running_with_queue_turn = thread_store.create_turn(
+    running_with_queue_turn = create_test_turn(
+        thread_store,
         running_and_queued_thread_id,
         prompt="running parent",
     )
-    thread_store.create_turn(
+    create_test_turn(
+        thread_store,
         running_and_queued_thread_id,
         prompt="running child",
         busy_policy="queue",
     )
 
-    archived_running_turn = thread_store.create_turn(
-        archived_thread_id, prompt="archived"
+    archived_running_turn = create_test_turn(
+        thread_store, archived_thread_id, prompt="archived"
     )
-    thread_store.create_turn(
+    create_test_turn(
+        thread_store,
         archived_thread_id,
         prompt="archived child",
         busy_policy="queue",
@@ -569,7 +579,7 @@ def test_binding_store_supports_repo_resource_owner_queries(tmp_path: Path) -> N
         agent_id="codex",
         repo_id="hub-repo",
     )
-    store.create_turn(thread_id, prompt="busy")
+    create_test_turn(store, thread_id, prompt="busy")
 
     listed = bindings.list_bindings(
         resource_kind="repo",

--- a/tests/core/orchestration/test_execution_history_diagnostics.py
+++ b/tests/core/orchestration/test_execution_history_diagnostics.py
@@ -13,6 +13,7 @@ from codex_autorunner.core.orchestration.execution_history_diagnostics import (
     ExecutionHistoryThresholds,
     ExecutionHistoryTopN,
     check_thresholds,
+    collect_canonical_turn_state_diagnostics,
     collect_execution_history_metrics,
     collect_top_n_heavy_executions,
     detect_completion_gap_repeated_attempts,
@@ -250,6 +251,113 @@ def _seed_execution(
                         1,
                     ),
                 )
+
+
+def _canonical_payloads(
+    *,
+    execution_id: str,
+    status: str,
+    agent: str = "codex",
+    model: str | None = "gpt-test",
+    error_text: str | None = None,
+) -> tuple[dict[str, object], dict[str, object]]:
+    request: dict[str, object] = {
+        "contract_version": 1,
+        "request_id": f"request-{execution_id}",
+        "target_id": "thread-1",
+        "target_kind": "thread",
+        "workspace_root": "/workspace",
+        "request_kind": "message",
+        "busy_policy": "queue",
+        "prompt_text": "Summarize state",
+        "input_items": [],
+        "context_profile": None,
+        "agent": agent,
+        "profile": None,
+        "model": model,
+        "model_payload": (
+            {"providerID": "zai-coding-plan", "modelID": "glm-5.1"}
+            if agent == "opencode"
+            else {}
+        ),
+        "reasoning": "high",
+        "approval_policy": "never",
+        "approval_mode": None,
+        "sandbox_policy": "dangerFullAccess",
+        "client_request_id": f"client-{execution_id}",
+        "idempotency_key": execution_id,
+        "correlation_id": None,
+        "origin": {
+            "kind": "surface",
+            "source_id": "discord:channel-1",
+            "surface_kind": "discord",
+            "surface_key": "channel-1",
+            "automation_rule_id": None,
+            "publish_operation_id": None,
+            "parent_request_id": None,
+            "metadata": {},
+        },
+        "metadata": {},
+        "delivery_intents": [],
+    }
+    record_status = "completed" if status == "ok" else status
+    record: dict[str, object] = {
+        "contract_version": 1,
+        "request_id": request["request_id"],
+        "execution_id": execution_id,
+        "status": record_status,
+        "queued_at": "2026-04-12T00:00:00Z",
+        "claimed_at": None,
+        "started_at": "2026-04-12T00:00:00Z",
+        "terminal_at": ("2026-04-12T00:05:00Z" if record_status != "running" else None),
+        "backend_conversation_id": "backend-thread-1",
+        "backend_turn_id": "backend-turn-1",
+        "assistant_text": "done" if record_status == "completed" else None,
+        "error_text": error_text,
+        "transcript_ref": None,
+        "timeline_ref": None,
+        "cold_trace_ref": None,
+        "conflict_evidence": {},
+        "metadata": {},
+        "request": request,
+    }
+    return request, record
+
+
+def _attach_canonical_payloads(
+    hub_root: Path,
+    *,
+    execution_id: str,
+    status: str,
+    agent: str = "codex",
+    model: str | None = "gpt-test",
+    error_text: str | None = None,
+) -> None:
+    request, record = _canonical_payloads(
+        execution_id=execution_id,
+        status=status,
+        agent=agent,
+        model=model,
+        error_text=error_text,
+    )
+    with open_orchestration_sqlite(hub_root, durable=False) as conn:
+        with conn:
+            conn.execute(
+                """
+                UPDATE orch_thread_executions
+                   SET turn_contract_version = 1,
+                       turn_request_json = ?,
+                       turn_record_json = ?,
+                       error_text = COALESCE(?, error_text)
+                 WHERE execution_id = ?
+                """,
+                (
+                    json.dumps(request),
+                    json.dumps(record),
+                    error_text,
+                    execution_id,
+                ),
+            )
 
 
 def test_collect_metrics_counts_executions_and_rows(tmp_path: Path) -> None:
@@ -709,6 +817,172 @@ def test_detect_completion_gap_no_false_positives(tmp_path: Path) -> None:
     detections = detect_completion_gap_repeated_attempts(hub_root)
 
     assert len(detections) == 0
+
+
+def test_canonical_turn_diagnostics_classify_stale_running(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    _seed_execution(
+        hub_root,
+        execution_id="exec-stale",
+        status="running",
+    )
+    with open_orchestration_sqlite(hub_root, durable=False) as conn:
+        with conn:
+            conn.execute(
+                """
+                UPDATE orch_thread_executions
+                   SET finished_at = NULL
+                 WHERE execution_id = ?
+                """,
+                ("exec-stale",),
+            )
+    _attach_canonical_payloads(hub_root, execution_id="exec-stale", status="running")
+
+    diagnostics = collect_canonical_turn_state_diagnostics(
+        hub_root,
+        stale_after_seconds=60,
+    )
+
+    assert len(diagnostics) == 1
+    diag = diagnostics[0]
+    assert diag.request_id == "request-exec-stale"
+    assert diag.execution_id == "exec-stale"
+    assert diag.surface_origin == "discord:channel-1"
+    assert diag.target["target_id"] == "thread-1"
+    assert diag.lifecycle_phase == "stale_running"
+    assert diag.recovery_action == "classify_stale_running"
+    assert diag.runtime_options["model"] == "gpt-test"
+
+
+def test_canonical_turn_diagnostics_classify_queued_replay(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    _seed_execution(hub_root, execution_id="exec-queued", status="queued")
+    _attach_canonical_payloads(hub_root, execution_id="exec-queued", status="queued")
+
+    diagnostics = collect_canonical_turn_state_diagnostics(hub_root)
+
+    assert diagnostics[0].lifecycle_phase == "queued"
+    assert diagnostics[0].recovery_action == "replay_queued"
+
+
+def test_canonical_turn_diagnostics_detect_duplicate_terminal_writes(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    _seed_execution(hub_root, execution_id="exec-dup", output_chunks=1)
+    _attach_canonical_payloads(hub_root, execution_id="exec-dup", status="completed")
+    with open_orchestration_sqlite(hub_root, durable=False) as conn:
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO orch_event_projections (
+                    event_id, event_family, event_type, target_kind,
+                    target_id, execution_id, repo_id, resource_kind,
+                    resource_id, run_id, timestamp, status, payload_json,
+                    processed
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "turn-timeline:exec-dup:9999",
+                    "turn.timeline",
+                    "turn_completed",
+                    "thread_target",
+                    "thread-1",
+                    "exec-dup",
+                    "repo-1",
+                    "repo",
+                    "repo-1",
+                    None,
+                    "2026-04-12T00:05:01Z",
+                    "ok",
+                    json.dumps(
+                        {
+                            "event": {
+                                "final_message": "done",
+                                "error_message": "",
+                            }
+                        }
+                    ),
+                    1,
+                ),
+            )
+
+    diag = collect_canonical_turn_state_diagnostics(hub_root)[0]
+
+    assert diag.terminal_status == "completed"
+    assert diag.evidence["duplicate_terminal_writes"] is True
+    assert diag.evidence["conflicting_terminal_writes"] is False
+
+
+def test_canonical_turn_diagnostics_detect_conflicting_terminal_writes(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    _seed_execution(hub_root, execution_id="exec-conflict", output_chunks=1)
+    _attach_canonical_payloads(
+        hub_root, execution_id="exec-conflict", status="completed"
+    )
+    with open_orchestration_sqlite(hub_root, durable=False) as conn:
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO orch_event_projections (
+                    event_id, event_family, event_type, target_kind,
+                    target_id, execution_id, repo_id, resource_kind,
+                    resource_id, run_id, timestamp, status, payload_json,
+                    processed
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "turn-timeline:exec-conflict:9999",
+                    "turn.timeline",
+                    "turn_failed",
+                    "thread_target",
+                    "thread-1",
+                    "exec-conflict",
+                    "repo-1",
+                    "repo",
+                    "repo-1",
+                    None,
+                    "2026-04-12T00:05:01Z",
+                    "error",
+                    json.dumps({"event": {"error_message": "late failure"}}),
+                    1,
+                ),
+            )
+
+    diag = collect_canonical_turn_state_diagnostics(hub_root)[0]
+
+    assert diag.evidence["duplicate_terminal_writes"] is True
+    assert diag.evidence["conflicting_terminal_writes"] is True
+
+
+def test_canonical_turn_diagnostics_preserve_opencode_first_event_timeout(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    _seed_execution(hub_root, execution_id="exec-opencode", status="failed")
+    _attach_canonical_payloads(
+        hub_root,
+        execution_id="exec-opencode",
+        status="failed",
+        agent="opencode",
+        model="zai-coding-plan/glm-5.1",
+        error_text="opencode_first_event_timeout: no first event",
+    )
+
+    diag = collect_canonical_turn_state_diagnostics(hub_root)[0]
+
+    assert diag.runtime_options["agent"] == "opencode"
+    assert diag.runtime_options["model"] == "zai-coding-plan/glm-5.1"
+    assert diag.terminal_status == "failed"
+    assert diag.evidence["runtime_error_code"] == "opencode_first_event_timeout"
+    assert "opencode_first_event_timeout" in diag.evidence["error_text"]
 
 
 def test_run_diagnostics_full_report(tmp_path: Path) -> None:

--- a/tests/core/orchestration/test_managed_thread_timeline.py
+++ b/tests/core/orchestration/test_managed_thread_timeline.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tests.support.turn_execution import create_test_turn
+
 from codex_autorunner.core.managed_thread_store import ManagedThreadStore
 from codex_autorunner.core.orchestration import (
     ManagedThreadDeliveryEnvelope,
@@ -65,7 +67,8 @@ def test_user_message_timeline_projects_capsule_visibility_metadata(
     tmp_path: Path,
 ) -> None:
     hub_root, store, thread_id = _store(tmp_path)
-    turn = store.create_turn(
+    turn = create_test_turn(
+        store,
         thread_id,
         prompt="<injected context>\nrepo guidance\n</injected context>\n\nFix login",
         metadata={
@@ -120,7 +123,8 @@ def test_completed_timeline_separates_intermediate_and_final_output(
     tmp_path: Path,
 ) -> None:
     hub_root, store, thread_id = _store(tmp_path)
-    turn = store.create_turn(
+    turn = create_test_turn(
+        store,
         thread_id,
         prompt="summarize the repo",
         metadata={
@@ -183,7 +187,7 @@ def test_high_volume_assistant_and_log_deltas_do_not_expand_default_timeline(
     tmp_path: Path,
 ) -> None:
     hub_root, store, thread_id = _store(tmp_path)
-    turn = store.create_turn(thread_id, prompt="stream a lot")
+    turn = create_test_turn(store, thread_id, prompt="stream a lot")
     turn_id = str(turn["managed_turn_id"])
     events = [
         OutputDelta(
@@ -232,7 +236,7 @@ def test_running_timeline_projects_progress_tool_group_and_approval(
     tmp_path: Path,
 ) -> None:
     hub_root, store, thread_id = _store(tmp_path)
-    turn = store.create_turn(thread_id, prompt="run tests")
+    turn = create_test_turn(store, thread_id, prompt="run tests")
     turn_id = str(turn["managed_turn_id"])
     persist_turn_timeline(
         hub_root,
@@ -319,13 +323,15 @@ def test_queued_user_messages_remain_distinct_and_ordered_while_running(
     tmp_path: Path,
 ) -> None:
     hub_root, store, thread_id = _store(tmp_path)
-    active = store.create_turn(thread_id, prompt="active turn")
-    queued_one = store.create_turn(
+    active = create_test_turn(store, thread_id, prompt="active turn")
+    queued_one = create_test_turn(
+        store,
         thread_id,
         prompt="queued one",
         busy_policy="queue",
     )
-    queued_two = store.create_turn(
+    queued_two = create_test_turn(
+        store,
         thread_id,
         prompt="queued two",
         busy_policy="queue",
@@ -370,7 +376,7 @@ def test_failed_and_interrupted_timelines_include_terminal_status(
     tmp_path: Path,
 ) -> None:
     hub_root, store, thread_id = _store(tmp_path)
-    failed = store.create_turn(thread_id, prompt="will fail")
+    failed = create_test_turn(store, thread_id, prompt="will fail")
     failed_id = str(failed["managed_turn_id"])
     persist_turn_timeline(
         hub_root,
@@ -386,7 +392,7 @@ def test_failed_and_interrupted_timelines_include_terminal_status(
     )
     assert store.mark_turn_finished(failed_id, status="error", error="boom")
 
-    interrupted = store.create_turn(thread_id, prompt="will stop")
+    interrupted = create_test_turn(store, thread_id, prompt="will stop")
     interrupted_id = str(interrupted["managed_turn_id"])
     persist_turn_timeline(
         hub_root,
@@ -519,7 +525,7 @@ def test_live_tail_event_carries_hidden_progress_metadata() -> None:
 
 def test_timeline_includes_delivery_state_items(tmp_path: Path) -> None:
     hub_root, store, thread_id = _store(tmp_path)
-    turn = store.create_turn(thread_id, prompt="deliver this")
+    turn = create_test_turn(store, thread_id, prompt="deliver this")
     turn_id = str(turn["managed_turn_id"])
     assert store.mark_turn_finished(turn_id, status="ok", assistant_text="done")
     ledger = SQLiteManagedThreadDeliveryLedger(hub_root, durable=False)
@@ -589,7 +595,7 @@ def test_timeline_projects_equivalent_delivery_state_for_chat_surfaces(
     tmp_path: Path,
 ) -> None:
     hub_root, store, thread_id = _store(tmp_path)
-    turn = store.create_turn(thread_id, prompt="deliver everywhere")
+    turn = create_test_turn(store, thread_id, prompt="deliver everywhere")
     turn_id = str(turn["managed_turn_id"])
     assert store.mark_turn_finished(turn_id, status="ok", assistant_text="done")
     ledger = SQLiteManagedThreadDeliveryLedger(hub_root, durable=False)

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -365,6 +365,7 @@ class _SerializedHubClient:
                 reasoning=request.reasoning,
                 client_request_id=request.client_request_id,
                 queue_payload=request.queue_payload,
+                turn_request=request.turn_request,
             )
         )
 

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Optional
 
+import pytest
+
 from codex_autorunner.agents.registry import AgentDescriptor
 from codex_autorunner.agents.types import TerminalTurnResult
 from codex_autorunner.core.hub_control_plane import (
@@ -32,6 +34,9 @@ from codex_autorunner.core.orchestration.runtime_threads import (
     begin_next_queued_runtime_thread_execution,
     begin_runtime_thread_execution,
     stream_runtime_thread_events,
+)
+from codex_autorunner.core.orchestration.turn_execution_contract import (
+    TurnExecutionContractError,
 )
 
 
@@ -445,6 +450,7 @@ async def test_runtime_threads_use_wait_for_turn_contract_for_session_runtimes(
             target_id=thread.thread_target_id,
             target_kind="thread",
             message_text="hello world",
+            model="anthropic/claude-sonnet-4",
         ),
     )
     outcome = await await_runtime_thread_outcome(
@@ -457,6 +463,31 @@ async def test_runtime_threads_use_wait_for_turn_contract_for_session_runtimes(
     assert outcome.status == "ok"
     assert harness.wait_calls == [(workspace_root, "session-1", "stream-turn-1")]
     assert outcome.assistant_text == "hello world"
+
+
+async def test_opencode_runtime_thread_requires_resolved_model_before_start(
+    tmp_path: Path,
+) -> None:
+    harness = _HarnessWithStream()
+    service = _build_service(tmp_path, harness, agent_id="opencode", name="OpenCode")
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target("opencode", workspace_root)
+
+    with pytest.raises(
+        TurnExecutionContractError,
+        match="opencode requests require resolved provider/model",
+    ):
+        await begin_runtime_thread_execution(
+            service,
+            MessageRequest(
+                target_id=thread.thread_target_id,
+                target_kind="thread",
+                message_text="hello world",
+            ),
+        )
+
+    assert harness.ensure_ready_calls == []
 
 
 async def test_runtime_threads_begin_and_wait_via_serialized_remote_store(
@@ -1121,6 +1152,7 @@ async def test_stream_runtime_thread_events_proxies_harness_stream(
             target_id=thread.thread_target_id,
             target_kind="thread",
             message_text="hello world",
+            model="anthropic/claude-sonnet-4",
         ),
     )
 

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -463,6 +463,16 @@ async def test_runtime_threads_use_wait_for_turn_contract_for_session_runtimes(
     assert outcome.status == "ok"
     assert harness.wait_calls == [(workspace_root, "session-1", "stream-turn-1")]
     assert outcome.assistant_text == "hello world"
+    turn_request = service.thread_store.get_turn_execution_request(
+        thread.thread_target_id,
+        started.execution.execution_id,
+    )
+    assert turn_request is not None
+    assert turn_request.model == "anthropic/claude-sonnet-4"
+    assert turn_request.model_payload == {
+        "providerID": "anthropic",
+        "modelID": "claude-sonnet-4",
+    }
 
 
 async def test_opencode_runtime_thread_requires_resolved_model_before_start(

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -1343,6 +1343,8 @@ async def test_claim_next_queued_execution_context_preserves_typed_request_paylo
             target_kind="thread",
             message_text="second",
             approval_mode="never",
+            model="gpt-5.4",
+            reasoning="high",
             input_items=[
                 {"type": "text", "text": "second"},
                 {"type": "image", "image_url": "https://example.com/diagram.png"},
@@ -1363,9 +1365,10 @@ async def test_claim_next_queued_execution_context_preserves_typed_request_paylo
     assert stored_request is not None
     assert stored_request.request_id == queued.execution_id
     assert stored_request.request_kind == "message"
+    assert stored_request.busy_policy == "queue"
     assert stored_request.client_request_id == "client-2"
-    assert stored_request.model is None
-    assert stored_request.reasoning is None
+    assert stored_request.model == "gpt-5.4"
+    assert stored_request.reasoning == "high"
     assert stored_request.approval_mode == "never"
     assert stored_request.approval_policy == "never"
     assert stored_request.sandbox_policy == {"mode": "workspace-write"}
@@ -1382,7 +1385,24 @@ async def test_claim_next_queued_execution_context_preserves_typed_request_paylo
     assert claimed is not None
     assert claimed.thread.thread_target_id == thread.thread_target_id
     assert claimed.execution.execution_id == queued.execution_id
+    assert claimed.turn_request is not None
+    assert claimed.turn_request.request_id == queued.execution_id
+    assert claimed.turn_request.request_kind == "message"
+    assert claimed.turn_request.busy_policy == "queue"
+    assert claimed.turn_request.client_request_id == "client-2"
+    assert claimed.turn_request.model == "gpt-5.4"
+    assert claimed.turn_request.reasoning == "high"
+    assert claimed.turn_request.approval_mode == "never"
+    assert claimed.turn_request.approval_policy == "never"
+    assert claimed.turn_request.sandbox_policy == {"mode": "workspace-write"}
+    assert claimed.turn_request.input_items == (
+        {"type": "text", "text": "second"},
+        {"type": "image", "image_url": "https://example.com/diagram.png"},
+    )
+    assert claimed.turn_request.context_profile == "car_core"
     assert claimed.request.message_text == "second"
+    assert claimed.request.model == "gpt-5.4"
+    assert claimed.request.reasoning == "high"
     assert claimed.request.approval_mode == "never"
     assert claimed.request.input_items == [
         {"type": "text", "text": "second"},

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -1356,6 +1356,19 @@ async def test_claim_next_queued_execution_context_preserves_typed_request_paylo
         client_request_id="client-2",
         sandbox_policy={"mode": "workspace-write"},
     )
+    stored_request = service.thread_store.get_turn_execution_request(
+        thread.thread_target_id,
+        queued.execution_id,
+    )
+    assert stored_request is not None
+    assert stored_request.request_id == queued.execution_id
+    assert stored_request.request_kind == "message"
+    assert stored_request.client_request_id == "client-2"
+    assert stored_request.model is None
+    assert stored_request.reasoning is None
+    assert stored_request.approval_mode == "never"
+    assert stored_request.approval_policy == "never"
+    assert stored_request.sandbox_policy == {"mode": "workspace-write"}
     service.record_execution_result(
         thread.thread_target_id,
         running.execution_id,
@@ -1389,6 +1402,14 @@ async def test_claim_next_queued_execution_context_preserves_typed_request_paylo
     assert claimed.request.metadata["capsule_refs"] == []
     assert claimed.client_request_id == "client-2"
     assert claimed.sandbox_policy == {"mode": "workspace-write"}
+    stored_record = service.thread_store.get_turn_execution_record(
+        thread.thread_target_id,
+        queued.execution_id,
+    )
+    assert stored_record is not None
+    assert stored_record.status == "running"
+    assert stored_record.request.request_id == queued.execution_id
+    assert stored_record.claimed_at is not None
 
 
 async def test_send_message_queues_when_thread_is_busy_by_default(

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -31,6 +31,8 @@ from codex_autorunner.core.orchestration import (
     OrchestrationBindingStore,
     PausedFlowTarget,
     SurfaceThreadMessageRequest,
+    TurnExecutionOrigin,
+    TurnExecutionRequest,
 )
 from codex_autorunner.core.orchestration.models import FlowTarget
 from codex_autorunner.core.orchestration.runtime_bindings import (
@@ -48,6 +50,28 @@ from codex_autorunner.core.orchestration.transcript_mirror import TranscriptMirr
 from codex_autorunner.core.pma_automation_store import PmaAutomationStore
 
 FIXTURE_PATH = Path(__file__).resolve().parents[2] / "fixtures" / "fake_acp_server.py"
+
+
+def _test_turn_request(
+    *,
+    request_id: str,
+    thread_target_id: str,
+    workspace_root: Path,
+    prompt: str,
+) -> TurnExecutionRequest:
+    return TurnExecutionRequest(
+        request_id=request_id,
+        target_id=thread_target_id,
+        target_kind="thread",
+        workspace_root=str(workspace_root),
+        request_kind="message",
+        busy_policy="reject",
+        prompt_text=prompt,
+        agent="codex",
+        approval_policy="never",
+        sandbox_policy="dangerFullAccess",
+        origin=TurnExecutionOrigin(kind="system", source_id="test"),
+    )
 
 
 @dataclass
@@ -1497,7 +1521,7 @@ async def test_send_review_preserves_request_kind_through_queue_claim_and_result
     assert queued.status == "queued"
     assert queued.request_kind == "review"
 
-    claimed = service.claim_next_queued_execution_request(thread.thread_target_id)
+    claimed = service.claim_next_queued_execution_context(thread.thread_target_id)
     assert claimed is None
 
     completed = service.record_execution_result(
@@ -1510,26 +1534,19 @@ async def test_send_review_preserves_request_kind_through_queue_claim_and_result
     assert completed.request_kind == "message"
 
     harness.next_turn_id = "backend-review-2"
-    claimed = service.claim_next_queued_execution_request(thread.thread_target_id)
+    claimed = service.claim_next_queued_execution_context(thread.thread_target_id)
     assert claimed is not None
-    (
-        claimed_thread,
-        claimed_execution,
-        claimed_request,
-        client_request_id,
-        sandbox_policy,
-    ) = claimed
-    assert claimed_thread.thread_target_id == thread.thread_target_id
-    assert claimed_execution.request_kind == "review"
-    assert claimed_request.kind == "review"
-    assert client_request_id is None
-    assert sandbox_policy is None
+    assert claimed.thread.thread_target_id == thread.thread_target_id
+    assert claimed.execution.request_kind == "review"
+    assert claimed.request.kind == "review"
+    assert claimed.client_request_id is None
+    assert claimed.sandbox_policy is None
 
     harness.provisional_backend_assert = (service, thread.thread_target_id)
     started = await service._start_execution(
-        claimed_thread,
-        claimed_request,
-        claimed_execution,
+        claimed.thread,
+        claimed.request,
+        claimed.execution,
         harness=harness,
         workspace_root=workspace_root,
         sandbox_policy=None,
@@ -2665,7 +2682,14 @@ def test_service_exposes_binding_queries_when_binding_store_is_configured(
         service.get_binding(surface_kind="telegram", surface_key="123:root") is not None
     )
     turn = ManagedThreadStore(hub_root).create_turn(
-        thread.thread_target_id, prompt="busy"
+        thread.thread_target_id,
+        prompt="busy",
+        turn_request=_test_turn_request(
+            request_id="busy-turn",
+            thread_target_id=thread.thread_target_id,
+            workspace_root=workspace_root,
+            prompt="busy",
+        ),
     )
     summaries = service.list_active_work_summaries(repo_id="repo-1")
     assert len(summaries) == 1

--- a/tests/core/orchestration/test_sqlite_migrations.py
+++ b/tests/core/orchestration/test_sqlite_migrations.py
@@ -14,6 +14,7 @@ from codex_autorunner.core.orchestration import (
     apply_orchestration_migrations,
     collect_orchestration_migration_status,
     current_orchestration_schema_version,
+    list_orchestration_table_definitions,
 )
 from codex_autorunner.core.orchestration import migrations as migrations_module
 from codex_autorunner.core.orchestration.legacy_backfill_gate import (
@@ -154,6 +155,223 @@ def test_apply_orchestration_migrations_sets_latest_schema_version(
     assert runs[0]["target_version"] == ORCHESTRATION_SCHEMA_VERSION
     assert len(attempts) == ORCHESTRATION_SCHEMA_VERSION
     assert {row["status"] for row in attempts} == {"completed"}
+
+
+def test_fresh_orchestration_schema_reports_turn_execution_contract(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "orchestration.sqlite3"
+
+    with _connect(db_path) as conn:
+        apply_orchestration_migrations(conn)
+        columns = {
+            row["name"]: row
+            for row in conn.execute("PRAGMA table_info(orch_thread_executions)")
+        }
+        table = next(
+            item
+            for item in list_orchestration_table_definitions()
+            if item.name == "orch_thread_executions"
+        )
+
+    assert columns["turn_contract_version"]["dflt_value"] == "1"
+    assert "turn_request_json" in columns
+    assert "turn_record_json" in columns
+    assert "Canonical turn execution request/record envelopes" in table.description
+
+
+def test_turn_execution_contract_migration_backfills_legacy_thread_rows(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "orchestration.sqlite3"
+
+    with _connect(db_path) as conn:
+        apply_orchestration_migrations(conn)
+        conn.execute(
+            """
+            INSERT INTO orch_thread_targets (
+                thread_target_id, agent_id, backend_thread_id, repo_id,
+                resource_kind, resource_id, workspace_root, scope_urn,
+                surface_urn, backend_binding_json, display_name,
+                lifecycle_status, runtime_status, status_reason, status_turn_id,
+                last_execution_id, last_message_preview, compact_seed,
+                metadata_json, created_at, updated_at, status_updated_at,
+                status_terminal
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "thread-legacy",
+                "codex",
+                "backend-conversation",
+                "repo-1",
+                "repo",
+                "repo-1",
+                str(tmp_path / "workspace"),
+                "repo:repo-1",
+                "discord:guild:channel",
+                "{}",
+                "Legacy",
+                "active",
+                "completed",
+                "done",
+                "turn-terminal",
+                "turn-terminal",
+                "hello",
+                None,
+                json.dumps(
+                    {
+                        "agent_profile": "pro",
+                        "approval_mode": "on-request",
+                        "approval_policy": "on-request",
+                        "sandbox_policy": {"mode": "workspace-write"},
+                    }
+                ),
+                "2026-05-01T00:00:00Z",
+                "2026-05-01T00:00:00Z",
+                "2026-05-01T00:00:00Z",
+                1,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO orch_thread_executions (
+                execution_id, thread_target_id, client_request_id, request_kind,
+                prompt_text, status, backend_turn_id, assistant_text, error_text,
+                model_id, reasoning_level, metadata_json, transcript_mirror_id,
+                started_at, finished_at, created_at, turn_contract_version,
+                turn_request_json, turn_record_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "turn-queued",
+                "thread-legacy",
+                "client-queued",
+                "review",
+                "queued prompt",
+                "queued",
+                None,
+                None,
+                None,
+                "gpt-5.4",
+                "high",
+                json.dumps({"correlation_id": "corr-1"}),
+                None,
+                "2026-05-01T00:01:00Z",
+                None,
+                "2026-05-01T00:01:00Z",
+                0,
+                None,
+                None,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO orch_thread_executions (
+                execution_id, thread_target_id, client_request_id, request_kind,
+                prompt_text, status, backend_turn_id, assistant_text, error_text,
+                model_id, reasoning_level, metadata_json, transcript_mirror_id,
+                started_at, finished_at, created_at, turn_contract_version,
+                turn_request_json, turn_record_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "turn-terminal",
+                "thread-legacy",
+                "client-terminal",
+                "message",
+                "terminal prompt",
+                "ok",
+                "backend-turn",
+                "terminal output",
+                None,
+                "gpt-5.4",
+                "medium",
+                json.dumps({"terminal": True}),
+                "transcript-turn",
+                "2026-05-01T00:02:00Z",
+                "2026-05-01T00:03:00Z",
+                "2026-05-01T00:02:00Z",
+                0,
+                None,
+                None,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO orch_queue_items (
+                queue_item_id, lane_id, source_kind, source_key, dedupe_key,
+                state, visible_at, claimed_at, completed_at, payload_json,
+                created_at, updated_at, idempotency_key
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "queue-queued",
+                "thread:thread-legacy",
+                "thread_execution",
+                "turn-queued",
+                "client-queued",
+                "queued",
+                "2026-05-01T00:01:00Z",
+                None,
+                None,
+                json.dumps(
+                    {
+                        "request": {
+                            "target_id": "thread-legacy",
+                            "target_kind": "thread",
+                            "message_text": "queued prompt",
+                            "kind": "review",
+                            "busy_policy": "queue",
+                            "agent_profile": "pro",
+                            "model": "gpt-5.4",
+                            "reasoning": "high",
+                            "approval_mode": "on-request",
+                            "input_items": [{"type": "text", "text": "queued prompt"}],
+                            "context_profile": "car_core",
+                            "metadata": {"runtime_prompt": "queued runtime"},
+                        },
+                        "client_request_id": "client-queued",
+                        "sandbox_policy": {"mode": "workspace-write"},
+                    }
+                ),
+                "2026-05-01T00:01:00Z",
+                "2026-05-01T00:01:00Z",
+                "client-queued",
+            ),
+        )
+        conn.execute("DELETE FROM orch_schema_migrations WHERE version = 37")
+
+        version = apply_orchestration_migrations(conn)
+        rows = {
+            row["execution_id"]: row
+            for row in conn.execute(
+                """
+                SELECT execution_id, turn_contract_version, turn_request_json,
+                       turn_record_json
+                  FROM orch_thread_executions
+                 WHERE thread_target_id = 'thread-legacy'
+                """
+            ).fetchall()
+        }
+
+    assert version == ORCHESTRATION_SCHEMA_VERSION
+    queued_request = json.loads(rows["turn-queued"]["turn_request_json"])
+    queued_record = json.loads(rows["turn-queued"]["turn_record_json"])
+    terminal_record = json.loads(rows["turn-terminal"]["turn_record_json"])
+    assert rows["turn-queued"]["turn_contract_version"] == 1
+    assert queued_request["request_kind"] == "review"
+    assert queued_request["client_request_id"] == "client-queued"
+    assert queued_request["model"] == "gpt-5.4"
+    assert queued_request["reasoning"] == "high"
+    assert queued_request["sandbox_policy"] == {"mode": "workspace-write"}
+    assert queued_request["approval_policy"] == "on-request"
+    assert queued_request["origin"]["surface_kind"] == "discord"
+    assert queued_record["status"] == "queued"
+    assert terminal_record["status"] == "completed"
+    assert terminal_record["backend_conversation_id"] == "backend-conversation"
+    assert terminal_record["backend_turn_id"] == "backend-turn"
+    assert terminal_record["assistant_text"] == "terminal output"
+    assert terminal_record["transcript_ref"] == "transcript-turn"
 
 
 def test_automation_migration_diagnostics_report_blocked_mirror(

--- a/tests/core/orchestration/test_thread_store_adapter.py
+++ b/tests/core/orchestration/test_thread_store_adapter.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tests.support.turn_execution import build_test_turn_request
+
 from codex_autorunner.core.managed_thread_store import ManagedThreadStore
 from codex_autorunner.core.orchestration.thread_store_adapter import (
     ManagedThreadExecutionStore,
@@ -45,6 +47,11 @@ def test_managed_thread_execution_store_records_thread_activity(
     execution = store.create_execution(
         thread.thread_target_id,
         prompt="Summarize the current queue",
+        turn_request=build_test_turn_request(
+            managed_thread_id=thread.thread_target_id,
+            workspace_root=str(workspace_root),
+            prompt="Summarize the current queue",
+        ),
     )
     store.record_thread_activity(
         thread.thread_target_id,

--- a/tests/core/orchestration/test_turn_execution_contract.py
+++ b/tests/core/orchestration/test_turn_execution_contract.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+from codex_autorunner.core.hub_control_plane import ExecutionCreateRequest
+from codex_autorunner.core.orchestration.models import QueuedExecutionRequest
 from codex_autorunner.core.orchestration.turn_execution_contract import (
     TURN_EXECUTION_CONTRACT_VERSION,
     DeliveryIntentRef,
@@ -194,3 +196,51 @@ def test_opencode_request_accepts_explicit_resolved_provider_model_payload() -> 
 def test_contract_rejects_non_json_safe_metadata() -> None:
     with pytest.raises(TurnExecutionContractError, match="JSON-safe"):
         _request(metadata={"bad": object()})
+
+
+def test_live_execution_create_request_rejects_legacy_partial_shape() -> None:
+    with pytest.raises(ValueError, match="turn_request is required"):
+        ExecutionCreateRequest.from_mapping(
+            {
+                "thread_target_id": "thread-1",
+                "prompt": "hello",
+                "request_kind": "message",
+            }
+        )
+
+
+def test_queued_execution_payload_rejects_legacy_request_shape() -> None:
+    legacy_payload = {
+        "request": {
+            "target_id": "thread-1",
+            "message_text": "hello",
+        },
+        "client_request_id": "client-1",
+    }
+
+    with pytest.raises(ValueError, match="canonical turn_request"):
+        QueuedExecutionRequest.from_payload(
+            legacy_payload,
+            thread_target_id="thread-1",
+        )
+
+
+def test_queued_execution_payload_uses_canonical_turn_request_fields() -> None:
+    request = _request(target_id="thread-1")
+
+    queued = QueuedExecutionRequest.from_payload(
+        {
+            "turn_request": request.to_dict(),
+            "client_request_id": "client-1",
+        },
+        thread_target_id="thread-1",
+    )
+
+    assert queued.request.model == "zai-coding-plan/glm-5.1"
+    assert queued.request.reasoning == "high"
+    assert queued.request.approval_mode == "strict"
+    assert queued.sandbox_policy == {
+        "type": "workspaceWrite",
+        "writableRoots": ["/repo"],
+        "networkAccess": False,
+    }

--- a/tests/core/orchestration/test_turn_execution_contract.py
+++ b/tests/core/orchestration/test_turn_execution_contract.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import pytest
+
+from codex_autorunner.core.orchestration.turn_execution_contract import (
+    TURN_EXECUTION_CONTRACT_VERSION,
+    DeliveryIntentRef,
+    TurnExecutionContractError,
+    TurnExecutionOrigin,
+    TurnExecutionRecord,
+    TurnExecutionRequest,
+)
+
+
+def test_contract_symbols_are_exported_from_orchestration_package() -> None:
+    from codex_autorunner.core import orchestration
+
+    assert orchestration.TurnExecutionRequest is TurnExecutionRequest
+    assert orchestration.TurnExecutionRecord is TurnExecutionRecord
+    assert orchestration.TurnExecutionContractError is TurnExecutionContractError
+
+
+def _origin() -> TurnExecutionOrigin:
+    return TurnExecutionOrigin(
+        kind="surface",
+        source_id="discord:channel-1:message-1",
+        surface_kind="discord",
+        surface_key="channel-1",
+        metadata={"message_id": "message-1"},
+    )
+
+
+def _request(**overrides: object) -> TurnExecutionRequest:
+    values: dict[str, object] = {
+        "request_id": "req-1",
+        "target_id": "thread-1",
+        "target_kind": "thread",
+        "workspace_root": "/repo",
+        "request_kind": "message",
+        "busy_policy": "queue",
+        "prompt_text": "hello",
+        "input_items": ({"type": "text", "text": "hello"},),
+        "context_profile": "car_core",
+        "agent": "opencode",
+        "profile": "code",
+        "model": "zai-coding-plan/glm-5.1",
+        "model_payload": {
+            "providerID": "zai-coding-plan",
+            "modelID": "glm-5.1",
+        },
+        "reasoning": "high",
+        "approval_policy": "never",
+        "approval_mode": "strict",
+        "sandbox_policy": {
+            "type": "workspaceWrite",
+            "writableRoots": ["/repo"],
+            "networkAccess": False,
+        },
+        "client_request_id": "client-1",
+        "idempotency_key": "idem-1",
+        "correlation_id": "corr-1",
+        "origin": _origin(),
+        "metadata": {"rule": {"name": "nightly"}},
+        "delivery_intents": (
+            DeliveryIntentRef(
+                kind="discord_reply",
+                intent_id="delivery-1",
+                metadata={"surface_key": "channel-1"},
+            ),
+        ),
+    }
+    values.update(overrides)
+    return TurnExecutionRequest(**values)  # type: ignore[arg-type]
+
+
+def test_turn_execution_request_round_trips_without_dropping_runtime_fields() -> None:
+    request = _request()
+
+    payload = request.to_dict()
+    restored = TurnExecutionRequest.from_mapping(payload)
+    restored_json = TurnExecutionRequest.from_json(request.to_json())
+
+    assert payload["contract_version"] == TURN_EXECUTION_CONTRACT_VERSION
+    assert restored.to_dict() == payload
+    assert restored_json.to_dict() == payload
+    assert restored.model == "zai-coding-plan/glm-5.1"
+    assert restored.reasoning == "high"
+    assert restored.approval_policy == "never"
+    assert restored.approval_mode == "strict"
+    assert restored.sandbox_policy == {
+        "type": "workspaceWrite",
+        "writableRoots": ["/repo"],
+        "networkAccess": False,
+    }
+    assert restored.client_request_id == "client-1"
+    assert restored.request_kind == "message"
+    assert restored.input_items == ({"type": "text", "text": "hello"},)
+    assert restored.context_profile == "car_core"
+    assert request.to_json() == restored.to_json()
+
+
+def test_turn_execution_record_round_trips_with_terminal_references() -> None:
+    record = TurnExecutionRecord(
+        request=_request(),
+        execution_id="exec-1",
+        status="completed",
+        queued_at="2026-05-21T01:00:00Z",
+        claimed_at="2026-05-21T01:00:01Z",
+        started_at="2026-05-21T01:00:02Z",
+        terminal_at="2026-05-21T01:00:03Z",
+        backend_conversation_id="conversation-1",
+        backend_turn_id="turn-1",
+        assistant_text="done",
+        transcript_ref="transcript://exec-1",
+        timeline_ref="timeline://exec-1",
+        cold_trace_ref="cold-trace://exec-1",
+        conflict_evidence={"duplicate_terminal": False},
+    )
+
+    payload = record.to_dict()
+    restored = TurnExecutionRecord.from_mapping(payload)
+
+    assert restored.to_dict() == payload
+    assert TurnExecutionRecord.from_json(record.to_json()).to_dict() == payload
+    assert restored.request_id == "req-1"
+    assert restored.backend_conversation_id == "conversation-1"
+    assert restored.backend_turn_id == "turn-1"
+    assert restored.assistant_text == "done"
+    assert restored.conflict_evidence == {"duplicate_terminal": False}
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"target_id": ""}, "target_id is required"),
+        ({"prompt_text": "", "input_items": ()}, "prompt_text or input_items"),
+        ({"request_kind": "unknown"}, "request_kind must be one of"),
+        ({"busy_policy": "wait"}, "busy_policy must be one of"),
+        (
+            {
+                "target_kind": "flow",
+                "origin": TurnExecutionOrigin(
+                    kind="surface",
+                    source_id="web:1",
+                    surface_kind="pma",
+                    surface_key="thread-1",
+                ),
+            },
+            "surface origin cannot target a flow",
+        ),
+    ],
+)
+def test_turn_execution_request_rejects_invalid_required_fields(
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(TurnExecutionContractError, match=message):
+        _request(**overrides)
+
+
+def test_surface_origin_requires_surface_identity() -> None:
+    with pytest.raises(TurnExecutionContractError, match="surface_kind"):
+        TurnExecutionOrigin(kind="surface", source_id="message-1")
+
+
+def test_opencode_request_requires_resolved_provider_model_payload() -> None:
+    with pytest.raises(TurnExecutionContractError, match="provider/model"):
+        _request(model=None, model_payload={})
+
+    with pytest.raises(TurnExecutionContractError, match="provider/model"):
+        _request(model="glm-5.1", model_payload={})
+
+    with pytest.raises(TurnExecutionContractError, match="providerID"):
+        _request(model_payload={})
+
+    with pytest.raises(TurnExecutionContractError, match="must match"):
+        _request(
+            model_payload={
+                "providerID": "zai-coding-plan",
+                "modelID": "glm-4.6",
+            }
+        )
+
+
+def test_opencode_request_accepts_explicit_resolved_provider_model_payload() -> None:
+    request = _request()
+
+    assert request.model_payload == {
+        "providerID": "zai-coding-plan",
+        "modelID": "glm-5.1",
+    }
+
+
+def test_contract_rejects_non_json_safe_metadata() -> None:
+    with pytest.raises(TurnExecutionContractError, match="JSON-safe"):
+        _request(metadata={"bad": object()})

--- a/tests/core/orchestration/test_turn_execution_contract.py
+++ b/tests/core/orchestration/test_turn_execution_contract.py
@@ -160,6 +160,15 @@ def test_turn_execution_request_rejects_invalid_required_fields(
         _request(**overrides)
 
 
+def test_turn_execution_request_preserves_literal_prompt_whitespace() -> None:
+    request = _request(prompt_text="  keep literal text\n")
+
+    assert request.prompt_text == "  keep literal text\n"
+    assert TurnExecutionRequest.from_mapping(request.to_dict()).prompt_text == (
+        "  keep literal text\n"
+    )
+
+
 def test_surface_origin_requires_surface_identity() -> None:
     with pytest.raises(TurnExecutionContractError, match="surface_kind"):
         TurnExecutionOrigin(kind="surface", source_id="message-1")

--- a/tests/core/test_automation_managed_thread_executor.py
+++ b/tests/core/test_automation_managed_thread_executor.py
@@ -206,6 +206,7 @@ def test_managed_thread_turn_materializes_opencode_model_in_canonical_record(
     tmp_path: Path,
 ) -> None:
     store, threads, thread_id = _store_rule_event(tmp_path)
+    started_workers: list[str] = []
     store.enqueue_job(
         _job(
             thread_id,
@@ -227,6 +228,7 @@ def test_managed_thread_turn_materializes_opencode_model_in_canonical_record(
             hub_root=tmp_path / "hub",
             automation_store=store,
             thread_store=threads,
+            queue_worker_starter_fn=started_workers.append,
         ),
     )
 
@@ -236,6 +238,7 @@ def test_managed_thread_turn_materializes_opencode_model_in_canonical_record(
 
     saved = store.get_job("job-1")
     assert result.running == 1
+    assert started_workers == [thread_id]
     assert saved.managed_thread_execution_id is not None
     request = threads.get_turn_execution_request(
         thread_id,

--- a/tests/core/test_automation_managed_thread_executor.py
+++ b/tests/core/test_automation_managed_thread_executor.py
@@ -202,6 +202,61 @@ def test_managed_thread_turn_dead_letters_when_queue_worker_unavailable(
     assert started_workers == []
 
 
+def test_managed_thread_turn_materializes_opencode_model_in_canonical_record(
+    tmp_path: Path,
+) -> None:
+    store, threads, thread_id = _store_rule_event(tmp_path)
+    store.enqueue_job(
+        _job(
+            thread_id,
+            executor={
+                "kind": EXECUTOR_MANAGED_THREAD_TURN,
+                "prompt": "Say hi to {{ event.payload.name }}",
+                "client_turn_id": "client-opencode-1",
+                "agent": "opencode",
+                "model": "zai-coding-plan/glm-5.1",
+                "reasoning": "medium",
+            },
+            policy={"approval_mode": "never_require_approval"},
+        )
+    )
+    registry = AutomationExecutorRegistry()
+    registry.register(
+        EXECUTOR_MANAGED_THREAD_TURN,
+        ManagedThreadTurnAutomationExecutor(
+            hub_root=tmp_path / "hub",
+            automation_store=store,
+            thread_store=threads,
+        ),
+    )
+
+    result = AutomationJobWorker(store, registry).process_once(
+        now="2026-01-01T00:00:00Z"
+    )
+
+    saved = store.get_job("job-1")
+    assert result.running == 1
+    assert saved.managed_thread_execution_id is not None
+    request = threads.get_turn_execution_request(
+        thread_id,
+        str(saved.managed_thread_execution_id),
+    )
+    record = threads.get_turn_execution_record(
+        thread_id,
+        str(saved.managed_thread_execution_id),
+    )
+    assert request is not None
+    assert record is not None
+    assert request.agent == "opencode"
+    assert request.model == "zai-coding-plan/glm-5.1"
+    assert request.model_payload == {
+        "providerID": "zai-coding-plan",
+        "modelID": "glm-5.1",
+    }
+    assert record.request.model == "zai-coding-plan/glm-5.1"
+    assert record.request.reasoning == "medium"
+
+
 def test_managed_thread_default_approval_pauses_unattended_job(tmp_path: Path) -> None:
     store, threads, thread_id = _store_rule_event(tmp_path)
     store.enqueue_job(_job(thread_id))

--- a/tests/core/test_hub_control_plane_contract.py
+++ b/tests/core/test_hub_control_plane_contract.py
@@ -23,6 +23,7 @@ from codex_autorunner.core.hub_control_plane import (
     evaluate_handshake_compatibility,
     redact_automation_mapping,
 )
+from tests.support.turn_execution import build_test_turn_request
 
 
 def test_control_plane_version_parsing_and_ordering() -> None:
@@ -302,6 +303,15 @@ def test_thread_target_response_round_trips_agent_and_backend_ids() -> None:
 
 
 def test_execution_models_round_trip_with_existing_execution_record() -> None:
+    turn_request = build_test_turn_request(
+        managed_thread_id="thread-1",
+        workspace_root="/repo",
+        prompt="Summarize the latest run",
+        busy_policy="queue",
+        model="gpt-5.4",
+        reasoning="medium",
+        client_turn_id="client-77",
+    ).to_dict()
     create_request = ExecutionCreateRequest.from_mapping(
         {
             "thread_target_id": "thread-1",
@@ -312,6 +322,7 @@ def test_execution_models_round_trip_with_existing_execution_record() -> None:
             "reasoning": "medium",
             "client_request_id": "client-77",
             "queue_payload": {"priority": "high"},
+            "turn_request": turn_request,
         }
     )
     execution_response = ExecutionResponse.from_mapping(
@@ -362,6 +373,7 @@ def test_execution_models_round_trip_with_existing_execution_record() -> None:
         "reasoning": "medium",
         "client_request_id": "client-77",
         "queue_payload": {"priority": "high"},
+        "turn_request": turn_request,
     }
     assert execution_response.execution is not None
     assert execution_response.execution.execution_id == "exec-1"

--- a/tests/core/test_hub_control_plane_service.py
+++ b/tests/core/test_hub_control_plane_service.py
@@ -53,6 +53,7 @@ from codex_autorunner.core.orchestration.sqlite import prepare_orchestration_sql
 from codex_autorunner.core.pma_notification_store import PmaNotificationStore
 from codex_autorunner.core.pma_transcripts import PmaTranscriptStore
 from codex_autorunner.core.ports.run_event import Completed, Started
+from tests.support.turn_execution import build_test_turn_request
 
 
 class _SupervisorStub:
@@ -102,6 +103,23 @@ def _build_service(tmp_path: Path) -> tuple[HubSharedStateService, str]:
     )
     thread_target_id = str(thread["managed_thread_id"])
     return service, thread_target_id
+
+
+def _test_turn_request(
+    tmp_path: Path,
+    thread_target_id: str,
+    *,
+    prompt: str,
+    busy_policy: str = "reject",
+    client_turn_id: str | None = None,
+) -> dict[str, object]:
+    return build_test_turn_request(
+        managed_thread_id=thread_target_id,
+        workspace_root=str(tmp_path / "hub" / "repos" / "repo-1"),
+        prompt=prompt,
+        busy_policy=busy_policy,
+        client_turn_id=client_turn_id,
+    ).to_dict()
 
 
 def test_shared_state_service_handshake_and_listing(tmp_path: Path) -> None:
@@ -414,6 +432,12 @@ def test_shared_state_service_execution_lifecycle_delegates_to_thread_store(
                 "thread_target_id": thread_target_id,
                 "prompt": "First turn",
                 "client_request_id": "client-1",
+                "turn_request": _test_turn_request(
+                    tmp_path,
+                    thread_target_id,
+                    prompt="First turn",
+                    client_turn_id="client-1",
+                ),
             }
         )
     )
@@ -425,6 +449,13 @@ def test_shared_state_service_execution_lifecycle_delegates_to_thread_store(
                 "busy_policy": "queue",
                 "client_request_id": "client-2",
                 "queue_payload": {"priority": "normal"},
+                "turn_request": _test_turn_request(
+                    tmp_path,
+                    thread_target_id,
+                    prompt="Second turn",
+                    busy_policy="queue",
+                    client_turn_id="client-2",
+                ),
             }
         )
     )
@@ -536,6 +567,11 @@ def test_shared_state_service_execution_queue_controls_delegate_to_thread_store(
             {
                 "thread_target_id": thread_target_id,
                 "prompt": "Running turn",
+                "turn_request": _test_turn_request(
+                    tmp_path,
+                    thread_target_id,
+                    prompt="Running turn",
+                ),
             }
         )
     )
@@ -545,6 +581,12 @@ def test_shared_state_service_execution_queue_controls_delegate_to_thread_store(
                 "thread_target_id": thread_target_id,
                 "prompt": "Queued one",
                 "busy_policy": "queue",
+                "turn_request": _test_turn_request(
+                    tmp_path,
+                    thread_target_id,
+                    prompt="Queued one",
+                    busy_policy="queue",
+                ),
             }
         )
     )
@@ -554,6 +596,12 @@ def test_shared_state_service_execution_queue_controls_delegate_to_thread_store(
                 "thread_target_id": thread_target_id,
                 "prompt": "Queued two",
                 "busy_policy": "queue",
+                "turn_request": _test_turn_request(
+                    tmp_path,
+                    thread_target_id,
+                    prompt="Queued two",
+                    busy_policy="queue",
+                ),
             }
         )
     )

--- a/tests/core/test_hub_control_plane_service.py
+++ b/tests/core/test_hub_control_plane_service.py
@@ -44,7 +44,10 @@ from codex_autorunner.core.managed_thread_store import (
     ManagedThreadStore,
     prepare_managed_thread_store,
 )
-from codex_autorunner.core.orchestration import SQLiteChatSurfaceEventJournal
+from codex_autorunner.core.orchestration import (
+    SQLiteChatSurfaceEventJournal,
+    TurnExecutionRequest,
+)
 from codex_autorunner.core.orchestration.cold_trace_store import ColdTraceStore
 from codex_autorunner.core.orchestration.sqlite import prepare_orchestration_sqlite
 from codex_autorunner.core.pma_notification_store import PmaNotificationStore
@@ -515,7 +518,10 @@ def test_shared_state_service_execution_lifecycle_delegates_to_thread_store(
     assert lookup.execution.backend_id == "backend-1"
     assert claimed.execution is not None
     assert claimed.execution.execution_id == second.execution.execution_id
-    assert claimed.queue_payload == {"priority": "normal"}
+    turn_request = TurnExecutionRequest.from_mapping(
+        claimed.queue_payload["turn_request"]
+    )
+    assert turn_request.prompt_text == "Second turn"
     assert interrupted.execution is not None
     assert interrupted.execution.status == "interrupted"
 

--- a/tests/core/test_publish_executor.py
+++ b/tests/core/test_publish_executor.py
@@ -21,6 +21,7 @@ from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
 from codex_autorunner.core.managed_thread_store import ManagedThreadStore
 from codex_autorunner.core.orchestration import (
     OrchestrationBindingStore,
+    TurnExecutionOrigin,
     TurnExecutionRequest,
 )
 from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
@@ -49,6 +50,28 @@ _ALLOW_REVIEW_COMMENT_REACTION_POLICY = {
 
 def _parse_utc(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _test_turn_request(
+    *,
+    request_id: str,
+    thread_target_id: str,
+    workspace_root: Path,
+    prompt: str,
+) -> TurnExecutionRequest:
+    return TurnExecutionRequest(
+        request_id=request_id,
+        target_id=thread_target_id,
+        target_kind="thread",
+        workspace_root=str(workspace_root),
+        request_kind="message",
+        busy_policy="reject",
+        prompt_text=prompt,
+        agent="codex",
+        approval_policy="never",
+        sandbox_policy="dangerFullAccess",
+        origin=TurnExecutionOrigin(kind="system", source_id="test"),
+    )
 
 
 class _QueuedClock:
@@ -1028,7 +1051,14 @@ def test_enqueue_managed_turn_executor_merges_into_existing_queued_scm_turn(
         metadata={"head_branch": "feature/scm-rebind"},
     )
     running_turn = thread_store.create_turn(
-        thread["managed_thread_id"], prompt="already running"
+        thread["managed_thread_id"],
+        prompt="already running",
+        turn_request=_test_turn_request(
+            request_id="already-running",
+            thread_target_id=thread["managed_thread_id"],
+            workspace_root=workspace_root,
+            prompt="already running",
+        ),
     )
     binding = PrBindingStore(hub_root).upsert_binding(
         provider="github",

--- a/tests/core/test_publish_executor.py
+++ b/tests/core/test_publish_executor.py
@@ -19,7 +19,10 @@ from codex_autorunner.adapters.github.publisher import (
 from codex_autorunner.adapters.github.service import RepoInfo
 from codex_autorunner.core.config import CONFIG_FILENAME, DEFAULT_HUB_CONFIG
 from codex_autorunner.core.managed_thread_store import ManagedThreadStore
-from codex_autorunner.core.orchestration import OrchestrationBindingStore
+from codex_autorunner.core.orchestration import (
+    OrchestrationBindingStore,
+    TurnExecutionRequest,
+)
 from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.pr_bindings import PrBindingStore
 from codex_autorunner.core.publish_executor import (
@@ -1159,7 +1162,8 @@ def test_enqueue_managed_turn_executor_merges_into_existing_queued_scm_turn(
         queued_turn["managed_turn_id"],
     )
     assert queued_payload is not None
-    assert queued_payload["request"]["message_text"] == queued_turn["prompt"]
+    turn_request = TurnExecutionRequest.from_mapping(queued_payload["turn_request"])
+    assert turn_request.prompt_text == queued_turn["prompt"]
 
 
 def test_enqueue_managed_turn_executor_rebinds_instead_of_merging_stale_archived_queue(

--- a/tests/core/test_remote_execution_store.py
+++ b/tests/core/test_remote_execution_store.py
@@ -27,6 +27,7 @@ from codex_autorunner.core.hub_control_plane.background_runner import (
 )
 from codex_autorunner.core.orchestration.interfaces import ThreadExecutionStore
 from codex_autorunner.core.orchestration.models import ExecutionRecord, ThreadTarget
+from tests.support.turn_execution import build_test_turn_request
 
 
 def _thread_payload() -> dict[str, Any]:
@@ -114,13 +115,13 @@ class _FakeHubClient:
                     status="running",
                 ),
                 "queue_payload": {
-                    "request": {
-                        "target_id": "thread-1",
-                        "target_kind": "thread",
-                        "message_text": "queued prompt",
-                        "kind": "message",
-                        "busy_policy": "queue",
-                    },
+                    "turn_request": build_test_turn_request(
+                        managed_thread_id="thread-1",
+                        workspace_root="/workspace",
+                        prompt="queued prompt",
+                        busy_policy="queue",
+                        client_turn_id="client-2",
+                    ).to_dict(),
                     "client_request_id": "client-2",
                 },
             }
@@ -274,6 +275,15 @@ def test_remote_execution_store_delegates_to_hub_client_for_thread_and_execution
         backend_runtime_instance_id="runtime-2",
     )
 
+    turn_request = build_test_turn_request(
+        managed_thread_id="thread-1",
+        workspace_root="/workspace",
+        prompt="Run this",
+        busy_policy="queue",
+        model="gpt-5.4",
+        reasoning="high",
+        client_turn_id="client-1",
+    )
     created_execution = store.create_execution(
         "thread-1",
         prompt="Run this",
@@ -283,6 +293,7 @@ def test_remote_execution_store_delegates_to_hub_client_for_thread_and_execution
         reasoning="high",
         client_request_id="client-1",
         queue_payload={"priority": "high"},
+        turn_request=turn_request,
     )
     fetched_execution = store.get_execution("thread-1", "exec-1")
     running_execution = store.get_running_execution("thread-1")
@@ -392,6 +403,7 @@ def test_remote_execution_store_delegates_to_hub_client_for_thread_and_execution
         "reasoning": "high",
         "client_request_id": "client-1",
         "queue_payload": {"priority": "high"},
+        "turn_request": turn_request.to_dict(),
     }
 
     set_thread_backend_request = client.calls[5][1]
@@ -504,9 +516,14 @@ def test_remote_execution_store_translates_transport_failures_to_hub_unavailable
     None
 ):
     store = RemoteThreadExecutionStore(_TransportFailingClient())
+    turn_request = build_test_turn_request(
+        managed_thread_id="thread-1",
+        workspace_root="/workspace",
+        prompt="Run this",
+    )
 
     with pytest.raises(HubControlPlaneError) as exc_info:
-        store.create_execution("thread-1", prompt="Run this")
+        store.create_execution("thread-1", prompt="Run this", turn_request=turn_request)
 
     assert exc_info.value.code == "hub_unavailable"
     assert "create_execution" in str(exc_info.value)

--- a/tests/pma_support/core.py
+++ b/tests/pma_support/core.py
@@ -24,6 +24,8 @@ from codex_autorunner.core.orchestration import (
     ColdTraceStore,
     ExecutionRecord,
     ThreadTarget,
+    TurnExecutionOrigin,
+    TurnExecutionRequest,
 )
 from codex_autorunner.core.pma_queue import PmaQueue, QueueItemState
 from codex_autorunner.core.pma_transcripts import (
@@ -70,6 +72,53 @@ def _hermes_cfg(
         "default_profile": "m4",
     }
     return cfg
+
+
+def _pma_queue_turn_payload(
+    hub_env,
+    *,
+    lane_id: str,
+    message: str,
+    client_turn_id: str,
+    wake_up: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"stream": False}
+    if wake_up is not None:
+        metadata["wake_up"] = wake_up
+    turn_request = TurnExecutionRequest(
+        request_id=client_turn_id,
+        target_id=lane_id,
+        target_kind="thread",
+        workspace_root=str(hub_env.hub_root),
+        request_kind="message",
+        busy_policy="queue",
+        prompt_text=message,
+        input_items=(),
+        context_profile=None,
+        agent="codex",
+        profile=None,
+        model=None,
+        model_payload={},
+        reasoning=None,
+        approval_policy="on-request",
+        approval_mode="on-request",
+        sandbox_policy={"policy": "dangerFullAccess"},
+        client_request_id=client_turn_id,
+        idempotency_key=client_turn_id,
+        correlation_id=client_turn_id,
+        origin=TurnExecutionOrigin(
+            kind="surface",
+            source_id=f"test:{lane_id}:{client_turn_id}",
+            surface_kind="web",
+            surface_key=lane_id,
+            metadata={"test": True},
+        ),
+        metadata=metadata,
+    )
+    payload: dict[str, Any] = {"turn_request": turn_request.to_dict()}
+    if wake_up is not None:
+        payload["wake_up"] = wake_up
+    return payload
 
 
 def test_build_pma_routes_does_not_construct_async_primitives_on_route_build(
@@ -360,6 +409,15 @@ def test_pma_chat_submits_through_surface_orchestration_ingress(
         "prompt_text": "hello through ingress",
         "pma_enabled": True,
     }
+    queue_items = anyio.run(PmaQueue(hub_env.hub_root).list_items, "pma:default")
+    assert len(queue_items) == 1
+    queue_payload = queue_items[0].payload
+    assert set(queue_payload) == {"turn_request"}
+    turn_request = TurnExecutionRequest.from_mapping(queue_payload["turn_request"])
+    assert turn_request.prompt_text == "hello through ingress"
+    assert turn_request.agent == "codex"
+    assert turn_request.target_id == "pma:default"
+    assert turn_request.origin.surface_kind == "web"
 
 
 @pytest.mark.anyio
@@ -540,6 +598,8 @@ def test_pma_chat_applies_model_reasoning_defaults(hub_env) -> None:
     class FakeClient:
         def __init__(self) -> None:
             self.turn_kwargs = None
+            self.approval_policy = None
+            self.sandbox_policy = None
 
         async def thread_resume(self, thread_id: str) -> None:
             return None
@@ -555,6 +615,8 @@ def test_pma_chat_applies_model_reasoning_defaults(hub_env) -> None:
             sandbox_policy: str,
             **turn_kwargs,
         ):
+            self.approval_policy = approval_policy
+            self.sandbox_policy = sandbox_policy
             self.turn_kwargs = turn_kwargs
             return FakeTurnHandle()
 
@@ -576,6 +638,8 @@ def test_pma_chat_applies_model_reasoning_defaults(hub_env) -> None:
         "model": "test-model",
         "effort": "high",
     }
+    assert app.state.app_server_supervisor.client.approval_policy == "on-request"
+    assert app.state.app_server_supervisor.client.sandbox_policy == "dangerFullAccess"
 
 
 def test_pma_chat_response_omits_legacy_delivery_fields(hub_env) -> None:
@@ -1367,7 +1431,14 @@ async def test_pma_second_lane_item_does_not_clobber_active_turn(hub_env) -> Non
     app.state.app_server_supervisor = FakeSupervisor()
     app.state.app_server_events = object()
 
+    async def _fast_snapshot(_supervisor: Any, *, hub_root: Path) -> dict[str, Any]:
+        _ = hub_root
+        return {}
+
+    app.state.pma_container.ports.build_hub_snapshot = _fast_snapshot
+
     queue = PmaQueue(hub_env.hub_root)
+    runtime_state = app.state.pma_container.runtime_state
     lane_id = "pma:test-concurrency"
     start_lane_worker = app.state.pma_lane_worker_start
     stop_lane_worker = app.state.pma_lane_worker_stop
@@ -1387,9 +1458,10 @@ async def test_pma_second_lane_item_does_not_clobber_active_turn(hub_env) -> Non
         try:
             with anyio.fail_after(2):
                 while True:
-                    active_resp = await client.get("/hub/pma/active")
-                    assert active_resp.status_code == 200
-                    active_payload = active_resp.json()
+                    active_payload = {
+                        "active": bool(runtime_state.pma_active),
+                        "current": await runtime_state.get_current_snapshot(),
+                    }
                     current = active_payload.get("current") or {}
                     if (
                         active_payload.get("active")
@@ -1406,11 +1478,12 @@ async def test_pma_second_lane_item_does_not_clobber_active_turn(hub_env) -> Non
             second_item, _ = await queue.enqueue(
                 lane_id,
                 "pma:test-concurrency:key-2",
-                {
-                    "message": "second turn",
-                    "agent": "codex",
-                    "client_turn_id": "turn-2",
-                },
+                _pma_queue_turn_payload(
+                    hub_env,
+                    lane_id=lane_id,
+                    message="second turn",
+                    client_turn_id="turn-2",
+                ),
             )
             await start_lane_worker(app, lane_id)
 
@@ -1440,7 +1513,10 @@ async def test_pma_second_lane_item_does_not_clobber_active_turn(hub_env) -> Non
             assert "already active" in (second_result.get("detail") or "").lower()
             assert turn_start_calls == 1
 
-            still_active = (await client.get("/hub/pma/active")).json()
+            still_active = {
+                "active": bool(runtime_state.pma_active),
+                "current": await runtime_state.get_current_snapshot(),
+            }
             assert still_active["active"] is True
             assert still_active["current"]["client_turn_id"] == "turn-1"
             assert still_active["current"]["thread_id"] == first_current["thread_id"]
@@ -1520,21 +1596,23 @@ async def test_pma_wakeup_turn_publishes_to_discord_and_telegram_outboxes(
     assert callable(start_lane_worker)
     assert callable(stop_lane_worker)
 
+    wake_up = {
+        "wakeup_id": "wakeup-123",
+        "repo_id": hub_env.repo_id,
+        "event_type": "managed_thread_completed",
+        "source": "lifecycle_subscription",
+        "run_id": "run-123",
+    }
     item, _ = await queue.enqueue(
         lane_id,
         "pma:test-publish:key-1",
-        {
-            "message": "Automation wake-up received.",
-            "agent": "codex",
-            "client_turn_id": "wakeup-123",
-            "wake_up": {
-                "wakeup_id": "wakeup-123",
-                "repo_id": hub_env.repo_id,
-                "event_type": "managed_thread_completed",
-                "source": "lifecycle_subscription",
-                "run_id": "run-123",
-            },
-        },
+        _pma_queue_turn_payload(
+            hub_env,
+            lane_id=lane_id,
+            message="Automation wake-up received.",
+            client_turn_id="wakeup-123",
+            wake_up=wake_up,
+        ),
     )
 
     try:
@@ -1593,21 +1671,23 @@ async def test_pma_wakeup_failure_publishes_failure_summary(hub_env) -> None:
     assert callable(start_lane_worker)
     assert callable(stop_lane_worker)
 
+    wake_up = {
+        "wakeup_id": "wakeup-456",
+        "repo_id": hub_env.repo_id,
+        "event_type": "managed_thread_failed",
+        "source": "lifecycle_subscription",
+        "run_id": "run-456",
+    }
     item, _ = await queue.enqueue(
         lane_id,
         "pma:test-publish:key-2",
-        {
-            "message": "Automation wake-up received.",
-            "agent": "codex",
-            "client_turn_id": "wakeup-456",
-            "wake_up": {
-                "wakeup_id": "wakeup-456",
-                "repo_id": hub_env.repo_id,
-                "event_type": "managed_thread_failed",
-                "source": "lifecycle_subscription",
-                "run_id": "run-456",
-            },
-        },
+        _pma_queue_turn_payload(
+            hub_env,
+            lane_id=lane_id,
+            message="Automation wake-up received.",
+            client_turn_id="wakeup-456",
+            wake_up=wake_up,
+        ),
     )
 
     try:
@@ -1690,21 +1770,23 @@ async def test_pma_wakeup_publish_retries_transient_telegram_enqueue_failure(
     assert callable(start_lane_worker)
     assert callable(stop_lane_worker)
 
+    wake_up = {
+        "wakeup_id": "wakeup-retry-123",
+        "repo_id": hub_env.repo_id,
+        "event_type": "managed_thread_completed",
+        "source": "lifecycle_subscription",
+        "run_id": "run-retry-123",
+    }
     item, _ = await queue.enqueue(
         lane_id,
         "pma:test-publish-retry:key-1",
-        {
-            "message": "Automation wake-up received.",
-            "agent": "codex",
-            "client_turn_id": "wakeup-retry-123",
-            "wake_up": {
-                "wakeup_id": "wakeup-retry-123",
-                "repo_id": hub_env.repo_id,
-                "event_type": "managed_thread_completed",
-                "source": "lifecycle_subscription",
-                "run_id": "run-retry-123",
-            },
-        },
+        _pma_queue_turn_payload(
+            hub_env,
+            lane_id=lane_id,
+            message="Automation wake-up received.",
+            client_turn_id="wakeup-retry-123",
+            wake_up=wake_up,
+        ),
     )
 
     try:
@@ -1813,21 +1895,23 @@ async def test_pma_wakeup_turn_publishes_using_prev_workspace_repo_context(
     assert callable(start_lane_worker)
     assert callable(stop_lane_worker)
 
+    wake_up = {
+        "wakeup_id": "wakeup-prev-workspace-123",
+        "repo_id": hub_env.repo_id,
+        "event_type": "managed_thread_completed",
+        "source": "lifecycle_subscription",
+        "run_id": "run-prev-workspace-123",
+    }
     item, _ = await queue.enqueue(
         lane_id,
         "pma:test-publish-prev-workspace:key-1",
-        {
-            "message": "Automation wake-up received.",
-            "agent": "codex",
-            "client_turn_id": "wakeup-prev-workspace-123",
-            "wake_up": {
-                "wakeup_id": "wakeup-prev-workspace-123",
-                "repo_id": hub_env.repo_id,
-                "event_type": "managed_thread_completed",
-                "source": "lifecycle_subscription",
-                "run_id": "run-prev-workspace-123",
-            },
-        },
+        _pma_queue_turn_payload(
+            hub_env,
+            lane_id=lane_id,
+            message="Automation wake-up received.",
+            client_turn_id="wakeup-prev-workspace-123",
+            wake_up=wake_up,
+        ),
     )
 
     try:

--- a/tests/routes/test_ticket_chat_routes.py
+++ b/tests/routes/test_ticket_chat_routes.py
@@ -29,9 +29,11 @@ def test_ticket_chat_route_passes_selected_profile_into_execution(
         profile,
         model=None,
         reasoning=None,
+        turn_request=None,
         on_meta=None,
         on_usage=None,
     ):
+        _ = turn_request
         observed.update(
             {
                 "target": target.target,

--- a/tests/support/turn_execution.py
+++ b/tests/support/turn_execution.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from codex_autorunner.agents.runtime_options import resolve_opencode_model_payload
+from codex_autorunner.core.managed_thread_store import ManagedThreadStore
+from codex_autorunner.core.orchestration import (
+    TurnExecutionOrigin,
+    TurnExecutionRequest,
+)
+
+
+def build_test_turn_request(
+    *,
+    managed_thread_id: str,
+    workspace_root: str,
+    agent: str = "codex",
+    prompt: str,
+    request_kind: str = "message",
+    busy_policy: str = "reject",
+    model: str | None = None,
+    reasoning: str | None = None,
+    client_turn_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> TurnExecutionRequest:
+    resolved_model = model
+    if agent == "opencode" and resolved_model is None:
+        resolved_model = "openai/gpt-5"
+    model_payload = (
+        dict(resolve_opencode_model_payload(resolved_model) or {})
+        if agent == "opencode"
+        else {}
+    )
+    return TurnExecutionRequest(
+        request_id=client_turn_id or uuid.uuid4().hex,
+        target_id=managed_thread_id,
+        target_kind="thread",
+        workspace_root=workspace_root,
+        request_kind=request_kind,  # type: ignore[arg-type]
+        busy_policy=busy_policy,  # type: ignore[arg-type]
+        prompt_text=prompt,
+        agent=agent,
+        model=resolved_model,
+        model_payload=model_payload,
+        reasoning=reasoning,
+        approval_policy="never",
+        sandbox_policy="dangerFullAccess",
+        client_request_id=client_turn_id,
+        idempotency_key=client_turn_id,
+        origin=TurnExecutionOrigin(kind="system", source_id="test"),
+        metadata=dict(metadata or {}),
+    )
+
+
+def create_test_turn(
+    store: ManagedThreadStore,
+    managed_thread_id: str,
+    *,
+    prompt: str,
+    request_kind: str = "message",
+    busy_policy: str = "reject",
+    model: str | None = None,
+    reasoning: str | None = None,
+    client_turn_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    queue_payload: dict[str, Any] | None = None,
+    force_queue: bool = False,
+) -> dict[str, Any]:
+    thread = store.get_thread(managed_thread_id)
+    if thread is None:
+        raise AssertionError(f"missing test thread: {managed_thread_id}")
+    agent = str(thread.get("agent_id") or thread.get("agent") or "codex")
+    turn_request = build_test_turn_request(
+        managed_thread_id=managed_thread_id,
+        workspace_root=str(thread.get("workspace_root") or ""),
+        agent=agent,
+        prompt=prompt,
+        request_kind=request_kind,
+        busy_policy=busy_policy,
+        model=model,
+        reasoning=reasoning,
+        client_turn_id=client_turn_id,
+        metadata=dict(metadata or {}),
+    )
+    return store.create_turn(
+        managed_thread_id,
+        prompt=prompt,
+        request_kind=request_kind,
+        busy_policy=busy_policy,
+        model=turn_request.model,
+        reasoning=reasoning,
+        client_turn_id=client_turn_id,
+        metadata=metadata,
+        queue_payload=queue_payload,
+        turn_request=turn_request,
+        force_queue=force_queue,
+    )

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
@@ -2599,7 +2599,7 @@ def test_managed_thread_message_route_preserves_literal_message_whitespace(
     assert response.status_code == 200
     payload = response.json()
     assert payload["delivered_message"] == literal_message
-    assert captured["request"].message_text == literal_message
+    assert captured["request"].prompt_text == literal_message
     runtime_prompt = captured["request"].metadata["runtime_prompt"]
     assert f"<user_message>\n{literal_message}" in runtime_prompt
     assert runtime_prompt.endswith("\n</user_message>\n")

--- a/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
+++ b/tests/surfaces/web/routes/pma_routes/test_managed_thread_runtime.py
@@ -825,7 +825,9 @@ def test_managed_thread_message_route_no_wait_returns_after_enqueue(
     assert payload["execution_state"] == "running"
     assert payload["managed_turn_id"] == "managed-turn-1"
     assert payload["delivered_message"] == "hello from route"
-    assert observed["prepare_request"].message_text == "hello from route"
+    assert observed["prepare_request"].prompt_text == "hello from route"
+    assert observed["prepare_request"].target_id == managed_thread_id
+    assert observed["prepare_request"].approval_policy == "never"
     assert observed["sandbox_policy"] == "dangerFullAccess"
     assert observed["background_started"] is True
 
@@ -2638,7 +2640,7 @@ def test_managed_thread_message_route_delegates_harness_to_shared_finalization(
             _ = thread_target_id
             return None
 
-        def claim_next_queued_execution_request(self, thread_target_id: str):
+        def claim_next_queued_execution_context(self, thread_target_id: str):
             _ = thread_target_id
             return None
 

--- a/tests/surfaces/web/routes/pma_routes/test_tail_stream_characterization.py
+++ b/tests/surfaces/web/routes/pma_routes/test_tail_stream_characterization.py
@@ -143,6 +143,41 @@ class TestManagedThreadStatusShape:
         payload = response.json()
         assert payload["turn"]["activity"] == "idle"
 
+    def test_status_running_thread_exposes_canonical_request_metadata(
+        self, hub_env
+    ) -> None:
+        _enable_pma(hub_env.hub_root)
+        app = create_hub_app(hub_env.hub_root)
+        store = ManagedThreadStore(hub_env.hub_root)
+        created = store.create_thread(
+            "opencode",
+            hub_env.repo_root.resolve(),
+            repo_id=hub_env.repo_id,
+        )
+        managed_thread_id = str(created["managed_thread_id"])
+        turn = store.create_turn(
+            managed_thread_id,
+            prompt="Run canonical diagnostics",
+            model="zai-coding-plan/glm-5.1",
+            reasoning="medium",
+        )
+
+        with TestClient(app) as client:
+            response = client.get(f"/hub/pma/threads/{managed_thread_id}/status")
+
+        assert response.status_code == 200
+        payload = response.json()
+        canonical = payload["turn"]["canonical_request"]
+        assert canonical["request_id"] == turn["managed_turn_id"]
+        assert canonical["target_id"] == managed_thread_id
+        assert canonical["runtime_options"]["agent"] == "opencode"
+        assert canonical["runtime_options"]["model"] == "zai-coding-plan/glm-5.1"
+        assert canonical["runtime_options"]["model_payload"] == {
+            "providerID": "zai-coding-plan",
+            "modelID": "glm-5.1",
+        }
+        assert canonical["runtime_options"]["reasoning"] == "medium"
+
     def test_status_endpoint_exposes_queue_depth_field(self, hub_env) -> None:
         _enable_pma(hub_env.hub_root)
         app = create_hub_app(hub_env.hub_root)

--- a/tests/surfaces/web/routes/test_hub_control_plane_routes.py
+++ b/tests/surfaces/web/routes/test_hub_control_plane_routes.py
@@ -36,6 +36,7 @@ from codex_autorunner.core.managed_thread_store import (
     ManagedThreadStore,
     prepare_managed_thread_store,
 )
+from codex_autorunner.core.orchestration import TurnExecutionRequest
 from codex_autorunner.core.orchestration.sqlite import prepare_orchestration_sqlite
 from codex_autorunner.core.pma_notification_store import PmaNotificationStore
 from codex_autorunner.core.ports.run_event import Completed, Started
@@ -456,7 +457,10 @@ async def test_hub_control_plane_http_client_round_trip(tmp_path: Path) -> None:
     assert finalized.execution.backend_id == "backend-77"
     assert claimed.execution is not None
     assert claimed.execution.execution_id == queued_execution.execution.execution_id
-    assert claimed.queue_payload == {"source": "test"}
+    turn_request = TurnExecutionRequest.from_mapping(
+        claimed.queue_payload["turn_request"]
+    )
+    assert turn_request.prompt_text == "Queued remote turn"
     assert setup_result.setup_command_count == 3
 
 

--- a/tests/surfaces/web/routes/test_hub_control_plane_routes.py
+++ b/tests/surfaces/web/routes/test_hub_control_plane_routes.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from tests.support.turn_execution import build_test_turn_request
 
 from codex_autorunner.core.hub_control_plane import (
     AutomationRequest,
@@ -105,6 +106,21 @@ def _build_test_app(tmp_path: Path) -> tuple[FastAPI, str]:
     app.state.hub_control_plane_service = service
     app.include_router(build_hub_control_plane_routes())
     return app, str(thread["managed_thread_id"])
+
+
+def _test_turn_request(
+    tmp_path: Path,
+    thread_target_id: str,
+    *,
+    prompt: str,
+    busy_policy: str = "reject",
+) -> dict[str, object]:
+    return build_test_turn_request(
+        managed_thread_id=thread_target_id,
+        workspace_root=str(tmp_path / "hub" / "repos" / "repo-1"),
+        prompt=prompt,
+        busy_policy=busy_policy,
+    ).to_dict()
 
 
 def test_hub_control_plane_routes_return_typed_validation_errors(
@@ -323,6 +339,11 @@ async def test_hub_control_plane_http_client_round_trip(tmp_path: Path) -> None:
                 {
                     "thread_target_id": thread_target_id,
                     "prompt": "First remote turn",
+                    "turn_request": _test_turn_request(
+                        tmp_path,
+                        thread_target_id,
+                        prompt="First remote turn",
+                    ),
                 }
             )
         )
@@ -333,6 +354,12 @@ async def test_hub_control_plane_http_client_round_trip(tmp_path: Path) -> None:
                     "prompt": "Queued remote turn",
                     "busy_policy": "queue",
                     "queue_payload": {"source": "test"},
+                    "turn_request": _test_turn_request(
+                        tmp_path,
+                        thread_target_id,
+                        prompt="Queued remote turn",
+                        busy_policy="queue",
+                    ),
                 }
             )
         )

--- a/tests/test_file_chat_execution.py
+++ b/tests/test_file_chat_execution.py
@@ -105,6 +105,7 @@ async def test_file_chat_service_non_stream_and_stream_share_turn_lifecycle(
     target_path.write_text("before\n", encoding="utf-8")
     request = _make_request(repo_root)
     calls: list[str] = []
+    canonical_requests: list[dict[str, object]] = []
 
     async def fake_execute_file_chat_agent_turn(
         _request,
@@ -113,6 +114,9 @@ async def test_file_chat_service_non_stream_and_stream_share_turn_lifecycle(
         message: str,
         **kwargs,
     ) -> dict[str, object]:
+        turn_request = kwargs.get("turn_request")
+        assert turn_request is not None
+        canonical_requests.append(turn_request.to_dict())
         on_meta = kwargs.get("on_meta")
         assert on_meta is not None
         await on_meta("codex", f"thread-{message}", f"turn-{message}")
@@ -158,6 +162,19 @@ async def test_file_chat_service_non_stream_and_stream_share_turn_lifecycle(
     )
     stream_items = [item async for item in stream_iter]
     assert calls == ["nonstream", "stream"]
+    assert [item["request_id"] for item in canonical_requests] == [
+        "client-nonstream",
+        "client-stream",
+    ]
+    assert {
+        key: canonical_requests[0][key]
+        for key in ("target_id", "target_kind", "request_kind", "agent")
+    } == {
+        key: canonical_requests[1][key]
+        for key in ("target_id", "target_kind", "request_kind", "agent")
+    }
+    assert canonical_requests[0]["approval_policy"] == "on-request"
+    assert canonical_requests[0]["sandbox_policy"] == "dangerFullAccess"
     assert [item.event for item in stream_items] == [
         "status",
         "app-server",
@@ -169,6 +186,72 @@ async def test_file_chat_service_non_stream_and_stream_share_turn_lifecycle(
     assert state.active_chats == {}
     assert state.current_by_client == {}
     assert state.last_by_client["client-stream"]["turn_id"] == "turn-stream"
+    assert state.last_by_client["client-stream"]["execution_id"] == "client-stream"
+    assert state.last_by_client["client-stream"]["turn_request"]["request_id"] == (
+        "client-stream"
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_chat_service_active_state_uses_canonical_execution_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path
+    target_path = repo_root / ".codex-autorunner" / "contextspace" / "spec.md"
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_text("before\n", encoding="utf-8")
+    request = _make_request(repo_root)
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    async def fake_execute_file_chat_agent_turn(
+        _request,
+        _repo_root: Path,
+        _target,
+        _message: str,
+        **kwargs,
+    ) -> dict[str, object]:
+        on_meta = kwargs.get("on_meta")
+        assert on_meta is not None
+        await on_meta("codex", "thread-active", "turn-active")
+        started.set()
+        await finish.wait()
+        return {
+            "status": "ok",
+            "message": "done",
+            "thread_id": "thread-active",
+            "turn_id": "turn-active",
+        }
+
+    monkeypatch.setattr(
+        file_chat_service,
+        "execute_file_chat_agent_turn",
+        fake_execute_file_chat_agent_turn,
+    )
+
+    run_task = asyncio.create_task(
+        file_chat_service.run_turn(
+            request,
+            file_chat_service.FileChatTurnRequest(
+                target="contextspace:spec",
+                message="active",
+                client_turn_id="client-active",
+            ),
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    snapshot = await file_chat_service.get_active_snapshot(request, "client-active")
+    assert snapshot.active is True
+    assert snapshot.current["execution_id"] == "client-active"
+    assert snapshot.current["turn_record"]["execution_id"] == "client-active"
+    assert snapshot.current["turn_request"]["request_id"] == "client-active"
+
+    finish.set()
+    result = await run_task
+    assert result["execution_id"] == "client-active"
+    last = await file_chat_service.get_active_snapshot(request, "client-active")
+    assert last.active is False
+    assert last.last_result["execution_id"] == "client-active"
 
 
 @pytest.mark.asyncio
@@ -204,6 +287,42 @@ async def test_file_chat_service_rejects_already_running_turn(
 
     assert exc_info.value.status_code == 409
     assert exc_info.value.detail == "Ticket chat already running"
+
+
+@pytest.mark.asyncio
+async def test_file_chat_service_rejects_opencode_without_resolved_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path
+    target_path = repo_root / ".codex-autorunner" / "contextspace" / "spec.md"
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_text("before\n", encoding="utf-8")
+    request = _make_request(repo_root)
+
+    async def fail_execute(*args, **kwargs):
+        raise AssertionError("OpenCode execution should not start")
+
+    monkeypatch.setattr(
+        file_chat_service,
+        "execute_file_chat_agent_turn",
+        fail_execute,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await file_chat_service.run_turn(
+            request,
+            file_chat_service.FileChatTurnRequest(
+                target="contextspace:spec",
+                message="edit",
+                agent="opencode",
+            ),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert (
+        exc_info.value.detail
+        == "opencode requests require resolved provider/model before execution"
+    )
 
 
 @pytest.mark.asyncio
@@ -856,13 +975,20 @@ async def test_execute_file_chat_reports_capability_driven_error_for_unsupported
         agent="broken",
     )
 
-    assert result == {
+    assert {
+        key: result[key]
+        for key in (
+            "status",
+            "detail",
+        )
+    } == {
         "status": "error",
         "detail": (
             "Agent 'broken' does not support file-chat execution "
             "(missing capability: message_turns)"
         ),
     }
+    assert result["turn_request"]["agent"] == "broken"
 
 
 def test_resolve_file_chat_agent_selection_rejects_invalid_hermes_profile(

--- a/tests/test_file_chat_routes.py
+++ b/tests/test_file_chat_routes.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from codex_autorunner.surfaces.web.routes import file_chat as file_chat_routes
+from codex_autorunner.surfaces.web.services import file_chat as file_chat_service
+
+
+def test_file_chat_route_builds_canonical_turn_before_execution(tmp_path, monkeypatch):
+    contextspace_dir = tmp_path / ".codex-autorunner" / "contextspace"
+    contextspace_dir.mkdir(parents=True)
+    (contextspace_dir / "spec.md").write_text("before\n", encoding="utf-8")
+
+    observed = {}
+
+    async def fake_execute_file_chat(
+        _request,
+        _repo_root,
+        _target,
+        _message,
+        *,
+        turn_request,
+        **_kwargs,
+    ):
+        observed["turn_request"] = turn_request.to_dict()
+        return {"status": "ok", "message": "done"}
+
+    monkeypatch.setattr(
+        file_chat_service,
+        "execute_file_chat_agent_turn",
+        fake_execute_file_chat,
+    )
+
+    app = FastAPI()
+    app.include_router(file_chat_routes.build_file_chat_routes())
+    app.state.engine = SimpleNamespace(repo_root=tmp_path)
+    app.state.config = SimpleNamespace()
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/file-chat",
+            json={
+                "target": "contextspace:spec",
+                "message": "Edit the spec",
+                "client_turn_id": "client-route",
+            },
+        )
+
+    assert response.status_code == 200
+    assert observed["turn_request"]["request_id"] == "client-route"
+    assert observed["turn_request"]["target_id"] == "contextspace_spec.md"
+    assert observed["turn_request"]["origin"]["surface_kind"] == "web"

--- a/tests/test_managed_thread_store.py
+++ b/tests/test_managed_thread_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import json
 import threading
 from pathlib import Path
 
@@ -19,7 +20,7 @@ from codex_autorunner.core.managed_thread_store import (
     managed_threads_db_lock_path,
 )
 from codex_autorunner.core.managed_thread_store_rows import ManagedThreadRecord
-from codex_autorunner.core.orchestration import ColdTraceStore
+from codex_autorunner.core.orchestration import ColdTraceStore, TurnExecutionRequest
 from codex_autorunner.core.orchestration.chat_surface_events import (
     SQLiteChatSurfaceEventJournal,
 )
@@ -698,8 +699,9 @@ def test_claim_next_queued_turn_promotes_queued_execution(tmp_path: Path) -> Non
     assert execution["managed_turn_id"] == queued_turn["managed_turn_id"]
     assert execution["request_kind"] == "review"
     assert execution["status"] == "running"
-    assert payload["request"]["kind"] == "review"
-    assert payload["request"]["message_text"] == "second"
+    turn_request = TurnExecutionRequest.from_mapping(payload["turn_request"])
+    assert turn_request.request_kind == "review"
+    assert turn_request.prompt_text == "second"
     assert store.get_queue_depth(thread["managed_thread_id"]) == 0
 
 
@@ -924,8 +926,9 @@ def test_claim_next_queued_turn_recovers_stale_running_execution(
     execution, payload = claimed
     assert execution["managed_turn_id"] == queued_turn["managed_turn_id"]
     assert execution["status"] == "running"
-    assert payload["request"]["kind"] == "review"
-    assert payload["request"]["message_text"] == "third queued"
+    turn_request = TurnExecutionRequest.from_mapping(payload["turn_request"])
+    assert turn_request.request_kind == "review"
+    assert turn_request.prompt_text == "third queued"
 
     stale_after = store.get_turn(
         thread["managed_thread_id"], stale_running_turn["managed_turn_id"]
@@ -1123,7 +1126,8 @@ def test_claim_next_queued_turn_recovers_old_running_execution_when_status_turn_
     execution, payload = claimed
     assert execution["managed_turn_id"] == queued_turn["managed_turn_id"]
     assert execution["status"] == "running"
-    assert payload["request"]["message_text"] == "second queued"
+    turn_request = TurnExecutionRequest.from_mapping(payload["turn_request"])
+    assert turn_request.prompt_text == "second queued"
 
     stale_after = store.get_turn(
         thread["managed_thread_id"], stale_running_turn["managed_turn_id"]
@@ -1177,8 +1181,9 @@ def test_claim_next_queued_turn_recovers_running_turn_when_thread_status_is_term
     execution, payload = claimed
     assert execution["managed_turn_id"] == queued_turn["managed_turn_id"]
     assert execution["status"] == "running"
-    assert payload["request"]["kind"] == "review"
-    assert payload["request"]["message_text"] == "second queued"
+    turn_request = TurnExecutionRequest.from_mapping(payload["turn_request"])
+    assert turn_request.request_kind == "review"
+    assert turn_request.prompt_text == "second queued"
 
     stale_after = store.get_turn(
         thread["managed_thread_id"], stale_running_turn["managed_turn_id"]
@@ -1398,6 +1403,64 @@ def test_create_turn_rejects_archived_thread(tmp_path: Path) -> None:
         store.create_turn(thread["managed_thread_id"], prompt="should reject")
 
     assert store.list_turns(thread["managed_thread_id"]) == []
+
+
+def test_queued_turn_payload_persists_canonical_turn_request_only(
+    tmp_path: Path,
+) -> None:
+    store = ManagedThreadStore(tmp_path / "hub")
+    thread = store.create_thread("opencode", tmp_path / "workspace")
+    running = store.create_turn(
+        thread["managed_thread_id"],
+        prompt="first",
+        model="zai-coding-plan/glm-5.1",
+    )
+    queued = store.create_turn(
+        thread["managed_thread_id"],
+        prompt="scheduled opencode request",
+        busy_policy="queue",
+        model="zai-coding-plan/glm-5.1",
+        reasoning="medium",
+        client_turn_id="client-turn-1905",
+        queue_payload={
+            "request": {
+                "message_text": "scheduled opencode request",
+                "model": "wrong/legacy",
+            },
+            "client_request_id": "legacy-client",
+        },
+    )
+
+    assert running["status"] == "running"
+    assert queued["status"] == "queued"
+    turn_request = store.get_turn_execution_request(
+        thread["managed_thread_id"], queued["managed_turn_id"]
+    )
+    assert turn_request is not None
+    assert turn_request.model == "zai-coding-plan/glm-5.1"
+    assert turn_request.model_payload == {
+        "providerID": "zai-coding-plan",
+        "modelID": "glm-5.1",
+    }
+    assert turn_request.reasoning == "medium"
+    assert turn_request.client_request_id == "client-turn-1905"
+
+    with open_orchestration_sqlite(store.hub_root) as conn:
+        row = conn.execute(
+            """
+            SELECT payload_json
+              FROM orch_queue_items
+             WHERE source_kind = 'thread_execution'
+               AND source_key = ?
+            """,
+            (queued["managed_turn_id"],),
+        ).fetchone()
+
+    assert row is not None
+    queue_payload = json.loads(str(row["payload_json"]))
+    assert set(queue_payload) == {"turn_request"}
+    assert queue_payload["turn_request"] == turn_request.to_dict()
+    assert "request" not in queue_payload
 
 
 def test_archived_thread_terminalizes_live_running_turn(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Refactors turn execution around a canonical durable request/record contract and migrates the main managed-thread, PMA, automation, file-chat, Discord, Telegram, diagnostics, and recovery paths to use it.

## Why

Issue #1905 exposed that model/runtime options could be lost as turns moved between automation, PMA queues, managed threads, publish operations, and runtime harnesses. The fix is to resolve and persist a single canonical turn command before execution rather than letting each surface reconstruct partial runtime payloads.

## What changed

- Adds `TurnExecutionRequest`, `TurnExecutionRecord`, and SQLite storage/migration support.
- Routes runtime execution and orchestration history through canonical turn state.
- Migrates PMA sends, managed-thread automations, publish/SCM turns, file chat, Discord, and Telegram entrypoints.
- Rebuilds diagnostics/recovery to inspect canonical records and expose missing model/profile/runtime fields.
- Removes legacy turn-shape assumptions in the migrated paths and locks regression coverage.

## Validation

- Commit hook aggregate validation passed.
- `ruff` passed.
- `mypy src/codex_autorunner` passed.
- Backend pytest passed: 9349 passed.
- Focused canonical/PMA suite passed: 235 passed.
- Web UI lab fast check passed: 27 scenarios.
- Web frontend lint, build, and Vitest passed: 835 passed, 2 skipped.
