### PR TITLE
[codex] Align flow retire cleanup with clean state

### DIFF
--- a/src/codex_autorunner/core/flows/archive_helpers.py
+++ b/src/codex_autorunner/core/flows/archive_helpers.py
@@ -86,6 +86,19 @@ def flow_run_archive_root(repo_root: Path, run_id: str) -> Path:
     return _run_archive_root(repo_root) / run_id
 
 
+def count_orphaned_flow_artifact_dirs(
+    repo_root: Path, records: list[Any] | None = None
+) -> int:
+    """Count live flow artifact dirs that no longer have a flow_runs row."""
+    flows_root = repo_root / ".codex-autorunner" / "flows"
+    if not flows_root.exists() or not flows_root.is_dir():
+        return 0
+    known_run_ids = _known_flow_run_ids(repo_root, records)
+    return sum(
+        1 for path in _iter_orphaned_flow_artifact_dirs(flows_root, known_run_ids)
+    )
+
+
 def _get_run_archive_retention_policy(
     repo_root: Path,
 ) -> Optional[RunArchiveRetentionPolicy]:
@@ -173,6 +186,100 @@ def _checkpoint_and_vacuum_flow_db(
             "flows.db checkpoint/vacuum skipped after archive (database may be busy): %s",
             exc,
         )
+
+
+def _known_flow_run_ids(repo_root: Path, records: list[Any] | None) -> set[str]:
+    if records is not None:
+        return {
+            str(record.id).strip()
+            for record in records
+            if getattr(record, "id", None) is not None and str(record.id).strip()
+        }
+    db_path = resolve_repo_flows_db_path(repo_root)
+    if not db_path.exists():
+        return set()
+    try:
+        with FlowStore(db_path, durable=_get_durable_writes(repo_root)) as store:
+            return {record.id for record in store.list_flow_runs()}
+    except (sqlite3.Error, OSError, RuntimeError, ValueError, TypeError):
+        return set()
+
+
+def _iter_orphaned_flow_artifact_dirs(
+    flows_root: Path, known_run_ids: set[str]
+) -> list[Path]:
+    try:
+        children = sorted(flows_root.iterdir(), key=lambda path: path.name)
+    except OSError:
+        return []
+    return [
+        child
+        for child in children
+        if child.is_dir() and child.name.strip() and child.name not in known_run_ids
+    ]
+
+
+def _archive_orphaned_flow_artifact_dirs(
+    repo_root: Path,
+    *,
+    records: list[Any],
+) -> dict[str, Any]:
+    flows_root = repo_root / ".codex-autorunner" / "flows"
+    orphan_dirs = _iter_orphaned_flow_artifact_dirs(
+        flows_root, _known_flow_run_ids(repo_root, records)
+    )
+    archived: list[str] = []
+    failed: list[dict[str, str]] = []
+    summaries: list[dict[str, Any]] = []
+
+    for orphan_dir in orphan_dirs:
+        run_id = orphan_dir.name
+        archive_root = flow_run_archive_root(repo_root, run_id)
+        target_flow_state_dir = _next_archive_dir(archive_root / "flow_state")
+        try:
+            execution = execute_archive_entries(
+                (
+                    ArchiveEntrySpec(
+                        label="flow_state",
+                        source=orphan_dir,
+                        dest=target_flow_state_dir,
+                        mode="move",
+                    ),
+                ),
+                worktree_root=repo_root,
+            )
+        except Exception as exc:  # intentional: sibling cleanup must stay best-effort
+            logger.warning(
+                "Failed to archive orphaned flow artifacts %s",
+                run_id,
+                exc_info=exc,
+            )
+            failed.append(
+                {
+                    "run_id": run_id,
+                    "error": str(exc).strip() or exc.__class__.__name__,
+                }
+            )
+            continue
+        if "flow_state" in execution.moved_paths:
+            archived.append(run_id)
+            summaries.append(
+                {
+                    "run_id": run_id,
+                    "archive_dir": str(archive_root),
+                    "archived_flow_state_dir": str(target_flow_state_dir),
+                    "archived_paths": list(execution.moved_paths),
+                    "missing_paths": list(execution.missing_paths),
+                }
+            )
+
+    return {
+        "archived_orphan_flow_state_ids": archived,
+        "archived_orphan_flow_state_count": len(archived),
+        "archived_orphan_flow_states": summaries,
+        "failed_orphan_flow_states": failed,
+        "failed_orphan_flow_state_count": len(failed),
+    }
 
 
 def build_flow_archive_entries(
@@ -590,9 +697,10 @@ def archive_terminal_flow_runs(
     maintain_db: bool = True,
 ) -> dict[str, Any]:
     excluded = exclude_run_ids or frozenset()
+    all_records = store.list_flow_runs(flow_type="ticket_flow")
     records = [
         record
-        for record in store.list_flow_runs(flow_type="ticket_flow")
+        for record in all_records
         if record.status.is_terminal() and record.id not in excluded
     ]
     archived_run_ids: list[str] = []
@@ -633,6 +741,14 @@ def archive_terminal_flow_runs(
             )
         if delete_run and store.delete_flow_run(record.id):
             deleted_run_ids.append(record.id)
+    orphan_summary = _archive_orphaned_flow_artifact_dirs(
+        repo_root,
+        records=[
+            record
+            for record in all_records
+            if record.id not in deleted_run_ids and record.id not in archived_run_ids
+        ],
+    )
     if maintain_db and deleted_run_ids:
         _checkpoint_and_vacuum_flow_db(
             store=store,
@@ -650,6 +766,7 @@ def archive_terminal_flow_runs(
         "archived_runs": archived_run_summaries,
         "failed_runs": failed_runs,
         "failed_run_count": len(failed_runs),
+        **orphan_summary,
     }
 
 

--- a/src/codex_autorunner/core/flows/archive_helpers.py
+++ b/src/codex_autorunner/core/flows/archive_helpers.py
@@ -189,20 +189,22 @@ def _checkpoint_and_vacuum_flow_db(
 
 
 def _known_flow_run_ids(repo_root: Path, records: list[Any] | None) -> set[str]:
+    known: set[str] = set()
     if records is not None:
-        return {
+        known.update(
             str(record.id).strip()
             for record in records
             if getattr(record, "id", None) is not None and str(record.id).strip()
-        }
+        )
     db_path = resolve_repo_flows_db_path(repo_root)
     if not db_path.exists():
-        return set()
+        return known
     try:
         with FlowStore(db_path, durable=_get_durable_writes(repo_root)) as store:
-            return {record.id for record in store.list_flow_runs()}
+            known.update(record.id for record in store.list_flow_runs())
     except (sqlite3.Error, OSError, RuntimeError, ValueError, TypeError):
-        return set()
+        pass
+    return known
 
 
 def _iter_orphaned_flow_artifact_dirs(

--- a/src/codex_autorunner/core/hub_worktree_manager.py
+++ b/src/codex_autorunner/core/hub_worktree_manager.py
@@ -39,7 +39,10 @@ from .destinations import (
     resolve_effective_repo_destination,
 )
 from .flows import FlowStore
-from .flows.archive_helpers import archive_terminal_flow_runs
+from .flows.archive_helpers import (
+    archive_terminal_flow_runs,
+    count_orphaned_flow_artifact_dirs,
+)
 from .force_attestation import enforce_force_attestation
 from .git_utils import (
     GitError,
@@ -1329,10 +1332,13 @@ print(
             finally:
                 store.close()
             terminal = [r for r in records if r.status.is_terminal()]
-            if not terminal:
+            orphan_flow_state_count = count_orphaned_flow_artifact_dirs(
+                repo_root, records
+            )
+            if not terminal and not orphan_flow_state_count:
                 continue
             if dry_run:
-                n = len(terminal)
+                n = len(terminal) + orphan_flow_state_count
                 flow_by_repo.append({"repo_id": entry.id, "count": n})
                 total_flow_count += n
                 continue
@@ -1350,6 +1356,10 @@ print(
                     exc_info=exc,
                 )
                 archived_here = 0
+            else:
+                archived_here += int(
+                    cleanup_summary.get("archived_orphan_flow_state_count") or 0
+                )
             if archived_here:
                 flow_by_repo.append({"repo_id": entry.id, "count": archived_here})
             total_flow_count += archived_here

--- a/tests/test_cli_ticket_flow_archive.py
+++ b/tests/test_cli_ticket_flow_archive.py
@@ -12,7 +12,10 @@ from codex_autorunner.bootstrap import seed_hub_files
 from codex_autorunner.cli import app
 from codex_autorunner.core.apps import install_app
 from codex_autorunner.core.config import CONFIG_FILENAME, load_hub_config
-from codex_autorunner.core.flows.archive_helpers import archive_flow_run_artifacts
+from codex_autorunner.core.flows.archive_helpers import (
+    archive_flow_run_artifacts,
+    archive_terminal_flow_runs,
+)
 from codex_autorunner.core.flows.models import FlowRunStatus
 from codex_autorunner.core.flows.store import FlowStore
 from codex_autorunner.core.force_attestation import FORCE_ATTESTATION_REQUIRED_ERROR
@@ -563,6 +566,39 @@ def test_ticket_flow_archive_cleans_related_terminal_runs(
         store.initialize()
         assert store.get_flow_run(archived_run_id) is None
         assert store.get_flow_run(stale_run_id) is None
+
+
+def test_terminal_flow_archive_cleans_orphaned_flow_artifact_dirs(
+    tmp_path: Path,
+) -> None:
+    repo_root = _setup_repo(tmp_path)
+    orphan_run_id = "99999999-8888-7777-6666-555555555555"
+    orphan_flow_dir = repo_root / ".codex-autorunner" / "flows" / orphan_run_id / "chat"
+    orphan_flow_dir.mkdir(parents=True, exist_ok=True)
+    (orphan_flow_dir / "outbound.jsonl").write_text(
+        '{"event_type":"flow_terminal_notice"}\n',
+        encoding="utf-8",
+    )
+
+    with FlowStore(repo_root / ".codex-autorunner" / "flows.db") as store:
+        store.initialize()
+        payload = archive_terminal_flow_runs(repo_root, store=store)
+
+    assert payload["archived_run_count"] == 0
+    assert payload["deleted_run_count"] == 0
+    assert payload["archived_orphan_flow_state_ids"] == [orphan_run_id]
+    assert payload["archived_orphan_flow_state_count"] == 1
+    assert not (repo_root / ".codex-autorunner" / "flows" / orphan_run_id).exists()
+    assert (
+        repo_root
+        / ".codex-autorunner"
+        / "archive"
+        / "runs"
+        / orphan_run_id
+        / "flow_state"
+        / "chat"
+        / "outbound.jsonl"
+    ).read_text(encoding="utf-8") == '{"event_type":"flow_terminal_notice"}\n'
 
 
 def test_ticket_flow_archive_tolerates_sibling_cleanup_failures(

--- a/tests/test_hub_supervisor.py
+++ b/tests/test_hub_supervisor.py
@@ -1204,6 +1204,50 @@ def test_cleanup_all_archives_all_terminal_flow_statuses(tmp_path: Path) -> None
         ).read_text(encoding="utf-8") == "{}"
 
 
+def test_cleanup_all_archives_orphaned_flow_artifact_dirs(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    _write_default_hub_config(hub_root)
+    supervisor = HubSupervisor(
+        load_hub_config(hub_root),
+        backend_factory_builder=build_agent_backend_factory,
+        app_server_supervisor_factory_builder=build_app_server_supervisor_factory,
+        backend_orchestrator_builder=build_backend_orchestrator,
+    )
+    base = supervisor.create_repo("base")
+    _init_git_repo(base.path)
+
+    orphan_run_id = "22222222-2222-2222-2222-222222222222"
+    with FlowStore(base.path / ".codex-autorunner" / "flows.db") as store:
+        store.initialize()
+    flow_dir = base.path / ".codex-autorunner" / "flows" / orphan_run_id / "chat"
+    flow_dir.mkdir(parents=True, exist_ok=True)
+    (flow_dir / "outbound.jsonl").write_text(
+        '{"event_type":"flow_terminal_notice"}\n',
+        encoding="utf-8",
+    )
+
+    dry = supervisor.cleanup_all(dry_run=True)
+    assert dry["flow_runs"]["retired_count"] == 1
+    assert dry["flow_runs"]["by_repo"] == [{"repo_id": base.id, "count": 1}]
+    assert (base.path / ".codex-autorunner" / "flows" / orphan_run_id).exists()
+
+    result = supervisor.cleanup_all(dry_run=False)
+
+    assert result["flow_runs"]["retired_count"] == 1
+    assert result["flow_runs"]["by_repo"] == [{"repo_id": base.id, "count": 1}]
+    assert not (base.path / ".codex-autorunner" / "flows" / orphan_run_id).exists()
+    assert (
+        base.path
+        / ".codex-autorunner"
+        / "archive"
+        / "runs"
+        / orphan_run_id
+        / "flow_state"
+        / "chat"
+        / "outbound.jsonl"
+    ).read_text(encoding="utf-8") == '{"event_type":"flow_terminal_notice"}\n'
+
+
 def test_cleanup_all_skips_worktree_when_binding_lookup_raises_runtime_error(
     tmp_path: Path, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- Archive orphaned `.codex-autorunner/flows/<run_id>` artifact directories when terminal flow cleanup runs, even if the corresponding `flows.db` row is already gone.
- Include orphaned flow artifact dirs in hub `cleanup_all` dry-run/live counts so cleanup reaches the same state that `Ticket flow: Clean` expects.
- Add regression coverage for direct terminal-flow cleanup and hub cleanup with an empty flow DB plus leftover flow artifact dirs.

## Root Cause
`/flow status` used `flows.db` as the source of truth for run existence, but ticket-flow cleanliness also considers live filesystem artifacts under `.codex-autorunner/flows/`. A DB-oriented retire could leave orphaned flow artifact directories behind, producing `No ticket_flow runs found` alongside `Ticket flow: Dirty (previous runs)`.

## Validation
- `.venv/bin/python -m pytest tests/test_cli_ticket_flow_archive.py::test_terminal_flow_archive_cleans_orphaned_flow_artifact_dirs tests/test_hub_supervisor.py::test_cleanup_all_archives_orphaned_flow_artifact_dirs`
- `.venv/bin/python -m pytest tests/test_cli_ticket_flow_archive.py::test_ticket_flow_archive_cleans_related_terminal_runs tests/test_hub_supervisor.py::test_cleanup_all_archives_all_terminal_flow_statuses`
- Commit hook core lane: mypy passed; 9,317 tests passed
