### PR TITLE
[codex] Repair legacy opencode migration backfill

### DIFF
--- a/src/codex_autorunner/core/orchestration/turn_execution_storage.py
+++ b/src/codex_autorunner/core/orchestration/turn_execution_storage.py
@@ -16,6 +16,8 @@ from .turn_execution_contract import (
 TURN_EXECUTION_REQUEST_COLUMN = "turn_request_json"
 TURN_EXECUTION_RECORD_COLUMN = "turn_record_json"
 TURN_EXECUTION_CONTRACT_VERSION_COLUMN = "turn_contract_version"
+LEGACY_OPENCODE_PROVIDER_ID = "legacy"
+LEGACY_OPENCODE_MODEL_ID = "unresolved"
 
 
 def _mapping(value: Any) -> dict[str, Any]:
@@ -31,6 +33,8 @@ def _metadata(row: Mapping[str, Any]) -> dict[str, Any]:
 
 def _request_data(queue_payload: Mapping[str, Any]) -> dict[str, Any]:
     request = queue_payload.get("request")
+    if not isinstance(request, Mapping):
+        request = queue_payload.get("turn_request")
     return dict(request) if isinstance(request, Mapping) else {}
 
 
@@ -82,14 +86,31 @@ def _model_and_payload(
 ) -> tuple[Optional[str], dict[str, Any]]:
     resolved_model = _normalize_optional_text(model)
     payload = _mapping(metadata_payload)
-    if agent != "opencode" or payload or resolved_model is None:
+    if agent != "opencode":
         return resolved_model, payload
-    if "/" not in resolved_model:
-        return resolved_model, payload
-    provider_id, model_id = (part.strip() for part in resolved_model.split("/", 1))
+    if resolved_model is None:
+        return (
+            f"{LEGACY_OPENCODE_PROVIDER_ID}/{LEGACY_OPENCODE_MODEL_ID}",
+            {
+                "providerID": LEGACY_OPENCODE_PROVIDER_ID,
+                "modelID": LEGACY_OPENCODE_MODEL_ID,
+            },
+        )
+    if "/" in resolved_model:
+        provider_id, model_id = (part.strip() for part in resolved_model.split("/", 1))
+    else:
+        provider_id = LEGACY_OPENCODE_PROVIDER_ID
+        model_id = resolved_model
+        resolved_model = f"{provider_id}/{model_id}"
     if provider_id and model_id:
         return resolved_model, {"providerID": provider_id, "modelID": model_id}
-    return resolved_model, payload
+    return (
+        f"{LEGACY_OPENCODE_PROVIDER_ID}/{LEGACY_OPENCODE_MODEL_ID}",
+        {
+            "providerID": LEGACY_OPENCODE_PROVIDER_ID,
+            "modelID": LEGACY_OPENCODE_MODEL_ID,
+        },
+    )
 
 
 def _origin_from_thread(thread: Mapping[str, Any]) -> TurnExecutionOrigin:
@@ -149,7 +170,9 @@ def build_turn_execution_request_from_storage(
             or execution_metadata.get("model")
             or thread_metadata.get("model")
         ),
-        metadata_payload=execution_metadata.get("model_payload"),
+        metadata_payload=(
+            request_data.get("model_payload") or execution_metadata.get("model_payload")
+        ),
     )
     return TurnExecutionRequest(
         request_id=str(
@@ -170,7 +193,9 @@ def build_turn_execution_request_from_storage(
             or _normalize_optional_text(thread.get("workspace_root"))
         ),
         request_kind=_request_kind(
-            execution.get("request_kind") or request_data.get("kind")
+            execution.get("request_kind")
+            or request_data.get("kind")
+            or request_data.get("request_kind")
         ),
         busy_policy=_busy_policy(
             request_data.get("busy_policy"), status=execution.get("status")
@@ -178,6 +203,7 @@ def build_turn_execution_request_from_storage(
         prompt_text=(
             _normalize_optional_text(execution.get("prompt_text"))
             or _normalize_optional_text(request_data.get("message_text"))
+            or _normalize_optional_text(request_data.get("prompt_text"))
             or "[legacy request prompt unavailable]"
         ),
         input_items=_input_items(request_data.get("input_items")),
@@ -189,6 +215,7 @@ def build_turn_execution_request_from_storage(
         agent=agent,
         profile=(
             request_data.get("agent_profile")
+            or request_data.get("profile")
             or thread_metadata.get("agent_profile")
             or execution_metadata.get("agent_profile")
         ),

--- a/tests/core/orchestration/test_sqlite_migrations.py
+++ b/tests/core/orchestration/test_sqlite_migrations.py
@@ -374,6 +374,190 @@ def test_turn_execution_contract_migration_backfills_legacy_thread_rows(
     assert terminal_record["transcript_ref"] == "transcript-turn"
 
 
+def test_turn_execution_contract_migration_repairs_legacy_opencode_models(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "orchestration.sqlite3"
+
+    with _connect(db_path) as conn:
+        apply_orchestration_migrations(conn)
+        conn.execute(
+            """
+            INSERT INTO orch_thread_targets (
+                thread_target_id, agent_id, backend_thread_id, repo_id,
+                resource_kind, resource_id, workspace_root, scope_urn,
+                surface_urn, backend_binding_json, display_name,
+                lifecycle_status, runtime_status, status_reason, status_turn_id,
+                last_execution_id, last_message_preview, compact_seed,
+                metadata_json, created_at, updated_at, status_updated_at,
+                status_terminal
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "thread-opencode-legacy",
+                "opencode",
+                "backend-opencode",
+                "repo-1",
+                "repo",
+                "repo-1",
+                str(tmp_path / "workspace"),
+                "repo:repo-1",
+                "discord:guild:channel",
+                "{}",
+                "Legacy OpenCode",
+                "active",
+                "completed",
+                "done",
+                "turn-unresolved",
+                "turn-unresolved",
+                "hello",
+                None,
+                "{}",
+                "2026-05-01T00:00:00Z",
+                "2026-05-01T00:00:00Z",
+                "2026-05-01T00:00:00Z",
+                1,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO orch_thread_executions (
+                execution_id, thread_target_id, client_request_id, request_kind,
+                prompt_text, status, backend_turn_id, assistant_text, error_text,
+                model_id, reasoning_level, metadata_json, transcript_mirror_id,
+                started_at, finished_at, created_at, turn_contract_version,
+                turn_request_json, turn_record_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "turn-unresolved",
+                "thread-opencode-legacy",
+                "client-unresolved",
+                "message",
+                "legacy prompt",
+                "ok",
+                "backend-turn",
+                "done",
+                None,
+                None,
+                None,
+                "{}",
+                None,
+                "2026-05-01T00:01:00Z",
+                "2026-05-01T00:02:00Z",
+                "2026-05-01T00:01:00Z",
+                0,
+                None,
+                None,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO orch_thread_executions (
+                execution_id, thread_target_id, client_request_id, request_kind,
+                prompt_text, status, backend_turn_id, assistant_text, error_text,
+                model_id, reasoning_level, metadata_json, transcript_mirror_id,
+                started_at, finished_at, created_at, turn_contract_version,
+                turn_request_json, turn_record_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "turn-legacy-model",
+                "thread-opencode-legacy",
+                "client-legacy-model",
+                "review",
+                None,
+                "queued",
+                None,
+                None,
+                None,
+                "glm-5.1",
+                "medium",
+                json.dumps(
+                    {
+                        "model_payload": {
+                            "providerID": "stale",
+                            "modelID": "wrong",
+                        }
+                    }
+                ),
+                None,
+                "2026-05-01T00:03:00Z",
+                None,
+                "2026-05-01T00:03:00Z",
+                0,
+                None,
+                None,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO orch_queue_items (
+                queue_item_id, lane_id, source_kind, source_key, dedupe_key,
+                state, visible_at, claimed_at, completed_at, payload_json,
+                created_at, updated_at, idempotency_key
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "queue-legacy-model",
+                "thread:thread-opencode-legacy",
+                "thread_execution",
+                "turn-legacy-model",
+                "client-legacy-model",
+                "queued",
+                "2026-05-01T00:03:00Z",
+                None,
+                None,
+                json.dumps(
+                    {
+                        "turn_request": {
+                            "target_id": "thread-opencode-legacy",
+                            "request_kind": "review",
+                            "busy_policy": "queue",
+                            "prompt_text": "canonical queued prompt",
+                            "profile": "pro",
+                            "reasoning": "medium",
+                        }
+                    }
+                ),
+                "2026-05-01T00:03:00Z",
+                "2026-05-01T00:03:00Z",
+                "client-legacy-model",
+            ),
+        )
+        conn.execute("DELETE FROM orch_schema_migrations WHERE version >= 37")
+
+        version = apply_orchestration_migrations(conn)
+        rows = {
+            row["execution_id"]: row
+            for row in conn.execute(
+                """
+                SELECT execution_id, turn_request_json, turn_record_json
+                  FROM orch_thread_executions
+                 WHERE thread_target_id = 'thread-opencode-legacy'
+                """
+            ).fetchall()
+        }
+
+    assert version == ORCHESTRATION_SCHEMA_VERSION
+    unresolved_request = json.loads(rows["turn-unresolved"]["turn_request_json"])
+    legacy_model_request = json.loads(rows["turn-legacy-model"]["turn_request_json"])
+    legacy_model_record = json.loads(rows["turn-legacy-model"]["turn_record_json"])
+    assert unresolved_request["model"] == "legacy/unresolved"
+    assert unresolved_request["model_payload"] == {
+        "providerID": "legacy",
+        "modelID": "unresolved",
+    }
+    assert legacy_model_request["model"] == "legacy/glm-5.1"
+    assert legacy_model_request["model_payload"] == {
+        "providerID": "legacy",
+        "modelID": "glm-5.1",
+    }
+    assert legacy_model_request["prompt_text"] == "canonical queued prompt"
+    assert legacy_model_request["profile"] == "pro"
+    assert legacy_model_record["status"] == "queued"
+
+
 def test_automation_migration_diagnostics_report_blocked_mirror(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- repair v37 legacy turn execution backfill so unresolved opencode models become a valid `legacy/unresolved` sentinel instead of crashing startup
- normalize providerless or stale opencode model payloads while preserving the old model name as `legacy/<model>`
- support both legacy `request` and canonical `turn_request` queue payloads during migration reconstruction

Closes #1912

## Validation
- pre-commit core lane: black, ruff, import-boundary checks, mypy, and full pytest suite (`9355 passed`)
- `.venv/bin/python -m pytest tests/core/orchestration/test_sqlite_migrations.py`
- `.venv/bin/python -m pytest tests/core/orchestration/test_turn_execution_contract.py`
- `.venv/bin/python -m pytest tests/core/orchestration/test_runtime_threads.py::test_runtime_threads_use_wait_for_turn_contract_for_session_runtimes tests/core/orchestration/test_runtime_threads.py::test_opencode_runtime_thread_requires_resolved_model_before_start`
- `.venv/bin/python -m pytest tests/core/orchestration/test_service.py::test_claim_next_queued_execution_context_preserves_typed_request_payload`
