### PR TITLE
fix(automation): migrate stale pma_turn executor_kind to managed_thread_turn (#1860)

### DIFF
--- a/src/codex_autorunner/core/automation/store.py
+++ b/src/codex_autorunner/core/automation/store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import sqlite3
 import uuid
 from pathlib import Path
@@ -34,10 +35,39 @@ def _json_object_from_row(row: sqlite3.Row, column: str) -> dict[str, Any]:
     return _json_loads_object(row[column])
 
 
+_log = logging.getLogger(__name__)
+
+
 class AutomationStore:
     def __init__(self, hub_root: Path, *, durable: bool = True) -> None:
         self._hub_root = Path(hub_root)
         self._durable = durable
+        self._migrate_stale_executor_kinds()
+
+    def _migrate_stale_executor_kinds(self) -> None:
+        try:
+            with open_orchestration_sqlite(
+                self._hub_root, durable=self._durable
+            ) as conn:
+                with conn:
+                    cursor = conn.execute(
+                        """
+                        UPDATE orch_automation_rules
+                           SET executor_kind = 'managed_thread_turn',
+                               updated_at = updated_at
+                         WHERE executor_kind = 'pma_turn'
+                        """
+                    )
+                    migrated = int(cursor.rowcount or 0)
+            if migrated:
+                _log.info(
+                    "migrated %d stale pma_turn executor_kind row(s) to managed_thread_turn",
+                    migrated,
+                )
+        except Exception:
+            _log.debug(
+                "stale executor_kind migration skipped (DB unavailable)", exc_info=True
+            )
 
     def upsert_rule(self, rule: AutomationRule) -> AutomationRule:
         with open_orchestration_sqlite(self._hub_root, durable=self._durable) as conn:


### PR DESCRIPTION
## Root cause

During the legacy subscription→automation migration (May 16-17), rows were written to `orch_automation_rules` with `executor_kind = 'pma_turn'. This value was later renamed to `managed_thread_turn` in the code's `EXECUTOR_KINDS` enum, but no corresponding data migration was added. Any DB containing these stale rows crashes the `/car/hub/automations` endpoint with HTTP 500.

## Error trace

```
GET /car/hub/automations
  → store.py:123 list_rules()
    → store.py:1107 _row_to_rule()
      → models.py:529 AutomationRule.create()
        → models.py:204 require_choice("pma_turn", ...)
          → ValueError: executor_kind must be one of:
              github_comment, github_reaction, managed_thread_turn,
              publish_chat_notification, publish_operation, ticket_flow
```

**Evidence:** 9 rows in production DB had `executor_kind = 'pma_turn', all system-owned legacy subscriptions (`rule_id` prefix `legacy-pma-subscription:`).

## Fix

Adds a startup data migration in `AutomationStore.__init__` that runs:

```sql
UPDATE orch_automation_rules
   SET executor_kind = 'managed_thread_turn', updated_at = updated_at
 WHERE executor_kind = 'pma_turn'
```

- Idempotent: safe to run multiple times (no-op after first run)
- Non-blocking: wrapped in try/except, never prevents startup if DB is unavailable
- Logs the number of migrated rows at INFO level

## Verification

- `pnpm run build` — passes
- All 9,203 existing tests pass (including full `core` lane with mypy strict)
- Migration is idempotent by design (`UPDATE ... WHERE` is a no-op when no rows match)

Closes #1860