### PR TITLE
[codex] Fix OpenCode silent turn liveness

### DIFF
--- a/src/codex_autorunner/adapters/agents/opencode_backend.py
+++ b/src/codex_autorunner/adapters/agents/opencode_backend.py
@@ -369,6 +369,11 @@ class OpenCodeBackend(AgentBackend):
             stall_timeout, first_event_timeout = opencode_stream_timeouts(
                 self._session_stall_timeout_seconds,
             )
+            prompt_task: Optional[asyncio.Task[Any]] = None
+
+            def _prompt_is_active() -> bool:
+                return prompt_task is not None and not prompt_task.done()
+
             output_task = asyncio.create_task(
                 collect_opencode_output(
                     client,
@@ -378,6 +383,7 @@ class OpenCodeBackend(AgentBackend):
                     model_payload=model_payload,
                     permission_policy=permission_policy,
                     part_handler=_part_handler,
+                    turn_activity_fetcher=_prompt_is_active,
                     ready_event=ready_event,
                     stall_timeout_seconds=stall_timeout,
                     first_event_timeout_seconds=first_event_timeout,
@@ -419,7 +425,7 @@ class OpenCodeBackend(AgentBackend):
                     executor=_run_prompt,
                 )
             )
-            prompt_task: Optional[asyncio.Task[Any]] = started_command.task
+            prompt_task = started_command.task
             runtime_task = asyncio.create_task(
                 observe_turn_runtime(
                     collect_task=output_task,

--- a/src/codex_autorunner/agents/opencode/harness.py
+++ b/src/codex_autorunner/agents/opencode/harness.py
@@ -1187,6 +1187,9 @@ class OpenCodeHarness(AgentHarness):
                 stall_timeout_seconds_value,
             )
 
+            def _command_is_active() -> bool:
+                return command_task is not None and not command_task.done()
+
             collect_task = asyncio.create_task(
                 collect_opencode_output_from_events(
                     None,
@@ -1207,6 +1210,7 @@ class OpenCodeHarness(AgentHarness):
                     respond_permission=_respond_permission,
                     reply_question=_reply_question,
                     reject_question=_reject_question,
+                    turn_activity_fetcher=_command_is_active,
                     event_stream_factory=_event_stream,
                     session_fetcher=_fetch_session,
                     provider_fetcher=_fetch_providers,

--- a/src/codex_autorunner/agents/opencode/runtime.py
+++ b/src/codex_autorunner/agents/opencode/runtime.py
@@ -65,6 +65,7 @@ from .protocol_payload import (
     summarize_question_answers,
 )
 from .stream_lifecycle import (
+    _OPENCODE_FIRST_EVENT_TIMEOUT_REASON,
     _OPENCODE_FIRST_EVENT_TIMEOUT_SECONDS,
     _OPENCODE_STREAM_STALL_TIMEOUT_SECONDS,
     LifecycleAction,
@@ -76,6 +77,7 @@ PermissionDecision = str
 PermissionHandler = Callable[[str, dict[str, Any]], Awaitable[PermissionDecision]]
 QuestionHandler = Callable[[str, dict[str, Any]], Awaitable[Optional[list[list[str]]]]]
 PartHandler = Callable[[str, dict[str, Any], Optional[str]], Awaitable[None]]
+TurnActivityFetcher = Callable[[], bool | Awaitable[bool]]
 
 
 @dataclass(frozen=True)
@@ -224,6 +226,7 @@ async def collect_opencode_output_from_events(
     reply_question: Optional[Callable[[str, list[list[str]]], Awaitable[None]]] = None,
     reject_question: Optional[Callable[[str], Awaitable[None]]] = None,
     part_handler: Optional[PartHandler] = None,
+    turn_activity_fetcher: Optional[TurnActivityFetcher] = None,
     event_stream_factory: Optional[Callable[[], AsyncIterator[SSEEvent]]] = None,
     session_fetcher: Optional[Callable[[], Awaitable[Any]]] = None,
     provider_fetcher: Optional[Callable[[], Awaitable[Any]]] = None,
@@ -258,6 +261,7 @@ async def collect_opencode_output_from_events(
         stall_timeout_seconds=stall_timeout_seconds,
         first_event_timeout_seconds=first_event_timeout_seconds,
         status_event_handler=part_handler,
+        turn_activity_fetcher=turn_activity_fetcher,
         logger=logger,
     )
 
@@ -655,9 +659,17 @@ async def collect_opencode_output_from_events(
         await lifecycle.close()
 
     result = await assembler.build_result()
+    error = result.error
+    if (
+        error
+        and error.startswith(_OPENCODE_FIRST_EVENT_TIMEOUT_REASON)
+        and result.output_source == "messages_snapshot"
+        and result.text
+    ):
+        error = None
     return OpenCodeTurnOutput(
         text=result.text,
-        error=result.error,
+        error=error,
         usage=result.usage,
         output_source=result.output_source,
         terminal_signal=terminal_signal,
@@ -679,6 +691,7 @@ async def collect_opencode_output(
     should_stop: Optional[Callable[[], bool]] = None,
     ready_event: Optional[Any] = None,
     part_handler: Optional[PartHandler] = None,
+    turn_activity_fetcher: Optional[TurnActivityFetcher] = None,
     stall_timeout_seconds: Optional[float] = _OPENCODE_STREAM_STALL_TIMEOUT_SECONDS,
     first_event_timeout_seconds: Optional[
         float
@@ -736,6 +749,7 @@ async def collect_opencode_output(
         reply_question=_reply_question,
         reject_question=_reject_question,
         part_handler=part_handler,
+        turn_activity_fetcher=turn_activity_fetcher,
         event_stream_factory=_stream_factory,
         model_payload=model_payload,
         session_fetcher=_fetch_session,

--- a/src/codex_autorunner/agents/opencode/stream_lifecycle.py
+++ b/src/codex_autorunner/agents/opencode/stream_lifecycle.py
@@ -9,6 +9,7 @@ to reconnect, poll session state, or fail a stalled stream.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import time
 from contextlib import suppress
@@ -37,6 +38,7 @@ _OPENCODE_POST_STALL_IDLE_WAIT_SECONDS = 30.0
 _OPENCODE_POST_STALL_IDLE_POLL_SECONDS = 5.0
 
 StatusEventHandler = Callable[[str, dict[str, Any], Optional[str]], Awaitable[None]]
+TurnActivityFetcher = Callable[[], bool | Awaitable[bool]]
 
 
 class LifecycleAction(Enum):
@@ -76,11 +78,13 @@ class StreamLifecycleController:
         stall_timeout_seconds: Optional[float],
         first_event_timeout_seconds: Optional[float],
         status_event_handler: Optional[StatusEventHandler],
+        turn_activity_fetcher: Optional[TurnActivityFetcher] = None,
         logger: Optional[logging.Logger] = None,
     ):
         self._session_id = session_id
         self._event_stream_factory = event_stream_factory
         self._session_fetcher = session_fetcher
+        self._turn_activity_fetcher = turn_activity_fetcher
         self._stall_timeout_seconds = stall_timeout_seconds
         self._first_event_timeout_seconds = first_event_timeout_seconds
         self._status_event_handler = status_event_handler
@@ -181,10 +185,7 @@ class StreamLifecycleController:
             and self._first_event_timeout_seconds is not None
         ):
             if now - self._stream_started_at >= self._first_event_timeout_seconds:
-                status_type = await self._poll_session_status_quiet()
-                if status_type and not status_is_idle(status_type):
-                    return await self._handle_stall_recovery(now=now)
-                return await self._fail_first_event_timeout(now=now)
+                return await self._handle_first_event_silence(now=now)
             return LifecycleDecision(action=LifecycleAction.CONTINUE)
 
         return await self._handle_stall_recovery(now=now)
@@ -204,10 +205,7 @@ class StreamLifecycleController:
             and self._first_event_timeout_seconds is not None
         ):
             if now - self._stream_started_at >= self._first_event_timeout_seconds:
-                status_type = await self._poll_session_status_quiet()
-                if status_type and not status_is_idle(status_type):
-                    return await self._handle_stall_recovery(now=now)
-                return await self._fail_first_event_timeout(now=now)
+                return await self._handle_first_event_silence(now=now)
             return LifecycleDecision(action=LifecycleAction.CONTINUE)
 
         if (
@@ -266,6 +264,18 @@ class StreamLifecycleController:
             )
             return None
 
+    async def _handle_first_event_silence(self, *, now: float) -> LifecycleDecision:
+        status_type = await self._poll_session_status_quiet()
+        if status_type and not status_is_idle(status_type):
+            return await self._handle_stall_recovery(now=now)
+        if await self._turn_is_active():
+            return await self._continue_silent_active_turn(
+                now=now,
+                timeout_kind="first_event",
+                status_type=status_type,
+            )
+        return await self._fail_first_event_timeout(now=now)
+
     async def _poll_session_status_quiet(self) -> Optional[str]:
         if self._session_fetcher is None:
             return None
@@ -277,6 +287,54 @@ class StreamLifecycleController:
                 "session fetch during timeout check failed", exc_info=True
             )
             return None
+
+    async def _turn_is_active(self) -> bool:
+        if self._turn_activity_fetcher is None:
+            return False
+        try:
+            active = self._turn_activity_fetcher()
+            if inspect.isawaitable(active):
+                active = await active
+            return bool(active)
+        except Exception:
+            self._logger.debug("turn activity check failed", exc_info=True)
+            return False
+
+    async def _continue_silent_active_turn(
+        self,
+        *,
+        now: float,
+        timeout_kind: str,
+        status_type: Optional[str],
+    ) -> LifecycleDecision:
+        idle_seconds = now - self._last_relevant_event_at
+        log_event(
+            self._logger,
+            logging.WARNING,
+            "opencode.stream.silent_while_turn_active",
+            session_id=self._session_id,
+            idle_seconds=idle_seconds,
+            timeout_kind=timeout_kind,
+            status_type=status_type,
+            reconnect_attempts=self._reconnect_attempts,
+        )
+        await self._emit_status(
+            {
+                "type": "stream_silent_turn_active",
+                "idleSeconds": idle_seconds,
+                "timeoutKind": timeout_kind,
+                "status": status_type,
+                "attempts": self._reconnect_attempts,
+            }
+        )
+        if self._stream_iter is not None:
+            await _close_stream(self._stream_iter)
+        if self._event_stream_factory is not None:
+            self._stream_iter = self._event_stream_factory().__aiter__()
+        if not self._received_any_event:
+            self._stream_started_at = now
+        self._last_relevant_event_at = now
+        return LifecycleDecision(action=LifecycleAction.CONTINUE)
 
     async def _fail_first_event_timeout(self, *, now: float) -> LifecycleDecision:
         timeout_seconds = self._first_event_timeout_seconds
@@ -428,6 +486,12 @@ class StreamLifecycleController:
         )
 
         if not reconnected:
+            if await self._turn_is_active():
+                return await self._continue_silent_active_turn(
+                    now=now,
+                    timeout_kind="stall",
+                    status_type=status_type,
+                )
             if status_type and not status_is_idle(status_type):
                 idle_wait_started_at = time.monotonic()
                 last_status_type = status_type

--- a/tests/core/test_sse.py
+++ b/tests/core/test_sse.py
@@ -1,0 +1,24 @@
+import json
+
+import pytest
+
+from codex_autorunner.core.sse import parse_sse_lines
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_lines_parses_named_and_default_events() -> None:
+    async def _lines():
+        yield "event: message"
+        yield 'data: {"type": "test", "value": 42}'
+        yield ""
+        yield "event: custom"
+        yield "data: hello"
+        yield ""
+
+    events = [event async for event in parse_sse_lines(_lines())]
+
+    assert len(events) == 2
+    assert events[0].event == "message"
+    assert json.loads(events[0].data) == {"type": "test", "value": 42}
+    assert events[1].event == "custom"
+    assert events[1].data == "hello"

--- a/tests/test_opencode_backend_streaming.py
+++ b/tests/test_opencode_backend_streaming.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from pathlib import Path
 from typing import Optional
@@ -45,6 +46,10 @@ class _FakeOpenCodeClient:
 
     async def prompt_async(self, *args, **kwargs):
         return {}
+
+    async def list_messages(self, session_id: str, **kwargs):
+        _ = session_id, kwargs
+        return []
 
     async def send_command(self, *args, **kwargs):
         return None
@@ -220,5 +225,56 @@ async def test_opencode_backend_passes_first_event_timeout_to_collector(
     assert captured["first_event_timeout_seconds"] == expected_first_event_timeout
     assert any(
         isinstance(event, Completed) and event.final_message == "ok"
+        for event in run_events
+    )
+
+
+@pytest.mark.anyio
+async def test_opencode_backend_does_not_fail_first_event_timeout_while_prompt_runs(
+    tmp_path: Path,
+) -> None:
+    class _SilentActiveClient(_FakeOpenCodeClient):
+        async def stream_events(
+            self, *, directory=None, ready_event=None, paths=None, session_id=None
+        ):
+            _ = directory, paths, session_id
+            if ready_event is not None:
+                ready_event.set()
+            while True:
+                await asyncio.sleep(3600)
+                yield SSEEvent(event="server.heartbeat", data="")
+
+        async def session_status(self, directory=None):
+            _ = directory
+            return {}
+
+        async def prompt_async(self, *args, **kwargs):
+            _ = args, kwargs
+            await asyncio.sleep(0.01)
+            return {}
+
+        async def list_messages(self, session_id: str, **kwargs):
+            _ = session_id, kwargs
+            return {
+                "data": [
+                    {
+                        "info": {"id": "assistant-1", "role": "assistant"},
+                        "parts": [{"type": "text", "text": "finished despite silence"}],
+                    }
+                ]
+            }
+
+    backend = OpenCodeBackend(
+        workspace_root=tmp_path,
+        supervisor=None,
+        session_stall_timeout_seconds=0.001,
+    )
+    backend._client = _SilentActiveClient([])  # type: ignore
+
+    run_events = [event async for event in backend.run_turn_events("s-silent", "Ping")]
+
+    assert any(
+        isinstance(event, Completed)
+        and event.final_message == "finished despite silence"
         for event in run_events
     )

--- a/tests/test_opencode_integration.py
+++ b/tests/test_opencode_integration.py
@@ -18,7 +18,6 @@ from codex_autorunner.core.orchestration.runtime_thread_events import (
     RuntimeThreadRunEventState,
     normalize_runtime_thread_raw_event,
 )
-from codex_autorunner.core.sse import parse_sse_lines
 from codex_autorunner.workspace import canonical_workspace_root, workspace_id_for_path
 
 
@@ -64,6 +63,55 @@ def _assert_registry_removed(workspace_root: Path, pid: int) -> None:
     assert read_process_record(workspace_root, "opencode", str(pid)) is None
 
 
+def _opencode_serve_command() -> list[str]:
+    opencode_bin = get_opencode_bin()
+    assert opencode_bin is not None
+    return [opencode_bin, "serve", "--hostname", "127.0.0.1", "--port", "0"]
+
+
+def _new_supervisor(
+    *,
+    request_timeout: float = 30.0,
+    max_handles: int = 3,
+    idle_ttl_seconds: float = 300.0,
+    server_scope: str = "workspace",
+) -> OpenCodeSupervisor:
+    return OpenCodeSupervisor(
+        _opencode_serve_command(),
+        request_timeout=request_timeout,
+        max_handles=max_handles,
+        idle_ttl_seconds=idle_ttl_seconds,
+        server_scope=server_scope,
+    )
+
+
+def _is_environmental_runtime_failure(
+    result_errors: list[str], raw_events: list[dict]
+) -> bool:
+    raw_event_text = json.dumps(raw_events).lower()
+    error_text = " ".join(result_errors).lower()
+    environmental_markers = (
+        "rate limit",
+        "api key",
+        "auth",
+        "unauthorized",
+        "quota",
+    )
+    return any(
+        marker in raw_event_text or marker in error_text
+        for marker in environmental_markers
+    )
+
+
+def _runtime_failure_detail(
+    result_status: str, result_errors: list[str], raw_events: list[dict]
+) -> str:
+    return (
+        f"status={result_status!r} errors={result_errors!r} "
+        f"raw_tail={json.dumps(raw_events[-5:], ensure_ascii=False)[:2000]}"
+    )
+
+
 @pytest.fixture(autouse=True)
 def skip_if_no_opencode():
     """Skip all tests in this file if OpenCode is not available."""
@@ -76,15 +124,7 @@ def skip_if_no_opencode():
 @pytest.fixture()
 async def supervisor(tmp_path: Path) -> AsyncGenerator[OpenCodeSupervisor, None]:
     """Create an OpenCode supervisor instance."""
-    opencode_bin = get_opencode_bin()
-    assert opencode_bin is not None
-    command = [opencode_bin, "serve", "--hostname", "127.0.0.1", "--port", "0"]
-    supervisor = OpenCodeSupervisor(
-        command,
-        request_timeout=30.0,
-        max_handles=3,
-        idle_ttl_seconds=300.0,
-    )
+    supervisor = _new_supervisor()
     yield supervisor
     await supervisor.close_all()
 
@@ -100,25 +140,21 @@ async def workspace(tmp_path: Path) -> AsyncGenerator[Path, None]:
 
 
 @pytest.mark.asyncio
-async def test_supervisor_starts_opencode_server(
+async def test_supervisor_lifecycle_reuse_and_close(
     supervisor: OpenCodeSupervisor, workspace: Path
 ) -> None:
-    """Test that supervisor can start an OpenCode server for a workspace."""
-    client = await supervisor.get_client(workspace)
-    assert client is not None
-    assert isinstance(client, OpenCodeClient)
-    await client.close()
-
-
-@pytest.mark.asyncio
-async def test_supervisor_reuses_handle(
-    supervisor: OpenCodeSupervisor, workspace: Path
-) -> None:
-    """Test that supervisor reuses an existing handle for the same workspace."""
+    """Supervisor should start OpenCode, reuse workspace handles, and close cleanly."""
     client1 = await supervisor.get_client(workspace)
     client2 = await supervisor.get_client(workspace)
+    assert isinstance(client1, OpenCodeClient)
     assert client1 is client2
-    await client1.close()
+
+    await supervisor.close_all()
+
+    client3 = await supervisor.get_client(workspace)
+    assert isinstance(client3, OpenCodeClient)
+    assert client3 is not client1
+    await client3.close()
 
 
 @pytest.mark.asyncio
@@ -126,8 +162,6 @@ async def test_global_scope_uses_single_server_for_two_workspaces(
     tmp_path: Path,
 ) -> None:
     """Global server scope should reuse one server process across workspaces."""
-    opencode_bin = get_opencode_bin()
-    assert opencode_bin is not None
     workspace1 = tmp_path / "ws1"
     workspace2 = tmp_path / "ws2"
     workspace1.mkdir()
@@ -135,11 +169,7 @@ async def test_global_scope_uses_single_server_for_two_workspaces(
     (workspace1 / ".git").mkdir()
     (workspace2 / ".git").mkdir()
 
-    supervisor = OpenCodeSupervisor(
-        [opencode_bin, "serve", "--hostname", "127.0.0.1", "--port", "0"],
-        request_timeout=30.0,
-        server_scope="global",
-    )
+    supervisor = _new_supervisor(server_scope="global")
 
     try:
         client1 = await supervisor.get_client(workspace1)
@@ -151,20 +181,6 @@ async def test_global_scope_uses_single_server_for_two_workspaces(
         assert handle.process.pid is not None
     finally:
         await supervisor.close_all()
-
-
-@pytest.mark.asyncio
-async def test_supervisor_closes_handle(
-    supervisor: OpenCodeSupervisor, workspace: Path
-) -> None:
-    """Test that supervisor can close a handle."""
-    client = await supervisor.get_client(workspace)
-    await supervisor.close_all()
-
-    # Getting a new client should create a new handle
-    client2 = await supervisor.get_client(workspace)
-    assert client2 is not client
-    await client2.close()
 
 
 @pytest.mark.asyncio
@@ -217,31 +233,16 @@ async def test_supervisor_max_handles_eviction(
 
 
 @pytest.mark.asyncio
-async def test_client_providers(workspace: Path) -> None:
-    """Test that client can fetch providers."""
-    command = [get_opencode_bin(), "serve", "--hostname", "127.0.0.1", "--port", "0"]
-    supervisor = OpenCodeSupervisor(command, request_timeout=30.0)
+async def test_client_session_catalog_and_stream_contract(workspace: Path) -> None:
+    """Client should cover provider, session, and SSE primitives without a model run."""
+    supervisor = _new_supervisor(request_timeout=30.0)
 
     try:
         client = await supervisor.get_client(workspace)
-        providers = await client.providers()
-        assert providers is not None
+
+        providers = await client.providers(directory=str(workspace))
         assert isinstance(providers, (dict, list))
-        await client.close()
-    finally:
-        await supervisor.close_all()
 
-
-@pytest.mark.asyncio
-async def test_client_create_and_list_sessions(workspace: Path) -> None:
-    """Test that client can create and list sessions."""
-    command = [get_opencode_bin(), "serve", "--hostname", "127.0.0.1", "--port", "0"]
-    supervisor = OpenCodeSupervisor(command, request_timeout=30.0)
-
-    try:
-        client = await supervisor.get_client(workspace)
-
-        # Create a session
         result = await client.create_session(
             title="Test Session",
             directory=str(workspace),
@@ -252,216 +253,55 @@ async def test_client_create_and_list_sessions(workspace: Path) -> None:
         session_id = result.get("id") or result.get("sessionID")
         assert session_id is not None
 
-        # List sessions
         sessions = await client.list_sessions(directory=str(workspace))
         assert sessions is not None
-        await client.close()
-    finally:
-        await supervisor.close_all()
 
-
-@pytest.mark.asyncio
-async def test_client_send_message(workspace: Path) -> None:
-    """Test that client can send a message to a session."""
-    command = [get_opencode_bin(), "serve", "--hostname", "127.0.0.1", "--port", "0"]
-    supervisor = OpenCodeSupervisor(command, request_timeout=30.0)
-
-    try:
-        client = await supervisor.get_client(workspace)
-
-        # Create a session
-        result = await client.create_session(directory=str(workspace))
-        session_id = result.get("id") or result.get("sessionID")
-        assert session_id is not None
-
-        # Send a simple message
-        response = await client.send_message(
-            session_id,
-            message="Hello, world!",
-        )
-        assert response is not None
-        await client.close()
-    finally:
-        await supervisor.close_all()
-
-
-@pytest.mark.asyncio
-async def test_client_stream_events(workspace: Path) -> None:
-    """Test that client can stream events."""
-    command = [get_opencode_bin(), "serve", "--hostname", "127.0.0.1", "--port", "0"]
-    supervisor = OpenCodeSupervisor(command, request_timeout=60.0)
-
-    try:
-        client = await supervisor.get_client(workspace)
-
-        # Create a session
-        result = await client.create_session(directory=str(workspace))
-        session_id = result.get("id") or result.get("sessionID")
-        assert session_id is not None
-
-        # Stream events for a short time
-        events_count = 0
-        event_types = set()
         ready_event = asyncio.Event()
-        timeout_task = asyncio.create_task(asyncio.sleep(10.0))
-        send_task: asyncio.Task[object] | None = None
+        events: list[str] = []
 
         async def collect_events():
-            nonlocal events_count, event_types
             async for event in client.stream_events(
-                directory=str(workspace), ready_event=ready_event
+                directory=str(workspace),
+                ready_event=ready_event,
+                session_id=session_id,
             ):
-                events_count += 1
-                event_types.add(event.event)
-                if events_count >= 3:
+                events.append(event.event)
+                if events:
                     break
 
         collect_task = asyncio.create_task(collect_events())
-        await ready_event.wait()
-        send_task = asyncio.create_task(
-            client.send_message(session_id, message="Test message")
-        )
-        done, pending = await asyncio.wait(
-            [collect_task, timeout_task],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
+        await asyncio.wait_for(ready_event.wait(), timeout=5.0)
+        await asyncio.wait_for(collect_task, timeout=10.0)
 
-        assert collect_task in done, "Timed out waiting for streamed events"
-        assert events_count >= 1
-        assert event_types
-
-        # Cancel pending tasks
-        for task in pending:
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-        if send_task is not None:
-            if send_task in done:
-                await send_task
-            else:
-                send_task.cancel()
-                try:
-                    await send_task
-                except asyncio.CancelledError:
-                    pass
-
+        assert events
         await client.close()
     finally:
         await supervisor.close_all()
 
 
 @pytest.mark.asyncio
-async def test_harness_model_catalog(workspace: Path) -> None:
-    """Test that harness can fetch model catalog."""
-    command = [get_opencode_bin(), "serve", "--hostname", "127.0.0.1", "--port", "0"]
-    supervisor = OpenCodeSupervisor(command, request_timeout=30.0)
+async def test_harness_catalog_conversation_stream_and_interrupt(
+    workspace: Path,
+) -> None:
+    """Harness should expose catalog, conversations, turn streaming, and interrupt."""
+    supervisor = _new_supervisor(request_timeout=30.0)
     harness = OpenCodeHarness(supervisor)
 
     try:
         catalog = await harness.model_catalog(workspace)
-        assert catalog is not None
-        assert catalog.models is not None
-        assert len(catalog.models) > 0
+        assert catalog.models
         assert catalog.default_model is not None
-    finally:
-        await supervisor.close_all()
 
-
-@pytest.mark.asyncio
-async def test_harness_conversation_lifecycle(workspace: Path) -> None:
-    """Test that harness can manage conversations."""
-    command = [get_opencode_bin(), "serve", "--hostname", "127.0.0.1", "--port", "0"]
-    supervisor = OpenCodeSupervisor(command, request_timeout=30.0)
-    harness = OpenCodeHarness(supervisor)
-
-    try:
-        # Create a conversation
         conv = await harness.new_conversation(workspace, title="Test Conversation")
         assert conv.agent == "opencode"
-        assert conv.id is not None
+        assert conv.id
 
-        # List conversations
         conversations = await harness.list_conversations(workspace)
-        assert len(conversations) > 0
+        assert any(item.id == conv.id for item in conversations)
 
-        # Resume conversation
         resumed = await harness.resume_conversation(workspace, conv.id)
         assert resumed.id == conv.id
-    finally:
-        await supervisor.close_all()
 
-
-@pytest.mark.asyncio
-async def test_harness_start_turn(workspace: Path) -> None:
-    """Test that harness can start a turn."""
-    command = [get_opencode_bin(), "serve", "--hostname", "127.0.0.1", "--port", "0"]
-    supervisor = OpenCodeSupervisor(command, request_timeout=30.0)
-    harness = OpenCodeHarness(supervisor)
-
-    try:
-        # Create a conversation
-        conv = await harness.new_conversation(workspace)
-
-        # Start a turn
-        turn = await harness.start_turn(
-            workspace,
-            conv.id,
-            prompt="What is 2+2?",
-            model=None,
-            reasoning=None,
-            approval_mode=None,
-            sandbox_policy=None,
-        )
-        assert turn.conversation_id == conv.id
-        assert turn.turn_id is not None
-    finally:
-        await supervisor.close_all()
-
-
-@pytest.mark.asyncio
-async def test_harness_start_review(workspace: Path) -> None:
-    """Test that harness can start a review."""
-    command = [get_opencode_bin(), "serve", "--hostname", "127.0.0.1", "--port", "0"]
-    supervisor = OpenCodeSupervisor(command, request_timeout=120.0)
-    harness = OpenCodeHarness(supervisor)
-
-    try:
-        # Create a conversation
-        conv = await harness.new_conversation(workspace)
-
-        # Write a test file to review
-        (workspace / "test.py").write_text("def foo():\n    return 1\n")
-
-        # Start a review with longer timeout - review can take longer to complete
-        turn = await harness.start_review(
-            workspace,
-            conv.id,
-            prompt=".",
-            model=None,
-            reasoning=None,
-            approval_mode=None,
-            sandbox_policy=None,
-        )
-        assert turn.conversation_id == conv.id
-        assert turn.turn_id is not None
-    finally:
-        await supervisor.close_all()
-
-
-@pytest.mark.asyncio
-async def test_harness_interrupt(workspace: Path) -> None:
-    """Test that harness can interrupt a turn."""
-    command = [get_opencode_bin(), "serve", "--hostname", "127.0.0.1", "--port", "0"]
-    supervisor = OpenCodeSupervisor(command, request_timeout=30.0)
-    harness = OpenCodeHarness(supervisor)
-
-    try:
-        # Create a conversation
-        conv = await harness.new_conversation(workspace)
-
-        # Start a turn
         turn = await harness.start_turn(
             workspace,
             conv.id,
@@ -471,57 +311,22 @@ async def test_harness_interrupt(workspace: Path) -> None:
             approval_mode=None,
             sandbox_policy=None,
         )
+        assert turn.conversation_id == conv.id
+        assert turn.turn_id
 
-        # Interrupt the turn (should not raise)
-        await harness.interrupt(workspace, conv.id, turn.turn_id)
-    finally:
-        await supervisor.close_all()
-
-
-@pytest.mark.asyncio
-async def test_harness_stream_turn_events(workspace: Path) -> None:
-    """Test that harness can stream turn events."""
-    command = [get_opencode_bin(), "serve", "--hostname", "127.0.0.1", "--port", "0"]
-    supervisor = OpenCodeSupervisor(command, request_timeout=30.0)
-    harness = OpenCodeHarness(supervisor)
-
-    try:
-        # Create a conversation
-        conv = await harness.new_conversation(workspace)
-
-        # Start a turn
-        turn = await harness.start_turn(
-            workspace,
-            conv.id,
-            prompt="Hello",
-            model=None,
-            reasoning=None,
-            approval_mode=None,
-            sandbox_policy=None,
-        )
-
-        # Stream events
-        events = []
-        timeout_task = asyncio.create_task(asyncio.sleep(10.0))
+        events: list[dict] = []
 
         async def collect_events():
             async for event in harness.stream_events(workspace, conv.id, turn.turn_id):
                 events.append(event)
-                if len(events) >= 2:
+                if events:
                     break
 
         collect_task = asyncio.create_task(collect_events())
-        done, pending = await asyncio.wait(
-            [collect_task, timeout_task],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
+        await asyncio.wait_for(collect_task, timeout=10.0)
+        assert events
 
-        for task in pending:
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+        await harness.interrupt(workspace, conv.id, turn.turn_id)
     finally:
         await supervisor.close_all()
 
@@ -532,13 +337,18 @@ async def test_harness_wait_for_turn_matches_runtime_event_fallback(
     workspace: Path,
 ) -> None:
     """Real OpenCode turns should agree with runtime-event fallback text."""
+    if os.environ.get("CAR_RUN_OPENCODE_MODEL_INTEGRATION") != "1":
+        pytest.skip(
+            "Set CAR_RUN_OPENCODE_MODEL_INTEGRATION=1 to run a live model-backed "
+            "OpenCode turn."
+        )
 
     harness = OpenCodeHarness(supervisor)
     conv = await harness.new_conversation(workspace)
     turn = await harness.start_turn(
         workspace,
         conv.id,
-        prompt="What is 2+2? Think carefully first, then answer in one short sentence.",
+        prompt="What is 2+2? Answer with only the number.",
         model=None,
         reasoning=None,
         approval_mode=None,
@@ -560,12 +370,14 @@ async def test_harness_wait_for_turn_matches_runtime_event_fallback(
 
     if result.status != "ok":
         await supervisor.close_all()
-        raw_event_text = json.dumps(result.raw_events).lower()
-        error_text = " ".join(result.errors).lower()
-        if "rate limit" in raw_event_text or "rate limit" in error_text:
-            pytest.skip("OpenCode runtime was rate limited during integration test")
-        pytest.skip(
-            f"OpenCode runtime returned non-ok status during integration test: {result.status}"
+        if _is_environmental_runtime_failure(result.errors, result.raw_events):
+            pytest.skip(
+                "OpenCode runtime was blocked by environment/auth/provider state: "
+                f"{_runtime_failure_detail(result.status, result.errors, result.raw_events)}"
+            )
+        pytest.fail(
+            "OpenCode runtime returned non-ok status: "
+            f"{_runtime_failure_detail(result.status, result.errors, result.raw_events)}"
         )
 
     assert result.status == "ok"
@@ -575,37 +387,9 @@ async def test_harness_wait_for_turn_matches_runtime_event_fallback(
 
 
 @pytest.mark.asyncio
-async def test_sse_event_parsing() -> None:
-    """Test SSE event parsing."""
-
-    async def mock_lines():
-        yield "event: message"
-        yield 'data: {"type": "test", "value": 42}'
-        yield ""
-        yield "event: custom"
-        yield "data: hello"
-        yield ""
-
-    events = []
-    async for event in parse_sse_lines(mock_lines()):
-        events.append(event)
-
-    assert len(events) == 2
-    assert events[0].event == "message"
-    assert json.loads(events[0].data) == {"type": "test", "value": 42}
-    assert events[1].event == "custom"
-    assert events[1].data == "hello"
-
-
-@pytest.mark.asyncio
-async def test_prune_idle_handles(workspace: Path, tmp_path: Path) -> None:
+async def test_prune_idle_handles(workspace: Path) -> None:
     """Test that supervisor prunes idle handles."""
-    command = [get_opencode_bin(), "serve", "--hostname", "127.0.0.1", "--port", "0"]
-    supervisor = OpenCodeSupervisor(
-        command,
-        request_timeout=30.0,
-        idle_ttl_seconds=1.0,
-    )
+    supervisor = _new_supervisor(request_timeout=30.0, idle_ttl_seconds=1.0)
 
     try:
         # Get client for workspace

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -1113,6 +1113,96 @@ async def test_collect_output_times_out_waiting_for_first_relevant_event() -> No
 
 
 @pytest.mark.anyio
+async def test_collect_output_keeps_waiting_when_command_active_without_events() -> (
+    None
+):
+    active_checks_remaining = 2
+    progress_events: list[dict[str, object]] = []
+
+    async def _status_fetcher():
+        if active_checks_remaining <= 0:
+            return {"status": {"type": "idle"}}
+        return {"status": None}
+
+    async def _messages_fetcher():
+        return {
+            "data": [
+                {
+                    "info": {"id": "assistant-1", "role": "assistant"},
+                    "parts": [{"type": "text", "text": "completed from snapshot"}],
+                }
+            ]
+        }
+
+    async def _part_handler(part_type: str, part: dict[str, object], delta_text):
+        if part_type == "status":
+            progress_events.append(part)
+        return None
+
+    def _turn_active() -> bool:
+        nonlocal active_checks_remaining
+        if active_checks_remaining <= 0:
+            return False
+        active_checks_remaining -= 1
+        return True
+
+    async def _silent_event_stream():
+        while True:
+            await asyncio.sleep(3600)
+            yield SSEEvent(event="server.heartbeat", data="")
+
+    output = await collect_opencode_output_from_events(
+        None,
+        session_id="s1",
+        event_stream_factory=lambda: _silent_event_stream(),
+        session_fetcher=_status_fetcher,
+        messages_fetcher=_messages_fetcher,
+        part_handler=_part_handler,
+        turn_activity_fetcher=_turn_active,
+        stall_timeout_seconds=0.001,
+        first_event_timeout_seconds=0.001,
+    )
+
+    assert output.error is None
+    assert output.text == "completed from snapshot"
+    assert output.output_source == "messages_snapshot"
+    assert any(
+        event.get("type") == "stream_silent_turn_active" for event in progress_events
+    )
+
+
+@pytest.mark.anyio
+async def test_collect_output_idle_inactive_first_event_silence_fails_without_snapshot() -> (
+    None
+):
+    async def _status_fetcher():
+        return {"status": {"type": "idle"}}
+
+    async def _messages_fetcher():
+        return {"data": []}
+
+    async def _silent_event_stream():
+        while True:
+            await asyncio.sleep(3600)
+            yield SSEEvent(event="server.heartbeat", data="")
+
+    output = await collect_opencode_output_from_events(
+        None,
+        session_id="missing-session",
+        event_stream_factory=lambda: _silent_event_stream(),
+        session_fetcher=_status_fetcher,
+        messages_fetcher=_messages_fetcher,
+        turn_activity_fetcher=lambda: False,
+        stall_timeout_seconds=0.001,
+        first_event_timeout_seconds=0.001,
+    )
+
+    assert output.text == ""
+    assert output.error is not None
+    assert "opencode_first_event_timeout" in output.error
+
+
+@pytest.mark.anyio
 async def test_collect_output_bounds_stall_reconnect_loop_if_session_missing(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Treat active OpenCode command tasks as explicit liveness evidence when SSE is silent before the first relevant event.
- Keep first-event and stall timeout failures for genuinely inactive/missing sessions.
- Consolidate OpenCode integration coverage into higher-signal live server/client/harness contracts and move pure SSE parsing to unit coverage.

## Root Cause
CAR treated OpenCode SSE silence as authoritative proof that a managed turn had failed. In the backend path, the stream collector could hit `opencode_first_event_timeout` while `prompt_async` was still running and OpenCode later completed the session successfully.

## Validation
- Pre-commit aggregate guardrails passed.
- Repo-wide mypy passed.
- Repo-wide pytest passed: 9,358 tests.
- Web UI lint/build/tests passed.
- Focused OpenCode suite passed: 144 passed, 1 opt-in live-model test skipped by default.
- Live OpenCode server integration passed for default non-model contracts: 7 passed, 1 skipped.

Closes #1915