### PR TITLE
[codex] Speed up automations workspace loading

### DIFF
--- a/src/codex_autorunner/core/automation/product.py
+++ b/src/codex_autorunner/core/automation/product.py
@@ -214,10 +214,23 @@ def automation_store(hub_root: Path) -> AutomationStore:
     return AutomationStore(hub_root)
 
 
-def automation_overview(store: AutomationStore, *, limit: int = 100) -> dict[str, Any]:
+def automation_overview(
+    store: AutomationStore,
+    *,
+    limit: int = 100,
+    recent_job_limit: int = 25,
+    include_job_history: bool = True,
+    include_raw: bool = True,
+) -> dict[str, Any]:
     take = max(1, min(int(limit or 100), 500))
     rules = store.list_rules()[:take]
-    rows = automation_rows(store, rules, recent_job_limit=25)
+    rows = automation_rows(
+        store,
+        rules,
+        recent_job_limit=recent_job_limit,
+        include_job_history=include_job_history,
+        include_raw=include_raw,
+    )
     summary = {
         "total": len(rows),
         "active": sum(1 for row in rows if row["enabled"]),
@@ -236,6 +249,8 @@ def automation_rows(
     rules: list[AutomationRule],
     *,
     recent_job_limit: int = 25,
+    include_job_history: bool = True,
+    include_raw: bool = True,
 ) -> list[dict[str, Any]]:
     rule_ids = [rule.rule_id for rule in rules]
     schedules_by_rule = store.schedules_by_rule(rule_ids)
@@ -243,12 +258,14 @@ def automation_rows(
         rule_ids, per_rule_limit=recent_job_limit
     )
     job_counts_by_rule = store.job_counts_by_rule(rule_ids)
-    all_jobs = [
-        job for rule in rules for job in recent_jobs_by_rule.get(rule.rule_id, [])
-    ]
-    execution_snapshots = automation_execution_snapshots_by_job_id(
-        all_jobs, hub_root=store.hub_root
-    )
+    execution_snapshots: Optional[dict[str, AutomationExecutionSnapshot]] = None
+    if include_job_history:
+        all_jobs = [
+            job for rule in rules for job in recent_jobs_by_rule.get(rule.rule_id, [])
+        ]
+        execution_snapshots = automation_execution_snapshots_by_job_id(
+            all_jobs, hub_root=store.hub_root
+        )
     return [
         _automation_row_from_enrichment(
             rule,
@@ -257,6 +274,8 @@ def automation_rows(
             recent_jobs=recent_jobs_by_rule.get(rule.rule_id, []),
             job_count=job_counts_by_rule.get(rule.rule_id, 0),
             execution_snapshots=execution_snapshots,
+            include_job_history=include_job_history,
+            include_raw=include_raw,
         )
         for rule in rules
     ]
@@ -278,6 +297,8 @@ def automation_row(store: AutomationStore, rule: AutomationRule) -> dict[str, An
         schedules=schedules,
         recent_jobs=recent_jobs,
         job_count=job_count,
+        include_job_history=True,
+        include_raw=True,
     )
 
 
@@ -289,41 +310,51 @@ def _automation_row_from_enrichment(
     recent_jobs: list[AutomationJob],
     job_count: int,
     execution_snapshots: Optional[dict[str, AutomationExecutionSnapshot]] = None,
+    include_job_history: bool = True,
+    include_raw: bool = True,
 ) -> dict[str, Any]:
     last_job = recent_jobs[0] if recent_jobs else None
     schedule = schedules[0] if schedules else None
     typed = _typed_product_projection(rule, schedule)
     snapshots = execution_snapshots
-    if snapshots is None and recent_jobs:
+    if include_job_history and snapshots is None and recent_jobs:
         snapshots = automation_execution_snapshots_by_job_id(
             recent_jobs, hub_root=store.hub_root
         )
-    return {
+    row: dict[str, Any] = {
         "id": rule.rule_id,
         "name": rule.name,
         "enabled": rule.enabled,
         "system_owned": rule.system_owned,
         "kind": display_kind(rule),
         "executor_kind": rule.executor_kind,
-        "executor": rule.executor,
         "trigger_kind": rule.trigger_kind,
-        "trigger": rule.trigger,
-        "filters": rule.filters,
         "target_policy": rule.target_policy,
-        "target": rule.target,
-        "policy": rule.policy,
-        "metadata": rule.metadata,
         "schedule": schedule.to_dict() if schedule is not None else None,
         "last_job": last_job.to_dict() if last_job is not None else None,
-        "jobs": [
-            _automation_job_row(job, store=store, execution_snapshots=snapshots)
-            for job in recent_jobs
-        ],
+        "jobs": [],
         "job_count": job_count,
         "created_at": rule.created_at,
         "updated_at": rule.updated_at,
         **typed,
     }
+    if include_raw:
+        row.update(
+            {
+                "executor": rule.executor,
+                "trigger": rule.trigger,
+                "filters": rule.filters,
+                "target": rule.target,
+                "policy": rule.policy,
+                "metadata": rule.metadata,
+            }
+        )
+    if include_job_history:
+        row["jobs"] = [
+            _automation_job_row(job, store=store, execution_snapshots=snapshots)
+            for job in recent_jobs
+        ]
+    return row
 
 
 def _automation_job_row(

--- a/src/codex_autorunner/surfaces/web/routes/automations.py
+++ b/src/codex_autorunner/surfaces/web/routes/automations.py
@@ -22,6 +22,7 @@ from ....core.time_utils import now_iso
 from ..app_state import HubAppContext
 
 AUTOMATION_WORKSPACE_ROUTE = "/hub/read-models/automations/workspace"
+AUTOMATION_WORKSPACE_INDEX_ROUTE = "/hub/read-models/automations/workspace-index"
 
 
 class AutomationCreateRequest(BaseModel):
@@ -82,6 +83,32 @@ def build_automation_routes(context: HubAppContext) -> APIRouter:
             "agent_defaults": _automation_agent_defaults(context),
             "generated_at": now_iso(),
         }
+
+    @router.get(AUTOMATION_WORKSPACE_INDEX_ROUTE)
+    async def automation_workspace_index(
+        limit: int = 100,
+        recent_job_limit: int = 1,
+        include_target_options: bool = False,
+    ) -> dict[str, Any]:
+        overview = automation_overview(
+            store(),
+            limit=limit,
+            recent_job_limit=recent_job_limit,
+            include_job_history=False,
+            include_raw=False,
+        )
+        payload = {
+            **overview,
+            "agent_defaults": _automation_agent_defaults(context),
+            "generated_at": now_iso(),
+        }
+        if include_target_options:
+            payload["target_options"] = _automation_target_options(context)
+        return payload
+
+    @router.get("/hub/read-models/automations/target-options")
+    async def automation_target_options() -> dict[str, Any]:
+        return {"target_options": _automation_target_options(context)}
 
     @router.get("/hub/automations")
     async def list_automations(limit: int = 100) -> dict[str, Any]:
@@ -236,4 +263,8 @@ def _automation_agent_defaults(context: HubAppContext) -> dict[str, Any]:
     }
 
 
-__all__ = ["AUTOMATION_WORKSPACE_ROUTE", "build_automation_routes"]
+__all__ = [
+    "AUTOMATION_WORKSPACE_INDEX_ROUTE",
+    "AUTOMATION_WORKSPACE_ROUTE",
+    "build_automation_routes",
+]

--- a/src/codex_autorunner/web_frontend/src/lib/api/client.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/client.ts
@@ -721,6 +721,12 @@ export class WebApiClient {
       ),
     getAutomationWorkspace: async (): Promise<ApiResult<AutomationWorkspace>> =>
       mapResult(await this.getJson<JsonRecord>('/hub/read-models/automations/workspace'), mapAutomationWorkspace),
+    getAutomationWorkspaceIndex: async (): Promise<ApiResult<AutomationWorkspace>> =>
+      mapResult(await this.getJson<JsonRecord>('/hub/read-models/automations/workspace-index'), mapAutomationWorkspace),
+    getAutomationTargetOptions: async (): Promise<ApiResult<AutomationTargetOption[]>> =>
+      mapResult(await this.getJson<JsonRecord>('/hub/read-models/automations/target-options'), (payload) =>
+        asArray(payload.target_options ?? payload.targetOptions).map(mapAutomationTargetOption)
+      ),
     listAutomations: async (): Promise<ApiResult<AutomationOverview>> =>
       mapResult(await this.getJson<JsonRecord>('/hub/automations'), mapAutomationOverview),
     getAutomation: async (ruleId: string): Promise<ApiResult<AutomationSummary>> =>

--- a/src/codex_autorunner/web_frontend/src/routes/automations/[[ruleId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/automations/[[ruleId]]/+page.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/state';
   import { onMount } from 'svelte';
   import AgentModelReasoningPicker from '$lib/components/AgentModelReasoningPicker.svelte';
+  import ContentSkeleton from '$lib/components/ContentSkeleton.svelte';
   import MasterDetail from '$lib/components/MasterDetail.svelte';
   import RunHistoryList from '$lib/components/tickets/RunHistoryList.svelte';
   import TicketPackEditor from '$lib/components/tickets/TicketPackEditor.svelte';
@@ -32,11 +33,15 @@
   let agents = $state<JsonRecord[]>([]);
   let models = $state<JsonRecord[]>([]);
   let loading = $state(true);
+  let loadingTargetOptions = $state(false);
   let loadingAgents = $state(false);
   let loadingModels = $state(false);
+  let detailLoadingId = $state<string | null>(null);
+  let modelCatalogAgentId = $state('');
   let saving = $state(false);
   let actionId = $state<string | null>(null);
   let error = $state<ApiError | null>(null);
+  let detailError = $state<ApiError | null>(null);
   let notice = $state<string | null>(null);
   let selectedKind = $state<SelectionKind>(null);
   let selectedId = $state<string>('');
@@ -68,6 +73,8 @@
   let policyDraft = $state('');
   let metadataDraft = $state('');
   let syncedSelectionKey = '';
+  let hydratedDetailIds = $state<string[]>([]);
+  let agentsHydrated = $state(false);
 
   const automations = $derived(overview?.automations ?? []);
   const presets = $derived(overview?.presets ?? []);
@@ -77,6 +84,15 @@
   const presetTargetOptions = $derived(targetOptions.filter((option) => option.kind === 'repo'));
   const selectedRepo = $derived(targetOptions.find((repo) => repo.id === selectedRepoId) ?? null);
   const scheduleTimeValue = $derived(`${pad(detailHour)}:${pad(detailMinute)}`);
+  const selectionResolved = $derived(
+    selectedKind === null || selectedAutomation() !== null || selectedPreset() !== null
+  );
+  const selectedAutomationHydrated = $derived(
+    selectedKind !== 'automation' || hydratedDetailIds.includes(selectedId)
+  );
+  const routeAutomationMissing = $derived(
+    Boolean(routeRuleId && overview && !loading && !automations.some((automation) => automation.id === routeRuleId))
+  );
 
   onMount(() => {
     void load();
@@ -88,10 +104,9 @@
   async function load(): Promise<void> {
     loading = true;
     error = null;
-    const automationResult = await webApi.hub.getAutomationWorkspace();
+    const automationResult = await webApi.hub.getAutomationWorkspaceIndex();
     if (automationResult.ok) {
-      overview = automationResult.data;
-      targetOptions = automationResult.data.targetOptions;
+      overview = mergeAutomationOverview(automationResult.data);
       if (!selectedRepoId) {
         selectedRepoId = presetTargetOptions.find((option) => !option.disabled)?.id ?? presetTargetOptions[0]?.id ?? '';
       }
@@ -103,10 +118,12 @@
     else error = automationResult.error;
     loading = false;
     syncDraftsForSelection(true);
-    void hydrateAgentCatalog();
+    if (selectedKind === 'automation' && selectedId) void hydrateAutomationDetail(selectedId, { force: true });
+    void hydrateTargetOptions();
   }
 
   async function hydrateAgentCatalog(): Promise<void> {
+    if (agentsHydrated || loadingAgents) return;
     loadingAgents = true;
     agentCatalogError = null;
     const agentResult = await webApi.pma.listAgents();
@@ -115,10 +132,54 @@
       agents = agentResult.data.agents;
       defaultAgentId = agentResult.data.default;
       defaultProfile = String(agentResult.data.defaults.profile ?? '');
+      agentsHydrated = true;
       syncDraftsForSelection(true);
+      if (selectedExecutorKind() === 'managed_thread_turn') void loadModels(selectedAgent, selectedModel, { keepReasoning: selectedKind === 'automation' });
     } else {
       agentCatalogError = agentResult.error.message;
     }
+  }
+
+  async function hydrateTargetOptions(): Promise<void> {
+    if (targetOptions.length || loadingTargetOptions) return;
+    loadingTargetOptions = true;
+    const result = await webApi.hub.getAutomationTargetOptions();
+    loadingTargetOptions = false;
+    if (result.ok) {
+      targetOptions = result.data;
+      if (!selectedRepoId) {
+        selectedRepoId = result.data.find((option) => option.kind === 'repo' && !option.disabled)?.id ?? result.data.find((option) => option.kind === 'repo')?.id ?? '';
+        syncDraftsForSelection(true);
+      }
+    }
+  }
+
+  function mergeAutomationOverview(next: AutomationOverview): AutomationOverview {
+    if (!overview || hydratedDetailIds.length === 0) return next;
+    const currentById = new Map(overview.automations.map((automation) => [automation.id, automation]));
+    return {
+      ...next,
+      automations: next.automations.map((automation) => {
+        const current = currentById.get(automation.id);
+        return current && hydratedDetailIds.includes(automation.id) ? current : automation;
+      })
+    };
+  }
+
+  async function hydrateAutomationDetail(ruleId: string, options: { force?: boolean } = {}): Promise<void> {
+    if (!ruleId || (!options.force && hydratedDetailIds.includes(ruleId)) || detailLoadingId === ruleId) return;
+    detailLoadingId = ruleId;
+    detailError = null;
+    const result = await webApi.hub.getAutomation(ruleId);
+    if (detailLoadingId === ruleId) detailLoadingId = null;
+    if (selectedKind !== 'automation' || selectedId !== ruleId) return;
+    if (!result.ok) {
+      detailError = result.error;
+      return;
+    }
+    replaceAutomation(result.data);
+    if (!hydratedDetailIds.includes(ruleId)) hydratedDetailIds = [...hydratedDetailIds, ruleId];
+    syncDraftsForSelection(true);
   }
 
   // The URL is the source of truth for which automation is open. Presets have no
@@ -126,6 +187,11 @@
   $effect(() => {
     const ruleId = routeRuleId;
     if (ruleId && automations.some((automation) => automation.id === ruleId)) {
+      selectedKind = 'automation';
+      selectedId = ruleId;
+      detailMode = 'detail';
+      void hydrateAutomationDetail(ruleId);
+    } else if (ruleId && overview && !loading) {
       selectedKind = 'automation';
       selectedId = ruleId;
       detailMode = 'detail';
@@ -138,6 +204,19 @@
       detailMode = selectedKind === 'preset' ? 'detail' : 'list';
     }
     syncDraftsForSelection(false);
+  });
+
+  $effect(() => {
+    if (!selectionResolved || !selectedAutomationHydrated) return;
+    if (selectedExecutorKind() === 'managed_thread_turn' && canEditPrompt()) void hydrateAgentCatalog();
+  });
+
+  $effect(() => {
+    if (!agentsHydrated || loadingModels) return;
+    if (selectedExecutorKind() !== 'managed_thread_turn' || !canEditPrompt()) return;
+    if (selectedAgent && modelCatalogAgentId !== selectedAgent) {
+      void loadModels(selectedAgent, selectedModel, { keepReasoning: selectedKind === 'automation' });
+    }
   });
 
   function automationRoute(ruleId: string): string {
@@ -171,10 +250,11 @@
   }
 
   function selectionKey(): string {
-    return `${selectedKind}:${selectedId}:${selectedAutomation()?.updatedAt ?? ''}:${selectedKind === 'preset' ? selectedRepoId : ''}`;
+    return `${selectedKind}:${selectedId}:${selectedAutomation()?.updatedAt ?? ''}:${selectedKind === 'preset' ? selectedRepoId : ''}:${selectedAutomationHydrated}`;
   }
 
   function syncDraftsForSelection(force: boolean): void {
+    if (selectedKind === 'automation' && !selectedAutomationHydrated) return;
     const key = selectionKey();
     if (!force && key === syncedSelectionKey) return;
     syncedSelectionKey = key;
@@ -195,7 +275,6 @@
         selectedProfile = stringValue(automation.raw.executor, 'profile') || stringValue(automation.raw.executor, 'agent_profile');
         selectedModel = stringValue(automation.raw.executor, 'model');
         selectedReasoning = stringValue(automation.raw.executor, 'reasoning');
-        void loadModels(selectedAgent, selectedModel, { keepReasoning: true });
       } else {
         clearAgentModelSelection();
       }
@@ -220,7 +299,6 @@
       selectedProfile = selectedAgent === 'hermes' ? defaultProfile : '';
       selectedModel = '';
       selectedReasoning = '';
-      void loadModels(selectedAgent, '', { keepReasoning: false });
     } else {
       clearAgentModelSelection();
     }
@@ -560,6 +638,7 @@
     selectedReasoning = '';
     models = [];
     loadingModels = false;
+    modelCatalogAgentId = '';
     modelCatalogError = null;
   }
 
@@ -575,6 +654,7 @@
     }
     loadingModels = true;
     models = [];
+    modelCatalogAgentId = agentId;
     const currentReasoning = selectedReasoning;
     const result = await webApi.pma.listAgentModels(agentId);
     loadingModels = false;
@@ -853,6 +933,9 @@
         <button type="button" class="primary-button list-create" onclick={() => openPmaWithDraft(createNewAutomationPrompt())}>
           Create with PMA
         </button>
+        {#if loading && overview}
+          <span class="refresh-chip">Refreshing</span>
+        {/if}
         {#if overview}
           <dl class="list-stats">
             <div class:active={overview.summary.active > 0}>
@@ -872,8 +955,8 @@
       </header>
 
       <div class="list-scroll">
-        {#if loading}
-          <div class="state-panel loading-state"><p>Loading automations…</p></div>
+        {#if loading && !overview}
+          <ContentSkeleton variant="chat-list" rows={4} />
         {:else}
           <div class="list-group">
             <div class="list-group-head">
@@ -940,7 +1023,22 @@
   {/snippet}
 
   {#snippet detail()}
-    {#if selectedKind === null}
+    {#if loading && !overview}
+      <section class="automation-detail automation-detail-empty" aria-label="Automation detail">
+        <ContentSkeleton variant="detail" rows={4} />
+      </section>
+    {:else if routeAutomationMissing}
+      <section class="automation-detail automation-detail-empty" aria-label="Automation detail">
+        <div class="detail-empty">
+          <p>Automation not found.</p>
+          <a class="ghost-button" href={href('/automations')}>Back to automations</a>
+        </div>
+      </section>
+    {:else if selectedKind === 'automation' && !selectedAutomationHydrated}
+      <section class="automation-detail automation-detail-empty" aria-label="Automation detail">
+        <ContentSkeleton variant="detail" rows={4} />
+      </section>
+    {:else if selectedKind === null || !selectionResolved}
       <section class="automation-detail automation-detail-empty" aria-label="Automation detail">
         <div class="detail-empty">
           <p>Pick an automation from the list, or start from a preset.</p>
@@ -950,6 +1048,9 @@
     <section class="automation-detail" aria-label="Automation detail">
       {#if error}
         <div class="automation-notice error" role="alert">{error.message}</div>
+      {/if}
+      {#if detailError}
+        <div class="automation-notice error" role="alert">{detailError.message}</div>
       {/if}
       {#if notice}
         <div class="automation-notice success" role="status">{notice}</div>
@@ -1320,6 +1421,18 @@
     width: 100%;
   }
 
+  .refresh-chip {
+    align-self: flex-start;
+    padding: 2px var(--space-2);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-2);
+    color: var(--color-ink-muted);
+    background: var(--color-surface-sunken);
+    font-size: 10px;
+    font-weight: 650;
+    text-transform: uppercase;
+  }
+
   .list-stats {
     margin: 0;
     display: grid;
@@ -1671,6 +1784,9 @@
   }
 
   .detail-empty {
+    display: grid;
+    justify-items: center;
+    gap: var(--space-3);
     text-align: center;
     color: var(--color-ink-muted);
     font-size: var(--font-size-1);

--- a/src/codex_autorunner/web_frontend/src/routes/automations/[[ruleId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/automations/[[ruleId]]/+page.svelte
@@ -175,6 +175,7 @@
     if (selectedKind !== 'automation' || selectedId !== ruleId) return;
     if (!result.ok) {
       detailError = result.error;
+      if (!hydratedDetailIds.includes(ruleId)) hydratedDetailIds = [...hydratedDetailIds, ruleId];
       return;
     }
     replaceAutomation(result.data);

--- a/src/codex_autorunner/web_frontend/src/routes/automations/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/automations/page.test.ts
@@ -13,10 +13,9 @@ describe('/automations page', () => {
     const { body } = render(Page);
 
     expect(body).toContain('Automations workspace');
-    expect(body).toContain('Loading automations');
-    // Detail pane is hidden until an automation or preset is selected — the empty
-    // state shows a hint instead of preselected detail chrome.
-    expect(body).toContain('Pick an automation from the list');
+    expect(body).toContain('skeleton-chat-list');
+    expect(body).toContain('skeleton-detail-hero');
+    expect(body).not.toContain('This is a template');
   });
 
   it('uses typed product projections for managed segregation, schedules, messages, and raw diagnostics', () => {
@@ -47,11 +46,12 @@ describe('/automations page', () => {
     expect(source).not.toContain('const PRESETS');
   });
 
-  it('loads the workspace read model before hydrating repo and agent controls', () => {
+  it('loads the workspace index before hydrating detail, repo, and agent controls', () => {
     const source = pageSource();
 
-    expect(source).toContain('webApi.hub.getAutomationWorkspace()');
-    expect(source).toContain('targetOptions = automationResult.data.targetOptions');
+    expect(source).toContain('webApi.hub.getAutomationWorkspaceIndex()');
+    expect(source).toContain('webApi.hub.getAutomation(ruleId)');
+    expect(source).toContain('webApi.hub.getAutomationTargetOptions()');
     expect(source).toContain("const presetTargetOptions = $derived(targetOptions.filter((option) => option.kind === 'repo'))");
     expect(source).toContain('{#each presetTargetOptions as repo}');
     expect(source).toContain('void hydrateAgentCatalog()');

--- a/tests/surfaces/web/test_hub_automation_routes.py
+++ b/tests/surfaces/web/test_hub_automation_routes.py
@@ -232,7 +232,9 @@ def test_hub_automation_workspace_batches_jobs_and_target_options(
     assert response.status_code == 200
     workspace = response.json()
     assert workspace["summary"]["failed_jobs"] == 1
-    assert len(workspace["automations"][0]["jobs"]) <= 25
+    assert len(workspace["automations"][0]["jobs"]) == 25
+    assert "executor" in workspace["automations"][0]
+    assert "target_options" in workspace
     assert set(workspace["agent_defaults"]) == {
         "default_agent",
         "default_profile",
@@ -240,6 +242,19 @@ def test_hub_automation_workspace_batches_jobs_and_target_options(
         "default_reasoning",
     }
     assert workspace["generated_at"]
+    index = client.get("/hub/read-models/automations/workspace-index")
+    assert index.status_code == 200
+    index_workspace = index.json()
+    assert len(index_workspace["automations"][0]["jobs"]) == 0
+    assert "executor" not in index_workspace["automations"][0]
+    assert "target_options" not in index_workspace
+    assert (
+        client.get(
+            "/hub/read-models/automations/workspace-index?include_target_options=true"
+        ).json()["target_options"]
+        is not None
+    )
+    assert client.get("/hub/read-models/automations/target-options").status_code == 200
 
     context = SimpleNamespace(
         supervisor=SimpleNamespace(


### PR DESCRIPTION
## Summary

- Add a reduced Automations workspace-index read model for fast first render while preserving the existing workspace route contract.
- Hydrate automation detail, target options, agents, and model catalogs lazily when the UI actually needs them.
- Replace blank loading forms with skeleton states, preserve list content during refresh, and show a not-found state for stale deep links.

## Root Cause

The Automations page paid for full workspace data before rendering: embedded job history, child execution snapshots, target options, and form draft hydration could all happen during initial load. The detail pane could also render from empty draft state before the selected automation or preset data was resolved.

## Review Notes

- A sub-agent review found stale hydrated detail rows and a workspace-route compatibility break. This PR now keeps /hub/read-models/automations/workspace compatible and uses /hub/read-models/automations/workspace-index for the reduced payload.
- Detail hydration now force-refreshes after index refreshes and ignores stale detail responses if selection changes.

## Validation

- pnpm web:test -- automations/page.test.ts
- .venv/bin/python -m pytest tests/surfaces/web/test_hub_automation_routes.py -q
- pnpm web:lint
- pnpm web:test
- pre-commit web-core-contract lane passed before the final Black-only amend: guardrails, mypy, 9356 Python tests, web lab, web build, web tests, SPA shell check
- Isolated reruns for unrelated flaky hook failures passed: tests/adapters/discord/test_dispatch_validation.py::test_public_flow_commands_keep_dispatch_preflight_errors_ephemeral and tests/test_opencode_agent_pool.py::test_run_turn_queues_busy_delegated_thread_and_shows_active_work
