### PR TITLE
[codex] Improve Discord queue interrupt handoff

### DIFF
--- a/src/codex_autorunner/adapters/chat/action_ux_contract.py
+++ b/src/codex_autorunner/adapters/chat/action_ux_contract.py
@@ -621,9 +621,9 @@ CHAT_ACTION_UX_CONTRACT: tuple[ChatActionUxContractEntry, ...] = (
     ),
     _control_entry(
         "queue_interrupt_send",
-        ack_class="defer_ephemeral",
+        ack_class="defer_component_update",
         control_priority="interrupt",
-        anchor_message_reuse="prefer",
+        anchor_message_reuse="require",
         optimistic_ui_allowed=True,
     ),
     _control_entry(

--- a/src/codex_autorunner/adapters/discord/car_handlers/queue_interrupt_handlers.py
+++ b/src/codex_autorunner/adapters/discord/car_handlers/queue_interrupt_handlers.py
@@ -25,6 +25,8 @@ from ..queue_status_lifecycle import (
 
 _logger = logging.getLogger(__name__)
 
+SWITCHING_TO_LATEST_MESSAGE_TEXT = "Switching to your latest message..."
+
 
 async def send_interrupt_component_response(
     service: Any,
@@ -264,18 +266,18 @@ async def handle_queued_turn_interrupt_send_button(
         service,
         interaction_id,
         interaction_token,
-        "Message received. Switching to it now...",
+        SWITCHING_TO_LATEST_MESSAGE_TEXT,
         components=[],
     )
     await service._handle_car_interrupt(
         interaction_id,
         interaction_token,
         channel_id=channel_id,
-        active_turn_text="Message received. Switching to it now...",
+        active_turn_text=SWITCHING_TO_LATEST_MESSAGE_TEXT,
         cancel_queued=False,
         allow_promoted_no_active_success=True,
         progress_reuse_source_message_id=source_message_id,
-        progress_reuse_acknowledgement="Message received. Switching to it now...",
+        progress_reuse_acknowledgement=SWITCHING_TO_LATEST_MESSAGE_TEXT,
         source="component",
         source_custom_id=custom_id,
         source_message_id=message_id,
@@ -416,17 +418,17 @@ async def handle_queue_interrupt_send_button(
         service,
         interaction_id,
         interaction_token,
-        "Message received. Switching to it now...",
+        SWITCHING_TO_LATEST_MESSAGE_TEXT,
         components=[],
     )
     await service._handle_car_interrupt(
         interaction_id,
         interaction_token,
         channel_id=channel_id,
-        active_turn_text="Message received. Switching to it now...",
+        active_turn_text=SWITCHING_TO_LATEST_MESSAGE_TEXT,
         allow_promoted_no_active_success=True,
         progress_reuse_source_message_id=action.queued_user_message_id,
-        progress_reuse_acknowledgement="Message received. Switching to it now...",
+        progress_reuse_acknowledgement=SWITCHING_TO_LATEST_MESSAGE_TEXT,
         dispatcher_conversation_id=action.conversation_id,
         source="component",
         source_custom_id=custom_id,

--- a/src/codex_autorunner/adapters/discord/car_handlers/queue_interrupt_handlers.py
+++ b/src/codex_autorunner/adapters/discord/car_handlers/queue_interrupt_handlers.py
@@ -214,11 +214,12 @@ async def handle_queued_turn_interrupt_send_button(
         custom_id
     )
     if not execution_id or not source_message_id:
-        await send_interrupt_component_response(
+        await defer_and_update_runtime_component_message(
             service,
             interaction_id,
             interaction_token,
             "Queued request is unavailable.",
+            components=[],
         )
         return
     binding = await service._store.get_binding(channel_id=channel_id)
@@ -228,11 +229,12 @@ async def handle_queued_turn_interrupt_send_button(
         service._get_discord_thread_binding(channel_id=channel_id, mode=mode)
     )
     if current_thread is None:
-        await send_interrupt_component_response(
+        await defer_and_update_runtime_component_message(
             service,
             interaction_id,
             interaction_token,
             "Queued request is unavailable.",
+            components=[],
         )
         return
     promoted = orchestration_service.promote_queued_execution(
@@ -240,11 +242,12 @@ async def handle_queued_turn_interrupt_send_button(
         execution_id,
     )
     if not promoted:
-        await send_interrupt_component_response(
+        await defer_and_update_runtime_component_message(
             service,
             interaction_id,
             interaction_token,
             "Queued request is no longer pending.",
+            components=[],
         )
         return
     get_running_execution = getattr(
@@ -255,11 +258,12 @@ async def handle_queued_turn_interrupt_send_button(
     if callable(get_running_execution):
         running_execution = get_running_execution(current_thread.thread_target_id)
         if running_execution is None:
-            await send_interrupt_component_response(
+            await defer_and_update_runtime_component_message(
                 service,
                 interaction_id,
                 interaction_token,
                 "Queued request moved to the front.",
+                components=[],
             )
             return
     await defer_and_update_runtime_component_message(

--- a/src/codex_autorunner/core/automation/store.py
+++ b/src/codex_autorunner/core/automation/store.py
@@ -51,14 +51,12 @@ class AutomationStore:
                 self._hub_root, durable=self._durable
             ) as conn:
                 with conn:
-                    cursor = conn.execute(
-                        """
+                    cursor = conn.execute("""
                         UPDATE orch_automation_rules
                            SET executor_kind = 'managed_thread_turn',
                                updated_at = updated_at
                          WHERE executor_kind = 'pma_turn'
-                        """
-                    )
+                        """)
                     migrated = int(cursor.rowcount or 0)
             if migrated:
                 _log.info(

--- a/src/codex_autorunner/core/orchestration/execution_history_diagnostics.py
+++ b/src/codex_autorunner/core/orchestration/execution_history_diagnostics.py
@@ -581,14 +581,12 @@ def collect_canonical_turn_state_diagnostics(
     resolved_now = now or datetime.now(timezone.utc)
     diagnostics: list[CanonicalTurnStateDiagnostic] = []
     with open_orchestration_sqlite(hub_root) as conn:
-        rows = conn.execute(
-            """
+        rows = conn.execute("""
             SELECT execution_id, thread_target_id, status, started_at, finished_at,
                    created_at, turn_request_json, turn_record_json, error_text
               FROM orch_thread_executions
              ORDER BY created_at ASC, execution_id ASC
-            """
-        ).fetchall()
+            """).fetchall()
         for row in rows:
             execution_id = str(row["execution_id"] or "").strip()
             request = _json_loads_object(row["turn_request_json"])

--- a/src/codex_autorunner/core/orchestration/migrations.py
+++ b/src/codex_autorunner/core/orchestration/migrations.py
@@ -1984,12 +1984,10 @@ def _apply_v37(conn: sqlite3.Connection) -> None:
                 request.request_id,
             ),
         )
-    conn.execute(
-        """
+    conn.execute("""
         CREATE INDEX IF NOT EXISTS idx_orch_thread_executions_turn_contract
             ON orch_thread_executions(turn_contract_version, status, created_at)
-        """
-    )
+        """)
 
 
 def _apply_v38(conn: sqlite3.Connection) -> None:

--- a/tests/adapters/discord/test_command_registry.py
+++ b/tests/adapters/discord/test_command_registry.py
@@ -141,7 +141,7 @@ def test_registry_matches_high_risk_component_and_modal_patterns() -> None:
     assert modal_route_for_custom_id("tickets_modal:abc123") is not None
 
 
-def test_interrupt_components_share_ephemeral_scheduler_ack_strategy() -> None:
+def test_interrupt_components_use_expected_scheduler_ack_strategy() -> None:
     assert component_scheduler_ack_strategy("cancel_turn") == "scheduler_ephemeral"
     assert (
         component_scheduler_ack_strategy("cancel_turn:thread-1:turn-1")
@@ -149,11 +149,11 @@ def test_interrupt_components_share_ephemeral_scheduler_ack_strategy() -> None:
     )
     assert (
         component_scheduler_ack_strategy("queue_interrupt_send:message-1")
-        == "scheduler_ephemeral"
+        == "scheduler_component_update"
     )
     assert (
         component_scheduler_ack_strategy("qis:turn-1:message-1")
-        == "scheduler_ephemeral"
+        == "scheduler_component_update"
     )
 
 

--- a/tests/adapters/discord/test_message_turns_transient_progress.py
+++ b/tests/adapters/discord/test_message_turns_transient_progress.py
@@ -579,7 +579,7 @@ async def test_deliver_result_reconciles_stale_siblings_without_final_message(
             dispatch,
             workspace_root=workspace,
             turn_result=support.DiscordMessageTurnResult(
-                final_message="Message received. Switching to it now...",
+                final_message="Switching to your latest message...",
                 execution_id="exec-2",
                 send_final_message=False,
             ),
@@ -1045,7 +1045,7 @@ async def test_orchestrated_turn_interrupt_send_falls_back_when_progress_ack_edi
         service,
         thread_target_id="thread-1",
         source_message_id="m-2",
-        acknowledgement="Message received. Switching to it now...",
+        acknowledgement="Switching to your latest message...",
     )
 
     result = await support.discord_message_turns_module._run_discord_orchestrated_turn_for_message(
@@ -1073,7 +1073,7 @@ async def test_orchestrated_turn_interrupt_send_falls_back_when_progress_ack_edi
     )
 
     assert result.send_final_message is True
-    assert result.final_message == "Message received. Switching to it now..."
+    assert result.final_message == "Switching to your latest message..."
     assert len(rest.channel_messages) == 1
     assert service._discord_turn_progress_reuse_requests == {}
     assert service._discord_reusable_progress_messages == {}

--- a/tests/adapters/discord/test_service_routing.py
+++ b/tests/adapters/discord/test_service_routing.py
@@ -3438,15 +3438,18 @@ async def test_component_interaction_queued_turn_interrupt_send_acknowledges_whe
         )
 
         assert interrupt_called is False
-        assert rest.followup_messages[-1]["payload"]["content"] == (
-            "Queued request moved to the front."
+        assert rest.followup_messages == []
+        assert len(rest.edited_original_interaction_responses) == 1
+        assert (
+            rest.edited_original_interaction_responses[0]["payload"]["content"]
+            == "Queued request moved to the front."
         )
     finally:
         await store.close()
 
 
 @pytest.mark.anyio
-async def test_queued_turn_interrupt_send_uses_followup_after_predefer(
+async def test_queued_turn_interrupt_send_updates_original_after_predefer(
     tmp_path: Path,
 ) -> None:
     service, rest, store = await _build_service(tmp_path, init_store=True)
@@ -3468,7 +3471,7 @@ async def test_queued_turn_interrupt_send_uses_followup_after_predefer(
             SimpleNamespace(thread_target_id="thread-1"),
         )
 
-        await service.defer_ephemeral(
+        await service.defer_component_update(
             interaction_id="interaction-1",
             interaction_token="token-1",
         )
@@ -3481,9 +3484,10 @@ async def test_queued_turn_interrupt_send_uses_followup_after_predefer(
             message_id="progress-2",
         )
 
-        assert len(rest.followup_messages) == 1
+        assert rest.followup_messages == []
+        assert len(rest.edited_original_interaction_responses) == 1
         assert (
-            rest.followup_messages[0]["payload"]["content"]
+            rest.edited_original_interaction_responses[0]["payload"]["content"]
             == "Queued request moved to the front."
         )
     finally:

--- a/tests/adapters/discord/test_service_routing.py
+++ b/tests/adapters/discord/test_service_routing.py
@@ -3171,15 +3171,18 @@ async def test_component_interaction_queue_interrupt_send_promotes_and_interrupt
             (
                 "queue_interrupt_send:m-2",
                 "channel-1",
-                "Message received. Switching to it now...",
+                "Switching to your latest message...",
                 "m-2",
                 conversation_id,
             )
         ]
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
+        assert rest.followup_messages == []
         assert len(rest.edited_original_interaction_responses) == 1
         assert (
             rest.edited_original_interaction_responses[0]["payload"]["content"]
-            == "Message received. Switching to it now..."
+            == "Switching to your latest message..."
         )
         assert (
             rest.edited_original_interaction_responses[0]["payload"]["components"] == []
@@ -3373,15 +3376,18 @@ async def test_component_interaction_queued_turn_interrupt_send_promotes_and_int
             (
                 "qis:turn-2:m-2",
                 "channel-1",
-                "Message received. Switching to it now...",
+                "Switching to your latest message...",
                 "m-2",
                 False,
             )
         ]
+        assert len(rest.interaction_responses) == 1
+        assert rest.interaction_responses[0]["payload"]["type"] == 6
+        assert rest.followup_messages == []
         assert len(rest.edited_original_interaction_responses) == 1
         assert (
             rest.edited_original_interaction_responses[0]["payload"]["content"]
-            == "Message received. Switching to it now..."
+            == "Switching to your latest message..."
         )
         assert (
             rest.edited_original_interaction_responses[0]["payload"]["components"] == []
@@ -7553,7 +7559,7 @@ async def test_car_interrupt_recovers_missing_backend_thread(tmp_path: Path) -> 
         service,
         thread_target_id="thread-1",
         source_message_id="m-2",
-        acknowledgement="Message received. Switching to it now...",
+        acknowledgement="Switching to your latest message...",
     )
     discord_message_turns._stash_discord_reusable_progress_message(
         service,
@@ -7574,7 +7580,7 @@ async def test_car_interrupt_recovers_missing_backend_thread(tmp_path: Path) -> 
             channel_id="channel-1",
             source_message_id="preview-1",
             progress_reuse_source_message_id="m-2",
-            progress_reuse_acknowledgement="Message received. Switching to it now...",
+            progress_reuse_acknowledgement="Switching to your latest message...",
         )
         assert len(rest.interaction_responses) == 1
         assert rest.interaction_responses[0]["payload"]["type"] == 5
@@ -7656,13 +7662,13 @@ async def test_car_interrupt_treats_promoted_no_active_as_success(
             "interaction-1",
             "token-1",
             channel_id="channel-1",
-            active_turn_text="Message received. Switching to it now...",
+            active_turn_text="Switching to your latest message...",
             cancel_queued=False,
             allow_promoted_no_active_success=True,
             dispatcher_conversation_id="conversation-1",
             source_message_id="preview-1",
             progress_reuse_source_message_id="m-2",
-            progress_reuse_acknowledgement="Message received. Switching to it now...",
+            progress_reuse_acknowledgement="Switching to your latest message...",
         )
         assert len(rest.interaction_responses) == 1
         assert rest.interaction_responses[0]["payload"]["type"] == 5
@@ -8071,7 +8077,7 @@ async def test_reset_discord_thread_binding_archives_after_lost_backend_recovery
         service,
         thread_target_id="thread-1",
         source_message_id="m-2",
-        acknowledgement="Message received. Switching to it now...",
+        acknowledgement="Switching to your latest message...",
     )
     discord_message_turns._stash_discord_reusable_progress_message(
         service,

--- a/tests/core/orchestration/test_sqlite_migrations.py
+++ b/tests/core/orchestration/test_sqlite_migrations.py
@@ -342,17 +342,12 @@ def test_turn_execution_contract_migration_backfills_legacy_thread_rows(
         conn.execute("DELETE FROM orch_schema_migrations WHERE version >= 37")
 
         version = apply_orchestration_migrations(conn)
-        rows = {
-            row["execution_id"]: row
-            for row in conn.execute(
-                """
+        rows = {row["execution_id"]: row for row in conn.execute("""
                 SELECT execution_id, turn_contract_version, turn_request_json,
                        turn_record_json
                   FROM orch_thread_executions
                  WHERE thread_target_id = 'thread-legacy'
-                """
-            ).fetchall()
-        }
+                """).fetchall()}
 
     assert version == ORCHESTRATION_SCHEMA_VERSION
     queued_request = json.loads(rows["turn-queued"]["turn_request_json"])
@@ -528,16 +523,11 @@ def test_turn_execution_contract_migration_repairs_legacy_opencode_models(
         conn.execute("DELETE FROM orch_schema_migrations WHERE version >= 37")
 
         version = apply_orchestration_migrations(conn)
-        rows = {
-            row["execution_id"]: row
-            for row in conn.execute(
-                """
+        rows = {row["execution_id"]: row for row in conn.execute("""
                 SELECT execution_id, turn_request_json, turn_record_json
                   FROM orch_thread_executions
                  WHERE thread_target_id = 'thread-opencode-legacy'
-                """
-            ).fetchall()
-        }
+                """).fetchall()}
 
     assert version == ORCHESTRATION_SCHEMA_VERSION
     unresolved_request = json.loads(rows["turn-unresolved"]["turn_request_json"])

--- a/tests/discord_message_turns_support.py
+++ b/tests/discord_message_turns_support.py
@@ -599,7 +599,7 @@ async def _run_interrupt_send_turn_harness(
         service,
         thread_target_id="thread-1",
         source_message_id=progress_source_message_id,
-        acknowledgement="Message received. Switching to it now...",
+        acknowledgement="Switching to your latest message...",
     )
     if pre_run is not None:
         await pre_run(service)
@@ -648,7 +648,7 @@ async def test_orchestrated_turn_interrupt_send_hands_off_progress_message(
     assert rest.edited_channel_messages[-1]["message_id"] == "msg-1"
     assert (
         rest.edited_channel_messages[-1]["payload"]["content"]
-        == "Message received. Switching to it now..."
+        == "Switching to your latest message..."
     )
     assert (
         discord_message_turns_module._claim_discord_reusable_progress_message(
@@ -708,7 +708,7 @@ async def test_orchestrated_turn_interrupt_send_acknowledges_when_progress_messa
     )
 
     assert result.send_final_message is True
-    assert result.final_message == "Message received. Switching to it now..."
+    assert result.final_message == "Switching to your latest message..."
     assert service._discord_turn_progress_reuse_requests == {}
     assert service._discord_reusable_progress_messages == {}
 
@@ -732,7 +732,7 @@ async def test_orchestrated_turn_interrupt_send_falls_back_when_progress_ack_edi
     )
 
     assert result.send_final_message is True
-    assert result.final_message == "Message received. Switching to it now..."
+    assert result.final_message == "Switching to your latest message..."
     assert len(rest.channel_messages) == 1
     assert service._discord_turn_progress_reuse_requests == {}
     assert service._discord_reusable_progress_messages == {}

--- a/tests/surfaces/web/test_hub_automation_routes.py
+++ b/tests/surfaces/web/test_hub_automation_routes.py
@@ -231,9 +231,10 @@ def test_hub_automation_workspace_batches_jobs_and_target_options(
 
     assert response.status_code == 200
     workspace = response.json()
+    workspace_rows = {row["id"]: row for row in workspace["automations"]}
     assert workspace["summary"]["failed_jobs"] == 1
-    assert len(workspace["automations"][0]["jobs"]) == 25
-    assert "executor" in workspace["automations"][0]
+    assert len(workspace_rows["rule-0"]["jobs"]) == 25
+    assert "executor" in workspace_rows["rule-0"]
     assert "target_options" in workspace
     assert set(workspace["agent_defaults"]) == {
         "default_agent",


### PR DESCRIPTION
## Summary
- Switch Discord queue interrupt send controls to component-update acknowledgements so the existing message is edited in place instead of creating an ephemeral handoff response.
- Reuse clearer handoff copy across queued interrupt paths and progress reuse.
- Add regression coverage that the Discord handoff uses interaction response type 6, sends no followup, and edits the component anchor.
- Include hook-required Black 26 formatting cleanup and update an automation route test to find the seeded rule by id after built-in automations are present.

## Validation
- `git diff --check`
- Focused Discord/action tests: 17 passed
- `CODEX_FAST_TEST_WORKERS=1 git commit -m "Improve Discord queue interrupt handoff"` pre-commit aggregate lane passed: guardrails, mypy, 9360 Python tests, web-ui lab, frontend lint/build/tests, SPA shell check

## Root Cause
The queue interrupt control was classified as an ephemeral acknowledgement. On Discord mobile that could surface a private interaction artifact such as “Original message was deleted” while CAR also updated the public progress/status message, making the handoff look like an error. Component-update acknowledgement keeps the transition anchored to the original message.