### PR TITLE
[codex] Fix hot-upgrade orchestration compatibility

### DIFF
--- a/src/codex_autorunner/adapters/chat/managed_thread_delivery_worker.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_delivery_worker.py
@@ -16,10 +16,15 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Optional
 
 from ...core.logging_utils import log_event
+from ...core.orchestration.compatibility import (
+    CompatibilityEvaluation,
+    SchemaCompatibilityError,
+)
 from ...core.orchestration.managed_thread_delivery import (
     ManagedThreadDeliveryAttemptResult,
     ManagedThreadDeliveryEngine,
@@ -43,6 +48,8 @@ class ManagedThreadDeliveryWorkerStats:
     recovery_sweeps: int = 0
     last_recovery_result: Optional[ManagedThreadDeliveryRecoverySweepResult] = None
     errors: int = 0
+    incompatible_runtime_detected: bool = False
+    last_compatibility: Optional[CompatibilityEvaluation] = None
 
 
 @dataclass
@@ -62,13 +69,16 @@ class ManagedThreadDeliveryWorker:
         adapter: ManagedThreadDeliveryAdapter,
         logger: logging.Logger,
         config: Optional[ManagedThreadDeliveryWorkerConfig] = None,
+        engine_factory: Optional[Callable[[], ManagedThreadDeliveryEngine]] = None,
     ) -> None:
         self._engine = engine
+        self._engine_factory = engine_factory
         self._adapter = adapter
         self._logger = logger
         self._config = config or ManagedThreadDeliveryWorkerConfig()
         self._stats = ManagedThreadDeliveryWorkerStats()
         self._tick_count: int = 0
+        self._parked_for_incompatible_runtime = False
 
     @property
     def stats(self) -> ManagedThreadDeliveryWorkerStats:
@@ -80,10 +90,15 @@ class ManagedThreadDeliveryWorker:
 
     async def run_once(self) -> None:
         """Execute one claim-deliver-record cycle, plus recovery if due."""
+        if self._parked_for_incompatible_runtime:
+            return
         self._tick_count += 1
-        if self._tick_count % self._config.recovery_interval_ticks == 0:
-            await self._run_recovery_sweep()
-        await self._claim_and_deliver_one()
+        try:
+            if self._tick_count % self._config.recovery_interval_ticks == 0:
+                await self._run_recovery_sweep()
+            await self._claim_and_deliver_one()
+        except SchemaCompatibilityError as exc:
+            self._park_incompatible_runtime(exc.evaluation)
 
     async def run_loop(self) -> None:
         """Run the worker loop until cancelled."""
@@ -96,9 +111,11 @@ class ManagedThreadDeliveryWorker:
             recovery_interval_ticks=self._config.recovery_interval_ticks,
         )
         try:
-            while True:
+            while not self._parked_for_incompatible_runtime:
                 try:
                     await self.run_once()
+                    if self._parked_for_incompatible_runtime:
+                        break
                 except asyncio.CancelledError:
                     raise
                 except Exception as exc:
@@ -123,10 +140,12 @@ class ManagedThreadDeliveryWorker:
                 deliveries_retried=self._stats.deliveries_retried,
                 deliveries_abandoned=self._stats.deliveries_abandoned,
                 errors=self._stats.errors,
+                incompatible_runtime_detected=self._stats.incompatible_runtime_detected,
             )
 
     async def _claim_and_deliver_one(self) -> None:
-        claim = self._engine.claim_next_delivery(adapter_key=self._adapter.adapter_key)
+        engine = self._current_engine()
+        claim = engine.claim_next_delivery(adapter_key=self._adapter.adapter_key)
         if claim is None:
             return
         self._stats.claims_processed += 1
@@ -154,7 +173,7 @@ class ManagedThreadDeliveryWorker:
                 )
         except asyncio.CancelledError:
             _record_attempt_safely(
-                self._engine,
+                engine,
                 record.delivery_id,
                 claim.claim_token,
                 ManagedThreadDeliveryAttemptResult(
@@ -165,6 +184,8 @@ class ManagedThreadDeliveryWorker:
                 adapter_key=self._adapter.adapter_key,
             )
             raise
+        except SchemaCompatibilityError:
+            raise
         except Exception as exc:
             result = ManagedThreadDeliveryAttemptResult(
                 outcome=ManagedThreadDeliveryOutcome.FAILED,
@@ -172,7 +193,7 @@ class ManagedThreadDeliveryWorker:
             )
 
         _record_attempt_safely(
-            self._engine,
+            self._current_engine(),
             record.delivery_id,
             claim.claim_token,
             result,
@@ -183,9 +204,11 @@ class ManagedThreadDeliveryWorker:
 
     async def _run_recovery_sweep(self) -> None:
         try:
-            sweep_result = self._engine.recovery_sweep(
+            sweep_result = self._current_engine().recovery_sweep(
                 adapter_key=self._adapter.adapter_key
             )
+        except SchemaCompatibilityError:
+            raise
         except Exception as exc:
             self._stats.errors += 1
             log_event(
@@ -227,6 +250,32 @@ class ManagedThreadDeliveryWorker:
         elif outcome == ManagedThreadDeliveryOutcome.ABANDONED:
             self._stats.deliveries_abandoned += 1
 
+    def _current_engine(self) -> ManagedThreadDeliveryEngine:
+        if self._engine_factory is not None:
+            return self._engine_factory()
+        return self._engine
+
+    def _park_incompatible_runtime(
+        self, compatibility: CompatibilityEvaluation
+    ) -> None:
+        if self._parked_for_incompatible_runtime:
+            return
+        self._parked_for_incompatible_runtime = True
+        self._stats.incompatible_runtime_detected = True
+        self._stats.last_compatibility = compatibility
+        log_event(
+            self._logger,
+            logging.ERROR,
+            "chat.managed_thread.delivery_worker.incompatible_runtime",
+            adapter_key=self._adapter.adapter_key,
+            compatibility=compatibility.to_dict(),
+            observed_schema=compatibility.observed_schema,
+            supported_schema=compatibility.supported_schema,
+            process_role=compatibility.process_role,
+            build_id=compatibility.build_id,
+            restart_required=compatibility.restart_required,
+        )
+
 
 def _record_attempt_safely(
     engine: ManagedThreadDeliveryEngine,
@@ -241,6 +290,8 @@ def _record_attempt_safely(
         engine.record_attempt_result(
             delivery_id, claim_token=claim_token, result=result
         )
+    except SchemaCompatibilityError:
+        raise
     except Exception as exc:
         log_event(
             logger,

--- a/src/codex_autorunner/adapters/discord/service.py
+++ b/src/codex_autorunner/adapters/discord/service.py
@@ -1052,9 +1052,13 @@ class DiscordBotService(DiscordInteractionResponseMixin):
                     default_execution_error="execution error",
                 )
 
-        engine = SQLiteManagedThreadDeliveryEngine(self._config.root)
+        def _build_engine() -> SQLiteManagedThreadDeliveryEngine:
+            return SQLiteManagedThreadDeliveryEngine(self._config.root)
+
+        engine = _build_engine()
         return ManagedThreadDeliveryWorker(
             engine=engine,
+            engine_factory=_build_engine,
             adapter=_DiscordDeliveryAdapter(),
             logger=self._logger,
         )

--- a/src/codex_autorunner/adapters/telegram/service.py
+++ b/src/codex_autorunner/adapters/telegram/service.py
@@ -689,10 +689,15 @@ class TelegramBotService(
                     cleanup=_cleanup,
                 )
 
-        state_root = Path(self._hub_root or self._config.root)
-        engine = SQLiteManagedThreadDeliveryEngine(state_root)
+        def _build_engine() -> SQLiteManagedThreadDeliveryEngine:
+            return SQLiteManagedThreadDeliveryEngine(
+                Path(self._hub_root or self._config.root)
+            )
+
+        engine = _build_engine()
         return ManagedThreadDeliveryWorker(
             engine=engine,
+            engine_factory=_build_engine,
             adapter=_TelegramDeliveryAdapter(),
             logger=self._logger,
         )

--- a/src/codex_autorunner/core/automation/engine.py
+++ b/src/codex_autorunner/core/automation/engine.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping, Optional
 from ..text_utils import _json_dumps
 from ..time_utils import now_iso
 from .models import (
+    EXECUTOR_KINDS,
     TRIGGER_KIND_EVENT,
     TRIGGER_KIND_SCHEDULE,
     AutomationEvent,
@@ -22,6 +23,7 @@ _TEMPLATE_RE = re.compile(r"{{\s*([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)*)\s*
 _ALLOWED_TEMPLATE_ROOTS = frozenset(
     {"event", "repo", "target", "pr", "schedule", "job", "metadata"}
 )
+_NON_EXECUTABLE_ERROR_CODE = "AUTOMATION_EXECUTOR_KIND_UNSUPPORTED"
 
 
 @dataclass(frozen=True)
@@ -31,6 +33,21 @@ class RuleEvaluationResult:
     jobs_created: int
     jobs_deduped: int
     jobs_skipped: int = 0
+
+
+class AutomationRuleNonExecutableError(ValueError):
+    def __init__(self, rule: AutomationRule) -> None:
+        self.code = _NON_EXECUTABLE_ERROR_CODE
+        self.rule_id = rule.rule_id
+        self.executor_kind = rule.executor_kind
+        super().__init__(
+            f"{self.code}: automation rule {rule.rule_id} uses unsupported "
+            f"executor_kind: {rule.executor_kind}"
+        )
+
+
+def automation_rule_executable(rule: AutomationRule) -> bool:
+    return bool(rule.executable) and rule.executor_kind in EXECUTOR_KINDS
 
 
 def _dig(context: Mapping[str, Any], path: str) -> Any:
@@ -84,6 +101,9 @@ class AutomationRuleEngine:
             if not self.matches_event(rule, event):
                 continue
             matched += 1
+            if not automation_rule_executable(rule):
+                skipped += 1
+                continue
             rule_result = self.enqueue_job_for_rule(rule, event)
             created += rule_result.jobs_created
             deduped += rule_result.jobs_deduped
@@ -99,6 +119,8 @@ class AutomationRuleEngine:
     def enqueue_job_for_rule(
         self, rule: AutomationRule, event: AutomationEvent
     ) -> RuleEvaluationResult:
+        if not automation_rule_executable(rule):
+            raise AutomationRuleNonExecutableError(rule)
         job = self._job_for_rule(rule, event)
         if self._blocked_by_policy(rule, event, job):
             return RuleEvaluationResult(
@@ -120,6 +142,8 @@ class AutomationRuleEngine:
     def job_for_rule(
         self, rule: AutomationRule, event: AutomationEvent
     ) -> AutomationJob:
+        if not automation_rule_executable(rule):
+            raise AutomationRuleNonExecutableError(rule)
         return self._job_for_rule(rule, event)
 
     def matches_event(self, rule: AutomationRule, event: AutomationEvent) -> bool:

--- a/src/codex_autorunner/core/automation/engine.py
+++ b/src/codex_autorunner/core/automation/engine.py
@@ -33,6 +33,7 @@ class RuleEvaluationResult:
     jobs_created: int
     jobs_deduped: int
     jobs_skipped: int = 0
+    skipped_reasons: tuple[dict[str, Any], ...] = ()
 
 
 class AutomationRuleNonExecutableError(ValueError):
@@ -48,6 +49,16 @@ class AutomationRuleNonExecutableError(ValueError):
 
 def automation_rule_executable(rule: AutomationRule) -> bool:
     return bool(rule.executable) and rule.executor_kind in EXECUTOR_KINDS
+
+
+def _non_executable_reason(rule: AutomationRule) -> dict[str, Any]:
+    return {
+        "code": _NON_EXECUTABLE_ERROR_CODE,
+        "rule_id": rule.rule_id,
+        "executor_kind": rule.executor_kind,
+        "known_executor": bool(rule.known_executor),
+        "executable": False,
+    }
 
 
 def _dig(context: Mapping[str, Any], path: str) -> Any:
@@ -97,23 +108,27 @@ class AutomationRuleEngine:
         created = 0
         deduped = 0
         skipped = 0
+        skipped_reasons: list[dict[str, Any]] = []
         for rule in self._store.list_rules(enabled=True):
             if not self.matches_event(rule, event):
                 continue
             matched += 1
             if not automation_rule_executable(rule):
                 skipped += 1
+                skipped_reasons.append(_non_executable_reason(rule))
                 continue
             rule_result = self.enqueue_job_for_rule(rule, event)
             created += rule_result.jobs_created
             deduped += rule_result.jobs_deduped
             skipped += rule_result.jobs_skipped
+            skipped_reasons.extend(rule_result.skipped_reasons)
         return RuleEvaluationResult(
             event=event,
             matched_rules=matched,
             jobs_created=created,
             jobs_deduped=deduped,
             jobs_skipped=skipped,
+            skipped_reasons=tuple(skipped_reasons),
         )
 
     def enqueue_job_for_rule(

--- a/src/codex_autorunner/core/automation/models.py
+++ b/src/codex_autorunner/core/automation/models.py
@@ -205,6 +205,13 @@ def require_choice(value: Any, *, field_name: str, choices: frozenset[str]) -> s
     return normalized
 
 
+def normalize_persisted_choice(value: Any, *, field_name: str) -> str:
+    text = _normalize_text(value)
+    if text is None:
+        raise ValueError(f"{field_name} is required")
+    return text
+
+
 def optional_text(value: Any) -> Optional[str]:
     return _normalize_text(value)
 
@@ -499,6 +506,8 @@ class AutomationRule:
     metadata: dict[str, Any]
     created_at: str
     updated_at: str
+    known_executor: bool = True
+    executable: bool = True
 
     @classmethod
     def create(
@@ -558,6 +567,91 @@ class AutomationRule:
             metadata=normalize_json_object(metadata, field_name="metadata"),
             created_at=stamp,
             updated_at=normalize_timestamp(updated_at, fallback=stamp),
+        )
+
+    @classmethod
+    def hydrate_persisted(
+        cls,
+        *,
+        name: str,
+        trigger_kind: str,
+        trigger: Optional[dict[str, Any]] = None,
+        filters: Optional[dict[str, Any]] = None,
+        target_policy: str = TARGET_POLICY_HUB,
+        target: Optional[dict[str, Any]] = None,
+        executor_kind: str,
+        executor: Optional[dict[str, Any]] = None,
+        policy: Optional[dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        rule_id: Optional[str] = None,
+        enabled: bool = True,
+        system_owned: bool = False,
+        created_at: Optional[str] = None,
+        updated_at: Optional[str] = None,
+    ) -> "AutomationRule":
+        normalized_executor_kind = normalize_persisted_choice(
+            executor_kind, field_name="executor_kind"
+        )
+        known_executor_kind = normalized_executor_kind.lower()
+        if known_executor_kind in EXECUTOR_KINDS:
+            return cls.create(
+                rule_id=rule_id,
+                name=name,
+                enabled=enabled,
+                system_owned=system_owned,
+                trigger_kind=trigger_kind,
+                trigger=trigger,
+                filters=filters,
+                target_policy=target_policy,
+                target=target,
+                executor_kind=known_executor_kind,
+                executor=executor,
+                policy=policy,
+                metadata=metadata,
+                created_at=created_at,
+                updated_at=updated_at,
+            )
+
+        normalized_trigger_kind = require_choice(
+            trigger_kind, field_name="trigger_kind", choices=TRIGGER_KINDS
+        )
+        normalized_target_policy = require_choice(
+            target_policy, field_name="target_policy", choices=TARGET_POLICIES
+        )
+        normalized_trigger = validate_trigger_contract(
+            normalized_trigger_kind,
+            normalize_json_object(trigger, field_name="trigger"),
+        )
+        normalized_target = validate_target_contract(
+            normalized_target_policy,
+            normalize_json_object(target, field_name="target"),
+        )
+        normalized_executor = normalize_json_object(executor, field_name="executor")
+        kind = normalized_executor.get("kind")
+        if kind is not None and kind != normalized_executor_kind:
+            raise _contract_error(
+                "AUTOMATION_CONTRACT_EXECUTOR_KIND_MISMATCH",
+                "executor.kind must match executor_kind when present",
+            )
+        stamp = normalize_timestamp(created_at)
+        return cls(
+            rule_id=optional_text(rule_id) or str(uuid.uuid4()),
+            name=optional_text(name) or "Untitled automation",
+            enabled=normalize_bool(enabled, fallback=True),
+            system_owned=normalize_bool(system_owned, fallback=False),
+            trigger_kind=normalized_trigger_kind,
+            trigger=normalized_trigger,
+            filters=normalize_json_object(filters, field_name="filters"),
+            target_policy=normalized_target_policy,
+            target=normalized_target,
+            executor_kind=normalized_executor_kind,
+            executor=normalized_executor,
+            policy=validate_policy(normalize_json_object(policy, field_name="policy")),
+            metadata=normalize_json_object(metadata, field_name="metadata"),
+            created_at=stamp,
+            updated_at=normalize_timestamp(updated_at, fallback=stamp),
+            known_executor=False,
+            executable=False,
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/codex_autorunner/core/automation/product.py
+++ b/src/codex_autorunner/core/automation/product.py
@@ -18,6 +18,7 @@ from .execution_graph import (
 from .models import (
     EXECUTOR_GITHUB_COMMENT,
     EXECUTOR_GITHUB_REACTION,
+    EXECUTOR_KINDS,
     EXECUTOR_MANAGED_THREAD_TURN,
     EXECUTOR_PUBLISH_CHAT_NOTIFICATION,
     EXECUTOR_PUBLISH_OPERATION,
@@ -328,6 +329,8 @@ def _automation_row_from_enrichment(
         "system_owned": rule.system_owned,
         "kind": display_kind(rule),
         "executor_kind": rule.executor_kind,
+        "known_executor": rule.known_executor,
+        "executable": rule.executable,
         "trigger_kind": rule.trigger_kind,
         "target_policy": rule.target_policy,
         "schedule": schedule.to_dict() if schedule is not None else None,
@@ -652,14 +655,20 @@ def _editable_projection(
     schedule_kind = schedule.schedule_kind if schedule is not None else None
     system_reason = _system_reason(rule)
     raw_editable = not rule.system_owned
+    executable = _known_executable_rule(rule)
     return {
-        "can_enable": True,
+        "can_enable": executable,
         "can_rename": raw_editable,
         "can_edit_schedule": raw_editable
+        and executable
         and schedule_kind in {SCHEDULE_DAILY, SCHEDULE_WEEKLY},
-        "can_edit_message": raw_editable and message["field"] == "prompt",
-        "can_edit_ticket_body": raw_editable and message["field"] == "ticket_body",
-        "can_run_now": True,
+        "can_edit_message": raw_editable
+        and executable
+        and message["field"] == "prompt",
+        "can_edit_ticket_body": raw_editable
+        and executable
+        and message["field"] == "ticket_body",
+        "can_run_now": executable,
         "can_edit_raw": False,
         "raw_edit_blocked_reason": (
             "Raw rule edits are available through the control-plane API."
@@ -892,6 +901,8 @@ def _executor_summary(
     return {
         "kind": rule.executor_kind,
         "label": _executor_label(rule.executor_kind),
+        "known_executor": rule.known_executor,
+        "executable": rule.executable,
         "agent": _optional_text(executor.get("agent")),
         "model": _optional_text(executor.get("model")),
         "reasoning": _optional_text(executor.get("reasoning")),
@@ -920,6 +931,16 @@ def _product_diagnostics(
     message: dict[str, Any],
 ) -> list[dict[str, str]]:
     diagnostics: list[dict[str, str]] = []
+    if not _known_executable_rule(rule):
+        diagnostics.append(
+            {
+                "code": "AUTOMATION_EXECUTOR_KIND_UNSUPPORTED",
+                "severity": "error",
+                "message": (
+                    "This automation uses an executor kind that this build cannot run."
+                ),
+            }
+        )
     if _legacy_source(rule) is not None:
         diagnostics.append(
             {
@@ -945,6 +966,14 @@ def _product_diagnostics(
             }
         )
     return diagnostics
+
+
+def _known_executable_rule(rule: AutomationRule) -> bool:
+    return (
+        bool(rule.known_executor)
+        and bool(rule.executable)
+        and rule.executor_kind in EXECUTOR_KINDS
+    )
 
 
 def _executor_label(executor_kind: str) -> str:

--- a/src/codex_autorunner/core/automation/scheduler.py
+++ b/src/codex_autorunner/core/automation/scheduler.py
@@ -24,6 +24,8 @@ class SchedulerProcessResult:
     events_created: int = 0
     jobs_created: int = 0
     jobs_deduped: int = 0
+    jobs_skipped: int = 0
+    skipped_reasons: tuple[dict[str, Any], ...] = ()
 
 
 class AutomationScheduler:
@@ -40,6 +42,8 @@ class AutomationScheduler:
         events = 0
         jobs = 0
         deduped = 0
+        skipped = 0
+        skipped_reasons: list[dict[str, Any]] = []
         for schedule in due:
             if schedule.next_fire_at is None:
                 continue
@@ -69,11 +73,15 @@ class AutomationScheduler:
             events += 1
             jobs += result.jobs_created
             deduped += result.jobs_deduped
+            skipped += result.jobs_skipped
+            skipped_reasons.extend(result.skipped_reasons)
         return SchedulerProcessResult(
             schedules_fired=fired,
             events_created=events,
             jobs_created=jobs,
             jobs_deduped=deduped,
+            jobs_skipped=skipped,
+            skipped_reasons=tuple(skipped_reasons),
         )
 
 

--- a/src/codex_autorunner/core/automation/store.py
+++ b/src/codex_autorunner/core/automation/store.py
@@ -1141,7 +1141,7 @@ class AutomationStore:
         return int(row["c"] if row is not None else 0)
 
     def _row_to_rule(self, row: sqlite3.Row) -> AutomationRule:
-        return AutomationRule.create(
+        return AutomationRule.hydrate_persisted(
             rule_id=row["rule_id"],
             name=row["name"],
             enabled=normalize_bool(row["enabled"]),

--- a/src/codex_autorunner/core/automation/worker.py
+++ b/src/codex_autorunner/core/automation/worker.py
@@ -33,6 +33,15 @@ class AutomationExecutor(Protocol):
     def execute(self, job: AutomationJob) -> AutomationExecutorResult: ...
 
 
+class AutomationExecutorUnavailableError(RuntimeError):
+    def __init__(self, kind: str) -> None:
+        self.code = "AUTOMATION_EXECUTOR_KIND_UNSUPPORTED"
+        self.executor_kind = str(kind or "").strip()
+        super().__init__(
+            f"{self.code}: automation executor is not registered: {self.executor_kind}"
+        )
+
+
 class AutomationExecutorRegistry:
     def __init__(self) -> None:
         self._executors: dict[str, AutomationExecutor] = {}
@@ -46,7 +55,7 @@ class AutomationExecutorRegistry:
     def get(self, kind: str) -> AutomationExecutor:
         text = str(kind or "").strip()
         if text not in self._executors:
-            raise KeyError(f"automation executor is not registered: {text}")
+            raise AutomationExecutorUnavailableError(text)
         return self._executors[text]
 
 
@@ -171,6 +180,28 @@ class AutomationJobWorker:
                         error_text=result.summary if status == JOB_FAILED else None,
                         executor_result=result.data,
                         execution_refs=result.execution_refs,
+                    )
+                )
+            except AutomationExecutorUnavailableError as exc:
+                error = str(exc)
+                self._store.fail_job(
+                    running.job_id, error_text=error, dead_letter=True, now=stamp
+                )
+                failed += 1
+                dead += 1
+                self._store.record_attempt(
+                    AutomationJobAttempt.create(
+                        job_id=running.job_id,
+                        attempt_number=running.attempt_count,
+                        status=JOB_DEAD_LETTERED,
+                        started_at=attempt_started_at,
+                        finished_at=stamp,
+                        error_text=error,
+                        executor_result={
+                            "code": exc.code,
+                            "executor_kind": exc.executor_kind,
+                            "executable": False,
+                        },
                     )
                 )
             except Exception as exc:

--- a/src/codex_autorunner/core/hub_control_plane/_handshake.py
+++ b/src/codex_autorunner/core/hub_control_plane/_handshake.py
@@ -120,6 +120,7 @@ class HandshakeResponse:
     capabilities: tuple[str, ...]
     hub_build_version: Optional[str] = None
     hub_asset_version: Optional[str] = None
+    compatibility: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "HandshakeResponse":
@@ -147,10 +148,17 @@ class HandshakeResponse:
             capabilities=normalize_string_set(data.get("capabilities")),
             hub_build_version=normalize_optional_text(data.get("hub_build_version")),
             hub_asset_version=normalize_optional_text(data.get("hub_asset_version")),
+            compatibility=(
+                dict(compatibility_payload)
+                if isinstance(
+                    compatibility_payload := data.get("compatibility"), Mapping
+                )
+                else {}
+            ),
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "api_version": self.api_version,
             "minimum_client_api_version": self.minimum_client_api_version,
             "schema_generation": self.schema_generation,
@@ -158,6 +166,9 @@ class HandshakeResponse:
             "hub_build_version": self.hub_build_version,
             "hub_asset_version": self.hub_asset_version,
         }
+        if self.compatibility:
+            payload["compatibility"] = dict(self.compatibility)
+        return payload
 
 
 @dataclass(frozen=True)

--- a/src/codex_autorunner/core/hub_control_plane/handshake_startup.py
+++ b/src/codex_autorunner/core/hub_control_plane/handshake_startup.py
@@ -19,6 +19,31 @@ from .models import (
 _STARTUP_RETRY_JITTER_RATIO = 0.1
 
 
+def _compatibility_from_hub_incompatible_error(
+    exc: HubControlPlaneError,
+    *,
+    client_api_version: str,
+    expected_schema_generation: int,
+) -> HandshakeCompatibility | None:
+    payload = exc.details.get("compatibility")
+    if not isinstance(payload, dict):
+        return None
+    observed_schema = payload.get("observed_schema")
+    try:
+        server_schema_generation = (
+            int(observed_schema) if observed_schema is not None else None
+        )
+    except (TypeError, ValueError):
+        server_schema_generation = None
+    return HandshakeCompatibility(
+        state="incompatible",
+        reason=str(payload.get("reason") or str(exc)),
+        client_api_version=client_api_version,
+        server_schema_generation=server_schema_generation,
+        expected_schema_generation=expected_schema_generation,
+    )
+
+
 def _jittered_retry_delay(delay_seconds: float) -> float:
     normalized_delay = max(delay_seconds, 0.0)
     if normalized_delay == 0.0:
@@ -93,6 +118,36 @@ async def perform_startup_hub_handshake(
             )
             return False, compatibility
         except HubControlPlaneError as exc:
+            if exc.code == "hub_incompatible":
+                error_compatibility = _compatibility_from_hub_incompatible_error(
+                    exc,
+                    client_api_version=client_api_version,
+                    expected_schema_generation=expected_schema_generation,
+                )
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    f"{log_event_name_prefix}.hub_control_plane.handshake_incompatible",
+                    hub_root=hub_root_str,
+                    reason=(
+                        error_compatibility.reason
+                        if error_compatibility is not None
+                        else str(exc)
+                    ),
+                    server_api_version=(
+                        error_compatibility.server_api_version
+                        if error_compatibility is not None
+                        else None
+                    ),
+                    client_api_version=client_api_version,
+                    server_schema_generation=(
+                        error_compatibility.server_schema_generation
+                        if error_compatibility is not None
+                        else None
+                    ),
+                    expected_schema_generation=expected_schema_generation,
+                )
+                return False, error_compatibility
             should_retry = (
                 startup_retry_deadline is not None
                 and exc.retryable

--- a/src/codex_autorunner/core/hub_control_plane/service.py
+++ b/src/codex_autorunner/core/hub_control_plane/service.py
@@ -12,6 +12,7 @@ from ..automation import (
     AutomationSchedule,
     AutomationStore,
 )
+from ..automation.engine import AutomationRuleNonExecutableError
 from ..managed_thread_store import ManagedThreadStore
 from ..orchestration.bindings import OrchestrationBindingStore
 from ..orchestration.cold_trace_store import ColdTraceStore
@@ -1038,8 +1039,21 @@ class HubSharedStateService:
             )
         )
         engine = AutomationRuleEngine(self._automation_store)
-        expected_job = engine.job_for_rule(rule, event)
-        result = engine.enqueue_job_for_rule(rule, event)
+        try:
+            expected_job = engine.job_for_rule(rule, event)
+            result = engine.enqueue_job_for_rule(rule, event)
+        except AutomationRuleNonExecutableError as exc:
+            raise HubControlPlaneError(
+                "hub_rejected",
+                str(exc),
+                details={
+                    "code": exc.code,
+                    "rule_id": exc.rule_id,
+                    "executor_kind": exc.executor_kind,
+                    "executable": False,
+                    "known_executor": False,
+                },
+            ) from exc
         job = self._automation_store.get_job_by_dedupe_key(expected_job.dedupe_key)
         if job is None:
             raise HubControlPlaneError(

--- a/src/codex_autorunner/core/hub_control_plane/service.py
+++ b/src/codex_autorunner/core/hub_control_plane/service.py
@@ -15,13 +15,17 @@ from ..automation import (
 from ..managed_thread_store import ManagedThreadStore
 from ..orchestration.bindings import OrchestrationBindingStore
 from ..orchestration.cold_trace_store import ColdTraceStore
+from ..orchestration.compatibility import SchemaCompatibilityError
 from ..orchestration.models import ExecutionRecord, ThreadTarget
 from ..orchestration.runtime_bindings import (
     RuntimeThreadBinding,
     normalize_backend_binding_state,
 )
 from ..orchestration.service import ManagedThreadExecutionStore
-from ..orchestration.sqlite import read_orchestration_compatibility_metadata
+from ..orchestration.sqlite import (
+    assert_current_orchestration_compatible,
+    read_orchestration_compatibility_metadata,
+)
 from ..orchestration.turn_timeline import (
     append_turn_events_to_cold_trace,
     persist_turn_timeline,
@@ -269,6 +273,19 @@ class HubSharedStateService:
         return CONTROL_PLANE_CAPABILITIES
 
     def handshake(self, request: HandshakeRequest) -> HandshakeResponse:
+        try:
+            evaluation = assert_current_orchestration_compatible(
+                self._hub_root,
+                process_role="hub",
+                durable=self._durable_writes,
+            )
+        except SchemaCompatibilityError as exc:
+            raise HubControlPlaneError(
+                "hub_incompatible",
+                "Hub restart required: orchestration schema is newer than this build supports",
+                retryable=False,
+                details={"compatibility": exc.evaluation.to_dict()},
+            ) from exc
         metadata = read_orchestration_compatibility_metadata(self._hub_root)
         if metadata is None:
             raise HubControlPlaneError(
@@ -283,7 +300,23 @@ class HubSharedStateService:
             capabilities=self.capabilities,
             hub_build_version=self._hub_build_version,
             hub_asset_version=self._hub_asset_version,
+            compatibility=evaluation.to_dict(),
         )
+
+    def _ensure_compatible(self) -> None:
+        try:
+            assert_current_orchestration_compatible(
+                self._hub_root,
+                process_role="hub",
+                durable=self._durable_writes,
+            )
+        except SchemaCompatibilityError as exc:
+            raise HubControlPlaneError(
+                "hub_incompatible",
+                "Hub restart required: orchestration schema is newer than this build supports",
+                retryable=False,
+                details={"compatibility": exc.evaluation.to_dict()},
+            ) from exc
 
     def get_notification_record(
         self, request: NotificationLookupRequest

--- a/src/codex_autorunner/core/managed_thread_identity.py
+++ b/src/codex_autorunner/core/managed_thread_identity.py
@@ -217,7 +217,12 @@ class ManagedThreadIdentityStore:
         return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
     def _prepare(self) -> None:
-        prepare_orchestration_sqlite(self._hub_root, durable=self._durable)
+        prepare_orchestration_sqlite(
+            self._hub_root,
+            durable=self._durable,
+            process_role="worker",
+            migration_mode="worker",
+        )
 
     def _import_marker_present(self, conn: Any) -> bool:
         row = conn.execute(

--- a/src/codex_autorunner/core/managed_thread_store_bootstrap.py
+++ b/src/codex_autorunner/core/managed_thread_store_bootstrap.py
@@ -74,7 +74,12 @@ class ManagedThreadStoreBootstrap:
 
     def prepare(self) -> None:
         with managed_threads_db_lock(self._db_path):
-            prepare_orchestration_sqlite(self._hub_root, durable=self._durable)
+            prepare_orchestration_sqlite(
+                self._hub_root,
+                durable=self._durable,
+                process_role="worker",
+                migration_mode="worker",
+            )
             ensure_legacy_orchestration_backfill(
                 self._hub_root,
                 durable=self._durable,

--- a/src/codex_autorunner/core/orchestration/__init__.py
+++ b/src/codex_autorunner/core/orchestration/__init__.py
@@ -82,6 +82,13 @@ from .chat_surface_read_model import (
     serialize_chat_surface_event,
 )
 from .cold_trace_store import ColdTraceStore
+from .compatibility import (
+    CompatibilityEvaluation,
+    CompatibilityRegistry,
+    ProcessCompatibilityDeclaration,
+    SchemaCompatibilityError,
+    evaluate_schema_compatibility,
+)
 from .context_capsule_ledger import SQLiteContextCapsuleLedger
 from .discord_interaction_lifecycle import (
     DiscordInteractionExecutionStatus,
@@ -170,6 +177,8 @@ from .models import (
 )
 from .sqlite import (
     ORCHESTRATION_DB_FILENAME,
+    assert_current_orchestration_compatible,
+    evaluate_current_orchestration_compatibility,
     initialize_orchestration_sqlite,
     resolve_orchestration_sqlite_path,
 )
@@ -299,6 +308,8 @@ __all__ = [
     "ChatSurfaceProjection",
     "ChatSurfaceReadService",
     "ChatSurfaceResourceOwner",
+    "CompatibilityEvaluation",
+    "CompatibilityRegistry",
     "CHAT_ARCHITECTURE_GOAL_CRITERIA",
     "CURRENT_CHAT_ARCHITECTURE_SIGNALS",
     "CHAT_SURFACE_EVENT_TYPES",
@@ -337,8 +348,10 @@ __all__ = [
     "OrchestrationFlowService",
     "OrchestrationThreadService",
     "PausedFlowTarget",
+    "ProcessCompatibilityDeclaration",
     "ManagedThreadExecutionStore",
     "RuntimeThreadHarness",
+    "SchemaCompatibilityError",
     "SQLiteChatOperationLedger",
     "SQLiteChatSurfaceEventJournal",
     "SQLiteContextCapsuleLedger",
@@ -369,6 +382,7 @@ __all__ = [
     "TurnExecutionRequest",
     "WorkspaceRuntimeAcquisition",
     "apply_orchestration_migrations",
+    "assert_current_orchestration_compatible",
     "audit_execution_history",
     "backfill_legacy_execution_history",
     "build_agent_definition",
@@ -392,6 +406,8 @@ __all__ = [
     "emit_binding_event",
     "emit_chat_surface_event",
     "evaluate_chat_architecture_goal",
+    "evaluate_current_orchestration_compatibility",
+    "evaluate_schema_compatibility",
     "get_agent_definition",
     "get_surface_orchestration_ingress",
     "initialize_orchestration_sqlite",

--- a/src/codex_autorunner/core/orchestration/__init__.py
+++ b/src/codex_autorunner/core/orchestration/__init__.py
@@ -177,9 +177,12 @@ from .models import (
 )
 from .sqlite import (
     ORCHESTRATION_DB_FILENAME,
+    OrchestrationMigrationRefusal,
+    OrchestrationMigrationRefused,
     assert_current_orchestration_compatible,
     evaluate_current_orchestration_compatibility,
     initialize_orchestration_sqlite,
+    resolve_orchestration_migration_lock_path,
     resolve_orchestration_sqlite_path,
 )
 from .threads import SurfaceThreadMessageRequest
@@ -411,6 +414,8 @@ __all__ = [
     "get_agent_definition",
     "get_surface_orchestration_ingress",
     "initialize_orchestration_sqlite",
+    "OrchestrationMigrationRefusal",
+    "OrchestrationMigrationRefused",
     "is_discord_interaction_execution_terminal",
     "is_discord_interaction_scheduler_terminal",
     "is_valid_discord_interaction_execution_transition",
@@ -436,6 +441,7 @@ __all__ = [
     "collect_orchestration_storage_maintenance_read_model",
     "record_from_intent",
     "resolve_execution_history_maintenance_policy",
+    "resolve_orchestration_migration_lock_path",
     "resolve_orchestration_sqlite_path",
     "serialize_chat_surface_event",
     "ticket_flow_chat_ledger_contract",

--- a/src/codex_autorunner/core/orchestration/compatibility.py
+++ b/src/codex_autorunner/core/orchestration/compatibility.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import os
+import socket
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from importlib import metadata as importlib_metadata
+from typing import Any, Literal, Mapping, Optional
+
+from ..time_utils import now_iso
+
+ProcessRole = Literal["hub", "worker", "discord", "telegram", "cli", "web", "pma"]
+CompatibilityStatus = Literal[
+    "compatible",
+    "restart_required",
+    "incompatible_schema",
+    "unknown",
+]
+
+
+def _normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def resolve_build_identity() -> tuple[str, Optional[str]]:
+    for distribution_name in ("codex-autorunner", "codex_autorunner"):
+        try:
+            version = importlib_metadata.version(distribution_name).strip()
+        except importlib_metadata.PackageNotFoundError:
+            continue
+        if version:
+            return version, None
+    return "unknown", "package_version_unavailable"
+
+
+@dataclass(frozen=True)
+class ProcessCompatibilityDeclaration:
+    process_id: str
+    role: str
+    pid: int
+    process_start_time: float
+    build_id: str
+    unknown_build_reason: Optional[str]
+    writer_identity: str
+    supported_control_plane_api_version: str
+    max_supported_schema_generation: int
+    observed_schema_generation: int
+    heartbeat_at: str
+    expires_at: str
+    ttl_seconds: int
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "ProcessCompatibilityDeclaration":
+        return cls(
+            process_id=_normalize_text(data.get("process_id")),
+            role=_normalize_text(data.get("role")) or "unknown",
+            pid=int(data.get("pid") or 0),
+            process_start_time=float(data.get("process_start_time") or 0.0),
+            build_id=_normalize_text(data.get("build_id")) or "unknown",
+            unknown_build_reason=(
+                _normalize_text(data.get("unknown_build_reason")) or None
+            ),
+            writer_identity=_normalize_text(data.get("writer_identity")),
+            supported_control_plane_api_version=_normalize_text(
+                data.get("supported_control_plane_api_version")
+            )
+            or "unknown",
+            max_supported_schema_generation=int(
+                data.get("max_supported_schema_generation") or 0
+            ),
+            observed_schema_generation=int(data.get("observed_schema_generation") or 0),
+            heartbeat_at=_normalize_text(data.get("heartbeat_at")),
+            expires_at=_normalize_text(data.get("expires_at")),
+            ttl_seconds=int(data.get("ttl_seconds") or 0),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "process_id": self.process_id,
+            "role": self.role,
+            "pid": self.pid,
+            "process_start_time": self.process_start_time,
+            "build_id": self.build_id,
+            "unknown_build_reason": self.unknown_build_reason,
+            "writer_identity": self.writer_identity,
+            "supported_control_plane_api_version": (
+                self.supported_control_plane_api_version
+            ),
+            "max_supported_schema_generation": self.max_supported_schema_generation,
+            "observed_schema_generation": self.observed_schema_generation,
+            "heartbeat_at": self.heartbeat_at,
+            "expires_at": self.expires_at,
+            "ttl_seconds": self.ttl_seconds,
+        }
+
+
+@dataclass(frozen=True)
+class CompatibilityEvaluation:
+    status: CompatibilityStatus
+    observed_schema: int
+    supported_schema: int
+    process_role: str
+    build_id: str
+    restart_required: bool
+    reason: Optional[str] = None
+    process_id: Optional[str] = None
+
+    @property
+    def compatible(self) -> bool:
+        return self.status == "compatible"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "observed_schema": self.observed_schema,
+            "supported_schema": self.supported_schema,
+            "process_role": self.process_role,
+            "build_id": self.build_id,
+            "restart_required": self.restart_required,
+            "reason": self.reason,
+            "process_id": self.process_id,
+        }
+
+
+@dataclass(frozen=True)
+class CompatibilityRegistry:
+    declarations: tuple[ProcessCompatibilityDeclaration, ...] = field(
+        default_factory=tuple
+    )
+    stale_declarations: tuple[ProcessCompatibilityDeclaration, ...] = field(
+        default_factory=tuple
+    )
+    updated_at: Optional[str] = None
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "CompatibilityRegistry":
+        declarations = tuple(
+            ProcessCompatibilityDeclaration.from_mapping(item)
+            for item in data.get("declarations", [])
+            if isinstance(item, Mapping)
+        )
+        stale_declarations = tuple(
+            ProcessCompatibilityDeclaration.from_mapping(item)
+            for item in data.get("stale_declarations", [])
+            if isinstance(item, Mapping)
+        )
+        return cls(
+            declarations=declarations,
+            stale_declarations=stale_declarations,
+            updated_at=_normalize_text(data.get("updated_at")) or None,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "updated_at": self.updated_at,
+            "declarations": [item.to_dict() for item in self.declarations],
+            "stale_declarations": [item.to_dict() for item in self.stale_declarations],
+        }
+
+
+def _parse_utc_timestamp(value: str) -> Optional[float]:
+    raw = _normalize_text(value)
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def classify_registry_declarations(
+    declarations: tuple[ProcessCompatibilityDeclaration, ...],
+    *,
+    now_timestamp: float,
+    pid_start_time_matches: Callable[[int, float], bool] | None = None,
+) -> tuple[
+    tuple[ProcessCompatibilityDeclaration, ...],
+    tuple[ProcessCompatibilityDeclaration, ...],
+]:
+    active: list[ProcessCompatibilityDeclaration] = []
+    stale: list[ProcessCompatibilityDeclaration] = []
+    for declaration in declarations:
+        expires_at = _parse_utc_timestamp(declaration.expires_at)
+        pid_matches = (
+            True
+            if pid_start_time_matches is None
+            else pid_start_time_matches(declaration.pid, declaration.process_start_time)
+        )
+        if expires_at is None or expires_at <= now_timestamp or not pid_matches:
+            stale.append(declaration)
+            continue
+        active.append(declaration)
+    return tuple(active), tuple(stale)
+
+
+class SchemaCompatibilityError(RuntimeError):
+    def __init__(self, evaluation: CompatibilityEvaluation) -> None:
+        super().__init__(
+            "orchestration.sqlite3 schema is newer than this build supports"
+        )
+        self.evaluation = evaluation
+
+
+def evaluate_schema_compatibility(
+    *,
+    observed_schema: int,
+    supported_schema: int,
+    process_role: str,
+    build_id: str,
+    process_id: Optional[str] = None,
+) -> CompatibilityEvaluation:
+    observed = max(0, int(observed_schema))
+    supported = max(0, int(supported_schema))
+    if observed > supported:
+        return CompatibilityEvaluation(
+            status="incompatible_schema",
+            observed_schema=observed,
+            supported_schema=supported,
+            process_role=process_role,
+            build_id=build_id,
+            restart_required=True,
+            reason="observed schema generation is newer than this process supports",
+            process_id=process_id,
+        )
+    return CompatibilityEvaluation(
+        status="compatible",
+        observed_schema=observed,
+        supported_schema=supported,
+        process_role=process_role,
+        build_id=build_id,
+        restart_required=False,
+        process_id=process_id,
+    )
+
+
+def build_process_declaration(
+    *,
+    role: str,
+    supported_control_plane_api_version: str,
+    max_supported_schema_generation: int,
+    observed_schema_generation: int,
+    ttl_seconds: int = 120,
+) -> ProcessCompatibilityDeclaration:
+    build_id, unknown_reason = resolve_build_identity()
+    pid = os.getpid()
+    process_id = f"{role}:{pid}:{uuid.uuid4()}"
+    heartbeat_at = now_iso()
+    expires_at = datetime.fromtimestamp(
+        time.time() + max(1, int(ttl_seconds)), tz=timezone.utc
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return ProcessCompatibilityDeclaration(
+        process_id=process_id,
+        role=role,
+        pid=pid,
+        process_start_time=time.time(),
+        build_id=build_id,
+        unknown_build_reason=unknown_reason,
+        writer_identity=f"{socket.gethostname()}:{pid}:{process_id}",
+        supported_control_plane_api_version=supported_control_plane_api_version,
+        max_supported_schema_generation=max(0, int(max_supported_schema_generation)),
+        observed_schema_generation=max(0, int(observed_schema_generation)),
+        heartbeat_at=heartbeat_at,
+        expires_at=expires_at,
+        ttl_seconds=max(1, int(ttl_seconds)),
+    )
+
+
+__all__ = [
+    "CompatibilityEvaluation",
+    "CompatibilityRegistry",
+    "CompatibilityStatus",
+    "ProcessCompatibilityDeclaration",
+    "ProcessRole",
+    "SchemaCompatibilityError",
+    "build_process_declaration",
+    "classify_registry_declarations",
+    "evaluate_schema_compatibility",
+    "resolve_build_identity",
+]

--- a/src/codex_autorunner/core/orchestration/compatibility.py
+++ b/src/codex_autorunner/core/orchestration/compatibility.py
@@ -243,10 +243,16 @@ def build_process_declaration(
     max_supported_schema_generation: int,
     observed_schema_generation: int,
     ttl_seconds: int = 120,
+    existing: ProcessCompatibilityDeclaration | None = None,
 ) -> ProcessCompatibilityDeclaration:
     build_id, unknown_reason = resolve_build_identity()
     pid = os.getpid()
-    process_id = f"{role}:{pid}:{uuid.uuid4()}"
+    if existing is not None and existing.role == role and existing.pid == pid:
+        process_id = existing.process_id
+        process_start_time = existing.process_start_time
+    else:
+        process_id = f"{role}:{pid}:{uuid.uuid4()}"
+        process_start_time = time.time()
     heartbeat_at = now_iso()
     expires_at = datetime.fromtimestamp(
         time.time() + max(1, int(ttl_seconds)), tz=timezone.utc
@@ -255,7 +261,7 @@ def build_process_declaration(
         process_id=process_id,
         role=role,
         pid=pid,
-        process_start_time=time.time(),
+        process_start_time=process_start_time,
         build_id=build_id,
         unknown_build_reason=unknown_reason,
         writer_identity=f"{socket.gethostname()}:{pid}:{process_id}",

--- a/src/codex_autorunner/core/orchestration/migrations.py
+++ b/src/codex_autorunner/core/orchestration/migrations.py
@@ -7,6 +7,7 @@ from typing import Callable
 
 from ..sqlite_utils import table_columns, table_exists
 from ..time_utils import now_iso
+from .compatibility import SchemaCompatibilityError, evaluate_schema_compatibility
 from .models import OrchestrationTableDefinition
 from .turn_execution_storage import (
     TURN_EXECUTION_CONTRACT_VERSION,
@@ -2418,8 +2419,13 @@ def apply_orchestration_migrations(conn: sqlite3.Connection) -> int:
     _ensure_migration_tables(conn)
     current_version = current_orchestration_schema_version(conn)
     if current_version > ORCHESTRATION_SCHEMA_VERSION:
-        raise RuntimeError(
-            "orchestration.sqlite3 schema is newer than this build supports"
+        raise SchemaCompatibilityError(
+            evaluate_schema_compatibility(
+                observed_schema=current_version,
+                supported_schema=ORCHESTRATION_SCHEMA_VERSION,
+                process_role="unknown",
+                build_id="unknown",
+            )
         )
     if current_version == ORCHESTRATION_SCHEMA_VERSION:
         return current_version

--- a/src/codex_autorunner/core/orchestration/sqlite.py
+++ b/src/codex_autorunner/core/orchestration/sqlite.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import time
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterator, Optional
 
@@ -16,6 +17,16 @@ from ..state_roots import (
 )
 from ..time_utils import now_iso
 from ..utils import atomic_write
+from .compatibility import (
+    CompatibilityEvaluation,
+    CompatibilityRegistry,
+    ProcessCompatibilityDeclaration,
+    SchemaCompatibilityError,
+    build_process_declaration,
+    classify_registry_declarations,
+    evaluate_schema_compatibility,
+    resolve_build_identity,
+)
 from .migrations import (
     ORCHESTRATION_SCHEMA_VERSION,
     apply_orchestration_migrations,
@@ -31,6 +42,7 @@ class OrchestrationCompatibilityMetadata:
     schema_generation: int
     prepared_at: str
     db_path: str
+    registry: CompatibilityRegistry = field(default_factory=CompatibilityRegistry)
 
     @classmethod
     def from_mapping(cls, data: dict[str, Any]) -> "OrchestrationCompatibilityMetadata":
@@ -47,6 +59,11 @@ class OrchestrationCompatibilityMetadata:
             schema_generation=schema_generation,
             prepared_at=prepared_at,
             db_path=db_path,
+            registry=CompatibilityRegistry.from_mapping(
+                registry_payload
+                if isinstance(registry_payload := data.get("registry"), dict)
+                else {}
+            ),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -54,6 +71,7 @@ class OrchestrationCompatibilityMetadata:
             "schema_generation": self.schema_generation,
             "prepared_at": self.prepared_at,
             "db_path": self.db_path,
+            "registry": self.registry.to_dict(),
         }
 
 
@@ -75,12 +93,42 @@ def _write_orchestration_compatibility_metadata(
     hub_root: Path,
     *,
     schema_generation: int,
+    declaration: ProcessCompatibilityDeclaration | None = None,
     prepared_at: Optional[str] = None,
 ) -> OrchestrationCompatibilityMetadata:
+    previous = read_orchestration_compatibility_metadata(hub_root)
+    registry = previous.registry if previous is not None else CompatibilityRegistry()
+    active_declarations, stale_declarations = classify_registry_declarations(
+        registry.declarations,
+        now_timestamp=time.time(),
+    )
+    stale_by_id = {
+        item.process_id: item
+        for item in (*registry.stale_declarations, *stale_declarations)
+    }
+    registry = CompatibilityRegistry(
+        declarations=active_declarations,
+        stale_declarations=tuple(stale_by_id.values()),
+        updated_at=registry.updated_at,
+    )
+    if declaration is not None:
+        now_text = now_iso()
+        active = {
+            item.process_id: item
+            for item in registry.declarations
+            if item.process_id != declaration.process_id
+        }
+        active[declaration.process_id] = declaration
+        registry = CompatibilityRegistry(
+            declarations=tuple(active.values()),
+            stale_declarations=registry.stale_declarations,
+            updated_at=now_text,
+        )
     metadata = OrchestrationCompatibilityMetadata(
         schema_generation=max(0, int(schema_generation)),
         prepared_at=prepared_at or now_iso(),
         db_path=str(resolve_orchestration_sqlite_path(hub_root)),
+        registry=registry,
     )
     metadata_path = resolve_orchestration_compatibility_metadata_path(hub_root)
     metadata_path.parent.mkdir(parents=True, exist_ok=True)
@@ -124,18 +172,117 @@ def initialize_orchestration_sqlite(hub_root: Path, *, durable: bool = True) -> 
 
 
 def prepare_orchestration_sqlite(
-    hub_root: Path, *, durable: bool = True
+    hub_root: Path,
+    *,
+    durable: bool = True,
+    process_role: str = "hub",
+    control_plane_api_version: str = "1.0.0",
+    heartbeat_ttl_seconds: int = 120,
 ) -> OrchestrationCompatibilityMetadata:
     """Explicitly prepare orchestration shared state for hub-owned startup."""
-    initialize_orchestration_sqlite(hub_root, durable=durable)
-    metadata = read_orchestration_compatibility_metadata(hub_root)
-    if metadata is not None:
-        return metadata
-    return OrchestrationCompatibilityMetadata(
-        schema_generation=ORCHESTRATION_SCHEMA_VERSION,
-        prepared_at=now_iso(),
-        db_path=str(resolve_orchestration_sqlite_path(hub_root)),
+    db_path = resolve_orchestration_sqlite_path(hub_root)
+    with open_sqlite(
+        db_path,
+        durable=durable,
+        busy_timeout_ms=orchestration_sqlite_busy_timeout_ms(),
+    ) as conn:
+        apply_orchestration_migrations(conn)
+        schema_generation = current_orchestration_schema_version(conn)
+    declaration = build_process_declaration(
+        role=process_role,
+        supported_control_plane_api_version=control_plane_api_version,
+        max_supported_schema_generation=ORCHESTRATION_SCHEMA_VERSION,
+        observed_schema_generation=schema_generation,
+        ttl_seconds=heartbeat_ttl_seconds,
     )
+    return _write_orchestration_compatibility_metadata(
+        hub_root,
+        schema_generation=schema_generation,
+        declaration=declaration,
+    )
+
+
+def evaluate_current_orchestration_compatibility(
+    hub_root: Path,
+    *,
+    process_role: str = "hub",
+    supported_schema_generation: int = ORCHESTRATION_SCHEMA_VERSION,
+    durable: bool = True,
+) -> CompatibilityEvaluation:
+    db_path = resolve_orchestration_sqlite_path(hub_root)
+    build_id, _unknown_reason = resolve_build_identity()
+    with open_sqlite(
+        db_path,
+        durable=durable,
+        busy_timeout_ms=orchestration_sqlite_busy_timeout_ms(),
+    ) as conn:
+        observed = current_orchestration_schema_version(conn)
+    return evaluate_schema_compatibility(
+        observed_schema=observed,
+        supported_schema=supported_schema_generation,
+        process_role=process_role,
+        build_id=build_id,
+    )
+
+
+def assert_current_orchestration_compatible(
+    hub_root: Path,
+    *,
+    process_role: str = "hub",
+    supported_schema_generation: int = ORCHESTRATION_SCHEMA_VERSION,
+    durable: bool = True,
+) -> CompatibilityEvaluation:
+    evaluation = evaluate_current_orchestration_compatibility(
+        hub_root,
+        process_role=process_role,
+        supported_schema_generation=supported_schema_generation,
+        durable=durable,
+    )
+    if not evaluation.compatible:
+        raise SchemaCompatibilityError(evaluation)
+    return evaluation
+
+
+def refresh_orchestration_process_heartbeat(
+    hub_root: Path,
+    *,
+    process_role: str,
+    observed_schema_generation: int,
+    control_plane_api_version: str = "1.0.0",
+    heartbeat_ttl_seconds: int = 120,
+) -> OrchestrationCompatibilityMetadata:
+    declaration = build_process_declaration(
+        role=process_role,
+        supported_control_plane_api_version=control_plane_api_version,
+        max_supported_schema_generation=ORCHESTRATION_SCHEMA_VERSION,
+        observed_schema_generation=observed_schema_generation,
+        ttl_seconds=heartbeat_ttl_seconds,
+    )
+    return _write_orchestration_compatibility_metadata(
+        hub_root,
+        schema_generation=observed_schema_generation,
+        declaration=declaration,
+    )
+
+
+def _read_orchestration_schema_version_if_present(conn: sqlite3.Connection) -> int:
+    row = conn.execute(
+        """
+        SELECT name
+          FROM sqlite_master
+         WHERE type = 'table'
+           AND name = 'orch_schema_migrations'
+         LIMIT 1
+        """
+    ).fetchone()
+    if row is None:
+        return 0
+    version_row = conn.execute(
+        "SELECT COALESCE(MAX(version), 0) AS version FROM orch_schema_migrations"
+    ).fetchone()
+    if version_row is None:
+        return 0
+    return int(version_row["version"] or 0)
 
 
 @contextmanager
@@ -154,18 +301,32 @@ def open_orchestration_sqlite(
     ) as conn:
         if migrate:
             apply_orchestration_migrations(conn)
+        else:
+            current_version = _read_orchestration_schema_version_if_present(conn)
+            if current_version > ORCHESTRATION_SCHEMA_VERSION:
+                raise SchemaCompatibilityError(
+                    evaluate_schema_compatibility(
+                        observed_schema=current_version,
+                        supported_schema=ORCHESTRATION_SCHEMA_VERSION,
+                        process_role="unknown",
+                        build_id="unknown",
+                    )
+                )
         yield conn
 
 
 __all__ = [
     "ORCHESTRATION_COMPATIBILITY_METADATA_FILENAME",
     "ORCHESTRATION_DB_FILENAME",
+    "assert_current_orchestration_compatible",
+    "evaluate_current_orchestration_compatibility",
     "initialize_orchestration_sqlite",
     "OrchestrationCompatibilityMetadata",
     "open_orchestration_sqlite",
     "orchestration_sqlite_busy_timeout_ms",
     "prepare_orchestration_sqlite",
     "read_orchestration_compatibility_metadata",
+    "refresh_orchestration_process_heartbeat",
     "resolve_orchestration_compatibility_metadata_path",
     "resolve_orchestration_sqlite_path",
 ]

--- a/src/codex_autorunner/core/orchestration/sqlite.py
+++ b/src/codex_autorunner/core/orchestration/sqlite.py
@@ -471,15 +471,13 @@ def refresh_orchestration_process_heartbeat(
 
 
 def _read_orchestration_schema_version_if_present(conn: sqlite3.Connection) -> int:
-    row = conn.execute(
-        """
+    row = conn.execute("""
         SELECT name
           FROM sqlite_master
          WHERE type = 'table'
            AND name = 'orch_schema_migrations'
          LIMIT 1
-        """
-    ).fetchone()
+        """).fetchone()
     if row is None:
         return 0
     version_row = conn.execute(
@@ -502,7 +500,7 @@ def open_orchestration_sqlite(
 ) -> Iterator[sqlite3.Connection]:
     """Open the canonical orchestration SQLite database."""
     db_path = resolve_orchestration_sqlite_path(hub_root)
-    mode = migration_mode or ("worker" if migrate else "worker")
+    mode = migration_mode or ("hub" if process_role == "hub" else "worker")
     role = process_role or mode
     if migrate:
         build_id, _unknown_reason = resolve_build_identity()

--- a/src/codex_autorunner/core/orchestration/sqlite.py
+++ b/src/codex_autorunner/core/orchestration/sqlite.py
@@ -154,6 +154,20 @@ def _registry_with_stale_declarations_pruned(
     )
 
 
+def _current_process_declaration(
+    registry: CompatibilityRegistry,
+    *,
+    process_role: str,
+) -> ProcessCompatibilityDeclaration | None:
+    import os
+
+    pid = os.getpid()
+    for declaration in registry.declarations:
+        if declaration.role == process_role and declaration.pid == pid:
+            return declaration
+    return None
+
+
 def _write_orchestration_compatibility_metadata(
     hub_root: Path,
     *,
@@ -337,23 +351,48 @@ def prepare_orchestration_sqlite(
     process_role: str = "hub",
     control_plane_api_version: str = "1.0.0",
     heartbeat_ttl_seconds: int = 120,
+    migration_mode: OrchestrationMigrationMode | None = None,
 ) -> OrchestrationCompatibilityMetadata:
     """Explicitly prepare orchestration shared state for hub-owned startup."""
     db_path = resolve_orchestration_sqlite_path(hub_root)
+    mode: OrchestrationMigrationMode = migration_mode or (
+        "hub" if process_role == "hub" else "worker"
+    )
     with file_lock(resolve_orchestration_migration_lock_path(hub_root)):
         with open_sqlite(
             db_path,
             durable=durable,
             busy_timeout_ms=orchestration_sqlite_busy_timeout_ms(),
         ) as conn:
-            apply_orchestration_migrations(conn)
+            current_version = _read_orchestration_schema_version_if_present(conn)
+            build_id, _unknown_reason = resolve_build_identity()
+            _assert_migration_permitted(
+                hub_root,
+                current_schema=current_version,
+                target_schema=ORCHESTRATION_SCHEMA_VERSION,
+                migration_mode=mode,
+                process_role=process_role,
+                build_id=build_id,
+            )
+            if current_version < ORCHESTRATION_SCHEMA_VERSION:
+                apply_orchestration_migrations(conn)
             schema_generation = current_orchestration_schema_version(conn)
+        existing_metadata = read_orchestration_compatibility_metadata(hub_root)
+        existing_declaration = (
+            _current_process_declaration(
+                existing_metadata.registry,
+                process_role=process_role,
+            )
+            if existing_metadata is not None
+            else None
+        )
         declaration = build_process_declaration(
             role=process_role,
             supported_control_plane_api_version=control_plane_api_version,
             max_supported_schema_generation=ORCHESTRATION_SCHEMA_VERSION,
             observed_schema_generation=schema_generation,
             ttl_seconds=heartbeat_ttl_seconds,
+            existing=existing_declaration,
         )
         return _write_orchestration_compatibility_metadata(
             hub_root,
@@ -411,12 +450,18 @@ def refresh_orchestration_process_heartbeat(
     control_plane_api_version: str = "1.0.0",
     heartbeat_ttl_seconds: int = 120,
 ) -> OrchestrationCompatibilityMetadata:
+    previous = read_orchestration_compatibility_metadata(hub_root)
+    registry = previous.registry if previous is not None else CompatibilityRegistry()
     declaration = build_process_declaration(
         role=process_role,
         supported_control_plane_api_version=control_plane_api_version,
         max_supported_schema_generation=ORCHESTRATION_SCHEMA_VERSION,
         observed_schema_generation=observed_schema_generation,
         ttl_seconds=heartbeat_ttl_seconds,
+        existing=_current_process_declaration(
+            registry,
+            process_role=process_role,
+        ),
     )
     return _write_orchestration_compatibility_metadata(
         hub_root,

--- a/src/codex_autorunner/core/orchestration/sqlite.py
+++ b/src/codex_autorunner/core/orchestration/sqlite.py
@@ -6,14 +6,16 @@ import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterator, Optional
+from typing import Any, Callable, Iterator, Literal, Optional
 
+from ..locks import file_lock
 from ..sqlite_utils import open_sqlite
 from ..state_roots import (
     ORCHESTRATION_COMPATIBILITY_METADATA_FILENAME,
     ORCHESTRATION_DB_FILENAME,
     resolve_hub_orchestration_compatibility_metadata_path,
     resolve_hub_orchestration_db_path,
+    resolve_hub_state_root,
 )
 from ..time_utils import now_iso
 from ..utils import atomic_write
@@ -35,6 +37,43 @@ from .migrations import (
 
 # Hub/chat orchestration DB: higher busy_timeout than generic SQLite defaults (#1266).
 _DEFAULT_ORCH_BUSY_TIMEOUT_MS = 30_000
+OrchestrationMigrationMode = Literal[
+    "hub",
+    "worker",
+    "test",
+    "upgrade",
+]
+_MIGRATION_LOCK_FILENAME = "orchestration.sqlite3.migrate.lock"
+
+
+@dataclass(frozen=True)
+class OrchestrationMigrationRefusal:
+    current_schema: int
+    target_schema: int
+    hub_supported_schema: int | None
+    caller_role: str
+    build_id: str
+    guidance: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "current_schema": self.current_schema,
+            "target_schema": self.target_schema,
+            "hub_supported_schema": self.hub_supported_schema,
+            "caller_role": self.caller_role,
+            "build_id": self.build_id,
+            "guidance": self.guidance,
+        }
+
+
+class OrchestrationMigrationRefused(SchemaCompatibilityError):
+    def __init__(
+        self,
+        evaluation: CompatibilityEvaluation,
+        refusal: OrchestrationMigrationRefusal,
+    ) -> None:
+        super().__init__(evaluation)
+        self.refusal = refusal
 
 
 @dataclass(frozen=True)
@@ -89,6 +128,32 @@ def resolve_orchestration_compatibility_metadata_path(hub_root: Path) -> Path:
     return resolve_hub_orchestration_compatibility_metadata_path(hub_root)
 
 
+def resolve_orchestration_migration_lock_path(hub_root: Path) -> Path:
+    return resolve_hub_state_root(hub_root) / _MIGRATION_LOCK_FILENAME
+
+
+def _registry_with_stale_declarations_pruned(
+    registry: CompatibilityRegistry,
+    *,
+    now_timestamp: float,
+    pid_start_time_matches: Callable[[int, float], bool] | None = None,
+) -> CompatibilityRegistry:
+    active_declarations, stale_declarations = classify_registry_declarations(
+        registry.declarations,
+        now_timestamp=now_timestamp,
+        pid_start_time_matches=pid_start_time_matches,
+    )
+    stale_by_id = {
+        item.process_id: item
+        for item in (*registry.stale_declarations, *stale_declarations)
+    }
+    return CompatibilityRegistry(
+        declarations=active_declarations,
+        stale_declarations=tuple(stale_by_id.values()),
+        updated_at=registry.updated_at,
+    )
+
+
 def _write_orchestration_compatibility_metadata(
     hub_root: Path,
     *,
@@ -98,18 +163,9 @@ def _write_orchestration_compatibility_metadata(
 ) -> OrchestrationCompatibilityMetadata:
     previous = read_orchestration_compatibility_metadata(hub_root)
     registry = previous.registry if previous is not None else CompatibilityRegistry()
-    active_declarations, stale_declarations = classify_registry_declarations(
-        registry.declarations,
+    registry = _registry_with_stale_declarations_pruned(
+        registry,
         now_timestamp=time.time(),
-    )
-    stale_by_id = {
-        item.process_id: item
-        for item in (*registry.stale_declarations, *stale_declarations)
-    }
-    registry = CompatibilityRegistry(
-        declarations=active_declarations,
-        stale_declarations=tuple(stale_by_id.values()),
-        updated_at=registry.updated_at,
     )
     if declaration is not None:
         now_text = now_iso()
@@ -155,19 +211,122 @@ def read_orchestration_compatibility_metadata(
         return None
 
 
+def _active_hub_declarations(
+    hub_root: Path,
+    *,
+    pid_start_time_matches: Callable[[int, float], bool] | None = None,
+) -> tuple[ProcessCompatibilityDeclaration, ...]:
+    metadata = read_orchestration_compatibility_metadata(hub_root)
+    registry = metadata.registry if metadata is not None else CompatibilityRegistry()
+    registry = _registry_with_stale_declarations_pruned(
+        registry,
+        now_timestamp=time.time(),
+        pid_start_time_matches=pid_start_time_matches,
+    )
+    return tuple(item for item in registry.declarations if item.role == "hub")
+
+
+def _migration_refusal_evaluation(
+    *,
+    current_schema: int,
+    target_schema: int,
+    hub_supported_schema: int | None,
+    caller_role: str,
+    build_id: str,
+    guidance: str,
+) -> OrchestrationMigrationRefused:
+    supported_schema = (
+        int(hub_supported_schema)
+        if hub_supported_schema is not None
+        else max(0, int(current_schema))
+    )
+    evaluation = CompatibilityEvaluation(
+        status="restart_required",
+        observed_schema=max(0, int(target_schema)),
+        supported_schema=max(0, supported_schema),
+        process_role=caller_role,
+        build_id=build_id,
+        restart_required=True,
+        reason=guidance,
+    )
+    refusal = OrchestrationMigrationRefusal(
+        current_schema=max(0, int(current_schema)),
+        target_schema=max(0, int(target_schema)),
+        hub_supported_schema=hub_supported_schema,
+        caller_role=caller_role,
+        build_id=build_id,
+        guidance=guidance,
+    )
+    return OrchestrationMigrationRefused(evaluation, refusal)
+
+
+def _assert_migration_permitted(
+    hub_root: Path,
+    *,
+    current_schema: int,
+    target_schema: int,
+    migration_mode: OrchestrationMigrationMode,
+    process_role: str,
+    build_id: str,
+    pid_start_time_matches: Callable[[int, float], bool] | None = None,
+) -> None:
+    if current_schema >= target_schema:
+        return
+    if migration_mode in {"hub", "upgrade", "test"}:
+        return
+
+    active_hubs = _active_hub_declarations(
+        hub_root,
+        pid_start_time_matches=pid_start_time_matches,
+    )
+    if active_hubs:
+        hub_supported_schema = min(
+            item.max_supported_schema_generation for item in active_hubs
+        )
+        if target_schema > hub_supported_schema:
+            raise _migration_refusal_evaluation(
+                current_schema=current_schema,
+                target_schema=target_schema,
+                hub_supported_schema=hub_supported_schema,
+                caller_role=process_role,
+                build_id=build_id,
+                guidance=(
+                    "restart the hub or run the hub-owned upgrade path before "
+                    "worker code advances orchestration.sqlite3"
+                ),
+            )
+        return
+
+    if current_schema == 0:
+        return
+
+    raise _migration_refusal_evaluation(
+        current_schema=current_schema,
+        target_schema=target_schema,
+        hub_supported_schema=None,
+        caller_role=process_role,
+        build_id=build_id,
+        guidance=(
+            "existing orchestration.sqlite3 migrations must be advanced by hub "
+            "startup or an explicit upgrade command"
+        ),
+    )
+
+
 def initialize_orchestration_sqlite(hub_root: Path, *, durable: bool = True) -> Path:
     """Create or migrate the canonical orchestration SQLite database."""
     db_path = resolve_orchestration_sqlite_path(hub_root)
-    with open_sqlite(
-        db_path,
-        durable=durable,
-        busy_timeout_ms=orchestration_sqlite_busy_timeout_ms(),
-    ) as conn:
-        apply_orchestration_migrations(conn)
-        _write_orchestration_compatibility_metadata(
-            hub_root,
-            schema_generation=current_orchestration_schema_version(conn),
-        )
+    with file_lock(resolve_orchestration_migration_lock_path(hub_root)):
+        with open_sqlite(
+            db_path,
+            durable=durable,
+            busy_timeout_ms=orchestration_sqlite_busy_timeout_ms(),
+        ) as conn:
+            apply_orchestration_migrations(conn)
+            _write_orchestration_compatibility_metadata(
+                hub_root,
+                schema_generation=current_orchestration_schema_version(conn),
+            )
     return db_path
 
 
@@ -181,25 +340,26 @@ def prepare_orchestration_sqlite(
 ) -> OrchestrationCompatibilityMetadata:
     """Explicitly prepare orchestration shared state for hub-owned startup."""
     db_path = resolve_orchestration_sqlite_path(hub_root)
-    with open_sqlite(
-        db_path,
-        durable=durable,
-        busy_timeout_ms=orchestration_sqlite_busy_timeout_ms(),
-    ) as conn:
-        apply_orchestration_migrations(conn)
-        schema_generation = current_orchestration_schema_version(conn)
-    declaration = build_process_declaration(
-        role=process_role,
-        supported_control_plane_api_version=control_plane_api_version,
-        max_supported_schema_generation=ORCHESTRATION_SCHEMA_VERSION,
-        observed_schema_generation=schema_generation,
-        ttl_seconds=heartbeat_ttl_seconds,
-    )
-    return _write_orchestration_compatibility_metadata(
-        hub_root,
-        schema_generation=schema_generation,
-        declaration=declaration,
-    )
+    with file_lock(resolve_orchestration_migration_lock_path(hub_root)):
+        with open_sqlite(
+            db_path,
+            durable=durable,
+            busy_timeout_ms=orchestration_sqlite_busy_timeout_ms(),
+        ) as conn:
+            apply_orchestration_migrations(conn)
+            schema_generation = current_orchestration_schema_version(conn)
+        declaration = build_process_declaration(
+            role=process_role,
+            supported_control_plane_api_version=control_plane_api_version,
+            max_supported_schema_generation=ORCHESTRATION_SCHEMA_VERSION,
+            observed_schema_generation=schema_generation,
+            ttl_seconds=heartbeat_ttl_seconds,
+        )
+        return _write_orchestration_compatibility_metadata(
+            hub_root,
+            schema_generation=schema_generation,
+            declaration=declaration,
+        )
 
 
 def evaluate_current_orchestration_compatibility(
@@ -291,27 +451,75 @@ def open_orchestration_sqlite(
     *,
     durable: bool = True,
     migrate: bool = True,
+    migration_mode: OrchestrationMigrationMode | None = None,
+    process_role: str | None = None,
+    pid_start_time_matches: Callable[[int, float], bool] | None = None,
 ) -> Iterator[sqlite3.Connection]:
     """Open the canonical orchestration SQLite database."""
     db_path = resolve_orchestration_sqlite_path(hub_root)
-    with open_sqlite(
-        db_path,
-        durable=durable,
-        busy_timeout_ms=orchestration_sqlite_busy_timeout_ms(),
-    ) as conn:
-        if migrate:
-            apply_orchestration_migrations(conn)
-        else:
+    mode = migration_mode or ("worker" if migrate else "worker")
+    role = process_role or mode
+    if migrate:
+        build_id, _unknown_reason = resolve_build_identity()
+        with open_sqlite(
+            db_path,
+            durable=durable,
+            busy_timeout_ms=orchestration_sqlite_busy_timeout_ms(),
+        ) as conn:
             current_version = _read_orchestration_schema_version_if_present(conn)
             if current_version > ORCHESTRATION_SCHEMA_VERSION:
                 raise SchemaCompatibilityError(
                     evaluate_schema_compatibility(
                         observed_schema=current_version,
                         supported_schema=ORCHESTRATION_SCHEMA_VERSION,
-                        process_role="unknown",
-                        build_id="unknown",
+                        process_role=role,
+                        build_id=build_id,
                     )
                 )
+            if current_version == ORCHESTRATION_SCHEMA_VERSION:
+                yield conn
+                return
+
+        with file_lock(resolve_orchestration_migration_lock_path(hub_root)):
+            with open_sqlite(
+                db_path,
+                durable=durable,
+                busy_timeout_ms=orchestration_sqlite_busy_timeout_ms(),
+            ) as conn:
+                current_version = _read_orchestration_schema_version_if_present(conn)
+                _assert_migration_permitted(
+                    hub_root,
+                    current_schema=current_version,
+                    target_schema=ORCHESTRATION_SCHEMA_VERSION,
+                    migration_mode=mode,
+                    process_role=role,
+                    build_id=build_id,
+                    pid_start_time_matches=pid_start_time_matches,
+                )
+                if current_version < ORCHESTRATION_SCHEMA_VERSION:
+                    apply_orchestration_migrations(conn)
+                    _write_orchestration_compatibility_metadata(
+                        hub_root,
+                        schema_generation=current_orchestration_schema_version(conn),
+                    )
+                yield conn
+        return
+
+    with open_sqlite(
+        db_path,
+        durable=durable,
+        busy_timeout_ms=orchestration_sqlite_busy_timeout_ms(),
+    ) as conn:
+        current_version = _read_orchestration_schema_version_if_present(conn)
+        if current_version > ORCHESTRATION_SCHEMA_VERSION:
+            raise SchemaCompatibilityError(
+                evaluate_schema_compatibility(
+                    observed_schema=current_version,
+                    supported_schema=ORCHESTRATION_SCHEMA_VERSION,
+                    process_role=role,
+                    build_id="unknown",
+                )
+            )
         yield conn
 
 
@@ -322,11 +530,14 @@ __all__ = [
     "evaluate_current_orchestration_compatibility",
     "initialize_orchestration_sqlite",
     "OrchestrationCompatibilityMetadata",
+    "OrchestrationMigrationRefusal",
+    "OrchestrationMigrationRefused",
     "open_orchestration_sqlite",
     "orchestration_sqlite_busy_timeout_ms",
     "prepare_orchestration_sqlite",
     "read_orchestration_compatibility_metadata",
     "refresh_orchestration_process_heartbeat",
     "resolve_orchestration_compatibility_metadata_path",
+    "resolve_orchestration_migration_lock_path",
     "resolve_orchestration_sqlite_path",
 ]

--- a/src/codex_autorunner/core/pma_automation_snapshot.py
+++ b/src/codex_autorunner/core/pma_automation_snapshot.py
@@ -191,6 +191,8 @@ def _attach_unified_automation_snapshot(
                     "trigger_kind",
                     "target_policy",
                     "executor_kind",
+                    "known_executor",
+                    "executable",
                     "metadata",
                 ),
             )

--- a/src/codex_autorunner/core/pma_queue.py
+++ b/src/codex_autorunner/core/pma_queue.py
@@ -96,7 +96,12 @@ class PmaQueueRepository:
 
     def __init__(self, hub_root: Path) -> None:
         self._hub_root = hub_root
-        prepare_orchestration_sqlite(self._hub_root, durable=True)
+        prepare_orchestration_sqlite(
+            self._hub_root,
+            durable=True,
+            process_role="worker",
+            migration_mode="worker",
+        )
 
     def insert_or_update_item(
         self, conn: sqlite3.Connection, item: PmaQueueItem
@@ -430,7 +435,12 @@ class PmaQueue:
         self._initialize_canonical_state()
 
     def _initialize_canonical_state(self) -> None:
-        prepare_orchestration_sqlite(self._hub_root, durable=True)
+        prepare_orchestration_sqlite(
+            self._hub_root,
+            durable=True,
+            process_role="worker",
+            migration_mode="worker",
+        )
 
     def _lane_queue_path(self, lane_id: str) -> Path:
         return self._mirror.lane_queue_path(lane_id)

--- a/src/codex_autorunner/core/scm_polling_watches.py
+++ b/src/codex_autorunner/core/scm_polling_watches.py
@@ -364,48 +364,113 @@ class ScmPollingWatchStore:
                     ),
                 )
             else:
-                reactivation_plan = plan_polling_watch_lifecycle_transition(
-                    ScmPollingWatchLifecycleTransition.REACTIVATE,
-                    current_state=row["state"],
-                )
-                conn.execute(
-                    """
-                    UPDATE orch_scm_polling_watches
-                       SET repo_slug = ?,
-                           repo_id = COALESCE(?, repo_id),
-                           pr_number = ?,
-                           workspace_root = ?,
-                           thread_target_id = CASE
-                               WHEN ? IS NULL THEN thread_target_id
-                               ELSE ?
-                           END,
-                           poll_interval_seconds = ?,
-                           state = ?,
-                           updated_at = ?,
-                           expires_at = ?,
-                           next_poll_at = ?,
-                           last_error_text = NULL,
-                           reaction_config_json = ?,
-                           snapshot_json = ?
-                     WHERE watch_id = ?
-                    """,
-                    (
-                        normalized_repo_slug,
-                        normalized_repo_id,
-                        normalized_pr_number,
-                        normalized_workspace_root,
-                        normalized_thread_target_id,
-                        normalized_thread_target_id,
-                        normalized_poll_interval,
-                        reactivation_plan.state.value,
-                        timestamp,
-                        normalized_expires_at,
-                        normalized_next_poll_at,
-                        _json_dumps(reaction_config_object),
-                        _json_dumps(snapshot_object),
-                        str(row["watch_id"]),
-                    ),
-                )
+                current_state = _watch_lifecycle_state(row["state"])
+                if current_state is ScmPollingWatchLifecycleState.EXPIRED:
+                    previous_watch_id = str(row["watch_id"])
+                    repaired_snapshot = dict(snapshot_object)
+                    repaired_snapshot["watch_repair"] = {
+                        "action": "recreated_expired_watch",
+                        "previous_watch_id": previous_watch_id,
+                        "repaired_at": timestamp,
+                    }
+                    watch_id = uuid.uuid4().hex
+                    create_plan = plan_polling_watch_lifecycle_transition(
+                        ScmPollingWatchLifecycleTransition.CREATE,
+                        current_state=None,
+                    )
+                    conn.execute(
+                        """
+                        DELETE FROM orch_scm_polling_watches
+                         WHERE watch_id = ?
+                        """,
+                        (previous_watch_id,),
+                    )
+                    conn.execute(
+                        """
+                        INSERT INTO orch_scm_polling_watches (
+                            watch_id,
+                            provider,
+                            binding_id,
+                            repo_slug,
+                            repo_id,
+                            pr_number,
+                            workspace_root,
+                            thread_target_id,
+                            poll_interval_seconds,
+                            state,
+                            started_at,
+                            updated_at,
+                            expires_at,
+                            next_poll_at,
+                            last_polled_at,
+                            last_error_text,
+                            reaction_config_json,
+                            snapshot_json
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)
+                        """,
+                        (
+                            watch_id,
+                            normalized_provider,
+                            normalized_binding_id,
+                            normalized_repo_slug,
+                            normalized_repo_id,
+                            normalized_pr_number,
+                            normalized_workspace_root,
+                            normalized_thread_target_id,
+                            normalized_poll_interval,
+                            create_plan.state.value,
+                            timestamp,
+                            timestamp,
+                            normalized_expires_at,
+                            normalized_next_poll_at,
+                            "recreated expired SCM polling watch",
+                            _json_dumps(reaction_config_object),
+                            _json_dumps(repaired_snapshot),
+                        ),
+                    )
+                else:
+                    reactivation_plan = plan_polling_watch_lifecycle_transition(
+                        ScmPollingWatchLifecycleTransition.REACTIVATE,
+                        current_state=current_state,
+                    )
+                    conn.execute(
+                        """
+                        UPDATE orch_scm_polling_watches
+                           SET repo_slug = ?,
+                               repo_id = COALESCE(?, repo_id),
+                               pr_number = ?,
+                               workspace_root = ?,
+                               thread_target_id = CASE
+                                   WHEN ? IS NULL THEN thread_target_id
+                                   ELSE ?
+                               END,
+                               poll_interval_seconds = ?,
+                               state = ?,
+                               updated_at = ?,
+                               expires_at = ?,
+                               next_poll_at = ?,
+                               last_error_text = NULL,
+                               reaction_config_json = ?,
+                               snapshot_json = ?
+                         WHERE watch_id = ?
+                        """,
+                        (
+                            normalized_repo_slug,
+                            normalized_repo_id,
+                            normalized_pr_number,
+                            normalized_workspace_root,
+                            normalized_thread_target_id,
+                            normalized_thread_target_id,
+                            normalized_poll_interval,
+                            reactivation_plan.state.value,
+                            timestamp,
+                            normalized_expires_at,
+                            normalized_next_poll_at,
+                            _json_dumps(reaction_config_object),
+                            _json_dumps(snapshot_object),
+                            str(row["watch_id"]),
+                        ),
+                    )
             refreshed = self._load_watch_row(
                 conn,
                 provider=normalized_provider,

--- a/src/codex_autorunner/surfaces/web/routes/automations.py
+++ b/src/codex_autorunner/surfaces/web/routes/automations.py
@@ -191,6 +191,8 @@ def build_automation_routes(context: HubAppContext) -> APIRouter:
             raise HTTPException(
                 status_code=404, detail=f"Automation not found: {rule_id}"
             ) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @router.delete("/hub/automations/{rule_id}")
     async def delete_automation(rule_id: str) -> dict[str, Any]:

--- a/src/codex_autorunner/surfaces/web/routes/hub_control_plane.py
+++ b/src/codex_autorunner/surfaces/web/routes/hub_control_plane.py
@@ -87,11 +87,30 @@ def _status_code_for_error(exc: HubControlPlaneError) -> int:
     return 500
 
 
+def _compatibility_payload(exc: HubControlPlaneError) -> dict[str, Any] | None:
+    payload = exc.details.get("compatibility")
+    return dict(payload) if isinstance(payload, Mapping) else None
+
+
 def _error_response(exc: HubControlPlaneError) -> JSONResponse:
+    content: dict[str, Any] = {"error": exc.info.to_dict()}
+    compatibility = _compatibility_payload(exc)
+    if compatibility is not None:
+        content["compatibility"] = compatibility
     return JSONResponse(
         status_code=_status_code_for_error(exc),
-        content={"error": exc.info.to_dict()},
+        content=content,
     )
+
+
+def _check_bound_service_compatibility(operation: Callable[[Any], Any]) -> None:
+    service = getattr(operation, "__self__", None)
+    ensure_compatible = getattr(service, "_ensure_compatible", None)
+    if (
+        callable(ensure_compatible)
+        and getattr(operation, "__name__", "") != "handshake"
+    ):
+        ensure_compatible()
 
 
 async def _run_control_plane_call(
@@ -104,6 +123,7 @@ async def _run_control_plane_call(
     except ValueError as exc:
         return _error_response(HubControlPlaneError("hub_rejected", str(exc)))
     try:
+        _check_bound_service_compatibility(operation)
         response_model = await asyncio.to_thread(operation, request_model)
     except HubControlPlaneError as exc:
         return _error_response(exc)
@@ -122,6 +142,7 @@ async def _run_control_plane_command(
     except ValueError as exc:
         return _error_response(HubControlPlaneError("hub_rejected", str(exc)))
     try:
+        _check_bound_service_compatibility(operation)
         await asyncio.to_thread(operation, request_model)
     except HubControlPlaneError as exc:
         return _error_response(exc)

--- a/src/codex_autorunner/surfaces/web/routes/system.py
+++ b/src/codex_autorunner/surfaces/web/routes/system.py
@@ -3,6 +3,7 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
 
 from ....core import update as update_core
 from ....core.config import HubConfig
@@ -10,6 +11,7 @@ from ....core.constants import DEFAULT_UPDATE_REPO_REF, DEFAULT_UPDATE_REPO_URL
 from ....core.orchestration.execution_history_maintenance import (
     collect_execution_history_database_health,
 )
+from ....core.orchestration.sqlite import evaluate_current_orchestration_compatibility
 from ....core.self_describe import collect_describe_data
 from ....core.update import (
     UpdateInProgressError,
@@ -78,10 +80,24 @@ def build_system_routes() -> APIRouter:
         base_path = getattr(request.app.state, "base_path", "")
         asset_version = getattr(request.app.state, "asset_version", None)
         orchestration_health = None
+        compatibility_payload = None
+        compatibility_ok = True
         if isinstance(config, HubConfig):
-            database_health = await asyncio.to_thread(
-                collect_execution_history_database_health,
+            compatibility = await asyncio.to_thread(
+                evaluate_current_orchestration_compatibility,
                 config.root,
+                process_role="hub",
+                durable=bool(getattr(config, "durable_writes", False)),
+            )
+            compatibility_ok = compatibility.compatible
+            compatibility_payload = compatibility.to_dict()
+            database_health = (
+                await asyncio.to_thread(
+                    collect_execution_history_database_health,
+                    config.root,
+                )
+                if compatibility.compatible
+                else None
             )
             last_housekeeping = getattr(
                 getattr(request.app, "state", None),
@@ -95,12 +111,14 @@ def build_system_routes() -> APIRouter:
                 ),
             )
         response: dict = {
-            "status": "ok",
+            "status": "ok" if compatibility_ok else "restart_required",
             "mode": mode,
             "base_path": base_path,
             "asset_version": asset_version,
             "orchestration": orchestration_health,
         }
+        if compatibility_payload is not None:
+            response["compatibility"] = compatibility_payload
         if mode == "hub":
             supervisor = getattr(request.app.state, "hub_supervisor", None)
             if supervisor is not None:
@@ -112,6 +130,8 @@ def build_system_routes() -> APIRouter:
             )
             if deferred_done is not None:
                 response["hub_deferred_startup_complete"] = deferred_done
+        if isinstance(config, HubConfig) and not compatibility_ok:
+            return JSONResponse(status_code=503, content=response)
         return response
 
     @router.get("/system/update/check", response_model=SystemUpdateCheckResponse)

--- a/src/codex_autorunner/surfaces/web/routes/system.py
+++ b/src/codex_autorunner/surfaces/web/routes/system.py
@@ -11,7 +11,10 @@ from ....core.constants import DEFAULT_UPDATE_REPO_REF, DEFAULT_UPDATE_REPO_URL
 from ....core.orchestration.execution_history_maintenance import (
     collect_execution_history_database_health,
 )
-from ....core.orchestration.sqlite import evaluate_current_orchestration_compatibility
+from ....core.orchestration.sqlite import (
+    evaluate_current_orchestration_compatibility,
+    refresh_orchestration_process_heartbeat,
+)
 from ....core.self_describe import collect_describe_data
 from ....core.update import (
     UpdateInProgressError,
@@ -91,6 +94,13 @@ def build_system_routes() -> APIRouter:
             )
             compatibility_ok = compatibility.compatible
             compatibility_payload = compatibility.to_dict()
+            if compatibility_ok:
+                await asyncio.to_thread(
+                    refresh_orchestration_process_heartbeat,
+                    config.root,
+                    process_role="hub",
+                    observed_schema_generation=compatibility.observed_schema,
+                )
             database_health = (
                 await asyncio.to_thread(
                     collect_execution_history_database_health,

--- a/src/codex_autorunner/surfaces/web/schemas.py
+++ b/src/codex_autorunner/surfaces/web/schemas.py
@@ -800,6 +800,7 @@ class SystemHealthResponse(ResponseModel):
     hub_startup_phase: Optional[str] = None
     hub_deferred_startup_complete: Optional[bool] = None
     orchestration: Optional[OrchestrationHealthPayload] = None
+    compatibility: Optional[Dict[str, Any]] = None
 
 
 class SystemUpdateResponse(ResponseModel):

--- a/tests/adapters/chat/test_managed_thread_delivery_worker.py
+++ b/tests/adapters/chat/test_managed_thread_delivery_worker.py
@@ -27,6 +27,10 @@ from codex_autorunner.core.orchestration import (
     SQLiteManagedThreadDeliveryEngine,
     initialize_orchestration_sqlite,
 )
+from codex_autorunner.core.orchestration.compatibility import (
+    CompatibilityEvaluation,
+    SchemaCompatibilityError,
+)
 from codex_autorunner.core.orchestration.managed_thread_delivery import (
     ManagedThreadDeliveryEnvelope,
     ManagedThreadDeliveryIntent,
@@ -144,6 +148,41 @@ class _RecordingAdapter:
         )
         self._call_index += 1
         return ManagedThreadDeliveryAttemptResult(outcome=outcome)
+
+
+class _IncompatibleEngine:
+    def __init__(self) -> None:
+        self.claim_calls = 0
+        self.evaluation = CompatibilityEvaluation(
+            status="incompatible_schema",
+            observed_schema=999,
+            supported_schema=1,
+            process_role="discord",
+            build_id="test-build",
+            restart_required=True,
+            reason="test schema mismatch",
+        )
+
+    def claim_next_delivery(self, *, adapter_key: str, now: Any = None) -> None:
+        _ = adapter_key, now
+        self.claim_calls += 1
+        raise SchemaCompatibilityError(self.evaluation)
+
+    def recovery_sweep(self, *, adapter_key: str, now: Any = None) -> None:
+        _ = adapter_key, now
+        raise SchemaCompatibilityError(self.evaluation)
+
+
+class _IncompatibleAdapter(_RecordingAdapter):
+    def __init__(self, evaluation: CompatibilityEvaluation) -> None:
+        super().__init__()
+        self._evaluation = evaluation
+
+    async def deliver_managed_thread_record(
+        self, record: Any, *, claim: Any
+    ) -> ManagedThreadDeliveryAttemptResult:
+        _ = record, claim
+        raise SchemaCompatibilityError(self._evaluation)
 
 
 @pytest.mark.anyio
@@ -328,6 +367,73 @@ async def test_worker_loop_cancels_cleanly(tmp_path: Path) -> None:
         await task
 
     assert worker.stats.errors == 0
+
+
+@pytest.mark.anyio
+async def test_worker_parks_on_incompatible_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _IncompatibleEngine()
+    adapter = _RecordingAdapter()
+    events: list[dict[str, Any]] = []
+
+    def _capture_log_event(logger: Any, level: int, event: str, **fields: Any) -> None:
+        _ = logger, level
+        events.append({"event": event, **fields})
+
+    monkeypatch.setattr(
+        "codex_autorunner.adapters.chat.managed_thread_delivery_worker.log_event",
+        _capture_log_event,
+    )
+    worker = ManagedThreadDeliveryWorker(
+        engine=engine,
+        adapter=adapter,
+        logger=logging.getLogger("test"),
+    )
+
+    await worker.run_once()
+    await worker.run_once()
+
+    assert worker.stats.incompatible_runtime_detected is True
+    assert worker.stats.last_compatibility == engine.evaluation
+    assert worker.stats.errors == 0
+    assert engine.claim_calls == 1
+    incompatible_events = [
+        event
+        for event in events
+        if event["event"] == "chat.managed_thread.delivery_worker.incompatible_runtime"
+    ]
+    assert len(incompatible_events) == 1
+    assert incompatible_events[0]["observed_schema"] == 999
+    assert incompatible_events[0]["supported_schema"] == 1
+
+
+@pytest.mark.anyio
+async def test_worker_parks_when_adapter_hits_incompatible_schema(
+    tmp_path: Path,
+) -> None:
+    engine = _make_engine(tmp_path)
+    _register_pending(engine)
+    evaluation = CompatibilityEvaluation(
+        status="incompatible_schema",
+        observed_schema=7,
+        supported_schema=6,
+        process_role="telegram",
+        build_id="test-build",
+        restart_required=True,
+    )
+    worker = ManagedThreadDeliveryWorker(
+        engine=engine,
+        adapter=_IncompatibleAdapter(evaluation),
+        logger=logging.getLogger("test"),
+    )
+
+    await worker.run_once()
+
+    assert worker.stats.incompatible_runtime_detected is True
+    assert worker.stats.last_compatibility == evaluation
+    assert worker.stats.deliveries_failed == 0
+    assert worker.stats.deliveries_retried == 0
 
 
 @pytest.mark.anyio

--- a/tests/core/orchestration/test_compatibility.py
+++ b/tests/core/orchestration/test_compatibility.py
@@ -9,6 +9,7 @@ from codex_autorunner.core.orchestration.compatibility import (
 from codex_autorunner.core.orchestration.sqlite import (
     prepare_orchestration_sqlite,
     read_orchestration_compatibility_metadata,
+    refresh_orchestration_process_heartbeat,
 )
 
 
@@ -50,6 +51,32 @@ def test_prepare_orchestration_sqlite_records_process_declaration(tmp_path) -> N
     assert declaration.observed_schema_generation == metadata.schema_generation
     assert declaration.heartbeat_at
     assert declaration.expires_at
+
+
+def test_refresh_orchestration_process_heartbeat_preserves_process_id(
+    tmp_path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    prepared = prepare_orchestration_sqlite(
+        hub_root,
+        durable=False,
+        process_role="hub",
+        heartbeat_ttl_seconds=1,
+    )
+    first = prepared.registry.declarations[0]
+
+    refreshed = refresh_orchestration_process_heartbeat(
+        hub_root,
+        process_role="hub",
+        observed_schema_generation=prepared.schema_generation,
+        heartbeat_ttl_seconds=120,
+    )
+
+    second = refreshed.registry.declarations[0]
+    assert second.process_id == first.process_id
+    assert second.pid == first.pid
+    assert second.ttl_seconds == 120
+    assert second.expires_at >= first.expires_at
 
 
 def test_registry_declarations_classify_stale_and_pid_reuse() -> None:

--- a/tests/core/orchestration/test_compatibility.py
+++ b/tests/core/orchestration/test_compatibility.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from codex_autorunner.core.orchestration import ORCHESTRATION_SCHEMA_VERSION
+from codex_autorunner.core.orchestration.compatibility import (
+    ProcessCompatibilityDeclaration,
+    classify_registry_declarations,
+    evaluate_schema_compatibility,
+)
+from codex_autorunner.core.orchestration.sqlite import (
+    prepare_orchestration_sqlite,
+    read_orchestration_compatibility_metadata,
+)
+
+
+def test_schema_compatibility_marks_newer_db_restart_required() -> None:
+    evaluation = evaluate_schema_compatibility(
+        observed_schema=ORCHESTRATION_SCHEMA_VERSION + 1,
+        supported_schema=ORCHESTRATION_SCHEMA_VERSION,
+        process_role="hub",
+        build_id="build-1",
+    )
+
+    assert evaluation.status == "incompatible_schema"
+    assert evaluation.restart_required is True
+    assert evaluation.observed_schema == ORCHESTRATION_SCHEMA_VERSION + 1
+    assert evaluation.supported_schema == ORCHESTRATION_SCHEMA_VERSION
+
+
+def test_prepare_orchestration_sqlite_records_process_declaration(tmp_path) -> None:
+    hub_root = tmp_path / "hub"
+
+    metadata = prepare_orchestration_sqlite(
+        hub_root,
+        durable=False,
+        process_role="hub",
+        control_plane_api_version="1.0.0",
+    )
+    reread = read_orchestration_compatibility_metadata(hub_root)
+
+    assert reread is not None
+    assert reread.schema_generation == ORCHESTRATION_SCHEMA_VERSION
+    declarations = reread.registry.declarations
+    assert len(declarations) == 1
+    declaration = declarations[0]
+    assert declaration.role == "hub"
+    assert declaration.process_id
+    assert declaration.pid > 0
+    assert declaration.writer_identity
+    assert declaration.max_supported_schema_generation == ORCHESTRATION_SCHEMA_VERSION
+    assert declaration.observed_schema_generation == metadata.schema_generation
+    assert declaration.heartbeat_at
+    assert declaration.expires_at
+
+
+def test_registry_declarations_classify_stale_and_pid_reuse() -> None:
+    fresh = ProcessCompatibilityDeclaration(
+        process_id="fresh",
+        role="hub",
+        pid=100,
+        process_start_time=10.0,
+        build_id="build",
+        unknown_build_reason=None,
+        writer_identity="writer",
+        supported_control_plane_api_version="1.0.0",
+        max_supported_schema_generation=1,
+        observed_schema_generation=1,
+        heartbeat_at="2026-05-22T00:00:00Z",
+        expires_at="2026-05-22T00:10:00Z",
+        ttl_seconds=600,
+    )
+    expired = ProcessCompatibilityDeclaration.from_mapping(
+        {**fresh.to_dict(), "process_id": "expired", "expires_at": "bad timestamp"}
+    )
+    reused_pid = ProcessCompatibilityDeclaration.from_mapping(
+        {**fresh.to_dict(), "process_id": "reused", "pid": 200}
+    )
+
+    active, stale = classify_registry_declarations(
+        (fresh, expired, reused_pid),
+        now_timestamp=0.0,
+        pid_start_time_matches=lambda pid, _start: pid != 200,
+    )
+
+    assert [item.process_id for item in active] == ["fresh"]
+    assert [item.process_id for item in stale] == ["expired", "reused"]

--- a/tests/core/orchestration/test_sqlite_schema.py
+++ b/tests/core/orchestration/test_sqlite_schema.py
@@ -22,6 +22,7 @@ from codex_autorunner.core.orchestration.sqlite import (
     OrchestrationCompatibilityMetadata,
     OrchestrationMigrationRefused,
     open_orchestration_sqlite,
+    prepare_orchestration_sqlite,
     read_orchestration_compatibility_metadata,
     resolve_orchestration_compatibility_metadata_path,
 )
@@ -325,6 +326,29 @@ def test_worker_migration_refuses_to_advance_past_live_hub_schema(
     assert raised.value.refusal.target_schema == ORCHESTRATION_SCHEMA_VERSION
     assert raised.value.refusal.hub_supported_schema == old_schema
     assert raised.value.evaluation.status == "restart_required"
+
+
+def test_worker_prepare_refuses_to_advance_past_live_hub_schema(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    old_schema = ORCHESTRATION_SCHEMA_VERSION - 1
+    _mark_db_at_previous_generation(hub_root)
+    _write_metadata(
+        hub_root,
+        schema_generation=old_schema,
+        declarations=(_hub_declaration(supported_schema=old_schema),),
+    )
+
+    with pytest.raises(OrchestrationMigrationRefused):
+        prepare_orchestration_sqlite(
+            hub_root,
+            durable=False,
+            process_role="worker",
+            migration_mode="worker",
+        )
+
+    assert _schema_generation(hub_root) == old_schema
 
 
 def test_hub_migration_can_advance_under_owned_mode(tmp_path: Path) -> None:

--- a/tests/core/orchestration/test_sqlite_schema.py
+++ b/tests/core/orchestration/test_sqlite_schema.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import json
 import sqlite3
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+
+import pytest
 
 from codex_autorunner.core.orchestration import (
     ORCHESTRATION_DB_FILENAME,
@@ -10,9 +14,16 @@ from codex_autorunner.core.orchestration import (
     list_orchestration_table_definitions,
     resolve_orchestration_sqlite_path,
 )
+from codex_autorunner.core.orchestration.compatibility import (
+    CompatibilityRegistry,
+    ProcessCompatibilityDeclaration,
+)
 from codex_autorunner.core.orchestration.sqlite import (
+    OrchestrationCompatibilityMetadata,
+    OrchestrationMigrationRefused,
     open_orchestration_sqlite,
     read_orchestration_compatibility_metadata,
+    resolve_orchestration_compatibility_metadata_path,
 )
 from codex_autorunner.core.state_roots import (
     resolve_hub_orchestration_db_path,
@@ -30,6 +41,81 @@ def _table_names(conn: sqlite3.Connection) -> set[str]:
 def _column_names(conn: sqlite3.Connection, table_name: str) -> set[str]:
     rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
     return {str(row["name"]) for row in rows}
+
+
+def _write_metadata(
+    hub_root: Path,
+    *,
+    schema_generation: int,
+    declarations: tuple[ProcessCompatibilityDeclaration, ...],
+) -> None:
+    path = resolve_orchestration_compatibility_metadata_path(hub_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    metadata = OrchestrationCompatibilityMetadata(
+        schema_generation=schema_generation,
+        prepared_at="2026-05-22T00:00:00Z",
+        db_path=str(resolve_orchestration_sqlite_path(hub_root)),
+        registry=CompatibilityRegistry(
+            declarations=declarations,
+            updated_at="2026-05-22T00:00:00Z",
+        ),
+    )
+    path.write_text(json.dumps(metadata.to_dict(), indent=2) + "\n", encoding="utf-8")
+
+
+def _hub_declaration(
+    *,
+    process_id: str = "hub-old",
+    pid: int = 100,
+    supported_schema: int = ORCHESTRATION_SCHEMA_VERSION - 1,
+    expires_at: str = "2999-01-01T00:00:00Z",
+) -> ProcessCompatibilityDeclaration:
+    return ProcessCompatibilityDeclaration(
+        process_id=process_id,
+        role="hub",
+        pid=pid,
+        process_start_time=10.0,
+        build_id="old-hub",
+        unknown_build_reason=None,
+        writer_identity="host:100:hub-old",
+        supported_control_plane_api_version="1.0.0",
+        max_supported_schema_generation=supported_schema,
+        observed_schema_generation=supported_schema,
+        heartbeat_at="2026-05-22T00:00:00Z",
+        expires_at=expires_at,
+        ttl_seconds=120,
+    )
+
+
+def _mark_db_at_previous_generation(hub_root: Path) -> None:
+    initialize_orchestration_sqlite(hub_root, durable=False)
+    with sqlite3.connect(resolve_orchestration_sqlite_path(hub_root)) as conn:
+        conn.execute(
+            "DELETE FROM orch_schema_migrations WHERE version = ?",
+            (ORCHESTRATION_SCHEMA_VERSION,),
+        )
+
+
+def _schema_generation(hub_root: Path) -> int:
+    with sqlite3.connect(resolve_orchestration_sqlite_path(hub_root)) as conn:
+        row = conn.execute(
+            "SELECT COALESCE(MAX(version), 0) FROM orch_schema_migrations"
+        ).fetchone()
+    return int(row[0] or 0)
+
+
+def _migration_run_count(hub_root: Path) -> int:
+    with sqlite3.connect(resolve_orchestration_sqlite_path(hub_root)) as conn:
+        row = conn.execute(
+            """
+            SELECT COUNT(*)
+              FROM orch_migration_runs
+             WHERE from_version = ?
+               AND target_version = ?
+            """,
+            (ORCHESTRATION_SCHEMA_VERSION - 1, ORCHESTRATION_SCHEMA_VERSION),
+        ).fetchone()
+    return int(row[0] or 0)
 
 
 def test_orchestration_sqlite_path_uses_hub_state_root(tmp_path: Path) -> None:
@@ -209,6 +295,105 @@ def test_open_without_migrate_does_not_prepare_schema(tmp_path: Path) -> None:
 
     assert "orch_schema_migrations" not in names
     assert read_orchestration_compatibility_metadata(hub_root) is None
+
+
+def test_worker_migration_refuses_to_advance_past_live_hub_schema(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    old_schema = ORCHESTRATION_SCHEMA_VERSION - 1
+    _mark_db_at_previous_generation(hub_root)
+    _write_metadata(
+        hub_root,
+        schema_generation=old_schema,
+        declarations=(_hub_declaration(supported_schema=old_schema),),
+    )
+
+    with pytest.raises(OrchestrationMigrationRefused) as raised:
+        with open_orchestration_sqlite(
+            hub_root,
+            durable=False,
+            migrate=True,
+            migration_mode="worker",
+            process_role="worker",
+            pid_start_time_matches=lambda _pid, _start: True,
+        ):
+            pass
+
+    assert _schema_generation(hub_root) == old_schema
+    assert raised.value.refusal.current_schema == old_schema
+    assert raised.value.refusal.target_schema == ORCHESTRATION_SCHEMA_VERSION
+    assert raised.value.refusal.hub_supported_schema == old_schema
+    assert raised.value.evaluation.status == "restart_required"
+
+
+def test_hub_migration_can_advance_under_owned_mode(tmp_path: Path) -> None:
+    hub_root = tmp_path / "hub"
+    _mark_db_at_previous_generation(hub_root)
+
+    with open_orchestration_sqlite(
+        hub_root,
+        durable=False,
+        migrate=True,
+        migration_mode="hub",
+        process_role="hub",
+    ) as conn:
+        assert _table_names(conn)
+
+    assert _schema_generation(hub_root) == ORCHESTRATION_SCHEMA_VERSION
+
+
+def test_worker_bootstrap_ignores_stale_or_reused_hub_declarations(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _write_metadata(
+        hub_root,
+        schema_generation=0,
+        declarations=(
+            _hub_declaration(process_id="expired", expires_at="2020-01-01T00:00:00Z"),
+            _hub_declaration(process_id="reused", pid=200),
+        ),
+    )
+
+    with open_orchestration_sqlite(
+        hub_root,
+        durable=False,
+        migrate=True,
+        migration_mode="worker",
+        process_role="worker",
+        pid_start_time_matches=lambda pid, _start: pid != 200,
+    ) as conn:
+        assert "orch_schema_migrations" in _table_names(conn)
+
+    assert _schema_generation(hub_root) == ORCHESTRATION_SCHEMA_VERSION
+
+
+def test_concurrent_hub_migrate_callers_serialize_schema_advancement(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _mark_db_at_previous_generation(hub_root)
+
+    def migrate() -> int:
+        with open_orchestration_sqlite(
+            hub_root,
+            durable=False,
+            migrate=True,
+            migration_mode="hub",
+            process_role="hub",
+        ):
+            return _schema_generation(hub_root)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = tuple(pool.map(lambda _: migrate(), range(2)))
+
+    assert results == (
+        ORCHESTRATION_SCHEMA_VERSION,
+        ORCHESTRATION_SCHEMA_VERSION,
+    )
+    assert _schema_generation(hub_root) == ORCHESTRATION_SCHEMA_VERSION
+    assert _migration_run_count(hub_root) == 1
 
 
 def test_table_definition_roles_cover_authoritative_mirror_projection_and_ops() -> None:

--- a/tests/core/test_automation_rule_engine.py
+++ b/tests/core/test_automation_rule_engine.py
@@ -13,6 +13,7 @@ from codex_autorunner.core.automation.models import (
     TRIGGER_KIND_EVENT,
     TRIGGER_KIND_MANUAL,
 )
+from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 
 
 def _rule(**overrides):
@@ -113,6 +114,42 @@ def test_rule_engine_dedupe_survives_store_restart(tmp_path) -> None:
     assert first.jobs_created == 1
     assert duplicate.jobs_deduped == 1
     assert [job.dedupe_key for job in restarted_store.list_jobs()] == ["stable"]
+
+
+def test_rule_engine_reports_unknown_executor_skip_reason(tmp_path) -> None:
+    store = AutomationStore(tmp_path)
+    store.upsert_rule(_rule())
+    with open_orchestration_sqlite(tmp_path) as conn:
+        with conn:
+            conn.execute(
+                """
+                UPDATE orch_automation_rules
+                   SET executor_kind = ?,
+                       executor_json = ?
+                 WHERE rule_id = ?
+                """,
+                (
+                    "agent_task_turn",
+                    '{"kind":"agent_task_turn"}',
+                    "rule-1",
+                ),
+            )
+
+    result = AutomationRuleEngine(
+        AutomationStore(tmp_path)
+    ).record_event_and_enqueue_jobs(_event())
+
+    assert result.jobs_created == 0
+    assert result.jobs_skipped == 1
+    assert result.skipped_reasons == (
+        {
+            "code": "AUTOMATION_EXECUTOR_KIND_UNSUPPORTED",
+            "rule_id": "rule-1",
+            "executor_kind": "agent_task_turn",
+            "known_executor": False,
+            "executable": False,
+        },
+    )
 
 
 def test_rule_engine_records_event_but_does_not_enqueue_disabled_rule(tmp_path) -> None:

--- a/tests/core/test_automation_scheduler.py
+++ b/tests/core/test_automation_scheduler.py
@@ -18,6 +18,7 @@ from codex_autorunner.core.automation.models import (
     TRIGGER_KIND_EVENT,
     TRIGGER_KIND_SCHEDULE,
 )
+from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 
 
 def _schedule_rule(rule_id="rule-1") -> AutomationRule:
@@ -91,6 +92,45 @@ def test_due_schedule_rule_uses_schedule_fire_event_path(tmp_path) -> None:
     assert job.event_id.startswith("schedule.fire:schedule-1:")
     assert job.target["repo_id"] == "repo-1"
     assert job.executor["message"] == "Fire daily-rule"
+
+
+def test_due_schedule_reports_unknown_executor_skip_reason(tmp_path) -> None:
+    store = AutomationStore(tmp_path)
+    store.upsert_rule(_schedule_rule())
+    store.upsert_schedule(
+        AutomationSchedule.create(
+            schedule_id="schedule-1",
+            rule_id="rule-1",
+            schedule_kind=SCHEDULE_ONE_SHOT,
+            next_fire_at="2026-01-01T00:00:00Z",
+        )
+    )
+    with open_orchestration_sqlite(tmp_path) as conn:
+        with conn:
+            conn.execute(
+                """
+                UPDATE orch_automation_rules
+                   SET executor_kind = ?,
+                       executor_json = ?
+                 WHERE rule_id = ?
+                """,
+                (
+                    "pma_operator_turn",
+                    '{"kind":"pma_operator_turn"}',
+                    "rule-1",
+                ),
+            )
+
+    result = AutomationScheduler(
+        AutomationStore(tmp_path),
+        AutomationRuleEngine(AutomationStore(tmp_path)),
+    ).process_due(now="2026-01-01T00:00:00Z")
+
+    assert result.schedules_fired == 1
+    assert result.jobs_created == 0
+    assert result.jobs_skipped == 1
+    assert result.skipped_reasons[0]["code"] == "AUTOMATION_EXECUTOR_KIND_UNSUPPORTED"
+    assert result.skipped_reasons[0]["executor_kind"] == "pma_operator_turn"
 
 
 def test_interval_daily_and_weekly_next_fire_calculation() -> None:

--- a/tests/core/test_automation_store.py
+++ b/tests/core/test_automation_store.py
@@ -99,6 +99,38 @@ def test_rule_crud_event_recording_and_json_roundtrip(tmp_path) -> None:
     )
 
 
+def test_persisted_rule_with_unknown_executor_kind_hydrates_without_rewriting(
+    tmp_path,
+) -> None:
+    store = AutomationStore(tmp_path)
+    store.upsert_rule(_rule())
+    with open_orchestration_sqlite(tmp_path) as conn:
+        with conn:
+            conn.execute(
+                """
+                UPDATE orch_automation_rules
+                   SET executor_kind = ?,
+                       executor_json = ?
+                 WHERE rule_id = ?
+                """,
+                (
+                    "agent_task_turn",
+                    json.dumps(
+                        {"kind": "agent_task_turn", "prompt": "Run future task"}
+                    ),
+                    "rule-1",
+                ),
+            )
+
+    loaded = store.get_rule("rule-1")
+    assert loaded is not None
+    assert loaded.executor_kind == "agent_task_turn"
+    assert loaded.executor["kind"] == "agent_task_turn"
+    assert loaded.known_executor is False
+    assert loaded.executable is False
+    assert store.list_rules()[0].executor_kind == "agent_task_turn"
+
+
 def test_record_event_preserves_first_seen_payload_for_duplicate_id(tmp_path) -> None:
     store = AutomationStore(tmp_path)
 

--- a/tests/core/test_automation_worker.py
+++ b/tests/core/test_automation_worker.py
@@ -173,6 +173,37 @@ def test_worker_dead_letters_after_max_attempts(tmp_path) -> None:
     assert store.list_attempts("job-1")[0].status == JOB_DEAD_LETTERED
 
 
+def test_worker_dead_letters_unknown_executor_without_retrying(tmp_path) -> None:
+    store = _store_with_rule_and_event(tmp_path)
+    store.enqueue_job(
+        _job(
+            "job-unknown",
+            executor={"kind": "agent_task_turn"},
+            policy={"max_attempts": 3},
+            max_attempts=3,
+        )
+    )
+    registry = AutomationExecutorRegistry()
+
+    result = AutomationJobWorker(store, registry).process_once(
+        now="2026-01-01T00:00:00Z"
+    )
+
+    saved = store.get_job("job-unknown")
+    attempt = store.list_attempts("job-unknown")[0]
+    assert result.failed == 1
+    assert result.retried == 0
+    assert result.dead_lettered == 1
+    assert saved.state == JOB_DEAD_LETTERED
+    assert "AUTOMATION_EXECUTOR_KIND_UNSUPPORTED" in saved.error_text
+    assert attempt.status == JOB_DEAD_LETTERED
+    assert attempt.executor_result == {
+        "code": "AUTOMATION_EXECUTOR_KIND_UNSUPPORTED",
+        "executor_kind": "agent_task_turn",
+        "executable": False,
+    }
+
+
 def test_worker_recovers_stale_claim_and_respects_running_concurrency(tmp_path) -> None:
     store = _store_with_rule_and_event(tmp_path)
     running, _ = store.enqueue_job(_job("running-job", dedupe_key="running"))

--- a/tests/core/test_hub_control_plane_handshake_startup.py
+++ b/tests/core/test_hub_control_plane_handshake_startup.py
@@ -79,3 +79,46 @@ async def test_startup_handshake_retries_with_jittered_info_logging(
         and record.levelno == logging.INFO
         for record in caplog.records
     )
+
+
+@pytest.mark.anyio
+async def test_startup_handshake_preserves_typed_hub_incompatible_details() -> None:
+    class _IncompatibleHubClient:
+        async def handshake(self, request: Any) -> Any:
+            _ = request
+            raise HubControlPlaneError(
+                "hub_incompatible",
+                "hub restart required",
+                retryable=False,
+                details={
+                    "compatibility": {
+                        "status": "incompatible_schema",
+                        "observed_schema": ORCHESTRATION_SCHEMA_VERSION + 1,
+                        "supported_schema": ORCHESTRATION_SCHEMA_VERSION,
+                        "process_role": "hub",
+                        "build_id": "old-build",
+                        "restart_required": True,
+                        "reason": "observed schema generation is newer",
+                    }
+                },
+            )
+
+    ok, compatibility = await perform_startup_hub_handshake(
+        hub_client=_IncompatibleHubClient(),
+        log_event_name_prefix="test",
+        handshake_client_name="test-client",
+        hub_root_str="/tmp/hub",
+        startup_monotonic=0.0,
+        retry_window_seconds=1.0,
+        retry_delay_seconds=0.5,
+        retry_max_delay_seconds=2.0,
+        client_api_version="1.0.0",
+        logger=logging.getLogger("test.handshake_startup.incompatible"),
+    )
+
+    assert ok is False
+    assert compatibility is not None
+    assert compatibility.state == "incompatible"
+    assert compatibility.server_schema_generation == ORCHESTRATION_SCHEMA_VERSION + 1
+    assert compatibility.expected_schema_generation == ORCHESTRATION_SCHEMA_VERSION
+    assert "observed schema generation" in (compatibility.reason or "")

--- a/tests/core/test_hub_control_plane_service.py
+++ b/tests/core/test_hub_control_plane_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from codex_autorunner.core.hub_control_plane import (
@@ -49,7 +50,10 @@ from codex_autorunner.core.orchestration import (
     TurnExecutionRequest,
 )
 from codex_autorunner.core.orchestration.cold_trace_store import ColdTraceStore
-from codex_autorunner.core.orchestration.sqlite import prepare_orchestration_sqlite
+from codex_autorunner.core.orchestration.sqlite import (
+    open_orchestration_sqlite,
+    prepare_orchestration_sqlite,
+)
 from codex_autorunner.core.pma_notification_store import PmaNotificationStore
 from codex_autorunner.core.pma_transcripts import PmaTranscriptStore
 from codex_autorunner.core.ports.run_event import Completed, Started
@@ -722,6 +726,56 @@ def test_shared_state_service_automation_rule_crud_and_manual_run(
     assert [job["job_id"] for job in jobs.jobs] == [run.job["job_id"]]
     assert len(events.events) == 1
     assert events.events[0]["raw_payload"]["secret"] == "[redacted]"
+
+
+def test_shared_state_service_lists_unknown_executor_but_rejects_manual_run(
+    tmp_path: Path,
+) -> None:
+    service, _thread_target_id = _build_service(tmp_path)
+    service.upsert_automation_rule(
+        AutomationRuleUpsertRequest.from_mapping(
+            {
+                "rule_id": "rule-future",
+                "name": "Future rule",
+                "trigger_kind": "event",
+                "trigger": {"event_types": ["manual.run"]},
+                "target_policy": "hub",
+                "executor_kind": "managed_thread_turn",
+            }
+        )
+    )
+    with open_orchestration_sqlite(tmp_path / "hub", durable=False) as conn:
+        with conn:
+            conn.execute(
+                """
+                UPDATE orch_automation_rules
+                   SET executor_kind = ?,
+                       executor_json = ?
+                 WHERE rule_id = ?
+                """,
+                (
+                    "pma_operator_turn",
+                    json.dumps({"kind": "pma_operator_turn", "prompt": "Future"}),
+                    "rule-future",
+                ),
+            )
+
+    listed = service.list_automation_rules(AutomationRuleListRequest.from_mapping({}))
+
+    rules = {rule["rule_id"]: rule for rule in listed.rules}
+    assert rules["rule-future"]["executor_kind"] == "pma_operator_turn"
+    assert rules["rule-future"]["known_executor"] is False
+    assert rules["rule-future"]["executable"] is False
+    try:
+        service.run_automation_rule(
+            AutomationRuleRunRequest.from_mapping({"rule_id": "rule-future"})
+        )
+    except Exception as exc:
+        assert getattr(exc, "details", {})["code"] == (
+            "AUTOMATION_EXECUTOR_KIND_UNSUPPORTED"
+        )
+    else:
+        raise AssertionError("unknown executor kind should not be manually runnable")
 
 
 def test_shared_state_service_automation_job_cancel_retry_and_detail(

--- a/tests/core/test_pma_automation_snapshot.py
+++ b/tests/core/test_pma_automation_snapshot.py
@@ -133,3 +133,5 @@ def test_snapshot_pma_automation_tolerates_unknown_executor_kind(tmp_path) -> No
 
     assert snapshot["rules"]["enabled_count"] == 1
     assert snapshot["rules"]["sample"][0]["executor_kind"] == "pma_operator_turn"
+    assert snapshot["rules"]["sample"][0]["known_executor"] is False
+    assert snapshot["rules"]["sample"][0]["executable"] is False

--- a/tests/core/test_pma_automation_snapshot.py
+++ b/tests/core/test_pma_automation_snapshot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 from codex_autorunner.core.automation import (
@@ -15,6 +16,7 @@ from codex_autorunner.core.automation.models import (
     TARGET_POLICY_HUB,
     TRIGGER_KIND_EVENT,
 )
+from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.core.pma_automation_snapshot import snapshot_pma_automation
 
 
@@ -96,3 +98,38 @@ def test_snapshot_pma_automation_includes_unified_read_model(tmp_path) -> None:
     assert snapshot["schedules"]["sample"][0]["schedule_id"] == "schedule-1"
     assert snapshot["jobs"]["pending_count"] == 1
     assert snapshot["jobs"]["recent_sample"][0]["job_id"] == "job-1"
+
+
+def test_snapshot_pma_automation_tolerates_unknown_executor_kind(tmp_path) -> None:
+    store = AutomationStore(tmp_path)
+    store.upsert_rule(
+        AutomationRule.create(
+            rule_id="rule-unknown",
+            name="Future automation",
+            trigger_kind=TRIGGER_KIND_EVENT,
+            trigger={"event_types": ["lifecycle.flow_completed"]},
+            target_policy=TARGET_POLICY_HUB,
+            executor_kind=EXECUTOR_MANAGED_THREAD_TURN,
+        )
+    )
+    with open_orchestration_sqlite(tmp_path) as conn:
+        with conn:
+            conn.execute(
+                """
+                UPDATE orch_automation_rules
+                   SET executor_kind = ?,
+                       executor_json = ?
+                 WHERE rule_id = ?
+                """,
+                (
+                    "pma_operator_turn",
+                    json.dumps({"kind": "pma_operator_turn", "prompt": "Future"}),
+                    "rule-unknown",
+                ),
+            )
+    supervisor = SimpleNamespace(hub_config=SimpleNamespace(root=tmp_path))
+
+    snapshot = snapshot_pma_automation(supervisor, max_items=10)
+
+    assert snapshot["rules"]["enabled_count"] == 1
+    assert snapshot["rules"]["sample"][0]["executor_kind"] == "pma_operator_turn"

--- a/tests/core/test_scm_canonical_shapes.py
+++ b/tests/core/test_scm_canonical_shapes.py
@@ -395,7 +395,7 @@ class TestScmPollingWatchShape:
         )
         assert reactivated.state.value == "active"
 
-    def test_watch_upsert_rejects_terminal_reactivation(self, tmp_path: Path) -> None:
+    def test_watch_upsert_repairs_expired_watch(self, tmp_path: Path) -> None:
         store = ScmPollingWatchStore(tmp_path)
         binding = PrBindingStore(tmp_path).upsert_binding(
             provider="github",
@@ -414,17 +414,25 @@ class TestScmPollingWatchShape:
             expires_at="2026-04-01T11:00:00Z",
         )
         store.close_watch(watch_id=first.watch_id, state="expired")
-        with pytest.raises(RuntimeError, match="invalid SCM polling watch"):
-            store.upsert_watch(
-                provider="github",
-                binding_id=binding.binding_id,
-                repo_slug="acme/widgets",
-                pr_number=17,
-                workspace_root=str(tmp_path / "repo"),
-                poll_interval_seconds=60,
-                next_poll_at="2026-04-01T10:02:00Z",
-                expires_at="2026-04-01T12:00:00Z",
-            )
+        repaired = store.upsert_watch(
+            provider="github",
+            binding_id=binding.binding_id,
+            repo_slug="acme/widgets",
+            pr_number=17,
+            workspace_root=str(tmp_path / "repo"),
+            poll_interval_seconds=60,
+            next_poll_at="2026-04-01T10:02:00Z",
+            expires_at="2026-04-01T12:00:00Z",
+        )
+
+        assert repaired.watch_id != first.watch_id
+        assert repaired.state == "active"
+        assert repaired.poll_interval_seconds == 60
+        assert repaired.last_error_text == "recreated expired SCM polling watch"
+        assert repaired.snapshot["watch_repair"]["action"] == (
+            "recreated_expired_watch"
+        )
+        assert repaired.snapshot["watch_repair"]["previous_watch_id"] == first.watch_id
 
     def test_watch_terminal_state_rejects_different_close_transition(
         self, tmp_path: Path

--- a/tests/surfaces/web/routes/test_hub_control_plane_routes.py
+++ b/tests/surfaces/web/routes/test_hub_control_plane_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import httpx
@@ -38,7 +39,11 @@ from codex_autorunner.core.managed_thread_store import (
     prepare_managed_thread_store,
 )
 from codex_autorunner.core.orchestration import TurnExecutionRequest
-from codex_autorunner.core.orchestration.sqlite import prepare_orchestration_sqlite
+from codex_autorunner.core.orchestration.migrations import ORCHESTRATION_SCHEMA_VERSION
+from codex_autorunner.core.orchestration.sqlite import (
+    prepare_orchestration_sqlite,
+    resolve_orchestration_sqlite_path,
+)
 from codex_autorunner.core.pma_notification_store import PmaNotificationStore
 from codex_autorunner.core.ports.run_event import Completed, Started
 from codex_autorunner.surfaces.web.routes.hub_control_plane import (
@@ -137,6 +142,36 @@ def test_hub_control_plane_routes_return_typed_validation_errors(
     assert response.status_code == 400
     assert response.json()["error"]["code"] == "hub_rejected"
     assert "client_name is required" in response.json()["error"]["message"]
+
+
+def test_hub_control_plane_routes_return_typed_compatibility_error(
+    tmp_path: Path,
+) -> None:
+    app, _thread_target_id = _build_test_app(tmp_path)
+    hub_root = tmp_path / "hub"
+    with sqlite3.connect(resolve_orchestration_sqlite_path(hub_root)) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO orch_schema_migrations(version, name, applied_at) VALUES (?, ?, ?)",
+            (ORCHESTRATION_SCHEMA_VERSION + 1, "future", "2026-05-22T00:00:00Z"),
+        )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/hub/api/control-plane/handshake",
+            json={"client_name": "discord", "client_api_version": "1.0.0"},
+        )
+
+    payload = response.json()
+    assert response.status_code == 409
+    assert payload["error"]["code"] == "hub_incompatible"
+    assert payload["compatibility"]["status"] == "incompatible_schema"
+    assert payload["compatibility"]["observed_schema"] == (
+        ORCHESTRATION_SCHEMA_VERSION + 1
+    )
+    assert payload["compatibility"]["supported_schema"] == ORCHESTRATION_SCHEMA_VERSION
+    assert payload["compatibility"]["process_role"] == "hub"
+    assert payload["compatibility"]["build_id"]
+    assert payload["compatibility"]["restart_required"] is True
 
 
 def test_hub_control_plane_list_surface_bindings_route_validates_limit(

--- a/tests/surfaces/web/test_hub_automation_routes.py
+++ b/tests/surfaces/web/test_hub_automation_routes.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
@@ -19,6 +20,7 @@ from codex_autorunner.core.automation.models import (
     TRIGGER_KIND_SCHEDULE,
 )
 from codex_autorunner.core.automation.product import automation_overview
+from codex_autorunner.core.orchestration.sqlite import open_orchestration_sqlite
 from codex_autorunner.server import create_hub_app
 from codex_autorunner.surfaces.web.routes.automations import _automation_target_options
 
@@ -288,6 +290,58 @@ def test_hub_automation_workspace_batches_jobs_and_target_options(
             "disabled": True,
         },
     ]
+
+
+def test_hub_automation_workspace_tolerates_unknown_executor_kind(tmp_path):
+    hub_root = tmp_path / "hub"
+    seed_hub_files(hub_root, force=True)
+    store = AutomationStore(hub_root)
+    store.upsert_rule(
+        AutomationRule.create(
+            rule_id="rule-future",
+            name="Future executor",
+            enabled=True,
+            trigger_kind=TRIGGER_KIND_EVENT,
+            trigger={"event_types": ["manual.run"]},
+            target_policy=TARGET_POLICY_HUB,
+            executor_kind=EXECUTOR_MANAGED_THREAD_TURN,
+            executor={"message": "Known before upgrade"},
+        )
+    )
+    with open_orchestration_sqlite(hub_root) as conn:
+        with conn:
+            conn.execute(
+                """
+                UPDATE orch_automation_rules
+                   SET executor_kind = ?,
+                       executor_json = ?
+                 WHERE rule_id = ?
+                """,
+                (
+                    "agent_task_turn",
+                    json.dumps({"kind": "agent_task_turn", "prompt": "Future task"}),
+                    "rule-future",
+                ),
+            )
+
+    client = TestClient(create_hub_app(hub_root))
+    response = client.get("/hub/read-models/automations/workspace")
+    run = client.post("/hub/automations/rule-future/run")
+
+    assert response.status_code == 200
+    rows = {row["id"]: row for row in response.json()["automations"]}
+    row = rows["rule-future"]
+    assert row["executor_kind"] == "agent_task_turn"
+    assert row["executor"]["kind"] == "agent_task_turn"
+    assert row["known_executor"] is False
+    assert row["executable"] is False
+    assert row["editable"]["can_run_now"] is False
+    assert row["executor_summary"]["known_executor"] is False
+    assert {item["code"] for item in row["diagnostics"]} >= {
+        "AUTOMATION_EXECUTOR_KIND_UNSUPPORTED"
+    }
+    assert run.status_code == 400
+    assert "AUTOMATION_EXECUTOR_KIND_UNSUPPORTED" in run.json()["detail"]
 
 
 def test_hub_automations_pause_and_resume(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #1921 by making hot-upgrade compatibility for the shared hub orchestration database explicit and enforceable.

- Adds a typed orchestration compatibility contract, process declarations, schema compatibility errors, and structured `hub_incompatible` control-plane responses.
- Makes automation read models tolerate unknown persisted `executor_kind` values while keeping create/update/execution paths strict and typed.
- Gates orchestration migrations behind hub-owned/explicit migration modes so worker/default paths cannot advance an existing shared DB past a live hub.
- Parks delivery workers on schema incompatibility and repairs expired SCM polling watches without invalid lifecycle loops.
- Adds subagent-review follow-up fixes for heartbeat refresh, startup handshake compatibility detail preservation, worker-mode prepare paths, and typed automation skip reasons.

## Validation

- Commit hook `web-core-contract` passed:
  - black, ruff, import boundaries, hub interface contracts, core import checks, destination contract drift, keyword contracts, migration observability sync
  - strict mypy over `src/codex_autorunner`
  - full pytest: `9380 passed`
  - Web UI lab fast check: `27 scenario(s), 0 failure(s)`
  - Svelte check: `0 errors and 0 warnings`
  - Web Hub build
  - frontend vitest: `835 passed, 2 skipped`
  - SPA shell route check
- Post-rebase targeted validation:
  - `.venv/bin/python -m pytest tests/core/orchestration/test_compatibility.py tests/core/orchestration/test_sqlite_schema.py tests/core/test_hub_control_plane_handshake_startup.py tests/core/test_pma_automation_snapshot.py tests/core/test_automation_rule_engine.py tests/core/test_automation_scheduler.py tests/surfaces/web/test_hub_automation_routes.py -q`
  - Result: `44 passed`
  - `.venv/bin/python -m ruff check ...` on touched source/tests
