### PR TITLE
[codex] Keep new chat selected during URL sync

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.test.ts
@@ -114,6 +114,47 @@ describe('chat detail session', () => {
     expect(clearCommittedDraftPlaceholderIfPersisted(committed, [chat({ id: 'managed-thread-1' })]).committedDraftChat).toBeNull();
   });
 
+  it('keeps a committed draft selected while the detail URL is still catching up', () => {
+    const state = {
+      ...initialChatDetailSessionState(),
+      activeChatId: 'managed-thread-1',
+      detailMode: 'detail' as const,
+      pendingCommittedDetailUrlChatId: 'managed-thread-1'
+    };
+
+    const command = activateChatDetailFromUrl(state, {
+      detailId: null,
+      chats: [chat({ id: 'other' })],
+      hasCachedDetail: () => false,
+      activeDetailLoadResult: () => null
+    });
+
+    expect(command.state.activeChatId).toBe('managed-thread-1');
+    expect(command.state.detailMode).toBe('detail');
+    expect(command.state.pendingCommittedDetailUrlChatId).toBe('managed-thread-1');
+    expect(command.runtime).toBeNull();
+  });
+
+  it('clears the committed draft URL guard once the committed detail route is visible', () => {
+    const state = {
+      ...initialChatDetailSessionState(),
+      activeChatId: 'managed-thread-1',
+      detailMode: 'detail' as const,
+      pendingCommittedDetailUrlChatId: 'managed-thread-1'
+    };
+
+    const command = activateChatDetailFromUrl(state, {
+      detailId: 'managed-thread-1',
+      chats: [chat({ id: 'managed-thread-1' })],
+      hasCachedDetail: () => true,
+      activeDetailLoadResult: () => ({ status: 'cache-hit', tags: [] })
+    });
+
+    expect(command.state.activeChatId).toBe('managed-thread-1');
+    expect(command.state.pendingCommittedDetailUrlChatId).toBeNull();
+    expect(command.runtime).toBeNull();
+  });
+
   it('persists read markers through an injected adapter', () => {
     const saved: Array<Record<string, string>> = [];
     const next = markSessionChatRead(

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.ts
@@ -148,6 +148,12 @@ export function activateChatDetailFromUrl(
       syncSelectors: false
     };
   }
+  if (detailId === state.activeChatId && state.pendingCommittedDetailUrlChatId === detailId) {
+    return noDetailCommand({
+      ...state,
+      pendingCommittedDetailUrlChatId: null
+    });
+  }
   if (detailId === state.activeChatId) return noDetailCommand(state);
   if (isLocalDraftChatId(state.activeChatId)) return noDetailCommand(state);
   if (state.localDraftChat && detailId === state.localDraftChat.id) {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -1195,13 +1195,7 @@
   }
 
   async function syncCommittedDetailUrl(detailId: string): Promise<void> {
-    try {
-      await syncDetailUrl(detailId);
-    } finally {
-      if (pendingCommittedDetailUrlChatId === detailId) {
-        pendingCommittedDetailUrlChatId = null;
-      }
-    }
+    await syncDetailUrl(detailId);
   }
 
   async function refreshActive(chatId: string, options: { quiet?: boolean } = {}): Promise<void> {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -1195,7 +1195,15 @@
   }
 
   async function syncCommittedDetailUrl(detailId: string): Promise<void> {
-    await syncDetailUrl(detailId);
+    try {
+      await syncDetailUrl(detailId);
+    } catch (error) {
+      if (pendingCommittedDetailUrlChatId === detailId) {
+        pendingCommittedDetailUrlChatId = null;
+        pageController.setRoute(currentRouteSnapshot());
+      }
+      throw error;
+    }
   }
 
   async function refreshActive(chatId: string, options: { quiet?: boolean } = {}): Promise<void> {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -52,6 +52,19 @@ describe('/chats page', () => {
     expect(pageSource).not.toContain('openChatTranscriptEventSource');
   });
 
+  it('clears the committed chat URL guard when committed detail navigation fails', () => {
+    const source = chatDetailPageSource();
+    const syncCommittedBody = source.match(
+      /async function syncCommittedDetailUrl[\s\S]*?\n  async function refreshActive/
+    )?.[0];
+
+    expect(syncCommittedBody).toContain('catch (error)');
+    expect(syncCommittedBody).toContain('pendingCommittedDetailUrlChatId = null;');
+    expect(syncCommittedBody).toContain('pageController.setRoute(currentRouteSnapshot());');
+    expect(syncCommittedBody).toContain('throw error;');
+    expect(syncCommittedBody).not.toContain('finally');
+  });
+
   it('keeps migrated PMA transcript, stream, queue, send, and normalization calls out of the page', () => {
     const pageSource = chatDetailPageSource();
     const forbiddenTokens = [


### PR DESCRIPTION
## What changed

- Keeps a newly committed chat selected while Svelte route state catches up from `/chats` to `/chats/{id}` after the first send.
- Moves clearing of `pendingCommittedDetailUrlChatId` into the session reducer, only after the committed detail route is actually visible.
- Adds regression coverage for the URL catch-up window and guard clearing behavior.

## Root cause

The first-send path converted a local draft chat into a real managed-thread chat ID, called `goto('/chats/{id}')`, then cleared the URL catch-up guard in a `finally`. If the route observer ran while Svelte still exposed `/chats` with no detail ID, `activateChatDetailFromUrl()` interpreted that as no selected chat and switched the workspace back to list mode. That hid the chat window until a later refresh or stream repair restored state.

## User impact

Sending the first message in a new chat should now keep the chat detail pane open immediately instead of briefly closing it.

## Validation

- `pnpm web:test -- chatDetailSession.test.ts chatSendController.test.ts chatDetailPageController.test.ts routes/chats/page.test.ts`
- `pnpm web:lint`
- `pnpm web:test`
- Commit hook web-ui lane: guardrails, repo-wide pytest (`9385 passed`), Web UI lab fast scenarios, Svelte lint, production web build, Web Hub frontend tests, SPA shell route check
