### PR TITLE
fix(chat): reject foreign model on managed-thread turns before dispatch

### DIFF
--- a/src/codex_autorunner/core/orchestration/__init__.py
+++ b/src/codex_autorunner/core/orchestration/__init__.py
@@ -222,7 +222,7 @@ if TYPE_CHECKING:
         build_surface_orchestration_ingress,
         get_surface_orchestration_ingress,
     )
-    from .thread_service import HarnessBackedOrchestrationService
+    from .thread_service import ForeignModelError, HarnessBackedOrchestrationService
     from .thread_store_adapter import (
         ManagedThreadExecutionStore,
     )
@@ -232,6 +232,10 @@ _LAZY_EXPORTS = {
     "FlowBackedOrchestrationService": (
         ".flow_service",
         "FlowBackedOrchestrationService",
+    ),
+    "ForeignModelError": (
+        ".thread_service",
+        "ForeignModelError",
     ),
     "HarnessBackedOrchestrationService": (
         ".thread_service",
@@ -323,6 +327,7 @@ __all__ = [
     "ExecutionRecord",
     "FlowBackedOrchestrationService",
     "FlowTarget",
+    "ForeignModelError",
     "FreshConversationRequiredError",
     "HarnessBackedOrchestrationService",
     "ManagedThreadDeliveryAttemptResult",

--- a/src/codex_autorunner/core/orchestration/thread_service.py
+++ b/src/codex_autorunner/core/orchestration/thread_service.py
@@ -55,6 +55,24 @@ logger = logging.getLogger("codex_autorunner.core.orchestration.service")
 HarnessFactory = Callable[..., RuntimeThreadHarness]
 
 
+class ForeignModelError(ValueError):
+    """Raised when a turn specifies a model the resolved agent cannot use.
+
+    An agent without the ``model_listing`` capability (e.g. Hermes/ACP) has no
+    caller-selectable model catalog, so any non-empty model on such a turn is
+    foreign. The turn is rejected before dispatch so the model never reaches
+    the agent session and never lands in ``orch_thread_executions`` (#1854).
+    """
+
+    def __init__(self, *, agent_id: str, model: str) -> None:
+        self.agent_id = agent_id
+        self.model = model
+        super().__init__(
+            f"Agent '{agent_id}' cannot use model '{model}': it does not "
+            "support model selection (missing 'model_listing' capability)."
+        )
+
+
 @dataclass(frozen=True)
 class PreparedThreadExecution:
     """Execution row plus enough context to start the runtime turn later."""
@@ -789,6 +807,20 @@ class HarnessBackedOrchestrationService(OrchestrationThreadService):
         definition = self.get_agent_definition(thread.agent_id)
         if definition is None:
             raise KeyError(f"Unknown agent definition '{thread.agent_id}'")
+
+        # Reject a caller-specified model the resolved agent cannot use, before
+        # the turn is created or dispatched. An agent without `model_listing`
+        # (e.g. Hermes/ACP) has no caller-selectable model catalog, so a
+        # non-empty model on such a turn is foreign. Letting it through pins
+        # the bad model onto the agent session and bricks every later turn
+        # (#1854). Raising here keeps the foreign model out of the agent
+        # session and out of orch_thread_executions entirely.
+        requested_model = (message_request.model or "").strip()
+        if requested_model and "model_listing" not in definition.capabilities:
+            raise ForeignModelError(
+                agent_id=definition.agent_id,
+                model=requested_model,
+            )
 
         workspace_root = Path(thread.workspace_root)
         if canonical_request is not None:

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -19,6 +19,7 @@ from codex_autorunner.core.hub_control_plane import (
 )
 from codex_autorunner.core.managed_thread_store import ManagedThreadStore
 from codex_autorunner.core.orchestration import (
+    ForeignModelError,
     HarnessBackedOrchestrationService,
     ManagedThreadExecutionStore,
     MappingAgentDefinitionCatalog,
@@ -290,12 +291,19 @@ class _HarnessWithStream:
 
 
 def _make_descriptor(
-    agent_id: str = "codex", *, name: str = "Codex"
+    agent_id: str = "codex",
+    *,
+    name: str = "Codex",
+    capabilities: Optional[frozenset[str]] = None,
 ) -> AgentDescriptor:
     return AgentDescriptor(
         id=agent_id,
         name=name,
-        capabilities=frozenset(["durable_threads", "message_turns", "review"]),
+        capabilities=(
+            capabilities
+            if capabilities is not None
+            else frozenset(["durable_threads", "message_turns", "review"])
+        ),
         make_harness=lambda _ctx: None,  # type: ignore[return-value]
     )
 
@@ -306,8 +314,11 @@ def _build_service(
     *,
     agent_id: str = "codex",
     name: str = "Codex",
+    capabilities: Optional[frozenset[str]] = None,
 ) -> HarnessBackedOrchestrationService:
-    descriptors = {agent_id: _make_descriptor(agent_id, name=name)}
+    descriptors = {
+        agent_id: _make_descriptor(agent_id, name=name, capabilities=capabilities)
+    }
     return HarnessBackedOrchestrationService(
         definition_catalog=MappingAgentDefinitionCatalog(descriptors),
         thread_store=ManagedThreadExecutionStore(ManagedThreadStore(tmp_path / "hub")),
@@ -440,7 +451,15 @@ async def test_runtime_threads_use_wait_for_turn_contract_for_session_runtimes(
     tmp_path: Path,
 ) -> None:
     harness = _HarnessWithStream()
-    service = _build_service(tmp_path, harness, agent_id="opencode", name="OpenCode")
+    service = _build_service(
+        tmp_path,
+        harness,
+        agent_id="opencode",
+        name="OpenCode",
+        capabilities=frozenset(
+            ["durable_threads", "message_turns", "review", "model_listing"]
+        ),
+    )
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     thread = service.create_thread_target("opencode", workspace_root)
@@ -480,7 +499,15 @@ async def test_opencode_runtime_thread_requires_resolved_model_before_start(
     tmp_path: Path,
 ) -> None:
     harness = _HarnessWithStream()
-    service = _build_service(tmp_path, harness, agent_id="opencode", name="OpenCode")
+    service = _build_service(
+        tmp_path,
+        harness,
+        agent_id="opencode",
+        name="OpenCode",
+        capabilities=frozenset(
+            ["durable_threads", "message_turns", "review", "model_listing"]
+        ),
+    )
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     thread = service.create_thread_target("opencode", workspace_root)
@@ -701,6 +728,73 @@ async def test_runtime_threads_stream_events_support_hermes_harness(
     assert started.thread.backend_thread_id == "session-1"
     assert events
     assert "message.completed" in events[-1]
+
+
+async def test_prepare_rejects_foreign_model_for_non_model_listing_agent(
+    tmp_path: Path,
+) -> None:
+    # Hermes has no `model_listing` capability, so a caller-specified model is
+    # foreign. The turn must be rejected before dispatch (#1854): the foreign
+    # model never reaches the agent session and no execution row is created.
+    harness = _HarnessWithWait()
+    service = _build_service(tmp_path, harness, agent_id="hermes", name="Hermes")
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target("hermes", workspace_root)
+
+    with pytest.raises(ForeignModelError) as excinfo:
+        await begin_runtime_thread_execution(
+            service,
+            MessageRequest(
+                target_id=thread.thread_target_id,
+                target_kind="thread",
+                message_text="hello hermes",
+                model="gpt-5.4-mini",
+            ),
+        )
+
+    assert excinfo.value.agent_id == "hermes"
+    assert excinfo.value.model == "gpt-5.4-mini"
+    # Never dispatched, and no execution row was created.
+    assert harness.start_turn_calls == []
+    assert service.get_running_execution(thread.thread_target_id) is None
+
+
+async def test_prepare_allows_model_for_model_listing_agent(
+    tmp_path: Path,
+) -> None:
+    # An agent that supports `model_listing` (codex/opencode in production) may
+    # receive a caller-specified model; the guard must not fire.
+    harness = _HarnessWithWait()
+    service = _build_service(
+        tmp_path,
+        harness,
+        capabilities=frozenset(
+            ["durable_threads", "message_turns", "review", "model_listing"]
+        ),
+    )
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    thread = service.create_thread_target("codex", workspace_root)
+
+    started = await begin_runtime_thread_execution(
+        service,
+        MessageRequest(
+            target_id=thread.thread_target_id,
+            target_kind="thread",
+            message_text="hello codex",
+            model="gpt-5.4-mini",
+        ),
+    )
+    outcome = await await_runtime_thread_outcome(
+        started,
+        interrupt_event=asyncio.Event(),
+        timeout_seconds=5,
+        execution_error_message="Managed thread execution failed",
+    )
+
+    assert outcome.status == "ok"
+    assert harness.start_turn_calls[0]["model"] == "gpt-5.4-mini"
 
 
 async def test_runtime_threads_allow_wait_results_without_raw_events(
@@ -1153,7 +1247,15 @@ async def test_stream_runtime_thread_events_proxies_harness_stream(
     tmp_path: Path,
 ) -> None:
     harness = _HarnessWithStream()
-    service = _build_service(tmp_path, harness, agent_id="opencode", name="OpenCode")
+    service = _build_service(
+        tmp_path,
+        harness,
+        agent_id="opencode",
+        name="OpenCode",
+        capabilities=frozenset(
+            ["durable_threads", "message_turns", "review", "model_listing"]
+        ),
+    )
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
     thread = service.create_thread_target("opencode", workspace_root)

--- a/tests/core/orchestration/test_runtime_threads.py
+++ b/tests/core/orchestration/test_runtime_threads.py
@@ -296,13 +296,16 @@ def _make_descriptor(
     name: str = "Codex",
     capabilities: Optional[frozenset[str]] = None,
 ) -> AgentDescriptor:
+    default_capabilities = {"durable_threads", "message_turns", "review"}
+    if agent_id in {"codex", "opencode"}:
+        default_capabilities.add("model_listing")
     return AgentDescriptor(
         id=agent_id,
         name=name,
         capabilities=(
             capabilities
             if capabilities is not None
-            else frozenset(["durable_threads", "message_turns", "review"])
+            else frozenset(default_capabilities)
         ),
         make_harness=lambda _ctx: None,  # type: ignore[return-value]
     )

--- a/tests/core/orchestration/test_service.py
+++ b/tests/core/orchestration/test_service.py
@@ -277,7 +277,15 @@ def _make_descriptor(
         capabilities=(
             capabilities
             if capabilities is not None
-            else frozenset(["durable_threads", "message_turns", "review", "approvals"])
+            else frozenset(
+                [
+                    "durable_threads",
+                    "message_turns",
+                    "review",
+                    "approvals",
+                    "model_listing",
+                ]
+            )
         ),
         make_harness=lambda _ctx: None,  # type: ignore[return-value]
     )

--- a/tests/test_opencode_agent_pool.py
+++ b/tests/test_opencode_agent_pool.py
@@ -244,17 +244,17 @@ def _build_descriptor(
     *,
     capabilities: Optional[frozenset[RuntimeCapability]] = None,
 ) -> AgentDescriptor:
+    default_capabilities = {
+        RuntimeCapability("durable_threads"),
+        RuntimeCapability("message_turns"),
+        RuntimeCapability("event_streaming"),
+    }
+    if agent_id in {"codex", "opencode"}:
+        default_capabilities.add(RuntimeCapability("model_listing"))
     return AgentDescriptor(
         id=agent_id,
         name=agent_id.title(),
-        capabilities=capabilities
-        or frozenset(
-            {
-                RuntimeCapability("durable_threads"),
-                RuntimeCapability("message_turns"),
-                RuntimeCapability("event_streaming"),
-            }
-        ),
+        capabilities=capabilities or frozenset(default_capabilities),
         make_harness=lambda ctx: ctx.fake_harness,
     )
 
@@ -266,17 +266,17 @@ def _build_contextual_descriptor(
     runtime_kind: Optional[str] = None,
     capabilities: Optional[frozenset[RuntimeCapability]] = None,
 ) -> AgentDescriptor:
+    default_capabilities = {
+        RuntimeCapability("durable_threads"),
+        RuntimeCapability("message_turns"),
+        RuntimeCapability("event_streaming"),
+    }
+    if agent_id in {"codex", "opencode"}:
+        default_capabilities.add(RuntimeCapability("model_listing"))
     return AgentDescriptor(
         id=agent_id,
         name=agent_id.title(),
-        capabilities=capabilities
-        or frozenset(
-            {
-                RuntimeCapability("durable_threads"),
-                RuntimeCapability("message_turns"),
-                RuntimeCapability("event_streaming"),
-            }
-        ),
+        capabilities=capabilities or frozenset(default_capabilities),
         make_harness=factory.make_harness,
         runtime_kind=runtime_kind,
     )

--- a/tests/test_ticket_flow_approval_config.py
+++ b/tests/test_ticket_flow_approval_config.py
@@ -93,16 +93,17 @@ class _FakeHarness:
 
 
 def _descriptor(agent_id: str = "codex", name: str = "Codex") -> AgentDescriptor:
+    capabilities = {
+        RuntimeCapability("durable_threads"),
+        RuntimeCapability("message_turns"),
+        RuntimeCapability("approvals"),
+    }
+    if agent_id in {"codex", "opencode"}:
+        capabilities.add(RuntimeCapability("model_listing"))
     return AgentDescriptor(
         id=agent_id,
         name=name,
-        capabilities=frozenset(
-            {
-                RuntimeCapability("durable_threads"),
-                RuntimeCapability("message_turns"),
-                RuntimeCapability("approvals"),
-            }
-        ),
+        capabilities=frozenset(capabilities),
         make_harness=lambda ctx: ctx.fake_harness,
     )
 


### PR DESCRIPTION
## Summary

A managed-thread turn that specified a model the resolved agent cannot use was accepted, ran to completion as `status=ok`, and stored an empty `assistant_text`. This rejects such a turn before it is dispatched, so the foreign model never reaches the agent session.

## Why this matters

> a single foreign-model turn poisons the whole chat. The guard should reject the foreign model **before** the turn is dispatched to the agent, so it never reaches the agent session at all.
>
> — @Git-on-my-level on #1854

Hermes chat `5dbc28` went dead because the frontend sent a Codex model (`gpt-5.4-mini`) on a Hermes chat. Turns 5-7 completed `ok` with zero assistant output and no error surfaced anywhere. Worse, Hermes (ACP) pins the bad model onto its session, so every later turn reuses the dead model and the chat stays bricked until a new chat is started or the session JSON is hand-edited.

The frontend selector bug is already fixed, but the backend had no guard. Any caller (web, Discord, Telegram, CLI, a future regression) that passes an unusable model gets the same silent dead turn.

The reported case is structural: Hermes has no `model_listing` capability, so it has no caller-selectable model catalog, and any non-empty model on such a turn is foreign by definition. The guard keys on that capability rather than fetching a live model catalog, so it costs nothing on the dispatch path and works for the reported agent (whose harness cannot list models at all).

## Changes

- Reject in `prepare_thread_execution` after the agent definition is resolved and before `create_execution`, so the foreign model never lands in `orch_thread_executions` and never reaches the ACP session.
- The check fires only when a non-empty model is set on an agent missing `model_listing`. Agents that support model selection (codex, opencode) are unaffected.
- `ForeignModelError` is exported from `core.orchestration` so callers can catch it.

## Testing

- `test_prepare_rejects_foreign_model_for_non_model_listing_agent`: a model on a Hermes thread raises `ForeignModelError`, the harness never starts a turn, and no execution row is created.
- `test_prepare_allows_model_for_model_listing_agent`: a `model_listing` agent still accepts a caller-specified model.
- Full orchestration suite passes (1091 tests).

This adds the pre-dispatch guard. It does not touch the frontend selector that originally sent the wrong model (already fixed per #1854).

Fixes #1854

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
