### PR TITLE
[codex] Fix chat projection facet schema drift

### DIFF
--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -17,6 +17,7 @@ from ..domain.workspace_scope import (
 )
 from ..hub_topology import load_hub_state
 from ..injected_context import strip_legacy_injected_context_transport_blocks
+from ..sqlite_utils import ensure_columns, table_columns
 from ..state_roots import resolve_repo_flows_db_path
 from ..text_utils import _normalize_optional_text, _parse_iso_timestamp
 from .chat_surface_events import ChatSurfaceEvent, SQLiteChatSurfaceEventJournal
@@ -38,6 +39,15 @@ CHAT_INDEX_PROJECTION_SCHEMA_VERSION = "chat.index.projection.facets.v1"
 DEFAULT_CHAT_TIMELINE_LIMIT = 50
 MAX_CHAT_TIMELINE_LIMIT = 200
 MAX_CHAT_TIMELINE_PAGE_SOURCE_LIMIT = 1000
+_CHAT_INDEX_PROJECTION_FACET_COLUMNS = (
+    ("facet_category", "facet_category TEXT"),
+    ("facet_turn_kind_list", "facet_turn_kind_list TEXT NOT NULL DEFAULT ''"),
+    ("facet_origin_kind_list", "facet_origin_kind_list TEXT NOT NULL DEFAULT ''"),
+    ("facet_transport_list", "facet_transport_list TEXT NOT NULL DEFAULT ''"),
+    ("facet_scope_kind", "facet_scope_kind TEXT"),
+    ("facet_scope_id", "facet_scope_id TEXT"),
+    ("facet_agent_kind", "facet_agent_kind TEXT"),
+)
 
 _TERMINAL_SUCCESS_STATUSES = {
     "completed",
@@ -907,6 +917,7 @@ class ChatSurfaceReadService:
             self._hub_root, durable=self._durable, migrate=True
         ) as conn:
             with conn:
+                _ensure_chat_index_projection_facet_schema(conn)
                 existing_meta = {
                     str(row["key"]): str(row["value"]) for row in conn.execute("""
                         SELECT key, value
@@ -1036,6 +1047,7 @@ class ChatSurfaceReadService:
             ) or not _table_exists(conn, "orch_chat_index_projection_meta"):
                 needs_rebuild = True
             else:
+                storage_repaired = _ensure_chat_index_projection_facet_schema(conn)
                 rows = conn.execute("""
                     SELECT key, value
                       FROM orch_chat_index_projection_meta
@@ -1043,7 +1055,8 @@ class ChatSurfaceReadService:
                     """).fetchall()
                 meta = {str(row["key"]): str(row["value"]) for row in rows}
                 needs_rebuild = (
-                    meta.get("source_signature") != source_signature
+                    storage_repaired
+                    or meta.get("source_signature") != source_signature
                     or meta.get("projection_schema_version")
                     != CHAT_INDEX_PROJECTION_SCHEMA_VERSION
                 )
@@ -4237,6 +4250,24 @@ def _row_get(row: Optional[Mapping[str, Any]], key: str) -> Any:
         return row[key]
     except (KeyError, IndexError):
         return None
+
+
+def _ensure_chat_index_projection_facet_schema(conn: Any) -> bool:
+    if not _table_exists(conn, "orch_chat_index_projection"):
+        return False
+    columns = table_columns(conn, "orch_chat_index_projection")
+    repaired = any(
+        column_name not in columns
+        for column_name, _ddl in _CHAT_INDEX_PROJECTION_FACET_COLUMNS
+    )
+    ensure_columns(
+        conn, "orch_chat_index_projection", _CHAT_INDEX_PROJECTION_FACET_COLUMNS
+    )
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_orch_chat_index_projection_facets
+            ON orch_chat_index_projection(facet_category, facet_scope_kind, facet_agent_kind)
+        """)
+    return repaired
 
 
 def _table_exists(conn: Any, table_name: str) -> bool:

--- a/src/codex_autorunner/core/orchestration/migrations.py
+++ b/src/codex_autorunner/core/orchestration/migrations.py
@@ -1570,6 +1570,13 @@ def _apply_v33(conn: sqlite3.Connection) -> None:
             ticket_id TEXT,
             run_id TEXT,
             group_id TEXT,
+            facet_category TEXT,
+            facet_turn_kind_list TEXT NOT NULL DEFAULT '',
+            facet_origin_kind_list TEXT NOT NULL DEFAULT '',
+            facet_transport_list TEXT NOT NULL DEFAULT '',
+            facet_scope_kind TEXT,
+            facet_scope_id TEXT,
+            facet_agent_kind TEXT,
             search_text TEXT NOT NULL DEFAULT '',
             sort_unread_priority INTEGER NOT NULL DEFAULT 0,
             sort_last_activity_desc REAL,
@@ -1608,6 +1615,10 @@ def _apply_v33(conn: sqlite3.Connection) -> None:
     conn.execute("""
         CREATE INDEX IF NOT EXISTS idx_orch_chat_index_projection_search
             ON orch_chat_index_projection(search_text)
+        """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_orch_chat_index_projection_facets
+            ON orch_chat_index_projection(facet_category, facet_scope_kind, facet_agent_kind)
         """)
 
 

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -1714,6 +1714,48 @@ def test_chat_index_snapshot_reads_rebuilt_sql_projection_without_reprojecting(
     assert archived["rows"][0]["effective_status"] == "archived"
 
 
+def test_chat_index_snapshot_repairs_missing_facet_projection_columns(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(hub_root, thread_id="thread-idle")
+    service = ChatSurfaceReadService(hub_root, durable=False)
+    service.rebuild_chat_index_projection()
+    facet_columns = (
+        "facet_category",
+        "facet_turn_kind_list",
+        "facet_origin_kind_list",
+        "facet_transport_list",
+        "facet_scope_kind",
+        "facet_scope_id",
+        "facet_agent_kind",
+    )
+
+    with open_orchestration_sqlite(hub_root, durable=False, migrate=True) as conn:
+        conn.execute("DROP INDEX IF EXISTS idx_orch_chat_index_projection_facets")
+        for column_name in facet_columns:
+            conn.execute(
+                f"ALTER TABLE orch_chat_index_projection DROP COLUMN {column_name}"
+            )
+
+    index = service.chat_index_snapshot(limit=20)
+
+    assert [row["managed_thread_id"] for row in index["rows"]] == ["thread-idle"]
+    with open_orchestration_sqlite(hub_root, durable=False, migrate=True) as conn:
+        columns = {
+            str(row["name"])
+            for row in conn.execute("PRAGMA table_info(orch_chat_index_projection)")
+        }
+        stored_schema_version = conn.execute("""
+            SELECT value
+              FROM orch_chat_index_projection_meta
+             WHERE key = 'projection_schema_version'
+            """).fetchone()["value"]
+
+    assert set(facet_columns).issubset(columns)
+    assert stored_schema_version == "chat.index.projection.facets.v1"
+
+
 def test_chat_index_rebuild_repairs_stale_archived_bound_surface_projection(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- make the chat index read model repair missing facet projection columns before status checks and rebuild inserts
- treat repaired projection storage as rebuild-worthy so facet values are repopulated immediately
- update the base chat projection table DDL to include the current facet columns and index
- add a regression test for v42 metadata with missing v39 facet columns

## Validation
- .venv/bin/python -m pytest tests/core/orchestration/test_chat_surface_read_model.py tests/core/orchestration/test_sqlite_migrations.py -q
- commit hook core lane: 9444 passed, strict mypy passed, ruff passed, black passed, guardrails passed

Closes #1929