### PR TITLE
[codex] Fix Hermes ACP chunk spacing

### DIFF
--- a/src/codex_autorunner/agents/acp/client.py
+++ b/src/codex_autorunner/agents/acp/client.py
@@ -158,7 +158,11 @@ class _PromptState:
         self._assistant_text = AssistantOutputState(stream_text=self.final_output)
 
     def note_output_delta(
-        self, text: str, *, merge_snapshot: bool = False
+        self,
+        text: str,
+        *,
+        merge_snapshot: bool = False,
+        preserve_word_boundaries: bool = False,
     ) -> ACPIngressNormalizedOutput:
         previous = self.final_output
         normalized = normalize_acp_ingress_output(
@@ -172,9 +176,13 @@ class _PromptState:
             self.last_output_normalized = True
             return normalized
         if merge_snapshot:
-            self._assistant_text.note_stream_snapshot(normalized.text)
+            self._assistant_text.note_stream_snapshot(
+                normalized.text, preserve_word_boundaries=preserve_word_boundaries
+            )
         else:
-            self._assistant_text.note_stream_delta(normalized.text)
+            self._assistant_text.note_stream_delta(
+                normalized.text, preserve_word_boundaries=preserve_word_boundaries
+            )
         self.final_output = self._assistant_text.text
         self.last_output_normalized = self.last_output_normalized or bool(
             normalized.trimmed
@@ -1197,6 +1205,7 @@ class ACPClient:
             normalized_delta = state.note_output_delta(
                 event.delta,
                 merge_snapshot=event.method == "session/update",
+                preserve_word_boundaries=event.method == "session/update",
             )
             self._log_ingress_normalization(state, normalized_delta)
             event = replace(event, delta=normalized_delta.text)

--- a/src/codex_autorunner/core/orchestration/runtime_thread_decoders.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_decoders.py
@@ -315,6 +315,7 @@ def _assistant_stream_events(
     *,
     timestamp: Optional[str] = None,
     stream_mode: str = RUN_EVENT_STREAM_MODE_SNAPSHOT,
+    preserve_word_boundaries: bool = False,
 ) -> list[RunEvent]:
     phase = str(params.get("phase") or "").strip().lower()
     if phase == "commentary":
@@ -335,6 +336,7 @@ def _assistant_stream_events(
     state.note_stream_text(
         content,
         merge_snapshot=stream_mode == RUN_EVENT_STREAM_MODE_SNAPSHOT,
+        preserve_word_boundaries=preserve_word_boundaries,
     )
     return [
         OutputDelta(
@@ -1077,6 +1079,7 @@ class SessionUpdateDecoder(MessageDecoder):
                 state,
                 timestamp=ts,
                 stream_mode=RUN_EVENT_STREAM_MODE_SNAPSHOT,
+                preserve_word_boundaries=True,
             )
         if update_kind == "agent_thought_chunk":
             progress_message = _extract_session_update_text(update)

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -386,11 +386,21 @@ class RuntimeThreadRunEventState:
             final_text=self.assistant_message_text,
         )
 
-    def note_stream_text(self, text: str, *, merge_snapshot: bool = True) -> None:
+    def note_stream_text(
+        self,
+        text: str,
+        *,
+        merge_snapshot: bool = True,
+        preserve_word_boundaries: bool = False,
+    ) -> None:
         if merge_snapshot:
-            self._assistant_text.note_stream_snapshot(text)
+            self._assistant_text.note_stream_snapshot(
+                text, preserve_word_boundaries=preserve_word_boundaries
+            )
         else:
-            self._assistant_text.note_stream_delta(text)
+            self._assistant_text.note_stream_delta(
+                text, preserve_word_boundaries=preserve_word_boundaries
+            )
         self.assistant_stream_text = self._assistant_text.stream_text
 
     def note_message_text(self, text: str) -> None:

--- a/src/codex_autorunner/core/orchestration/stream_text_merge.py
+++ b/src/codex_autorunner/core/orchestration/stream_text_merge.py
@@ -5,6 +5,70 @@ from dataclasses import dataclass
 _NO_SPACE_BEFORE = frozenset(",.;:!?)]}")
 _NO_SPACE_AFTER = frozenset("([{")
 
+# Latin subword prefixes where Hermes-style token streams may split one word
+# across chunks (for example ``inter`` + ``national`` -> ``international``).
+_SUBWORD_PREFIXES_2 = frozenset({"de", "ex", "im", "in", "re", "un"})
+_SUBWORD_PREFIXES_3_PLUS = frozenset(
+    {
+        "anti",
+        "counter",
+        "dis",
+        "extra",
+        "hyper",
+        "inter",
+        "macro",
+        "mega",
+        "meta",
+        "micro",
+        "mis",
+        "mono",
+        "multi",
+        "non",
+        "over",
+        "post",
+        "pre",
+        "pseudo",
+        "semi",
+        "sub",
+        "super",
+        "trans",
+        "under",
+    }
+)
+
+# Short compounds that stay glued when split across tiny trailing chunks.
+_SHORT_COMPOUND_MERGES = frozenset(
+    {
+        "redo",
+        "undo",
+        "preset",
+        "reapply",
+        "reopen",
+        "retest",
+        "reedit",
+    }
+)
+
+
+def _likely_subword_prefix_continuation(current: str, incoming: str) -> bool:
+    """True when ``current + incoming`` is probably one word split for streaming."""
+    if not current or not incoming:
+        return False
+    merged = f"{current}{incoming}"
+    if merged.lower() in _SHORT_COMPOUND_MERGES:
+        return True
+    if not merged.isascii() or not merged.isalpha() or not merged.islower():
+        return False
+    if incoming in _SUBWORD_PREFIXES_2 | _SUBWORD_PREFIXES_3_PLUS:
+        return False
+    if len(incoming) < 4:
+        return False
+    if current in _SUBWORD_PREFIXES_3_PLUS:
+        return True
+    if len(current) == 2 and current in _SUBWORD_PREFIXES_2:
+        return len(merged) >= 7
+    return False
+
 
 def _needs_readable_boundary(current: str, incoming: str) -> bool:
     if not current or not incoming:
@@ -20,6 +84,9 @@ def _needs_readable_boundary(current: str, incoming: str) -> bool:
     if incoming and all(char == "*" for char in incoming):
         return previous in {".", ":", ";", "!", "?"}
     if previous.isalnum() and (next_char.isalnum() or next_char in {"`", "*"}):
+        if previous.isalpha() and next_char.isalpha():
+            if _likely_subword_prefix_continuation(current, incoming):
+                return False
         return True
     if previous in {"`", "*"} and next_char.isalnum():
         return True

--- a/src/codex_autorunner/core/orchestration/stream_text_merge.py
+++ b/src/codex_autorunner/core/orchestration/stream_text_merge.py
@@ -2,6 +2,42 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+_NO_SPACE_BEFORE = frozenset(",.;:!?)]}")
+_NO_SPACE_AFTER = frozenset("([{")
+
+
+def _needs_readable_boundary(current: str, incoming: str) -> bool:
+    if not current or not incoming:
+        return False
+    previous = current[-1]
+    next_char = incoming[0]
+    if previous.isspace() or next_char.isspace():
+        return False
+    if next_char in _NO_SPACE_BEFORE:
+        return False
+    if previous in _NO_SPACE_AFTER:
+        return False
+    if incoming and all(char == "*" for char in incoming):
+        return previous in {".", ":", ";", "!", "?"}
+    if previous.isalnum() and (next_char.isalnum() or next_char in {"`", "*"}):
+        return True
+    if previous in {"`", "*"} and next_char.isalnum():
+        return True
+    if previous in {".", ":", ";", "!", "?"} and next_char in {"`", "*"}:
+        return True
+    return False
+
+
+def append_assistant_stream_text_readably(current: str, incoming: str) -> str:
+    """Append tokenized assistant chunks without erasing word boundaries."""
+
+    if not incoming:
+        return current
+    if not current:
+        return incoming
+    separator = " " if _needs_readable_boundary(current, incoming) else ""
+    return f"{current}{separator}{incoming}"
+
 
 def merge_assistant_stream_text(current: str, incoming: str) -> str:
     """Merge overlapping streamed assistant chunks without duplicating prefixes."""
@@ -27,16 +63,30 @@ class AssistantTextAccumulator:
     stream_text: str = ""
     final_text: str = ""
 
-    def append_delta(self, text: str) -> str:
+    def append_delta(self, text: str, *, preserve_word_boundaries: bool = False) -> str:
         """Record a strict append-only stream delta."""
         if isinstance(text, str) and text:
-            self.stream_text = f"{self.stream_text}{text}"
+            if preserve_word_boundaries:
+                self.stream_text = append_assistant_stream_text_readably(
+                    self.stream_text, text
+                )
+            else:
+                self.stream_text = f"{self.stream_text}{text}"
         return self.text
 
-    def merge_snapshot(self, text: str) -> str:
+    def merge_snapshot(
+        self, text: str, *, preserve_word_boundaries: bool = False
+    ) -> str:
         """Record a stream chunk that may be cumulative or overlap prior chunks."""
         if isinstance(text, str) and text:
-            self.stream_text = merge_assistant_stream_text(self.stream_text, text)
+            merged = merge_assistant_stream_text(self.stream_text, text)
+            if (
+                preserve_word_boundaries
+                and merged == f"{self.stream_text}{text}"
+                and not text.startswith(self.stream_text)
+            ):
+                merged = append_assistant_stream_text_readably(self.stream_text, text)
+            self.stream_text = merged
         return self.text
 
     def replace_final(self, text: str) -> str:
@@ -56,11 +106,19 @@ class AssistantTextAccumulator:
 class AssistantOutputState(AssistantTextAccumulator):
     """Reduced assistant output state, distinct from append-only timelines."""
 
-    def note_stream_delta(self, text: str) -> str:
-        return self.append_delta(text)
+    def note_stream_delta(
+        self, text: str, *, preserve_word_boundaries: bool = False
+    ) -> str:
+        return self.append_delta(
+            text, preserve_word_boundaries=preserve_word_boundaries
+        )
 
-    def note_stream_snapshot(self, text: str) -> str:
-        return self.merge_snapshot(text)
+    def note_stream_snapshot(
+        self, text: str, *, preserve_word_boundaries: bool = False
+    ) -> str:
+        return self.merge_snapshot(
+            text, preserve_word_boundaries=preserve_word_boundaries
+        )
 
     def note_final_message(self, text: str) -> str:
         return self.replace_final(text)

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -70,6 +70,33 @@ def test_prompt_state_session_update_snapshots_merge_without_duplication() -> No
     assert state.final_output == "fixture reply"
 
 
+def test_prompt_state_session_update_chunks_preserve_word_boundaries() -> None:
+    state = _PromptState(session_id="session-1", turn_id="turn-1")
+
+    for chunk in (
+        "Confirmed:",
+        "**",
+        "`/car/hub/read-models/chats`",
+        "returns",
+        "500",
+        "**",
+        "everything",
+        "else",
+        "is",
+        "healthy.",
+    ):
+        state.note_output_delta(
+            chunk,
+            merge_snapshot=True,
+            preserve_word_boundaries=True,
+        )
+
+    assert (
+        state.final_output
+        == "Confirmed: **`/car/hub/read-models/chats` returns 500** everything else is healthy."
+    )
+
+
 @pytest.mark.parametrize(("method"), ("session/update", "session/request_permission"))
 @pytest.mark.asyncio
 async def test_client_maps_session_scoped_official_events_without_turn_id(

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -769,6 +769,48 @@ async def test_normalize_runtime_thread_raw_event_handles_official_session_updat
     assert output[0].content == "hello world"
 
 
+async def test_normalize_runtime_thread_raw_event_preserves_hermes_token_boundaries() -> (
+    None
+):
+    state = RuntimeThreadRunEventState()
+
+    for chunk in (
+        "Confirmed:",
+        "**",
+        "`/car/hub/read-models/chats`",
+        "returns",
+        "500",
+        "**",
+        "everything",
+        "else",
+        "is",
+        "healthy.",
+    ):
+        events = await normalize_runtime_thread_raw_event(
+            {
+                "message": {
+                    "method": "session/update",
+                    "params": {
+                        "sessionId": "session-1",
+                        "turnId": "turn-1",
+                        "update": {
+                            "sessionUpdate": "agent_message_chunk",
+                            "content": {"type": "text", "text": chunk},
+                        },
+                    },
+                }
+            },
+            state,
+        )
+        assert len(events) == 1
+        assert isinstance(events[0], OutputDelta)
+
+    assert (
+        state.best_assistant_text()
+        == "Confirmed: **`/car/hub/read-models/chats` returns 500** everything else is healthy."
+    )
+
+
 async def test_normalize_runtime_thread_raw_event_maps_official_commentary_update_to_notice() -> (
     None
 ):

--- a/tests/core/orchestration/test_stream_text_merge.py
+++ b/tests/core/orchestration/test_stream_text_merge.py
@@ -27,6 +27,12 @@ def test_merge_assistant_stream_text_concatenates_when_no_overlap() -> None:
     assert merge_assistant_stream_text("alpha", "beta") == "alphabeta"
 
 
+def test_append_assistant_stream_text_readably_keeps_subword_splits_glued() -> None:
+    assert append_assistant_stream_text_readably("inter", "national") == "international"
+    assert append_assistant_stream_text_readably("non", "sense") == "nonsense"
+    assert append_assistant_stream_text_readably("re", "do") == "redo"
+
+
 def test_append_assistant_stream_text_readably_preserves_word_boundaries() -> None:
     text = ""
     for chunk in (
@@ -47,6 +53,13 @@ def test_append_assistant_stream_text_readably_preserves_word_boundaries() -> No
         text
         == "Confirmed: **`/car/hub/read-models/chats` returns 500** everything else is healthy."
     )
+
+
+def test_assistant_text_accumulator_subword_snapshots_avoid_spurious_spaces() -> None:
+    accumulator = AssistantTextAccumulator()
+    accumulator.merge_snapshot("inter", preserve_word_boundaries=True)
+    accumulator.merge_snapshot("national", preserve_word_boundaries=True)
+    assert accumulator.text == "international"
 
 
 def test_assistant_text_accumulator_records_strict_deltas() -> None:

--- a/tests/core/orchestration/test_stream_text_merge.py
+++ b/tests/core/orchestration/test_stream_text_merge.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from codex_autorunner.core.orchestration.stream_text_merge import (
     AssistantTextAccumulator,
+    append_assistant_stream_text_readably,
     merge_assistant_stream_text,
 )
 
@@ -24,6 +25,28 @@ def test_merge_assistant_stream_text_appends_only_non_overlapping_suffix() -> No
 
 def test_merge_assistant_stream_text_concatenates_when_no_overlap() -> None:
     assert merge_assistant_stream_text("alpha", "beta") == "alphabeta"
+
+
+def test_append_assistant_stream_text_readably_preserves_word_boundaries() -> None:
+    text = ""
+    for chunk in (
+        "Confirmed:",
+        "**",
+        "`/car/hub/read-models/chats`",
+        "returns",
+        "500",
+        "**",
+        "everything",
+        "else",
+        "is",
+        "healthy.",
+    ):
+        text = append_assistant_stream_text_readably(text, chunk)
+
+    assert (
+        text
+        == "Confirmed: **`/car/hub/read-models/chats` returns 500** everything else is healthy."
+    )
 
 
 def test_assistant_text_accumulator_records_strict_deltas() -> None:


### PR DESCRIPTION
## Summary
- Preserve readable word boundaries when reducing Hermes ACP `session/update` assistant chunks.
- Keep existing overlap/snapshot merge behavior for other stream paths.
- Add regression coverage for the production-style token stream that was garbling Discord output.

## Root Cause
Hermes can emit word-level `agent_message_chunk` updates such as `alpha`, `beta`, `gamma`, `delta`, `.`. CAR treated those updates like raw cumulative snapshots and concatenated them without spaces before persisting and delivering them to Discord.

## Validation
- Live local Hermes ACP smoke: `/Users/dazheng/.local/bin/hermes-m4-pma acp` emitted `['alpha', 'beta', 'gamma', 'delta', '.']` and CAR reduced it to `alpha beta gamma delta.`\n- `.venv/bin/python -m pytest tests/core/orchestration/test_stream_text_merge.py tests/core/orchestration/test_runtime_thread_events.py::test_normalize_runtime_thread_raw_event_preserves_hermes_token_boundaries tests/agents/acp/test_client.py::test_prompt_state_session_update_chunks_preserve_word_boundaries -q`\n- `.venv/bin/python -m pytest tests/core/orchestration/test_runtime_thread_decoders.py::TestSessionUpdateDecoder tests/agents/acp/test_event_normalization.py -q`\n- `.venv/bin/python -m pytest tests/agents/acp/test_client.py tests/agents/hermes/test_hermes_supervisor.py -q`\n- Commit hook aggregate lane: guardrails, mypy, full pytest (`9445 passed`), Web UI lint/build/tests (`846 passed`)\n