### PR TITLE
Default CAR apps to blessed main

### DIFF
--- a/src/codex_autorunner/bootstrap.py
+++ b/src/codex_autorunner/bootstrap.py
@@ -11,7 +11,12 @@ from .core.about_car import (
     ensure_tickets_agents_file_for_repo,
 )
 from .core.config_contract import ConfigError
-from .core.config_defaults import DEFAULT_HUB_CONFIG
+from .core.config_defaults import (
+    BLESSED_APP_REPO_ID,
+    BLESSED_APP_REPO_REF,
+    BLESSED_APP_REPO_URL,
+    DEFAULT_HUB_CONFIG,
+)
 from .core.config_generated import (
     GENERATED_CONFIG_HEADER as CORE_GENERATED_CONFIG_HEADER,
 )
@@ -33,6 +38,9 @@ HUB_CAR_SHIM_REL_PATH = Path(".codex-autorunner/bin/car")
 HUB_CAR_SHIM_ROOT_BASENAME = "car"
 PMA_DOCS_GENERATED_MARKER = "<!-- CAR:PMA_DOCS_GENERATED -->"
 PMA_ALWAYS_REFRESH_DOCS = frozenset({"prompt.md", "ABOUT_CAR.md"})
+DEFAULT_AUTOOPTIMIZE_APP_REF = (
+    f"{BLESSED_APP_REPO_ID}:apps/autooptimize@{BLESSED_APP_REPO_REF}"
+)
 
 
 def sample_todo() -> str:
@@ -57,6 +65,12 @@ def _write_doc_if_changed(path: Path, content: str) -> None:
     if existing == content:
         return
     atomic_write(path, content)
+
+
+def _render_app_doc_placeholders(content: str) -> str:
+    return content.replace(
+        "__DEFAULT_AUTOOPTIMIZE_APP_REF__", DEFAULT_AUTOOPTIMIZE_APP_REF
+    ).replace("__BLESSED_APP_REPO_URL__", BLESSED_APP_REPO_URL)
 
 
 def pma_dir(hub_root: Path) -> Path:
@@ -391,7 +405,7 @@ When pruning, append the prior context to the hub PMA `context_log.md` with a ti
 
 
 def pma_notes_content() -> str:
-    return PMA_DOCS_GENERATED_MARKER + "\n" + """# PMA Operations Guide
+    content = """# PMA Operations Guide
 
 ## Tickets (create/modify)
 
@@ -412,16 +426,17 @@ def pma_notes_content() -> str:
 ## CAR apps
 
 - Use `car apps list --repo <path>` to discover apps from configured app repos.
-- Use `car apps show blessed:apps/autooptimize --repo <path>` when a user asks about AutoOptimize.
+- Use `car apps show __DEFAULT_AUTOOPTIMIZE_APP_REF__ --repo <path>` when a user asks about AutoOptimize.
 - To use AutoOptimize:
-  `car apps install blessed:apps/autooptimize --repo <path>`
+  `car apps install __DEFAULT_AUTOOPTIMIZE_APP_REF__ --repo <path>`
   then
   `car apps apply blessed.autooptimize --repo <path> --set goal="<goal>"`.
 - If install reports an existing provenance conflict from the old in-repo
   AutoOptimize bundle, rerun with
-  `car apps install blessed:apps/autooptimize --repo <path> --force`.
+  `car apps install __DEFAULT_AUTOOPTIMIZE_APP_REF__ --repo <path> --force`.
 - Inspect runnable tools with `car apps tools blessed.autooptimize --repo <path>`.
-- Blessed app repo: `https://github.com/Git-on-my-level/blessed-car-apps`
+- Default app source: `__DEFAULT_AUTOOPTIMIZE_APP_REF__`
+- Blessed app repo: `__BLESSED_APP_REPO_URL__`
 
 ## Ticket flow (start/resume)
 
@@ -598,6 +613,7 @@ Notes:
 - Handlers should be idempotent; duplicate events can occur by design.
 - Canonical durable storage: hub `orchestration.sqlite3` automation tables.
 """
+    return PMA_DOCS_GENERATED_MARKER + "\n" + _render_app_doc_placeholders(content)
 
 
 def pma_about_content() -> str:
@@ -605,7 +621,7 @@ def pma_about_content() -> str:
 
 
 def pma_agents_content() -> str:
-    return """# PMA AGENTS (durable guidance + defaults)
+    content = """# PMA AGENTS (durable guidance + defaults)
 
 This document is jointly maintained by the user and PMA.
 
@@ -630,14 +646,15 @@ This document is jointly maintained by the user and PMA.
 ## CAR app shortcuts (optional)
 
 - Discover apps with `car apps list --repo <path>`.
-- AutoOptimize lives at `blessed:apps/autooptimize` and installs as `blessed.autooptimize`.
+- AutoOptimize lives at `__DEFAULT_AUTOOPTIMIZE_APP_REF__` and installs as `blessed.autooptimize`.
 - When a user asks to use AutoOptimize, inspect it with
-  `car apps show blessed:apps/autooptimize --repo <path>`, install it with
-  `car apps install blessed:apps/autooptimize --repo <path>`, then apply it with
+  `car apps show __DEFAULT_AUTOOPTIMIZE_APP_REF__ --repo <path>`, install it with
+  `car apps install __DEFAULT_AUTOOPTIMIZE_APP_REF__ --repo <path>`, then apply it with
   `car apps apply blessed.autooptimize --repo <path> --set goal="<goal>"`.
 - If install reports a provenance conflict from an older in-repo
   AutoOptimize install, rerun the install command with `--force`.
-- Blessed app repo: `https://github.com/Git-on-my-level/blessed-car-apps`
+- Default app source: `__DEFAULT_AUTOOPTIMIZE_APP_REF__`
+- Blessed app repo: `__BLESSED_APP_REPO_URL__`
 
 ## CLI help-first rule
 
@@ -649,6 +666,7 @@ This document is jointly maintained by the user and PMA.
 - Default to managed threads for straightforward single-session work; promote to ticket flow only when the work needs ordered multi-step structure.
 - After implementation work, add a final review ticket, then a ticket to open a PR.
 """
+    return _render_app_doc_placeholders(content)
 
 
 def pma_active_context_content() -> str:

--- a/src/codex_autorunner/core/config_defaults.py
+++ b/src/codex_autorunner/core/config_defaults.py
@@ -11,6 +11,9 @@ from .report_retention import (
 TWELVE_HOUR_SECONDS = 12 * 60 * 60
 PMA_DEFAULT_MAX_TEXT_CHARS = 10_000
 PMA_DEFAULT_TURN_IDLE_TIMEOUT_SECONDS = 1800
+BLESSED_APP_REPO_ID = "blessed"
+BLESSED_APP_REPO_URL = "https://github.com/Git-on-my-level/blessed-car-apps"
+BLESSED_APP_REPO_REF = "main"
 
 
 def _default_agents_section() -> Dict[str, Any]:
@@ -345,10 +348,10 @@ def _default_apps_section() -> Dict[str, Any]:
         "enabled": True,
         "repos": [
             {
-                "id": "blessed",
-                "url": "https://github.com/Git-on-my-level/blessed-car-apps",
+                "id": BLESSED_APP_REPO_ID,
+                "url": BLESSED_APP_REPO_URL,
                 "trusted": True,
-                "default_ref": "main",
+                "default_ref": BLESSED_APP_REPO_REF,
             }
         ],
     }

--- a/tests/core/apps/test_apps_config.py
+++ b/tests/core/apps/test_apps_config.py
@@ -11,6 +11,11 @@ from codex_autorunner.core.config import (
     load_hub_config,
     load_repo_config,
 )
+from codex_autorunner.core.config_defaults import (
+    BLESSED_APP_REPO_ID,
+    BLESSED_APP_REPO_REF,
+    BLESSED_APP_REPO_URL,
+)
 from codex_autorunner.core.config_parsers import (
     _parse_apps_config,
     _parse_templates_config,
@@ -109,11 +114,10 @@ def test_default_loaded_config_exposes_apps_shape(tmp_path: Path) -> None:
     repo_config = load_repo_config(repo_root, hub_path=hub_root)
 
     assert hub_config.apps.enabled is True
-    assert hub_config.apps.repos
-    assert hub_config.apps.repos[0].id == "blessed"
-    assert hub_config.apps.repos[0].url == (
-        "https://github.com/Git-on-my-level/blessed-car-apps"
-    )
+    assert len(hub_config.apps.repos) == 1
+    assert hub_config.apps.repos[0].id == BLESSED_APP_REPO_ID
+    assert hub_config.apps.repos[0].url == BLESSED_APP_REPO_URL
+    assert hub_config.apps.repos[0].default_ref == BLESSED_APP_REPO_REF
     assert repo_config.apps.enabled is True
     assert repo_config.apps.repos == hub_config.apps.repos
 
@@ -124,7 +128,12 @@ def test_default_hub_config_keeps_template_and_app_catalogs_separate() -> None:
         "https://github.com/Git-on-my-level/car-ticket-templates"
     )
 
-    assert DEFAULT_HUB_CONFIG["apps"]["repos"][0]["id"] == "blessed"
-    assert DEFAULT_HUB_CONFIG["apps"]["repos"][0]["url"] == (
-        "https://github.com/Git-on-my-level/blessed-car-apps"
-    )
+    app_repos = DEFAULT_HUB_CONFIG["apps"]["repos"]
+    assert app_repos == [
+        {
+            "id": BLESSED_APP_REPO_ID,
+            "url": BLESSED_APP_REPO_URL,
+            "trusted": True,
+            "default_ref": BLESSED_APP_REPO_REF,
+        }
+    ]

--- a/tests/test_pma_bootstrap.py
+++ b/tests/test_pma_bootstrap.py
@@ -72,14 +72,17 @@ def test_pma_files_created_on_hub_init(tmp_path: Path) -> None:
     assert "--path <hub_root>" in about_content
     assert "https://github.com/Git-on-my-level/car-ticket-templates" in about_content
     assert "## CAR apps" in about_content
-    assert "car apps show blessed:apps/autooptimize --repo <path>" in about_content
-    assert "car apps install blessed:apps/autooptimize --repo <path>" in about_content
+    assert "car apps show blessed:apps/autooptimize@main --repo <path>" in about_content
+    assert (
+        "car apps install blessed:apps/autooptimize@main --repo <path>" in about_content
+    )
     assert "car apps apply blessed.autooptimize --repo <path>" in about_content
     assert "provenance conflict from the old in-repo" in about_content
     assert (
-        "car apps install blessed:apps/autooptimize --repo <path> --force"
+        "car apps install blessed:apps/autooptimize@main --repo <path> --force"
         in about_content
     )
+    assert "Default app source: `blessed:apps/autooptimize@main`" in about_content
     assert "https://github.com/Git-on-my-level/blessed-car-apps" in about_content
     assert "Ticket flow mechanics (planning constraints)" in about_content
     assert "Ticket turn prompt context" in about_content
@@ -103,10 +106,14 @@ def test_pma_files_created_on_hub_init(tmp_path: Path) -> None:
     assert "--path <hub_root>" in agents_content
     assert "https://github.com/Git-on-my-level/car-ticket-templates" in agents_content
     assert "## CAR app shortcuts" in agents_content
-    assert "AutoOptimize lives at `blessed:apps/autooptimize`" in agents_content
-    assert "car apps install blessed:apps/autooptimize --repo <path>" in agents_content
+    assert "AutoOptimize lives at `blessed:apps/autooptimize@main`" in agents_content
+    assert (
+        "car apps install blessed:apps/autooptimize@main --repo <path>"
+        in agents_content
+    )
     assert "provenance conflict from an older in-repo" in agents_content
     assert "rerun the install command with `--force`" in agents_content
+    assert "Default app source: `blessed:apps/autooptimize@main`" in agents_content
     assert "https://github.com/Git-on-my-level/blessed-car-apps" in agents_content
     assert (
         "Default to managed threads for straightforward single-session work"


### PR DESCRIPTION
## Summary
- centralize the blessed CAR apps repo default as blessed/main
- update generated PMA app guidance to use explicit blessed:apps/autooptimize@main installs
- add regression coverage that seeded installs expose only the blessed app repo default

## Validation
- commit hook aggregate validation passed: guardrails, ruff, mypy, full pytest (9448 passed), Web Hub lint/build/tests (846 passed)
- focused pytest: tests/core/apps/test_apps_config.py tests/test_pma_bootstrap.py