### PR TITLE
[codex] Fix chat facet filter semantics

### DIFF
--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -2766,13 +2766,16 @@ def _chat_row_facet_category(row: Mapping[str, Any]) -> str:
         return "ticket_run"
     if _chat_row_has_automation_facts(row):
         return "automation"
-    turn_kinds = set(_chat_row_facet_turn_kinds(row))
-    origin_kinds = set(_chat_row_facet_origin_kinds(row))
-    if turn_kinds & {"publish", "recovery", "lifecycle"}:
-        return "system"
-    if origin_kinds & {"publish", "recovery", "system"}:
+    if _chat_row_is_explicit_system_control_plane(row):
         return "system"
     return "regular"
+
+
+def _chat_row_is_explicit_system_control_plane(row: Mapping[str, Any]) -> bool:
+    explicit_kind = _normalize_kind(row.get("chat_kind") or row.get("thread_kind"))
+    if explicit_kind in {"system", "internal", "control_plane", "control-plane"}:
+        return True
+    return "system" in set(_chat_row_facet_origin_kinds(row))
 
 
 def _chat_row_has_automation_facts(row: Mapping[str, Any]) -> bool:
@@ -3015,6 +3018,8 @@ def _chat_index_facet_counts(
         for value in _values_from_pipe_list(row["facet_origin_kind_list"]):
             _increment_count(counts["origin_kind"], value)
         for value in _values_from_pipe_list(row["facet_transport_list"]):
+            if value == "pma":
+                continue
             _increment_count(counts["transport"], value)
         _increment_count(counts["scope_kind"], _normalize_text(row["facet_scope_kind"]))
         _increment_count(counts["agent_kind"], _normalize_text(row["facet_agent_kind"]))

--- a/src/codex_autorunner/surfaces/web/read_model_contracts.py
+++ b/src/codex_autorunner/surfaces/web/read_model_contracts.py
@@ -163,7 +163,13 @@ class ChatIndexFacets(ReadModelContract):
 
 
 class ChatFacetCounts(ReadModelContract):
-    """Backend projection counts for the full matching chat-index scope."""
+    """Backend projection counts for the full matching chat-index scope.
+
+    Counts are computed before pagination for the current backend query/filter
+    scope. ``transport`` is the user-facing external-channel count set and
+    intentionally excludes the PMA home/control surface even though rows may
+    still carry ``pma`` in ``facets.transports`` for badges and compatibility.
+    """
 
     category: dict[ChatFacetCategory, int] = Field(default_factory=dict)
     turn_kind: dict[ChatFacetTurnKind, int] = Field(default_factory=dict)

--- a/src/codex_autorunner/web_frontend/src/app.css
+++ b/src/codex_autorunner/web_frontend/src/app.css
@@ -3941,6 +3941,11 @@ textarea:hover {
   margin: 0;
 }
 
+.state-panel .state-panel-detail {
+  color: var(--color-ink-muted);
+  font-size: var(--font-size-0);
+}
+
 .state-panel button {
   justify-self: start;
   margin-left: 0;

--- a/src/codex_autorunner/web_frontend/src/lib/components/FilterRow.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/FilterRow.svelte
@@ -15,6 +15,7 @@
   interface Props {
     items: FilterChip[];
     ariaLabel?: string;
+    label?: string;
     rootClass?: string;
     role?: 'tablist';
     itemRole?: 'tab';
@@ -26,6 +27,7 @@
   const {
     items,
     ariaLabel,
+    label,
     rootClass = '',
     role,
     itemRole,
@@ -95,6 +97,9 @@
 
 <div class="filter-row-container" bind:this={containerEl}>
   <div class="{rowClass} filter-row-measure" bind:this={measureEl} aria-hidden="true">
+    {#if label}
+      <span class="filter-row-label">{label}</span>
+    {/if}
     {#each items as item (item.key)}
       <button class="chip" type="button" tabindex="-1" data-filter-chip>
         {item.label}
@@ -107,6 +112,9 @@
 
   {#if collapsed}
     <div class={rowClass} aria-label={ariaLabel}>
+      {#if label}
+        <span class="filter-row-label">{label}</span>
+      {/if}
       <!-- Keep the collapsed menu button-driven; native details/summary can swallow option clicks
         when this absolute menu is layered over virtualized scroll content. -->
       <div class="filter-dropdown" class:open={dropdownOpen} bind:this={dropdownEl}>
@@ -149,6 +157,9 @@
     </div>
   {:else}
     <div class={rowClass} {role} aria-label={ariaLabel}>
+      {#if label}
+        <span class="filter-row-label">{label}</span>
+      {/if}
       {#each items as item (item.key)}
         <button
           class:active={item.active}
@@ -218,5 +229,17 @@
   .filter-dropdown-menu :global(.chip) {
     justify-content: space-between;
     width: 100%;
+  }
+
+  .filter-row-label {
+    display: inline-flex;
+    align-items: center;
+    min-height: 26px;
+    color: var(--color-ink-muted);
+    font-size: var(--font-size-0);
+    font-weight: 700;
+    letter-spacing: 0;
+    text-transform: uppercase;
+    white-space: nowrap;
   }
 </style>

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -41,6 +41,7 @@ import {
   pmaChatKindLabel,
   pmaChatHeaderScopeLine,
   pmaChatIsAutomation,
+  chatCategoryLabel,
   chatRunGroupSummaryParts,
   chatMessengerSurface,
   pmaChatScopeLabelFromChat,
@@ -1023,6 +1024,31 @@ describe('PMA chat view helpers', () => {
     const list = [discordChat, hubChat];
     expect(filterPmaChats(list, chatSurfaceFilterToken('discord'), '')).toEqual([discordChat]);
     expect(chatSurfaceFilterOptions(list)).toEqual([{ slug: 'discord', label: 'Discord', count: 1 }]);
+  });
+
+  it('keeps PMA out of external channel filter options', () => {
+    const pmaOnly = {
+      ...baseChat,
+      id: 'pma-only',
+      title: 'PMA home chat',
+      raw: { facets: { category: 'regular', turnKinds: ['message'], originKinds: ['surface'], transports: ['pma'] } }
+    };
+    const discordBound = {
+      ...baseChat,
+      id: 'discord-bound',
+      title: 'Discord bound chat',
+      raw: { facets: { category: 'regular', turnKinds: ['message'], originKinds: ['surface'], transports: ['pma', 'discord'] } }
+    };
+
+    expect(chatMessengerSurface(pmaOnly)).toBeNull();
+    expect(chatSurfaceFilterOptions([pmaOnly, discordBound])).toEqual([
+      { slug: 'discord', label: 'Discord', count: 1 }
+    ]);
+  });
+
+  it('labels regular chat facets as user-facing chats', () => {
+    expect(chatCategoryLabel('regular')).toBe('Chats');
+    expect(chatCategoryLabel('ticket_run')).toBe('Ticket Runs');
   });
 
   it('renders transport badges from typed facets instead of raw surface fields', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -26,6 +26,8 @@ export type ChatFilter = ChatStatusFilter | 'ticket_runs' | 'automation' | `surf
 /** Token for the chats sidebar filter that lists only ticket-flow run groups (collapsed headers). */
 export const CHAT_TICKET_RUNS_FILTER = 'ticket_runs' as const satisfies ChatFilter;
 
+export const CHAT_EXTERNAL_TRANSPORT_FILTERS = ['discord', 'telegram', 'notification'] as const satisfies readonly ChatFacetTransport[];
+
 /** Synthetic list selection id for pinned PMA Memory in the chats sidebar. */
 export const CHAT_MEMORY_LIST_ID = '__memory__';
 
@@ -81,6 +83,16 @@ export function pmaChatFacets(chat: PmaChatSummary | null): ChatIndexFacets | nu
 
 export function chatTransportLabel(transport: ChatFacetTransport): string {
   return transport === 'pma' ? 'PMA' : messengerSurfaceLabel(transport);
+}
+
+export function chatCategoryLabel(category: ChatIndexFacets['category']): string {
+  const map: Record<ChatIndexFacets['category'], string> = {
+    regular: 'Chats',
+    ticket_run: 'Ticket Runs',
+    automation: 'Automation',
+    system: 'System'
+  };
+  return map[category];
 }
 
 export function pmaChatTransportBadges(

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -20,7 +20,6 @@
     type PmaQueuedTurn
   } from '$lib/api/client';
   import {
-    CHAT_TICKET_RUN_GROUP_WINDOW_REQUEST,
     invalidateReadModelTags,
     readModelEntityStore,
     readModelEntityTags,
@@ -236,7 +235,7 @@
     search
   });
   const currentChatIndexRequest = $derived<ChatIndexWindowRequest>(chatIndexRequestForCurrentFilters());
-  const ticketRunGroupRequest = $derived<ChatIndexWindowRequest>(CHAT_TICKET_RUN_GROUP_WINDOW_REQUEST);
+  const ticketRunGroupRequest = $derived<ChatIndexWindowRequest>(chatTicketRunGroupRequestForFilters());
   const persistedChats = $derived<PmaChatSummary[]>(selectPmaChats(readModelState, currentChatIndexRequest));
   const facetPersistedChats = $derived<PmaChatSummary[]>(selectPmaChats(readModelState, { filter: 'all', limit: 50 }));
   const backendTicketRunGroups = $derived(selectTicketRunGroups(readModelState, ticketRunGroupRequest));
@@ -780,6 +779,20 @@
     };
   }
 
+  function chatTicketRunGroupRequestForFilters(): ChatIndexWindowRequest {
+    return {
+      filter: statusFilter,
+      query: search.trim() || null,
+      facets: {
+        categories: ['ticket_run'],
+        transports: transportFilter ? [transportFilter] : [],
+        scopeKinds: scopeKindFilter ? [scopeKindFilter] : []
+      },
+      groupBy: 'ticket_run',
+      limit: 50
+    };
+  }
+
   function chatStatusFilterCounts(): Record<ChatStatusFilter, number> {
     const counters = selectedChatWindowView.window ? selectedChatWindowView.counters : readModelState.chatCounters;
     const knownChats = facetChats;
@@ -946,6 +959,10 @@
 
   $effect(() => {
     pageController.setIndexRequest(currentChatIndexRequest);
+  });
+
+  $effect(() => {
+    chatIndexSession.setCompanionRequests([ticketRunGroupRequest]);
   });
 
   $effect(() => {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -119,12 +119,14 @@
     mergeChatFacetSourceChats,
     mergeLocalChatPlaceholders,
     CHAT_FILTER_ORDER,
+    CHAT_EXTERNAL_TRANSPORT_FILTERS,
     CHAT_TICKET_RUNS_FILTER,
     pmaChatKind,
     pmaChatKindLabel,
     pmaChatHeaderScopeLine,
     pmaChatFacets,
     pmaChatTransportBadges,
+    chatCategoryLabel,
     chatTransportLabel,
     pmaChatScopeTagView,
     progressPercent,
@@ -495,8 +497,7 @@
   const filterSummaryChips = $derived(
     buildChatFilterSummaryChips(chatListFilters, {
       status: filterChipLabel,
-      category: (key) =>
-        key === 'ticket_run' ? 'Ticket Runs' : facetChipLabel(key),
+      category: chatCategoryLabel,
       transport: chatTransportLabel,
       scopeKind: facetChipLabel
     })
@@ -806,15 +807,13 @@
 
   function chatCategoryFilterOptions(): { key: ChatFacetCategory; label: string; count: number }[] {
     const counts = contextualFacetCounts.category;
-    const order: { key: ChatFacetCategory; label: string }[] = [
-      { key: 'regular', label: 'Regular' },
-      { key: 'ticket_run', label: 'Ticket Runs' },
-      { key: 'automation', label: 'Automation' },
-      { key: 'system', label: 'System' }
+    const order: { key: ChatFacetCategory; label: string; count: number }[] = [
+      { key: 'regular', label: chatCategoryLabel('regular'), count: counts.regular ?? 0 },
+      { key: 'ticket_run', label: chatCategoryLabel('ticket_run'), count: ticketRunGroupCount },
+      { key: 'automation', label: chatCategoryLabel('automation'), count: counts.automation ?? 0 },
+      { key: 'system', label: chatCategoryLabel('system'), count: counts.system ?? 0 }
     ];
-    return order
-      .map((item) => ({ ...item, count: counts[item.key] ?? 0 }))
-      .filter((item) => item.count > 0 || categoryFilter === item.key);
+    return order.filter((item) => item.count > 0 || categoryFilter === item.key);
   }
 
   const hasNonStatusFilter = $derived(
@@ -881,8 +880,7 @@
 
   function chatTransportFilterOptions(): { key: ChatFacetTransport; label: string; count: number }[] {
     const counts = contextualFacetCounts.transport;
-    const order: ChatFacetTransport[] = ['pma', 'discord', 'telegram', 'notification'];
-    return order
+    return [...CHAT_EXTERNAL_TRANSPORT_FILTERS]
       .map((transport) => ({ key: transport, label: chatTransportLabel(transport), count: counts[transport] ?? 0 }))
       .filter((item) => item.count > 0 || transportFilter === item.key);
   }
@@ -1520,6 +1518,15 @@
   function chatIndexLoadError(): ApiError | null {
     const data = safePageData();
     return data?.chatIndex?.status === 'error' ? data.chatIndex.error : null;
+  }
+
+  function apiErrorDetailText(error: ApiError): string | null {
+    const parts = [
+      error.status ? `HTTP ${error.status}` : null,
+      error.code && error.code !== `http_${error.status ?? ''}` ? error.code : null
+    ].filter(Boolean);
+    if (parts.length === 0) return null;
+    return parts.join(' · ');
   }
 
   function currentRouteSnapshot() {
@@ -2468,6 +2475,9 @@
         <div class="state-panel error">
           <strong>Could not load chats</strong>
           <p>{visibleChatError.message}</p>
+          {#if apiErrorDetailText(visibleChatError)}
+            <p class="state-panel-detail">{apiErrorDetailText(visibleChatError)}</p>
+          {/if}
           <button type="button" onclick={() => void pageController.refreshIndex()}>Retry</button>
         </div>
       {:else}

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -176,18 +176,22 @@ describe('/chats page', () => {
         category: { regular: 2, automation: 1 },
         turnKind: { automation: 1 },
         originKind: { automation: 1 },
-        transport: { pma: 2, discord: 1 },
+        transport: { pma: 2, discord: 4 },
         scopeKind: { hub: 2, worktree: 1 },
         agentKind: { coding_agent: 1 }
       }
     });
 
     const { body } = render(Page);
+    const pageSource = chatDetailPageSource();
 
     expect(body).toContain('More filters');
-    expect(body).toContain('Automation');
     expect(body).toContain('Discord');
+    expect(body).not.toContain('PMA 2');
     expect(body).toContain('Automation Discord');
+    expect(pageSource).toContain("chatCategoryLabel('regular')");
+    expect(pageSource).toContain('CHAT_EXTERNAL_TRANSPORT_FILTERS');
+    expect(pageSource).toContain('contextualFacetCounts.transport');
   });
 
   it('renders cached chat rows instead of the skeleton while the index cursor is still missing', () => {
@@ -291,11 +295,14 @@ describe('/chats page', () => {
     );
 
     const { body } = render(Page);
+    const pageSource = chatDetailPageSource();
 
+    expect(body).toContain('More filters');
     expect(body).toContain('2 active');
     expect(body).toContain('3/5 done');
     expect(body).toContain('Generic completed chat');
     expect(body).not.toContain('4/6 done');
+    expect(pageSource).toContain('ticketRunGroupCount');
   });
 
   it('registers ticket-run aggregate refresh as a chat-index companion window', () => {

--- a/src/codex_autorunner/web_frontend/vite.config.ts
+++ b/src/codex_autorunner/web_frontend/vite.config.ts
@@ -1,10 +1,52 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
+import type { ProxyOptions } from 'vite';
+import type { ServerResponse } from 'node:http';
+
+function isServerResponse(response: unknown): response is ServerResponse {
+  return (
+    typeof response === 'object' &&
+    response !== null &&
+    'writeHead' in response &&
+    'end' in response
+  );
+}
+
+function hubProxy(target: string, options: ProxyOptions = {}): ProxyOptions {
+  return {
+    target,
+    changeOrigin: false,
+    ...options,
+    configure(proxy, proxyOptions) {
+      options.configure?.(proxy, proxyOptions);
+      proxy.on('error', (error, request, response) => {
+        if (!isServerResponse(response) || response.headersSent) return;
+        const code = typeof error === 'object' && error && 'code' in error
+          ? String((error as { code?: unknown }).code)
+          : 'proxy_error';
+        const detail = [
+          `Hub proxy failed while forwarding ${request.method ?? 'GET'} ${request.url ?? ''}.`,
+          `Target ${target} is not reachable.`,
+          code ? `Underlying error: ${code}` : null
+        ].filter(Boolean).join(' ');
+        response.writeHead(502, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({
+          code: 'hub_proxy_error',
+          detail,
+          proxy_target: target,
+          upstream_error_code: code,
+          request_path: request.url ?? null
+        }));
+      });
+    }
+  };
+}
 
 export default defineConfig(() => {
   const hubTarget =
     process.env.CAR_HUB_PROXY_TARGET?.trim() ||
     `http://127.0.0.1:${process.env.CAR_HUB_PROXY_PORT ?? '4173'}`;
+  const hubBasePath = (process.env.CAR_HUB_PROXY_BASE_PATH?.trim() || '/car').replace(/\/+$/, '');
 
   return {
     plugins: [sveltekit()],
@@ -14,12 +56,13 @@ export default defineConfig(() => {
       // changeOrigin:true breaks that for split-port dev (5173 UI vs 4173 API) while
       // production serves the built SPA from the hub (single origin, no proxy).
       proxy: {
-        '/hub': { target: hubTarget, changeOrigin: false, ws: true },
-        '/api': { target: hubTarget, changeOrigin: false },
-        '/health': { target: hubTarget, changeOrigin: false },
-        '/repos': {
-          target: hubTarget,
-          changeOrigin: false,
+        '/hub': hubProxy(hubTarget, { ws: true }),
+        '/api': hubProxy(hubTarget),
+        '/health': hubProxy(hubTarget),
+        [`${hubBasePath}/hub`]: hubProxy(hubTarget, { ws: true }),
+        [`${hubBasePath}/api`]: hubProxy(hubTarget),
+        [`${hubBasePath}/health`]: hubProxy(hubTarget),
+        '/repos': hubProxy(hubTarget, {
           bypass(req) {
             const path = req.url?.split('?')[0] ?? '';
             if (/^\/repos\/[^/]+\/api(\/|$)/.test(path)) {
@@ -27,7 +70,7 @@ export default defineConfig(() => {
             }
             return req.url;
           }
-        }
+        })
       }
     },
     build: {},

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -572,6 +572,15 @@ def test_chat_index_regular_category_excludes_ticket_automation_and_system(
 ) -> None:
     hub_root = tmp_path / "hub"
     _seed_thread(hub_root, thread_id="regular")
+    for request_kind in ("recovery", "publish", "lifecycle"):
+        _seed_thread(hub_root, thread_id=f"ordinary-{request_kind}")
+        _seed_execution(
+            hub_root,
+            thread_id=f"ordinary-{request_kind}",
+            status="completed",
+            execution_id=f"exec-ordinary-{request_kind}",
+            metadata={"origin": {"kind": request_kind, "source_id": "test"}},
+        )
     _seed_thread(
         hub_root,
         thread_id="ticket",
@@ -594,6 +603,15 @@ def test_chat_index_regular_category_excludes_ticket_automation_and_system(
         metadata={},
     )
     with open_orchestration_sqlite(hub_root, durable=False, migrate=True) as conn:
+        for request_kind in ("recovery", "publish", "lifecycle"):
+            conn.execute(
+                """
+                UPDATE orch_thread_executions
+                   SET request_kind = ?
+                 WHERE execution_id = ?
+                """,
+                (request_kind, f"exec-ordinary-{request_kind}"),
+            )
         conn.execute(
             """
             UPDATE orch_thread_executions
@@ -621,7 +639,12 @@ def test_chat_index_regular_category_excludes_ticket_automation_and_system(
         facets={"categories": ["regular"]},
         limit=20,
     )
-    assert [row["managed_thread_id"] for row in regular["rows"]] == ["regular"]
+    assert {row["managed_thread_id"] for row in regular["rows"]} == {
+        "ordinary-lifecycle",
+        "ordinary-publish",
+        "ordinary-recovery",
+        "regular",
+    }
 
     all_rows = {
         row["managed_thread_id"]: row
@@ -630,6 +653,56 @@ def test_chat_index_regular_category_excludes_ticket_automation_and_system(
     assert all_rows["ticket"]["facets"]["category"] == "ticket_run"
     assert all_rows["automation"]["facets"]["category"] == "automation"
     assert all_rows["system"]["facets"]["category"] == "system"
+    assert all_rows["ordinary-recovery"]["facets"]["category"] == "regular"
+    assert "recovery" in all_rows["ordinary-recovery"]["facets"]["turn_kinds"]
+    assert "recovery" in all_rows["ordinary-recovery"]["facets"]["origin_kinds"]
+
+
+def test_chat_index_regular_category_keeps_non_system_recovery_metadata(
+    tmp_path: Path,
+) -> None:
+    hub_root = tmp_path / "hub"
+    _seed_thread(hub_root, thread_id="regular-recovery")
+    _seed_execution(
+        hub_root,
+        thread_id="regular-recovery",
+        status="completed",
+        metadata={},
+    )
+    with open_orchestration_sqlite(hub_root, durable=False, migrate=True) as conn:
+        conn.execute(
+            """
+            UPDATE orch_thread_executions
+               SET request_kind = 'recovery',
+                   turn_request_json = ?
+             WHERE thread_target_id = 'regular-recovery'
+            """,
+            (
+                json.dumps(
+                    {
+                        "request_id": "req-regular-recovery",
+                        "target_kind": "thread",
+                        "target_id": "regular-recovery",
+                        "request_kind": "recovery",
+                        "prompt": "recover",
+                        "origin": {"kind": "surface", "source_id": "discord"},
+                    }
+                ),
+            ),
+        )
+
+    snapshot = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(
+        view="all",
+        limit=20,
+    )
+
+    row = next(
+        row
+        for row in snapshot["rows"]
+        if row["managed_thread_id"] == "regular-recovery"
+    )
+    assert row["facets"]["category"] == "regular"
+    assert "recovery" in row["facets"]["turn_kinds"]
 
 
 def test_chat_index_transport_facets_and_counts(tmp_path: Path) -> None:
@@ -671,12 +744,20 @@ def test_chat_index_transport_facets_and_counts(tmp_path: Path) -> None:
         limit=20,
     )
 
-    assert snapshot["facet_counts"]["transport"]["pma"] == 3
+    assert "pma" not in snapshot["facet_counts"]["transport"]
     assert snapshot["facet_counts"]["transport"]["discord"] == 1
     assert snapshot["facet_counts"]["transport"]["telegram"] == 1
     assert snapshot["facet_counts"]["transport"]["notification"] == 1
     rows = {row["managed_thread_id"]: row for row in snapshot["rows"]}
+    assert "pma" in rows["pma-thread"]["facets"]["transports"]
     assert "notification" in rows["discord-thread"]["facets"]["transports"]
+
+    discord = ChatSurfaceReadService(hub_root, durable=False).chat_index_snapshot(
+        view="all",
+        facets={"transports": ["discord"]},
+        limit=20,
+    )
+    assert [row["managed_thread_id"] for row in discord["rows"]] == ["discord-thread"]
 
 
 def test_chat_index_visible_chrome_uses_user_visible_prompt_metadata_not_delimiter_stripping(

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -696,6 +696,64 @@ def test_hub_read_models_chats_returns_backend_facets_and_counts(hub_env) -> Non
     assert snapshot.facet_request.categories == ["automation"]
 
 
+def test_hub_read_models_chats_transport_counts_are_external_channels(
+    hub_env,
+) -> None:
+    for index in range(5):
+        _insert_chat_thread_row(
+            hub_env.hub_root,
+            thread_id=f"route-pma-{index}",
+            repo_id="repo",
+            resource_kind="repo",
+            resource_id="repo",
+            display_name=f"Route PMA {index}",
+            runtime_status="idle",
+            updated_at=f"2026-05-11T00:0{index}:00Z",
+        )
+    _insert_chat_thread_row(
+        hub_env.hub_root,
+        thread_id="route-discord",
+        repo_id="repo",
+        resource_kind="repo",
+        resource_id="repo",
+        display_name="Route Discord",
+        runtime_status="idle",
+        updated_at="2026-05-10T00:00:00Z",
+    )
+    OrchestrationBindingStore(hub_env.hub_root, durable=True).upsert_binding(
+        surface_kind="discord",
+        surface_key="guild:channel",
+        thread_target_id="route-discord",
+        repo_id="repo",
+        resource_kind="repo",
+        resource_id="repo",
+    )
+
+    client = TestClient(create_hub_app(hub_env.hub_root))
+    response = client.get(
+        "/hub/read-models/chats",
+        params={"filter": "all", "limit": "1"},
+    )
+
+    assert response.status_code == 200
+    snapshot = load_read_model_contract(ChatIndexSnapshot, response.json())
+    assert snapshot.facet_counts.transport == {"discord": 1}
+
+    discord_response = client.get(
+        "/hub/read-models/chats",
+        params=[("filter", "all"), ("transport", "discord"), ("limit", "1")],
+    )
+
+    assert discord_response.status_code == 200
+    discord_snapshot = load_read_model_contract(
+        ChatIndexSnapshot, discord_response.json()
+    )
+    assert [row.chat_id for row in discord_snapshot.rows] == ["route-discord"]
+    assert discord_snapshot.rows[0].facets is not None
+    assert "discord" in discord_snapshot.rows[0].facets.transports
+    assert "pma" not in discord_snapshot.facet_counts.transport
+
+
 def test_chat_index_contract_status_matches_backend_effective_statuses(
     hub_env,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes the chat facet system so type/channel filters match the actual chat semantics after the move to backend-provided facet snapshots.

## Root Cause

The new facet-driven filtering mixed row classification, transport badges, and filter dimensions too loosely:

- ordinary chats with recovery/publish/lifecycle metadata could be counted as `system`
- `pma` was counted as a channel filter even though it is the home/control surface and appears on many rows as a badge
- the frontend rendered category labels and counts directly from raw facets, so `regular` surfaced as an implementation category rather than the user-facing `Chats` concept

## Changes

- Tightened backend chat category classification so only explicit control-plane rows count as `system`.
- Kept PMA available as a row badge while excluding it from channel facet filter counts.
- Updated the chat filter UI integration to use backend window facet counts with upstream's collapsed `More Filters` UX.
- Added clearer labels for category filters (`Chats`, `Ticket Runs`, `System`).
- Improved Vite hub proxy errors so dev failures surface the underlying proxy error code.
- Added regression tests for category classification, external channel counts, and frontend filter rendering.

## Validation

- Commit hook passed on the original commit before rebase:
  - Black/Ruff/import boundary checks
  - mypy
  - full Python test suite: `9450 passed`
  - Web UI lint/build/tests: `848 passed, 2 skipped`
- Post-rebase focused checks:
  - `.venv/bin/python -m pytest -q tests/core/orchestration/test_chat_surface_read_model.py tests/surfaces/web/test_hub_chat_read_model_routes.py` -> `75 passed`
  - `pnpm --filter @codex-autorunner/web-hub exec vitest run src/routes/chats/page.test.ts src/lib/viewModels/pmaChat.test.ts` -> `105 passed`
  - `pnpm --filter @codex-autorunner/web-hub lint` -> `svelte-check found 0 errors and 0 warnings`

## Notes

Also opened #1934 for a separate artifact-delivery runtime target env issue discovered while trying to send the screenshot from this branch.
