### PR TITLE
[codex] Resolve stale clean commit barriers

### DIFF
--- a/src/codex_autorunner/core/flows/reconciler.py
+++ b/src/codex_autorunner/core/flows/reconciler.py
@@ -881,20 +881,14 @@ def reconcile_flow_run(
                     dict(record.state or {}),
                 )
                 state = _with_commit_barrier_recovery(state, commit_barrier)
-                if state != (record.state or {}):
+                state_changed = state != (record.state or {})
+                if state_changed:
                     updated = store.update_flow_run_status(
                         run_id=record.id,
                         status=record.status,
                         state=state,
                     )
-                    emit_reconcile_noop(
-                        store=store,
-                        run_id=record.id,
-                        status=record.status,
-                        note=decision.note,
-                        worker_status=health.status,
-                    )
-                    return (updated or record), bool(updated), False
+                    record = updated or record
                 if record.status == FlowRunStatus.PAUSED and health.status in {
                     "dead",
                     "invalid",
@@ -917,6 +911,14 @@ def reconcile_flow_run(
                         worker_status=health.status,
                         crash_info=crash_info,
                     )
+                elif state_changed:
+                    emit_reconcile_noop(
+                        store=store,
+                        run_id=record.id,
+                        status=record.status,
+                        note=decision.note,
+                        worker_status=health.status,
+                    )
                 else:
                     emit_reconcile_noop(
                         store=store,
@@ -925,7 +927,7 @@ def reconcile_flow_run(
                         note="reconcile-noop",
                         worker_status=health.status,
                     )
-                return record, False, False
+                return record, state_changed, False
 
             result = reduce_flow_lifecycle(
                 record.status,
@@ -955,16 +957,20 @@ def reconcile_flow_run(
                 if result.state is not NO_CHANGE
                 else dict(record.state or {})
             )
-            state = _with_resolved_external_commit_barrier(repo_root, state)
             if restart_state_override is not None:
-                state = restart_state_override
+                state = _with_resolved_external_commit_barrier(
+                    repo_root, restart_state_override
+                )
             elif restart_policy.exhausted:
+                state = _with_resolved_external_commit_barrier(repo_root, state)
                 state = _with_restart_exhausted(
                     state,
                     max_attempts=restart_policy.max_attempts,
                     reason="restart-attempts-exhausted",
                     health=health,
                 )
+            else:
+                state = _with_resolved_external_commit_barrier(repo_root, state)
             state = _with_commit_barrier_recovery(state, commit_barrier)
             for effect in result.effects:
                 if effect.kind == EffectKind.ENRICH_FAILURE_PAYLOAD:

--- a/src/codex_autorunner/core/flows/reconciler.py
+++ b/src/codex_autorunner/core/flows/reconciler.py
@@ -959,7 +959,8 @@ def reconcile_flow_run(
             )
             if restart_state_override is not None:
                 state = _with_resolved_external_commit_barrier(
-                    repo_root, restart_state_override
+                    repo_root,
+                    restart_state_override,
                 )
             elif restart_policy.exhausted:
                 state = _with_resolved_external_commit_barrier(repo_root, state)

--- a/src/codex_autorunner/core/flows/reconciler.py
+++ b/src/codex_autorunner/core/flows/reconciler.py
@@ -193,6 +193,20 @@ def _git_status_porcelain(repo_root: Path) -> Optional[str]:
     return (proc.stdout or "").strip()
 
 
+def _git_head(repo_root: Path) -> Optional[str]:
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return (proc.stdout or "").strip() or None
+
+
 def _ticket_marked_done(path: Path) -> bool:
     try:
         text = path.read_text(encoding="utf-8")
@@ -228,6 +242,9 @@ def _commit_barrier_observation(
     ticket_path = repo_root / current_ticket
     current_ticket_done = ticket_path.exists() and _ticket_marked_done(ticket_path)
     dirty_status = _git_status_porcelain(repo_root) if current_ticket_done else None
+    commit_pending = bool(commit.get("pending")) and (
+        dirty_status is None or bool(dirty_status)
+    )
     raw_retries = commit.get("retries")
     retries = (
         raw_retries
@@ -244,7 +261,7 @@ def _commit_barrier_observation(
         current_ticket=current_ticket,
         current_ticket_done=current_ticket_done,
         worktree_dirty=bool(dirty_status),
-        commit_pending=bool(commit.get("pending")),
+        commit_pending=commit_pending,
         barrier_epoch=(
             commit.get("barrier_epoch")
             if isinstance(commit.get("barrier_epoch"), str)
@@ -256,6 +273,54 @@ def _commit_barrier_observation(
             commit.get("exhausted") or commit.get("resolution_state") == "exhausted"
         ),
     )
+
+
+def _with_resolved_external_commit_barrier(
+    repo_root: Path,
+    state: dict[str, Any],
+) -> dict[str, Any]:
+    updated = dict(state)
+    engine = updated.get("ticket_engine")
+    if not isinstance(engine, dict):
+        return updated
+    commit = engine.get("commit")
+    if not isinstance(commit, dict) or not commit.get("pending"):
+        return updated
+    current_ticket = engine.get("current_ticket")
+    if not isinstance(current_ticket, str) or not current_ticket.strip():
+        return updated
+    ticket_path = repo_root / current_ticket
+    if not (ticket_path.exists() and _ticket_marked_done(ticket_path)):
+        return updated
+    dirty_status = _git_status_porcelain(repo_root)
+    if dirty_status is None or dirty_status.strip():
+        return updated
+
+    head_after = _git_head(repo_root)
+    worktree_summary = commit.get("worktree_summary")
+    worktree_summary = (
+        dict(worktree_summary) if isinstance(worktree_summary, dict) else {}
+    )
+    resolved = {
+        **commit,
+        "pending": False,
+        "commit_pending": False,
+        "worktree_dirty": False,
+        "status_porcelain": "",
+        "head_after": head_after or commit.get("head_after"),
+        "agent_committed_this_turn": True,
+        "resolution_state": "committed_externally",
+        "resolved_at": now_iso(),
+        "worktree_summary": {
+            **worktree_summary,
+            "status_porcelain": "",
+            "head_after": head_after or worktree_summary.get("head_after"),
+        },
+    }
+    new_engine = dict(engine)
+    new_engine["commit"] = resolved
+    updated["ticket_engine"] = new_engine
+    return updated
 
 
 def _restart_state(record: FlowRunRecord) -> dict[str, Any]:
@@ -811,25 +876,25 @@ def reconcile_flow_run(
                     return (updated or record), bool(updated), False
 
             if trigger is None:
-                if commit_barrier.required:
-                    state = _with_commit_barrier_recovery(
-                        dict(record.state or {}),
-                        commit_barrier,
+                state = _with_resolved_external_commit_barrier(
+                    repo_root,
+                    dict(record.state or {}),
+                )
+                state = _with_commit_barrier_recovery(state, commit_barrier)
+                if state != (record.state or {}):
+                    updated = store.update_flow_run_status(
+                        run_id=record.id,
+                        status=record.status,
+                        state=state,
                     )
-                    if state != (record.state or {}):
-                        updated = store.update_flow_run_status(
-                            run_id=record.id,
-                            status=record.status,
-                            state=state,
-                        )
-                        emit_reconcile_noop(
-                            store=store,
-                            run_id=record.id,
-                            status=record.status,
-                            note=decision.note,
-                            worker_status=health.status,
-                        )
-                        return (updated or record), bool(updated), False
+                    emit_reconcile_noop(
+                        store=store,
+                        run_id=record.id,
+                        status=record.status,
+                        note=decision.note,
+                        worker_status=health.status,
+                    )
+                    return (updated or record), bool(updated), False
                 if record.status == FlowRunStatus.PAUSED and health.status in {
                     "dead",
                     "invalid",
@@ -890,6 +955,7 @@ def reconcile_flow_run(
                 if result.state is not NO_CHANGE
                 else dict(record.state or {})
             )
+            state = _with_resolved_external_commit_barrier(repo_root, state)
             if restart_state_override is not None:
                 state = restart_state_override
             elif restart_policy.exhausted:

--- a/src/codex_autorunner/core/ticket_flow_operator.py
+++ b/src/codex_autorunner/core/ticket_flow_operator.py
@@ -1142,6 +1142,11 @@ def _extract_commit_barrier_status(record: FlowRunRecord) -> Optional[dict[str, 
         if not isinstance(candidate, dict) or not candidate:
             continue
         payload = dict(candidate)
+        if (
+            payload.get("worktree_dirty") is False
+            and payload.get("required") is not True
+        ):
+            continue
         pending = any(
             bool(payload.get(key))
             for key in (

--- a/src/codex_autorunner/core/ticket_flow_operator.py
+++ b/src/codex_autorunner/core/ticket_flow_operator.py
@@ -1144,6 +1144,7 @@ def _extract_commit_barrier_status(record: FlowRunRecord) -> Optional[dict[str, 
         payload = dict(candidate)
         if (
             payload.get("worktree_dirty") is False
+            and payload.get("commit_pending") is not True
             and payload.get("required") is not True
         ):
             continue

--- a/tests/core/test_ticket_flow_operator.py
+++ b/tests/core/test_ticket_flow_operator.py
@@ -154,7 +154,7 @@ def test_extract_commit_barrier_ignores_resolved_clean_contradiction(
                 "ticket_engine": {
                     "commit": {
                         "pending": True,
-                        "commit_pending": True,
+                        "commit_pending": False,
                         "worktree_dirty": False,
                         "resolution_state": "pending",
                     }
@@ -165,6 +165,35 @@ def test_extract_commit_barrier_ignores_resolved_clean_contradiction(
         commit_barrier = operator_module._extract_commit_barrier_status(record)
 
     assert commit_barrier is None
+
+
+def test_extract_commit_barrier_keeps_unknown_worktree_state(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / ".codex-autorunner" / "flows.db"
+    with FlowStore(db_path) as store:
+        store.initialize()
+        record = store.create_flow_run(
+            run_id="unknown-worktree-barrier",
+            flow_type="ticket_flow",
+            input_data={},
+            state={
+                "recovery": {
+                    "commit_barrier": {
+                        "pending": True,
+                        "commit_pending": True,
+                        "worktree_dirty": False,
+                        "resolution_state": "pending",
+                    }
+                }
+            },
+        )
+
+        commit_barrier = operator_module._extract_commit_barrier_status(record)
+
+    assert commit_barrier is not None
+    assert commit_barrier["pending"] is True
+    assert commit_barrier["commit_pending"] is True
 
 
 def test_build_ticket_flow_run_state_marks_live_stale_alive_as_attention(

--- a/tests/core/test_ticket_flow_operator.py
+++ b/tests/core/test_ticket_flow_operator.py
@@ -140,6 +140,33 @@ def test_codex_runtime_preflight_decodes_non_utf8_version_output(
     assert any(detail.startswith("version: codex") for detail in details)
 
 
+def test_extract_commit_barrier_ignores_resolved_clean_contradiction(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / ".codex-autorunner" / "flows.db"
+    with FlowStore(db_path) as store:
+        store.initialize()
+        record = store.create_flow_run(
+            run_id="clean-barrier",
+            flow_type="ticket_flow",
+            input_data={},
+            state={
+                "ticket_engine": {
+                    "commit": {
+                        "pending": True,
+                        "commit_pending": True,
+                        "worktree_dirty": False,
+                        "resolution_state": "pending",
+                    }
+                }
+            },
+        )
+
+        commit_barrier = operator_module._extract_commit_barrier_status(record)
+
+    assert commit_barrier is None
+
+
 def test_build_ticket_flow_run_state_marks_live_stale_alive_as_attention(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/flows/test_flow_reconcile.py
+++ b/tests/flows/test_flow_reconcile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import uuid
 from pathlib import Path
 from types import SimpleNamespace
@@ -29,6 +30,105 @@ def test_commit_barrier_recovery_facet_clears_when_observation_clears() -> None:
 
     assert "commit_barrier" not in updated["recovery"]
     assert "commit_barrier" in state["recovery"]
+
+
+def test_reconcile_resolves_stale_clean_commit_barrier(
+    monkeypatch, tmp_path: Path
+) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    ticket_path = tmp_path / ".codex-autorunner" / "tickets" / "TICKET-001.md"
+    ticket_path.parent.mkdir(parents=True, exist_ok=True)
+    ticket_path.write_text(
+        "---\nticket_id: ticket-1\ndone: true\n---\n\nDone\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".gitignore").write_text(
+        ".codex-autorunner/flows.db*\n.codex-autorunner/flows/\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "work.txt").write_text("committed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "external commit"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    db = tmp_path / ".codex-autorunner" / "flows.db"
+    store = FlowStore(db)
+    store.initialize()
+    run_id = "run-clean-barrier"
+    record = store.create_flow_run(
+        run_id=run_id,
+        flow_type="ticket_flow",
+        input_data={},
+        state={
+            "ticket_engine": {
+                "current_ticket": ".codex-autorunner/tickets/TICKET-001.md",
+                "commit": {
+                    "pending": True,
+                    "barrier_epoch": "commit-barrier:test",
+                    "head_before": "before",
+                    "head_after": "before",
+                    "status_porcelain": "M work.txt",
+                    "worktree_summary": {
+                        "head_before": "before",
+                        "head_after": "before",
+                        "status_porcelain": "M work.txt",
+                    },
+                },
+            },
+            "recovery": {
+                "commit_barrier": {
+                    "pending": True,
+                    "worktree_dirty": True,
+                    "resolution_state": "pending",
+                }
+            },
+        },
+        current_step="ticket_turn",
+    )
+    store.update_flow_run_status(run_id=record.id, status=FlowRunStatus.RUNNING)
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.check_worker_health",
+        lambda repo_root, run_id: SimpleNamespace(
+            is_alive=True, status="alive", artifact_path=tmp_path
+        ),
+    )
+
+    current_record = store.get_flow_run(record.id)
+    assert current_record is not None
+    recovered, updated, locked = reconcile_flow_run(tmp_path, current_record, store)
+
+    assert updated is True
+    assert locked is False
+    assert "recovery" not in recovered.state
+    commit = recovered.state["ticket_engine"]["commit"]
+    assert commit["pending"] is False
+    assert commit["resolution_state"] == "committed_externally"
+    assert commit["head_after"] == head
+    assert commit["status_porcelain"] == ""
 
 
 def test_reconcile_pending_stop_requested_without_worker_marks_stopped(

--- a/tests/flows/test_flow_reconcile.py
+++ b/tests/flows/test_flow_reconcile.py
@@ -131,6 +131,99 @@ def test_reconcile_resolves_stale_clean_commit_barrier(
     assert commit["status_porcelain"] == ""
 
 
+def test_reconcile_spawn_failure_keeps_external_commit_barrier_resolution(
+    monkeypatch, tmp_path: Path
+) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    ticket_path = tmp_path / ".codex-autorunner" / "tickets" / "TICKET-001.md"
+    ticket_path.parent.mkdir(parents=True, exist_ok=True)
+    ticket_path.write_text(
+        "---\nticket_id: ticket-1\ndone: true\n---\n\nDone\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".gitignore").write_text(
+        ".codex-autorunner/flows.db*\n.codex-autorunner/flows/\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "work.txt").write_text("committed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "external commit"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    db = tmp_path / ".codex-autorunner" / "flows.db"
+    store = FlowStore(db)
+    store.initialize()
+    run_id = str(uuid.uuid4())
+    record = store.create_flow_run(
+        run_id=run_id,
+        flow_type="ticket_flow",
+        input_data={},
+        state={
+            "ticket_engine": {
+                "status": "running",
+                "current_ticket": ".codex-autorunner/tickets/TICKET-001.md",
+                "commit": {
+                    "pending": True,
+                    "barrier_epoch": "commit-barrier:test",
+                    "head_before": "before",
+                    "head_after": "before",
+                    "status_porcelain": "M work.txt",
+                },
+            }
+        },
+        current_step="ticket_turn",
+    )
+    store.update_flow_run_status(run_id=record.id, status=FlowRunStatus.RUNNING)
+    artifact_dir = tmp_path / ".codex-autorunner" / "flows" / run_id
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.check_worker_health",
+        lambda repo_root, run_id: SimpleNamespace(
+            is_alive=False,
+            status="dead",
+            pid=12345,
+            message="worker PID not running",
+            artifact_path=artifact_dir / "worker.json",
+        ),
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.spawn_flow_worker",
+        lambda repo_root, run_id: (_ for _ in ()).throw(OSError("spawn boom")),
+    )
+
+    current_record = store.get_flow_run(record.id)
+    assert current_record is not None
+    recovered, updated, locked = reconcile_flow_run(tmp_path, current_record, store)
+
+    assert recovered.status == FlowRunStatus.FAILED
+    assert updated is True
+    assert locked is False
+    commit = recovered.state["ticket_engine"]["commit"]
+    assert commit["pending"] is False
+    assert commit["resolution_state"] == "committed_externally"
+    assert commit["status_porcelain"] == ""
+    assert recovered.state["recovery"]["restart"]["last_failure_reason"] == (
+        "spawn_failed: spawn boom"
+    )
+
+
 def test_reconcile_pending_stop_requested_without_worker_marks_stopped(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/flows/test_worker_crash.py
+++ b/tests/flows/test_worker_crash.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -141,6 +142,129 @@ def test_reconcile_paused_dead_worker_creates_crash_dispatch(
 
     artifacts = store.get_artifacts(run_id)
     assert any(artifact.kind == "worker_crash" for artifact in artifacts)
+
+
+def test_reconcile_paused_dead_worker_dispatch_survives_barrier_cleanup(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path
+    subprocess.run(["git", "init"], cwd=repo_root, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    )
+    (repo_root / ".gitignore").write_text(
+        ".codex-autorunner/flows.db*\n.codex-autorunner/flows/\n",
+        encoding="utf-8",
+    )
+    ticket_path = repo_root / ".codex-autorunner" / "tickets" / "TICKET-001.md"
+    ticket_path.parent.mkdir(parents=True, exist_ok=True)
+    ticket_path.write_text(
+        "---\nticket_id: ticket-1\ndone: true\n---\n\nDone\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "-A"], cwd=repo_root, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "ticket committed externally"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    )
+
+    run_id = "323e4567-e89b-12d3-a456-426614174001"
+    db = repo_root / ".codex-autorunner" / "flows.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    store = FlowStore(db)
+    store.initialize()
+
+    state = {
+        "ticket_engine": {
+            "status": "paused",
+            "reason_code": "user_pause",
+            "current_ticket": ".codex-autorunner/tickets/TICKET-001.md",
+            "commit": {
+                "pending": True,
+                "barrier_epoch": "commit-barrier:test",
+                "head_before": "before",
+                "head_after": "before",
+                "status_porcelain": "M work.txt",
+            },
+        },
+        "recovery": {
+            "commit_barrier": {
+                "pending": True,
+                "worktree_dirty": True,
+                "resolution_state": "pending",
+            }
+        },
+    }
+    store.create_flow_run(
+        run_id=run_id,
+        flow_type="ticket_flow",
+        input_data={
+            "workspace_root": str(repo_root),
+            "runs_dir": ".codex-autorunner/runs",
+        },
+        state=state,
+    )
+    store.update_flow_run_status(
+        run_id=run_id,
+        status=FlowRunStatus.PAUSED,
+        state=state,
+    )
+
+    def _fake_health(_repo_root: Path, _run_id: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            is_alive=False,
+            status="dead",
+            pid=9876,
+            message="worker PID not running",
+            exit_code=137,
+            stderr_tail="",
+            artifact_path=repo_root
+            / ".codex-autorunner"
+            / "flows"
+            / run_id
+            / "worker.json",
+            crash_info=None,
+        )
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.check_worker_health", _fake_health
+    )
+
+    current = store.get_flow_run(run_id)
+    assert current is not None
+    recovered, updated, locked = reconcile_flow_run(repo_root, current, store)
+
+    assert recovered.status == FlowRunStatus.PAUSED
+    assert updated is True
+    assert locked is False
+    assert "commit_barrier" not in recovered.state.get("recovery", {})
+    commit = recovered.state["ticket_engine"]["commit"]
+    assert commit["pending"] is False
+    assert commit["resolution_state"] == "committed_externally"
+
+    dispatch_path = (
+        repo_root
+        / ".codex-autorunner"
+        / "runs"
+        / run_id
+        / "dispatch_history"
+        / "0001"
+        / "DISPATCH.md"
+    )
+    assert dispatch_path.exists()
+    dispatch_raw = dispatch_path.read_text(encoding="utf-8")
+    assert "Worker crashed" in dispatch_raw
 
 
 def test_write_worker_exit_info_with_shutdown_intent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Resample live git state before reporting a commit barrier as pending.
- Mark clean pending barriers as `committed_externally` and clear stale recovery overlays.
- Ignore contradictory clean-worktree barrier payloads in run-state projection.

## Validation
- Commit hook core lane: 9463 passed, guardrails passed.
- `.venv/bin/python -m pytest tests/flows/test_flow_reconcile.py tests/core/test_ticket_flow_operator.py -q`
- `.venv/bin/python -m pytest tests/test_hub_messages.py::test_hub_messages_commit_barrier_reads_ticket_engine_commit -q`

Closes #1917