### PR TITLE
[codex] Recover stale-alive commit barriers

### DIFF
--- a/src/codex_autorunner/core/flows/reconciler.py
+++ b/src/codex_autorunner/core/flows/reconciler.py
@@ -216,6 +216,7 @@ def _ticket_marked_done(path: Path) -> bool:
 def _commit_barrier_observation(
     repo_root: Path, record: FlowRunRecord
 ) -> CommitBarrierObservation:
+    workspace_root = _resolve_workspace_root(repo_root, record)
     state = record.state if isinstance(record.state, dict) else {}
     engine = state.get("ticket_engine") if isinstance(state, dict) else {}
     engine = engine if isinstance(engine, dict) else {}
@@ -225,9 +226,11 @@ def _commit_barrier_observation(
 
     commit = engine.get("commit")
     commit = commit if isinstance(commit, dict) else {}
-    ticket_path = repo_root / current_ticket
+    ticket_path = workspace_root / current_ticket
     current_ticket_done = ticket_path.exists() and _ticket_marked_done(ticket_path)
-    dirty_status = _git_status_porcelain(repo_root) if current_ticket_done else None
+    dirty_status = (
+        _git_status_porcelain(workspace_root) if current_ticket_done else None
+    )
     raw_retries = commit.get("retries")
     retries = (
         raw_retries
@@ -392,10 +395,12 @@ def _with_restart_attempt(
     restart.update(
         {
             "count": count,
+            "attempt_id": f"restart:{count}",
             "max_attempts": max_attempts,
             "last_attempted_at": now_iso(),
             "last_failure_reason": failure_reason,
             "last_reason": reason,
+            "last_outcome": "failed" if failure_reason else "attempting",
             "exhausted": count >= max_attempts if max_attempts > 0 else False,
         }
     )
@@ -408,6 +413,42 @@ def _with_restart_attempt(
         recovery["stale_alive"] = stale_alive_recovery_payload(health)
     else:
         recovery.pop("stale_alive", None)
+    updated["recovery"] = recovery
+    return updated
+
+
+def _with_restart_outcome(
+    state: dict[str, Any],
+    *,
+    outcome: str,
+    spawn_pid: Optional[int] = None,
+    failure_reason: Optional[str] = None,
+) -> dict[str, Any]:
+    updated = dict(state)
+    recovery = updated.get("recovery")
+    recovery = dict(recovery) if isinstance(recovery, dict) else {}
+    restart = recovery.get("restart")
+    restart = dict(restart) if isinstance(restart, dict) else {}
+    restart["last_outcome"] = outcome
+    if spawn_pid is not None:
+        restart["last_spawn_pid"] = spawn_pid
+    if failure_reason is not None:
+        restart["last_failure_reason"] = failure_reason
+    recovery["restart"] = restart
+    updated["recovery"] = recovery
+    return updated
+
+
+def _with_stale_alive_recovery(
+    state: dict[str, Any],
+    health: Optional[Any],
+) -> dict[str, Any]:
+    if health is None or getattr(health, "status", None) != "stale_alive":
+        return state
+    updated = dict(state)
+    recovery = updated.get("recovery")
+    recovery = dict(recovery) if isinstance(recovery, dict) else {}
+    recovery["stale_alive"] = stale_alive_recovery_payload(health)
     updated["recovery"] = recovery
     return updated
 
@@ -747,6 +788,18 @@ def reconcile_flow_run(
                     max_attempts=restart_policy.max_attempts,
                     reason=decision.note,
                     health=health,
+                    persist_stale_alive=(
+                        health.status == "stale_alive" and commit_barrier.required
+                    ),
+                )
+                restart_state = _with_commit_barrier_recovery(
+                    restart_state,
+                    commit_barrier,
+                )
+                store.update_flow_run_status(
+                    run_id=record.id,
+                    status=record.status,
+                    state=restart_state,
                 )
                 try:
                     if health.status == "stale_alive":
@@ -784,7 +837,16 @@ def reconcile_flow_run(
                         health=health,
                         persist_stale_alive=True,
                     )
+                    restart_state_override = _with_commit_barrier_recovery(
+                        restart_state_override,
+                        commit_barrier,
+                    )
                 else:
+                    restart_state = _with_restart_outcome(
+                        restart_state,
+                        outcome="spawned",
+                        spawn_pid=getattr(proc, "pid", None),
+                    )
                     store.set_stop_requested(record.id, False)
                     updated = store.update_flow_run_status(
                         run_id=record.id,
@@ -899,6 +961,8 @@ def reconcile_flow_run(
                     reason="restart-attempts-exhausted",
                     health=health,
                 )
+            elif commit_barrier.required:
+                state = _with_stale_alive_recovery(state, health)
             state = _with_commit_barrier_recovery(state, commit_barrier)
             for effect in result.effects:
                 if effect.kind == EffectKind.ENRICH_FAILURE_PAYLOAD:

--- a/src/codex_autorunner/core/flows/reconciler.py
+++ b/src/codex_autorunner/core/flows/reconciler.py
@@ -404,6 +404,7 @@ def _with_restart_attempt(
             "exhausted": count >= max_attempts if max_attempts > 0 else False,
         }
     )
+    restart.pop("last_spawn_pid", None)
     recovery["restart"] = restart
     if (
         persist_stale_alive

--- a/src/codex_autorunner/core/flows/supervisor.py
+++ b/src/codex_autorunner/core/flows/supervisor.py
@@ -46,6 +46,9 @@ class RecoveryIntentKind(str, Enum):
     WORKER_CRASH = "worker_crash"
     STALE_WORKER_REAPED = "stale_worker_reaped"
     STALE_ALIVE_WORKER = "stale_alive_worker"
+    STALE_ALIVE_COMMIT_BARRIER_ACTIVE = "stale_alive_commit_barrier_active"
+    STALE_ALIVE_COMMIT_BARRIER_EXHAUSTED = "stale_alive_commit_barrier_exhausted"
+    STALE_ALIVE_UNKNOWN = "stale_alive_unknown"
     BACKEND_DISCONNECT = "backend_disconnect"
     COMMIT_BARRIER_REQUIRED = "commit_barrier_required"
     COMMIT_BARRIER_EXHAUSTED = "commit_barrier_exhausted"
@@ -301,7 +304,16 @@ def supervise_flow_recovery(
                 intents,
                 effects,
                 note=(
-                    "stale-alive-worker"
+                    (
+                        "stale-alive-commit-barrier-active"
+                        if (
+                            worker.status == WorkerHealthStatus.STALE_ALIVE
+                            and observation.commit_barrier.required
+                            and not observation.commit_barrier.exhausted
+                            and observation.restart.can_attempt
+                        )
+                        else "stale-alive-worker"
+                    )
                     if worker.status == WorkerHealthStatus.STALE_ALIVE
                     else (
                         "stale-worker-reaped"
@@ -484,6 +496,38 @@ def _append_worker_dead_decision(
             )
         )
 
+    if stale_alive:
+        if observation.commit_barrier.required:
+            intents.append(
+                RecoveryIntent(
+                    (
+                        RecoveryIntentKind.STALE_ALIVE_COMMIT_BARRIER_EXHAUSTED
+                        if observation.commit_barrier.exhausted
+                        else RecoveryIntentKind.STALE_ALIVE_COMMIT_BARRIER_ACTIVE
+                    ),
+                    (
+                        "stale-alive-commit-barrier-exhausted"
+                        if observation.commit_barrier.exhausted
+                        else "stale-alive-commit-barrier-active"
+                    ),
+                    {
+                        **_worker_data(worker),
+                        "current_ticket": observation.commit_barrier.current_ticket,
+                        "barrier_epoch": observation.commit_barrier.barrier_epoch,
+                        "commit_retries": observation.commit_barrier.retries,
+                        "commit_max_retries": observation.commit_barrier.max_retries,
+                    },
+                )
+            )
+        else:
+            intents.append(
+                RecoveryIntent(
+                    RecoveryIntentKind.STALE_ALIVE_UNKNOWN,
+                    "stale-alive-without-classified-blocker",
+                    _worker_data(worker),
+                )
+            )
+
     if observation.commit_barrier.required:
         _append_commit_barrier_intent(observation, intents, effects)
 
@@ -534,7 +578,14 @@ def _append_worker_dead_decision(
         effects.append(
             _effect(SupervisorEffectKind.NOTIFY_SURFACES, "restart_exhausted")
         )
-    elif observation.restart.can_attempt and not observation.commit_barrier.required:
+    elif observation.restart.can_attempt and (
+        not observation.commit_barrier.required
+        or (
+            stale_alive
+            and observation.commit_barrier.required
+            and not observation.commit_barrier.exhausted
+        )
+    ):
         intents.append(
             RecoveryIntent(
                 RecoveryIntentKind.RESTART_ATTEMPTED,
@@ -545,7 +596,16 @@ def _append_worker_dead_decision(
                 },
             )
         )
-        effects.append(_effect(SupervisorEffectKind.SPAWN_WORKER, "restart_attempted"))
+        effects.append(
+            _effect(
+                SupervisorEffectKind.SPAWN_WORKER,
+                (
+                    "stale_alive_commit_barrier_active"
+                    if stale_alive and observation.commit_barrier.required
+                    else "restart_attempted"
+                ),
+            )
+        )
 
 
 def _append_commit_barrier_intent(

--- a/tests/core/flows/test_flow_supervisor.py
+++ b/tests/core/flows/test_flow_supervisor.py
@@ -121,7 +121,10 @@ def test_policy_classifies_stale_alive_worker_as_unhealthy() -> None:
     )
 
     assert decision.note == "stale-alive-worker"
-    assert _intent_kinds(decision) == [RecoveryIntentKind.STALE_ALIVE_WORKER]
+    assert _intent_kinds(decision) == [
+        RecoveryIntentKind.STALE_ALIVE_WORKER,
+        RecoveryIntentKind.STALE_ALIVE_UNKNOWN,
+    ]
     assert SupervisorEffectKind.WRITE_CRASH_ARTIFACT in _effect_kinds(decision)
     trigger = decision.first_lifecycle_trigger()
     assert trigger is not None
@@ -140,9 +143,77 @@ def test_policy_restarts_stale_alive_worker_when_budget_remains() -> None:
 
     assert _intent_kinds(decision) == [
         RecoveryIntentKind.STALE_ALIVE_WORKER,
+        RecoveryIntentKind.STALE_ALIVE_UNKNOWN,
         RecoveryIntentKind.RESTART_ATTEMPTED,
     ]
     assert SupervisorEffectKind.SPAWN_WORKER in _effect_kinds(decision)
+
+
+def test_policy_restarts_stale_alive_commit_barrier_when_budget_remains() -> None:
+    decision = supervise_flow_recovery(
+        FlowSupervisorObservation(
+            run=_run(),
+            worker=_worker(
+                WorkerHealthStatus.STALE_ALIVE,
+                pid=123,
+                last_semantic_progress_at="2026-05-12T00:00:00+00:00",
+                stale_reason="semantic_progress_stale_without_active_tool",
+                semantic_stale_age_seconds=2400,
+            ),
+            commit_barrier=CommitBarrierObservation(
+                current_ticket=".codex-autorunner/tickets/TICKET-001.md",
+                current_ticket_done=True,
+                worktree_dirty=True,
+                commit_pending=True,
+                barrier_epoch="commit-barrier:abc",
+                retries=1,
+                max_retries=3,
+            ),
+            restart=RestartPolicyObservation(enabled=True, attempts=0, max_attempts=2),
+        )
+    )
+
+    assert decision.note == "stale-alive-commit-barrier-active"
+    assert _intent_kinds(decision) == [
+        RecoveryIntentKind.STALE_ALIVE_WORKER,
+        RecoveryIntentKind.STALE_ALIVE_COMMIT_BARRIER_ACTIVE,
+        RecoveryIntentKind.COMMIT_BARRIER_REQUIRED,
+        RecoveryIntentKind.RESTART_ATTEMPTED,
+    ]
+    assert SupervisorEffectKind.SPAWN_WORKER in _effect_kinds(decision)
+    spawn_effects = [
+        effect
+        for effect in decision.effects
+        if effect.kind == SupervisorEffectKind.SPAWN_WORKER
+    ]
+    assert spawn_effects[0].data["reason"] == "stale_alive_commit_barrier_active"
+
+
+def test_policy_does_not_restart_exhausted_stale_alive_commit_barrier() -> None:
+    decision = supervise_flow_recovery(
+        FlowSupervisorObservation(
+            run=_run(),
+            worker=_worker(WorkerHealthStatus.STALE_ALIVE, pid=123),
+            commit_barrier=CommitBarrierObservation(
+                current_ticket=".codex-autorunner/tickets/TICKET-001.md",
+                current_ticket_done=True,
+                worktree_dirty=True,
+                commit_pending=True,
+                barrier_epoch="commit-barrier:abc",
+                retries=3,
+                max_retries=3,
+                exhausted=True,
+            ),
+            restart=RestartPolicyObservation(enabled=True, attempts=0, max_attempts=2),
+        )
+    )
+
+    assert _intent_kinds(decision) == [
+        RecoveryIntentKind.STALE_ALIVE_WORKER,
+        RecoveryIntentKind.STALE_ALIVE_COMMIT_BARRIER_EXHAUSTED,
+        RecoveryIntentKind.COMMIT_BARRIER_EXHAUSTED,
+    ]
+    assert SupervisorEffectKind.SPAWN_WORKER not in _effect_kinds(decision)
 
 
 def test_policy_treats_signal_shutdown_as_recoverable_crash() -> None:

--- a/tests/flows/test_flow_reconcile.py
+++ b/tests/flows/test_flow_reconcile.py
@@ -4,6 +4,8 @@ import uuid
 from pathlib import Path
 from types import SimpleNamespace
 
+from tests.support.git_test_helpers import init_git_repo as _init_git_repo
+
 from codex_autorunner.core.flows.models import FlowEventType, FlowRunStatus
 from codex_autorunner.core.flows.reconciler import (
     _with_commit_barrier_recovery,
@@ -688,6 +690,387 @@ def test_stale_alive_worker_restarts_same_running_ticket_flow_run(
     restart = recovered.state["recovery"]["restart"]
     assert restart["count"] == 1
     assert "stale_alive" not in recovered.state["recovery"]
+
+
+def test_stale_alive_commit_barrier_restarts_and_preserves_recovery_payload(
+    monkeypatch, tmp_path: Path
+) -> None:
+    db = tmp_path / "flows.db"
+    store = FlowStore(db)
+    store.initialize()
+    run_id = str(uuid.uuid4())
+    _init_git_repo(tmp_path)
+    ticket_path = tmp_path / "TICKET-001.md"
+    ticket_path.write_text(
+        "---\ndone: true\n---\n\n# Ticket\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "work.txt").write_text("dirty\n", encoding="utf-8")
+    record = store.create_flow_run(
+        run_id=run_id,
+        flow_type="ticket_flow",
+        input_data={},
+        state={
+            "ticket_engine": {
+                "status": "running",
+                "current_ticket": "TICKET-001.md",
+                "commit": {
+                    "pending": True,
+                    "barrier_epoch": "commit-barrier:abc",
+                    "retries": 1,
+                    "max_retries": 3,
+                    "resolution_state": "pending",
+                },
+            }
+        },
+        current_step="ticket_turn",
+    )
+    store.update_flow_run_status(
+        run_id=record.id,
+        status=FlowRunStatus.RUNNING,
+        state=record.state,
+    )
+    artifact_dir = tmp_path / ".codex-autorunner" / "flows" / run_id
+    artifact_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler._latest_semantic_progress_at",
+        lambda _record, _store: "2026-05-12T00:00:00+00:00",
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.now_iso",
+        lambda: "2026-05-12T01:00:00+00:00",
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.check_worker_health",
+        lambda repo_root, run_id: SimpleNamespace(
+            is_alive=True,
+            status="alive",
+            pid=12345,
+            message="worker running",
+            active_tool=None,
+            artifact_path=artifact_dir / "worker.json",
+        ),
+    )
+    terminated: list[tuple[str, int]] = []
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.terminate_flow_worker_pid",
+        lambda repo_root, run_id, *, pid, reason: terminated.append((run_id, pid))
+        or True,
+    )
+    spawned: list[str] = []
+
+    def fake_spawn(repo_root: Path, run_id: str):
+        spawned.append(run_id)
+        return (
+            SimpleNamespace(pid=999),
+            SimpleNamespace(close=lambda: None),
+            SimpleNamespace(close=lambda: None),
+        )
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.spawn_flow_worker",
+        fake_spawn,
+    )
+
+    current_record = store.get_flow_run(record.id)
+    assert current_record is not None
+    recovered, updated, locked = reconcile_flow_run(tmp_path, current_record, store)
+
+    assert recovered.status == FlowRunStatus.RUNNING
+    assert updated is True
+    assert locked is False
+    assert terminated == [(run_id, 12345)]
+    assert spawned == [run_id]
+    recovery = recovered.state["recovery"]
+    restart = recovery["restart"]
+    assert restart["count"] == 1
+    assert restart["attempt_id"] == "restart:1"
+    assert restart["last_reason"] == "stale-alive-commit-barrier-active"
+    assert restart["last_outcome"] == "spawned"
+    assert restart["last_spawn_pid"] == 999
+    assert recovery["stale_alive"]["worker_pid"] == 12345
+    assert recovery["stale_alive"]["semantic_stale_age_seconds"] == 3600
+    commit_barrier = recovery["commit_barrier"]
+    assert commit_barrier["pending"] is True
+    assert commit_barrier["current_ticket"] == "TICKET-001.md"
+    assert commit_barrier["barrier_epoch"] == "commit-barrier:abc"
+    assert commit_barrier["retries"] == 1
+    assert commit_barrier["max_retries"] == 3
+    assert commit_barrier["worktree_dirty"] is True
+
+
+def test_stale_alive_commit_barrier_uses_ticket_flow_workspace_root(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    workspace_root = tmp_path / "workspace"
+    repo_root.mkdir()
+    workspace_root.mkdir()
+    _init_git_repo(workspace_root)
+    db = tmp_path / "flows.db"
+    store = FlowStore(db)
+    store.initialize()
+    run_id = str(uuid.uuid4())
+    ticket_path = workspace_root / "TICKET-001.md"
+    ticket_path.write_text(
+        "---\ndone: true\n---\n\n# Ticket\n",
+        encoding="utf-8",
+    )
+    (workspace_root / "work.txt").write_text("dirty\n", encoding="utf-8")
+    record = store.create_flow_run(
+        run_id=run_id,
+        flow_type="ticket_flow",
+        input_data={"workspace_root": str(workspace_root)},
+        state={
+            "ticket_engine": {
+                "status": "running",
+                "current_ticket": "TICKET-001.md",
+                "commit": {
+                    "pending": False,
+                    "barrier_epoch": "commit-barrier:workspace",
+                    "retries": 0,
+                    "max_retries": 2,
+                    "resolution_state": "pending",
+                },
+            }
+        },
+        current_step="ticket_turn",
+    )
+    store.update_flow_run_status(
+        run_id=record.id,
+        status=FlowRunStatus.RUNNING,
+        state=record.state,
+    )
+    artifact_dir = repo_root / ".codex-autorunner" / "flows" / run_id
+    artifact_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler._latest_semantic_progress_at",
+        lambda _record, _store: "2026-05-12T00:00:00+00:00",
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.now_iso",
+        lambda: "2026-05-12T01:00:00+00:00",
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.check_worker_health",
+        lambda _repo_root, _run_id: SimpleNamespace(
+            is_alive=True,
+            status="alive",
+            pid=12345,
+            message="worker running",
+            active_tool=None,
+            artifact_path=artifact_dir / "worker.json",
+        ),
+    )
+    terminated: list[tuple[str, int]] = []
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.terminate_flow_worker_pid",
+        lambda _repo_root, run_id, *, pid, reason: terminated.append((run_id, pid))
+        or True,
+    )
+    spawned: list[str] = []
+
+    def fake_spawn(_repo_root: Path, run_id: str):
+        spawned.append(run_id)
+        return (
+            SimpleNamespace(pid=999),
+            SimpleNamespace(close=lambda: None),
+            SimpleNamespace(close=lambda: None),
+        )
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.spawn_flow_worker",
+        fake_spawn,
+    )
+
+    current_record = store.get_flow_run(record.id)
+    assert current_record is not None
+    recovered, updated, locked = reconcile_flow_run(repo_root, current_record, store)
+
+    assert recovered.status == FlowRunStatus.RUNNING
+    assert updated is True
+    assert locked is False
+    assert terminated == [(run_id, 12345)]
+    assert spawned == [run_id]
+    commit_barrier = recovered.state["recovery"]["commit_barrier"]
+    assert commit_barrier["current_ticket_done"] is True
+    assert commit_barrier["worktree_dirty"] is True
+    assert commit_barrier["commit_pending"] is False
+
+
+def test_failed_stale_alive_commit_barrier_rescue_persists_diagnostics(
+    monkeypatch, tmp_path: Path
+) -> None:
+    db = tmp_path / "flows.db"
+    store = FlowStore(db)
+    store.initialize()
+    run_id = str(uuid.uuid4())
+    _init_git_repo(tmp_path)
+    ticket_path = tmp_path / "TICKET-001.md"
+    ticket_path.write_text("---\ndone: true\n---\n", encoding="utf-8")
+    (tmp_path / "work.txt").write_text("dirty\n", encoding="utf-8")
+    record = store.create_flow_run(
+        run_id=run_id,
+        flow_type="ticket_flow",
+        input_data={},
+        state={
+            "ticket_engine": {
+                "status": "running",
+                "current_ticket": "TICKET-001.md",
+                "commit": {
+                    "pending": True,
+                    "barrier_epoch": "commit-barrier:abc",
+                    "retries": 1,
+                    "max_retries": 3,
+                    "resolution_state": "pending",
+                },
+            }
+        },
+        current_step="ticket_turn",
+    )
+    store.update_flow_run_status(
+        run_id=record.id,
+        status=FlowRunStatus.RUNNING,
+        state=record.state,
+    )
+    artifact_dir = tmp_path / ".codex-autorunner" / "flows" / run_id
+    artifact_dir.mkdir(parents=True)
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler._latest_semantic_progress_at",
+        lambda _record, _store: "2026-05-12T00:00:00+00:00",
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.now_iso",
+        lambda: "2026-05-12T01:00:00+00:00",
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.check_worker_health",
+        lambda _repo_root, _run_id: SimpleNamespace(
+            is_alive=True,
+            status="alive",
+            pid=12345,
+            message="worker running",
+            active_tool=None,
+            artifact_path=artifact_dir / "worker.json",
+        ),
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.terminate_flow_worker_pid",
+        lambda _repo_root, _run_id, *, pid, reason: False,
+    )
+    spawned: list[str] = []
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.spawn_flow_worker",
+        lambda _repo_root, run_id: spawned.append(run_id),
+    )
+
+    current_record = store.get_flow_run(record.id)
+    assert current_record is not None
+    recovered, updated, locked = reconcile_flow_run(tmp_path, current_record, store)
+
+    assert recovered.status == FlowRunStatus.FAILED
+    assert updated is True
+    assert locked is False
+    assert spawned == []
+    recovery = recovered.state["recovery"]
+    assert recovery["stale_alive"]["worker_pid"] == 12345
+    assert recovery["commit_barrier"]["barrier_epoch"] == "commit-barrier:abc"
+    assert recovery["commit_barrier"]["pending"] is True
+    restart = recovery["restart"]
+    assert restart["last_outcome"] == "failed"
+    assert restart["last_failure_reason"].startswith("spawn_failed:")
+
+
+def test_stale_alive_exhausted_commit_barrier_does_not_spawn(
+    monkeypatch, tmp_path: Path
+) -> None:
+    db = tmp_path / "flows.db"
+    store = FlowStore(db)
+    store.initialize()
+    run_id = str(uuid.uuid4())
+    _init_git_repo(tmp_path)
+    ticket_path = tmp_path / "TICKET-001.md"
+    ticket_path.write_text(
+        "---\ndone: true\n---\n\n# Ticket\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "work.txt").write_text("dirty\n", encoding="utf-8")
+    record = store.create_flow_run(
+        run_id=run_id,
+        flow_type="ticket_flow",
+        input_data={},
+        state={
+            "ticket_engine": {
+                "status": "running",
+                "current_ticket": "TICKET-001.md",
+                "commit": {
+                    "pending": True,
+                    "barrier_epoch": "commit-barrier:abc",
+                    "retries": 3,
+                    "max_retries": 3,
+                    "exhausted": True,
+                    "resolution_state": "exhausted",
+                },
+            }
+        },
+        current_step="ticket_turn",
+    )
+    store.update_flow_run_status(
+        run_id=record.id,
+        status=FlowRunStatus.RUNNING,
+        state=record.state,
+    )
+    artifact_dir = tmp_path / ".codex-autorunner" / "flows" / run_id
+    artifact_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler._latest_semantic_progress_at",
+        lambda _record, _store: "2026-05-12T00:00:00+00:00",
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.now_iso",
+        lambda: "2026-05-12T01:00:00+00:00",
+    )
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.check_worker_health",
+        lambda repo_root, run_id: SimpleNamespace(
+            is_alive=True,
+            status="alive",
+            pid=12345,
+            message="worker running",
+            active_tool=None,
+            artifact_path=artifact_dir / "worker.json",
+        ),
+    )
+    terminated: list[str] = []
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.terminate_flow_worker_pid",
+        lambda repo_root, run_id, *, pid, reason: terminated.append(run_id) or True,
+    )
+    spawned: list[str] = []
+    monkeypatch.setattr(
+        "codex_autorunner.core.flows.reconciler.spawn_flow_worker",
+        lambda repo_root, run_id: spawned.append(run_id),
+    )
+
+    current_record = store.get_flow_run(record.id)
+    assert current_record is not None
+    recovered, updated, locked = reconcile_flow_run(tmp_path, current_record, store)
+
+    assert recovered.status == FlowRunStatus.FAILED
+    assert updated is True
+    assert locked is False
+    assert terminated == []
+    assert spawned == []
+    commit_barrier = recovered.state["recovery"]["commit_barrier"]
+    assert commit_barrier["pending"] is True
+    assert commit_barrier["resolution_state"] == "exhausted"
+    assert recovered.state["recovery"]["stale_alive"]["worker_pid"] == 12345
+    assert (
+        recovered.state["recovery"]["stale_alive"]["semantic_stale_age_seconds"] == 3600
+    )
 
 
 def test_stale_alive_restart_does_not_spawn_if_live_worker_cannot_be_stopped(

--- a/tests/flows/test_flow_reconcile.py
+++ b/tests/flows/test_flow_reconcile.py
@@ -9,6 +9,7 @@ from tests.support.git_test_helpers import init_git_repo as _init_git_repo
 from codex_autorunner.core.flows.models import FlowEventType, FlowRunStatus
 from codex_autorunner.core.flows.reconciler import (
     _with_commit_barrier_recovery,
+    _with_restart_attempt,
     reconcile_flow_run,
 )
 from codex_autorunner.core.flows.store import FlowStore
@@ -31,6 +32,31 @@ def test_commit_barrier_recovery_facet_clears_when_observation_clears() -> None:
 
     assert "commit_barrier" not in updated["recovery"]
     assert "commit_barrier" in state["recovery"]
+
+
+def test_restart_attempt_clears_prior_spawn_pid() -> None:
+    state = {
+        "recovery": {
+            "restart": {
+                "count": 1,
+                "max_attempts": 3,
+                "last_outcome": "spawned",
+                "last_spawn_pid": 999,
+            }
+        }
+    }
+
+    updated = _with_restart_attempt(
+        state,
+        max_attempts=3,
+        reason="stale-alive-commit-barrier-active",
+    )
+
+    restart = updated["recovery"]["restart"]
+    assert restart["count"] == 2
+    assert restart["last_outcome"] == "attempting"
+    assert "last_spawn_pid" not in restart
+    assert "last_spawn_pid" in state["recovery"]["restart"]
 
 
 def test_reconcile_pending_stop_requested_without_worker_marks_stopped(


### PR DESCRIPTION
## Summary
- classify stale-alive commit-barrier stalls separately from generic stale workers
- allow bounded worker respawn for active commit barriers while preserving stale-alive and commit-barrier diagnostics
- resolve commit-barrier observation against the ticket-flow workspace root and cover active, exhausted, unknown, and failed-rescue paths

Fixes #1866.

## Validation
- pre-commit hook core lane passed: guardrails, black, ruff, import boundaries, contracts, mypy, and 9467 pytest tests
- focused check: `.venv/bin/python -m pytest tests/core/flows/test_flow_supervisor.py tests/flows/test_flow_reconcile.py`
- final subagent review: no release blockers

## Notes
- `.codex-autorunner/contextspace/spec.md` was written locally for CAR context, but repo guardrails intentionally forbid committing `.codex-autorunner/` context files.