### PR TITLE
[codex] Simplify artifact current target resolution

### DIFF
--- a/docs/ops/artifact-compat.md
+++ b/docs/ops/artifact-compat.md
@@ -3,7 +3,7 @@
 Normal agent-facing delivery should use the artifact journal:
 
 ```bash
-car artifacts send <file> --to current
+car artifacts send <file>
 ```
 
 This page is for operators debugging broken target injection, stranded files, or
@@ -12,18 +12,20 @@ generated repo docs, or normal chat-agent instructions.
 
 ## Current target diagnostics
 
-`--to current` requires these runtime environment variables:
+`--to current` first uses these runtime environment variables when present:
 
 - `CAR_ARTIFACT_TARGET_SURFACE`
 - `CAR_ARTIFACT_TARGET_CONVERSATION_KEY`
 - `CAR_ARTIFACT_WORKSPACE_SCOPE` when the target is workspace-scoped
 
-If the first two variables are missing, fix the chat/runtime target injection
-before asking an agent to send files.
+If they are absent, the CLI falls back to the unique Discord or Telegram chat
+binding for the current repo/worktree. If no binding exists or multiple bindings
+match, pass an explicit target.
 
 ## Explicit operator send
 
-Use an explicit target only when debugging current-target wiring:
+Use an explicit target to send somewhere other than the current turn or bound
+chat:
 
 ```bash
 car artifacts send <file> --to explicit --surface <surface> --conversation <conversation>

--- a/docs/ops/browser-render-workflows.md
+++ b/docs/ops/browser-render-workflows.md
@@ -38,7 +38,7 @@ Use `demo` when you need deterministic, step-by-step interactions from a manifes
 
 Use `demo-workflow` when you need built-in multi-service startup ordering, readiness checks, demo capture, export manifest generation, and optional legacy outbox publishing.
 
-Artifact delivery note: `car render` still publishes to `.codex-autorunner/filebox/outbox/` for compatibility. To send a rendered file to a chat target, prefer `car artifacts send <file> --to current`; import already-published legacy files with `car artifacts import-legacy` when needed.
+Artifact delivery note: `car render` still publishes to `.codex-autorunner/filebox/outbox/` for compatibility. To send a rendered file to a chat target, prefer `car artifacts send <file>`; import already-published legacy files with `car artifacts import-legacy` when needed.
 
 ## URL Mode vs Serve Mode
 

--- a/docs/ops/drift-prevention.md
+++ b/docs/ops/drift-prevention.md
@@ -2,7 +2,7 @@
 
 Keep long-running repos from diverging between control surfaces (web, PMA, Telegram) and filesystem state.
 
-- **Artifact delivery first.** Send files through `car artifacts send <file> --to current` when the active target is available. FileBox outbox paths are compatibility ingress for the active hub/repo scope, not a global delivery contract.
+- **Artifact delivery first.** Send files through `car artifacts send <file>` when the active target or one unique chat binding is available. FileBox outbox paths are compatibility ingress for the active hub/repo scope, not a global delivery contract.
 - **FileBox compatibility.** Upload and fetch files through the shared FileBox (`/api/filebox` or `/hub/filebox/{repo_id}`) only. `tests/test_filebox.py` guards the `.codex-autorunner/filebox/` compatibility contract.
 - **Pending turns.** Client turn IDs are persisted per ticket/workspace; refresh pages resume streams and clear pending state on completion so thinking UI stays aligned with backend turns.
 - **Checks.** Run `make check` (includes `pytest`) before opening PRs; FileBox and artifact-delivery tests ensure inbox/outbox compatibility and journal behavior stay stable across surfaces.

--- a/src/codex_autorunner/bootstrap.py
+++ b/src/codex_autorunner/bootstrap.py
@@ -519,7 +519,7 @@ Do NOT copy `.codex-autorunner/` between worktrees:
 - User uploads arrive in `.codex-autorunner/filebox/inbox/`.
 - Archive reviewed uploads with `car pma file consume|dismiss <filename> --path <hub_root>`.
 - Restore archived uploads with `car pma file restore <filename> --path <hub_root>`.
-- Send user-facing files with `car artifacts send <file> --to current` when the active target is available.
+- Send user-facing files with `car artifacts send <file>` when the active target or one unique chat binding is available.
 
 ## PMA dispatches (user attention)
 

--- a/src/codex_autorunner/core/artifact_instructions.py
+++ b/src/codex_autorunner/core/artifact_instructions.py
@@ -12,7 +12,7 @@ ARTIFACT_WORKSPACE_SCOPE_ENV = "CAR_ARTIFACT_WORKSPACE_SCOPE"
 
 @dataclass(frozen=True)
 class ArtifactDeliveryCommands:
-    send_current: str = "car artifacts send <file> --to current"
+    send_current: str = "car artifacts send <file>"
     list_deliveries: str = "car artifacts list"
     inspect_delivery: str = "car artifacts inspect <delivery_id>"
 

--- a/src/codex_autorunner/core/chat_bindings.py
+++ b/src/codex_autorunner/core/chat_bindings.py
@@ -639,6 +639,7 @@ def _read_orchestration_binding_rows(
                     ON t.thread_target_id = b.target_id
                  WHERE b.disabled_at IS NULL
                    AND b.target_kind = 'thread'
+                   AND COALESCE(t.lifecycle_status, 'active') != 'archived'
                 """).fetchall()
     except sqlite3.OperationalError as exc:
         if "no such table" in str(exc).lower():

--- a/src/codex_autorunner/core/chat_bindings.py
+++ b/src/codex_autorunner/core/chat_bindings.py
@@ -627,8 +627,12 @@ def _read_orchestration_binding_rows(
                     b.surface_kind,
                     b.surface_key,
                     b.repo_id,
+                    b.resource_kind,
+                    b.resource_id,
                     b.updated_at,
                     t.repo_id AS thread_repo_id,
+                    t.resource_kind AS thread_resource_kind,
+                    t.resource_id AS thread_resource_id,
                     t.workspace_root
                   FROM orch_bindings AS b
              LEFT JOIN orch_thread_targets AS t
@@ -651,6 +655,12 @@ def _read_orchestration_binding_rows(
             repo_id_by_workspace=repo_id_by_workspace,
             workspace_values=((workspace_root,) if workspace_root is not None else ()),
         )
+        resource_kind = _normalize_scope(
+            row["resource_kind"] or row["thread_resource_kind"]
+        )
+        resource_id = _normalize_scope(row["resource_id"] or row["thread_resource_id"])
+        if repo_id is None and resource_kind in {"repo", "worktree"}:
+            repo_id = resource_id
         if repo_id is None:
             continue
         surface_kind = _normalize_scope(row["surface_kind"])
@@ -662,6 +672,8 @@ def _read_orchestration_binding_rows(
                 "surface_kind": surface_kind,
                 "surface_key": surface_key,
                 "repo_id": repo_id,
+                "resource_kind": resource_kind,
+                "resource_id": resource_id,
                 "workspace_root": workspace_root,
                 "updated_at": row["updated_at"],
             }
@@ -817,6 +829,190 @@ def orchestration_surface_targets_for_thread(
         seen.add(pair)
         out.append(pair)
     return tuple(out)
+
+
+def active_chat_binding_targets_for_repo(
+    *, hub_root: Path, raw_config: Mapping[str, Any], repo_id: str
+) -> tuple[tuple[str, str], ...]:
+    """Return active Discord/Telegram surface targets for a repo or worktree id."""
+
+    normalized_repo_id = _normalize_repo_id(repo_id)
+    if normalized_repo_id is None:
+        return ()
+    repo_id_by_workspace = _repo_id_by_workspace_path(hub_root, raw_config)
+    targets: list[tuple[str, str]] = []
+    for row in _read_orchestration_binding_rows(
+        hub_root=hub_root, repo_id_by_workspace=repo_id_by_workspace
+    ):
+        if not _binding_row_matches_repo(
+            row_repo_id=row["repo_id"],
+            row_resource_kind=row["resource_kind"],
+            row_resource_id=row["resource_id"],
+            row_workspace=row["workspace_root"],
+            repo_id=normalized_repo_id,
+            repo_id_by_workspace=repo_id_by_workspace,
+        ):
+            continue
+        surface_kind = _normalize_scope(row["surface_kind"])
+        surface_key = _normalize_scope(row["surface_key"])
+        if surface_kind in {"discord", "telegram"} and surface_key is not None:
+            targets.append((surface_kind, surface_key))
+
+    targets.extend(
+        _read_discord_binding_targets_for_repo(
+            db_path=_resolve_discord_state_path(hub_root, raw_config),
+            repo_id=normalized_repo_id,
+            repo_id_by_workspace=repo_id_by_workspace,
+        )
+    )
+    targets.extend(
+        _read_telegram_binding_targets_for_repo(
+            db_path=_resolve_telegram_state_path(hub_root, raw_config),
+            repo_id=normalized_repo_id,
+            repo_id_by_workspace=repo_id_by_workspace,
+        )
+    )
+
+    out: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for surface_kind, surface_key in targets:
+        pair = (surface_kind, surface_key)
+        if pair in seen:
+            continue
+        seen.add(pair)
+        out.append(pair)
+    return tuple(out)
+
+
+def _binding_row_matches_repo(
+    *,
+    row_repo_id: Any,
+    row_resource_kind: Any,
+    row_resource_id: Any,
+    row_workspace: Any,
+    repo_id: str,
+    repo_id_by_workspace: Mapping[str, str],
+) -> bool:
+    resolved_repo_id = _resolve_bound_repo_id(
+        repo_id=row_repo_id,
+        repo_id_by_workspace=repo_id_by_workspace,
+        workspace_values=(row_workspace,),
+    )
+    if resolved_repo_id == repo_id:
+        return True
+    resource_kind = _normalize_scope(row_resource_kind)
+    resource_id = _normalize_scope(row_resource_id)
+    return resource_kind in {"repo", "worktree"} and resource_id == repo_id
+
+
+def _read_discord_binding_targets_for_repo(
+    *,
+    db_path: Path,
+    repo_id: str,
+    repo_id_by_workspace: Mapping[str, str],
+) -> tuple[tuple[str, str], ...]:
+    if not db_path.exists():
+        return ()
+    try:
+        with open_sqlite(db_path) as conn:
+            columns = _table_columns(conn, "channel_bindings")
+            if not columns or "channel_id" not in columns:
+                return ()
+            select_columns = [
+                "channel_id",
+                "repo_id" if "repo_id" in columns else "NULL AS repo_id",
+                (
+                    "workspace_path"
+                    if "workspace_path" in columns
+                    else "NULL AS workspace_path"
+                ),
+                (
+                    "resource_kind"
+                    if "resource_kind" in columns
+                    else "NULL AS resource_kind"
+                ),
+                "resource_id" if "resource_id" in columns else "NULL AS resource_id",
+            ]
+            rows = conn.execute(
+                f"SELECT {', '.join(select_columns)} FROM channel_bindings"
+            ).fetchall()
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            return ()
+        raise RuntimeError(
+            f"Failed reading Discord chat bindings from {db_path}: {exc}"
+        ) from exc
+
+    targets: list[tuple[str, str]] = []
+    for row in rows:
+        channel_id = _normalize_scope(row["channel_id"])
+        if channel_id is None:
+            continue
+        if _binding_row_matches_repo(
+            row_repo_id=row["repo_id"],
+            row_resource_kind=row["resource_kind"],
+            row_resource_id=row["resource_id"],
+            row_workspace=row["workspace_path"],
+            repo_id=repo_id,
+            repo_id_by_workspace=repo_id_by_workspace,
+        ):
+            targets.append(("discord", channel_id))
+    return tuple(targets)
+
+
+def _read_telegram_binding_targets_for_repo(
+    *,
+    db_path: Path,
+    repo_id: str,
+    repo_id_by_workspace: Mapping[str, str],
+) -> tuple[tuple[str, str], ...]:
+    if not db_path.exists():
+        return ()
+    try:
+        with open_sqlite(db_path) as conn:
+            columns = _table_columns(conn, "telegram_topics")
+            if not columns or "topic_key" not in columns:
+                return ()
+            select_columns = [
+                "topic_key",
+                "chat_id" if "chat_id" in columns else "NULL AS chat_id",
+                "thread_id" if "thread_id" in columns else "NULL AS thread_id",
+                "scope" if "scope" in columns else "NULL AS scope",
+                "repo_id" if "repo_id" in columns else "NULL AS repo_id",
+                (
+                    "workspace_path"
+                    if "workspace_path" in columns
+                    else "NULL AS workspace_path"
+                ),
+            ]
+            rows = conn.execute(
+                f"SELECT {', '.join(select_columns)} FROM telegram_topics"
+            ).fetchall()
+            scope_map = _read_telegram_current_scope_map(conn)
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            return ()
+        raise RuntimeError(
+            f"Failed reading Telegram chat bindings from {db_path}: {exc}"
+        ) from exc
+
+    targets: list[tuple[str, str]] = []
+    for row in rows:
+        topic = _normalize_scope(row["topic_key"])
+        if topic is None or not _is_current_telegram_topic_row(
+            row=row, scope_map=scope_map
+        ):
+            continue
+        if _binding_row_matches_repo(
+            row_repo_id=row["repo_id"],
+            row_resource_kind=None,
+            row_resource_id=None,
+            row_workspace=row["workspace_path"],
+            repo_id=repo_id,
+            repo_id_by_workspace=repo_id_by_workspace,
+        ):
+            targets.append(("telegram", topic))
+    return tuple(targets)
 
 
 def _orchestration_binding_timestamps_by_workspace(
@@ -1267,6 +1463,7 @@ __all__ = [
     "active_chat_binding_counts",
     "active_chat_binding_counts_by_source",
     "active_chat_binding_metadata_by_thread",
+    "active_chat_binding_targets_for_repo",
     "backfill_adapter_chat_surface_events",
     "emit_adapter_archive_chat_surface_event",
     "emit_adapter_binding_chat_surface_event",

--- a/src/codex_autorunner/core/pma_prompt_builder.py
+++ b/src/codex_autorunner/core/pma_prompt_builder.py
@@ -34,7 +34,7 @@ PMA_FASTPATH = """<pma_fastpath>
 You are PMA (Project Management Agent) inside Codex Autorunner (CAR). Treat the filesystem as truth; prefer creating/updating CAR artifacts over "chat-only" plans.
 
 Artifact delivery contract:
-- Send user-facing files with `car artifacts send <file> --to current` when an artifact delivery target is active.
+- Send user-facing files with `car artifacts send <file>` when an artifact delivery target or unique chat binding is active.
 - Use the injected artifact delivery context for the active surface and conversation target.
 - Use `car artifacts list`, `car artifacts inspect`, `car artifacts retry`, and `car artifacts cancel` for journal-backed lifecycle.
 
@@ -176,7 +176,7 @@ def render_pma_discoverability_preamble(
             "Automation quickstart: use `car automation ...` for scheduled automations, `car pma thread ... --notify-on terminal` for terminal follow-up, and `car pma thread subscribe` for thread-scoped lifecycle subscriptions.\n"
             f'Automation recipes and migration notes: `{pma_docs_dir / "ABOUT_CAR.md"}` -> "Managed-thread automation wake-ups".\n'
             "Ticket templates: pass `--repo <path>` (a git worktree) for every `car templates` subcommand; add `--path <hub_root>` when the shell cwd is not inside the hub tree. Examples: `car templates list --repo <path>`, `car templates search <query> --repo <path>`, `car templates show <id> --repo <path>`, `car templates apply <id> --repo <path>`.\n"
-            "To send a file to the user, use `car artifacts send <file> --to current` when an artifact delivery target is active.\n"
+            "To send a file to the user, use `car artifacts send <file>` when an artifact delivery target or unique chat binding is active.\n"
             f"User uploaded files are in `{resolved_hub / '.codex-autorunner' / 'filebox' / 'inbox'}`.\n\n"
         )
     else:
@@ -191,7 +191,7 @@ def render_pma_discoverability_preamble(
             "Automation quickstart: use `car automation ...` for scheduled automations, `car pma thread ... --notify-on terminal` for terminal follow-up, and `car pma thread subscribe` for thread-scoped lifecycle subscriptions.\n"
             'Automation recipes and migration notes: `<hub_root>/.codex-autorunner/pma/docs/ABOUT_CAR.md` -> "Managed-thread automation wake-ups".\n'
             "Ticket templates: pass `--repo <path>` (a git worktree) for every `car templates` subcommand; add `--path <hub_root>` when the shell cwd is not inside the hub tree. Examples: `car templates list --repo <path>`, `car templates search <query>`, `car templates show <id>`, `car templates apply <id>`.\n"
-            "To send a file to the user, use `car artifacts send <file> --to current` when an artifact delivery target is active.\n"
+            "To send a file to the user, use `car artifacts send <file>` when an artifact delivery target or unique chat binding is active.\n"
             "User uploaded files are in `<hub_root>/.codex-autorunner/filebox/inbox/`.\n\n"
         )
     if pma_docs:

--- a/src/codex_autorunner/surfaces/cli/commands/artifacts.py
+++ b/src/codex_autorunner/surfaces/cli/commands/artifacts.py
@@ -90,8 +90,8 @@ def _current_bound_chat_target(root: Path) -> tuple[str, str, str | None] | None
     try:
         hub = load_hub_config(root)
         manifest = load_manifest(hub.manifest_path, hub.root)
-    except (ConfigError, ManifestError, OSError, ValueError):
-        return None
+    except (ConfigError, ManifestError, OSError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
     repo = manifest.get_by_path(hub.root, root)
     if repo is None:
         return None

--- a/src/codex_autorunner/surfaces/cli/commands/artifacts.py
+++ b/src/codex_autorunner/surfaces/cli/commands/artifacts.py
@@ -21,8 +21,11 @@ from ....core.artifact_instructions import (
     ARTIFACT_WORKSPACE_SCOPE_ENV,
     current_artifact_target_failure_message,
 )
+from ....core.chat_bindings import active_chat_binding_targets_for_repo
+from ....core.config import ConfigError, load_hub_config
 from ....core.filebox import list_regular_files, outbox_dir, outbox_pending_dir
 from ....core.utils import RepoNotFoundError, find_repo_root
+from ....manifest import ManifestError, load_manifest
 
 
 def _root(root: Optional[Path]) -> Path:
@@ -56,25 +59,110 @@ def _states(value: Optional[str]) -> tuple[DeliveryState, ...] | None:
     return tuple(states)
 
 
-def _current_target() -> tuple[str, str, str | None]:
-    surface = os.environ.get(ARTIFACT_TARGET_SURFACE_ENV, "").strip()
-    conversation = os.environ.get(ARTIFACT_TARGET_CONVERSATION_ENV, "").strip()
-    workspace = os.environ.get(ARTIFACT_WORKSPACE_SCOPE_ENV, "").strip() or None
+_CHAT_BINDING_SURFACES = frozenset({"discord", "telegram"})
+
+
+def _current_target(
+    root: Path, env: Optional[dict[str, str]] = None
+) -> tuple[str, str, str | None]:
+    values = os.environ if env is None else env
+    surface = values.get(ARTIFACT_TARGET_SURFACE_ENV, "").strip()
+    conversation = values.get(ARTIFACT_TARGET_CONVERSATION_ENV, "").strip()
+    workspace = values.get(ARTIFACT_WORKSPACE_SCOPE_ENV, "").strip() or None
     if not surface or not conversation:
-        message = current_artifact_target_failure_message(os.environ)
-        raise typer.BadParameter(message or "current artifact target is unavailable")
+        if surface or conversation or workspace:
+            message = current_artifact_target_failure_message(values)
+            raise typer.BadParameter(
+                message or "current artifact target is unavailable"
+            )
+        bound_target = _current_bound_chat_target(root)
+        if bound_target is not None:
+            return bound_target
+        message = current_artifact_target_failure_message(values)
+        raise typer.BadParameter(
+            message
+            or "current artifact target is unavailable and no unique chat binding was found"
+        )
     return surface, conversation, workspace
+
+
+def _current_bound_chat_target(root: Path) -> tuple[str, str, str | None] | None:
+    try:
+        hub = load_hub_config(root)
+        manifest = load_manifest(hub.manifest_path, hub.root)
+    except (ConfigError, ManifestError, OSError, ValueError):
+        return None
+    repo = manifest.get_by_path(hub.root, root)
+    if repo is None:
+        return None
+    candidates: list[tuple[str, str, str]] = []
+    for surface_kind, surface_key in active_chat_binding_targets_for_repo(
+        hub_root=hub.root,
+        raw_config=hub.raw,
+        repo_id=repo.id,
+    ):
+        if surface_kind not in _CHAT_BINDING_SURFACES:
+            continue
+        conversation = _artifact_conversation_for_binding(surface_kind, surface_key)
+        if conversation is not None:
+            candidates.append((surface_kind, conversation, f"repo:{root}"))
+    unique_candidates = sorted(set(candidates))
+    if not unique_candidates:
+        return None
+    if len(unique_candidates) == 1:
+        return unique_candidates[0]
+    lines = [
+        "Current artifact target is ambiguous; multiple active chat bindings match "
+        f"{root}:"
+    ]
+    lines.extend(
+        f"- {surface}:{conversation}" for surface, conversation, _ in unique_candidates
+    )
+    lines.append(
+        "Pass --to explicit with --surface and --conversation to choose a target."
+    )
+    raise typer.BadParameter("\n".join(lines))
+
+
+def _artifact_conversation_for_binding(
+    surface: object, surface_key: object
+) -> str | None:
+    surface = str(surface or "").strip()
+    surface_key = str(surface_key or "").strip()
+    if not surface or not surface_key:
+        return None
+    if surface == "discord":
+        if surface_key.startswith("channel:"):
+            return surface_key
+        return f"channel:{surface_key}"
+    if surface == "telegram":
+        try:
+            chat_raw, thread_raw, _scope = surface_key.split(":", 2)
+        except ValueError:
+            try:
+                chat_raw, thread_raw = surface_key.split(":", 1)
+            except ValueError:
+                return f"topic:{surface_key}"
+        chat_raw = chat_raw.strip()
+        thread_raw = thread_raw.strip()
+        if not chat_raw or not thread_raw:
+            return f"topic:{surface_key}"
+        if thread_raw == "root":
+            return f"chat:{chat_raw}"
+        return f"chat:{chat_raw}/thread:{thread_raw}"
+    return None
 
 
 def _target(
     *,
+    root: Path,
     to: str,
     surface: Optional[str],
     conversation: Optional[str],
     workspace_scope: Optional[str],
 ) -> tuple[str, str, str | None]:
     if to == "current":
-        return _current_target()
+        return _current_target(root)
     if to != "explicit":
         raise typer.BadParameter("--to must be current or explicit")
     if not surface or not conversation:
@@ -189,13 +277,14 @@ def register_artifacts_commands(app: typer.Typer) -> None:
         json_output: bool = typer.Option(False, "--json", help="Emit JSON output"),
     ) -> None:
         """Queue a file for artifact delivery."""
+        repo_root = _root(root)
         target_surface, target_conversation, target_workspace = _target(
+            root=repo_root,
             to=to,
             surface=surface,
             conversation=conversation,
             workspace_scope=workspace_scope,
         )
-        repo_root = _root(root)
         storage = ArtifactFileBoxStorage(repo_root)
         service = storage.delivery
         intent = storage.enqueue_delivery_file(
@@ -239,13 +328,15 @@ def register_artifacts_commands(app: typer.Typer) -> None:
         json_output: bool = typer.Option(False, "--json", help="Emit JSON output"),
     ) -> None:
         """Import legacy FileBox outbox files into delivery records."""
+        repo_root = _root(root)
         target_surface, target_conversation, target_workspace = _target(
+            root=repo_root,
             to=to,
             surface=surface,
             conversation=conversation,
             workspace_scope=workspace_scope,
         )
-        service = ArtifactDeliveryService(_root(root))
+        service = ArtifactDeliveryService(repo_root)
         intents = service.import_legacy_outbox(
             target_surface=target_surface,
             target_conversation_key=target_conversation,

--- a/tests/adapters/discord/test_service_normalization.py
+++ b/tests/adapters/discord/test_service_normalization.py
@@ -123,7 +123,8 @@ def test_build_attachment_context_payload_formats_transcripts_and_images() -> No
     assert "Transcript: spoken request" in payload.prompt_text
     assert "Transcript may be inaccurate." in payload.prompt_text
     assert "Artifact delivery (this turn):" in payload.prompt_text
-    assert "car artifacts send <file> --to current" in payload.prompt_text
+    assert "car artifacts send <file>" in payload.prompt_text
+    assert "--to current" not in payload.prompt_text
     assert "filebox/outbox" not in payload.prompt_text
     assert payload.user_visible_transcript == "User:\nspoken request"
     assert payload.native_input_items_payload == [

--- a/tests/discord_message_turns_support.py
+++ b/tests/discord_message_turns_support.py
@@ -2514,7 +2514,8 @@ async def test_message_create_non_pma_injects_filebox_hint_for_outbox_keyword(
         prompt = captured_prompts[0]
         assert "outbox me" in prompt
         assert "Artifact delivery (this turn):" in prompt
-        assert "car artifacts send <file> --to current" in prompt
+        assert "car artifacts send <file>" in prompt
+        assert "--to current" not in prompt
         assert "channel:channel-1" in prompt
         assert str(inbox_dir(workspace.resolve())) in prompt
     finally:

--- a/tests/pma_context_support.py
+++ b/tests/pma_context_support.py
@@ -1909,7 +1909,8 @@ def test_format_pma_prompt_includes_artifact_delivery_contract(tmp_path: Path) -
 
     hub = tmp_path.expanduser().resolve()
     assert "Artifact delivery contract:" in result
-    assert "car artifacts send <file> --to current" in result
+    assert "car artifacts send <file>" in result
+    assert "--to current" not in result
     assert str(hub / ".codex-autorunner/filebox/outbox") not in result
     assert str(hub / ".codex-autorunner/filebox/inbox") in result
     assert "--to explicit" not in result

--- a/tests/test_artifact_instructions.py
+++ b/tests/test_artifact_instructions.py
@@ -11,7 +11,7 @@ from codex_autorunner.core.artifact_instructions import (
 )
 
 
-def test_agent_artifact_instructions_are_current_target_only(tmp_path: Path) -> None:
+def test_agent_artifact_instructions_use_default_send_command(tmp_path: Path) -> None:
     rendered = render_agent_artifact_instructions(
         ArtifactDeliveryContext(
             surface="telegram",
@@ -23,7 +23,8 @@ def test_agent_artifact_instructions_are_current_target_only(tmp_path: Path) -> 
     )
 
     assert "Artifact delivery (this turn):" in rendered
-    assert "car artifacts send <file> --to current" in rendered
+    assert "car artifacts send <file>" in rendered
+    assert "--to current" not in rendered
     assert "chat:1/thread:2" in rendered
     assert "filebox/inbox" in rendered
     assert "--to explicit" not in rendered
@@ -43,7 +44,8 @@ def test_agent_artifact_instructions_omit_inbox_when_absent() -> None:
         )
     )
 
-    assert "car artifacts send <file> --to current" in rendered
+    assert "car artifacts send <file>" in rendered
+    assert "--to current" not in rendered
     assert "User uploads may appear under" not in rendered
 
 
@@ -51,7 +53,8 @@ def test_human_artifact_overview_uses_same_current_command() -> None:
     rendered = render_human_artifact_overview(include_upload_inbox=True)
 
     assert "## Artifact delivery" in rendered
-    assert "car artifacts send <file> --to current" in rendered
+    assert "car artifacts send <file>" in rendered
+    assert "--to current" not in rendered
     assert "car artifacts list" in rendered
     assert ".codex-autorunner/filebox/inbox/" in rendered
     assert "filebox/outbox" not in rendered

--- a/tests/test_cli_artifacts.py
+++ b/tests/test_cli_artifacts.py
@@ -1,14 +1,103 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 from typer.testing import CliRunner
 
 from codex_autorunner.cli import app
 from codex_autorunner.core.artifact_delivery import ArtifactDeliveryService
+from codex_autorunner.core.config import CONFIG_FILENAME
+from codex_autorunner.core.orchestration.bindings import OrchestrationBindingStore
+from tests.conftest import write_test_config
 
 runner = CliRunner()
+
+
+def _write_hub_with_repo(
+    hub_root: Path, repo_root: Path, repo_id: str, *, kind: str = "base"
+) -> None:
+    write_test_config(
+        hub_root / CONFIG_FILENAME,
+        {"mode": "hub", "hub": {"manifest": ".codex-autorunner/manifest.yml"}},
+    )
+    write_test_config(
+        hub_root / ".codex-autorunner" / "manifest.yml",
+        {
+            "version": 2,
+            "repos": [
+                {
+                    "id": repo_id,
+                    "path": repo_root.relative_to(hub_root).as_posix(),
+                    "kind": kind,
+                    "enabled": True,
+                    "auto_run": False,
+                }
+            ],
+        },
+    )
+
+
+def _write_discord_channel_binding(
+    hub_root: Path, *, channel_id: str, workspace_path: Path, repo_id: str
+) -> None:
+    db_path = hub_root / ".codex-autorunner" / "discord_state.sqlite3"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS channel_bindings (
+                channel_id TEXT PRIMARY KEY,
+                workspace_path TEXT,
+                repo_id TEXT,
+                resource_kind TEXT,
+                resource_id TEXT
+            )
+            """)
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO channel_bindings (
+                channel_id, workspace_path, repo_id, resource_kind, resource_id
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (channel_id, str(workspace_path), repo_id, "repo", repo_id),
+        )
+
+
+def _write_telegram_topic_binding(
+    hub_root: Path, *, topic_key: str, workspace_path: Path, repo_id: str
+) -> None:
+    db_path = hub_root / ".codex-autorunner" / "telegram_state.sqlite3"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    chat_id, thread_id = topic_key.split(":", 1)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS telegram_topics (
+                topic_key TEXT PRIMARY KEY,
+                chat_id INTEGER NOT NULL,
+                thread_id INTEGER,
+                scope TEXT,
+                workspace_path TEXT,
+                repo_id TEXT
+            )
+            """)
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO telegram_topics (
+                topic_key, chat_id, thread_id, scope, workspace_path, repo_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                topic_key,
+                int(chat_id),
+                int(thread_id),
+                None,
+                str(workspace_path),
+                repo_id,
+            ),
+        )
 
 
 def test_artifacts_send_list_inspect_retry_cancel(tmp_path: Path) -> None:
@@ -131,3 +220,125 @@ def test_artifacts_import_legacy_queues_scoped_delivery_records(tmp_path: Path) 
     assert rows[0]["target_surface"] == "discord"
     assert rows[0]["target_conversation_key"] == "channel:123"
     assert rows[0]["metadata"]["legacy_filebox_source"] == "outbox"
+
+
+def test_artifacts_send_defaults_to_unique_bound_chat(
+    tmp_path: Path, monkeypatch
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "repo"
+    repo_root.mkdir(parents=True)
+    _write_hub_with_repo(hub_root, repo_root, "repo")
+    _write_discord_channel_binding(
+        hub_root,
+        channel_id="123",
+        workspace_path=repo_root,
+        repo_id="repo",
+    )
+    for key in (
+        "CAR_ARTIFACT_TARGET_SURFACE",
+        "CAR_ARTIFACT_TARGET_CONVERSATION_KEY",
+        "CAR_ARTIFACT_WORKSPACE_SCOPE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    source = repo_root / "report.txt"
+    source.write_text("report\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "artifacts",
+            "send",
+            str(source),
+            "--root",
+            str(repo_root),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["target_surface"] == "discord"
+    assert payload["target_conversation_key"] == "channel:123"
+    assert payload["workspace_scope"] == f"repo:{repo_root.resolve()}"
+
+
+def test_artifacts_send_fails_when_bound_chat_is_ambiguous(
+    tmp_path: Path, monkeypatch
+) -> None:
+    hub_root = tmp_path / "hub"
+    repo_root = hub_root / "repo"
+    repo_root.mkdir(parents=True)
+    _write_hub_with_repo(hub_root, repo_root, "repo")
+    _write_discord_channel_binding(
+        hub_root,
+        channel_id="123",
+        workspace_path=repo_root,
+        repo_id="repo",
+    )
+    _write_telegram_topic_binding(
+        hub_root,
+        topic_key="456:789",
+        workspace_path=repo_root,
+        repo_id="repo",
+    )
+    for key in (
+        "CAR_ARTIFACT_TARGET_SURFACE",
+        "CAR_ARTIFACT_TARGET_CONVERSATION_KEY",
+        "CAR_ARTIFACT_WORKSPACE_SCOPE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    source = repo_root / "report.txt"
+    source.write_text("report\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["artifacts", "send", str(source), "--root", str(repo_root)],
+    )
+
+    assert result.exit_code != 0
+    assert "Current artifact target is ambiguous" in result.output
+    assert "discord:channel:123" in result.output
+    assert "telegram:chat:456/thread:789" in result.output
+
+
+def test_artifacts_send_defaults_to_worktree_orchestration_binding(
+    tmp_path: Path, monkeypatch
+) -> None:
+    hub_root = tmp_path / "hub"
+    worktree_root = hub_root / "worktrees" / "repo-feature"
+    worktree_root.mkdir(parents=True)
+    _write_hub_with_repo(hub_root, worktree_root, "repo-feature", kind="worktree")
+    OrchestrationBindingStore(hub_root).upsert_binding(
+        surface_kind="discord",
+        surface_key="worktree-channel",
+        thread_target_id="thread-worktree",
+        resource_kind="worktree",
+        resource_id="repo-feature",
+    )
+    for key in (
+        "CAR_ARTIFACT_TARGET_SURFACE",
+        "CAR_ARTIFACT_TARGET_CONVERSATION_KEY",
+        "CAR_ARTIFACT_WORKSPACE_SCOPE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    source = worktree_root / "report.txt"
+    source.write_text("report\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "artifacts",
+            "send",
+            str(source),
+            "--root",
+            str(worktree_root),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["target_surface"] == "discord"
+    assert payload["target_conversation_key"] == "channel:worktree-channel"
+    assert payload["workspace_scope"] == f"repo:{worktree_root.resolve()}"

--- a/tests/test_telegram_car_context.py
+++ b/tests/test_telegram_car_context.py
@@ -116,7 +116,8 @@ async def test_telegram_file_hints_injected_for_plain_text_outbox_keyword(
     )
 
     assert "Artifact delivery (this turn):" in prompt
-    assert "car artifacts send <file> --to current" in prompt
+    assert "car artifacts send <file>" in prompt
+    assert "--to current" not in prompt
     assert "chat:3/thread:4" in prompt
     assert "Legacy pending outbox:" not in prompt
     assert "User uploads may appear under:" in prompt


### PR DESCRIPTION
## Summary
- Make `car artifacts send <file>` / `--to current` resolve env targets first, then fall back to one unique bound Discord/Telegram chat for the current repo or worktree.
- Add shared chat binding target resolution across orchestration bindings plus real Discord/Telegram adapter state.
- Update agent-facing artifact instructions and docs to prefer the simpler default command while preserving explicit target sends.

Fixes #1934

## Validation
- Subagent review completed; final pass found no blocking issues.
- `PYTHONPATH=src ~/.pyenv/versions/3.12.8/bin/python -m pytest -q -o addopts='' tests/test_cli_artifacts.py tests/test_artifact_instructions.py tests/test_pma_context_snapshot.py::test_format_pma_prompt_includes_artifact_delivery_contract tests/test_telegram_car_context.py tests/adapters/discord/test_service_normalization.py::test_build_attachment_context_payload_formats_transcripts_and_images`
- `python -m ruff check ...` for touched Python files
- Pre-commit aggregate validation passed: guardrails, ruff, import boundaries, mypy, CLI hint validation, 9464 pytest tests, Web UI build/tests, SPA shell check.
