### PR TITLE
[codex] Fix chat unread auto-read

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.ts
@@ -319,17 +319,6 @@ export function markChatGroupRead(
   return next;
 }
 
-export function markActiveSummaryRead(
-  markers: ChatLastSeenMap,
-  chat: PmaChatSummary | null,
-  store: ChatDetailReadMarkerStore = browserReadMarkerStore
-): ChatLastSeenMap {
-  if (!chat?.updatedAt) return markers;
-  const next = markChatRead(markers, chat.id, chat.updatedAt);
-  if (next !== markers) store.save(next);
-  return next;
-}
-
 export function loadPinnedChats(storage: BrowserStorageAdapter | null = browserLocalStorage()): PinnedChatMap {
   if (!storage) return {};
   try {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -54,7 +54,6 @@
     chatSummaryForSessionId,
     initialChatDetailSessionState,
     isLocalDraftChatId,
-    markActiveSummaryRead,
     markChatGroupRead,
     markSessionChatRead,
     markVisibleChatsRead,
@@ -994,13 +993,6 @@
     if (!chat || isLocalDraftChatId(chat.id) || !chat.agentId) return;
     if (`${chat.id}|${chat.agentId}` === syncedSelectorKey) return;
     syncSelectorsToActiveChat();
-  });
-
-  $effect(() => {
-    if (!activeChat) return;
-    const next = markActiveSummaryRead(lastSeenMap, activeChat);
-    if (next === lastSeenMap) return;
-    readModelEntityStore.optimisticReadMarkers(next, `read-active:${activeChat.id}:${Date.now()}`);
   });
 
   $effect(() => {

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -52,6 +52,15 @@ describe('/chats page', () => {
     expect(pageSource).not.toContain('openChatTranscriptEventSource');
   });
 
+  it('does not mark active chat updates read without an explicit read action', () => {
+    const pageSource = chatDetailPageSource();
+
+    expect(pageSource).toContain('onMarkRead: markActiveChatRead');
+    expect(pageSource).toContain('markSessionChatRead(lastSeenMap, activeChatId, chats, localDraftChat)');
+    expect(pageSource).not.toContain('markActiveSummaryRead');
+    expect(pageSource).not.toContain('read-active:');
+  });
+
   it('clears the committed chat URL guard when committed detail navigation fails', () => {
     const source = chatDetailPageSource();
     const syncCommittedBody = source.match(


### PR DESCRIPTION
## Summary
- Stop the chat detail page from marking the active chat read every time its backend summary updates.
- Keep explicit read actions intact, including selecting a chat and marking visible/group chats read.
- Add a regression test that prevents the automatic `read-active` marker path from returning.

## Root cause
The active-chat summary effect observed `activeChat.updatedAt` changes and immediately saved that timestamp as the local read marker. When an agent completed a turn, the completion updated the active chat summary and the UI marked the chat read before the user explicitly revisited it.

## Validation
- `pnpm vitest run src/routes/chats/page.test.ts src/lib/application/chatDetailSession.test.ts src/lib/viewModels/unread.test.ts`
- `pnpm run lint`
- Commit hook web-ui lane: repo guardrails, mypy, full pytest suite, build, full web frontend tests, SPA shell check