### PR TITLE
[codex] Surface Discord schema mismatch errors

### DIFF
--- a/src/codex_autorunner/adapters/discord/command_runner.py
+++ b/src/codex_autorunner/adapters/discord/command_runner.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Deque, Optional, Protocol, Sequence, Set
 
 from ...core.logging_utils import log_event
+from ...core.orchestration.compatibility import SchemaCompatibilityError
+from .errors import schema_compatibility_user_message
 from .ingress import IngressContext, IngressTiming, RuntimeInteractionEnvelope
 from .interaction_dispatch import (
     execute_ingressed_interaction,
@@ -854,7 +856,7 @@ class CommandRunner:
                 interaction_id=ctx.interaction_id,
                 exc=exc,
             )
-            await self._send_error_followup(ctx)
+            await self._send_error_followup(ctx, exc=exc)
         finally:
             if stall_task is not None:
                 stall_task.cancel()
@@ -969,13 +971,21 @@ class CommandRunner:
                 exc=exc,
             )
 
-    async def _send_error_followup(self, ctx: IngressContext) -> None:
+    async def _send_error_followup(
+        self,
+        ctx: IngressContext,
+        *,
+        exc: BaseException | None = None,
+    ) -> None:
         try:
+            text = "An unexpected error occurred. Please try again later."
+            if isinstance(exc, SchemaCompatibilityError):
+                text = schema_compatibility_user_message(exc)
             await self._service.send_or_respond_ephemeral(
                 interaction_id=ctx.interaction_id,
                 interaction_token=ctx.interaction_token,
                 deferred=ctx.deferred,
-                text="An unexpected error occurred. Please try again later.",
+                text=text,
             )
         except Exception as exc:
             log_event(

--- a/src/codex_autorunner/adapters/discord/errors.py
+++ b/src/codex_autorunner/adapters/discord/errors.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from ...core.exceptions import PermanentError, TransientError
+from ...core.orchestration.compatibility import SchemaCompatibilityError
 
 
 class DiscordError(Exception):
@@ -38,6 +39,16 @@ class DiscordPermanentError(DiscordAPIError, PermanentError):
 
     recoverable = PermanentError.recoverable
     severity = PermanentError.severity
+
+
+def schema_compatibility_user_message(exc: SchemaCompatibilityError) -> str:
+    evaluation = exc.evaluation
+    return (
+        "CAR runtime schema mismatch: orchestration.sqlite3 is at schema "
+        f"{evaluation.observed_schema}, but this process supports schema "
+        f"{evaluation.supported_schema}. Restart or refresh the CAR hub/runtime, "
+        "then retry the command."
+    )
 
 
 def is_unknown_interaction_error(error: BaseException | str | None) -> bool:

--- a/src/codex_autorunner/adapters/discord/interaction_dispatch.py
+++ b/src/codex_autorunner/adapters/discord/interaction_dispatch.py
@@ -18,8 +18,9 @@ import logging
 from typing import Any
 
 from ...core.logging_utils import log_event
+from ...core.orchestration.compatibility import SchemaCompatibilityError
 from .effects import DiscordEffectDeliveryError
-from .errors import DiscordTransientError
+from .errors import DiscordTransientError, schema_compatibility_user_message
 from .ingress import (
     IngressContext,
     InteractionKind,
@@ -52,6 +53,12 @@ async def handle_component_interaction(
         user_msg = exc.user_message or "An error occurred. Please try again later."
         await service.respond_ephemeral(
             ctx.interaction_id, ctx.interaction_token, user_msg
+        )
+    except SchemaCompatibilityError as exc:
+        await service.respond_ephemeral(
+            ctx.interaction_id,
+            ctx.interaction_token,
+            schema_compatibility_user_message(exc),
         )
     except DiscordEffectDeliveryError as exc:
         log_event(
@@ -95,6 +102,12 @@ async def handle_modal_submit_interaction(
             ctx.interaction_id,
             ctx.interaction_token,
             user_msg,
+        )
+    except SchemaCompatibilityError as exc:
+        await service.respond_ephemeral(
+            ctx.interaction_id,
+            ctx.interaction_token,
+            schema_compatibility_user_message(exc),
         )
     except DiscordEffectDeliveryError as exc:
         log_event(
@@ -163,6 +176,8 @@ async def handle_autocomplete_interaction(
             delivery_status=exc.delivery_status,
             exc=exc,
         )
+        await _respond_empty_autocomplete(service, ctx)
+    except SchemaCompatibilityError:
         await _respond_empty_autocomplete(service, ctx)
     except Exception as exc:  # intentional: top-level autocomplete error handler
         log_event(
@@ -250,6 +265,12 @@ async def execute_ingressed_interaction(
     except DiscordTransientError as exc:
         user_msg = exc.user_message or "An error occurred. Please try again later."
         await service.respond_ephemeral(interaction_id, interaction_token, user_msg)
+    except SchemaCompatibilityError as exc:
+        await service.respond_ephemeral(
+            interaction_id,
+            interaction_token,
+            schema_compatibility_user_message(exc),
+        )
     except DiscordEffectDeliveryError as exc:
         log_event(
             service._logger,

--- a/tests/adapters/discord/test_command_runner.py
+++ b/tests/adapters/discord/test_command_runner.py
@@ -18,6 +18,10 @@ from codex_autorunner.adapters.discord.ingress import (
     IngressTiming,
     InteractionKind,
 )
+from codex_autorunner.core.orchestration.compatibility import (
+    SchemaCompatibilityError,
+    evaluate_schema_compatibility,
+)
 
 
 def _make_ctx(
@@ -149,6 +153,17 @@ class _FakeService:
             deferred=deferred,
             text=text,
         )
+
+
+def _schema_compatibility_error() -> SchemaCompatibilityError:
+    return SchemaCompatibilityError(
+        evaluate_schema_compatibility(
+            observed_schema=43,
+            supported_schema=42,
+            process_role="discord",
+            build_id="test-build",
+        )
+    )
 
 
 def _slash_payload(
@@ -644,6 +659,37 @@ async def test_handler_error_sends_error_followup() -> None:
     service._respond_ephemeral.assert_awaited()
     call_args = service._respond_ephemeral.call_args
     assert "unexpected error" in call_args[0][2].lower()
+
+
+@pytest.mark.anyio
+async def test_schema_compatibility_error_sends_actionable_followup() -> None:
+    service = _FakeService()
+
+    async def failing_handler(*args: Any, **kwargs: Any) -> None:
+        raise _schema_compatibility_error()
+
+    service._handle_car_command.side_effect = failing_handler
+
+    runner = CommandRunner(
+        service,
+        config=RunnerConfig(timeout_seconds=5.0),
+        logger=service._logger,
+    )
+    ctx = _make_ctx(command_path=("car", "flow", "start"))
+    payload = _slash_payload(subcommand_name="flow")
+
+    runner.submit(ctx, payload)
+    for _ in range(30):
+        if service._respond_ephemeral.await_count > 0:
+            break
+        await asyncio.sleep(0.005)
+
+    service._respond_ephemeral.assert_awaited()
+    call_args = service._respond_ephemeral.call_args
+    text = call_args[0][2]
+    assert "schema mismatch" in text
+    assert "schema 43" in text
+    assert "schema 42" in text
 
 
 @pytest.mark.anyio

--- a/tests/adapters/discord/test_execute_ingressed.py
+++ b/tests/adapters/discord/test_execute_ingressed.py
@@ -21,6 +21,10 @@ from codex_autorunner.adapters.discord.ingress import (
 from codex_autorunner.adapters.discord.interaction_dispatch import (
     execute_ingressed_interaction,
 )
+from codex_autorunner.core.orchestration.compatibility import (
+    SchemaCompatibilityError,
+    evaluate_schema_compatibility,
+)
 
 
 def _ctx(
@@ -78,6 +82,17 @@ class _FakeService:
         self._handle_approval_component = AsyncMock()
         self.respond_ephemeral = AsyncMock()
         self.respond_autocomplete = AsyncMock()
+
+
+def _schema_compatibility_error() -> SchemaCompatibilityError:
+    return SchemaCompatibilityError(
+        evaluate_schema_compatibility(
+            observed_schema=43,
+            supported_schema=42,
+            process_role="discord",
+            build_id="test-build",
+        )
+    )
 
 
 @pytest.mark.anyio
@@ -295,3 +310,20 @@ async def test_callback_errors_are_logged_separately_from_handler_errors() -> No
     assert callback_events
     assert callback_events[0]["interaction_id"] == "inter-1"
     service.respond_ephemeral.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_slash_schema_compatibility_error_is_actionable() -> None:
+    service = _FakeService()
+    service._handle_car_command.side_effect = _schema_compatibility_error()
+    ctx = _ctx(command_path=("car", "flow", "start"))
+
+    await execute_ingressed_interaction(service, ctx, {})
+
+    service.respond_ephemeral.assert_awaited_once()
+    call_args = service.respond_ephemeral.call_args
+    text = call_args[0][2]
+    assert "schema mismatch" in text
+    assert "schema 43" in text
+    assert "schema 42" in text
+    assert "Restart or refresh" in text


### PR DESCRIPTION
## Summary
- Surface orchestration schema compatibility failures in Discord interactions as actionable ephemeral errors instead of generic fallback text.
- Add Discord slash/runner coverage for SchemaCompatibilityError handling.
- Root cause observed in hub logs for the failing /flow start attempts: OrchestrationMigrationRefused, "orchestration.sqlite3 schema is newer than this build supports".

## Validation
- PYTHONPATH=src .venv/bin/python -m pytest tests/adapters/discord/test_execute_ingressed.py tests/adapters/discord/test_command_runner.py
- .venv/bin/python scripts/chat_surface_latency_budgets.py --profile check-chat-surface-lab
- pre-commit hook: guardrails, mypy, full pytest, chat-surface lab deterministic checks, chat-surface latency budgets