### PR TITLE
[codex] Keep new chat detail mounted

### DIFF
--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.test.ts
@@ -5,6 +5,7 @@ import type { ChatListEntry } from '$lib/viewModels/pmaChat';
 import {
   activateChatDetailFromUrl,
   activateRequestedChatFromRows,
+  chatSummaryForSessionId,
   clearCommittedDraftPlaceholderIfPersisted,
   commitLocalDraftChat,
   initialChatDetailSessionState,
@@ -112,6 +113,30 @@ describe('chat detail session', () => {
       'managed-thread-1'
     );
     expect(clearCommittedDraftPlaceholderIfPersisted(committed, [chat({ id: 'managed-thread-1' })]).committedDraftChat).toBeNull();
+  });
+
+  it('resolves a committed draft placeholder even when the active chat window is stale', () => {
+    const draft = chat({
+      id: 'draft:pma:1',
+      title: 'New chat',
+      lifecycleStatus: 'draft',
+      raw: { draft: true }
+    });
+    const committed = commitLocalDraftChat(
+      startLocalDraftChat(initialChatDetailSessionState(), draft),
+      draft,
+      'managed-thread-1',
+      now
+    );
+
+    expect(chatSummaryForSessionId('managed-thread-1', [], null, committed.committedDraftChat)).toMatchObject({
+      id: 'managed-thread-1',
+      title: 'New chat',
+      raw: {
+        draft_committed_placeholder: true,
+        managed_thread_id: 'managed-thread-1'
+      }
+    });
   });
 
   it('keeps a committed draft selected while the detail URL is still catching up', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.ts
@@ -86,8 +86,10 @@ export function chatSummaryForSessionId(
 ): PmaChatSummary | null {
   if (!chatId) return null;
   if (localDraftChat?.id === chatId) return localDraftChat;
-  if (committedDraftChat?.id === chatId) return committedDraftChat;
-  return chats.find((chat) => chat.id === chatId) ?? null;
+  return (
+    chats.find((chat) => chat.id === chatId) ??
+    (committedDraftChat?.id === chatId ? committedDraftChat : null)
+  );
 }
 
 export function requestedChatDetailFromUrl(

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailSession.ts
@@ -81,10 +81,12 @@ export function isLocalDraftChatId(chatId: string | null): boolean {
 export function chatSummaryForSessionId(
   chatId: string | null,
   chats: PmaChatSummary[],
-  localDraftChat: PmaChatSummary | null
+  localDraftChat: PmaChatSummary | null,
+  committedDraftChat: PmaChatSummary | null = null
 ): PmaChatSummary | null {
   if (!chatId) return null;
   if (localDraftChat?.id === chatId) return localDraftChat;
+  if (committedDraftChat?.id === chatId) return committedDraftChat;
   return chats.find((chat) => chat.id === chatId) ?? null;
 }
 

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -267,7 +267,7 @@
   );
 
   function chatSummaryForId(chatId: string | null): PmaChatSummary | null {
-    return chatSummaryForSessionId(chatId, chats, localDraftChat)
+    return chatSummaryForSessionId(chatId, chats, localDraftChat, committedDraftChat)
       ?? (chatId ? selectPmaChats(readModelState).find((chat) => chat.id === chatId) ?? null : null);
   }
   const transcriptCards = $derived<ChatTranscriptCard[]>(selectChatTranscript(readModelState, activeChatId));


### PR DESCRIPTION
## Summary

Keep the chat detail pane mounted during the first-send handoff from a local draft chat ID to the committed managed thread ID.

## Root Cause

After the backend created the managed thread, the page switched `activeChatId` to the real thread ID before the active chat index window always contained that row. During that stale-window interval, `activeChat` resolved to null, so the right-side chat panel fell back to the no-selection state and the composer briefly disappeared.

## Changes

- Allow `chatSummaryForSessionId` to resolve a committed draft placeholder.
- Pass `committedDraftChat` into the chat page's active-chat resolver.
- Add a regression test for stale active windows during committed draft handoff.

## Validation

- `pnpm vitest run src/lib/application/chatDetailSession.test.ts src/lib/application/chatSendController.test.ts src/routes/chats/page.test.ts`
- `pnpm web:lint`
- Commit hook web-ui lane passed, including repo guardrails, mypy, pytest, frontend build, `pnpm web:test`, and SPA shell check.