### PR TITLE
[codex] Clarify chat-bound display metadata

### DIFF
--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -2272,17 +2272,6 @@ def _chat_index_rows_from_surfaces(
             identity_title = _managed_thread_identity_title(row)
             row["title"] = identity_title
             row["chat_display_name"] = identity_title
-        row["display_title"] = _normalize_text(row.get("chat_display_name")) or str(
-            row.get("title") or row.get("chat_id") or row.get("row_id") or ""
-        )
-        _apply_ticket_flow_child_state(row)
-        row["technical_title"] = _normalize_text(row.get("technical_title")) or str(
-            row.get("managed_thread_id") or row.get("row_id") or ""
-        )
-        primary_surface = row.get("surface")
-        if not isinstance(primary_surface, Mapping):
-            primary_surface = _primary_surface(row)
-        row["primary_surface"] = dict(primary_surface) if primary_surface else None
         row["surface_bindings"] = [
             dict(surface)
             for surface in row.get("surfaces", [])
@@ -2293,6 +2282,21 @@ def _chat_index_rows_from_surfaces(
         row["binding_display_name"] = (
             binding_display_names[0] if binding_display_names else None
         )
+        row["display_title"] = _normalize_text(row.get("chat_display_name")) or str(
+            row.get("title") or row.get("chat_id") or row.get("row_id") or ""
+        )
+        if row.get("managed_thread_id") is not None:
+            binding_title = _direct_external_binding_display_name(row)
+            if binding_title is not None:
+                row["display_title"] = binding_title
+        _apply_ticket_flow_child_state(row)
+        row["technical_title"] = _normalize_text(row.get("technical_title")) or str(
+            row.get("managed_thread_id") or row.get("row_id") or ""
+        )
+        primary_surface = row.get("surface")
+        if not isinstance(primary_surface, Mapping):
+            primary_surface = _primary_surface(row)
+        row["primary_surface"] = dict(primary_surface) if primary_surface else None
         if (
             row.get("managed_thread_id") is not None
             and _normalize_kind(row.get("lifecycle_status")) != "archived"
@@ -2462,6 +2466,23 @@ def _binding_display_names(surfaces: Iterable[Mapping[str, Any]]) -> list[str]:
         if name not in names:
             names.append(name)
     return names
+
+
+def _direct_external_binding_display_name(row: Mapping[str, Any]) -> Optional[str]:
+    for surface in row.get("surface_bindings") or []:
+        if not isinstance(surface, Mapping):
+            continue
+        surface_kind = _normalize_kind(surface.get("surface_kind"))
+        if surface_kind in {None, "pma", "managed_thread", "notification"}:
+            continue
+        name = _visible_chrome_text(
+            surface.get("binding_display_name")
+            or surface.get("display_name")
+            or surface.get("title")
+        )
+        if name is not None and not _is_surface_id_title(name, surface):
+            return name
+    return None
 
 
 def _primary_surface(row: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:

--- a/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
+++ b/src/codex_autorunner/core/orchestration/chat_surface_read_model.py
@@ -2667,6 +2667,7 @@ def _chat_row_search_text(row: Mapping[str, Any]) -> str:
     values = [
         row.get("managed_thread_id"),
         _visible_chrome_text(row.get("title")),
+        _visible_chrome_text(row.get("display_title")),
         row.get("repo_id"),
         row.get("resource_kind"),
         row.get("resource_id"),

--- a/src/codex_autorunner/surfaces/web/read_model_contracts.py
+++ b/src/codex_autorunner/surfaces/web/read_model_contracts.py
@@ -36,6 +36,7 @@ __all__ = [
     "ChatIndexPatchEvent",
     "ChatIndexRow",
     "ChatIndexSnapshot",
+    "ChatSurfaceBinding",
     "ChatQueueSummary",
     "ChatRuntimeProjection",
     "ChatThreadProjection",
@@ -218,6 +219,16 @@ class ChatRuntimeProjection(ReadModelContract):
     reasoning_source: str
 
 
+class ChatSurfaceBinding(ReadModelContract):
+    surface_kind: str
+    surface_key: str
+    surface_urn: Optional[str] = None
+    lifecycle: Optional[str] = None
+    display_name: Optional[str] = None
+    title: Optional[str] = None
+    binding_display_name: Optional[str] = None
+
+
 class ChatIndexRow(ReadModelContract):
     """Chat row contract shared by snapshots and patch payloads.
 
@@ -240,8 +251,8 @@ class ChatIndexRow(ReadModelContract):
     title: str
     display_title: Optional[str] = None
     technical_title: Optional[str] = None
-    primary_surface: Optional[dict[str, Any]] = None
-    surface_bindings: list[dict[str, Any]] = Field(default_factory=list)
+    primary_surface: Optional[ChatSurfaceBinding] = None
+    surface_bindings: list[ChatSurfaceBinding] = Field(default_factory=list)
     binding_display_name: Optional[str] = None
     binding_display_names: list[str] = Field(default_factory=list)
     lifecycle: Optional[str] = None

--- a/src/codex_autorunner/surfaces/web/services/chat_read_models.py
+++ b/src/codex_autorunner/surfaces/web/services/chat_read_models.py
@@ -28,6 +28,7 @@ from ..read_model_contracts import (
     ChatIndexSnapshot,
     ChatQueueSummary,
     ChatRuntimeProjection,
+    ChatSurfaceBinding,
     ChatThreadProjection,
     ChatTimelineIdentity,
     ChatTimelineItem,
@@ -653,13 +654,13 @@ def hub_chat_row_to_chat_index_row(raw: Mapping[str, Any]) -> ChatIndexRow:
 
     normalized_status = chat_effective_status_from_row(raw)
     surface_bindings = [
-        dict(cast(Mapping[str, Any], surface))
+        _chat_surface_binding(surface)
         for surface in raw.get("surface_bindings") or raw.get("surfaces") or []
         if isinstance(surface, Mapping)
     ]
     primary_surface = raw.get("primary_surface") or raw.get("surface")
     primary_surface_out = (
-        dict(cast(Mapping[str, Any], primary_surface))
+        _chat_surface_binding(primary_surface)
         if isinstance(primary_surface, Mapping)
         else None
     )
@@ -766,6 +767,26 @@ def hub_chat_row_to_chat_index_row(raw: Mapping[str, Any]) -> ChatIndexRow:
             _ticket_status_from_raw(raw, normalized_status) if is_ticket_flow else None
         ),
         debug=debug_payload or None,
+    )
+
+
+def _chat_surface_binding(surface: Mapping[str, Any]) -> ChatSurfaceBinding:
+    return ChatSurfaceBinding(
+        surface_kind=str(
+            surface.get("surface_kind") or surface.get("surfaceKind") or ""
+        ),
+        surface_key=str(surface.get("surface_key") or surface.get("surfaceKey") or ""),
+        surface_urn=_str_or_none(
+            surface.get("surface_urn") or surface.get("surfaceUrn")
+        ),
+        lifecycle=_str_or_none(surface.get("lifecycle")),
+        display_name=_str_or_none(
+            surface.get("display_name") or surface.get("displayName")
+        ),
+        title=_str_or_none(surface.get("title")),
+        binding_display_name=_str_or_none(
+            surface.get("binding_display_name") or surface.get("bindingDisplayName")
+        ),
     )
 
 

--- a/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/api/readModelContracts.ts
@@ -114,6 +114,16 @@ export type ChatRuntimeProjection = {
   reasoningSource: string;
 };
 
+export type ChatSurfaceBinding = {
+  surfaceKind: string;
+  surfaceKey: string;
+  surfaceUrn?: string | null;
+  lifecycle?: string | null;
+  displayName?: string | null;
+  title?: string | null;
+  bindingDisplayName?: string | null;
+};
+
 export function normalizeChatFacetRequest(request: Partial<ChatFacetRequest> | null | undefined): ChatFacetRequest {
   return {
     categories: sortedUniqueFacetValues(request?.categories),
@@ -159,8 +169,8 @@ export type ChatIndexRow = {
   title: string;
   displayTitle?: string | null;
   technicalTitle?: string | null;
-  primarySurface?: Record<string, unknown> | null;
-  surfaceBindings?: Record<string, unknown>[];
+  primarySurface?: ChatSurfaceBinding | null;
+  surfaceBindings?: ChatSurfaceBinding[];
   bindingDisplayName?: string | null;
   bindingDisplayNames?: string[];
   lifecycle?: string | null;
@@ -594,8 +604,6 @@ function snakeToCamel(value: string): string {
 }
 
 const opaqueContractRecordKeys = new Set([
-  'primarySurface',
-  'surfaceBindings',
   'sortKey',
   'identity',
   'parentLinks',

--- a/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/chatDetailPageController.test.ts
@@ -105,16 +105,16 @@ describe('ChatDetailPageController', () => {
       ticketRunGroupRequest: CHAT_TICKET_RUN_GROUP_WINDOW_REQUEST
     });
     harness.store.applyChatIndexSnapshot(chatIndexSnapshot([
-      chatIndexRow('active', { primarySurface: { surface_kind: 'managed_thread', surface_key: 'scope-1' } })
+      chatIndexRow('active', { primarySurface: { surfaceKind: 'managed_thread', surfaceKey: 'scope-1' } })
     ]));
     harness.liveProjection.activate.mockClear();
 
     harness.store.applyChatIndexSnapshot(chatIndexSnapshot([
       chatIndexRow('active', {
         status: 'archived',
-        primarySurface: { surface_kind: 'managed_thread', surface_key: 'scope-1' }
+        primarySurface: { surfaceKind: 'managed_thread', surfaceKey: 'scope-1' }
       }),
-      chatIndexRow('replacement', { primarySurface: { surface_kind: 'managed_thread', surface_key: 'scope-1' } })
+      chatIndexRow('replacement', { primarySurface: { surfaceKind: 'managed_thread', surfaceKey: 'scope-1' } })
     ]));
 
     expect(harness.sessionState.activeChatId).toBe('replacement');

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.test.ts
@@ -103,6 +103,60 @@ describe('read model view-model selectors', () => {
     expect(pmaChatSummaryToChatIndexRow(summary).facets?.category).toBe('ticket_run');
   });
 
+  it('trusts backend display titles for chat-bound rows', () => {
+    const row: ChatIndexRow = {
+      chatId: 'discord-chat-1',
+      surface: 'discord',
+      title: 'Can you root cause why this failed?',
+      displayTitle: 'Personal Workspace / #car-1',
+      bindingDisplayName: 'Personal Workspace / #car-1',
+      status: 'idle',
+      unreadCount: 0,
+      lastActivityAt: now,
+      facets: {
+        category: 'regular',
+        turnKinds: ['message'],
+        originKinds: ['surface'],
+        transports: ['discord'],
+        scopeKind: 'worktree',
+        scopeId: 'repo-1--discord-1',
+        agentKind: 'coding_agent'
+      }
+    };
+
+    expect(chatIndexRowToPmaChatSummary(row).title).toBe('Personal Workspace / #car-1');
+  });
+
+  it('does not infer titles from surface bindings when display title is available', () => {
+    const row: ChatIndexRow = {
+      chatId: 'telegram-chat-1',
+      surface: 'pma',
+      title: 'Latest Telegram message',
+      displayTitle: 'Latest Telegram message',
+      status: 'idle',
+      unreadCount: 0,
+      lastActivityAt: now,
+      surfaceBindings: [
+        {
+          surfaceKind: 'telegram',
+          surfaceKey: 'chat-123',
+          displayName: 'Audits / safe-global'
+        }
+      ],
+      facets: {
+        category: 'regular',
+        turnKinds: ['message'],
+        originKinds: ['surface'],
+        transports: ['telegram'],
+        scopeKind: 'repo',
+        scopeId: 'repo-1',
+        agentKind: 'pma'
+      }
+    };
+
+    expect(chatIndexRowToPmaChatSummary(row).title).toBe('Latest Telegram message');
+  });
+
   it('keeps active rebound chat-index rows visible despite stale raw surface archive fields', () => {
     const row: ChatIndexRow = {
       chatId: 'discord-rebound-active',
@@ -124,13 +178,14 @@ describe('read model view-model selectors', () => {
         agentKind: 'coding_agent'
       },
       primarySurface: {
-        surface_kind: 'pma',
+        surfaceKind: 'pma',
+        surfaceKey: 'thread-1',
         lifecycle: 'running'
       },
       surfaceBindings: [
         {
-          surface_kind: 'discord',
-          surface_key: 'channel-1',
+          surfaceKind: 'discord',
+          surfaceKey: 'channel-1',
           lifecycle: 'archived'
         }
       ]

--- a/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/data/readModelViewModels.ts
@@ -134,7 +134,7 @@ export function legacyChatIndexRecordToChatIndexRow(raw: JsonRecord): ChatIndexR
 }
 
 export function chatIndexRowToPmaChatSummary(row: ChatIndexRow): PmaChatSummary {
-  const title = row.displayTitle ?? row.bindingDisplayName ?? row.title;
+  const title = row.displayTitle ?? row.title;
   const raw: JsonRecord = {
     row,
     id: row.chatId,

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -37,6 +37,7 @@ import {
   modelReasoningOptions,
   modelSelectorState,
   pmaChatTransportBadges,
+  pmaChatBadgeViews,
   showPmaAgentBadge,
   pmaChatKind,
   pmaChatKindLabel,
@@ -1082,6 +1083,9 @@ describe('PMA chat view helpers', () => {
     expect(pmaChatTransportBadges(codingAgentChat)).toEqual([]);
     expect(showPmaAgentBadge(pmaAgentChat)).toBe(true);
     expect(showPmaAgentBadge(codingAgentChat)).toBe(false);
+    expect(pmaChatBadgeViews(pmaAgentChat).map((badge) => badge.label)).toEqual(['PMA']);
+    expect(pmaChatBadgeViews(pmaAgentChat, { showPmaAgent: false })).toEqual([]);
+    expect(pmaChatBadgeViews(codingAgentChat).map((badge) => badge.label)).toEqual(['Coding agent']);
   });
 
   it('labels regular chat facets as user-facing chats', () => {
@@ -1105,6 +1109,11 @@ describe('PMA chat view helpers', () => {
     };
 
     expect(pmaChatTransportBadges(chat).map((badge) => badge.slug)).toEqual(['discord', 'notification']);
+    expect(pmaChatBadgeViews(chat, { agentLabel: 'Codex' }).map((badge) => badge.label)).toEqual([
+      'Discord',
+      'Notifications',
+      'Codex'
+    ]);
   });
 
   it('gives notification chats their own surface filter from typed transport facets', () => {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -109,6 +109,36 @@ export function pmaChatTransportBadges(
     }));
 }
 
+export type PmaChatBadgeView =
+  | { kind: 'agent-kind'; label: string; className: string }
+  | { kind: 'category'; label: string; className: string }
+  | { kind: 'surface'; label: string; className: string }
+  | { kind: 'agent'; label: string; className: string };
+
+export function pmaChatBadgeViews(
+  chat: PmaChatSummary | null,
+  opts: { agentLabel?: string | null; showPmaAgent?: boolean } = {}
+): PmaChatBadgeView[] {
+  const badges: PmaChatBadgeView[] = [];
+  if (opts.showPmaAgent !== false && showPmaAgentBadge(chat)) {
+    badges.push({ kind: 'agent-kind', label: 'PMA', className: 'chat-kind-badge pma' });
+  }
+  if (pmaChatKind(chat) === 'coding_agent') {
+    badges.push({ kind: 'agent-kind', label: pmaChatKindLabel('coding_agent'), className: 'chat-kind-badge coding_agent' });
+  }
+  if (pmaChatFacets(chat)?.category === 'automation') {
+    badges.push({ kind: 'category', label: 'Automation', className: 'chat-kind-badge automation' });
+  }
+  for (const transport of pmaChatTransportBadges(chat)) {
+    badges.push({ kind: 'surface', label: transport.label, className: `chat-surface-badge ${transport.badgeClass}` });
+  }
+  const agentLabel = opts.agentLabel?.trim();
+  if (agentLabel) {
+    badges.push({ kind: 'agent', label: agentLabel, className: 'chat-agent-tag' });
+  }
+  return badges;
+}
+
 /** True when the chat is owned by the project manager agent, not merely PMA-surface reachable. */
 export function showPmaAgentBadge(chat: PmaChatSummary | null): boolean {
   if (!chat) return false;
@@ -532,8 +562,8 @@ export function pmaChatBindingKey(chat: PmaChatSummary | null): string | null {
   const primarySurface = raw.primary_surface;
   if (primarySurface && typeof primarySurface === 'object' && !Array.isArray(primarySurface)) {
     const primary = primarySurface as Record<string, unknown>;
-    const primaryKind = typeof primary.surface_kind === 'string' ? primary.surface_kind.trim() : '';
-    const primaryKey = typeof primary.surface_key === 'string' ? primary.surface_key.trim() : '';
+    const primaryKind = typeof (primary.surface_kind ?? primary.surfaceKind) === 'string' ? String(primary.surface_kind ?? primary.surfaceKind).trim() : '';
+    const primaryKey = typeof (primary.surface_key ?? primary.surfaceKey) === 'string' ? String(primary.surface_key ?? primary.surfaceKey).trim() : '';
     if (primaryKind && primaryKey) return `${primaryKind}:${primaryKey}`;
   }
   return null;

--- a/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/[[chatId]]/+page.svelte
@@ -122,9 +122,7 @@
     pmaChatKind,
     pmaChatKindLabel,
     pmaChatHeaderScopeLine,
-    pmaChatFacets,
-    pmaChatTransportBadges,
-    showPmaAgentBadge,
+    pmaChatBadgeViews,
     chatCategoryLabel,
     chatTransportLabel,
     pmaChatScopeTagView,
@@ -684,7 +682,7 @@
     const text = (card.message.text ?? '').trim();
     return text.length > 120 ? text.slice(text.length - 120) : text;
   });
-  const activeTransportBadges = $derived(pmaChatTransportBadges(activeChat));
+  const activeChatBadges = $derived(pmaChatBadgeViews(activeChat, { showPmaAgent: false }));
   const activeSharedFileCount = $derived(activeSurfaceDeliveries.length);
   const activeRepoIngress = $derived(repoIngressForChat(activeChat));
   const createChatLabel = $derived(creating ? 'Creating...' : '+ New');
@@ -2443,11 +2441,10 @@
         repoLabel: repoLabelForRepoId,
         worktreeLabel: (wid) => worktreeScopeOption(wid)?.label ?? null
       })}
-      {@const facets = pmaChatFacets(chat)}
-      {@const transportBadges = pmaChatTransportBadges(chat)}
       {@const listScopeAccent = chatListScopeAccentLabel(chat, scopeTags)}
       {@const listScopeAccentHex = listScopeAccent ? repoAccent(listScopeAccent) : null}
       {@const listAgentLabel = agentDisplayForChat(agents, chat)}
+      {@const listBadges = pmaChatBadgeViews(chat, { agentLabel: listAgentLabel })}
       <div
         class:active={chat.id === activeChatId}
         class:nested
@@ -2512,21 +2509,9 @@
               {#if isPmaChatArchived(chat)}
                 <span class="chat-scope-kind-tag retired">Retired</span>
               {/if}
-              {#if showPmaAgentBadge(chat)}
-                <span class="chat-kind-badge pma">PMA</span>
-              {/if}
-              {#if pmaChatKind(chat) === 'coding_agent'}
-                <span class={`chat-kind-badge ${pmaChatKind(chat)}`}>{pmaChatKindLabel(pmaChatKind(chat))}</span>
-              {/if}
-              {#if facets?.category === 'automation'}
-                <span class="chat-kind-badge automation">Automation</span>
-              {/if}
-              {#each transportBadges as transport}
-                <span class={`chat-surface-badge ${transport.badgeClass}`}>{transport.label}</span>
+              {#each listBadges as badge}
+                <span class={badge.className}>{badge.label}</span>
               {/each}
-              {#if listAgentLabel}
-                <span class="chat-agent-tag">{listAgentLabel}</span>
-              {/if}
             </span>
           {/if}
 
@@ -2736,12 +2721,8 @@
             </span>
           </div>
           <p class="chat-header-subtitle">
-            <span class={`chat-kind-badge ${activeChatKind}`}>{activeChatKindLabel}</span>
-            {#if pmaChatFacets(activeChat)?.category === 'automation'}
-              <span class="chat-kind-badge automation">Automation</span>
-            {/if}
-            {#each activeTransportBadges as transport}
-              <span class={`chat-surface-badge ${transport.badgeClass}`}>{transport.label}</span>
+            {#each activeChatBadges as badge}
+              <span class={badge.className}>{badge.label}</span>
             {/each}
             {#if activeChat.status === 'done' && displayedProgress?.elapsedSeconds !== null && displayedProgress?.elapsedSeconds !== undefined && statusBar}
               <span class={`status-dot status-${activeChat.status}`} aria-hidden="true"></span>

--- a/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
+++ b/src/codex_autorunner/web_frontend/src/routes/chats/page.test.ts
@@ -266,6 +266,17 @@ describe('/chats page', () => {
     expect(pageSource).toContain('contextualFacetCounts.transport');
   });
 
+  it('does not render the generic Chat kind badge in the active header', () => {
+    const pageSource = chatDetailPageSource();
+    const subtitleBody = pageSource.match(
+      /<p class="chat-header-subtitle">[\s\S]*?<\/p>/
+    )?.[0];
+
+    expect(subtitleBody).toBeTruthy();
+    expect(pageSource).toContain("pmaChatBadgeViews(activeChat, { showPmaAgent: false })");
+    expect(subtitleBody).toContain('{#each activeChatBadges as badge}');
+  });
+
   it('renders cached chat rows instead of the skeleton while the index cursor is still missing', () => {
     readModelEntityStore.upsertChatIndexRows([chatIndexRow()]);
 
@@ -287,8 +298,8 @@ describe('/chats page', () => {
         status: 'running',
         unreadCount: 0,
         lastActivityAt: '2026-05-11T12:00:00Z',
-        primarySurface: { surface_kind: 'pma', lifecycle: 'running' },
-        surfaceBindings: [{ surface_kind: 'discord', surface_key: 'channel-1', lifecycle: 'archived' }]
+        primarySurface: { surfaceKind: 'pma', surfaceKey: 'thread-1', lifecycle: 'running' },
+        surfaceBindings: [{ surfaceKind: 'discord', surfaceKey: 'channel-1', lifecycle: 'archived' }]
       },
       {
         chatId: 'discord-old-archived',

--- a/tests/contracts/web/test_read_model_contracts.py
+++ b/tests/contracts/web/test_read_model_contracts.py
@@ -159,7 +159,7 @@ def test_chat_index_snapshot_and_patch_round_trip_with_camel_case_payloads() -> 
     assert payload["rows"][0]["facets"]["turnKinds"] == ["message", "review"]
     assert payload["facetRequest"]["categories"] == ["ticket_run"]
     assert payload["facetCounts"]["transport"]["discord"] == 14
-    assert payload["rows"][0]["surfaceBindings"][0]["surface_kind"] == "discord"
+    assert payload["rows"][0]["surfaceBindings"][0]["surfaceKind"] == "discord"
     assert load_read_model_contract(ChatIndexSnapshot, payload) == snapshot
 
     event = ChatIndexPatchEvent(

--- a/tests/core/orchestration/test_chat_surface_read_model.py
+++ b/tests/core/orchestration/test_chat_surface_read_model.py
@@ -2361,7 +2361,7 @@ def test_chat_index_uses_message_preview_before_thread_id_fallback(
     ][0]
 
     assert row["title"] == "Investigate failed deploy"
-    assert row["display_title"] == "Investigate failed deploy"
+    assert row["display_title"] == "Agent Nexus / #deploys"
     assert row["binding_display_name"] == "Agent Nexus / #deploys"
 
 

--- a/tests/surfaces/web/test_hub_chat_read_model_routes.py
+++ b/tests/surfaces/web/test_hub_chat_read_model_routes.py
@@ -1474,9 +1474,9 @@ def test_hub_read_models_chats_includes_binding_display_contract_fields(
     assert response.status_code == 200
     row = response.json()["rows"][0]
     assert row["chatId"] == "thread-0003"
-    assert row["displayTitle"] == "Thread 0003"
+    assert row["displayTitle"] == "Release room"
     assert row["technicalTitle"] == "thread-0003"
-    assert row["primarySurface"]["surface_kind"] == "pma"
+    assert row["primarySurface"]["surfaceKind"] == "pma"
     assert "Release room" in row["bindingDisplayNames"]
     assert row["archiveState"] == "active"
     assert row["resourceKind"] == "ticket"


### PR DESCRIPTION
## Summary
- make chat-index displayTitle the backend-owned UI title for direct Discord/Telegram bindings while preserving managed-thread title fields
- type chat surface bindings in Python and TypeScript read-model contracts
- centralize chat row/header badge assembly in the PMA chat view model

## Validation
- commit hook: web-core-contract lane passed
- repo-wide mypy passed via hook
- repo-wide pytest passed via hook
- Web Hub build, tests, and SPA shell check passed via hook
- pnpm web:lint
- pnpm web:test
- .venv/bin/python -m pytest -q tests/contracts/web/ tests/core/orchestration/test_chat_surface_read_model.py tests/surfaces/web/test_hub_chat_read_model_routes.py tests/test_managed_threads_messages.py::test_global_first_send_uses_hub_genesis_after_worktree_discord_chat_and_keeps_pma_title