### PR TITLE
[codex] Fix Hermes chat formatting

### DIFF
--- a/src/codex_autorunner/adapters/chat/managed_thread_progress.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_progress.py
@@ -96,7 +96,12 @@ def apply_run_event_to_progress_tracker(
                 tracker.note_output(delta, new_segment=True)
                 tracker.end_output_segment()
         else:
-            tracker.note_output(delta)
+            tracker.note_output(
+                delta,
+                preserve_word_boundaries=bool(
+                    run_event.data.get("preserve_word_boundaries")
+                ),
+            )
         return ProgressTrackerEventOutcome(changed=True)
 
     if isinstance(run_event, ToolCall):

--- a/src/codex_autorunner/adapters/chat/progress_primitives.py
+++ b/src/codex_autorunner/adapters/chat/progress_primitives.py
@@ -4,6 +4,9 @@ import time
 from dataclasses import dataclass, field
 from typing import Optional
 
+from ...core.orchestration.stream_text_merge import (
+    append_assistant_stream_text_readably,
+)
 from ...core.text_utils import _truncate_text
 
 COMPACT_MAX_ACTIONS = 10
@@ -47,7 +50,9 @@ def _truncate_tail(text: str, limit: int) -> str:
     return f"...{text[-(limit - 3) :]}"
 
 
-def _merge_output_text(current: str, incoming: str) -> str:
+def _merge_output_text(
+    current: str, incoming: str, *, preserve_word_boundaries: bool = False
+) -> str:
     if not current:
         return incoming
     if incoming.startswith(current):
@@ -58,6 +63,8 @@ def _merge_output_text(current: str, incoming: str) -> str:
     for overlap in range(max_overlap, 0, -1):
         if current[-overlap:] == incoming[:overlap]:
             return f"{current}{incoming[overlap:]}"
+    if preserve_word_boundaries:
+        return append_assistant_stream_text_readably(current, incoming)
     return f"{current}{incoming}"
 
 
@@ -280,6 +287,7 @@ class TurnProgressTracker:
         text: str,
         *,
         new_segment: bool = False,
+        preserve_word_boundaries: bool = False,
     ) -> None:
         output_piece = _normalize_output_text(text)
         if not output_piece.strip():
@@ -299,7 +307,11 @@ class TurnProgressTracker:
             return
         current_output = self.actions[self.last_output_index].text
         self.output_buffer = _truncate_tail(
-            _merge_output_text(current_output, output_piece),
+            _merge_output_text(
+                current_output,
+                output_piece,
+                preserve_word_boundaries=preserve_word_boundaries,
+            ),
             self.max_output_chars,
         )
         self.update_action_raw(self.last_output_index, self.output_buffer, "update")

--- a/src/codex_autorunner/agents/hermes/supervisor.py
+++ b/src/codex_autorunner/agents/hermes/supervisor.py
@@ -125,6 +125,55 @@ async def _assistant_text_from_turn_events(
     return state.assistant_stream_text.strip()
 
 
+def _text_without_whitespace(value: str) -> str:
+    return "".join(str(value or "").split())
+
+
+def _formatted_current_turn_output(
+    *,
+    final_output: str,
+    stream_output: str,
+) -> str:
+    """Prefer terminal formatting while keeping only the current streamed turn.
+
+    Hermes ACP exposes two imperfect views: `session/update` chunks are scoped
+    to the active turn but may be tokenizer fragments with poor spacing, while
+    terminal `finalOutput` preserves formatting but may include prior transcript
+    text. The compact suffix match lets the stream prove the current-turn scope
+    before we trust terminal formatting.
+    """
+
+    final_text = str(final_output or "")
+    stream_text = str(stream_output or "")
+    if not final_text.strip():
+        return stream_text.strip()
+    if not stream_text.strip():
+        return final_text.strip()
+    final_stripped = final_text.strip()
+    stream_stripped = stream_text.strip()
+    if final_stripped == stream_stripped:
+        return final_stripped
+
+    stream_compact = _text_without_whitespace(stream_stripped)
+    if not stream_compact:
+        return final_stripped
+    compact_suffix_reversed: list[str] = []
+    target_length = len(stream_compact)
+    for index in range(len(final_text) - 1, -1, -1):
+        char = final_text[index]
+        if char.isspace():
+            continue
+        compact_suffix_reversed.append(char)
+        if len(compact_suffix_reversed) > target_length:
+            break
+        if (
+            len(compact_suffix_reversed) == target_length
+            and "".join(reversed(compact_suffix_reversed)) == stream_compact
+        ):
+            return final_text[index:].strip()
+    return stream_stripped
+
+
 def _replace_session_update_content_text(content: Any, text: str) -> Any:
     if isinstance(content, dict):
         updated = dict(content)
@@ -622,7 +671,10 @@ class HermesSupervisor:
             )
         else:
             if stream_assistant_text:
-                assistant_text = stream_assistant_text
+                assistant_text = _formatted_current_turn_output(
+                    final_output=result.final_output,
+                    stream_output=stream_assistant_text,
+                )
         log_event(
             self._logger,
             logging.INFO,

--- a/src/codex_autorunner/core/orchestration/runtime_thread_decoders.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_decoders.py
@@ -345,6 +345,9 @@ def _assistant_stream_events(
             content=content,
             delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
             stream_mode=stream_mode,
+            data=(
+                {"preserve_word_boundaries": True} if preserve_word_boundaries else {}
+            ),
         )
     ]
 

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -280,6 +280,9 @@ def note_run_event_state(
             event_state.note_stream_text(
                 str(run_event.content or ""),
                 merge_snapshot=run_event.stream_mode == RUN_EVENT_STREAM_MODE_SNAPSHOT,
+                preserve_word_boundaries=bool(
+                    run_event.data.get("preserve_word_boundaries")
+                ),
             )
             return
         if run_event.delta_type == RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE:

--- a/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
+++ b/src/codex_autorunner/core/orchestration/runtime_turn_terminal_state.py
@@ -412,8 +412,12 @@ class RuntimeTurnTerminalStateMachine:
             stream_text=self.last_assistant_text,
         )
 
-    def _note_assistant_stream_text(self, text: str) -> None:
-        self._assistant_text.note_stream_snapshot(text)
+    def _note_assistant_stream_text(
+        self, text: str, *, preserve_word_boundaries: bool = False
+    ) -> None:
+        self._assistant_text.note_stream_snapshot(
+            text, preserve_word_boundaries=preserve_word_boundaries
+        )
         self.last_assistant_text = self._assistant_text.text
 
     def _note_assistant_message_text(self, text: str) -> None:
@@ -442,7 +446,10 @@ class RuntimeTurnTerminalStateMachine:
     ) -> None:
         event_timestamp = timestamp or now_iso()
         if isinstance(event, AssistantDelta):
-            self._note_assistant_stream_text(event.text)
+            self._note_assistant_stream_text(
+                event.text,
+                preserve_word_boundaries=event.source == "session/update",
+            )
             return
         if isinstance(event, AssistantMessage):
             self._note_assistant_message_text(event.text)

--- a/src/codex_autorunner/core/ports/run_event.py
+++ b/src/codex_autorunner/core/ports/run_event.py
@@ -46,6 +46,7 @@ class OutputDelta:
     content: str
     delta_type: str = "text"
     stream_mode: str = RUN_EVENT_STREAM_MODE_DELTA
+    data: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/tests/agents/hermes/test_hermes_supervisor.py
+++ b/tests/agents/hermes/test_hermes_supervisor.py
@@ -17,6 +17,7 @@ from codex_autorunner.agents.acp.events import normalize_notification
 from codex_autorunner.agents.hermes.supervisor import (
     HermesSupervisor,
     HermesSupervisorError,
+    _formatted_current_turn_output,
     _should_close_turn_buffer,
     build_hermes_supervisor_from_config,
     hermes_runtime_preflight,
@@ -34,6 +35,26 @@ FIXTURE_PATH = Path(__file__).resolve().parents[2] / "fixtures" / "fake_acp_serv
 
 def fixture_command(scenario: str) -> list[str]:
     return [sys.executable, "-u", str(FIXTURE_PATH), "--scenario", scenario]
+
+
+def test_formatted_current_turn_output_prefers_terminal_spacing() -> None:
+    assert (
+        _formatted_current_turn_output(
+            final_output="### 🔴 Active (Running Now) | Thread",
+            stream_output="###🔴Active(Running Now)|Thread",
+        )
+        == "### 🔴 Active (Running Now) | Thread"
+    )
+
+
+def test_formatted_current_turn_output_trims_cumulative_terminal_output() -> None:
+    assert (
+        _formatted_current_turn_output(
+            final_output="prior reply\n\n### 🔴 Active (Running Now) | Thread",
+            stream_output="###🔴Active(Running Now)|Thread",
+        )
+        == "### 🔴 Active (Running Now) | Thread"
+    )
 
 
 class _HermesPreflightConfig:

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -804,6 +804,7 @@ async def test_normalize_runtime_thread_raw_event_preserves_hermes_token_boundar
         )
         assert len(events) == 1
         assert isinstance(events[0], OutputDelta)
+        assert events[0].data == {"preserve_word_boundaries": True}
 
     assert (
         state.best_assistant_text()

--- a/tests/core/orchestration/test_runtime_turn_terminal_state.py
+++ b/tests/core/orchestration/test_runtime_turn_terminal_state.py
@@ -368,6 +368,32 @@ def test_runtime_turn_terminal_state_machine_reduces_semantic_events() -> None:
     assert state.terminal_signals[0].status == "ok"
 
 
+def test_runtime_turn_terminal_state_preserves_hermes_session_update_word_boundaries() -> (
+    None
+):
+    state = RuntimeTurnTerminalStateMachine(
+        backend_thread_id="thread-1",
+        backend_turn_id="turn-1",
+    )
+
+    for chunk in ("Alpha", "beta", "gamma", "delta", "."):
+        state.note_raw_event(
+            {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "session-1",
+                    "turnId": "turn-1",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"type": "text", "text": chunk},
+                    },
+                },
+            }
+        )
+
+    assert state.last_assistant_text == "Alpha beta gamma delta."
+
+
 def test_unknown_raw_event_remains_observable_without_terminal_mutation() -> None:
     state = RuntimeTurnTerminalStateMachine(
         backend_thread_id="thread-1",

--- a/tests/test_telegram_progress_stream.py
+++ b/tests/test_telegram_progress_stream.py
@@ -1,6 +1,14 @@
+from codex_autorunner.adapters.chat.managed_thread_progress import (
+    ProgressRuntimeState,
+    apply_run_event_to_progress_tracker,
+)
 from codex_autorunner.adapters.telegram.progress_stream import (
     TurnProgressTracker,
     render_progress_text,
+)
+from codex_autorunner.core.ports.run_event import (
+    RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
+    OutputDelta,
 )
 
 
@@ -58,6 +66,82 @@ def test_note_output_does_not_insert_artificial_spaces_between_chunks() -> None:
     tracker.note_output("tration")
     tracker.note_output(" isn't")
     tracker.note_output(" broken")
+
+    rendered = render_progress_text(tracker, max_length=2000, now=1.0)
+
+    assert "orchestration isn't broken" in rendered
+    assert "orches tration" not in rendered
+
+
+def test_note_output_preserves_hermes_token_word_boundaries() -> None:
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="hermes",
+        model="mock-model",
+        label="working",
+        max_actions=10,
+        max_output_chars=200,
+    )
+
+    for chunk in ("Alpha", "beta", "gamma", "delta", "."):
+        tracker.note_output(chunk, preserve_word_boundaries=True)
+
+    rendered = render_progress_text(tracker, max_length=2000, now=1.0)
+
+    assert "Alpha beta gamma delta." in rendered
+    assert "Alphabetagammadelta" not in rendered
+
+
+def test_assistant_stream_progress_preserves_hermes_token_word_boundaries() -> None:
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="hermes",
+        model="mock-model",
+        label="working",
+        max_actions=10,
+        max_output_chars=200,
+    )
+    runtime_state = ProgressRuntimeState()
+
+    for chunk in ("Alpha", "beta", "gamma", "delta", "."):
+        apply_run_event_to_progress_tracker(
+            tracker,
+            OutputDelta(
+                timestamp="2026-01-01T00:00:00Z",
+                content=chunk,
+                delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
+                data={"preserve_word_boundaries": True},
+            ),
+            runtime_state=runtime_state,
+        )
+
+    rendered = render_progress_text(tracker, max_length=2000, now=1.0)
+
+    assert "Alpha beta gamma delta." in rendered
+    assert "Alphabetagammadelta" not in rendered
+
+
+def test_assistant_stream_progress_keeps_regular_split_word_chunks_glued() -> None:
+    tracker = TurnProgressTracker(
+        started_at=0.0,
+        agent="codex",
+        model="mock-model",
+        label="working",
+        max_actions=10,
+        max_output_chars=200,
+    )
+    runtime_state = ProgressRuntimeState()
+
+    for chunk in ("orches", "tration", " isn't", " broken"):
+        apply_run_event_to_progress_tracker(
+            tracker,
+            OutputDelta(
+                timestamp="2026-01-01T00:00:00Z",
+                content=chunk,
+                delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
+            ),
+            runtime_state=runtime_state,
+        )
 
     rendered = render_progress_text(tracker, max_length=2000, now=1.0)
 


### PR DESCRIPTION
## Summary

- Fix Hermes ACP final-response selection so terminal `finalOutput` supplies formatting while scoped `session/update` stream output proves the current-turn suffix.
- Carry an explicit `OutputDelta.data["preserve_word_boundaries"]` signal for Hermes token streams instead of changing all assistant stream merging.
- Preserve Hermes token word boundaries in live progress and terminal-state reducers, with regressions for both Hermes and regular split-word streams.

## Root cause

Real Hermes streams assistant output as token fragments without leading spaces, while `prompt/completed.finalOutput` preserves formatting but can be cumulative for durable sessions. CAR was using stream text too broadly for final output and live rendering, which mangled spaces and markdown/table formatting across web, Discord, and other chat surfaces.

## Validation

- Real local `hermes acp` probe: observed token chunks like `Alpha`, `beta`, `gamma`, `delta`, `.` plus correctly spaced terminal `finalOutput`.
- Sub-agent review completed; its medium finding about overbroad stream merging was addressed with an explicit run-event metadata flag and negative regression.
- `git commit` aggregate hook passed: black, ruff, import boundaries, hub contracts, mypy, repo pytest (`9528 passed`), frontend build, frontend tests (`872 passed, 2 skipped`), and SPA shell check.
- Focused checks before commit: Hermes/progress/runtime suites and run-event contract/history tests passed.
