### PR TITLE
[codex] Add context compaction transcript cards

### DIFF
--- a/src/codex_autorunner/core/hub_control_plane/service.py
+++ b/src/codex_autorunner/core/hub_control_plane/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from importlib import metadata as importlib_metadata
 from pathlib import Path
@@ -602,6 +603,19 @@ class HubSharedStateService:
         self._thread_store.set_thread_compact_seed(
             request.thread_target_id,
             request.compact_seed,
+        )
+        self._thread_store.append_action(
+            "managed_thread_compact",
+            managed_thread_id=request.thread_target_id,
+            payload_json=json.dumps(
+                {
+                    "summary_length": len(request.compact_seed),
+                    "summary": request.compact_seed,
+                    "summary_preview": request.compact_seed[:240],
+                    "reset_backend": True,
+                },
+                ensure_ascii=True,
+            ),
         )
         return ThreadTargetResponse(
             thread=_thread_target_from_store_row(

--- a/src/codex_autorunner/core/hub_control_plane/service.py
+++ b/src/codex_autorunner/core/hub_control_plane/service.py
@@ -612,7 +612,7 @@ class HubSharedStateService:
                     "summary_length": len(request.compact_seed),
                     "summary": request.compact_seed,
                     "summary_preview": request.compact_seed[:240],
-                    "reset_backend": True,
+                    "reset_backend": False,
                 },
                 ensure_ascii=True,
             ),

--- a/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
@@ -343,7 +343,7 @@ def _provider_compaction_payload_from_notice(
         preview=_normalize_optional_text(event_data.get("preview")),
         scope="provider_session",
         started_fresh_session=False,
-        stored_by_car=summary is not None,
+        stored_by_car=False,
         raw_event=event,
     )
 

--- a/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
@@ -23,6 +23,10 @@ from .progress_projection import (
     ProgressProjectionState,
     reduce_progress_event_merged,
 )
+from .run_notice_visibility import (
+    is_context_compaction_notice_kind,
+    is_internal_run_notice_kind,
+)
 from .turn_timeline import list_turn_timeline, list_turn_timelines
 
 TIMELINE_CONTRACT_VERSION = "managed_thread_timeline.v3"
@@ -219,6 +223,129 @@ def _progress_label_text(value: Any) -> str:
     if text is None:
         return ""
     return " ".join(text.replace("_", " ").replace(".", " ").split())
+
+
+def _is_internal_run_notice(event: dict[str, Any], progress_item: Any = None) -> bool:
+    progress = progress_item if isinstance(progress_item, dict) else {}
+    return any(
+        is_internal_run_notice_kind(candidate)
+        for candidate in (
+            event.get("kind"),
+            event.get("title"),
+            event.get("event_type"),
+            event.get("progress_kind"),
+            progress.get("kind"),
+            progress.get("title"),
+            progress.get("progress_kind"),
+        )
+    )
+
+
+def _context_compaction_preview(summary: Optional[str], fallback: str) -> str:
+    text = _normalize_optional_text(summary)
+    if text is None:
+        return fallback
+    first_line = next(
+        (line.strip() for line in text.splitlines() if line.strip()), text
+    )
+    return _truncate_text(first_line, 240)
+
+
+def _context_compaction_payload(
+    *,
+    source: str,
+    provider: Optional[str],
+    summary: Optional[str],
+    preview: Optional[str],
+    scope: str,
+    started_fresh_session: bool,
+    stored_by_car: bool,
+    raw_event: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    normalized_summary = _normalize_optional_text(summary)
+    normalized_preview = _normalize_optional_text(
+        preview
+    ) or _context_compaction_preview(
+        normalized_summary,
+        "No retained summary was exposed.",
+    )
+    return {
+        "source": source,
+        "provider": _normalize_optional_text(provider),
+        "summary": normalized_summary,
+        "preview": normalized_preview,
+        "scope": scope,
+        "started_fresh_session": started_fresh_session,
+        "stored_by_car": stored_by_car,
+        "raw_event": raw_event,
+    }
+
+
+def _provider_compaction_payload_from_notice(
+    event: dict[str, Any],
+) -> Optional[dict[str, Any]]:
+    run_notice = event.get("run_notice")
+    notice = run_notice if isinstance(run_notice, dict) else {}
+    data = event.get("data")
+    event_data = data if isinstance(data, dict) else {}
+    notice_data = notice.get("data")
+    if isinstance(notice_data, dict):
+        event_data = {**notice_data, **event_data}
+    progress_item = event.get("progress_item")
+    progress = progress_item if isinstance(progress_item, dict) else {}
+    if not any(
+        is_context_compaction_notice_kind(candidate)
+        for candidate in (
+            event.get("kind"),
+            event.get("title"),
+            event.get("event_type"),
+            event.get("progress_kind"),
+            notice.get("kind"),
+            progress.get("kind"),
+            progress.get("title"),
+            event_data.get("kind"),
+            event_data.get("event_type"),
+        )
+    ):
+        return None
+    summary = (
+        _normalize_optional_text(event_data.get("summary"))
+        or _normalize_optional_text(event_data.get("retained_context"))
+        or _normalize_optional_text(event_data.get("compact_seed"))
+        or _normalize_optional_text(progress.get("summary"))
+        or _normalize_optional_text(event.get("summary"))
+    )
+    message = _normalize_optional_text(
+        event.get("message")
+    ) or _normalize_optional_text(notice.get("message"))
+    if (
+        summary is None
+        and message
+        and message.lower()
+        not in {
+            "context compaction",
+            "provider context compaction",
+            "runtime context compaction",
+        }
+    ):
+        summary = message
+    provider = (
+        _normalize_optional_text(event_data.get("provider"))
+        or _normalize_optional_text(event_data.get("provider_id"))
+        or _normalize_optional_text(event_data.get("runtime"))
+        or _normalize_optional_text(event_data.get("agent"))
+        or _normalize_optional_text(progress.get("provider"))
+    )
+    return _context_compaction_payload(
+        source="provider",
+        provider=provider,
+        summary=summary,
+        preview=_normalize_optional_text(event_data.get("preview")),
+        scope="provider_session",
+        started_fresh_session=False,
+        stored_by_car=summary is not None,
+        raw_event=event,
+    )
 
 
 def _progress_display_title(
@@ -765,6 +892,34 @@ def _append_timeline_event_items(
             continue
 
         if event_type == "run_notice":
+            provider_compaction = _provider_compaction_payload_from_notice(event)
+            if provider_compaction is not None:
+                item_id = f"turn:{managed_turn_id}:context_compaction:{event_stable_id}"
+                items.append(
+                    ManagedThreadTimelineItem(
+                        item_id=item_id,
+                        kind="lifecycle",
+                        order_key=_order_key(timestamp, sequence, item_id),
+                        timestamp=timestamp,
+                        managed_thread_id=managed_thread_id,
+                        managed_turn_id=managed_turn_id,
+                        status=str(entry.get("status") or "recorded"),
+                        identity=_timeline_identity(item_id),
+                        provenance=_timeline_provenance(source_event_ids=[event_index]),
+                        payload={
+                            "lifecycle_kind": "context_compaction",
+                            "title": "Runtime compacted context",
+                            "text": "The provider summarized or pruned its internal session context.",
+                            "context_compaction": provider_compaction,
+                            "source_event_ids": [event_index],
+                            "source_event_type": event_type,
+                        },
+                    )
+                )
+                sequence += 1
+                continue
+            if _is_internal_run_notice(event, progress_item):
+                continue
             if _merge_streamed_intermediate_timeline_item(
                 items,
                 progress_item=progress_item,
@@ -1013,6 +1168,33 @@ def timeline_item_from_tail_event(
     if (
         event_type in {"progress", "assistant_update"} and progress_kind != "approval"
     ) or progress_kind in {"assistant_update", "notice"}:
+        provider_compaction = _provider_compaction_payload_from_notice(tail_event)
+        if provider_compaction is not None:
+            item_id = f"turn:{normalized_turn_id}:context_compaction:{source_event_key}"
+            item = {
+                **base,
+                "item_id": item_id,
+                "kind": "lifecycle",
+                "payload": {
+                    "lifecycle_kind": "context_compaction",
+                    "title": "Runtime compacted context",
+                    "text": "The provider summarized or pruned its internal session context.",
+                    "context_compaction": provider_compaction,
+                    "source_event_ids": source_event_ids,
+                    "source_event_type": event_type,
+                    "live_tail_event": dict(tail_event),
+                },
+            }
+            return _with_contract_metadata(
+                item,
+                progress_item_ids=_progress_item_ids_from_items(progress_items),
+                source_event_ids=source_event_ids,
+                progress_event_ids=_progress_event_ids_from_items(progress_items)
+                or list(source_event_ids),
+                cursor_event_id=event_id or None,
+            )
+        if _is_internal_run_notice(tail_event, progress):
+            return None
         item_id = f"turn:{normalized_turn_id}:intermediate:" f"{source_event_key}"
         text = str(tail_event.get("summary") or "")
         title = _progress_display_title(
@@ -1291,6 +1473,10 @@ def _append_compact_lifecycle_item(
     payload = _decode_action_payload(action)
     timestamp = _normalize_optional_text(action.get("created_at"))
     item_id = f"action:{action_id}:compact"
+    summary = _normalize_optional_text(
+        payload.get("summary")
+    ) or _normalize_optional_text(payload.get("compact_seed"))
+    preview = _normalize_optional_text(payload.get("summary_preview"))
     items.append(
         ManagedThreadTimelineItem(
             item_id=item_id,
@@ -1304,9 +1490,18 @@ def _append_compact_lifecycle_item(
             provenance=_timeline_provenance(),
             payload={
                 **payload,
-                "lifecycle_kind": "chat_compacted",
-                "title": "Chat compacted",
-                "text": "Chat compacted. The next message starts a fresh backend session with the compacted context.",
+                "lifecycle_kind": "context_compaction",
+                "title": "Context compacted by CAR",
+                "text": "Earlier conversation was summarized and will be injected into the next turn.",
+                "context_compaction": _context_compaction_payload(
+                    source="car",
+                    provider=_normalize_optional_text(payload.get("provider")),
+                    summary=summary,
+                    preview=preview,
+                    scope="managed_thread",
+                    started_fresh_session=bool(payload.get("reset_backend") is True),
+                    stored_by_car=True,
+                ),
                 "action_id": action_id,
                 "action_type": action_type,
             },

--- a/src/codex_autorunner/core/orchestration/managed_thread_transcript.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_transcript.py
@@ -9,6 +9,7 @@ from .managed_thread_timeline import (
     build_managed_thread_timeline,
     timeline_item_from_tail_event,
 )
+from .run_notice_visibility import is_internal_run_notice_kind
 
 TRANSCRIPT_CONTRACT_VERSION = "managed_thread_transcript.v2"
 
@@ -244,6 +245,34 @@ def _timeline_item_to_transcript_rows(item: Mapping[str, Any]) -> list[dict[str,
         title = _optional_text(payload.get("title")) or "Chat compacted"
         text = _optional_text(payload.get("text")) or "Chat compacted."
         preview = _optional_text(payload.get("summary_preview"))
+        compaction = _mapping(payload.get("context_compaction"))
+        if compaction or _optional_text(payload.get("lifecycle_kind")) in {
+            "chat_compacted",
+            "context_compaction",
+        }:
+            if not compaction:
+                compaction = {
+                    "source": "car",
+                    "provider": None,
+                    "summary": None,
+                    "preview": preview,
+                    "scope": "managed_thread",
+                    "started_fresh_session": payload.get("reset_backend") is True,
+                    "stored_by_car": True,
+                }
+            return [
+                {
+                    "kind": "context_compaction",
+                    "id": item_id,
+                    "title": title,
+                    "text": f"{text}\n\n{preview}" if preview else text,
+                    "detail": _json_detail(payload.get("event") or payload),
+                    "context_compaction": compaction,
+                    "turn_id": managed_turn_id,
+                    "order_key": order_key,
+                    "timestamp": timestamp,
+                }
+            ]
         return [
             {
                 "kind": "lifecycle",
@@ -488,6 +517,19 @@ def _is_hidden_intermediate(payload: Mapping[str, Any]) -> bool:
         return True
     intermediate_kind = str(payload.get("intermediate_kind") or "").lower()
     event_type = str(payload.get("event_type") or "").lower()
+    event = _mapping(payload.get("event"))
+    if any(
+        is_internal_run_notice_kind(candidate)
+        for candidate in (
+            intermediate_kind,
+            payload.get("title"),
+            event.get("kind"),
+            event.get("title"),
+            progress_item.get("kind"),
+            progress_item.get("title"),
+        )
+    ):
+        return True
     return event_type == "output_delta" and intermediate_kind in {
         "assistant_stream",
         "assistant_message",

--- a/src/codex_autorunner/core/orchestration/run_notice_visibility.py
+++ b/src/codex_autorunner/core/orchestration/run_notice_visibility.py
@@ -5,6 +5,8 @@ from typing import Any
 CHAT_EXECUTION_JOURNAL_NOTICE_KIND = "chat_execution_journal"
 COMPACTION_SUMMARY_NOTICE_KIND = "compaction_summary"
 DECODE_FAILURE_NOTICE_KIND = "decode_failure"
+PROVIDER_CONTEXT_COMPACTION_NOTICE_KIND = "provider_context_compaction"
+CONTEXT_COMPACTION_NOTICE_KIND = "context_compaction"
 
 INTERNAL_RUN_NOTICE_KINDS = frozenset(
     {
@@ -16,4 +18,18 @@ INTERNAL_RUN_NOTICE_KINDS = frozenset(
 
 
 def is_internal_run_notice_kind(kind: Any) -> bool:
-    return str(kind or "").strip().lower() in INTERNAL_RUN_NOTICE_KINDS
+    text = str(kind or "").strip().lower()
+    token = "_".join(text.replace(".", "_").replace("-", "_").split())
+    return token in INTERNAL_RUN_NOTICE_KINDS
+
+
+def is_context_compaction_notice_kind(kind: Any) -> bool:
+    text = str(kind or "").strip().lower()
+    token = "_".join(text.replace(".", "_").replace("-", "_").split())
+    return token in {
+        PROVIDER_CONTEXT_COMPACTION_NOTICE_KIND,
+        CONTEXT_COMPACTION_NOTICE_KIND,
+        "runtime_context_compaction",
+        "provider_compaction",
+        "runtime_compaction",
+    }

--- a/src/codex_autorunner/core/pma/tail_serialization.py
+++ b/src/codex_autorunner/core/pma/tail_serialization.py
@@ -296,11 +296,18 @@ def _tail_event_from_run_event(
         grouped = (*state.tool_group_items.get(item.group_id, ()), item)
         state.tool_group_items[item.group_id] = grouped
         progress_items = list(grouped)
-    return _tail_event_from_progress_item(
+    tail_event = _tail_event_from_progress_item(
         item,
         received_at=received_at,
         progress_items=progress_items,
     )
+    if isinstance(run_event, RunNotice):
+        tail_event["run_notice"] = {
+            "kind": run_event.kind,
+            "message": run_event.message,
+            "data": dict(run_event.data),
+        }
+    return tail_event
 
 
 def _tail_event_type_from_progress_item(item: ProgressProjectionItem) -> str:

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/managed_threads.py
@@ -1446,6 +1446,7 @@ def build_managed_thread_crud_routes(
                 {
                     "old_backend_thread_id": old_backend_thread_id,
                     "summary_length": len(summary),
+                    "summary": summary,
                     "summary_preview": _truncate_text(summary, 240),
                     "reset_backend": reset_backend,
                 },

--- a/src/codex_autorunner/web_frontend/src/lib/application/currentTicketChatPreviewProjection.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/application/currentTicketChatPreviewProjection.ts
@@ -148,7 +148,13 @@ function rowPreview(row: Record<string, unknown>): { text: string; role: Current
     const role = String((message as Record<string, unknown>).role ?? '') === 'user' ? 'user' : 'assistant';
     return { text, role };
   }
-  if (kind === 'intermediate' || kind === 'tool_group' || kind === 'approval' || kind === 'lifecycle') {
+  if (
+    kind === 'intermediate' ||
+    kind === 'tool_group' ||
+    kind === 'approval' ||
+    kind === 'lifecycle' ||
+    kind === 'context_compaction'
+  ) {
     const text = String(row.text ?? row.summary ?? row.title ?? '').trim();
     return text ? { text, role: 'intermediate' } : null;
   }

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.svelte
@@ -175,6 +175,23 @@
     return `${ref.capsuleId} v${ref.capsuleVersion} · ${ref.scope}`;
   }
 
+  function compactionSourceLabel(card: Extract<ChatTranscriptCard, { kind: 'context_compaction' }>): string {
+    if (card.compaction.source === 'car') return 'CAR';
+    if (card.compaction.provider) return card.compaction.provider;
+    if (card.compaction.source === 'provider') return 'Provider';
+    return 'Runtime';
+  }
+
+  function compactionScopeLabel(value: string | null): string {
+    if (value === 'managed_thread') return 'Managed thread';
+    if (value === 'provider_session') return 'Provider session';
+    return value || 'Context';
+  }
+
+  function compactionPreview(card: Extract<ChatTranscriptCard, { kind: 'context_compaction' }>): string {
+    return card.compaction.preview || card.compaction.summary || card.text || 'No retained summary was exposed.';
+  }
+
   function displayCardsFor(input: ChatTranscriptCard[]): ChatTranscriptCard[] {
     const cached = displayCardCache.get(input);
     if (cached) return cached;
@@ -413,6 +430,46 @@
       </section>
       <div></div>
     </article>
+  {:else if card.kind === 'context_compaction'}
+    <details class="tool-call-bar context-compaction-card">
+      <summary>
+        <span>{compactionSourceLabel(card)}</span>
+        <strong>{compactionPreview(card)}</strong>
+      </summary>
+      <div class="thinking-trace-body markdown-body">
+        <p>{card.text}</p>
+        {#if card.compaction.summary}
+          <h4>Retained context</h4>
+          {@html renderMarkdownToHtml(card.compaction.summary, { openLinksInNewTab: true })}
+        {:else}
+          <p>No retained summary was exposed.</p>
+        {/if}
+        <dl class="compaction-meta">
+          <div>
+            <dt>Source</dt>
+            <dd>{compactionSourceLabel(card)}</dd>
+          </div>
+          <div>
+            <dt>Scope</dt>
+            <dd>{compactionScopeLabel(card.compaction.scope)}</dd>
+          </div>
+          <div>
+            <dt>Fresh session</dt>
+            <dd>{card.compaction.startedFreshSession ? 'yes' : 'no'}</dd>
+          </div>
+          <div>
+            <dt>Stored by CAR</dt>
+            <dd>{card.compaction.storedByCar ? 'yes' : 'no'}</dd>
+          </div>
+        </dl>
+        {#if card.detail}
+          <details class="compaction-raw-detail">
+            <summary>Raw details</summary>
+            <pre class="timeline-detail">{card.detail}</pre>
+          </details>
+        {/if}
+      </div>
+    </details>
   {:else if card.kind === 'ticket'}
     <article class="artifact-card ticket-card">
       <span class="artifact-type">Ticket</span>

--- a/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/components/ChatTranscriptCards.test.ts
@@ -74,6 +74,39 @@ describe('ChatTranscriptCards', () => {
     expect(body).toContain('Visible user-facing note.');
   });
 
+  it('renders context compaction as an expandable retained-context card', () => {
+    const cards: ChatTranscriptCard[] = [
+      {
+        kind: 'context_compaction',
+        id: 'compact-1',
+        title: 'Context compacted by CAR',
+        text: 'Earlier conversation was summarized.',
+        detail: '{"action_type":"managed_thread_compact"}',
+        turnId: null,
+        orderKey: '00000002|compact',
+        timestamp: '2026-05-10T00:01:00.000Z',
+        compaction: {
+          source: 'car',
+          provider: null,
+          summary: 'Keep the current goal.',
+          preview: 'Keep the current goal.',
+          scope: 'managed_thread',
+          startedFreshSession: true,
+          storedByCar: true
+        }
+      }
+    ];
+
+    const { body } = render(ChatTranscriptCards, { props: { cards } });
+
+    expect(body).toContain('class="tool-call-bar context-compaction-card"');
+    expect(body).toContain('<span>CAR</span>');
+    expect(body).toContain('Keep the current goal.');
+    expect(body).toContain('Retained context');
+    expect(body).toContain('<dt>Fresh session</dt>');
+    expect(body).toContain('<dd>yes</dd>');
+  });
+
   it('renders richer progress labels when the model supplies them', () => {
     const cards: ChatTranscriptCard[] = [
       {

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.test.ts
@@ -1927,14 +1927,21 @@ describe('PMA chat view helpers', () => {
     ).toEqual([]);
   });
 
-  it('renders compaction lifecycle timeline items as visible dividers', () => {
+  it('renders CAR compaction lifecycle timeline items as context compaction cards', () => {
     const cards = buildChatTranscriptCards(
       [
         timelineItem('action:1:compact', 'lifecycle', {
-          lifecycle_kind: 'chat_compacted',
-          title: 'Chat compacted',
-          text: 'Chat compacted. The next message starts a fresh backend session with the compacted context.',
-          summary_preview: 'Keep the current goal and constraints.'
+          lifecycle_kind: 'context_compaction',
+          title: 'Context compacted by CAR',
+          text: 'Earlier conversation was summarized and will be injected into the next turn.',
+          context_compaction: {
+            source: 'car',
+            summary: 'Keep the current goal and constraints.',
+            preview: 'Keep the current goal and constraints.',
+            scope: 'managed_thread',
+            started_fresh_session: true,
+            stored_by_car: true
+          }
         })
       ],
       null,
@@ -1943,9 +1950,50 @@ describe('PMA chat view helpers', () => {
 
     expect(cards).toHaveLength(1);
     expect(cards[0]).toMatchObject({
-      kind: 'lifecycle',
-      title: 'Chat compacted',
-      text: expect.stringContaining('Keep the current goal and constraints.')
+      kind: 'context_compaction',
+      title: 'Context compacted by CAR',
+      compaction: {
+        source: 'car',
+        summary: 'Keep the current goal and constraints.',
+        startedFreshSession: true,
+        storedByCar: true
+      }
+    });
+  });
+
+  it('renders provider-native compaction lifecycle timeline items as context compaction cards', () => {
+    const cards = buildChatTranscriptCards(
+      [
+        timelineItem('turn:one:context_compaction:1', 'lifecycle', {
+          lifecycle_kind: 'context_compaction',
+          title: 'Runtime compacted context',
+          text: 'The provider summarized or pruned its internal session context.',
+          context_compaction: {
+            source: 'provider',
+            provider: 'opencode',
+            summary: null,
+            preview: 'No retained summary was exposed.',
+            scope: 'provider_session',
+            started_fresh_session: false,
+            stored_by_car: false
+          }
+        })
+      ],
+      null,
+      []
+    );
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      kind: 'context_compaction',
+      title: 'Runtime compacted context',
+      compaction: {
+        source: 'provider',
+        provider: 'opencode',
+        preview: 'No retained summary was exposed.',
+        startedFreshSession: false,
+        storedByCar: false
+      }
     });
   });
 

--- a/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
+++ b/src/codex_autorunner/web_frontend/src/lib/viewModels/pmaChat.ts
@@ -222,8 +222,29 @@ export type ChatTranscriptCard =
   | { kind: 'turn_summary'; id: string; title: string; cards: ChatTranscriptCard[]; turnId: string | null; orderKey: string; timestamp: string | null }
   | { kind: 'approval'; id: string; title: string; summary: string; detail: string | null; turnId: string | null; orderKey: string; timestamp: string | null }
   | { kind: 'lifecycle'; id: string; title: string; text: string; detail: string | null; turnId: string | null; orderKey: string; timestamp: string | null }
+  | {
+      kind: 'context_compaction';
+      id: string;
+      title: string;
+      text: string;
+      detail: string | null;
+      compaction: ChatContextCompaction;
+      turnId: string | null;
+      orderKey: string;
+      timestamp: string | null;
+    }
   | { kind: 'ticket'; id: string; title: string; summary: string | null; ticketId: string }
   | { kind: 'artifact'; id: string; artifact: SurfaceArtifact };
+
+export type ChatContextCompaction = {
+  source: 'car' | 'provider' | 'unknown';
+  provider: string | null;
+  summary: string | null;
+  preview: string | null;
+  scope: string | null;
+  startedFreshSession: boolean;
+  storedByCar: boolean;
+};
 
 export type ChatToolCallCard = {
   id: string;
@@ -1585,10 +1606,36 @@ function mapChatTranscriptRow(raw: Record<string, unknown>): ChatTranscriptCard 
       timestamp: nullableString(raw.timestamp)
     };
   }
+  if (kind === 'context_compaction') {
+    return {
+      kind: 'context_compaction',
+      id,
+      title: stringValue(raw.title) || 'Context compacted',
+      text: stringValue(raw.text),
+      detail: nullableString(raw.detail),
+      compaction: mapContextCompaction(asRecord(raw.context_compaction)),
+      turnId: nullableString(raw.turn_id),
+      orderKey: stringValue(raw.order_key),
+      timestamp: nullableString(raw.timestamp)
+    };
+  }
   if (kind === 'artifact') {
     return { kind: 'artifact', id, artifact: mapTranscriptArtifact(asRecord(raw.artifact)) };
   }
   return null;
+}
+
+function mapContextCompaction(raw: Record<string, unknown>): ChatContextCompaction {
+  const source = stringValue(raw.source).toLowerCase();
+  return {
+    source: source === 'car' || source === 'provider' ? source : 'unknown',
+    provider: nullableString(raw.provider),
+    summary: nullableString(raw.summary),
+    preview: nullableString(raw.preview),
+    scope: nullableString(raw.scope),
+    startedFreshSession: Boolean(raw.started_fresh_session ?? raw.startedFreshSession),
+    storedByCar: Boolean(raw.stored_by_car ?? raw.storedByCar)
+  };
 }
 
 function mapTranscriptToolCard(raw: Record<string, unknown>): ChatToolCallCard {
@@ -2138,6 +2185,20 @@ function timelineItemToCard(item: PmaTimelineItem): ChatTranscriptCard[] {
     const title = stringValue(item.payload.title) || 'Chat compacted';
     const preview = stringValue(item.payload.summary_preview);
     const text = stringValue(item.payload.text) || 'Chat compacted.';
+    const compaction = asRecord(item.payload.context_compaction);
+    if (compaction && Object.keys(compaction).length > 0) {
+      return [{
+        kind: 'context_compaction',
+        id: item.id,
+        title,
+        text: preview ? `${text}\n\n${preview}` : text,
+        detail: timelineDetail(item),
+        compaction: mapContextCompaction(compaction),
+        turnId: item.turnId,
+        orderKey: item.orderKey,
+        timestamp: item.timestamp
+      }];
+    }
     return [{
       kind: 'lifecycle',
       id: item.id,

--- a/tests/core/orchestration/test_managed_thread_timeline.py
+++ b/tests/core/orchestration/test_managed_thread_timeline.py
@@ -523,6 +523,45 @@ def test_live_tail_event_carries_hidden_progress_metadata() -> None:
     assert item["payload"]["progress_item"]["hidden"] is True
 
 
+def test_live_tail_event_projects_provider_compaction_run_notice_data() -> None:
+    item = timeline_item_from_tail_event(
+        managed_thread_id="thread-1",
+        managed_turn_id="turn-1",
+        tail_event={
+            "event_id": 5,
+            "event_type": "progress",
+            "summary": "Provider retained key state.",
+            "title": "Provider Context Compaction",
+            "received_at": "2026-05-06T10:00:05Z",
+            "run_notice": {
+                "kind": "provider_context_compaction",
+                "message": "Provider retained key state.",
+                "data": {
+                    "provider": "opencode",
+                    "summary": "Provider retained key state.",
+                },
+            },
+            "progress_item": {
+                "item_id": "progress:notice:0005",
+                "kind": "notice",
+                "state": "running",
+                "title": "Provider Context Compaction",
+                "summary": "Provider retained key state.",
+                "event_ids": [5],
+            },
+            "progress_kind": "notice",
+            "progress_state": "running",
+        },
+    )
+
+    assert item is not None
+    assert item["kind"] == "lifecycle"
+    compaction = item["payload"]["context_compaction"]
+    assert compaction["source"] == "provider"
+    assert compaction["provider"] == "opencode"
+    assert compaction["summary"] == "Provider retained key state."
+
+
 def test_timeline_includes_delivery_state_items(tmp_path: Path) -> None:
     hub_root, store, thread_id = _store(tmp_path)
     turn = create_test_turn(store, thread_id, prompt="deliver this")
@@ -571,7 +610,8 @@ def test_timeline_includes_compaction_lifecycle_item(tmp_path: Path) -> None:
         "managed_thread_compact",
         managed_thread_id=thread_id,
         payload_json=(
-            '{"summary_length": 42, "summary_preview": "Keep the current goal.", '
+            '{"summary_length": 42, "summary": "Keep the current goal.\\nPreserve constraints.", '
+            '"summary_preview": "Keep the current goal.", '
             '"reset_backend": true}'
         ),
     )
@@ -585,10 +625,54 @@ def test_timeline_includes_compaction_lifecycle_item(tmp_path: Path) -> None:
     lifecycle = [item for item in payload["items"] if item["kind"] == "lifecycle"]
     assert len(lifecycle) == 1
     assert lifecycle[0]["item_id"] == "action:1:compact"
-    assert lifecycle[0]["payload"]["lifecycle_kind"] == "chat_compacted"
-    assert lifecycle[0]["payload"]["title"] == "Chat compacted"
-    assert lifecycle[0]["payload"]["summary_preview"] == "Keep the current goal."
-    assert lifecycle[0]["payload"]["reset_backend"] is True
+    assert lifecycle[0]["payload"]["lifecycle_kind"] == "context_compaction"
+    assert lifecycle[0]["payload"]["title"] == "Context compacted by CAR"
+    compaction = lifecycle[0]["payload"]["context_compaction"]
+    assert compaction["source"] == "car"
+    assert compaction["summary"] == "Keep the current goal.\nPreserve constraints."
+    assert compaction["preview"] == "Keep the current goal."
+    assert compaction["scope"] == "managed_thread"
+    assert compaction["started_fresh_session"] is True
+
+
+def test_timeline_projects_provider_native_compaction_notice(tmp_path: Path) -> None:
+    hub_root, store, thread_id = _store(tmp_path)
+    turn = create_test_turn(store, thread_id, prompt="continue")
+    turn_id = str(turn["managed_turn_id"])
+    persist_turn_timeline(
+        hub_root,
+        execution_id=turn_id,
+        target_kind="thread_target",
+        target_id=thread_id,
+        events=[
+            RunNotice(
+                timestamp="2026-05-06T10:00:00Z",
+                kind="provider_context_compaction",
+                message="Provider retained key state.",
+                data={
+                    "provider": "opencode",
+                    "summary": "Provider retained key state.",
+                },
+            )
+        ],
+    )
+
+    payload = build_managed_thread_timeline(
+        hub_root,
+        thread_store=store,
+        managed_thread_id=thread_id,
+    )
+
+    lifecycle = [item for item in payload["items"] if item["kind"] == "lifecycle"]
+    assert len(lifecycle) == 1
+    assert lifecycle[0]["payload"]["lifecycle_kind"] == "context_compaction"
+    assert lifecycle[0]["payload"]["title"] == "Runtime compacted context"
+    compaction = lifecycle[0]["payload"]["context_compaction"]
+    assert compaction["source"] == "provider"
+    assert compaction["provider"] == "opencode"
+    assert compaction["summary"] == "Provider retained key state."
+    assert compaction["scope"] == "provider_session"
+    assert compaction["started_fresh_session"] is False
 
 
 def test_timeline_projects_equivalent_delivery_state_for_chat_surfaces(

--- a/tests/core/orchestration/test_managed_thread_transcript.py
+++ b/tests/core/orchestration/test_managed_thread_transcript.py
@@ -31,6 +31,19 @@ def _intermediate_item(payload: dict) -> dict:
     }
 
 
+def _lifecycle_item(payload: dict) -> dict:
+    return {
+        "kind": "lifecycle",
+        "item_id": "action:1:compact",
+        "order_key": "003",
+        "timestamp": "2026-05-10T12:00:02Z",
+        "managed_thread_id": "thread-1",
+        "managed_turn_id": None,
+        "payload": payload,
+        "identity": {"timeline_item_id": "action:1:compact"},
+    }
+
+
 def test_transcript_projects_legacy_injected_prompt_as_model_context() -> None:
     rows = transcript_rows_from_timeline_items(
         [
@@ -63,7 +76,6 @@ def test_transcript_hides_internal_lifecycle_notices() -> None:
                     "text": "terminal=3977ms",
                     "event_type": "run_notice",
                     "event": {"kind": "chat_execution_journal"},
-                    "hidden": True,
                 }
             ),
             _intermediate_item(
@@ -72,7 +84,6 @@ def test_transcript_hides_internal_lifecycle_notices() -> None:
                     "text": "Compacted hot timeline rows.",
                     "event_type": "run_notice",
                     "event": {"kind": "compaction_summary"},
-                    "progress_item": {"hidden": True},
                 }
             ),
             _intermediate_item(
@@ -80,7 +91,7 @@ def test_transcript_hides_internal_lifecycle_notices() -> None:
                     "intermediate_kind": "notice",
                     "text": "Decoder missed event shape.",
                     "event_type": "run_notice",
-                    "progress_item": {"hidden": True},
+                    "event": {"kind": "decode_failure"},
                 }
             ),
             _intermediate_item(
@@ -97,6 +108,44 @@ def test_transcript_hides_internal_lifecycle_notices() -> None:
     assert len(rows) == 1
     assert rows[0]["kind"] == "intermediate"
     assert rows[0]["text"] == "Reading files"
+
+
+def test_transcript_projects_context_compaction_card() -> None:
+    rows = transcript_rows_from_timeline_items(
+        [
+            _lifecycle_item(
+                {
+                    "lifecycle_kind": "context_compaction",
+                    "title": "Context compacted by CAR",
+                    "text": "Earlier conversation was summarized.",
+                    "context_compaction": {
+                        "source": "car",
+                        "provider": None,
+                        "summary": "Keep the current goal.",
+                        "preview": "Keep the current goal.",
+                        "scope": "managed_thread",
+                        "started_fresh_session": True,
+                        "stored_by_car": True,
+                    },
+                }
+            )
+        ]
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "context_compaction"
+    assert rows[0]["id"] == "action:1:compact"
+    assert rows[0]["title"] == "Context compacted by CAR"
+    assert rows[0]["text"] == "Earlier conversation was summarized."
+    assert rows[0]["context_compaction"] == {
+        "source": "car",
+        "provider": None,
+        "summary": "Keep the current goal.",
+        "preview": "Keep the current goal.",
+        "scope": "managed_thread",
+        "started_fresh_session": True,
+        "stored_by_car": True,
+    }
 
 
 def test_transcript_projects_capsule_only_model_context_refs() -> None:

--- a/tests/core/test_hub_control_plane_service.py
+++ b/tests/core/test_hub_control_plane_service.py
@@ -38,6 +38,7 @@ from codex_autorunner.core.hub_control_plane import (
     RunningExecutionLookupRequest,
     SurfaceBindingListRequest,
     SurfaceBindingUpsertRequest,
+    ThreadCompactSeedUpdateRequest,
     ThreadTargetListRequest,
     TranscriptHistoryRequest,
     TranscriptWriteRequest,
@@ -162,6 +163,28 @@ def test_shared_state_service_thread_listing_accepts_status_alias(
 
     assert [thread.thread_target_id for thread in active.threads] == [thread_target_id]
     assert [thread.thread_target_id for thread in idle.threads] == [thread_target_id]
+
+
+def test_shared_state_service_compact_seed_records_compaction_action(
+    tmp_path: Path,
+) -> None:
+    service, thread_target_id = _build_service(tmp_path)
+
+    response = service.update_thread_compact_seed(
+        ThreadCompactSeedUpdateRequest(
+            thread_target_id=thread_target_id,
+            compact_seed="Keep the current goal.",
+        )
+    )
+
+    assert response.thread is not None
+    store = ManagedThreadStore(tmp_path / "hub", durable=False, bootstrap_on_init=False)
+    actions = store.list_thread_actions(thread_target_id)
+    assert len(actions) == 1
+    assert actions[0]["action_type"] == "managed_thread_compact"
+    payload = json.loads(actions[0]["payload_json"])
+    assert payload["summary"] == "Keep the current goal."
+    assert payload["summary_preview"] == "Keep the current goal."
 
 
 def test_shared_state_service_reply_lookup_and_binding_idempotency(


### PR DESCRIPTION
## Summary
- add structured transcript projection for CAR-driven and provider-native context compaction events
- persist CAR compaction summaries into compact actions from web/control-plane paths
- render expandable retained-context cards in Web Hub, including live provider metadata and current-ticket previews

## Review
- sub-agent review found two issues: current-ticket previews could drop the new card kind, and live provider compaction metadata could be lost before snapshot repair
- both findings were fixed before this PR

## Validation
- commit hook passed: `web-core-contract`
- includes full repo pytest, strict mypy, ruff, black, import-boundary checks, frontend build, frontend tests, and SPA shell checks
- targeted checks also passed before commit: orchestration/control-plane pytest, PMA chat Vitest, and `pnpm -w run web:lint`

## Note
- I did not rewrite the existing `thread-1475853023816319006-ac6f933e07` remote branch because it is stale and diverged with unrelated old PR commits; this PR uses a fresh branch.