### PR TITLE
[codex] Fix ACP preservation of Hermes markdown spacing

### DIFF
--- a/src/codex_autorunner/agents/acp/output_normalizer.py
+++ b/src/codex_autorunner/agents/acp/output_normalizer.py
@@ -37,18 +37,24 @@ class ACPIngressNormalizedOutput:
 
 
 def _latest_assistant_section(text: str) -> tuple[str, bool]:
-    current = str(text or "").strip()
+    # ACP agent_message_chunk payloads may be true deltas whose leading spaces
+    # and standalone newlines are semantically part of markdown output.
+    # Only transcript marker extraction may trim; plain chunks stay exact.
+    current = str(text or "")
     if not current:
         return "", False
+    stripped = current.strip()
+    if not stripped:
+        return current, False
     matches = [
-        match.group(1).strip() for match in _ASSISTANT_MARKER_RE.finditer(current)
+        match.group(1).strip() for match in _ASSISTANT_MARKER_RE.finditer(stripped)
     ]
     matches = [match for match in matches if match]
     if matches:
         return matches[-1], True
     marker = "\n\nAssistant:\n"
-    if marker in current:
-        return current.rsplit(marker, 1)[-1].strip(), True
+    if marker in stripped:
+        return stripped.rsplit(marker, 1)[-1].strip(), True
     return current, False
 
 
@@ -69,7 +75,13 @@ def normalize_acp_ingress_output(
         )
 
     candidate, transcript_projection = _latest_assistant_section(raw)
-    if not candidate.strip():
+    if not candidate and input_kind != "current_turn_snapshot":
+        return ACPIngressNormalizedOutput(
+            text="",
+            classification="invalid_stale_output",
+            input_kind=input_kind,
+        )
+    if not candidate.strip() and input_kind != "current_turn_snapshot":
         return ACPIngressNormalizedOutput(
             text="",
             classification="invalid_stale_output",

--- a/src/codex_autorunner/core/orchestration/stream_text_merge.py
+++ b/src/codex_autorunner/core/orchestration/stream_text_merge.py
@@ -39,6 +39,7 @@ _SUBWORD_PREFIXES_3_PLUS = frozenset(
 # Short compounds that stay glued when split across tiny trailing chunks.
 _SHORT_COMPOUND_MERGES = frozenset(
     {
+        "inbox",
         "redo",
         "undo",
         "preset",
@@ -48,6 +49,15 @@ _SHORT_COMPOUND_MERGES = frozenset(
         "reedit",
     }
 )
+
+
+def _trailing_alpha_run(text: str) -> str:
+    run = []
+    for char in reversed(text):
+        if not char.isalpha():
+            break
+        run.append(char)
+    return "".join(reversed(run))
 
 
 def _likely_subword_prefix_continuation(current: str, incoming: str) -> bool:
@@ -83,9 +93,13 @@ def _needs_readable_boundary(current: str, incoming: str) -> bool:
         return False
     if incoming and all(char == "*" for char in incoming):
         return previous in {".", ":", ";", "!", "?"}
+    if previous.isdigit() and next_char.isdigit():
+        return False
     if previous.isalnum() and (next_char.isalnum() or next_char in {"`", "*"}):
         if previous.isalpha() and next_char.isalpha():
-            if _likely_subword_prefix_continuation(current, incoming):
+            if _likely_subword_prefix_continuation(
+                _trailing_alpha_run(current), incoming
+            ):
                 return False
         return True
     if previous in {"`", "*"} and next_char.isalnum():
@@ -129,16 +143,37 @@ class AssistantTextAccumulator:
 
     stream_text: str = ""
     final_text: str = ""
+    last_stream_chunk_had_explicit_spacing: bool = False
+
+    @staticmethod
+    def _has_explicit_spacing(text: str) -> bool:
+        return any(char.isspace() for char in text)
+
+    def _should_append_verbatim(self, text: str) -> bool:
+        # ACP streams are mixed in practice. Hermes chunks often carry leading
+        # spaces for the next word and then finish that same word in a following
+        # chunk (``" Sit"`` + ``"rep"``), while other agents still need a
+        # readable-boundary fallback later in the same turn.
+        return (
+            self._has_explicit_spacing(text)
+            or self.last_stream_chunk_had_explicit_spacing
+        )
 
     def append_delta(self, text: str, *, preserve_word_boundaries: bool = False) -> str:
         """Record a strict append-only stream delta."""
         if isinstance(text, str) and text:
             if preserve_word_boundaries:
-                self.stream_text = append_assistant_stream_text_readably(
-                    self.stream_text, text
-                )
+                if self._should_append_verbatim(text):
+                    self.stream_text = f"{self.stream_text}{text}"
+                else:
+                    self.stream_text = append_assistant_stream_text_readably(
+                        self.stream_text, text
+                    )
             else:
                 self.stream_text = f"{self.stream_text}{text}"
+            self.last_stream_chunk_had_explicit_spacing = self._has_explicit_spacing(
+                text
+            )
         return self.text
 
     def merge_snapshot(
@@ -149,11 +184,15 @@ class AssistantTextAccumulator:
             merged = merge_assistant_stream_text(self.stream_text, text)
             if (
                 preserve_word_boundaries
+                and not self._should_append_verbatim(text)
                 and merged == f"{self.stream_text}{text}"
                 and not text.startswith(self.stream_text)
             ):
                 merged = append_assistant_stream_text_readably(self.stream_text, text)
             self.stream_text = merged
+            self.last_stream_chunk_had_explicit_spacing = self._has_explicit_spacing(
+                text
+            )
         return self.text
 
     def replace_final(self, text: str) -> str:

--- a/tests/agents/acp/test_client.py
+++ b/tests/agents/acp/test_client.py
@@ -97,6 +97,86 @@ def test_prompt_state_session_update_chunks_preserve_word_boundaries() -> None:
     )
 
 
+def test_prompt_state_session_update_chunks_preserve_exact_whitespace() -> None:
+    state = _PromptState(session_id="session-1", turn_id="turn-1")
+
+    for chunk in (
+        "##",
+        " P",
+        "MA",
+        " Sit",
+        "rep",
+        " -",
+        " ",
+        "202",
+        "6",
+        "-",
+        "05",
+        "-",
+        "27",
+        "\n",
+        "###",
+        " Snapshot",
+        " Status",
+        ":",
+        " St",
+        "ale",
+        "\n",
+        "|",
+        " Section",
+        " |",
+        " Count",
+        " |",
+        " St",
+        "ale",
+        " |\n",
+        "|",
+        "---",
+        "|",
+        "---",
+        ":",
+        "|",
+        "---",
+        ":",
+        "|\n",
+        "|",
+        " p",
+        "ma",
+        "_file",
+        "_in",
+        "box",
+        " |",
+        " ",
+        "5",
+        " |",
+        " ",
+        "5",
+        " |\n\n",
+        "Bottom",
+        " line",
+        ":",
+        " No",
+        " active",
+        " work",
+        " blocking",
+        ".",
+    ):
+        state.note_output_delta(
+            chunk,
+            merge_snapshot=True,
+            preserve_word_boundaries=True,
+        )
+
+    assert state.final_output == (
+        "## PMA Sitrep - 2026-05-27\n"
+        "### Snapshot Status: Stale\n"
+        "| Section | Count | Stale |\n"
+        "|---|---:|---:|\n"
+        "| pma_file_inbox | 5 | 5 |\n\n"
+        "Bottom line: No active work blocking."
+    )
+
+
 @pytest.mark.parametrize(("method"), ("session/update", "session/request_permission"))
 @pytest.mark.asyncio
 async def test_client_maps_session_scoped_official_events_without_turn_id(

--- a/tests/core/orchestration/test_stream_text_merge.py
+++ b/tests/core/orchestration/test_stream_text_merge.py
@@ -62,6 +62,30 @@ def test_assistant_text_accumulator_subword_snapshots_avoid_spurious_spaces() ->
     assert accumulator.text == "international"
 
 
+def test_assistant_text_accumulator_mixed_spacing_snapshots_keep_fallback() -> None:
+    accumulator = AssistantTextAccumulator()
+
+    for chunk in (
+        "Confirmed:",
+        "\n",
+        "**",
+        "`/car/hub/read-models/chats`",
+        "returns",
+        "500",
+        "**",
+        "everything",
+        "else",
+        "is",
+        "healthy.",
+    ):
+        accumulator.merge_snapshot(chunk, preserve_word_boundaries=True)
+
+    assert (
+        accumulator.text
+        == "Confirmed:\n**`/car/hub/read-models/chats` returns 500** everything else is healthy."
+    )
+
+
 def test_assistant_text_accumulator_records_strict_deltas() -> None:
     accumulator = AssistantTextAccumulator()
 


### PR DESCRIPTION
## Summary
- Preserve exact leading spaces and standalone newline chunks from ACP agent_message_chunk payloads instead of stripping them during ingress normalization.
- Keep the readable-boundary fallback only for streams that have not shown explicit whitespace, so older spacing-poor streams still render readably without corrupting markdown-aware streams.
- Add a regression with the real Hermes ACP chunk shape that previously produced split PMA text and flattened tables.

## Root Cause
CAR treated Hermes ACP session/update text as snapshot-like current-turn text and normalized it with strip. That removed leading spaces and newline-only chunks before the stream reducer saw them. The later readable-boundary heuristic then guessed spaces back in the wrong places, producing split words and flattened markdown in Discord and Web UI.

## Reproduction / Validation
- Reproduced mismatch before the fix: hermes-m4-pma -z returned correctly formatted markdown; hermes-m4-pma acp through CAR returned mangled markdown.
- After the fix, real HermesSupervisor with hermes-m4-pma acp returned the exact expected markdown/table text.
- .venv/bin/pytest tests/agents/acp tests/agents/hermes/test_hermes_supervisor.py tests/core/orchestration/test_stream_text_merge.py -q => 234 passed.
- .venv/bin/pytest tests/core/orchestration/test_runtime_thread_events.py tests/core/orchestration/test_runtime_thread_decoders.py tests/core/orchestration/test_runtime_turn_terminal_state.py tests/agents/acp/test_client.py::test_prompt_state_session_update_chunks_preserve_exact_whitespace -q => 215 passed.
- Commit hook aggregate lane passed: repo pytest 9532 passed, mypy clean, frontend build/tests 877 passed / 2 skipped.