### PR TITLE
[codex] Fix OpenCode stream word boundaries

### DIFF
--- a/src/codex_autorunner/adapters/chat/managed_thread_progress.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_progress.py
@@ -101,6 +101,7 @@ def apply_run_event_to_progress_tracker(
                 preserve_word_boundaries=bool(
                     run_event.data.get("preserve_word_boundaries")
                 ),
+                strict_append=bool(run_event.data.get("strict_append")),
             )
         return ProgressTrackerEventOutcome(changed=True)
 

--- a/src/codex_autorunner/adapters/chat/progress_primitives.py
+++ b/src/codex_autorunner/adapters/chat/progress_primitives.py
@@ -288,6 +288,7 @@ class TurnProgressTracker:
         *,
         new_segment: bool = False,
         preserve_word_boundaries: bool = False,
+        strict_append: bool = False,
     ) -> None:
         output_piece = _normalize_output_text(text)
         if not output_piece.strip():
@@ -306,14 +307,16 @@ class TurnProgressTracker:
             )
             return
         current_output = self.actions[self.last_output_index].text
-        self.output_buffer = _truncate_tail(
-            _merge_output_text(
+        merged_output = (
+            f"{current_output}{output_piece}"
+            if strict_append
+            else _merge_output_text(
                 current_output,
                 output_piece,
                 preserve_word_boundaries=preserve_word_boundaries,
-            ),
-            self.max_output_chars,
+            )
         )
+        self.output_buffer = _truncate_tail(merged_output, self.max_output_chars)
         self.update_action_raw(self.last_output_index, self.output_buffer, "update")
 
     def note_commentary(self, text: str) -> None:

--- a/src/codex_autorunner/agents/opencode/output_assembly.py
+++ b/src/codex_autorunner/agents/opencode/output_assembly.py
@@ -17,6 +17,9 @@ import httpx
 
 from ...core.coercion import coerce_int
 from ...core.logging_utils import log_event
+from ...core.orchestration.stream_text_merge import (
+    append_assistant_stream_text_readably,
+)
 from ...core.runtime_identity import RUNTIME_STAGE_EFFECTIVE, RuntimeIdentityStage
 from ...core.time_utils import now_iso
 from .constants import OPENCODE_MODEL_CONTEXT_KEYS
@@ -238,24 +241,50 @@ class OutputAssembler:
         part_dict: Optional[dict[str, Any]],
     ) -> None:
         """Append a text delta to the output, with dedupe bookkeeping."""
-        self._append_text_for_message(part_message_id, delta_text)
         if isinstance(part_id, str) and part_id:
             if isinstance(part_dict, dict):
                 text = part_dict.get("text")
                 if isinstance(text, str):
+                    last_len = self._part_lengths.get(part_id, 0)
+                    if len(text) > last_len:
+                        self._append_text_for_message(
+                            part_message_id,
+                            text[last_len:],
+                            preserve_word_boundaries=False,
+                        )
+                    elif delta_text:
+                        self._append_text_for_message(part_message_id, delta_text)
                     self._part_lengths[part_id] = len(text)
                 else:
+                    self._append_text_for_message(part_message_id, delta_text)
                     self._part_lengths[part_id] = self._part_lengths.get(
                         part_id, 0
                     ) + len(delta_text)
             else:
+                self._append_text_for_message(part_message_id, delta_text)
                 self._part_lengths[part_id] = self._part_lengths.get(part_id, 0) + len(
                     delta_text
                 )
         elif isinstance(part_dict, dict):
             text = part_dict.get("text")
             if isinstance(text, str):
+                if self._last_full_text and text.startswith(self._last_full_text):
+                    self._append_text_for_message(
+                        part_message_id,
+                        text[len(self._last_full_text) :],
+                        preserve_word_boundaries=False,
+                    )
+                elif text != self._last_full_text:
+                    self._append_text_for_message(
+                        part_message_id,
+                        text,
+                        preserve_word_boundaries=False,
+                    )
                 self._last_full_text = text
+            else:
+                self._append_text_for_message(part_message_id, delta_text)
+        else:
+            self._append_text_for_message(part_message_id, delta_text)
 
     async def on_full_text_part(
         self,
@@ -488,22 +517,59 @@ class OutputAssembler:
         if self._pending_no_id:
             self._pending_no_id.clear()
 
-    def _append_text_for_message(self, message_id: Optional[str], text: str) -> None:
+    def _append_text_for_message(
+        self,
+        message_id: Optional[str],
+        text: str,
+        *,
+        preserve_word_boundaries: bool = True,
+    ) -> None:
         if not text:
             return
         if message_id is None:
             if self._no_id_role == "assistant":
-                self._text_parts.append(text)
+                self._append_readable_text(
+                    self._text_parts,
+                    text,
+                    preserve_word_boundaries=preserve_word_boundaries,
+                )
             else:
-                self._pending_no_id.append(text)
+                self._append_readable_text(
+                    self._pending_no_id,
+                    text,
+                    preserve_word_boundaries=preserve_word_boundaries,
+                )
             return
         role = self._message_roles.get(message_id)
         if role == "user":
             return
         if role == "assistant":
-            self._text_parts.append(text)
+            self._append_readable_text(
+                self._text_parts,
+                text,
+                preserve_word_boundaries=preserve_word_boundaries,
+            )
             return
-        self._pending_text.setdefault(message_id, []).append(text)
+        self._append_readable_text(
+            self._pending_text.setdefault(message_id, []),
+            text,
+            preserve_word_boundaries=preserve_word_boundaries,
+        )
+
+    def _append_readable_text(
+        self,
+        parts: list[str],
+        text: str,
+        *,
+        preserve_word_boundaries: bool = True,
+    ) -> None:
+        if not parts:
+            parts.append(text)
+            return
+        if not preserve_word_boundaries:
+            parts[-1] = f"{parts[-1]}{text}"
+            return
+        parts[-1] = append_assistant_stream_text_readably(parts[-1], text)
 
     def _flush_pending_text(self, message_id: Optional[str]) -> None:
         if not message_id:

--- a/src/codex_autorunner/agents/opencode/output_assembly.py
+++ b/src/codex_autorunner/agents/opencode/output_assembly.py
@@ -89,6 +89,7 @@ class OutputAssembler:
 
         self._text_parts: list[str] = []
         self._part_lengths: dict[str, int] = {}
+        self._part_accumulated_text: dict[str, str] = {}
         self._last_full_text = ""
         self._error: Optional[str] = None
         self._message_roles: dict[str, str] = {}
@@ -255,16 +256,13 @@ class OutputAssembler:
                     elif delta_text:
                         self._append_text_for_message(part_message_id, delta_text)
                     self._part_lengths[part_id] = len(text)
+                    self._part_accumulated_text[part_id] = text
                 else:
                     self._append_text_for_message(part_message_id, delta_text)
-                    self._part_lengths[part_id] = self._part_lengths.get(
-                        part_id, 0
-                    ) + len(delta_text)
+                    self._track_part_delta(part_id, delta_text)
             else:
                 self._append_text_for_message(part_message_id, delta_text)
-                self._part_lengths[part_id] = self._part_lengths.get(part_id, 0) + len(
-                    delta_text
-                )
+                self._track_part_delta(part_id, delta_text)
         elif isinstance(part_dict, dict):
             text = part_dict.get("text")
             if isinstance(text, str):
@@ -302,6 +300,7 @@ class OutputAssembler:
             if len(text) > last_len:
                 self._append_text_for_message(part_message_id, text[last_len:])
                 self._part_lengths[part_id] = len(text)
+                self._part_accumulated_text[part_id] = text
         else:
             if self._last_full_text and text.startswith(self._last_full_text):
                 self._append_text_for_message(
@@ -555,6 +554,12 @@ class OutputAssembler:
             text,
             preserve_word_boundaries=preserve_word_boundaries,
         )
+
+    def _track_part_delta(self, part_id: str, delta_text: str) -> None:
+        accumulated = self._part_accumulated_text.get(part_id, "")
+        updated = append_assistant_stream_text_readably(accumulated, delta_text)
+        self._part_accumulated_text[part_id] = updated
+        self._part_lengths[part_id] = len(updated)
 
     def _append_readable_text(
         self,

--- a/src/codex_autorunner/core/orchestration/runtime_thread_decoders.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_decoders.py
@@ -29,6 +29,7 @@ from ..ports.run_event import (
     RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
     RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
     RUN_EVENT_DELTA_TYPE_LOG_LINE,
+    RUN_EVENT_STREAM_MODE_DELTA,
     RUN_EVENT_STREAM_MODE_SNAPSHOT,
     ApprovalRequested,
     Failed,
@@ -545,20 +546,43 @@ def _normalize_message_part_updated(
             _extract_part_message_id(params),
             content,
             timestamp=timestamp,
+            preserve_word_boundaries=True,
         )
 
     if part and bool(part.get("ignored")):
         return []
 
     if part_type in {"", "text"}:
-        content = _extract_output_delta(params)
+        part_text = part.get("text")
+        content = part_text if isinstance(part_text, str) else ""
+        has_part_snapshot = bool(content)
+        if not content:
+            content = _extract_output_delta(params)
         if not content:
             return []
-        return state.note_message_part_text(
+        events = state.note_message_part_text(
             _extract_part_message_id(params),
             content,
             timestamp=timestamp,
+            preserve_word_boundaries=not has_part_snapshot,
         )
+        delta_content = _event_extract_output_delta(params, include_part_text=False)
+        if not has_part_snapshot or not delta_content:
+            return events
+        return [
+            (
+                OutputDelta(
+                    timestamp=event.timestamp,
+                    content=delta_content,
+                    delta_type=event.delta_type,
+                    stream_mode=RUN_EVENT_STREAM_MODE_DELTA,
+                    data={"strict_append": True},
+                )
+                if isinstance(event, OutputDelta)
+                else event
+            )
+            for event in events
+        ]
 
     if part_type == "reasoning":
         content = _extract_opencode_reasoning_text(params, part_for_processing, state)

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -356,9 +356,13 @@ def merge_runtime_thread_raw_events(
     return merge_runtime_raw_events(streamed_raw_events, result_raw_events)
 
 
-def _merge_pending_stream_text(current: str, incoming: str) -> str:
+def _merge_pending_stream_text(
+    current: str, incoming: str, *, preserve_word_boundaries: bool = False
+) -> str:
     accumulator = AssistantTextAccumulator(stream_text=current)
-    accumulator.merge_snapshot(incoming)
+    accumulator.merge_snapshot(
+        incoming, preserve_word_boundaries=preserve_word_boundaries
+    )
     return accumulator.stream_text
 
 
@@ -476,42 +480,59 @@ class RuntimeThreadRunEventState:
         text: str,
         *,
         timestamp: Optional[str] = None,
+        preserve_word_boundaries: bool = False,
     ) -> list[RunEvent]:
         event_timestamp = timestamp or now_iso()
         if not isinstance(text, str) or not text:
             return []
         if message_id is None:
             if not self.message_roles_seen:
-                self.note_stream_text(text)
+                self.note_stream_text(
+                    text, preserve_word_boundaries=preserve_word_boundaries
+                )
                 return [
                     OutputDelta(
                         timestamp=event_timestamp,
                         content=text,
                         delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
                         stream_mode=RUN_EVENT_STREAM_MODE_SNAPSHOT,
+                        data=(
+                            {"preserve_word_boundaries": True}
+                            if preserve_word_boundaries
+                            else {}
+                        ),
                     )
                 ]
             self.pending_stream_no_id = _merge_pending_stream_text(
                 self.pending_stream_no_id,
                 text,
+                preserve_word_boundaries=preserve_word_boundaries,
             )
             return []
         role = self.message_roles.get(message_id)
         if role == "user":
             return []
         if role == "assistant":
-            self.note_stream_text(text)
+            self.note_stream_text(
+                text, preserve_word_boundaries=preserve_word_boundaries
+            )
             return [
                 OutputDelta(
                     timestamp=event_timestamp,
                     content=text,
                     delta_type=RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM,
                     stream_mode=RUN_EVENT_STREAM_MODE_SNAPSHOT,
+                    data=(
+                        {"preserve_word_boundaries": True}
+                        if preserve_word_boundaries
+                        else {}
+                    ),
                 )
             ]
         self.pending_stream_by_message[message_id] = _merge_pending_stream_text(
             self.pending_stream_by_message.get(message_id, ""),
             text,
+            preserve_word_boundaries=preserve_word_boundaries,
         )
         return []
 

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -153,10 +153,19 @@ class RuntimeEventDriver:
                 }:
                     self.timeline_assistant_chunks.append(event.content)
                     if event.delta_type == RUN_EVENT_DELTA_TYPE_ASSISTANT_STREAM:
+                        preserve_word_boundaries = bool(
+                            event.data.get("preserve_word_boundaries")
+                        )
                         if event.stream_mode == RUN_EVENT_STREAM_MODE_SNAPSHOT:
-                            self.assistant_output.note_stream_snapshot(event.content)
+                            self.assistant_output.note_stream_snapshot(
+                                event.content,
+                                preserve_word_boundaries=preserve_word_boundaries,
+                            )
                         else:
-                            self.assistant_output.note_stream_delta(event.content)
+                            self.assistant_output.note_stream_delta(
+                                event.content,
+                                preserve_word_boundaries=preserve_word_boundaries,
+                            )
                     else:
                         self.assistant_output.note_final_message(event.content)
                     continue

--- a/src/codex_autorunner/core/orchestration/stream_text_merge.py
+++ b/src/codex_autorunner/core/orchestration/stream_text_merge.py
@@ -128,7 +128,7 @@ def _looks_like_token_continuation(current: str, incoming: str) -> bool:
     fragment = _current_word_fragment(current)
     if any(char in fragment for char in "/._-`*"):
         return True
-    if any(char in incoming for char in "/_-") or "." in incoming[:-1]:
+    if "." in incoming[:-1]:
         return True
     return _likely_subword_prefix_continuation(current_alpha, incoming_alpha)
 

--- a/tests/agents/opencode/test_output_assembly.py
+++ b/tests/agents/opencode/test_output_assembly.py
@@ -83,6 +83,37 @@ async def test_text_delta_recovers_missing_opencode_word_boundaries() -> None:
 
 
 @pytest.mark.anyio
+async def test_text_delta_part_lengths_include_readable_inserted_spaces() -> None:
+    asm = OutputAssembler(session_id="s1")
+    msg_id, role = asm.on_register_message_role(
+        {"info": {"id": "a1", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id, role)
+
+    await asm.on_text_delta(
+        part_message_id="a1",
+        delta_text="Currently",
+        part_id="p1",
+        part_dict=None,
+    )
+    await asm.on_text_delta(
+        part_message_id="a1",
+        delta_text="on",
+        part_id="p1",
+        part_dict=None,
+    )
+    await asm.on_text_delta(
+        part_message_id="a1",
+        delta_text="branch",
+        part_id="p1",
+        part_dict={"type": "text", "text": "Currently on branch"},
+    )
+
+    result = await asm.build_result()
+    assert result.text == "Currently on branch"
+
+
+@pytest.mark.anyio
 async def test_full_text_part_incremental() -> None:
     asm = OutputAssembler(session_id="s1")
     await asm.on_full_text_part(

--- a/tests/agents/opencode/test_output_assembly.py
+++ b/tests/agents/opencode/test_output_assembly.py
@@ -56,6 +56,33 @@ async def test_text_delta_with_part_id_dedupe() -> None:
 
 
 @pytest.mark.anyio
+async def test_text_delta_recovers_missing_opencode_word_boundaries() -> None:
+    asm = OutputAssembler(session_id="s1")
+    msg_id, role = asm.on_register_message_role(
+        {"info": {"id": "a1", "role": "assistant"}}
+    )
+    asm.on_handle_role_update(msg_id, role)
+
+    for delta in (
+        "Currently",
+        "on",
+        "branch",
+        "fix/automations-pma-turn-",
+        "migration",
+        ".",
+    ):
+        await asm.on_text_delta(
+            part_message_id="a1",
+            delta_text=delta,
+            part_id="p1",
+            part_dict=None,
+        )
+
+    result = await asm.build_result()
+    assert result.text == "Currently on branch fix/automations-pma-turn-migration."
+
+
+@pytest.mark.anyio
 async def test_full_text_part_incremental() -> None:
     asm = OutputAssembler(session_id="s1")
     await asm.on_full_text_part(

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -1081,6 +1081,41 @@ async def test_normalize_runtime_thread_raw_event_handles_opencode_message_part_
     assert state.best_assistant_text() == "OK"
 
 
+async def test_opencode_text_part_updates_preserve_readable_word_boundaries() -> None:
+    state = RuntimeThreadRunEventState()
+
+    for text in (
+        "Currently",
+        "on",
+        "branch",
+        "fix/automations-pma-turn-",
+        "migration",
+        ".",
+    ):
+        await normalize_runtime_thread_raw_event(
+            format_sse(
+                "app-server",
+                {
+                    "message": {
+                        "method": "message.part.updated",
+                        "params": {
+                            "properties": {
+                                "part": {"type": "text"},
+                                "delta": text,
+                            }
+                        },
+                    }
+                },
+            ),
+            state,
+        )
+
+    assert (
+        state.best_assistant_text()
+        == "Currently on branch fix/automations-pma-turn-migration."
+    )
+
+
 async def test_normalize_runtime_thread_raw_event_maps_opencode_reasoning_parts_to_thinking() -> (
     None
 ):

--- a/tests/core/orchestration/test_runtime_thread_events.py
+++ b/tests/core/orchestration/test_runtime_thread_events.py
@@ -1116,6 +1116,45 @@ async def test_opencode_text_part_updates_preserve_readable_word_boundaries() ->
     )
 
 
+@pytest.mark.anyio
+async def test_runtime_event_driver_preserves_opencode_delta_only_word_boundaries() -> (
+    None
+):
+    driver = RuntimeEventDriver()
+
+    await driver.consume_raw_events(
+        [
+            format_sse(
+                "app-server",
+                {
+                    "message": {
+                        "method": "message.part.updated",
+                        "params": {
+                            "properties": {
+                                "part": {"type": "text"},
+                                "delta": text,
+                            }
+                        },
+                    }
+                },
+            )
+            for text in (
+                "Currently",
+                "on",
+                "branch",
+                "fix/automations-pma-turn-",
+                "migration",
+                ".",
+            )
+        ]
+    )
+
+    assert (
+        driver.best_assistant_text()
+        == "Currently on branch fix/automations-pma-turn-migration."
+    )
+
+
 async def test_normalize_runtime_thread_raw_event_maps_opencode_reasoning_parts_to_thinking() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- Prefer OpenCode cumulative `part.text` snapshots for internal run state and final assistant text.
- Preserve raw text deltas for flow/UI contracts, then strict-append them in chat progress rendering.
- Add readable word-boundary recovery for delta-only OpenCode chunks, including cases like `repo.` + `Currently` and `branch` + `fix/...`.

## Root Cause
OpenCode stream updates may arrive as small text pieces without leading whitespace. CAR was merging those pieces like generic snapshots/deltas, so adjacent chunks could render as `repo.Currently`, `main.Good`, or `branchfix/...` in Discord/Web progress. The fix also avoids the opposite regression by trusting cumulative OpenCode `part.text` snapshots when available, so subword updates such as `Debug` + `ging` remain `Debugging`.

## Validation
- Real OpenCode CLI: `/opt/homebrew/bin/opencode` version `1.15.10`; `opencode run --format json --model zai-coding-plan/glm-5.1 ...` produced `Currently on branch fix/automations-pma-turn-migration. Now done.` in session `ses_1983594dcffeoHyqwjbz5UytXv`.
- Real OpenCode server: `opencode serve --hostname 127.0.0.1 --port 49217`; CAR `OpenCodeClient` decoded session `ses_198349044ffeQFqSu9VIa2P2yX` to `Currently on branch fix/automations-pma-turn-migration. Now done.` with the patched decoder.
- `.venv/bin/python -m pytest tests/core/orchestration/test_stream_text_merge.py tests/core/orchestration/test_runtime_thread_events.py tests/core/orchestration/test_runtime_thread_decoders.py tests/agents/opencode/test_output_assembly.py tests/test_opencode_runtime.py -q`
- `.venv/bin/python -m pytest tests/test_opencode_agent_pool.py::test_run_turn_preserves_whitespace_in_opencode_text_part_deltas tests/test_backend_run_event_contract.py::test_opencode_backend_run_turn_events_obeys_contract tests/test_opencode_backend_streaming.py::test_opencode_streaming_real_events_ignore_user_prompt tests/agents/opencode/test_output_assembly.py tests/core/orchestration/test_runtime_thread_events.py -q`
- Commit hook aggregate lane passed: repo-wide mypy, repo-wide pytest, guardrails, frontend build/tests.
