### PR TITLE
Add generic user input request support

### DIFF
--- a/src/codex_autorunner/adapters/agents/opencode_backend.py
+++ b/src/codex_autorunner/adapters/agents/opencode_backend.py
@@ -10,6 +10,7 @@ import httpx
 from ...agents.opencode.client import OpenCodeClient, OpenCodeProtocolError
 from ...agents.opencode.event_decoder import decode_sse_event
 from ...agents.opencode.logging import OpenCodeEventFormatter
+from ...agents.opencode.protocol_types import QuestionEvent
 from ...agents.opencode.runtime import (
     build_turn_id,
     collect_opencode_output,
@@ -46,6 +47,7 @@ from ...core.ports.run_event import (
     Started,
     TokenUsage,
     ToolCall,
+    UserInputRequested,
 )
 from ...core.sse import SSEEvent
 from ...core.text_delta_coalescer import StreamingTextCoalescer
@@ -601,6 +603,33 @@ class OpenCodeBackend(AgentBackend):
                     timestamp=now_iso(), tool_name=tool_name, tool_input=tool_input
                 )
             )
+
+        elif isinstance(decoded, QuestionEvent) or payload_type == "question":
+            if isinstance(decoded, QuestionEvent):
+                request_id = decoded.question_id
+                question = decoded.question
+                context = {"context": decoded.context} if decoded.context else {}
+            else:
+                request_id = str(
+                    payload.get("id")
+                    or payload.get("questionID")
+                    or payload.get("questionId")
+                    or payload.get("question_id")
+                    or ""
+                ).strip()
+                question = str(payload.get("question") or "").strip()
+                context = {}
+            if request_id:
+                questions = ({"id": request_id, "question": question},)
+                events.append(
+                    UserInputRequested(
+                        timestamp=now_iso(),
+                        request_id=request_id,
+                        description=question or "User input requested",
+                        questions=questions,
+                        context={**payload, **context},
+                    )
+                )
 
         elif payload_type == "usage":
             usage = payload.get("usage")

--- a/src/codex_autorunner/adapters/app_server/client.py
+++ b/src/codex_autorunner/adapters/app_server/client.py
@@ -1014,6 +1014,11 @@ class CodexAppServerClient:
                 method=method,
                 turn_id=turn_id or approval.params.get("turnId"),
             )
+            self._schedule_notification_handler(
+                message,
+                method=method,
+                handled=True,
+            )
             try:
                 decision = await self._callback_registry.approval_adapter_for(
                     approval
@@ -1067,6 +1072,11 @@ class CodexAppServerClient:
                 method=method,
                 turn_id=user_input.request.turn_id or user_input.params.get("turnId"),
                 question_count=len(user_input.request.questions),
+            )
+            self._schedule_notification_handler(
+                message,
+                method=method,
+                handled=True,
             )
             try:
                 result = await self._callback_registry.user_input_adapter_for(

--- a/src/codex_autorunner/adapters/app_server/supervisor.py
+++ b/src/codex_autorunner/adapters/app_server/supervisor.py
@@ -12,7 +12,12 @@ from ...core.managed_processes import reap_managed_processes
 from ...core.managed_processes.registry import list_process_records
 from ...core.supervisor_utils import evict_lru_handle_locked, pop_idle_handles_locked
 from ...workspace import canonical_workspace_root, workspace_id_for_path
-from .client import ApprovalHandler, CodexAppServerClient, NotificationHandler
+from .client import (
+    ApprovalHandler,
+    CodexAppServerClient,
+    NotificationHandler,
+    UserInputHandler,
+)
 
 EnvBuilder = Callable[[Path, str, Path], Dict[str, str]]
 _ACTIVE_TURN_DRAIN_TIMEOUT_SECONDS = 30.0
@@ -81,6 +86,7 @@ class WorkspaceAppServerSupervisor:
         state_root: Path,
         env_builder: EnvBuilder,
         approval_handler: Optional[ApprovalHandler] = None,
+        question_handler: Optional[UserInputHandler] = None,
         notification_handler: Optional[NotificationHandler] = None,
         logger: Optional[logging.Logger] = None,
         auto_restart: Optional[bool] = None,
@@ -112,6 +118,7 @@ class WorkspaceAppServerSupervisor:
         self._state_root = state_root
         self._env_builder = env_builder
         self._approval_handler = approval_handler
+        self._question_handler = question_handler
         self._notification_handler = notification_handler
         self._logger = logger or logging.getLogger(__name__)
         if auto_restart is None:
@@ -295,6 +302,7 @@ class WorkspaceAppServerSupervisor:
                 env=env,
                 workspace_id=workspace_id,
                 approval_handler=self._approval_handler,
+                question_handler=self._question_handler,
                 default_approval_decision=self._default_approval_decision,
                 auto_restart=self._auto_restart,
                 request_timeout=self._request_timeout,

--- a/src/codex_autorunner/adapters/chat/action_ux_contract.py
+++ b/src/codex_autorunner/adapters/chat/action_ux_contract.py
@@ -210,16 +210,21 @@ def _discord_component_entry(
     )
 
 
-def _discord_modal_entry(route_id: str) -> ChatActionUxContractEntry:
+def _discord_modal_entry(
+    route_id: str,
+    *,
+    queue_policy: ChatActionQueuePolicy = "scheduler_serialized",
+    control_priority: ChatActionPriority = "normal",
+) -> ChatActionUxContractEntry:
     return ChatActionUxContractEntry(
         id=f"discord_modal.{route_id}",
         surface="discord_modal",
         lookup_keys=(f"discord_modal:{route_id}",),
         ack_class="defer_ephemeral",
-        queue_policy="scheduler_serialized",
+        queue_policy=queue_policy,
         first_visible_feedback=_first_visible_feedback_for_ack("defer_ephemeral"),
         optimistic_ui_allowed=False,
-        control_priority="normal",
+        control_priority=control_priority,
         anchor_message_reuse="never",
     )
 
@@ -587,6 +592,16 @@ CHAT_ACTION_UX_CONTRACT: tuple[ChatActionUxContractEntry, ...] = (
         control_priority="control",
     ),
     _discord_component_entry(
+        "user_input.button",
+        queue_policy="bypass_active_turn",
+        control_priority="control",
+    ),
+    _discord_component_entry(
+        "user_input.select",
+        queue_policy="bypass_active_turn",
+        control_priority="control",
+    ),
+    _discord_component_entry(
         "turn.continue",
         queue_policy="control_priority",
         control_priority="control",
@@ -594,6 +609,11 @@ CHAT_ACTION_UX_CONTRACT: tuple[ChatActionUxContractEntry, ...] = (
     ),
     # Discord modals and autocomplete.
     _discord_modal_entry("tickets.modal_submit"),
+    _discord_modal_entry(
+        "user_input.modal_submit",
+        queue_policy="bypass_active_turn",
+        control_priority="control",
+    ),
     _discord_autocomplete_entry("car.bind.workspace"),
     _discord_autocomplete_entry("car.model.name"),
     _discord_autocomplete_entry("car.skills.search"),

--- a/src/codex_autorunner/adapters/chat/execution_event_journal.py
+++ b/src/codex_autorunner/adapters/chat/execution_event_journal.py
@@ -20,6 +20,7 @@ from ...core.ports.run_event import (
     TokenUsage,
     ToolCall,
     ToolResult,
+    UserInputRequested,
 )
 from ...core.runtime_identity import RuntimeIdentityStage
 from ...core.time_utils import now_iso
@@ -256,6 +257,22 @@ def journal_events_from_run_events(
                     "context": dict(event.context),
                 },
             )
+        elif isinstance(event, UserInputRequested):
+            mapped = _standard_journal_event(
+                timestamp=event.timestamp,
+                domain="user_input",
+                name="requested",
+                event_index=event_index,
+                event_type=event_type,
+                source_event_type="user_input_requested",
+                status="requested",
+                message=event.description,
+                data={
+                    "request_id": event.request_id,
+                    "questions": [dict(question) for question in event.questions],
+                    "context": dict(event.context),
+                },
+            )
         elif isinstance(event, TokenUsage):
             mapped = _standard_journal_event(
                 timestamp=event.timestamp,
@@ -380,6 +397,23 @@ def _run_event_from_timeline_entry(entry: Mapping[str, Any]) -> Optional[RunEven
             timestamp=str(payload.get("timestamp") or ""),
             request_id=str(payload.get("request_id") or ""),
             description=str(payload.get("description") or ""),
+            context=_copy_mapping(payload.get("context")),
+        )
+    if event_type == "user_input_requested":
+        questions = payload.get("questions")
+        return UserInputRequested(
+            timestamp=str(payload.get("timestamp") or ""),
+            request_id=str(payload.get("request_id") or ""),
+            description=str(payload.get("description") or ""),
+            questions=(
+                tuple(
+                    dict(question)
+                    for question in questions
+                    if isinstance(question, Mapping)
+                )
+                if isinstance(questions, list)
+                else ()
+            ),
             context=_copy_mapping(payload.get("context")),
         )
     if event_type == "token_usage":

--- a/src/codex_autorunner/adapters/chat/managed_thread_progress.py
+++ b/src/codex_autorunner/adapters/chat/managed_thread_progress.py
@@ -15,6 +15,7 @@ from ...core.ports.run_event import (
     OutputDelta,
     RunNotice,
     ToolCall,
+    UserInputRequested,
 )
 from .progress_primitives import (
     ProgressAction,
@@ -113,6 +114,15 @@ def apply_run_event_to_progress_tracker(
     if isinstance(run_event, ApprovalRequested):
         summary = run_event.description.strip() if run_event.description else ""
         tracker.note_approval(summary or "Approval requested")
+        return ProgressTrackerEventOutcome(changed=True, force=True)
+
+    if isinstance(run_event, UserInputRequested):
+        summary = run_event.description.strip() if run_event.description else ""
+        tracker.add_action(
+            "question",
+            summary or "User input requested",
+            "waiting",
+        )
         return ProgressTrackerEventOutcome(changed=True, force=True)
 
     if isinstance(run_event, RunNotice):

--- a/src/codex_autorunner/adapters/discord/interaction_component_handlers.py
+++ b/src/codex_autorunner/adapters/discord/interaction_component_handlers.py
@@ -400,6 +400,15 @@ async def _handle_approval_component(service: Any, ctx: Any) -> None:
     )
 
 
+async def _handle_user_input_component(service: Any, ctx: Any) -> None:
+    await service._handle_user_input_component(
+        ctx.interaction_id,
+        ctx.interaction_token,
+        custom_id=ctx.custom_id or "",
+        values=ctx.values,
+    )
+
+
 async def _handle_queue_cancel_component(service: Any, ctx: Any) -> None:
     await service._handle_queue_cancel_button(
         ctx.interaction_id,

--- a/src/codex_autorunner/adapters/discord/interaction_registry.py
+++ b/src/codex_autorunner/adapters/discord/interaction_registry.py
@@ -138,6 +138,7 @@ from .interaction_component_handlers import (
     _handle_update_cancel_component,
     _handle_update_confirm_component,
     _handle_update_target_select_component,
+    _handle_user_input_component,
 )
 from .interaction_slash_builders import (
     BOOLEAN as BOOLEAN,
@@ -1574,6 +1575,18 @@ _COMPONENT_ROUTES: tuple[ComponentRoute, ...] = (
         workspace_lock_policy="bound_workspace",
     ),
     ComponentRoute(
+        id="user_input.button",
+        custom_id_prefix="question:",
+        handler=_handle_user_input_component,
+        workspace_lock_policy="bound_workspace",
+    ),
+    ComponentRoute(
+        id="user_input.select",
+        custom_id_prefix="question_select:",
+        handler=_handle_user_input_component,
+        workspace_lock_policy="bound_workspace",
+    ),
+    ComponentRoute(
         id="queue.cancel",
         custom_id_prefix="queue_cancel:",
         handler=_handle_queue_cancel_component,
@@ -1621,6 +1634,17 @@ _MODAL_ROUTES: tuple[ModalRoute, ...] = (
             custom_id=ctx.custom_id or "",
             values=ctx.modal_values or {},
         ),
+    ),
+    _modal_route(
+        id="user_input.modal_submit",
+        custom_id_prefix="question_modal:",
+        handler=lambda service, ctx: service._handle_user_input_modal_submit(
+            ctx.interaction_id,
+            ctx.interaction_token,
+            custom_id=ctx.custom_id or "",
+            values=ctx.modal_values or {},
+        ),
+        workspace_lock_policy="bound_workspace",
     ),
 )
 

--- a/src/codex_autorunner/adapters/discord/message_turns.py
+++ b/src/codex_autorunner/adapters/discord/message_turns.py
@@ -1129,13 +1129,14 @@ async def _execute_discord_thread_message(
         allow_cross_repo=dispatch.pma_enabled,
     )
     if existing_session_prompt_text is not None:
-        existing_session_prompt_text, _ = (
-            await dispatch.service._maybe_inject_github_context(
-                existing_session_prompt_text,
-                request_workspace_root,
-                link_source_text=dispatch.turn_text,
-                allow_cross_repo=dispatch.pma_enabled,
-            )
+        (
+            existing_session_prompt_text,
+            _,
+        ) = await dispatch.service._maybe_inject_github_context(
+            existing_session_prompt_text,
+            request_workspace_root,
+            link_source_text=dispatch.turn_text,
+            allow_cross_repo=dispatch.pma_enabled,
         )
     if dispatch.pending_compact_seed:
         prompt_text = f"{dispatch.pending_compact_seed}\n\n{prompt_text}"
@@ -2313,6 +2314,37 @@ async def _run_discord_orchestrated_turn_for_message(
             supervision.set_execution_id(progress_execution_id)
         if bool(getattr(submission, "queued", False)):
             return
+        service._register_discord_turn_approval_context(
+            started_execution=started_execution,
+            channel_id=channel_id,
+        )
+        configure_turn_handlers = getattr(
+            getattr(started_execution, "harness", None),
+            "configure_turn_handlers",
+            None,
+        )
+        backend_thread_id = (
+            str(
+                getattr(started_execution.thread, "backend_thread_id", "") or ""
+            ).strip()
+            or None
+        )
+        backend_turn_id = (
+            str(getattr(started_execution.execution, "backend_id", "") or "").strip()
+            or None
+        )
+        if callable(configure_turn_handlers) and backend_thread_id and backend_turn_id:
+            configure_turn_handlers(
+                backend_thread_id,
+                backend_turn_id,
+                question_handler=lambda request_id, props: (
+                    service._handle_opencode_question_request(
+                        request_id,
+                        props,
+                        turn_id=backend_turn_id,
+                    )
+                ),
+            )
         await _set_progress_lease_state(
             execution_id=progress_execution_id,
             state="active",
@@ -2575,6 +2607,11 @@ async def _run_discord_orchestrated_turn_for_message(
         )
 
     async def _after_completion(_flow: Any) -> None:
+        started_execution = getattr(_flow, "started_execution", None)
+        if started_execution is not None:
+            service._clear_discord_turn_approval_context(
+                started_execution=started_execution
+            )
         await _stop_progress_heartbeat()
 
     if turn_envelope is None:

--- a/src/codex_autorunner/adapters/discord/service.py
+++ b/src/codex_autorunner/adapters/discord/service.py
@@ -330,6 +330,7 @@ from .interaction_registry import (
 from .interaction_scheduler import (
     schedule_ingressed_interaction as _schedule_ingressed_interaction,
 )
+from .interaction_session import InteractionSessionKind
 from .interactions import extract_interaction_id, extract_interaction_token
 from .managed_thread_delivery import deliver_discord_managed_thread_record
 from .managed_thread_routing import build_discord_thread_orchestration_service
@@ -415,6 +416,8 @@ from .service_normalization import (
     build_attachment_context_payload,
     build_discord_approval_message,
     build_discord_queue_status_message,
+    build_discord_user_input_components,
+    format_discord_user_input_prompt,
     format_hub_flow_overview_line,
 )
 from .service_responses import DiscordInteractionResponseMixin
@@ -635,6 +638,40 @@ class _DiscordPendingApproval:
     message_id: Optional[str]
     prompt: str
     future: asyncio.Future[ApprovalDecision]
+
+
+@dataclass
+class _DiscordPendingUserInput:
+    token: str
+    request_id: str
+    turn_id: str
+    channel_id: str
+    message_id: Optional[str]
+    question_index: int
+    question: dict[str, Any]
+    options: list[str]
+    future: asyncio.Future[list[str] | None]
+
+
+def _discord_question_options(question: Mapping[str, Any]) -> tuple[list[str], bool]:
+    multiple = bool(question.get("multiple"))
+    for key in ("options", "choices"):
+        raw = question.get(key)
+        if not isinstance(raw, list):
+            continue
+        options: list[str] = []
+        for option in raw:
+            if isinstance(option, str) and option.strip():
+                options.append(option.strip())
+                continue
+            if isinstance(option, Mapping):
+                for label_key in ("label", "text", "value", "name", "id"):
+                    value = option.get(label_key)
+                    if isinstance(value, str) and value.strip():
+                        options.append(value.strip())
+                        break
+        return options, multiple
+    return [], multiple
 
 
 @dataclass(frozen=True)
@@ -902,6 +939,7 @@ class DiscordBotService(DiscordInteractionResponseMixin):
             root_app_server_command,
             state_root=self._app_server_state_root,
             env_builder=self._build_workspace_env,
+            question_handler=self._handle_backend_user_input_request,
             notification_handler=cast(
                 Callable[[Mapping[str, object]], Awaitable[None]],
                 self.app_server_events.handle_notification,
@@ -988,6 +1026,7 @@ class DiscordBotService(DiscordInteractionResponseMixin):
             {}
         )
         self._discord_pending_approvals: dict[str, _DiscordPendingApproval] = {}
+        self._discord_pending_user_inputs: dict[str, _DiscordPendingUserInput] = {}
         self._update_status_notifier = discord_update_service.ChatUpdateStatusNotifier(
             platform="discord",
             logger=self._logger,
@@ -3304,6 +3343,230 @@ class DiscordBotService(DiscordInteractionResponseMixin):
                     },
                 )
 
+    async def _handle_backend_user_input_request(
+        self, request: dict[str, Any]
+    ) -> dict[str, Any]:
+        params_raw = request.get("params")
+        params: dict[str, Any] = (
+            dict(params_raw) if isinstance(params_raw, dict) else {}
+        )
+        request_id = str(request.get("id") or "").strip()
+        if not request_id:
+            return {"answers": {}}
+        questions_raw = params.get("questions")
+        questions = (
+            [question for question in questions_raw if isinstance(question, dict)]
+            if isinstance(questions_raw, list)
+            else []
+        )
+        answers = await self._ask_discord_user_input_questions(
+            request_id=request_id,
+            turn_id=str(params.get("turnId") or params.get("turn_id") or ""),
+            questions=questions,
+        )
+        if answers is None:
+            return {"answers": {}}
+        normalized: dict[str, dict[str, list[str]]] = {}
+        for index, question in enumerate(questions):
+            question_id = question.get("id")
+            if not isinstance(question_id, str) or not question_id.strip():
+                continue
+            normalized[question_id.strip()] = {
+                "answers": answers[index] if index < len(answers) else []
+            }
+        return {"answers": normalized}
+
+    async def _handle_opencode_question_request(
+        self,
+        request_id: str,
+        props: dict[str, Any],
+        *,
+        turn_id: str,
+    ) -> list[list[str]] | None:
+        questions_raw = props.get("questions") if isinstance(props, dict) else None
+        questions = (
+            [question for question in questions_raw if isinstance(question, dict)]
+            if isinstance(questions_raw, list)
+            else []
+        )
+        return await self._ask_discord_user_input_questions(
+            request_id=request_id,
+            turn_id=turn_id,
+            questions=questions,
+        )
+
+    async def _ask_discord_user_input_questions(
+        self,
+        *,
+        request_id: str,
+        turn_id: str,
+        questions: list[dict[str, Any]],
+    ) -> list[list[str]] | None:
+        context = self._discord_turn_approval_contexts.get(turn_id)
+        if context is None or not questions:
+            return None
+        answers: list[list[str]] = []
+        for index, question in enumerate(questions):
+            options, _multiple = _discord_question_options(question)
+            token = uuid.uuid4().hex[:12]
+            loop = asyncio.get_running_loop()
+            future: asyncio.Future[list[str] | None] = loop.create_future()
+            prompt = format_discord_user_input_prompt(
+                question,
+                index=index,
+                total=len(questions),
+            )
+            pending = _DiscordPendingUserInput(
+                token=token,
+                request_id=request_id,
+                turn_id=turn_id,
+                channel_id=context.channel_id,
+                message_id=None,
+                question_index=index,
+                question=dict(question),
+                options=options,
+                future=future,
+            )
+            try:
+                response = await self._send_channel_message(
+                    context.channel_id,
+                    {
+                        "content": format_discord_message(prompt),
+                        "components": build_discord_user_input_components(
+                            token,
+                            question_index=index,
+                            question=question,
+                        ),
+                    },
+                )
+            except (DiscordAPIError, OSError) as exc:
+                log_event(
+                    self._logger,
+                    logging.WARNING,
+                    "discord.user_input.send_failed",
+                    channel_id=context.channel_id,
+                    request_id=request_id,
+                    turn_id=turn_id,
+                    question_index=index,
+                    exc=exc,
+                )
+                return None
+            message_id = response.get("id") if isinstance(response, dict) else None
+            if isinstance(message_id, str) and message_id:
+                pending.message_id = message_id
+            self._discord_pending_user_inputs[token] = pending
+            try:
+                result = await future
+            finally:
+                self._discord_pending_user_inputs.pop(token, None)
+            if result is None:
+                return None
+            answers.append(result)
+        return answers
+
+    async def _handle_user_input_component(
+        self,
+        interaction_id: str,
+        interaction_token: str,
+        *,
+        custom_id: str,
+        values: Optional[list[str]] = None,
+    ) -> None:
+        parts = custom_id.split(":")
+        token = parts[1] if len(parts) >= 2 else ""
+        action = parts[2] if len(parts) >= 3 else ""
+        pending = self._discord_pending_user_inputs.get(token)
+        if pending is None:
+            await self._respond_ephemeral(
+                interaction_id,
+                interaction_token,
+                "Question already handled",
+            )
+            return
+        if action == "answer":
+            await self.respond_modal(
+                interaction_id,
+                interaction_token,
+                kind=InteractionSessionKind.COMPONENT,
+                custom_id=f"question_modal:{token}",
+                title="Answer question",
+                components=[
+                    {
+                        "type": 18,
+                        "label": "Answer"[:45],
+                        "component": {
+                            "type": 4,
+                            "custom_id": "answer",
+                            "style": 2,
+                            "required": True,
+                            "max_length": 4000,
+                        },
+                    }
+                ],
+            )
+            return
+        self._discord_pending_user_inputs.pop(token, None)
+        selected_values: list[str] | None
+        if custom_id.startswith("question_select:"):
+            selected_values = []
+            for value in values or []:
+                try:
+                    option_index = int(value)
+                except ValueError:
+                    continue
+                if 0 <= option_index < len(pending.options):
+                    selected_values.append(pending.options[option_index])
+        else:
+            selected_values = None
+        if not pending.future.done():
+            pending.future.set_result(selected_values)
+        await self._respond_ephemeral(
+            interaction_id,
+            interaction_token,
+            "Answered" if selected_values is not None else "Canceled",
+        )
+        if pending.message_id:
+            with contextlib.suppress(DiscordAPIError, OSError, RuntimeError):
+                await self._delete_channel_message(
+                    pending.channel_id,
+                    pending.message_id,
+                )
+
+    async def _handle_user_input_modal_submit(
+        self,
+        interaction_id: str,
+        interaction_token: str,
+        *,
+        custom_id: str,
+        values: dict[str, Any],
+    ) -> None:
+        token = custom_id.split(":", 1)[1].strip() if ":" in custom_id else ""
+        pending = self._discord_pending_user_inputs.pop(token, None)
+        if pending is None:
+            await self._respond_ephemeral(
+                interaction_id,
+                interaction_token,
+                "Question already handled",
+            )
+            return
+        answer = values.get("answer")
+        selected_values = (
+            [answer.strip()] if isinstance(answer, str) and answer.strip() else []
+        )
+        if not pending.future.done():
+            pending.future.set_result(selected_values)
+        await self._respond_ephemeral(
+            interaction_id,
+            interaction_token,
+            "Answered",
+        )
+        if pending.message_id:
+            with contextlib.suppress(DiscordAPIError, OSError, RuntimeError):
+                await self._delete_channel_message(
+                    pending.channel_id,
+                    pending.message_id,
+                )
+
     def _build_workspace_env(
         self, workspace_root: Path, workspace_id: str, state_dir: Path
     ) -> dict[str, str]:
@@ -4131,8 +4394,7 @@ class DiscordBotService(DiscordInteractionResponseMixin):
                 surface_key,
                 progress_message_id,
                 record_id=(
-                    "discord:managed-thread-progress-cleanup:"
-                    f"{progress_send_record_id}"
+                    f"discord:managed-thread-progress-cleanup:{progress_send_record_id}"
                 ),
             )
             return

--- a/src/codex_autorunner/adapters/discord/service.py
+++ b/src/codex_autorunner/adapters/discord/service.py
@@ -413,6 +413,7 @@ from .service_lifecycle import (
 from .service_normalization import (
     DiscordAttachmentAdapter,
     SavedDiscordAttachment,
+    _extract_question_options,
     build_attachment_context_payload,
     build_discord_approval_message,
     build_discord_queue_status_message,
@@ -651,27 +652,6 @@ class _DiscordPendingUserInput:
     question: dict[str, Any]
     options: list[str]
     future: asyncio.Future[list[str] | None]
-
-
-def _discord_question_options(question: Mapping[str, Any]) -> tuple[list[str], bool]:
-    multiple = bool(question.get("multiple"))
-    for key in ("options", "choices"):
-        raw = question.get(key)
-        if not isinstance(raw, list):
-            continue
-        options: list[str] = []
-        for option in raw:
-            if isinstance(option, str) and option.strip():
-                options.append(option.strip())
-                continue
-            if isinstance(option, Mapping):
-                for label_key in ("label", "text", "value", "name", "id"):
-                    value = option.get(label_key)
-                    if isinstance(value, str) and value.strip():
-                        options.append(value.strip())
-                        break
-        return options, multiple
-    return [], multiple
 
 
 @dataclass(frozen=True)
@@ -3407,7 +3387,7 @@ class DiscordBotService(DiscordInteractionResponseMixin):
             return None
         answers: list[list[str]] = []
         for index, question in enumerate(questions):
-            options, _multiple = _discord_question_options(question)
+            options, _multiple = _extract_question_options(question)
             token = uuid.uuid4().hex[:12]
             loop = asyncio.get_running_loop()
             future: asyncio.Future[list[str] | None] = loop.create_future()

--- a/src/codex_autorunner/adapters/discord/service_normalization.py
+++ b/src/codex_autorunner/adapters/discord/service_normalization.py
@@ -29,6 +29,8 @@ from .components import (
     build_button,
     build_queue_notice_buttons,
     build_queue_status_buttons,
+    build_select_menu,
+    build_select_option,
 )
 from .rendering import format_discord_message, truncate_for_discord
 
@@ -362,6 +364,78 @@ def build_discord_approval_message(
     return DiscordMessagePayload(
         content=format_discord_approval_prompt(request),
         components=build_discord_approval_components(token),
+    )
+
+
+def _extract_question_text(question: Mapping[str, Any]) -> str:
+    for key in ("text", "prompt", "title", "label", "question", "header"):
+        value = question.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "Question"
+
+
+def _extract_question_options(question: Mapping[str, Any]) -> tuple[list[str], bool]:
+    multiple = bool(question.get("multiple"))
+    for key in ("options", "choices"):
+        raw = question.get(key)
+        if not isinstance(raw, list):
+            continue
+        options: list[str] = []
+        for option in raw:
+            if isinstance(option, str) and option.strip():
+                options.append(option.strip())
+                continue
+            if isinstance(option, Mapping):
+                for label_key in ("label", "text", "value", "name", "id"):
+                    value = option.get(label_key)
+                    if isinstance(value, str) and value.strip():
+                        options.append(value.strip())
+                        break
+        return options, multiple
+    return [], multiple
+
+
+def format_discord_user_input_prompt(
+    question: Mapping[str, Any], *, index: int, total: int
+) -> str:
+    prefix = f"Question {index + 1} of {total}" if total > 1 else "Question"
+    return f"{prefix}:\n{_extract_question_text(question)}"
+
+
+def build_discord_user_input_components(
+    token: str,
+    *,
+    question_index: int,
+    question: Mapping[str, Any],
+) -> tuple[dict[str, Any], ...]:
+    options, multiple = _extract_question_options(question)
+    if not options:
+        return (
+            build_action_row(
+                [
+                    build_button("Answer", f"question:{token}:answer"),
+                    build_button("Cancel", f"question:{token}:cancel"),
+                ]
+            ),
+        )
+    select_options = [
+        build_select_option(label[:100], str(index))
+        for index, label in enumerate(options[:25])
+    ]
+    return (
+        build_action_row(
+            [
+                build_select_menu(
+                    f"question_select:{token}:{question_index}",
+                    select_options,
+                    placeholder="Choose answer",
+                    min_values=1,
+                    max_values=len(select_options) if multiple else 1,
+                )
+            ]
+        ),
+        build_action_row([build_button("Cancel", f"question:{token}:cancel")]),
     )
 
 

--- a/src/codex_autorunner/adapters/telegram/service.py
+++ b/src/codex_autorunner/adapters/telegram/service.py
@@ -374,6 +374,7 @@ class TelegramBotService(
             state_root=self._app_server_state_root,
             env_builder=self._build_workspace_env,
             approval_handler=self._handle_approval_request,
+            question_handler=self._handle_backend_user_input_request,
             notification_handler=self._handle_buffered_app_server_notification,
             logger=self._logger,
             auto_restart=self._app_server_auto_restart,
@@ -560,6 +561,36 @@ class TelegramBotService(
         self._instance_lock: Optional[FileLock] = None
         self._delivery_worker: Optional[ManagedThreadDeliveryWorker] = None
         self._delivery_worker_task: Optional[asyncio.Task[None]] = None
+
+    async def _handle_backend_user_input_request(
+        self, request: dict[str, Any]
+    ) -> dict[str, Any]:
+        params_raw = request.get("params")
+        params: dict[str, Any] = (
+            dict(params_raw) if isinstance(params_raw, dict) else {}
+        )
+        request_id = str(request.get("id") or "").strip()
+        questions_raw = params.get("questions")
+        questions = (
+            [question for question in questions_raw if isinstance(question, dict)]
+            if isinstance(questions_raw, list)
+            else []
+        )
+        answers = await self._handle_question_request(
+            request_id=request_id,
+            turn_id=str(params.get("turnId") or params.get("turn_id") or ""),
+            thread_id=str(params.get("threadId") or params.get("thread_id") or ""),
+            questions=questions,
+        )
+        normalized: dict[str, dict[str, list[str]]] = {}
+        for index, question in enumerate(questions):
+            question_id = question.get("id")
+            if not isinstance(question_id, str) or not question_id.strip():
+                continue
+            normalized[question_id.strip()] = {
+                "answers": answers[index] if answers and index < len(answers) else []
+            }
+        return {"answers": normalized}
 
     def _build_delivery_worker(self) -> ManagedThreadDeliveryWorker:
         service = self

--- a/src/codex_autorunner/core/hub_control_plane/_run_events.py
+++ b/src/codex_autorunner/core/hub_control_plane/_run_events.py
@@ -16,6 +16,7 @@ from ..ports.run_event import (
     TokenUsage,
     ToolCall,
     ToolResult,
+    UserInputRequested,
 )
 from ..runtime_identity import RuntimeIdentityStage
 from ._normalizers import normalize_required_text
@@ -32,6 +33,8 @@ def serialize_run_event(event: RunEvent) -> dict[str, Any]:
         event_type = "tool_result"
     elif isinstance(event, ApprovalRequested):
         event_type = "approval_requested"
+    elif isinstance(event, UserInputRequested):
+        event_type = "user_input_requested"
     elif isinstance(event, TokenUsage):
         event_type = "token_usage"
     elif isinstance(event, ProviderRuntimeReported):
@@ -71,6 +74,14 @@ def deserialize_run_event(data: Mapping[str, Any]) -> RunEvent:
         return ToolResult(**event_payload)
     if event_type == "approval_requested":
         return ApprovalRequested(**event_payload)
+    if event_type == "user_input_requested":
+        questions = event_payload.get("questions")
+        if isinstance(questions, list):
+            event_payload["questions"] = tuple(
+                dict(question) if isinstance(question, Mapping) else question
+                for question in questions
+            )
+        return UserInputRequested(**event_payload)
     if event_type == "token_usage":
         return TokenUsage(**event_payload)
     if event_type == "provider_runtime_reported":

--- a/src/codex_autorunner/core/orchestration/execution_history.py
+++ b/src/codex_autorunner/core/orchestration/execution_history.py
@@ -16,6 +16,7 @@ from ..ports.run_event import (
     TokenUsage,
     ToolCall,
     ToolResult,
+    UserInputRequested,
 )
 from ..text_utils import _truncate_text
 
@@ -44,6 +45,7 @@ _TIMELINE_HOT_FAMILY_BY_EVENT_TYPE: dict[str, ExecutionHistoryEventFamily] = {
     "tool_result": "tool_result",
     "approval_requested": "run_notice",
     "token_usage": "token_usage",
+    "user_input_requested": "run_notice",
     "run_notice": "run_notice",
     "turn_completed": "terminal",
     "turn_failed": "terminal",
@@ -340,7 +342,14 @@ def classify_run_event_family(event: RunEvent) -> ExecutionHistoryEventFamily:
     if isinstance(event, (Completed, Failed, Interrupted)):
         return "terminal"
     if isinstance(
-        event, (Started, ApprovalRequested, RunNotice, ProviderRuntimeReported)
+        event,
+        (
+            Started,
+            ApprovalRequested,
+            UserInputRequested,
+            RunNotice,
+            ProviderRuntimeReported,
+        ),
     ):
         return "run_notice"
     raise TypeError(f"Unsupported run event type '{type(event).__name__}'")

--- a/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
+++ b/src/codex_autorunner/core/orchestration/managed_thread_timeline.py
@@ -14,6 +14,7 @@ from ..ports.run_event import (
     RunNotice,
     ToolCall,
     ToolResult,
+    UserInputRequested,
 )
 from ..text_utils import _truncate_text
 from .managed_thread_delivery_ledger import SQLiteManagedThreadDeliveryLedger
@@ -562,6 +563,24 @@ def _progress_item_for_entry(
             description=str(event.get("description") or ""),
             context=dict(context) if isinstance(context, dict) else {},
         )
+    elif event_type == "user_input_requested":
+        questions = event.get("questions")
+        context = event.get("context")
+        run_event = UserInputRequested(
+            timestamp=timestamp,
+            request_id=str(event.get("request_id") or ""),
+            description=str(event.get("description") or ""),
+            questions=(
+                tuple(
+                    dict(question)
+                    for question in questions
+                    if isinstance(question, dict)
+                )
+                if isinstance(questions, list)
+                else ()
+            ),
+            context=dict(context) if isinstance(context, dict) else {},
+        )
     if run_event is None:
         return None, False
     return reduce_progress_event_merged(
@@ -853,16 +872,21 @@ def _append_timeline_event_items(
             continue
 
         flush_tool_group()
-        if event_type == "approval_requested":
+        if event_type in {"approval_requested", "user_input_requested"}:
             request_id = str(event.get("request_id") or event_stable_id)
-            item_id = f"turn:{managed_turn_id}:approval:{request_id}"
+            is_user_input = event_type == "user_input_requested"
+            item_id = (
+                f"turn:{managed_turn_id}:user_input:{request_id}"
+                if is_user_input
+                else f"turn:{managed_turn_id}:approval:{request_id}"
+            )
             progress_item_ids, progress_event_ids = _progress_item_metadata(
                 progress_item
             )
             items.append(
                 ManagedThreadTimelineItem(
                     item_id=item_id,
-                    kind="approval",
+                    kind="user_input" if is_user_input else "approval",
                     order_key=_order_key(timestamp, sequence, item_id),
                     timestamp=timestamp,
                     managed_thread_id=managed_thread_id,
@@ -1195,7 +1219,7 @@ def timeline_item_from_tail_event(
             )
         if _is_internal_run_notice(tail_event, progress):
             return None
-        item_id = f"turn:{normalized_turn_id}:intermediate:" f"{source_event_key}"
+        item_id = f"turn:{normalized_turn_id}:intermediate:{source_event_key}"
         text = str(tail_event.get("summary") or "")
         title = _progress_display_title(
             fallback_kind=progress_kind or event_type or "Update",

--- a/src/codex_autorunner/core/orchestration/progress_projection.py
+++ b/src/codex_autorunner/core/orchestration/progress_projection.py
@@ -17,6 +17,7 @@ from ..ports.run_event import (
     TokenUsage,
     ToolCall,
     ToolResult,
+    UserInputRequested,
 )
 from ..redaction import redact_text
 from ..text_utils import _truncate_text
@@ -378,6 +379,17 @@ def reduce_progress_event(
             state="waiting",
             title="Approval requested",
             summary=_summary(event.description, "Approval requested"),
+            event_ids=(event_id,),
+            timestamp=timestamp,
+        )
+
+    if isinstance(event, UserInputRequested):
+        return ProgressProjectionItem(
+            item_id=f"progress:user_input:{event.request_id or event_key}",
+            kind="user_input",
+            state="waiting",
+            title="User input requested",
+            summary=_summary(event.description, "User input requested"),
             event_ids=(event_id,),
             timestamp=timestamp,
         )

--- a/src/codex_autorunner/core/orchestration/runtime_thread_decoders.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_decoders.py
@@ -38,6 +38,7 @@ from ..ports.run_event import (
     TokenUsage,
     ToolCall,
     ToolResult,
+    UserInputRequested,
 )
 from ..time_utils import now_iso
 from .codex_item_normalizers import (
@@ -209,6 +210,47 @@ def _approval_summary(method: str, params: dict[str, Any]) -> str:
                 return ", ".join(paths)
         return "File approval requested"
     return "Approval requested"
+
+
+def _extract_question_text(question: dict[str, Any]) -> str:
+    for key in ("text", "prompt", "title", "label", "question", "header"):
+        value = question.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "Question"
+
+
+def _extract_user_input_questions(params: dict[str, Any]) -> tuple[dict[str, Any], ...]:
+    questions = params.get("questions")
+    if isinstance(questions, list):
+        return tuple(
+            dict(question) for question in questions if isinstance(question, dict)
+        )
+    question_text = None
+    for key in ("question", "text", "prompt", "title", "label", "header"):
+        value = params.get(key)
+        if isinstance(value, str) and value.strip():
+            question_text = value.strip()
+            break
+    if isinstance(question_text, str) and question_text.strip():
+        question_id = (
+            params.get("id") or params.get("questionId") or params.get("question_id")
+        )
+        question: dict[str, Any] = dict(params)
+        if isinstance(question_id, str) and question_id.strip():
+            question["id"] = question_id.strip()
+        context = params.get("context")
+        if isinstance(context, list):
+            question["context"] = context
+        return (question,)
+    return ()
+
+
+def _user_input_summary(params: dict[str, Any]) -> str:
+    questions = _extract_user_input_questions(params)
+    if questions:
+        return _extract_question_text(questions[0])
+    return "User input requested"
 
 
 def _extract_already_streamed_flag(payload: dict[str, Any]) -> bool:
@@ -659,6 +701,7 @@ class CodexItemDecoder(MessageDecoder):
                     "item/agentMessage/delta",
                     "item/toolCall/start",
                     "item/toolCall/end",
+                    "item/tool/requestUserInput",
                 }
             )
             | _APPROVAL_METHODS
@@ -728,6 +771,18 @@ class CodexItemDecoder(MessageDecoder):
                     status="error" if error else "completed",
                     result=result,
                     error=error,
+                )
+            ]
+
+        if method == "item/tool/requestUserInput":
+            request_id = _request_id_for_event(method, params)
+            return [
+                UserInputRequested(
+                    timestamp=ts,
+                    request_id=request_id,
+                    description=_user_input_summary(params),
+                    questions=_extract_user_input_questions(params),
+                    context=dict(params),
                 )
             ]
 
@@ -958,6 +1013,7 @@ class PermissionDecoder(MessageDecoder):
                 "permission/decision",
                 "permission",
                 "question",
+                "question.asked",
             }
         )
 
@@ -1019,12 +1075,12 @@ class PermissionDecoder(MessageDecoder):
             ]
 
         request_id = _request_id_for_event(method, params)
-        question_text = str(params.get("question") or "").strip()
         return [
-            ApprovalRequested(
+            UserInputRequested(
                 timestamp=ts,
                 request_id=request_id,
-                description=question_text or "Question pending",
+                description=_user_input_summary(params),
+                questions=_extract_user_input_questions(params),
                 context=dict(params),
             )
         ]

--- a/src/codex_autorunner/core/orchestration/runtime_thread_events.py
+++ b/src/codex_autorunner/core/orchestration/runtime_thread_events.py
@@ -24,6 +24,7 @@ from ..ports.run_event import (
     Started,
     TokenUsage,
     ToolCall,
+    UserInputRequested,
 )
 from ..sse import SSEEvent, parse_sse_lines
 from ..time_utils import now_iso
@@ -52,6 +53,7 @@ DECODE_FAILURE_REASON_MALFORMED_SSE_JSON = "malformed_sse_json"
 DIRECT_RUN_EVENT_TYPES = (
     OutputDelta,
     ToolCall,
+    UserInputRequested,
     ApprovalRequested,
     RunNotice,
     TokenUsage,

--- a/src/codex_autorunner/core/orchestration/turn_timeline.py
+++ b/src/codex_autorunner/core/orchestration/turn_timeline.py
@@ -22,6 +22,7 @@ from ..ports.run_event import (
     TokenUsage,
     ToolCall,
     ToolResult,
+    UserInputRequested,
 )
 from ..text_utils import _json_dumps, _truncate_text
 from .cold_trace_store import ColdTraceStore, ColdTraceWriter
@@ -49,6 +50,7 @@ _HOT_FAMILY_ROW_LIMITS = {
     "tool_result": 128,
     "output_delta": 200,
     "run_notice": 100,
+    "user_input_requested": 64,
     "token_usage": 64,
     "terminal": 8,
 }
@@ -80,6 +82,8 @@ def _event_type_and_status(event: RunEvent) -> tuple[str, str]:
         return "tool_result", event.status or "recorded"
     if isinstance(event, ApprovalRequested):
         return "approval_requested", "recorded"
+    if isinstance(event, UserInputRequested):
+        return "user_input_requested", "recorded"
     if isinstance(event, TokenUsage):
         return "token_usage", "recorded"
     if isinstance(event, ProviderRuntimeReported):
@@ -442,6 +446,14 @@ class _CheckpointAccumulator:
                 event.description, _CHECKPOINT_PREVIEW_CHARS
             )
             self.progress_text_kind = "approval"
+            self.progress_char_count = len(event.description)
+            return
+
+        if isinstance(event, UserInputRequested):
+            self.progress_text_preview = _truncate_text(
+                event.description, _CHECKPOINT_PREVIEW_CHARS
+            )
+            self.progress_text_kind = "user_input"
             self.progress_char_count = len(event.description)
             return
 

--- a/src/codex_autorunner/core/orchestration/turn_timeline.py
+++ b/src/codex_autorunner/core/orchestration/turn_timeline.py
@@ -4,7 +4,7 @@ import json
 import logging
 from dataclasses import asdict
 from datetime import datetime, timezone
-from typing import Any, Iterable, Optional, Sequence
+from typing import Any, Iterable, Mapping, Optional, Sequence
 
 from ..ports.run_event import (
     RUN_EVENT_DELTA_TYPE_ASSISTANT_MESSAGE,
@@ -50,10 +50,27 @@ _HOT_FAMILY_ROW_LIMITS = {
     "tool_result": 128,
     "output_delta": 200,
     "run_notice": 100,
-    "user_input_requested": 64,
     "token_usage": 64,
     "terminal": 8,
 }
+_HOT_EVENT_TYPE_ROW_LIMITS = {
+    "user_input_requested": 64,
+}
+
+
+def _hot_persist_spill_metrics(
+    hot_rows: Mapping[str, int],
+    *,
+    family: str,
+    event_type: str,
+) -> tuple[str, int]:
+    normalized_event_type = str(event_type or "").strip()
+    type_limit = _HOT_EVENT_TYPE_ROW_LIMITS.get(normalized_event_type)
+    if type_limit is not None and hot_rows.get(normalized_event_type, 0) >= type_limit:
+        return normalized_event_type, type_limit
+    return family, _HOT_FAMILY_ROW_LIMITS.get(family, 0)
+
+
 _COALESCED_NOTICE_KINDS = frozenset({"progress", "thinking"})
 logger = logging.getLogger(__name__)
 
@@ -141,11 +158,13 @@ def _collect_execution_family_hot_rows(
         ).fetchall()
     family_hot_rows: dict[str, int] = {}
     for row in rows:
-        family = timeline_hot_family_for_event_type(row["event_type"])
+        event_type = str(row["event_type"] or "").strip()
+        count = int(row["cnt"] or 0)
+        if event_type in _HOT_EVENT_TYPE_ROW_LIMITS:
+            family_hot_rows[event_type] = family_hot_rows.get(event_type, 0) + count
+        family = timeline_hot_family_for_event_type(event_type)
         if family:
-            family_hot_rows[family] = family_hot_rows.get(family, 0) + int(
-                row["cnt"] or 0
-            )
+            family_hot_rows[family] = family_hot_rows.get(family, 0) + count
     return family_hot_rows
 
 
@@ -262,8 +281,13 @@ class _HotProjectionState:
         self.last_notice_by_kind = _seed_notice_memory(hub_root, execution_id)
         self.last_output_by_type = _seed_output_memory(hub_root, execution_id)
 
-    def note_hot_persisted(self, family: str) -> None:
+    def note_hot_persisted(self, family: str, *, event_type: str = "") -> None:
         self.family_hot_rows[family] = self.family_hot_rows.get(family, 0) + 1
+        normalized_event_type = str(event_type or "").strip()
+        if normalized_event_type in _HOT_EVENT_TYPE_ROW_LIMITS:
+            self.family_hot_rows[normalized_event_type] = (
+                self.family_hot_rows.get(normalized_event_type, 0) + 1
+            )
 
     def note_deduped(self, family: str) -> None:
         self.deduped_counts[family] = self.deduped_counts.get(family, 0) + 1
@@ -287,7 +311,12 @@ class _HotProjectionState:
                 content, _HOT_STATE_OUTPUT_MAX_CHARS
             )
 
-    def allows_hot_persist(self, family: str) -> bool:
+    def allows_hot_persist(self, family: str, *, event_type: str = "") -> bool:
+        normalized_event_type = str(event_type or "").strip()
+        type_limit = _HOT_EVENT_TYPE_ROW_LIMITS.get(normalized_event_type)
+        if type_limit is not None:
+            if self.family_hot_rows.get(normalized_event_type, 0) >= type_limit:
+                return False
         limit = _HOT_FAMILY_ROW_LIMITS.get(family)
         if limit is None:
             return True
@@ -808,7 +837,12 @@ def persist_turn_timeline(
                         deduped_count=hot_state.deduped_counts.get(family, 0),
                     )
                 continue
-            if not hot_state.allows_hot_persist(family):
+            if not hot_state.allows_hot_persist(family, event_type=event_type):
+                limit_key, hot_limit = _hot_persist_spill_metrics(
+                    hot_state.family_hot_rows,
+                    family=family,
+                    event_type=event_type,
+                )
                 hot_state.note_spilled(
                     family,
                     has_cold_trace=bool(
@@ -825,8 +859,8 @@ def persist_turn_timeline(
                         and cold_trace_writer is not None
                         and routing.capture_cold_trace
                     ),
-                    hot_rows_so_far=hot_state.family_hot_rows.get(family, 0),
-                    hot_limit=_HOT_FAMILY_ROW_LIMITS.get(family, 0),
+                    hot_rows_so_far=hot_state.family_hot_rows.get(limit_key, 0),
+                    hot_limit=hot_limit,
                 )
                 continue
             event_payload = build_hot_projection_envelope(
@@ -902,7 +936,7 @@ def persist_turn_timeline(
                     1,
                 ),
             )
-            hot_state.note_hot_persisted(family)
+            hot_state.note_hot_persisted(family, event_type=event_type)
     if count > 0:
         store.save_checkpoint(checkpoint_accumulator.build())
     return count

--- a/src/codex_autorunner/core/pma/tail_serialization.py
+++ b/src/codex_autorunner/core/pma/tail_serialization.py
@@ -32,6 +32,7 @@ from ..ports.run_event import (
     TokenUsage,
     ToolCall,
     ToolResult,
+    UserInputRequested,
 )
 from ..redaction import redact_text
 from ..text_utils import _normalize_optional_text as normalize_optional_text
@@ -401,6 +402,23 @@ def _run_event_from_timeline_entry(entry: dict[str, Any]) -> Any | None:
             timestamp=timestamp,
             request_id=str(event.get("request_id") or ""),
             description=str(event.get("description") or ""),
+            context=coerce_dict(event.get("context")),
+        )
+    if event_type == "user_input_requested":
+        questions = event.get("questions")
+        return UserInputRequested(
+            timestamp=timestamp,
+            request_id=str(event.get("request_id") or ""),
+            description=str(event.get("description") or ""),
+            questions=(
+                tuple(
+                    dict(question)
+                    for question in questions
+                    if isinstance(question, dict)
+                )
+                if isinstance(questions, list)
+                else ()
+            ),
             context=coerce_dict(event.get("context")),
         )
     if event_type == "token_usage":

--- a/src/codex_autorunner/core/ports/__init__.py
+++ b/src/codex_autorunner/core/ports/__init__.py
@@ -11,6 +11,7 @@ from .run_event import (
     Started,
     TokenUsage,
     ToolCall,
+    UserInputRequested,
 )
 from .scope_resolver import ResolvedScope, ScopeResolver
 from .surface_port import (
@@ -57,5 +58,6 @@ __all__ = [
     "TicketStore",
     "TokenUsage",
     "ToolCall",
+    "UserInputRequested",
     "now_iso",
 ]

--- a/src/codex_autorunner/core/ports/run_event.py
+++ b/src/codex_autorunner/core/ports/run_event.py
@@ -74,6 +74,15 @@ class ApprovalRequested:
 
 
 @dataclass(frozen=True)
+class UserInputRequested:
+    timestamp: str
+    request_id: str
+    description: str
+    questions: tuple[dict[str, Any], ...] = ()
+    context: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class TokenUsage:
     timestamp: str
     usage: dict[str, Any]
@@ -117,6 +126,7 @@ RunEvent = Union[
     ToolCall,
     ToolResult,
     ApprovalRequested,
+    UserInputRequested,
     TokenUsage,
     ProviderRuntimeReported,
     RunNotice,
@@ -151,6 +161,7 @@ __all__ = [
     "TokenUsage",
     "ToolCall",
     "ToolResult",
+    "UserInputRequested",
     "is_terminal_run_event",
     "now_iso",
 ]

--- a/src/codex_autorunner/surfaces/web/routes/file_chat_routes/execution_agents.py
+++ b/src/codex_autorunner/surfaces/web/routes/file_chat_routes/execution_agents.py
@@ -445,7 +445,7 @@ async def execute_opencode(
             workspace_path=str(repo_root),
             model_payload=model_payload,
             permission_policy=PERMISSION_ALLOW,
-            question_policy="auto_first_option",
+            question_policy="reject",
             should_stop=interrupt_event.is_set,
             ready_event=ready_event,
             part_handler=_part_handler,

--- a/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime_execution.py
+++ b/src/codex_autorunner/surfaces/web/routes/pma_routes/chat_runtime_execution.py
@@ -37,6 +37,7 @@ from .....core.pma.runtime_results import (
 from .....core.ports.run_event import (
     Completed,
     RunEvent,
+    UserInputRequested,
 )
 from .....core.time_utils import now_iso
 from ...services.pma import get_pma_request_context
@@ -705,6 +706,39 @@ async def execute_opencode(
             if asyncio.iscoroutine(maybe):
                 await maybe
 
+    async def _question_handler(
+        request_id: str,
+        props: dict[str, Any],
+    ) -> list[list[str]] | None:
+        questions_raw = props.get("questions") if isinstance(props, dict) else None
+        questions = (
+            tuple(
+                dict(question)
+                for question in questions_raw
+                if isinstance(question, dict)
+            )
+            if isinstance(questions_raw, list)
+            else ()
+        )
+        description = "User input requested"
+        if questions:
+            first = questions[0]
+            for key in ("text", "prompt", "title", "label", "question", "header"):
+                value = first.get(key)
+                if isinstance(value, str) and value.strip():
+                    description = value.strip()
+                    break
+        timeline_events.append(
+            UserInputRequested(
+                timestamp=now_iso(),
+                request_id=request_id,
+                description=description,
+                questions=questions,
+                context=dict(props),
+            )
+        )
+        return None
+
     stall_timeout, first_event_timeout = opencode_stream_timeouts(
         stall_timeout_seconds,
     )
@@ -715,7 +749,7 @@ async def execute_opencode(
             workspace_path=str(hub_root),
             model_payload=model_payload,
             permission_policy=PERMISSION_ALLOW,
-            question_policy="auto_first_option",
+            question_handler=_question_handler,
             should_stop=interrupt_event.is_set,
             ready_event=ready_event,
             part_handler=_timeline_part_handler,

--- a/tests/adapters/chat/test_action_ux_contract.py
+++ b/tests/adapters/chat/test_action_ux_contract.py
@@ -177,6 +177,25 @@ def test_approval_and_question_callbacks_bypass_queue() -> None:
         ), f"{callback_id} should bypass queue but queue_policy={entry.queue_policy}"
 
 
+def test_discord_user_input_components_and_modal_bypass_queue() -> None:
+    button = discord_component_ux_contract_for_route(
+        "user_input.button",
+        custom_id="question:token:answer",
+    )
+    select = discord_component_ux_contract_for_route(
+        "user_input.select",
+        custom_id="question_select:token:0",
+    )
+    modal = discord_modal_ux_contract_for_route("user_input.modal_submit")
+
+    assert button is not None
+    assert button.queue_policy == "bypass_active_turn"
+    assert select is not None
+    assert select.queue_policy == "bypass_active_turn"
+    assert modal is not None
+    assert modal.queue_policy == "bypass_active_turn"
+
+
 def test_cancel_selection_bypasses_queue() -> None:
     entry = telegram_callback_ux_contract_for_callback("cancel", {"kind": "agent"})
     assert entry is not None

--- a/tests/adapters/chat/test_execution_event_journal.py
+++ b/tests/adapters/chat/test_execution_event_journal.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from codex_autorunner.adapters.chat.execution_event_journal import (
+    journal_events_from_run_events,
     journal_events_from_timeline_entries,
 )
+from codex_autorunner.core.ports.run_event import UserInputRequested
 
 
 def test_journal_replays_turn_interrupted_as_interrupted_event() -> None:
@@ -26,3 +28,24 @@ def test_journal_replays_turn_interrupted_as_interrupted_event() -> None:
     assert journal[0].status == "interrupted"
     assert journal[0].source_event_type == "interrupted"
     assert journal[0].message == "Runtime thread interrupted"
+
+
+def test_journal_records_user_input_requests() -> None:
+    journal = journal_events_from_run_events(
+        [
+            UserInputRequested(
+                timestamp="2026-05-15T00:00:00Z",
+                request_id="question-1",
+                description="Which framework?",
+                questions=({"id": "framework", "text": "Which framework?"},),
+                context={"source": "opencode"},
+            )
+        ]
+    )
+
+    assert len(journal) == 1
+    assert journal[0].domain == "user_input"
+    assert journal[0].name == "requested"
+    assert journal[0].status == "requested"
+    assert journal[0].source_event_type == "user_input_requested"
+    assert journal[0].data["request_id"] == "question-1"

--- a/tests/adapters/discord/test_service_normalization.py
+++ b/tests/adapters/discord/test_service_normalization.py
@@ -9,7 +9,9 @@ from codex_autorunner.adapters.discord.service_normalization import (
     build_attachment_context_payload,
     build_discord_approval_message,
     build_discord_queue_notice_message,
+    build_discord_user_input_components,
     format_discord_update_status_message,
+    format_discord_user_input_prompt,
     format_hub_flow_overview_line,
 )
 
@@ -27,15 +29,40 @@ def test_build_discord_approval_message_shapes_prompt_and_components() -> None:
     )
 
     assert message.content == (
-        "Approval required\n"
-        "Reason: Need permission\n"
-        "Command: /bin/zsh -c ps -p 123"
+        "Approval required\nReason: Need permission\nCommand: /bin/zsh -c ps -p 123"
     )
     payload = message.to_payload()
     action_rows = payload["components"]
     assert action_rows[0]["components"][0]["custom_id"] == "approval:abc123:accept"
     assert action_rows[0]["components"][1]["custom_id"] == "approval:abc123:decline"
     assert action_rows[1]["components"][0]["custom_id"] == "approval:abc123:cancel"
+
+
+def test_build_discord_user_input_components_support_select_and_text_modal() -> None:
+    prompt = format_discord_user_input_prompt(
+        {"text": "Which framework?", "options": ["pytest", "unittest"]},
+        index=0,
+        total=1,
+    )
+    select_components = build_discord_user_input_components(
+        "tok123",
+        question_index=0,
+        question={"text": "Which framework?", "options": ["pytest", "unittest"]},
+    )
+    text_components = build_discord_user_input_components(
+        "tok456",
+        question_index=0,
+        question={"text": "Describe the change"},
+    )
+
+    assert prompt == "Question:\nWhich framework?"
+    assert select_components[0]["components"][0]["custom_id"] == (
+        "question_select:tok123:0"
+    )
+    assert [button["custom_id"] for button in text_components[0]["components"]] == [
+        "question:tok456:answer",
+        "question:tok456:cancel",
+    ]
 
 
 def test_build_discord_queue_notice_message_serializes_optional_components() -> None:

--- a/tests/core/orchestration/test_progress_projection.py
+++ b/tests/core/orchestration/test_progress_projection.py
@@ -18,6 +18,7 @@ from codex_autorunner.core.ports.run_event import (
     TokenUsage,
     ToolCall,
     ToolResult,
+    UserInputRequested,
 )
 
 
@@ -227,6 +228,25 @@ def test_progress_projection_keeps_approvals_and_notices_interleaved() -> None:
 
     assert [item.kind for item in items] == ["notice", "approval", "notice"]
     assert [item.event_ids for item in items] == [(1,), (2,), (3,)]
+
+
+def test_progress_projection_projects_user_input_requests() -> None:
+    items = _project(
+        UserInputRequested(
+            timestamp="2026-05-06T10:00:02Z",
+            request_id="question-1",
+            description="Which framework?",
+            questions=({"id": "framework", "text": "Which framework?"},),
+            context={"source": "opencode"},
+        )
+    )
+
+    assert len(items) == 1
+    assert items[0].kind == "user_input"
+    assert items[0].state == "waiting"
+    assert items[0].title == "User input requested"
+    assert items[0].summary == "Which framework?"
+    assert items[0].item_id == "progress:user_input:question-1"
 
 
 def test_progress_projection_merges_streamed_progress_fragments() -> None:

--- a/tests/core/orchestration/test_runtime_thread_decoders.py
+++ b/tests/core/orchestration/test_runtime_thread_decoders.py
@@ -29,6 +29,7 @@ from codex_autorunner.core.ports.run_event import (
     TokenUsage,
     ToolCall,
     ToolResult,
+    UserInputRequested,
 )
 
 
@@ -137,6 +138,7 @@ class TestCodexItemDecoder:
         assert "item/toolCall/end" in methods
         assert "item/commandExecution/requestApproval" in methods
         assert "item/fileChange/requestApproval" in methods
+        assert "item/tool/requestUserInput" in methods
 
     def test_item_started_structural_event_returns_empty(self) -> None:
         state, ctx = _ctx(
@@ -367,6 +369,32 @@ class TestCodexItemDecoder:
         assert isinstance(events[0], ApprovalRequested)
         assert "src/main.py" in events[0].description
 
+    def test_request_user_input(self) -> None:
+        params = {
+            "requestId": "question-1",
+            "questions": [
+                {
+                    "id": "framework",
+                    "text": "Which framework?",
+                    "options": [{"label": "pytest"}, {"label": "unittest"}],
+                }
+            ],
+        }
+        state, ctx = _ctx("item/tool/requestUserInput", params)
+        events = self.decoder.decode("item/tool/requestUserInput", params, state, ctx)
+
+        assert len(events) == 1
+        assert isinstance(events[0], UserInputRequested)
+        assert events[0].request_id == "question-1"
+        assert events[0].description == "Which framework?"
+        assert events[0].questions == (
+            {
+                "id": "framework",
+                "text": "Which framework?",
+                "options": [{"label": "pytest"}, {"label": "unittest"}],
+            },
+        )
+
     def test_empty_delta_returns_empty(self) -> None:
         state, ctx = _ctx(
             "item/reasoning/summaryTextDelta",
@@ -523,6 +551,7 @@ class TestPermissionDecoder:
         assert "permission/decision" in methods
         assert "permission" in methods
         assert "question" in methods
+        assert "question.asked" in methods
 
     def test_permission_requested(self) -> None:
         state, ctx = _ctx(
@@ -568,8 +597,27 @@ class TestPermissionDecoder:
         state, ctx = _ctx("question", {"question": "Continue?"})
         events = self.decoder.decode("question", {"question": "Continue?"}, state, ctx)
         assert len(events) == 1
-        assert isinstance(events[0], ApprovalRequested)
+        assert isinstance(events[0], UserInputRequested)
         assert events[0].description == "Continue?"
+
+    def test_question_asked(self) -> None:
+        state, ctx = _ctx(
+            "question.asked",
+            {"id": "question-1", "text": "Pick one", "choices": ["a", "b"]},
+        )
+        events = self.decoder.decode(
+            "question.asked",
+            {"id": "question-1", "text": "Pick one", "choices": ["a", "b"]},
+            state,
+            ctx,
+        )
+
+        assert len(events) == 1
+        assert isinstance(events[0], UserInputRequested)
+        assert events[0].request_id == "question-1"
+        assert events[0].questions == (
+            {"id": "question-1", "text": "Pick one", "choices": ["a", "b"]},
+        )
 
 
 class TestUsageDecoder:

--- a/tests/test_app_server_client.py
+++ b/tests/test_app_server_client.py
@@ -780,21 +780,30 @@ async def test_approval_flow(tmp_path: Path) -> None:
 @pytest.mark.anyio
 async def test_request_user_input_flow(tmp_path: Path) -> None:
     questions: list[dict] = []
+    notifications: list[dict] = []
 
     async def answer(request: dict) -> dict:
         questions.append(request)
         return {"answers": {"framework": {"answers": ["pytest"]}}}
 
+    async def notify(message: dict) -> None:
+        notifications.append(message)
+
     client = CodexAppServerClient(
         fixture_command("question"),
         cwd=tmp_path,
         question_handler=answer,
+        notification_handler=notify,
     )
     try:
         thread = await client.thread_start(str(tmp_path))
         handle = await client.turn_start(thread["id"], "hi")
         result = await handle.wait()
         assert questions
+        assert any(
+            event.get("method") == "item/tool/requestUserInput"
+            for event in notifications
+        )
         assert result.status == "completed"
         assert result.final_message == "Selected framework: pytest"
         assert result.agent_messages == ["Selected framework: pytest"]


### PR DESCRIPTION
## Summary
- add a canonical `UserInputRequested` run event and wire it through runtime decoding, progress projection, journals, PMA tail serialization, and managed-thread timeline state
- support app-server/OpenCode question requests across Discord, Telegram, and web/PMA without auto-answer fallback behavior
- add Discord select/modal collection for option and free-text questions, plus shared action UX routing for active-turn bypass

## Validation
- `make typecheck-strict PYTHON=.venv/bin/python`
- `.venv/bin/python -m pytest tests/core/orchestration/test_runtime_thread_events.py tests/core/orchestration/test_runtime_thread_decoders.py tests/core/orchestration/test_progress_projection.py tests/core/orchestration/test_managed_thread_timeline.py tests/core/test_pma_tail_serialization.py tests/adapters/chat/test_execution_event_journal.py tests/adapters/chat/test_action_ux_contract.py tests/adapters/chat/test_managed_thread_progress_parity.py tests/adapters/discord/test_service_normalization.py tests/adapters/discord/test_components.py tests/test_app_server_client.py::test_request_user_input_flow tests/test_app_server_registry.py tests/adapters/app_server/test_callback_registry.py`
- commit hook aggregate lane passed: guardrails, Black/Ruff, import/interface checks, strict mypy, full fast pytest, frontend build/tests, chat-apps lane

Note: the first aggregate hook attempt hit an unrelated SQLite timeout in `tests/core/orchestration/test_bindings.py::test_binding_store_active_work_excludes_idle_completed_and_archived_threads`; the test passed standalone and the retry passed the aggregate lane.